### PR TITLE
fix(mochi): refuse a corrupt pin store instead of rewriting it (#8088)

### DIFF
--- a/src/kiro_crew/apps/builtins/mochi/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/mochi/backend/routes.py
@@ -69,7 +69,11 @@ from kiro_crew.apps.builtins.mochi.petdex_import import (
     list_installed,
     read_installed,
 )
-from kiro_crew.apps.builtins.mochi.pinned_files_service import DATA_FILE_NAME, pins_mutation
+from kiro_crew.apps.builtins.mochi.pinned_files_service import (
+    DATA_FILE_NAME,
+    PinsCorruptError,
+    pins_mutation,
+)
 from kiro_crew.apps.builtins.mochi.queue_file import QUEUE_FILE as _QUEUE_FILE
 from kiro_crew.apps.builtins.mochi.queue_file import queue_mutation
 from kiro_crew.apps.builtins.mochi.redact import redact_tree
@@ -287,6 +291,28 @@ async def _handle_bg_usage(request: web.Request) -> web.Response:
 # ── Pinned files ────────────────────────────────────────────────────────────
 
 
+def _pins_corrupt() -> web.Response:
+    """Map the pin store's corruption refusal to a coded response.
+
+    The update reader refuses a corrupt pin list rather than replacing it
+    (#8088, mirroring #7805), so these handlers can now see a
+    ``PinsCorruptError`` that previously could not happen. Letting it escape
+    gives aiohttp's bare 500 with no ``code`` for the UI to branch on, and
+    reporting ``{"ok": false}`` instead would be read as "no such pin" -- for
+    mark-seen, as outright success. 500 rather than 503: corruption does not
+    clear on retry, a person has to repair the file, and the bytes it still
+    holds are exactly why the mutation refused.
+
+    The exception text is deliberately not echoed: pin labels and paths are
+    agent-authored (they are redacted on the way out of ``_handle_pinned_get``),
+    and the fixed message already says everything the caller can act on.
+    """
+    return web.json_response(
+        {"error": "the pin list is unreadable and must be repaired", "code": "pins_corrupt"},
+        status=500,
+    )
+
+
 async def _handle_pinned_get(request: web.Request) -> web.Response:
     # Pin labels are agent-authored (pin_file) — redact before the browser.
     return web.json_response({"pins": _redact_plan_tree(_rt().pinned.get_pins())})
@@ -305,7 +331,10 @@ async def _handle_pinned_unpin(request: web.Request) -> web.Response:
     # makes this a blocking wait — on the loop that would stall chat streaming and
     # the heartbeat for as long as the other side holds it. Same reason the pack
     # and queue writes are offloaded.
-    ok = await asyncio.to_thread(_rt().pinned.remove_pin, path)
+    try:
+        ok = await asyncio.to_thread(_rt().pinned.remove_pin, path)
+    except PinsCorruptError:
+        return _pins_corrupt()
     return web.json_response({"ok": ok})
 
 
@@ -318,7 +347,10 @@ async def _handle_pinned_mark_seen(request: web.Request) -> web.Response:
             {"error": "body must contain path", "code": "path_required"}, status=400
         )
     # Same cross-process lock as unpin above — see there.
-    await asyncio.to_thread(_rt().pinned.mark_seen, path)
+    try:
+        await asyncio.to_thread(_rt().pinned.mark_seen, path)
+    except PinsCorruptError:
+        return _pins_corrupt()
     return web.json_response({"ok": True})
 
 

--- a/src/kiro_crew/apps/builtins/mochi/mcp_server.py
+++ b/src/kiro_crew/apps/builtins/mochi/mcp_server.py
@@ -40,7 +40,11 @@ from typing import Any
 
 from kiro_crew.apps.builtins.mochi import queue_file as qf
 from kiro_crew.apps.builtins.mochi import watchlist_file as wf
-from kiro_crew.apps.builtins.mochi.pinned_files_service import pins_mutation
+from kiro_crew.apps.builtins.mochi.pinned_files_service import (
+    PinsCorruptError,
+    pins_mutation,
+    read_pins_for_update,
+)
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
 from kiro_crew.validation import ValidationError, validate_mcp_tool_arguments
 
@@ -603,16 +607,23 @@ def _tool_pin_file(args: dict[str, Any]) -> str:
     # next mutation. The service reloads from disk inside the same lock, which is
     # what makes the two writers agree.
     with pins_mutation(str(pins_path)):
