### PR TITLE
fix(artifacts): guard artifact-folder icon write-back with a per-folder epoch

### DIFF
--- a/src/kiro_crew/artifacts.py
+++ b/src/kiro_crew/artifacts.py
@@ -3577,7 +3577,61 @@ class ArtifactFolderStore:
         self._path = (path or (config_dir() / self._FILE)).expanduser()
         self._lock = threading.Lock()
         self._folders: _List[dict[str, Any]] = []
+        #: Per-folder icon epoch, bumped under ``self._lock`` by every
+        #: user-visible mutation a generated icon must not outlive: a manual
+        #: icon set, an icon clear, and a rename. An in-flight generation task
+        #: captures the epoch at scheduling time and its write-back
+        #: (:meth:`set_icon_if_epoch`) is dropped unless the epoch is
+        #: unchanged. One invariant closes all three races that a bare
+        #: existence check leaves open and that a value-pin cannot catch: a
+        #: clear (absent -> absent) and a rename (icon untouched) both leave
+        #: the icon VALUE unchanged, so only a counter distinguishes them.
+        #: Deliberately per-folder rather than a store-wide generation
+        #: counter, which would cancel a legitimate icon delivery whenever an
+        #: unrelated folder changed mid-generation. Held per store INSTANCE
+        #: (not module-level as in the chat-folder original, whose folders
+        #: live on DashboardState rather than in a store object) so two stores
+        #: over different JSON paths cannot alias each other's folder ids. In
+        #: memory on purpose -- in-flight tasks die with the process, so the
+        #: epoch has nothing to survive a restart for. Entries are dropped on
+        #: a confirmed folder delete. Ported from the chat-folder guard
+        #: ``_CHAT_FOLDER_ICON_EPOCHS`` (issue #7991).
+        self._icon_epochs: dict[str, int] = {}
         self._load()
+
+    def _bump_icon_epoch_locked(self, folder_id: str) -> None:
+        """Invalidate any in-flight icon generation for this folder.
+
+        Must be called with ``self._lock`` held -- holding the lock is what
+        orders the bump against :meth:`set_icon_if_epoch`'s check, so a
+        mutation can never interleave between that check and its write.
+        """
+        self._icon_epochs[folder_id] = self._icon_epochs.get(folder_id, 0) + 1
+
+    def set_icon_if_epoch(
+        self, folder_id: str, icon: str, expected_epoch: int
+    ) -> dict[str, Any] | None:
+        """Apply a generated icon only while the folder's epoch is unchanged.
+
+        The re-find, the epoch check and the write share one critical section,
+        so a manual icon set, an icon clear, or a rename that lands while
+        generation was in flight wins over the stale generated result. Returns
+        the updated folder, or ``None`` when the write was dropped (folder
+        deleted mid-generation, or the epoch moved).
+
+        Does NOT bump the epoch: this is the generated result landing, not a
+        user-visible mutation that later generations must lose to.
+        """
+        with self._lock:
+            folder = self._by_id().get(folder_id)
+            if folder is None:
+                return None  # deleted mid-generation; drop the icon
+            if self._icon_epochs.get(folder_id, 0) != expected_epoch:
+                # Icon or name changed while generation ran -- drop the result.
+                return None
+            folder["icon"] = str(icon or "")[:16]
+            self._save()
+            return dict(folder)
 
     # ── persistence ───────────────────────────────────────────────────────
 
@@ -3709,15 +3763,32 @@ class ArtifactFolderStore:
             )
             return dict(folder)
 
-    def rename(self, folder_id: str, name: str) -> dict[str, Any]:
+    def rename(self, folder_id: str, name: str) -> tuple[dict[str, Any], int]:
+        """Rename, returning the folder AND the icon epoch this rename produced.
+
+        The epoch comes back from inside the same critical section as the bump,
+        which is the only way a caller can arm background icon generation
+        safely. Renaming and then READING the epoch back would be two lock
+        acquisitions: a competing manual icon set landing between them bumps the
+        epoch again, the later read would capture THAT epoch, and the generated
+        icon would then satisfy :meth:`set_icon_if_epoch` and clobber the manual
+        pick -- the very race the epoch exists to prevent. Returning it closes
+        that window by construction, because there is no read to lose.
+
+        The tuple is deliberately the ONLY spelling of this mutation: a
+        dict-returning ``rename`` alongside it would be a second spelling of one
+        write, and the two would drift.
+        """
         name = self._clean_name(name)
         with self._lock:
             folder = self._by_id().get(folder_id)
             if folder is None:
                 raise ArtifactNotFoundError(f"folder not found: {folder_id}")
             folder["name"] = name
+            # An in-flight icon was derived from the OLD name -- invalidate it.
+            self._bump_icon_epoch_locked(folder_id)
             self._save()
-            return dict(folder)
+            return dict(folder), self._icon_epochs[folder_id]
 
     def reparent(self, folder_id: str, new_parent: str = "") -> dict[str, Any]:
         """Move a folder under ``new_parent`` (``""`` = root). Cycle-guarded."""
@@ -3756,6 +3827,9 @@ class ArtifactFolderStore:
             if folder is None:
                 raise ArtifactNotFoundError(f"folder not found: {folder_id}")
             folder["icon"] = str(icon or "")[:16]
+            # A manual set OR a clear (icon == "") invalidates any in-flight
+            # generation: its result was derived before the user's choice.
+            self._bump_icon_epoch_locked(folder_id)
             self._save()
             return dict(folder)
 
@@ -3930,6 +4004,20 @@ class ArtifactFolderStore:
                         f["parent_id"] = parent
             self._folders = [f for f in self._folders if f.get("id") not in affected_ids]
             self._save()
