### PR TITLE
feat: default the CLI installer to managed Python with a sticky opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,18 +156,26 @@ Pin an exact version:
 curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --version 0.1.0
 ```
 
-**Experimental** — run on a fully managed Python instead of the system one.
-The installer fetches a SHA-256-pinned [uv](https://docs.astral.sh/uv/) and
-provisions a self-contained CPython 3.12 into `~/.kiro/crew-python`, so the
-install never depends on (or breaks with) the system interpreter:
+**Managed Python by default.** The installer runs Kiro Crew on a fully managed
+Python instead of the system one: it fetches a SHA-256-pinned
+[uv](https://docs.astral.sh/uv/) and provisions a self-contained CPython 3.12
+into `~/.kiro/crew-python`, so the install never depends on (or breaks with)
+the system interpreter. Existing installs migrate the next time this installer
+itself runs — a staged update applied from the dashboard or the CLI's update
+command keeps its current interpreter. To run
+on the system interpreter instead:
 
 ```bash
-curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --managed-python
+curl -fsSL https://download.crew.kiro.dev/cli.sh | sh -s -- --system-python
 ```
 
 The choice is sticky: it is recorded next to the channel, so later re-runs of
-the installer — including the one `kirocrew update` performs — keep using the
-managed interpreter without the flag. Opt back out with `--system-python`.
+the installer keep it without
+the flag. Opt back in with `--managed-python`. If the managed interpreter
+cannot be downloaded (no network path to the mirror), the installer falls back
+to a usable system Python 3.12+ for that run; point air-gapped hosts at a
+mirror with `KIROCREW_UV_URL` (the uv tarball) and `UV_PYTHON_INSTALL_MIRROR`
+(the interpreter archive).
 
 Open `http://localhost:5476` and start a conversation. The web dashboard works
 without messaging credentials. Add a messaging channel —
@@ -395,12 +403,13 @@ the published manifest, installs through `pipx` when available or a managed
 virtual environment at `~/.kiro/crew-venv` (beside the data home; override with
 `KIROCREW_VENV`), and records the channel in `~/.kiro/crew/channel`. The channels
 are `stable`, `insider`, and `nightly`, and `KIROCREW_CHANNEL` sets the default.
-On Linux and macOS, when the system lacks a Python 3.12+ interpreter the
-installer provisions one itself — no package manager, no sudo: it downloads a
-SHA-256-pinned [uv](https://docs.astral.sh/uv/) binary (or uses your installed
-`uv`) and installs a python-build-standalone CPython 3.12 into
-`~/.kiro/crew-python`. Pass `--managed-python` to always use the provisioned
-interpreter and skip the system ones. The
+On Linux and macOS the installer provisions its own Python by default — no
+package manager, no sudo: it downloads a SHA-256-pinned
+[uv](https://docs.astral.sh/uv/) binary (an installed `uv` on `PATH` is
+deliberately not used) and
+installs a python-build-standalone CPython 3.12 into `~/.kiro/crew-python`.
+Pass `--system-python` to run on a system Python 3.12+ instead (sticky across
+updates). The
 signed installer never pipes an unsigned third-party script into a shell.
 
 **Pin an exact wheel.** You can also install one exact wheel directly and pin it to its published

--- a/cli.sh
+++ b/cli.sh
@@ -12,21 +12,25 @@
 # venv). No unsigned/checksum-only fallback exists. Unlike install.sh (which
 # builds from a git clone), this pulls the published wheel.
 #
-# Python: uses the system interpreter (>=3.12) when one exists; otherwise — or
-# always, with --managed-python — provisions a python-build-standalone CPython
-# via a SHA-256-pinned uv into a user-owned directory. No package manager, no
-# sudo, works on old-glibc distros (CentOS 7).
+# Python: provisions a python-build-standalone CPython via a SHA-256-pinned uv
+# into a user-owned directory (the default) — no package manager, no sudo,
+# works on old-glibc distros (CentOS 7). Opt out with --system-python to run on
+# a system interpreter (>=3.12) instead; the choice is recorded and survives
+# updates. If the managed default cannot be provisioned (no network), the run
+# falls back to a usable system interpreter rather than failing.
 #
 # Options / env:
 #   --channel <nightly|insider|stable>   (default: stable; env KIROCREW_CHANNEL)
 #   --version <X.Y.Z>                    pin an exact version, verified against
 #                                        its immutable signed CLI manifest
 #   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
-#   --managed-python                     skip the system interpreters and run on
-#                                        a uv-provisioned Python instead (sticky:
-#                                        later runs and updates keep the choice;
-#                                        opt out with --system-python)
+#   --managed-python                     force the managed default back on after
+#                                        a recorded --system-python opt-out
 #                                        (env KIROCREW_MANAGED_PYTHON=1)
+#   --system-python                      run on the system interpreter instead
+#                                        of the managed default (sticky: later
+#                                        runs and updates keep the choice)
+#                                        (env KIROCREW_MANAGED_PYTHON=0)
 # ──────────────────────────────────────────────────────────────────────
 set -eu
 
@@ -46,8 +50,9 @@ ARTIFACT_BASE="${KIROCREW_CDN_BASE:-https://download.crew.kiro.dev}"
 CHANNEL="${KIROCREW_CHANNEL:-stable}"
 PIN_VERSION=""
 # Three states: "" = undecided (fall back to the persisted python-mode marker,
-# then to system), "1" = managed, "0" = system. An explicit env value or flag
-# always outranks the marker, so an operator can override a sticky choice.
+# then to the managed default), "1" = managed, "0" = system. An explicit env
+# value or flag always outranks the marker, so an operator can override a
+# sticky choice.
 MANAGED_PYTHON="${KIROCREW_MANAGED_PYTHON:-}"
 
 # Pinned uv release used to provision a managed Python interpreter when the
@@ -106,16 +111,22 @@ Options / env:
   --version <X.Y.Z>                    pin an exact version, verified against
                                        its immutable signed CLI manifest
   --cdn <base-url>                     (default CloudFront; env KIROCREW_CDN_BASE)
-  --managed-python                     skip the system interpreters and run on a
-                                       uv-provisioned Python instead (sticky: later
-                                       runs and updates keep the choice)
-  --system-python                      opt back out of a recorded managed-python
-                                       choice and use the system interpreter
+  --managed-python                     force the managed default back on after
+                                       a recorded --system-python opt-out
                                        (env KIROCREW_MANAGED_PYTHON=1)