-        data = _read_json(pins_path, {"version": 1, "pins": []})
-        pins = data.get("pins", [])
-        if any(p.get("path") == path for p in pins):
+        # read_pins_for_update, not the lenient _read_json with an empty default:
+        # the write below replaces the WHOLE file, so a corrupt store read as
+        # `{"pins": []}` would be ZEROED here (#8088). That is strictly worse than
+        # the gateway service's version of the same bug, which at least wrote its
+        # live in-memory list back. Both writers share the one reader so refusing
+        # in the service cannot be undone by the next pin_file from this process.
+        try:
+            pins = read_pins_for_update(str(pins_path)) or []
+        except PinsCorruptError:
+            return "Error: pin_file failed: the pin list is corrupt and must be repaired"
+        if any(_pin_path(p) == path for p in pins):
             return _ok({"ok": True, "alreadyPinned": True})
         entry = {"path": path, "pinnedAt": _now_ms()}
         if args.get("label"):
             entry["label"] = args["label"]
         pins.append(entry)
-        data["pins"] = pins
-        _write_json(pins_path, data)
+        _write_json(pins_path, {"version": 1, "pins": pins})
     return _ok({"ok": True, "pins": len(pins)})
 
 
@@ -622,11 +633,13 @@ def _tool_unpin_file(args: dict[str, Any]) -> str:
         return "Error: unpin_file failed: path is required"
     pins_path = _data_dir() / _PINNED_FILE
     with pins_mutation(str(pins_path)):
-        data = _read_json(pins_path, {"version": 1, "pins": []})
-        before = data.get("pins", [])
-        after = [p for p in before if p.get("path") != path]
-        data["pins"] = after
-        _write_json(pins_path, data)
+        # Same strict read as pin_file above -- see there.
+        try:
+            before = read_pins_for_update(str(pins_path)) or []
+        except PinsCorruptError:
+            return "Error: unpin_file failed: the pin list is corrupt and must be repaired"
+        after = [p for p in before if _pin_path(p) != path]
+        _write_json(pins_path, {"version": 1, "pins": after})
     return _ok({"ok": True, "removed": len(before) - len(after)})
 
 
@@ -641,6 +654,13 @@ def _tool_read_mochi_file(args: dict[str, Any]) -> str:
     if not target.is_file():
         return _ok({"exists": False, "which": which})
     return target.read_text(encoding="utf-8")
+
+
+def _pin_path(entry: Any) -> Any:
+    """A stored pin entry may be a stray scalar (the service round-trips garbage
+    entries unvalidated), and ``(1).get`` raises. Mirror the service's
+    ``_entry_path`` so a malformed row is simply never a match."""
+    return entry.get("path") if isinstance(entry, dict) else None
 
 
 def _read_json(path: Path, default: Any) -> Any:

--- a/src/kiro_crew/apps/builtins/mochi/pinned_files_service.py
+++ b/src/kiro_crew/apps/builtins/mochi/pinned_files_service.py
@@ -83,6 +83,96 @@ REWATCH_RETRY_MS = 1_000
 DATA_FILE_NAME = "pinned-files.json"
 DATA_VERSION = 1
 
