### PR TITLE
fix(auto-improvement): an offline run reports failure, not DONE, and the record survives a restart

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/runner.py
@@ -34,6 +34,7 @@ an afternoon and $50. Every one of these is overridable from config.
 from __future__ import annotations
 
 import logging
+import math
 import threading
 import time
 from collections import deque
@@ -82,6 +83,24 @@ STATUS_STOPPING = "stopping"
 STATUS_DONE = "done"
 STATUS_ERROR = "error"
 
+#: Filename of the last run's terminal record, written beside the archive's own
+#: ``run.meta.json``.
+#:
+#: A SIBLING file rather than a field inside ``run.meta.json`` on purpose. That document is
+#: owned by :mod:`..spine.archive` and written from inside ``driver.run()`` after preflight,
+#: so a run that ends before the archive writes has no metadata document to carry the field
+#: -- and an offline run, the case this record exists to explain, is exactly such a run. A
+#: record that is missing precisely when it is needed is not a record.
+TERMINAL_RECORD_NAME = "run.state.json"
+
+#: Statuses a persisted record is allowed to claim when it is read back at startup.
+#:
+#: The record is written only at a TERMINAL transition, so any other value in the file is
+#: stale or hand-edited. Restoring ``running`` from disk would make a fresh process report a
+#: live run with no thread behind it -- the same "UI spins forever" lie ``status()`` already
+#: guards against for a torn-down thread -- so a non-terminal record is ignored, not restored.
+_PERSISTABLE_STATUSES = frozenset({STATUS_DONE, STATUS_ERROR})
+
 
 class _CalibrationStopped(Exception):
     """Internal signal that a Stop click landed between calibration phases.
@@ -89,6 +108,21 @@ class _CalibrationStopped(Exception):
     Caught in :meth:`RunSupervisor._calibrate_loop` and recorded as a clean stop
     rather than a failure — a stopped calibration has proven no ruler and writes
     none, but it is not an error the operator needs to see reported.
+    """
+
+
+class AgentRunnerOffline(Exception):
+    """A run finished its cycles with no agent runner, so it attempted no work.
+
+    Carried as an exception, and raised nowhere, so the offline outcome can be recorded
+    through :meth:`RunSupervisor._fail` -- the ONE redaction site for anything that reaches
+    ``RunState.error`` and therefore the ``GET /run`` response. A second hand-rolled terminal
+    assignment beside it is exactly the drift
+    ``test_every_terminal_error_site_goes_through_the_helper`` exists to prevent.
+
+    PUBLIC name, unusually for a signal class, because ``_fail`` composes
+    ``f"{type(exc).__name__}: {detail}"`` -- the class name is rendered to the operator, so it
+    is part of the user-visible contract rather than an implementation detail.
     """
 
 
@@ -114,6 +148,24 @@ class RunState:
     quiescence: dict[str, Any] = field(default_factory=dict)
     #: Terminal run counters, copied off the spine's ``Stats`` when the loop returns.
     stats: dict[str, Any] = field(default_factory=dict)
+    #: WHY this run has no agent runner, or ``""`` when one came online.
+    #:
+    #: Carried per-run rather than on the supervisor because it decides this run's TERMINAL
+    #: STATUS: an offline run's discovery early-returns an empty candidate list, so the loop
+    #: quiesces and ``driver.run()`` returns cleanly, and a clean return used to be reported
+    #: as ``done``. Set from :meth:`RunSupervisor._build_runner` via :meth:`RunSupervisor.start`.
+    offline_reason: str = ""
+    #: Where THIS run's terminal record belongs, bound when the run started.
+    #:
+    #: Load-bearing, not a cache. :func:`_terminal_record_path` resolves
+    #: ``store.results_dir()``, which is scoped to the ACTIVE repository+branch workspace, and
+    #: the terminal write happens after the run has gone non-active -- at which point a
+    #: retarget is admitted again (``routes._ACTIVE_RUN_STATUSES`` holds only the in-flight
+    #: statuses). Resolving at write time could therefore file this run's outcome under a
+    #: DIFFERENT repository and leave its own workspace with no record at all. Bound at the
+    #: same instant as the driver's ``archive_root``, so the record and the archive can never
+    #: land in different workspaces. Raised by the GPT review of this branch.
+    record_path: Path | None = None
 
 
 #: Stands in for one activity string the redactor could not scan. A placeholder rather than a
