### PR TITLE
fix(security): close 3 watchdog findings (stub prefix, ReDoS, md)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -3352,7 +3352,16 @@ def _md_inline_code(text: str) -> str:
     content both begins and ends with a space or newline (unless the content is
     nothing but whitespace, which is left alone). One space of padding -- which
     that same rule then removes -- is what keeps such content intact.
+
+    A line break inside the content is collapsed to a space FIRST. A code span is
+    inline, so it cannot span a paragraph: a newline in the content ends the
+    enclosing paragraph and everything after it is parsed as fresh markdown --
+    outside the fence, and so past :func:`_md_escape_inline`,
+    :func:`_md_link_target` and the redaction gate. Collapsed rather than emitted
+    as a fenced block, because a block would change the document structure at
+    every call site while the escape is what actually has to hold.
     """
+    text = re.sub(r"\r\n?|\n", " ", text)
     fence = _md_backtick_fence(text, 1)
     first, last = text[:1], text[-1:]
     edge_stripped = first in (" ", "\n") and last in (" ", "\n") and text.strip() != ""
@@ -3411,8 +3420,18 @@ def _md_one_line(text: str) -> str:
     would be eaten by a blanket whitespace collapse. Only a newline has to go,
     and a code span's own padding sits inside its backticks where no newline can
     reach it.
+
+    Split on the line breaks rather than matched with a regex. The pattern this
+    replaces made the leading whitespace run and the newline anchor compete for
+    the same characters, so on a long newline-FREE whitespace run -- content a
+    provider controls, bounded only by the 8MiB fetch cap -- the engine retried
+    every split of that run at every starting offset before failing. A split,
+    strip and join reads each character a fixed number of times. The collapsed
+    set is unchanged: a maximal whitespace run containing at least one line break
+    becomes one space, and the whitespace class strip uses is the one the pattern
+    matched.
     """
-    return re.sub(r"\s*\n\s*", " ", text).strip()
+    return " ".join(seg for seg in (line.strip() for line in text.split("\n")) if seg)
 
 
 def _md_guard_line_expansion(text: str, per_line: int) -> None:

--- a/src/kiro_crew/mcp_gateway/gatewayd.py
+++ b/src/kiro_crew/mcp_gateway/gatewayd.py
@@ -60,7 +60,12 @@ from kiro_crew.mcp_caller import _parent_pid as _ppid_fn
 from kiro_crew.mcp_caller import new_tenant_nonce
 from kiro_crew.mcp_gateway import credwatch, hazards, socketsec, tool_surface, transport
 from kiro_crew.mcp_gateway.apps import sweep_spool as apps_sweep_spool
-from kiro_crew.mcp_gateway.backend import Backend, BackendGone, spawn_backend
+from kiro_crew.mcp_gateway.backend import (
+    INTERNAL_STUB_PREFIXES,
+    Backend,
+    BackendGone,
+    spawn_backend,
+)
 from kiro_crew.mcp_gateway.backend_tmp import sweep_all_backend_tmp
 from kiro_crew.mcp_gateway.breaker import CircuitBreaker
 from kiro_crew.mcp_gateway.hashing import hash_effective_env, non_secret_env