+
+class PinsCorruptError(Exception):
+    """The stored pin list could not be read into something a mutation can merge into.
+
+    Raised only on the UPDATE path (:func:`read_pins_for_update`) so a mutation
+    abandons itself instead of rewriting the whole file from a list it was never
+    able to reconcile against what is on disk. Named and public because TWO
+    PROCESSES mutate this file -- the gateway service below and the MCP server's
+    ``pin_file`` / ``unpin_file`` -- and both have to recognise the refusal, so
+    a module-private name would leave the second writer destroying what the
+    first one just refused to touch.
+
+    Modelled on ops-mission-control's ``CorruptDocumentError`` rather than the
+    bare ``json.JSONDecodeError`` the aws-control readers raise (#7805): that
+    app reached for the plain type only because the named one lived in another
+    app, which does not apply to a type declared in the module both writers
+    already import.
+
+    The startup :meth:`PinnedFilesService.load` path deliberately does NOT raise
+    this. There a corrupt file is replaced on purpose and preserved as a
+    ``.bak.<now_ms>`` sidecar first (:meth:`_backup_corrupted`), which is a
+    decision with a recovery copy, not a silent loss under someone else's write.
+    """
+
+
+def read_pins_for_update(file_path: str) -> list[Any] | None:
+    """Read the stored pin list for a read-modify-write, REFUSING on corruption.
+
+    Returns the stored list, or ``None`` when the file does not exist yet -- the
+    one case where "nothing to carry forward" is true, so a first pin on a fresh
+    install proceeds against an empty list.
+
+    Every caller rewrites the WHOLE file from what this returns, so a read that
+    failed must not degrade to a usable-looking answer: doing that writes the
+    caller's own list over rows another process wrote and this one never loaded,
+    and the unparseable file was their only remaining copy. Three shapes refuse,
+    because each one reaches that same whole-file rewrite:
+
+    * a parse failure -- the truncated bytes still hold most of the records
+      verbatim, and only a person can recover them;
+    * a read error the filesystem raised (a transient EACCES/EIO, a scanner
+      holding the handle on Windows) -- the store is still there, this process
+      just could not see it this instant;
+    * valid JSON whose root is not an object, or whose ``pins`` is not a list --
+      no parse failure at all, so left uncaught it would be the quietest loss of
+      the three.
+
+    Decoding is STRICT here, unlike :meth:`PinnedFilesService.load` and the Node
+    original, which use ``errors="replace"``. That leniency only surfaces as a
+    parse failure when the bad byte falls OUTSIDE a JSON string; inside a quoted
+    value -- a pin label, or a path on a filesystem that does not enforce UTF-8 --
+    it becomes U+FFFD, ``json.loads`` SUCCEEDS, and the whole-file rewrite then
+    persists the mangled text. That is the same irreversible loss as the three
+    refusals above, reached without any parse failure to catch it, so an
+    undecodable byte is a fourth refusal rather than a repair. Found in review
+    (GPT 5.6).
+
+    ``load`` keeps the lenient decode: it does not write, and a corrupt file it
+    accepts is preserved as a ``.bak.<now_ms>`` sidecar first. A mangled label
+    read at startup can therefore reach memory, but it can no longer reach DISK,
+    because every write path first re-reads through this reader and refuses.
+    """
+    try:
+        raw = Path(file_path).read_bytes().decode("utf-8")
+    except FileNotFoundError:
+        return None
+    except UnicodeDecodeError as err:
+        # Deliberately BEFORE the OSError arm: UnicodeDecodeError is a ValueError,
+        # not an OSError, so it would otherwise escape this function unwrapped and
+        # slip past every caller's PinsCorruptError clause.
+        logger.warning(
+            "[PinnedFilesService] Non-UTF-8 bytes in %s; refusing to overwrite it", file_path
+        )
+        raise PinsCorruptError(f"pin list is not valid UTF-8: {err.reason}") from err
+    except OSError as err:
+        logger.warning("[PinnedFilesService] Unreadable %s; refusing to overwrite it", file_path)
+        raise PinsCorruptError(f"pin list is unreadable: {err}") from err
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as err:
+        logger.warning("[PinnedFilesService] Corrupt %s; refusing to overwrite it", file_path)
+        raise PinsCorruptError("pin list is not valid JSON") from err
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("pins"), list):
+        logger.warning(
+            "[PinnedFilesService] Wrong shape in %s; refusing to overwrite it", file_path
+        )
+        raise PinsCorruptError("pin list root is not an object with a pins array")
+    return parsed["pins"]
+
+
 # Timer actions stored in the shared per-file slot.
 _ACTION_DEBOUNCE = "debounce"
 
@@ -200,29 +290,32 @@ class PinnedFilesService:
         self._watched.clear()
         self._timers.clear()
 
-    def _reload_pins_from_disk(self) -> None:
-        """Refresh ``_pins`` from the file without touching watchers or timers.
+    def _reload_pins_for_update(self) -> None:
+        """Refresh ``_pins`` from disk before a mutation, REFUSING on corruption.
 
         Cheaper and narrower than ``load``: it exists so a mutation can pick up
         another process's write before applying its own, without tearing down the
         watcher state ``load`` rebuilds.
+
+        Raises :class:`PinsCorruptError` -- see :func:`read_pins_for_update`, the
+        chokepoint this and the MCP server's two pin tools share so that
+        refusing here cannot be undone by the other process's next write. An
+        absent file leaves ``_pins`` as it is, which is what lets a fresh
+        install add its first pin.
         """
-        try:
-            raw = Path(self._file_path).read_text(encoding="utf-8", errors="replace")
-            parsed = json.loads(raw)
-        except (FileNotFoundError, json.JSONDecodeError):
-            return
-        except OSError as err:
-            logger.warning("[PinnedFilesService] reload read error: %s", err)
-            return
-        if isinstance(parsed, dict) and isinstance(parsed.get("pins"), list):
-            self._pins = parsed["pins"]
+        pins = read_pins_for_update(self._file_path)
+        if pins is not None:
+            self._pins = pins
 
     # ── Public API ─────────────────────────────────────────────────────────
 
     def add_pin(self, file_path: str, label: str | None = None, *, now_ms: int) -> bool:
         """Add a pin. False if the path is relative, sensitive, duplicate, or the
