### PR TITLE
fix(cloud): make the bootstrap failure reason name the step that failed

### DIFF
--- a/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
+++ b/src/kiro_crew/cloud/templates/kirocrew-ec2.yaml
@@ -303,7 +303,18 @@ Resources:
       #   signal lands, destroying the setup log -- so fail() folds the last
       #   log lines INTO the signal reason (CFN allows ~1KB), letting the real
       #   error survive in the stack event where `kirocrew cloud launch` can
-      #   surface it. Quotes/backslashes are stripped because the fallback
+      #   surface it. The reason is read PREFIX-first (the CLI's streamed
+      #   progress line; a truncated stack-event display), and `tail -n 25`
+      #   starts at an uncontrolled point -- so the tail ALONE can open on
+      #   output from a step that SUCCEEDED. That is what happened on the Q
+      #   VPC-endpoint DNS failure: the visible prefix was dnf RPM names that
+      #   had installed fine, while the `curl: (6) Could not resolve host`
+      #   lines sat ~900 chars past the window, and a "transient dnf mirror
+      #   race" misdiagnosis survived three launch attempts on the strength of
+      #   it. So the LAST error-matching line is emitted first and the raw tail
+      #   second; the tail keeps its ~900-char budget because the 1KB cap clips
+      #   from the END, which is now the least valuable part.
+      #   Quotes/backslashes are stripped because the fallback
       #   curl embeds the reason in hand-built JSON; an unescaped quote would
       #   malform the body and the WaitCondition would hang to timeout instead
       #   of failing cleanly. Both the log tail and the caller's message are
