### PR TITLE
feat(members): add a members.dispatch switch and a worker/session schema parity test

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1317,6 +1317,36 @@
       "defaultValue": "steer"
     },
     {
+      "path": "members",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Members",
+      "help": "Crew-member behavior settings.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {
+        "dispatch": true
+      }
+    },
+    {
+      "path": "members.dispatch",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Member Dispatch",
+      "help": "On by default: the automatic, zero-configuration grant that lets a crew member's DM session dispatch and patrol worker sessions it creates WITHOUT the operator having to turn on `agent.session_control`. Turning it OFF removes that automatic grant and puts member callers back under the ordinary `agent.session_control` switch, so an operator can keep a member chat-only without disabling the member entirely. The creator-ownership boundary (a member only reaches workers it created itself) still binds regardless of this switch.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": true
+    },
+    {
       "path": "cron_history",
       "kind": "core",
       "type": "object",

--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -88,7 +88,7 @@ that is out of bounds is visible after the fact even though nothing happened.
 
 | Refusal | Status | Why |
 |---------|--------|-----|
-| Config switch off (`agent.session_control`) | 403 | Operator opted out. **Exception:** a crew-member DM slot (`member-*` caller key) bypasses this switch — see "Member callers" below |
+| Config switch off (`agent.session_control`) | 403 | Operator opted out. **Exception:** a crew-member DM slot (`member-*` caller key) bypasses this switch **while `members.dispatch` is on (the default)** — see "Member callers" below |
 | Caller session cannot be identified | 403 | An unidentifiable caller makes the self-target guard blind |
 | Caller is an unattended session (`cron-*`, `workflow-*`) | 403 | A scheduled job acting on live conversations is not a handoff |
 | Caller is itself incognito, temporary, or app-scoped | 403 | Caller-side isolation — the direction the target-side checks cannot see |
@@ -114,11 +114,33 @@ A crew member's pinned DM slot (caller key prefixed `member-`, created only by
 work into worker sessions it creates, patrols them, and reports back, with no
 operator configuration. Two rules give it that shape:
 
-- **The `agent.session_control` switch does not gate a member caller.** Members
-  work out of the box — this is the zero-configuration contract, and it is a
-  deliberate trade-off: an operator who turned session control off has NOT
-  thereby disabled member dispatch. There is currently no separate switch for
-  it; disabling a member disables its dispatch.
+- **The `agent.session_control` switch does not gate a member caller while
+  `members.dispatch` is on (the default).** Members work out of the box — this is
+  the zero-configuration contract, and it is a deliberate trade-off: an operator
+  who turned session control off has NOT thereby disabled member dispatch.
+  `members.dispatch` is the operator switch over that automatic grant. Left at
+  its default (`true`) the member bypass stands and members dispatch with zero
+  configuration. Setting `members.dispatch: false` removes the bypass and puts
+  member callers back under the ordinary `agent.session_control` requirement — so
+  a member with the switch off is refused (`session_control_disabled`), letting an
+  operator keep a member chat-only without disabling the member entirely. The
+  switch only narrows a member's reach; the creator-ownership rule below still
+  binds regardless of it.
+  **It is an operator preference, not a containment ceiling.** It lives in
+  `config.json`, which the agent's file-edit tools cannot modify —
+  `is_sensitive_write_path` covers it and `hooks.on_tool_call` refuses the write.
+  What it is not fenced against is a shell: `config.json` is deliberately absent
+  from `_WRITE_PROTECTED_BASH_LEAVES`, so a redirect from an auto-approved bash
+  command still lands, the same softness `agent.session_control` already has.
+  (`config.json` is equally deliberately absent from `_SENSITIVE_HOME_DIRS`, which
+  is the shared read+write gate — reading it is routine, so adding it there to
+  close the shell gap would break the dashboard file viewer and knowledge
+  indexing. The gap belongs to the bash leaf list.)
+  The boundary that binds *against the member* is the creator-ownership rule
+  below, which no config write relaxes. An
+  operator who needs enforcement the agent cannot undo wants a governance profile
+  scope or a keystone file, neither of which this switch is; that seam is not
+  built yet.
 - **A member caller may only act on sessions it created.** Slot creation records
   `created_by` (the creator's caller key) in the slot's birth metadata; it is
   persisted with the session and rehydrated on restart (both restore paths).
@@ -334,6 +356,45 @@ handles the malformed case -- `bool("false")` is `True`, so a user who wrote the
 value in an editor that quotes it would otherwise get the opposite of what they
 read -- and the lookup now supplies `False` for the absent case, so nothing has to
 infer a grant from silence.
+
+`members.dispatch` (bool, default **true**) is the operator switch over the
+automatic member grant described in "Member callers". Its default is the OPPOSITE
+of `agent.session_control`: it defaults **on** so a crew member dispatches and
+patrols its worker sessions with zero configuration. Only ABSENCE resolves to
+`true` — that is the zero-configuration contract. A malformed value resolves to
+`false` (`_safe_bool(..., False)`), the same direction as `agent.session_control`:
+`bool("false")` is `True`, so an operator who wrote the value in an editor that
+quotes it would otherwise get the opposite of what they read, on a grant they were
+trying to withdraw. For that to work the malformed value has to survive advisory
+validation, so `members` and `members.dispatch` are both in
+`validation._FAIL_CLOSED_PATHS` — without those entries `_apply_field_default`
+deletes the value first and the loader reads its ON default. Setting it to a
+real `false` removes the member bypass at both gates, so a member caller with
+`agent.session_control` off is refused (`session_control_disabled`), giving an
+operator a lever to keep a member chat-only without disabling the member. The
+switch only ever narrows a member's reach: the creator-ownership boundary still
+binds regardless, and a member with dispatch off is treated as an ordinary caller
+(needs the switch) but gains no wider reach. Fail-safe direction matches
+`agent.session_control`: a config read that raises resolves the switch to off
+(bypass dropped), so unrelated config corruption cannot silently keep the
+automatic grant alive.
+
+The ON default makes one more case fail-safe-relevant that `agent.session_control`
+(default off) does not have: a load that SUCCEEDS but **discarded** the value.
+`load()` degrades rather than raising on an unreadable config file or a `members`
+section that is not an object, and hands back the `dispatch=True` default — which
+would re-grant a bypass the operator had turned off. `member_dispatch_enabled()`
+therefore also resolves to off when `degraded_sections` contains
+`DEGRADED_WHOLE_CONFIG` (`*`) or `members`, the same signal `publish_governance`
+reads for the same reason. Re-reading the file cannot substitute for it: `load()`
+rewrites `config.json` in normalized form, so the parse that discarded the value is
+the only witness that it existed. The `members` half of that check depends on the
+`_FAIL_CLOSED_PATHS` entry above: validation runs first, and if it repairs a
+non-object `members` away then `_coerced_section` never witnesses the coercion,
+`degraded_sections` stays empty, and this branch cannot fire at all. All three
+layers — validation preserving the evidence, the loader recording it, the gate
+reading it — are pinned end to end from a real `config.json` in
+`test/test_member_session_control.py`.
 
 ## What is deliberately not here
 

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -211,6 +211,7 @@ from kiro_crew.config.sections import (  # noqa: F401
     KnowledgeConfig,
     McpConfig,
     McpGatewayConfig,
+    MembersConfig,
     MemoryConfig,
     MemoryStoreConfig,
     MessagingConfig,
@@ -1829,6 +1830,10 @@ class KiroCrewConfig:
         default_factory=MessagingConfig,
         metadata=_meta("Messaging", "Channel-neutral messaging transport settings."),
     )
+    members: MembersConfig = field(
+        default_factory=MembersConfig,
+        metadata=_meta("Members", "Crew-member behavior settings."),
+    )
     cron_history: CronHistoryConfig = field(
         default_factory=CronHistoryConfig,
         metadata=_meta("Cron History", "Cron execution history storage limits."),
@@ -2420,6 +2425,7 @@ class KiroCrewConfig:
         skills_data = _coerced_section(data, "skills", _degraded)
         session_summary_data = _coerced_section(data, "session_summary", _degraded)
         messaging_data = _coerced_section(data, "messaging", _degraded)
+        members_data = _coerced_section(data, "members", _degraded)
         telemetry_data = _coerced_section(data, "telemetry", _degraded)
         orchestrator_data = _coerced_section(data, "orchestrator", _degraded)
         watchdog_data = _coerced_section(data, "watchdog", _degraded)
@@ -2699,6 +2705,18 @@ class KiroCrewConfig:
                 eager_spawn=bool(session_data.get("eager_spawn", True)),
                 archive_retention_days=_archive_retention_days(session_data),
                 watchdog_rss_max_mb=_safe_int(session_data.get("watchdog_rss_max_mb", 0), 0),
+            ),
+            members=MembersConfig(
+                # ABSENCE means ON, unlike `agent.session_control`: this is the
+                # zero-configuration grant that lets a crew member dispatch worker
+                # sessions out of the box, so the lookup supplies a real `True`.
+                # A MALFORMED value falls to False instead, the same direction as
+                # `agent.session_control`: `bool("false")` is True, so an operator
+                # who wrote the value in an editor that quotes it would otherwise
+                # get the opposite of what they read -- on a grant they were trying
+                # to withdraw. Only the two shapes are distinguished; nothing here
+                # infers the grant from a value it could not parse.
+                dispatch=_safe_bool(members_data.get("dispatch", True), False),
             ),
             taskrunner=TaskRunnerConfig(
                 max_parallel_steps=taskrunner_data.get(
@@ -3583,6 +3601,7 @@ class KiroCrewConfig:
         d: dict = {
             "agent": asdict(self.agent),
             "session": asdict(self.session),
+            "members": asdict(self.members),
             "memory": asdict(self.memory),
             "slack": asdict(self.slack),
             "publish": asdict(self.publish),

--- a/src/kiro_crew/config/resolution.py
+++ b/src/kiro_crew/config/resolution.py
@@ -66,6 +66,7 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "watchdog",
         "resource_limits",
         "messaging",
+        "members",
         "cron_history",
         "knowledge",
         "heartbeat",
@@ -131,6 +132,33 @@ DEGRADED_WHOLE_CONFIG = "*"
 #: so the tailnet gate denies on exactly the narrowing it enforces, and an
 #: unrelated malformed ``dashboard`` value does not.
 DEGRADED_TAILSCALE = "dashboard.tailscale"
+
+
+#: ``degraded_sections`` key for "the operator's ``members`` settings could not
+#: be read this load". It is the config dataclass's own FIELD name, which is what
+#: ``_coerced_section`` records; ``TestMemberDispatchSwitch`` pins the two
+#: together, because a rename that missed this constant would leave the gate
+#: silently matching nothing and reading its ON default instead.
+DEGRADED_MEMBERS = "members"
+
+
+def member_dispatch_unknown(sections: frozenset[str]) -> bool:
+    """Whether *sections* means ``members.dispatch`` could not be read.
+
+    Two shapes lose it: an unreadable config FILE, and a ``members`` section that
+    is not a JSON object. Both leave ``dispatch`` at its dataclass default, which
+    is **on** — so a gate that trusted it would re-grant a bypass the operator had
+    turned off, with no error. Scoped deliberately to this section plus the
+    whole-file marker: an unrelated malformed section says nothing about what the
+    operator asked for here, and denying on it would turn any config typo into a
+    silent withdrawal of the zero-configuration contract.
+
+    Lives here beside :func:`_coerced_section`, the mechanism that records the
+    key, for the same reason :func:`tailnet_identity_unknown` does: the
+    "was this value real?" question gets one answer rather than one shadow parser
+    per gate.
+    """
+    return bool(sections & {DEGRADED_WHOLE_CONFIG, DEGRADED_MEMBERS})
 
 
 def tailnet_identity_unknown(sections: frozenset[str]) -> bool:

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -1265,6 +1265,24 @@ class MessagingConfig:
 
 
 @dataclass
+class MembersConfig:
+    dispatch: bool = field(
+        default=True,
+        metadata=_meta(
+            "Member Dispatch",
+            "On by default: the automatic, zero-configuration grant that lets a "
+            "crew member's DM session dispatch and patrol worker sessions it "
+            "creates WITHOUT the operator having to turn on `agent.session_control`. "
+            "Turning it OFF removes that automatic grant and puts member callers "
+            "back under the ordinary `agent.session_control` switch, so an operator "
+            "can keep a member chat-only without disabling the member entirely. The "
+            "creator-ownership boundary (a member only reaches workers it created "
+            "itself) still binds regardless of this switch.",
+        ),
+    )
+
+
+@dataclass
 class CronHistoryConfig:
     cron_summary_cap: int = field(
         default=200,

--- a/src/kiro_crew/config/validation.py
+++ b/src/kiro_crew/config/validation.py
@@ -170,6 +170,18 @@ def _actual_type_name(value: object) -> str:
 #:   segments it is already past ``_apply_field_default``'s depth cap, so a
 #:   malformed list value is kept today.
 #:
+#: * ``members`` (the section) and ``members.dispatch``: the default is again
+#:   **open** — ``dispatch`` defaults ``true``, the zero-configuration grant
+#:   that lets a crew member drive worker sessions without the operator
+#:   enabling ``agent.session_control``. Repairing a malformed value therefore
+#:   restores the grant the operator was trying to withdraw: removing a quoted
+#:   ``{"dispatch": "false"}`` makes the loader read its ON default, and
+#:   removing a non-object ``members`` also robs ``_coerced_section`` of the
+#:   only evidence that a setting was discarded, so ``degraded_sections``
+#:   stays empty and ``member_dispatch_enabled()``'s fail-closed branch can
+#:   never fire. Preserved, the loader's ``_safe_bool(..., False)`` sees the
+#:   malformed value and the gate refuses.
+#:
 #: Exact-match only: this is a per-path judgment, not a subtree rule. The
 #: registry is only half of a fix — a preserved value changes nothing unless
 #: the loader RECORDS the degradation and a gate reads
@@ -181,6 +193,8 @@ _FAIL_CLOSED_PATHS = frozenset(
         "publish.allowed_destinations",
         "dashboard",
         "dashboard.tailscale",
+        "members",
+        "members.dispatch",
     }
 )
 

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -42,6 +42,7 @@ from kiro_crew.config.loader import (
     default_project_dir,
     resolve_agent_bindings,
 )
+from kiro_crew.config.resolution import member_dispatch_unknown
 from kiro_crew.dashboard.chat_delivery import sanitize_outbound
 from kiro_crew.dashboard.chat_folders import _unhide_folder
 from kiro_crew.dashboard.chat_persistence import _TRANSIENT_ROLES as _PERSISTENCE_TRANSIENT_ROLES
@@ -144,6 +145,59 @@ def session_control_enabled() -> bool:
     except Exception:
         logger.warning(
             "session_control: config read failed — refusing until config loads", exc_info=True
+        )
+        return False
+
+
+def member_dispatch_enabled() -> bool:
+    """Whether the automatic member session-dispatch grant is switched on.
+
+    ``members.dispatch`` defaults ON — the zero-configuration contract that lets
+    a crew member DM session dispatch and patrol its worker sessions without the
+    operator turning on ``agent.session_control``. When an operator sets it to
+    ``false`` this returns False, which drops the member bypass at the gates and
+    puts member callers back under the ordinary switch (keeping a member
+    chat-only without disabling it entirely).
+
+    Only ABSENCE resolves to the ON default. Three other shapes resolve to False,
+    because in each the operator's setting is UNKNOWN and an ON default would
+    invent a grant they may have withdrawn:
+
+    * a config read that RAISES — the same conservative posture as
+      :func:`session_control_enabled`, so unrelated corruption cannot silently
+      keep the automatic grant alive;
+    * a load that SUCCEEDED but discarded the value —
+      :func:`member_dispatch_unknown` covers both shapes (an unreadable config
+      file, and a ``members`` section that is not an object). ``load()`` keeps
+      going in both cases and hands back the ``dispatch=True`` default, so without
+      this branch a ``config.json`` that could not be parsed would re-grant a
+      bypass the operator had turned off. Re-reading the file cannot recover the
+      setting: ``load()`` rewrites ``config.json`` in normalized form, so by the
+      time this gate looks the malformed text is gone — the parse that discarded it
+      is the only witness, which is why it reports through ``degraded_sections``
+      (the same mechanism ``publish_governance`` reads);
+    * a ``dispatch`` value that is present but not a bool — the loader's
+      ``_safe_bool(..., False)`` resolves it here, and ``members``/
+      ``members.dispatch`` sit in ``validation._FAIL_CLOSED_PATHS`` so the
+      malformed value survives advisory validation for it to see.
+
+    Resolving False only ever WIDENS the requirement — a member falls back to
+    needing ``agent.session_control``, and the ownership boundary binds either way
+    — so failing closed costs a diagnosable refusal, never wider reach.
+    """
+    try:
+        cfg = KiroCrewConfig.load()
+        if member_dispatch_unknown(cfg.degraded_sections):
+            logger.warning(
+                "member_dispatch: config unreadable or 'members' section malformed — "
+                "dropping member bypass; fix the file and restart the gateway to clear"
+            )
+            return False
+        return bool(cfg.members.dispatch)
+    except Exception:
+        logger.warning(
+            "member_dispatch: config read failed — dropping member bypass until config loads",
+            exc_info=True,
         )
         return False
 
@@ -660,7 +714,21 @@ async def create_session(
     # still needs the switch. The member's automatic grant is bounded by
     # ownership in `authorize_target`, not here: creation makes the caller
     # the owner by construction.
-    if not session_control_enabled() and not _member_caller(caller_key):
+    #
+    # The member bypass is itself gated by the operator switch
+    # `members.dispatch` (default ON): when an operator turns it OFF,
+    # `member_dispatch_enabled()` is False, the bypass drops, and a member
+    # caller falls back to needing `agent.session_control` like any other
+    # caller — the lever that keeps a member chat-only without disabling it.
+    # It is an operator PREFERENCE, not a containment ceiling. `config.json` is
+    # write-protected against the agent's FILE-EDIT tools (`is_sensitive_write_path`
+    # at the `hooks.on_tool_call` gate), but it is deliberately absent from
+    # `_WRITE_PROTECTED_BASH_LEAVES`, so a shell redirect an operator auto-approved
+    # still reaches it. The boundary that binds against the member itself is the
+    # ownership check in `authorize_target`, which no config write relaxes.
+    if not session_control_enabled() and not (
+        _member_caller(caller_key) and member_dispatch_enabled()
+    ):
         raise SessionControlError(
             "session control is disabled in config (agent.session_control)",
             code="session_control_disabled",
@@ -1029,13 +1097,15 @@ def authorize_target(
     recorded in the SEL, so an attempt to reach a session that is out of bounds
     is visible after the fact even though nothing happened.
 
-    ``skip_enabled_check`` omits ONLY the ``session_control_enabled()`` config
-    read. It exists for a re-check that must run SYNCHRONOUSLY with no event-loop
-    suspension (``close_target``'s point-of-no-return callback): the feature was
-    already confirmed enabled when the operation was first authorized, whether
-    session control got switched off mid-operation is not a containment boundary,
-    and the config read is the one part of this function that can touch the disk
-    on a cache miss. Every containment and identity refusal still runs.
+    ``skip_enabled_check`` omits ONLY the two config reads that decide whether the
+    surface is switched on for this caller — ``session_control_enabled()`` and, for
+    a member caller, ``member_dispatch_enabled()``. It exists for a re-check that
+    must run SYNCHRONOUSLY with no event-loop suspension (``close_target``'s
+    point-of-no-return callback): the feature was already confirmed enabled when
+    the operation was first authorized, whether a switch got turned off
+    mid-operation is not a containment boundary, and those reads are the only parts
+    of this function that can touch the disk on a cache miss. Every containment and
+    identity refusal still runs.
     """
 
     def deny(reason: str, code: str, status: int = 403) -> SessionControlError:
@@ -1081,7 +1151,18 @@ def authorize_target(
     # WITHOUT `agent.session_control` — dispatching and patrolling workers is
     # its operating model — and is bounded instead by the ownership check
     # below, which restricts it to slots it created itself.
-    if not skip_enabled_check and not session_control_enabled() and not _member_caller(caller_key):
+    #
+    # The member bypass is itself gated by the operator switch
+    # `members.dispatch` (default ON): with it OFF, the bypass drops and a
+    # member caller falls back under `agent.session_control`. The ownership
+    # check below still binds regardless, so dropping the bypass only ever
+    # narrows a member's reach, never widens it — and that check, not this
+    # `config.json` preference, is what binds against the member itself.
+    if (
+        not skip_enabled_check
+        and not session_control_enabled()
+        and not (_member_caller(caller_key) and member_dispatch_enabled())
+    ):
         raise deny(
             "session control is disabled in config (agent.session_control)",
             "session_control_disabled",
@@ -1418,9 +1499,10 @@ async def close_target(
         # a channel mirror or link in that window — archiving a now-channel-backed
         # session the caller was never allowed to reach.
         #
-        # `skip_enabled_check=True` omits the ONE part of authorize_target that
-        # can touch the disk (`session_control_enabled()`'s config read): the
-        # feature was already confirmed enabled above, whether it was switched off
+        # `skip_enabled_check=True` omits the only parts of authorize_target that
+        # can touch the disk (the `session_control_enabled()` and
+        # `member_dispatch_enabled()` config reads): the feature was already
+        # confirmed enabled above, whether it was switched off
         # mid-close is not a containment boundary, and skipping it is what lets
         # this run with no await — an async prewarm-then-check would put an await
         # back before the pop and reopen the very window this closes. Every

--- a/test/test_config_module_boundaries.py
+++ b/test/test_config_module_boundaries.py
@@ -75,6 +75,7 @@ MCP_PROBE_TIMEOUT_MAX
 MCP_PROBE_TIMEOUT_MIN
 McpConfig
 McpGatewayConfig
+MembersConfig
 MemoryConfig
 MemoryStoreConfig
 MessagingConfig

--- a/test/test_member_session_control.py
+++ b/test/test_member_session_control.py
@@ -21,11 +21,16 @@ tool-level coverage here is registration only.
 
 from __future__ import annotations
 
+import asyncio
+import json
+from dataclasses import fields
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from kiro_crew.config import loader, validation
+from kiro_crew.config.resolution import DEGRADED_MEMBERS, DEGRADED_WHOLE_CONFIG
 from kiro_crew.dashboard import session_control as sc
 from kiro_crew.members import DM_SLOT_KEY_PREFIX
 
@@ -125,6 +130,219 @@ class TestAuthorizeTargetMemberPath:
         assert exc_info.value.code == "session_control_disabled"
 
 
+class TestMemberDispatchSwitch:
+    """The ``members.dispatch`` operator switch over the member bypass.
+
+    The member bypass at both gates is gated by ``member_dispatch_enabled()``
+    (``members.dispatch``, default ON). These tests pin the OFF path — the whole
+    point of the change — which the existing member tests never touch because
+    the config default resolves the switch ON, so a regression dropping the
+    ``member_dispatch_enabled()`` term would leave every other member test green.
+
+    We mirror the existing style: patch ``sc.session_control_enabled`` to the
+    global-OFF posture the switch is meant to override, and patch
+    ``sc.member_dispatch_enabled`` to flip it. With the switch OFF a member
+    caller must be refused with ``session_control_disabled`` at BOTH gates; with
+    it ON the bypass must still stand.
+
+    The resolver's own fail-safe direction gets its own cases below. Its ON
+    default makes a DEGRADED load — one that succeeded but discarded the value —
+    as dangerous as one that raised, which is a case ``agent.session_control``
+    (default off) does not have.
+    """
+
+    def test_authorize_target_refuses_member_when_dispatch_off(self):
+        # Global switch off AND members.dispatch off: the member bypass drops,
+        # so a member caller is refused just like any ordinary caller.
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        worker = _slot("chat-1-w1", created_by=member)
+        state = _State({member: _slot(member), "chat-1-w1": worker})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=False),
+            patch.object(sc, "_resolve_slot", return_value=worker),
+        ):
+            with pytest.raises(sc.SessionControlError) as exc_info:
+                sc.authorize_target(
+                    state,
+                    caller_session_key="dashboard:whatever",
+                    target="chat-1-w1",
+                    operation="send",
+                )
+        assert exc_info.value.code == "session_control_disabled"
+
+    def test_authorize_target_bypass_stands_when_dispatch_on(self):
+        # Global switch off but members.dispatch ON: the bypass holds, so the
+        # member gets PAST the config gate (and its own ownership check).
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        worker = _slot("chat-1-w1", created_by=member)
+        state = _State({member: _slot(member), "chat-1-w1": worker})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=True),
+            patch.object(sc, "_resolve_slot", return_value=worker),
+        ):
+            try:
+                sc.authorize_target(
+                    state,
+                    caller_session_key="dashboard:whatever",
+                    target="chat-1-w1",
+                    operation="send",
+                )
+            except sc.SessionControlError as exc:
+                assert exc.code not in ("session_control_disabled", "not_creator"), exc.code
+
+    def test_create_session_refuses_member_when_dispatch_off(self):
+        # The create gate carries the same conjunction. With both switches off a
+        # member caller can no longer create a session — the switch narrows it.
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        state = _State({member: _slot(member)})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=False),
+        ):
+            with pytest.raises(sc.SessionControlError) as exc_info:
+                asyncio.run(sc.create_session(state, caller_session_key="dashboard:whatever"))
+        assert exc_info.value.code == "session_control_disabled"
+
+    def test_create_session_bypass_stands_when_dispatch_on(self):
+        # members.dispatch ON: the member passes the config gate. It may still
+        # fail later on deployment-specific plumbing, but NOT at the switch.
+        member = DM_SLOT_KEY_PREFIX + "radar"
+        state = _State({member: _slot(member)})
+        with (
+            patch.object(sc, "caller_slot_key", return_value=member),
+            patch.object(sc, "session_control_enabled", return_value=False),
+            patch.object(sc, "member_dispatch_enabled", return_value=True),
+        ):
+            try:
+                asyncio.run(sc.create_session(state, caller_session_key="dashboard:whatever"))
+            except sc.SessionControlError as exc:
+                # A SessionControlError is fine as long as it is NOT the config
+                # gate rejecting the member — the bypass must have carried it
+                # past the switch.
+                assert exc.code != "session_control_disabled", exc.code
+            except Exception:
+                # Any non-SessionControlError means the member already cleared
+                # the config gate and tripped on deployment-specific plumbing
+                # our fixture does not provide — exactly what we want to prove.
+                pass
+
+    def test_member_dispatch_enabled_fails_closed_on_config_read_error(self):
+        # A config read that RAISES resolves to False (fail closed), the same
+        # conservative posture as session_control_enabled: the bypass is dropped
+        # rather than left silently alive on config corruption.
+        with patch.object(sc.KiroCrewConfig, "load", side_effect=RuntimeError("boom")):
+            assert sc.member_dispatch_enabled() is False
+
+    @pytest.mark.parametrize(
+        "degraded",
+        [
+            # An unreadable / non-object config FILE. `_mark_file_degraded` adds
+            # both the bare marker and a per-file entry; the bare one is what a
+            # gate matches on.
+            frozenset({DEGRADED_WHOLE_CONFIG, DEGRADED_WHOLE_CONFIG + "config.json"}),
+            # A present `members` section that is not a JSON object, e.g.
+            # `{"members": []}` — coerced to `{}`, so `dispatch` came back as the
+            # dataclass default, not from the operator.
+            frozenset({DEGRADED_MEMBERS}),
+        ],
+    )
+    def test_degraded_load_drops_the_bypass_despite_the_on_default(self, degraded):
+        # `load()` DEGRADES rather than raising on both shapes: it returns a
+        # config whose `members.dispatch` is the True default. Trusting that
+        # default would re-grant a bypass an operator had set to false, with no
+        # error, and re-reading the file cannot recover the setting because
+        # `load()` has already rewritten config.json in normalized form. So the
+        # unknown must resolve to off.
+        cfg = SimpleNamespace(
+            degraded_sections=degraded,
+            members=SimpleNamespace(dispatch=True),
+        )
+        with patch.object(sc.KiroCrewConfig, "load", return_value=cfg):
+            assert sc.member_dispatch_enabled() is False
+
+    def test_an_unrelated_degraded_section_leaves_the_bypass_alone(self):
+        # Scoped, not blanket: a malformed `slack` section says nothing about
+        # what the operator asked for here, and denying on it would turn every
+        # unrelated config typo into a silent withdrawal of the zero-config
+        # contract this feature exists to provide.
+        cfg = SimpleNamespace(
+            degraded_sections=frozenset({"slack", "dashboard.tailscale"}),
+            members=SimpleNamespace(dispatch=True),
+        )
+        with patch.object(sc.KiroCrewConfig, "load", return_value=cfg):
+            assert sc.member_dispatch_enabled() is True
+
+    def test_a_clean_load_reports_the_operators_value_either_way(self):
+        # The degraded guard must not swallow the ordinary path: a clean load
+        # returns exactly what the operator set.
+        for value, expected in ((True, True), (False, False)):
+            cfg = SimpleNamespace(
+                degraded_sections=frozenset(),
+                members=SimpleNamespace(dispatch=value),
+            )
+            with patch.object(sc.KiroCrewConfig, "load", return_value=cfg):
+                assert sc.member_dispatch_enabled() is expected
+
+    #: Every ``members`` shape an operator can actually write, and the grant each
+    #: must resolve to. Absence is the only one that may resolve ON.
+    _END_TO_END_SHAPES = [
+        # No config at all, and an empty section: the zero-configuration grant.
+        ({}, True),
+        ({"members": {}}, True),
+        ({"members": {"dispatch": True}}, True),
+        # An explicit withdrawal, and the same withdrawal written by an editor
+        # that quoted it. `bool("false")` is True, so the quoted form is the one
+        # that used to hand back the opposite of what the operator read.
+        ({"members": {"dispatch": False}}, False),
+        ({"members": {"dispatch": "false"}}, False),
+        # A `members` section that is not an object: whatever it carried is gone,
+        # so the operator's intent is UNKNOWN and cannot be read as consent.
+        ({"members": []}, False),
+        ({"members": "nope"}, False),
+        # Scoped: an unrelated malformed section says nothing about this grant.
+        ({"slack": [], "members": {"dispatch": True}}, True),
+    ]
+
+    @pytest.mark.parametrize("payload,expected", _END_TO_END_SHAPES)
+    def test_end_to_end_from_a_real_config_file(self, tmp_path, payload, expected):
+        # The mocked cases above hand `member_dispatch_enabled()` a hand-built
+        # `degraded_sections`, which proves the gate reads it but NOT that the
+        # loader ever puts `members` there. Three layers have to cooperate for
+        # that -- validation preserving the malformed value, the loader recording
+        # the coercion, the gate reading it -- and only a real config.json
+        # exercises all three. Without this test the guard passed while being
+        # unreachable in production: the advisory jsonschema pass repaired the
+        # value before `_coerced_section` could witness it.
+        (tmp_path / "config.json").write_text(json.dumps(payload), encoding="utf-8")
+        loader._invalidate_config_cache()
+        with patch.object(loader, "config_dir", return_value=tmp_path):
+            assert sc.member_dispatch_enabled() is expected
+        loader._invalidate_config_cache()
+
+    def test_the_members_paths_are_exempt_from_validation_repair(self):
+        # The registry entry is load-bearing, not decoration: `_apply_field_default`
+        # deletes a schema-violating value, and for a grant whose default is ON
+        # that deletion IS the widening -- it happens before any detector runs.
+        assert "members" in validation._FAIL_CLOSED_PATHS
+        assert "members.dispatch" in validation._FAIL_CLOSED_PATHS
+        data = {"members": {"dispatch": "false"}}
+        assert validation._apply_field_default(data, "members.dispatch") is False
+        assert data == {"members": {"dispatch": "false"}}
+
+    def test_degraded_section_key_matches_the_real_config_field(self):
+        # `DEGRADED_MEMBERS` is the string `degraded_sections` reports for this
+        # section, which is the config dataclass's FIELD name. Renaming the
+        # section without updating the constant would not fail any behavioural
+        # test — the gate would simply stop matching and fall back to reading the
+        # ON default, i.e. it would fail OPEN silently. Pin the two together.
+        assert DEGRADED_MEMBERS in {f.name for f in fields(sc.KiroCrewConfig)}
+
+
 class TestWorkerToolsRegistered:
     def test_worker_tools_advertised_on_kirocrew_core(self):
         from kiro_crew.mcp_tools import build_tool_list
@@ -137,6 +355,102 @@ class TestWorkerToolsRegistered:
 
         advertised = {t["name"] for t in workers.schemas()}
         assert advertised == set(workers.HANDLERS)
+
+
+class TestWorkerSessionSchemaParity:
+    """Each ``WORKER_*_SCHEMA`` must stay within its ``SESSION_*_SCHEMA`` twin.
+
+    The four ``worker_*`` kirocrew-core tools and the four ``session_*``
+    kirocrew-dashboard tools forward to the SAME ``/api/session-control/*``
+    gateway endpoints, so the shape those endpoints accept must not depend on
+    which server the caller happened to reach. Today that parity is held only
+    by the comment above ``WORKER_CREATE_SCHEMA`` in ``validation.py``; this
+    test turns it into an executable invariant.
+
+    Parity here is a *narrowing*, not byte equality: ``worker_create``
+    deliberately omits ``folder`` (a member's workers land unfiled in v1, per
+    that comment). So for each pair we assert the worker property set is a
+    subset of the session set (the worker introduces no field the endpoint
+    would reject), and that the only fields the session set carries beyond the
+    worker set are the explicitly documented ``allowed_missing`` ones. A field
+    added to a ``session_*`` schema but forgotten on ``worker_*`` — or an
+    accidental extra worker narrowing — both trip this test.
+    """
+
+    # worker schema -> (session schema, properties worker may omit)
+    @classmethod
+    def _pairs(cls):
+        from kiro_crew import validation as v
+
+        return [
+            (v.WORKER_CREATE_SCHEMA, v.SESSION_CREATE_SCHEMA, {"folder"}),
+            (v.WORKER_SEND_SCHEMA, v.SESSION_SEND_SCHEMA, set()),
+            (v.WORKER_READ_SCHEMA, v.SESSION_READ_MESSAGE_SCHEMA, set()),
+            (v.WORKER_STOP_SCHEMA, v.SESSION_STOP_SCHEMA, set()),
+        ]
+
+    def test_worker_property_sets_stay_within_session_counterparts(self):
+        for worker_schema, session_schema, allowed_missing in self._pairs():
+            worker_props = {f.name for f in worker_schema.fields}
+            session_props = {f.name for f in session_schema.fields}
+            # (a) The worker surface never introduces a property the shared
+            # endpoint would not accept from the session surface.
+            assert worker_props <= session_props, (
+                f"{worker_schema.tool_name} introduces "
+                f"{worker_props - session_props} absent from "
+                f"{session_schema.tool_name}"
+            )
+            # (b) The ONLY narrowing is the documented one — a new session_*
+            # field forgotten on worker_* (or an accidental worker omission)
+            # fails here.
+            assert session_props - worker_props == allowed_missing, (
+                f"{worker_schema.tool_name} vs {session_schema.tool_name}: "
+                f"expected only {allowed_missing} to be omitted, got "
+                f"{session_props - worker_props}"
+            )
+
+    def test_shared_fields_have_compatible_type_and_required(self):
+        # A shared field must not just carry the same type/required flag: the
+        # value bounds that decide what the shared /api/session-control/*
+        # endpoint ACCEPTS must line up too. A future divergence in max_len,
+        # min_val, max_val, pattern, or the enum allow-list between a worker_*
+        # and its session_* twin would otherwise pass here while making the
+        # accepted payload depend on which server the caller reached — the exact
+        # failure mode this parity test exists to prevent.
+        def _pattern_src(field):
+            # FieldSpec.pattern is a compiled re.Pattern (or None); compare the
+            # source string so two independently-compiled equivalents match and
+            # a genuine divergence is still caught.
+            pat = field.pattern
+            return None if pat is None else pat.pattern
+
+        for worker_schema, session_schema, _allowed_missing in self._pairs():
+            worker_fields = {f.name: f for f in worker_schema.fields}
+            session_fields = {f.name: f for f in session_schema.fields}
+            for name in worker_fields.keys() & session_fields.keys():
+                wf = worker_fields[name]
+                sf = session_fields[name]
+                assert wf.type == sf.type, (
+                    f"{worker_schema.tool_name}.{name} type {wf.type!r} != "
+                    f"{session_schema.tool_name}.{name} type {sf.type!r}"
+                )
+                assert wf.required == sf.required, (
+                    f"{worker_schema.tool_name}.{name} required={wf.required} != "
+                    f"{session_schema.tool_name}.{name} required={sf.required}"
+                )
+                # Value bounds — everything on FieldSpec that constrains the
+                # accepted input for a shared field.
+                for attr in ("default", "max_len", "min_val", "max_val", "allowed"):
+                    assert getattr(wf, attr) == getattr(sf, attr), (
+                        f"{worker_schema.tool_name}.{name} {attr}="
+                        f"{getattr(wf, attr)!r} != {session_schema.tool_name}.{name} "
+                        f"{attr}={getattr(sf, attr)!r}"
+                    )
+                assert _pattern_src(wf) == _pattern_src(sf), (
+                    f"{worker_schema.tool_name}.{name} pattern "
+                    f"{_pattern_src(wf)!r} != {session_schema.tool_name}.{name} "
+                    f"pattern {_pattern_src(sf)!r}"
+                )
 
 
 class TestCreatedByRecentSessionRestore:


### PR DESCRIPTION
Implements the two follow-ups recorded on #8073 out of the member session-control review lanes (Design Review and First Principles CONCERNS on PR #8021).

## ⚠️ Blocked: the base branch's PR was closed, and this PR cannot land as-is

**This PR is stacked on `feat/member-session-control` (PR #8021), and #8021 is now CLOSED — by maintainer decision, not for a defect.** The closing comment reconsiders the *delivery mechanism* (member-facing `worker_*` twins mounted on `kirocrew-core`, a workaround for template-granularity tool mounting) and names the preferred long-term shape: per-session tool mounting, after which members would use the one `session_*` surface with a member authorization branch instead of twin tools. That comment also records that these two follow-ups "remain relevant to any reland".

Neither half of this PR can exist on `main` independently — `_member_caller`, `member_dispatch_enabled`'s gate sites, and every `WORKER_*_SCHEMA` live only on the closed branch. So there is no smaller rebase available: retargeting this PR to `main` would carry #8021's whole feature, i.e. re-land the mechanism that was closed on purpose. **That is a maintainer call, not a rebase.** Three options:

1. **Hold this PR** until the reland's shape is decided, then re-apply these two changes onto it (the switch's gate sites and the parity test's schema pairs both move with the reland).
2. **Reopen #8021 as-is** and land it, after which this PR lands on top (base already correct, one commit).
3. **Close this PR too**, leaving #8073 as the record — the follow-ups are already described there.
4. **Split the parity test out** (raised by the Design lane on the second review round, not by me). The two halves have different dependency shapes: `TestWorkerSessionSchemaParity` needs the `WORKER_*_SCHEMA` constants to exist but touches no gate conjunction, so it could land with the reland's first commit while the switch waits for the gate shape. I have **not** done this — it repartitions a blocked PR and is a fourth option nobody has ruled on.

Recommendation: **(1) or (3)**, with (4) worth considering if the reland lands incrementally. Neither follow-up is worth reopening a delivery mechanism the maintainer withdrew, and both are cheap to re-apply against whatever surface the reland uses.

**On the `members.*` vs `agent.member_dispatch` spelling: this branch does not decide it, and must not be read as having decided it.** The First Principles lane is right that because merge is already deferred, nothing freezes yet — so switching the key now would itself pre-commit to a surface the reland may not want. The fail-closed machinery (`DEGRADED_MEMBERS`, `_FAIL_CLOSED_PATHS`, the end-to-end test) is written to transfer verbatim whatever the key's final home turns out to be; only the two gate conjunctions are reland-shaped. If option 2 is ever taken, resolve the key's home **before** landing — landing then moving it is the one cost holding avoids for free.

Everything below describes what the branch contains; it is review-ready against its stated base.

## 1. `members.dispatch` operator switch (default on)

- New `MembersConfig.dispatch: bool = True`. **Only absence resolves on** — that is the zero-configuration contract. A malformed value resolves **off** via `_safe_bool(..., False)`, matching `agent.session_control`: `bool("false")` is `True`, so an operator whose editor quoted the value would otherwise get the opposite of what they read, on a grant they were trying to withdraw.
- New `member_dispatch_enabled()` in `session_control.py`, consumed at both `_member_caller` bypass gates (the create path and `authorize_target`). Setting `members.dispatch: false` drops the bypass and puts member callers back under `agent.session_control`, keeping a member chat-only without disabling the member. The third `_member_caller` site — the creator-ownership check — is deliberately ungated: it must bind either way, and gating it would widen, not narrow.
- **It is an operator preference, not a containment ceiling, and the spec and gate comments say so.** `config.json` *is* fenced against the agent's file-edit tools (`is_sensitive_write_path`, enforced at `hooks.on_tool_call`); what it is not fenced against is a shell, because `config.json` is deliberately absent from `_WRITE_PROTECTED_BASH_LEAVES` — the same softness `agent.session_control` already has. It is equally deliberately absent from `_SENSITIVE_HOME_DIRS`, the shared read+write gate, since reading it is routine, so that list is **not** where the residual gap belongs; the spec now says which list is. What binds against the member itself is the ownership check, which no config write relaxes. (This is the Design lane's CONCERNS, addressed by making the promise match the mechanism rather than by claiming enforcement that does not exist.)
- `docs/system-specs/modules/session-control.md` updated in the same commit.

### Fail-safe direction (addresses the GPT 5.6 blocking finding)

Only **absence** resolves to the ON default. Three shapes resolve to **off**, because the ON default makes each of them fail **open** in a way `agent.session_control` (default off) cannot:

- a config read that **raises** — matching `session_control_enabled()`;
- a load that **succeeded but discarded the value** — an unreadable config file, or a `members` section that is not an object. `load()` degrades rather than raising and hands back the `dispatch=True` default, so trusting it would silently re-grant a bypass the operator had turned off. Re-reading the file cannot recover the setting: `load()` rewrites `config.json` in normalized form, so the parse that discarded it is the only witness — the same reason `publish_governance` reads `degraded_sections`;
- a `dispatch` value that is **present but not a bool**, resolved by `_safe_bool(..., False)` above.

**The last two shapes only become reachable because `members` and `members.dispatch` join `validation._FAIL_CLOSED_PATHS`.** `_apply_field_default` repairs a schema violation by *deleting* the value, and for a grant whose default is open that deletion **is** the widening: it also robs `_coerced_section` of the only evidence a setting was discarded, so `degraded_sections` stays empty and a guard keyed on it can never fire. That registry already exists for exactly this criterion — `publish` and `dashboard.tailscale` are there for their own open defaults, and its docstring says the judgment turns on the *direction* of the field's default. `members` joins it as data, with no evaluator change.

The degraded guard is **scoped** to that section plus the whole-file marker, so an unrelated malformed section (e.g. `slack`) does not withdraw the zero-config contract. It lives in `resolution.member_dispatch_unknown()`, beside the `_coerced_section` mechanism that records the key and beside `tailnet_identity_unknown`, its established sibling; `DEGRADED_MEMBERS` is pinned against `KiroCrewConfig`'s own field names, because a rename would make the gate stop matching and fall back to the ON default — failing open with no test going red.

**Class audit.** The sibling switch `session_control_enabled()` defaults **False**, so a degraded `agent` section already resolves it closed; `members.dispatch` is the only session-control switch whose ON default made a degraded read fail open. The class has **two** members, not one: the gate in `session_control.py` and the parse in `loader.py`, which was itself a permission-bearing config default resolving the wrong way. Both are fixed. The third `_member_caller` site reads no config.


### End-to-end coverage, not just mocked

The degraded guard is now pinned from a **real `config.json`** across all eight shapes an operator can write — `{}`, `{"members":{}}`, `dispatch:true`, `dispatch:false`, `dispatch:"false"`, `{"members":[]}`, `{"members":"nope"}`, and an unrelated malformed `slack` — because three layers have to cooperate (validation preserving the evidence, the loader recording it, the gate reading it) and only a real load exercises all three. A hand-built `degraded_sections` alone is what let the first version of this guard pass while being **unreachable in production**; those mocked cases are kept as unit coverage, and the real-file test is what holds the line.

## 2. `worker_*` / `session_*` schema parity test

`TestWorkerSessionSchemaParity` turns `validation.py`'s comment-only claim into an executable invariant: each `WORKER_*_SCHEMA` property set is a subset of its `SESSION_*_SCHEMA` twin, the only omission is the documented `worker_create` `{folder}`, and every shared field's type, required flag, **default** and value bounds (`max_len`, `min_val`, `max_val`, `allowed`, `pattern`) must match. The four `worker_*` and four `session_*` tools forward to the same `/api/session-control/*` endpoints, so the accepted payload must not depend on which server the caller reached.

## Verification

Falsification-verified — each new test reds when the thing it pins is broken:

| Mutation | Result |
|---|---|
| Drop `members` / `members.dispatch` from `_FAIL_CLOSED_PATHS` | 4 failed (the quoted-bool and both non-object shapes, end to end, plus the registry pin) |
| Revert the loader to `_safe_bool(..., True)` | 1 failed (`{"members": {"dispatch": "false"}}` resolves on again) |
| Remove the `degraded_sections` guard from `member_dispatch_enabled()` | 2 failed (both degraded shapes) |
| `worker_read.limit` `max_val` 100 → 200 | 1 failed (bound divergence named) |
| Drop `since` from `WORKER_READ_SCHEMA` | 1 failed (property-set divergence named) |

Gates, all exit 0: `isort --check-only` (it also fixed a real ordering violation this branch had in `loader.py` — `MembersConfig` sorted after `MemoryConfig`), `check_black_formatting.py`, `flake8`, `mypy --platform linux` (1270 files), `check_subprocess_encoding.py`, `docs-lint.sh`, `check_brand_name.py`, `check_harness_parity.py`, `check_changelog_history.py`. Tests: `test_security_posture.py`, `test_member_session_control.py` (40), `test_config_module_boundaries.py`, `test_queue_drain_revalidation.py`, `test_config_baseline.py`, `test_config_schema.py`, `test_session_control*.py`, the eight `test_governance_*.py` files, every `test_config_*.py` / `test_validation*.py` file, and every test file referencing `degraded_sections` — all green. `scrub-lint.sh --no-history` fails only on `test/test_atomic_write_named_duplicates.py:155,157`, which reproduces identically on `origin/main` and is untouched by this diff.

## Governance check

No `SCOPE_CATALOG` scope, capability row, approval ordinal or pointer permit is added, so `effective = POLICY ∩ PROFILE` and its evaluator are untouched and `CONTRACT_VERSION` stays at 1. The switch is ordinary `config.json` operator surface, and the diff adds it as data (a section dataclass plus a regenerated `config-baseline.json`), not as an evaluator edit. Nothing here is expressed as the absence of something: the gate is `_member_caller(caller_key) and member_dispatch_enabled()`, and the unknown-setting cases resolve to the narrower answer.

## Open advisory verdict, not addressed here

First Principles CONCERNS asks to subtract the `members` section and put the boolean on `agent` as `agent.member_dispatch`. The argument is sound on today's diff — one field, one reader, and two of this branch's five original commits were forgotten section wiring. It is not applied because the key name becomes un-renameable operator surface at merge, and *which* surface it belongs on is exactly what the reland decides: under the maintainer's preferred shape the member branch lives on the `session_*` surface, which changes the answer. Moving it now would mean moving it twice. Recorded as a decision for the reland rather than papered over.


