### PR TITLE
fix(transcribe): derive ffmpeg pin completeness from a real source of truth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ dev = [
     # so those tests actually run; the runtime dependency stays optional, because
     # a user who does not enable Teams should not carry a crypto library.
     "PyJWT[crypto]==2.13.0",
+    # Test-only, NOT a runtime dependency. test_transcribe.py's pin-completeness
+    # test imports imageio_ffmpeg._definitions.FNAME_PER_PLATFORM to derive the
+    # authoritative bundled-decoder filename set; without the package installed the
+    # test would importorskip and silently pass, which is the "green while checking
+    # nothing" shape that test exists to end. imageio_ffmpeg stays a packaging and
+    # runtime concern for the desktop bundle, NOT a core install_requires. Pinned to
+    # the exact version the desktop matrix ships (packaging/build-desktop.sh).
+    "imageio-ffmpeg==0.6.0",
 ]
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -191,6 +191,15 @@ dev =
     # pin identical to the group's.
     jsonschema==4.26.0
     PyJWT[crypto]==2.13.0
+    # Test-only, NOT a runtime dependency -- see the [dependency-groups] dev
+    # rationale in pyproject.toml (kept in lockstep with it). test_transcribe.py's
+    # pin-completeness test imports imageio_ffmpeg._definitions.FNAME_PER_PLATFORM
+    # to derive the authoritative bundled-decoder filename set; without the package
+    # the test would importorskip and silently pass, which is the "green while
+    # checking nothing" shape that test exists to end. imageio_ffmpeg stays a
+    # packaging and runtime concern for the desktop bundle, NOT a core
+    # install_requires.
+    imageio-ffmpeg==0.6.0
 
 [options.packages.find]
 where = src

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -124,15 +124,26 @@ def _ffmpeg_candidate_dirs() -> list[str]:
 _FFMPEG_CANDIDATE_DIRS = _ffmpeg_candidate_dirs()
 
 
-# imageio-ffmpeg==0.6.0 executables, taken from the four wheels that the desktop
-# matrix installs. The filename selects the platform artifact; size makes a
-# truncated payload fail cheaply; SHA-256 is the trust anchor. Desktop build
-# staging is intentionally writable, so path placement or a removable `.git`
-# marker cannot establish provenance. These are the bytes the WHEEL publishes.
+# imageio-ffmpeg==0.6.0 executables, taken from the published wheels that the
+# desktop matrix installs -- one per shipped platform, and which platforms those
+# are is _SHIPPED_FFMPEG_PLATFORMS below rather than a count restated here. The
+# filename selects the platform artifact; size makes a truncated payload fail
+# cheaply; SHA-256 is the trust anchor. Desktop build staging is intentionally
+# writable, so path placement or a removable `.git` marker cannot establish
+# provenance. These are the bytes the WHEEL publishes.
 _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
     "ffmpeg-macos-aarch64-v7.1": (
         49_368_728,
         "6d175a4743ca50256e89a8cdd731100f9cee33bd79aeea46894d209410dc6617",
+    ),
+    # The macOS universal DMG's x86_64 (Intel) slice. Digest taken from the
+    # published imageio-ffmpeg==0.6.0 wheel member
+    # imageio_ffmpeg/binaries/ffmpeg-macos-x86_64-v7.1 (macosx_10_9_x86_64),
+    # byte-verified rather than copied from prose. It is a shipped platform, so
+    # the pin-completeness test cannot be green while it is absent.
+    "ffmpeg-macos-x86_64-v7.1": (
+        75_991_688,
+        "4a4a968b98859588e98500ae25973d80a5ca5eed0724222b9f76360dcb72a001",
     ),
     "ffmpeg-linux-aarch64-v7.0.2": (
         51_134_160,
@@ -147,6 +158,35 @@ _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
         "2ce797a0f88d7f067180338fb227f7b1928ea727bd9a4d7a1d022f7c52af71a3",
     ),
 }