+  --system-python                      run on the system interpreter (>=3.12)
+                                       instead of the managed default (sticky:
+                                       later runs and updates keep the choice)
+                                       (env KIROCREW_MANAGED_PYTHON=0)
   KIROCREW_VENV                        override the managed venv location
   KIROCREW_PYTHON_DIR                  override where uv-provisioned interpreters
                                        are stored (default: beside the data home,
                                        ~/.kiro/crew-python)
+  KIROCREW_UV_URL                      mirror base for the uv release tarballs
+                                       (default: the uv GitHub release tree; the
+                                       SHA-256 pin is enforced either way)
+  UV_PYTHON_INSTALL_MIRROR             mirror for the python-build-standalone
+                                       interpreter downloads (read by uv)
 EOF
       exit 0 ;;
     *) echo "kirocrew-install: unknown argument '$1'" >&2; exit 2 ;;
@@ -242,46 +253,54 @@ _resolve_python() {
 # dependency-free binary, and the interpreters it installs are prebuilt
 # python-build-standalone archives that unpack into a user-owned directory —
 # no package manager, no sudo, and they run on old-glibc distros (CentOS 7)
-# whose base repos never reach 3.10. An installed `uv` on PATH is used as-is
-# (the user already made that trust decision); otherwise the pinned uv release
-# is downloaded and verified against the SHA-256 digests above before it runs.
+# whose base repos never reach 3.10. The pinned uv release is downloaded and
+# verified against the SHA-256 digests above before it runs -- an installed
+# `uv` on PATH is never consulted (see the note inside).
 # Sets PY on success. Network/platform failures return 1 so the caller can
 # print guidance; a digest mismatch is a security stop and errs immediately.
 _provision_python_via_uv() {
   _uv_bin=""
-  if command -v uv >/dev/null 2>&1; then
-    _uv_bin="$(command -v uv)"
-    echo "Using installed uv ($_uv_bin) to provision Python ($UV_PYTHON_SERIES) ..."
-  else
-    # GNU tar's -z shells out to gzip, so both must exist before downloading.
-    for _uv_tool in tar gzip; do
-      if ! command -v "$_uv_tool" >/dev/null 2>&1; then
-        echo "kirocrew-install: $_uv_tool is required to unpack uv" >&2
-        return 1
-      fi
-    done
-    case "$(uname -s)/$(uname -m)" in
-      Linux/x86_64)              _uv_target="x86_64-unknown-linux-musl";  _uv_sha="$UV_SHA_LINUX_X64" ;;
-      Linux/aarch64|Linux/arm64) _uv_target="aarch64-unknown-linux-musl"; _uv_sha="$UV_SHA_LINUX_ARM64" ;;
-      Darwin/x86_64)             _uv_target="x86_64-apple-darwin";        _uv_sha="$UV_SHA_MACOS_X64" ;;
-      Darwin/arm64)              _uv_target="aarch64-apple-darwin";       _uv_sha="$UV_SHA_MACOS_ARM64" ;;
-      *)
-        echo "kirocrew-install: no pinned uv build for $(uname -s)/$(uname -m)" >&2
-        return 1 ;;
-    esac
-    echo "Downloading uv $UV_VERSION ($_uv_target) ..."
-    # -L: GitHub release assets redirect to a storage host; --proto-redir keeps
-    # every hop on HTTPS (curl's redirect default would also allow plain http).
-    curl -fsSL --proto '=https' --proto-redir '=https' \
-      "https://github.com/astral-sh/uv/releases/download/$UV_VERSION/uv-$_uv_target.tar.gz" \
-      -o "$TMP/uv.tar.gz" || return 1
-    _uv_got="$($SHA_CMD "$TMP/uv.tar.gz" | awk '{print $1}')"
-    [ "$_uv_got" = "$_uv_sha" ] \
-      || err "uv download SHA-256 mismatch (expected $_uv_sha, got $_uv_got) — refusing to continue"
-    ( cd "$TMP" && tar -xzf uv.tar.gz ) || return 1
-    _uv_bin="$TMP/uv-$_uv_target/uv"
-    [ -x "$_uv_bin" ] || return 1
-  fi
+  # An installed `uv` on PATH is deliberately NOT consulted. With managed as
+  # the default, every install and update run reaches this function, and PATH
+  # commonly leads with user-writable directories (~/.local/bin) that an agent
+  # session can write -- a planted `uv` shim would be executed by the user's
+  # own unattended update run. The pinned, SHA-256-verified tarball is the
+  # only uv this script runs. The download recurs on every managed run; a
+  # failure degrades to a usable system interpreter unless managed was
+  # explicitly requested this run (see the mode block below).
+  # GNU tar's -z shells out to gzip, so both must exist before downloading.
+  for _uv_tool in tar gzip; do
+    if ! command -v "$_uv_tool" >/dev/null 2>&1; then
+      echo "kirocrew-install: $_uv_tool is required to unpack uv" >&2
+      return 1
+    fi
+  done
+  case "$(uname -s)/$(uname -m)" in
+    Linux/x86_64)              _uv_target="x86_64-unknown-linux-musl";  _uv_sha="$UV_SHA_LINUX_X64" ;;
+    Linux/aarch64|Linux/arm64) _uv_target="aarch64-unknown-linux-musl"; _uv_sha="$UV_SHA_LINUX_ARM64" ;;
+    Darwin/x86_64)             _uv_target="x86_64-apple-darwin";        _uv_sha="$UV_SHA_MACOS_X64" ;;
+    Darwin/arm64)              _uv_target="aarch64-apple-darwin";       _uv_sha="$UV_SHA_MACOS_ARM64" ;;
+    *)
+      echo "kirocrew-install: no pinned uv build for $(uname -s)/$(uname -m)" >&2
+      return 1 ;;
+  esac
+  echo "Downloading uv $UV_VERSION ($_uv_target) ..."
+  # -L: GitHub release assets redirect to a storage host; --proto-redir keeps
+  # every hop on HTTPS (curl's redirect default would also allow plain http).
+  # KIROCREW_UV_URL points air-gapped / proxied hosts at a mirror of the uv
+  # release tree; the SHA-256 pin below still applies, so a mirror can serve
+  # the bytes but never substitute them. (uv's own python-build-standalone
+  # download honors UV_PYTHON_INSTALL_MIRROR, which inherits through env.)
+  _uv_base="${KIROCREW_UV_URL:-https://github.com/astral-sh/uv/releases/download}"
+  curl -fsSL --proto '=https' --proto-redir '=https' \
+    "${_uv_base%/}/$UV_VERSION/uv-$_uv_target.tar.gz" \
+    -o "$TMP/uv.tar.gz" || return 1
+  _uv_got="$($SHA_CMD "$TMP/uv.tar.gz" | awk '{print $1}')"
+  [ "$_uv_got" = "$_uv_sha" ] \
+    || err "uv download SHA-256 mismatch (expected $_uv_sha, got $_uv_got) — refusing to continue"
+  ( cd "$TMP" && tar -xzf uv.tar.gz ) || return 1
+  _uv_bin="$TMP/uv-$_uv_target/uv"
+  [ -x "$_uv_bin" ] || return 1
   # The interpreter store lives BESIDE the data home, like the managed venv and
   # for the same blast-radius reason: no data-home-wide operation may ever
   # reach the interpreter that the venv's shebangs point at.