-        list is full."""
+        list is full.
+
+        Raises :class:`PinsCorruptError` when the stored list could not be read;
+        that is not a rejected pin, it is a store that needs repair.
+        """
         if not os.path.isabs(file_path):
             return False
 
@@ -239,8 +332,9 @@ class PinnedFilesService:
         with pins_mutation(self._file_path):
             # Pick up the other process's writes BEFORE deciding, or a duplicate
             # check against stale state re-adds a pin the agent just removed and
-            # the persist below drops the one it just added.
-            self._reload_pins_from_disk()
+            # the persist below drops the one it just added. A corrupt store
+            # raises here, before the whole-file persist below could overwrite it.
+            self._reload_pins_for_update()
 
             if len(self._pins) >= MAX_PINS:
                 return False
@@ -269,9 +363,13 @@ class PinnedFilesService:
         return True
 
     def remove_pin(self, file_path: str) -> bool:
-        """Remove a pin. False if not found."""
+        """Remove a pin. False if not found.
+
+        Raises :class:`PinsCorruptError` when the stored list could not be read
+        -- distinct from the ``False`` above, which means the pin was not there.
+        """
         with pins_mutation(self._file_path):
-            self._reload_pins_from_disk()
+            self._reload_pins_for_update()
             idx = next((i for i, p in enumerate(self._pins) if _entry_path(p) == file_path), -1)
             if idx == -1:
                 return False
