### PR TITLE
fix(mcp-gateway): do not rewrite agent overlays from a failed settings read (#5344)

### DIFF
--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -922,6 +922,197 @@ def _injectable_settings_servers(
     return out
 
 
+def _overlay_inputs_unchanged(
+    stored: dict[str, Any] | None,
+    current: dict[str, Any],
+    *,
+    source_name: str,
+) -> bool:
+    """Return ``True`` when every input the overlay for *source_name* was built
+    from still matches this pass -- everything EXCEPT the settings entry.
+
+    Used to decide whether a previous overlay may be KEPT on a pass that cannot
+    establish the injection set. Keeping one defers every input that overlay
+    encodes, not only the injection: the agent's own spec (an ``autoApprove``
+    entry removed, a server disabled) and the policy knobs
+    ``_build_stub_entry`` bakes into each stub's argv (``--sandbox-mode``,
+    ``--approval-mode``, ``--poolable``, the work dir, the socket, the identity
+    keys). A revocation or a tightened policy is a deliberate instruction and
+    must not wait for the next boot, so a keep is only honest when nothing it
+    would defer has changed.
+
+    The settings entry is the ONE input compared conditionally, and only because
+    a transient fault is what makes it unanswerable: ``_rewrite_inputs_fingerprint``
+    signs that file with ``_stat_sig``, which returns ``None`` when it cannot be
+    read, and that ``None`` is why control reaches the rewrite loop instead of the
+    cached early return. So it is skipped when this pass could not sign the file --
+    demanding a match there would refuse every keep on exactly the path this
+    protects. When the signature IS available and differs, the file demonstrably
+    changed and the keep is refused: read_text and read_bytes are separate calls,
+    so a fault can hit one and not the other, and a settings revocation kept alive
+    by a stale injected entry is an absorbed instruction, not a deferred edit.
+    Every other input is compared unconditionally, so a new fingerprinted input is
+    covered without being enumerated here.
+
+    ``False`` whenever the answer cannot be established: no stored fingerprint
+    (one is unlinked at the end of every uncacheable pass, so two consecutive
+    faulty passes cannot keep), a malformed one, or a source this pass could not
+    sign. The caller then rewrites, which is the pre-existing behaviour.
+    """
+    if stored is None:
+        return False
+    prev = stored.get("inputs")
+    if not isinstance(prev, dict):
+        return False
+    for key in set(prev) | set(current):
+        if key == "sources":
+            continue
+        if key == "settings":
+            cur_settings = current.get("settings")
+            if cur_settings is None:
+                continue  # unsignable this pass: the unanswerable input
+            if prev.get("settings") != cur_settings:
+                return False  # signable AND changed: a real, known difference
+            continue
+        if prev.get(key) != current.get(key):
+            return False
+    prev_sources = prev.get("sources")
+    cur_sources = current.get("sources")
+    if not isinstance(prev_sources, dict) or not isinstance(cur_sources, dict):
+        return False
+    sig = cur_sources.get(source_name)
+    # A ``None`` signature means this pass could not read or stat that source,
+    # so "unchanged" is not established -- never assume it.
+    return sig is not None and prev_sources.get(source_name) == sig
+
+
+def _kept_artifacts_vouched(
+    stored: dict[str, Any] | None,
+    *,
+    overlay_dir: Path,
+    env_dir: Path,
+) -> bool:
+    """Validate and re-protect the SHARED artifacts a keep would serve.
+
+    A keep serves files this pass did not write, which is the same position
+    ``_cached_rewrite_result`` is in -- and that path does not merely check
+    existence. It compares every recorded output against ``_stat_sig`` (a
+    tampered or edited artifact must be regenerated, not served) and re-asserts
+    owner-only protection on each one, because a chmod or DACL edit changes no
+    size, mtime or digest and so is invisible to a signature. A keep must offer
+    the same guarantees or it becomes a way to have a tampered overlay served,
+    and a loosened sidecar ACL left unrepaired, by inducing one transient fault.
+
+    This covers the pass-wide set: the env sidecar directory, every recorded
+    sidecar, and the recorded ``shutil.which`` probes. A kept overlay still
+    points ``--env-file`` at those sidecars, the sidecar prune is skipped on this
+    pass, and mapping sidecars to individual agents would require parsing stub
+    argv -- so if the set cannot be vouched for, no keep is allowed and every
+    agent is rewritten through the protect-before-content writers. Per-overlay
+    validation is separate; see ``_kept_overlay_vouched``.
+
+    The which() re-probe is here for the same reason the cached path has it, and
+    it is not covered by any signature: directory contents are which() input the
+    stat fingerprint cannot see, and a kept overlay's stub argv embeds the
+    ABSOLUTE path a previous pass resolved. A target binary removed, moved
+    between PATH prefixes, or newly shadowed would otherwise leave the kept
+    overlay launching a dead path for the rest of the gateway's lifetime.
+
+    Fail-loud like the cached path: ``restrict_to_owner`` raises on both
+    platforms, and any failure returns ``False`` rather than serving an
+    artifact whose protection could not be re-asserted.
+    """
+    if stored is None:
+        return False
+    outputs = stored.get("outputs")
+    if not isinstance(outputs, dict):
+        return False
+    sidecar_sigs = outputs.get("sidecars")
+    if not isinstance(sidecar_sigs, dict):
+        return False
+    which_probes = stored.get("which")
+    if not isinstance(which_probes, dict):
+        return False
+    try:
+        for name, sig in sidecar_sigs.items():
+            if _stat_sig(env_dir / name) != sig:
+                return False
+        if env_dir.is_dir():
+            platform_compat.make_owner_only_dir(env_dir)
+            if platform_compat.IS_POSIX:
+                # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- 0o700 is OWNER-ONLY, the tightest traversable mode for this credential-sidecar directory; the rule's suggested 0o644 would grant world-read and drop the execute bit a directory needs. Raw os.chmod (not make_owner_only_dir alone) because this path must FAIL LOUD into the full rewrite, matching _cached_rewrite_result.  # noqa: E501
+                os.chmod(env_dir, 0o700)
+        for name in sidecar_sigs:
+            platform_compat.restrict_to_owner(env_dir / name)
+        # The settings overlay is KEPT on this pass (#5328), and it carries the
+        # passed-through env of every non-poolable / HTTP-SSE global server, so a
+        # loosened ACL on it would otherwise persist for the gateway's lifetime.
+        # Only the protection is re-asserted, not the content: its recorded
+        # signature is deliberately NOT compared, because no available action
+        # would improve on a mismatch -- this pass cannot rewrite it (the source
+        # is unreadable), must not delete it (#5328: that strips every global
+        # server), and refusing the agent keeps would not repair it while making
+        # the injection loss worse. Guarded on existence rather than treated as a
+        # refusal: an absent settings overlay has no ACL to repair and is not
+        # something this pass is serving.
+        settings_overlay_file = overlay_dir.parent / "settings" / "mcp.json"
+        if outputs.get("settings_overlay") is not None and (
+            settings_overlay_file.is_file()
+        ):
+            platform_compat.make_owner_only_dir(settings_overlay_file.parent)
+            if platform_compat.IS_POSIX:
+                # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- 0o700 is OWNER-ONLY, the tightest traversable mode for a directory holding a credential-bearing overlay; the rule's suggested 0o644 would grant world-read and drop the execute bit a directory needs. Raw os.chmod because this path must FAIL LOUD into the full rewrite, matching _cached_rewrite_result.  # noqa: E501
+                os.chmod(settings_overlay_file.parent, 0o700)
+            platform_compat.restrict_to_owner(settings_overlay_file)
+    except OSError:
+        return False
+    # Same comparison the cached path makes, for the same reason.
+    for key, recorded in which_probes.items():
+        bare, _, search_path = key.partition(_WHICH_KEY_SEP)
+        try:
+            current = shutil.which(bare, path=search_path) or ""
+        except OSError:
+            return False
+        if current != recorded:
+            return False
+    return True
+
+
+def _kept_overlay_vouched(
+    stored: dict[str, Any] | None,
+    *,
+    overlay_dir: Path,
+    name: str,
+) -> bool:
+    """Validate and re-protect ONE overlay a keep would serve.
+
+    The per-agent half of :func:`_kept_artifacts_vouched`: the overlay must
+    still carry the size+mtime+digest the previous run recorded for it, and its
+    owner-only protection must be re-assertable. An overlay with no recorded
+    signature is refused too -- there is nothing to compare it against, and an
+    unvouched artifact must be regenerated rather than served.
+    """
+    if stored is None:
+        return False
+    outputs = stored.get("outputs")
+    if not isinstance(outputs, dict):
+        return False
+    overlay_sigs = outputs.get("overlays")
+    if not isinstance(overlay_sigs, dict):
+        return False
+    sig = overlay_sigs.get(name)
+    if sig is None:
+        return False
+    target = overlay_dir / name
+    try:
+        if _stat_sig(target) != sig:
+            return False
+        platform_compat.restrict_to_owner(target)
+    except OSError:
+        return False
+    return True
+
+
 def _stat_sig(path: Path) -> list[Any] | None:
     """Return ``[size, mtime_ns, sha256]`` for *path*, or ``None`` if it
     cannot be read. Size and nanosecond mtime are cheap discriminators, but
@@ -1416,6 +1607,12 @@ def rewrite_agents(
     settings_src_spec: dict[str, Any] | None = None
     settings_poolable: dict[str, Any] = {}
     settings_read_transient = False
+    # ``True`` only when this pass ESTABLISHED that there is nothing usable to
+    # relocate: confirmed absent, present but not a regular file, or bad content.
+    # Deliberately NOT the same as "we ended up with no spec", which a transient
+    # fault also produces. It is what licenses pruning the previous settings
+    # overlay, and it is read once, below, instead of being re-derived there.
+    settings_prunable = False
     if kiro_settings_json.is_file():
         try:
             loaded = json.loads(kiro_settings_json.read_text())
@@ -1428,6 +1625,10 @@ def rewrite_agents(
                     identity_keys=identity_keys,
                     notes=notes,
                 )
+            else:
+                # Valid JSON, wrong shape: deterministic, and fixing it changes
+                # the stat signature, so this classification is safe to cache.
+                settings_prunable = True
         except OSError as exc:
             # Transient read failure: same reasoning as the per-agent site —
             # do not cache a pass that treated an existing settings file as
@@ -1437,7 +1638,39 @@ def rewrite_agents(
             logger.warning("failed to read global mcp.json: %s", exc)
         except json.JSONDecodeError as exc:
             # Content problem — cacheable; a fix changes the stat signature.
+            settings_prunable = True
             logger.warning("failed to read global mcp.json: %s", exc)
+    else:
+        # ``is_file()`` answers False for a missing file AND for a stat fault
+        # whose errno pathlib chooses to swallow, so it cannot be read as
+        # "absent" on its own. Only SOME faults are swallowed: measured on
+        # CPython 3.12, EACCES/EIO/EPERM propagate (the caller's ``except
+        # Exception`` then abandons the pass without touching an overlay), while
+        # ENOENT/EBADF/ENOTDIR/ELOOP return False. ENOTDIR and ELOOP are
+        # reachable without the file being gone -- a directory component
+        # momentarily replaced, an atomic directory swap, a symlink being
+        # re-pointed -- and reading those as absent rewrote every overlay with an
+        # empty injection set, which is #5344 through the stat path rather than
+        # the read path.
+        #
+        # So classify explicitly, and do it HERE rather than beside the prune:
+        # ONE classification then serves both the injection decision below and
+        # the prune, instead of the prune's answer arriving after the agent loop
+        # has already acted on a different one. Only ``FileNotFoundError`` may
+        # mean absent; every other OSError means unknown.
+        try:
+            kiro_settings_json.stat()
+        except FileNotFoundError:
+            settings_prunable = True  # confirmed absent: deleted between runs
+        except OSError as exc:
+            notes.source_read_failed = True  # unknown: keep and retry
+            settings_read_transient = True
+            logger.warning("failed to stat global mcp.json: %s", exc)
+        else:
+            # Stats fine but is not a regular file (e.g. a directory in its
+            # place): a permanent misconfiguration, deterministic like bad
+            # content, not a transient fault to retry forever.
+            settings_prunable = True
 
     # Names of agents whose overlay could not be refreshed THIS PASS for a
     # TRANSIENT reason (source read failure, overlay write failure). The prune
@@ -1450,7 +1683,83 @@ def rewrite_agents(
     # behave differently.
     transient_keep: set[str] = set()
 
+    # A settings read that FAILED is not a settings file that declared nothing.
+    # ``settings_poolable`` is empty on that path because the pass could not
+    # ASK, so an agent overlay written from it reflects a fact this pass never
+    # established: every globally-declared poolable server silently stops being
+    # pooled for the rest of this gateway's lifetime. Its tools do not vanish --
+    # the raw entry still merges from the real settings file -- but it runs
+    # per-session and unpooled, with none of the identity the stub carries. The
+    # pass is already uncacheable (``notes.source_read_failed`` was set at the
+    # read site), so a restart self-heals; the degraded window is a whole
+    # gateway lifetime (#5344).
+    #
+    # Refuse to rewrite instead, exactly as the per-agent transient read
+    # failure below does -- but only where refusing PRESERVES something. An
+    # agent that has a previous overlay keeps it: that overlay carries both its
+    # own wrapped servers and the injected globals, so nothing is dropped. An
+    # agent with NO previous overlay is still written, because there the empty
+    # injection set is not the conflation this guards against -- no injected
+    # copy exists to drop, and refusing would leave that agent with no overlay
+    # at all, unpooling its OWN servers too. That is strictly worse than the
+    # fault warrants, and worse than what this pass does today.
+    #
+    # The trade on a kept overlay is staleness in the other direction, and it is
+    # bounded to the injection set alone: a keep is only honest when NOTHING
+    # ELSE the overlay encodes has changed. Keeping one otherwise defers the
+    # agent's own spec (an autoApprove entry removed, a server disabled) and the
+    # policy knobs _build_stub_entry bakes into every stub argv (--sandbox-mode,
+    # --approval-mode, --poolable, work dir, socket, identity keys) -- all
+    # deliberate instructions, unlike a transient fault. So the keep is gated on
+    # _overlay_inputs_unchanged: the stored fingerprint must show this pass's
+    # inputs matching the ones that overlay was built from, every input except
+    # the settings entry the failed read made unknowable. One comparison covers
+    # every dimension, so a future fingerprinted input is covered without being
+    # enumerated at this site.
+    #
+    # Gated on nothing else: with an empty stub set nothing is wrapped and
+    # ``_injectable_settings_servers`` returns nothing whatever the file says, so
+    # a keep and a rewrite produce identical bytes there. An extra
+    # ``bool(stub_set)`` term would be unobservable -- no test can distinguish
+    # it -- so the fingerprint comparison below carries the whole decision.
+    injection_unknown = settings_read_transient
+    # A keep SERVES artifacts this pass did not write, so it must carry the same
+    # guarantees the other serve-without-writing path does. Vouch for the shared
+    # set once: if the recorded sidecars cannot be validated and re-protected, no
+    # keep is allowed at all and every agent goes through the
+    # protect-before-content writers instead.
+    if injection_unknown and not _kept_artifacts_vouched(
+        stored, overlay_dir=overlay_dir, env_dir=env_sidecar_dir_for_stubs(stubs_dir)
+    ):
+        injection_unknown = False
+        logger.warning(
+            "global mcp.json unreadable this pass, but the recorded env sidecars "
+            "could not be validated and re-protected: rewriting every agent "
+            "overlay rather than serving artifacts this pass cannot vouch for"
+        )
+    if injection_unknown:
+        logger.warning(
+            "global mcp.json unreadable this pass: keeping the previous overlay "
+            "of each agent whose other inputs are unchanged, instead of "
+            "rewriting it without the servers that file declares (kept overlays "
+            "stay in effect until a later pass succeeds)"
+        )
+
     for path in sorted(source_dir.glob("*.json")):
+        if (
+            injection_unknown
+            and (overlay_dir / path.name).is_file()
+            and _overlay_inputs_unchanged(
+                stored, current_inputs, source_name=path.name
+            )
+            and _kept_overlay_vouched(stored, overlay_dir=overlay_dir, name=path.name)
+        ):
+            # Keep without classifying: the spec is not read on this path, so a
+            # source whose CONTENT is deterministically bad is kept too, unlike
+            # the read below which prunes it. The pass is uncacheable, so the
+            # next boot reads that source and prunes its overlay then.
+            transient_keep.add(path.name)
+            continue
         try:
             spec = json.loads(path.read_text())
         except OSError as exc:
@@ -1650,26 +1959,14 @@ def rewrite_agents(
             settings_overlay_path = None
             overlay_write_failed = True
     else:
-        # ``settings_src_spec`` is None: the source is absent, was unreadable
-        # this pass, or carried bad content. Only CONFIRMED absence and
-        # deterministic bad content prune the previous overlay (matching the
-        # per-agent rule and the cached path's keying); a transient read
-        # failure keeps it (#5328). Classify with an explicit ``stat()``
-        # rather than ``is_file()``, which folds a stat fault (ACL hiccup,
-        # transient I/O error) into "absent" and would delete a healthy
-        # overlay — treat a stat fault as transient: keep, and mark the pass
-        # uncacheable so the next boot retries.
-        prune_settings = False
-        if not settings_read_transient:
-            try:
-                kiro_settings_json.stat()
-            except FileNotFoundError:
-                prune_settings = True  # confirmed absent: deleted between runs
-            except OSError:
-                notes.source_read_failed = True  # unknown: keep and retry
-            else:
-                prune_settings = True  # present but bad content: deterministic
-        if prune_settings and settings_overlay_file.is_file():
+        # ``settings_src_spec`` is None: the source is absent, was unreadable or
+        # unstatable this pass, or carried bad content. Only CONFIRMED absence
+        # and deterministic bad content prune the previous overlay (matching the
+        # per-agent rule and the cached path's keying); a transient read or a
+        # swallowed stat fault keeps it (#5328). That classification was made
+        # once at the read site above -- re-deriving it here is what let the
+        # agent loop act on a different answer than the prune (#5344).
+        if settings_prunable and settings_overlay_file.is_file():
             try:
                 settings_overlay_file.unlink()
             except OSError:

--- a/test/test_mcp_gateway_rewriter_fingerprint.py
+++ b/test/test_mcp_gateway_rewriter_fingerprint.py
@@ -11,10 +11,13 @@ strictly worse than the boot cost the cache removes.
 from __future__ import annotations
 
 import ast
+import contextlib
+import errno
 import inspect
 import json
 import os
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -370,6 +373,45 @@ def rewrite_counter(monkeypatch: pytest.MonkeyPatch) -> dict[str, int]:
 def _bump_mtime(path: Path) -> None:
     st = path.stat()
     os.utime(path, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
+
+
+@contextlib.contextmanager
+def _settings_unreadable() -> "Iterator[None]":
+    """Make ``settings/mcp.json`` unreadable for the duration, as a real
+    transient I/O fault does.
+
+    Both read paths must fail together, and which ones they are is the point.
+    ``_rewrite_inputs_fingerprint`` signs the file with ``_stat_sig``, which
+    uses ``read_bytes``; the pass itself uses ``read_text``. Faulting only
+    ``read_text`` leaves the signature intact, so on otherwise-unchanged inputs
+    the cached early return fires and the rewrite loop is never entered -- the
+    degraded path under test would not run at all. Faulting both makes the
+    signature ``None``, which is what forces the full rewrite on a real fault,
+    while leaving every agent source signature comparable.
+    """
+    real_read_text = Path.read_text
+    real_read_bytes = Path.read_bytes
+
+    def _is_settings(p: Path) -> bool:
+        return p.name == "mcp.json" and "settings" in p.parts
+
+    def flaky_text(self: Path, *args: Any, **kwargs: Any) -> str:
+        if _is_settings(self):
+            raise OSError("transient I/O error")
+        return real_read_text(self, *args, **kwargs)
+
+    def flaky_bytes(self: Path, *args: Any, **kwargs: Any) -> bytes:
+        if _is_settings(self):
+            raise OSError("transient I/O error")
+        return real_read_bytes(self, *args, **kwargs)
+
+    Path.read_text = flaky_text  # type: ignore[method-assign]
+    Path.read_bytes = flaky_bytes  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        Path.read_text = real_read_text  # type: ignore[method-assign]
+        Path.read_bytes = real_read_bytes  # type: ignore[method-assign]
 
 
 def test_unchanged_inputs_skip_the_rewrite_and_return_identical_result(
@@ -1175,6 +1217,459 @@ def test_transient_settings_read_failure_is_not_cached(
     assert fp.is_file()
     # The settings overlay is (still) present after the healthy retry.
     assert (tmp_path / "mcp-gateway" / "settings" / "mcp.json").is_file()
+
+
+def test_transient_settings_read_failure_does_not_rewrite_agent_overlays(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A settings read that FAILED is not a settings file that declared
+    nothing: the injection set is unknown, not empty, so no agent overlay may
+    be written from it (#5344).
+
+    A healthy pass relocates each poolable settings server OUT of the settings
+    overlay and INTO every agent overlay. #5328 made the degraded pass keep the
+    previous settings overlay -- but the agent loop still ran with an empty
+    injection set, so a rewritten agent overlay dropped those servers while the
+    kept settings overlay no longer listed them either. They existed in NEITHER
+    location for the rest of the gateway's lifetime. The pass must refuse to
+    rewrite instead, exactly as the per-agent transient read failure does."""
+    _mk_tree(tmp_path)
+    _rewrite(tmp_path)  # healthy pass: global-x relocated into every agent
+    overlay_dir = tmp_path / "mcp-gateway" / "agents"
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    for i in range(2):
+        healthy = json.loads((overlay_dir / f"agent-{i}.json").read_text())
+        assert "global-x" in healthy["mcpServers"]
+    # The relocation is what makes the loss total: settings no longer lists it.
+    assert "global-x" not in json.loads(settings_overlay.read_text())["mcpServers"]
+    before = {p.name: p.read_bytes() for p in overlay_dir.glob("*.json")}
+    assert before
+
+    # Fault the settings file itself, which is what forces the rewrite: the
+    # fingerprint signs it with _stat_sig (read_bytes), so an unreadable file
+    # makes that signature None and the cached early return cannot fire. No
+    # agent source is touched -- their signatures must stay comparable, which is
+    # what licenses the keep.
+    with _settings_unreadable():
+        _, target_env = _rewrite(tmp_path)
+
+    # No agent overlay was rewritten at all: byte-identical to the healthy pass.
+    for i in range(2):
+        kept = json.loads((overlay_dir / f"agent-{i}.json").read_text())
+        assert "global-x" in kept["mcpServers"], (
+            "the injected global server must survive a settings read failure"
+        )
+    assert {p.name: p.read_bytes() for p in overlay_dir.glob("*.json")} == before
+    # A kept overlay's stub still needs its target mapping published, or it
+    # resolves through the bare-name fallback.
+    assert any("GLOBAL_X" in key for key in target_env)
+    # Degraded pass stays uncacheable: the next boot retries the read.
+    assert not (overlay_dir / _FINGERPRINT_NAME).exists()
+
+    # The fault clears: the next pass rewrites normally and re-caches.
+    _rewrite(tmp_path)
+    assert (overlay_dir / _FINGERPRINT_NAME).is_file()
+    for i in range(2):
+        healed = json.loads((overlay_dir / f"agent-{i}.json").read_text())
+        assert "global-x" in healed["mcpServers"]
+
+
+def test_a_changed_agent_spec_is_not_deferred_by_a_settings_read_failure(
+    tmp_path: Path,
+) -> None:
+    """A keep defers everything the overlay encodes, not just the injection
+    set, so it is only honest while nothing else has changed. An agent whose own
+    spec changed -- an ``autoApprove`` entry removed, a server disabled, a
+    server dropped -- must be REWRITTEN even though that costs the injected
+    globals for that agent this pass: a revocation is a deliberate instruction
+    and cannot wait for the next boot, while the lost injection self-heals."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert "global-x" in json.loads(overlay.read_text())["mcpServers"]
+
+    # The operator revokes an approval on the agent's own server.
+    (src / "agent-0.json").write_text(
+        json.dumps({
+            "name": "agent-0",
+            "mcpServers": {"srv": {"command": _CMD, "args": ["a0"],
+                                   "env": {"K": "v"}, "disabled": True}},
+        })
+    )
+    with _settings_unreadable():
+        _rewrite(tmp_path)
+
+    spec = json.loads(overlay.read_text())
+    assert spec["mcpServers"]["srv"].get("disabled") is True, (
+        "a revoked/disabled server must not be deferred to the next boot"
+    )
+    # The cost is declared: the injection could not be established this pass.
+    assert "global-x" not in spec["mcpServers"]
+    assert not (
+        tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    ).exists()
+
+
+def test_a_deleted_overlay_is_rebuilt_even_on_a_settings_read_failure(
+    tmp_path: Path,
+) -> None:
+    """"Inputs unchanged" does not imply "there is an overlay to keep".
+
+    A missing output is itself a reason the cached early return did not fire, so
+    this pass can reach the loop with every input signature still matching while
+    the overlay file is gone. Adding that agent to the keep set would leave it
+    with NO overlay -- unpooling its own servers -- when a rewrite was available.
+    The existence check is what separates the two."""
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)  # healthy pass: fingerprint stored, overlay written
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert overlay.is_file()
+
+    overlay.unlink()  # the output vanishes; every input signature still matches
+    with _settings_unreadable():
+        _rewrite(tmp_path)
+
+    assert overlay.is_file(), "a vanished overlay must be rebuilt, not withheld"
+    servers = json.loads(overlay.read_text())["mcpServers"]
+    assert servers["srv"].get("_kirocrew_mcp_gateway_wrapped") is True
+
+
+def test_settings_read_failure_with_nothing_stubbed_still_rewrites(
+    tmp_path: Path,
+) -> None:
+    """With nothing opted in, a settings read failure changes nothing.
+
+    This pins the OUTCOME rather than a predicate: an empty stub set is not a
+    special case in the keep decision, because nothing is wrapped and
+    ``_injectable_settings_servers`` returns nothing whatever the file says, so a
+    keep and a rewrite would produce identical bytes. What must still hold is
+    that an edit to the agent's own spec lands on such a pass."""
+    src = _mk_tree(tmp_path)
+    _rewrite(tmp_path, stub_servers=frozenset())
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert "late" not in json.loads(overlay.read_text())["mcpServers"]
+
+    # A real source change, so a refusal would be visible as a stale overlay.
+    (src / "agent-0.json").write_text(
+        json.dumps({
+            "name": "agent-0",
+            "mcpServers": {"late": {"command": _CMD, "args": ["l"]}},
+        })
+    )
+    with _settings_unreadable():
+        _rewrite(tmp_path, stub_servers=frozenset())
+
+    assert "late" in json.loads(overlay.read_text())["mcpServers"]
+
+
+def test_settings_read_failure_still_writes_an_agent_with_no_overlay(
+    tmp_path: Path,
+) -> None:
+    """The #5344 refusal only withholds a rewrite where withholding PRESERVES
+    something. An agent with no previous overlay has no injected copy to drop,
+    so refusing would leave it with no overlay at all -- unpooling its own
+    servers too, which is worse than the fault warrants and worse than what
+    this pass does without the fix. It must still be written."""
+    _mk_tree(tmp_path, n_agents=1)
+    overlay_dir = tmp_path / "mcp-gateway" / "agents"
+    with _settings_unreadable():
+        _rewrite(tmp_path)  # first pass ever: nothing to keep
+
+    written = overlay_dir / "agent-0.json"
+    assert written.is_file(), "a cold pass must not be withheld"
+    servers = json.loads(written.read_text())["mcpServers"]
+    # The agent's OWN server is still wrapped and pooled.
+    assert servers["srv"].get("_kirocrew_mcp_gateway_wrapped") is True
+    # The injected global is absent -- unknowable this pass -- but its raw entry
+    # still merges from the real settings file, so no server is lost.
+    assert "global-x" not in servers
+    # Still uncacheable: the next boot injects it.
+    assert not (overlay_dir / _FINGERPRINT_NAME).exists()
+
+
+def test_disabling_sharing_is_not_deferred_by_a_settings_read_failure(
+    tmp_path: Path,
+) -> None:
+    """Preserving an injection set must never defer a POLICY change.
+    ``_build_stub_entry`` bakes ``--poolable`` into every wrapped entry iff
+    sharing was on, so an operator who sets ``mcp_gateway.enabled = false`` and
+    hits a transient settings read failure in the same pass would otherwise keep
+    shared backends for the whole gateway lifetime. ``pooling_enabled`` is a
+    fingerprinted input, so the keep is refused and the overlay rewritten."""
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)  # healthy pass with sharing ON
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert "--poolable" in json.loads(overlay.read_text())["mcpServers"]["srv"]["args"]
+
+    with _settings_unreadable():
+        _rewrite(tmp_path, pooling_enabled=False)  # operator turns sharing OFF
+
+    args = json.loads(overlay.read_text())["mcpServers"]["srv"]["args"]
+    assert "--poolable" not in args, "an explicit policy change must not be deferred"
+
+
+@contextlib.contextmanager
+def _settings_text_unreadable() -> "Iterator[None]":
+    """Fault ONLY ``read_text`` on settings/mcp.json, leaving ``read_bytes`` live.
+
+    The narrow fault the wide one deliberately avoids, and it is reachable: the
+    two are separate syscalls, so a fault can hit one and not the other. The
+    fingerprint still SIGNS the file (``_stat_sig`` uses ``read_bytes``) while the
+    pass cannot parse it, which is the only state where a settings change is both
+    real and known during a settings fault.
+    """
+    real_read_text = Path.read_text
+
+    def flaky_text(self: Path, *args: Any, **kwargs: Any) -> str:
+        if self.name == "mcp.json" and "settings" in self.parts:
+            raise OSError("transient I/O error")
+        return real_read_text(self, *args, **kwargs)
+
+    Path.read_text = flaky_text  # type: ignore[method-assign]
+    try:
+        yield
+    finally:
+        Path.read_text = real_read_text  # type: ignore[method-assign]
+
+
+def test_a_known_settings_change_refuses_the_keep(tmp_path: Path) -> None:
+    """The settings input is skipped only when it cannot be SIGNED, never when it
+    is signable and differs.
+
+    ``read_text`` and ``read_bytes`` are separate calls, so the fingerprint can
+    sign a NEW settings file on the same pass whose parse failed. Skipping the
+    comparison unconditionally would then keep overlays built from the old
+    settings -- so a server revoked in settings/mcp.json would stay live, wrapped,
+    in every agent overlay for the gateway's lifetime. That is an absorbed
+    instruction, not a deferred edit."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert "global-x" in json.loads(overlay.read_text())["mcpServers"]
+
+    # The operator revokes the global server, and the parse (not the stat) faults.
+    (src.parent / "settings" / "mcp.json").write_text(
+        json.dumps({
+            "mcpServers": {
+                "global-x": {"command": _CMD, "args": ["g"], "disabled": True}
+            }
+        })
+    )
+    with _settings_text_unreadable():
+        _rewrite(tmp_path)
+
+    assert "global-x" not in json.loads(overlay.read_text())["mcpServers"], (
+        "a signable, changed settings file must refuse the keep"
+    )
+
+
+def test_a_tampered_overlay_is_not_served_by_a_keep(tmp_path: Path) -> None:
+    """A keep serves an artifact this pass did not write, so it must validate the
+    recorded signature exactly as ``_cached_rewrite_result`` does. Otherwise one
+    induced transient fault is enough to have an edited overlay served -- its
+    stub argv would diverge from the ``target_env`` gatewayd spawns from."""
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+
+    spec = json.loads(overlay.read_text())
+    spec["mcpServers"]["srv"]["args"] = ["--tampered"]
+    overlay.write_text(json.dumps(spec, indent=2) + "\n")
+
+    with _settings_unreadable():
+        _rewrite(tmp_path)
+
+    args = json.loads(overlay.read_text())["mcpServers"]["srv"]["args"]
+    assert "--tampered" not in args, "an edited overlay must be rewritten, not kept"
+
+
+def test_an_unvouched_sidecar_blocks_every_keep(tmp_path: Path) -> None:
+    """The sidecar set is vouched for once per pass, and a failure withdraws the
+    keep for EVERY agent.
+
+    A kept overlay still points ``--env-file`` at those sidecars and the sidecar
+    prune is skipped on this pass, so serving a kept overlay beside a sidecar set
+    that cannot be validated and re-protected would leave a credential file
+    unrepaired. Mirrors the cached path, which refuses wholesale."""
+    _mk_tree(tmp_path, n_agents=2)
+    _rewrite(tmp_path)
+    env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
+    sidecars = sorted(env_dir.glob("*.json"))
+    assert sidecars
+
+    sidecars[0].write_text(json.dumps({"K": "tampered"}))
+
+    with _settings_unreadable():
+        _rewrite(tmp_path)
+
+    # No keep happened, so every overlay was rewritten -- without the injection.
+    for i in range(2):
+        servers = json.loads(
+            (tmp_path / "mcp-gateway" / "agents" / f"agent-{i}.json").read_text()
+        )["mcpServers"]
+        assert "global-x" not in servers, (
+            "an unvouched sidecar set must withdraw the keep for every agent"
+        )
+
+
+def test_a_vanished_target_binary_refuses_the_keep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A kept overlay's stub argv embeds the ABSOLUTE path a previous pass
+    resolved, and directory contents are which() input no signature can see. So
+    the keep re-runs the recorded probes exactly as the cached path does: a target
+    binary removed, moved between PATH prefixes, or newly shadowed must refuse the
+    keep, or the kept overlay launches a dead path for the gateway's lifetime."""
+    bin_dir = tmp_path / "extra-bin"
+    bin_dir.mkdir()
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
+    exe_name = "kirocrew-test-vanishing-cmd" + (".bat" if os.name == "nt" else "")
+    exe = bin_dir / exe_name
+    exe.write_text("#!/bin/sh\nexit 0\n")
+    exe.chmod(0o755)
+
+    src = _mk_tree(tmp_path, n_agents=1, with_env=False)
+    spec = json.loads((src / "agent-0.json").read_text())
+    spec["mcpServers"]["srv"]["command"] = "kirocrew-test-vanishing-cmd"
+    (src / "agent-0.json").write_text(json.dumps(spec))
+    _rewrite(tmp_path)
+
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    args = json.loads(overlay.read_text())["mcpServers"]["srv"]["args"]
+    assert os.path.normcase(args[args.index("--target-command") + 1]) == (
+        os.path.normcase(str(exe))
+    )
+    assert "global-x" in json.loads(overlay.read_text())["mcpServers"]
+
+    exe.unlink()  # the binary goes away; no PATH change, no spec change
+    with _settings_unreadable():
+        _rewrite(tmp_path)
+
+    # The keep was refused, so the overlay was rewritten -- and the now-dead
+    # bare command is left unwrapped rather than pointed at a stale path.
+    servers = json.loads(overlay.read_text())["mcpServers"]
+    assert "global-x" not in servers, (
+        "a vanished target binary must refuse the keep"
+    )
+    assert "--target-command" not in json.dumps(servers.get("srv", {}))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits")
+def test_a_keep_retightens_every_artifact_it_serves(tmp_path: Path) -> None:
+    """A chmod changes no signature, so a keep must re-assert owner-only
+    protection on everything it serves -- the kept overlay, the env sidecars and
+    their directory, and the settings overlay (file and dir) that #5328 keeps on
+    this pass. Mirrors the cache-hit path's guarantee, for the same reason: on
+    Windows the file DACL rather than the directory is what carries access, and
+    these files hold the passed-through env of non-poolable servers.
+
+    The fingerprint file is deliberately NOT in the set: this pass unlinks it
+    (uncacheable), so re-protecting a file about to be deleted is a no-op."""
+    import stat as _stat
+
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay_dir = tmp_path / "mcp-gateway" / "agents"
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
+    artifacts = [overlay_dir / "agent-0.json", settings_overlay,
+                 *env_dir.glob("*.json")]
+    assert len(artifacts) >= 3  # incl. at least one sidecar
+    for a in artifacts:
+        a.chmod(0o644)
+    settings_overlay.parent.chmod(0o755)
+    env_dir.chmod(0o755)
+
+    with _settings_unreadable():
+        _rewrite(tmp_path)
+
+    # The keep happened (the injected global survived) AND everything it serves
+    # was retightened.
+    assert "global-x" in json.loads(
+        (overlay_dir / "agent-0.json").read_text()
+    )["mcpServers"]
+    for a in artifacts:
+        assert _stat.S_IMODE(a.stat().st_mode) == 0o600, a
+    assert _stat.S_IMODE(settings_overlay.parent.stat().st_mode) == 0o700
+    assert _stat.S_IMODE(env_dir.stat().st_mode) == 0o700
+
+
+def test_a_swallowed_stat_fault_is_unknown_not_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``is_file()`` answers False for a missing file AND for some stat faults,
+    and only the errnos in ``pathlib._IGNORED_ERRNOS`` are swallowed that way.
+
+    Measured on CPython 3.12: EACCES, EIO and EPERM RAISE out of the pass (the
+    caller logs "rewriter failed -- falling back" and touches nothing), but
+    ENOENT, EBADF, ENOTDIR and ELOOP return False. ENOTDIR is reachable without
+    the file being gone -- a directory component momentarily replaced, an atomic
+    directory swap, a symlink being re-pointed -- and reading it as "absent"
+    rewrites every overlay with an empty injection set, which is #5344 through
+    the stat path instead of the read path. Only ``FileNotFoundError`` may mean
+    absent; every other OSError means unknown."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    assert "global-x" in json.loads(overlay.read_text())["mcpServers"]
+    assert settings_overlay.is_file()
+
+    real_stat = Path.stat
+    fail = {"on": True}
+
+    def flaky_stat(self: Path, *args: Any, **kwargs: Any) -> Any:
+        if fail["on"] and self.name == "mcp.json" and "settings" in self.parts:
+            raise OSError(errno.ENOTDIR, os.strerror(errno.ENOTDIR))
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", flaky_stat)
+    # Confirm first: this errno really is swallowed, so the pass sees "absent".
+    assert (src.parent / "settings" / "mcp.json").is_file() is False
+    _rewrite(tmp_path)
+    fail["on"] = False
+
+    assert "global-x" in json.loads(overlay.read_text())["mcpServers"], (
+        "a swallowed stat fault must read as unknown, not as an absent file"
+    )
+    # The previous settings overlay survives too, and the pass is not cached.
+    assert settings_overlay.is_file()
+    assert not (
+        tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    ).exists()
+
+
+@pytest.mark.parametrize(
+    "payload, why",
+    [
+        ("{not json", "bad content"),
+        ('["not", "a", "mapping"]', "valid JSON of the wrong shape"),
+    ],
+    ids=["bad_json", "non_dict"],
+)
+def test_deterministic_settings_content_prunes_its_overlay(
+    tmp_path: Path, payload: str, why: str
+) -> None:
+    """A settings source that is present but unusable prunes the previous
+    settings overlay, exactly as a deleted source does -- unlike a transient
+    fault, which keeps it (#5328).
+
+    Both branches were reachable and uncovered: a mutation removing either
+    prune reddened nothing until these existed, and an earlier attempt at the
+    #5344 classification silently stopped pruning on both. The distinction that
+    matters is deterministic-vs-transient, not spec-vs-no-spec: fixing bad
+    content changes the file's stat signature, so this pass is safe to cache."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    assert settings_overlay.is_file(), "healthy pass writes the settings overlay"
+
+    (src.parent / "settings" / "mcp.json").write_text(payload)
+    _rewrite(tmp_path)
+
+    assert not settings_overlay.exists(), f"{why} must prune the stale overlay"
+    # Deterministic, so the pass is cacheable -- the transient arm is not.
+    assert (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).is_file()
 
 
 def test_malformed_json_source_is_still_cacheable(


### PR DESCRIPTION
## 1. What is the problem?

In `rewrite_agents`, a transient `OSError` reading `~/.kiro/settings/mcp.json`
leaves `settings_poolable` empty -- and the pass then rewrote **every** agent
overlay with that empty injection set. The read failing and the file declaring
nothing produced identical output, so the pass persisted a conclusion it never
established.

A healthy pass relocates each poolable settings server OUT of the settings
overlay and INTO every agent's own overlay (wrapped with that agent's identity).
When the next pass hits a transient settings read failure, the overlay it writes
no longer carries those servers.

## 2. Why this issue matters to the user

Every globally-declared poolable server silently stops being pooled for the rest
of the gateway's lifetime. Its tools do not disappear -- the raw entry still
merges from the real settings file -- but it launches per session, unpooled, with
none of the caller identity the stub carries. Nothing reports this: the pass logs
one read warning and otherwise looks like a normal rewrite.

The read failure that triggers it need not recur. One hiccup at boot is enough,
and the degraded state then lasts until the gateway restarts.

(The linked issue predicted the servers would exist in *neither* location. That
overstates it: the settings overlay the rewriter writes has no reader in this
tree, so the raw copy still merges. The mechanism, and the lifetime-long
degradation, are exactly as reported -- filed separately as the inert-overlay
question, see below.)

## 3. How our fix solves it

Distinguish "the read failed" from "the file declared nothing": on a transient
settings read failure an agent keeps its previous overlay -- which carries both
its own wrapped servers and the injected globals -- instead of being rewritten
without the injection. This reuses the `transient_keep` machinery #5328 added for
a per-agent read failure, so a kept overlay's `target_env` mappings are still
republished.

A keep defers **everything that overlay encodes**, not only the injection set, so
it is only honest while nothing else has changed. `_overlay_inputs_unchanged`
compares the stored fingerprint's inputs against this pass's -- every input
except the settings entry -- and only then may an overlay be kept:

* **The agent's own spec**, by source signature. A revoked `autoApprove` entry or
  a newly disabled server is applied now rather than deferred to the next boot.
* **Every policy knob `_build_stub_entry` bakes into a stub's argv** --
  `--sandbox-mode`, `--approval-mode`, `--poolable`, the work dir, the socket, the
  identity keys -- because each is a fingerprinted input. One comparison covers
  every dimension, so a future fingerprinted input is covered without being
  enumerated at the call site.

The settings entry is the one input compared **conditionally**, and only because a
transient fault is what makes it unanswerable: `_rewrite_inputs_fingerprint` signs
that file with `_stat_sig`, which returns `None` when it cannot be read, and that
`None` is why control reaches the rewrite loop instead of the cached early return.
So it is skipped when this pass could not sign the file -- demanding a match there
would refuse every keep on exactly the path this protects. When the signature **is**
available and differs, the file demonstrably changed and the keep is refused:
`read_text` and `read_bytes` are separate calls, so the fingerprint can sign a new
settings file on a pass whose parse failed, and a server revoked in
`settings/mcp.json` left alive and wrapped in every overlay is an absorbed
instruction, not a deferred edit.

A keep also **serves artifacts this pass did not write**, which is the position
`_cached_rewrite_result` is in. Four of its guarantees were added to this PR one
review round at a time before anyone noticed the pattern, so the remaining work was
not to guess a fifth: its **complete** validation set was enumerated from the
function and each entry answered. The table below is the claim -- a reviewer can
check it for completeness against `_cached_rewrite_result` in one read rather than
discovering a gap.

| what the cached path validates before serving | does the keep do it | why |
| --- | --- | --- |
| recorded signature of every overlay | yes, **per agent** | An edited overlay is rewritten, not served: its stub argv would diverge from the `target_env` gatewayd spawns from. Per-agent rather than wholesale is deliberate and stronger -- a tampered overlay costs only its own agent a rewrite, where the cached path must refuse everything. |
| recorded signature of every sidecar | yes, pass-wide | A kept overlay points `--env-file` at those and the sidecar prune is skipped on this pass, so a partial vouch would leave a credential file unrepaired. A failure withdraws the keep for **every** agent, as the cached path refuses wholesale. |
| recorded `shutil.which` probes re-run | yes, pass-wide | Directory contents are which() input no signature can see, and a kept overlay's stub argv embeds an absolute path a previous pass resolved. A removed, moved or newly shadowed binary would otherwise leave it launching a dead path for the gateway's lifetime. |
| owner-only re-assertion: each overlay | yes | A chmod or DACL edit changes no size, mtime or digest, so a signature cannot see it. On Windows the file DACL rather than the directory carries access. |
| owner-only re-assertion: sidecars + their dir | yes | Same, and these are the credential files. |
| owner-only re-assertion: settings overlay + its dir | yes | #5328 keeps this file on this pass and it carries the passed-through env of every non-poolable / HTTP-SSE global server, so a loosened ACL would persist for the gateway's lifetime. This is the entry the enumeration turned up that no review round had reached yet. |
| owner-only re-assertion: the fingerprint file | **no, by construction** | This pass unlinks the fingerprint (`notes.source_read_failed` makes it uncacheable), so re-protecting a file about to be deleted is a no-op. |
| recorded signature of the settings overlay | **no, no action available** | On a mismatch nothing would improve: the source is unreadable so it cannot be rewritten, deleting it would strip every global server (#5328), and refusing the agent keeps would not repair it while making the injection loss worse. Reported rather than silently skipped. |
| remove a stray settings overlay when none was recorded | **no, must not** | This is the one branch where the two paths genuinely diverge: the cached path unlinks it, while on a transient path #5328 requires keeping it. It is also why the two cannot yet share one validator -- see below. |
| fingerprint shape and traversal validation | yes, inherited | Every consumer reaches `stored` through `_load_fingerprint`, which rejects a non-dict payload, a malformed signature, and any overlay/sidecar name containing a separator or `.`/`..` before it can be joined onto a directory. |

Without these, one induced transient fault would be enough to have a tampered
overlay served and a loosened credential ACL left unrepaired.

**Why not one shared validator.** It is the right end state and it is not in this
PR. The two paths differ on the stray-settings-overlay branch above, and that
difference is itself a shipped fix, so extracting a shared validator means
parameterizing `_cached_rewrite_result` -- the hot path, which this PR otherwise
leaves untouched and which existing tests pin. Refactoring the hot path to tidy the
cold one inverts the risk. Tracked on #8111 with this function's other accumulated
debt. If a reviewer would rather see the extraction here, say so and it will be done
here instead.

The keep further requires the overlay to exist. "Inputs unchanged" does not imply
there is something to keep: a vanished output is itself a reason the cached early
return did not fire, and withholding there would leave that agent with no overlay
at all -- unpooling its own servers when a rewrite was available. A cold pass
falls out of the same rule, since no stored fingerprint means nothing is
established.

Chain from symptom to root cause: server not pooled for a gateway lifetime <-
agent overlay lacks the injected entry <- overlay written with an empty
`settings_poolable` <- `settings_poolable` empty because the read raised, not
because the file was empty <- the two cases were indistinguishable downstream.

Two bounded residues, both degrading to the pre-fix behaviour and never worse
than it, and both closed by the next boot because the path is already uncacheable
(`notes.source_read_failed`):

* An agent whose own spec changed on a faulty pass is rewritten, so it loses the
  injected globals for that pass. Applying a revocation immediately is worth more
  than preserving an injection that self-heals.
* The fingerprint is unlinked at the end of every uncacheable pass, so two
  consecutive faulty passes cannot keep anything.

One further delta, stated because it lives only in a code comment otherwise: on a
withheld pass the agent spec is not read, so a source with deterministically bad
JSON keeps its overlay for that pass rather than having it pruned. The next boot
reads that source and prunes it then.

## 4. What tests we did

Thirteen cases added to `test/test_mcp_gateway_rewriter_fingerprint.py`, beside the
existing transient-fault family. The mutation table is keyed by test NAME rather
than by index, because an earlier revision of this description carried an index
table that went stale when the test set changed.

**The reported defect**

* `test_transient_settings_read_failure_does_not_rewrite_agent_overlays` -- the
  injected global survives, every overlay is byte-identical to the healthy pass,
  its target mapping is still published, the pass stays uncacheable, and the next
  clean pass rewrites normally. Fails on `main` with `AssertionError: the injected
  global server must survive a settings read failure`.

**A keep must not defer anything else**

* `test_a_changed_agent_spec_is_not_deferred_by_a_settings_read_failure` -- an
  agent whose server is newly `disabled` is rewritten, so the revocation lands;
  the lost injection is asserted as the declared cost.
* `test_disabling_sharing_is_not_deferred_by_a_settings_read_failure` -- turning
  sharing off during the fault rewrites the overlay, so `--poolable` is gone.
* `test_a_known_settings_change_refuses_the_keep` -- the parse faults while the
  stat succeeds, so the changed settings file is both real and known; the keep is
  refused rather than keeping a revoked global server wrapped.

**A keep must not serve an artifact it cannot vouch for**

* `test_a_tampered_overlay_is_not_served_by_a_keep` -- an edited overlay fails its
  recorded signature and is rewritten.
* `test_an_unvouched_sidecar_blocks_every_keep` -- one unvouchable sidecar
  withdraws the keep for every agent.
* `test_a_vanished_target_binary_refuses_the_keep` -- a resolved bare command's
  binary is removed with no PATH or spec change, so the recorded probe disagrees
  and the keep is refused rather than serving a dead absolute path.
* `test_a_keep_retightens_every_artifact_it_serves` -- POSIX; every artifact a keep
  serves is chmod'ed to 0o644 and its directories loosened, and the keep restores
  0o600 / 0o700 on all of them while still preserving the injected global.

**The fault must be recognised at both syscalls**

* `test_a_swallowed_stat_fault_is_unknown_not_absent` -- `OSError(ENOTDIR)` is one
  of the errnos `is_file()` swallows, so it is indistinguishable from a missing
  file without an explicit `stat()`; the injected global must survive it.
* `test_deterministic_settings_content_prunes_its_overlay[bad_json, non_dict]` --
  the other side of that classification: a present-but-unusable settings source
  still prunes its stale overlay and stays cacheable. **Both branches were
  reachable with no test at all** -- mutations removing either prune reddened
  nothing until these were added, on `main` as well as here.

**A keep must not withhold what it cannot preserve**

* `test_a_deleted_overlay_is_rebuilt_even_on_a_settings_read_failure` -- every
  input signature still matches but the output is gone, so the agent is rebuilt.
* `test_settings_read_failure_still_writes_an_agent_with_no_overlay` -- a cold pass
  is written, its own server wrapped.

Every gate was mutation-verified, and each mutation reddens only tests that reach
the condition it removes:

| mutation | reddens |
| --- | --- |
| `injection_unknown = False` (restore the conflation) | `..._does_not_rewrite_agent_overlays` |
| stop comparing the per-agent source signature | `..._a_changed_agent_spec_...` and `..._with_nothing_stubbed_still_rewrites` |
| stop comparing the global policy inputs | `..._disabling_sharing_is_not_deferred_...` |
| skip the settings key unconditionally | `..._a_known_settings_change_refuses_the_keep` |
| stop validating the kept overlay's signature | `..._a_tampered_overlay_is_not_served_by_a_keep` |
| stop vouching for the sidecar set | `..._an_unvouched_sidecar_blocks_every_keep` |
| stop re-running the recorded which() probes | `..._a_vanished_target_binary_refuses_the_keep` |
| drop any of the three owner-only re-assertions | `..._a_keep_retightens_every_artifact_it_serves` |
| drop the overlay existence check | `..._a_deleted_overlay_is_rebuilt_...` |
| read a swallowed stat fault as absent again | `..._a_swallowed_stat_fault_is_unknown_not_absent` |
| stop classifying bad content as prunable | `..._prunes_its_overlay[bad_json]` |
| stop classifying a non-dict payload as prunable | `..._prunes_its_overlay[non_dict]` |

The three owner-only re-assertion sites (kept overlay, sidecars, settings overlay)
were each mutated separately and each reddens that one test, so the test covers all
three rather than passing on one of them.

The source-signature mutation reddens two tests and both are inside its blast
radius -- one asserts a revocation lands, the other asserts a source edit lands on
a pass with nothing stubbed, and both reach the keep decision through that
comparison. The cold-pass test pins an outcome rather than a condition: no stored
fingerprint already makes `_overlay_inputs_unchanged` return `False`, so no mutation
isolates it.

**Every red was confirmed to be an `AssertionError` on a value claim**, not an
exception thrown from the mutated line. That distinction matters here more than
usual: `rewrite_agents` runs under a caller whose `except Exception` logs "rewriter
failed -- falling back" and swallows everything, so a mutation that made a predicate
RAISE rather than change its ANSWER would be invisible as an error and would redden
tests for a reason unrelated to the predicate. None did.

Two conditions were **removed** during this work for failing that bar -- a
`bool(stub_set)` term, and in an earlier revision a bespoke `--poolable` argv
comparison. Neither could be reddened once the fingerprint comparison subsumed it,
so neither was carried. A non-reddening mutation has more than one meaning, and the
two cases here needed opposite responses: `bool(stub_set)` was genuinely
unobservable, while the overlay existence check was not -- the suite simply had no
test reaching it, so a test was added instead.

**Fault width matters.** `_settings_unreadable` faults `read_bytes` and `read_text`
together, as an unreadable file does. Faulting only `read_text` leaves the
fingerprint signature intact, so on otherwise-unchanged inputs the cached early
return fires and the degraded path never runs -- a fault narrower than a real one
can make a test exercise a path the real fault would never reach. That narrower
fault is now its own helper, `_settings_text_unreadable`, used deliberately for the
one case where a settings change is both real and known during a fault.


**Which source produced this evidence.** A green paste does not say whose
`kiro_crew` was imported, and this branch was developed in a git worktree with no
virtualenv of its own, beside a shared venv whose editable install points at a
different checkout. So the module under test was confirmed rather than assumed:
`setup.cfg` sets `pythonpath = src`, which pytest prepends **rootdir-relative**, so
a run rooted in the working tree imports that tree's `src` ahead of any
site-packages `.pth`. Verified by loading the package under a real pytest run and
reading `rewriter.__file__`, which resolved inside the working tree, with
`PYTHONPATH` unset and again with it set explicitly. The mutation results were then
re-confirmed by tagging the mutated line with a marker, asserting through the same
import that the marker was present in the loaded module, and only then observing the
test go red -- so the file that reddened is provably the file that was mutated.

Local gates: `test_mcp_gateway_rewriter_fingerprint.py` 61 passed,
`test_mcp_gateway_rewriter.py` 36 passed, plus every other test file importing the
rewriter -- cluster_fixes 16, session_inject 23, shutdown_and_env 56, stub_optin 7,
gatewayd_coverage 149, shareability 87, handlers_mcp_coverage 134, pinned_staging
53, acp_runtime 303. flake8 and isort clean on both files; the baselined black gate
passes; `mypy src/kiro_crew/` reports only two pre-existing `transcribe.py`
boto3-stub errors, reproduced unchanged on a clean `main` checkout.

## 5. Any other suggestions on the work

While establishing whether a refusal is safe for the caller, two adjacent facts
turned up that are deliberately NOT in this diff:

* The settings overlay this function writes (`<overlay_dir>/../settings/mcp.json`)
  has **no reader** anywhere in `src/`. The path is computed in
  `config/loader.py`, threaded through `providers/acp.py` into `AcpClient` and
  `AcpRuntime` as `_mcp_gateway_settings_mcp_json`, stored -- and never read. The
  per-agent overlay is live (consumed by `pooled_session_servers` at
  `session/new`), so the injection half of the relocation works while the drop
  half changes nothing.
* This function's closing comment states the settings overlay "is bind-mounted by
  `sandbox.py` via a fixed location derived from the overlay dir". `sandbox.py`
  contains no such mount.
* The `#5328` comment beside the settings-overlay prune said `is_file()` "folds a
  stat fault (ACL hiccup, transient I/O error) into 'absent'". That is wrong for
  those two errnos specifically -- `Path.is_file()` swallows only
  ENOENT/EBADF/ENOTDIR/ELOOP and re-raises EACCES, EIO and EPERM -- and a review
  lane reasoned from it to report a defect with an unreachable mechanism. But the
  underlying defect was real for the errnos that ARE swallowed while the file still
  exists (ENOTDIR, ELOOP), so this PR now fixes it and states the errno boundary
  precisely rather than repeating the comment's claim. Recorded on #8111 as a
  correction, since the misleading comment is what cost a round in both directions.

Filed separately rather than widened into this PR, which is scoped to the read
conflation.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a transient-fault flag that only suppresses CACHING while the degraded
value is still written to a durable artifact

This generalizes, and the same function has now produced it twice. `rewrite_agents`
already had the right idiom -- a transient fault sets `notes.source_read_failed`
-- but that flag only decides whether the pass is *cached*. It never gated the
*write*. #5328 was the prune side of exactly that gap (a transient fault deleted a
healthy overlay), and #5344 is the write side (a transient fault published an
overlay derived from a read that never happened). Suppressing the cache bounds how
long a bad conclusion survives; it does not stop the bad conclusion from being
published in the first place, and a gateway lifetime is long enough to matter.

The reviewable question this suggests, for any handler that sets a
transient/degraded flag: does the flag reach the code that WRITES, or only the
code that decides whether to remember? If a durable artifact is produced on the
degraded path, the flag has to reach that decision too.

Corollary worth naming, because it is where the first draft of this fix went
wrong: "refuse to write" is not automatically safe either. Refusing must be
compared against what the write would have produced, per artifact -- refusing
pass-wide here would have unpooled an agent's own servers when it had no previous
overlay, trading the reported defect for a new one. And a refusal must never
absorb a deliberate instruction: keeping a stale artifact deferred an operator's
sharing change until `_overlay_encodes_pooling` was added to catch it.

Closes #5344