@@ -302,30 +321,84 @@ _provision_python_via_uv() {
   return 1
 }
 
+# Materialize and self-check the embedded trust root. The key id is the
+# SHA-256 fingerprint of SubjectPublicKeyInfo DER, so an accidental edit to
+# either pinned value fails before the network is consulted. This runs BEFORE
+# the interpreter block below -- the managed-Python default may download uv,
+# and the fail-before-network guarantee must not depend on how the
+# interpreter is provisioned -- so it uses openssl (a hard prerequisite
+# checked above) rather than an interpreter to decode the key.
+printf '%s' "$CLI_MANIFEST_PUBLIC_KEY_B64" \
+  | openssl base64 -d -A > "$TMP/cli-manifest-public.pem" 2>/dev/null || true
+if ! [ -s "$TMP/cli-manifest-public.pem" ] \
+    || ! openssl pkey -pubin -in "$TMP/cli-manifest-public.pem" \
+      -outform DER -out "$TMP/cli-manifest-public.der" 2>/dev/null; then
+  err "embedded CLI manifest public key is invalid"
+fi
+PINNED_KEY_SHA="$($SHA_CMD "$TMP/cli-manifest-public.der" | awk '{print $1}')"
+[ "$CLI_MANIFEST_KEY_ID" = "sha256:$PINNED_KEY_SHA" ] \
+  || err "embedded CLI manifest public key fingerprint mismatch"
+
 PY=""
 # The interpreter choice is STICKY: a completed install records its mode in
 # the data home (next to `channel`), and a later run without an explicit flag
 # or env value reuses it. Without this, every re-run of the one-liner -- most
-# importantly the one `kirocrew update` performs -- would silently flip a
-# --managed-python install back onto whatever system interpreter it finds.
-# Opt back out explicitly with --system-python (or KIROCREW_MANAGED_PYTHON=0).
+# importantly the one `kirocrew update` performs -- would silently flip the
+# interpreter under an existing install.
+#
+# Managed is the DEFAULT: with no flag, no env value, and no recorded pin,
+# the installer provisions a python-build-standalone CPython via uv. Opt out
+# with --system-python (or KIROCREW_MANAGED_PYTHON=0), which records a
+# `system-pinned` marker so the choice survives updates. A bare `system`
+# marker is NOT an opt-out: earlier installers recorded it for every default
+# install, so it only says "an old default ran here" -- such installs migrate
+# onto the managed default at their next update.
 _DATA_HOME="${KIROCREW_HOME:-$HOME/.kiro/crew}"
 # The marker is agent-writable state, so the READ is guarded like the write:
 # only a plain regular file counts (a planted symlink -- e.g. to /dev/zero --
 # or a FIFO would wedge an unbounded read or spoof the mode), and the read is
 # bounded to the first bytes rather than slurping the file.
 _py_mode_file="$_DATA_HOME/python-mode"
-if [ -z "$MANAGED_PYTHON" ] && [ -f "$_py_mode_file" ] && [ ! -L "$_py_mode_file" ] \
-    && [ "$(head -c 16 "$_py_mode_file" 2>/dev/null || true)" = "managed" ]; then
-  echo "Reusing the recorded managed-python choice (override with --system-python)."
-  MANAGED_PYTHON=1
+# Tracks whether the resolved mode was ASKED FOR in THIS run (flag or env
+# value). Only an explicit managed request fails hard when uv cannot
+# provision. A `managed` marker records a DEFAULTED choice, so marker-driven
+# runs keep the degrade-to-system fallback below -- otherwise the first
+# successful default install would turn every later update into a hard
+# network dependency on the uv download.
+PY_MODE_EXPLICIT=0
+PY_MODE_FALLBACK=0
+[ -n "$MANAGED_PYTHON" ] && PY_MODE_EXPLICIT=1
+if [ -z "$MANAGED_PYTHON" ] && [ -f "$_py_mode_file" ] && [ ! -L "$_py_mode_file" ]; then
+  case "$(head -c 16 "$_py_mode_file" 2>/dev/null || true)" in
+    managed)
+      echo "Reusing the recorded managed-python choice (override with --system-python)."
+      MANAGED_PYTHON=1 ;;
+    system-pinned)
+      echo "Reusing the recorded system-python choice (override with --managed-python)."
+      MANAGED_PYTHON=0; PY_MODE_EXPLICIT=1 ;;
+  esac
 fi
-[ -n "$MANAGED_PYTHON" ] || MANAGED_PYTHON=0
+[ -n "$MANAGED_PYTHON" ] || MANAGED_PYTHON=1
 
 if [ "$MANAGED_PYTHON" = "1" ]; then
-  echo "managed-python: skipping system interpreters."
-  _provision_python_via_uv \
-    || err "could not provision a managed Python via uv. Check the network connection, or install Python >=3.12 yourself and re-run without --managed-python."
+  echo "Using a managed Python (the default; opt out with --system-python)."
+  # Interpreters in the store are ALWAYS resolved through the pinned,
+  # SHA-256-verified uv binary (`uv python install` is idempotent, so a
+  # healthy interpreter is reused without a re-download). The store is never
+  # scanned or executed directly: it lives on an agent-writable disk, and a
+  # planted executable there would otherwise run inside the user's own
+  # unattended update.
+  if ! _provision_python_via_uv; then
+    if [ "$PY_MODE_EXPLICIT" = "1" ]; then
+      err "could not provision a managed Python via uv. Check the network connection, or re-run with --system-python to use a system interpreter instead."
+    fi
+    _resolve_python || true
+    if [ -n "$PY" ]; then
+      echo "kirocrew-install: WARNING: could not provision a managed Python (network?); using the system interpreter $PY for this run. The next run retries the managed default." >&2
+      MANAGED_PYTHON=0
+      PY_MODE_FALLBACK=1
+    fi
+  fi
 else
   _resolve_python || true
   if [ -z "$PY" ]; then
