### PR TITLE
fix(sandbox): a zombie proves no mount pin, it is not a coverage gap

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -4186,13 +4186,31 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
       window escapes the re-listing; that needs the full pid space to wrap
       within the scan's milliseconds, and the residual error is
       retention-side only on the next sweep.)
-    - A read failure is forgiven ONLY when the pid provably belongs to a
-      DIFFERENT real user (its ``/proc/<pid>`` stats to a uid that is not
-      ours, not root, and not the host's overflow uid) — such a process
-      cannot be binding a source this uid staged, because the sandboxed child
-      keeps this uid and NO_NEW_PRIVS. Root can enter any namespace, and a
-      holder in a foreign user namespace stats as the overflow uid, so those
-      count as coverage gaps.
+    - A read failure is forgiven in two cases and counts as a coverage gap
+      otherwise. ``EINVAL`` says that TASK has no ``nsproxy``, which is not yet
+      a statement about the NAMESPACE: a thread-group leader can exit through
+      ``pthread_exit`` while sibling threads keep running, and threads share the
+      nsproxy, so a live namespace can sit behind a zombie leader while
+      ``proc_root`` — which lists only leaders — shows nothing else to scan. So
+      the group is consulted through ``/proc/<pid>/task/<tid>/mountinfo``, with
+      exactly two outcomes per sibling and no third: one that READS contributes
+      pins and nothing else, and one that does not read, for ANY reason,
+      makes coverage unprovable. Departed siblings are counted rather than
+      excused, because one exiting between the listing and its read may have
+      spawned a successor THREAD first, and a thread is invisible to the outer
+      re-listing (which enumerates thread-group leaders only), so no re-listing
+      can recover it. Tasks in one group can also hold DIFFERENT mount
+      namespaces, since a thread may ``unshare(CLONE_NEWNS)``, so a readable
+      sibling never speaks for an unreadable one. When every sibling reads, the
+      leader's own departure still makes this a vanish, because a departing task
+      may have handed its namespace to a PROCESS forked after this pass's
+      listing and only a re-listing can see that. Any OTHER errno on the leader
+      is forgiven only when the pid provably belongs to a DIFFERENT real user
+      (its ``/proc/<pid>`` stats to a uid that is not ours, not root, and not
+      the host's overflow uid) — such a process cannot be binding a source this
+      uid staged, because the sandboxed child keeps this uid and NO_NEW_PRIVS.
+      Root can enter any namespace, and a holder in a foreign user namespace
+      stats as the overflow uid, so those count as coverage gaps.
 
     A namespace held only by an nsfs fd or a bind-mounted ``ns/mnt`` — zero
     member processes — has no mountinfo to scan and is out of scope; the
@@ -4207,6 +4225,22 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
     own_uid = getuid() if getuid is not None else None
     overflow_uid = _overflow_uid()
 
+    def _collect(mountinfo_path: str) -> None:
+        """Add every prefix-shaped bind SOURCE named in one mountinfo to ``pinned``.
+
+        Propagates ``OSError`` exactly as ``open`` would, so each caller decides
+        what an unreadable task means for coverage.
+        """
+        with open(mountinfo_path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if _MOUNT_SOURCE_PREFIX not in line:
+                    continue
+                fields = line.split()
+                if len(fields) > 3:
+                    source = os.path.basename(fields[3])
+                    if source.startswith(_MOUNT_SOURCE_PREFIX):
+                        pinned.add(source)
+
     for _ in range(_PIN_SCAN_MAX_PASSES):
         try:
             listed = [n for n in os.listdir(proc_root) if n.isdecimal()]
@@ -4219,24 +4253,77 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
         for name in new_pids:
             seen.add(name)
             try:
-                with open(
-                    os.path.join(proc_root, name, "mountinfo"),
-                    encoding="utf-8",
-                    errors="replace",
-                ) as fh:
-                    for line in fh:
-                        if _MOUNT_SOURCE_PREFIX not in line:
-                            continue
-                        fields = line.split()
-                        if len(fields) > 3:
-                            source = os.path.basename(fields[3])
-                            if source.startswith(_MOUNT_SOURCE_PREFIX):
-                                pinned.add(source)
+                _collect(os.path.join(proc_root, name, "mountinfo"))
             except (FileNotFoundError, ProcessLookupError):
                 # May have handed its namespace to a child forked before the
                 # exit — visible to the next listing, so take another pass.
                 vanished = True
-            except OSError:
+            except OSError as exc:
+                if exc.errno == errno.EINVAL:
+                    # EINVAL says THIS TASK's nsproxy is gone, so this task is a
+                    # member of no mount namespace. That is NOT yet a statement
+                    # about the namespace: a thread-group leader can exit through
+                    # ``pthread_exit`` while sibling THREADS keep running, and
+                    # threads share the nsproxy, so the namespace — and its binds
+                    # on our sources — can still be alive behind a zombie leader.
+                    # ``proc_root`` lists only thread-group LEADERS, so the
+                    # re-listing below can never see those threads. Measured on a
+                    # real zombie leader: ``/proc/<tgid>/mountinfo`` is EINVAL
+                    # while ``/proc/<tgid>/task/<live-tid>/mountinfo`` reads fine.
+                    # So ask the group before concluding anything; one readable
+                    # thread yields the WHOLE namespace's mount table, because
+                    # every thread in the group shares it.
+                    task_dir = os.path.join(proc_root, name, "task")
+                    try:
+                        tids = os.listdir(task_dir)
+                    except FileNotFoundError:
+                        tids = []  # the group is gone entirely
+                    except OSError:
+                        complete = False  # cannot ask — coverage unprovable
+                        continue
+                    unaccounted = 0
+                    for tid in tids:
+                        if tid == name:
+                            continue  # the leader: it already answered EINVAL
+                        try:
+                            _collect(os.path.join(task_dir, tid, "mountinfo"))
+                        except OSError:
+                            unaccounted += 1
+                    # INVARIANT, and there is deliberately no third case: a sibling
+                    # that READS contributes pins and nothing else, and a sibling
+                    # that does not read, for ANY reason, makes coverage unprovable.
+                    #
+                    # Departed siblings are counted too, rather than excused. One
+                    # that exits between the ``tids`` snapshot and its read may have
+                    # spawned a successor THREAD first, and a successor thread is
+                    # invisible to the outer re-listing, which enumerates
+                    # thread-group LEADERS only — so no re-listing can recover it
+                    # and only fail-closed is honest. The cost is transient, never a
+                    # stall: a sibling caught mid-exit is a race, so the next sweep
+                    # sees a settled group, whereas the zombie LEADER this branch
+                    # exists for is a steady state and stays reclaimable.
+                    #
+                    # Tasks in one group can also hold DIFFERENT mount namespaces (a
+                    # thread may ``unshare(CLONE_NEWNS)``, and the launcher's own
+                    # user namespace grants its descendants the CAP_SYS_ADMIN that
+                    # needs), so a readable sibling never speaks for an unreadable
+                    # one.
+                    if unaccounted:
+                        complete = False
+                        continue
+                    # Otherwise this is a VANISH, unconditionally. Reaching this
+                    # branch at all means the LEADER departed, and a departing task
+                    # may have handed its namespace to a process forked after this
+                    # pass's listing, which only a re-listing can see — so a
+                    # sibling that could be read must not be able to cancel it:
+                    # the pins it yields are kept, its success is not evidence.
+                    #
+                    # This terminates: the pid enters ``seen`` above and is never
+                    # re-read, so a stable zombie costs exactly one extra pass,
+                    # while genuine churn exhausts ``_PIN_SCAN_MAX_PASSES`` and
+                    # returns complete=False, which retains rather than removes.
+                    vanished = True
+                    continue
                 try:
                     st_uid: int | None = os.stat(os.path.join(proc_root, name)).st_uid
                 except OSError:
@@ -4374,15 +4461,18 @@ def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) 
         # An always-closed pin scan is otherwise indistinguishable from a
         # working one while the dominant (directory) leak class re-accumulates
         # — surface it so an operator can tell retention from reclamation.
-        pinned_note = (
-            "pinned by a live mount namespace"
-            if pin_scan is not None and pin_scan[1]
-            else "pin scan incomplete"
-        )
-        logger.info(
+        scan_complete = pin_scan is not None and pin_scan[1]
+        # WARNING for the incomplete case, INFO for the benign pinned one.
+        # Holding entries back because a live namespace binds them is normal
+        # operation; holding them back because coverage is unprovable is a
+        # FAULT that stops directory reclamation host-wide until the runtime
+        # tmpfs is out of inodes. At INFO it also does not reach a default
+        # deployment's log at all, which is how the leak this guards against
+        # ran unobserved while this very line fired on every sweep.
+        (logger.info if scan_complete else logger.warning)(
             "sandbox mount-source sweep: %d dir candidate(s) held back (%s)",
             dirs_held_back,
-            pinned_note,
+            ("pinned by a live mount namespace" if scan_complete else "pin scan incomplete"),
         )
     return removed
 

--- a/test/test_sandbox_mount_source_sweep.py
+++ b/test/test_sandbox_mount_source_sweep.py
@@ -29,8 +29,13 @@ Two halves lock the fix in:
 from __future__ import annotations
 
 import ast
+import builtins
+import errno
+import logging
 import os
 import shutil
+import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -81,6 +86,26 @@ def _pin(monkeypatch: pytest.MonkeyPatch, names: set[str], *, complete: bool = T
         "kiro_crew.sandbox._mount_pinned_source_names",
         lambda proc_root="/proc": (names, complete),
     )
+
+
+def _raise_einval_for(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
+    """Fail ``open()`` on ONE path the way procfs fails for a namespaceless task.
+
+    ``/proc/<pid>/mountinfo`` is synthesized per read from the task's
+    ``nsproxy``; once that is gone (the task has exited and awaits reap) the
+    open returns ``EINVAL``. No real file can be made to do that, and a real
+    zombie's pid cannot be planted under ``tmp_path``, so the errno is injected
+    for the one target path and every other open is delegated untouched.
+    """
+    real_open = builtins.open
+    target_str = str(target)
+
+    def fake_open(file, *args, **kwargs):  # noqa: ANN001, ANN202
+        if str(file) == target_str:
+            raise OSError(errno.EINVAL, os.strerror(errno.EINVAL), target_str)
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
 
 
 class TestMountSourceSweep:
@@ -446,6 +471,350 @@ class TestMountPinnedSourceNames:
         assert pinned == set()
         assert complete is False
 
+    def test_namespaceless_task_is_not_a_coverage_gap(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """``EINVAL`` establishes absence-of-pin; it must not read as a gap.
+
+        procfs answers ``EINVAL`` for one reason here — the task's ``nsproxy``
+        is already gone, i.e. it has exited and awaits reap — so it belongs to
+        NO mount namespace and can reference no source. That is the strongest
+        evidence this scan can obtain, yet it was filed as "coverage
+        unprovable", which holds back EVERY directory candidate. One unreaped
+        child (routine on any host) therefore disabled directory reclamation
+        permanently and host-wide, until the runtime tmpfs was out of inodes
+        and ``systemd-run --scope`` could no longer start a spawn.
+        """
+        proc = tmp_path / "proc"
+        self._write_mountinfo(
+            proc,
+            "301",
+            "36 35 0:22 /kirocrew_sb_5_aa /home/u/.aws rw - tmpfs tmpfs rw\n",
+        )
+        zombie = proc / "302"
+        zombie.mkdir()
+        (zombie / "mountinfo").write_text("")  # present, but the READ raises
+        _raise_einval_for(monkeypatch, zombie / "mountinfo")
+
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+
+        assert pinned == {"kirocrew_sb_5_aa"}
+        assert complete is True
+
+    def test_namespaceless_task_still_forces_a_rescan_for_its_successor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Forgiving ``EINVAL`` must not also skip the re-listing.
+
+        The task has EXITED, so it may have handed its namespace to a child
+        forked after this pass's listing, and only another listing can see
+        that successor. Forgiving without a rescan would report complete while
+        the successor's pin went unrecorded — and the sweep would then rmdir a
+        source a live namespace still binds, leaving that mount's root inode
+        ``S_DEAD`` and every create under the masked path failing.
+        """
+        proc = tmp_path / "proc"
+        proc.mkdir()
+        (proc / "1").mkdir()
+        (proc / "1" / "mountinfo").write_text("")
+        gone = proc / "401"
+        gone.mkdir()
+        (gone / "mountinfo").write_text("")
+        _raise_einval_for(monkeypatch, gone / "mountinfo")
+        successor = proc / "402"
+        successor.mkdir()
+        (successor / "mountinfo").write_text(
+            "36 35 0:22 /kirocrew_sb_11_bb /home/u/.ssh rw - tmpfs tmpfs rw\n"
+        )
+        real_listdir = os.listdir
+        calls = {"n": 0}
+
+        def listing(path):  # noqa: ANN001
+            if str(path) == str(proc):
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return ["1", "401"]  # the successor is not yet visible
+                return ["1", "401", "402"]
+            return real_listdir(path)
+
+        monkeypatch.setattr(os, "listdir", listing)
+
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+
+        assert calls["n"] >= 2, "a namespaceless task must trigger another listing pass"
+        assert pinned == {"kirocrew_sb_11_bb"}
+        assert complete is True
+
+    @pytest.mark.skipif(
+        not os.path.isdir("/proc/self") or not os.path.exists("/bin/true"),
+        reason="needs a real Linux procfs and a trivial child to leave unreaped",
+    )
+    def test_kernel_answers_einval_for_a_real_zombie(self):
+        """Pin the KERNEL premise the forgiveness rests on.
+
+        The fix reads one errno as proof of "no mount namespace". If a future
+        kernel answers something else for a task past ``exit_task_namespaces``,
+        that proof silently becomes a coverage gap again and directory
+        reclamation dies exactly as before, with no test failing. So assert the
+        behaviour directly, on a zombie this test creates: an exited child that
+        is deliberately not reaped until the assertions are done.
+        """
+        child = subprocess.Popen(["/bin/true"])  # noqa: S603 - fixed argv, no shell
+        try:
+            deadline = time.time() + 5.0
+            state = ""
+            while time.time() < deadline:
+                try:
+                    with open(f"/proc/{child.pid}/stat") as fh:
+                        state = fh.read().rsplit(") ", 1)[1][0]
+                except OSError:  # pragma: no cover - raced the reap
+                    break
+                if state == "Z":
+                    break
+                time.sleep(0.01)
+            if state != "Z":  # pragma: no cover - scheduler-dependent
+                pytest.skip("child did not reach the zombie state in time")
+
+            with pytest.raises(OSError) as caught:
+                with open(f"/proc/{child.pid}/mountinfo"):
+                    pass
+            assert caught.value.errno == errno.EINVAL
+            assert not isinstance(caught.value, FileNotFoundError)
+        finally:
+            child.wait()
+
+    def test_zombie_leader_with_a_live_thread_is_pinned_not_forgiven(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A live namespace can sit behind a zombie LEADER, and must still pin.
+
+        A thread-group leader can exit through ``pthread_exit`` while sibling
+        threads keep running. Threads share the ``nsproxy``, so the mount
+        namespace -- and its binds on our staged sources -- stays alive, yet
+        ``/proc/<tgid>/mountinfo`` answers EINVAL because the LEADER's nsproxy is
+        gone. ``/proc`` lists only leaders, so the vanish re-listing can never see
+        the surviving thread either. Forgiving on the leader's errno alone would
+        report ``complete=True`` with that namespace's pin unrecorded, and the
+        sweep would then rmdir a source it still binds, leaving the mount's root
+        inode S_DEAD and every create under the masked credential path failing.
+
+        Measured kernel behaviour, pinned by
+        ``test_kernel_answers_einval_for_a_zombie_leader_with_a_live_thread``.
+        """
+        proc = tmp_path / "proc"
+        self._write_mountinfo(proc, "500", "")
+        leader = proc / "501"
+        leader.mkdir()
+        (leader / "mountinfo").write_text("")  # present, but the READ raises
+        _raise_einval_for(monkeypatch, leader / "mountinfo")
+        thread_dir = leader / "task" / "502"
+        thread_dir.mkdir(parents=True)
+        (thread_dir / "mountinfo").write_text(
+            "36 35 0:22 /kirocrew_sb_21_tt /home/u/.aws rw - tmpfs tmpfs rw\n"
+        )
+
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+
+        assert pinned == {"kirocrew_sb_21_tt"}
+        assert complete is True
+
+    def test_group_with_no_namespace_left_is_still_a_vanish(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When NO task in the group holds a namespace, absence-of-pin is real.
+
+        The task dir carries only the leader, so nothing in the group can be
+        binding a source: coverage is kept and the entry stays reclaimable. (The
+        re-listing this records is asserted by the successor test above.)
+        """
+        proc = tmp_path / "proc"
+        self._write_mountinfo(proc, "600", "")
+        leader = proc / "601"
+        (leader / "task" / "601").mkdir(parents=True)
+        (leader / "mountinfo").write_text("")
+        _raise_einval_for(monkeypatch, leader / "mountinfo")
+
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+
+        assert pinned == set()
+        assert complete is True
+
+    @pytest.mark.skipif(
+        os.getuid() == 0 if hasattr(os, "getuid") else True,
+        reason="root ignores file modes; the EACCES probe needs a non-root uid",
+    )
+    def test_unreadable_thread_in_the_group_marks_the_scan_incomplete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A group we cannot interrogate is a coverage gap, not a free pass.
+
+        The leader answers EINVAL and the one sibling thread cannot be read, so
+        whether that namespace binds a source is unknown and directory removal
+        must stay closed.
+        """
+        proc = tmp_path / "proc"
+        self._write_mountinfo(proc, "700", "")
+        leader = proc / "701"
+        leader.mkdir()
+        (leader / "mountinfo").write_text("")
+        _raise_einval_for(monkeypatch, leader / "mountinfo")
+        thread_dir = leader / "task" / "702"
+        thread_dir.mkdir(parents=True)
+        sibling = thread_dir / "mountinfo"
+        sibling.write_text("irrelevant\n")
+        os.chmod(sibling, 0)
+        try:
+            pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+        finally:
+            os.chmod(sibling, 0o644)
+
+        assert pinned == set()
+        assert complete is False
+
+    @pytest.mark.skipif(
+        not os.path.isdir("/proc/self"),
+        reason="needs a real Linux procfs to observe a zombie leader",
+    )
+    def test_kernel_answers_einval_for_a_zombie_leader_with_a_live_thread(self):
+        """Pin the kernel behaviour the thread-group step exists for.
+
+        The leader exits through ``pthread_exit`` while a sibling thread runs on.
+        The tgid read must answer EINVAL (its nsproxy is gone) while the sibling's
+        per-task read must SUCCEED (the namespace is alive). If a kernel ever made
+        both answer the same way, the reachability argument for consulting the
+        group would be gone and this fails instead of the sweep quietly removing a
+        live bind source.
+        """
+        program = (
+            "import ctypes, threading, time\n"
+            "threading.Thread(target=time.sleep, args=(30,)).start()\n"
+            "time.sleep(0.2)\n"
+            "ctypes.CDLL('libc.so.6', use_errno=True).pthread_exit(None)\n"
+        )
+        child = subprocess.Popen([sys.executable, "-c", program])  # noqa: S603
+        try:
+            deadline = time.time() + 10.0
+            state = ""
+            while time.time() < deadline:
+                try:
+                    with open("/proc/%d/stat" % child.pid) as fh:
+                        state = fh.read().rsplit(") ", 1)[1][0]
+                except OSError:  # pragma: no cover - raced the exit
+                    break
+                if state == "Z":
+                    break
+                time.sleep(0.02)
+            if state != "Z":  # pragma: no cover - platform/scheduler dependent
+                pytest.skip("leader did not become a zombie while a thread lived")
+
+            with pytest.raises(OSError) as caught:
+                with open("/proc/%d/mountinfo" % child.pid):
+                    pass
+            assert caught.value.errno == errno.EINVAL
+
+            tids = os.listdir("/proc/%d/task" % child.pid)
+            siblings = [t for t in tids if t != str(child.pid)]
+            assert siblings, "the surviving thread must still be listed under task/"
+            readable = []
+            for tid in siblings:
+                try:
+                    with open("/proc/%d/task/%s/mountinfo" % (child.pid, tid)) as fh:
+                        fh.read()
+                    readable.append(tid)
+                except OSError:
+                    pass
+            assert readable, (
+                "a surviving thread's mountinfo must be readable -- that is the "
+                "only way the scan can see the namespace behind a zombie leader"
+            )
+        finally:
+            child.kill()
+            child.wait()
+
+    @pytest.mark.skipif(
+        os.getuid() == 0 if hasattr(os, "getuid") else True,
+        reason="root ignores file modes; the EACCES probe needs a non-root uid",
+    )
+    def test_a_readable_sibling_must_not_mask_an_unreadable_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """One unaccounted task sinks coverage, whatever a sibling reported.
+
+        Tasks in one thread group can hold DIFFERENT mount namespaces: a thread
+        may ``unshare(CLONE_NEWNS)``, and the launcher's own user namespace grants
+        its descendants the CAP_SYS_ADMIN that needs. So reading one sibling
+        proves nothing about a sibling that cannot be read, and letting the
+        readable one satisfy coverage would report ``complete=True`` while an
+        unread namespace may still bind a source -- which the sweep would then
+        remove, leaving that mount's root inode S_DEAD.
+
+        The pin that WAS read still counts: pins are additive and real either way.
+        """
+        proc = tmp_path / "proc"
+        self._write_mountinfo(proc, "800", "")
+        leader = proc / "801"
+        leader.mkdir()
+        (leader / "mountinfo").write_text("")
+        _raise_einval_for(monkeypatch, leader / "mountinfo")
+        readable = leader / "task" / "802"
+        readable.mkdir(parents=True)
+        (readable / "mountinfo").write_text(
+            "36 35 0:22 /kirocrew_sb_31_rr /home/u/.aws rw - tmpfs tmpfs rw\n"
+        )
+        opaque = leader / "task" / "803"
+        opaque.mkdir(parents=True)
+        blocked = opaque / "mountinfo"
+        blocked.write_text("irrelevant\n")
+        os.chmod(blocked, 0)
+        try:
+            pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+        finally:
+            os.chmod(blocked, 0o644)
+
+        assert pinned == {"kirocrew_sb_31_rr"}, "the pin that was read must be kept"
+        assert complete is False, "an unaccounted sibling must sink coverage"
+
+    @pytest.mark.parametrize("departure", ["gone", "namespaceless"])
+    def test_a_departed_sibling_sinks_coverage_even_beside_a_readable_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, departure: str
+    ):
+        """A sibling that does not read makes coverage unprovable, full stop.
+
+        A sibling exiting between the ``tids`` listing and its read may have spawned
+        a successor THREAD first. A thread is invisible to the outer re-listing,
+        which enumerates thread-group LEADERS only, so unlike a successor PROCESS it
+        cannot be recovered by taking another pass -- fail-closed is the only honest
+        answer. Excusing the departure instead would report ``complete=True`` with
+        that successor's namespace never read, and the sweep would then remove a
+        source it may still bind, leaving the mount's root inode S_DEAD.
+
+        The pin that WAS read still counts: pins are additive and real either way.
+        Both departure shapes are covered -- gone (``ENOENT``) and namespaceless
+        (``EINVAL``).
+        """
+        proc = tmp_path / "proc"
+        self._write_mountinfo(proc, "900", "")
+        leader = proc / "901"
+        leader.mkdir()
+        (leader / "mountinfo").write_text("")
+        _raise_einval_for(monkeypatch, leader / "mountinfo")
+        readable = leader / "task" / "902"
+        readable.mkdir(parents=True)
+        (readable / "mountinfo").write_text(
+            "36 35 0:22 /kirocrew_sb_41_aa /home/u/.aws rw - tmpfs tmpfs rw\n"
+        )
+        departed = leader / "task" / "903"
+        departed.mkdir(parents=True)
+        if departure == "namespaceless":
+            (departed / "mountinfo").write_text("")
+            _raise_einval_for(monkeypatch, departed / "mountinfo")
+        # "gone" leaves no mountinfo file at all, so the read raises ENOENT.
+
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
+
+        assert pinned == {"kirocrew_sb_41_aa"}, "the pin that was read must be kept"
+        assert complete is False, "a sibling that did not read must sink coverage"
+
     def test_missing_proc_root_reports_incomplete(self, tmp_path: Path):
         pinned, complete = _mount_pinned_source_names(proc_root=str(tmp_path / "noproc"))
         assert pinned == set()
@@ -489,6 +858,51 @@ class TestMountPinnedSourceNames:
                 "(e.g. the test itself runs sandboxed) — fail-closed retention applies"
             )
         assert complete is True
+
+
+class TestHeldBackDiagnostic:
+    """Retention must be distinguishable from reclamation in the log.
+
+    A permanently-closed pin scan produces the same observable as a healthy
+    one — zero removals — while the dominant (directory) leak class
+    re-accumulates. The report exists to break that tie, so its LEVEL is part
+    of the contract: at INFO it does not reach a default deployment's log at
+    all, which is how the exhaustion this sweep guards against ran unobserved
+    while this very line fired on every sweep.
+    """
+
+    def test_unprovable_coverage_is_reported_as_a_fault(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        _pin(monkeypatch, set(), complete=False)
+        _make_dir(tmp_path, f"kirocrew_sb_{_DEAD_PID}_held01")
+
+        with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
+            removed = _cleanup_stale_sandbox_mount_sources(roots=[str(tmp_path)])
+
+        assert removed == 0
+        held = [r for r in caplog.records if "held back" in r.getMessage()]
+        assert len(held) == 1
+        assert held[0].levelno == logging.WARNING
+        assert "pin scan incomplete" in held[0].getMessage()
+
+    def test_a_live_pin_stays_ordinary_information(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """Holding an entry a live namespace binds is correct operation, not a
+        fault — it must not be escalated, or the fault signal drowns."""
+        name = f"kirocrew_sb_{_DEAD_PID}_pinned1"
+        _pin(monkeypatch, {name}, complete=True)
+        _make_dir(tmp_path, name)
+
+        with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
+            removed = _cleanup_stale_sandbox_mount_sources(roots=[str(tmp_path)])
+
+        assert removed == 0
+        held = [r for r in caplog.records if "held back" in r.getMessage()]
+        assert len(held) == 1
+        assert held[0].levelno == logging.INFO
+        assert "pinned by a live mount namespace" in held[0].getMessage()
 
 
 class TestMountSourceCandidateRoots:


### PR DESCRIPTION
## Problem / Motivation

Every sandboxed spawn stages bind-mount SOURCES on a tmpfs root: one empty dir per
`SENSITIVE_DIRS` entry, one empty file per `SENSITIVE_FILES` entry, named
`kirocrew_sb_<pid>_*`. The kernel pins each source for its mount's lifetime, so the
launcher cannot unlink them and they orphan when the sandboxed process exits.
`_cleanup_stale_sandbox_mount_sources` exists to reclaim them.

It never reclaimed a single directory. Removing a source directory a live namespace
still binds leaves that mount's root inode `S_DEAD`, so a dir goes only once
`_mount_pinned_source_names` has POSITIVELY established that no mount namespace
references it. That proof was unobtainable in practice:
`open("/proc/<pid>/mountinfo")` returns `EINVAL` when the task's `nsproxy` is gone,
and the handler filed any same-uid read failure as a coverage gap. A zombie awaiting
reap is exactly such a task, and zombies are routine: on the reporting host one
frequently-invoked command-line wrapper left a pair behind on every invocation, so
the count sat at a steady 4, old ones replaced by new ones.

One unreaped child therefore held back EVERY directory candidate, permanently and
host-wide. Plain files kept being reclaimed, so the sweep looked healthy.

Measured on the reporting host, read-only, before the fix:

```
scan_complete = False   pinned entries = 594
dirs reclaimable = 0    dirs held back = 28418    files reclaimable = 2038
```

The end state was `/run/user/$UID` at 3244751/3244751 inodes, `IFree=0`. `systemd-run
--scope` could then allocate no transient unit, so every sandboxed spawn died with no
exit status at all. The symptom was a flood of `process exited (rc=None)` and ACP
being unable to start any session. `df -h` read 69% used throughout, because the
garbage is empty directories: no bytes, one inode each.

## Why it matters

This is a full stop, not a degradation: with the runtime tmpfs out of inodes no agent
session, subagent, or sandboxed tool call can start at all, and the machine gives no
usable signal about why. `df -h` looks fine, which sends the operator to the wrong
filesystem.

It is also self-accelerating. Each failed spawn stages its own ~29 entries before
dying, so pressure produces garbage faster. On the reporting host the surviving
entries were 12-48 per hour during normal operation and 3540 in the hour the spawns
started failing.

The accumulation rate is ordinary traffic, not an outlier: 121 sandboxed spawns in
2 minutes, dominated by short-lived `gh pr view` calls from PR-watch polling. At 29
entries each that is ~1740 entries/minute, so 3.24M inodes are consumed in roughly
31 hours of normal use. The leak also migrates rather than stopping: once
`/run/user/$UID` returns ENOSPC the launcher's candidate chain falls through to
`/dev/shm`, where 6481 entries had already accumulated.

And nothing said so. The `dirs_held_back` report exists precisely to distinguish
retention from reclamation, and it fired on every sweep, at INFO, which the
reporting host's log does not collect. A `journalctl` grep over 14 days returned zero
occurrences of the line while the leak ran the whole time.

## What changed (motivation → approach → change)

**Symptom.** Every sandboxed spawn fails with no exit status; `df -i` on
`/run/user/$UID` shows `IFree=0` while `df -h` shows 69% used.

**Root cause.** `_mount_pinned_source_names` treats an `EINVAL` mountinfo read as a
coverage gap. `EINVAL` is returned from `mounts_open_common` for exactly one reason:
`nsproxy == NULL`, i.e. that task has exited and awaits reap. Such a task belongs to
no mount namespace of its own. The scan was filing the strongest available evidence
of absence as "absence not provable", and one such task closes the gate for the
entire host.

**Change.** `EINVAL` is now read as what the kernel means by it, with one step the
first draft of this PR did not have and needs.

`EINVAL` says THAT TASK has no `nsproxy`. It is not yet a statement about the
NAMESPACE: a thread-group leader can exit through `pthread_exit` while sibling
threads keep running, and threads share the `nsproxy`, so a live namespace still
binding our sources can sit behind a zombie leader. `proc_root` lists only
thread-group LEADERS, so a re-listing cannot see those threads either. Measured on a
real zombie leader:

```
leader state                  : Z
/proc/<tgid>/mountinfo        : EINVAL
/proc/<tgid>/task entries     : ['<leader>', '<worker>']
  task/<leader>/mountinfo     : EINVAL
  task/<worker>/mountinfo     : OK      <- the namespace is alive and readable
os.path.exists('/proc/<pid>') : True    <- so only the 24h age backstop makes it a candidate
```

So the group is consulted, under one invariant: **reading a sibling collects PINS and
never votes on the verdict.** Two things decide that instead.

- A task the scan could neither read nor classify as departed **sinks coverage**,
  whatever any sibling reported. Tasks in one group can hold DIFFERENT mount
  namespaces -- a thread may `unshare(CLONE_NEWNS)`, and the launcher's own user
  namespace grants its descendants the CAP_SYS_ADMIN that needs -- so a readable
  sibling proves nothing about an unreadable one.
- Otherwise it is a **VANISH, unconditionally**, forcing another `/proc` listing.
  Reaching this branch at all means the LEADER departed, and a departing task may
  have handed its namespace to a process forked after this pass's listing, which
  only a re-listing can see. A sibling that could be read must not cancel that.
- It terminates: the pid enters `seen` and is never re-read, so a stable zombie
  costs exactly one extra pass, while genuine churn exhausts
  `_PIN_SCAN_MAX_PASSES` and returns `complete=False`, which retains rather than
  removes.
- Every other errno is unchanged. An `EACCES` read of a live same-uid holder still
  records a coverage gap and still retains its entries, so the fail-closed property
  the gate exists for is intact.

Consulting the group rather than declaring coverage incomplete on sight is
deliberate: the latter would restore the exact shape this PR removes, since one
long-lived multi-threaded process with a zombie leader would again close the gate
for every directory on the host.

The verdict deliberately does not consult whether any sibling read successfully.
Letting it do so produced two successive blocking findings on this predicate -- a
readable sibling masking an unreadable one, then a readable sibling masking a
DEPARTED one, which suppressed the re-listing that a departing task's successor
needs. Removing that variable from the verdict closes the class rather than its
instances.

Two smaller parts of the same defect:

- The held-back report moves to WARNING when coverage is unprovable, and stays at
  INFO when a live namespace holds the pin. The first is an operational fault that
  stops reclamation host-wide; the second is correct operation. At INFO the fault was
  unobservable in a default deployment, which is why this ran for weeks.
- The `_mount_pinned_source_names` docstring stated the old read-failure rule
  verbatim ("forgiven ONLY when the pid provably belongs to a DIFFERENT real user").
  A stale rule on this exact predicate is part of how the defect survived review, so
  it moves with the code. No spec under `docs/` restates the rule (checked), so
  nothing else needed syncing.

## Tests

All in `test/test_sandbox_mount_source_sweep.py`.

Coverage predicate:

- `test_namespaceless_task_is_not_a_coverage_gap`: an `EINVAL` read must not make
  the scan incomplete, and the other pids' pins are still collected.
- `test_namespaceless_task_still_forces_a_rescan_for_its_successor`: asserts the
  re-listing happens and that a successor appearing only on the second listing has
  its pin recorded.
- `test_zombie_leader_with_a_live_thread_is_pinned_not_forgiven`: the leader answers
  `EINVAL` while a sibling thread's per-task mountinfo names a bind source. The pin
  must be recorded and coverage kept.
- `test_group_with_no_namespace_left_is_still_a_vanish`: a group whose task dir holds
  only the dead leader stays reclaimable, so the fix does not over-retain.
- `test_unreadable_thread_in_the_group_marks_the_scan_incomplete`: a group that
  cannot be interrogated is a gap, not a free pass.
- `test_a_readable_sibling_must_not_mask_an_unreadable_one`: the pin that was read is
  kept, and coverage is still unprovable.
- `test_a_readable_sibling_must_not_mask_a_departed_one[gone|namespaceless]`: a
  departed sibling forces the re-listing even when another sibling read fine, and the
  successor visible only on the second listing has its pin recorded.

Kernel premises, asserted directly so a future errno or procfs change fails a test
instead of silently killing the sweep again:

- `test_kernel_answers_einval_for_a_real_zombie` (single-threaded zombie).
- `test_kernel_answers_einval_for_a_zombie_leader_with_a_live_thread` (the tgid read
  answers `EINVAL` while the surviving thread's read succeeds).

Report level:

- `test_unprovable_coverage_is_reported_as_a_fault` and
  `test_a_live_pin_stays_ordinary_information`.

Mutation-verified. Reverting `src/kiro_crew/sandbox.py` to the base and keeping the
tests gives **8 failed, 38 passed, 1 skipped**:

| how it fails without the change | test |
|---|---|
| `assert set() == {'kirocrew_sb_21_tt'}` -- the pin behind the zombie leader is lost | `..._zombie_leader_with_a_live_thread_is_pinned_not_forgiven` |
| the read sibling's pin is dropped entirely | `..._readable_sibling_must_not_mask_an_unreadable_one` |
| the re-listing is not triggered | `..._namespaceless_task_still_forces_a_rescan_for_its_successor` |
| the re-listing is not triggered (departed sibling, gone) | `..._readable_sibling_must_not_mask_a_departed_one[gone]` |
| the re-listing is not triggered (departed sibling, namespaceless) | `..._readable_sibling_must_not_mask_a_departed_one[namespaceless]` |
| `assert False is True` | `..._namespaceless_task_is_not_a_coverage_gap` |
| `assert False is True` | `..._group_with_no_namespace_left_is_still_a_vanish` |
| `assert 20 == 30` | `..._unprovable_coverage_is_reported_as_a_fault` |

With the change: **47 passed, 0 skipped**.

The zero skips matter. `test_real_host_scan_can_reach_complete_when_unconstrained`
already existed to prove this fail-closed gate can OPEN somewhere real, and was
written to `pytest.skip()` when it cannot, on the exact condition that kept it
permanently closed. It skipped silently on the reporting host, so the guarantee it
claims to enforce was never checked. It now asserts and passes.

Neighbouring suites: all 21 `test_sandbox*` files plus
`test_doctor_sandbox_verdict.py`, 1060 passed, 1 skipped.

## Manual verification

Read-only projection against the live `/proc` and `/run/user/$UID` of the reporting
host, running both predicates over identical state in the same second:

| | `scan_complete` | dirs reclaimable | dirs held back |
|---|---|---|---|
| before | False | 0 | 28418 |
| after | True | 28418 | 0 |

Supporting measurements on that host: all coverage gaps were zombies (`state=Z`), and
across all 1383 pids there were **zero** processes returning `EINVAL` that were not
zombies; other real users' live processes read `OK` and were never gaps at all; no
same-uid live process was unreadable. Inode use was independently observed climbing
4,609 -> 13,824 -> 34,976 over ~26 minutes (~1100/min) with the unfixed code live.

The zombie-leader state was reproduced separately, out of tree, with a child that
starts a thread and then calls `pthread_exit` from its leader; the table under "What
changed" is that probe's output.

No UI surface is touched.

## Related Issues

no linked issue: found by direct diagnosis of a live host outage; an issue search for
this leak returned nothing, so there is no tracked report to close.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a fail-closed proof-of-absence counts a probe FAILURE as "unprovable"
without asking whether that particular failure mode is itself positive proof of
absence, so one routine and benign failure disables the whole mechanism, permanently
and silently. Two aggravating shapes travelled with it and are worth the same
question: coverage was global all-or-nothing over a per-entry decision, and the one
diagnostic that would have exposed the stall was emitted at a level the default
deployment does not collect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
