### PR TITLE
fix(config): route the last direct config writers through the advisory lock

### DIFF
--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -39,10 +39,11 @@ from kiro_crew.apps.manifest import (
 )
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import (
+    ConfigReadError,
     config_dir,
     config_local_path,
     config_path,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.pinned_fs import supports_pinned_walk
@@ -1210,15 +1211,36 @@ def _drop_trust_grant(name: str) -> None:
     # Preserve the no-grant fast path: ordinary uninstalls perform no config write.
     if not (has_name or has_repository or has_local):
         return
-    agent_raw["apps_trusted"] = [
-        a for a in (base_grants if isinstance(base_grants, list) else []) if a != name
-    ]
-    if isinstance(repositories, dict):
-        repositories = dict(repositories)
-        repositories.pop(name, None)
-        agent_raw["apps_trusted_repositories"] = repositories
-    if isinstance(local_grants, list):
-        agent_raw["apps_trusted_local"] = [a for a in local_grants if a != name]
+
+    def _revoke(raw_locked: dict) -> dict | None:
+        # Re-derived under the advisory lock. The read above decided WHETHER a
+        # grant exists (and the fast path for the ordinary no-grant uninstall);
+        # this is the read the write is derived from, so a settings write that
+        # landed in between is carried forward instead of being reverted.
+        agent_locked = raw_locked.get("agent")
+        if not isinstance(agent_locked, dict):
+            return None
+        base_locked = agent_locked.get("apps_trusted")
+        repos_locked = agent_locked.get("apps_trusted_repositories")
+        local_locked = agent_locked.get("apps_trusted_local")
+        if not (
+            (isinstance(base_locked, list) and name in base_locked)
+            or (isinstance(repos_locked, dict) and name in repos_locked)
+            or (isinstance(local_locked, list) and name in local_locked)
+        ):
+            # Another writer already revoked it. Skip the write rather than
+            # rewriting the document with identical bytes.
+            return None
+        agent_locked["apps_trusted"] = [
+            a for a in (base_locked if isinstance(base_locked, list) else []) if a != name
+        ]
+        if isinstance(repos_locked, dict):
+            repos_copy = dict(repos_locked)
+            repos_copy.pop(name, None)
+            agent_locked["apps_trusted_repositories"] = repos_copy
+        if isinstance(local_locked, list):
+            agent_locked["apps_trusted_local"] = [a for a in local_locked if a != name]
+        return raw_locked
     # Concurrency: this is the repo's standard config read-modify-write, and it
     # inherits that model exactly — no cross-process lock, atomic (tmp+rename) on
     # the way out so no reader can see a torn file. `read_config_for_update`'s own
@@ -1236,7 +1258,13 @@ def _drop_trust_grant(name: str) -> None:
     # also a single-key edit of the raw document rather than a re-serialisation of
     # the whole config, so what it can clobber is bounded to a concurrent edit that
     # lands inside the same read-to-write window.
-    write_config_atomically(path, raw)
+    try:
+        update_config_locked(path, mutate=_revoke, stamp_meta=False)
+    except ConfigReadError as exc:
+        # RAISE rather than return, for the same reason as the read above: a
+        # silent bail is the "uninstalled but still trusted" state the caller
+        # must not reach. Fails closed, so nothing was written.
+        raise RuntimeError(f"{path} is unreadable: {exc}") from exc
     logger.info("Dropped third-party trust grant for uninstalled app %s", name)
     # Audited, because this REVOKES an execution permission. The dashboard's revoke
     # endpoint emits its own SEL event, but this path runs from `kirocrew app
@@ -1343,26 +1371,45 @@ def _restore_trust_grant(
     if _has_trust_grant(name):
         return
     path = config_path()
-    raw = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
-    if not isinstance(raw, dict):
-        raise RuntimeError(f"{path} does not hold a JSON object")
-    agent_raw = raw.setdefault("agent", {})
-    if not isinstance(agent_raw, dict):
-        raise RuntimeError(f"{path} has a non-object agent section")
-    grants = agent_raw.get("apps_trusted")
-    agent_raw["apps_trusted"] = [*(grants if isinstance(grants, list) else []), name]
-    if repository:
-        repositories = agent_raw.get("apps_trusted_repositories")
-        bindings = dict(repositories) if isinstance(repositories, dict) else {}
-        bindings[name] = repository
-        agent_raw["apps_trusted_repositories"] = bindings
-    if local:
-        local_grants = agent_raw.get("apps_trusted_local")
-        local_names = list(local_grants) if isinstance(local_grants, list) else []
-        if name not in local_names:
-            local_names.append(name)
-        agent_raw["apps_trusted_local"] = local_names
-    write_config_atomically(path, raw)
+
+    def _restore(raw: dict) -> dict:
+        # Read and write inside one hold of the ``<config>.json.lock`` sidecar,
+        # so the restore cannot republish a document that predates a concurrent
+        # settings write. The CLI runs this in its own process, which is exactly
+        # the writer an in-process asyncio lock cannot serialize against.
+        agent_raw = raw.setdefault("agent", {})
+        if not isinstance(agent_raw, dict):
+            raise RuntimeError(f"{path} has a non-object agent section")
+        # Append only when absent. The pre-lock ``_has_trust_grant`` check above
+        # answered "should this restore run at all"; it is not the read this write
+        # is derived from, so a dashboard re-grant landing between it and the
+        # acquire would otherwise be duplicated into the persisted list. Same
+        # guarded shape as the ``apps_trusted_local`` branch below, and the same
+        # re-derive-under-the-lock rule ``_drop_trust_grant`` follows.
+        grants = agent_raw.get("apps_trusted")
+        granted = list(grants) if isinstance(grants, list) else []
+        if name not in granted:
+            granted.append(name)
+        agent_raw["apps_trusted"] = granted
+        if repository:
+            repositories = agent_raw.get("apps_trusted_repositories")
+            bindings = dict(repositories) if isinstance(repositories, dict) else {}
+            bindings[name] = repository
+            agent_raw["apps_trusted_repositories"] = bindings
+        if local:
+            local_grants = agent_raw.get("apps_trusted_local")
+            local_names = list(local_grants) if isinstance(local_grants, list) else []
+            if name not in local_names:
+                local_names.append(name)
+            agent_raw["apps_trusted_local"] = local_names
+        return raw
+
+    try:
+        update_config_locked(path, mutate=_restore, stamp_meta=False)
+    except ConfigReadError as exc:
+        # Unchanged shape: a document that is not a readable JSON object refuses
+        # the restore, and ``uninstall_app`` folds it into ``restore_note``.
+        raise RuntimeError(f"{path} does not hold a JSON object: {exc}") from exc
 
     # The CLI and dashboard run in different processes, so a same-name
     # replacement can land after the pre-write check.  Recheck the exact durable

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -19,8 +19,7 @@ from kiro_crew.config.loader import (
     ConfigReadError,
     build_provider_factory,
     config_path,
-    read_config_for_update,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.constants import BANNER, DATA_WARNING
 from kiro_crew.hooks import (
@@ -1007,14 +1006,21 @@ async def _interactive(
 
 
 def _ensure_default_agent_in_config() -> None:
-    """Ensure config.json includes a default KiroCrew agent for fresh installs."""
-    p = config_path()
-    try:
-        data = read_config_for_update(p)
-    except ConfigReadError:
-        logger.warning("Skipping default-agent seed: config unreadable")
-        return
-    if not data.get("agents"):
+    """Ensure config.json includes a default Kiro Crew agent for fresh installs.
+
+    Through :func:`update_config_locked` so the seed shares the advisory
+    ``<path>.lock`` with every other config writer. The read that decides
+    whether to seed has to happen INSIDE that lock: a dashboard or
+    ``kirocrew config set`` write landing between an outside read and this
+    write would be replaced by a document that never saw it.
+    """
+
+    def _seed(data: dict) -> dict | None:
+        if data.get("agents"):
+            # Another writer already seeded, or the operator has agents of
+            # their own: returning None skips the write entirely rather than
+            # rewriting the file with identical bytes.
+            return None
         data["agents"] = {
             "default": {
                 "kiro_agent": "kirocrew",
@@ -1023,4 +1029,14 @@ def _ensure_default_agent_in_config() -> None:
             }
         }
         data["default_agent"] = "default"
-        write_config_atomically(p, data)
+        return data
+
+    try:
+        # stamp_meta=False: this seed is a delta, and the writer it replaced
+        # stamped nothing. Adding a meta block here would make a fresh install's
+        # first chat rewrite a key this function does not own.
+        update_config_locked(config_path(), mutate=_seed, stamp_meta=False)
+    except ConfigReadError:
+        # Unchanged semantics: fail closed. Seeding over an unreadable config
+        # would drop every other setting it holds.
+        logger.warning("Skipping default-agent seed: config unreadable")

--- a/src/kiro_crew/cli_setup.py
+++ b/src/kiro_crew/cli_setup.py
@@ -23,12 +23,13 @@ from kiro_crew.config.loader import (
     CRED_OWNER_ID,
     CRED_SLACK_APP_TOKEN,
     CRED_SLACK_BOT_TOKEN,
+    ConfigReadError,
     _default_workspace_base,
     _workspace_dir_file,
     config_local_path,
     config_path,
     env_path,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.constants import DATA_WARNING, MIN_NODE_MAJOR
 from kiro_crew.sandbox import unavailable_kind
@@ -629,17 +630,42 @@ def _setup_whatsapp() -> None:
             print(f"  ⚠️  {cfg_file} does not contain a JSON object; skipping.\n")
             return
         cfg = loaded
-    if not isinstance(cfg.get("whatsapp"), dict):
-        if "whatsapp" in cfg:
-            print("  ⚠️  'whatsapp' section is not an object; leaving config untouched.\n")
-            return
-        cfg["whatsapp"] = {}
-    cfg["whatsapp"]["enabled"] = True
+    if not isinstance(cfg.get("whatsapp"), dict) and "whatsapp" in cfg:
+        print("  ⚠️  'whatsapp' section is not an object; leaving config untouched.\n")
+        return
+
+    # The read above answered "may this step run"; it is NOT the read the write
+    # is derived from. That one happens inside ``update_config_locked``'s hold on
+    # the ``<config>.lock`` sidecar, so a dashboard settings write or a
+    # ``kirocrew config set`` landing between the two is carried forward instead
+    # of being replaced by this older snapshot.
+    section_clash: list[str] = []
+
+    def _enable(data: dict) -> dict | None:
+        section = data.get("whatsapp")
+        if not isinstance(section, dict):
+            if "whatsapp" in data:
+                # Re-checked under the lock: another writer may have replaced the
+                # section since the read above. Skip the write, report outside.
+                section_clash.append("whatsapp")
+                return None
+            section = {}
+            data["whatsapp"] = section
+        section["enabled"] = True
+        return data
+
     try:
-        write_config_atomically(cfg_file, cfg)
+        update_config_locked(cfg_file, mutate=_enable, stamp_meta=False)
+    except ConfigReadError as exc:
+        # Does not inherit OSError, so it needs naming next to the write failure.
+        print(f"  ⚠️  Could not read {cfg_file}: {exc}\n")
+        return
     except OSError as exc:
         print(f"  ⚠️  Could not write {cfg_file}: {exc}")
         print("     Nothing was enabled. Enable it from Settings → Channels instead.\n")
+        return
+    if section_clash:
+        print("  ⚠️  'whatsapp' section is not an object; leaving config untouched.\n")
         return
     print("  ✅ Recorded: whatsapp.enabled = true")
     print("     Next: start the gateway, then scan the QR from")
@@ -740,7 +766,16 @@ def _setup_slash_command() -> None:
             return
 
     print("── Slash Command ──\n")
-    current = cfg.get("slack", {}).get("command", "kirocrew")
+    # A non-object ``slack`` is an operator value this step cannot merge into.
+    # Guarded HERE as well as in the write below, because this read is what runs
+    # first: ``.get("slack", {}).get(...)`` raised AttributeError on a scalar and
+    # took the whole wizard down with a traceback. Refusing the step is the same
+    # answer the whatsapp and sandbox steps give for their own sections.
+    slack_section = cfg.get("slack")
+    if slack_section is not None and not isinstance(slack_section, dict):
+        print("  ⚠️  'slack' section is not an object; leaving config untouched.\n")
+        return
+    current = (slack_section or {}).get("command", "kirocrew")
     # EOF keeps the current value (same reasoning as the workspace step).
     raw = _input_or_skip(f"  Slash command name [{current}]: ") or ""
     if raw:
@@ -754,8 +789,32 @@ def _setup_slash_command() -> None:
         print("  ⚠️  Command name too long (max 32 chars).")
         raw = current
 
-    cfg.setdefault("slack", {})["command"] = raw
-    write_config_atomically(cfg_file, cfg)
+    # Re-checked under the lock, and it must ABORT rather than replace: a
+    # non-dict ``slack`` is an operator value this step did not write and cannot
+    # merge into, so overwriting it with a fresh object would destroy it while
+    # reporting success. Absent is the only case that may be created. Same rule
+    # as the whatsapp and sandbox steps above.
+    section_clash: list[str] = []
+
+    def _apply(data: dict) -> dict | None:
+        section = data.get("slack")
+        if not isinstance(section, dict):
+            if "slack" in data:
+                section_clash.append("slack")
+                return None
+            section = {}
+            data["slack"] = section
+        section["command"] = raw
+        return data
+
+    try:
+        update_config_locked(cfg_file, mutate=_apply, stamp_meta=False)
+    except ConfigReadError as exc:
+        print(f"  ⚠️  Could not read {cfg_file}: {exc}")
+        return
+    if section_clash:
+        print("  ⚠️  'slack' section is not an object; leaving config untouched.\n")
+        return
     print(f"  ✅ Slash command: /{raw}\n")
 
 
@@ -870,11 +929,9 @@ def _setup_sandbox_consent() -> None:
         print(f"     in {cfg_file}\n")
         return
 
-    if not isinstance(cfg.get("agent"), dict):
-        if "agent" in cfg:
-            print("  ⚠️  'agent' section is not an object; leaving config untouched.\n")
-            return
-        cfg["agent"] = {}
+    if not isinstance(cfg.get("agent"), dict) and "agent" in cfg:
+        print("  ⚠️  'agent' section is not an object; leaving config untouched.\n")
+        return
 
     # Audit-or-deny, BEFORE the write: this persists an execution permission, so
     # it belongs in the tamper-evident log next to the ``denied`` event
@@ -904,9 +961,29 @@ def _setup_sandbox_consent() -> None:
         print("     left fail-closed. Fix the audit log, then re-run setup.\n")
         return
 
-    cfg["agent"]["sandbox_allow_unsandboxed_exec"] = True
+    # Under the sidecar lock, and the grant is applied to the document as it
+    # stands there -- the snapshot read before the prompt is only what decided
+    # whether to ask. The audit above stays ahead of the acquire, so the
+    # audit-then-write ordering is unchanged.
+    section_clash: list[str] = []
+
+    def _grant(data: dict) -> dict | None:
+        section = data.get("agent")
+        if not isinstance(section, dict):
+            if "agent" in data:
+                section_clash.append("agent")
+                return None
+            section = {}
+            data["agent"] = section
+        section["sandbox_allow_unsandboxed_exec"] = True
+        return data
+
     try:
-        write_config_atomically(cfg_file, cfg)
+        update_config_locked(cfg_file, mutate=_grant, stamp_meta=False)
+    except ConfigReadError as exc:
+        print(f"  ⚠️  Could not read {cfg_file}: {exc}")
+        print("     Nothing was granted — the host stays fail-closed.\n")
+        return
     except OSError as exc:
         # A locked or read-only config (common on Windows when another process
         # holds it) must not abort the whole wizard after the user has already
@@ -915,6 +992,9 @@ def _setup_sandbox_consent() -> None:
         print(f"  ⚠️  Could not write {cfg_file}: {exc}")
         print("     Nothing was granted — the host stays fail-closed. Set")
         print("     agent.sandbox_allow_unsandboxed_exec=true by hand to opt in.\n")
+        return
+    if section_clash:
+        print("  ⚠️  'agent' section is not an object; leaving config untouched.\n")
         return
     print("  ✅ Recorded: agent.sandbox_allow_unsandboxed_exec = true\n")
 
@@ -999,8 +1079,18 @@ def _setup_timezone() -> None:
                 print("  ⏭  Skipped after too many attempts.\n")
                 return
 
-    data["timezone"] = tz_val
-    write_config_atomically(cfg_file, data)
+    def _apply(existing: dict) -> dict:
+        existing["timezone"] = tz_val
+        return existing
+
+    try:
+        update_config_locked(cfg_file, mutate=_apply, stamp_meta=False)
+    except ConfigReadError as exc:
+        # The pre-prompt read already refuses a corrupt config; this covers a
+        # file that went bad while the operator was answering, and refuses the
+        # same way rather than surfacing a traceback out of the wizard.
+        print(f"  ⚠️  Could not read {cfg_file}: {exc}")
+        return
     print(f"  ✅ Timezone saved: {tz_val}\n")
 
 
@@ -1047,14 +1137,28 @@ def _maybe_setup_dashboard_url() -> None:
         print("  ⏭  Skipped. Dashboard will bind to localhost only.\n")
         return
 
-    # Persist to config.json
-    try:
-        data: dict = {}
-        if cfg_file.exists():
-            data = json.loads(cfg_file.read_text(encoding="utf-8"))
-        dashboard = data.setdefault("dashboard", {})
+    # Persist to config.json. The read is inside the lock hold, so the URL
+    # cannot be written over a document that predates another writer's change.
+    #
+    # A non-dict ``dashboard`` RAISES rather than being replaced: it is an
+    # operator value this step cannot merge into, and the broad handler below
+    # already reports exactly that as "Failed to save" and writes nothing --
+    # which is what this step did before it took the lock, when the same shape
+    # raised out of ``setdefault``.
+    def _apply(data: dict) -> dict:
+        dashboard = data.get("dashboard")
+        if dashboard is None and "dashboard" not in data:
+            dashboard = {}
+            data["dashboard"] = dashboard
+        elif not isinstance(dashboard, dict):
+            raise TypeError(
+                f"'dashboard' in {cfg_file} is not an object; refusing to replace it"
+            )
         dashboard["url"] = answer
-        write_config_atomically(cfg_file, data)
+        return data
+
+    try:
+        update_config_locked(cfg_file, mutate=_apply, stamp_meta=False)
         print(f"  ✅ Dashboard URL saved: {answer}")
         print("  Token auth will be required for all requests.\n")
     except Exception as e:

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1121,14 +1121,43 @@ def update_config_locked(
 ) -> dict:
     """Perform an atomic read-modify-write of a config file under an advisory lock.
 
-    The locked primitive for the converted config.json writers and the required
-    path for new config.json mutations.  Legacy writers that pre-date this
-    function (dashboard agents endpoint, updates.py, security.py,
-    messaging.py, mcp.py, core.py STT) still use
-    :func:`write_config_atomically` directly and rely on the in-process asyncio
-    ``_get_config_lock()`` only.  ``memory.py`` was in that list and has been
-    converted; it now reaches this function through
+    The locked primitive for every DIRECT
+    ``write_config_atomically(config_path())`` caller outside this module, and
+    the required path for new ``config.json`` mutations.  **No such caller
+    remains** -- the dashboard agents endpoint, ``security.py``, the apps manager
+    and the CLI setup wizard were the last of them and are converted (#8032);
+    ``memory.py`` was converted earlier and reaches this function through
     ``dashboard/chat_utils.run_config_write``.
+    ``TestEveryConfigWriterIsLocked`` in
+    ``test/test_config_rmw_preserves_settings.py`` is the ratchet that keeps the
+    list from regrowing.
+
+    Read "direct caller outside this module" strictly: it is the exact set the
+    ratchet checks, and it is NOT the same as "every writer that reaches
+    ``config.json``".  :meth:`KiroCrewConfig.save` calls
+    :func:`write_config_atomically` and does NOT come through here -- see the
+    second family below.
+
+    A SECOND family of writers still bypasses this lock, and the ratchet does
+    NOT reach it -- for two different reasons, neither of which is visible from a
+    call site:
+
+    * Writers that reach ``config_path()`` through
+      ``kiro_crew.agent._atomic_json_write`` (``messaging.py``'s per-channel
+      savers, ``core.py``'s STT PUT, ``mcp.py``'s gateway-enable). The ratchet
+      matches calls to :func:`write_config_atomically`, and these make none.
+    * Writers that go through :meth:`KiroCrewConfig.save` (``updates.py``'s
+      log-level PUT, ``core.py``'s theme PUT, several ``agents.py`` agent CRUD
+      endpoints). ``save`` DOES call :func:`write_config_atomically` directly,
+      but it does so from inside this module, which the ratchet exempts -- so the
+      write is invisible to it at every caller.
+
+    Both rely on the in-process asyncio ``_get_config_lock()`` only, which
+    serializes same-loop callers and nothing else, so they can still interleave
+    with a holder of this lock.  Converting them is follow-up work; do not read
+    the ratchet's green as covering them, and note that an ALIASED import of
+    :func:`write_config_atomically` would evade it for the same matching reason
+    as the first bullet.
 
     Contract:
 

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -54,10 +54,10 @@ from kiro_crew.config.loader import (
     coerce_effort,
     inject_kiro_cli_api_key,
     normalize_agent_model,
-    read_config_for_update,
     resolve_agent_bindings,
     resolve_agent_config_path,
     resolve_effective_model,
+    update_config_locked,
     write_config_atomically,
 )
 from kiro_crew.config.schema import SCHEMA_REGISTRY, config_entry_to_dict
@@ -68,6 +68,7 @@ from kiro_crew.dashboard.chat_utils import (
     SLASH_COMMAND_DESCRIPTIONS,
     _history_key_for,
     is_deprecated_model,
+    run_config_write,
 )
 from kiro_crew.dashboard.handlers._shared import (
     MAX_AGENT_SKILLS,
@@ -932,17 +933,29 @@ def _commit_agent_config_locked(
             ", ".join(preserved),
         )
     sanitize(config)
-    # (1) The one fallible READ, and it precedes every write.
+
+    # (1)+(2) config.json, read AND written inside one hold of the
+    # ``<config>.json.lock`` sidecar. The caller's ``_get_config_lock()`` is an
+    # asyncio lock: it serializes this against sibling handlers on this event
+    # loop and nothing else. The ~69 ``update_config_locked`` writers -- the CLI,
+    # the boot refresh, another gateway process -- take the advisory lock
+    # instead, so without this the two families could interleave and whichever
+    # renamed second published a document that never saw the other's change.
     #
-    # Fail closed: writing back a {} baseline would drop every other setting
-    # just to record removedTools (see read_config_for_update).
-    mc_cfg = read_config_for_update(mc_cfg_path)
-    if removed_per_key:
-        mc_cfg["removedTools"] = removed_per_key
-    else:
-        mc_cfg.pop("removedTools", None)
-    # (2) config.json — the snapshot the read above produced, still current.
-    write_config_atomically(mc_cfg_path, mc_cfg)
+    # Still the one fallible READ, and it still precedes every write: with the
+    # default ``on_corrupt="fail"`` an unreadable config raises
+    # :class:`ConfigReadError` out of here before anything durable happens, so
+    # the caller's 500 stays exact. Failing closed is the point -- writing back a
+    # {} baseline would drop every other setting just to record removedTools
+    # (see read_config_for_update).
+    def _record_removed_tools(mc_cfg: dict) -> dict:
+        if removed_per_key:
+            mc_cfg["removedTools"] = removed_per_key
+        else:
+            mc_cfg.pop("removedTools", None)
+        return mc_cfg
+
+    update_config_locked(mc_cfg_path, mutate=_record_removed_tools, stamp_meta=False)
     # (3) agent_model_state.json bookkeeping — after (2), before (4).
     changed = agent_state.lift_and_strip_bookkeeping(config, name)
     # (4) the installed spec, under the caller's bridge-file lock.
@@ -1239,6 +1252,7 @@ async def api_default_agent(request: web.Request) -> web.Response:
                 status=400,
             )
         path = _h.config_path()
+
         # This read-modify-write must hold the SAME in-process lock every other
         # ``config.json`` RMW in the dashboard takes (agent create/update/delete,
         # capability install/uninstall, the agent-config PUT). The event loop no
@@ -1247,24 +1261,36 @@ async def api_default_agent(request: web.Request) -> web.Response:
         # can capture a baseline the worker is about to republish — and the last
         # atomic rename silently reverts the other side's unrelated settings.
         #
-        # Loop-side ``async with`` rather than an offload: the lock is an
-        # asyncio lock (``LoopBoundLock``) acquired exactly this way by every
-        # sibling RMW in this module, and the read and write below are
-        # synchronous with NO await between them, so once the lock is held the
-        # pair is already indivisible — a worker hop would add a cancellation
-        # point where today there is none.
-        async with _get_config_lock():
-            try:
-                data = read_config_for_update(path)
-            except ConfigReadError:
-                # Fail closed: writing back a {} baseline would drop every other setting.
-                logger.exception("Refusing to set default agent: config unreadable")
-                return web.json_response(
-                    {"error": "failed to read config file", "code": "config_unreadable"},
-                    status=500,
-                )
+        # That lock is not sufficient on its own, though: it is an asyncio lock,
+        # so it serializes only same-loop callers. The read-modify-write itself
+        # goes through ``update_config_locked``, which holds the
+        # ``<config>.json.lock`` sidecar across its own read and write and so
+        # also serializes against the CLI, worker threads and other processes.
+        #
+        # ``run_config_write`` is the one async entry point that holds BOTH --
+        # its own docstring says so -- and it is what every other converted
+        # dashboard writer uses. It takes the loop-side lock, dispatches the
+        # synchronous read-modify-write to a worker thread so an unbounded
+        # advisory-flock wait never stalls the gateway, and SHIELDS that worker
+        # in a drain loop so the lock cannot be released with a write still in
+        # flight. Composing those three by hand here would be a third copy of a
+        # helper that already exists, free to drift from it.
+        def _set_default(data: dict) -> dict:
             data["default_agent"] = name
-            write_config_atomically(path, data)
+            return data
+
+        try:
+            await run_config_write(
+                update_config_locked, path, mutate=_set_default, stamp_meta=False
+            )
+        except ConfigReadError:
+            # Fail closed: writing back a {} baseline would drop every other
+            # setting. Nothing durable ran, so this 500 is exact.
+            logger.exception("Refusing to set default agent: config unreadable")
+            return web.json_response(
+                {"error": "failed to read config file", "code": "config_unreadable"},
+                status=500,
+            )
         return web.json_response({"ok": True, "default_agent": name})
     cfg = KiroCrewConfig.load()
     return web.json_response({"default_agent": cfg.default_agent})

--- a/src/kiro_crew/dashboard/handlers/security.py
+++ b/src/kiro_crew/dashboard/handlers/security.py
@@ -65,12 +65,13 @@ from kiro_crew.apps.registry import (
 from kiro_crew.apps.routes import app_lifecycle_lock
 from kiro_crew.apps.teardown import teardown_app_runtime
 from kiro_crew.config.loader import (
+    ConfigReadError,
     KiroCrewConfig,
     _invalidate_config_cache,
     config_local_path,
     config_path,
     denied_commands_path,
-    write_config_atomically,
+    update_config_locked,
 )
 from kiro_crew.dashboard.handlers.agents import _get_config_lock
 from kiro_crew.executors import governance_executor
@@ -1064,26 +1065,32 @@ async def _mutate_agent_config(mutate) -> None:
     """
     def _read_modify_write() -> None:
         path = config_path()
-        raw: dict = {}
-        if path.is_file():
-            try:
-                loaded = json.loads(path.read_text(encoding="utf-8"))
-            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-                raise ConfigCorruptError(f"{path} is unreadable: {exc}") from exc
-            if not isinstance(loaded, dict):
-                raise ConfigCorruptError(f"{path} is not a JSON object")
-            raw = loaded
-        # Inside the lock, so a concurrent writer cannot add an overlay between the
-        # check and the write.
-        owned = _overlay_owned_trust_settings()
-        if owned:
-            raise TrustSettingOverlayOwned(owned)
-        agent_raw = raw.get("agent")
-        if not isinstance(agent_raw, dict):
-            agent_raw = {}
-            raw["agent"] = agent_raw
-        mutate(agent_raw)
-        write_config_atomically(path, raw)
+
+        def _apply(raw: dict) -> dict:
+            # Runs inside ``update_config_locked``'s hold on the
+            # ``<config>.json.lock`` sidecar, so neither the overlay check nor
+            # the grant edit can be separated from the write by ANY other
+            # writer -- including the CLI and other processes, which the
+            # surrounding asyncio lock cannot reach.
+            owned = _overlay_owned_trust_settings()
+            if owned:
+                raise TrustSettingOverlayOwned(owned)
+            agent_raw = raw.get("agent")
+            if not isinstance(agent_raw, dict):
+                agent_raw = {}
+                raw["agent"] = agent_raw
+            mutate(agent_raw)
+            return raw
+
+        try:
+            update_config_locked(path, mutate=_apply, stamp_meta=False)
+        except ConfigReadError as exc:
+            # Same refusal as before, reported through this module's own error
+            # type so callers keep turning it into a coded 409. The locked read
+            # fails closed by default (``on_corrupt="fail"``), so the existing
+            # file is never replaced with defaults -- an absent file is still a
+            # genuine empty starting point and proceeds.
+            raise ConfigCorruptError(f"{path} is unreadable: {exc}") from exc
         # save() would have done this; a raw write must do it explicitly or the
         # grant does not take effect until a restart — and a REVOKE that does not
         # take effect is the exact failure this feature exists to prevent.

--- a/test/test_api_agent_config_put_succeeds.py
+++ b/test/test_api_agent_config_put_succeeds.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from aiohttp import web
 
+import kiro_crew.config.loader as loader_module
 from kiro_crew.dashboard.handlers import api_agent_config
 
 
@@ -462,8 +463,16 @@ async def test_agent_config_write_goes_through_one_shielded_offload(tmp_path):
         return False
 
     def _recording_write(path, data, **kwargs):  # noqa: ANN001 - mirrors the real signature
-        writes.append(("mc_cfg" if Path(path) == mc_cfg else "spec", inside_offload))
+        writes.append(("spec", inside_offload))
         Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    real_locked = loader_module.update_config_locked
+
+    def _recording_locked(path, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        # The ``config.json`` half is now one locked read-modify-write, so this
+        # is where that durable write is observed.
+        writes.append(("mc_cfg", inside_offload))
+        return real_locked(path, **kwargs)
 
     with (
         patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
@@ -479,6 +488,10 @@ async def test_agent_config_write_goes_through_one_shielded_offload(tmp_path):
         patch(
             "kiro_crew.dashboard.handlers.agents.write_config_atomically",
             _recording_write,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.update_config_locked",
+            _recording_locked,
         ),
         patch("kiro_crew.dashboard.handlers.mcp._offload_config_write", _recording_offload),
     ):
@@ -644,8 +657,15 @@ async def test_agent_config_put_lock_releases_only_after_every_write_landed(tmp_
         return False
 
     def _recording_write(path, data, **kwargs):  # noqa: ANN001 - mirrors the real signature
-        completed.append("mc_cfg" if Path(path) == mc_cfg else "spec")
+        completed.append("spec")
         Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    real_locked = loader_module.update_config_locked
+
+    def _recording_locked(path, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        result = real_locked(path, **kwargs)
+        completed.append("mc_cfg")
+        return result
 
     @contextlib.asynccontextmanager
     async def _recording_lock():
@@ -675,6 +695,10 @@ async def test_agent_config_put_lock_releases_only_after_every_write_landed(tmp_
         patch(
             "kiro_crew.dashboard.handlers.agents.write_config_atomically",
             _recording_write,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.update_config_locked",
+            _recording_locked,
         ),
     ):
         task = asyncio.ensure_future(api_agent_config(request))
@@ -767,7 +791,10 @@ async def test_agent_config_put_unreadable_config_persists_nothing(tmp_path, mon
 
     request.json = mock_json
 
-    def _unreadable(path):  # noqa: ANN001 - mirrors the real signature
+    def _unreadable(path, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        # The fallible read now lives INSIDE the locked primitive, which raises
+        # it before invoking the mutate callback, so the seam moves here. The
+        # property is unchanged: the unit's first durable step refuses.
         raise ConfigReadError("config.json is corrupt")
 
     with (
@@ -784,7 +811,7 @@ async def test_agent_config_put_unreadable_config_persists_nothing(tmp_path, mon
             "kiro_crew.platform.governance.sanitize_agent_config_governance",
             lambda config: None,
         ),
-        patch("kiro_crew.dashboard.handlers.agents.read_config_for_update", _unreadable),
+        patch("kiro_crew.dashboard.handlers.agents.update_config_locked", _unreadable),
     ):
         response = await api_agent_config(request)
 
@@ -933,10 +960,11 @@ async def test_agent_config_put_failed_config_write_leaves_bookkeeping_untouched
 
     request.json = mock_json
 
-    def _config_write_fails(path, data, **kwargs):  # noqa: ANN001 - mirrors the real signature
-        if Path(path) == mc_cfg:
-            raise OSError("disk full")
-        Path(path).write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    def _config_write_fails(path, **kwargs):  # noqa: ANN001 - mirrors the real signature
+        # The ``config.json`` write is now the locked primitive, so the injected
+        # I/O failure moves there. Still the unit's FIRST durable step, which is
+        # what the assertions below pin.
+        raise OSError("disk full")
 
     with (
         patch("kiro_crew.dashboard.handlers._installed_agent_config", return_value=installed),
@@ -953,7 +981,7 @@ async def test_agent_config_put_failed_config_write_leaves_bookkeeping_untouched
             lambda config: None,
         ),
         patch(
-            "kiro_crew.dashboard.handlers.agents.write_config_atomically",
+            "kiro_crew.dashboard.handlers.agents.update_config_locked",
             _config_write_fails,
         ),
     ):
@@ -1076,7 +1104,7 @@ async def test_default_agent_write_holds_the_config_lock(tmp_path):
     """
     import contextlib
 
-    from kiro_crew.config.loader import read_config_for_update, write_config_atomically
+    from kiro_crew.config.loader import update_config_locked
     from kiro_crew.dashboard.handlers import api_default_agent
 
     mc_cfg = tmp_path / "config.json"
@@ -1103,13 +1131,23 @@ async def test_default_agent_write_holds_the_config_lock(tmp_path):
         finally:
             holding = False
 
-    def _recording_read(path):  # noqa: ANN001 - mirrors the real signature
-        observed.append(("read", holding))
-        return read_config_for_update(path)
+    def _recording_locked(path, *, mutate, **kwargs):  # noqa: ANN001 - real signature
+        """Observe both halves of the locked read-modify-write.
 
-    def _recording_write(path, data):  # noqa: ANN001 - mirrors the real signature
+        The read is no longer a separate call the handler makes: it happens
+        inside ``update_config_locked``, immediately before it invokes *mutate*.
+        Recording at the callback is therefore the read, and recording after the
+        primitive returns is the write -- the same two observations as before,
+        taken where they now happen.
+        """
+
+        def _observed_mutate(data: dict) -> dict:
+            observed.append(("read", holding))
+            return mutate(data)
+
+        result = update_config_locked(path, mutate=_observed_mutate, **kwargs)
         observed.append(("write", holding))
-        write_config_atomically(path, data)
+        return result
 
     loaded = MagicMock()
     loaded.agents = {"kirocrew": MagicMock()}
@@ -1120,8 +1158,7 @@ async def test_default_agent_write_holds_the_config_lock(tmp_path):
         patch("kiro_crew.dashboard.handlers.config_path", return_value=mc_cfg),
         patch("kiro_crew.dashboard.handlers.agents.KiroCrewConfig", fake_config_cls),
         patch("kiro_crew.dashboard.handlers.agents._get_config_lock", _recording_lock),
-        patch("kiro_crew.dashboard.handlers.agents.read_config_for_update", _recording_read),
-        patch("kiro_crew.dashboard.handlers.agents.write_config_atomically", _recording_write),
+        patch("kiro_crew.dashboard.handlers.agents.update_config_locked", _recording_locked),
     ):
         resp = await api_default_agent(request)
 
@@ -1131,6 +1168,14 @@ async def test_default_agent_write_holds_the_config_lock(tmp_path):
     # lets a sibling RMW land between this read and it, which is the whole defect.
     assert all(held for _step, held in observed), (
         f"the default-agent read-modify-write ran OUTSIDE the config lock: {observed}"
+    )
+    # And the ADVISORY lock was taken too, not just the in-process one (#8032).
+    # The asyncio lock above serializes same-loop callers only, so on its own it
+    # leaves the CLI and other processes free to interleave with this RMW.
+    assert (tmp_path / "config.json.lock").exists(), (
+        "the default-agent RMW did not route through update_config_locked: no "
+        "<config>.lock sidecar was taken, so it is still unserialized against "
+        "the CLI, worker threads and other processes"
     )
     # And the RMW itself still preserves unrelated settings.
     assert json.loads(mc_cfg.read_text(encoding="utf-8")) == {

--- a/test/test_config_rmw_preserves_settings.py
+++ b/test/test_config_rmw_preserves_settings.py
@@ -619,3 +619,164 @@ class TestAutoUpdateToggleKeepsSettings:
         # The unreadable file is left exactly as it was — not replaced by a
         # one-key config that silently drops every real setting.
         assert path.read_text(encoding="utf-8") == torn
+
+
+class TestEveryConfigWriterIsLocked:
+    """No direct ``write_config_atomically(config_path())`` caller may reappear (#8032).
+
+    ``update_config_locked`` holds an advisory lock on a ``<path>.lock`` sidecar
+    for its whole read-modify-write. Its guarantee is only as strong as the set
+    of writers that participate: a writer that renames ``config.json`` without
+    taking that lock can land between a participant's read and write, and the
+    second rename wins with a document that never saw the other's change. The
+    loss is silent and the lost data is user configuration.
+
+    That list was drained once by hand (the dashboard agents endpoint,
+    ``security.py``, the apps manager, the CLI setup wizard). Without a ratchet
+    it regrows: the write is one obvious line and nothing about it announces the
+    lock it is missing. So this walks the AST rather than asserting on a
+    hand-maintained list, in the shape ``TestNoFailOpenConfigWriters`` above
+    established.
+
+    **What it does NOT cover.** Only calls to ``write_config_atomically``. A
+    second family of writers reaches ``config.json`` through
+    ``kiro_crew.agent._atomic_json_write`` or :meth:`KiroCrewConfig.save`
+    (``messaging.py``'s channel savers, ``core.py``'s STT and theme PUTs,
+    ``mcp.py``'s gateway-enable, ``updates.py``'s log-level PUT, several
+    ``agents.py`` CRUD endpoints) and still bypasses the lock. Green here does
+    not mean every config writer is locked -- it means this class of them is.
+    """
+
+    #: The primitive itself writes through ``write_config_atomically`` by
+    #: definition, and ``KiroCrewConfig.save`` is the head of the second family
+    #: above. Both live here, so the module is exempt as a whole.
+    _ALLOWED_FILES = {"loader.py"}
+
+    #: Resolvers whose return value IS a config document path.
+    _CONFIG_PATH_FUNCS = {"config_path", "config_local_path"}
+
+    def test_no_unlocked_config_write_outside_the_primitive(self):
+        import ast
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        offenders: list[str] = []
+
+        def _is_config_path_call(node: ast.AST) -> bool:
+            if not isinstance(node, ast.Call):
+                return False
+            name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+            return name in self._CONFIG_PATH_FUNCS
+
+        for path in root.rglob("*.py"):
+            if "_vendor" in path.parts or path.name in self._ALLOWED_FILES:
+                continue
+            src = path.read_text(encoding="utf-8", errors="replace")
+            if "write_config_atomically" not in src:
+                continue
+            try:
+                tree = ast.parse(src)
+            except SyntaxError:
+                continue
+            # Scope per function: the same local name (``path``, ``cfg_file``) is
+            # reused across unrelated functions, so a file-wide binding map
+            # reports false positives -- and, worse, would let a genuine offender
+            # hide behind an unrelated function's rebinding of the same name.
+            funcs = [
+                n
+                for n in ast.walk(tree)
+                if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            ]
+            for func in funcs:
+                config_names: set[str] = set()
+                for node in ast.walk(func):
+                    if not isinstance(node, ast.Assign) or not _is_config_path_call(node.value):
+                        continue
+                    for tgt in node.targets:
+                        if isinstance(tgt, ast.Name):
+                            config_names.add(tgt.id)
+                for node in ast.walk(func):
+                    if not isinstance(node, ast.Call):
+                        continue
+                    called = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+                    if called != "write_config_atomically" or not node.args:
+                        continue
+                    target = node.args[0]
+                    hit = _is_config_path_call(target) or (
+                        isinstance(target, ast.Name) and target.id in config_names
+                    )
+                    if hit:
+                        offenders.append(f"{path.name}:{node.lineno} ({func.name})")
+
+        assert not offenders, (
+            "config.json / config.local.json must be written through "
+            "update_config_locked(), which holds the <path>.lock sidecar across "
+            "the whole read-modify-write. A direct write_config_atomically() "
+            "here takes no advisory lock, so it can land between another "
+            "writer's read and write and silently revert it (#8032). For an "
+            "async handler, go through dashboard/chat_utils.run_config_write or "
+            "the module's own shielded offload.\n  " + "\n  ".join(sorted(set(offenders)))
+        )
+
+    def test_the_ratchet_would_catch_a_reintroduced_writer(self, tmp_path):
+        """The scan is not vacuous: the shape it forbids is actually detected.
+
+        A ratchet asserting an empty list is indistinguishable from a ratchet
+        whose matcher is broken, and this one has to see through a local variable
+        to work at all. So the detector is exercised on both spellings a
+        regression would take.
+        """
+        import ast
+
+        source = (
+            "def handler():\n"
+            "    path = config_path()\n"
+            "    data = read_config_for_update(path)\n"
+            "    data['k'] = 1\n"
+            "    write_config_atomically(path, data)\n"
+            "\n"
+            "def inline():\n"
+            "    write_config_atomically(config_local_path(), {})\n"
+            "\n"
+            "def innocent(path):\n"
+            "    write_config_atomically(path, {})\n"
+        )
+        tree = ast.parse(source)
+
+        def _is_config_path_call(node):
+            if not isinstance(node, ast.Call):
+                return False
+            name = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+            return name in self._CONFIG_PATH_FUNCS
+
+        flagged: set[str] = set()
+        for func in [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        ]:
+            config_names = {
+                tgt.id
+                for node in ast.walk(func)
+                if isinstance(node, ast.Assign) and _is_config_path_call(node.value)
+                for tgt in node.targets
+                if isinstance(tgt, ast.Name)
+            }
+            for node in ast.walk(func):
+                if not isinstance(node, ast.Call) or not node.args:
+                    continue
+                called = getattr(node.func, "attr", None) or getattr(node.func, "id", None)
+                if called != "write_config_atomically":
+                    continue
+                target = node.args[0]
+                if _is_config_path_call(target) or (
+                    isinstance(target, ast.Name) and target.id in config_names
+                ):
+                    flagged.add(func.name)
+
+        assert flagged == {"handler", "inline"}, (
+            "the ratchet's matcher does not see the shape it exists to forbid "
+            f"(flagged: {sorted(flagged)}). ``innocent`` writes a CALLER-SUPPLIED "
+            "path -- the agent-spec write in agents.py is that shape -- and must "
+            "not be flagged."
+        )

--- a/test/test_config_writers_advisory_lock.py
+++ b/test/test_config_writers_advisory_lock.py
@@ -1,0 +1,513 @@
+"""Converted config writers share the advisory lock, so neither side is lost (#8032).
+
+``update_config_locked`` holds an advisory lock on a ``<path>.lock`` sidecar for
+the whole read-modify-write. A writer that instead reads with a bare
+``read_config_for_update`` / ``json.loads`` and writes with
+``write_config_atomically`` under the in-process asyncio ``_get_config_lock()``
+is serialized against same-loop callers ONLY -- not against a holder of the
+sidecar, not against a worker thread, and not against another process. Such a
+writer and a locked read-modify-write can therefore interleave, and whichever
+renames second publishes a document that never saw the other's change.
+
+Each test here drives one converted writer against a locked writer in the
+interleave that used to lose data, and asserts BOTH changes survive. They fail on
+the pre-conversion shape and pass after it, which is the property that matters:
+"holds a lock" is not observable, "did not lose the other writer's setting" is.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import unittest.mock
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config import loader as cfg_loader
+
+#: Bounded so a regression fails the test instead of hanging the suite.
+_TIMEOUT = 30.0
+
+
+@pytest.fixture()
+def cfg_file(tmp_path: Path) -> Path:
+    """A ``config.json`` carrying settings BOTH writers must preserve.
+
+    ``model`` belongs to neither writer, so it is the canary for a whole-document
+    clobber; ``session.timeout_secs`` proves a nested section survives.
+    """
+    path = tmp_path / "config.json"
+    path.write_text(
+        json.dumps(
+            {
+                "model": "sonnet",
+                "session": {"timeout_secs": 7200},
+                "agent": {"apps_trusted": ["zibble-app"], "model": "sonnet"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestAppsManagerTrustRevoke:
+    """``apps.manager._drop_trust_grant`` -- the CLI-side uninstall writer.
+
+    It runs synchronously in the ``kirocrew`` CLI process and in the dashboard's
+    ``subprocess_executor()`` worker thread. Neither can take the loop's asyncio
+    lock, so the sidecar is the only thing that can serialize it against a
+    settings write.
+    """
+
+    def test_a_locked_writer_landing_mid_revoke_is_not_lost(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two writers, deterministically interleaved: neither may lose the other.
+
+        Writer A is an ordinary locked config write (the shape ``kirocrew config
+        set`` and the dashboard settings PATCH both use), suspended inside its
+        mutate callback so it is holding the sidecar. Writer B is the trust
+        revoke, started while A holds it.
+
+        Before the conversion B took no advisory lock: it read straight away --
+        observing the document as it was BEFORE A's write -- and renamed over the
+        top, so exactly one of the two changes reached disk depending on who
+        renamed last. After it, B waits for the sidecar and re-reads inside its
+        own hold, so both land.
+        """
+        from kiro_crew.apps import manager as appmanager
+
+        monkeypatch.setattr(appmanager, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(appmanager, "config_local_path", lambda: cfg_file.parent / "local.json")
+
+        a_holding = threading.Event()
+        a_may_finish = threading.Event()
+        errors: list[BaseException] = []
+
+        def _settings_write(data: dict) -> dict:
+            a_holding.set()
+            assert a_may_finish.wait(_TIMEOUT), "test bug: the settings write was never released"
+            data.setdefault("session", {})["autocompact_pct"] = 42.0
+            return data
+
+        def _writer_a() -> None:
+            try:
+                cfg_loader.update_config_locked(cfg_file, mutate=_settings_write, stamp_meta=False)
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        def _writer_b() -> None:
+            try:
+                appmanager._drop_trust_grant("zibble-app")
+            except BaseException as exc:  # pragma: no cover - surfaced below
+                errors.append(exc)
+
+        thread_a = threading.Thread(target=_writer_a, daemon=True)
+        thread_b = threading.Thread(target=_writer_b, daemon=True)
+        # try/finally: an assertion below would otherwise exit with a writer
+        # still parked on the event, leaking it into later tests.
+        try:
+            thread_a.start()
+            assert a_holding.wait(_TIMEOUT), "the settings write never reached its mutate"
+
+            thread_b.start()
+            # Give B a chance to reach (or block on) its write before A resumes.
+            # A short join, not a bare sleep: it returns as soon as B is done in
+            # the unlocked case, and simply times out while B is blocked.
+            thread_b.join(timeout=1.0)
+
+            a_may_finish.set()
+            thread_a.join(timeout=_TIMEOUT)
+            thread_b.join(timeout=_TIMEOUT)
+            assert not thread_a.is_alive(), "the settings write did not finish"
+            assert not thread_b.is_alive(), "the trust revoke did not finish"
+        finally:
+            a_may_finish.set()
+            for thread in (thread_a, thread_b):
+                if thread.is_alive():
+                    thread.join(timeout=_TIMEOUT)
+
+        assert not errors, f"writer raised: {errors!r}"
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["agent"]["apps_trusted"] == [], (
+            "the trust revoke was lost -- the app is still trusted after being "
+            "uninstalled, which is the 'uninstalled but still trusted' state the "
+            "withdrawal exists to prevent"
+        )
+        assert on_disk["session"]["autocompact_pct"] == 42.0, (
+            "the settings write that landed while the revoke was in flight was "
+            "lost -- the revoke does not share the advisory lock"
+        )
+        # Neither writer owns these, so a whole-document clobber shows up here.
+        assert on_disk["model"] == "sonnet"
+        assert on_disk["session"]["timeout_secs"] == 7200
+
+    def test_the_revoke_takes_the_sidecar(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Structural companion: the lock is taken on the sidecar, not the file.
+
+        ``write_config_atomically`` replaces the inode, so a lock on the config
+        file's own fd would not serialize against the rename. Asserting the
+        sidecar exists pins that the revoke reached the primitive at all, which
+        the interleave test above can only show indirectly.
+        """
+        from kiro_crew.apps import manager as appmanager
+
+        monkeypatch.setattr(appmanager, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(appmanager, "config_local_path", lambda: cfg_file.parent / "local.json")
+
+        appmanager._drop_trust_grant("zibble-app")
+
+        assert (cfg_file.parent / "config.json.lock").exists(), (
+            "the trust revoke wrote config.json without taking the <config>.lock "
+            "sidecar, so it is still unserialized against every other writer"
+        )
+        assert json.loads(cfg_file.read_text(encoding="utf-8"))["agent"]["apps_trusted"] == []
+
+    def test_an_unreadable_config_refuses_instead_of_resetting(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-closed is preserved: a corrupt config is refused, never replaced.
+
+        The conversion must not quietly become ``on_corrupt="reset"``. A revoke
+        that wrote a single-key document over a truncated config would destroy
+        every setting the file holds -- the exact loss ``read_config_for_update``
+        exists to prevent -- and the old code raised here for the same reason.
+        """
+        from kiro_crew.apps import manager as appmanager
+
+        monkeypatch.setattr(appmanager, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(appmanager, "config_local_path", lambda: cfg_file.parent / "local.json")
+        cfg_file.write_text('{"agent": {"apps_trus', encoding="utf-8")
+        before = cfg_file.read_text(encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="unreadable"):
+            appmanager._drop_trust_grant("zibble-app")
+
+        assert (
+            cfg_file.read_text(encoding="utf-8") == before
+        ), "the unreadable config was overwritten"
+
+
+class TestSetupWizardWriters:
+    """``cli_setup`` -- the widest read-to-write window in the tree.
+
+    A wizard step reads the document to compute a prompt default, then blocks on
+    the operator, then writes. Whatever lands during the prompt is inside that
+    window, so this family is where a whole-document rewrite is most likely to
+    revert a real setting.
+    """
+
+    def test_a_write_during_the_prompt_survives_the_slash_command_step(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The write applies to the document as it stands, not to the pre-prompt read.
+
+        Driven through the prompt itself rather than with threads: the competing
+        locked write runs from inside ``_input_or_skip``, i.e. strictly after the
+        step's own read and strictly before its write. That is the interleave in
+        its exact worst case, with no timing to be flaky about.
+        """
+        from kiro_crew import cli_setup
+
+        monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
+
+        def _answer_after_a_competing_write(_prompt: str) -> str:
+            # Lands while the wizard is between its read and its write.
+            cfg_loader.update_config_locked(
+                cfg_file,
+                mutate=lambda data: {**data, "timezone": "Asia/Shanghai"},
+                stamp_meta=False,
+            )
+            return "zibble-cmd"
+
+        monkeypatch.setattr(cli_setup, "_input_or_skip", _answer_after_a_competing_write)
+
+        cli_setup._setup_slash_command()
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["slack"]["command"] == "zibble-cmd", "the wizard's own edit was lost"
+        assert on_disk["timezone"] == "Asia/Shanghai", (
+            "the config write that landed while the operator was answering was "
+            "reverted -- the wizard wrote back its pre-prompt snapshot"
+        )
+        assert on_disk["model"] == "sonnet"
+        assert on_disk["session"]["timeout_secs"] == 7200
+
+    def test_a_write_during_the_prompt_survives_the_timezone_step(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same window on the step with the most prompts, hence the widest one."""
+        from kiro_crew import cli_setup
+
+        monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
+
+        def _answer_after_a_competing_write(_prompt: str) -> str:
+            cfg_loader.update_config_locked(
+                cfg_file,
+                mutate=lambda data: {**data, "auto_update": True},
+                stamp_meta=False,
+            )
+            return "America/Los_Angeles"
+
+        monkeypatch.setattr(cli_setup, "_input_or_skip", _answer_after_a_competing_write)
+        monkeypatch.setattr(cli_setup, "_detect_system_timezone", lambda: "")
+
+        cli_setup._setup_timezone()
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["timezone"] == "America/Los_Angeles", "the wizard's own edit was lost"
+        assert (
+            on_disk["auto_update"] is True
+        ), "the config write that landed while the operator was answering was reverted"
+        assert on_disk["model"] == "sonnet"
+
+
+class TestAForeignSectionIsNeverReplaced:
+    """A mutate callback must ABORT on a non-dict section, not overwrite it.
+
+    These live beside the lock tests because the callback is what the conversion
+    introduced: the pre-lock code reached its section through
+    ``dict.setdefault``, which on a scalar either raised (slash command) or was
+    caught and reported as a save failure (dashboard URL). A callback that
+    instead assigns a fresh ``{}`` over that scalar destroys an operator value
+    the step does not own AND reports success -- silent config loss, in the exact
+    shape #8032 exists to stop, reintroduced by the fix for it.
+
+    A section that is genuinely ABSENT is still created; that is the ordinary
+    path and must keep working, so each case is pinned in both directions.
+    """
+
+    @staticmethod
+    def _seed(cfg_file: Path, section: object, key: str) -> None:
+        cfg_file.write_text(json.dumps({"model": "sonnet", key: section}), encoding="utf-8")
+
+    def test_the_slash_command_step_leaves_a_scalar_slack_section_alone(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from kiro_crew import cli_setup
+
+        monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(cli_setup, "_input_or_skip", lambda _prompt: "zibble-cmd")
+        self._seed(cfg_file, "not-an-object", "slack")
+        before = cfg_file.read_text(encoding="utf-8")
+
+        cli_setup._setup_slash_command()
+
+        assert cfg_file.read_text(encoding="utf-8") == before, (
+            "the step replaced a non-object 'slack' section with a fresh one, "
+            "destroying the operator's value"
+        )
+        out = capsys.readouterr().out
+        assert "not an object" in out, "the refusal was silent"
+        assert "✅" not in out, "the step reported success after writing nothing"
+
+    def test_the_slash_command_step_still_creates_an_absent_slack_section(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cli_setup
+
+        monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(cli_setup, "_input_or_skip", lambda _prompt: "zibble-cmd")
+        cfg_file.write_text(json.dumps({"model": "sonnet"}), encoding="utf-8")
+
+        cli_setup._setup_slash_command()
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["slack"]["command"] == "zibble-cmd"
+        assert on_disk["model"] == "sonnet"
+
+    def test_the_dashboard_url_step_leaves_a_scalar_dashboard_section_alone(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from kiro_crew import cli_setup
+
+        monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
+        self._seed(cfg_file, "not-an-object", "dashboard")
+        before = cfg_file.read_text(encoding="utf-8")
+
+        loaded = unittest.mock.MagicMock()
+        loaded.dashboard.url = "http://old:1234"
+        loaded.load_credentials.return_value = {
+            "SLACK_APP_TOKEN": "xapp-fake",
+            "SLACK_BOT_TOKEN": "xoxb-fake",
+        }
+        monkeypatch.setattr(cli_setup.KiroCrewConfig, "load", staticmethod(lambda: loaded))
+        monkeypatch.setattr(cli_setup.socket, "gethostbyname", lambda _h: "10.0.0.1")
+        monkeypatch.setattr(cli_setup.socket, "gethostname", lambda: "zibble-host")
+        monkeypatch.setattr("builtins.input", lambda _prompt: "http://zibble-host:5476")
+
+        cli_setup._maybe_setup_dashboard_url()
+
+        assert (
+            cfg_file.read_text(encoding="utf-8") == before
+        ), "the step replaced a non-object 'dashboard' section with a fresh one"
+        out = capsys.readouterr().out
+        assert "Failed to save" in out, "the refusal was silent"
+
+    def test_the_dashboard_url_step_still_creates_an_absent_dashboard_section(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cli_setup
+
+        monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
+        cfg_file.write_text(json.dumps({"model": "sonnet"}), encoding="utf-8")
+
+        loaded = unittest.mock.MagicMock()
+        loaded.dashboard.url = "http://old:1234"
+        loaded.load_credentials.return_value = {
+            "SLACK_APP_TOKEN": "xapp-fake",
+            "SLACK_BOT_TOKEN": "xoxb-fake",
+        }
+        monkeypatch.setattr(cli_setup.KiroCrewConfig, "load", staticmethod(lambda: loaded))
+        monkeypatch.setattr(cli_setup.socket, "gethostbyname", lambda _h: "10.0.0.1")
+        monkeypatch.setattr(cli_setup.socket, "gethostname", lambda: "zibble-host")
+        monkeypatch.setattr("builtins.input", lambda _prompt: "http://zibble-host:5476")
+
+        cli_setup._maybe_setup_dashboard_url()
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["dashboard"]["url"] == "http://zibble-host:5476"
+        assert on_disk["model"] == "sonnet"
+
+
+class TestTheSeedWritesNoMetaBlock:
+    """``_ensure_default_agent_in_config`` must not stamp ``meta`` (#8032 round 2).
+
+    The writer it replaced stamped nothing, and this conversion is about the lock
+    rather than the document's shape. Without ``stamp_meta=False`` a fresh
+    install's first chat would rewrite a key this function does not own, which is
+    a shape change smuggled in by a locking fix.
+    """
+
+    def test_the_seed_adds_no_meta_key(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew import cli_chat
+
+        monkeypatch.setattr(cli_chat, "config_path", lambda: cfg_file)
+        cfg_file.write_text(json.dumps({"model": "sonnet"}), encoding="utf-8")
+
+        cli_chat._ensure_default_agent_in_config()
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["agents"]["default"]["kiro_agent"] == "kirocrew"
+        assert on_disk["default_agent"] == "default"
+        assert "meta" not in on_disk, (
+            "the default-agent seed stamped a meta block -- the writer it "
+            "replaced stamped nothing, so this is an unrelated shape change"
+        )
+        assert on_disk["model"] == "sonnet"
+
+    def test_the_seed_skips_entirely_when_agents_already_exist(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """mutate returns None, so the file is not rewritten at all."""
+        from kiro_crew import cli_chat
+
+        monkeypatch.setattr(cli_chat, "config_path", lambda: cfg_file)
+        cfg_file.write_text(
+            json.dumps({"agents": {"mine": {"kiro_agent": "zibble"}}}), encoding="utf-8"
+        )
+        before = cfg_file.read_text(encoding="utf-8")
+
+        cli_chat._ensure_default_agent_in_config()
+
+        assert (
+            cfg_file.read_text(encoding="utf-8") == before
+        ), "the seed rewrote a config that already had agents"
+
+
+class TestARestoredGrantIsNotDuplicated:
+    """``_restore_trust_grant`` must append under the lock, not on top of it.
+
+    The pre-lock ``_has_trust_grant`` check answers "should this restore run at
+    all". It is not the read the write is derived from, so a dashboard re-grant
+    landing between that check and the advisory acquire is invisible to it -- and
+    an unconditional append then persists the name twice. A duplicated entry in
+    ``apps_trusted`` is a corrupted consent record: it is the durable list that
+    decides whether a third-party app may execute, so it must hold each name
+    once and exactly once.
+
+    ``apps_trusted_local`` in the same callback was already guarded, which is
+    what makes the base list's unconditional append an inconsistency rather than
+    a deliberate choice.
+    """
+
+    def test_a_regrant_landing_before_the_lock_is_not_appended_twice(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The restore observes the re-grant under the lock and leaves one entry.
+
+        Driven deterministically: the competing locked re-grant runs from inside
+        ``_has_trust_grant``, i.e. strictly after the restore's own pre-lock check
+        has been answered and strictly before its acquire. That is the window in
+        its exact worst case, with no timing to be flaky about.
+        """
+        from kiro_crew.apps import manager as appmanager
+
+        monkeypatch.setattr(appmanager, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(appmanager, "config_local_path", lambda: cfg_file.parent / "local.json")
+
+        # No grant yet, so the restore has work to do.
+        cfg_file.write_text(
+            json.dumps({"model": "sonnet", "agent": {"apps_trusted": []}}), encoding="utf-8"
+        )
+
+        installed = object()
+        monkeypatch.setattr(appmanager, "_read_installed", lambda _n: installed)
+
+        def _regrant_then_report_absent(_name: str) -> bool:
+            # The dashboard re-grants while the restore is between its check and
+            # its acquire. Reports False so the restore proceeds, exactly as it
+            # would have on the stale answer.
+            cfg_loader.update_config_locked(
+                cfg_file,
+                mutate=lambda data: {
+                    **data,
+                    "agent": {**data.get("agent", {}), "apps_trusted": ["zibble-app"]},
+                },
+                stamp_meta=False,
+            )
+            return False
+
+        monkeypatch.setattr(appmanager, "_has_trust_grant", _regrant_then_report_absent)
+
+        appmanager._restore_trust_grant(
+            "zibble-app", had_grant=True, expected_app=installed  # type: ignore[arg-type]
+        )
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["agent"]["apps_trusted"] == ["zibble-app"], (
+            "the restore appended a name the locked document already held -- the "
+            f"persisted consent list is corrupted: {on_disk['agent']['apps_trusted']}"
+        )
+        assert on_disk["model"] == "sonnet"
+
+    def test_a_restore_with_no_existing_grant_still_adds_the_name(
+        self, cfg_file: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ordinary path is unchanged: absent means append."""
+        from kiro_crew.apps import manager as appmanager
+
+        monkeypatch.setattr(appmanager, "config_path", lambda: cfg_file)
+        monkeypatch.setattr(appmanager, "config_local_path", lambda: cfg_file.parent / "local.json")
+        cfg_file.write_text(
+            json.dumps({"model": "sonnet", "agent": {"apps_trusted": ["other-app"]}}),
+            encoding="utf-8",
+        )
+
+        installed = object()
+        monkeypatch.setattr(appmanager, "_read_installed", lambda _n: installed)
+        monkeypatch.setattr(appmanager, "_has_trust_grant", lambda _n: False)
+
+        appmanager._restore_trust_grant(
+            "zibble-app", had_grant=True, expected_app=installed  # type: ignore[arg-type]
+        )
+
+        on_disk = json.loads(cfg_file.read_text(encoding="utf-8"))
+        assert on_disk["agent"]["apps_trusted"] == ["other-app", "zibble-app"]
+        assert on_disk["model"] == "sonnet"

--- a/test/test_sandbox_unsandboxed_exec_consent.py
+++ b/test/test_sandbox_unsandboxed_exec_consent.py
@@ -56,10 +56,22 @@ def _run_consent(
             if sel_raises:
                 raise OSError("audit log unwritable")
 
-    def _write(path, data, **kwargs):
+    def _locked_write(path, *, mutate, **kwargs):
+        """Stand-in for ``update_config_locked`` with the same contract.
+
+        The step now routes its read-modify-write through the advisory-locked
+        primitive, so the seam moves there. The fake keeps the part these tests
+        depend on: the mutate callback is handed the CURRENT document and the
+        file is written only when it returns one.
+        """
         if write_raises:
             raise OSError("config is locked by another process")
-        path.write_text(json.dumps(data), encoding="utf-8")
+        existing = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+        result = mutate(existing)
+        if result is None:
+            return existing
+        path.write_text(json.dumps(result), encoding="utf-8")
+        return result
 
     monkeypatch.setattr(cli_setup, "unavailable_kind", lambda *a, **k: kind)
     monkeypatch.setattr(cli_setup.sys.stdin, "isatty", lambda: tty, raising=False)
@@ -67,7 +79,7 @@ def _run_consent(
     monkeypatch.setattr(cli_setup, "sel", lambda: _FakeSel())
     monkeypatch.setattr(cli_setup, "config_path", lambda: cfg_file)
     monkeypatch.setattr(cli_setup, "config_local_path", lambda: local_file)
-    monkeypatch.setattr(cli_setup, "write_config_atomically", _write)
+    monkeypatch.setattr(cli_setup, "update_config_locked", _locked_write)
     monkeypatch.setattr(cli_setup, "_input_or_skip", lambda _prompt: answer)
 
     cli_setup._setup_sandbox_consent()

--- a/test/test_trusted_apps_api.py
+++ b/test/test_trusted_apps_api.py
@@ -2577,22 +2577,23 @@ def test_restore_postcheck_withdraws_grant_if_installed_occupant_changes(
     def _delete_failure(*args, **kwargs):
         raise OSError("device busy")
 
-    real_write = appmanager.write_config_atomically
+    real_write = appmanager.update_config_locked
     writes = 0
 
-    def _write_then_replace(path, raw):
+    def _write_then_replace(path, **kwargs):
         nonlocal writes
         writes += 1
-        real_write(path, raw)
+        result = real_write(path, **kwargs)
         if writes == 2:  # pre-delete drop is first; restore write is second
             changed = appmanager._read_installed(_APP)
             assert changed is not None
             changed.version = "9.9.9"
             appmanager._write_installed(_APP, changed)
+        return result
 
     with (
         patch.object(appmanager.shutil, "rmtree", _delete_failure),
-        patch.object(appmanager, "write_config_atomically", _write_then_replace),
+        patch.object(appmanager, "update_config_locked", _write_then_replace),
     ):
         result = appmanager.uninstall_app(_APP)
 
@@ -2697,7 +2698,7 @@ def test_uninstall_writes_no_config_at_all_when_there_is_no_grant(
     )
     _install(tmp_path, _APP, enabled=False)
 
-    with patch.object(appmanager, "write_config_atomically") as writes:
+    with patch.object(appmanager, "update_config_locked") as writes:
         result = appmanager.uninstall_app(_APP)
 
     assert result.ok is True, result.error


### PR DESCRIPTION
## Problem / Motivation

`update_config_locked` takes an advisory lock on a `<path>.lock` sidecar for its whole read-modify-write, and its own docstring calls it "the required path for new `config.json` mutations". Eleven writers that pre-date it still called `write_config_atomically` directly and relied on the in-process asyncio `_get_config_lock()` instead.

That lock is a `LoopBoundLock`. It serializes callers on the same event loop in the same process and nothing else — not a holder of the sidecar (all ~69 `update_config_locked` call sites), not a worker thread, not another process. So a locked read-modify-write and one of these writers could interleave, and whichever renamed second published a document that never saw the other's change.

Concretely: `kirocrew config set model opus` and a `kirocrew setup` timezone step running at the same time, or the dashboard settings PATCH and an app uninstall's trust withdrawal. One of the two changes just is not there afterwards. Nothing errors, nothing logs, and the endpoint reports success.

## Why it matters

Two things are true and neither is visible from a single call site.

Every current `update_config_locked` caller believes it has mutual exclusion. Against these eleven it did not — a partially adopted lock reads as safety without providing it, and the data it fails to protect is the user's whole configuration file, including inline channel credentials.

And `_get_config_lock()` could not be adopted from the other side to close the gap: it is an asyncio lock, so a synchronous writer, a worker-thread writer, or the CLI in a separate process cannot acquire it at all. Any fix that bridges the two primitives ends up inventing a lock-ordering discipline for one call site. Conversion is the only shape that scales.

## What changed (motivation → approach → change)

Every remaining direct `write_config_atomically(config_path())` caller now routes through `update_config_locked`, keeping each site's existing failure semantics.

**All eleven were already fail-closed** — each one bails rather than resetting when the config is unreadable — so every conversion takes the default `on_corrupt="fail"` and no site gains a reset path. `stamp_meta=False` at every converted site, because none of these writers stamped `meta` before and this change is about the lock, not the document shape.

| Site | Shape before | Conversion |
|---|---|---|
| `agents.py` `_commit_agent_config_locked` | read+write already inside the shielded offload | synchronous `update_config_locked`; `ConfigReadError` still escapes as the unit's first step, so the handler's 500 stays exact |
| `agents.py` `api_default_agent` | loop-side read+write under the asyncio lock | moved into the module's own shielded `_offload_config_write` — the advisory acquire can WAIT, and an unbounded flock wait on the loop would stall the gateway |
| `security.py` `_mutate_agent_config` | own `_get_config_lock` + `run_in_executor` | overlay-owned check moves inside the mutate callback so it stays in the same hold as the write; `ConfigReadError` is translated to this module's `ConfigCorruptError` so callers keep answering a coded 409 |
| `apps/manager.py` `_drop_trust_grant`, `_restore_trust_grant` | unlocked; the CLI runs both in its own process | synchronous `update_config_locked`. The no-grant fast path is preserved (mutate returns `None`, no write) and re-derived under the lock, so a concurrent revoke is a no-op rather than a redundant rewrite |
| `cli_setup.py` ×5 (whatsapp, slash command, sandbox consent, timezone, dashboard URL) and `cli_chat.py` `_ensure_default_agent_in_config` | read → prompt → write | see below |

The wizard has the widest read-to-write window in the tree: it reads to compute a prompt default, blocks on the operator, then writes. The pre-prompt read **stays** — it decides whether the step runs and it produces the existing operator-facing messages — but it is no longer the read the write is derived from. Section shape guards are re-checked inside the lock. The sandbox-consent step's audit-then-write ordering is unchanged: the SEL event stays ahead of the acquire, so a failure between the two still leaves a record without a grant and never a grant without a record.

### A mutate callback aborts on a foreign section; it never replaces one

The first revision of this PR got this wrong, and the GPT review lane caught it. A callback that assigns a fresh `{}` over a non-dict section destroys an operator value the step does not own **and reports success** — the same silent-config-loss shape this PR exists to remove, reintroduced by the fix for it. Both the slash-command and dashboard-URL sites now abort; a section that is genuinely *absent* is still created, which is the ordinary path.

Fixing only the callback would have shipped a **dead guard**. `_setup_slash_command`'s pre-lock read does `cfg.get("slack", {}).get("command", ...)`, which raised `AttributeError` on a scalar section and took the whole wizard down with a traceback before the write path was ever reached. So the read is guarded on the same rule, and that pre-existing crash becomes the clean refusal the whatsapp and sandbox steps already give.

`agents.py:750` is deliberately **not** converted: it writes the kiro-cli agent spec, not `config.json`.

**Three entries on the issue's list were false, and were verified against `origin/main` rather than taken on trust.** `apps/manager.py`'s `config_local_path()` use is a read-only precondition check. `handlers/telemetry.py` never writes config at all — `git log -S` finds no such write anywhere in its history.

### The docstring is corrected, not deleted

The issue asks for the "legacy writers" paragraph to be removed. It is **replaced** instead, because deleting it would make the docstring wrong in the other direction: a second family of writers still bypasses this lock, and the ratchet below does not reach it — for two different reasons that are worth stating precisely, since the paragraph exists to mark exactly that boundary.

- Writers reaching `config_path()` through `kiro_crew.agent._atomic_json_write` (`messaging.py`'s per-channel savers, `core.py`'s STT PUT, `mcp.py`'s gateway-enable) make no `write_config_atomically` call at all, so the matcher never sees them.
- Writers going through `KiroCrewConfig.save()` (`updates.py`'s log-level PUT, `core.py`'s theme PUT, several `agents.py` CRUD endpoints) *do* call `write_config_atomically` directly — but from inside `loader.py`, which the ratchet exempts, so the write is invisible at every caller.

That is ~16 further sites and is why this PR stops here: each needs its own failure-semantics judgement, and folding them in would triple the review surface. The docstring now names them so the next reader does not read the ratchet's green as covering them.

## Tests

**`test/test_config_writers_advisory_lock.py` (new).** Drives a converted writer against a locked writer in the exact interleave that used to lose data, and asserts **both** changes survive — plus a canary key neither writer owns, so a whole-document clobber names what it destroyed. "Holds a lock" is not observable; "did not lose the other writer's setting" is.

Red-before proven by restoring the pre-conversion shape at each site:

| Site restored | Result |
|---|---|
| `apps/manager.py` trust revoke | 2 tests red |
| `cli_setup.py` slash-command step | red |
| `cli_setup.py` timezone step | red |
| slash-command / dashboard-URL foreign-section clobber | 2 tests red |
| `cli_chat.py` missing `stamp_meta=False` | red |

The two interleave cases on the wizard need no threads: the competing locked write is driven from **inside the prompt**, i.e. strictly after the step's read and strictly before its write. That is the worst case of the window with no timing to be flaky about. The apps-manager case uses the repo's established `threading.Event` pair with a bounded `_TIMEOUT`, so a regression fails on an assertion instead of hanging the suite. Further tests pin that fail-closed survived the conversion (an unreadable config is refused, never replaced), that a foreign section is refused **in both directions** (absent is still created), and that the default-agent seed stamps no `meta` and skips the write entirely when agents already exist.

**`TestEveryConfigWriterIsLocked` in `test/test_config_rmw_preserves_settings.py`** — the ratchet the issue asks for, so the list cannot regrow. Walks the AST per function, tracking names bound to `config_path()` / `config_local_path()`, so it catches a write through a local variable (`path = config_path()` … `write_config_atomically(path, data)`) and not only an inline call. Per-function scoping matters both ways: file-wide bindings would report false positives, and would also let a genuine offender hide behind an unrelated function's rebinding of the same name. `config/loader.py` is exempt — it holds the primitive and `KiroCrewConfig.save`.

It carries a **self-test**: a scan asserting an empty offender list is indistinguishable from a scan whose matcher is broken, so the detector is exercised on both spellings a regression would take, and on a caller-supplied path (the `agents.py:750` shape) which must *not* be flagged.

**Four existing tests took their seam on the writer this change replaces** and move to `update_config_locked`. Every pinned property is unchanged; two are strengthened — `test_default_agent_write_holds_the_config_lock` now also asserts the `<config>.lock` sidecar was taken, which is precisely the guarantee the asyncio lock it already checked cannot give.

## Manual verification

N/A — the defect is a lost update between two writers, which is only observable deterministically under an injected interleave. The new tests are that interleave; a manual reproduction would be a race and would prove less.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend and test files only — the diff touches no frontend path and renders no pixel.

## Related Issues

Surfaced by #7793 / #7937.

## Pattern harvest

Rule candidate: `lint`

Pattern: a shared locking primitive adopted by most but not all writers of a resource — the guarantee is only as strong as the participating set, and a partially adopted lock reads as safety at every call site while providing none. Shipped as `TestEveryConfigWriterIsLocked`, which is the generalizable half: the defect is not "these eleven sites forgot a lock" but "nothing made forgetting it visible". A second, narrower pattern showed up during review and is worth naming: converting a bare read-modify-write into a `mutate` callback silently changes what happens to a value the callback does not own, so an in-place `setdefault` that used to crash or refuse can become an overwrite that reports success. The residual is named honestly in the primitive's docstring — the same class still exists for writers reaching the file through `_atomic_json_write` / `KiroCrewConfig.save`, and an aliased import of `write_config_atomically` would also evade the AST matcher.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `update_config_locked`'s docstring
- [x] No secrets, credentials, or internal references in the diff

Closes #8032