@@ -335,22 +408,9 @@ else
 fi
 [ -n "$PY" ] || err "Python >=3.12 is required and could not be found or provisioned. Install Python 3.12+ yourself (your distro's packages, or https://www.python.org/downloads/), then re-run."
 
-# Materialize and self-check the embedded trust root. The key id is the SHA-256
-# fingerprint of SubjectPublicKeyInfo DER, so an accidental edit to either
-# pinned value fails before the network is consulted.
-if ! printf '%s' "$CLI_MANIFEST_PUBLIC_KEY_B64" \
-    | "$PY" -c 'import base64,sys; open(sys.argv[1], "xb").write(base64.b64decode(sys.stdin.buffer.read(), validate=True))' \
-        "$TMP/cli-manifest-public.pem" 2>/dev/null; then
-  err "embedded CLI manifest public key is malformed"
-fi
-if ! openssl pkey -pubin -in "$TMP/cli-manifest-public.pem" \
-    -outform DER -out "$TMP/cli-manifest-public.der" 2>/dev/null; then
-  err "embedded CLI manifest public key is invalid"
-fi
-PINNED_KEY_SHA="$($SHA_CMD "$TMP/cli-manifest-public.der" | awk '{print $1}')"
-[ "$CLI_MANIFEST_KEY_ID" = "sha256:$PINNED_KEY_SHA" ] \
-  || err "embedded CLI manifest public key fingerprint mismatch"
-
+# The trust root was materialized and self-checked BEFORE the interpreter
+# block above: the managed-Python default may download uv, and a corrupted
+# trust root must fail before any network I/O.
 if [ -n "$PIN_VERSION" ]; then
   case "$PIN_VERSION" in
     *[!A-Za-z0-9._+]*) err "invalid pinned version '$PIN_VERSION'" ;;
@@ -537,25 +597,62 @@ else
   # Rebuilding over an EXISTING venv must not keep the old interpreter: the
   # venv module rewrites pyvenv.cfg but leaves an existing bin/python* symlink
   # in place, producing a hybrid that CLAIMS the new interpreter while running
-  # the old one -- silently defeating --managed-python for an existing install
-  # and dying with a dangling shebang the day the old interpreter disappears.
-  # Remove ONLY the interpreter links so the venv rebuild recreates them
-  # against $PY. Never `--clear`: that empties site-packages and the
-  # entrypoint too, so a download failure in the pip step below would leave
-  # the user with NO working install where a plain re-run used to keep the
-  # old one. The links are the only stale asset, and they are regenerated by
-  # the very next command. Guards: pyvenv.cfg proves the target IS a venv (a
-  # mis-pointed KIROCREW_VENV at a plain directory is never touched), and a
-  # symlinked venv root (trailing slash stripped so `-L` sees the link
-  # itself) is left as-is -- the venv module refuses a symlink root anyway,
-  # and removing links inside its target first would break the linked venv
-  # before that refusal.
+  # the old one. And a rebuild is not committed until the wheel lands: a
+  # relink to a different interpreter series orphans the old site-packages,
+  # so a download failure in the pip step below would otherwise leave a venv
+  # that can no longer import the CLI at all. Make the rebuild transactional:
+  # move the working venv aside (a rename, so it costs nothing), build fresh,
+  # and restore the original on failure. Guards: pyvenv.cfg proves the target
+  # IS a venv (a mis-pointed KIROCREW_VENV at a plain directory is never
+  # touched), and a symlinked venv root (trailing slash stripped so `-L` sees
+  # the link itself) is left as-is. If the rename itself fails (exotic
+  # filesystem), fall back to removing only the stale interpreter links so
+  # the rebuild still cannot produce the hybrid.
+  _VENV_BACKUP=""
   if [ -f "$VENV/pyvenv.cfg" ] && [ ! -L "${VENV%/}" ]; then
-    rm -f "$VENV/bin/python" "$VENV/bin/python3" "$VENV/bin"/python3.* 2>/dev/null || true
+    _VENV_BACKUP="${VENV%/}.pre-rebuild.$$"
+    # A tree already at the backup path (a crashed earlier run whose PID was
+    # recycled) would make `mv` nest the venv INSIDE it instead of renaming.
+    # That tree may be the only WORKING install left -- a run interrupted
+    # between its move-aside and its restore parks the good venv exactly
+    # there -- so it is never deleted: pick the next free sibling instead.
+    _n=0
+    while [ -e "$_VENV_BACKUP" ]; do
+      _n=$((_n + 1))
+      _VENV_BACKUP="${VENV%/}.pre-rebuild.$$.$_n"
+    done
+    if ! mv "$VENV" "$_VENV_BACKUP" 2>/dev/null; then
+      _VENV_BACKUP=""
+      rm -f "$VENV/bin/python" "$VENV/bin/python3" "$VENV/bin"/python3.* 2>/dev/null || true
+    fi
   fi
-  "$PY" -m venv "$VENV"
+  # EVERY failure after the move-aside must restore the backup -- under
+  # `set -eu` an unguarded command would exit past the restore and leave the
+  # working install orphaned at the backup path.
+  if ! "$PY" -m venv "$VENV"; then
+    if [ -n "$_VENV_BACKUP" ] && [ -d "$_VENV_BACKUP" ]; then
+      rm -rf "$VENV" 2>/dev/null || true
+      mv "$_VENV_BACKUP" "$VENV" 2>/dev/null \
+        && err "creating the venv at $VENV failed (disk full?). The previous install was restored and keeps working; re-run this installer to retry." \
+        || err "creating the venv at $VENV failed and the previous install could not be restored from $_VENV_BACKUP."
+    fi
+    err "creating the venv at $VENV failed."
+  fi
   "$VENV/bin/pip" install --quiet --upgrade pip >/dev/null 2>&1 || true
-  "$VENV/bin/pip" install --quiet "$WHL"
+  # On failure, put the pre-rebuild venv back so the previous install keeps
+  # working -- then name the retry instead of dying with a raw pip trace.
+  if ! "$VENV/bin/pip" install --quiet "$WHL"; then
+    if [ -n "$_VENV_BACKUP" ] && [ -d "$_VENV_BACKUP" ]; then
+      rm -rf "$VENV" 2>/dev/null || true
+      mv "$_VENV_BACKUP" "$VENV" 2>/dev/null \
+        && err "installing the wheel into $VENV failed (network?). The previous install was restored and keeps working; re-run this installer to retry." \
+        || err "installing the wheel into $VENV failed and the previous install could not be restored from $_VENV_BACKUP. Re-run this installer to complete the install."
+    fi
+    err "installing the wheel into $VENV failed. Re-run this installer to complete the install; until then the previous 'kirocrew' command may be unusable."
+  fi
+  if [ -n "$_VENV_BACKUP" ] && [ -d "$_VENV_BACKUP" ]; then
+    rm -rf "$_VENV_BACKUP" 2>/dev/null || true
+  fi
   # Keep the stable launch path (`${VENV}-current`) naming the tree that holds
   # the LAST-INSTALLED version. The gateway's shadow-venv updater
   # (kiro_crew/platform/wheel_engine.py) promotes this same symlink to a fresh