+
+# The upstream imageio_ffmpeg platform KEYS the desktop matrix actually ships a
+# bundled decoder for. This is the maintainer-owned source of truth for WHICH
+# platforms are covered; the completeness test in test_transcribe.py maps each key
+# through imageio_ffmpeg._definitions.FNAME_PER_PLATFORM to derive the authoritative
+# filename set and asserts _PACKAGED_FFMPEG_ARTIFACTS covers exactly it. Keys, not
+# filenames, so this module imports no imageio_ffmpeg at all (not a core dependency).
+#
+# Each key ties to the build leg that ships it:
+#   macos-aarch64 + macos-x86_64 = the ONE universal DMG from the macos-15 leg of
+#       .github/workflows/build-desktop.yml; the Makefile's `desktop` target builds
+#       that single DMG covering arm64 AND x86_64, so both slices ship together.
+#   linux-x86_64  = ubuntu-22.04 leg of build-desktop.yml.
+#   linux-aarch64 = ubuntu-22.04-arm leg of build-desktop.yml.
+#   windows-x86_64 = .github/workflows/build-windows.yml.
+#
+# windows-i686 (upstream ffmpeg-win32-v4.2.2.exe) is DELIBERATELY excluded: no
+# 32-bit Windows target exists in any build workflow or the Electron config.
+# Adding a win32 lane must add its key here, which then forces a pin via the
+# completeness test.
+_SHIPPED_FFMPEG_PLATFORMS: frozenset[str] = frozenset(
+    {
+        "macos-aarch64",
+        "macos-x86_64",
+        "linux-x86_64",
+        "linux-aarch64",
+        "windows-x86_64",
+    }
+)
 
 # Artifacts the macOS app signer REWRITES on its way into a release, so the
 # upstream digest above cannot be the only anchor. Signing replaces the wheel's
