### PR TITLE
fix(dashboard): warn when redaction rewrites a credential in chat text

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -239,6 +239,7 @@ from kiro_crew.providers.base import (
 from kiro_crew.quick_prompts import QUICK_PROMPTS
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import (
+    CREDENTIAL_REDACTION_TAGS,
     StreamRedactor,
     is_sensitive_path,
     oauth_url_contains_credential,
@@ -2975,6 +2976,35 @@ def _prepare_mirror_msg(raw_user_message: str) -> str:
     return safe[:500]
 
 
+def _redaction_notice(count: int) -> str:
+    """Build the user-visible notice for a segment that had credentials removed.
+
+    ``count`` is the number of redaction placeholders standing in the persisted
+    text, so the wording always matches what the user can see in the message
+    above it. The notice carries no secret bytes -- by the time it is built, a tag
+    has already replaced them.
+
+    Says "a redaction placeholder" rather than naming a specific tag: the
+    redactor emits more than one (see ``CREDENTIAL_REDACTION_TAGS``), so naming
+    one would print a marker the user cannot find in the text whenever the
+    substitution came from a different pass.
+
+    The second sentence is the part that matters and is deliberately blunt: a
+    redacted command is not a working command. Saying only "a credential was
+    removed" would still leave the user pasting text that cannot run, which is
+    the failure issue #6189 reports (the reporter lost time to an opaque
+    ``getaddrinfo EAI_AGAIN`` far from the real cause).
+    """
+    subject = "A credential" if count == 1 else f"{count} credentials"
+    verb = "was" if count == 1 else "were"
+    return (
+        f"Security notice: {subject} in this message {verb} replaced with a "
+        "redaction placeholder before it reached this page. Any command shown "
+        "above will not work if you paste it as-is; supply the secret yourself "
+        "on the machine where you run it."
+    )
+
+
 def _flush_segment(
     state: DashboardState,
     slot: _ChatSlot,
@@ -3056,6 +3086,41 @@ def _flush_segment(
         last_msg["variants"] = pending_list
         last_msg["variant_idx"] = len(pending_list) - 1
         slot._pending_variants = []
+    # Tell the user the text was altered. Until now this was silent: the
+    # `cred_warnings` above are logged and nothing else, so a user copied a
+    # command whose credential had become a placeholder and only found out when
+    # it failed downstream (issue #6189).
+    #
+    # The count comes from the TAG in the persisted text, not from
+    # `cred_warnings`, because on the streaming path that list is almost always
+    # empty HERE: the run loop redacts every chunk before it enters
+    # `assistant_text` (EVENT_TEXT_CHUNK branch), so this call re-redacts
+    # already-clean text and reports nothing. `cred_warnings` only fires for a
+    # credential split across chunk boundaries, which is the rarer case. Reading
+    # the artifact instead of the event answers the question the user actually
+    # has -- "is what I am about to copy still what the assistant wrote?" -- and
+    # stays correct wherever the substitution happened: per-chunk, the
+    # StreamRedactor wire pass, or this call. All three write the same tag.
+    #
+    # Broadcast unconditionally: `quiet_persist` exists to suppress a DUPLICATE
+    # of the pre-steer assistant text that clients already rendered, and a notice
+    # row has no streamed counterpart to duplicate. Suppressing it there would
+    # drop the warning on exactly the path this fix exists to cover.
+    # The count sums every CREDENTIAL tag the redactor can emit, read from
+    # `CREDENTIAL_REDACTION_TAGS` which `security.py` owns beside the passes that
+    # write them. Enumerating tags by hand here is what previously left an
+    # encoded-credential-only segment silently rewritten and undercounted a mixed
+    # one; asking the redactor's own module means a newly added tag cannot escape.
+    #
+    # SCOPE: credentials only, so this notice does NOT fire for the
+    # `redact_exfiltration_urls` pass a few lines above, which rewrites a URL to
+    # `[REDACTED: suspicious URL to <domain>]` just as silently. Same root cause,
+    # same function, different rewriter -- tracked separately rather than widened
+    # into this fix, because issue #6189 reports the credential case and the notice
+    # wording ("A credential ... was replaced") would have to change to cover both.
+    _cred_redactions = sum(redacted.count(tag) for tag in CREDENTIAL_REDACTION_TAGS)
+    if _cred_redactions:
+        slot.append("notice", _redaction_notice(_cred_redactions), "msg msg-info")
     # Re-append any stop_event that belongs to this segment's trailing run,
     # placed AFTER the finalized assistant message so the UI shows
     # prose → stop card.

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -12486,6 +12486,37 @@ _REDACTED_CREDENTIAL_TAG = "[REDACTED: credential]"
 # scan matches.
 REDACTED_CREDENTIAL_TAG = _REDACTED_CREDENTIAL_TAG
 
+#: Replacement tag for pass 2 (a base64-encoded credential). DISTINCT from
+#: ``_REDACTED_CREDENTIAL_TAG`` and deliberately not a superstring of it, so a
+#: consumer counting one tag does not accidentally match the other. Kept PRIVATE:
+#: consumers should ask ``CREDENTIAL_REDACTION_TAGS`` below rather than name
+#: individual tags, which is the whole point of that registry.
+_REDACTED_ENCODED_CREDENTIAL_TAG = "[REDACTED: encoded credential]"
+
+#: EVERY tag :func:`redact_credentials` can substitute for a credential, owned
+#: HERE beside the passes that emit them rather than enumerated by each caller.
+#: A consumer that needs to answer "did the CREDENTIAL redactor replace something
+#: in this text" must check all of them: pass 1 (plaintext patterns) and pass 3
+#: (bare secret runs) write ``_REDACTED_CREDENTIAL_TAG``, pass 2 (base64-encoded)
+#: writes ``_REDACTED_ENCODED_CREDENTIAL_TAG``.
+#:
+#: Scope is deliberately CREDENTIALS ONLY, and a consumer must not read it as "was
+#: this text rewritten at all". :func:`redact_exfiltration_urls` is a separate
+#: rewriter that substitutes ``[REDACTED: suspicious URL to <domain>]`` -- a
+#: variable string, so it is prefix-matched rather than compared, which is why it
+#: is not a member here. Text can therefore be rewritten with every tag in this
+#: tuple absent.
+#:
+#: This tuple exists because the enumeration used to live at the call site, where
+#: it silently missed the encoded tag and under-reported redactions on the
+#: dashboard chat notice. Co-locating it means a NEW tag is added next to the list
+#: that must name it; ``test_every_redaction_tag_constant_is_registered`` fails if
+#: one is added without registering it, so the drift cannot recur silently.
+#:
+#: Invariant relied on by callers that SUM per-tag counts: no tag is a substring
+#: of another, so one substitution cannot be counted twice.
+CREDENTIAL_REDACTION_TAGS = (_REDACTED_CREDENTIAL_TAG, _REDACTED_ENCODED_CREDENTIAL_TAG)
+
 
 def redact_credentials(text: str) -> tuple[str, list[str]]:
     """Redact raw credential patterns from text, including base64-encoded.
@@ -12538,7 +12569,7 @@ def redact_credentials(text: str) -> tuple[str, list[str]]:
     for chunk in b64_chunks:
         decoded = _decode_b64_chunk(chunk)
         if decoded:
-            result = result.replace(chunk, "[REDACTED: encoded credential]", 1)
+            result = result.replace(chunk, _REDACTED_ENCODED_CREDENTIAL_TAG, 1)
             warnings.append(f"Redacted base64-encoded credential ({len(chunk)} chars)")
 
     # 3. Detect and redact BARE 40-char AWS secret keys with no label/prefix

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -998,7 +998,118 @@ class TestFlushSegment:
 
         chat_runner._flush_segment(state, slot, "secret AKIAIOSFODNN7EXAMPLE here")
 
-        assert "AKIAIOSFODNN7EXAMPLE" not in slot.messages[-1]["content"]
+        # Target the assistant row by role, not `messages[-1]`: a redacted
+        # segment now also appends a notice row after it, and asserting on the
+        # last row would pass even if the assistant text still held the secret.
+        # Selected via a list + assertion rather than `next(...)` so a missing row
+        # fails on an assertion naming what WAS there, instead of a StopIteration
+        # that cannot distinguish "no assistant row" from "the flush threw".
+        assistants = [m for m in slot.messages if m.get("role") == "assistant"]
+        assert len(assistants) == 1, f"expected one assistant row, got {slot.messages}"
+        assert "AKIAIOSFODNN7EXAMPLE" not in assistants[0]["content"]
+
+    def test_a_redacted_connection_string_warns_the_user(self, tmp_path):
+        """issue #6189: the corruption must not be silent.
+
+        Uses the reporter's exact command. The assistant row keeps the mangled
+        text (redaction is not weakened), but a notice row now follows it saying
+        so and warning that the command will not run as pasted.
+        """
+        from kiro_crew.security import REDACTED_CREDENTIAL_TAG
+
+        state, slot = _state(tmp_path), _slot()
+        command = "echo 'DATABASE_URL=postgresql://user:pass@host:5432/db' >> .env"
+
+        chat_runner._flush_segment(state, slot, command)
+
+        roles = [m.get("role") for m in slot.messages]
+        assert roles == ["assistant", "notice"]
+        assistant, notice = slot.messages[0], slot.messages[1]
+        # Redaction still happened -- the credential is gone from what is stored.
+        assert "user:pass" not in assistant["content"]
+        assert REDACTED_CREDENTIAL_TAG in assistant["content"]
+        # ...and the user is now told, including that it will not run as pasted.
+        assert "Security notice" in notice["content"]
+        assert "will not work if you paste it as-is" in notice["content"]
+        assert notice["cls"] == "msg msg-info"
+        # The notice must never carry the secret it is reporting on.
+        assert "user:pass" not in notice["content"]
+
+    def test_the_notice_counts_multiple_credentials(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        chat_runner._flush_segment(
+            state,
+            slot,
+            "first postgresql://a:b@h1/db then mysql://c:d@h2/db",
+        )
+
+        # Assert on the collected rows rather than `next(...)`: a bare `next` over a
+        # generator raises StopIteration when the row is missing, and a raise cannot
+        # distinguish "no notice was appended" from "_flush_segment threw before
+        # appending one". An assertion on the list says which.
+        notices = [m for m in slot.messages if m.get("role") == "notice"]
+        assert len(notices) == 1, f"expected exactly one notice row, got {notices}"
+        assert "2 credentials" in notices[0]["content"]
+        assert "were replaced" in notices[0]["content"]
+
+    def test_a_clean_segment_gets_no_notice(self, tmp_path):
+        state, slot = _state(tmp_path), _slot()
+
+        chat_runner._flush_segment(state, slot, "here is a plain answer")
+
+        assert [m.get("role") for m in slot.messages] == ["assistant"]
+
+    def test_an_encoded_credential_also_warns(self, tmp_path):
+        """A base64-encoded credential is redacted by a DIFFERENT pass and tag.
+
+        `redact_credentials` pass 2 substitutes `[REDACTED: encoded credential]`,
+        which is not a substring of the plaintext tag. Counting only the plaintext
+        tag left this segment silently rewritten -- the same #6189 failure, just
+        reached by another pass.
+        """
+        import base64
+
+        from kiro_crew.security import (
+            _REDACTED_ENCODED_CREDENTIAL_TAG,
+            REDACTED_CREDENTIAL_TAG,
+        )
+
+        state, slot = _state(tmp_path), _slot()
+        # The issue's own connection string, base64-encoded.
+        blob = base64.b64encode(b"postgresql://user:pass@host:5432/db").decode()
+
+        chat_runner._flush_segment(state, slot, f"decode this: {blob}")
+
+        # Assert on collected rows, not `next(...)`. The roles list is also the
+        # witness that `_flush_segment` RAN to completion: if it had thrown before
+        # appending, there would be no assistant row either, so a missing notice
+        # beside a present assistant row isolates the count as the cause.
+        roles = [m.get("role") for m in slot.messages]
+        assert roles == ["assistant", "notice"], f"unexpected rows: {roles}"
+        assistant, notice = slot.messages[0], slot.messages[1]
+        # Redacted by pass 2, so ONLY the encoded tag is present.
+        assert _REDACTED_ENCODED_CREDENTIAL_TAG in assistant["content"]
+        assert REDACTED_CREDENTIAL_TAG not in assistant["content"]
+        assert "A credential" in notice["content"]
+        assert "will not work if you paste it as-is" in notice["content"]
+
+    def test_the_two_credential_tags_do_not_overlap(self):
+        """Summing per-tag counts must not double-count one substitution.
+
+        `_flush_segment` adds `redacted.count(tag)` across every tag in
+        `CREDENTIAL_REDACTION_TAGS`. That is only safe while no tag contains
+        another; if a tag were ever renamed to a superstring of another, a single
+        redaction would report as two and the notice would overcount.
+        """
+        from kiro_crew.security import CREDENTIAL_REDACTION_TAGS
+
+        for outer in CREDENTIAL_REDACTION_TAGS:
+            for inner in CREDENTIAL_REDACTION_TAGS:
+                if outer is inner:
+                    continue
+                assert inner not in outer, f"{inner!r} is a substring of {outer!r}"
+        assert len(set(CREDENTIAL_REDACTION_TAGS)) == len(CREDENTIAL_REDACTION_TAGS)
 
     def test_trailing_stop_event_is_replaced_below_the_segment(self, tmp_path):
         state, slot = _state(tmp_path), _slot()

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -309,6 +309,53 @@ class TestRedactCredentials:
         # host after @ may remain — only the credential prefix is redacted
         assert "[REDACTED: credential]" in result
 
+    def test_every_redaction_tag_constant_is_registered(self) -> None:
+        """A new credential tag must be added to ``CREDENTIAL_REDACTION_TAGS``.
+
+        Consumers ask that tuple "did the redactor replace something here" -- the
+        dashboard chat notice (issue #6189) counts it to tell the user their text
+        was rewritten. A tag that exists but is not registered is invisible to
+        every such consumer, which is exactly how the encoded-credential tag came
+        to be missed. This ratchet makes that omission fail here instead of
+        silently degrading a user-facing warning.
+        """
+        from kiro_crew import security
+
+        declared = {
+            name: value
+            for name, value in vars(security).items()
+            if name.startswith("_REDACTED_") and name.endswith("_TAG")
+            if isinstance(value, str)
+        }
+        assert declared, "tag-constant naming changed; this ratchet no longer sees them"
+
+        unregistered = {
+            name: value
+            for name, value in declared.items()
+            if value not in security.CREDENTIAL_REDACTION_TAGS
+        }
+        assert not unregistered, (
+            "redaction tag(s) not in CREDENTIAL_REDACTION_TAGS: "
+            f"{sorted(unregistered)} -- add them there so consumers that ask "
+            "'was anything redacted' (e.g. the dashboard chat notice) can see them"
+        )
+
+    def test_pass_two_emits_a_registered_tag(self) -> None:
+        """The base64 pass must substitute a tag consumers actually look for."""
+        import base64
+
+        from kiro_crew.security import (
+            _REDACTED_ENCODED_CREDENTIAL_TAG,
+            CREDENTIAL_REDACTION_TAGS,
+        )
+
+        blob = base64.b64encode(b"postgresql://user:pass@host:5432/db").decode()
+        result, warnings = redact_credentials(f"blob: {blob}")
+
+        assert _REDACTED_ENCODED_CREDENTIAL_TAG in result
+        assert _REDACTED_ENCODED_CREDENTIAL_TAG in CREDENTIAL_REDACTION_TAGS
+        assert any("base64-encoded" in w for w in warnings)
+
     @pytest.mark.parametrize(
         "mongo",
         [


### PR DESCRIPTION
## 1. What is the problem?

Credential redaction rewrites a `scheme://user:pass@host` connection string to
`[REDACTED: credential]` in the assistant text the user copies out of the
dashboard chat, and tells the user nothing about it.

Reproduced byte-identical to the report, by calling the shipped redactor on the
reporter's exact string:

```
in:  echo 'DATABASE_URL=postgresql://user:pass@host:5432/db' >> .env
out: echo 'DATABASE_URL=[REDACTED: credential]host:5432/db' >> .env
```

The matching branch is one alternative inside `_CREDENTIAL_PATTERNS`
(`security.py:11527-11537`): `(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|...)://[^\s:/@]*:[^\s/]+@`.
The password class `[^\s/]+` is greedy and excludes `/` but allows `@`, so the
match ends at the final `@` of the authority and stops before the host. That is
why `host:5432/db` survives and the result is a syntactically plausible but
broken URL rather than an obviously empty one.

Two things are wrong, and only one of them is the substitution:

* the pasted command does not work, and
* nothing says the text was altered.

The second is what turns a visible redaction into a debugging problem. Every
call site on this path discards the signal it already has. `redact_credentials`
returns `(text, warnings)`, and the chat path spells it
`safe_chunk, _ = redact_credentials(safe_chunk)` (`chat_runner.py:6603`).
`_flush_segment` does bind the list, then routes it only to
`logger.warning` (`chat_runner.py:3036-3038`). Slack is identical
(`slack/handler.py:3824-3828`). No surface has ever told a chat user that their
message was rewritten.

## 2. Why this issue matters to the user

The user copies a command the assistant wrote, runs it, and it silently writes a
broken value. The failure then surfaces far from its cause: the reporter got
`getaddrinfo EAI_AGAIN` out of a container at boot, because the `.env` line was
74 chars instead of ~130 and had no `@`. Nothing in that error points back at
the chat message, so the time goes on debugging DNS and Prisma instead.

It reproduces 100% of the time whenever the assistant emits a full connection
string, and the assistant emits one whenever it is asked to write a
`DATABASE_URL`.

## 3. How our fix solves it

**The redactor is not weakened, and that is a deliberate choice, not an
omission.** The chat bubble IS the egress this control guards: the same text is
broadcast to WS/SSE clients (`chat_runner.py:6631`) and persisted into the
transcript (`chat_runner.py:3044`). The issue suggests keeping the value
copyable by redacting only at the display layer; on this path that means
transmitting the real credential to the browser and storing it in the session
transcript. Today the raw string exists only as the in-flight chunk and is never
persisted. Making the command paste-able means undoing that. That trades a
usability bug for a credential leak, so this PR does not do it.

So this PR fixes the half that can be fixed without that trade: the silence. A
segment whose persisted text carries redaction placeholders now appends a
`notice` row stating that a credential was replaced and, explicitly, that the
command will not run as pasted:

> Security notice: A credential in this message was replaced with a redaction
> placeholder before it reached this page. Any command shown above will not work
> if you paste it as-is; supply the secret yourself on the machine where you run
> it.

That second clause is the point. A notice that only said "a credential was
removed" would still leave the user pasting text that cannot run.

Two implementation notes, both load-bearing:

**The count is read from the tag in the persisted text, not from
`cred_warnings`.** On the streaming path that list is essentially always empty
at the flush: the run loop redacts every chunk before it enters `assistant_text`
(`chat_runner.py:6602-6605`), so the flush-time call re-redacts already-clean
text and reports nothing. `cred_warnings` only fires for a credential split
across chunk boundaries. Counting the tag also makes the notice correct
regardless of WHICH of the three sites did the substitution - per-chunk, the
`StreamRedactor` wire pass, or the flush - because all three write the same
`REDACTED_CREDENTIAL_TAG`. Hooking the event would have required hooking all
three; reading the artifact hooks none, and answers the question the user
actually has: is what I am about to copy still what the assistant wrote?

**The notice broadcasts even under `quiet_persist`.** That flag exists to
suppress a duplicate of pre-steer assistant text clients already rendered; a
notice row has no streamed counterpart to duplicate, and suppressing it would
drop the warning on one of the paths this fix exists to cover.

**The count sums every tag the redactor can emit, and `security.py` owns the
list.** This was a real gap in the first revision, found by the Opus lane. Pass 2
replaces a base64-encoded credential with `[REDACTED: encoded credential]`, which
is NOT a substring of the plaintext tag, so counting one tag left an
encoded-credential-only segment silently rewritten - the same #6189 failure
reached through a different pass - and undercounted a mixed segment.

The first fix for that enumerated both tags at the call site, which the First
Principles lane correctly called out as the very mechanism that produced the
undercount: a third tag added in `security.py` would escape the notice again. So
the list is now `CREDENTIAL_REDACTION_TAGS`, owned by `security.py` beside the
passes that write the tags, and `chat_runner` asks for it instead of naming tags
itself - a net subtraction, since the two-constant import and the local tuple both
go away. `test_every_redaction_tag_constant_is_registered` fails if a
`_REDACTED_*_TAG` constant is not registered in it, so the drift cannot recur
silently rather than merely being relocated. A second test pins the non-overlap
invariant that makes summing per-tag counts safe.

The encoded tag stays PRIVATE. An earlier revision gave it a public alias mirroring
`REDACTED_CREDENTIAL_TAG`, but once callers ask the registry that alias had zero
non-test consumers, so it was unjustified API surface and the First Principles lane
was right to ask for it back. Tests import the private constant, which
`test_credential_prefilter.py` already does for `_REDACTED_CREDENTIAL_TAG`.

No frontend change is needed: the `notice` role already renders as a
`NoticeCard` (`website/src/pages/ChatPage.tsx:6856`).

## 4. What tests we did

Three new tests in `TestFlushSegment`, plus two added after the Opus finding, plus
one existing test corrected.

New:
* `test_a_redacted_connection_string_warns_the_user` - the reporter's exact
  command; asserts the assistant row still has the credential removed (redaction
  intact), that a notice follows it, that the notice says the command will not
  work as pasted, and that the notice itself carries no secret.
* `test_the_notice_counts_multiple_credentials` - two connection strings report
  "2 credentials".
* `test_a_clean_segment_gets_no_notice` - no placeholders, no notice row.
* `test_an_encoded_credential_also_warns` - the issue's own connection string,
  base64-encoded so only pass 2 fires; asserts the encoded tag is present, the
  plaintext tag is not, and a notice is still raised.
* `test_the_two_credential_tags_do_not_overlap` - pins the invariant that makes
  summing per-tag counts safe.
* `test_every_redaction_tag_constant_is_registered` (in `test_security.py`) - the
  drift ratchet: a `_REDACTED_*_TAG` constant that is not in
  `CREDENTIAL_REDACTION_TAGS` fails here, naming the offender.
* `test_pass_two_emits_a_registered_tag` (in `test_security.py`) - the encoded pass
  substitutes a tag consumers actually look for.

Corrected: `test_credentials_in_the_segment_are_redacted` asserted on
`slot.messages[-1]`, which is now the notice row. Left alone it would have kept
passing while no longer checking the assistant text at all - a security test
passing vacuously. It now selects the assistant row by role.

Mutation-verified against the revision this body is published with, each mutation
applied to the committed tree and reverted with `git checkout` (never `stash`).
Keyed by test NAME, not position, and every red reported with the error TYPE it
arrived as - because a red that arrives as an EXCEPTION proves nothing about the
predicate: it shows the machinery stopped running, not that the value changed. Each
mutation below changes what the count ANSWERS while leaving every name bound.

1. count forced to `0` (notice never appends) -> 3 red, all assertions:
   * `test_a_redacted_connection_string_warns_the_user` - `AssertionError: assert ['assistant'] == ['assistant', 'notice']`
   * `test_the_notice_counts_multiple_credentials` - `AssertionError: expected exactly one notice row, got []`
   * `test_an_encoded_credential_also_warns` - `AssertionError: unexpected rows: ['assistant']`

   The `['assistant']` in those messages is load-bearing: it witnesses that
   `_flush_segment` ran to completion and only the notice was absent.
2. zero-guard dropped (`if True:`) -> 4 red. Three are assertions on exact role
   lists (`test_a_clean_segment_gets_no_notice`,
   `test_trailing_stop_event_is_replaced_below_the_segment`,
   `test_unparseable_cls_is_not_a_stop_event`) - an extra row genuinely changes
   them. The fourth, `test_pending_variants_are_attached_and_broadcast`, fails with
   `KeyError: 'variant_idx'` because it reads `slot.messages[-1]`, which the notice
   displaces. That red is EXCLUDED from the evidence: it arrived as an exception, so
   it says nothing about the predicate. It is also not a production defect -
   `_flush_segment` binds `last_msg` before appending the notice, and the load-path
   analogue `_attach_variants` runs immediately after its own `append`, so its
   `messages[-1]` is always its own row.
3. plurality hardcoded singular -> 1 red, assertion:
   `test_the_notice_counts_multiple_credentials` - `AssertionError: assert '2 credentials' in 'Security notice: A credential in...'`
4. tag set narrowed to `CREDENTIAL_REDACTION_TAGS[:1]` -> 1 red, assertion:
   `test_an_encoded_credential_also_warns` - `AssertionError: unexpected rows: ['assistant']`
5. an unregistered `_REDACTED_MUTANT5_TAG` added to `security.py` -> 1 red,
   assertion: `test_every_redaction_tag_constant_is_registered` names the offender.

No test in this file locates a row with a bare `next(...)`, deliberately: `next`
over a generator raises `StopIteration` when the row is missing, and that raise
cannot distinguish "no notice was appended" from "the flush threw before appending
one". Every lookup is a list plus an assertion that prints what WAS there, so no red
here can arrive as an exception.

Harness provenance, so a reviewer can tell which tree these numbers came from
without re-running anything. pytest resolves `rootdir` to this worktree and reads
its `setup.cfg`, whose `[tool:pytest]` sets `pythonpath = src`; that PREPENDS to
`sys.path`, so every number above was measured against
`kirocrew-fix-6189/src/kiro_crew`, not against the main checkout. The worktree's
own venv agrees independently - its editable install resolves `kiro_crew` to the
same path.

This matters here specifically because `main` already performs the redaction these
tests assert, so a run against the wrong module would show the baseline rows
passing and only the new rows failing - indistinguishable from a genuinely weak
test. Two things rule that out: the provenance above, and the fact that
`_redaction_notice` and `CREDENTIAL_REDACTION_TAGS` do not exist on `main` at all,
so the notice tests could not have passed against it under any conditions.

Suites run (each file its own invocation, `-p no:randomly -n0`):
`test_chat_runner_coverage.py` 272 passed; `test_security.py` 1265 passed, 1
skipped; `test_dashboard_chat.py` 735 passed; `test_post_compaction_continuation.py`
55 passed (this one asserts on the `_flush_segment` call-site source text, and
stays green because this change adds no call-site argument);
`test_slot_chunk_retention.py` 16, `test_chat_steer.py` 19,
`test_inline_tool_cards_props.py` 7. isort, flake8 and mypy clean on all four
changed files, and the project's own `scripts/check_black_formatting.py` gate
passes - `security.py` is in the black baseline on main, so it is deliberately NOT
reformatted here; the diff to it is additive.

## 5. Any other suggestions on the work

**This warns; it does not make the command paste-able.** That residue is
deliberate, so the trailer is `Refs`, not `Closes`. Of the four fixes the issue
proposes, only "warn explicitly" is implementable without changing the security
posture. The other three - skip redaction inside execution-intended fences,
display-layer-only redaction with the clipboard intact, and distinguishing an
assistant-GENERATED value from an echoed user secret - all require either
shipping the credential to the client or adding provenance the redactor does not
have. Those remain a maintainer call, which is what the earlier `needs-human`
routing was right about; this PR is the part that did not need that decision.

The reporter also asked for the copy action itself to be blocked. Not done here:
that is frontend behaviour on a control this diff does not touch, and the notice
is the backend half it would need either way.

Two adjacent gaps found while tracing this, deliberately NOT fixed to keep the
diff narrow:

* **The non-dashboard channels are explicitly DEFERRED, not fixed.** They keep the
  exact silence this PR ends for the dashboard, and they are filed as
  [#8123](https://github.com/kirodotdev/KiroCrew/issues/8123): Slack final text
  (`slack/handler.py:3826`), Slack thinking (`slack/handler.py:3961`), iMessage
  (`imessage/renderer.py:56`), and the shared messaging scrubbers
  (`messaging/renderer.py:230`, `messaging/driver.py:266`). The First Principles
  lane asked for this deferral to have an owner, and it was right to - the sharpest
  case is `slack/handler.py:3935`, where the branch
  `if _stream_had_redaction or _render_redacted or exfil_warnings or cred_warnings:`
  already reads the signal and rewrites the posted message because of it, and still
  tells the user nothing. Each surface needs its own delivery (the `notice` row is a
  dashboard mechanism), which is what makes the general fix larger than this diff
  rather than a line of it.
* Exfiltration-URL redaction has the identical silence on this same path
  (`exfil_warnings` logged only, `chat_runner.py:3034-3035`). It rewrites text the
  user copies just as credential redaction does. Not filed separately: it is the
  same structural point as #8123 and worth deciding once, rather than opening a
  second issue that the same change would close.

Checked against the sibling issue #8042 / [PR #8055](https://github.com/kirodotdev/KiroCrew/pull/8055):
no overlap. That PR lives entirely in `dashboard/handlers/files.py` plus
`test/test_project_tree.py` with zero lines in `security.py`, and it concerns
pass 3 (the bare-secret run amplification) whereas this is pass 1
(`_CREDENTIAL_PATTERNS`). This PR's only `security.py` change is additive and
nowhere near that: a new tag constant beside the existing `REDACTED_CREDENTIAL_TAG`
alias, and pass 2's inline literal swapped for it (byte-identical value). No
regex, no matching behaviour, and no line either issue's mechanism depends on is
touched.

## Pattern harvest

Rule candidate: semgrep (or a targeted lint)
Pattern: a redactor's warnings channel discarded at a user-facing surface

`redact_credentials` returns `(text, warnings)`. That warnings list is the
subsystem's only way to say it acted, and on this path every caller threw it
away: `safe_chunk, _ = redact_credentials(safe_chunk)` at the chunk site
(`chat_runner.py:6603`), and a `logger.warning`-only consumer at the flush
(`chat_runner.py:3036-3038`). The effect is a security control that silently
rewrites text the user is about to copy.

Not a one-off: the same discard shape appears at roughly 550 call sites in the
tree, and two are the adjacent gaps named above - exfiltration-URL redaction on
this very path, and the Slack final-text path. The bug is structural, not local.

The generalizable rule: in a module that renders to a human surface, binding a
redactor's warnings element to `_`, or consuming it only through a logger, should
be flagged, because it turns a visible mutation into a silent one.

The honest caveat is scope, and it is why this PR does not ship that lint. Most
of those ~550 sites redact log lines, tool titles and internal metadata, where a
user-facing notice would be pure noise. A useful rule has to key on "this string
is rendered to a person", which the call site alone does not say. So this PR
fixes the one path where that is provably true and leaves the rule as a
candidate rather than asserting a tree-wide invariant it cannot yet enforce.

Refs #6189