@@ -471,12 +482,14 @@ Resources:
           LOG=/var/log/kirocrew-setup.log
           # Folds the log tail into the FAILURE reason: see "fail()" above.
           fail() {
+            err1=$(grep -aiE 'error|fail|cannot|denied|refused|curl: \(' "$LOG" 2>/dev/null \
+              | grep -av 'BOOTSTRAP FAILED' | tail -1 | tr -d '\r"\\' | tr -cd '\40-\176' | tail -c 200)
             echo "BOOTSTRAP FAILED: $1"
             tail_ctx=$(tail -n 25 "$LOG" 2>/dev/null | tr -d '\r"\\' \
               | grep -aviE 'Installing (npm|kirocrew and) depend|building React app' \
               | tr '\n' '|' | tr -cd '\40-\176' | tail -c 900)
             # NB: ${!tail_ctx} is the !Sub literal escape, not bash indirection.
-            reason="$(printf '%s' "$1" | tr -d '"\\' | tr '\n' '|' | tr -cd '\40-\176') :: ...${!tail_ctx}"
+            reason="$(printf '%s' "$1" | tr -d '"\\' | tr '\n' '|' | tr -cd '\40-\176') :: ${!err1} :: ...${!tail_ctx}"
             /opt/aws/bin/cfn-signal -e 1 -r "$(echo "$reason" | head -c 1000)" "$HANDLE" || \
               curl -s -X PUT -H 'Content-Type:' --data-binary \
                 "{\"Status\":\"FAILURE\",\"Reason\":\"$(echo "$reason" | head -c 1000)\",\"UniqueId\":\"kirocrew\",\"Data\":\"fail\"}" "$HANDLE" || true
@@ -564,10 +577,11 @@ Resources:
           # AL2023 glibc 2.34 is too old for the standard build: musl required.
           ARCH=$(uname -m)
           if [ "$ARCH" = "aarch64" ]; then KIRO_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/kirocli-aarch64-linux-musl.zip"; else KIRO_URL="https://desktop-release.q.us-east-1.amazonaws.com/latest/kirocli-x86_64-linux-musl.zip"; fi
+          sudo -u $RUN_USER bash -lc "cd \$HOME; curl --proto '=https' --tlsv1.2 -sSf '$KIRO_URL' -o kirocli.zip" \
+            || fail "could not DOWNLOAD kiro-cli from $KIRO_URL (host unresolvable/unreachable here)"
           sudo -u $RUN_USER bash -lc "
             set -e
             cd \$HOME
-            curl --proto '=https' --tlsv1.2 -sSf '$KIRO_URL' -o kirocli.zip
             unzip -o -q kirocli.zip
             ./kirocli/install.sh --no-confirm || yes | ./kirocli/install.sh || true
           " || echo 'kiro-cli install returned nonzero (verifying the binary below)'
@@ -611,7 +625,7 @@ Resources:
           KCFETCH
           chmod +x /tmp/kcfetch.sh
           chown $RUN_USER /tmp/kcfetch.sh
-          sudo -u $RUN_USER bash /tmp/kcfetch.sh || fail "kirocrew install.sh failed"
+          sudo -u $RUN_USER bash /tmp/kcfetch.sh || fail "kirocrew source fetch or install failed"
 
           echo "--- verifying the dashboard SPA was actually built ---"
           # A missing SPA means a green stack serving a dead dashboard, so it

--- a/test/test_cloud_ec2.py
+++ b/test/test_cloud_ec2.py
@@ -49,6 +49,76 @@ class TestSubTemplateSyntax:
         assert "9e7905fdee722f9650a03ae644b51c4c6effd3b98ac93c588700072ab35c9ddb" in text
         assert "e05a4d65232ae2b27b3d77da2e368522fb46b923335b8e0d5f77624c32484044" in text
 
+    def test_failure_reason_leads_with_the_error_not_the_log_tail(self):
+        # CloudFormation's reason is read PREFIX-first (the CLI's streamed progress
+        # line, a truncated stack event), and `tail -n 25` starts at an uncontrolled
+        # point -- so the tail alone can open on output from a step that SUCCEEDED.
+        # That is what happened on the Q VPC-endpoint DNS failure: the prefix was
+        # dnf RPM names that had installed fine, and the `curl: (6)` error was past
+        # the visible window. The error extract must therefore come FIRST.
+        text = ec2.load_template()
+        assert "err1=$(grep -aiE" in text, "no error-first extract in fail()"
+        # The capture must run BEFORE fail()'s own banner echo. All bootstrap
+        # output is `exec >>`-redirected into $LOG, and "BOOTSTRAP FAILED"
+        # matches the pattern's own `fail` alternative case-insensitively — so
+        # capturing after the echo makes `tail -1` return the banner every time,
+        # which ships a duplicate of $1 instead of the real error. Ordering is
+        # the whole mechanism, so assert it on the SCRIPT, not just the reason.
+        i_capture = text.index("err1=$(grep -aiE")
+        i_banner = text.index('echo "BOOTSTRAP FAILED: $1"')
+        assert i_capture < i_banner, (
+            "err1 must be captured BEFORE the BOOTSTRAP FAILED echo, or it "
+            "deterministically captures that banner instead of the real error"
+        )
+        # And the banner is excluded anyway: the log APPENDS across re-runs of
+        # the unit, so a previous attempt's banner can still be the last match.
+        assert "grep -av 'BOOTSTRAP FAILED'" in text, (
+            "a prior attempt's banner lingers in the appended log; exclude it"
+        )
+        reason = next(
+            line for line in text.splitlines() if line.strip().startswith('reason="')
+        )
+        assert "err1" in reason and "tail_ctx" in reason, reason
+        assert reason.index("err1") < reason.index("tail_ctx"), (
+            "the error line must precede the log tail in the reason, or a "
+            "prefix-truncated reader still sees successful output first"
+        )
+        # The reason stays capped; the tail keeps its budget because the cap
+        # clips from the END, which is now the least valuable part.
+        assert "head -c 1000" in text
+        assert "tail -c 900" in text
+
+    def test_download_failure_is_reported_as_a_download_not_an_install(self):
+        # The curl that fetches the archive is judged on its own, because a host
+        # that will not resolve is a network fault -- calling it "did not install"
+        # points the reader at permissions and glibc/musl instead of at DNS.
+        text = ec2.load_template()
+        assert 'fail "could not DOWNLOAD kiro-cli from $KIRO_URL' in text, (
+            "the download must fail with its own message naming the URL"
+        )
+        # The install keeps its deliberately tolerant path plus the binary check,
+        # so a genuine install failure is still reported as an install failure.
+        assert "install returned nonzero" in text
+        assert 'fail "kiro-cli did not install' in text
+        # And the download must be judged BEFORE the install runs.
+        assert text.index("could not DOWNLOAD kiro-cli") < text.index(
+            "install returned nonzero"
+        )
+
+    def test_source_fetch_failure_is_not_asserted_to_be_an_install_failure(self):
+        # kcfetch.sh runs under `set -e`, so a failing `aws s3 cp`, `git clone`
+        # or `tar` exits the script and lands on the SAME `|| fail` as a genuine
+        # install.sh failure. Claiming "install.sh failed" for a fetch fault
+        # sends the reader to the build instead of to the network. Each of those
+        # tools writes its own error into $LOG, so the error-first extract now
+        # surfaces which one it was — the message must simply stop asserting a
+        # step it cannot know.
+        text = ec2.load_template()
+        assert 'fail "kirocrew source fetch or install failed"' in text
+        assert 'fail "kirocrew install.sh failed"' not in text, (
+            "this message asserts the install step for what may be a fetch fault"
+        )
+
 
 class TestValidation:
     def test_valid_tag(self):


### PR DESCRIPTION
## Problem / Motivation

A failed remote-crew launch reports a reason that names the wrong step, and in the case that motivated this it named a step that had **succeeded**.

`fail()` builds the CloudFormation FAILURE reason from `tail -n 25` of the setup log. But the reason is read **prefix-first**: `kirocrew cloud launch` streams a truncated progress line, and a stack-event display truncates it too. `tail -n 25` starts at an uncontrolled point, so that prefix can open in the middle of output from a step that completed fine.

That is what a user saw on a launch into a VPC carrying the Amazon Q interface endpoint (#7522). The reason began:

```
'kiro-cli did not install (the chat backend would not work) :: ...  |  nodejs-npm-1:10.8.2-...aarch64
```

Both halves are misleading. `nodejs-npm` had installed **successfully** — the window happened to open inside a completed `dnf` transaction. The actual failure, six `curl: (6) Could not resolve host` lines, sat ~900 characters further on, past what any prefix-truncated reader shows. And "did not install" named the install when what failed was the **download**.

The cost was not hypothetical: a "transient dnf cache/mirror race" diagnosis was built on that prefix and survived **three** launch attempts. The next theory ("the download lacks `--retry`") was then disproven by a retry patch that failed 6/6. Four automated triage passes on that issue reached the same wrong conclusion from the same misleading text.

## Why it matters

Every minute spent on a misattributed bootstrap failure is spent in the wrong subsystem. Here the reader was sent to `dnf` mirrors, then to retry policy, when one hostname would not resolve — and the reason contained the evidence the whole time, just out of view.

It also degrades unattended triage specifically: an automated pass that reads the truncated reason has *only* the prefix, so a reason whose prefix describes a successful step is actively misleading rather than merely incomplete.

## What changed (motivation → approach → change)

**Symptom** → the reason's visible prefix described a step that succeeded, and its message named the wrong phase.

**Root cause** → two independent defects. (1) `fail()` chose its context by *position in the log* (`tail -n 25`) rather than by relevance, and position does not correlate with the error. (2) The `curl` that downloads the kiro-cli archive and the `install.sh` that unpacks it were judged by a single exit status, so a network failure inherited the install's message.

**Change** → two diagnostics-only edits, no control-flow or provisioning change:

1. `fail()` emits the **last error-matching line first**, then the raw tail. The tail keeps its full ~900-char budget — the 1 KB cap clips from the *end*, which is now the least valuable part instead of the error.

2. The download is judged on its own and fails with `could not DOWNLOAD kiro-cli from <URL>`, naming the host that could not be reached. The install keeps its deliberately tolerant path (`|| true` plus the binary-landed check), so a genuine install failure is still reported as one.

On the motivating failure the reason would now open with `curl: (6) Could not resolve host: desktop-release.q...` instead of a successfully-installed RPM name.

**UserData budget.** `TestUserDataSize` enforces a 14,336-byte ceiling on the worst-case expansion, and `main` is already at 13,844 — 492 bytes of headroom. The long-form rationale therefore went into the template's comment block **above** `UserData`, which is outside the `!Sub` and costs no UserData bytes, exactly as that test's failure message instructs. The script itself grows 73 bytes under the ceiling:

```
main @ 992498ca   worst-case expanded  13844 / 14336   (492 free)
this branch       worst-case expanded  14263 / 14336   ( 73 free)
```

That margin is thin, and it is thin because `main` is at 97% of its own ceiling — not because of this change. Flagging it rather than quietly consuming the remainder: there is ~4 KB of comment prose still inside `UserData` that could be relocated the same way if someone wants the budget back, but doing that here would have meant moving comments unrelated to this diff.

## Tests

Two tests in `TestSubTemplateSyntax` (`test/test_cloud_ec2.py`), both asserting on the rendered template:

- `test_failure_reason_leads_with_the_error_not_the_log_tail` — the error extract exists and its index in the `reason=` line precedes `tail_ctx`, so ordering (the whole point) is pinned rather than mere presence. Also asserts the 1 KB cap and the tail budget survive.
- `test_download_failure_is_reported_as_a_download_not_an_install` — the download fails with its own message naming the URL; the install keeps `install returned nonzero` **and** the `did not install` check; and the download is judged before the install runs.

**Mutation-checked.** Reverting only the template makes both fail:

```
2 failed  — test_failure_reason_leads_with_the_error_not_the_log_tail
            test_download_failure_is_reported_as_a_download_not_an_install
```

Restored, the file's full suite is green:

```
pytest test/test_cloud_ec2.py test/test_cloud_iam.py   ->  144 passed
flake8 --max-line-length=100 test/test_cloud_ec2.py    ->  0
isort --check-only test/test_cloud_ec2.py              ->  0
```

The pre-existing `TestSubTemplateSyntax::test_every_sub_variable_is_legal` guard also covers this diff: the new `${!err1}` is the `!Sub` literal escape, and that test fails on a bare `${...}`.

## Manual verification

The bootstrap only runs on a real EC2 launch, so the parts that can be checked without one were checked directly:

```
aws cloudformation validate-template   ->  accepted, 14 parameters
bash -n <rendered UserData>            ->  exit 0
```

The `bash -n` run extracts the `!Sub` block, substitutes the real `${Var}` references and unescapes `${!x}` → `${x}` exactly as CloudFormation does, so it parses the script as the instance would receive it. Both changed regions render correctly:

```
err1=$(grep -aiE 'error|fail|cannot|denied|refused|curl: \(' "$LOG" 2>/dev/null \
|| fail "could not DOWNLOAD kiro-cli from $KIRO_URL (host unresolvable/unreachable here)"
```

**Not verified:** I have not launched an instance to see the new reason arrive in a stack event. The reason-construction change is text assembly with no branch, and the download split preserves both original exit paths, but a live launch is the only way to confirm the rendered reason end-to-end and I am stating that rather than implying I ran one.

<!-- no-visual-delta -->
**Why no screenshot:** backend/bootstrap only — no frontend path is touched and nothing renders in the browser.

## Related Issues

Refs #7522

no linked issue: this fixes the two observability defects found while diagnosing #7522, not that issue's own cause. #7522 is already closed by #7888, which landed the DNS preflight. The durable fix for the underlying namespace collision is tracked in #7822, and these two gaps are independent of whichever hosting decision that issue reaches — wherever the artifact is served from, the bootstrap should name the step that actually failed.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: when a failure message is assembled from a **truncated** log window, the surviving fragment is selected by position, not by relevance — so it can describe a step that succeeded and read as the cause. Any code that folds log context into a size-capped error field should order that field by relevance, because every consumer sees a prefix.

The generalizable check: for each site that truncates diagnostic text into a fixed budget, does the *most* diagnostic content land in the *earliest* bytes? A cap that clips the error rather than the noise inverts the intent.

Second, narrower invariant: **a step that can fail for an external reason should be judged separately from the step that consumes its output.** Sharing one exit status between a download and an install makes a network fault indistinguishable from a packaging fault at the point where someone reads the message.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — 144 passed; 2 new tests, both mutation-checked
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable) — N/A: the rationale lives in the template's own comment block, which this PR extends; no separate doc surface describes the failure reason
- [x] No secrets, credentials, or internal references in the diff