+            # Release the icon-epoch guards only after the removal is
+            # CONFIRMED persisted. _save() raising propagates out of this
+            # block, so the pop is skipped and the guard stays armed. Note
+            # what a failed _save() actually leaves behind: self._folders was
+            # already filtered above, so the folder is gone from memory but
+            # SURVIVES on disk, and any later reload brings it back. Keeping
+            # its epoch is the conservative side of that split -- resetting it
+            # to 0 would let a stale in-flight generation clobber a manual
+            # icon on the record that comes back. After a confirmed delete the
+            # entries have nothing left to guard (set_icon_if_epoch already
+            # drops a folder it cannot re-find); popping keeps the registry
+            # from growing with every deleted id.
+            for _gone in affected_ids:
+                self._icon_epochs.pop(_gone, None)
 
         # Phase 2: artifacts. ``affected_ids`` is the subtree for cascade, or
         # just the single folder for the safe path.

--- a/src/kiro_crew/dashboard/handlers/artifacts.py
+++ b/src/kiro_crew/dashboard/handlers/artifacts.py
@@ -2858,10 +2858,24 @@ async def api_artifact_folders(request: web.Request) -> web.Response:
     return _json_response({"folders": out})
 
 
-def _spawn_artifact_folder_icon_task(request: web.Request, folder_id: str, name: str) -> None:
+def _spawn_artifact_folder_icon_task(
+    request: web.Request, folder_id: str, name: str, *, expected_epoch: int
+) -> None:
     """Fire-and-forget: derive a single-emoji icon for an artifact folder via
     the shared LLM helper (same mechanism as chat-sidebar folders) and store
-    it. Best-effort — any failure leaves the folder with the default glyph."""
+    it. Best-effort — any failure leaves the folder with the default glyph.
+
+    The write-back goes through ``set_icon_if_epoch``, which re-finds the
+    folder, checks the epoch and writes inside ONE critical section under the
+    store lock. So a folder deleted while generation was in flight is never
+    resurrected, and a manual icon set, an icon clear, or a rename that lands
+    while generation is pending wins over the stale generated result.
+    ``expected_epoch`` is the epoch this generation is pinned to, and each
+    caller obtains it without ever reading the epoch back: the rename path takes
+    the value :meth:`ArtifactFolderStore.rename` returns from inside its own
+    bump's critical section, and the create path pins 0, which a fresh folder's
+    epoch is by construction. A read-back would be a second lock acquisition and
+    could capture a competing mutation's epoch (issue #7991)."""
     state = request.app.get("state")
     if state is None:
         return
