### PR TITLE
refactor(apps): drop two shadow imports and unchain a timeout ternary

### DIFF
--- a/src/kiro_crew/apps/lifecycle.py
+++ b/src/kiro_crew/apps/lifecycle.py
@@ -234,7 +234,13 @@ class LifecycleDispatcher:
         if not tasks:
             return True
 
-        wait_timeout = timeout if timeout is not None else (_HOOK_TIMEOUT_SEC if bounded else None)
+        wait_timeout: float | None
+        if timeout is not None:
+            wait_timeout = timeout
+        elif bounded:
+            wait_timeout = _HOOK_TIMEOUT_SEC
+        else:
+            wait_timeout = None
         done, pending = await asyncio.wait(tasks, timeout=wait_timeout)
         if done:
             # Do not rely on done-callback scheduling order: asyncio.wait may

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -1797,7 +1797,6 @@ async def handle_open_app(request: web.Request) -> web.Response:
         return web.json_response({"error": denied, "code": "app_execution_denied"}, status=403)
 
     # Detect cloud/remote — no DISPLAY and not macOS desktop
-    import os
     import platform
 
     is_local = (
@@ -2713,11 +2712,7 @@ def _open_ui_file(name: str, file_path: str) -> tuple[int, os.stat_result] | str
         # has no link to refuse. Checked on the DESCRIPTOR, which is what makes
         # it race-free. Inline rather than `pinned_fs.refuse_hardlink_alias`
         # for the same double-close reason `_read_declared_art` documents.
-        if (
-            not stat.S_ISREG(st.st_mode)
-            or st.st_nlink != 1
-            or st.st_size > _UI_MAX_BYTES
-        ):
+        if not stat.S_ISREG(st.st_mode) or st.st_nlink != 1 or st.st_size > _UI_MAX_BYTES:
             os.close(fd)
             return "not_found"
     except OSError:

--- a/src/kiro_crew/apps/scaffold.py
+++ b/src/kiro_crew/apps/scaffold.py
@@ -497,7 +497,6 @@ def scaffold_app(
     if not description:
         description = f"A Kiro Crew app: {display_name}"
     if not author:
-        import os
         author = os.environ.get("USER", "developer")
 
     app_dir = output_dir / name


### PR DESCRIPTION
## Problem / Motivation

The `apps` module carried the three sites the module-simplification detector still
reports there, all of them pure readability debt:

- `src/kiro_crew/apps/routes.py` and `src/kiro_crew/apps/scaffold.py` each
  re-imported `os` *inside a function* while the module already binds `os` at
  module scope. The inner statement re-binds the same `sys.modules` singleton, so
  it does nothing but make a reader stop and check whether it does.
- `LifecycleDispatcher.stop_detached_startup_hooks` chose its `asyncio.wait`
  deadline through a nested ternary
  (`timeout if timeout is not None else (_HOOK_TIMEOUT_SEC if bounded else None)`),
  which packs a three-way decision on a fail-closed teardown path into one 98-column
  line.

## Why it matters

`stop_detached_startup_hooks` is the trust-withdrawal path: a wrong deadline here is
the difference between "teardown retains trust and returns a retryable failure" and
"teardown reports success with a live `AppContext`". A reader auditing that contract
should be able to see the three cases without unpacking a nested conditional. The two
dead imports are smaller but cost the same kind of attention — each one invites the
reader to wonder what lazy-import constraint they are protecting, when the answer is
none.

## What changed (motivation → approach → change)

Behaviour-preserving only. No behaviour was intended to change and none did.

**Two shadow imports deleted.** `os` is bound at module scope in both files
(`routes.py:16`, `scaffold.py:10`), unconditionally — not under `TYPE_CHECKING`, not
under a platform branch, not in a `try/except ImportError`. So the in-function
statement was a strict no-op and its removal adds no module-level import and no
gateway boot cost.

Two things deliberately **not** touched, because they look like the same pattern and
are not:

- `routes.py` keeps its in-function `import platform`. The module scope binds
  `platform_compat`, never `platform`, so that one is a genuine lazy import and
  deleting it would raise `NameError`.
- `scaffold.py:176`'s `import os` stays: it is inside `_BACKEND_TEMPLATE`, the
  source text scaffolded apps get written, not code this module runs.

Neither deleted line was a `from X import Y` (which resolves at call time and can be
observed by a test that patches the attribute on the source module), and no test
anywhere patches `kiro_crew.apps.routes.os` or `kiro_crew.apps.scaffold.os`.

**The nested ternary became `if`/`elif`/`else`**, same operands in the same order, so
branch precedence and short-circuiting are unchanged. Three details are worth naming:

- **Keeping the guard as `is not None` rather than truthiness is load-bearing, and
  not hypothetically.** `dispatch_shutdown` calls this method with
  `bounded=True, timeout=_GATEWAY_STARTUP_CLEANUP_TIMEOUT_SEC`, and that constant is
  `0.0` (`lifecycle.py:41`) — a deliberate non-blocking poll so that shutdown only
  observes already-terminal tasks. An `if timeout:` rewrite would have fallen through
  to the `bounded` arm and turned that into a 30-second wait *per enabled app* on
  every gateway shutdown. The diff tests `is not None`, so `0.0` still selects the
  explicit-timeout arm.
- The new form still reads `_HOOK_TIMEOUT_SEC` as a **module global at call time**,
  which is what `test/test_lifecycle_hooks.py` relies on when it monkeypatches that
  constant (14 tests do).
- The `wait_timeout: float | None` annotation is **not required by mypy today** —
  verified by deleting it and re-running mypy, which still passes, because the first
  assignment is `timeout`, itself already `float | None`. It is kept anyway: it states
  the widened type at the site, and it stops a later branch reorder (any ordering that
  assigns the `float` arm first) from narrowing the inference to `float` and reddening
  the `None` arm.

**One black reflow rode along, and it is worth naming.** `routes.py` was already
unformatted on `main` *and* absent from `.github/black-baseline.txt`, so editing the
file at all pulls it into the black gate's scope and the gate then requires the whole
file formatted. That collapses one untouched `or` chain in `_open_ui_file` from five
lines onto one — identical operands, identical order, identical short-circuiting, and
the `os.close(fd)` / `return "not_found"` body and enclosing `try`/`except OSError`
are untouched. The alternative was dropping `routes.py` from the PR and leaving a
detected site behind; formatting a file the repo's own gate says should be formatted
is the better trade.

### Prohibitions observed

- No in-function `from X import Y` deleted.
- No lazy import hoisted; nothing new is eager on the gateway boot path.
- No security keystone file in the diff — no matcher, deny rule, guard, SEL audit
  emit, redaction call or governance intersection changed shape.

## Tests

No new tests. This diff adds no behaviour to lock in, and the existing suite already
pins the paths it touches — most directly the 14 tests in
`test/test_lifecycle_hooks.py` that monkeypatch `_HOOK_TIMEOUT_SEC` and exercise
`stop_detached_startup_hooks` in both its bounded and unbounded shapes, which is
exactly the decision the rewritten branch makes.

## Manual verification

N/A — unit coverage sufficient; this is a behaviour-preserving refactor with no
runtime surface of its own.

Gates run locally on the Python 3.12 CI-parity venv, all exit 0: `flake8`,
`isort --check-only`, `mypy` (1,277 files), `check_black_formatting.py`,
`check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
`docs-lint.sh`, `check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`.

Targeted tests — the 21 test modules that import `apps.lifecycle`, `apps.routes` or
`apps.scaffold` — pass: **1,679 passed, 1 skipped, 0 failed**.

One failure appeared on a wider ad-hoc selection and was attributed, not assumed:
`test_token_auth.py::test_ambiguous_app_and_window_names_cannot_collide` exercises
`dashboard.server.discover_app_window_entries`, which this diff does not touch. It
passes in isolation, and a pristine `origin/main` worktree run with the same file
selection fails **four** tests including that one — a superset of this branch's, so
the cause is selection ordering on `main`, not this diff.

## Related Issues

no linked issue: routine module-simplification sweep, not tracked by an issue.

## Review

Reviewed before opening by a five-lens read-only fleet: AUTOSDE blocking rules,
behaviour equivalence, import semantics, security keystone / boot path, and comment
accuracy plus the deterministic `code-review.yml` grep rules. All five returned no
findings, so there was nothing for the refutation pass to contest.

Two of their *positive* observations did change this PR, and are worth surfacing
because both corrected me rather than the code:

- The `timeout=0.0` production path above. I had described `is not None` as merely
  matching the original; a lens found the actual caller that makes it load-bearing.
- My first commit message claimed the `float | None` annotation was required by mypy.
  It is not — I checked by removing it and re-running mypy, which passes. The message
  and the paragraph above now say so, and the annotation is kept on its real merit.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — three Python files under
`src/kiro_crew/apps/`, nothing under `website/`, so there is no rendered surface and
the `changes` job reports `only_backend=true`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
