### PR TITLE
fix(apps): refuse a corrupt document in the four update readers instead of replacing it (#7805)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -128,11 +128,9 @@ src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_sync_git.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_notify_out.py
-src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_providers_datadog_cov80.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_schedule_file.py
-src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_slack_out.py
 src/kiro_crew/apps/builtins/ops_mission_control/tests/test_webhook.py
 src/kiro_crew/apps/builtins/papyrus/backend/gitops.py

--- a/src/kiro_crew/apps/builtins/aws_control/backend/library.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/library.py
@@ -84,12 +84,32 @@ def read_ledger() -> dict[str, Any]:
     A DISPLAY read: the Library list must keep rendering local artifacts on a
     ledger it could not load. See :func:`_read_ledger_for_update` for why the
     single writer may not stand on the same answer.
+
+    An absent file is silent -- no push has happened yet, not a fault. Anything
+    else is logged, because the state this degrades into looks exactly like
+    health: every artifact renders as never pushed, which is also what a
+    healthy fresh install shows.
     """
     try:
         data = json.loads(_ledger_path().read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         return {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning(
+            "aws-control library: push ledger unreadable; every artifact will "
+            "render as never pushed",
+            exc_info=True,
+        )
+        return {}
+    if not isinstance(data, dict):
+        # The same degradation reached without a parse failure -- and the same
+        # silence problem, so it gets the same log line.
+        logger.warning(
+            "aws-control library: push ledger root is not an object; every "
+            "artifact will render as never pushed"
+        )
+        return {}
+    return data
 
 
 def _read_ledger_for_update() -> dict[str, Any]:
@@ -104,14 +124,37 @@ def _read_ledger_for_update() -> dict[str, Any]:
     offers a re-push (a duplicate billable upload) and leaves the real cloud
     copies with no record to remove them by.
 
-    Corruption keeps reading as empty, matching the display read and the
-    per-account tolerance :func:`_update_ledger` already applies.
+    Corruption propagates too (#7805, mirroring #7794): "cannot merge into" is
+    not "safe to destroy". A truncated ledger still holds most of its records
+    verbatim, and replacing it discards the operator's only chance to recover
+    them by hand. Two shapes that never reach ``json.loads``'s own raise are
+    folded into the same refusal: a byte stream that is not UTF-8 (a
+    ``ValueError`` but NOT a ``JSONDecodeError``, so unwrapped it would slip
+    past every corruption clause at the callers) and valid JSON whose root is
+    not an object (which parses without raising, so coercing it to ``{}``
+    would destroy a document nobody could read). Plain ``json.JSONDecodeError``
+    rather than another app's named type -- see :func:`shares._load_for_update`
+    in this app for the reasoning.
+
+    The per-ACCOUNT tolerance in :func:`_update_ledger` (a corrupted scalar
+    entry for the account being written is reset) is deliberately untouched:
+    it replaces one account's unusable entry while carrying every other row
+    forward verbatim, not the whole document. The sidecar-preserve alternative
+    for even that case is tracked in #7789.
     """
     try:
         data = json.loads(_ledger_path().read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError:
         return {}
-    return data if isinstance(data, dict) else {}
+    except UnicodeDecodeError as exc:
+        raise json.JSONDecodeError(
+            f"push ledger is not valid UTF-8: {exc.reason}",
+            exc.object.decode("utf-8", "replace")[:120],
+            0,
+        ) from exc
+    if not isinstance(data, dict):
+        raise json.JSONDecodeError("push ledger root is not a JSON object", str(data)[:120], 0)
+    return data
 
 
 def _write_ledger(ledger: dict[str, Any]) -> None:
@@ -136,8 +179,9 @@ def _update_ledger(account: str, mutate: Callable[[dict[str, Any]], bool]) -> bo
     did, so a reconcile that finds nothing stale costs no disk write on a
     surface that renders on every page load.
 
-    Raises ``OSError`` when the existing ledger could not be read; see
-    :func:`_read_ledger_for_update` for why that is not collapsed to an empty
+    Raises ``OSError`` when the existing ledger could not be read and
+    ``json.JSONDecodeError`` when it could not be parsed; see
+    :func:`_read_ledger_for_update` for why neither is collapsed to an empty
     document here.
 
     The lock is held for a read plus an atomic rename and nothing else. Callers

--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import json
 import logging
 import os
 import shutil
@@ -343,6 +344,28 @@ def _not_found(message: str, code: str) -> web.Response:
 
 def _conflict(message: str, code: str) -> web.Response:
     return web.json_response({"error": message, "code": code}, status=409)
+
+
+def _ledger_corrupt(code: str) -> web.Response:
+    """Map a ledger reader's corruption refusal to a coded response.
+
+    The share and library ledger update readers refuse a corrupt document
+    rather than replacing it (#7805), so mutation handlers can see a
+    ``json.JSONDecodeError`` that previously could not happen. Letting it
+    escape gives aiohttp's bare 500 -- no ``code`` for the UI to branch on --
+    and letting a handler's ``except ValueError`` arm claim it (it IS a
+    ``ValueError``) reports corruption as a client mistake. 500 rather than
+    503: corruption does not clear on retry, the file needs a person to repair
+    it, and the bytes it still holds are exactly why the mutation refused.
+
+    The exception's own text is deliberately NOT echoed: a decode error's
+    payload can carry document content, and the fixed message says everything
+    the caller can act on.
+    """
+    return web.json_response(
+        {"error": "the local ledger is unreadable and must be repaired", "code": code},
+        status=500,
+    )
 
 
 def _safe_error(exc: BaseException) -> str:
@@ -1253,6 +1276,13 @@ async def _handle_drive_share(request: web.Request) -> web.Response:
             )
     except AWSError as exc:
         return _aws_failed(exc)
+    except json.JSONDecodeError:
+        # record_share is the ledger write inside the lock. The URL was minted
+        # (presigning is local math, nothing durable exists in AWS) but the
+        # ledger refused to record it, so it must NOT be handed out: returning
+        # it would create a live unrevokable bearer grant with no local record
+        # -- the exact under-reporting the strict reader exists to prevent.
+        return _ledger_corrupt("share_ledger_corrupt")
     return web.json_response({"url": url, "share": record})
 
 
@@ -1358,7 +1388,10 @@ async def _handle_shares_list(request: web.Request) -> web.Response:
 
 async def _handle_share_forget(request: web.Request) -> web.Response:
     share_id = request.match_info.get("id", "")
-    removed = await asyncio.to_thread(shares_mod.forget_share, share_id)
+    try:
+        removed = await asyncio.to_thread(shares_mod.forget_share, share_id)
+    except json.JSONDecodeError:
+        return _ledger_corrupt("share_ledger_corrupt")
     if removed is None:
         return _not_found("unknown share", "unknown_share")
     return web.json_response({"forgotten": True})
@@ -1550,6 +1583,14 @@ async def _reconciled_remote_slugs(request: web.Request) -> tuple[set[str] | Non
         slugs = {f for f in folders if library_mod.valid_slug(f)}
         try:
             await asyncio.to_thread(library_mod.reconcile, account, slugs, observed_at=observed_at)
+        except json.JSONDecodeError:
+            # The strict update reader refused a corrupt ledger (#7805). Same
+            # degradation as the OSError arm below -- this route is best-effort by
+            # contract and the LIST must keep rendering (its rows come from the
+            # lenient display read) -- but the reason differs on the axis the
+            # operator acts on: this does not clear on retry, the file needs repair.
+            logger.warning("aws-control library reconcile refused: ledger corrupt")
+            return None, "the local sync ledger is corrupt and must be repaired"
         except OSError as exc:
             # The reconcile WRITES, and this route is best-effort by contract. An
             # unwritable ledger directory, or a lock this platform refuses to
@@ -1636,6 +1677,11 @@ async def _handle_library_remove(request: web.Request) -> web.Response:
             result = await asyncio.to_thread(
                 library_mod.library_remove, profile, region, bucket, account, slug
             )
+    except json.JSONDecodeError:
+        # Before the ``ValueError`` arm for the same subclass reason as the push
+        # handler: without it a corrupt ledger reads as ``invalid_slug``, blaming
+        # the request for a store that needs repair.
+        return _ledger_corrupt("library_ledger_corrupt")
     except ValueError as exc:
         return _bad_request(_safe_error(exc), "invalid_slug")
     except AWSError as exc:
@@ -1677,6 +1723,15 @@ async def _handle_library_push(request: web.Request) -> web.Response:
             )
     except ArtifactNotFoundError:
         return _not_found("unknown artifact", "unknown_artifact")
+    except json.JSONDecodeError:
+        # MUST precede the ``ValueError`` arm below: ``JSONDecodeError`` subclasses
+        # ``ValueError``, so without this the ledger's corruption refusal (#7805)
+        # would be reported as ``not_pushable`` -- a 400 blaming the artifact for a
+        # store the operator has to repair. The objects may already be in the
+        # bucket (upload precedes the ledger write); the honest answer is that the
+        # push is NOT recorded, which the next reconcile will surface as
+        # ``remoteOnly`` once the ledger is repaired.
+        return _ledger_corrupt("library_ledger_corrupt")
     except ValueError as exc:
         return _bad_request(_safe_error(exc), "not_pushable")
     except AWSError as exc:

--- a/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/shares.py
@@ -62,12 +62,32 @@ def _load() -> list[dict[str, Any]]:
     A DISPLAY read: :func:`list_shares` must render on a store it could not
     load rather than failing the Access section. See :func:`_load_for_update`
     for why a mutation may not stand on the same answer.
+
+    An absent file is silent -- that is a store with no shares yet, not a fault.
+    Anything else is logged, because the state this degrades into looks exactly
+    like health: an empty Access section renders as "nothing is shared", which
+    for a ledger of live presigned URLs is the one wrong answer nobody would
+    question.
     """
     try:
         data = json.loads(_store_path().read_text(encoding="utf-8"))
-        return data if isinstance(data, list) else []
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         return []
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning(
+            "aws-control shares: ledger unreadable; the Access section will render empty",
+            exc_info=True,
+        )
+        return []
+    if not isinstance(data, list):
+        # The same degradation reached without a parse failure -- same silence
+        # problem, same log line.
+        logger.warning(
+            "aws-control shares: ledger root is not an array; the Access section "
+            "will render empty"
+        )
+        return []
+    return data
 
 
 def _load_for_update() -> list[dict[str, Any]]:
@@ -75,21 +95,71 @@ def _load_for_update() -> list[dict[str, Any]]:
 
     Both mutations below rewrite the WHOLE file from what they read, so an
     empty base is not "nothing to carry forward" -- it is "forget every share
-    already recorded". Only a missing file makes that true. An unreadable one
+    already recorded". Only a MISSING file makes that true. An unreadable one
     (a transient EACCES/EIO, a scanner holding the handle on Windows) is a
     ledger we still have, and this one is the only local record of live
     PRESIGNED URLs: they are bearer grants that cannot be revoked, so a
     truncated ledger under-reports access that is still working. The error
     propagates and the mutation is abandoned instead.
 
-    A corrupt document keeps reading as empty, matching the display read: it
-    parsed to nothing usable, so there is nothing to lose by replacing it.
+    Corruption propagates too (#7805, mirroring #7794): a document that failed
+    to parse carries nothing to merge into, but "cannot merge into" is not
+    "safe to destroy". A truncated file still holds most of its records
+    verbatim, and replacing it discards the operator's only chance to recover
+    them by hand -- silently, while a refusal costs one skipped mutation and a
+    visible error. Two shapes that never reach ``json.loads``'s own raise are
+    folded into the same refusal: a byte stream that is not UTF-8 (which
+    arrives as ``UnicodeDecodeError`` -- a ``ValueError`` but NOT a
+    ``JSONDecodeError``, so left unwrapped it would slip past every corruption
+    clause at the callers), and valid JSON whose root is not an array (which
+    parses without raising, so normalizing it to ``[]`` would destroy a
+    document nobody could read -- the same loss, reached without a parse
+    failure).
+
+    Plain ``json.JSONDecodeError`` rather than ops-mission-control's named
+    ``CorruptDocumentError``: that type lives in another app and apps do not
+    import each other.
+
+    The per-ROW check exists because this reader's return value is not written
+    back verbatim: both mutations pipe it through :func:`_prune`, whose damage
+    path silently DROPS any row it cannot read an ``expiresAt`` from -- a
+    non-object row, a missing stamp, a mangled one -- and the whole-file
+    rewrite then takes those rows with it. That is the same coercion loss the
+    secret store's strict reader refuses, arriving one call later. So every
+    row must hold the one field the retention pass needs to make a
+    keep/expire decision; a row it would drop for DAMAGE refuses the mutation,
+    while the deliberate expiry drop (a parseable stamp in the past) stays
+    what it is: retention, not loss. The refusal names the row's index and
+    nothing else -- entry content must not ride on an exception that crosses
+    into responses and logs.
     """
     try:
         data = json.loads(_store_path().read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError:
         return []
-    return data if isinstance(data, list) else []
+    except UnicodeDecodeError as exc:
+        raise json.JSONDecodeError(
+            f"share ledger is not valid UTF-8: {exc.reason}",
+            exc.object.decode("utf-8", "replace")[:120],
+            0,
+        ) from exc
+    if not isinstance(data, list):
+        raise json.JSONDecodeError("share ledger root is not a JSON array", str(data)[:120], 0)
+    for index, entry in enumerate(data):
+        damaged = not isinstance(entry, dict)
+        if not damaged:
+            try:
+                dt.datetime.fromisoformat(entry["expiresAt"])
+            except (KeyError, ValueError, TypeError):
+                damaged = True
+        if damaged:
+            raise json.JSONDecodeError(
+                f"share ledger entry {index} has no readable expiresAt, so the "
+                "retention pass would silently drop it",
+                "",
+                0,
+            )
+    return data
 
 
 def _save(entries: list[dict[str, Any]]) -> None:

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/policy_store.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.ops_mission_control.backend.models import CorruptDocumentError
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 
@@ -132,16 +133,42 @@ def _read() -> dict[str, Any]:
     """The stored ceiling, or ``{}`` when there is nothing readable.
 
     A DISPLAY/GATE read: it must degrade to the caller's DEFAULT rather than
-    raise, because every reader here backs a security decision that has a safe
-    answer -- an unreadable ceiling reads as ``observe`` with no act-rules, which
-    is the most restrictive state, not a permissive one. See
-    :func:`_read_for_update` for why a writer may not stand on the same answer.
+    raise. Every caller left on this path has a RESTRICTIVE default -- an
+    unreadable ceiling reads as ``observe`` with no act-rules, the destination
+    and identity keys read as unset -- so degrading is the safe direction. The
+    one key whose default is permissive (``PRIMARY_KEY``, see
+    ``rotation.is_primary``) does NOT read through here: authority decisions
+    go through :func:`read_authority`, which refuses what this read degrades.
+    Found in review (GPT 5.6), two rounds: swallowing more here widened the
+    fail-open door, and scoping it out as pre-existing was rightly rejected --
+    a corrupt file granting prune authority is the corruption-enables-
+    destruction failure this change exists to remove.
+
+    An absent file is silent -- no ceiling has been stored yet, not a fault.
+    A degraded read is logged: the state is restrictive but it is also
+    silent, and nothing else would tell an operator their configuration has
+    stopped applying.
     """
     try:
         raw = json.loads(policy_path().read_text(encoding="utf-8"))
-    except (FileNotFoundError, OSError, json.JSONDecodeError):
+    except FileNotFoundError:
         return {}
-    return raw if isinstance(raw, dict) else {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        logger.warning(
+            "ops-mission-control: keystone policy file unreadable; every key will "
+            "read as its restrictive default",
+            exc_info=True,
+        )
+        return {}
+    if not isinstance(raw, dict):
+        # The same degradation reached without a parse failure -- same silence
+        # problem, same log line.
+        logger.warning(
+            "ops-mission-control: keystone policy file root is not an object; "
+            "every key will read as its restrictive default"
+        )
+        return {}
+    return raw
 
 
 def _read_for_update() -> dict[str, Any]:
@@ -164,15 +191,34 @@ def _read_for_update() -> dict[str, Any]:
     arriving by accident instead of by attack. The error propagates and the
     write is abandoned instead.
 
-    Corruption keeps reading as empty, matching :func:`_read`: the document
-    parsed to nothing usable, so there is no stored ceiling left to lose by
-    replacing it.
+    Corruption propagates too (#7805, mirroring #7794): "cannot merge into" is
+    not "safe to destroy", and for THIS file silent replacement re-opens the
+    exact bypass the keystone floor exists to prevent -- a truncated document
+    rewritten from empty reverts every fenced key to a value the constrained
+    party can influence. Every corruption door raises the one named type,
+    :class:`CorruptDocumentError`: a parse failure, a byte stream that is not
+    UTF-8 (a ``ValueError`` but NOT a ``JSONDecodeError``, so unwrapped it
+    would slip past every corruption clause at the callers), and valid JSON
+    whose root is not an object (which parses without raising, so coercing it
+    to ``{}`` would destroy a document nobody could read). No per-entry check
+    beyond the root: values here are arbitrary JSON passed through verbatim,
+    so a parsed document survives a read-write cycle by construction.
     """
     try:
         raw = json.loads(policy_path().read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError):
+    except FileNotFoundError:
         return {}
-    return raw if isinstance(raw, dict) else {}
+    except json.JSONDecodeError as exc:
+        raise CorruptDocumentError(exc.msg, exc.doc, exc.pos) from exc
+    except UnicodeDecodeError as exc:
+        raise CorruptDocumentError(
+            f"policy file is not valid UTF-8: {exc.reason}",
+            exc.object.decode("utf-8", "replace")[:120],
+            0,
+        ) from exc
+    if not isinstance(raw, dict):
+        raise CorruptDocumentError("policy file root is not a JSON object", str(raw)[:120], 0)
+    return raw
 
 
 #: Lock filename beside the policy file. Not the policy file itself: locking the file being
@@ -309,6 +355,34 @@ def get(key: str, default: Any = None) -> Any:
         raise KeyError(f"{key!r} is not an operator-only key; use config.json for it")
     data = _read()
     return data.get(key, default)
+
+
+def read_authority(key: str, default: Any = None) -> Any:
+    """Read one operator-only value for an AUTHORITY decision -- strict, never lenient.
+
+    :func:`get` degrades an unreadable or corrupt file to the caller's default, which is
+    safe exactly when the default is the restrictive answer -- true for every key here
+    except one. ``PRIMARY_KEY`` defaults to TRUE (``rotation.is_primary``), so the lenient
+    read turns a truncated policy file into GRANTED ledger-prune authority: the corrupt
+    file becomes the key that unlocks destroying shared knowledge, which is the exact
+    corruption-enables-destruction failure #7805 exists to remove. Found in review
+    (GPT 5.6), which correctly rejected scoping this out as pre-existing.
+
+    Reuses :func:`_read_for_update`'s read, deliberately: one strict reader, one set of
+    corruption doors (parse failure, non-UTF-8, non-object root), no second copy to
+    drift. Only a MISSING file reads as the default -- a fresh install is genuinely the
+    default state, while an unreadable or corrupt file is an UNKNOWN state, and an
+    authority check that cannot read its input must refuse rather than guess. Callers
+    whose failure posture is "deny" catch the raise and answer False.
+
+    Not folded into :func:`get` wholesale because the restrictive-default keys WANT the
+    lenient read: failing ``read_mode`` on a transient EACCES would wedge every
+    authorization gate on a condition that clears by itself, to protect keys whose
+    degraded answer is already the safe one.
+    """
+    if key not in OPERATOR_ONLY_KEYS:  # pragma: no cover — programming error, not input
+        raise KeyError(f"{key!r} is not an operator-only key; use config.json for it")
+    return _read_for_update().get(key, default)
 
 
 def put(key: str, value: Any) -> None:

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/rotation.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/rotation.py
@@ -658,7 +658,35 @@ def is_primary() -> bool:
         # False: a missed nightly hygiene pass is recoverable on the next run, whereas
         # every instance pruning the shared ledger is not.
         return bool(me) and me.lower() == leader.lower()
-    return bool(policy_store.get(policy_store.PRIMARY_KEY, True))
+    # The STRICT read, not `get`: this flag defaults to True, so the lenient read
+    # turns an unreadable or corrupt policy file into granted prune authority --
+    # the corrupt file becoming the key that unlocks destroying shared knowledge
+    # (#7805). Refuse for the same reason the no-login case above answers False:
+    # a skipped hygiene pass is recoverable, a wrong prune is not.
+    try:
+        flag = policy_store.read_authority(policy_store.PRIMARY_KEY, True)
+    except (OSError, ValueError):
+        # ValueError covers the strict reader's corruption doors (JSONDecodeError
+        # and the non-UTF-8 wrap are both ValueError subclasses).
+        logger.warning(
+            "ops-mission-control: policy file unreadable; refusing primary-tier "
+            "authority until it is repaired",
+            exc_info=True,
+        )
+        return False
+    if not isinstance(flag, bool):
+        # Type-exact, not truthiness: `bool("false")` is True, so a hand-repaired
+        # file holding the STRING "false" would grant the authority its author
+        # meant to withhold -- and hand-repair is exactly what the corruption
+        # refusals above send the operator to do. The settings route only writes
+        # real booleans, so any other type is an unknown state, and an authority
+        # check that cannot type its input refuses. Found in review (GPT 5.6).
+        logger.warning(
+            "ops-mission-control: primary_instance is not a boolean; refusing "
+            "primary-tier authority until it is repaired"
+        )
+        return False
+    return flag
 
 
 def primary_owner() -> str:

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
@@ -2174,6 +2174,15 @@ async def _handle_put_secret(request: web.Request) -> web.StreamResponse:
 
     try:
         await asyncio.to_thread(put_secret, provider_id, field_name, value)
+    except json.JSONDecodeError as exc:
+        # The store's update reader now refuses a corrupt document rather than
+        # replacing it (#7805), so this handler can see a failure that previously
+        # could not happen. Same shared mapper as the settings writes, for the same
+        # reason: translating it at some handlers and not others is worse than not
+        # translating it anywhere. 500-with-code rather than the OSError arm's 503:
+        # corruption does not clear on retry, it needs a person to repair the file.
+        logger.warning("ops-mission-control: secret save refused, store corrupt")
+        return _store_read_refusal(exc, code="secret_store")
     except OSError as exc:
         # Reported, not raised — the same shape ``_handle_rotation_arm`` uses for a
         # refusing cron store, and for the same reason its comment gives: escaping
@@ -2197,6 +2206,15 @@ async def _handle_delete_secret(request: web.Request) -> web.StreamResponse:
         )
     try:
         removed = await asyncio.to_thread(delete_secret, provider_id)
+    except json.JSONDecodeError as exc:
+        # The revocation route needs the corruption refusal MORE than the save
+        # route: on the old lenient read a corrupt store reported the provider
+        # absent, so the operator was told the token was already gone while it sat
+        # readable in the corrupt bytes -- and a rewrite here would then destroy
+        # the only copy. A coded refusal leaves them correctly believing the token
+        # is still live and the file worth repairing.
+        logger.warning("ops-mission-control: secret revocation refused, store corrupt")
+        return _store_read_refusal(exc, code="secret_store")
     except OSError as exc:
         # The revocation route needs this MORE than the save route. Its whole purpose
         # is to let an operator stop trusting a credential, and the failure this

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/secrets.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from kiro_crew import platform_compat
+from kiro_crew.apps.builtins.ops_mission_control.backend.models import CorruptDocumentError
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.sel import sel
@@ -198,18 +199,43 @@ class KeystoneFileBackend:
         return self._pinned_path if self._pinned_path is not None else secrets_path()
 
     @staticmethod
-    def _coerce(raw: Any) -> dict[str, dict[str, str]]:
+    def _coerce(raw: Any, *, strict: bool = False) -> dict[str, dict[str, str]]:
         """Normalize a parsed store to ``provider -> {field: value}``, all strings.
 
         Shared by both readers below so the only thing that can differ between
         them is which read FAILURES are allowed to answer "empty".
+
+        ``strict`` is the update path, and its rule is the one three review
+        rounds converged on for the incident index (see
+        ``store._coerce_index``): deserialize, re-serialize, and refuse if
+        anything that was on disk did not survive. The lenient coercion drops a
+        provider whose entry is not an object and retypes a field that is not a
+        string -- right for a LOOKUP, where the worst outcome is "not
+        configured", and destruction on the update path, where the caller
+        rewrites the whole file from what this returns. The refusal names the
+        entry's POSITION and nothing else: in a malformed document ANY part --
+        the provider key included -- can be a pasted credential, so no
+        document content may ride on an exception that crosses into responses
+        and logs. Found in review (GPT 5.6), which produced the counterexample
+        ``{"<token>": "scalar"}``.
         """
         if not isinstance(raw, dict):
+            if strict:
+                raise CorruptDocumentError("secret store root is not a JSON object", "", 0)
             return {}
         out: dict[str, dict[str, str]] = {}
         for provider, fields in raw.items():
             if isinstance(fields, dict):
                 out[str(provider)] = {str(k): str(v) for k, v in fields.items()}
+        if strict:
+            for index, (provider, fields) in enumerate(raw.items()):
+                if out.get(str(provider)) != fields:
+                    raise CorruptDocumentError(
+                        f"secret store entry at position {index} would not survive "
+                        "a read-write cycle",
+                        "",
+                        0,
+                    )
         return out
 
     def _read(self) -> dict[str, dict[str, str]]:
@@ -221,10 +247,35 @@ class KeystoneFileBackend:
         ``has_secrets`` check instead of 500ing the route. See
         :meth:`_read_for_update` for why a mutation may not stand on the same
         answer.
+
+        An absent file is silent -- no secret has been stored yet, not a fault.
+        Anything else is logged, because the state this degrades into looks
+        exactly like health: every provider reads as unconfigured, polling
+        stops, and nothing else would prompt an operator to look.
         """
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, OSError, json.JSONDecodeError):
+        except FileNotFoundError:
+            return {}
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            # The message is a fixed literal with NO interpolated value — the only
+            # dynamic content is the traceback, and a decode error's rendering never
+            # includes the document. Semgrep matches on the word "secret" in the
+            # message string, not on the argument (see the sibling annotation on
+            # the backend-set log line below).
+            logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                "ops-mission-control: secret store unreadable; every provider will "
+                "read as unconfigured",
+                exc_info=True,
+            )
+            return {}
+        if not isinstance(raw, dict):
+            # The same degradation reached without a parse failure -- same
+            # silence problem, same log line. Fixed literal, no content.
+            logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                "ops-mission-control: secret store root is not an object; every "
+                "provider will read as unconfigured"
+            )
             return {}
         return self._coerce(raw)
 
@@ -241,15 +292,51 @@ class KeystoneFileBackend:
         PagerDuty and Datadog, and every poll fails closed until they do. The
         error propagates and the mutation is abandoned instead.
 
-        Corruption keeps reading as empty, matching :meth:`_read`: the document
-        parsed to nothing usable, so there is no stored token left to lose by
-        replacing it.
+        Corruption propagates too (#7805, mirroring #7794's decision for the
+        incident index): "cannot merge into" is not "safe to destroy". A
+        truncated store still holds most of its tokens verbatim -- readable
+        right up to the moment a rewrite replaces them -- and a refusal costs
+        one skipped mutation and a visible error. Every corruption door raises
+        the one named type, :class:`CorruptDocumentError`: a parse failure, a
+        byte stream that is not UTF-8 (``UnicodeDecodeError`` is a
+        ``ValueError`` but NOT a ``JSONDecodeError``, so unwrapped it slips
+        past every corruption clause at the callers), and -- via the strict
+        coercion -- valid JSON whose content would not survive a read-write
+        cycle.
+
+        One deliberate divergence from the index reader it mirrors: the
+        refusal carries ``""`` where that one forwards ``exc.doc``, and the
+        exception CHAIN is severed rather than kept. The doc is the raw file
+        text, and HERE that text is the credential store -- and the chain is
+        not cosmetics, because ``__cause__`` (or ``__context__`` under ``from
+        None``) keeps the original parser exception alive with the full
+        document on it. What debugging loses is repaid in the message: the
+        parser's own line/column are folded into the text, which is the part a
+        log actually renders.
         """
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, json.JSONDecodeError):
+        except FileNotFoundError:
             return {}
-        return self._coerce(raw)
+        except json.JSONDecodeError as exc:
+            # The REAL location is folded into the message text, because the
+            # scrubbed empty ``doc`` below makes the exception's own rendering
+            # recompute a meaningless "line 1 column 1".
+            corrupt_msg = (
+                f"{exc.msg} (at line {exc.lineno} column {exc.colno} of the stored document)"
+            )
+        except UnicodeDecodeError as exc:
+            corrupt_msg = f"secret store is not valid UTF-8: {exc.reason}"
+        else:
+            return self._coerce(raw, strict=True)
+        # Raised OUTSIDE the except block, deliberately: ``raise ... from exc``
+        # keeps the original exception -- whose ``doc``/``object`` attribute IS
+        # the raw credential file -- reachable through ``__cause__``, and even
+        # ``from None`` leaves it on ``__context__``. Constructing the refusal
+        # after the handler has exited severs the chain entirely, so no copy of
+        # the store's bytes rides on the exception that crosses into route
+        # handlers and log formatters. Found in review (GPT 5.6).
+        raise CorruptDocumentError(corrupt_msg, "", 0)
 
     def _lock(self) -> "_SecretLock":
         return _SecretLock(self._path)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/store.py
@@ -351,16 +351,16 @@ def _read_index_for_update() -> dict[str, Incident]:
     logs survive on disk but nothing indexes them any more, and an open incident
     that is no longer listed is never swept, resolved, or answered.
 
-    Corruption propagates too, and that is a DELIBERATE divergence from the four
+    Corruption propagates too, which began as a DELIBERATE divergence from the four
     merged siblings of this idiom (``library.py``, ``shares.py``, ``secrets.py``,
-    ``policy_store.py``), which all still read an unparseable document as empty.
-    Their justification is real -- a document that failed to parse carries nothing
+    ``policy_store.py``), which then read an unparseable document as empty.
+    Their justification was real -- a document that failed to parse carries nothing
     to merge into -- but "cannot merge into" is not "safe to destroy". A truncated
     index still holds most of its records verbatim, and replacing it discards the
     operator's only chance to recover them by hand. Refusing costs one skipped
     mutation and a visible error; overwriting costs the records, silently. Found in
-    review (GPT 5.6). The siblings need the same treatment in a follow-up --
-    ``secrets.py`` most of all, since there the discarded bytes are credentials.
+    review (GPT 5.6). The siblings received the same treatment in #7805, so the
+    divergence is closed and this paragraph is its record, not its tracker.
     """
     try:
         raw = json.loads(index_path().read_text(encoding="utf-8"))

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_policy_store.py
@@ -83,9 +83,7 @@ class TestTheCeilingIsOnTheKeystoneFloor(_HomeIsolated):
         from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store, rotation
 
         policy_store.set_mode("act")
-        policy_store.set_rules(
-            [{"mode": "act", "source": "cloudwatch", "resource_glob": "prod-*"}]
-        )
+        policy_store.set_rules([{"mode": "act", "source": "cloudwatch", "resource_glob": "prod-*"}])
         self.assertEqual(rotation.app_mode(), "act")
         rules = rotation.load_rules()
         self.assertEqual(len(rules), 1)
@@ -396,10 +394,12 @@ class TestActRulesAreAuthorable(_HomeIsolated):
         """A ten-rule submission with one bad entry must say WHICH one."""
         from kiro_crew.apps.builtins.ops_mission_control.backend import rotation
 
-        ok, code, _ = rotation.save_rules([
-            {"source": "cloudwatch", "mode": "act", "resource_glob": "prod-*"},
-            {"source": "datadog", "mode": "act"},
-        ])
+        ok, code, _ = rotation.save_rules(
+            [
+                {"source": "cloudwatch", "mode": "act", "resource_glob": "prod-*"},
+                {"source": "datadog", "mode": "act"},
+            ]
+        )
         self.assertFalse(ok)
         self.assertEqual(code, "rule_1_invalid")
 
@@ -687,7 +687,8 @@ class TestPolicyLockdownOrdering(_HomeIsolated):
 
         self.assertTrue(sizes, "premise: the lockdown ran at all")
         self.assertEqual(
-            sizes[0], 0,
+            sizes[0],
+            0,
             f"the file already held payload bytes when it was locked down: {sizes[0]} bytes",
         )
 
@@ -708,11 +709,13 @@ class TestPolicyLockdownOrdering(_HomeIsolated):
                 policy_store.set_mode(models.MODE_ACT)
 
         self.assertEqual(
-            policy_store.policy_path().read_bytes(), before,
+            policy_store.policy_path().read_bytes(),
+            before,
             "the previous ceiling was altered",
         )
         self.assertEqual(
-            policy_store.read_mode("unset"), models.MODE_OBSERVE,
+            policy_store.read_mode("unset"),
+            models.MODE_OBSERVE,
             "a failed new write destroyed the previously recorded ceiling",
         )
 
@@ -740,11 +743,13 @@ class TestPolicyLockdownOrdering(_HomeIsolated):
                 policy_store.set_mode(models.MODE_ACT)
 
         self.assertEqual(
-            policy_store.policy_path().read_bytes(), before,
+            policy_store.policy_path().read_bytes(),
+            before,
             "the previous ceiling was altered",
         )
         self.assertEqual(
-            policy_store.read_mode("unset"), models.MODE_OBSERVE,
+            policy_store.read_mode("unset"),
+            models.MODE_OBSERVE,
             "a transient write failure destroyed the previously recorded ceiling",
         )
 
@@ -803,15 +808,18 @@ class TestTheCeilingIsNeverPublishedOverAFailedRead(_HomeIsolated):
                 policy_store.put("primary_instance", True)
 
         self.assertEqual(
-            policy_store.policy_path().read_bytes(), before,
+            policy_store.policy_path().read_bytes(),
+            before,
             "a failed read was published back over the ceiling",
         )
         self.assertEqual(
-            policy_store.get("slack_channel"), "#ops-the-operator-chose",
+            policy_store.get("slack_channel"),
+            "#ops-the-operator-chose",
             "a failed read dropped the operator's outbound destination",
         )
         self.assertEqual(
-            policy_store.get("ledger_sync_remote"), "https://git.example/ops-ledger.git",
+            policy_store.get("ledger_sync_remote"),
+            "https://git.example/ops-ledger.git",
             "a failed read dropped the operator's ledger remote",
         )
 
@@ -842,12 +850,140 @@ class TestTheCeilingIsNeverPublishedOverAFailedRead(_HomeIsolated):
         policy_store.set_ceiling(mode="act")
         self.assertEqual(policy_store.read_mode("observe"), "act")
 
-    def test_a_corrupt_ceiling_still_repairs_on_write(self):
-        """Existing tolerance, pinned so the unreadable-file guard is not
-        mistaken for a licence to start failing on corruption too."""
+    def test_a_corrupt_ceiling_refuses_the_write_and_is_left_intact(self):
+        """#7805: a corrupt policy file is refused, never rewritten.
+
+        The old tolerance read an unparseable document as empty and let the
+        write publish over it -- and for THIS file a rewrite-from-empty reverts
+        every fenced key to a value the constrained party can influence, which
+        is the exact bypass the keystone floor exists to prevent. A truncated
+        document still holds the operator's keys verbatim; refusing keeps them
+        recoverable.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+        from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
+            CorruptDocumentError,
+        )
+
+        policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
+        corrupt = '{"mode": "observe", "slack_channel": "#ops-the-operator-chose"'
+        policy_store.policy_path().write_text(corrupt, encoding="utf-8")
+        # The NAMED type, not just the base class: every corruption door of this
+        # reader is contracted to raise CorruptDocumentError, and asserting only
+        # json.JSONDecodeError would keep a regression to the bare parser
+        # exception green. (It still IS a JSONDecodeError, which is what the
+        # callers' corruption arms catch.)
+        with self.assertRaises(CorruptDocumentError):
+            policy_store.set_ceiling(mode="act")
+        with self.assertRaises(CorruptDocumentError):
+            policy_store.put("slack_channel", "#somewhere-else")
+        self.assertEqual(
+            policy_store.policy_path().read_text(encoding="utf-8"),
+            corrupt,
+            "the write rewrote a corrupt policy file instead of refusing",
+        )
+        # The gate readers stay lenient: the degraded answer is the most
+        # restrictive state, and failing them would wedge the app on a file
+        # only a person can repair.
+        self.assertEqual(policy_store.read_mode("observe"), "observe")
+
+    def test_a_ceiling_that_is_not_utf8_takes_the_corruption_path(self):
+        """``UnicodeDecodeError`` is a ``ValueError`` but NOT a
+        ``JSONDecodeError``; unwrapped it would slip past every corruption
+        clause at the callers."""
         from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
 
         policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
-        policy_store.policy_path().write_text("{ not json", encoding="utf-8")
-        policy_store.set_ceiling(mode="act")
-        self.assertEqual(policy_store.read_mode("observe"), "act")
+        policy_store.policy_path().write_bytes(b"\xff\xfe not utf8")
+        with self.assertRaises(json.JSONDecodeError):
+            policy_store.put("slack_channel", "#anywhere")
+        self.assertEqual(policy_store.policy_path().read_bytes(), b"\xff\xfe not utf8")
+
+    def test_a_ceiling_that_parses_to_a_non_object_refuses_the_write(self):
+        """A bare array parses without raising, so coercing it to ``{}`` would
+        let the rewrite destroy a document nobody could read -- the same loss,
+        reached without a parse failure."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
+        policy_store.policy_path().write_text('["not", "an", "object"]', encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            policy_store.set_ceiling(mode="act")
+        self.assertEqual(
+            policy_store.policy_path().read_text(encoding="utf-8"), '["not", "an", "object"]'
+        )
+
+    def test_an_unreadable_or_corrupt_ceiling_refuses_primary_authority(self):
+        """A corrupt policy file must never GRANT prune authority.
+
+        ``PRIMARY_KEY`` is the one operator-only key whose default is
+        permissive (True), so the lenient gate read turned a truncated policy
+        file into granted ledger-prune authority -- the corrupt file becoming
+        the key that unlocks destroying shared knowledge, the exact
+        corruption-enables-destruction failure #7805 removes. Found in review
+        (GPT 5.6), two rounds. Authority decisions now go through the STRICT
+        :func:`policy_store.read_authority`, and ``rotation.is_primary``
+        answers False when it cannot read its input.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import (
+            policy_store,
+            rotation,
+        )
+
+        policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
+        for corrupt_bytes in (
+            b'{"primary_instance": true',  # truncated JSON
+            b"\xff\xfe not utf8",  # not UTF-8
+            b'["not", "an", "object"]',  # wrong root
+        ):
+            policy_store.policy_path().write_bytes(corrupt_bytes)
+            with self.assertRaises(ValueError, msg=corrupt_bytes):
+                policy_store.read_authority(policy_store.PRIMARY_KEY, True)
+            self.assertFalse(
+                rotation.is_primary(),
+                f"a corrupt policy file ({corrupt_bytes!r}) granted primary authority",
+            )
+        # A MISSING file is genuinely the default state: solo installs keep
+        # working (the flag defaults True on a file that never existed).
+        policy_store.policy_path().unlink()
+        self.assertTrue(policy_store.read_authority(policy_store.PRIMARY_KEY, True))
+
+    def test_a_non_boolean_primary_flag_refuses_authority(self):
+        """Type-exact, not truthiness: ``bool("false")`` is True, so a
+        hand-repaired file holding the STRING "false" would grant the authority
+        its author meant to withhold -- and hand-repair is exactly where the
+        corruption refusals send the operator. Found in review (GPT 5.6)."""
+        import json as _json
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import (
+            policy_store,
+            rotation,
+        )
+
+        policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
+        for bad in ('"false"', '"true"', "1", "0", "null"):
+            policy_store.policy_path().write_text(
+                f'{{"primary_instance": {bad}}}', encoding="utf-8"
+            )
+            self.assertFalse(
+                rotation.is_primary(),
+                f"a non-boolean primary_instance ({bad}) granted primary authority",
+            )
+        # Real booleans keep their meaning in both directions.
+        for real, expected in ((True, True), (False, False)):
+            policy_store.policy_path().write_text(
+                _json.dumps({"primary_instance": real}), encoding="utf-8"
+            )
+            self.assertEqual(rotation.is_primary(), expected, real)
+
+    def test_the_display_read_still_degrades_restrictively_on_any_failure(self):
+        """The lenient read stays lenient for the restrictive-default keys:
+        failing ``read_mode`` on a transient fault would wedge every
+        authorization gate to protect keys whose degraded answer is already
+        the safe one."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store
+
+        policy_store.policy_path().parent.mkdir(parents=True, exist_ok=True)
+        for corrupt_bytes in (b"{ not json", b"\xff\xfe not utf8", b'["wrong root"]'):
+            policy_store.policy_path().write_bytes(corrupt_bytes)
+            self.assertEqual(policy_store.read_mode("observe"), "observe", corrupt_bytes)

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
@@ -3382,6 +3382,62 @@ class TestAStoreThatRefusesToWriteIsReportedNotCrashed(unittest.IsolatedAsyncioT
         self.assertEqual(body["code"], "secret_store_unwritable")
         self.assertNotIn("removed", body, "the refusal must not claim a removal verdict")
 
+    async def test_a_corrupt_secret_store_is_a_coded_500_on_save(self):
+        """Corruption is not retryable, so it must not be advertised as a 503.
+
+        The store's update reader now refuses a corrupt document rather than
+        replacing it (#7805), and this handler caught only ``OSError`` -- so the
+        refusal protecting the operator's only copy of every provider token
+        would have surfaced as aiohttp's bare uncoded 500.
+        """
+        token = "u+ThisIsTheActualTokenValue"
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        def _corrupt(*_a, **_kw):
+            raise corrupt
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes, "put_secret", _corrupt):
+                client = await self._client(app)
+                resp = await client.put(
+                    "/api/apps/ops-mission-control/providers/pagerduty/secret",
+                    json={"field": "api_token", "value": token},
+                )
+                self.assertEqual(resp.status, 500)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "secret_store_corrupt")
+        self.assertIs(body["ok"], False)
+        # A refusal must not echo the credential it failed to store, nor the
+        # document bytes the decode error may carry.
+        self.assertNotIn(token, json.dumps(body))
+        self.assertNotIn("{ not json", json.dumps(body))
+
+    async def test_a_corrupt_secret_store_is_a_coded_500_on_revocation(self):
+        """The revocation half: the old lenient read answered "nothing to
+        revoke" over a store whose token was still on disk; the corrupt refusal
+        must leave the operator correctly believing the token is still live."""
+        corrupt = json.JSONDecodeError("Expecting value", "{ not json", 2)
+
+        def _corrupt(*_a, **_kw):
+            raise corrupt
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes, "delete_secret", _corrupt):
+                client = await self._client(app)
+                resp = await client.delete(
+                    "/api/apps/ops-mission-control/providers/pagerduty/secret"
+                )
+                self.assertEqual(resp.status, 500)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "secret_store_corrupt")
+        self.assertNotIn("removed", body, "the refusal must not claim a removal verdict")
+
     async def test_a_refused_ceiling_write_is_a_coded_503(self):
         """The ceiling is the one value where a silent partial apply is a security state."""
         from kiro_crew.apps.builtins.ops_mission_control.backend import policy_store

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_security.py
@@ -12,6 +12,7 @@ so this is the test that catches it.
 """
 
 import contextlib
+import json
 import os
 import shutil
 import tempfile
@@ -300,6 +301,15 @@ class TestSecretBackend(unittest.TestCase):
         (self.tmp / "secrets.json").write_text("{ not json", encoding="utf-8")
         self.assertEqual(self.backend.get("pagerduty", "api_token"), "")
 
+    def test_non_utf8_file_degrades_to_empty(self):
+        # New with #7805: UnicodeDecodeError previously escaped the lookup read
+        # (a ValueError, not a JSONDecodeError). The lenient read must treat a
+        # corrupt byte stream as one condition regardless of which decoder
+        # noticed it -- failing a render would wedge the Settings UI on a file
+        # only a person can repair.
+        (self.tmp / "secrets.json").write_bytes(b"\xff\xfe not utf8")
+        self.assertEqual(self.backend.get("pagerduty", "api_token"), "")
+
 
 class TestSecretStoreLockdownOrdering(unittest.TestCase):
     """The store's write must never publish a token file it has not protected.
