### PR TITLE
fix: forward --no-suppress-first-run through the pod-e2e harness

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
+++ b/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--fe-only] [--video]
+# pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--fe-only] [--video] [--no-suppress-first-run]
 #
 # Run the full e2e flow for ONE worktree against an ISOLATED pod instance,
 # never touching the live gateway:
@@ -21,6 +21,7 @@ set -uo pipefail
 
 # ---------------------------------------------------------------- args ----
 NAME="" ; KEEP=0 ; NO_STOP=0 ; RUN_API=1 ; RUN_FE=1 ; VIDEO=0
+NO_SUPPRESS_FIRST_RUN=0
 for a in "$@"; do
   case "$a" in
     --keep)     KEEP=1 ;;
@@ -28,11 +29,14 @@ for a in "$@"; do
     --api-only) RUN_FE=0 ;;
     --fe-only)  RUN_API=0 ;;
     --video)    VIDEO=1 ;;
+    # Documented in SKILL.md and accepted by pod-playwright.py; without this
+    # arm the catch-all below rejects the documented spelling with exit 64.
+    --no-suppress-first-run) NO_SUPPRESS_FIRST_RUN=1 ;;
     -*)         echo "unknown flag: $a" >&2; exit 64 ;;
     *)          NAME="$a" ;;
   esac
 done
-[ -n "$NAME" ] || { echo "usage: pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--fe-only] [--video]" >&2; exit 64; }
+[ -n "$NAME" ] || { echo "usage: pod-e2e.sh <worktree-name> [--keep] [--no-stop] [--api-only] [--fe-only] [--video] [--no-suppress-first-run]" >&2; exit 64; }
 # Pod names are [a-zA-Z0-9._-] without leading dots — reject anything that
 # could traverse paths (slashes, '..') before NAME is used in any path.
 case "$NAME" in
@@ -405,6 +409,7 @@ if [ "$RUN_FE" -eq 1 ] && [ "$HEALTHY" -eq 1 ]; then
     PW_ARGS=("$PW_RUNNER" --base-url "$BASE_URL" --artifact-dir "$ARTIFACT_DIR" --checkout "$CHECKOUT")
     PW_ARGS+=(--teardown-timeout "${POD_E2E_TEARDOWN_TIMEOUT:-30}")
     [ "$VIDEO" -eq 1 ] && PW_ARGS+=(--video)
+    [ "$NO_SUPPRESS_FIRST_RUN" -eq 1 ] && PW_ARGS+=(--no-suppress-first-run)
     # Declarative manifest parse: extract ONLY the PLAYWRIGHT_SPEC value.
     # The manifest is branch-controlled — never source/eval it on the host.
     PLAYWRIGHT_SPEC=""

--- a/test/test_pod_e2e_harness_paths.py
+++ b/test/test_pod_e2e_harness_paths.py
@@ -187,6 +187,83 @@ def test_realpath_dir_collapses_dotdot_in_a_missing_tail(symlinked_home):
 
 
 # --------------------------------------------------------------------------