@@ -294,9 +392,15 @@ class PinnedFilesService:
 
     def mark_seen(self, file_path: str) -> None:
         """Clear a file's ``updatedAt``. Persists and broadcasts even when it was
-        already unset — the original assigned ``undefined`` unconditionally."""
+        already unset — the original assigned ``undefined`` unconditionally.
+
+        Raises :class:`PinsCorruptError` when the stored list could not be read.
+        Returning quietly would report success for a mutation that did not
+        happen, which for this method is indistinguishable from the normal
+        already-unset case.
+        """
         with pins_mutation(self._file_path):
-            self._reload_pins_from_disk()
+            self._reload_pins_for_update()
             entry = next((p for p in self._pins if _entry_path(p) == file_path), None)
             if entry is None:
                 return
@@ -413,7 +517,21 @@ class PinnedFilesService:
             return
 
         with pins_mutation(self._file_path):
-            self._reload_pins_from_disk()
+            try:
+                self._reload_pins_for_update()
+            except PinsCorruptError:
+                # The ONE swallow: this runs on the owner's tick loop, where the
+                # only caller is a timer firing, so an escaping exception would
+                # take down every other tick (stats, watchlist, presence) over a
+                # file this path merely wanted to stamp. Dropping the stamp is
+                # the same degradation a failed ``_persist`` already takes below.
+                # The mutation paths a user drove RAISE instead, so the operator
+                # still learns the store needs repair.
+                logger.warning(
+                    "[PinnedFilesService] Skipping updatedAt for %s: pin store corrupt",
+                    file_path,
+                )
+                return
             entry = next((p for p in self._pins if _entry_path(p) == file_path), None)
             if entry is None:
                 return

--- a/test/test_mochi_pinned_files_cov80.py
+++ b/test/test_mochi_pinned_files_cov80.py
@@ -46,6 +46,11 @@ def _write_pins(tmp_path: Path, pins: list[Any]) -> Path:
     return p
 
 
+def _read_pins(tmp_path: Path) -> list[Any]:
+    payload = json.loads((tmp_path / DATA_FILE_NAME).read_text(encoding="utf-8"))
+    return payload["pins"]
+
+
 class TestFileExists:
     def test_a_non_string_or_empty_path_never_exists(self):
         assert _file_exists(None) is False
@@ -132,13 +137,216 @@ class TestLoad:
         assert list(tmp_path.glob("*.bak.*")) == []
 
 
-class TestReloadFromDisk:
-    def test_an_unreadable_file_leaves_the_in_memory_list_untouched(self, tmp_path):
+class TestReadPinsForUpdate:
+    """#8088: the update reader refuses a store it could not read, so the
+    whole-file rewrite that follows every caller cannot destroy it."""
+
+    def test_a_missing_file_reads_as_nothing_to_carry_forward(self, tmp_path):
+        # The one case where an empty base is true: a first pin on a fresh
+        # install must still land, so absence returns None rather than refusing.
+        assert pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME)) is None
+
+    def test_a_valid_file_returns_its_stored_list(self, tmp_path):
+        _write_pins(tmp_path, [{"path": "/from-disk"}])
+        assert pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME)) == [{"path": "/from-disk"}]
+
+    def test_unparseable_bytes_refuse(self, tmp_path):
+        (tmp_path / DATA_FILE_NAME).write_text("{ this is not json", encoding="utf-8")
+        with pytest.raises(pfs.PinsCorruptError):
+            pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME))
+
+    def test_non_utf8_bytes_outside_a_string_refuse(self, tmp_path):
+        (tmp_path / DATA_FILE_NAME).write_bytes(b'{"pins": [\xff\xfe]}')
+        with pytest.raises(pfs.PinsCorruptError):
+            pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME))
+
+    def test_a_non_utf8_byte_INSIDE_a_json_string_refuses(self, tmp_path):
+        # The lenient decode's blind spot: U+FFFD inside a quoted value parses
+        # CLEANLY, so nothing downstream could have caught it. Strict decoding is
+        # what makes this a refusal rather than a silent rewrite.
+        (tmp_path / DATA_FILE_NAME).write_bytes(
+            b'{"version": 1, "pins": [{"path": "/a", "label": "caf\xe9"}]}'
+        )
+        with pytest.raises(pfs.PinsCorruptError):
+            pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME))
+
+    def test_valid_json_of_the_wrong_shape_refuses(self, tmp_path):
+        # Parses fine, so nothing raises on its own -- the quietest of the losses.
+        (tmp_path / DATA_FILE_NAME).write_text(json.dumps({"pins": "nope"}), encoding="utf-8")
+        with pytest.raises(pfs.PinsCorruptError):
+            pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME))
+        (tmp_path / DATA_FILE_NAME).write_text(json.dumps([1, 2]), encoding="utf-8")
+        with pytest.raises(pfs.PinsCorruptError):
+            pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME))
+
+    def test_an_unreadable_file_refuses(self, tmp_path):
+        (tmp_path / DATA_FILE_NAME).mkdir()  # a directory where the file should be
+        with pytest.raises(pfs.PinsCorruptError):
+            pfs.read_pins_for_update(str(tmp_path / DATA_FILE_NAME))
+
+    def test_the_service_reload_leaves_its_list_untouched_when_refusing(self, tmp_path):
+        (tmp_path / DATA_FILE_NAME).write_text("{ nope", encoding="utf-8")
         svc, _ = _svc(tmp_path)
         svc._pins = [{"path": "/kept"}]
-        (tmp_path / DATA_FILE_NAME).mkdir()
-        svc._reload_pins_from_disk()
+        with pytest.raises(pfs.PinsCorruptError):
+            svc._reload_pins_for_update()
         assert svc.get_pins() == [{"path": "/kept"}]
+
+
+class TestCorruptStoreIsNotOverwrittenOnMutation:
+    """#8088: a corrupt pin store must survive a mutation, not be rewritten from
+    the in-memory list -- that rewrite discarded rows another process wrote which
+    this one never loaded, and the corrupt file is their only copy.
+
+    The mutation cases deliberately do NOT assert on the exception type: what
+    regressed is the FILE, so the assertion that has to fail on the buggy code is
+    the one about its bytes. ``TestRefusalIsTheNamedType`` below pins the type.
+    """
+
+    @staticmethod
+    def _attempt(call) -> None:
+        """Run a mutation that is expected to refuse, tolerating either shape --
+        so the byte assertion that follows is what decides the test."""
+        try:
+            call()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def test_add_pin_does_not_overwrite_a_corrupt_store(self, tmp_path):
+        corrupt = "{ cross-process rows this process never parsed"
+        pins_file = tmp_path / DATA_FILE_NAME
+        pins_file.write_text(corrupt, encoding="utf-8")
+        svc, events = _svc(tmp_path)
+        svc._pins = [{"path": "/only-in-memory"}]  # a good-looking but partial list
+
+        target = tmp_path / "notes.txt"
+        target.write_text("x", encoding="utf-8")
+        self._attempt(lambda: svc.add_pin(str(target), now_ms=NOW))
+
+        # The refusal happened before _persist: the corrupt bytes are intact.
+        assert pins_file.read_text(encoding="utf-8") == corrupt
+        assert events == []
+        assert svc.get_watched_paths() == set()
+
+    def test_remove_pin_does_not_overwrite_a_corrupt_store(self, tmp_path):
+        corrupt = "]]] not json [[["
+        pins_file = tmp_path / DATA_FILE_NAME
+        pins_file.write_text(corrupt, encoding="utf-8")
+        svc, events = _svc(tmp_path)
+        svc._pins = [{"path": "/only-in-memory"}]
+
+        self._attempt(lambda: svc.remove_pin("/only-in-memory"))
+
+        assert pins_file.read_text(encoding="utf-8") == corrupt
+        assert events == []
+
+    def test_mark_seen_does_not_overwrite_a_corrupt_store(self, tmp_path):
+        # The sharpest case: mark_seen has no failure return, so before this fix
+        # the route reported ok while the store was being replaced.
+        corrupt = "<<garbage>>"
+        pins_file = tmp_path / DATA_FILE_NAME
+        pins_file.write_text(corrupt, encoding="utf-8")
+        svc, events = _svc(tmp_path)
+        svc._pins = [{"path": "/only-in-memory", "updatedAt": NOW}]
+
+        self._attempt(lambda: svc.mark_seen("/only-in-memory"))
+
+        assert pins_file.read_text(encoding="utf-8") == corrupt
+        assert events == []
+
+    def test_a_watch_event_skips_the_stamp_instead_of_crashing_the_tick(self, tmp_path):
+        # The one path that swallows the refusal: it fires from the owner's tick
+        # loop, where an escaping error would take down every other tick.
+        target = tmp_path / "watched.txt"
+        target.write_text("x", encoding="utf-8")
+        corrupt = "{ truncated"
+        pins_file = tmp_path / DATA_FILE_NAME
+        pins_file.write_text(corrupt, encoding="utf-8")
+        svc, events = _svc(tmp_path)
+        svc._pins = [{"path": str(target)}]
+
+        svc.on_watch_event(str(target), "change", now_ms=NOW)
+        svc.tick(NOW + DEBOUNCE_MS)  # must not raise
+
+        assert pins_file.read_text(encoding="utf-8") == corrupt
+        assert events == []
+
+    def test_the_mcp_pin_tools_do_not_overwrite_a_corrupt_store(self, tmp_path, monkeypatch):
+        # The SECOND writer of the same file, and the worse half of the bug: its
+        # lenient read defaulted to an EMPTY list, so a corrupt store was zeroed
+        # rather than merely reverted to one process's view.
+        from kiro_crew.apps.builtins.mochi import mcp_server
+
+        corrupt = '{"pins": [{"path": "/a"}, {"path": ' + '"/truncated'
+        pins_file = tmp_path / DATA_FILE_NAME
+        pins_file.write_text(corrupt, encoding="utf-8")
+        monkeypatch.setattr(mcp_server, "_data_dir", lambda: tmp_path)
+
+        out = mcp_server._tool_pin_file({"path": str(tmp_path / "x.txt")})
+        assert "corrupt" in out
+        assert pins_file.read_text(encoding="utf-8") == corrupt
+
+        out = mcp_server._tool_unpin_file({"path": "/a"})
+        assert "corrupt" in out
+        assert pins_file.read_text(encoding="utf-8") == corrupt
+
+    def test_a_mutation_preserves_a_non_utf8_byte_in_a_label(self, tmp_path):
+        # The sharpest loss of the set: valid JSON, so before the strict decode the
+        # mutation succeeded and wrote U+FFFD over the operator's only copy of the
+        # original byte. Nothing raised and nothing was logged.
+        raw = b'{"version": 1, "pins": [{"path": "/a", "label": "caf\xe9 notes"}]}'
+        pins_file = tmp_path / DATA_FILE_NAME
+        pins_file.write_bytes(raw)
+        svc, events = _svc(tmp_path)
+        svc._pins = [{"path": "/a", "label": "caf\ufffd notes"}]  # what a lenient read yields
+
+        target = tmp_path / "notes.txt"
+        target.write_text("x", encoding="utf-8")
+        self._attempt(lambda: svc.add_pin(str(target), now_ms=NOW))
+
+        assert pins_file.read_bytes() == raw
+        assert events == []
+
+    def test_a_missing_store_still_lets_the_first_pin_land(self, tmp_path):
+        # Regression guard: refusing on corruption must NOT refuse on absence,
+        # or a fresh install could never add its first pin.
+        svc, _ = _svc(tmp_path)
+        target = tmp_path / "notes.txt"
+        target.write_text("x", encoding="utf-8")
+        assert svc.add_pin(str(target), now_ms=NOW) is True
+        written = json.loads((tmp_path / DATA_FILE_NAME).read_text(encoding="utf-8"))
+        assert [p["path"] for p in written["pins"]] == [str(target)]
+
+    def test_the_mcp_pin_tools_still_work_on_a_healthy_store(self, tmp_path, monkeypatch):
+        # The strict read must not break the ordinary path it now guards.
+        from kiro_crew.apps.builtins.mochi import mcp_server
+
+        _write_pins(tmp_path, [{"path": "/a"}])
+        monkeypatch.setattr(mcp_server, "_data_dir", lambda: tmp_path)
+
+        mcp_server._tool_pin_file({"path": "/b"})
+        assert [p["path"] for p in _read_pins(tmp_path)] == ["/a", "/b"]
+        mcp_server._tool_unpin_file({"path": "/a"})
+        assert [p["path"] for p in _read_pins(tmp_path)] == ["/b"]
+
+
+class TestRefusalIsTheNamedType:
+    """Both writers have to recognise the SAME refusal, so it is one public type
+    rather than a module-private one -- see PinsCorruptError's docstring."""
+
+    def test_each_mutator_raises_pins_corrupt_error(self, tmp_path):
+        (tmp_path / DATA_FILE_NAME).write_text("{ nope", encoding="utf-8")
+        svc, _ = _svc(tmp_path)
+        svc._pins = [{"path": "/p"}]
+        target = tmp_path / "notes.txt"
+        target.write_text("x", encoding="utf-8")
+
+        with pytest.raises(pfs.PinsCorruptError):
+            svc.add_pin(str(target), now_ms=NOW)
+        with pytest.raises(pfs.PinsCorruptError):
+            svc.remove_pin("/p")
+        with pytest.raises(pfs.PinsCorruptError):
+            svc.mark_seen("/p")
 
 
 class TestAddPinGuards:


### PR DESCRIPTION
## Problem / Motivation

`PinnedFilesService._reload_pins_from_disk` caught `(FileNotFoundError, json.JSONDecodeError)` and returned with `_pins` unchanged, and all four of its callers then `_persist()` a whole-file rewrite of `pinned-files.json`. A corrupt pin store was therefore silently replaced by whatever the in-memory list held.

Two writers mutate this file — the gateway service and the MCP server's `pin_file` / `unpin_file` — and the MCP side had the worse half of the same bug: it read through `_read_json` with a `{"version": 1, "pins": []}` default, so a corrupt store was **zeroed** rather than merely reverted to one process's view. Fixing only the service would have left that writer free to destroy what the service had just refused to touch, so both now go through one reader.

Same lenient-read-feeding-whole-file-rewrite class as #7620, #7788, #7794 and #7805.

## Why it matters

What is lost is exactly the rows another process wrote that this one never loaded, and the unparseable file was their only remaining copy — so the loss is silent and unrecoverable. On the MCP path the whole store goes. The pin list also drives a poller that stamps `updatedAt`, so a background tick could trigger the rewrite with no user action at all.

The user-visible half was just as quiet: `mark-seen` has no failure return, so the route reported `{"ok": true}` while the store was being replaced.

## What changed (motivation → approach → change)

