### PR TITLE
refactor: split manifest publication from the pinned fixture copy

### DIFF
--- a/src/kiro_crew/pod/runtime.py
+++ b/src/kiro_crew/pod/runtime.py
@@ -1980,11 +1980,9 @@ def seed_home_from_scenario(cfg: PodConfig, name: str, scenario: str) -> bool:
                     )
                 _prepare_seeded_home_fd(home_fd)
                 return False
-            seed_mod.copy_fixture_into_dir_fd(
-                scenario,
-                home_fd,
-                before_manifest=_prepare_seeded_home_fd,
-            )
+            seed_mod.copy_fixture_into_dir_fd(scenario, home_fd)
+            _prepare_seeded_home_fd(home_fd)
+            seed_mod.publish_fixture_manifest(scenario, home_fd)
             held = os.fstat(home_fd)
             named = os.stat(home_dir.name, dir_fd=root_fd, follow_symlinks=False)
             if (held.st_dev, held.st_ino) != (named.st_dev, named.st_ino):

--- a/src/kiro_crew/seed.py
+++ b/src/kiro_crew/seed.py
@@ -16,7 +16,6 @@ import shutil
 import stat
 import sys
 from pathlib import Path
-from typing import Callable
 
 try:  # py3.9+ stdlib; kept in a try so older runtimes raise cleanly.
     from importlib.resources import files as _resource_files
@@ -172,20 +171,15 @@ def _resolve_fixture(name: str) -> Path:
     return candidate
 
 
-def copy_fixture_into_dir_fd(
-    fixture_name: str,
-    dst_fd: int,
-    *,
-    before_manifest: Callable[[int], None],
-) -> None:
+def copy_fixture_into_dir_fd(fixture_name: str, dst_fd: int) -> None:
     """Copy one shipped fixture into an already-pinned empty directory.
 
     Both source and destination are traversed through directory descriptors;
-    no destination component is reopened by name. The manifest is copied LAST:
-    callers use it as the completion marker, so a failed partial copy cannot be
-    mistaken for a finished seed on the next boot. *before_manifest* lets the
-    caller finish descriptor-relative setup under the same held root before that
-    completion marker becomes visible.
+    no destination component is reopened by name. The completion manifest is
+    deliberately NOT copied: callers use it as the completion marker, so they
+    finish descriptor-relative setup under the same held root and then publish
+    the marker last via :func:`publish_fixture_manifest`. A failed partial copy
+    therefore cannot be mistaken for a finished seed on the next boot.
 
     This cannot delegate to ``stage_tree_pinned``: that helper accepts a
     destination PATH and opens/closes its root internally, while this boundary
@@ -213,14 +207,10 @@ def copy_fixture_into_dir_fd(
 
     def _walk(src_fd: int, target_fd: int, display: Path) -> None:
         nonlocal manifest_seen
-        names = sorted(
-            os.listdir(src_fd),
-            key=lambda value: (value == FIXTURE_MANIFEST, value),
-        )
-        for name in names:
+        for name in sorted(os.listdir(src_fd)):
             if display == src and name == FIXTURE_MANIFEST:
-                before_manifest(target_fd)
                 manifest_seen = True
+                continue
             shown = display / name
             st = os.stat(name, dir_fd=src_fd, follow_symlinks=False)
             if stat.S_ISLNK(st.st_mode):
@@ -278,6 +268,56 @@ def copy_fixture_into_dir_fd(
             )
     finally:
         os.close(src_fd)
+
+
+def publish_fixture_manifest(fixture_name: str, dst_fd: int) -> None:
+    """Publish the fixture's completion manifest into an already-seeded home.
+
+    This is the commit step of the seeding transaction: it runs only after
+    :func:`copy_fixture_into_dir_fd` and the caller's descriptor-relative setup
+    both succeeded, writing the marker through the same held destination
+    descriptor so the completion signal can never appear over a partial tree.
+    """
+    src = _resolve_fixture(fixture_name)
+
+    def _refuse_skip(reason: str, path: str) -> None:
+        raise SeedError(
+            f"fixture {fixture_name!r} contains an unsupported {reason}: {path}",
+            guardrail=SeedError.GUARDRAIL_ROOT_ESCAPE,
+        )
+
+    src_fd = pinned_fs.open_dir_pinned(
+        src,
+        what=f"fixture {fixture_name!r}",
+        refusal=SeedError,
+    )
+    try:
+        copied = pinned_fs.copy_file_pinned(
+            str(src / FIXTURE_MANIFEST),
+            dir_fd=src_fd,
+            name=FIXTURE_MANIFEST,
+            dst_dir_fd=dst_fd,
+            dst_name=FIXTURE_MANIFEST,
+            force_mode=0o600,
+            on_skip=_refuse_skip,
+        )
+    except FileNotFoundError as exc:
+        raise SeedError(
+            f"fixture {fixture_name!r} has no {FIXTURE_MANIFEST} completion marker",
+            guardrail=SeedError.GUARDRAIL_RESOLVE_FAILED,
+        ) from exc
+    except FileExistsError as exc:
+        raise SeedError(
+            f"seed destination already holds {FIXTURE_MANIFEST}; refusing to re-publish",
+            guardrail=SeedError.GUARDRAIL_RESOLVE_FAILED,
+        ) from exc
+    finally:
+        os.close(src_fd)
+    if not copied:  # pragma: no cover - the reporter above always raises
+        raise SeedError(
+            f"fixture completion marker could not be published: {FIXTURE_MANIFEST}",
+            guardrail=SeedError.GUARDRAIL_RESOLVE_FAILED,
+        )
 
 
 def _protected_homes() -> set[Path]:

--- a/test/test_pod_seed_scenarios.py
+++ b/test/test_pod_seed_scenarios.py
@@ -199,7 +199,7 @@ class TestSeedHomeFromScenario:
         outside = tmp_path / "outside"
         outside.mkdir()
 
-        def _swap_then_write(scenario: str, dst_fd: int, *, before_manifest=None) -> None:
+        def _swap_then_write(scenario: str, dst_fd: int) -> None:
             home.rename(held)
             home.symlink_to(outside, target_is_directory=True)
             fd = os.open("proof.txt", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=dst_fd)
@@ -431,7 +431,7 @@ class TestBootAppliesTheScenario:
         a completed scenario and start the gateway.
         """
 