+# args: a documented flag must be accepted AND reach the driver
+#
+# SKILL.md tells the operator to "pass --no-suppress-first-run" when testing the
+# onboarding flow itself, and pod-playwright.py accepts it — but the runner's
+# arg loop hit its `-*)` catch-all and exited 64, so the documented spelling
+# aborted the run before a single phase. Accepting it without appending it to
+# PW_ARGS would be just as broken (a silent no-op), so both halves are driven
+# out of the shipped script here.
+# --------------------------------------------------------------------------
+
+ARGS = _fragment('NAME="" ; KEEP=0', "\ndone")
+PW_BUILD = _fragment('PW_ARGS=("$PW_RUNNER"', 'PW_CMD=("$PW_PY" -u "${PW_ARGS[@]}")')
+
+
+def _driver_argv(tmp_path: Path, *argv: str) -> subprocess.CompletedProcess:
+    """Parse *argv* with the real loop, then build the real driver command.
+
+    Coupling the two fragments is the point: a flag the parser accepts but the
+    builder drops is the defect, and only the end-to-end argv shows it.
+    """
+    snippet = "\n".join(
+        [
+            "set -uo pipefail",
+            ARGS,
+            # Minimum context the construction block reads. MANIFEST is empty so
+            # the --spec branch stays out of the way.
+            "PW_RUNNER=/drv/pod-playwright.py ; PW_PY=/usr/bin/python3",
+            "BASE_URL=http://127.0.0.1:7811 ; ARTIFACT_DIR=/art ; CHECKOUT=/wt",
+            'MANIFEST=""',
+            PW_BUILD,
+            'printf "%s\\n" "${PW_CMD[@]}"',
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", snippet, "pod-e2e.sh", *argv],
+        cwd=tmp_path,
+        env={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        encoding="utf-8",
+    )
+
+
+def test_no_suppress_first_run_is_accepted_and_forwarded(tmp_path):
+    """The regression: the documented flag exited 64 instead of reaching the driver."""
+    res = _driver_argv(tmp_path, "smoke", "--no-suppress-first-run")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "unknown flag" not in res.stderr, res.stderr
+    argv = res.stdout.split()
+    assert "--no-suppress-first-run" in argv, f"never forwarded to the driver: {argv}"
+    # It must not be mistaken for the worktree NAME by the loop's `*)` arm.
+    assert "NAME=--no-suppress-first-run" not in res.stdout
+
+
+def test_first_run_suppression_stays_the_default(tmp_path):
+    """Absent the flag, nothing is appended — suppression is the documented default."""
+    res = _driver_argv(tmp_path, "smoke")
+    assert res.returncode == 0, res.stdout + res.stderr
+    assert "--no-suppress-first-run" not in res.stdout, res.stdout
+
+
+def test_unknown_flags_are_still_rejected(tmp_path):
+    """The catch-all must survive: a typo may not be silently swallowed."""
+    res = _driver_argv(tmp_path, "smoke", "--no-supress-first-run")
+    assert res.returncode == 64, res.stdout + res.stderr
+    assert "unknown flag" in res.stderr, res.stderr
+
+
+def test_usage_text_lists_the_flag():
+    """A flag the parser takes but the usage line hides is undiscoverable."""
+    lines = SCRIPT.read_text(encoding="utf-8").splitlines()
+    header = next(ln for ln in lines if ln.startswith("# pod-e2e.sh <worktree-name>"))
+    usage = next(ln for ln in lines if ln.lstrip().startswith('[ -n "$NAME" ]'))
+    for where, text in (("header", header), ("usage message", usage)):
+        assert "--no-suppress-first-run" in text, f"{where} omits the flag: {text}"
+
+
+# --------------------------------------------------------------------------
 # resolver: must mirror pod/runtime.py resolve_checkout() exactly
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
# Forward --no-suppress-first-run through the pod-e2e harness

`SKILL.md` tells the operator to pass `--no-suppress-first-run` when the onboarding flow itself is under test, and `pod-playwright.py` accepts and honors the flag — but the `pod-e2e.sh` wrapper's argument loop hit its `-*)` catch-all and exited 64, so the documented spelling aborted the run before a single phase. This is the one correctness fix approved for the verification-controller plan (slice 4).

## The fix

`src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh` (+7/−2):

- the arg loop accepts `--no-suppress-first-run`;
- the Playwright driver invocation appends it to `PW_ARGS` when set — accepting without forwarding would be an equally broken silent no-op;
- the header and usage line now list the flag so it is discoverable.

Suppression remains the default; nothing is appended when the flag is absent.

## Red-first proof

`test_no_suppress_first_run_is_accepted_and_forwarded` runs the script's real parse loop and real driver-command construction end-to-end. Before the fix: `unknown flag: --no-suppress-first-run`, exit 64 (`assert 64 == 0`). After: exit 0 with the flag present in the driver argv and not mistaken for the worktree name.

Three guard tests pin the surrounding contract: suppression stays the default without the flag, a typo (`--no-supress-first-run`) is still rejected with exit 64, and the header/usage text must list the flag.

## Verification

- Focused pytest on `test/test_pod_e2e_harness_paths.py`: 28 passed.
- Black ratchet, subprocess-encoding gate, isort, flake8, mypy (1,269 files): all passed.
- Full `bash -n` syntax check of the script: passed.
- Presence check against current `origin/main` confirmed no part of the fix had already shipped.

No `SKILL.md` change: it already documents the intended behavior; the code now matches it. Independent of the open seeding PR #7841.

## Pattern harvest

Defect class: a wrapper script's hand-rolled arg loop drifts from the interface it wraps — the flag is documented in `SKILL.md` and accepted by `pod-playwright.py`, but `pod-e2e.sh`'s catch-all rejects it, so the documented spelling fails before any phase runs.

Rule candidate: test. The added tests retire the class for this harness: the coupled parse-loop→driver-argv fragment test proves acceptance AND forwarding end-to-end (accepting without forwarding would be a silent no-op), and `test_usage_text_lists_the_flag` fails when a parsed flag is missing from the header/usage text. If a second wrapper/driver flag-parity defect appears in this repo, the follow-up is a sweep test cross-checking `pod-e2e.sh`'s accepted flags against `pod-playwright.py`'s argparse surface; one occurrence does not yet justify that machinery.