@@ -657,10 +754,15 @@ _write_marker() {
 _write_marker channel "$CHANNEL"
 # Record the interpreter mode so the next run -- including the re-run that
 # `kirocrew update` performs -- keeps the same choice without the flag.
+# `system-pinned` is only ever written for an EXPLICIT system choice; a
+# transient fallback from the managed default records nothing, so the next
+# run retries managed instead of freezing a network hiccup into a pin.
 if [ "$MANAGED_PYTHON" = "1" ]; then
   _write_marker python-mode managed
+elif [ "$PY_MODE_FALLBACK" = "1" ]; then
+  :
 else
-  _write_marker python-mode system
+  _write_marker python-mode system-pinned
 fi
 
 echo ""

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -148,24 +148,35 @@ home (`~/.kiro/crew-venv`, override with `KIROCREW_VENV`) and symlinks
 data home, so no whole-home operation can ever delete the live interpreter. The
 selected channel is recorded to `~/.kiro/crew/channel`.
 
-If the host has no Python 3.12+, the installer provisions one itself instead of
-touching the system: it downloads a SHA-256-pinned [uv](https://docs.astral.sh/uv/)
-binary (or uses an already-installed `uv` on `PATH`), then installs a
+The installer provisions its own Python by default instead of depending on the
+system one: it downloads a SHA-256-pinned [uv](https://docs.astral.sh/uv/)
+binary (an installed `uv` on `PATH` is deliberately never executed -- `PATH`
+commonly leads with agent-writable directories), then installs a
 [python-build-standalone](https://github.com/astral-sh/python-build-standalone)
 CPython 3.12 into a user-owned directory beside the data home
 (`~/.kiro/crew-python`, override with `KIROCREW_PYTHON_DIR`). No package
 manager, no sudo, and the prebuilt interpreter runs on old-glibc distros
-(CentOS 7) whose base repos never reach 3.10. Pass `--managed-python` (or set
-`KIROCREW_MANAGED_PYTHON=1`) to always use the uv-provisioned interpreter and
-skip the system ones entirely — useful when the system Python is fragile or
-version-managed. The choice is sticky: it is recorded in the data home
-(`python-mode`, next to `channel`), so later installer runs — including the
-re-run `kirocrew update` performs — keep it without the flag; opt back out
-with `--system-python`. The signed installer never pipes an unsigned
-third-party script into a shell: uv is fetched as a tarball and verified
-against pinned digests, exactly like the wheel itself. When it finishes it
-prints the next step: `kirocrew gateway` to start now, or `kirocrew service
-install` to run it as a service.
+(CentOS 7) whose base repos never reach 3.10. Pass `--system-python` (or set
+`KIROCREW_MANAGED_PYTHON=0`) to run on a system Python 3.12+ instead — the
+choice is sticky: it is recorded in the data home (`python-mode`, next to
+`channel`), so later installer runs keep it without the flag; opt back in
+with `--managed-python`.
+Installs that predate the managed default migrate onto it at their next
+direct installer run — on a managed venv, a staged update applied from the
+dashboard or the CLI's update command keeps its current interpreter — unless
+they recorded the `--system-python` opt-out. A re-run resolves the
+interpreter through the pinned uv binary; an already-provisioned interpreter
+is reused rather than re-downloaded.
+If the managed
+interpreter cannot be downloaded and a usable system Python 3.12+ exists, the
+run falls back to it with a warning (and retries the managed default next
+time); air-gapped hosts can point `KIROCREW_UV_URL` at a mirror of the uv
+release tree and `UV_PYTHON_INSTALL_MIRROR` at a mirror of the interpreter
+archives — the pinned SHA-256 digests are enforced either way. The signed
+installer never pipes an unsigned third-party script into a shell: uv is
+fetched as a tarball and verified against pinned digests, exactly like the
+wheel itself. When it finishes it prints the next step: `kirocrew gateway` to
+start now, or `kirocrew service install` to run it as a service.
 
 ### b. From source (development)
 

--- a/test/test_installer_distro.py
+++ b/test/test_installer_distro.py
@@ -48,6 +48,7 @@ def _run_cli_with_fake_env(
     with_uv: str | None = None,
     curl_stub: str | None = None,
     extra_args: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run cli.sh with a PATH that has NO usable python3 and a recording
     ``curl`` stub. Returns the process result plus the marker directory the
@@ -129,12 +130,10 @@ def _run_cli_with_fake_env(
         )
         stub.chmod(0o755)
 
-    # openssl needs to exist so cli.sh's tool preflight passes and it reaches
-    # the Python block; it is never actually reached in these scenarios, but
-    # `command -v` must find it.
-    openssl = tools / "openssl"
-    openssl.write_text("#!/bin/sh\nexit 0\n")
-    openssl.chmod(0o755)
+    # openssl must be REAL: the trust-root self-check runs before the Python
+    # block (fail-before-network), so these scenarios execute it for the
+    # embedded key before reaching the interpreter ladder under test.
+    _link_real("openssl")
 
     env = {
         # Isolated: ONLY the fake tools dir. No system bin dirs, so no real
@@ -142,6 +141,7 @@ def _run_cli_with_fake_env(
         "PATH": str(tools),
         "HOME": str(tmp_path / "home"),
         "KIROCREW_HOME": str(tmp_path / "data-home"),
+        **(extra_env or {}),
     }
     argv = [str(tools / "sh"), str(CLI_SH), *(extra_args or [])]
     result = run_bounded(argv, env)
@@ -233,51 +233,28 @@ def test_cli_falls_back_to_pinned_uv_when_no_python(tmp_path: Path) -> None:
     assert "Python >=3.12 is required and could not be found or provisioned" in combined
 
 
-def test_cli_uses_installed_uv_before_downloading_one(tmp_path: Path) -> None:
-    """An already-present `uv` on PATH is the user's own trust decision — the
-    installer must drive IT (python install + python find) instead of
-    downloading another copy."""
+def test_cli_never_executes_a_path_uv(tmp_path: Path) -> None:
+    """A `uv` on PATH must NEVER be executed. With managed as the default,
+    every install and update run reaches the provisioning path, and PATH
+    commonly leads with user-writable directories (~/.local/bin) an agent
+    session can write -- a planted shim there would run inside the user's own
+    unattended update. Only the pinned, SHA-256-verified tarball is trusted."""
     uv_marker = tmp_path / "markers" / "uv"
-    fake_python = tmp_path / "tools" / "uv-python"
     uv_stub = (
         "#!/bin/sh\n"
         f'printf "%s\\n" "$*" >> "{uv_marker}"\n'
-        'case "$*" in\n'
-        f'  *"python find"*) echo "{fake_python}" ;;\n'
-        "esac\n"
         "exit 0\n"
     )
-    result, markers = _run_cli_with_fake_env(
-        tmp_path,
-        with_uv=uv_stub,
-        # The provisioned interpreter must satisfy the same >=3.12 usability
-        # probe as a system one; this stub models the PBS python uv installed.
-        interpreters={
-            "uv-python": (
-                "#!/bin/sh\n"
-                'case "$*" in\n'
-                "  *version_info*) exit 0 ;;\n"
-                "  *--version*) echo 'Python 3.12.0' ;;\n"
-                "  *) exit 0 ;;\n"
-                "esac\n"
-            ),
-        },
-    )
+    result, markers = _run_cli_with_fake_env(tmp_path, with_uv=uv_stub)
 
-    recorded = (markers / "uv").read_text()
-    assert "python install cpython-3.12" in recorded
-    assert "python find cpython-3.12" in recorded
-    # No uv tarball download happened: the only curl traffic (if any) is the
-    # manifest fetch that comes AFTER the python gate passed.
-    curl_marker = markers / "curl"
-    if curl_marker.exists():
-        assert "astral-sh/uv" not in curl_marker.read_text()
-    # The run got PAST the python gate: whatever it fails on later (this
-    # hermetic env cannot satisfy the trust-root/manifest steps), it must not
-    # be the interpreter requirement.
-    combined = result.stdout + result.stderr
-    assert "Python >=3.12 is required" not in combined, combined
-    assert "could not provision a managed Python" not in combined, combined
+    # The planted PATH uv was never invoked ...
+    assert not (markers / "uv").exists(), (
+        "cli.sh executed a uv found on PATH -- the pinned-tarball-only "
+        "trust decision has been lost"
+    )
+    # ... and the pinned tarball download was attempted instead.
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
 
 
 def test_cli_managed_python_flag_skips_system_interpreters(tmp_path: Path) -> None:
@@ -459,6 +436,109 @@ def test_cli_link_removal_never_reaches_a_symlinked_venv(tmp_path: Path) -> None
     assert '[ ! -L "${VENV%/}" ]' in CLI_SH.read_text()
 
 
+def test_cli_restores_the_previous_venv_when_the_wheel_install_fails(
+    tmp_path: Path,
+) -> None:
+    """A venv rebuild is transactional: the working venv is MOVED ASIDE before
+    the fresh build, and a wheel-install failure puts it back. Without this,
+    a default migration that relinks the venv to a different interpreter
+    series and then loses the network at the pip step leaves a venv that can
+    no longer import its old site-packages -- the previous install is
+    destroyed by a run that delivered nothing."""
+    ver = f"{sys.version_info[0]}.{sys.version_info[1]}"
+    venv_dir = tmp_path / "crew-venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--without-pip", str(venv_dir)],
+        check=True,
+        cwd=tmp_path,
+    )
+    survivor = venv_dir / "lib" / f"python{ver}" / "site-packages" / "keepme.txt"
+    survivor.parent.mkdir(parents=True, exist_ok=True)
+    survivor.write_text("previous working install")
+
+    # The exact transactional shape cli.sh runs: back up, rebuild, simulate a
+    # failed pip step, restore.
+    script = (
+        f'V="{venv_dir}"; BK=""; '
+        f'if [ -f "$V/pyvenv.cfg" ] && [ ! -L "$V" ]; then '
+        f'BK="$V.pre-rebuild.$$"; mv "$V" "$BK" || BK=""; fi; '
+        f'"{sys.executable}" -m venv --without-pip "$V"; '
+        f"if ! false; then "  # the pip step, failing
+        f'if [ -n "$BK" ] && [ -d "$BK" ]; then '
+        f'rm -rf "$V"; mv "$BK" "$V" && exit 3; fi; exit 4; fi'
+    )
+    result = subprocess.run(["sh", "-c", script], cwd=tmp_path)
+
+    assert result.returncode == 3, "the restore path did not run"
+    assert survivor.read_text() == "previous working install", (
+        "the pre-rebuild venv was not restored after the failed wheel "
+        "install -- the migration is no longer rollback-safe"
+    )
+    assert not list(tmp_path.glob("crew-venv.pre-rebuild.*")), (
+        "the restore left a stray backup tree behind"
+    )
+    # Pin the transactional shape in cli.sh itself.
+    text = CLI_SH.read_text()
+    assert 'mv "$VENV" "$_VENV_BACKUP"' in text, (
+        "cli.sh no longer moves the working venv aside before the rebuild"
+    )
+    assert 'mv "$_VENV_BACKUP" "$VENV"' in text, (
+        "cli.sh no longer restores the pre-rebuild venv on a failed wheel "
+        "install"
+    )
+    # The venv-creation step after the move-aside must be guarded too:
+    # under `set -eu` an unguarded `"$PY" -m venv` failure (disk full at
+    # ensurepip time) would exit past the restore and orphan the backup.
+    assert 'if ! "$PY" -m venv "$VENV"; then' in text, (
+        "cli.sh runs venv creation unguarded after the move-aside -- a "
+        "creation failure under set -eu skips the restore and destroys the "
+        "working install"
+    )
+    # A tree already at the backup path (recycled PID) may be the only
+    # WORKING install left by an interrupted earlier run, so it is never
+    # deleted -- the move-aside picks the next free sibling instead.
+    assert 'rm -rf "$_VENV_BACKUP"' not in text.split('if ! "$PY" -m venv')[0], (
+        "cli.sh deletes whatever sits at the backup path before the "
+        "move-aside -- an interrupted earlier run parks the working venv "
+        "exactly there, so a recycled PID would destroy it"
+    )
+    assert 'while [ -e "$_VENV_BACKUP" ]; do' in text, (
+        "cli.sh no longer steps past an occupied backup path before the "
+        "move-aside -- mv would nest the venv inside the stale tree"
+    )
+
+
+def test_cli_venv_rebuild_preserves_a_stale_backup(tmp_path: Path) -> None:
+    """A tree already sitting at the backup path is a working venv parked by
+    an interrupted earlier run (rename done, restore never reached). With a
+    recycled PID the new run must NOT delete it: it steps to the next free
+    sibling, so both the parked venv and the one being rebuilt survive a
+    second failure."""
+    venv_dir = tmp_path / "crew-venv"
+    venv_dir.mkdir()
+    (venv_dir / "pyvenv.cfg").write_text("home = /usr/bin\n")
+    (venv_dir / "marker").write_text("current")
+
+    script = (
+        f'V="{venv_dir}"; STALE="$V.pre-rebuild.$$"; '
+        f'mkdir "$STALE"; echo parked > "$STALE/marker"; '
+        # The exact path-selection shape cli.sh runs.
+        f'BK="$V.pre-rebuild.$$"; n=0; '
+        f'while [ -e "$BK" ]; do n=$((n + 1)); BK="$V.pre-rebuild.$$.$n"; done; '
+        f'mv "$V" "$BK" || exit 4; '
+        f'[ "$(cat "$STALE/marker")" = parked ] || exit 5; '
+        f'[ "$(cat "$BK/marker")" = current ] || exit 6; '
+        f'[ "$BK" = "$STALE.1" ] || exit 7'
+    )
+    result = subprocess.run(["sh", "-c", script], cwd=tmp_path)
+    assert result.returncode == 0, (
+        f"exit {result.returncode}: the move-aside destroyed or nested into "
+        "the stale backup instead of stepping past it"
+    )
+    backups = sorted(p.name for p in tmp_path.glob("crew-venv.pre-rebuild.*"))
+    assert len(backups) == 2, backups
+
+
 def test_cli_reuses_a_recorded_managed_python_choice(tmp_path: Path) -> None:
     """A completed --managed-python install records its mode; a later run
     WITHOUT the flag must reuse it -- most importantly the re-run that
@@ -518,6 +598,179 @@ def test_cli_system_python_flag_overrides_the_recorded_choice(tmp_path: Path) ->
     curl_marker = markers / "curl"
     if curl_marker.exists():
         assert "astral-sh/uv" not in curl_marker.read_text()
+
+
+_USABLE_PY312_STUB = (
+    "#!/bin/sh\n"
+    'case "$*" in\n'
+    "  *version_info*) exit 0 ;;\n"
+    "  *--version*) echo 'Python 3.12.0' ;;\n"
+    "  *) exit 0 ;;\n"
+    "esac\n"
+)
+
+
+def test_cli_defaults_to_managed_python(tmp_path: Path) -> None:
+    """With no flag, no env value, and no recorded pin, the installer must go
+    for the managed interpreter EVEN THOUGH a usable system python3.12 is on
+    PATH -- managed is the default, not the fallback."""
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={"python3.12": _USABLE_PY312_STUB},
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Using a managed Python (the default" in combined
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+
+
+def test_cli_legacy_system_marker_migrates_to_managed(tmp_path: Path) -> None:
+    """A bare `system` marker is what earlier installers recorded for EVERY
+    default install -- it is not an opt-out. Such installs must migrate onto
+    the managed default; only `system-pinned` (written by --system-python)
+    holds an install on the system interpreter."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").write_text("system\n")
+
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={"python3.12": _USABLE_PY312_STUB},
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Reusing the recorded system-python choice" not in combined
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+
+
+def test_cli_system_pinned_marker_stays_on_system(tmp_path: Path) -> None:
+    """A recorded `system-pinned` marker (the --system-python opt-out) must
+    survive a flag-less re-run -- the exact shape `kirocrew update` performs --
+    and never reach for uv."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").write_text("system-pinned\n")
+
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={"python3.12": _USABLE_PY312_STUB},
+    )
+
+    combined = result.stdout + result.stderr
+    assert "Reusing the recorded system-python choice" in combined
+    assert "Python >=3.12 is required" not in combined, combined
+    curl_marker = markers / "curl"
+    if curl_marker.exists():
+        assert "astral-sh/uv" not in curl_marker.read_text()
+
+
+def test_cli_default_managed_falls_back_to_system_on_provision_failure(
+    tmp_path: Path,
+) -> None:
+    """The managed DEFAULT must not turn a working install path into a hard
+    network dependency: when the uv download fails and a usable system
+    interpreter exists, the run degrades to it with a warning. Only an
+    EXPLICIT managed request (flag / env / recorded pin) fails hard -- that
+    contract is pinned by test_cli_managed_python_flag_skips_system_interpreters."""
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={"python3.12": _USABLE_PY312_STUB},
+    )
+
+    combined = result.stdout + result.stderr
+    # The uv download was attempted (default = managed) ...
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+    # ... failed (recording curl exits 22), and the run degraded to the
+    # system interpreter instead of dying at the python gate.
+    assert "could not provision a managed Python (network?)" in combined
+    assert "Python >=3.12 is required" not in combined, combined
+    # A transient fallback must never freeze into a pin: the fallback branch
+    # writes no python-mode marker, so the next run retries managed.
+    text = CLI_SH.read_text()
+    assert '_write_marker python-mode system-pinned' in text
+    assert '_write_marker python-mode system\n' not in text
+    assert 'PY_MODE_FALLBACK' in text
+
+
+def test_cli_never_executes_a_store_interpreter_directly(tmp_path: Path) -> None:
+    """An interpreter already sitting in the store must NOT be executed or
+    reused by a direct scan: the store lives on an agent-writable disk, so a
+    planted executable there would run inside the user's own unattended
+    update. Interpreters are only ever resolved through the pinned,
+    SHA-256-verified uv binary."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").write_text("managed\n")
+    store = tmp_path / "data-home-python" / "cpython-3.12.10-linux" / "bin"
+    store.mkdir(parents=True)
+    executed_marker = tmp_path / "markers" / "store-python-executed"
+    planted = store / "python3.12"
+    planted.write_text(
+        "#!/bin/sh\n"
+        f'printf ran > "{executed_marker}"\n'
+        'case "$*" in\n'
+        "  *version_info*) exit 0 ;;\n"
+        "  *--version*) echo 'Python 3.12.0' ;;\n"
+        "  *) exit 0 ;;\n"
+        "esac\n"
+    )
+    planted.chmod(0o755)
+
+    result, markers = _run_cli_with_fake_env(tmp_path)
+
+    assert not executed_marker.exists(), (
+        "cli.sh executed an interpreter found by scanning the store -- the "
+        "resolve-only-through-pinned-uv decision has been lost"
+    )
+    # The run went for the pinned uv tarball instead.
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+
+
+def test_cli_marker_driven_managed_run_falls_back_on_provision_failure(
+    tmp_path: Path,
+) -> None:
+    """A `managed` marker records a DEFAULTED choice, not an explicit request:
+    when the uv download fails on a marker-driven re-run (the shape every
+    `kirocrew update` takes after the first successful default install) and a
+    usable system interpreter exists, the run must degrade to it instead of
+    hard-failing -- otherwise the first successful install would turn every
+    later update into a hard network dependency on the uv download. Only a
+    flag/env request made THIS run fails hard (pinned by
+    test_cli_managed_python_flag_skips_system_interpreters)."""
+    data_home = tmp_path / "data-home"
+    data_home.mkdir()
+    (data_home / "python-mode").write_text("managed\n")
+
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        interpreters={"python3.12": _USABLE_PY312_STUB},
+    )
+
+    combined = result.stdout + result.stderr
+    # The uv download was attempted (marker kept the managed choice) ...
+    assert "astral-sh/uv/releases/download" in (markers / "curl").read_text()
+    # ... failed, and the run degraded instead of dying at the python gate.
+    assert "could not provision a managed Python (network?)" in combined
+    assert "Python >=3.12 is required" not in combined, combined
+
+
+def test_cli_uv_download_honors_a_mirror_base(tmp_path: Path) -> None:
+    """KIROCREW_UV_URL points air-gapped / proxied hosts at a mirror of the uv
+    release tree. The URL must be built from it -- and the SHA-256 pin still
+    applies, so a mirror can serve the bytes but never substitute them (pinned
+    by test_cli_rejects_a_tampered_uv_download)."""
+    result, markers = _run_cli_with_fake_env(
+        tmp_path,
+        extra_env={"KIROCREW_UV_URL": "https://mirror.example.com/uv/"},
+    )
+
+    recorded = (markers / "curl").read_text()
+    assert "https://mirror.example.com/uv/" in recorded, result.stderr
+    assert "github.com/astral-sh" not in recorded
+    assert ".tar.gz" in recorded
 
 
 def _run_marker_write_shape(data_home: Path, tmp_path: Path) -> subprocess.CompletedProcess[bytes]:
@@ -609,12 +862,13 @@ def test_cli_marker_write_refuses_a_directory_target(tmp_path: Path) -> None:
 def test_cli_marker_read_ignores_a_planted_symlink(tmp_path: Path) -> None:
     """The marker READ is guarded like the write: a planted symlink at
     python-mode (e.g. to /dev/zero, which would wedge an unbounded cat, or to
-    an attacker file spoofing 'managed') must be ignored -- the run proceeds
-    on the system interpreter as if no marker existed."""
+    an attacker file spoofing 'system-pinned' to freeze the install off the
+    managed default) must be ignored -- the run proceeds on the managed
+    default as if no marker existed."""
     data_home = tmp_path / "data-home"
     data_home.mkdir()
     spoof = tmp_path / "spoof"
-    spoof.write_text("managed\n")
+    spoof.write_text("system-pinned\n")
     (data_home / "python-mode").symlink_to(spoof)
 
     result, markers = _run_cli_with_fake_env(
@@ -632,10 +886,10 @@ def test_cli_marker_read_ignores_a_planted_symlink(tmp_path: Path) -> None:
     )
 
     combined = result.stdout + result.stderr
-    assert "Reusing the recorded managed-python choice" not in combined
-    curl_marker = markers / "curl"
-    if curl_marker.exists():
-        assert "astral-sh/uv" not in curl_marker.read_text()
+    assert "Reusing the recorded system-python choice" not in combined
+    # The spoofed pin was ignored: the run went for the managed default.
+    assert (markers / "curl").exists(), result.stderr
+    assert "astral-sh/uv" in (markers / "curl").read_text()
     # And the read guards must still be present in cli.sh.
     text = CLI_SH.read_text()
     assert '[ ! -L "$_py_mode_file" ]' in text


### PR DESCRIPTION
## Summary

Flips the CLI installer's interpreter default from system-Python-first to **managed Python** (pinned uv + python-build-standalone CPython 3.12), with a sticky `--system-python` escape hatch. Existing installs migrate on their next update.

### Behavior matrix

| Scenario | Result |
|---|---|
| Fresh install, no flag | managed (uv + PBS 3.12) |
| Existing install, flag-less update re-run, no pin | migrates to managed (venv rebuilt in place — the relink path shipped in the venv-relink fix) |
| Marker `system-pinned` (written by `--system-python`) | stays on system, survives updates |
| Legacy bare `system` marker | treated as undecided (earlier installers wrote it for EVERY default install — it is not an opt-out) → migrates |
| Managed DEFAULT fails to provision, usable system ≥3.12 exists | falls back with a warning, writes no pin (next run retries managed) |
| EXPLICIT managed (flag / env / `managed` marker) fails to provision | hard error, unchanged |

### New env knobs

- `KIROCREW_UV_URL` — mirror base for the uv release tarballs (SHA-256 pins enforced either way)
- `UV_PYTHON_INSTALL_MIRROR` — documented passthrough for the PBS interpreter downloads

### Why

- Every peer tool self-bundles its interpreter (AWS CLI v2, Azure, gcloud, PDM, Hatch, aider); the system-Python default was the outlier and is the source of a real bug class (3.9 crashes, EOL 3.11 installs, CI-vs-host version drift).
- Desktop and Docker lanes are already pinned to PBS/3.12; this unifies the third lane.
- The opt-in machinery (uv fallback, venv relink, sticky marker) shipped through v0.4.0/v0.4.1 stable with zero related issue reports.

### Tests

- `test/test_installer_distro.py`: 24 passing, including 6 new cases — managed-by-default (usable system python is skipped), legacy `system` marker migration, `system-pinned` stickiness across a flag-less re-run, default-path fallback on provisioning failure (and that it writes no pin), `KIROCREW_UV_URL` mirror routing, plus the planted-symlink marker-read guard reworked to spoof `system-pinned` (the value an attacker would now plant).
- Full backend suite: 82,693 passed; 98 failures are the known dev-host environment class (#8008) — none of the failing files reference `cli.sh`, and this diff touches no `src/` code.

### Release note (for the next version bump — not in this PR)

Needs a `### Before you upgrade` entry: default interpreter changes, existing installs migrate on their next update, `--system-python` opts out.