@@ -337,7 +347,8 @@ class TestSecretStoreLockdownOrdering(unittest.TestCase):
 
         self.assertTrue(sizes, "premise: the lockdown ran at all")
         self.assertEqual(
-            sizes[0], 0,
+            sizes[0],
+            0,
             f"the file already held payload bytes when it was locked down: {sizes[0]} bytes",
         )
 
@@ -356,11 +367,13 @@ class TestSecretStoreLockdownOrdering(unittest.TestCase):
                 self.backend.put("datadog", "api_key", "x" * 32)
 
         self.assertEqual(
-            (self.tmp / "secrets.json").read_bytes(), before,
+            (self.tmp / "secrets.json").read_bytes(),
+            before,
             "the previous store was altered",
         )
         self.assertEqual(
-            self.backend.get("pagerduty", "api_token"), "u+secretvalue",
+            self.backend.get("pagerduty", "api_token"),
+            "u+secretvalue",
             "a failed new write destroyed the previously stored token",
         )
 
@@ -386,11 +399,13 @@ class TestSecretStoreLockdownOrdering(unittest.TestCase):
                 self.backend.put("datadog", "api_key", "x" * 32)
 
         self.assertEqual(
-            (self.tmp / "secrets.json").read_bytes(), before,
+            (self.tmp / "secrets.json").read_bytes(),
+            before,
             "the previous store was altered",
         )
         self.assertEqual(
-            self.backend.get("pagerduty", "api_token"), "u+secretvalue",
+            self.backend.get("pagerduty", "api_token"),
+            "u+secretvalue",
             "a transient write failure destroyed the previously stored token",
         )
 