@@ -2872,8 +2886,10 @@ def _spawn_artifact_folder_icon_task(request: web.Request, folder_id: str, name:
             if not icon:
                 return
             fstore = get_default_folder_store()
-            if fstore.exists(folder_id):
-                await _run_off_loop(lambda: fstore.set_icon(folder_id, icon))
+            # No exists() pre-check: it was a TOCTOU gap (the folder could go
+            # away, or its icon change, between the check and the write) and
+            # set_icon_if_epoch subsumes it by re-finding under the lock.
+            await _run_off_loop(lambda: fstore.set_icon_if_epoch(folder_id, icon, expected_epoch))
         except Exception:  # noqa: BLE001 — best-effort background task
             logger.debug("artifact folder icon generation failed for %s", folder_id, exc_info=True)
 
@@ -2927,7 +2943,14 @@ async def api_artifact_folder_create(request: web.Request) -> web.Response:
         _audit(tool="artifact_folder_create", request=request, outcome="error", error=str(exc))
         return _err(str(exc), status=500)
     # Derive an emoji icon from the name in the background (chat-folder parity).
-    _spawn_artifact_folder_icon_task(request, folder["id"], name)
+    # A just-created folder's icon epoch is 0 by construction -- create() never
+    # touches the registry, and delete() pops its entry, so even a reused id
+    # reads 0. Passing the literal is deliberate rather than re-reading it: a
+    # read here would be a second lock acquisition, and any mutation landing in
+    # that window would raise the epoch, so the read would capture the
+    # COMPETING value and the generated icon would then clobber it. With 0
+    # pinned, any such mutation makes the write-back lose, which is correct.
+    _spawn_artifact_folder_icon_task(request, folder["id"], name, expected_epoch=0)
     _audit(
         tool="artifact_folder_create",
         request=request,
@@ -2963,6 +2986,12 @@ async def api_artifact_folder_update(request: web.Request) -> web.Response:
     if folder is None:  # exists() checked above; guards against a concurrent delete
         return _err("folder not found", status=404)
 
+    # Set by _apply_updates when it renames: the icon epoch the rename's own
+    # bump produced, read inside that same critical section. The handler must
+    # arm background generation with THIS value and never re-read the epoch
+    # afterwards -- see ArtifactFolderStore.rename for why a re-read is a race.
+    armed_icon_epoch: dict[str, int] = {}
+
     def _apply_updates() -> dict[str, Any]:
         # Each mutation persists via _save() (fsync/replace) — runs in the
         # executor, off the event loop.
@@ -2970,7 +2999,7 @@ async def api_artifact_folder_update(request: web.Request) -> web.Response:
         if f is None:
             raise ArtifactNotFoundError(f"folder not found: {fid}")
         if "name" in body:
-            f = fstore.rename(fid, str(body["name"]))
+            f, armed_icon_epoch["value"] = fstore.rename(fid, str(body["name"]))
         if "parent_id" in body:
             f = fstore.reparent(fid, str(body.get("parent_id") or ""))
         if "icon" in body:
@@ -3012,7 +3041,15 @@ async def api_artifact_folder_update(request: web.Request) -> web.Response:
     # A rename re-derives the emoji icon from the new name (chat-folder
     # parity) — unless this same request set an explicit icon, which wins.
     if "name" in body and "icon" not in body:
-        _spawn_artifact_folder_icon_task(request, fid, str(body["name"]))
+        # Arm with the epoch the rename itself produced, captured under the
+        # rename's own lock. Re-reading it here instead would pick up a manual
+        # icon set that landed in between and let the generated icon overwrite
+        # it. A missing value means the rename did not run, so nothing to arm.
+        epoch = armed_icon_epoch.get("value")
+        if epoch is not None:
+            _spawn_artifact_folder_icon_task(
+                request, fid, str(body["name"]), expected_epoch=epoch
+            )
     return _json_response(_serialize_folder(updated, path=fstore.breadcrumb(fid)))
 
 

--- a/test/test_artifact_folder_icons.py
+++ b/test/test_artifact_folder_icons.py
@@ -1,0 +1,553 @@
+"""Per-folder icon epoch on ARTIFACT folders (issue #7991).
+
+The chat-folder subsystem closed three stale-write-back races with a per-folder
+icon epoch (``_CHAT_FOLDER_ICON_EPOCHS``, PR #7353). Artifact folders guarded
+their async icon write-back with a bare ``fstore.exists()`` check, which only
+catches deletion — these tests pin the ported guard:
+
+* a **manual icon set** while generation is in flight is not clobbered,
+* an **icon clear** mid-generation is not overwritten (the value would be
+  absent -> absent, so no value-pin could catch it),
+* a **rename** mid-generation drops the icon derived from the old name,
+* the epoch entry is popped only after a **confirmed** delete, so a failed
+  store write leaves the guard armed instead of resetting it to 0.
+
+Mirrors ``test/test_chat_folder_icons.py``. The store-layer class exercises
+:class:`ArtifactFolderStore` directly (``test_artifact_folders.py`` fixture
+style); the handler-layer class drives the real HTTP handlers through the
+``stores`` + ``_request`` shape of ``test_artifact_folder_handlers.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew import artifacts as art_mod
+from kiro_crew.artifacts import ArtifactFolderStore, ArtifactStore
+from kiro_crew.dashboard.handlers import artifacts as art_handlers
+from kiro_crew.dashboard.handlers.artifacts import (
+    api_artifact_folder_create,
+    api_artifact_folder_delete,
+    api_artifact_folder_update,
+)
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fstore(tmp_path: Path) -> ArtifactFolderStore:
+    return ArtifactFolderStore(path=tmp_path / "artifact_folders.json")
+
+
+@pytest.fixture
+def stores(tmp_path: Path, monkeypatch):
+    """Isolated artifact + folder stores wired into the module globals."""
+    store = ArtifactStore(root=tmp_path / "artifacts")
+    folders = ArtifactFolderStore(path=tmp_path / "artifact_folders.json")
+    monkeypatch.setattr(art_mod, "_default_store", store)
+    monkeypatch.setattr(art_mod, "_default_folder_store", folders)
+    return store, folders
+
+
+@pytest.fixture
+def patch_restricted(monkeypatch):
+    def _stub(_state, req) -> bool:
+        return req.app.get("_restricted_session", False)
+
+    monkeypatch.setattr(art_handlers, "_is_restricted_session", _stub)
+
+
+def _request(
+    *,
+    body: dict | None = None,
+    match: dict | None = None,
+    query: dict | None = None,
+) -> MagicMock:
+    req = MagicMock()
+    req.headers = {"X-Session-Key": "dashboard:test"}
+    req.match_info = match or {}
+    req.query = query or {}
+    encoded = json.dumps(body).encode() if isinstance(body, dict) else b""
+    req.read = AsyncMock(return_value=encoded)
+    req.app = {"state": MagicMock(), "_restricted_session": False}
+    return req
+
+
+def _body(resp) -> dict:
+    return json.loads(resp.body)
+
+
+def _epoch(store: ArtifactFolderStore, folder_id: str) -> int:
+    """Read a folder's icon epoch for assertions.
+
+    Local to the tests on purpose: the store exposes no public accessor, because
+    no production caller may READ the epoch back -- create pins 0 and rename
+    returns its own. Shipping a getter for the tests' benefit would be a method
+    with zero production callers.
+    """
+    return store._icon_epochs.get(folder_id, 0)
+
+
+async def _drain_icon_tasks() -> None:
+    """Wait for this test's in-flight icon write-backs before asserting.
+
+    ``_ARTIFACT_FOLDER_ICON_TASKS`` is a module-global set that every test
+    touching the create handler populates, so it can hold tasks belonging to
+    an EARLIER test's event loop -- awaiting one of those raises
+    ``ValueError: The future belongs to a different loop``. Filtering on the
+    running loop selects exactly the tasks this test created, because each
+    test gets its own loop. ``return_exceptions`` keeps a background task's
+    own failure from surfacing as a drain error; the assertions that follow
+    are what judge the outcome.
+    """
+    loop = asyncio.get_running_loop()
+    mine = [
+        t
+        for t in list(art_handlers._ARTIFACT_FOLDER_ICON_TASKS)
+        if t.get_loop() is loop and not t.done()
+    ]
+    if mine:
+        await asyncio.gather(*mine, return_exceptions=True)
+
+
+@asynccontextmanager
+async def _held_generation(
+    gen: Callable[[asyncio.Event], Any],
+) -> AsyncIterator[asyncio.Event]:
+    """Patch the emoji generator with a held implementation, guaranteeing release.
+
+    ``gen`` is a factory taking the release Event and returning the coroutine
+    function to install. The ``finally`` is the point of this helper: a held
+    task parks on ``release.wait()``, and if an assertion aborts the body before
+    the release, that task stays parked while still strongly referenced by the
+    module-global ``_ARTIFACT_FOLDER_ICON_TASKS``. It then outlives its event
+    loop and poisons a LATER test that awaits that set -- the sibling handler
+    suite awaits it unfiltered, so the failure surfaces far from its cause.
+    Releasing and draining on every exit path keeps a failing assertion's blast
+    radius inside its own test.
+    """
+    release = asyncio.Event()
+    with patch.object(art_handlers, "generate_emoji_for_name", AsyncMock(side_effect=gen(release))):
+        try:
+            yield release
+        finally:
+            release.set()
+            await _drain_icon_tasks()
+
+
+# ── Store layer ─────────────────────────────────────────────────────────────
+
+
+class TestStoreIconEpoch:
+    def test_a_fresh_folder_starts_at_epoch_zero(self, fstore: ArtifactFolderStore) -> None:
+        f = fstore.create("Reports")
+        assert _epoch(fstore, f["id"]) == 0
+
+    def test_an_unknown_folder_reads_epoch_zero(self, fstore: ArtifactFolderStore) -> None:
+        assert _epoch(fstore, "nope") == 0
+
+    def test_set_icon_bumps_the_epoch(self, fstore: ArtifactFolderStore) -> None:
+        f = fstore.create("Reports")
+        fstore.set_icon(f["id"], "🧪")
+        assert _epoch(fstore, f["id"]) == 1
+
+    def test_an_icon_clear_bumps_the_epoch(self, fstore: ArtifactFolderStore) -> None:
+        """A clear is the race a value-pin cannot catch: the icon VALUE goes
+        absent -> absent, so only a counter records that the user acted."""
+        f = fstore.create("Reports")
+        assert _epoch(fstore, f["id"]) == 0
+        fstore.set_icon(f["id"], "")
+        assert _epoch(fstore, f["id"]) == 1
+
+    def test_rename_bumps_the_epoch(self, fstore: ArtifactFolderStore) -> None:
+        f = fstore.create("Reports")
+        fstore.rename(f["id"], "Quarterly")
+        assert _epoch(fstore, f["id"]) == 1
+
+    def test_set_icon_if_epoch_writes_when_the_epoch_matches(
+        self, fstore: ArtifactFolderStore
+    ) -> None:
+        f = fstore.create("Reports")
+        out = fstore.set_icon_if_epoch(f["id"], "🚀", 0)
+        assert out is not None and out["icon"] == "🚀"
+        assert fstore.get(f["id"])["icon"] == "🚀"
+
+    def test_the_generated_write_back_does_not_bump_the_epoch(
+        self, fstore: ArtifactFolderStore
+    ) -> None:
+        """It is a generated result landing, not a user mutation later
+        generations must lose to."""
+        f = fstore.create("Reports")
+        fstore.set_icon_if_epoch(f["id"], "🚀", 0)
+        assert _epoch(fstore, f["id"]) == 0
+
+    def test_set_icon_if_epoch_drops_a_stale_write(self, fstore: ArtifactFolderStore) -> None:
+        f = fstore.create("Reports")
+        captured = _epoch(fstore, f["id"])
+        fstore.set_icon(f["id"], "🧪")  # the user acts while generation runs
+        assert fstore.set_icon_if_epoch(f["id"], "🚀", captured) is None
+        assert fstore.get(f["id"])["icon"] == "🧪"
+
+    def test_set_icon_if_epoch_drops_a_write_for_a_deleted_folder(
+        self, tmp_path: Path, fstore: ArtifactFolderStore
+    ) -> None:
+        store = ArtifactStore(root=tmp_path / "artifacts")
+        f = fstore.create("Reports")
+        fstore.delete(f["id"], delete_contents=False, artifact_store=store)
+        assert fstore.set_icon_if_epoch(f["id"], "🚀", 0) is None
+
+    def test_a_confirmed_delete_pops_the_epoch_entry(
+        self, tmp_path: Path, fstore: ArtifactFolderStore
+    ) -> None:
+        store = ArtifactStore(root=tmp_path / "artifacts")
+        f = fstore.create("Reports")
+        fstore.set_icon(f["id"], "🧪")
+        assert fstore._icon_epochs.get(f["id"]) == 1
+        fstore.delete(f["id"], delete_contents=False, artifact_store=store)
+        assert f["id"] not in fstore._icon_epochs
+
+    def test_a_cascade_delete_pops_every_subtree_entry(
+        self, tmp_path: Path, fstore: ArtifactFolderStore
+    ) -> None:
+        store = ArtifactStore(root=tmp_path / "artifacts")
+        parent = fstore.create("Reports")
+        child = fstore.create("Q3", parent_id=parent["id"])
+        fstore.set_icon(parent["id"], "🧪")
+        fstore.set_icon(child["id"], "📈")
+        fstore.delete(parent["id"], delete_contents=True, artifact_store=store)
+        assert parent["id"] not in fstore._icon_epochs
+        assert child["id"] not in fstore._icon_epochs
+
+    def test_a_failed_delete_commit_keeps_the_epoch_guard(
+        self, tmp_path: Path, fstore: ArtifactFolderStore, monkeypatch
+    ) -> None:
+        """Popping before the write is confirmed would leave the folder present
+        with its epoch reset to 0, letting a stale in-flight generation clobber
+        the manual icon the user just chose."""
+        store = ArtifactStore(root=tmp_path / "artifacts")
+        f = fstore.create("Reports")
+        fstore.set_icon(f["id"], "🧪")
+        assert fstore._icon_epochs.get(f["id"]) == 1
+
+        def _boom() -> None:
+            raise OSError("simulated store write failure")
+
+        monkeypatch.setattr(fstore, "_save", _boom)
+        with pytest.raises(OSError):
+            fstore.delete(f["id"], delete_contents=False, artifact_store=store)
+        # The guard survived the failed commit, so the stale result still loses.
+        assert fstore._icon_epochs.get(f["id"]) == 1
+        assert fstore.set_icon_if_epoch(f["id"], "🚀", 0) is None
+
+    def test_epochs_are_per_store_instance(self, tmp_path: Path) -> None:
+        """Two stores over different files must not alias each other's folder
+        ids — a module-level registry keyed only by folder id would."""
+        a = ArtifactFolderStore(path=tmp_path / "a.json")
+        b = ArtifactFolderStore(path=tmp_path / "b.json")
+        fa = a.create("Reports")
+        a.set_icon(fa["id"], "🧪")
+        assert _epoch(a, fa["id"]) == 1
+        assert _epoch(b, fa["id"]) == 0
+
+    def test_rename_returns_its_own_bump(self, fstore: ArtifactFolderStore) -> None:
+        f = fstore.create("Reports")
+        folder, armed = fstore.rename(f["id"], "Quarterly")
+        assert folder["name"] == "Quarterly"
+        assert armed == _epoch(fstore, f["id"]) == 1
+
+    def test_the_returned_epoch_is_what_a_read_back_would_have_lost(
+        self, fstore: ArtifactFolderStore
+    ) -> None:
+        """The epoch a rename arms generation with must be the one its OWN bump
+        produced. Reading it back afterwards picks up a manual icon set that
+        landed in between, and the generated icon then satisfies the check and
+        clobbers the manual pick."""
+        f = fstore.create("Reports")
+        _folder, armed = fstore.rename(f["id"], "Quarterly")
+        # A manual pick lands after the rename, before the generated result.
+        fstore.set_icon(f["id"], "🧪")
+        # Armed with the rename's own epoch, the stale generation loses.
+        assert fstore.set_icon_if_epoch(f["id"], "🚀", armed) is None
+        assert fstore.get(f["id"])["icon"] == "🧪"
+        # A read-back at this point would have returned the manual set's epoch,
+        # and the stale write would have satisfied the check and landed.
+        assert _epoch(fstore, f["id"]) != armed
+
+    def test_an_unrelated_folders_mutation_does_not_invalidate_a_generation(
+        self, fstore: ArtifactFolderStore
+    ) -> None:
+        """The epoch is per-folder, not a store-wide generation counter."""
+        target = fstore.create("Reports")
+        other = fstore.create("Scratch")
+        captured = _epoch(fstore, target["id"])
+        fstore.set_icon(other["id"], "🧪")
+        fstore.rename(other["id"], "Scratchpad")
+        out = fstore.set_icon_if_epoch(target["id"], "🚀", captured)
+        assert out is not None and out["icon"] == "🚀"
+
+
+# ── Handler layer: the three mid-generation races ────────────────────────────
+
+
+class TestIconRacesThroughHandlers:
+    @pytest.mark.asyncio
+    async def test_create_generates_and_writes_the_icon(self, stores, patch_restricted) -> None:
+        _store, folders = stores
+        with patch.object(
+            art_handlers, "generate_emoji_for_name", AsyncMock(return_value="🚀")
+        ) as gen:
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            assert resp.status == 201
+            fid = _body(resp)["id"]
+            await _drain_icon_tasks()
+        gen.assert_awaited_once()
+        assert folders.get(fid)["icon"] == "🚀"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_generation_leaves_the_folder_unchanged(
+        self, stores, patch_restricted
+    ) -> None:
+        _store, folders = stores
+        with patch.object(art_handlers, "generate_emoji_for_name", AsyncMock(return_value="")):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            fid = _body(resp)["id"]
+            await _drain_icon_tasks()
+        assert not folders.get(fid).get("icon")
+
+    @pytest.mark.asyncio
+    async def test_a_folder_deleted_mid_generation_is_not_resurrected(
+        self, stores, patch_restricted
+    ) -> None:
+        store, folders = stores
+        created: dict[str, Any] = {}
+
+        async def _gen(_state: Any, _name: str) -> str:
+            folders.delete(created["id"], delete_contents=False, artifact_store=store)
+            return "🚀"
+
+        with patch.object(art_handlers, "generate_emoji_for_name", AsyncMock(side_effect=_gen)):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            created["id"] = _body(resp)["id"]
+            await _drain_icon_tasks()
+        assert folders.get(created["id"]) is None
+
+    @pytest.mark.asyncio
+    async def test_a_manual_icon_set_mid_generation_is_not_clobbered(
+        self, stores, patch_restricted
+    ) -> None:
+        _store, folders = stores
+        created: dict[str, Any] = {}
+
+        def _gen(release: asyncio.Event) -> Any:
+            async def _run(_state: Any, _name: str) -> str:
+                await release.wait()  # hold generation until the PATCH lands
+                return "🚀"
+
+            return _run
+
+        async with _held_generation(_gen):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            created["id"] = _body(resp)["id"]
+            patched = await api_artifact_folder_update(
+                _request(body={"icon": "🧪"}, match={"id": created["id"]})
+            )
+            assert patched.status == 200
+        assert folders.get(created["id"])["icon"] == "🧪"
+
+    @pytest.mark.asyncio
+    async def test_an_icon_clear_mid_generation_is_not_overwritten(
+        self, stores, patch_restricted
+    ) -> None:
+        """An explicit clear must win. Under a value-pin the clear left the
+        icon equal to its at-schedule value (absent -> absent), so the stale
+        emoji landed anyway."""
+        _store, folders = stores
+        created: dict[str, Any] = {}
+
+        def _gen(release: asyncio.Event) -> Any:
+            async def _run(_state: Any, _name: str) -> str:
+                await release.wait()
+                return "🚀"
+
+            return _run
+
+        async with _held_generation(_gen):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            created["id"] = _body(resp)["id"]
+            patched = await api_artifact_folder_update(
+                _request(body={"icon": ""}, match={"id": created["id"]})
+            )
+            assert patched.status == 200
+        assert not folders.get(created["id"]).get("icon")
+
+    @pytest.mark.asyncio
+    async def test_a_rename_mid_generation_drops_the_stale_icon(
+        self, stores, patch_restricted
+    ) -> None:
+        """The pending emoji was derived from the OLD name; the rename's own
+        regeneration is what supplies the new one."""
+        _store, folders = stores
+        created: dict[str, Any] = {}
+        first = {"hit": False}
+
+        def _gen(release: asyncio.Event) -> Any:
+            async def _run(_state: Any, _name: str) -> str:
+                if not first["hit"]:
+                    first["hit"] = True
+                    await release.wait()
+                    return "🚀"  # stale: derived from "Rocketry"
+                return "🧬"  # the rename's own regeneration
+
+            return _run
+
+        async with _held_generation(_gen):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            created["id"] = _body(resp)["id"]
+            patched = await api_artifact_folder_update(
+                _request(body={"name": "Chemistry"}, match={"id": created["id"]})
+            )
+            assert patched.status == 200
+        folder = folders.get(created["id"])
+        assert folder["name"] == "Chemistry"
+        # The stale "Rocketry" emoji lost; only the post-rename result may land.
+        assert folder.get("icon") != "🚀"
+
+    @pytest.mark.asyncio
+    async def test_a_rename_then_manual_pick_keeps_the_manual_icon(
+        self, stores, patch_restricted
+    ) -> None:
+        """The case named in the issue: artifact rename REGENERATES, so a
+        rename followed by a manual pick must not lose to the regenerated
+        result."""
+        _store, folders = stores
+        created: dict[str, Any] = {}
+        calls = {"n": 0}
+
+        def _gen(release: asyncio.Event) -> Any:
+            async def _run(_state: Any, _name: str) -> str:
+                calls["n"] += 1
+                if calls["n"] == 1:
+                    return "🚀"  # create-time generation, lands immediately
+                await release.wait()  # rename-time regeneration, held
+                return "🧬"
+
+            return _run
+
+        async with _held_generation(_gen):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            created["id"] = _body(resp)["id"]
+            await _drain_icon_tasks()
+            renamed = await api_artifact_folder_update(
+                _request(body={"name": "Chemistry"}, match={"id": created["id"]})
+            )
+            assert renamed.status == 200
+            picked = await api_artifact_folder_update(
+                _request(body={"icon": "🧪"}, match={"id": created["id"]})
+            )
+            assert picked.status == 200
+        assert folders.get(created["id"])["icon"] == "🧪"
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_icon_in_the_same_patch_wins_over_regeneration(
+        self, stores, patch_restricted
+    ) -> None:
+        """rename + icon in ONE request sets the icon and arms no generation,
+        which is the contract the handler comment already asserted."""
+        _store, folders = stores
+        with patch.object(
+            art_handlers, "generate_emoji_for_name", AsyncMock(return_value="🚀")
+        ) as gen:
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            fid = _body(resp)["id"]
+            await _drain_icon_tasks()
+            gen.reset_mock()
+            patched = await api_artifact_folder_update(
+                _request(body={"name": "Chemistry", "icon": "🧪"}, match={"id": fid})
+            )
+            assert patched.status == 200
+            await _drain_icon_tasks()
+        gen.assert_not_awaited()
+        assert folders.get(fid)["icon"] == "🧪"
+
+    @pytest.mark.asyncio
+    async def test_a_manual_pick_in_the_arming_window_is_not_clobbered(
+        self, stores, patch_restricted, monkeypatch
+    ) -> None:
+        """The window between the rename committing and the handler arming
+        generation. Capturing the epoch by re-reading it there picks up the
+        competing manual set's epoch, so the generated icon satisfies the check
+        and overwrites the user's pick. The rename must arm with the epoch its
+        own bump produced instead."""
+        _store, folders = stores
+        with patch.object(art_handlers, "generate_emoji_for_name", AsyncMock(return_value="🧬")):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            fid = _body(resp)["id"]
+            await _drain_icon_tasks()
+
+            real_off_loop = art_handlers._run_off_loop
+            fired = {"done": False}
+
+            async def _hooked(fn):  # type: ignore[no-untyped-def]
+                out = await real_off_loop(fn)
+                # Land a manual pick the instant _apply_updates has committed,
+                # i.e. inside the arming window.
+                if not fired["done"]:
+                    fired["done"] = True
+                    folders.set_icon(fid, "🧪")
+                return out
+
+            monkeypatch.setattr(art_handlers, "_run_off_loop", _hooked)
+            patched = await api_artifact_folder_update(
+                _request(body={"name": "Chemistry"}, match={"id": fid})
+            )
+            assert patched.status == 200
+            assert fired["done"], "the arming-window hook never fired"
+            await _drain_icon_tasks()
+        assert folders.get(fid)["icon"] == "🧪"
+
+    @pytest.mark.asyncio
+    async def test_a_manual_pick_before_a_created_folders_icon_lands_wins(
+        self, stores, patch_restricted
+    ) -> None:
+        """Create arms with epoch 0 by construction. A manual pick landing
+        before the generated result raises the epoch, so the generated icon
+        must lose rather than overwrite it."""
+        _store, folders = stores
+        created: dict[str, str] = {}
+
+        def _gen(release: asyncio.Event) -> Any:
+            async def _run(_state: Any, _name: str) -> str:
+                await release.wait()
+                return "🚀"
+
+            return _run
+
+        async with _held_generation(_gen):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            created["id"] = _body(resp)["id"]
+            folders.set_icon(created["id"], "🧪")
+        assert folders.get(created["id"])["icon"] == "🧪"
+
+    @pytest.mark.asyncio
+    async def test_a_delete_through_the_handler_releases_the_epoch(
+        self, stores, patch_restricted
+    ) -> None:
+        _store, folders = stores
+        with patch.object(art_handlers, "generate_emoji_for_name", AsyncMock(return_value="🚀")):
+            resp = await api_artifact_folder_create(_request(body={"name": "Rocketry"}))
+            fid = _body(resp)["id"]
+            await _drain_icon_tasks()
+        patched = await api_artifact_folder_update(_request(body={"icon": "🧪"}, match={"id": fid}))
+        assert patched.status == 200
+        assert folders._icon_epochs.get(fid) == 1
+        deleted = await api_artifact_folder_delete(_request(match={"id": fid}))
+        assert deleted.status == 200
+        assert fid not in folders._icon_epochs

--- a/test/test_artifact_folders.py
+++ b/test/test_artifact_folders.py
@@ -128,7 +128,7 @@ class TestFolderCrud:
 
     def test_rename(self, folders: ArtifactFolderStore) -> None:
         f = folders.create("Reports")
-        renamed = folders.rename(f["id"], "Archive")
+        renamed, _epoch = folders.rename(f["id"], "Archive")
         assert renamed["name"] == "Archive"
         assert folders.get(f["id"])["name"] == "Archive"
 


### PR DESCRIPTION
## Problem / Motivation

`_spawn_artifact_folder_icon_task` (`src/kiro_crew/dashboard/handlers/artifacts.py`) guarded its async icon write-back with only an existence check (`fstore.exists(folder_id)`), which catches deletion and nothing else. Three stale-write-back races stayed open for ARTIFACT folders — the same three the chat-folder subsystem closes with a per-folder icon epoch:

- a **manual icon set** while generation was in flight was clobbered by the stale generated result;
- an **icon clear** mid-generation was overwritten. The icon VALUE goes absent -> absent, so a value-pin could not have caught this one either — only a counter can;
- a **rename** mid-generation landed an icon derived from the old name. Because an artifact-folder rename *regenerates*, a rename followed by a manual pick also lost to the regenerated result.

## Why it matters

The user's own explicit choice silently loses to a background LLM result, seconds after they made it. There is no error and no retry affordance — the icon they picked just turns into a different one, and the only recovery is to notice and pick again. The handler even carries a comment asserting that "an explicit icon wins", which the async path could violate.

## What changed (motivation → approach → change)

Root cause: nothing carried a per-folder version, so the write-back had no way to tell "the folder still wants this icon" from "the user has since acted". `exists()` answers a different question.

Approach: port the chat-folder guard (`_CHAT_FOLDER_ICON_EPOCHS` / `_bump_icon_epoch` in `src/kiro_crew/dashboard/chat_folders.py`, PR #7353) to the artifact folder store, preserving its ordering contract:

| Step | Under the store lock? |
|---|---|
| Epoch bump on icon set / clear / rename | **Yes** — inside `set_icon` / `rename`, same critical section as the field write |
| Epoch capture for arming | **Yes** — *returned from* the mutation; never read back |
| Epoch check + icon write-back | **Yes** — both inside `set_icon_if_epoch`, one critical section |
| Epoch pop on delete | Only after `_save()` confirmed the removal |

Concretely:

- `ArtifactFolderStore` gains `self._icon_epochs`, `_bump_icon_epoch_locked()` and `set_icon_if_epoch()`.
- `set_icon` bumps — one call site covers both a manual set and a clear (`icon == ""`).
- `rename` bumps and returns `(folder, epoch)` — the epoch its own bump produced.
- `delete` pops the affected ids (whole subtree on cascade) **after** `_save()`, so a failed commit keeps the guard armed.
- The PATCH handler arms generation with the epoch `rename` returned. The create path pins `0`.

**Arming has to be atomic with the mutation** — this is the subtle half, and the first revision of this PR got it wrong (caught by the GPT lane; see the disposition comments). `rename()` followed by a separate epoch read is *two* lock acquisitions: a manual icon set landing between them bumps the epoch again, the later read captures **that** epoch, and the generated icon then satisfies `set_icon_if_epoch` and overwrites the user's pick — reintroducing exactly the race the epoch exists to prevent. Returning the value from inside the bump's own critical section closes the window by construction: there is no read to lose. The create path pins `0` for the same reason — a fresh id has no registry entry (and `delete` pops, so even a reused id reads 0), and a read there could only pick up a competing bump.

**No epoch getter ships, deliberately.** Those two paths are the only ways a caller obtains an epoch, so a public read-back accessor would have had zero production callers — and the read it enables *is* the bug above. An earlier revision did add one; the First Principles lane flagged it as a rider and it is gone (see its disposition). Tests read the registry through a local helper instead. For the same reason `rename()` is the single spelling of that mutation rather than a dict-returning wrapper sitting beside a tuple-returning twin, which would drift.

Two deliberate deviations from the chat-folder original, both because the artifact side is a store object rather than `DashboardState`:

1. **The epoch is per store INSTANCE, not module-level.** `ArtifactFolderStore` is constructed per JSON path (and tests construct their own over `tmp_path`); a module-level dict keyed only by folder id would let two stores alias each other's ids. Locked to `self._lock`, which is the lock that orders the bump against the check.
2. **`set_icon_if_epoch` is a store method rather than a callback.** Chat folders mutate through `state.mutate_folders(callback)`, so the epoch check can live inside the caller's callback. `ArtifactFolderStore` exposes discrete lock-taking methods, so the check-and-write has to be one method to stay in one critical section.

The `exists()` pre-check is **removed** rather than kept alongside the epoch: it was itself a TOCTOU gap (the folder could vanish, or its icon change, between the check and the write), and re-finding the folder under the lock subsumes it. That also drops a lock acquisition from the event loop inside the background task.

## Note on PR #7353

#7353 is still open, so `_CHAT_FOLDER_ICON_EPOCHS` is not on `main` yet. This PR is nonetheless self-contained and lands on `main` as-is: the artifact-side bug is real on `main` today (see the red-before results below), and #7353 touches neither `src/kiro_crew/artifacts.py` nor `src/kiro_crew/dashboard/handlers/artifacts.py`, so there is no file collision and no ordering dependency. The pattern was read off #7353's branch to match it.

Worth flagging for whoever reviews #7353: the late-capture defect found here applies to its shape too — it captures `_CHAT_FOLDER_ICON_EPOCHS.get(fid, 0)` after `mutate_folders(_apply)` returns, which is the same two-step read this PR had to replace.

## Tests

`test/test_artifact_folder_icons.py`, mirroring `test/test_chat_folder_icons.py`. 27 tests across both layers.

Store layer (`TestStoreIconEpoch`):

- fresh folder and unknown folder read epoch 0;
- `set_icon` bumps; an icon **clear** bumps (the case a value-pin cannot see); `rename` bumps;
- `set_icon_if_epoch` writes on a matching epoch, and does **not** bump (a generated result landing is not a user mutation);
- `set_icon_if_epoch` drops a stale write, and drops a write for a deleted folder;
- a confirmed delete pops the entry; a cascade delete pops every subtree entry;
- a **failed** delete commit keeps the guard armed, and the stale result still loses;
- epochs are per store instance; an unrelated folder's mutations do not invalidate a pending generation;
- `rename` returns its own bump, and that returned value is exactly what a read-back would have lost — the atomicity contract.

Handler layer (`TestIconRacesThroughHandlers`) — the races end-to-end through the real handlers:

- create generates and writes the icon; a failed generation leaves the folder unchanged; a folder deleted mid-generation is not resurrected;
- **manual icon set mid-generation is not clobbered**;
- **icon clear mid-generation is not overwritten**;
- **rename mid-generation drops the stale old-name icon**;
- **rename-then-manual-pick keeps the manual icon** (the case named in the issue);
- **a manual pick landing inside the arming window is not clobbered** (the GPT finding);
- **a manual pick before a created folder's icon lands wins**;
- an explicit icon in the same PATCH as a rename wins and arms no generation;
- a delete through the handler releases the epoch.

**Red-before proven per mechanism, separately.** With the two source files reverted and the tests kept, the four original races fail as genuine clobbers, not as missing API:

```
FAILED test_a_manual_icon_set_mid_generation_is_not_clobbered  - AssertionError: assert '🚀' == '🧪'
FAILED test_an_icon_clear_mid_generation_is_not_overwritten    - AssertionError: assert not '🚀'
FAILED test_a_rename_mid_generation_drops_the_stale_icon       - AssertionError: assert '🚀' != '🚀'
FAILED test_a_rename_then_manual_pick_keeps_the_manual_icon    - AssertionError: assert '🧬' == '🧪'
```

With **only** the late epoch capture restored (everything else fixed), the arming-window test fails on its own:

```
FAILED test_a_manual_pick_in_the_arming_window_is_not_clobbered - AssertionError: assert '🧬' == '🧪'
```

Test-hygiene notes, both fixing real CI reds this PR hit: the drain helper filters in-flight tasks to the **current running loop**, because `_ARTIFACT_FOLDER_ICON_TASKS` is module-global and other test files populate it via the create handler — gathering the whole set awaits futures from earlier tests' closed loops (`ValueError: The future belongs to a different loop`, 7 shard failures). And a `_held_generation` context manager owns the release Event and drains in a `finally`, so an aborting assertion cannot leave a task parked on it.

Local gates: the baselined `black` gate (scope clean, no baseline churn), `isort`, `flake8`, `mypy`, `check_sync_io_in_async`, `check_testpaths_coverage`, `check_loop_bound_locks`, `check_brand_name`, `check_harness_parity` all pass. 486 tests green across the six artifact suites.

## Manual verification

N/A — unit coverage sufficient. Every race here is timing-dependent and is driven deterministically instead: an `asyncio.Event` holds the generator open while the competing mutation lands through the real HTTP handler, and the arming-window case hooks `_run_off_loop` so the competing pick lands the instant the rename commits. That is more reliable than reproducing them by hand.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (store + its handler). The rendered glyph is unchanged; it just stops being the wrong one.

## Pattern harvest

Rule candidate: semgrep

Pattern: a versioned-guard counter (epoch / generation) read in a **separate lock acquisition** from the mutation that bumped it, then used as the expected value for a later compare-and-set. The read can observe a competing writer's bump, so the stale actor's write satisfies the comparison and lands — silently defeating the guard it was supposed to arm. The counter must be returned from inside the mutation's own critical section; a subsequent read-back is never equivalent, which is why this change ships no accessor for it.

This is the defect the GPT lane caught in this PR's first revision, and it is worth a rule precisely because the code reads as correct: the bump *is* under the lock, the check *is* under the lock, and only the capture in between is not.

Closes #7991
