### PR TITLE
fix(babysit): stop the gated ack contradicting itself at max_cycles=0

### DIFF
--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -959,7 +959,8 @@ def monitor_start(name: str, args: dict[str, Any]) -> str:
             + (
                 f"observing {gated.target} every {interval_secs}s and "
                 "re-injecting the message only when it changes, so quiet cycles "
-                f"cost no turn and the {max_cycles or 0} cap counts delivered turns"
+                "cost no turn"
+                + (f" and the {max_cycles} cap counts delivered turns" if max_cycles else "")
                 if gated is not None
                 else f"the message will re-inject every {interval_secs}s"
             )

--- a/test/test_monitor_start_ack.py
+++ b/test/test_monitor_start_ack.py
@@ -76,6 +76,38 @@ def test_the_ack_carries_the_opt_out_to_the_scheduler(bound_session):
     assert gated is not None and gated.get("gate") is True, "absent means gated"
 
 
+def test_a_gated_loop_with_zero_max_cycles_does_not_contradict_itself(bound_session):
+    """max_cycles=0 means "unlimited", so the ack must describe the cap exactly once.
+
+    The cap clause and the "NO cycle cap" clause live far apart in the ack
+    expression, so an explicit zero renders BOTH unless the cadence clause shares
+    the tail's truthiness guard -- asserting the loop both counts a cap and has
+    none -- on the one parameter that decides whether an unattended loop can spend
+    without limit.
+    """
+    out = _ack("Watch https://github.com/acme/widgets/pull/42", max_cycles=0)
+    assert not (
+        "cap counts" in out and "NO cycle cap" in out
+    ), "an unlimited gated loop must not both count a cap and declare none"
+    # The unlimited loop must POSITIVELY declare it has no cap, not just omit the
+    # contradiction: silence here would let a bounded-sounding ack ship for a loop
+    # that can actually spend without limit.
+    assert "NO cycle cap" in out, "a zero-cap gated loop must declare it has no cap"
+    assert "cap counts" not in out, "and must not also claim a cap counts turns"
+
+
+def test_a_gated_loop_with_a_truthy_max_cycles_states_the_cap(bound_session):
+    """A truthy cap is the counterpart: the ack must state the cap and NOT deny it.
+
+    The zero-cap case proves the "unlimited" branch renders alone; this proves the
+    bounded branch does too, so the two clauses never both appear -- the same
+    contradiction, guarded from the other side.
+    """
+    out = _ack("Watch https://github.com/acme/widgets/pull/42", max_cycles=5)
+    assert "cap counts" in out, "a bounded gated loop must state its cap counts turns"
+    assert "NO cycle cap" not in out, "and must not also declare it has no cap"
+
+
 def test_an_ambiguous_instruction_is_reported_as_ungated(bound_session):
     """Two subjects means no inference, so the ack must not claim a gate."""
     out = _ack(


### PR DESCRIPTION
Fixes #8100.

## Problem

When `monitor_start` armed a GATED loop with an explicit `max_cycles=0` (documented as "unlimited"), the acknowledgement contradicted itself in one sentence. The gated cadence clause in `src/kiro_crew/mcp_tools/control.py` unconditionally rendered `the {max_cycles or 0} cap counts delivered turns` while the shared tail appended `, with NO cycle cap` for the same falsy value, so the agent read both a 0-cap and a no-cap.

This matters because the ack is what the model reads back to learn the loop's semantics, and the cycle cap is the runaway backstop. An ack that asserts both a cap and no cap leaves the agent unable to tell whether a bound exists on exactly the parameter that decides whether an unattended loop can spend without limit.

## Fix

Gate the cadence clause on `max_cycles` being truthy, so the falsy case is described exactly once by the existing `, with NO cycle cap` tail:

```python
"cost no turn"
+ (f" and the {max_cycles} cap counts delivered turns" if max_cycles else "")
```

The ungated branch was unaffected and left unchanged.

### Which side was wrong, and why the ack moved rather than the engine

`0` genuinely means unlimited here, on both of the surfaces that define it, so the ack was the wrong one:

- **Engine** — `autonudge.py`'s cap check is `if loop.max_cycles and loop.cycle_count >= loop.max_cycles`, so a falsy cap is never enforced. A `0` loop runs until `autonudge_stop`, the STOP sentinel, or `max_runtime_secs`.
- **Skill** — the babysit skill documents `max_cycles` as a runaway backstop rather than a finish line, and says to "pass `0` for unlimited only when the user explicitly asks for an unbounded loop".

So the engine and the documented contract already agree that `0` is unlimited-on-purpose; only the ack disagreed with them. Making `0` *refuse* would be a behaviour change to a documented escape hatch, and making the message vaguer would hide the one fact the reader needs. Documented behaviour is therefore unchanged, and no spec or SKILL.md moves with this commit.

## Class audit — one site, not an instance fix

Both clauses were grepped repo-wide (`NO cycle cap`, `cap counts`, `max_cycles or 0`):

| Site | Renders a cap-counts clause? | State |
|---|---|---|
| `mcp_tools/control.py:963` (gated cadence) | yes | **fixed here** |
| `mcp_tools/control.py:969` (shared tail) | no — already `if max_cycles else ", with NO cycle cap"` | already correct |
| `dashboard/session_directive_apply.py:238` (directive applier ack) | no such clause exists on that path | not affected |

There is no second site that can render the contradiction, so this closes the class.

## Test

`test/test_monitor_start_ack.py` gains two tests pinning both sides:

- `test_a_gated_loop_with_zero_max_cycles_does_not_contradict_itself` — an unlimited gated loop must *positively* declare `NO cycle cap` and must not also claim `cap counts`. Asserting the positive matters: mere silence would let a bounded-sounding ack ship for a loop that can spend without limit.
- `test_a_gated_loop_with_a_truthy_max_cycles_states_the_cap` — the counterpart, so the bounded branch is pinned from the other side and the two clauses can never both appear.

Confirmed the first fails without the fix and passes with it.

## Pattern harvest

The two clauses describing one parameter sat ~6 lines apart in a single chained-`+` expression, and only one of them had the truthiness guard. `max_cycles or 0` reads as defensive normalisation, which is exactly why the missing guard survived review: it looks like the falsy case *was* handled, when it only coerced `None` into a value that then rendered as a false claim.

Rule candidate: when two fragments of one user-facing message describe the same parameter, every fragment must share the parameter's falsy guard — an `x or 0` in a template is a rendering default, never evidence the empty case was considered. Too narrow to encode as a lint (there is no way to tell which fragments describe the same value), and the general form — "no hardcoded user-facing strings, one owner per limit" — is already in AGENTS.md; the durable defence is the test shape used here, asserting the message states the fact exactly once from both sides rather than merely asserting the absence of the wrong word.

## Verification

- `test/test_monitor_start_ack.py` passes in full, plus the babysit / autonudge / monitor suites.
- `isort`, `flake8`, `mypy --platform linux`, `scripts/check_black_formatting.py`, `scripts/check_builtin_skill_scope.py`, `scripts/docs-lint.sh`, and `test/test_security_posture.py` clean.
- Rebased onto current `main` and squashed to one commit. The earlier three-dot range that two review lanes read as also containing a `skills.py` sync rework was stale-base noise: that work is main's own #8050, this branch never carried it, and the range is now exactly the two files above (+33/-1).

Refs #7634.