-        def _copy_then_die(scenario: str, dst_fd: int, *, before_manifest=None) -> None:
+        def _copy_then_die(scenario: str, dst_fd: int) -> None:
             fd = os.open("partial.txt", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=dst_fd)
             try:
                 os.write(fd, b"partial")

--- a/test/test_seed.py
+++ b/test/test_seed.py
@@ -58,11 +58,11 @@ def test_pinned_fixture_copy_publishes_completion_manifest_last(
     monkeypatch.setattr(seed_mod.pinned_fs, "copy_file_pinned", _record)
     dst_fd = os.open(destination, seed_mod.pinned_fs.dir_flags())
     try:
-        seed_mod.copy_fixture_into_dir_fd(
-            "minimal",
-            dst_fd,
-            before_manifest=lambda _fd: copied.append("<setup>"),
-        )
+        seed_mod.copy_fixture_into_dir_fd("minimal", dst_fd)
+        assert seed_mod.FIXTURE_MANIFEST not in copied
+        assert not (destination / seed_mod.FIXTURE_MANIFEST).exists()
+        copied.append("<setup>")
+        seed_mod.publish_fixture_manifest("minimal", dst_fd)
     finally:
         os.close(dst_fd)
 


### PR DESCRIPTION
# Split manifest publication from the pinned fixture copy

Completes the First Principles subtraction accepted on #7841 and deliberately punted off that PR's frozen-green head (owner ruling on `c783365cf`): the `before_manifest` callback threaded through `copy_fixture_into_dir_fd` is replaced by an explicit three-step transaction at the caller.

## What changed

- `copy_fixture_into_dir_fd(fixture, dst_fd)` now copies the fixture tree and deliberately **skips** the completion manifest — no callback parameter.
- New `publish_fixture_manifest(fixture, dst_fd)` is the explicit commit step: it writes the marker through the same held destination descriptor, refuses to re-publish over an existing marker, and refuses a fixture with no marker.
- `pod/runtime.py` sequences the transaction explicitly: pinned copy → descriptor-bound config/workspace setup → manifest publication.

## Invariants preserved (pinned by existing tests, kept green)

- The manifest is published **last**, strictly after setup — the ordering test now additionally asserts the marker is absent on disk after the copy step.
- A setup failure publishes no marker; an interrupted copy stays non-bootable on direct systemd restart.
- The raced-symlink test still proves no bytes reach an external target.

## Provenance and verification

- The diff is byte-equivalent to the locally validated candidate that the real-pod acceptance smoke posted on #7841 covered: stable patch ID `7aea6dc12f48c5900b31f5f95e16d43cf8091b16` matches the accepted delta exactly; it applied to current main with no drift.
- Focused seed/pod suites: 455 passed, 1 skipped.
- Black ratchet, subprocess-encoding, isort, flake8, mypy: all green.

4 files, +68/−30. No behavior change to the seeding contract; this is the accepted API subtraction only.