@@ -174,6 +226,40 @@ def _unsandboxed_agent_accepted() -> bool:
     """
     config = store.read_json(store.config_path(), {}) or {}
     return bool(config.get("acceptUnsandboxedAgentRisk") is True)
+
+
+def _terminal_record_path() -> Path:
+    """Where the ACTIVE workspace's last terminal record lives, beside the archive's metadata.
+
+    Resolved per call, never module-cached: ``store.results_dir()`` is scoped to the active
+    repository+branch, so a cached value would point a second target's record at the first
+    one's directory.
+
+    Who calls it matters. :meth:`RunSupervisor._hydrate_terminal_record` calls it live, and
+    should: it answers "what happened in the workspace I am looking at NOW". A RUN must not --
+    it binds the answer once, into ``RunState.record_path``, so a retarget cannot move its
+    outcome to another repository between the terminal transition and the write.
+    """
+    return store.results_dir() / TERMINAL_RECORD_NAME
+
+
+def _as_count(value: Any) -> int:
+    """A non-negative counter read back off disk, or ``0``.
+
+    Not :func:`_pos_int`: that helper substitutes its default for anything ``<= 0`` because
+    its callers are budget caps where zero is meaningless. Here zero is the MOST important
+    value -- ``cycle: 0`` is what an offline run records -- so it must survive the round trip.
+
+    ``OverflowError`` is in the tuple, not only ``TypeError``/``ValueError``: this reads
+    JSON off disk, ``json.loads`` turns ``1e309`` into ``float('inf')``, and ``int(inf)``
+    raises ``OverflowError`` -- which the usual two-name tuple does NOT catch. Measured.
+    Raised by the GPT review of this branch.
+    """
+    try:
+        out = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return out if out > 0 else 0
 
 
 def _redact_activity(value: Any) -> Any:
@@ -238,6 +324,81 @@ class RunSupervisor:
         self._reserved = False
         self._driver: Any = None
         self._stop_requested = False
+        #: WHY the last :meth:`_build_runner` call produced no agent runner, or ``""``.
+        #: Written on EVERY call so it is self-clearing: a previous offline run cannot leak
+        #: its reason into a later run whose runner came online. Read by :meth:`start`, which
+        #: copies it onto that run's :class:`RunState`.
+        self._offline_reason = ""
+        self._hydrate_terminal_record()
+
+    def _hydrate_terminal_record(self) -> None:
+        """Seed ``_state`` from the last run's persisted terminal record.
+
+        Called ONCE, from ``__init__``, which is what keeps :meth:`status` honest about being
+        a cheap in-memory read (this module's header promises exactly that). Without it the
+        record would be written and never shown: a gateway restart after a failed run reports
+        ``idle``, which is the "nothing persisted, no trace after a restart" half of the
+        reported defect -- persisting a record nobody reads back fixes nothing.
+
+        Best-effort by construction. A missing, unreadable, malformed or non-terminal record
+        leaves the supervisor idle, which is the pre-existing behaviour, and this NEVER raises:
+        it runs inside the process-wide singleton every run route resolves through, so a
+        failure here would take out run reporting entirely rather than degrade it -- and
+        because ``get_supervisor()`` caches only on success, one raise would 500 EVERY
+        subsequent request, not just the first. That guarantee is STRUCTURAL: the whole body is
+        inside the ``try``, not just the read, so a coercion that turns out to be non-total
+        (``int(float('inf'))`` raising ``OverflowError`` was exactly that) degrades to idle
+        instead of wedging the app.
+
+        COST, stated plainly: this is the only I/O in the supervisor's construction, and
+        ``get_supervisor()`` builds the singleton lazily -- so the first request to reach it (a
+        ``GET /run`` handler, on the event loop) pays two small reads and the ``store``
+        directory ``mkdir``s. Once per process, on a document of a few hundred bytes. The
+        alternative -- reading on the idle path of :meth:`status` -- pays it on every poll and
+        makes that method's documented "cheap, in-memory" contract false.
+        """
+        try:
+            record = store.read_json(_terminal_record_path(), None)
+            if not isinstance(record, dict):
+                return
+            status = str(record.get("status") or "")
+            if status not in _PERSISTABLE_STATUSES:
+                return
+            numbers = (
+                record.get("cycle"),
+                record.get("kept"),
+                record.get("drafted"),
+                record.get("started_at"),
+                record.get("finished_at"),
+            )
+            if any(isinstance(n, float) and not math.isfinite(n) for n in numbers):
+                # A non-finite number means the document is corrupt, and coercing it is worse
+                # than declining it: `json.loads` turns `1e309` into `inf`, which passes
+                # `_pos_float`'s `> 0` guard untouched and would be re-serialized into the
+                # `GET /run` response as the literal `Infinity` -- not valid JSON, so the
+                # browser's `JSON.parse` rejects the WHOLE payload and the app shows nothing.
+                # Declining the record leaves the supervisor idle, which is what every other
+                # corrupt-record path already does. Raised by the GPT review of this branch.
+                logger.warning(
+                    "%s: ignoring the terminal run record -- it carries a non-finite number",
+                    store.APP_NAME,
+                )
+                return
+            self._state = RunState(
+                status=status,
+                run_id=str(record.get("run_id") or ""),
+                cycle=_as_count(record.get("cycle")),
+                kept=_as_count(record.get("kept")),
+                drafted=_as_count(record.get("drafted")),
+                error=str(record.get("error") or ""),
+                started_at=_pos_float(record.get("started_at"), 0.0),
+                finished_at=_pos_float(record.get("finished_at"), 0.0),
+                offline_reason=str(record.get("offline_reason") or ""),
+            )
+        except Exception:  # noqa: BLE001 -- see docstring: must not break every run route
+            logger.warning(
+                "%s: could not restore the terminal run record", store.APP_NAME, exc_info=True
+            )
 
     # ── progress sink (called from the worker thread) ─────────────────────────
 
@@ -316,6 +477,9 @@ class RunSupervisor:
                     store.APP_NAME,
                     unconfined,
                 )
+                self._offline_reason = (
+                    f"the provider-backed agent runner was refused because {unconfined}"
+                )
                 return None
             runner = SessionAgentRunner(stop_check=stop_check, on_activity=self._on_agent_activity)
             # Register the tool-restricted discovery agent so kiro-cli resolves it by name.
@@ -342,7 +506,13 @@ class RunSupervisor:
                     "is configured and its permission gate must not be bypassed",
                     store.APP_NAME,
                 )
+                self._offline_reason = (
+                    "the tool-restricted discovery agent could not be registered, and falling "
+                    "back to the subprocess agent would bypass the configured provider's "
+                    "permission gate"
+                )
                 return None
+            self._offline_reason = ""
             return runner
         # NO subprocess fallback. Review asked for this removal on every head, and after the
         # two fall-through holes were closed the remaining objection turned out to be right on
@@ -362,6 +532,11 @@ class RunSupervisor:
             "%s: no provider-backed agent runner available — running offline (the subprocess "
             "fallback is deliberately not used: it would bypass the provider permission gate)",
             store.APP_NAME,
+        )
+        self._offline_reason = (
+            "no provider-backed agent runner is available: SessionAgentRunner.available() is "
+            "False, which means the gateway config load or the provider-factory construction "
+            "raised rather than that no provider is configured"
         )
         return None
 
@@ -547,6 +722,12 @@ class RunSupervisor:
 
         driver = self._build_driver(config)
         run_id = f"run-{int(time.time())}"
+        # Bind this run's terminal-record path NOW, immediately after `_build_driver` bound the
+        # driver's `archive_root` to `store.results_dir()`. Both name the active workspace, so
+        # binding them at the same instant is what guarantees the record and the archive cannot
+        # end up in different repositories' subtrees. Resolved outside the lock because
+        # `store.results_dir()` touches the filesystem. See `RunState.record_path`.
+        record_path = _terminal_record_path()
 
         with self._lock:
             # Re-check under the lock: two concurrent POSTs could both pass the probe
@@ -559,8 +740,30 @@ class RunSupervisor:
                 status=STATUS_RUNNING,
                 run_id=run_id,
                 started_at=time.time(),
+                # Captured from the just-built driver's runner selection. Read here rather
+                # than in the worker thread so the run OWNS the reason from the moment it
+                # exists, and a later ``_build_runner`` call cannot change this run's answer.
+                offline_reason=self._offline_reason,
+                record_path=record_path,
             )
             self._state.activity.append({"t": time.time(), "note": f"run {run_id} starting"})
+            if self._offline_reason:
+                # Surfaced at the START, not only at the end. The feed is the operator's live
+                # view, and the ``logger.warning`` that names this reason goes to the
+                # process's stdout/stderr pipe -- which a supervised gateway does not capture
+                # into its log file -- so without this entry the reason exists nowhere the
+                # operator can reach. A run in this state cannot discover anything: the
+                # profile's discovery early-returns an empty candidate list on a ``None``
+                # runner, so every cycle is empty by construction.
+                self._state.activity.append(
+                    {
+                        "t": time.time(),
+                        "error": _redact_activity(
+                            f"agent runner OFFLINE -- this run cannot discover anything: "
+                            f"{self._offline_reason}"
+                        ),
+                    }
+                )
             thread = threading.Thread(
                 target=self._run_loop,
                 args=(driver,),
@@ -878,6 +1081,54 @@ class RunSupervisor:
         with self._lock:
             self._state.activity.append({"t": time.time(), "note": text})
 
+    def _persist_terminal_state(self) -> None:
+        """Write this run's terminal status/error/counters to disk. Call WITHOUT ``_lock``.
+
+        The half of the fix that outlives the process. :class:`RunState` is in-memory only, so
+        before this a run's terminal status and error died with the gateway: a restart reported
+        ``idle`` with no trace on disk that a run had ended at cycle 0, or why. Read back by
+        :meth:`_hydrate_terminal_record` in a later process.
+
+        The SNAPSHOT is taken under the lock and the WRITE happens outside it, because
+        ``store.write_json_atomic`` fsyncs and this module's contract is that ``_lock`` is held
+        for microseconds and never across blocking I/O -- every ``status()`` poll waits on it.
+
+        Deliberately does NOT carry ``activity``: that feed is a bounded in-memory ring of raw
+        model output, scanned by :func:`_redact_activity` on the way in for DISPLAY, and
+        persisting it would turn a display buffer into a durable copy of agent text. What
+        happened to the run is already in ``status`` and ``error``.
+
+        Best-effort. A failed write is logged and swallowed: the outcome is already correct in
+        memory, and losing the durable copy must not turn a reported failure into a second one.
+
+        The destination is the path the RUN bound at ``start()``, not one resolved here. By the
+        time this runs the terminal status is already set, so the run reads as non-active and a
+        repository retarget is admitted again -- resolving now could file this outcome under a
+        different repository and leave its own workspace with no record. See
+        ``RunState.record_path``; the live fallback covers only a state ``start()`` cannot
+        produce.
+        """
+        with self._lock:
+            st = self._state
+            path = st.record_path
+            record = {
+                "run_id": st.run_id,
+                "status": st.status,
+                "error": st.error,
+                "cycle": st.cycle,
+                "kept": st.kept,
+                "drafted": st.drafted,
+                "started_at": st.started_at,
+                "finished_at": st.finished_at,
+                "offline_reason": st.offline_reason,
+            }
+        try:
+            store.write_json_atomic(path or _terminal_record_path(), record)
+        except Exception:  # noqa: BLE001 -- a durability failure must not mask the outcome
+            logger.warning(
+                "%s: could not persist the terminal run record", store.APP_NAME, exc_info=True
+            )
+
     def _run_loop(self, driver: Any) -> None:
         """The worker thread body. Catches EVERYTHING: an escaping exception here would
         kill the thread silently and leave the UI reporting ``running`` forever."""
@@ -891,13 +1142,41 @@ class RunSupervisor:
             with self._lock:
                 self._state.stats = _stats_dict(stats)
                 self._state.kept = int(getattr(stats, "kept", 0) or 0)
-                self._state.status = STATUS_DONE
                 self._state.stage = ""
-                self._state.finished_at = time.time()
-                self._state.activity.append({"t": time.time(), "note": "run finished"})
+                offline = self._state.offline_reason
+                if not offline:
+                    self._state.status = STATUS_DONE
+                    self._state.finished_at = time.time()
+                    self._state.activity.append({"t": time.time(), "note": "run finished"})
+            if offline:
+                # A clean return is NOT success here. With no agent runner the profile's
+                # discovery early-returns an empty candidate list, so every cycle finds
+                # nothing, the budget's quiescence break fires after `quiesce_after` empty
+                # cycles, and `driver.run()` returns its stats normally. Reporting that as
+                # DONE made a run that could not even LOOK indistinguishable from one that
+                # looked and found nothing -- and DONE is what every downstream reader takes
+                # as "this worked".
+                #
+                # STATUS_ERROR (which is what `_fail` records) rather than a new `offline`
+                # status, deliberately. `error` is the ONLY terminal status the UI renders a
+                # message for -- `SetupPanel` falls through to the idle label for anything
+                # else -- so a novel status would still show the operator nothing, reproducing
+                # the very defect this fixes. It is also what the sibling subsystem already
+                # uses for an absent runner (`pr_watchers` records `runner unavailable: ...`
+                # as STATUS_ERROR), and nothing in this app auto-retries on a terminal status
+                # (the only `start()` caller is the POST /run handler, and the app declares no
+                # crons), so a hard failure cannot provoke a retry loop against a runner that
+                # is simply absent.
+                #
+                # Through `_fail` rather than assigning here: that helper is the single
+                # redaction site for anything reaching `RunState.error`, which `status()`
+                # serializes into `GET /run`.
+                self._fail(AgentRunnerOffline(f"the run did no work because {offline}"))
+            self._persist_terminal_state()
         except BaseException as exc:  # noqa: BLE001 — a run failure is state, not a crash
             logger.exception("%s: run failed", store.APP_NAME)
             self._fail(exc)
+            self._persist_terminal_state()
 
     def status(self) -> dict[str, Any]:
         """A JSON-ready snapshot. Cheap, lock-guarded, safe to poll on the event loop.
@@ -909,10 +1188,14 @@ class RunSupervisor:
             st = self._state
             alive = self._thread is not None and self._thread.is_alive()
             # A thread that died without setting a terminal status (only possible if the
-            # interpreter tore it down) must not be reported as still running.
+            # interpreter tore it down) must not be reported as still running. An OFFLINE run
+            # is not `done` on this path either: the thread never reached the terminal
+            # transition, but the run still had no agent runner, and reporting the same lie
+            # here would just move it one branch over.
             status = st.status
             if status in (STATUS_RUNNING, STATUS_STOPPING) and not alive:
-                status = STATUS_DONE if not st.error else STATUS_ERROR
+                clean = not st.error and not st.offline_reason
+                status = STATUS_DONE if clean else STATUS_ERROR
             return {
                 "status": status,
                 "run_id": st.run_id,

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_runner.py
@@ -313,6 +313,217 @@ class TestStatusShape:
         assert "ruler not trusted" in st["error"]
 
 
+class TestOfflineRunIsNotReportedAsDone:
+    """A run with no agent runner did no work, so it must not end in the success state.
+
+    With ``agent_runner=None`` the profile's discovery early-returns an empty candidate
+    list, so every cycle finds nothing, the budget's quiescence break fires, and
+    ``driver.run()`` returns its stats CLEANLY. The supervisor used to take that as success
+    and report ``done`` with an empty ``error`` -- a state indistinguishable from a run that
+    genuinely searched and found nothing.
+
+    ``_build_driver`` is patched, which is exactly how the sibling tests in this file drive
+    the loop; ``_offline_reason`` is set by hand to stand in for what ``_build_runner``
+    records, and ``test_build_runner_records_why_it_went_offline`` covers that real function
+    separately so the two halves are not asserted only against each other.
+    """
+
+    @staticmethod
+    def _start_offline(
+        supervisor: R.RunSupervisor,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        reason: str = "no provider-backed agent runner is available",
+    ) -> None:
+        clone = _tiny_repo(tmp_path / "clone")
+
+        class _InstantDriver:
+            def run(self, **_kw: Any) -> Any:
+                return _FakeStats()
+
+            def request_stop(self) -> None:
+                pass
+
+        monkeypatch.setattr(supervisor, "_build_driver", lambda _cfg: _InstantDriver())
+        supervisor._offline_reason = reason
+        supervisor.start({"clone": str(clone)})
+        _join(supervisor)
+
+    def test_an_offline_run_ends_in_error_not_done(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._start_offline(supervisor, tmp_path, monkeypatch, reason="the factory raised")
+        st = supervisor.status()
+        assert st["status"] == R.STATUS_ERROR, st
+        assert st["status"] != R.STATUS_DONE
+        # The reason must reach the field the UI actually renders, not just a log line.
+        assert "the factory raised" in st["error"]
+
+    def test_the_offline_reason_is_surfaced_when_the_run_starts(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Not only at the end: the operator watching the feed sees it immediately."""
+        self._start_offline(supervisor, tmp_path, monkeypatch, reason="the factory raised")
+        errors = [e for e in supervisor.status()["activity"] if "error" in e]
+        assert any("OFFLINE" in str(e["error"]) for e in errors), errors
+
+    def test_a_run_with_a_live_runner_still_ends_done(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control. An empty ``_offline_reason`` must keep the success path intact --
+        a fix that reports every quiesced run as an error is a different bug, not this one."""
+        self._start_offline(supervisor, tmp_path, monkeypatch, reason="")
+        st = supervisor.status()
+        assert st["status"] == R.STATUS_DONE, st
+        assert st["error"] == ""
+
+    def test_the_terminal_state_is_persisted(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``RunState`` is in-memory only, so without a durable record the outcome dies
+        with the process and a restart shows no trace that a run ended at cycle 0."""
+        self._start_offline(supervisor, tmp_path, monkeypatch, reason="the factory raised")
+        record = json.loads(R._terminal_record_path().read_text(encoding="utf-8"))
+        assert record["status"] == R.STATUS_ERROR
+        assert "the factory raised" in record["error"]
+        assert record["offline_reason"] == "the factory raised"
+        assert record["cycle"] == 0
+
+    def test_a_fresh_supervisor_reports_the_persisted_failure(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The reload. A new supervisor is what a restarted gateway has, and it must still
+        be able to say what happened rather than reporting a blank ``idle``."""
+        self._start_offline(supervisor, tmp_path, monkeypatch, reason="the factory raised")
+        revived = R.RunSupervisor()
+        st = revived.status()
+        assert st["status"] == R.STATUS_ERROR, st
+        assert "the factory raised" in st["error"]
+
+    def test_the_record_lands_in_the_workspace_the_run_started_in(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repository retarget must not move a finished run's outcome to another workspace.
+
+        `_terminal_record_path()` resolves `store.results_dir()`, which is scoped to the ACTIVE
+        repository+branch. The terminal write happens after the status is already terminal, so
+        the run reads as non-active and `routes._refuse_while_running` admits a retarget in
+        exactly that window. Resolving the path at write time therefore filed the outcome under
+        whichever repository happened to be selected by then, and left the run's own workspace
+        with no record. Raised by the GPT review of this branch.
+        """
+        clone = _tiny_repo(tmp_path / "clone")
+        release = threading.Event()
+
+        class _BlockingDriver:
+            """Parks in ``run`` so the retarget lands while the run is genuinely in flight."""
+
+            def run(self, **_kw: Any) -> Any:
+                release.wait(timeout=10.0)
+                return _FakeStats()
+
+            def request_stop(self) -> None:
+                release.set()
+
+        monkeypatch.setattr(supervisor, "_build_driver", lambda _cfg: _BlockingDriver())
+        supervisor._offline_reason = "the factory raised"
+        started_in = R._terminal_record_path()
+        supervisor.start({"clone": str(clone)})
+
+        # Retarget the app at the repository the run was NOT started against.
+        store.write_json_atomic(
+            store.config_path(), {"target_display": "owner/somewhere-else", "branch": "main"}
+        )
+        retargeted_to = R._terminal_record_path()
+        # The premise: the two workspaces really are different directories, so this test would
+        # be vacuous if `workspace_key()` ever stopped depending on the configured target.
+        assert retargeted_to != started_in
+
+        release.set()
+        _join(supervisor)
+        assert started_in.exists(), "the outcome did not land in the run's own workspace"
+        assert not retargeted_to.exists(), "the outcome leaked into the retargeted workspace"
+
+    def test_a_failing_run_also_persists_its_terminal_record(
+        self, supervisor: R.RunSupervisor, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The durable record covers the ordinary failure path too, not only the offline one."""
+        clone = _tiny_repo(tmp_path / "clone")
+
+        class _ExplodingDriver:
+            def run(self, **_kw: Any) -> Any:
+                raise RuntimeError("ruler not trusted")
+
+            def request_stop(self) -> None:
+                pass
+
+        monkeypatch.setattr(supervisor, "_build_driver", lambda _cfg: _ExplodingDriver())
+        supervisor.start({"clone": str(clone)})
+        _join(supervisor)
+        record = json.loads(R._terminal_record_path().read_text(encoding="utf-8"))
+        assert record["status"] == R.STATUS_ERROR
+        assert "ruler not trusted" in record["error"]
+
+    def test_an_extreme_persisted_counter_does_not_wedge_the_app(self, tmp_path: Path) -> None:
+        """`1e309` on disk is `float('inf')` in memory, and `int(inf)` raises OverflowError --
+        which a `(TypeError, ValueError)` tuple does NOT catch. Raised on the event loop inside
+        the process-wide singleton, and `get_supervisor()` caches only on success, so one such
+        record would 500 EVERY `GET /run` for the life of the process, not just the first.
+        Raised by the GPT review of this branch.
+        """
+        R._terminal_record_path().parent.mkdir(parents=True, exist_ok=True)
+        R._terminal_record_path().write_text(
+            '{"status": "error", "error": "boom", "cycle": 1e309}', encoding="utf-8"
+        )
+        # Constructing must not raise, and must not be reported as a real run.
+        assert R.RunSupervisor().status()["status"] == R.STATUS_IDLE
+
+    def test_a_non_finite_timestamp_cannot_poison_the_run_response(self, tmp_path: Path) -> None:
+        """The sibling of the counter crash, from the SAME input. `inf` sails through
+        `_pos_float`'s `> 0` guard, and `json.dumps(inf)` emits the literal `Infinity` -- not
+        valid JSON, so the browser's `JSON.parse` rejects the whole `GET /run` payload and the
+        app shows nothing. Fixing only the counter would leave this live.
+        """
+        R._terminal_record_path().parent.mkdir(parents=True, exist_ok=True)
+        R._terminal_record_path().write_text(
+            '{"status": "error", "error": "boom", "started_at": 1e309}', encoding="utf-8"
+        )
+        status = R.RunSupervisor().status()
+        # Round-tripping through STRICT json is the real assertion: `allow_nan=False` rejects
+        # exactly what a browser rejects.
+        json.loads(json.dumps(status, allow_nan=False))
+
+    def test_a_non_terminal_persisted_record_is_ignored(self, tmp_path: Path) -> None:
+        """A stale or hand-edited ``running`` record must not resurrect a run with no thread
+        behind it -- that is the UI-spins-forever lie ``status()`` already guards against."""
+        R._terminal_record_path().parent.mkdir(parents=True, exist_ok=True)
+        R._terminal_record_path().write_text(
+            json.dumps({"status": R.STATUS_RUNNING, "run_id": "run-1"}), encoding="utf-8"
+        )
+        assert R.RunSupervisor().status()["status"] == R.STATUS_IDLE
+
+    def test_a_corrupt_persisted_record_leaves_the_supervisor_idle(self, tmp_path: Path) -> None:
+        """Startup hydration is best-effort: it runs inside the process-wide singleton every
+        run route resolves through, so it must degrade rather than break run reporting."""
+        R._terminal_record_path().parent.mkdir(parents=True, exist_ok=True)
+        R._terminal_record_path().write_text("{not json", encoding="utf-8")
+        assert R.RunSupervisor().status()["status"] == R.STATUS_IDLE
+
+    def test_build_runner_records_why_it_went_offline(
+        self, supervisor: R.RunSupervisor, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The real ``_build_runner``: going offline must leave a reason behind, because the
+        ``logger.warning`` it already emits goes to the process's stdout/stderr pipe, which a
+        supervised gateway does not capture into its log file."""
+        from kiro_crew.apps.builtins.auto_improvement.spine import agent_runner as AR
+
+        monkeypatch.setattr(AR.SessionAgentRunner, "available", staticmethod(lambda: False))
+        assert supervisor._build_runner(stop_check=lambda: False) is None
+        assert supervisor._offline_reason
+        assert "available" in supervisor._offline_reason
+
+
 class TestStop:
     def test_stop_on_an_idle_supervisor_is_a_noop(self, supervisor: R.RunSupervisor) -> None:
         result = supervisor.stop()


### PR DESCRIPTION
## 1. What is the problem?

Starting an Auto-Improvement run on a host where the agent runner cannot be constructed
produces a run that does zero work and then reports **success**.

`RunSupervisor._build_runner()` returns `None` on three deliberate fail-closed branches
(credentials unconfined, the tool-restricted discovery agent cannot be registered, no
provider-backed runner available). With `agent_runner=None` the github_repo profile's
discovery early-returns `DiscoveryResult(candidates=[], ...)`, so every cycle finds
nothing, the budget's quiescence break fires after `quiesce_after` empty cycles, and
`driver.run()` returns its stats **cleanly**. `_run_loop` took that clean return as
success and set `STATUS_DONE` with `error=""`.

Two things then made it undiagnosable:

- the only line naming the cause was a `logger.warning`, which on a toolbox-supervised
  gateway goes to the process's stdout/stderr pipe rather than into `gateway.log`;
- `RunState` is in-memory only, so a poll after a restart reported `idle` with no trace
  on disk that a run had ended at cycle 0, or why.

## 2. Why this issue matters to the user

The operator presses **Start Run**, sees `run-... starting`, and the button reverts to
Stopped with no message. `done` is not a neutral word here: it is what the UI, and every
downstream reader of the run status, takes as "this worked". A run that could not even
*look* became indistinguishable from a run that looked and found nothing -- and the
second is the one thing this run cannot have done. Because the offline condition is
deterministic (a config or registration state, not a transient), the loop stays
permanently silent: every Start produces another `done` run that improves nothing, with
no signal telling the operator what to fix.

## 3. How our fix solves it -- from symptom to root cause

Symptom (`Stopped`, no message) -> `_run_loop` reports `STATUS_DONE` on a clean
`driver.run()` return -> the return IS clean because quiescence is the designed exit for
"no candidates" -> there are no candidates because `agent_runner is None` -> the reason
for `None` exists only in a log line nobody captures, and no terminal state is written
anywhere durable.

The fix closes it at both ends of that chain.

**Surfacing.** `_build_runner()` now records *why* it went offline at each of its three
offline exits, and clears the field on the online path so a reason cannot leak into a
later run whose runner came up. `start()` copies that reason onto the run's `RunState`
and appends it to the activity feed **immediately**, so the operator sees it when the run
begins rather than only when it ends. `_run_loop` then ends an offline run in
`STATUS_ERROR` instead of `STATUS_DONE`.

**Why `STATUS_ERROR` and not a new `offline` status.** This was the product call the
triage comment flagged, so here is the reasoning rather than just the outcome:

- `error` is the **only** terminal status the UI renders a message for. `SetupPanel.tsx`
  reads `running ? ... : run?.status === 'error' ? run?.error : idleStatus`, so a novel
  status value falls through to the **idle** label -- the operator would still see
  nothing, which reproduces the exact defect being fixed. Making a new status visible
  would need backend + frontend + 12 i18n catalogs; reusing `error` is visible today.
- **No retry storm is possible.** The concern with a hard failure is a caller that
  retries on any non-DONE. There is no such caller: the only `supervisor.start()` call
  site is the `POST /run` handler (a human pressing Start), and `app.json` declares no
  crons. The one backend consumer, `routes._ACTIVE_RUN_STATUSES`, is
  `{running, calibrating, stopping}`, so `error` and a hypothetical `offline` are treated
  **identically** (inactive) by it.
- It matches the app's existing vocabulary: the sibling subsystem already records an
  absent runner as `STATUS_ERROR` with `runner unavailable: ...`
  (`pr_watchers._run_watcher`). And `status()` already *derived* `STATUS_ERROR` from a
  non-empty `error`, so this is the state the existing machinery implied.

**Persisting.** The terminal status, error and counters are written to
`results/run.state.json` and read back once at supervisor construction, so a restarted
gateway can still say what happened. A **sibling** file rather than a field in
`run.meta.json`, deliberately: that document is owned by `spine/archive.py` and written
from inside `driver.run()`, so an offline run may never reach the write at all -- a
record that is missing precisely in the case it exists to explain is not a record. Only
terminal statuses are accepted on read-back, so a stale or hand-edited `running` record
cannot resurrect a run with no thread behind it.

**The record is bound to the run's own workspace**, at the instant `_build_driver` binds
the driver's `archive_root`, rather than resolved at the terminal write.
`_terminal_record_path()` resolves `store.results_dir()`, which is scoped to the ACTIVE
repository+branch -- and by the time the write runs the status is already terminal, so the
run reads as non-active and `routes._refuse_while_running` admits a repository retarget in
exactly that window. Resolving late could file a finished run's outcome under a different
repository and leave its own workspace with no record. Binding both paths at one instant
means the record and the archive can never land in different workspaces.

**Reading the record back cannot wedge the app.** `_hydrate_terminal_record` runs inside
the process-wide singleton, and `get_supervisor()` caches only on success, so one raise
there would 500 **every** subsequent `GET /run`, not just the first. Its "never raises"
promise is therefore structural -- the whole body is inside the `try`, not just the read --
and two concrete non-total paths are closed: `_as_count` catches `OverflowError` (`json`
turns `1e309` into `float('inf')` and `int(inf)` raises it, which a
`(TypeError, ValueError)` tuple does not catch), and a record carrying any **non-finite**
number is declined as corrupt rather than coerced. The second is not decoration: `inf`
sails through `_pos_float`'s `> 0` guard into a timestamp, and `json.dumps(inf)` emits the
literal `Infinity`, which is not valid JSON -- the browser's `JSON.parse` rejects the whole
`GET /run` payload, so fixing only the counter would have left a live way to blank the app.

Two details worth naming for review:

- The offline outcome is recorded **through `_fail`**, not by assigning `_state.error`
  directly. `_fail` is the single redaction site for anything reaching `GET /run`, and
  `test_every_terminal_error_site_goes_through_the_helper` enforces that. The first draft
  of this change did assign directly and that guard caught it; it is satisfied properly
  rather than exempted, via a purpose-built `AgentRunnerOffline` whose name is public
  because `_fail` renders the exception class name to the operator.
- The record is snapshotted under `_lock` and written **outside** it, because
  `write_json_atomic` fsyncs and this module's contract is that the lock is never held
  across blocking I/O.

## 4. What tests we did

**Which code was under test.** A green paste does not show whose module ran, so this is
stated explicitly: the evidence below comes from
`python -m pytest <file> -p no:randomly -q` run from the worktree root, and a pytest
plugin that reports `runner.__file__` after collection confirms every run imported
`.../kirocrew-fix-6566/src/.../backend/runner.py` -- the branch's own file, carrying its
new `record_path` field and `AgentRunnerOffline` symbol. This was re-confirmed by running
the three load-bearing mutations a second time with `PYTHONPATH=<worktree>/src` set
explicitly: identical reddening, identical imported path.

The mechanism is `setup.cfg` (`[tool:pytest]`, `pythonpath = src`), which pytest resolves
against the rootdir -- and because `setup.cfg` is tracked and therefore present in the
worktree, the rootdir IS the worktree, so `src` is prepended ahead of any editable install by
an explicit ini setting. (An earlier revision of this section credited pytest's "basedir
insertion" instead. That was wrong, and the correction strengthens the claim rather than
weakening it: basedir insertion depends on `__init__.py` layout, an ini setting does not.
The same revision reported that a bare import raises `ModuleNotFoundError` and concluded
there was "no reachable copy" of the package anywhere. That observation is real but narrow --
a standalone script gets no rootdir and no ini file, and on this interpreter the only
editable `.pth` points at a directory that no longer exists -- so it says nothing about
another checkout being unreachable in general. Neither claim is load-bearing: the provenance
plugin and the explicit-`PYTHONPATH` re-run above establish the conclusion on their own.)

Twelve tests, each mutation-verified. The mutation is stated and confirmed to redden -- and
each newly-red test was checked to have failed on an ASSERTION about the value rather than on
an exception, because a mutation that changes whether the predicate RUNS instead of what it
ANSWERS can redden broadly while proving nothing. Nine are pure `AssertionError`. Three are
exception-shaped BY DESIGN, named here so the claim is checkable rather than blanket: the
hydration mutation pins "this must never raise" (a raise inside the process-wide supervisor
would 500 every subsequent `GET /run`), and the two non-finite mutations use
`json.dumps(status, allow_nan=False)` as the probe, which rejects exactly what a browser's
`JSON.parse` rejects.

| mutation | reddens |
| --- | --- |
| run loop ignores `offline_reason` (reports DONE again) | `test_an_offline_run_ends_in_error_not_done`, `test_the_terminal_state_is_persisted`, `test_a_fresh_supervisor_reports_the_persisted_failure` |
| success branch does not persist | `test_the_terminal_state_is_persisted`, `test_a_fresh_supervisor_reports_the_persisted_failure`, `test_the_record_lands_in_the_workspace_the_run_started_in` |
| no hydration at startup | `test_a_fresh_supervisor_reports_the_persisted_failure` |
| a persisted `running` record is restored | `test_a_non_terminal_persisted_record_is_ignored` |
| the reason is not surfaced at start | `test_the_offline_reason_is_surfaced_when_the_run_starts` |
| `_build_runner` records no reason | `test_build_runner_records_why_it_went_offline` |
| the failure branch does not persist | `test_a_failing_run_also_persists_its_terminal_record` |
| EVERY run reported offline (over-firing) | `test_a_run_with_a_live_runner_still_ends_done` |
| *compound*: `isinstance` guard removed **and** the wide `try` narrowed | `test_a_corrupt_persisted_record_leaves_the_supervisor_idle` |
| record path resolved at write time | `test_the_record_lands_in_the_workspace_the_run_started_in` |
| non-finite guard removed | `test_an_extreme_persisted_counter_does_not_wedge_the_app`, `test_a_non_finite_timestamp_cannot_poison_the_run_response` |
| *compound*: non-finite guard removed **and** `_as_count` not total | `test_a_non_finite_timestamp_cannot_poison_the_run_response` |

Two entries are deliberately compound, and that is a property of the code rather than a
weak test: the corrupt-record path is now defended by three independent layers
(`store.read_json`'s existing swallow, the `isinstance` guard, and the wide `try`), so no
single-point mutation can redden it -- removing two of them does. Likewise `_as_count`'s
`OverflowError` catch sits *beneath* the non-finite guard as a helper-level floor, so it
only becomes observable once the guard above it is gone.

The two properties the issue asks for are asserted separately: the state is **not** `done`
(`assert st["status"] != R.STATUS_DONE`), and it **survives a reload** -- a second
`RunSupervisor()`, which is what a restarted gateway has, still reports the failure and
its reason.

Suites run locally, one file at a time:

- `tests/test_runner.py` -- 32 passed, 5 skipped (the pre-existing userns-gated classes)
- `tests/test_dogfood_learnings.py` -- 303 passed (includes the redaction drift guard)
- `tests/test_shutdown_stops_run.py` -- 2 passed
- `test/test_ai_runner_coverage.py` -- 97 passed
- `test/test_ai_backend_routes_coverage.py` -- 155 passed

Gates: `check_black_formatting.py` passed with both files in scope; `isort` and `flake8`
clean; the `subprocess_encoding` / `agent_sdk_boundary` / `sync_io_in_async` /
`lockdown_before_publish` gates pass. `mypy src/kiro_crew/` reports **zero** errors in
`auto_improvement`; its 4 errors are pre-existing boto3-stub drift in `transcribe.py` and
`ops_mission_control/.../cloudwatch.py`, neither of which this change touches.

## 5. Any other suggestions on the work

This is `Refs`, not `Closes`, and the count is the answer:
`closingIssuesReferences` is deliberately 0. The issue accumulated several distinct
mechanisms and this change fixes only the one in its title -- the terminal state and its
persistence. Untouched, and each a separate change under `spine/`:

- `SessionAgentRunner.available()` still swallows the provider-factory exception with a
  bare `except Exception: return False`. The triage comment already noted this piece is
  self-contained and mechanical; it is the natural follow-up, and it would make the
  reason this change now surfaces *specific* rather than "config load or factory
  construction raised".
- `ensure_agent_registered()` fails closed on a whole-file byte compare against an agent
  file the platform itself rewrites (global MCP-server merge), which is the reported
  real-world trigger for going offline in the first place.
- The discovery-step findings: `max_turns=16` exhausted by reading before the agent
  emits, and `_normalize_surface` reducing an emitted path to its basename and dropping
  it when that basename does not resolve at the clone root.

One behaviour deliberately **not** changed: a run still starts and burns its quiescence
cycles when the runner is offline, rather than being refused up front at `start()`.
Refusing would arguably be better product behaviour, but it changes `start()`'s contract
(today a 200 with a `run_id`) and is a wider change than the reported mechanism.

## Pattern harvest

Rule candidate: semgrep -- or, closer to this repo's habits, a `scripts/check_*.py` drift
guard in the family CI already runs.

Pattern: a fail-closed branch that returns a **falsy sentinel** (`None`, `False`, `[]`,
`""`) while making **no logging call**, or logging as its only record. The sentinel then
travels onward as ordinary data and the failure has no durable trace. This one issue
contains two instances of the shape: `SessionAgentRunner.available()` is literally
`except Exception: return False` with nothing logged (still open, untouched here), and
`_build_runner()` returned `None` with the reason recorded *only* in a `logger.warning`
that a supervised gateway does not capture. The mechanical form worth encoding first is
the narrow one: an `except Exception:` handler whose body is a bare `return <falsy>` and
contains no `log`/`logger` call.

The broader rule the mechanical one approximates, for the review prompt / AGENTS.md: when
a function signals "I could not do the work" by RETURNING a sentinel instead of raising,
whatever reports the operation's outcome must **consume** that sentinel. A work loop whose
normal exit is also its no-work exit cannot tell "found nothing" from "could not look", so
reporting its clean return as success manufactures a success nobody can back. The
reviewable smell is a terminal `status = <SUCCESS>` assignment on a path where a
capability flag captured during setup is never read again.

Second, narrower candidate surfaced by review of this branch: `except (TypeError,
ValueError)` around an `int()` / `float()` coercion of **externally-sourced** data is
incomplete -- `int(float('inf'))` raises `OverflowError`, and `json.loads` produces `inf`
from `1e309`. A grep for that exact two-name tuple near a numeric coercion of file, HTTP,
or agent input is mechanical and would have caught this one.

Refs #6566