`read_pins_for_update(file_path)` is the shared update-path reader. It returns the stored list, `None` when the file is absent (the one case where an empty base is true, so a first pin on a fresh install still lands), and raises the new public `PinsCorruptError` on the three shapes that all reach the same whole-file rewrite:

- a parse failure — the truncated bytes still hold most of the records verbatim, and only a person can recover them;
- a read error the filesystem raised (a transient EACCES/EIO, a scanner holding the handle on Windows) — the store is still there, this process just could not see it this instant;
- valid JSON whose root is not an object, or whose `pins` is not a list — no parse failure at all, so left uncaught it would be the quietest loss of the three.

A fourth refusal covers an **undecodable byte**, and decoding is strict here where `load` and the Node original use `errors="replace"`. That leniency only surfaces as a parse failure when the bad byte falls *outside* a JSON string; inside a quoted value — a pin label, or a path on a filesystem that does not enforce UTF-8 — it becomes U+FFFD, `json.loads` **succeeds**, and the whole-file rewrite persists the mangled text. Proven directly: a store holding `"label": "caf\xe9 notes"` came back from a mutation with byte `0xe9` gone and `\ufffd` written in its place. Raised by GPT 5.6 review (`span=617a8d5961a6`) and fixed in this PR.

`load` keeps the lenient decode: it does not write, and a file it accepts is preserved as a `.bak.<now_ms>` sidecar first. A mangled label can still reach memory at startup; it can no longer reach disk, because every write path re-reads through this reader.

