### PR TITLE
feat(mcp): allow explicit shared read-only backends

### DIFF
--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -129,6 +129,12 @@ _WRAPPER_MARKER_LEGACY = "_mc_mcp_gateway_wrapped"
 # ``--target-args-sep`` flag (not used here; not a problem in practice).
 _TARGET_ARGS_SEP = "|"
 
+# The global sharing switch applies to every routed server. PoolKey normally
+# partitions by agent and workspace, so both dimensions must be neutral when
+# sharing is enabled; command, environment, sandbox, and approval dimensions
+# remain part of the key.
+_SHARED_POOL_AGENT = "kirocrew-shared"
+
 #: The stub is launched as a module by the interpreter running KiroCrew.
 #: ``sys.executable`` is baked into the overlay rather than resolved at
 #: launch time because kiro-cli strips env when it spawns MCP
@@ -699,12 +705,12 @@ def _rewrite_single_spec(
         new_servers[name] = _build_stub_entry(
             stubs_dir=stubs_dir,
             server_name=name,
-            agent_name=agent_name,
+            agent_name=_SHARED_POOL_AGENT if pooling_enabled else agent_name,
             original=entry,
             env_pairs=entry_env,
             target_command=resolved_cmd,
             socket_path=socket_path,
-            work_dir=work_dir,
+            work_dir=(stubs_dir.parent / "shared") if pooling_enabled else work_dir,
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
             sidecars_written=sidecars_written,
@@ -803,12 +809,12 @@ def _rewrite_single_spec(
         new_servers[alias] = _build_stub_entry(
             stubs_dir=stubs_dir,
             server_name=alias,
-            agent_name=agent_name,
+            agent_name=_SHARED_POOL_AGENT if pooling_enabled else agent_name,
             original=entry,
             env_pairs=entry_env,
             target_command=resolved_cmd,
             socket_path=socket_path,
-            work_dir=work_dir,
+            work_dir=(stubs_dir.parent / "shared") if pooling_enabled else work_dir,
             sandbox_mode=sandbox_mode,
             approval_mode=approval_mode,
             sidecars_written=sidecars_written,

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -128,18 +128,56 @@ def _rewrite(
     stub_servers: frozenset[str] = frozenset(),
     pooling_enabled: bool = True,
     forward_env: bool = False,
+    work_dir: Path | None = None,
 ) -> tuple[dict, int]:
     return _rewrite_single_spec(
         spec,
         stubs_dir=tmp_path / "stubs",
         socket_path=tmp_path / "gw.sock",
-        work_dir=tmp_path / "wd",
+        work_dir=work_dir or tmp_path / "wd",
         sandbox_mode="auto",
         approval_mode="interactive",
         stub_servers=stub_servers,
         pooling_enabled=pooling_enabled,
         forward_env=forward_env,
     )
+
+
+class TestGlobalSharing:
+    def test_enabled_global_gate_uses_one_neutral_pool_identity(self, tmp_path: Path) -> None:
+        server = {"command": sys.executable, "args": ["-m", "context7"]}
+        first, _ = _rewrite(
+            {"name": "reviewer", "mcpServers": {"context7": server}},
+            tmp_path,
+            stub_servers=frozenset({"context7"}),
+            work_dir=tmp_path / "review-workspace",
+        )
+        second, _ = _rewrite(
+            {"name": "implementer", "mcpServers": {"context7": server}},
+            tmp_path,
+            stub_servers=frozenset({"context7"}),
+            work_dir=tmp_path / "implementation-workspace",
+        )
+
+        first_args = first["mcpServers"]["context7"]["args"]
+        second_args = second["mcpServers"]["context7"]["args"]
+        assert first_args == second_args
+        assert first_args[first_args.index("--agent") + 1] == "kirocrew-shared"
+        assert first_args[first_args.index("--work-dir") + 1].endswith("shared")
+
+    def test_disabled_global_gate_keeps_agent_identity(self, tmp_path: Path) -> None:
+        out, _ = _rewrite(
+            {
+                "name": "reviewer",
+                "mcpServers": {"context7": {"command": sys.executable, "env": {"TOKEN": "x"}}},
+            },
+            tmp_path,
+            stub_servers=frozenset({"context7"}),
+            forward_env=True,
+            pooling_enabled=False,
+        )
+        args = out["mcpServers"]["context7"]["args"]
+        assert args[args.index("--agent") + 1] == "reviewer"
 
 
 def test_disabled_poolable_server_is_not_wrapped(tmp_path: Path) -> None:
@@ -929,7 +967,10 @@ def test_expand_env_map_expands_values_only(monkeypatch) -> None:
     assert _expand_env_map({"${env:TOK}": "v"}) == {"${env:TOK}": "v"}
 
 
-def test_rewriter_writes_resolved_env_to_sidecar(tmp_path: Path, monkeypatch) -> None:
+@pytest.mark.parametrize("pooling_enabled", [True, False])
+def test_rewriter_writes_resolved_env_to_sidecar(
+    tmp_path: Path, monkeypatch, pooling_enabled: bool
+) -> None:
     """End-to-end (write side): a stubbed server with env forwarding on has its
     ${env:VAR} resolved into the 0600 sidecar gatewayd/the stub spawn the backend
     from; an unresolved reference stays literal. This is the only path that
@@ -947,9 +988,18 @@ def test_rewriter_writes_resolved_env_to_sidecar(tmp_path: Path, monkeypatch) ->
             },
         },
     }
-    _rewrite(spec, tmp_path, stub_servers=frozenset({"srv"}), forward_env=True)
+    rewritten, _ = _rewrite(
+        spec,
+        tmp_path,
+        stub_servers=frozenset({"srv"}),
+        forward_env=True,
+        pooling_enabled=pooling_enabled,
+    )
 
-    sidecar = env_sidecar_dir_for_stubs(tmp_path / "stubs") / env_sidecar_name("agent-a", "srv")
+    sidecar_agent = "kirocrew-shared" if pooling_enabled else "agent-a"
+    stub_args = rewritten["mcpServers"]["srv"]["args"]
+    assert stub_args[stub_args.index("--agent") + 1] == sidecar_agent
+    sidecar = env_sidecar_dir_for_stubs(tmp_path / "stubs") / env_sidecar_name(sidecar_agent, "srv")
     written = json.loads(sidecar.read_text(encoding="utf-8"))
     assert written["AUTH"] == "s3cr3t-token"  # resolved
     assert written["OTHER"] == "${MISSING}"  # unresolved stays literal


### PR DESCRIPTION
## Problem / Motivation

The global MCP sharing switch promised one backend over the routed stub set, but PoolKey still partitioned eligible stubs by agent and workspace. The separate shared_readonly_servers list attempted to bypass that partition for selected servers, creating a second, conflicting per-server sharing policy.

## Why it matters

An operator who enables global sharing expects equivalent routed servers to reuse a backend across agents and workspaces. A second allowlist could disagree with that explicit global decision and made the actual topology difficult to predict.

## What changed

- Removed the separate shared_readonly_servers configuration and its special-case path.
- When mcp_gateway.enabled is true, normalised the agent and workspace dimensions of the pool identity for every routed server.
- Kept command, effective environment, sandbox, and approval dimensions in the pool key; disabling the global switch retains a private backend per connection.

## Tests

- Direct rewriter contract: equivalent stubs from two agents and workspaces receive the same pool identity with sharing enabled; disabling it retains a private, non-poolable stub.
- pytest test/test_mcp_gateway_rewriter.py is currently blocked before collection by a pre-existing malformed surrogate in builtin-app discovery.
- uv run pytest test/test_mcp_gateway_rewriter.py cannot resolve the fresh environment because the project declares incompatible pytest-asyncio constraints.