@@ -1842,6 +1847,33 @@ def _audit_peer_identity_denied(reason: str, peer_pid: int | None, stub_uuid: st
         logger.debug("SEL audit emit for peer identity denial failed", exc_info=True)
 
 
+def _audit_reserved_stub_prefix_denied(stub_uuid: str) -> None:
+    """SEL audit: a registrant naming a reserved internal stub prefix was refused.
+
+    The prefix decides whether `Backend` treats a request as the gateway's own
+    and skips the model-visibility filter, so claiming one is an attempt to
+    acquire an exemption rather than a malformed frame -- the same class of
+    access decision as :func:`_audit_peer_identity_denied`, and recorded the
+    same way. The sibling rejects on this path (a malformed Register, an empty
+    stub_uuid) stay WARNING-only because they are schema failures with no
+    control being evaded.
+
+    ``stub_uuid`` is peer-supplied, but the SEL serializes each event with
+    ``json.dumps``, which escapes the control characters a forged log line would
+    need, so it is recorded as received rather than pre-sanitized.
+    """
+    try:
+        SecurityEventLog().log_api_access(
+            caller="unverified-peer",
+            operation="mcp-gateway.reserved-stub-prefix-denied",
+            outcome="denied",
+            source="gateway",
+            resources=f"stub_uuid={stub_uuid}",
+        )
+    except Exception:  # pragma: no cover — audit must never break the handler
+        logger.debug("SEL audit emit for reserved stub prefix denial failed", exc_info=True)
+
+
 async def _apply_claim(
     frame: dict[str, Any], pool: Optional["BackendPool"] = None
 ) -> dict[str, Any]:
@@ -2480,6 +2512,23 @@ async def _handle_connection(
             {"type": "rejected", "reason": "missing stub_uuid"},
         )
         logger.warning("rejected Register: missing stub_uuid")
+        return
+
+    # A reserved prefix is the gateway's OWN marker: `Backend` treats any stub
+    # uuid starting with one as an internal request and skips both the MCP Apps
+    # render path and the model-visibility filter (`INTERNAL_STUB_PREFIXES`).
+    # That check is correct for requests the gateway mints itself, so the gap is
+    # here: a stub that simply NAMES itself with the prefix at registration
+    # inherits the exemption and can list tools the model is meant not to see.
+    # Refused at the door, because the prefix is not a namespace a client may
+    # enter.
+    if stub_uuid.startswith(INTERNAL_STUB_PREFIXES):
+        await _write_json_line(
+            writer,
+            {"type": "rejected", "reason": "reserved stub_uuid prefix"},
+        )
+        logger.warning("rejected Register: reserved stub_uuid prefix %r", stub_uuid)
+        _audit_reserved_stub_prefix_denied(stub_uuid)
         return
 
     caller = _caller_from_register(register)

--- a/test/test_gatewayd_more_coverage.py
+++ b/test/test_gatewayd_more_coverage.py
@@ -403,6 +403,48 @@ class TestControlFrames:
         await _handle(_ScriptedReader(_register_frame(stub_uuid="")), writer, _fake_pool())
         assert writer.frames() == [{"type": "rejected", "reason": "missing stub_uuid"}]
 
+    @pytest.mark.asyncio
+    async def test_register_naming_a_reserved_stub_prefix_is_rejected(self, peer_ok):
+        """`Backend` exempts an internally-prefixed stub uuid from the MCP Apps
+        render path AND the model-visibility filter, so a stub that merely NAMES
+        itself with the prefix would inherit both exemptions and be served tools
+        the model is meant not to see. The prefix is the gateway's own; refuse it
+        at registration."""
+        from kiro_crew.mcp_gateway.backend import INTERNAL_STUB_PREFIXES
+
+        assert INTERNAL_STUB_PREFIXES  # a silently empty tuple would pass vacuously
+        for prefix in INTERNAL_STUB_PREFIXES:
+            writer = _FakeWriter()
+            await _handle(
+                _ScriptedReader(_register_frame(stub_uuid=f"{prefix}deadbeef")),
+                writer,
+                _fake_pool(),
+            )
+            assert writer.frames() == [
+                {"type": "rejected", "reason": "reserved stub_uuid prefix"}
+            ], prefix
+
+    @pytest.mark.asyncio
+    async def test_reserved_stub_prefix_rejection_is_audited(self, peer_ok, monkeypatch):
+        """The refusal is an access decision, so it belongs in the SEL and not
+        only in the WARNING log.
+
+        Without this, the one connection someone tried to sneak an internal
+        exemption through is the one connection the security event log has no
+        record of -- the operator sees a denial that never happened rather than
+        one that did.
+        """
+        from kiro_crew.mcp_gateway.backend import INTERNAL_STUB_PREFIXES
+
+        audited: list[str] = []
+        monkeypatch.setattr(gw, "_audit_reserved_stub_prefix_denied", audited.append)
+        await _handle(
+            _ScriptedReader(_register_frame(stub_uuid=f"{INTERNAL_STUB_PREFIXES[0]}deadbeef")),
+            _FakeWriter(),
+            _fake_pool(),
+        )
+        assert audited == [f"{INTERNAL_STUB_PREFIXES[0]}deadbeef"]
+
 
 # --- registration bookkeeping ------------------------------------------------
 

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -677,6 +677,11 @@ _AUDIT_CASES = [
     ("_audit_pool_fallback", ("caller", "demo-mcp", "pool full"), "mcp-gateway.fallback"),
     ("_audit_pool_rejected", ("caller", "demo-mcp", "unknown target"), "mcp-gateway.ensure_backend"),
     ("_audit_prewarm_spawn", ("demo-mcp",), "mcp-gateway.prewarm-spawn"),
+    (
+        "_audit_reserved_stub_prefix_denied",
+        ("__app_call__deadbeef",),
+        "mcp-gateway.reserved-stub-prefix-denied",
+    ),
 ]
 
 

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -7764,6 +7764,35 @@ class TestAdfToMarkdown:
         adf = self._doc(self._para(self._text(" foo", [{"type": "code"}])))
         assert source._adf_to_markdown(adf) == "` foo`"
 
+    def test_newline_in_a_code_span_cannot_break_out_of_the_fence(self):
+        """A code span is inline, so a newline in its content ends the paragraph
+        and everything after it is parsed as fresh markdown -- outside the fence,
+        and so past the inline escape and the link-target scan."""
+        payload = "safe\n\n# Injected\n[x](javascript:alert(1))"
+        node = self._text(payload, [{"type": "code"}])
+        out = source._adf_to_markdown(self._doc(self._para(node)))
+        assert "\n" not in out
+        assert out == "`safe  # Injected [x](javascript:alert(1))`"
+
+    def test_carriage_return_in_a_code_span_is_collapsed_too(self):
+        """CommonMark ends a line on a bare CR and on CRLF, not only on LF."""
+        for raw in ("a\rb", "a\r\nb"):
+            out = source._adf_to_markdown(
+                self._doc(self._para(self._text(raw, [{"type": "code"}])))
+            )
+            assert out == "`a b`", raw
+
+    def test_folding_a_long_whitespace_run_is_linear(self):
+        """A provider-controlled newline-FREE whitespace run, bounded only by the
+        8MiB fetch cap, used to be folded by a pattern whose whitespace runs and
+        newline anchor competed for the same characters: 200k spaces took ~45s of
+        backtracking, per heading and per table cell. The budget is ~100x the
+        linear cost, so this fails only on a return to quadratic scanning."""
+        payload = " " * 200_000 + "x"
+        start = time.monotonic()
+        assert source._md_one_line(payload) == "x"
+        assert time.monotonic() - start < 2.0
+
     def test_empty_marked_text_emits_nothing(self):
         """A marked empty text node must not leave its bare delimiters behind."""
         for mark in ("strong", "em", "strike", "code"):


### PR DESCRIPTION
## Problem / Motivation

Three security findings, each verified live against `origin/main` before this branch was cut, in two unrelated subsystems:

1. **Model-hidden-tool filter bypass at stub registration (MEDIUM)** — `Backend` exempts any stub uuid starting with `INTERNAL_STUB_PREFIXES` from both the MCP Apps render path and the model-visibility filter (`backend.py:3294`). `_handle_stub_conn` rejected only an **empty** `stub_uuid`, so a registrant could simply name itself with the reserved prefix and inherit both exemptions.
2. **ReDoS in the markdown one-line fold (MEDIUM)** — `_md_one_line` folded with `re.sub(r"\s*\n\s*", " ", text)`. `\s` matches a newline too, so the two runs and the anchor compete for the same characters.
3. **Markdown code-span breakout (MEDIUM)** — `_md_inline_code` fenced ADF `code`-marked text but let **interior newlines** through verbatim.

## Why it matters

**#1** hands a registrant two exemptions it should never hold. The model-visibility filter is what withholds hidden tools from a `tools/list`, and its SEL audit is what records the withhold — so a stub that inherits the internal exemption is served the unfiltered surface *and* leaves no audit trail of the withhold that never happened.

**#2** is a denial of service on provider-supplied content. `_md_one_line` is called **per heading** (`:3501`) and **per table cell** (`:4007`), and the content is bounded only by the 8MiB fetch cap. Measured against this branch's base: 200k spaces took **45.3s** in a single call, 20k took 455ms. A document with many such cells stalls the handler for as long as the provider cares to make it.

**#3** is a full escape from the markdown sanitizer. A blank line inside the code content ends the enclosing paragraph, and everything after it is parsed as fresh markdown — **outside** the fence, and so past `_md_escape_inline`, `_md_link_target` and the redaction gate. Whatever those three exist to stop is reachable through it.

## What changed (motivation → approach → change)

**#1 `src/kiro_crew/mcp_gateway/gatewayd.py`.** The `backend.py:3294` guard is correct and is untouched — the gap is registration-side, so that is where the fix goes. Immediately after the existing empty-`stub_uuid` reject, and in the same shape, a `stub_uuid` starting with `INTERNAL_STUB_PREFIXES` is refused with `{"type": "rejected", "reason": "reserved stub_uuid prefix"}` plus a warning. `INTERNAL_STUB_PREFIXES` is imported from `backend` rather than re-spelled, so adding a prefix there keeps registration and interception in agreement.

The refusal is also **audited**, via a new `_audit_reserved_stub_prefix_denied` beside its closest sibling `_audit_peer_identity_denied`. This is the one reject on this path that is a security control rather than a schema check: a malformed Register (`:2413`) and an empty `stub_uuid` (`:2485`) stay WARNING-only because nothing is being evaded, whereas claiming a reserved prefix is an attempt to *acquire an exemption* — the same class of access decision as the `_audit_peer_denied` / `_audit_pool_rejected` family this module already records. Leaving it unaudited would also have contradicted this PR's own rationale above, which counts the missing SEL record as part of the harm.

The peer-supplied `stub_uuid` is recorded as received rather than pre-sanitized, and that was traced rather than assumed: `log_api_access` runs `resources` through `_redact_and_clip`, which redacts and clips but does **not** strip control characters, so the escaping comes from the writer — `sel.py:1094` serializes each event as `json.dumps(asdict(event)) + "\n"`, and JSON escapes CR/LF. A forged log line is not reachable, so a sanitizing pass would be dead code.

No false-positive risk, checked rather than assumed: the gateway's own internal stubs are attached **in-process** — `Backend.attach_stub` for `__app_call__` (`app_call.py:95`), `probe_tool_surface` for `__tool_surface__` — and never arrive as a Register frame over the socket. Verified by grepping every use of both prefixes.

**#2 `_md_one_line`.** Replaced the regex with `" ".join(seg for seg in (line.strip() for line in text.split("\n")) if seg)`. Split/strip/join reads each character a fixed number of times, so the pathological input is linear.

An intermediate pattern (`[^\S\n]*\n[^\S\n]*(?:\n[^\S\n]*)*`) was tried first and **measured 4x worse** — the leading run still backtracks through every offset. Recorded because it looks like the fix and is not one.

Output is unchanged, not merely believed to be: a differential harness compared old and new over 40,031 inputs — 31 hand-written edge cases plus 40,000 random strings over an alphabet of `a`, space, `\t`, `\n`, `\r`, `\v`, `\f`, backtick, `\x85`, `\u00a0`, `\u2028`, `\x1c`, `\u3000` — with **zero** mismatches. That alphabet is load-bearing: `str.split("\n")` splits only on `\n`, where `str.splitlines()` would also split on `\v`, `\f` and `\r`, which the old pattern did **not** match.

| input | old | new |
| --- | --- | --- |
| 200k spaces + `x` | 45,349ms | 0.34ms |
| 20k spaces + `x` | 455ms | 0.04ms |

**#3 `_md_inline_code`.** One line, `text = re.sub(r"\r\n?|\n", " ", text)`, ahead of the fence computation, so every downstream step (fence length, boundary padding) sees content that cannot contain a line break. `\r\n?|\n` rather than `\n` alone because CommonMark ends a line on a bare CR and on CRLF too.

Collapsed rather than promoted to a fenced block: the caller is `_adf_apply_marks`, which composes an **inline** run, so a block would change the document structure at every call site — and the escape, not the rendering shape, is what has to hold.

**Scope note.** An earlier revision of this branch also carried a fix for the bare-name `kiro-cli` spawn in the gateway's unattended auto-update (`src/kiro_crew/slack/gateway.py`). **It is dropped here** because #7712 already owns that fix under #7704: same `resolve_kiro_cli()` approach, plus the `asyncio.to_thread` offload, plus the `cli_server.py` sibling call site and the `docs/system-specs/modules/cli.md` update this branch did not carry. Both touched the same lines, so a second copy would only conflict with it. The one thing this branch had that #7712 does not — an explicit `env=` on the spawn — is raised as a comment on #7712 rather than kept here.

## Tests

- `test_gatewayd_more_coverage.py::test_register_naming_a_reserved_stub_prefix_is_rejected` — iterates `INTERNAL_STUB_PREFIXES` (asserting it is non-empty first, so it cannot pass vacuously) and pins the exact reject frame for each prefix.
- `test_gatewayd_more_coverage.py::test_reserved_stub_prefix_rejection_is_audited` — pins that the **reject path** emits the SEL event, not merely that the helper exists.
- `test_mcp_gatewayd_coverage.py` `_AUDIT_CASES` — the new emitter joins the shared table, inheriting both contracts every sibling emitter is held to: the documented operation name, and that a `SecurityEventLog` failure never propagates to the caller.
- `test_source_providers.py::test_newline_in_a_code_span_cannot_break_out_of_the_fence` — `safe\n\n# Injected\n[x](javascript:alert(1))` yields a single-line span with no newline anywhere in the output.
- `test_source_providers.py::test_carriage_return_in_a_code_span_is_collapsed_too` — bare CR and CRLF, the two cases a `\n`-only fix would miss.
- `test_source_providers.py::test_folding_a_long_whitespace_run_is_linear` — 200k spaces under a 2.0s budget, ~100x the measured linear cost of 0.34ms, so it fails only on a return to quadratic scanning rather than on machine noise.

## Manual verification

- **Full suite on the affected surfaces**: `test_source_providers`, `test_gatewayd_more_coverage`, `test_gatewayd_diag`, `test_gatewayd_self_exit`, `test_mcp_gatewayd_coverage`, `test_source_providers_comment_guard`, `test_source_provider_plugin`, `test_slack_gateway`, `test_governance_updates`, `test_spawn_audit` → **1155 passed**.
- **Two failures are pre-existing, not this diff's**: `test_provider_executable_accepts_user_owned_install` and `..._symlinked_install` fail on this host from home ownership. Reproduced identically on `origin/main` in a clean `git worktree`, and they pass in this PR's own CI run — environmental, outside this diff.
- Gates: `flake8`, `isort`, `mypy --platform linux` clean. `black` — the two test files fail `--check` on `origin/main` too under Python 3.12 against a `py314` target, so it was scoped: black was run on a copy of each changed file and **no reformat hunk overlaps a line this branch adds**.
- Diff-scoped gates run with their base ref exported (`BRAND_BASE_REF`, `FOCUS_CUE_BASE_REF`, `CHANGELOG_BASE_REF`, `HARNESS_BASE_REF` = `git merge-base HEAD origin/main`) so they enforce rather than report — all four pass, each naming the base sha in its output. `docs-lint`: 259 files, pass. No doc or spec references the changed behaviour (grepped), so none needed updating.

### Revert-verify

Every guard was mutated back to the defect and confirmed to fail, then restored and confirmed to pass:

| finding | mutation | result |
| --- | --- | --- |
| #1 | delete the prefix reject | FAIL — `AssertionError: __app_call__` |
| #1 (audit) | delete the `_audit_reserved_stub_prefix_denied` call | FAIL — `assert [] == ['__app_call__deadbeef']` |
| #2 | restore `re.sub(r"\s*\n\s*", ...)` | FAIL — `assert (… - …) < 2.0` at **45.58s** |
| #3 | delete the collapse | FAIL — `assert '\n' not in '`safe\n\n\\# …'`, and the CR test on `ab` |

All four then pass on the restored tree, and each mutation script asserted the file was byte-identical to the original afterwards.

## Related Issues

no linked issue: the findings came from a security watchdog sweep rather than filed issues. The dropped fourth finding is tracked separately as #7704 and fixed by #7712.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a regex whose quantified run can also match its own anchor (`\s*\n\s*`, `.*X.*`), making the run and the anchor compete and the scan quadratic.

Finding #2 reads as obviously correct and is a DoS on attacker-controlled input. The mis-fix attempted here — a variant that measured 4x **worse** — shows the trap survives a careful first attempt, so the reviewable signal is the *shape* of the pattern, not the intent behind it. A review prompt that flags "quantifier whose character class contains the anchor it is searching for" would catch both the original and the bad fix.

Findings #1 and #3 are each a single missing check at a boundary, and the general lesson ("validate at the door, not only at the consumer") is already project doctrine — no new rule.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc references the changed behaviour
- [x] No secrets, credentials, or internal references in the diff