The refusal is a **named public type** rather than the bare `json.JSONDecodeError` the aws-control readers raise in #8084: that app reached for the plain type only because the named one lived in another app, which does not apply to a type declared in the module both writers already import. Modelled on ops-mission-control's `CorruptDocumentError`.

`add_pin` / `remove_pin` / `mark_seen` propagate it, and the two HTTP handlers map it to `500 {"code": "pins_corrupt"}`. Returning `{"ok": false}` would read as "no such pin", and for mark-seen as outright success. 500 rather than 503: corruption does not clear on retry, a person has to repair the file, and the bytes it still holds are exactly why the mutation refused. The exception text is not echoed — pin labels and paths are agent-authored and are redacted on the way out of the GET handler.

`_process_watch_event` is the **one** path that swallows the refusal and logs instead. It fires from the owner's tick loop, where an escaping error would take down every other tick (stats, watchlist, presence) over a file it merely wanted to stamp; dropping the stamp is the same degradation a failed `_persist` already takes there. Every path a user drove raises, so the operator still learns the store needs repair.

The startup `load` path is deliberately untouched: there a corrupt file is replaced on purpose and preserved as a `.bak.<now_ms>` sidecar first, which is a decision with a recovery copy rather than a silent loss under someone else's write.

**Refuse-only rather than #7789's sidecar-preserve**, which the issue asked to weigh: this file already has the sidecar exactly where a replacement is intended, and the update path's whole problem is that no replacement was intended at all. Extending the sidecar there would mint a `.bak` on every refused mutation of the same unchanged bytes. This is one more data point for #7789, not a decision taken on its behalf.

## Tests

`test/test_mochi_pinned_files_cov80.py`, 13 new tests across three classes.

- `TestReadPinsForUpdate` — absence returns `None`; a healthy file returns its list; unparseable bytes, a non-UTF-8 byte outside a string, a non-UTF-8 byte **inside** a JSON string, a wrong-shaped root, and an unreadable file each refuse; the service's reload leaves `_pins` untouched when refusing.
- `TestCorruptStoreIsNotOverwrittenOnMutation` — `add_pin`, `remove_pin`, `mark_seen`, a debounced watch event, and both MCP pin tools all leave the corrupt bytes intact and broadcast nothing; a mutation preserves a non-UTF-8 byte in a label; a missing store still lets the first pin land; the MCP tools still work on a healthy store.
- `TestRefusalIsTheNamedType` — each mutator raises `PinsCorruptError`.

The mutation cases assert on the **file's bytes**, not on the exception type, so they fail on the buggy code for the reason that regressed rather than because a new symbol is missing; the type is pinned separately.

**Red-before**, with these tests run against pristine `origin/main` source — **13 failed / 27 passed**, each on a behavioural assertion:

| path | behaviour on `main` |
| --- | --- |
| `add_pin` | rewrote the corrupt file from its in-memory list |
| `remove_pin` | rewrote it, landing `"pins": []` |
| `mark_seen` | rewrote it |
| debounced watch event | rewrote it from the tick loop |
| `_tool_pin_file` | returned `{"ok": true, "pins": 1}` and zeroed it |
| `_tool_unpin_file` | zeroed it |

All 13 pass on this branch.

## Manual verification

N/A — no UI change. The behaviour is a refusal on a corrupt on-disk file, which the red-before table above exercises end to end through the public mutators, the tick loop and both MCP tools.

Local gates: 610 tests green (all 17 `test_mochi_*.py` plus `test_black_gate_contract.py`), `black`, `isort`, `flake8`, `mypy` (23 files), and the sync-io-in-async gate.

<!-- no-visual-delta -->

## Pattern harvest

Rule candidate: semgrep

Pattern: `read_text(errors="replace")` (or any lossy decode) on a read whose value is written back to the same file.

A lossy decode is a repair, and a repair is only safe on a path that does not persist what it read. On a read-modify-write path the substituted character is written over the original bytes, so the loss is silent and irreversible — and, uniquely among the corruption shapes, it produces **valid** JSON, so no parse-failure clause downstream can catch it. The same file legitimately keeps the lenient decode on its display/startup path, which is why the rule has to key on the read reaching a writer rather than on the decode call alone.

This is the fifth instance of the enclosing class (lenient read feeding a whole-file rewrite: #7620, #7788, #7794, #7805, this PR), and the decode variant is the one the earlier four did not cover — they raised on `UnicodeDecodeError` because they decoded strictly to begin with.

Closes #8088