@@ -449,11 +464,13 @@ class TestSecretStoreNeverPublishesOverAFailedRead(unittest.TestCase):
                 self.backend.delete("pagerduty")
 
         self.assertEqual(
-            self.store.read_bytes(), before,
+            self.store.read_bytes(),
+            before,
             "a failed read was published back over the store",
         )
         self.assertEqual(
-            self.backend.get("pagerduty", "api_token"), "u+thisisthestoredtoken",
+            self.backend.get("pagerduty", "api_token"),
+            "u+thisisthestoredtoken",
             "a failed read destroyed a token that was still on disk",
         )
 
@@ -483,13 +500,108 @@ class TestSecretStoreNeverPublishesOverAFailedRead(unittest.TestCase):
         self.backend.put("pagerduty", "api_token", "u+thefirsttoken")
         self.assertEqual(self.backend.get("pagerduty", "api_token"), "u+thefirsttoken")
 
-    def test_a_corrupt_store_still_repairs_on_write(self):
-        """Existing tolerance, pinned so the unreadable-file guard is not
-        mistaken for a licence to start failing on corruption too. A document
-        that parsed to nothing usable has no stored token left to lose."""
+    def test_a_corrupt_store_refuses_the_save_and_is_left_intact(self):
+        """#7805: a corrupt store is refused, never rewritten.
+
+        The old tolerance read an unparseable document as empty and let ``put``
+        publish over it -- destroying tokens a truncated JSON still held
+        verbatim, silently, when this file is the only copy of every provider
+        credential on the box. Byte-for-byte intactness is the half a raise
+        alone does not prove.
+        """
+        corrupt = '{"pagerduty": {"api_token": "u+recoverabletoken"}'  # truncated
+        self.store.write_text(corrupt, encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            self.backend.put("datadog", "api_key", "a" * 32)
+        self.assertEqual(
+            self.store.read_text(encoding="utf-8"),
+            corrupt,
+            "the mutation rewrote a corrupt store instead of refusing",
+        )
+
+    def test_a_corrupt_store_refuses_the_revocation_and_is_left_intact(self):
+        """The delete half: the old lenient read reported the provider absent,
+        so the operator was told there was nothing to revoke while the token
+        sat readable in the corrupt bytes -- and a later ``put`` would then
+        have destroyed it."""
+        corrupt = '{"pagerduty": {"api_token": "u+recoverabletoken"}'
+        self.store.write_text(corrupt, encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            self.backend.delete("pagerduty")
+        self.assertEqual(self.store.read_text(encoding="utf-8"), corrupt)
+
+    def test_the_corruption_refusal_is_the_named_type_with_no_document_bytes(self):
+        """Every corruption door raises ``CorruptDocumentError``, and NO copy of
+        the store's bytes rides anywhere on it: not the message, not ``doc``,
+        and not the exception CHAIN -- ``__cause__``/``__context__`` would keep
+        the original parser exception alive with the full document on it.
+        The adversarial shape is a TOKEN-SHAPED PROVIDER KEY: in a malformed
+        document any part can be a pasted credential, so a message that names
+        the key leaks it. Found in review (GPT 5.6)."""
+        from kiro_crew.apps.builtins.ops_mission_control.backend.models import (
+            CorruptDocumentError,
+        )
+
+        token = "u+PastedTokenThatLandedInTheWrongPlace"
+        # Door 1: parse failure -- the document text (token included) must not
+        # survive on the refusal or its chain.
+        self.store.write_text(f'{{"{token}": {{"api_token": "x"}}', encoding="utf-8")
+        with self.assertRaises(CorruptDocumentError) as ctx:
+            self.backend.put("datadog", "api_key", "a" * 32)
+        exc = ctx.exception
+        self.assertNotIn(token, str(exc))
+        self.assertNotIn(token, exc.doc)
+        self.assertIsNone(exc.__cause__, "the chained cause carries the full document")
+        self.assertIsNone(exc.__context__, "the implicit context carries the full document")
+
+        # Door 2: valid JSON the strict coercion refuses -- the counterexample
+        # from review: the token IS the provider key of the unusable entry.
+        self.store.write_text(f'{{"{token}": "scalar-not-a-dict"}}', encoding="utf-8")
+        with self.assertRaises(CorruptDocumentError) as ctx:
+            self.backend.put("datadog", "api_key", "a" * 32)
+        exc = ctx.exception
+        self.assertNotIn(token, str(exc))
+        self.assertNotIn(token, exc.doc)
+        self.assertIsNone(exc.__cause__)
+        self.assertIsNone(exc.__context__)
+
+    def test_a_store_that_is_not_utf8_takes_the_corruption_path(self):
+        """Not valid UTF-8 never reaches ``json.loads``, so it arrives as
+        ``UnicodeDecodeError`` -- a ``ValueError`` but NOT a ``JSONDecodeError``.
+        Unwrapped it would slip past every corruption clause at the callers;
+        one corrupt byte stream must be ONE condition regardless of which
+        decoder noticed it first."""
+        self.store.write_bytes(b"\xff\xfe not utf8 \x00")
+        with self.assertRaises(json.JSONDecodeError):
+            self.backend.put("datadog", "api_key", "a" * 32)
+        self.assertEqual(self.store.read_bytes(), b"\xff\xfe not utf8 \x00")
+
+    def test_valid_json_that_is_not_an_object_refuses_the_write(self):
+        """A bare array parses without raising, so coercing it to ``{}`` would
+        let the rewrite destroy a document nobody could read -- the same loss,
+        reached without a parse failure."""
+        self.store.write_text('["u+token-in-a-list"]', encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            self.backend.put("datadog", "api_key", "a" * 32)
+        self.assertEqual(self.store.read_text(encoding="utf-8"), '["u+token-in-a-list"]')
+
+    def test_an_entry_the_coercion_would_drop_refuses_the_write(self):
+        """Deserialize, re-serialize, refuse if anything on disk did not
+        survive: a provider entry that is not an object is dropped by the
+        lenient coercion, so on the update path it must refuse -- the rewrite
+        would silently delete whatever those bytes held."""
+        doc = json.dumps({"pagerduty": "u+scalar-not-a-dict", "datadog": {"api_key": "k"}})
+        self.store.write_text(doc, encoding="utf-8")
+        with self.assertRaises(json.JSONDecodeError):
+            self.backend.put("datadog", "api_key", "a" * 32)
+        self.assertEqual(self.store.read_text(encoding="utf-8"), doc)
+
+    def test_the_lookup_read_still_tolerates_corruption(self):
+        """The asymmetry is the point: failing a render would turn a
+        recoverable file into an unusable app. ``get`` answers "not configured"
+        and the fail-closed ``has_secrets`` check refuses the provider."""
         self.store.write_text("{ not json", encoding="utf-8")
-        self.backend.put("pagerduty", "api_token", "u+afterthecorruption")
-        self.assertEqual(self.backend.get("pagerduty", "api_token"), "u+afterthecorruption")
+        self.assertEqual(self.backend.get("pagerduty", "api_token"), "")
 
 
 class TestDescribeSecrets(unittest.TestCase):
@@ -750,9 +862,7 @@ class TestEveryRedactionSinkUsesTheSameSeam(unittest.TestCase):
         import importlib
         import inspect
 
-        mod = importlib.import_module(
-            f"kiro_crew.apps.builtins.ops_mission_control.backend.{name}"
-        )
+        mod = importlib.import_module(f"kiro_crew.apps.builtins.ops_mission_control.backend.{name}")
         return inspect.getsource(mod)
 
     def test_no_sink_imports_the_core_redactor_directly(self):

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
@@ -3301,12 +3301,13 @@ class TestTheIndexIsNeverPublishedOverAFailedRead(_HomeIsolated):
         """Inverted deliberately: this used to assert repair-on-write.
 
         The four merged siblings of this idiom (`library.py`, `shares.py`,
-        `secrets.py`, `policy_store.py`) still read an unparseable document as empty,
-        and their reasoning is real -- nothing parsed, so there is nothing to merge
-        into. But "cannot merge into" is not "safe to destroy": a truncated index
-        still holds most of its records verbatim, and the mutation would replace the
-        file and take them with it. Refusing costs one skipped mutation and a visible
-        error; the old behaviour cost the records, silently. Found in review (GPT 5.6).
+        `secrets.py`, `policy_store.py`) used to read an unparseable document as
+        empty (their reasoning was real -- nothing parsed, so there is nothing to
+        merge into), until #7805 gave them this same refusal. "Cannot merge into"
+        is not "safe to destroy": a truncated index still holds most of its records
+        verbatim, and the mutation would replace the file and take them with it.
+        Refusing costs one skipped mutation and a visible error; the old behaviour
+        cost the records, silently. Found in review (GPT 5.6).
 
         The fixture writes malformed JSON to the real index path, so the corruption
         is reached by the update reader itself rather than simulated -- and `claim`

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -810,13 +810,116 @@ class TestShares:
         shares.record_share(account=ACCOUNT, section="drive", key="first.txt", expires_secs=3600)
         assert [e["key"] for e in shares.list_shares(ACCOUNT)] == ["first.txt"]
 
-    def test_a_corrupt_share_store_still_repairs_on_write(self, tmp_path):
-        # Existing tolerance, pinned alongside the new guard.
+    def test_a_corrupt_share_store_refuses_the_mutation_and_is_left_intact(self, tmp_path):
+        # #7805: a corrupt ledger is refused, never rewritten. The old tolerance
+        # read it as empty and let the whole-file rewrite destroy records a
+        # truncated JSON still held verbatim -- and this ledger is the only local
+        # record of live presigned URLs, which are unrevokable bearer grants.
+        import json as _json
+
         from kiro_crew.apps.builtins.aws_control.backend import shares
 
-        (tmp_path / "shares.json").write_text("[not json", encoding="utf-8")
-        shares.record_share(account=ACCOUNT, section="drive", key="after.txt", expires_secs=3600)
-        assert [e["key"] for e in shares.list_shares(ACCOUNT)] == ["after.txt"]
+        corrupt = '[{"id": "recoverable-share", "key": "live.txt"}'  # truncated
+        (tmp_path / "shares.json").write_text(corrupt, encoding="utf-8")
+        with pytest.raises(_json.JSONDecodeError):
+            shares.record_share(
+                account=ACCOUNT, section="drive", key="after.txt", expires_secs=3600
+            )
+        with pytest.raises(_json.JSONDecodeError):
+            shares.forget_share("recoverable-share")
+        assert (tmp_path / "shares.json").read_text(
+            encoding="utf-8"
+        ) == corrupt, "a mutation rewrote a corrupt share ledger instead of refusing"
+        # The display read stays lenient: the Access section renders (empty)
+        # rather than failing on a file only a person can repair.
+        assert shares.list_shares(ACCOUNT) == []
+
+    def test_a_share_store_that_is_not_utf8_takes_the_corruption_path(self, tmp_path):
+        # UnicodeDecodeError is a ValueError but NOT a JSONDecodeError; unwrapped
+        # it would slip past every corruption clause at the callers.
+        import json as _json
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        (tmp_path / "shares.json").write_bytes(b"\xff\xfe not utf8")
+        with pytest.raises(_json.JSONDecodeError):
+            shares.record_share(account=ACCOUNT, section="drive", key="x.txt", expires_secs=3600)
+        assert (tmp_path / "shares.json").read_bytes() == b"\xff\xfe not utf8"
+        # And the DISPLAY read tolerates the same bytes (new with #7805:
+        # UnicodeDecodeError previously escaped it): the Access section renders
+        # empty rather than failing on a file only a person can repair.
+        assert shares.list_shares(ACCOUNT) == []
+
+    def test_a_share_store_that_parses_to_a_non_array_refuses_the_mutation(self, tmp_path):
+        # Valid JSON with the wrong root parses without raising, so coercing it
+        # to [] would let the rewrite destroy a document nobody could read.
+        import json as _json
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        (tmp_path / "shares.json").write_text('{"not": "a list"}', encoding="utf-8")
+        with pytest.raises(_json.JSONDecodeError):
+            shares.record_share(account=ACCOUNT, section="drive", key="x.txt", expires_secs=3600)
+        assert (tmp_path / "shares.json").read_text(encoding="utf-8") == '{"not": "a list"}'
+
+    def test_damaged_rows_refuse_the_mutation_instead_of_being_pruned_away(self, tmp_path):
+        # The loss arrives one call later than the parse: both mutations pipe
+        # the ledger through _prune, whose damage path silently DROPS any row
+        # it cannot read an expiresAt from, and the whole-file rewrite takes
+        # those rows with it. Measured in review (Opus): a valid-JSON ledger
+        # holding one non-object row, one row with no expiry, and one with a
+        # mangled expiry lost all three to a single record_share. Every damaged
+        # shape must refuse; the deliberate expiry drop stays retention.
+        import json as _json
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        for damaged in (
+            "a-damaged-row-that-is-not-an-object",
+            {"id": "no-expiry", "key": "secret-report.pdf", "account": "111"},
+            {"id": "bad-expiry", "key": "b.pdf", "expiresAt": "NOT-A-DATE"},
+        ):
+            doc = _json.dumps(
+                [damaged, {"id": "healthy", "key": "c.pdf", "expiresAt": "2999-01-01T00:00:00"}]
+            )
+            (tmp_path / "shares.json").write_text(doc, encoding="utf-8")
+            with pytest.raises(_json.JSONDecodeError):
+                shares.record_share(
+                    account=ACCOUNT, section="drive", key="new.txt", expires_secs=3600
+                )
+            with pytest.raises(_json.JSONDecodeError):
+                shares.forget_share("healthy")
+            assert (tmp_path / "shares.json").read_text(encoding="utf-8") == doc, damaged
+
+    def test_the_damaged_row_refusal_names_no_entry_content(self, tmp_path):
+        # The refusal names the row's index and nothing else: a share note or
+        # key from a hand-edited ledger must not ride on an exception that
+        # crosses into responses and logs.
+        import json as _json
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        (tmp_path / "shares.json").write_text(
+            _json.dumps([{"id": "x", "key": "leakable-object-key.pdf"}]), encoding="utf-8"
+        )
+        with pytest.raises(_json.JSONDecodeError) as excinfo:
+            shares.record_share(account=ACCOUNT, section="drive", key="n.txt", expires_secs=3600)
+        assert "leakable-object-key.pdf" not in str(excinfo.value)
+        assert "leakable-object-key.pdf" not in excinfo.value.doc
+
+    def test_an_expired_row_is_still_retention_not_damage(self, tmp_path):
+        # The keep/expire decision must survive the strict per-row check: a
+        # parseable stamp in the past is the deliberate drop, not a refusal.
+        import json as _json
+
+        from kiro_crew.apps.builtins.aws_control.backend import shares
+
+        (tmp_path / "shares.json").write_text(
+            _json.dumps([{"id": "dead", "key": "old.txt", "expiresAt": "2000-01-01T00:00:00"}]),
+            encoding="utf-8",
+        )
+        shares.record_share(account=ACCOUNT, section="drive", key="new.txt", expires_secs=3600)
+        assert [e["key"] for e in shares.list_shares(ACCOUNT)] == ["new.txt"]
 
     def test_expired_shares_are_pruned_and_forget_removes(self):
         from kiro_crew.apps.builtins.aws_control.backend import shares

--- a/test/test_aws_control_library.py
+++ b/test/test_aws_control_library.py
@@ -70,6 +70,15 @@ class TestReadLedger:
         path.write_text('["not", "a", "dict"]', encoding="utf-8")
         assert library.read_ledger() == {}
 
+    def test_a_non_utf8_ledger_reads_as_empty(self, tmp_path, monkeypatch):
+        # New with #7805: UnicodeDecodeError previously escaped the display
+        # read (it is a ValueError, not a JSONDecodeError). The lenient read
+        # must treat a corrupt byte stream as one condition regardless of
+        # which decoder noticed it.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_bytes(b"\xff\xfe not utf8")
+        assert library.read_ledger() == {}
+
     def test_valid_dict_round_trips(self, tmp_path, monkeypatch):
         path = _ledger_at(monkeypatch, tmp_path)
         path.write_text(json.dumps({ACCOUNT: {"s": {"version": 2}}}), encoding="utf-8")
@@ -457,13 +466,39 @@ class TestUpdateLedger:
         assert library._update_ledger(ACCOUNT, _adds_a_record) is True
         assert library.read_ledger()[ACCOUNT] == {"new": {"version": 1}}
 
-    def test_a_corrupt_ledger_still_repairs_on_write(self, tmp_path, monkeypatch):
-        # Existing tolerance, pinned so the unreadable-file guard is not mistaken
-        # for a licence to start failing on corruption too.
+    def test_a_corrupt_ledger_refuses_the_write_and_is_left_intact(self, tmp_path, monkeypatch):
+        # #7805: a corrupt ledger is refused, never rewritten. The old tolerance
+        # read it as empty and let the whole-file rewrite drop every other
+        # account's push state -- records a truncated JSON still held verbatim.
         path = _ledger_at(monkeypatch, tmp_path)
-        path.write_text("{not json", encoding="utf-8")
-        assert library._update_ledger(ACCOUNT, _adds_a_record) is True
-        assert library.read_ledger()[ACCOUNT] == {"new": {"version": 1}}
+        corrupt = '{"acct": {"slug": {"version": 1}}'  # truncated
+        path.write_text(corrupt, encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            library._update_ledger(ACCOUNT, _adds_a_record)
+        assert (
+            path.read_text(encoding="utf-8") == corrupt
+        ), "the writer rewrote a corrupt ledger instead of refusing"
+        # The display read stays lenient: the Library list renders on a ledger
+        # it could not load rather than failing the route.
+        assert library.read_ledger() == {}
+
+    def test_a_ledger_that_is_not_utf8_takes_the_corruption_path(self, tmp_path, monkeypatch):
+        # UnicodeDecodeError is a ValueError but NOT a JSONDecodeError; unwrapped
+        # it would slip past every corruption clause at the callers.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_bytes(b"\xff\xfe not utf8")
+        with pytest.raises(json.JSONDecodeError):
+            library._update_ledger(ACCOUNT, _adds_a_record)
+        assert path.read_bytes() == b"\xff\xfe not utf8"
+
+    def test_a_ledger_that_parses_to_a_non_object_refuses_the_write(self, tmp_path, monkeypatch):
+        # Valid JSON with the wrong root parses without raising, so coercing it
+        # to {} would let the rewrite destroy a document nobody could read.
+        path = _ledger_at(monkeypatch, tmp_path)
+        path.write_text('["not", "a", "dict"]', encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            library._update_ledger(ACCOUNT, _adds_a_record)
+        assert path.read_text(encoding="utf-8") == '["not", "a", "dict"]'
 
 
 # --------------------------------------------------------------------------

--- a/test/test_aws_control_routes.py
+++ b/test/test_aws_control_routes.py
@@ -1490,6 +1490,39 @@ class TestDriveShare:
             )
         assert resp.status == 502
 
+    def test_share_withholds_the_url_when_the_ledger_refuses_as_corrupt(self):
+        # #7805: the ledger reader refuses a corrupt document rather than
+        # replacing it. A mint that could not be RECORDED must not be handed
+        # out — the URL would be a live unrevokable bearer grant with no local
+        # record, the exact under-reporting the strict reader exists to prevent.
+        handlers = _registered()
+        p1, p2, p3 = _enabled_owner_env()
+        req = _request("POST", f"/drive/{ACCOUNT}/share", match_info={"account": ACCOUNT})
+        req.json = AsyncMock(return_value={"section": "drive", "key": "a.txt"})  # type: ignore[method-assign]
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(routes_mod, "publish_denied_reason", return_value=""),
+            mock.patch.object(routes_mod.storage_mod, "object_exists", return_value=True),
+            mock.patch.object(routes_mod.storage_mod, "presign", return_value="https://signed"),
+            mock.patch.object(
+                routes_mod.shares_mod,
+                "record_share",
+                side_effect=json.JSONDecodeError("Expecting value", "[ not json", 2),
+            ),
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/share")](req)  # type: ignore[operator]
+            )
+        assert resp.status == 500
+        body = _payload(resp)
+        assert body["code"] == "share_ledger_corrupt"
+        assert "https://signed" not in json.dumps(body)
+        assert "[ not json" not in json.dumps(body)
+
 
 # ---------------------------------------------------------------------------
 # Shares list + forget
@@ -1764,6 +1797,27 @@ class TestSharesListForget:
             )
         assert resp.status == 404
         assert _payload(resp)["code"] == "unknown_share"
+
+    def test_forget_reports_a_corrupt_ledger_instead_of_claiming_unknown(self):
+        # #7805: on the old lenient read a corrupt ledger made every share read
+        # as absent, so forget answered 404 "unknown share" while the record sat
+        # readable in the corrupt bytes — and the rewrite then destroyed it.
+        handlers = _registered()
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(
+                routes_mod.shares_mod,
+                "forget_share",
+                side_effect=json.JSONDecodeError("Expecting value", "[ not json", 2),
+            ),
+        ):
+            req = _request("POST", "/shares/sh-1/forget", match_info={"id": "sh-1"})
+            req.json = AsyncMock(return_value={})  # type: ignore[method-assign]
+            resp = asyncio.run(
+                handlers[("POST", "/shares/{id}/forget")](req)  # type: ignore[operator]
+            )
+        assert resp.status == 500
+        assert _payload(resp)["code"] == "share_ledger_corrupt"
 
 
 # ---------------------------------------------------------------------------
@@ -2201,6 +2255,40 @@ class TestLibrary:
         # Reported, not swallowed: the payload must not claim a reconcile happened.
         assert body["reconciled"] is False and body["remoteError"]
 
+    def test_library_list_survives_a_corrupt_ledger(self):
+        # #7805: the strict update reader refuses a corrupt ledger with
+        # JSONDecodeError. The list route is best-effort by contract and its
+        # rows come from the LENIENT display read, so the render must survive
+        # and the degradation must be reported — with a reason that says
+        # "repair", not "retry".
+        handlers = _registered()
+        rows = [{"slug": "x", "name": "X"}]
+        p1, p2, p3 = _enabled_owner_env()
+        with (
+            p1,
+            p2,
+            p3,
+            _consent_ok(),
+            _drive_found(),
+            mock.patch.object(routes_mod.storage_mod, "list_library_folders", return_value=["x"]),
+            mock.patch.object(routes_mod.library_mod, "list_pushable", return_value=rows),
+            mock.patch.object(
+                routes_mod.library_mod,
+                "reconcile",
+                side_effect=json.JSONDecodeError("Expecting value", "{ not json", 2),
+            ),
+        ):
+            resp = asyncio.run(
+                handlers[("GET", "/library/{account}")](  # type: ignore[operator]
+                    _request("GET", f"/library/{ACCOUNT}", match_info={"account": ACCOUNT})
+                )
+            )
+        body = _payload(resp)
+        assert resp.status == 200
+        assert body["artifacts"] == rows
+        assert body["reconciled"] is False
+        assert "corrupt" in body["remoteError"]
+
     def test_library_list_audits_an_identity_denial_it_degrades_past(self):
         # _guarded's own rule: a permission DECISION reaches SEL. This route
         # degrades instead of failing, so without an explicit audit the decision
@@ -2373,6 +2461,16 @@ class TestLibrary:
         assert resp.status == 400
         assert _payload(resp)["code"] == "not_pushable"
 
+    def test_push_reports_a_corrupt_ledger_not_a_client_error(self):
+        # #7805, the trap the issue names: JSONDecodeError subclasses ValueError,
+        # so without its own arm the ledger's corruption refusal would be
+        # reported as 400 not_pushable — blaming the artifact for a store the
+        # operator has to repair, on a push whose upload may already be in the
+        # bucket.
+        resp = self._push(side_effect=json.JSONDecodeError("Expecting value", "{ not json", 2))
+        assert resp.status == 500
+        assert _payload(resp)["code"] == "library_ledger_corrupt"
+
     def test_push_surfaces_an_aws_error(self):
         resp = self._push(side_effect=AWSError("put denied"))
         assert resp.status == 502
@@ -2454,6 +2552,16 @@ class TestLibrary:
         resp, _removed = self._remove(side_effect=ValueError("'x/y' is not an artifact slug"))
         assert resp.status == 400
         assert _payload(resp)["code"] == "invalid_slug"
+
+    def test_remove_reports_a_corrupt_ledger_not_an_invalid_slug(self):
+        # #7805: JSONDecodeError subclasses ValueError, so without its own arm
+        # the ledger's corruption refusal reads as 400 invalid_slug — blaming
+        # the request for a store the operator has to repair.
+        resp, _removed = self._remove(
+            side_effect=json.JSONDecodeError("Expecting value", "{ not json", 2)
+        )
+        assert resp.status == 500
+        assert _payload(resp)["code"] == "library_ledger_corrupt"
 
     def test_remove_surfaces_an_aws_error(self):
         # A failed delete must NOT report success: the objects are still there,


### PR DESCRIPTION
<!-- no-visual-delta --> Backend-only: four JSON store readers and their route handlers; no UI surface changes, so no screenshots.

## Summary

Closes #7805.

The four merged `*_for_update` read-modify-write readers — `shares._load_for_update`, `library._read_ledger_for_update`, `KeystoneFileBackend._read_for_update` (the provider credential store), and `policy_store._read_for_update` (the keystone policy file) — caught `json.JSONDecodeError` alongside `FileNotFoundError` and returned an empty container, so a corrupt or truncated file was silently read as empty and then rewritten whole, destroying bytes a person could still have recovered by hand. This mirrors the #7794 decision for the incident index and app config: only a MISSING file reads as empty; corruption refuses.

Per reader:
- All four propagate parse failures, wrap non-UTF-8 byte streams (`UnicodeDecodeError` is a `ValueError` but NOT a `JSONDecodeError`, so unwrapped it slips past every corruption clause), and refuse valid JSON whose root has the wrong type (which parses without raising, so normalizing destroys a document nobody could read).
- `secrets.py` additionally refuses any entry the coercion would lose (deserialize → re-serialize → refuse if anything on disk did not survive), and its refusals carry NO document content: fixed messages, empty `doc`, and a fully severed exception chain (`__cause__`/`__context__` both `None`), because here the raw file text IS the credential store. The parser's real line/column are folded into the message text.
- `shares.py` also checks per ROW that `expiresAt` is readable, because both mutations pipe the reader's return through `_prune`, whose damage path silently drops rows it cannot read a stamp from — the same coercion loss, one call later. The deliberate expiry drop (parseable stamp in the past) remains retention.
- The ops-mission-control pair raises the named `CorruptDocumentError`; the aws_control pair raises plain `json.JSONDecodeError` (the named type lives in another app; apps do not import each other).

Every caller of the four mutation paths was audited for the `JSONDecodeError`-under-`ValueError` trap the issue names:
- aws_control push and remove routes gained a corruption arm AHEAD of their tolerant `except ValueError` arms (without it, corruption reads as `not_pushable` / `invalid_slug` — a 400 blaming the client for a store that needs repair).
- The share mint route withholds a minted-but-unrecorded presigned URL (returning it would create a live unrevokable bearer grant with no local record); mint/forget answer a coded 500 `share_ledger_corrupt` via a shared helper.
- The reconcile caller degrades to `reconciled: false` with a repair-worded `remoteError` and keeps rendering (rows come from the lenient display read).
- ops-mission-control secret save/revocation answer the shared `_store_read_refusal` mapper's coded 500 `secret_store_corrupt`; the policy-store writes were already wired through `_settings_write_or_refuse`'s corruption arm.

Display/lookup reads stay lenient — that asymmetry is the point — and LOG when they degrade for any reason other than an absent file, mirroring #7794's display reads. Per-call logging with no dedup matches the merged precedent (`store._read_index_unlocked`). All four also now tolerate `UnicodeDecodeError` (previously it escaped them) — safe because every value read leniently now has a restrictive default. The one exception, `primary_instance` (defaults True, so a degraded read GRANTS ledger-prune authority — the corrupt file becoming the key that unlocks destroying shared knowledge), no longer reads through the lenient path at all: `rotation.is_primary` now uses the new strict `policy_store.read_authority`, which reuses the update reader's corruption doors and answers False when the file cannot be read. Two GPT lane rounds drove this: round 1 flagged the widened door, round 2 correctly rejected scoping the pre-existing doors out as out-of-scope.

Deliberately untouched, same as the issue scopes it: `_update_ledger`'s per-ACCOUNT scalar reset (replaces one account's unusable entry while carrying every other row forward; the sidecar-preserve alternative is tracked in #7789). Two further lenient-read-feeding-rewrite siblings named by the First Principles lane are tracked: `backup.py` as item 1 of #7789, `mochi/pinned_files_service.py` as #8088. The stale "siblings need a follow-up" rationale in `store.py` and `test_store_and_gate.py` is updated to record that #7805 landed it.

## Review

Two pre-push blind review lanes (GPT 5.6, Opus). Both blocking findings fixed at root:
- GPT: the strict-coercion refusal interpolated the untrusted provider key (counterexample `{"<token>": "scalar"}`) and `raise ... from exc` kept the full credential document reachable via `__cause__.doc`. Fixed: position-only message; chain severed by raising outside the handler; adversarial token-shaped-key test asserts the whole chain.
- Opus: a damaged-but-parseable share ledger was still rewritten (`_prune` drops rows on `KeyError/ValueError/TypeError`), while the reader's docstring claimed the case could not happen. Fixed: strict per-row check; docstring corrected; regression test reproduces the reviewer's measured 3-row loss.

Accepted advisories: stale #7794 docstrings updated; `nosemgrep` annotation on the new fixed-literal warning (sibling precedent in-file); `CorruptDocumentError` pinned in policy tests; display-read `UnicodeDecodeError` tolerance now tested per module. Not changed: per-call degradation logging (matches merged #7794 precedent); the route test's `assertNotIn(token, …)` belt assertion stays alongside the discriminating doc-bytes assertion.

## Tests

- 1279 passed / 44 skipped across `test/test_aws_control_app.py`, `test/test_aws_control_routes.py`, `test/test_aws_control_library.py`, and the full `ops_mission_control` suite.
- New regression tests per reader: corrupt file refuses AND is left byte-for-byte intact; absent file is still a first write; non-UTF-8 takes the corruption path; valid-JSON-wrong-root refuses; secrets coercion-lossy entry refuses; shares damaged-row shapes (non-object row, missing stamp, mangled stamp) refuse while expired rows stay retention; no document bytes on any refusal (message, `doc`, or exception chain, token-shaped-key adversarial case).
- Route-level: corrupt secret store answers coded 500 on save and revocation; push answers `library_ledger_corrupt` not `not_pushable`; remove answers it not `invalid_slug`; share mint withholds the URL; library list survives a corrupt ledger and reports repair.
- Mutation-verified both directions: 10 distinct mutations (lenient-read restore ×4, root-check drop, strict-coercion drop, doc-leak restore ×2, per-row-check drop, route-arm removal ×3) each caught by a different named test.
- Local gates: black-baseline (2 graduated entries pruned), isort, flake8 7.1.0, mypy 1.14.1, subprocess-encoding, brand, harness parity, sync-io-in-async, lockdown-before-publish — all green.

## Pattern harvest

Rule candidate: a `*_for_update` reader's strictness must cover every transform between the read and the write (root type, row shape, coercion round-trip), not just the parse — a lenient normalizer downstream of a strict reader reintroduces the same silent loss one call later.
Rule candidate: an exception raised from a credential store must carry no document content anywhere reachable — message, `doc`, `__cause__`, or `__context__`; raise outside the `except` block to sever the chain.
Class: lenient-read-feeding-whole-file-rewrite (#7620, #7788, #7794, #7805; remainder tracked in #7789).
<!-- readiness-refresh 8d47e7f4d -->
<!-- readiness-refresh 326349603 -->
<!-- readiness-refresh 9b250159c -->
