### PR TITLE
fix(skills): collapse identical multi-root skill copies in the injected index

### DIFF
--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -631,6 +631,66 @@ def _disabled_app_names() -> frozenset[str]:
         return frozenset()
 
 
+def _skill_content_digest(path: str, cache: dict[str, "bytes | None"]) -> "bytes | None":
+    """SHA-256 of the file at *path*, memoized in *cache*; ``None`` if unreadable.
+
+    Only ever called for rows whose cheap fingerprint already collided, so the
+    read cost is zero on the no-duplicate path and one read per colliding copy
+    otherwise. ``None`` (unreadable) never compares equal — a row that cannot
+    be verified identical is kept, not dropped.
+    """
+    if path in cache:
+        return cache[path]
+    try:
+        digest: bytes | None = hashlib.sha256(Path(path).read_bytes()).digest()
+    except OSError:
+        digest = None
+    cache[path] = digest
+    return digest
+
+
+def _dedupe_identical_skills(skills: list[dict]) -> list[dict]:
+    """Drop later rows that are verified byte-identical copies of an earlier row.
+
+    Two stages, so correctness never rests on a metadata coincidence:
+
+    1. **Candidate fingerprint** — ``(name, description, size_bytes)``, the
+       fields a summary line is rendered from, all already loaded by
+       ``list_skills()``. No collision (the overwhelmingly common case) means
+       no file I/O at all.
+    2. **Content verification** — on a fingerprint collision only, hash the
+       actual file bytes of both rows and drop the later row **only when the
+       digests match**. Equal-metadata skills whose bodies differ (which the
+       pinned path would inject in full) are all kept; an unreadable file is
+       kept, never dropped.
+
+    The first row wins, preserving the walk order's operator-installed
+    precedence. Confined project rows are exempt entirely: their reads are
+    gated through the descriptor-pinned reader, and mirrored-root duplicates
+    only arise from unconfined trees anyway.
+    """
+    seen: dict[tuple[str, str, int], list[dict]] = {}
+    digest_cache: dict[str, bytes | None] = {}
+    out: list[dict] = []
+    for s in skills:
+        if s.get("confine_root"):
+            out.append(s)
+            continue
+        fp = (str(s.get("name", "")), str(s.get("description", "")), int(s.get("size_bytes") or 0))
+        rivals = seen.setdefault(fp, [])
+        this_digest = None
+        if rivals:
+            this_digest = _skill_content_digest(str(s.get("path", "")), digest_cache)
+            if this_digest is not None and any(
+                _skill_content_digest(str(r.get("path", "")), digest_cache) == this_digest
+                for r in rivals
+            ):
+                continue  # verified byte-identical copy of an earlier row
+        rivals.append(s)
+        out.append(s)
+    return out
+
+
 @functools.lru_cache(maxsize=None)
 def _builtin_dir_app_name(pkg_dir: str) -> str | None:
     """The manifest name of the builtin app shipped in *pkg_dir*, or ``None``.
@@ -4708,6 +4768,18 @@ class SkillsLoader:
             if not s.get("repo_scope")
             or self._repo_scope_satisfied(str(s["repo_scope"]), project_dir)
         ]
+        # Collapse verified byte-identical copies of the same skill before
+        # anything is rendered, for the same reason the scope filter above
+        # lives here: this is the single place that covers the index, both
+        # renderers, and the pinned set. Multi-root installs commonly
+        # materialize one skill twice — a package tree and a flat mirror of it
+        # — at different key depths, so `_iter_uncached`'s per-key shadowing
+        # never sees the collision and the injected index carries N identical
+        # summary lines (and, for a pinned skill, N identical full bodies).
+        # Dropping a copy is only safe when the bytes are the same, and
+        # `_dedupe_identical_skills` verifies exactly that: same-metadata rows
+        # whose content differs are all kept.
+        all_skills = _dedupe_identical_skills(all_skills)
         if not all_skills:
             return ""
         if budget is None:

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -1303,6 +1303,79 @@ class TestSkillsLoaderExtraPaths:
         )
         assert "LocalBody" in loader.load_skill("dup")
 
+    def test_identical_copy_at_different_depth_deduped_in_context(self, tmp_path):
+        """A physical copy of a skill nested one level deeper in another root
+        (a package tree plus a flat mirror of it) yields ONE index line, not two.
+
+        The per-key shadowing in enumeration cannot catch this: the copies have
+        different dir-relative keys (``pkg/tool`` vs ``tool``), so both survive
+        to ``list_skills()`` and, before the fingerprint dedup, both rendered
+        identical summary lines differing only in path.
+        """
+        body = "---\nname: tool\ndescription: One tool\n---\n# Tool\nSame bytes.\n"
+        local = tmp_path / "local"
+        local.mkdir()
+        extra = tmp_path / "extra"
+        _create_skill(extra, "tool", body)
+        _create_skill(extra, "mirror-pkg/tool", body)
+        loader = SkillsLoader(
+            skills_path=local,
+            install_builtins=False,
+            config=_cfg_with_extra([str(extra)]),
+        )
+        # Both copies are enumerated (different keys) ...
+        keys = {s["key"] for s in loader.list_skills()}
+        assert {"tool", "mirror-pkg/tool"} <= keys
+        # ... but the injected index carries exactly one line for the skill,
+        # on the legacy full-dump path and the budgeted lazy path alike.
+        legacy = loader.get_context()
+        assert legacy.count("**tool**") == 1
+        lazy = loader.get_context(budget=10_000)
+        assert lazy.count("**tool**") == 1
+
+    def test_same_name_different_content_not_deduped(self, tmp_path):
+        """Same frontmatter name with different content is a legitimate
+        collision, not a mirror copy — both index lines must survive."""
+        local = tmp_path / "local"
+        local.mkdir()
+        extra = tmp_path / "extra"
+        _create_skill(extra, "tool", "---\nname: tool\ndescription: Original\n---\n# A\n")
+        _create_skill(
+            extra, "fork-pkg/tool", "---\nname: tool\ndescription: Forked variant\n---\n# B\n"
+        )
+        loader = SkillsLoader(
+            skills_path=local,
+            install_builtins=False,
+            config=_cfg_with_extra([str(extra)]),
+        )
+        legacy = loader.get_context()
+        assert legacy.count("**tool**") == 2
+        assert "Original" in legacy and "Forked variant" in legacy
+
+    def test_equal_metadata_different_bytes_not_deduped(self, tmp_path):
+        """Equal (name, description, size) with DIFFERENT bodies is a metadata
+        coincidence, not a copy — content verification must keep both.
+
+        The pinned path injects full bodies, so dropping a same-size row on
+        metadata alone would silently lose one skill's instructions. The two
+        bodies below are the same byte length but different procedures.
+        """
+        local = tmp_path / "local"
+        local.mkdir()
+        extra = tmp_path / "extra"
+        head = "---\nname: tool\ndescription: One tool\nalways: true\n---\n"
+        _create_skill(extra, "tool", head + "# Tool\nStep: run AAAA.\n")
+        _create_skill(extra, "mirror-pkg/tool", head + "# Tool\nStep: run BBBB.\n")
+        loader = SkillsLoader(
+            skills_path=local,
+            install_builtins=False,
+            config=_cfg_with_extra([str(extra)]),
+        )
+        rows = [s for s in loader.list_skills() if s["name"] == "tool"]
+        assert rows[0]["size_bytes"] == rows[1]["size_bytes"]  # fingerprints collide
+        legacy = loader.get_context()
+        assert "run AAAA" in legacy and "run BBBB" in legacy  # both bodies survive
+
     def test_nonexistent_extra_path_ignored(self, tmp_path):
         local = tmp_path / "local"
         local.mkdir()


### PR DESCRIPTION
## Problem / Motivation

A skill installed through more than one discovery root — typically a package tree plus a flat mirror of the same package — enumerates under **different dir-relative keys** (`pkg/tool` vs `tool`). The per-key shadowing in `_iter_uncached` therefore never sees the collision, and `get_context()` renders N identical summary lines (and, for a pinned skill, N identical full bodies).

Observed on a real multi-root install: **~160 of ~350 lines in the injected skills index were literal duplicates** (every skill from two mirrored roots listed twice). The cost is not one-time: the skills index is re-injected after every context compaction (`needs_reinjection`), so a fatter index both costs more per injection **and brings the next compaction closer** — a small positive-feedback loop on exactly the sessions that are already long.

This is the same class of pure-duplication waste as #8071 (resumed-session re-injection), one surface over.

## Why it matters

For affected installs the index roughly doubles: thousands of tokens of identical lines per session start, again per compaction, with zero informational gain — a verified-identical duplicate advertises the same identity and the same bytes as its survivor.

## What changed (motivation → approach → change)

- **Motivation**: collapse physical copies of the same skill before the index is rendered, without ever collapsing skills that merely *look* alike.
- **Approach**: dedupe at the `get_context()` choke point — the same single place the `repo_scope` filter already lives, which (per its own comment) covers the index, both renderers, and the pinned set. **Two stages, so correctness never rests on a metadata coincidence**:
  1. *Candidate fingerprint* — `(name, description, size_bytes)`, all already loaded by `list_skills()`: zero I/O when nothing collides (the common case).
  2. *Content verification* — on a fingerprint collision only, hash the actual file bytes (memoized) and drop a later row **only when verified byte-identical** to an earlier one. Equal-metadata rows whose bodies differ are all kept; an unreadable file is kept, never dropped; confined project rows are exempt entirely (their reads stay behind the descriptor-pinned reader, and mirrored-root duplicates only arise from unconfined trees).
- **Change**: two module-level helpers (`_dedupe_identical_skills`, `_skill_content_digest`) + one call in `get_context()`. First row wins, preserving the walk order's operator-installed precedence.

`list_skills()` itself is untouched: the dashboard Skills page still shows every physical copy (it reports paths and per-copy ownership), only the prompt injection is deduplicated.

**Declared, deliberately out of scope here** (sibling surfaces of the same root cause, counted by the First Principles review): `get_triggered_skills` still matches a mirrored skill under both keys and injects both bodies per trigger, and `search_skills` returns both rows. Fixing those means deduping at enumeration, which would also change the dashboard's physical view — a wider behavioral decision than this index fix. Flagged for the maintainers' backlog in the review disposition (issue creation is restricted for outside contributors); happy to do the follow-up.

## Tests

- `test_identical_copy_at_different_depth_deduped_in_context` — reproduces the mirror layout (`tool` + `mirror-pkg/tool`, identical bytes): both copies enumerate in `list_skills()`, but the legacy full-dump path and the budgeted lazy path each render exactly one index line.
- `test_same_name_different_content_not_deduped` — same frontmatter name, different description: both lines survive.
- `test_equal_metadata_different_bytes_not_deduped` — **the coincidence case**: equal `(name, description, size_bytes)` with different same-length bodies (pinned) — content verification keeps both full bodies.
- Full `test/test_skills.py`: 148 passed. Neighboring `get_context` consumers (`test_skill_budget.py`, `test_agent_template_skills.py`): 217 total passed. `flake8` clean; `scripts/check_black_formatting.py` passes.

## Manual verification

On the multi-root install where the duplication was measured, the injected index drops from ~350 lines to ~190 with identical skill coverage (every unique skill still listed once; the byte-hash stage confirms only true copies were dropped).

## Screenshots / video

N/A (context-injection change; no UI surface).

## Related Issues

Sibling of #8071 (resumed-session slim injection) — same dedup principle applied to the skills-index surface. The hardcoded multi-root scan itself carries a `TODO(aim-governance follow-up)` in `agent.py` to route through the `McpToolingProvider.extra_skills()` CPP seam; this PR is complementary (dedup is needed regardless of how the roots are sourced).

## Pattern harvest

Not generalizable: the two-stage fingerprint-then-verify shape is specific to this call site's data (metadata already in hand, bytes one read away); other injected surfaces dedupe on their own rendered identity. The choke-point placement follows the existing `repo_scope` precedent rather than establishing a new one.

## Checklist

- [x] Tests added for the new behavior (positive + negative + coincidence case)
- [x] Full test file and neighboring suites pass locally
- [x] `flake8` and the baselined black gate pass
- [ ] CodeQL — not applicable on fork PRs (default setup emits no check-run)

## Contribution License Agreement

I confirm that this contribution is made under the terms of the license found in the root of this repository, and that I have the authority necessary to make this contribution on behalf of its copyright owner.