@@ -164,7 +204,20 @@ _PACKAGED_FFMPEG_ARTIFACTS: dict[str, tuple[int, str]] = {
 #   - a valid Developer ID signature from our own team on the exact bytes staged
 #     for execution, which is what a released app carries.
 # Neither anchor is a path or a filesystem-permission claim.
-_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS: frozenset[str] = frozenset({"ffmpeg-macos-aarch64-v7.1"})
+# BOTH macOS slices are here: build-desktop.sh ships the arm64 AND x86_64
+# imageio-ffmpeg executables as plain Mach-O under Contents/Resources, and the app
+# signer signs every nested binary with Developer ID + hardened runtime + secure
+# timestamp (generate-manifest.py enumerates them). So the released Intel-Mac slice
+# authenticates via its signature anchor exactly like the arm64 slice, its bytes
+# having been rewritten by signing away from the pinned upstream digest.
+#
+# The set is therefore exactly the macos-* members of _SHIPPED_FFMPEG_PLATFORMS, and
+# test_transcribe.py asserts that equality rather than a subset: a macOS slice added
+# above but forgotten here has no anchor left once signing has rewritten its bytes,
+# so a SIGNED release would refuse its own decoder.
+_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS: frozenset[str] = frozenset(
+    {"ffmpeg-macos-aarch64-v7.1", "ffmpeg-macos-x86_64-v7.1"}
+)
 
 # Upper bound on a signer-rewritten payload, whose exact size is unknowable in
 # source. Signing appends a code-signature superblob to a ~50 MB executable, so

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4166,9 +4166,21 @@ class TestDoctorStt:
                 return None
             return f"/usr/local/bin/{binary}"
 
+        # `ffmpeg` has to answer BOTH routes into `transcribe._find_ffmpeg`. The
+        # bundled-interpreter branch never probes PATH: it lists the imageio-ffmpeg
+        # package resource, which is a really-installed dev dependency here, so a
+        # bundled arm left unpinned reports the test environment's decoder instead of
+        # the arrangement it asked for -- and reports it as PRESENT, the permissive
+        # answer. The value is unused: the report prints availability, not a path.
+        packaged_decoder = "/kirocrew-bundle/Resources/ffmpeg" if ffmpeg else None
+
         code = 0
         with (
             patch("kiro_crew.cli_doctor.shutil.which", side_effect=_which),
+            patch(
+                "kiro_crew.transcribe._packaged_ffmpeg_resource",
+                return_value=packaged_decoder,
+            ),
             patch("kiro_crew.cli_doctor.KIRO_AGENTS_DIR", tmp_path),
             patch("kiro_crew.cli_doctor.subprocess.run", return_value=mock_run),
             patch("urllib.request.urlopen", side_effect=urllib.error.URLError("no gateway")),

--- a/test/test_pip_deps_consistency.py
+++ b/test/test_pip_deps_consistency.py
@@ -301,6 +301,12 @@ def test_dev_extra_pins_agree_with_the_dev_dependency_group():
     ``importorskip`` does the same for the Teams token gate. A missing entry
     means a locally green pytest that never ran those guards; a version skew is
     quieter still -- both sides run, against different behavior.
+
+    imageio-ffmpeg is the loud member of the same family: ``test_transcribe.py``
+    imports it at module scope deliberately, so a ``.[dev]`` install without it
+    turns that whole module into a collection error rather than a silent skip.
+    It is listed here so deleting the setup.cfg line fails on the line that
+    explains why, instead of as an unexplained ImportError.
     """
     group_pins = _pinned_versions(_dependency_group_requirements("dev"))
     extra_pins = _pinned_versions(_extra_requirements("dev"))
@@ -308,7 +314,7 @@ def test_dev_extra_pins_agree_with_the_dev_dependency_group():
     assert group_pins, "pyproject.toml [dependency-groups] dev declares no == pins"
 
     # The enablers must be present in the extra, not merely consistent-if-present.
-    for enabler in ("jsonschema", "pyjwt"):
+    for enabler in ("jsonschema", "pyjwt", "imageio-ffmpeg"):
         assert enabler in extra_pins, (
             f"setup.cfg [options.extras_require] dev must pin {enabler!r} in sync "
             "with pyproject's [dependency-groups] dev -- without it a `.[dev]` "

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -10,19 +10,32 @@ whisper.cpp decodes one.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.machinery
 import importlib.util
 import os
+import re
 import subprocess
 import sys
 import threading
 import types
 import wave
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import imageio_ffmpeg
 import numpy as np
 import pytest
+
+# The authoritative upstream map of platform key -> shipped ffmpeg filename, plus
+# the resolver for which key THIS host is. The pin-completeness test derives the
+# expected filename set from the map rather than hand-copying names, so a
+# one-character drift fails at test time. imageio-ffmpeg is a dev dependency
+# precisely so this import (and the tests) run for real; a `pytest.importorskip`
+# here would silently pass and reproduce the very "green while checking nothing"
+# shape these tests replace.
+from imageio_ffmpeg._definitions import FNAME_PER_PLATFORM, get_platform
 
 from kiro_crew import platform_compat as _pc
 from kiro_crew import stt, transcribe
@@ -1221,6 +1234,17 @@ class TestTranscriptRedaction:
 # ffmpeg discovery: bundled with desktop releases, with system fallback for source
 # ---------------------------------------------------------------------------
 
+# Floor for a plausible pinned ffmpeg payload. The real upstream executables are
+# 49-88 MB, so this is an order of magnitude below the smallest of them: it is here
+# to catch a size transcribed with digits dropped, not to track a version, and it
+# must stay far enough below the true sizes that an upstream bump never trips it.
+_MIN_PLAUSIBLE_FFMPEG_BYTES = 8 * 1024 * 1024
+
+# GitHub Actions sets CI=true on every runner. Used only to decide whether a test
+# that cannot obtain its inputs is allowed to skip: a developer machine may lack
+# them, a runner may not.
+_RUNNING_UNDER_CI = os.environ.get("CI", "").strip().lower() in {"1", "true", "yes"}
+
 
 class TestBundledFfmpeg:
     """Resolve only the executable inside the pinned imageio-ffmpeg wheel."""
@@ -1742,27 +1766,141 @@ class TestBundledFfmpeg:
         assert unknown.exists()
 
     def test_release_artifact_pins_cover_every_supported_desktop(self):
-        assert transcribe._PACKAGED_FFMPEG_ARTIFACTS == {
-            # NOT "...v7.1.gz": a compressed payload is decompressed and scanned
-            # by the Apple notary service, which rejects the unsigned executable
-            # inside it and fails the whole macOS release (#6746 regression).
-            "ffmpeg-macos-aarch64-v7.1": (
-                49_368_728,
-                "6d175a4743ca50256e89a8cdd731100f9cee33bd79aeea46894d209410dc6617",
-            ),
-            "ffmpeg-linux-aarch64-v7.0.2": (
-                51_134_160,
-                "6bb182d0d75d23028db82e9e4f723ca69b853d055698486e6984ddb2c06fb8ce",
-            ),
-            "ffmpeg-linux-x86_64-v7.0.2": (
-                79_826_272,
-                "e7e7fb30477f717e6f55f9180a70386c62677ef8a4d4d1a5d948f4098aa3eb99",
-            ),
-            "ffmpeg-win-x86_64-v7.1.exe": (
-                87_638_016,
-                "2ce797a0f88d7f067180338fb227f7b1928ea727bd9a4d7a1d022f7c52af71a3",
-            ),
+        """The pin list must cover EXACTLY the shipped desktop platforms.
+
+        No more, no less. The expected filenames are DERIVED from upstream
+        imageio_ffmpeg._definitions.FNAME_PER_PLATFORM through the maintainer-owned
+        source of truth transcribe._SHIPPED_FFMPEG_PLATFORMS, rather than
+        hand-copied into this test. So an omitted platform, a one-character name
+        typo, or a stale version suffix fails loudly HERE instead of silently at
+        runtime, where _open_packaged_ffmpeg_resource() would treat the missed
+        filename as an absent binary and report a generic "missing or damaged"
+        decoder.
+        """
+        # A stale or renamed platform key would silently drop that platform's
+        # binary from expected_filenames below, so check membership first.
+        missing_keys = transcribe._SHIPPED_FFMPEG_PLATFORMS - set(FNAME_PER_PLATFORM)
+        assert not missing_keys, (
+            f"_SHIPPED_FFMPEG_PLATFORMS keys absent from upstream "
+            f"FNAME_PER_PLATFORM (renamed or removed upstream?): {sorted(missing_keys)}"
+        )
+
+        expected_filenames = {
+            FNAME_PER_PLATFORM[key] for key in transcribe._SHIPPED_FFMPEG_PLATFORMS
         }
+        assert set(transcribe._PACKAGED_FFMPEG_ARTIFACTS) == expected_filenames
+
+    def test_host_platform_pin_matches_the_real_installed_bytes(self):
+        """The pin for THIS host's platform is checked against the actual bytes.
+
+        Deriving the KEY set from upstream says nothing about the (size, sha256)
+        VALUES, and the digest is what the module calls its trust anchor: a
+        fat-fingered or truncated one ships a decoder that no platform can
+        authenticate. imageio-ffmpeg is a real dev dependency, so its wheel puts
+        this platform's executable in site-packages -- the same upstream bytes the
+        desktop build stages -- which turns one transcribed literal per host into a
+        checked claim. Across the Linux, Windows and macOS-arm64 legs that covers
+        three of the five pins; the two no runner can supply are shape-guarded
+        below.
+
+        CI may not skip this. Every CI leg runs on a platform the desktop matrix
+        ships, and pip resolves that platform's imageio-ffmpeg wheel, which carries
+        the executable -- so under CI both of those are requirements rather than
+        luck, and a resolver that produced the pure-Python wheel instead has
+        silently removed the only byte-level check on the pinned values. A skip
+        scores as a pass, which is the exact "green while checking nothing" shape
+        this whole class of test exists to end, so it becomes a red instead. A
+        contributor on an unshipped platform, or one whose environment genuinely
+        cannot supply the bytes, still skips -- fetching them over the network is
+        not something a unit test may do.
+        """
+        host_key = get_platform()
+        filename = FNAME_PER_PLATFORM.get(host_key)
+        binary = (
+            Path(imageio_ffmpeg.__file__).parent / "binaries" / filename
+            if filename is not None
+            else None
+        )
+
+        unavailable = ""
+        if host_key not in transcribe._SHIPPED_FFMPEG_PLATFORMS:
+            unavailable = f"host platform {host_key!r} is not a shipped desktop target"
+        elif binary is None or not binary.is_file():
+            unavailable = f"imageio-ffmpeg installed no upstream executable at {binary}"
+
+        if unavailable:
+            assert not _RUNNING_UNDER_CI, (
+                "CI must check this host's pin against the real installed bytes, "
+                f"and cannot: {unavailable}"
+            )
+            pytest.skip(unavailable)
+
+        assert binary is not None  # narrowed by the guard above
+
+        payload = binary.read_bytes()
+        assert (
+            len(payload),
+            hashlib.sha256(payload).hexdigest(),
+        ) == transcribe._PACKAGED_FFMPEG_ARTIFACTS[filename], (
+            f"the pin for {filename} disagrees with the bytes imageio-ffmpeg "
+            "actually installs -- one of the two is wrong"
+        )
+
+    def test_every_pin_is_a_well_formed_size_and_sha256(self):
+        """Shape guard for the pinned values no CI leg can hash.
+
+        macOS Intel and linux-aarch64 have no runner that installs their upstream
+        executable, and the only gate that EXECUTES a staged decoder
+        (``_packaged_ffmpeg_version_probe``, called from
+        ``local_voice_runtime_gate`` in packaging/build-desktop.sh) is skipped for
+        the Intel slice. So for those two entries a truncated digest or a
+        zero-length size would otherwise reach a desktop user as a generic
+        "missing or damaged decoder" remedy with CI fully green. The bounds are
+        deliberately loose -- an ffmpeg build is tens of megabytes and a signed one
+        stays under _MAX_SIGNED_FFMPEG_BYTES -- so a legitimate version bump passes
+        while a transcription slip does not.
+        """
+        assert transcribe._PACKAGED_FFMPEG_ARTIFACTS, "the pin table must not be empty"
+
+        for filename, (size, digest) in sorted(transcribe._PACKAGED_FFMPEG_ARTIFACTS.items()):
+            assert (
+                _MIN_PLAUSIBLE_FFMPEG_BYTES <= size <= transcribe._MAX_SIGNED_FFMPEG_BYTES
+            ), f"{filename}: pinned size {size} is not a plausible ffmpeg payload"
+            assert re.fullmatch(
+                r"[0-9a-f]{64}", digest
+            ), f"{filename}: pinned digest is not a lowercase 64-hex SHA-256: {digest!r}"
+
+        # Two platforms pinning one digest is the copy-paste slip that a per-entry
+        # check cannot see, and it authorizes one platform's bytes to run as
+        # another's.
+        digests = [digest for _, digest in transcribe._PACKAGED_FFMPEG_ARTIFACTS.values()]
+        assert len(set(digests)) == len(
+            digests
+        ), f"duplicate pinned digest across platforms: {digests}"
+
+    def test_signer_rewritten_artifacts_are_exactly_the_macos_slices(self):
+        """The signature-anchored set is derived, not hand-listed.
+
+        The macOS app signer rewrites every nested Mach-O on its way into a
+        release, so exactly the macOS slices -- and only those -- are the ones
+        whose pinned upstream digest cannot match the released bytes and which
+        therefore need the signature anchor instead. Deriving the set means adding
+        a macOS slice cannot forget it: an omitted name makes every SIGNED release
+        on that platform refuse its own decoder, because the digest cannot match
+        post-signing and the signature anchor is never consulted for a name that is
+        not listed.
+        """
+        expected = {
+            FNAME_PER_PLATFORM[key]
+            for key in transcribe._SHIPPED_FFMPEG_PLATFORMS
+            if key.startswith("macos-")
+        }
+        assert transcribe._SIGNER_REWRITTEN_FFMPEG_ARTIFACTS == expected
+        # Authenticating-by-signature a name the module never pins would be a claim
+        # about nothing.
+        assert transcribe._SIGNER_REWRITTEN_FFMPEG_ARTIFACTS <= set(
+            transcribe._PACKAGED_FFMPEG_ARTIFACTS
+        )
 
     @pytest.mark.asyncio
     async def test_authenticated_bytes_remain_bound_until_spawn(self, monkeypatch, tmp_path):


### PR DESCRIPTION
Closes the structural defect in #8120.

## Problem

The bundled-ffmpeg allow-list `_PACKAGED_FFMPEG_ARTIFACTS` in `src/kiro_crew/transcribe.py` was hand-maintained, one literal per architecture, and duplicated as a literal inside `test/test_transcribe.py` (`test_release_artifact_pins_cover_every_supported_desktop`, which asserted the dict equalled a copy of itself). Nothing checked the list against the artifacts the desktop matrix actually ships, so a shipped platform (x86_64 macOS, covered by the universal DMG) could be silently missing and surface at runtime as a generic 'missing or damaged' decoder. A one-character name typo failed identically to an absent binary, with no diagnostic, and neither the test suite nor a reviewer could see it.

## Design decision

The issue left the architecture call to a maintainer: where the complete set should come from, and whether to enforce it at build time or test time. This PR introduces a **maintainer-owned source of truth expressed as upstream `imageio_ffmpeg` platform keys**, enforced at **test time**. Keys (not filenames) are used so the source module imports no `imageio_ffmpeg` at runtime; `imageio_ffmpeg` is a desktop-packaging concern, not a core dependency. The test uses a hard module-level import backed by a real dev dependency (not `importorskip`) so it cannot silently skip and reproduce the 'green while checking nothing' defect.

## Changes

- **src/kiro_crew/transcribe.py**: add `_SHIPPED_FFMPEG_PLATFORMS` (frozenset of 5 upstream platform keys: macos-aarch64, macos-x86_64, linux-x86_64, linux-aarch64, windows-x86_64), each annotated to its build leg; `windows-i686` documented as intentionally excluded (no 32-bit Windows target in any build workflow). Add the byte-verified Intel-Mac pin `ffmpeg-macos-x86_64-v7.1`, grouped with the other macOS slice, and add it to `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS`. No runtime `import imageio_ffmpeg`.
- **test/test_transcribe.py**: rewrite `test_release_artifact_pins_cover_every_supported_desktop` to derive the expected filename set from upstream `FNAME_PER_PLATFORM` via `_SHIPPED_FFMPEG_PLATFORMS` and assert set-equality against the real `_PACKAGED_FFMPEG_ARTIFACTS` (with an upstream-key membership pre-check). Because that assertion covers the KEYS only, the pinned `(size, sha256)` VALUES — the module's stated trust anchor — get their own two guards, so the rewrite is strictly stronger than the literal-copy assertion it replaces rather than a trade: `test_host_platform_pin_matches_the_real_installed_bytes` hashes the executable imageio-ffmpeg actually installs for `get_platform()` and asserts it equals that platform's pin (a real check, not a transcription, and it covers three of the five names across the Linux, Windows and macOS-arm64 legs), and **CI may not skip it** — a runner that cannot supply those bytes reds instead, because a skip scores as a pass and would be this PR's own defect shape; `test_every_pin_is_a_well_formed_size_and_sha256` requires every entry to be a lowercase 64-hex digest with a plausible size bounded by `_MAX_SIGNED_FFMPEG_BYTES`, and requires the five digests to be distinct. `test_signer_rewritten_artifacts_are_exactly_the_macos_slices` derives `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS` from the `macos-*` members of `_SHIPPED_FFMPEG_PLATFORMS` and asserts equality, not a subset, so a macOS slice added to the pins but forgotten there cannot pass.
- **test/test_pip_deps_consistency.py**: add `imageio-ffmpeg` to the required-enabler tuple in `test_dev_extra_pins_agree_with_the_dev_dependency_group`. `test/test_transcribe.py` now imports it at module scope on purpose, so a `.[dev]` install missing it turns that whole module into a collection error; listing it here means deleting the `setup.cfg` line fails on the assertion that explains why.
- **pyproject.toml** + **setup.cfg**: add `imageio-ffmpeg==0.6.0` to dev deps in lockstep; not added to core `install_requires`. Runtime behaviour is unchanged for a source install: the packaged decoder is only ever resolved behind `platform_compat.is_bundled_interpreter()`, so an importable `imageio_ffmpeg` in a contributor venv is never executed.
- **test/test_cli.py**: pin the packaged-decoder seam in `TestDoctorStt._report`. Making imageio-ffmpeg a real dev dependency puts a genuine, digest-matching decoder in site-packages, and the bundled-interpreter branch of `transcribe._find_ffmpeg` resolves that package resource instead of probing PATH — so `ffmpeg=False` no longer described the bundled arm and `test_doctor_bundled_desktop_never_requests_a_system_ffmpeg_install` read '✅ available'. The flag now answers both routes, at the helper rather than in the one test, so every arm of that class is covered.

## Testing

- `pytest test/test_transcribe.py test/test_cli.py test/test_security_posture.py test/test_pip_deps_consistency.py test/test_spawn_audit.py test/test_stt_config_field_types.py test/test_extras.py` => green, exit 0; the four files this PR touches (`test_transcribe.py`, `test_cli.py`, `test_pip_deps_consistency.py`, `test_security_posture.py`) => 573 passed, 4 skipped, run both with `CI` unset and with `CI=true`.
- isort, flake8, `mypy --platform linux src/kiro_crew` (1279 files), `scripts/check_black_formatting.py`, `scripts/check_subprocess_encoding.py`, `scripts/check_harness_parity.py`, `scripts/check_brand_name.py`, `scripts/check_changelog_history.py`, `scripts/docs-lint.sh` => all exit 0.
- The doctor failure above was reproduced locally and the seam pin proven causal: without it the test fails with the exact CI assertion, with it the test passes.
- Sibling audit for that class: `test/test_transcribe.py` pins `_trusted_site_package_roots`, `test/test_dashboard_handlers_core_coverage.py` and `test/test_stt_config_field_types.py` stub `_find_ffmpeg` itself, so the `TestDoctorStt` helper was the only site letting the real resolver reach site-packages.
- Mutation-verified, by rebinding the module constants at `pytest_configure` from a `-p` plugin so no file is edited. Each mutation reds exactly the guard that owns it: dropping the Intel-Mac entry (the original defect's shape) -> 2 failed; a one-character platform-key drift -> caught by the membership pre-check; flipping one hex character of the linux-x86_64 digest -> the host-leg hash check fails; truncating a digest to 63 characters, or setting a size to 0, or pinning one digest for two platforms -> the shape check fails; dropping `ffmpeg-macos-x86_64-v7.1` from `_SIGNER_REWRITTEN_FFMPEG_ARTIFACTS`, or adding a non-macOS name to it -> the derived-equality check fails. Each of those last five passed silently before this round.
- The CI no-skip guard is proven both ways: with the package's `binaries` directory made unreachable, an unset `CI` skips with the reason printed and `CI=true` fails with `CI must check this host's pin against the real installed bytes`. It is safe on every leg by construction — `imageio_ffmpeg.get_platform()` is `windows-x86_64` on 64-bit Windows and `macos-aarch64` on Apple Silicon, both members of `_SHIPPED_FFMPEG_PLATFORMS`, and imageio-ffmpeg 0.6.0 publishes no `py3-none-any` wheel at all, so every CI platform resolves a wheel that carries the executable.
- **Residual, stated rather than papered over:** a shape-valid single-character flip in the `macos-x86_64` or `linux-aarch64` digest is still caught by no test, and cannot be — no CI runner installs those two upstream executables, and fetching them over the network is not something a unit test may do. That is why those two get the shape guard and the distinctness guard instead. Re-adding a literal copy of the values to the test would restore only a two-edit ratchet, which is the exact antipattern this PR removes.
- The Intel-Mac pin was re-verified against the freshly downloaded published wheel `imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl`: member `imageio_ffmpeg/binaries/ffmpeg-macos-x86_64-v7.1`, size 75991688, sha256 4a4a968b98859588e98500ae25973d80a5ca5eed0724222b9f76360dcb72a001 — byte-identical to the pin.

## Pattern harvest

Rule candidate: a completeness claim must be derived from a source outside the thing it checks. The defect was not a wrong value; it was a test structurally incapable of failing for the reason it existed. `assert MODULE._CONST == { <the same literal, retyped> }` pins spelling and nothing else, yet it reads as coverage, so the missing platform stayed invisible to the suite and to reviewers. The mechanical signal is cheap and semgrep-shaped: a test whose only assertion compares a module constant to an inline literal reproducing that constant's own contents. The fix shape is always the same — derive the expected side from whatever authoritative artifact already exists (an upstream table, a build matrix, a workflow file), and keep the hand-maintained residue as small as the problem allows, here five platform keys instead of five filenames plus a size and a digest each. The judgment half generalizes past tests: whenever a comment, a constant name or a PR body says a set covers *every* X, ask where X is read from. If X exists only in a maintainer's head the claim is untested by construction, and that question applies to any allow-list, capability table or pin list whose completeness is load-bearing.

Rule candidate: adding a dependency is a change to what every test may assume is ABSENT. This PR's own dev dependency broke a passing test, because that test arranged 'no decoder' by patching one route and relied on the package simply not being installed for the other. Worth checking on any dependency addition, and worth naming because of the direction it fails in: the unpinned seam answered PRESENT, the permissive value, so the arm asserting a graceful-degradation message is exactly the arm that goes green for the wrong reason. The fix belongs on the shared arrangement helper, not on the one test that happened to notice.

## Notes

- The Intel-Mac pin necessarily overlaps the one-entry addition in #8030, since the structural completeness test cannot be green while a shipped platform is unpinned; the comment on the entry states why it cannot be deferred.
- **Design lane suggestion (advisory, verdict PASS): a test tying the dev-dep `imageio-ffmpeg` pin to `packaging/build-desktop.sh`.** Not added, because the version sync point is already covered twice and the failure it describes is loud rather than silent: `test_pip_deps_consistency.py::test_dev_extra_pins_agree_with_the_dev_dependency_group` pins `setup.cfg` against `pyproject.toml` for every shared `==` dep (imageio-ffmpeg included, automatically), `website/electron/test/packaging.test.js:352` reds if `build-desktop.sh` moves off `imageio-ffmpeg==0.6.0`, and if a packaging bump ever slipped past both, the shipped bytes would fail the pinned digest at the pre-signing desktop build gate on the arm64, Linux and Windows legs. That last clause is **narrower than an earlier revision of this body claimed**, and the correction is why this round added value guards: `local_voice_runtime_gate` in `packaging/build-desktop.sh` is the only caller of `_packaged_ffmpeg_version_probe` and it is skipped for the Intel slice, so the executing gate does not cover the platform this PR adds. The pin for that platform is now guarded by shape and digest-distinctness in the test suite instead. A third grep-based assertion would still buy no coverage the digest anchor does not already enforce.
- **Design lane suggestion on the previous head (advisory, verdict PASS): `test_host_platform_pin_matches_the_real_installed_bytes` had two `pytest.skip` exits, so its byte-level value check could vanish silently.** Fixed rather than rebutted — the lane is right, and it is this PR's own thesis pointed back at the test it adds. Under `CI` a host that is a shipped platform but cannot supply the bytes now fails with a message naming which condition broke; a contributor whose environment genuinely cannot supply them still skips, since fetching them over the network is not something a unit test may do.
- Enforcement is at test time rather than build time, consistent with the routing guidance; a renamed-away upstream key is mitigated by the membership pre-check.
- `docs/system-specs/features/stt-streaming.md` needs no edit: it documents the decoder's two cryptographic anchors and that the macOS slice ships uncompressed, both unchanged, and it never enumerated the pinned platforms (that enumeration is new, and lives in the constant).


