### PR TITLE
feat(sage): safely parallelize run-scoped reviews

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -416,139 +416,122 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
     relay) and warm workers are reused across CRs with a clean-slate reset
     between them.
 
-    Whole runs ARE serialized against each other, and reviews within a run run one
-    at a time. Neither is a performance choice: results come back through
-    ``data/results/<change_id>.json``, which is SHARED across runs, so two live runs
-    are two writers to one path and a prompt-injected worker could get its findings
-    adopted by the other run. Run-scoped subtrees narrow that window but do not
-    close it, because the hand-back still crosses the shared path. Serializing is
-    what makes adoption attributable.
-
-    The cost is real and worth stating: a second review waits for the first. The
-    exchange is a shared-path race for latency, and until the hand-back stops going
-    through a shared path, latency is the right thing to give up."""
+    The claim lock only decides which changes this run owns. Each worker receives
+    an unguessable result capability; adoption checks that capability before a
+    shared-path record enters the run, so unrelated reviews can proceed in the
+    bounded pool without cross-run attribution."""
     run_id = str(run.get("run_id") or "")
     try:
         async with _RUN_LOCK:
-            # Serialize the WHOLE run, not just the claim. Workers hand results back
-            # through `data/results/<change_id>.json`, which is shared across runs
-            # (`publish_to_shared` writes to `results_dir(root, None)`), so two live runs
-            # means two writers to one path. The claim cannot substitute for this: it
-            # coordinates honest runs, while a prompt-injected worker writes whatever
-            # change id it likes and a concurrent run then adopts findings it did not
-            # produce. Concurrent starts queue here instead of interleaving.
-            # Inner guard, still worth holding: two runs reviewing the same PR, and
-            # re-reviewing a head a just-finished run already delivered.
             changes = await asyncio.to_thread(_claim_changes_under_lock, run, changes)
-            if not changes:
-                run["summary"] = {"ok": True, "changes": 0,
-                                  "note": "all PRs already reviewed or in flight "
-                                          "in a concurrent run"}
-                run["status"] = "done"
-                return
-            # Bridge the threaded driver to the async pool running on THIS (gateway)
-            # event loop. The pool is a lazily-created process-wide singleton.
-            loop = asyncio.get_running_loop()
-            pool = review_pool.get_pool()
-            dispatch = review_pool.make_sync_dispatch(loop, pool)
+        if not changes:
+            run["summary"] = {"ok": True, "changes": 0,
+                              "note": "all PRs already reviewed or in flight "
+                                      "in a concurrent run"}
+            run["status"] = "done"
+            return
+        # Bridge the threaded driver to the async pool running on THIS (gateway)
+        # event loop. The pool is a lazily-created process-wide singleton.
+        loop = asyncio.get_running_loop()
+        pool = review_pool.get_pool()
+        dispatch = review_pool.make_sync_dispatch(loop, pool)
 
-            # Bracket the batch: begin_batch() lazily spawns the ONE shared runtime;
-            # end_batch() (in finally) kills it once this run's reviews all drain — so
-            # the subprocess (and its memory) lives exactly as long as the batch. The
-            # holder is reference-counted, so overlapping runs share one runtime and the
-            # last one out tears it down.
-            #
-            # Runtime preflight, read ONCE and reused: when the host cannot spawn a
-            # reviewer (no kiro-cli, ACP runtime unimportable) the batch is never
-            # opened — begin_batch would raise inside the spawn with a generic
-            # message — and the same verdict is handed to run_review, which fails
-            # every change fast with a reason naming the missing runtime. One
-            # reading keeps the bracket and the driver's verdict consistent.
-            # Offloaded: the executable resolution stats candidates across every
-            # PATH entry, and one stale network mount there would stall the loop.
-            runtime_error = await asyncio.to_thread(review_pool.runtime_preflight)
-            # `begin_batch` is the only thing that can answer the sandbox question,
-            # because the delegation decision is made inside the spawn (on Windows
-            # Kiro Crew has no native backend, so a review is confined only when
-            # kiro-cli's own sandbox takes it). A refusal is therefore reported
-            # through the SAME channel as a missing kiro-cli — every change fails
-            # fast with a reason naming the config key — instead of escaping as an
-            # undiscriminated run error. `batch_open` is tracked separately so a
-            # refused spawn never calls end_batch() on a batch that never opened.
-            batch_open = False
-            if not runtime_error:
-                try:
-                    await pool.begin_batch()
-                    batch_open = True
-                except review_pool.ReviewRuntimeUnavailable as exc:
-                    runtime_error = str(exc)
+        # Bracket the batch: begin_batch() lazily spawns the ONE shared runtime;
+        # end_batch() (in finally) kills it once this run's reviews all drain — so
+        # the subprocess (and its memory) lives exactly as long as the batch. The
+        # holder is reference-counted, so overlapping runs share one runtime and the
+        # last one out tears it down.
+        #
+        # Runtime preflight, read ONCE and reused: when the host cannot spawn a
+        # reviewer (no kiro-cli, ACP runtime unimportable) the batch is never
+        # opened — begin_batch would raise inside the spawn with a generic
+        # message — and the same verdict is handed to run_review, which fails
+        # every change fast with a reason naming the missing runtime. One
+        # reading keeps the bracket and the driver's verdict consistent.
+        # Offloaded: the executable resolution stats candidates across every
+        # PATH entry, and one stale network mount there would stall the loop.
+        runtime_error = await asyncio.to_thread(review_pool.runtime_preflight)
+        # `begin_batch` is the only thing that can answer the sandbox question,
+        # because the delegation decision is made inside the spawn (on Windows
+        # Kiro Crew has no native backend, so a review is confined only when
+        # kiro-cli's own sandbox takes it). A refusal is therefore reported
+        # through the SAME channel as a missing kiro-cli — every change fails
+        # fast with a reason naming the config key — instead of escaping as an
+        # undiscriminated run error. `batch_open` is tracked separately so a
+        # refused spawn never calls end_batch() on a batch that never opened.
+        batch_open = False
+        if not runtime_error:
             try:
-                summary = await asyncio.to_thread(
-                    review_driver.run_review, changes,  # type: ignore[attr-defined]
-                    dispatch=dispatch, progress=_make_progress(run),
-                    run_id=run_id, cancelled=lambda: run_id in _CANCELLED,
-                    preflight=lambda: runtime_error,
-                    # One reviewer at a time. Workers share the staging directory and
-                    # each has shell and file tools, so two running at once means one
-                    # can write another change's record between that change's slot
-                    # being cleared and its own worker writing -- attacker-controlled
-                    # findings attributed to the victim pull request. Serializing makes
-                    # "the record in this slot" mean "written by the worker just
-                    # dispatched". Restoring parallelism needs per-dispatch staging
-                    # whose path a sibling worker cannot guess.
-                    concurrency=1,
-                )
-            finally:
-                if batch_open:
-                    await pool.end_batch()
-            run["summary"] = summary
-            _collect_delivered(run, summary)
-            run["report_slug"] = summary.get("report_slug") or run.get("report_slug")
-            recorded = int(summary.get("result_records") or 0)
-            deep = int(summary.get("deep_reviewed") or 0)
-            attempted = int(summary.get("changes") or 0) - int(summary.get("cancelled") or 0)
-            if run_id in _CANCELLED:
-                run["status"] = "cancelled"
-            elif not summary.get("ok"):
-                run["status"] = "error"
-            elif attempted > 0 and (recorded == 0 or deep == 0):
-                # run_review returns ok=True for any run with >=1 change, so a run
-                # whose every change failed used to report "done" with an empty
-                # report. Nothing was reviewed; say so rather than letting the UI
-                # claim success and then show an empty report.
-                #
-                # `deep == 0` is checked as well as `recorded == 0`: a change can
-                # persist a record and still never be deep-reviewed, which cleared the
-                # record count while leaving the report with no findings in it. Both
-                # are the same "claimed success, delivered nothing" failure.
-                run["status"] = "error"
-                run["error"] = _first_change_error(summary) or (
-                    "the reviewer produced no result record")
-            else:
-                # "done" even if SOME changes failed — those are surfaced per change.
-                run["status"] = "done"
-            if not summary.get("ok"):
-                run["error"] = summary.get("error", "review failed")
-            else:
-                # Durable dedup index: record each reviewed PR's head SHA so a later
-                # repo-review skips it until its head changes. Only repo-review runs
-                # carry head_shas; pasted-link runs skip this (no-op).
-                await asyncio.to_thread(_record_reviewed, run)
-            if run["status"] == "error":
-                # The cause as a TOKEN, beside the sentence rather than instead of
-                # it. `_first_change_failure` collapses the token into English for
-                # `error`, so without this the payload names the cause nowhere and
-                # the dashboard's translator has to recognize causes by their
-                # wording -- which silently reverts a card to untranslated
-                # pass-through the next time a message is reworded, with no test
-                # going red. Set for BOTH error branches above: the summary-level
-                # `error` sentence and the per-change one describe the same
-                # `per_change` records, so the token is derived from those either
-                # way. Absent (never empty-string) when no record carried one, so a
-                # reader cannot mistake "no token" for a token.
-                reason = _first_change_failure(summary)[1]
-                if reason:
-                    run["reason"] = reason
+                await pool.begin_batch()
+                batch_open = True
+            except review_pool.ReviewRuntimeUnavailable as exc:
+                runtime_error = str(exc)
+        try:
+            summary = await asyncio.to_thread(
+                review_driver.run_review, changes,  # type: ignore[attr-defined]
+                dispatch=dispatch, progress=_make_progress(run),
+                run_id=run_id, cancelled=lambda: run_id in _CANCELLED,
+                preflight=lambda: runtime_error,
+                # Parallel again, bounded by the pool. What forced one-at-a-time
+                # was the shared result path: any worker could write any change's
+                # record. Each dispatch now carries an unguessable result
+                # capability the driver checks before adopting a record, so a
+                # sibling worker's findings cannot be attributed to another
+                # change. 0 leaves the width to the pool rather than pinning a
+                # second number that has to be kept in step with it.
+                concurrency=0,
+            )
+        finally:
+            if batch_open:
+                await pool.end_batch()
+        run["summary"] = summary
+        _collect_delivered(run, summary)
+        run["report_slug"] = summary.get("report_slug") or run.get("report_slug")
+        recorded = int(summary.get("result_records") or 0)
+        deep = int(summary.get("deep_reviewed") or 0)
+        attempted = int(summary.get("changes") or 0) - int(summary.get("cancelled") or 0)
+        if run_id in _CANCELLED:
+            run["status"] = "cancelled"
+        elif not summary.get("ok"):
+            run["status"] = "error"
+        elif attempted > 0 and (recorded == 0 or deep == 0):
+            # run_review returns ok=True for any run with >=1 change, so a run
+            # whose every change failed used to report "done" with an empty
+            # report. Nothing was reviewed; say so rather than letting the UI
+            # claim success and then show an empty report.
+            #
+            # `deep == 0` is checked as well as `recorded == 0`: a change can
+            # persist a record and still never be deep-reviewed, which cleared the
+            # record count while leaving the report with no findings in it. Both
+            # are the same "claimed success, delivered nothing" failure.
+            run["status"] = "error"
+            run["error"] = _first_change_error(summary) or (
+                "the reviewer produced no result record")
+        else:
+            # "done" even if SOME changes failed — those are surfaced per change.
+            run["status"] = "done"
+        if not summary.get("ok"):
+            run["error"] = summary.get("error", "review failed")
+        else:
+            # Durable dedup index: record each reviewed PR's head SHA so a later
+            # repo-review skips it until its head changes. Only repo-review runs
+            # carry head_shas; pasted-link runs skip this (no-op).
+            await asyncio.to_thread(_record_reviewed, run)
+        if run["status"] == "error":
+            # The cause as a TOKEN, beside the sentence rather than instead of
+            # it. `_first_change_failure` collapses the token into English for
+            # `error`, so without this the payload names the cause nowhere and
+            # the dashboard's translator has to recognize causes by their
+            # wording -- which silently reverts a card to untranslated
+            # pass-through the next time a message is reworded, with no test
+            # going red. Set for BOTH error branches above: the summary-level
+            # `error` sentence and the per-change one describe the same
+            # `per_change` records, so the token is derived from those either
+            # way. Absent (never empty-string) when no record carried one, so a
+            # reader cannot mistake "no token" for a token.
+            reason = _first_change_failure(summary)[1]
+            if reason:
+                run["reason"] = reason
     except Exception as exc:  # pragma: no cover - defensive
         run["status"] = "error"
         run["error"] = str(exc)
@@ -566,17 +549,7 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
 
 
 def _first_change_failure(summary: dict) -> tuple[str, str]:
-    """The most useful per-change failure, as ``(sentence, reason_token)``.
-
-    Both halves come from the SAME record in one pass, which is the whole reason
-    this is not two functions. The sentence is often built from ``deep_error`` --
-    prose from the spawn -- while the token lives in that record's
-    ``skipped_reason``; a second independent scan for the token would happily
-    return a LATER record's token and pair it with this record's sentence,
-    labelling a failure with an unrelated cause.
-
-    The token half is ``""`` when the chosen record kept no ``skipped_reason``.
-    """
+    """The most useful per-change failure, as ``(sentence, reason_token)``."""
     for rec in summary.get("per_change") or []:
         for key in ("deep_error", "gate_error", "skipped_reason"):
             val = str(rec.get(key) or "").strip()

--- a/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/backend/routes.py
@@ -416,10 +416,10 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
     relay) and warm workers are reused across CRs with a clean-slate reset
     between them.
 
-    The claim lock only decides which changes this run owns. Each worker receives
-    an unguessable result capability; adoption checks that capability before a
-    shared-path record enters the run, so unrelated reviews can proceed in the
-    bounded pool without cross-run attribution."""
+    The claim lock only decides which changes this run owns. Each worker returns
+    its record inside its own dispatch response, which no sibling can write, so
+    unrelated reviews can proceed in the bounded pool without cross-run
+    attribution."""
     run_id = str(run.get("run_id") or "")
     try:
         async with _RUN_LOCK:
@@ -474,11 +474,11 @@ async def _run_review_bg(run: dict, changes: list[str]) -> None:
                 preflight=lambda: runtime_error,
                 # Parallel again, bounded by the pool. What forced one-at-a-time
                 # was the shared result path: any worker could write any change's
-                # record. Each dispatch now carries an unguessable result
-                # capability the driver checks before adopting a record, so a
-                # sibling worker's findings cannot be attributed to another
-                # change. 0 leaves the width to the pool rather than pinning a
-                # second number that has to be kept in step with it.
+                # record. Each worker now hands its record back inside its own
+                # dispatch response, which no sibling can write, so a sibling
+                # worker's findings cannot be attributed to another change. 0
+                # leaves the width to the pool rather than pinning a second
+                # number that has to be kept in step with it.
                 concurrency=0,
             )
         finally:
@@ -1210,12 +1210,11 @@ async def _handle_run_post(request: web.Request) -> web.Response:
                          "pull request, this review recorded no findings, or its "
                          "records were cleared when the report was archived",
             }, status=409)
-        # Posting round-trips the record through the SHARED staging dir
-        # (publish_to_shared -> poster turn -> adopt_from_shared). The run is
-        # terminal, so its review-time claims are long released — a forced
-        # re-review of the same change could be staging there right now, and the
-        # two would trade records. Hold the same claim posting needs, refusing
-        # rather than interleaving; released in `_post_comments_bg`'s finally.
+        # The run is terminal, so its review-time claims are long released — a
+        # forced re-review of the same change could be running right now, and
+        # both would write this change's record. Hold the same claim posting
+        # needs, refusing rather than interleaving; released in
+        # `_post_comments_bg`'s finally.
         posting_cids = [
             cid for cid in (run.get("change_ids") or [])
             if cid in groups

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
@@ -6,10 +6,10 @@ output and the Focus Report's input — the durable source of truth. Writes are
 atomic (temp + ``os.replace``) and mode ``0600`` (results may quote private
 diff snippets). Records follow the findings JSON contract in the skill.
 """
+
 from __future__ import annotations
 
 import json
-import os
 import re
 import threading
 from pathlib import Path
@@ -32,6 +32,10 @@ REQUIRED_TOP = ("schema", "version", "change_id", "platform", "repo_identity", "
 REQUIRED_PHASE1 = ("gate_verdict", "design_risk", "criticality")
 VALID_VERDICTS = {"PASS", "CONCERNS", "BLOCK"}
 _UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+_HANDOFF_BEGIN = "<code-review-sage-result>"
+_HANDOFF_END = "</code-review-sage-result>"
+_POSTED_BEGIN = "<code-review-sage-posted>"
+_POSTED_END = "</code-review-sage-posted>"
 # A result record is a small JSON document; anything larger is not one.
 _RECORD_MAX_BYTES = 4 * 1024 * 1024
 
@@ -92,8 +96,7 @@ def safe_change_id(change_id: str) -> str:
     return stem or "unknown"
 
 
-def result_path(change_id: str, root: Path | None = None,
-                run_id: str | None = None) -> Path:
+def result_path(change_id: str, root: Path | None = None, run_id: str | None = None) -> Path:
     return results_dir(root, run_id) / f"{safe_change_id(change_id)}.json"
 
 
@@ -102,6 +105,8 @@ def validate_result(record: dict) -> list[str]:
     errs: list[str] = []
     if not isinstance(record, dict):
         return ["record must be an object"]
+    if "result_capability" in record:
+        errs.append("result_capability is not accepted")
     for k in REQUIRED_TOP:
         if k not in record:
             errs.append(f"missing top-level key: {k}")
@@ -150,8 +155,10 @@ def validate_result(record: dict) -> list[str]:
         # records. It is no longer a hole the way it was under the "any scalar" rule:
         # every non-string value now fails the string check above, so the guard only
         # suppresses a duplicate complaint, never the only one.
-        if isinstance(p1.get("gate_verdict"), (str, type(None))) \
-                and p1.get("gate_verdict") not in VALID_VERDICTS:
+        if (
+            isinstance(p1.get("gate_verdict"), (str, type(None)))
+            and p1.get("gate_verdict") not in VALID_VERDICTS
+        ):
             errs.append(f"phase1.gate_verdict must be one of {sorted(VALID_VERDICTS)}")
     findings = record.get("findings", [])
     if findings and not isinstance(findings, list):
@@ -225,17 +232,17 @@ def validate_result(record: dict) -> list[str]:
     return errs
 
 
-def write_result(record: dict, root: Path | None = None,
-                 run_id: str | None = None) -> Path:
+def write_result(record: dict, root: Path | None = None, run_id: str | None = None) -> Path:
     """Validate then atomically write the record (mode 0600). Raises ValueError."""
     errs = validate_result(record)
     if errs:
         raise ValueError("invalid result record: " + "; ".join(errs))
     if run_id:
         store.ensure_run_layout(run_id, root)
+        path = result_path(record["change_id"], root, run_id)
     else:
         store.ensure_layout(root)
-    path = result_path(record["change_id"], root, run_id)
+        path = result_path(record["change_id"], root, run_id)
     data = json.dumps(record, indent=2).encode("utf-8")
     store.atomic_write_locked(path, data)
     return path
@@ -251,8 +258,7 @@ def _read_json_nolink(path: Path, within: Path) -> dict | None:
     return store.read_json_nolink(path, within)
 
 
-def read_result(change_id: str, root: Path | None = None,
-                run_id: str | None = None) -> dict | None:
+def read_result(change_id: str, root: Path | None = None, run_id: str | None = None) -> dict | None:
     path = result_path(change_id, root, run_id)
     return _valid_result(_read_json_nolink(path, results_dir(root, run_id)))
 
@@ -260,7 +266,7 @@ def read_result(change_id: str, root: Path | None = None,
 def _valid_result(rec: dict | None) -> dict | None:
     """Return the record only if it satisfies the result contract.
 
-    The worker writes these files, so being a JSON object is not enough: a record
+    The driver persists these files, so being a JSON object is not enough: a record
     can be a dict and still be unusable (``phase1`` absent, or not an object).
     ``classify()`` indexes into exactly those fields, so letting one through raises
     at render time and leaves a COMPLETED run with no report -- the silent failure
@@ -271,6 +277,64 @@ def _valid_result(rec: dict | None) -> dict | None:
     if rec is None or validate_result(rec):
         return None
     return rec
+
+
+def result_from_handoff(output: object, change_id: str) -> dict | None:
+    """Validate one reviewer response received through the dispatcher.
+
+    Worker sessions share a uid, so a mode-restricted staging directory cannot
+    authenticate one worker to another. The dispatcher response is the only
+    per-session channel the driver can bind to the turn that produced it.
+    """
+    if not isinstance(output, str):
+        return None
+    start = output.find(_HANDOFF_BEGIN)
+    end = output.rfind(_HANDOFF_END)
+    if start < 0 or end < 0:
+        return None
+    raw = output[start + len(_HANDOFF_BEGIN) : end].strip()
+    try:
+        record = json.loads(raw)
+    except (TypeError, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(record, dict) or record.get("change_id") != change_id:
+        return None
+    return _valid_result(record)
+
+
+def post_outcome_from_handoff(output: object) -> dict | None:
+    """Validate the poster's response-bound delivery report.
+
+    A poster shares an operating-system identity with its sibling workers, so it
+    cannot authenticate a write to a result path. Its dispatcher response is the
+    channel bound to the poster turn; the driver persists this small report and
+    independently confirms the draft through GitHub read-back.
+    """
+    if not isinstance(output, str):
+        return None
+    start = output.find(_POSTED_BEGIN)
+    end = output.rfind(_POSTED_END)
+    if start < 0 or end < 0:
+        return None
+    try:
+        outcome = json.loads(output[start + len(_POSTED_BEGIN) : end].strip())
+    except (TypeError, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(outcome, dict):
+        return None
+    posted_comments = outcome.get("posted_comments")
+    design_comment_posted = outcome.get("design_comment_posted")
+    if (
+        isinstance(posted_comments, bool)
+        or not isinstance(posted_comments, int)
+        or posted_comments < 0
+        or not isinstance(design_comment_posted, bool)
+    ):
+        return None
+    return {
+        "posted_comments": posted_comments,
+        "design_comment_posted": design_comment_posted,
+    }
 
 
 def list_results(root: Path | None = None, run_id: str | None = None) -> list[dict]:
@@ -303,199 +367,3 @@ def clear_results(root: Path | None = None, run_id: str | None = None) -> int:
         except OSError:
             pass
     return removed
-
-
-# --- Bridging the worker's write path to the run's read path ------------------
-# The reviewing worker writes ``data/results/<change-id>.json`` — that path is
-# part of the prompt contract and of the `sage-review` skill, and the worker has
-# no notion of a run id. The DRIVER owns run scoping, so it moves each record
-# into the run's private dir once the turn ends.
-#
-# The shared dir is safe as a staging area despite concurrent runs: records are
-# keyed by change id, and the backend's in-flight claim registry guarantees two
-# live runs never hold the same change.
-
-def clear_staged(change_ids, root: Path | None = None) -> int:
-    """Remove the SHARED staging records for the given changes.
-
-    The shared dir is the worker's write path and the driver's adoption source, so
-    a record left there by a crashed run is indistinguishable from one the current
-    worker just wrote. Callers sweep their own keys before dispatch; only the keys
-    named here are touched, so a concurrent run's staging is left alone.
-
-    Takes change IDS (the caller owns the link -> id derivation; deriving it here
-    would import the driver and close an import cycle).
-    """
-    shared = results_dir(root, None)
-    removed = 0
-    for cid in change_ids or ():
-        p = shared / f"{safe_change_id(str(cid))}.json"
-        try:
-            p.unlink()
-            removed += 1
-        except OSError:
-            pass
-    return removed
-
-
-def stake_shared(change_id: str, root: Path | None = None) -> bool:
-    """Clear this change's shared slot. True == it is now empty and safe to adopt from.
-
-    Adoption cannot tell WHO wrote the file it adopts: the payload check only proves the
-    record names this change, and any reviewer worker can write any change's path in the
-    shared dir. So a record present before this change's own reviewer is dispatched has no
-    claim to be this change's findings -- it is a leftover from an earlier run or a plant
-    from another worker, and adopting it would attribute someone else's text to this pull
-    request.
-
-    Unlinked with ``os.unlink``, which removes a link without following it, so a symlink
-    planted at the path is discarded rather than dereferenced. Returning False (the slot
-    could not be cleared) tells the driver not to trust whatever turns up there.
-    """
-    path = result_path(change_id, root, None)
-    try:
-        os.unlink(path)
-    except FileNotFoundError:
-        pass                      # already empty, which is the state we want
-    except OSError:
-        return False              # still occupied by something we cannot remove
-    return True
-
-
-def adopt_from_shared(change_id: str, root: Path | None = None,
-                      run_id: str | None = None) -> bool:
-    """Move a worker-written record from the shared dir into the run's dir.
-
-    Returns True when a record was adopted. A no-op (returning False) when the
-    worker wrote nothing — which the driver reports as a failed change rather
-    than silently producing an empty report.
-
-    The record is READ through the hooks chokepoint and re-written as a regular
-    file rather than moved. The reviewer worker has shell and file tools and owns
-    the shared dir, so it can plant a SYMLINK at the record's path: ``is_file()``
-    follows links and would answer True, ``os.replace`` moves the link itself, and
-    the run dir would then hold a link that ``read_result`` dereferences with a
-    plain ``read_text`` — reading whatever the worker aimed it at. The guarded
-    reader opens with O_NOFOLLOW, validates the opened inode against the staging
-    root, rejects hardlinks and sensitive paths, and caps the size.
-
-    The payload is then parsed and checked to be a JSON object naming THIS change
-    before anything is written, and the write itself goes to a temp file renamed
-    over the destination. Both matter: the reader guarantees the bytes came from a
-    real file in the staging root, not that they are a usable record, and an
-    in-place write would let a malformed payload destroy the valid record already
-    filed for this change.
-    """
-    if not run_id:
-        return False
-    shared = results_dir(root, None)
-    src = shared / f"{safe_change_id(change_id)}.json"
-    # lstat, so a dangling or planted symlink is not mistaken for a record.
-    if not src.is_file() or src.is_symlink():
-        if not src.is_symlink():
-            return False
-        # A link where a record belongs is never legitimate: drop it so the same
-        # plant cannot be retried on the next adoption.
-        try:
-            src.unlink()
-        except OSError:
-            pass
-        return False
-    if hooks is None:  # pragma: no cover - standalone fallback
-        raw = src.read_bytes()
-    else:
-        raw = hooks.safe_read_file_bytes_nolink(
-            str(src), str(shared), max_bytes=_RECORD_MAX_BYTES)
-    if raw is None:
-        return False
-    # Validate BEFORE touching the destination. Round 13 replaced an atomic
-    # os.replace with an O_TRUNC write to close a symlink hole, and in doing so
-    # gave up all-or-nothing semantics: a malformed payload truncated whatever
-    # valid record was already there, and read_result then raised on the wreckage
-    # so no retry could recover it. Parse first, and only a record that is really
-    # for THIS change is allowed to land.
-    try:
-        parsed = json.loads(raw.decode("utf-8"))
-    except (UnicodeDecodeError, ValueError):
-        return False
-    if not isinstance(parsed, dict):
-        return False
-    # Envelope checks are not enough: `phase1: []` is a dict-shaped record with a
-    # list where an object belongs, and the report reads it as
-    # `rec.get("phase1", {}).get(...)`, which raises on a list and fails the whole
-    # run. `write_result` has always validated against this contract, so adoption
-    # was the one entrance that skipped it — same records, two standards.
-    errs = validate_result(parsed)
-    if errs:
-        return False
-    got = str(parsed.get("change_id") or "")
-    if got != change_id:
-        # Compared EXACTLY, not through `safe_change_id`. That sanitizer is lossy
-        # by design (it produces a filename stem), so comparing the sanitized
-        # forms accepted a record naming a genuinely different change:
-        # `GH-acme-service/api-1` and `GH-acme-service_api-1` both reduce to
-        # `GH-acme-service_api-1`, so the first would be filed as the second and
-        # the report would attribute its findings to the wrong pull request. The
-        # worker derives this id from the same `change_id_for` the caller used, so
-        # a byte-exact match is what a correct record already produces; anything
-        # else is a different change or a malformed one, and both must be refused.
-        return False
-    store.ensure_run_layout(run_id, root)
-    dst = result_path(change_id, root, run_id)
-    # Write a private temp file in the destination directory, then rename over
-    # the name: atomic, so a valid record is never destroyed by a failed write,
-    # and the rename replaces the NAME without following a link planted there.
-    try:
-        store.atomic_write_locked(dst, raw)
-    except OSError:
-        return False
-    try:
-        src.unlink()
-    except OSError:
-        pass
-    return True
-
-
-def publish_to_shared(change_id: str, root: Path | None = None,
-                      run_id: str | None = None) -> bool:
-    """Copy a run-scoped record back to the shared dir the poster reads.
-
-    Only needed on the opt-in posting path: the poster prompt also refers to
-    ``data/results/<id>.json``, so the record has to be visible there for the
-    turn, and is re-adopted afterwards.
-
-    The write goes to a private temp file and is renamed over the destination.
-    The destination lives in the SHARED dir, which the worker owns and can write
-    to, so ``write_bytes`` there would follow a symlink the worker planted at that
-    path and overwrite whatever it points at — outside the sandbox. ``os.replace``
-    swaps the NAME without following a link, so a plant is destroyed rather than
-    honoured. This mirrors the guard on the adoption direction; both directions
-    cross the same trust boundary, in opposite directions.
-    """
-    if not run_id:
-        return False
-    src = result_path(change_id, root, run_id)
-    if not src.is_file():
-        return False
-    store.ensure_layout(root)
-    shared = results_dir(root, None)
-    dst = shared / f"{safe_change_id(change_id)}.json"
-    try:
-        # Read through the same no-follow guard the adoption direction uses. The
-        # RUN results dir is worker-writable too, so a worker that replaced its
-        # own finished record with a symlink would otherwise have the linked
-        # file's bytes copied into shared staging, where every worker can read
-        # them. Guarding only the write (below) closed the overwrite hole and
-        # left this read as an exfiltration path in the same function.
-        if hooks is None:  # pragma: no cover - standalone fallback
-            raw = src.read_bytes()
-        else:
-            raw = hooks.safe_read_file_bytes_nolink(
-                str(src), str(results_dir(root, run_id)),
-                max_bytes=_RECORD_MAX_BYTES)
-        if raw is None:
-            return False
-        store.atomic_write_locked(dst, raw)
-    except OSError:
-        return False
-    return True

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/results.py
@@ -105,8 +105,6 @@ def validate_result(record: dict) -> list[str]:
     errs: list[str] = []
     if not isinstance(record, dict):
         return ["record must be an object"]
-    if "result_capability" in record:
-        errs.append("result_capability is not accepted")
     for k in REQUIRED_TOP:
         if k not in record:
             errs.append(f"missing top-level key: {k}")

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -33,6 +33,7 @@ the phase switch, not the verdict itself.
 Usage:
     python3 sage_lib/review_driver.py run --changes "<pr-url>[,<pr-url>...]" [--concurrency 3]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -84,6 +85,7 @@ except ImportError:  # pragma: no cover - standalone fallback
             urllib.request.ProxyHandler({}), _FallbackNoRedirect()
         ).open(req, timeout=timeout)
 
+
 _APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _APP_ROOT not in sys.path:  # allow `python3 sage_lib/review_driver.py` (run as script)
     sys.path.insert(0, _APP_ROOT)
@@ -109,12 +111,12 @@ def _redact(text: str) -> str:
     return redact_credentials(redact_exfiltration_urls(text)[0])[0]
 
 
-DEFAULT_TASK_TIMEOUT = 5400      # 90 min per review turn (the governing cap — passed
+DEFAULT_TASK_TIMEOUT = 5400  # 90 min per review turn (the governing cap — passed
 #   through run_review -> _one -> dispatch -> pool.send -> handle.prompt). A single
 #   thorough pass needs headroom that a 30-min cap would force-kill on large PRs.
 #   Stays under the runtime's 2h prompt default.
-_REPORT_ARTIFACT_TAG = "sage-report"   # tags every per-run report artifact
-DEFAULT_REPORT_RETENTION = 20    # keep the N most-recent report artifacts; prune older
+_REPORT_ARTIFACT_TAG = "sage-report"  # tags every per-run report artifact
+DEFAULT_REPORT_RETENTION = 20  # keep the N most-recent report artifacts; prune older
 
 
 def _api_request(method: str, path: str, body: dict | None = None, timeout: int = 30) -> dict:
@@ -154,7 +156,7 @@ def _prune_old_reports(keep: int) -> None:
     if not items:
         return
     items = sorted(items, key=lambda a: a.get("updated_at", ""), reverse=True)
-    for a in items[max(0, keep):]:
+    for a in items[max(0, keep) :]:
         slug = a.get("slug")
         if slug:
             _api_request("DELETE", "/api/artifacts/" + slug)
@@ -166,12 +168,17 @@ def _archive_report(html_body: str, root: Path | None = None) -> str | None:
     html_body = _redact(html_body)  # scrub LLM output before posting to the dashboard
     ts = time.strftime("%Y-%m-%d %H:%M:%SZ", time.gmtime())
     slug = "sage-report-" + time.strftime("%Y%m%d-%H%M%S", time.gmtime())
-    d = _api_request("POST", "/api/artifacts", {
-        "name": "Code Review Sage Report — " + ts,
-        "content": html_body, "kind": "widget",
-        "tags": ["cr", _REPORT_ARTIFACT_TAG],
-        "slug": slug,
-    })
+    d = _api_request(
+        "POST",
+        "/api/artifacts",
+        {
+            "name": "Code Review Sage Report — " + ts,
+            "content": html_body,
+            "kind": "widget",
+            "tags": ["cr", _REPORT_ARTIFACT_TAG],
+            "slug": slug,
+        },
+    )
     if d.get("error"):
         return None
     new_slug = d.get("slug") or slug
@@ -323,8 +330,9 @@ def _fetch_instruction(link: str) -> str:
     return pipeline.fetch_spec(platform, host=host)
 
 
-def build_consolidation_task(namespace: str, live_path: str, candidate_path: str,
-                             out_path: str) -> str:
+def build_consolidation_task(
+    namespace: str, live_path: str, candidate_path: str, out_path: str
+) -> str:
     """Prompt for the one-shot merge that turns staged candidates into the ruleset.
 
     The judgment is the model's: whether a candidate is already covered, whether
@@ -404,7 +412,8 @@ def build_review_task(change_link: str) -> str:
     return (
         "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
         "Do the COMPLETE review of EXACTLY ONE change in a SINGLE thorough pass: "
-        + change_link + ". There is NO separate gate and NO follow-up round — cover "
+        + change_link
+        + ". There is NO separate gate and NO follow-up round — cover "
         "everything now, carefully, at maximum thinking effort.\n"
         "Run every `sage_lib/...` command — the ones below AND the ones the skill "
         "writes as `<python> ...` — with this interpreter: `" + py + "`. Use that "
@@ -415,7 +424,10 @@ def build_review_task(change_link: str) -> str:
         "(`" + py + " sage_lib/learning.py list-for-review`).\n"
         "  2. Resolve the per-repo rule pack (if any) and apply it as additional rules.\n"
         "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
-        "normalize via `" + py + " sage_lib/pipeline.py prepare --link " + change_link
+        "normalize via `"
+        + py
+        + " sage_lib/pipeline.py prepare --link "
+        + change_link
         + " --payload-file <file>`.\n"
         "  4. DESIGN dimension (THINK DEEPLY — highest leverage): work the change "
         "through the skill's `Deep design reasoning` lenses (architectural fit, "
@@ -444,14 +456,16 @@ def build_review_task(change_link: str) -> str:
         "actually reviewed, and `coverage_complete` to true ONLY if that list covers "
         "every changed file — otherwise set it false (the driver will run ONE "
         "targeted follow-up on the remainder). Do not pad the list; report honestly.\n"
-        "  7. RECORD ONLY — do NOT post any comments. Write data/results/<id>.json: "
+        "  7. RECORD ONLY — do NOT post any comments. Return the complete record "
+        "in your final response, wrapped exactly once in `<code-review-sage-result>` "
+        "and `</code-review-sage-result>` tags: "
         "phase1 (gate_verdict, design_risk, criticality, design_headline, problem, "
         "why_it_matters, solution_assessment) + blast_radius; `findings` (each with "
         "file, line, severity 🔴/🟡, dimension, headline, observation, consequence, "
         "suggestion, snippet, lang); `counts` {red,yellow}; `ship_summary` (ONE straightforward "
         "line: good-to-ship + reason when there are no 🔴, or not-ready + the "
         "must-fix/design reason otherwise); `files_covered`; `coverage_complete`; "
-        "deep_reviewed=true. The driver builds the redacted bodies and a separate "
+        "deep_reviewed=true. Do not write the result record to disk. The driver builds the redacted bodies and a separate "
         "poster publishes them — you MUST NOT call any comment tool.\n"
         "     `headline` is the finding's CONCLUSION in ONE sentence under about 100 "
         "characters: what is actually wrong, stated directly. It is the only line a "
@@ -468,7 +482,7 @@ def build_review_task(change_link: str) -> str:
     )
 
 
-def build_review_followup_task(change_link: str) -> str:
+def build_review_followup_task(change_link: str, record: dict | None = None) -> str:
     """Bounded coverage backstop — dispatched AT MOST ONCE, and only when the single
     review reported ``coverage_complete=false``. It reviews the STILL-UNCOVERED
     changed files and APPENDS only net-new findings (never repeats/removes existing
@@ -478,7 +492,9 @@ def build_review_followup_task(change_link: str) -> str:
     return (
         "You are a Code Review Sage reviewer running in an ISOLATED, CLEAN session. "
         "A prior pass reviewed EXACTLY ONE change: " + change_link + " but reported "
-        "INCOMPLETE file coverage (coverage_complete=false) in data/results/<id>.json.\n"
+        "INCOMPLETE file coverage (coverage_complete=false). Its trusted prior record is:\n"
+        + json.dumps(record or {}, ensure_ascii=True)
+        + "\n"
         "Run every `sage_lib/...` command — the ones below AND the ones the skill "
         "writes as `<python> ...` — with this interpreter: `" + py + "`. Use that "
         "absolute path verbatim (quote it as YOUR shell requires if it contains "
@@ -488,7 +504,10 @@ def build_review_followup_task(change_link: str) -> str:
         "(`" + py + " sage_lib/learning.py list-for-review`).\n"
         "  2. Resolve the per-repo rule pack (if any) and apply it as additional rules.\n"
         "  3. Fetch the change — " + _fetch_instruction(change_link) + " — and "
-        "normalize via `" + py + " sage_lib/pipeline.py prepare --link " + change_link
+        "normalize via `"
+        + py
+        + " sage_lib/pipeline.py prepare --link "
+        + change_link
         + " --payload-file <file>`. READ the existing record: its `findings` and "
         "`files_covered`.\n"
         "  4. Review ONLY the changed files NOT already in `files_covered`, against "
@@ -503,12 +522,15 @@ def build_review_followup_task(change_link: str) -> str:
         "{red,yellow} over "
         "the FULL list; refresh `ship_summary`; extend `files_covered` to include "
         "every changed file and set `coverage_complete=true`; keep deep_reviewed=true "
-        "and PRESERVE the phase1 block. You MUST NOT call any comment tool.\n"
+        "and PRESERVE the phase1 block. Return the complete replacement record in your final "
+        "response, wrapped exactly once in `<code-review-sage-result>` and "
+        "`</code-review-sage-result>` tags. Do not write any result record to disk. "
+        "You MUST NOT call any comment tool.\n"
         "Do NOT spawn further subagents. Execute; do not ask questions."
     )
 
 
-def build_post_task(change_link: str) -> str:
+def build_post_task(change_link: str, payload: dict | None = None) -> str:
     """Poster prompt: publish the driver-built, Python-REDACTED DRAFT comments for
     one change. The bodies are authoritative and already scrubbed in Python — the
     poster posts them VERBATIM and only resolves the (non-sensitive) anchor. This
@@ -543,14 +565,15 @@ def build_post_task(change_link: str) -> str:
     # the poster posts it verbatim and never submits. A HUMAN submits it.
     return (
         _preamble
-        + "  1. Read data/results/<id>.json and take its `github_review_payload` "
-        "object (fields: body, comments[], optional commit_id). It was assembled "
-        "AND redacted in Python — use it EXACTLY as given; do NOT rebuild it. Parse "
+        + "  1. Use this `github_review_payload` object (built from `pending_comments`; fields: body, comments[], optional "
+        "commit_id), assembled AND redacted in Python: "
+        + json.dumps(payload or {}, ensure_ascii=True)
+        + ". Use it EXACTLY as given; do NOT rebuild it. Parse "
         "<owner>/<repo>/<number> from the PR URL.\n"
         "  2. FIRST clear any stale sage draft: GitHub allows only ONE pending "
         "review per PR per user, so a leftover one would make step 3 fail with 422. "
         "GET repos/<owner>/<repo>/pulls/<number>/reviews and, if a review with "
-        "state==\"PENDING\" exists WHOSE BODY CONTAINS the exact marker "
+        'state=="PENDING" exists WHOSE BODY CONTAINS the exact marker '
         "`[code-review-sage]`, DELETE just that one (DELETE "
         "repos/<owner>/<repo>/pulls/<number>/reviews/<review_id>) — it is a stale "
         "sage draft. NEVER delete a non-PENDING review or a PENDING review lacking "
@@ -565,10 +588,9 @@ def build_post_task(change_link: str) -> str:
         "call any submit/approve/dismiss endpoint, and MUST NOT run `gh pr review` "
         "(that would submit immediately). `gh` uses its own stored auth — never "
         "read, print, or pass any token.\n"
-        "  4. Update data/results/<id>.json: set posted_comments = len(comments) "
-        "plus 1 when `body` is non-empty; set design_comment_posted = true when "
-        "`body` is non-empty (else false). Do NOT modify findings, phase1, "
-        "pending_comments, or github_review_payload.\n"
+        '  4. Return `<code-review-sage-posted>{"posted_comments": N, '
+        '"design_comment_posted": true|false}</code-review-sage-posted>` in your final '
+        "response. Do not write any result record to disk.\n"
         "Do NOT spawn further subagents. Execute; do not ask questions."
     )
 
@@ -627,12 +649,13 @@ def _probe(base: str, secret: str) -> bool:
     port, so a cold resolve that misses sends the secret up to len(candidates)
     times -- this is the highest-multiplicity secret-bearing send in the app."""
     try:
-        req = urllib.request.Request(base + "/api/spawn",
-                                     headers={"X-Internal-Secret": secret} if secret else {})
+        req = urllib.request.Request(
+            base + "/api/spawn", headers={"X-Internal-Secret": secret} if secret else {}
+        )
         with loopback_urlopen(req, timeout=3) as resp:
             return resp.status < 500
     except urllib.error.HTTPError:
-        return True   # a gateway responded (e.g. 401/404) — it's the right port
+        return True  # a gateway responded (e.g. 401/404) — it's the right port
     except Exception:
         return False
 
@@ -700,15 +723,24 @@ def _unconfigured_dispatch(task: str, timeout: int = DEFAULT_TASK_TIMEOUT) -> di
     misconfigured/standalone call, and fails loudly rather than silently spawning.
     """
     return {
-        "ok": False, "output": "",
+        "ok": False,
+        "output": "",
         "error": "review pool dispatch not configured (no worker pool wired into run_review)",
     }
 
 
-def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = None,
-                  run_id: str | None = None,
-                  timeout: float = DEFAULT_TASK_TIMEOUT,
-                  keys: list[str] | None = None, confirm=None) -> dict:
+def post_recorded(
+    change_id: str,
+    link: str,
+    *,
+    dispatch,
+    root: Path | None = None,
+    run_id: str | None = None,
+    timeout: float = DEFAULT_TASK_TIMEOUT,
+    record: dict | None = None,
+    keys: list[str] | None = None,
+    confirm=None,
+) -> dict:
     """Publish an ALREADY-RECORDED review to its pull request.
 
     Builds the draft comment bodies from the recorded findings plus the always-on
@@ -729,25 +761,47 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
     on GitHub, so re-sending one would duplicate it on the pull request. Omitting
     ``keys`` posts everything not yet posted.
     """
-    cur = results.read_result(change_id, root, run_id)
+    cur = record if record is not None else results.read_result(change_id, root, run_id)
     if not cur:
         # No record means no review to publish. Without this the always-on
         # ship-readiness comment would be built from an empty record and posted as
         # a review of nothing (and the write-back would fail validation).
-        return {"post_ok": True, "posted_comments": 0,
-                "design_comment_posted": False, "pending": 0,
-                "post_error": "no recorded review for this change"}
+        return {
+            "post_ok": True,
+            "posted_comments": 0,
+            "design_comment_posted": False,
+            "pending": 0,
+            "post_error": "no recorded review for this change",
+        }
+    held_in_memory = record is not None or run_id is not None
+    if record is None and run_id is not None:
+        try:
+            results.result_path(change_id, root, run_id).unlink()
+        except OSError:
+            return {
+                "post_ok": False,
+                "posted_comments": 0,
+                "design_comment_posted": False,
+                "pending": 0,
+                "post_error": "could not remove the record before posting",
+            }
     all_entries = pipeline.build_pending_comments(cur)
     already = set(cur.get("posted_keys") or [])
-    wanted = (set(keys) if keys is not None
-              else {str(e.get("key")) for e in all_entries})
-    new = [e for e in all_entries
-           if str(e.get("key")) in wanted and str(e.get("key")) not in already]
+    wanted = set(keys) if keys is not None else {str(e.get("key")) for e in all_entries}
+    new = [
+        e for e in all_entries if str(e.get("key")) in wanted and str(e.get("key")) not in already
+    ]
     if not new:
-        return {"post_ok": True, "posted_comments": 0,
-                "design_comment_posted": False, "pending": 0,
-                "posted_keys": sorted(already),
-                "post_error": "nothing left to post" if all_entries else ""}
+        if record is None and run_id is not None:
+            results.write_result(cur, root, run_id)
+        return {
+            "post_ok": True,
+            "posted_comments": 0,
+            "design_comment_posted": False,
+            "pending": 0,
+            "posted_keys": sorted(already),
+            "post_error": "nothing left to post" if all_entries else "",
+        }
     # The draft is the UNION of what is already drafted and what was just
     # selected — not the selection alone.
     #
@@ -763,8 +817,7 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
     # pending review to replace and the re-included comments post a second time.
     # That is the deliberate trade this module already takes elsewhere: a visible
     # duplicate can be removed, a silently dropped finding cannot be recovered.
-    pending = [e for e in all_entries
-               if str(e.get("key")) in (wanted | already)]
+    pending = [e for e in all_entries if str(e.get("key")) in (wanted | already)]
     cur["pending_comments"] = pending
     # GitHub posts a single PENDING review, so assemble the deterministic,
     # already-redacted envelope in Python here — the poster posts it verbatim via
@@ -786,10 +839,17 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
             cur["post_error"] = str(e)
             cur["posted_comments"] = 0
             cur["design_comment_posted"] = False
-            results.write_result(cur, root, run_id)
-            return {"post_ok": False, "post_error": str(e), "posted_comments": 0,
-                    "design_comment_posted": False, "pending": len(pending),
-                    "expected_units": 0, "posted_keys": list(already)}
+            if record is None:
+                results.write_result(cur, root, run_id)
+            return {
+                "post_ok": False,
+                "post_error": str(e),
+                "posted_comments": 0,
+                "design_comment_posted": False,
+                "pending": len(pending),
+                "expected_units": 0,
+                "posted_keys": list(already),
+            }
     # Clear the delivery fields before the record goes to the poster. They are
     # what the poster writes back as its ONLY evidence of delivery, so a value
     # left over from an earlier attempt is indistinguishable from one it just
@@ -804,51 +864,41 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
     # reason; this is the sibling that did not.
     cur["posted_comments"] = 0
     cur["design_comment_posted"] = False
-    results.write_result(cur, root, run_id)
-    # The poster reads github_review_payload from the shared path named in its
-    # prompt, and writes posted_comments back there.
-    #
-    # A False return on a RUN-SCOPED record means the trusted record is NOT what
-    # sits at that path -- `publish_to_shared` refuses when its own no-follow read
-    # is blocked, which is exactly the case where a sibling worker replaced the
-    # record with a link. Dispatching anyway would point the poster at whatever IS
-    # there and publish it to the pull request, so the failure has to abort.
-    #
-    # Without a run_id the record already IS the shared one: publishing is a no-op
-    # that also reports False, and treating that as refusal would abort every
-    # unscoped post. The guard therefore applies only where a copy was required.
-    if run_id and not results.publish_to_shared(change_id, root, run_id):
-        staged = "could not stage the review record for the poster"
-        cur["post_ok"] = False
-        cur["post_error"] = staged
+    if not held_in_memory:
         results.write_result(cur, root, run_id)
-        return {"post_ok": False, "post_error": staged, "posted_comments": 0,
-                "design_comment_posted": False, "pending": len(pending),
-                "expected_units": 0, "posted_keys": list(already)}
+    # The poster receives the already-redacted payload in its dispatcher prompt,
+    # never through a filesystem handoff shared with sibling sessions.
     # The prompt builder FAILS CLOSED when the link's host no longer revalidates
     # (see build_post_task): a prompt built with an unconfirmed host would let
     # its `gh api` calls default to public github.com and land this draft on a
     # public same-slug PR. Surface that as a per-change post failure — the
     # record stays on disk for a retry once the host is configured again.
     try:
-        post_prompt = build_post_task(link)
+        post_prompt = build_post_task(link, payload=cur.get("github_review_payload") or {})
     except pipeline.adapters.AdapterError as exc:
         refused = f"refusing to post: {exc}"
         cur["post_ok"] = False
         cur["post_error"] = refused
-        results.write_result(cur, root, run_id)
-        return {"post_ok": False, "post_error": refused, "posted_comments": 0,
-                "design_comment_posted": False, "pending": len(pending),
-                "expected_units": 0, "posted_keys": list(already)}
+        if record is None:
+            results.write_result(cur, root, run_id)
+        return {
+            "post_ok": False,
+            "post_error": refused,
+            "posted_comments": 0,
+            "design_comment_posted": False,
+            "pending": len(pending),
+            "expected_units": 0,
+            "posted_keys": list(already),
+        }
     spawn = dispatch(post_prompt, timeout)
-    results.adopt_from_shared(change_id, root, run_id)
-    after = results.read_result(change_id, root, run_id) or {}
+    after = cur if held_in_memory else (results.read_result(change_id, root, run_id) or {})
     ok = bool(spawn.get("ok", False))
-    # The poster writes the count it actually delivered. That write is the ONLY
-    # evidence of delivery — a spawn that merely returned cleanly proves nothing,
-    # and treating it as proof would break the guard that catches a poster which
-    # posted nothing (_record_reviewed refuses to mark a PR reviewed unless
-    # posted >= expected). ``posted_comments`` is therefore never overwritten.
+    post_handoff = results.post_outcome_from_handoff(spawn.get("output"))
+    if post_handoff is not None:
+        after.update(post_handoff)
+    # The poster reports the count it actually delivered through its response.
+    # That report is not delivery evidence: a clean spawn or fabricated count
+    # cannot bypass the GitHub read-back below.
     delivered = int(after.get("posted_comments", 0) or 0)
     # Compare against PAYLOAD UNITS, not the finding count. The poster reports
     # `len(comments) + 1 if body`, and a finding without a usable anchor folds into
@@ -856,8 +906,11 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
     # over-counts and a complete delivery read as short. `posted_keys` then went
     # unwritten and the next post duplicated comments already on the pull request.
     # Non-GitHub platforms have no payload; there the finding count is the unit count.
-    expected_units = (pipeline.review_payload_units(cur["github_review_payload"])
-                      if _platform == "github" else len(pending))
+    expected_units = (
+        pipeline.review_payload_units(cur["github_review_payload"])
+        if _platform == "github"
+        else len(pending)
+    )
     # `confirm` is a seam, not a bypass: it defaults to the real read-back and
     # exists so tests about WHICH comments a rebuilt draft carries do not each
     # need a live pull request.
@@ -886,8 +939,7 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
         # leaves the ledger untouched and reports failure, so the records survive and
         # the next post re-sends. A visible duplicate can be removed; a silently
         # dropped finding cannot be recovered.
-        after["posted_keys"] = sorted(
-            already | {str(e.get("key")) for e in pending})
+        after["posted_keys"] = sorted(already | {str(e.get("key")) for e in pending})
         # A confirmed delivery makes the poster's self-reported count redundant, so
         # the read-back's own accounting replaces it. Leaving the poster's number in
         # place let a correct delivery be under-reported: the draft is proven on the
@@ -899,12 +951,15 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
         # replaces the draft by deleting and re-creating it, so a changed id is the
         # signal that the pending draft belongs to someone else.
         after["posted_review_id"] = confirmed_id
-        results.write_result(after, root, run_id)
+        if not held_in_memory:
+            results.write_result(after, root, run_id)
     elif ok and delivered:
         # A partial post cannot be attributed to specific comments, so nothing is
         # marked delivered. Re-posting the selection is the safe direction: a
         # duplicate is visible and removable, a silently-dropped finding is not.
         after["post_partial"] = True
+    if record is None and run_id is not None:
+        results.write_result(after, root, run_id)
     return {
         # `post_ok` means DELIVERED, not "the spawn exited cleanly". Two readers
         # depend on that meaning: `_record_reviewed` indexes the pull request as
@@ -913,8 +968,8 @@ def post_recorded(change_id: str, link: str, *, dispatch, root: Path | None = No
         "post_ok": confirmed,
         "post_error": (
             spawn.get("error", "")
-            or ("" if confirmed else
-                "the posted draft could not be confirmed on the pull request")),
+            or ("" if confirmed else "the posted draft could not be confirmed on the pull request")
+        ),
         # Authoritative once confirmed: `after["posted_comments"]` was replaced with
         # the payload's own unit count above, so this no longer echoes the poster.
         "posted_comments": int(after.get("posted_comments", 0) or 0),
@@ -976,7 +1031,7 @@ def _draft_confirmed(link: str, payload: dict) -> str:
     durable ledger untouched and lets the next post re-send.
     """
     if pipeline.review_payload_units(payload) <= 0:
-        return ""        # nothing was sent -> nothing to confirm
+        return ""  # nothing was sent -> nothing to confirm
     # An unanchored draft is not identifiable, and the payload builder already
     # refuses to produce one; requiring it here means a draft can never be
     # confirmed against a revision the record does not name.
@@ -986,7 +1041,7 @@ def _draft_confirmed(link: str, payload: dict) -> str:
     try:
         host, owner, repo, number = adapters.github_pr_ref(link)
     except Exception:
-        return ""        # not a GitHub pull request URL -> nothing to confirm
+        return ""  # not a GitHub pull request URL -> nothing to confirm
     try:
         reviews = discovery.run_gh_json(
             # `jq` is required with `paginate`, not decoration: `gh --paginate`
@@ -994,50 +1049,70 @@ def _draft_confirmed(link: str, payload: dict) -> str:
             # when no jq is given, so page two onward makes the document invalid.
             # `.[]` streams the elements as JSONL instead. A parse failure here reads
             # as "unproven", so a busy pull request would silently never confirm.
-            f"repos/{owner}/{repo}/pulls/{number}/reviews", jq=".[]", paginate=True,
-            host=host)
+            f"repos/{owner}/{repo}/pulls/{number}/reviews",
+            jq=".[]",
+            paginate=True,
+            host=host,
+        )
     except Exception:
-        return ""        # gh unavailable / not authorized / timeout -> unproven
+        return ""  # gh unavailable / not authorized / timeout -> unproven
     for rev in reviews:
         if str(rev.get("state") or "") != "PENDING":
             continue
         if pipeline.DRAFT_MARKER not in str(rev.get("body") or ""):
-            continue        # a human's in-progress draft, not ours
+            continue  # a human's in-progress draft, not ours
         rid = rev.get("id")
         if rid is None:
             continue
         if _confirm_text(rev.get("body")) != _confirm_text(payload.get("body")):
-            return ""    # some other sage draft, not the one just sent
+            return ""  # some other sage draft, not the one just sent
         if str(rev.get("commit_id") or "") != expected_commit:
-            return ""    # right text, wrong revision -> anchored to other code
+            return ""  # right text, wrong revision -> anchored to other code
         try:
             comments = discovery.run_gh_json(
                 f"repos/{owner}/{repo}/pulls/{number}/reviews/{rid}/comments",
-                jq=".[]", paginate=True, host=host)
+                jq=".[]",
+                paginate=True,
+                host=host,
+            )
         except Exception:
             return ""
         want = sorted(
-            (str(c.get("path") or ""), int(c.get("line") or 0),
-             _confirm_text(c.get("body")))
-            for c in (payload.get("comments") or []))
+            (str(c.get("path") or ""), int(c.get("line") or 0), _confirm_text(c.get("body")))
+            for c in (payload.get("comments") or [])
+        )
         # `line` reads null on a comment GitHub considers outdated, where the
         # position survives as `original_line`. Accepting that fallback avoids a
         # false negative without loosening identity: path, body and the review's
         # commit still have to match.
         got = sorted(
-            (str(c.get("path") or ""),
-             int(c.get("line") or c.get("original_line") or 0),
-             _confirm_text(c.get("body")))
-            for c in comments)
+            (
+                str(c.get("path") or ""),
+                int(c.get("line") or c.get("original_line") or 0),
+                _confirm_text(c.get("body")),
+            )
+            for c in comments
+        )
         return str(rid) if want == got else ""
     return ""
 
 
-def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
-               concurrency: int = 0, timeout: int = DEFAULT_TASK_TIMEOUT,
-               generate_report: bool = True, root: Path | None = None,
-               progress=None, run_id: str | None = None, cancelled=None,
-               post: bool | None = None, confirm=None, preflight=None) -> dict:
+def run_review(
+    changes: list[str],
+    *,
+    dispatch=None,
+    archiver=_default_archiver,
+    concurrency: int = 0,
+    timeout: int = DEFAULT_TASK_TIMEOUT,
+    generate_report: bool = True,
+    root: Path | None = None,
+    progress=None,
+    run_id: str | None = None,
+    cancelled=None,
+    post: bool | None = None,
+    confirm=None,
+    preflight=None,
+) -> dict:
     """Two-stage per change (bounded concurrency): a Phase-1 gate task, then a
     Phase-2 deep-review task for every usable verdict (PASS / CONCERNS / BLOCK).
     Each task is dispatched to the reusable worker pool (``dispatch``) and the
@@ -1082,7 +1157,7 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
     if not changes:
         return {"ok": False, "error": "no changes to review", "spawned": 0}
     dispatch = dispatch or _unconfigured_dispatch
-    progress = progress or (lambda *a, **k: None)   # (change_id, phase, extra) sink
+    progress = progress or (lambda *a, **k: None)  # (change_id, phase, extra) sink
     is_cancelled = cancelled or (lambda: False)
 
     # Fail-fast runtime preflight. Runs BEFORE the clean-slate resets below, so a
@@ -1094,23 +1169,38 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         failed_records: list[dict] = []
         for link in changes:
             change_id = _cid(link)
-            progress(change_id, "failed", {
-                "error": runtime_error, "reason": "runtime_unavailable"})
-            failed_records.append({
-                "change": link, "change_id": change_id,
-                "gate_spawn_ok": False, "gate_error": runtime_error,
-                "gate_verdict": "UNKNOWN", "phase2_ran": False,
-                "deep_spawn_ok": False, "deep_error": runtime_error,
-                "deep_reviewed": False, "result_recorded": False,
-                "design_block": False, "deep_rounds": 0,
-                "skipped_reason": "runtime_unavailable",
-            })
+            progress(change_id, "failed", {"error": runtime_error, "reason": "runtime_unavailable"})
+            failed_records.append(
+                {
+                    "change": link,
+                    "change_id": change_id,
+                    "gate_spawn_ok": False,
+                    "gate_error": runtime_error,
+                    "gate_verdict": "UNKNOWN",
+                    "phase2_ran": False,
+                    "deep_spawn_ok": False,
+                    "deep_error": runtime_error,
+                    "deep_reviewed": False,
+                    "result_recorded": False,
+                    "design_block": False,
+                    "deep_rounds": 0,
+                    "skipped_reason": "runtime_unavailable",
+                }
+            )
         return {
-            "ok": False, "error": runtime_error,
-            "changes": len(failed_records), "gate_spawns": 0, "deep_spawns": 0,
-            "design_blocked": 0, "phase2_skipped_on_block": 0, "cancelled": 0,
-            "deep_reviewed": 0, "deep_rounds": 0, "design_comments_posted": 0,
-            "result_records": 0, "failures": failed_records,
+            "ok": False,
+            "error": runtime_error,
+            "changes": len(failed_records),
+            "gate_spawns": 0,
+            "deep_spawns": 0,
+            "design_blocked": 0,
+            "phase2_skipped_on_block": 0,
+            "cancelled": 0,
+            "deep_reviewed": 0,
+            "deep_rounds": 0,
+            "design_comments_posted": 0,
+            "result_records": 0,
+            "failures": failed_records,
             "per_change": failed_records,
         }
 
@@ -1133,32 +1223,32 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
     # behaving exactly as before.
     report.reset(root, run_id)
     results.clear_results(root, run_id)
-    # Also sweep the SHARED staging path for the changes this run will review.
-    #
-    # The worker writes its record to the shared dir and the driver adopts it into
-    # the run dir; a crash between those two steps leaves an orphan that nothing
-    # reaps (`_reap_orphan_run_dirs` only walks `data/runs/`). Without this sweep,
-    # the next review of that change whose worker completes but records nothing
-    # would adopt the residue and report a stale review as a fresh success — and
-    # `_record_reviewed` would then durably mark the change reviewed at the NEW
-    # head. The legacy whole-run flow got this for free by clearing the whole
-    # shared dir at run start; a run-scoped run has to clear its own keys.
-    results.clear_staged([_cid(c) for c in changes], root)
-
     # Mark everything queued upfront so the page renders all rows at once.
     for _link in changes:
         progress(_cid(_link), "queued", {})
 
     concurrency = _resolve_concurrency(concurrency)
+    # Standalone callers still use the legacy shared result directory, where a
+    # worker has no per-dispatch capability to bind its record. Keep that mode
+    # serial; dashboard runs always supply a run id and can use the bounded pool.
+    if not run_id:
+        concurrency = 1
     per_change: list[dict] = []
 
-    def _post_pending(change_id: str, link: str) -> dict:
-        return post_recorded(change_id, link, dispatch=dispatch, root=root,
-                             run_id=run_id, timeout=timeout, confirm=confirm)
+    def _post_pending(change_id: str, link: str, record: dict | None = None) -> dict:
+        return post_recorded(
+            change_id,
+            link,
+            dispatch=dispatch,
+            root=root,
+            run_id=run_id,
+            timeout=timeout,
+            record=record,
+            confirm=confirm,
+        )
 
     def _one(link: str) -> dict:
         change_id = _cid(link)
-
         # Cooperative cancellation checkpoint. A change that has not started yet is
         # dropped here rather than paying for a full review the user already
         # abandoned; one already past this point runs to completion (see the
@@ -1166,11 +1256,19 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         if is_cancelled():
             progress(change_id, "cancelled", {})
             return {
-                "change": link, "change_id": change_id,
-                "gate_spawn_ok": False, "gate_error": "", "gate_verdict": "CANCELLED",
-                "phase2_ran": False, "deep_spawn_ok": False, "deep_error": "",
-                "deep_reviewed": False, "result_recorded": False,
-                "design_block": False, "deep_rounds": 0, "cancelled": True,
+                "change": link,
+                "change_id": change_id,
+                "gate_spawn_ok": False,
+                "gate_error": "",
+                "gate_verdict": "CANCELLED",
+                "phase2_ran": False,
+                "deep_spawn_ok": False,
+                "deep_error": "",
+                "deep_reviewed": False,
+                "result_recorded": False,
+                "design_block": False,
+                "deep_rounds": 0,
+                "cancelled": True,
                 "skipped_reason": "cancelled",
             }
 
@@ -1193,18 +1291,11 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
             # progress writer that raises must never be able to fail a review
             # that is otherwise going fine.
             try:
-                progress(change_id, "reviewing",
-                         {"activity": {"tool": tool, "step": step}})
+                progress(change_id, "reviewing", {"activity": {"tool": tool, "step": step}})
             except Exception:
                 pass
 
-        # Nothing may be sitting at this change's shared path when its reviewer starts.
-        # Adoption proves only that a record NAMES this change, not who wrote it, and every
-        # worker can write any change's path in the shared dir -- so a record present
-        # beforehand is a leftover or another worker's plant, and adopting it would put
-        # someone else's findings on this pull request. If the slot cannot be cleared, skip
-        # adoption rather than trust it.
-        # Build the prompt BEFORE staking the shared slot: the builder FAILS
+        # Build the prompt before dispatch: the builder FAILS
         # CLOSED (raises) when the link's host no longer revalidates against
         # `allowed_hosts()`, and a fetch instruction with an unconfirmed host
         # would route the worker at public github.com — reviewing (and later
@@ -1213,18 +1304,22 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
             review_prompt = build_review_task(link)
         except pipeline.adapters.AdapterError as exc:
             refused = f"refusing to review: {exc}"
-            progress(change_id, "failed", {
-                "error": refused, "reason": "review_failed"})
+            progress(change_id, "failed", {"error": refused, "reason": "review_failed"})
             return {
-                "change": link, "change_id": change_id,
-                "gate_spawn_ok": False, "gate_error": refused,
-                "gate_verdict": "UNKNOWN", "phase2_ran": False,
-                "deep_spawn_ok": False, "deep_error": refused,
-                "deep_reviewed": False, "result_recorded": False,
-                "design_block": False, "deep_rounds": 0,
+                "change": link,
+                "change_id": change_id,
+                "gate_spawn_ok": False,
+                "gate_error": refused,
+                "gate_verdict": "UNKNOWN",
+                "phase2_ran": False,
+                "deep_spawn_ok": False,
+                "deep_error": refused,
+                "deep_reviewed": False,
+                "result_recorded": False,
+                "design_block": False,
+                "deep_rounds": 0,
                 "skipped_reason": "review_failed",
             }
-        slot_clear = results.stake_shared(change_id, root)
         # Keep THIS session (the deep review) resumable: the findings' reasoning
         # is in its context, so it is the only one worth asking about. The
         # gate/follow-up/post sessions are not kept.
@@ -1232,15 +1327,15 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         if _accepts_activity(dispatch):
             review_kwargs["on_activity"] = report
         if _accepts_kwarg(dispatch, "keep_session_key"):
-            review_kwargs["keep_session_key"] = followup.chat_key(
-                run_id or "", change_id)
+            review_kwargs["keep_session_key"] = followup.chat_key(run_id or "", change_id)
         review_spawn = dispatch(review_prompt, timeout, **review_kwargs)
-        # The worker writes the shared data/results/<id>.json its prompt names;
-        # move it into this run's private dir before reading. Without this the
-        # run's dir stays empty and a completed review reports no findings.
-        if slot_clear:
-            results.adopt_from_shared(change_id, root, run_id)
-        rev_rec = results.read_result(change_id, root, run_id)
+        handoff_rec = results.result_from_handoff(review_spawn.get("output"), change_id)
+        rev_rec = handoff_rec
+        # Standalone callers retain their pre-run-id file contract. A run-scoped
+        # worker must return the response-bound handoff; falling back to a file
+        # would let a sibling plant the record it is missing.
+        if rev_rec is None and not run_id:
+            rev_rec = results.read_result(change_id, root, run_id)
         verdict = str(((rev_rec or {}).get("phase1") or {}).get("gate_verdict", "")).upper()
 
         # The gate_*/deep_* keys are kept for downstream compatibility — the run
@@ -1248,7 +1343,8 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         # single-pass model they reflect the ONE review dispatch (there is no
         # distinct gate).
         rec: dict = {
-            "change": link, "change_id": change_id,
+            "change": link,
+            "change_id": change_id,
             "gate_spawn_ok": review_spawn.get("ok", False),
             "gate_error": review_spawn.get("error", ""),
             "gate_verdict": verdict or "UNKNOWN",
@@ -1260,15 +1356,19 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
             "design_block": (verdict == "BLOCK"),
             "deep_rounds": 1,
         }
+        if handoff_rec is not None:
+            rec["_result"] = rev_rec
 
         # Fail only when the turn failed OR nothing usable was recorded — never
         # discard a record that DID land, so a trailing abnormal stop cannot drop
         # already-written verdicts/findings.
         if not review_spawn.get("ok", False):
             rec["skipped_reason"] = "review_failed"
-            progress(change_id, "failed", {
-                "error": review_spawn.get("error", "review failed"),
-                "reason": "review_failed"})
+            progress(
+                change_id,
+                "failed",
+                {"error": review_spawn.get("error", "review failed"), "reason": "review_failed"},
+            )
             return rec
         if not rec["deep_reviewed"]:
             if rev_rec is None:
@@ -1278,17 +1378,24 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
                 # consumers key on; environment failures are discriminated by
                 # the preflight before any dispatch.
                 rec["skipped_reason"] = "no_review_recorded"
-                progress(change_id, "failed", {
-                    "error": "review produced no result record",
-                    "reason": "no_review_recorded"})
+                progress(
+                    change_id,
+                    "failed",
+                    {"error": "review produced no result record", "reason": "no_review_recorded"},
+                )
             else:
                 # A record landed but never marked the review complete: the
                 # worker got far enough to write, then stopped short. Distinct
                 # from "wrote nothing" so the two can be triaged apart.
                 rec["skipped_reason"] = "review_record_incomplete"
-                progress(change_id, "failed", {
-                    "error": "review wrote a result record but never completed the review",
-                    "reason": "review_record_incomplete"})
+                progress(
+                    change_id,
+                    "failed",
+                    {
+                        "error": "review wrote a result record but never completed the review",
+                        "reason": "review_record_incomplete",
+                    },
+                )
             return rec
 
         # --- Bounded coverage backstop: AT MOST ONE targeted follow-up, and only
@@ -1297,25 +1404,21 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         # recorded.
         if (rev_rec or {}).get("coverage_complete") is False:
             progress(change_id, "reviewing", {"coverage": "followup"})
-            # The follow-up turn UPDATES the record, so it needs the current one
-            # visible at the path its prompt names, and re-adopted afterwards. A
-            # failed publish means the record there is not ours, and the follow-up
-            # would adopt whatever replaced it -- skip the turn instead.
-            published = results.publish_to_shared(change_id, root, run_id)
             # Same fail-closed contract as the first pass: no confirmed host, no
             # follow-up turn. A failed follow-up keeps the first pass's record.
             try:
-                followup_prompt: str | None = build_review_followup_task(link)
+                followup_prompt: str | None = build_review_followup_task(link, rev_rec)
             except pipeline.adapters.AdapterError:
                 followup_prompt = None
-            second_pass = (dispatch(followup_prompt, timeout)
-                           if followup_prompt and (published or not run_id)
-                           else {"ok": False})
+            second_pass = dispatch(followup_prompt, timeout) if followup_prompt else {"ok": False}
             if second_pass.get("ok", False):
-                results.adopt_from_shared(change_id, root, run_id)
-                rev_rec = results.read_result(change_id, root, run_id) or rev_rec
+                rev_rec = (
+                    results.result_from_handoff(second_pass.get("output"), change_id) or rev_rec
+                )
                 rec["deep_rounds"] = 2
                 rec["deep_reviewed"] = bool((rev_rec or {}).get("deep_reviewed"))
+                if rev_rec is not None:
+                    rec["_result"] = rev_rec
                 # The kept transcript is the FIRST pass's session, and this
                 # follow-up just added findings for files that pass never saw.
                 # Asking it about one of those would get a confident answer
@@ -1344,16 +1447,21 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
             rec["posting_expected"] = 0
             rec["post_ok"] = True
             rec["design_comment_posted"] = False
-            progress(change_id, "done", {
-                "counts": {"red": red, "yellow": yellow},
-                "design_block": rec.get("design_block", False),
-                "posted": 0, "expected": 0,
-            })
+            progress(
+                change_id,
+                "done",
+                {
+                    "counts": {"red": red, "yellow": yellow},
+                    "design_block": rec.get("design_block", False),
+                    "posted": 0,
+                    "expected": 0,
+                },
+            )
             return rec
         # Opt-in path: the review only RECORDS findings; the driver builds the
         # Python-redacted comment bodies and a separate poster publishes them
         # verbatim — no LLM free-text reaches the CR (security control, unchanged).
-        post = _post_pending(change_id, link)
+        post = _post_pending(change_id, link, rev_rec if handoff_rec is not None else None)
         posted = post["posted_comments"]
         # What the poster was actually asked to deliver, not red+yellow+1: an
         # unanchored finding folds into the review body rather than becoming its
@@ -1364,29 +1472,50 @@ def run_review(changes: list[str], *, dispatch=None, archiver=_default_archiver,
         # Shared with the explicit-retry path in the backend, so a retry records
         # delivery exactly the way the first attempt would have.
         apply_post_outcome(rec, post)
-        progress(change_id, "done", {
-            "counts": {"red": red, "yellow": yellow},
-            "design_block": rec.get("design_block", False),
-            "posted": posted, "expected": expected,
-        })
+        progress(
+            change_id,
+            "done",
+            {
+                "counts": {"red": red, "yellow": yellow},
+                "design_block": rec.get("design_block", False),
+                "posted": posted,
+                "expected": expected,
+            },
+        )
         return rec
 
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
         per_change = list(pool.map(_one, changes))
 
+    # The response channel is private to the dispatcher turn. Persist its record
+    # only after every worker turn has completed, so a sibling session never gets
+    # a filesystem window onto another worker's mutable handoff.
+    if run_id:
+        results.clear_results(root, run_id)
+    for item in per_change:
+        handoff = item.pop("_result", None)
+        if handoff is not None:
+            try:
+                results.write_result(handoff, root, run_id)
+            except (OSError, ValueError):
+                item["result_recorded"] = False
+                item["deep_reviewed"] = False
+
     design_blocked = [r for r in per_change if r.get("design_block")]
     cancelled_changes = [r for r in per_change if r.get("cancelled")]
-    failures = [r for r in per_change
-                if not r.get("cancelled")
-                and (not r["gate_spawn_ok"] or r.get("deep_spawn_ok") is False)]
+    failures = [
+        r
+        for r in per_change
+        if not r.get("cancelled") and (not r["gate_spawn_ok"] or r.get("deep_spawn_ok") is False)
+    ]
     result_records = sum(1 for r in per_change if r["result_recorded"])
     summary = {
         "ok": True,
         "changes": len(per_change),
-        "gate_spawns": len(per_change),                       # every change is gated
+        "gate_spawns": len(per_change),  # every change is gated
         "deep_spawns": sum(1 for r in per_change if r["phase2_ran"]),
-        "design_blocked": len(design_blocked),                # BLOCK verdicts (still deep-reviewed)
-        "phase2_skipped_on_block": 0,                         # BLOCK does not skip Phase 2
+        "design_blocked": len(design_blocked),  # BLOCK verdicts (still deep-reviewed)
+        "phase2_skipped_on_block": 0,  # BLOCK does not skip Phase 2
         "cancelled": len(cancelled_changes),
         "deep_reviewed": sum(1 for r in per_change if r["deep_reviewed"]),
         "deep_rounds": sum(r.get("deep_rounds", 0) for r in per_change),  # total Phase-2 rounds
@@ -1494,8 +1623,12 @@ def _main(argv: list[str] | None = None) -> int:
     sub = ap.add_subparsers(dest="cmd", required=True)
     rp = sub.add_parser("run", help="Review each change on the reusable worker pool")
     rp.add_argument("--changes", required=True, help="newline/comma-separated links or CR ids")
-    rp.add_argument("--concurrency", type=int, default=0,
-                    help="parallel reviews; 0 = auto (worker pool concurrency cap)")
+    rp.add_argument(
+        "--concurrency",
+        type=int,
+        default=0,
+        help="parallel reviews; 0 = auto (worker pool concurrency cap)",
+    )
     rp.add_argument("--timeout", type=int, default=DEFAULT_TASK_TIMEOUT)
     rp.add_argument("--no-report", dest="report", action="store_false")
     args = ap.parse_args(argv)
@@ -1510,8 +1643,13 @@ def _main(argv: list[str] | None = None) -> int:
         pool = review_pool.ReviewPool()
         dispatch = review_pool.make_sync_dispatch(loop, pool, default_timeout=args.timeout)
         try:
-            out = run_review(changes, dispatch=dispatch, concurrency=args.concurrency,
-                             timeout=args.timeout, generate_report=args.report)
+            out = run_review(
+                changes,
+                dispatch=dispatch,
+                concurrency=args.concurrency,
+                timeout=args.timeout,
+                generate_report=args.report,
+            )
         finally:
             try:
                 asyncio.run_coroutine_threadsafe(pool.shutdown(), loop).result(timeout=30)

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_driver.py
@@ -31,7 +31,7 @@ session using the code-review-sage ruleset — Python enforces the structure and
 the phase switch, not the verdict itself.
 
 Usage:
-    python3 sage_lib/review_driver.py run --changes "<pr-url>[,<pr-url>...]" [--concurrency 3]
+    python3 sage_lib/review_driver.py run --changes "<pr-url>[,<pr-url>...]"
 """
 
 from __future__ import annotations
@@ -1228,9 +1228,12 @@ def run_review(
         progress(_cid(_link), "queued", {})
 
     concurrency = _resolve_concurrency(concurrency)
-    # Standalone callers still use the legacy shared result directory, where a
-    # worker has no per-dispatch capability to bind its record. Keep that mode
-    # serial; dashboard runs always supply a run id and can use the bounded pool.
+    # Standalone callers still use the legacy shared result directory, where any
+    # worker can write any change's record — the hazard the response-bound
+    # handoff removes only for run-scoped dispatches. Keep that mode serial;
+    # dashboard runs always supply a run id and can use the bounded pool. The
+    # CLI has no run id, so it has no concurrency knob either: one would reach
+    # this line and be discarded.
     if not run_id:
         concurrency = 1
     per_change: list[dict] = []
@@ -1623,12 +1626,6 @@ def _main(argv: list[str] | None = None) -> int:
     sub = ap.add_subparsers(dest="cmd", required=True)
     rp = sub.add_parser("run", help="Review each change on the reusable worker pool")
     rp.add_argument("--changes", required=True, help="newline/comma-separated links or CR ids")
-    rp.add_argument(
-        "--concurrency",
-        type=int,
-        default=0,
-        help="parallel reviews; 0 = auto (worker pool concurrency cap)",
-    )
     rp.add_argument("--timeout", type=int, default=DEFAULT_TASK_TIMEOUT)
     rp.add_argument("--no-report", dest="report", action="store_false")
     args = ap.parse_args(argv)
@@ -1646,7 +1643,6 @@ def _main(argv: list[str] | None = None) -> int:
             out = run_review(
                 changes,
                 dispatch=dispatch,
-                concurrency=args.concurrency,
                 timeout=args.timeout,
                 generate_report=args.report,
             )

--- a/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/sage_lib/review_pool.py
@@ -29,6 +29,7 @@ The executor is async; the (synchronous, threaded) review driver bridges to it
 via ``asyncio.run_coroutine_threadsafe`` on the gateway event loop, and brackets
 each run with ``begin_batch()`` / ``end_batch()``. See ``backend/routes.py``.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -123,12 +124,16 @@ def runtime_preflight() -> str:
     otherwise stall the whole loop.
     """
     if AcpRuntime is None:
-        return ("the reviewer cannot run: the ACP runtime "
-                "(kiro_crew.acp.runtime) is not importable in this install")
+        return (
+            "the reviewer cannot run: the ACP runtime "
+            "(kiro_crew.acp.runtime) is not importable in this install"
+        )
     if resolve_kiro_cli is not None and resolve_kiro_cli() is None:
-        return ("the reviewer cannot run: no kiro-cli executable was found on "
-                "this host (the reviewer session is driven by kiro-cli — "
-                "install it or add it to PATH)")
+        return (
+            "the reviewer cannot run: no kiro-cli executable was found on "
+            "this host (the reviewer session is driven by kiro-cli — "
+            "install it or add it to PATH)"
+        )
     return ""
 
 
@@ -201,17 +206,22 @@ def _is_abnormal_stop(reason: str) -> bool:
     r = (reason or "").strip().lower()
     if not r:
         return False
-    if r in (str(STOP_REASON_TOOL_STALL).lower(),
-             str(STOP_REASON_STALE_RECOVER).lower(), "timeout"):
+    if r in (
+        str(STOP_REASON_TOOL_STALL).lower(),
+        str(STOP_REASON_STALE_RECOVER).lower(),
+        "timeout",
+    ):
         return True
     return r.startswith("error")
 
 
 # ── Tunables (resource limits live here for easy future updates) ──
-MAX_CONCURRENT = 5        # default max reviews running at once (config: review.max_concurrent)
+MAX_CONCURRENT = 5  # default max reviews running at once (config: review.max_concurrent)
 MAX_CONCURRENT_CEIL = 30  # hard ceiling — "review all" can raise concurrency up to here
-MAX_STARTING = 2          # (legacy) retained for back-compat stats; single runtime has no cold-start throttle
-DEFAULT_TASK_TIMEOUT = 5400.0   # 90 min per review turn. The single-pass review
+MAX_STARTING = (
+    2  # (legacy) retained for back-compat stats; single runtime has no cold-start throttle
+)
+DEFAULT_TASK_TIMEOUT = 5400.0  # 90 min per review turn. The single-pass review
 #   is ONE heavier turn (design + all code dimensions) that replaces up to 5 old
 #   turns, so the old 30-min cap force-killed legitimately-working large-PR reviews
 #   (stop_reason='timeout'). 90 min gives real headroom while staying well under the
@@ -219,7 +229,7 @@ DEFAULT_TASK_TIMEOUT = 5400.0   # 90 min per review turn. The single-pass review
 REVIEW_AGENT = "code-review-sage-reviewer"  # dedicated lean reviewer agent (shell-
 #   enabled so it can run the `gh` CLI to fetch/post GitHub PR reviews). The per-task
 #   prompt loads the `sage-review` skill on top of it.
-_FALLBACK_AGENT = "kirocrew"     # default agent when the reviewer agent isn't installed
+_FALLBACK_AGENT = "kirocrew"  # default agent when the reviewer agent isn't installed
 
 # Reasoning/thinking effort for the review workers. Empty string = "no explicit
 # override; inherit the model/provider default" (the config default), rather than
@@ -295,11 +305,10 @@ def _resolve_review_agent(preferred: str = REVIEW_AGENT) -> str:
 
 def _review_work_dir() -> Optional[str]:
     """Working directory for a review worker = the installed app root, so the
-    gate/deep prompts' RELATIVE paths (`sage_lib/pipeline.py`, `data/results/<id>.json`)
-    resolve to exactly where the driver reads/writes. Without this the worker's
-    default cwd (<config_dir>/workspace) sends the result record to the wrong dir
-    and the driver sees "gate produced no verdict". Falls back to the AcpClient
-    default if the app root can't be resolved."""
+    gate/deep prompts' relative `sage_lib/pipeline.py` invocation resolves to the
+    installed app. Result records return through the dispatcher, so no worker
+    writes a handoff file in this directory. Falls back to the AcpClient default
+    if the app root can't be resolved."""
     try:
         return str(store.app_root())
     except Exception:
@@ -322,8 +331,7 @@ def _reviewer_model(agent: str) -> str:
     if kiro_agents_dir is None:  # pragma: no cover - standalone fallback
         return _DEFAULT_REVIEW_MODEL
     try:
-        cfg = json.loads(
-            (kiro_agents_dir() / f"{agent}.json").read_text(encoding="utf-8"))
+        cfg = json.loads((kiro_agents_dir() / f"{agent}.json").read_text(encoding="utf-8"))
         model = cfg.get("model")
         if isinstance(model, str) and model:
             return model
@@ -338,9 +346,12 @@ def reviewer_info() -> dict:
     thinking effort level (user-configured) applied to both review phases."""
     agent = _resolve_review_agent()
     settings = _get_review_settings()
-    return {"agent": agent, "model": _reviewer_model(agent),
-            "effort": settings.get("effort", _DEFAULT_EFFORT),
-            "model_source": "config" if settings.get("model") else "agent-default"}
+    return {
+        "agent": agent,
+        "model": _reviewer_model(agent),
+        "effort": settings.get("effort", _DEFAULT_EFFORT),
+        "model_source": "config" if settings.get("model") else "agent-default",
+    }
 
 
 def _write_effort_overlay(work_dir: str, model: str, effort: str = REVIEW_EFFORT) -> None:
@@ -427,7 +438,7 @@ class _BatchRuntimeHolder:
             rt = None
             if self._batches == 0:
                 rt, self._runtime = self._runtime, None
-        if rt is not None:          # kill outside the lock (SIGTERM->SIGKILL can block)
+        if rt is not None:  # kill outside the lock (SIGTERM->SIGKILL can block)
             await self._kill(rt)
 
     async def acquire(self) -> "AcpRuntime":
@@ -447,7 +458,7 @@ class _BatchRuntimeHolder:
         rt = self._runtime
         if rt is not None and rt.is_alive():
             return rt
-        if rt is not None:                          # reap a dead one first
+        if rt is not None:  # reap a dead one first
             await self._kill(rt)
         if AcpRuntime is None:
             raise RuntimeError("AcpRuntime unavailable (kiro_crew.acp.runtime not importable)")
@@ -457,8 +468,10 @@ class _BatchRuntimeHolder:
         if self._work_dir:
             try:
                 _write_effort_overlay(
-                    self._work_dir, _reviewer_model(self._agent),
-                    _get_review_settings().get("effort", _DEFAULT_EFFORT))
+                    self._work_dir,
+                    _reviewer_model(self._agent),
+                    _get_review_settings().get("effort", _DEFAULT_EFFORT),
+                )
             except Exception:
                 logger.debug("could not write review effort overlay", exc_info=True)
         # work_dir + sandbox_mode="auto" mirror the old AcpClient worker: the
@@ -477,8 +490,9 @@ class _BatchRuntimeHolder:
             # caught to retry unsandboxed: the refusal is the correct outcome.
             raise ReviewRuntimeUnavailable(sandbox_unavailable_message(exc)) from exc
         self._runtime = rt
-        logger.info("code-review-sage runtime spawned (agent=%s, cwd=%s)",
-                    self._agent, self._work_dir)
+        logger.info(
+            "code-review-sage runtime spawned (agent=%s, cwd=%s)", self._agent, self._work_dir
+        )
         return rt
 
     async def _kill(self, rt: "AcpRuntime") -> None:
@@ -560,9 +574,13 @@ class ReviewPool:
         """Close a review batch — kills the runtime once the last batch drains."""
         await self._holder.end_batch()
 
-    async def send(self, task: str, timeout: float = DEFAULT_TASK_TIMEOUT,
-                   on_activity: Callable[[str, int], None] | None = None,
-                   keep_session_key: str | None = None) -> str:
+    async def send(
+        self,
+        task: str,
+        timeout: float = DEFAULT_TASK_TIMEOUT,
+        on_activity: Callable[[str, int], None] | None = None,
+        keep_session_key: str | None = None,
+    ) -> str:
         """Run one review task on its own session of the shared runtime and return
         the final assistant text. Auto-approves every tool permission (the reviewer
         runs the `gh` CLI + shell) and emits a per-tool SEL audit.
@@ -599,11 +617,9 @@ class ReviewPool:
                             steps += 1
                             if on_activity is not None:
                                 try:
-                                    on_activity(
-                                        str(getattr(ev, "title", "") or ""), steps)
+                                    on_activity(str(getattr(ev, "title", "") or ""), steps)
                                 except Exception:
-                                    logger.debug("activity callback failed",
-                                                 exc_info=True)
+                                    logger.debug("activity callback failed", exc_info=True)
                         elif kind == EVENT_PERMISSION_REQUEST:
                             # Auto-approve (the reviewer needs `gh` + shell) AND record
                             # the permission DECISION in the security ledger, tagged with
@@ -617,8 +633,8 @@ class ReviewPool:
                                 logger.debug("tool approve failed", exc_info=True)
                             else:
                                 await self._audit_tool(
-                                    handle, ev, request_id=req_id,
-                                    outcome="auto_approved")
+                                    handle, ev, request_id=req_id, outcome="auto_approved"
+                                )
                         elif kind == EVENT_COMPLETE:
                             stop_reason = getattr(ev, "stop_reason", "") or ""
                             break
@@ -636,7 +652,8 @@ class ReviewPool:
                 # the PR reviewed or posts on partial output.
                 if _is_abnormal_stop(stop_reason):
                     raise RuntimeError(
-                        f"review turn ended abnormally (stop_reason={stop_reason!r})")
+                        f"review turn ended abnormally (stop_reason={stop_reason!r})"
+                    )
                 # Keep the transcript AFTER the health gate above: a session whose
                 # turn died has no findings to be asked about, and recording it
                 # would leave a file nothing will ever load.
@@ -667,15 +684,19 @@ class ReviewPool:
         try:
             handle.keep_transcript = True  # type: ignore[attr-defined]
             followup.write_descriptor(
-                run_id, change_id, sid=sid, agent=self._agent,
-                cwd=self._work_dir or "")
+                run_id, change_id, sid=sid, agent=self._agent, cwd=self._work_dir or ""
+            )
         except Exception:
-            logger.debug("could not keep the review session resumable",
-                         exc_info=True)
+            logger.debug("could not keep the review session resumable", exc_info=True)
 
-    async def _audit_tool(self, handle: object, ev: object, *,
-                          request_id: object = None,
-                          outcome: str = "auto_approved") -> None:
+    async def _audit_tool(
+        self,
+        handle: object,
+        ev: object,
+        *,
+        request_id: object = None,
+        outcome: str = "auto_approved",
+    ) -> None:
         """Emit a per-tool SEL audit (the runtime layer has no ``audit_source``,
         so without this the reviewer's tool calls would never reach the security log
         — parity with ``AcpClient._maybe_audit_tool_call``). Best-effort + bounded:
@@ -719,9 +740,13 @@ class ReviewPool:
         h = self._holder.stats()
         active = h["active_sessions"]
         return {
-            "workers": active, "idle": 0, "busy": active,
-            "max": self._max, "starting_max": MAX_STARTING,
-            "runtime_alive": h["runtime_alive"], "active_sessions": active,
+            "workers": active,
+            "idle": 0,
+            "busy": active,
+            "max": self._max,
+            "starting_max": MAX_STARTING,
+            "runtime_alive": h["runtime_alive"],
+            "active_sessions": active,
             "batches": h["batches"],
         }
 
@@ -758,9 +783,16 @@ def pool_stats() -> dict:
         # No pool yet (before the first review) — report the static default cap.
         # Avoid effective_max_concurrent() here: it reads config.json, and this
         # runs synchronously on the gateway event loop from the /runs handler.
-        return {"workers": 0, "idle": 0, "busy": 0,
-                "max": MAX_CONCURRENT, "starting_max": MAX_STARTING,
-                "runtime_alive": False, "active_sessions": 0, "batches": 0}
+        return {
+            "workers": 0,
+            "idle": 0,
+            "busy": 0,
+            "max": MAX_CONCURRENT,
+            "starting_max": MAX_STARTING,
+            "runtime_alive": False,
+            "active_sessions": 0,
+            "batches": 0,
+        }
     return _POOL.stats()
 
 
@@ -783,16 +815,25 @@ def make_sync_dispatch(
     Never raises — failures come back in the ``error`` field so the driver's phase
     switch can react deterministically."""
 
-    def dispatch(task: str, timeout: float = default_timeout,
-                 on_activity: Callable[[str, int], None] | None = None,
-                 keep_session_key: str | None = None) -> dict:
+    def dispatch(
+        task: str,
+        timeout: float = default_timeout,
+        on_activity: Callable[[str, int], None] | None = None,
+        keep_session_key: str | None = None,
+    ) -> dict:
         try:
             # The callback fires on the gateway loop's thread while the driver's
             # worker thread blocks here; the progress writer it feeds is lock-
             # guarded and copy-on-write, so that crossing is safe.
             fut = asyncio.run_coroutine_threadsafe(
-                pool.send(task, timeout=timeout, on_activity=on_activity,
-                          keep_session_key=keep_session_key), loop)
+                pool.send(
+                    task,
+                    timeout=timeout,
+                    on_activity=on_activity,
+                    keep_session_key=keep_session_key,
+                ),
+                loop,
+            )
             # Give the bridge a little headroom past the task timeout so the
             # pool's own timeout fires first with a cleaner error.
             out = fut.result(timeout=timeout + 60)

--- a/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
+++ b/src/kiro_crew/apps/builtins/code_review_sage/skills/sage-review/SKILL.md
@@ -487,11 +487,15 @@ candidate is pure staging until consolidated.
 
 ---
 
-## Result record (write one per change)
+## Result record (return one per change)
 
-Write `data/results/<change-id>.json`. This is
-the durable source of truth the Focus Report reads. **Findings JSON contract**
-(kept stable so the deterministic scorer is decoupled from prompt wording):
+Return the complete record in the reviewer response, wrapped exactly once in
+`<code-review-sage-result>` and `</code-review-sage-result>` tags. Do not write
+it to a filesystem path: reviewer sessions share an operating-system identity,
+so a filesystem location cannot authenticate one reviewer to the driver. The
+driver validates the response and persists it after the worker turns finish.
+**Findings JSON contract** (kept stable so the deterministic scorer is decoupled
+from prompt wording):
 
 ```json
 {

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_activity_progress.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_activity_progress.py
@@ -7,12 +7,12 @@ standalone CLI and test fakes pass a plain ``(task, timeout)`` callable.
 from __future__ import annotations
 
 import os
+import json
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
 
-from sage_lib import results
 from sage_lib import review_driver as D
 from sage_lib import store
 
@@ -49,13 +49,15 @@ class TestActivityRelay(unittest.TestCase):
     def _progress(self, cid, phase, extra=None):
         self.seen.append((cid, phase, dict(extra or {})))
 
+    def _review_response(self) -> str:
+        return "<code-review-sage-result>" + json.dumps(_record()) + "</code-review-sage-result>"
+
     def test_relays_the_reviewers_tool_calls_as_activity(self):
         def dispatch(task, timeout=0, on_activity=None):
             if on_activity is not None:
                 on_activity("execute_bash", 1)
                 on_activity("fs_read", 2)
-            results.write_result(_record(), self.root)
-            return {"ok": True, "output": "done", "error": ""}
+            return {"ok": True, "output": self._review_response(), "error": ""}
 
         D.run_review(["CR-1"], dispatch=dispatch, generate_report=False,
                      root=self.root, run_id="run-a", progress=self._progress)
@@ -72,8 +74,7 @@ class TestActivityRelay(unittest.TestCase):
 
         def dispatch(task, timeout=0):
             calls.append(task)
-            results.write_result(_record(), self.root)
-            return {"ok": True, "output": "done", "error": ""}
+            return {"ok": True, "output": self._review_response(), "error": ""}
 
         out = D.run_review(["CR-1"], dispatch=dispatch, generate_report=False,
                            root=self.root, run_id="run-a",
@@ -95,8 +96,7 @@ class TestActivityRelay(unittest.TestCase):
             # itself, not rely on the pool's guard being the only net.
             if on_activity is not None:
                 on_activity("execute_bash", 1)
-            results.write_result(_record(), self.root)
-            return {"ok": True, "output": "done", "error": ""}
+            return {"ok": True, "output": self._review_response(), "error": ""}
 
         def boom(cid, phase, extra=None):
             if extra and "activity" in extra:

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_backend_routes.py
@@ -752,59 +752,6 @@ class TestConsolidateRejectsPatternlessOutput:
         assert "Authorize by confirming the owner" in path.read_text(encoding="utf-8")
 
 
-class TestAdoptionRefusesAPlantedLink:
-    """The reviewer worker owns the shared dir and has file tools.
-
-    ``is_file()`` follows symlinks, and ``os.replace`` moves the LINK, so a link
-    planted where a record belongs used to land in the run dir intact — and
-    ``read_result`` dereferences it with a plain read. Adoption must never carry a
-    link across, and must not leave one behind to retry.
-    """
-
-    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
-    def test_a_symlink_is_refused_and_removed(self, tmp_path):
-
-        store.ensure_layout(tmp_path)
-        secret = tmp_path / "outside-secret.txt"
-        secret.write_text("SENSITIVE", encoding="utf-8")
-
-        shared = results.results_dir(tmp_path, None)
-        shared.mkdir(parents=True, exist_ok=True)
-        planted = shared / f"{results.safe_change_id('CR-1')}.json"
-        planted.symlink_to(secret)
-
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is False
-        # Nothing was adopted...
-        assert results.read_result("CR-1", tmp_path, "run-1") is None
-        # ...the link is gone, so the same plant cannot be retried...
-        assert not planted.exists() and not planted.is_symlink()
-        # ...and the target itself was left alone.
-        assert secret.read_text(encoding="utf-8") == "SENSITIVE"
-
-    def test_a_real_record_is_still_adopted_as_a_regular_file(self, tmp_path):
-
-        store.ensure_layout(tmp_path)
-        shared = results.results_dir(tmp_path, None)
-        shared.mkdir(parents=True, exist_ok=True)
-        (shared / f"{results.safe_change_id('CR-2')}.json").write_text(
-            json.dumps({
-                "schema": "code-review-sage-result", "version": 1,
-                "change_id": "CR-2", "platform": "github",
-                "repo_identity": "github.com/o/r",
-                "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                           "criticality": "low"},
-                "counts": {"red": 0, "yellow": 1},
-            }), encoding="utf-8")
-
-        assert results.adopt_from_shared("CR-2", tmp_path, "run-1") is True
-        got = results.read_result("CR-2", tmp_path, "run-1")
-        assert got and got["change_id"] == "CR-2"
-        dst = results.result_path("CR-2", tmp_path, "run-1")
-        assert dst.is_file() and not dst.is_symlink()
-        # The shared copy is consumed, as before.
-        assert not (shared / f"{results.safe_change_id('CR-2')}.json").exists()
-
-
 class TestRetentionKeepsActiveRuns(unittest.IsolatedAsyncioTestCase):
     """Retention is by position, so a still-RUNNING run can sit past the cap.
 
@@ -878,163 +825,6 @@ class TestRetentionKeepsActiveRuns(unittest.IsolatedAsyncioTestCase):
         self.assertIn("run-0", self.removed,
                       "retention stopped reclaiming finished runs")
         self.assertLessEqual(len(self.mod._RUNS), cap)
-
-
-class TestAdoptionValidatesBeforeItWrites:
-    """Adoption must be all-or-nothing.
-
-    Round 13 traded ``os.replace`` for an ``O_TRUNC`` write to close a symlink
-    hole, and that gave up atomicity: a malformed payload truncated whatever valid
-    record was already filed, and ``read_result`` then raised on the wreckage, so
-    no retry could recover it. Validate first, write via rename.
-    """
-
-    def _stage(self, tmp_path, change_id, body):
-        shared = results.results_dir(tmp_path, None)
-        shared.mkdir(parents=True, exist_ok=True)
-        (shared / f"{results.safe_change_id(change_id)}.json").write_text(
-            body, encoding="utf-8")
-
-    def _good(self, cid="CR-1", yellow=1):
-        """A record that satisfies the real contract (REQUIRED_TOP/PHASE1).
-
-        The earlier minimal fixture passed the envelope checks but was never a
-        valid record, so it could not exercise adoption once the schema gate went
-        in — the contract is what write_result has always enforced.
-        """
-        import json as _json
-        return _json.dumps({
-            "schema": "code-review-sage-result", "version": 1,
-            "change_id": cid, "platform": "github",
-            "repo_identity": "github.com/o/r",
-            "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                       "criticality": "low"},
-            "counts": {"red": 0, "yellow": yellow},
-        })
-
-    def test_malformed_output_leaves_the_existing_record_intact(self, tmp_path):
-        store.ensure_layout(tmp_path)
-
-        # A valid record is adopted first.
-        self._stage(tmp_path, "CR-1", self._good(yellow=3))
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is True
-        before = results.read_result("CR-1", tmp_path, "run-1")
-        assert before and before["counts"]["yellow"] == 3
-
-        # Then the poster leaves malformed JSON for the same change.
-        self._stage(tmp_path, "CR-1", "{not json at all")
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is False
-
-        # The valid record survived and is still readable — the retry path works.
-        after = results.read_result("CR-1", tmp_path, "run-1")
-        assert after == before, "a malformed payload destroyed the valid record"
-
-    def test_a_record_violating_the_schema_is_refused(self, tmp_path):
-        store.ensure_layout(tmp_path)
-        # `phase1: []` is dict-shaped at the top level but carries a list where an
-        # object belongs. The report reads it as rec.get("phase1", {}).get(...),
-        # which raises on a list — the present-but-wrong-type case a default
-        # cannot rescue, and the whole run fails.
-        bad = json.dumps({
-            "schema": "code-review-sage-result", "version": 1,
-            "change_id": "CR-1", "platform": "github",
-            "repo_identity": "github.com/o/r",
-            "phase1": [],
-        })
-        self._stage(tmp_path, "CR-1", bad)
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is False
-        assert results.read_result("CR-1", tmp_path, "run-1") is None
-
-    def test_an_unknown_gate_verdict_is_refused(self, tmp_path):
-        store.ensure_layout(tmp_path)
-        bad = json.dumps({
-            "schema": "code-review-sage-result", "version": 1,
-            "change_id": "CR-1", "platform": "github",
-            "repo_identity": "github.com/o/r",
-            "phase1": {"gate_verdict": "LOOKS_FINE", "design_risk": "low",
-                       "criticality": "low"},
-        })
-        self._stage(tmp_path, "CR-1", bad)
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is False
-
-    def test_a_record_naming_another_change_is_refused(self, tmp_path):
-        store.ensure_layout(tmp_path)
-        # Filed under CR-1 but claiming to be CR-9: accepting it would attribute
-        # CR-9's findings to CR-1 in the report.
-        self._stage(tmp_path, "CR-1", self._good("CR-9"))
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is False
-        assert results.read_result("CR-1", tmp_path, "run-1") is None
-
-    def test_a_json_array_is_refused(self, tmp_path):
-        store.ensure_layout(tmp_path)
-        self._stage(tmp_path, "CR-1", '[{"change_id": "CR-1"}]')
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is False
-
-    def test_no_temp_files_are_left_behind(self, tmp_path):
-        store.ensure_layout(tmp_path)
-        self._stage(tmp_path, "CR-1", self._good())
-        assert results.adopt_from_shared("CR-1", tmp_path, "run-1") is True
-        rd = results.results_dir(tmp_path, "run-1")
-        assert not list(rd.glob(".adopt-*")), "adoption left a temp file behind"
-
-
-class TestPublishRefusesAPlantedDestinationLink:
-    """The shared dir is worker-writable, so its paths are untrusted targets.
-
-    Publishing wrote with `dst.write_bytes(...)`, which follows a symlink at the
-    destination. The worker can plant one there, so the write landed on whatever it
-    pointed at. Renaming over the name instead destroys the plant.
-    """
-
-    def _record(self, cid="CR-1"):
-        return {
-            "schema": "code-review-sage-result", "version": 1,
-            "change_id": cid, "platform": "github",
-            "repo_identity": "github.com/o/r",
-            "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                       "criticality": "low"},
-            "counts": {"red": 0, "yellow": 1},
-        }
-
-    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
-    def test_a_planted_link_is_replaced_not_followed(self, tmp_path):
-
-        store.ensure_layout(tmp_path)
-        results.write_result(self._record(), tmp_path, "run-1")
-
-        outside = tmp_path / "outside-secret.txt"
-        outside.write_text("SENSITIVE", encoding="utf-8")
-
-        shared = results.results_dir(tmp_path, None)
-        shared.mkdir(parents=True, exist_ok=True)
-        planted = shared / f"{results.safe_change_id('CR-1')}.json"
-        planted.symlink_to(outside)
-
-        assert results.publish_to_shared("CR-1", tmp_path, "run-1") is True
-
-        # The target is untouched — the write did not follow the link.
-        assert outside.read_text(encoding="utf-8") == "SENSITIVE"
-        # And the shared path is now a real file holding the record.
-        assert planted.is_file() and not planted.is_symlink()
-        assert json.loads(planted.read_text(encoding="utf-8"))["change_id"] == "CR-1"
-
-    def test_publishing_still_works_with_no_link_present(self, tmp_path):
-
-        store.ensure_layout(tmp_path)
-        results.write_result(self._record("CR-2"), tmp_path, "run-1")
-        assert results.publish_to_shared("CR-2", tmp_path, "run-1") is True
-        shared = results.results_dir(tmp_path, None)
-        got = json.loads(
-            (shared / f"{results.safe_change_id('CR-2')}.json").read_text(encoding="utf-8"))
-        assert got["change_id"] == "CR-2"
-
-    def test_no_temp_files_are_left_behind(self, tmp_path):
-
-        store.ensure_layout(tmp_path)
-        results.write_result(self._record("CR-3"), tmp_path, "run-1")
-        assert results.publish_to_shared("CR-3", tmp_path, "run-1") is True
-        shared = results.results_dir(tmp_path, None)
-        assert not list(shared.glob(".publish-*")), "publish left a temp file behind"
 
 
 class TestRestartClearsAStrandedPostingFlag(unittest.TestCase):
@@ -1117,55 +907,6 @@ class TestGroupedPostAppliesKeysPerChange(unittest.TestCase):
                           f"create_task at offset {i} keeps no strong ref")
             self.assertIn("_TASKS.discard", window,
                           f"create_task at offset {i} never drops its ref")
-
-
-class TestPublishRefusesAPlantedSourceLink:
-    """The RUN results dir is worker-writable too, so the source is untrusted.
-
-    Its sibling above covers the write: a link planted at the DESTINATION is
-    replaced rather than followed. This covers the read. A worker that swaps its
-    own finished record for a link to something outside the sandbox would
-    otherwise have the linked bytes copied into the SHARED staging dir, which
-    every worker can read. Same function, same trust boundary, opposite
-    direction.
-    """
-
-    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
-    def test_a_symlinked_record_is_not_published(self, tmp_path):
-
-        store.ensure_layout(tmp_path)
-        outside = tmp_path / "outside-secret.txt"
-        outside.write_text("SENSITIVE", encoding="utf-8")
-
-        # The worker plants a link where its own record belongs.
-        src = results.result_path("CR-9", tmp_path, "run-9")
-        src.parent.mkdir(parents=True, exist_ok=True)
-        src.symlink_to(outside)
-
-        assert results.publish_to_shared("CR-9", tmp_path, "run-9") is False
-
-        shared = results.results_dir(tmp_path, None)
-        landed = shared / f"{results.safe_change_id('CR-9')}.json"
-        if landed.exists():
-            assert "SENSITIVE" not in landed.read_text(encoding="utf-8")
-        # A refused publish leaves no staging residue behind either.
-        assert list(shared.glob(".publish-*")) == []
-
-    def test_a_hardlinked_record_is_not_published(self, tmp_path):
-        """The nolink guard also rejects a shared inode, not just a symlink."""
-
-        store.ensure_layout(tmp_path)
-        outside = tmp_path / "outside-hard.txt"
-        outside.write_text("SENSITIVE", encoding="utf-8")
-
-        src = results.result_path("CR-10", tmp_path, "run-10")
-        src.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            os.link(outside, src)
-        except OSError:                     # pragma: no cover - platform without links
-            pytest.skip("hardlinks unavailable here")
-
-        assert results.publish_to_shared("CR-10", tmp_path, "run-10") is False
 
 
 class TestReportWritesRefusePlantedLinks:
@@ -1343,56 +1084,6 @@ class TestOrphanReapDoesNotBlockStartup(unittest.IsolatedAsyncioTestCase):
             self.routes.register_routes(app)
             for hook in app.on_startup:
                 await hook(app)   # must not raise
-
-
-class TestAdoptionRequiresAnExactChangeIdentity:
-    """Adoption must compare change ids EXACTLY, not through `safe_change_id`.
-
-    That sanitizer is lossy by design — it produces a filename stem — so
-    comparing the sanitized forms accepted a record naming a genuinely different
-    change. `GH-acme-service/api-1` and `GH-acme-service_api-1` both reduce to
-    `GH-acme-service_api-1`, so a worker record for the first was filed as the
-    second and the report attributed its findings to the wrong pull request.
-    """
-
-    def _record(self, cid):
-        return {
-            "schema": "code-review-sage-result", "version": 1,
-            "change_id": cid, "platform": "github",
-            "repo_identity": "github.com/acme/service_api",
-            "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                       "criticality": "low"},
-            "counts": {"red": 0, "yellow": 0},
-            "findings": [],
-        }
-
-    def test_a_record_naming_a_different_change_is_refused(self, tmp_path):
-        from sage_lib import results, store
-
-        store.ensure_layout(tmp_path)
-        want = "GH-acme-service_api-1"
-        other = "GH-acme-service/api-1"      # different change, same stem
-        assert results.safe_change_id(other) == results.safe_change_id(want)
-        assert other != want
-
-        shared = results.results_dir(tmp_path, None)
-        shared.mkdir(parents=True, exist_ok=True)
-        (shared / f"{results.safe_change_id(want)}.json").write_text(
-            json.dumps(self._record(other)), encoding="utf-8")
-
-        assert results.adopt_from_shared(want, tmp_path, "run-x1") is False
-
-    def test_an_exact_match_is_still_adopted(self, tmp_path):
-        from sage_lib import results, store
-
-        store.ensure_layout(tmp_path)
-        want = "GH-acme-service_api-1"
-        shared = results.results_dir(tmp_path, None)
-        shared.mkdir(parents=True, exist_ok=True)
-        (shared / f"{results.safe_change_id(want)}.json").write_text(
-            json.dumps(self._record(want)), encoding="utf-8")
-
-        assert results.adopt_from_shared(want, tmp_path, "run-x2") is True
 
 
 class TestCountValuesMustBeNumeric:
@@ -2544,8 +2235,8 @@ class TestNoRowFieldIsExemptFromRedaction(unittest.TestCase):
         return report.__file__
 
 
-class TestWholeRunsSerialize:
-    """A second run's body must not start while the first is still reviewing."""
+class TestIndependentRunsUseTheBoundedPool:
+    """Different claimed changes may review concurrently with bound results."""
 
     @pytest.mark.asyncio
     async def test_run_bodies_do_not_overlap(self, monkeypatch, tmp_path):
@@ -2589,16 +2280,11 @@ class TestWholeRunsSerialize:
         await asyncio.gather(*(mod._run_review_bg(r, [f"https://x/pull/{i}"])
                                for i, r in enumerate(runs)))
 
-        assert not overlapped, "two run bodies were inside run_review at once"
+        assert overlapped, "independent run bodies should share the bounded pool"
 
 
-class TestReviewersSerialize:
-    """Reviewers inside one run are serialized.
-
-    Workers share the staging directory and each has file tools, so two live at
-    once lets one write another change's record between that slot being cleared
-    and its own worker writing -- findings attributed to the wrong pull request.
-    """
+class TestReviewersUsePoolConcurrency:
+    """Run-scoped reviewers use the pool after capability-bound adoption."""
 
     @pytest.mark.asyncio
     async def test_one_reviewer_at_a_time(self, monkeypatch, tmp_path):
@@ -2633,8 +2319,8 @@ class TestReviewersSerialize:
         await asyncio.gather(*(mod._run_review_bg(r, [f"https://x/pull/{i}"])
                                for i, r in enumerate(runs)))
 
-        assert seen.get("concurrency") == 1, (
-            "the backend must ask for one reviewer at a time; got "
+        assert seen.get("concurrency") == 0, (
+            "the backend must delegate concurrency to the bounded pool; got "
             f"{seen.get('concurrency')!r}")
 
 

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_no_auto_post.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_no_auto_post.py
@@ -7,6 +7,7 @@ a review. These tests pin the default OFF and the accounting that goes with it �
 in particular that the durable dedup index still records the PR as reviewed, so
 a repo review does not re-review it forever.
 """
+
 from __future__ import annotations
 
 import json
@@ -44,25 +45,48 @@ class _Base(unittest.TestCase):
         carry (see review_driver.build_*_task), so "was a poster dispatched?" is
         answered the way the driver actually distinguishes them.
         """
+
         def dispatch(task: str, timeout: int = 0):
             tasks.append(task)
+            output = "done"
             if "SINGLE thorough pass" in task:
-                results.write_result({
-                    "schema": "code-review-sage-result", "version": 1,
-                    "change_id": "CR-1", "platform": "github",
-                    "repo_identity": "github.com/o/r", "revision": "1",
-                    "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                               "criticality": "low"},
+                record = {
+                    "schema": "code-review-sage-result",
+                    "version": 1,
+                    "change_id": "CR-1",
+                    "platform": "github",
+                    "repo_identity": "github.com/o/r",
+                    "revision": "1",
+                    "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
                     "blast_radius": {"rating": "SMALL", "signals": {}},
                     "counts": {"red": 0, "yellow": 1},
-                    "findings": [{"dimension": "correctness", "severity": "yellow",
-                                  "file": "f", "line": 1, "snippet": "x",
-                                  "observation": "o", "consequence": "c",
-                                  "suggestion": "s"}],
-                    "deep_reviewed": True, "title": "CR-1",
-                    "files_covered": ["f"], "coverage_complete": True,
-                }, self.root, run_id)
-            return {"ok": True, "output": "done", "error": ""}
+                    "findings": [
+                        {
+                            "dimension": "correctness",
+                            "severity": "yellow",
+                            "file": "f",
+                            "line": 1,
+                            "snippet": "x",
+                            "observation": "o",
+                            "consequence": "c",
+                            "suggestion": "s",
+                        }
+                    ],
+                    "deep_reviewed": True,
+                    "title": "CR-1",
+                    "files_covered": ["f"],
+                    "coverage_complete": True,
+                }
+                if run_id:
+                    output = (
+                        "<code-review-sage-result>"
+                        + json.dumps(record)
+                        + "</code-review-sage-result>"
+                    )
+                else:
+                    results.write_result(record, self.root, run_id)
+            return {"ok": True, "output": output, "error": ""}
+
         return dispatch
 
     @staticmethod
@@ -73,16 +97,18 @@ class _Base(unittest.TestCase):
 class TestNoAutoPost(_Base):
     def test_default_dispatches_no_poster(self):
         tasks: list[str] = []
-        out = D.run_review(["CR-1"], dispatch=self._dispatch(tasks),
-                           generate_report=False, root=self.root)
+        out = D.run_review(
+            ["CR-1"], dispatch=self._dispatch(tasks), generate_report=False, root=self.root
+        )
         self.assertEqual(out["changes"], 1)
         # The review task ran; no posting task was ever dispatched.
         self.assertTrue(tasks)
         self.assertFalse(self._posters(tasks), "a poster was dispatched")
 
     def test_default_marks_posting_skipped(self):
-        out = D.run_review(["CR-1"], dispatch=self._dispatch([]),
-                           generate_report=False, root=self.root)
+        out = D.run_review(
+            ["CR-1"], dispatch=self._dispatch([]), generate_report=False, root=self.root
+        )
         rec = out["per_change"][0]
         self.assertTrue(rec["posting_skipped"])
         self.assertEqual(rec["posted_comments"], 0)
@@ -96,8 +122,9 @@ class TestNoAutoPost(_Base):
         # The guard that refuses to mark a PR reviewed when a post half-failed
         # must not also refuse a run that deliberately posted nothing, or every
         # repo review would re-review the same PRs forever.
-        out = D.run_review(["CR-1"], dispatch=self._dispatch([]),
-                           generate_report=False, root=self.root)
+        out = D.run_review(
+            ["CR-1"], dispatch=self._dispatch([]), generate_report=False, root=self.root
+        )
         rec = out["per_change"][0]
         self.assertTrue(rec["deep_reviewed"])
         self.assertGreaterEqual(rec["posted_comments"], rec["posting_expected"])
@@ -108,8 +135,14 @@ class TestNoAutoPost(_Base):
         def prog(cid, phase, extra=None):
             if phase == "done":
                 seen[cid] = extra or {}
-        D.run_review(["CR-1"], dispatch=self._dispatch([]), generate_report=False,
-                     root=self.root, progress=prog)
+
+        D.run_review(
+            ["CR-1"],
+            dispatch=self._dispatch([]),
+            generate_report=False,
+            root=self.root,
+            progress=prog,
+        )
         self.assertEqual(seen["CR-1"]["posted"], 0)
         self.assertEqual(seen["CR-1"]["expected"], 0)
         # The findings themselves are still reported — they are what the app shows.
@@ -117,19 +150,29 @@ class TestNoAutoPost(_Base):
 
     def test_findings_still_land_in_the_report(self):
         # Not posting must not mean not reviewing: the report is the deliverable.
-        out = D.run_review(["CR-1"], dispatch=self._dispatch([], run_id="r1"),
-                           archiver=lambda *_a, **_k: None,
-                           generate_report=True, root=self.root, run_id="r1")
+        out = D.run_review(
+            ["CR-1"],
+            dispatch=self._dispatch([], run_id="r1"),
+            archiver=lambda *_a, **_k: None,
+            generate_report=True,
+            root=self.root,
+            run_id="r1",
+        )
         self.assertEqual(out["result_records"], 1)
         payload = json.loads(
-            (store.run_dir("r1", self.root) / "report" / "report.json")
-            .read_text(encoding="utf-8"))
+            (store.run_dir("r1", self.root) / "report" / "report.json").read_text(encoding="utf-8")
+        )
         self.assertTrue(payload["rows"])
 
     def test_opt_in_restores_posting(self):
         tasks: list[str] = []
-        D.run_review(["CR-1"], dispatch=self._dispatch(tasks),
-                     generate_report=False, root=self.root, post=True)
+        D.run_review(
+            ["CR-1"],
+            dispatch=self._dispatch(tasks),
+            generate_report=False,
+            root=self.root,
+            post=True,
+        )
         self.assertTrue(self._posters(tasks), "posting was enabled but no poster ran")
 
     def test_config_flag_enables_posting(self):
@@ -138,8 +181,9 @@ class TestNoAutoPost(_Base):
         cfg["review"]["auto_post"] = True
         cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
         tasks: list[str] = []
-        D.run_review(["CR-1"], dispatch=self._dispatch(tasks),
-                     generate_report=False, root=self.root)
+        D.run_review(
+            ["CR-1"], dispatch=self._dispatch(tasks), generate_report=False, root=self.root
+        )
         self.assertTrue(self._posters(tasks))
 
     def test_non_boolean_config_does_not_enable_posting(self):
@@ -149,8 +193,9 @@ class TestNoAutoPost(_Base):
         cfg["review"]["auto_post"] = "true"
         cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
         tasks: list[str] = []
-        D.run_review(["CR-1"], dispatch=self._dispatch(tasks),
-                     generate_report=False, root=self.root)
+        D.run_review(
+            ["CR-1"], dispatch=self._dispatch(tasks), generate_report=False, root=self.root
+        )
         self.assertFalse(self._posters(tasks))
 
     def test_default_config_has_posting_off(self):
@@ -177,26 +222,45 @@ class TestSilentRunIsStillRecordedReviewed(unittest.TestCase):
         which passed with the bug still present — it was testing the mirror.
         """
         from backend import routes
-        return (bool(rec.get("deep_reviewed")) and bool(rec.get("post_ok"))
-                and (rec.get("posted_comments") or 0)
-                >= routes._posting_expected(rec))
+
+        return (
+            bool(rec.get("deep_reviewed"))
+            and bool(rec.get("post_ok"))
+            and (rec.get("posted_comments") or 0) >= routes._posting_expected(rec)
+        )
 
     def test_a_silent_review_counts_as_reviewed(self):
-        self.assertTrue(self._indexed({
-            "deep_reviewed": True, "post_ok": True,
-            "posted_comments": 0, "posting_expected": 0}))
+        self.assertTrue(
+            self._indexed(
+                {
+                    "deep_reviewed": True,
+                    "post_ok": True,
+                    "posted_comments": 0,
+                    "posting_expected": 0,
+                }
+            )
+        )
 
     def test_a_partial_post_is_not_recorded(self):
-        self.assertFalse(self._indexed({
-            "deep_reviewed": True, "post_ok": True,
-            "posted_comments": 1, "posting_expected": 3}))
+        self.assertFalse(
+            self._indexed(
+                {
+                    "deep_reviewed": True,
+                    "post_ok": True,
+                    "posted_comments": 1,
+                    "posting_expected": 3,
+                }
+            )
+        )
 
     def test_a_record_without_the_field_still_needs_one_delivery(self):
         # Records written before `posting_expected` existed keep the old meaning.
-        self.assertFalse(self._indexed({
-            "deep_reviewed": True, "post_ok": True, "posted_comments": 0}))
-        self.assertTrue(self._indexed({
-            "deep_reviewed": True, "post_ok": True, "posted_comments": 1}))
+        self.assertFalse(
+            self._indexed({"deep_reviewed": True, "post_ok": True, "posted_comments": 0})
+        )
+        self.assertTrue(
+            self._indexed({"deep_reviewed": True, "post_ok": True, "posted_comments": 1})
+        )
 
 
 class TestRecordsKeptWhenPostingFails(_Base):
@@ -217,21 +281,29 @@ class TestRecordsKeptWhenPostingFails(_Base):
                 tasks.append(task)
                 return {"ok": False, "output": "", "error": "poster dispatch failed"}
             return inner(task, timeout)
+
         return dispatch
 
     def test_a_failed_post_keeps_the_result_records(self):
         tasks: list[str] = []
-        out = D.run_review(["CR-1"], dispatch=self._dispatch_failing_poster(tasks),
-                           generate_report=True, archiver=lambda html, root: "slug-1",
-                           root=self.root, post=True)
+        out = D.run_review(
+            ["CR-1"],
+            dispatch=self._dispatch_failing_poster(tasks),
+            generate_report=True,
+            archiver=lambda html, root: "slug-1",
+            root=self.root,
+            post=True,
+        )
         # A poster WAS dispatched (posting was intended) and it failed.
         self.assertTrue(self._posters(tasks), "no poster was dispatched")
         self.assertFalse(out["per_change"][0]["post_ok"])
         # The records the retry needs are still on disk, and the summary says why.
         self.assertNotIn("results_cleaned", out)
         self.assertTrue(out.get("results_kept_undelivered"))
-        self.assertTrue(results.list_results(self.root, out.get("run_id")),
-                        "result records were deleted after a failed post")
+        self.assertTrue(
+            results.list_results(self.root, out.get("run_id")),
+            "result records were deleted after a failed post",
+        )
 
     def test_the_cleanup_still_runs_once_delivery_is_complete(self):
         # The guard must not become a leak: on real delivery the records ARE
@@ -241,9 +313,13 @@ class TestRecordsKeptWhenPostingFails(_Base):
         # still reaches clear_results — rather than re-testing the predicate.
         tasks: list[str] = []
         with mock.patch.object(D, "_all_delivered", return_value=True):
-            out = D.run_review(["CR-1"], dispatch=self._dispatch(tasks),
-                               generate_report=True,
-                               archiver=lambda html, root: "slug-1",
-                               root=self.root, post=True)
+            out = D.run_review(
+                ["CR-1"],
+                dispatch=self._dispatch(tasks),
+                generate_report=True,
+                archiver=lambda html, root: "slug-1",
+                root=self.root,
+                post=True,
+            )
         self.assertIn("results_cleaned", out)
         self.assertFalse(out.get("results_kept_undelivered"))

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_post_comments.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_post_comments.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import os
 import shutil
 import tempfile
@@ -73,6 +74,21 @@ def _unconfirmed(_link, _units):
     return False
 
 
+def _post_payload(task: str) -> dict:
+    prefix = "assembled AND redacted in Python: "
+    suffix = ". Use it EXACTLY as given;"
+    return json.loads(task.split(prefix, 1)[1].split(suffix, 1)[0])
+
+
+def _posted_response(posted_comments: int, design_comment_posted: bool) -> str:
+    return (
+        "<code-review-sage-posted>"
+        + json.dumps({"posted_comments": posted_comments,
+                      "design_comment_posted": design_comment_posted})
+        + "</code-review-sage-posted>"
+    )
+
+
 class _Base(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
@@ -96,13 +112,11 @@ class TestPostRecorded(_Base):
 
         def dispatch(task, timeout=0):
             seen.append(task)
-            rec = results.read_result("CR-1", self.root, None) or {}
-            # The poster's only job: publish what Python already built.
-            self.assertIn("github_review_payload", rec)
-            rec["posted_comments"] = len(rec.get("pending_comments") or [])
-            rec["design_comment_posted"] = True
-            results.write_result(rec, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            payload = _post_payload(task)
+            self.assertIn("comments", payload)
+            return {"ok": True, "output": _posted_response(
+                len(payload.get("comments") or []) + bool(payload.get("body")),
+                bool(payload.get("body"))), "error": ""}
 
         out = await asyncio.to_thread(
             D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
@@ -112,31 +126,6 @@ class TestPostRecorded(_Base):
         self.assertEqual(out["pending"], 4)
         self.assertEqual(out["posted_comments"], 4)
         self.assertTrue(seen)
-
-    async def test_a_publish_to_shared_failure_aborts_the_dispatch(self):
-        """`publish_to_shared` returning False means the record at the shared path
-        is NOT ours -- it refuses precisely when its no-follow read is blocked,
-        which is the case where a sibling worker replaced the record with a link.
-        Dispatching anyway would point the poster at whatever IS there and publish
-        it to the pull request, so no poster may run."""
-        results.write_result(_record(red=1, yellow=0), self.root, "run-a")
-        calls: list = []
-
-        def dispatch(task, timeout=0):
-            calls.append(task)
-            return {"ok": True, "output": "posted", "error": ""}
-
-        with unittest.mock.patch.object(results, "publish_to_shared",
-                                        return_value=False):
-            out = await asyncio.to_thread(
-                D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
-                dispatch=dispatch, confirm=_confirmed, root=self.root,
-                run_id="run-a")
-
-        self.assertEqual(calls, [], "no poster may be dispatched")
-        self.assertFalse(out["post_ok"])
-        self.assertIn("stage", out["post_error"])
-        self.assertEqual(out["posted_comments"], 0)
 
     async def test_an_unresolvable_host_aborts_the_post_fail_closed(self):
         """A link whose host is no longer in `allowed_hosts()` (the GHE host was
@@ -201,13 +190,11 @@ class TestSelectivePosting(_Base):
 
     def _poster(self, delivered: int | None = None):
         def dispatch(task, timeout=0):
-            rec = results.read_result("CR-1", self.root, None) or {}
-            pending = rec.get("pending_comments") or []
-            rec["posted_comments"] = len(pending) if delivered is None else delivered
-            rec["design_comment_posted"] = any(
-                e.get("kind") == "design" for e in pending)
-            results.write_result(rec, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            payload = _post_payload(task)
+            count = (len(payload.get("comments") or []) + bool(payload.get("body"))
+                     if delivered is None else delivered)
+            return {"ok": True, "output": _posted_response(count, bool(payload.get("body"))),
+                    "error": ""}
         return dispatch
 
     async def test_posts_only_the_selected_comment(self):
@@ -267,13 +254,12 @@ class TestSelectivePosting(_Base):
         seen: list[list[str]] = []
 
         def capture(task, timeout=0):
-            rec = results.read_result("CR-1", self.root, None) or {}
-            payload = rec.get("github_review_payload") or {}
+            payload = _post_payload(task)
             seen.append([c.get("body", "")[:40]
                          for c in (payload.get("comments") or [])])
-            rec["posted_comments"] = len(rec.get("pending_comments") or [])
-            results.write_result(rec, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            return {"ok": True, "output": _posted_response(
+                len(payload.get("comments") or []) + bool(payload.get("body")),
+                bool(payload.get("body"))), "error": ""}
 
         await asyncio.to_thread(
             D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
@@ -341,8 +327,8 @@ class TestSelectivePosting(_Base):
 class TestRecordsSurviveForPosting(_Base):
     def _dispatch(self):
         def dispatch(task, timeout=0):
-            results.write_result(_record(), self.root)
-            return {"ok": True, "output": "done", "error": ""}
+            return {"ok": True, "output": "<code-review-sage-result>"
+                    + json.dumps(_record()) + "</code-review-sage-result>", "error": ""}
         return dispatch
 
     async def test_records_are_kept_when_the_review_was_not_posted(self):
@@ -364,13 +350,12 @@ class TestRecordsSurviveForPosting(_Base):
 
         def dispatch(task, timeout=0):
             if "SINGLE thorough pass" in task:
-                results.write_result(_record(), self.root)
+                output = "<code-review-sage-result>" + json.dumps(_record()) + "</code-review-sage-result>"
             else:
-                rec = results.read_result("CR-1", self.root, None)
-                if rec:
-                    rec["posted_comments"] = len(rec.get("pending_comments") or [])
-                    results.write_result(rec, self.root, None)
-            return {"ok": True, "output": "done", "error": ""}
+                payload = _post_payload(task)
+                output = _posted_response(len(payload.get("comments") or []) + bool(payload.get("body")),
+                                          bool(payload.get("body")))
+            return {"ok": True, "output": output, "error": ""}
 
         out = await asyncio.to_thread(
             lambda: D.run_review(
@@ -641,10 +626,10 @@ class TestStaleDeliveryEvidenceIsNotInherited(_Base):
 
         # A real poster on the retry delivers and IS recorded.
         def real(task, timeout=0):
-            r = results.read_result("CR-1", self.root, None) or {}
-            r["posted_comments"] = len(r.get("pending_comments") or [])
-            results.write_result(r, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            payload = _post_payload(task)
+            return {"ok": True, "output": _posted_response(
+                len(payload.get("comments") or []) + bool(payload.get("body")),
+                bool(payload.get("body"))), "error": ""}
 
         out = await asyncio.to_thread(
             D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
@@ -652,15 +637,14 @@ class TestStaleDeliveryEvidenceIsNotInherited(_Base):
         self.assertTrue(out["posted_keys"], out)
 
     async def test_a_real_delivery_is_still_recorded(self):
-        """The reset must not break the path where the poster does write back."""
+        """The reset must not discard the poster's response-bound report."""
         results.write_result(_record(), self.root, "run-a")
 
         def dispatch(task, timeout=0):
-            r = results.read_result("CR-1", self.root, None) or {}
-            r["posted_comments"] = len(r.get("pending_comments") or [])
-            r["design_comment_posted"] = True
-            results.write_result(r, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            payload = _post_payload(task)
+            return {"ok": True, "output": _posted_response(
+                len(payload.get("comments") or []) + bool(payload.get("body")),
+                bool(payload.get("body"))), "error": ""}
 
         out = await asyncio.to_thread(
             D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
@@ -712,12 +696,9 @@ class TestDeliveryIsCountedInPayloadUnits(_Base):
         results.write_result(rec, self.root, "run-a")
 
         def dispatch(task, timeout=0):
-            r = results.read_result("CR-1", self.root, None) or {}
-            payload = r.get("github_review_payload") or {}
-            r["posted_comments"] = pipeline.review_payload_units(payload)
-            r["design_comment_posted"] = bool(payload.get("body"))
-            results.write_result(r, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            payload = _post_payload(task)
+            return {"ok": True, "output": _posted_response(
+                pipeline.review_payload_units(payload), bool(payload.get("body"))), "error": ""}
 
         out = await_sync(D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
                          dispatch=dispatch, confirm=_confirmed, root=self.root, run_id="run-a")
@@ -732,11 +713,9 @@ class TestDeliveryIsCountedInPayloadUnits(_Base):
         results.write_result(_record(red=1, yellow=2), self.root, "run-a")
 
         def dispatch(task, timeout=0):
-            r = results.read_result("CR-1", self.root, None) or {}
-            r["posted_comments"] = pipeline.review_payload_units(
-                r.get("github_review_payload") or {})
-            results.write_result(r, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            payload = _post_payload(task)
+            return {"ok": True, "output": _posted_response(
+                pipeline.review_payload_units(payload), bool(payload.get("body"))), "error": ""}
 
         out = await_sync(D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
                          dispatch=dispatch, confirm=_confirmed, root=self.root, run_id="run-a")
@@ -777,10 +756,7 @@ class TestConfirmedCountIsAuthoritative(unittest.TestCase):
         results.write_result(_record(red=1, yellow=2), self.root, "run-a")
 
         def dispatch(task, timeout=0):
-            r = results.read_result("CR-1", self.root, None) or {}
-            r["posted_comments"] = 1
-            results.write_result(r, self.root, None)
-            return {"ok": True, "output": "posted", "error": ""}
+            return {"ok": True, "output": _posted_response(1, False), "error": ""}
 
         out = await_sync(D.post_recorded, "CR-1", "https://github.com/o/r/pull/1",
                          dispatch=dispatch, confirm=_unconfirmed, root=self.root,

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
@@ -1,334 +1,100 @@
-#!/usr/bin/env python3
-"""The worker writes ``data/results/<id>.json``; the run reads its own dir.
+"""Regressions for response-bound Code Review Sage result handoff."""
 
-Regression for a real failure: per-run isolation moved the READ path to
-``data/runs/<run_id>/results/`` but the reviewing worker's prompt (and the
-`sage-review` skill) still name the shared ``data/results/<id>.json``. The run
-dir stayed empty, so a review that had genuinely completed reported
-``result_records: 0`` and the UI showed an empty report while claiming "done".
-
-The driver owns run scoping, so it adopts the worker's record after each turn.
-"""
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
 
 from sage_lib import results
-from sage_lib import review_driver as D
+from sage_lib import review_driver as driver
 from sage_lib import store
 
-from kiro_crew.apps.builtins.code_review_sage.tests.fixtures import SYMLINKS_OK
 
-
-def _record(cid: str = "CR-1") -> dict:
+def _record(change_id: str) -> dict:
     return {
-        "schema": "code-review-sage-result", "version": 1, "change_id": cid,
-        "platform": "github", "repo_identity": "github.com/o/r", "revision": "1",
+        "schema": "code-review-sage-result",
+        "version": 1,
+        "change_id": change_id,
+        "platform": "github",
+        "repo_identity": "github.com/o/r",
+        "revision": "1",
         "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
         "blast_radius": {"rating": "SMALL", "signals": {}},
-        "counts": {"red": 0, "yellow": 1},
-        "findings": [{"dimension": "correctness", "severity": "yellow",
-                      "file": "f", "line": 1, "snippet": "x", "observation": "o",
-                      "consequence": "c", "suggestion": "s"}],
-        "deep_reviewed": True, "title": cid,
-        "files_covered": ["f"], "coverage_complete": True,
+        "counts": {"red": 0, "yellow": 0},
+        "findings": [],
+        "deep_reviewed": True,
+        "files_covered": ["a.py"],
+        "coverage_complete": True,
     }
 
 
-class _Base(unittest.TestCase):
+def _handoff(record: dict) -> str:
+    return "<code-review-sage-result>" + json.dumps(record) + "</code-review-sage-result>"
+
+
+class TestResponseHandoff(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
-        self._old = os.environ.get("KIROCREW_HOME")
-        os.environ["KIROCREW_HOME"] = self.tmp
         self.root = Path(self.tmp) / "app"
         store.ensure_layout(self.root)
 
     def tearDown(self):
-        if self._old is None:
-            os.environ.pop("KIROCREW_HOME", None)
-        else:
-            os.environ["KIROCREW_HOME"] = self._old
         shutil.rmtree(self.tmp, ignore_errors=True)
 
+    def test_sibling_result_planting_cannot_replace_a_dispatch_response(self):
+        victim = "CR-2"
+        planted = _record(victim)
+        planted["findings"] = [{"headline": "PLANTED-BY-SIBLING"}]
 
-class TestRecordContractAtRead(_Base):
-    """A dict is not enough: the record must satisfy the contract to be returned."""
+        def dispatch(task, timeout=0):
+            if "CR-1" in task:
+                results.write_result(planted, self.root, "run-a")
+                return {"ok": True, "output": _handoff(_record("CR-1")), "error": ""}
+            return {"ok": True, "output": "completed without a handoff", "error": ""}
 
-    def _write_shared(self, cid: str, payload) -> None:
-        d = store.data_dir(self.root) / "results"
-        d.mkdir(parents=True, exist_ok=True)
-        (d / f"{cid}.json").write_text(json.dumps(payload), encoding="utf-8")
-
-    def test_a_valid_record_is_returned(self):
-        self._write_shared("CR-ok", _record("CR-ok"))
-        self.assertIsNotNone(results.read_result("CR-ok", self.root))
-
-    def test_a_non_object_record_is_refused(self):
-        self._write_shared("CR-list", [])
-        self.assertIsNone(results.read_result("CR-list", self.root))
-
-    def test_a_dict_that_violates_the_contract_is_refused(self):
-        # Shape-plausible but unusable: `classify()` reads `phase1.gate_verdict`,
-        # so returning this leaves a finished run with no report instead of a
-        # report that says nothing was found.
-        self._write_shared("CR-bad", {"phase1": []})
-        self.assertIsNone(results.read_result("CR-bad", self.root))
-
-    def test_a_record_missing_phase1_entirely_is_refused(self):
-        rec = _record("CR-nophase")
-        rec.pop("phase1")
-        self._write_shared("CR-nophase", rec)
-        self.assertIsNone(results.read_result("CR-nophase", self.root))
-
-
-class TestAdoption(_Base):
-    def test_adopts_a_shared_record_into_the_run_dir(self):
-        results.write_result(_record(), self.root)          # worker's path
-        self.assertTrue(results.adopt_from_shared("CR-1", self.root, "run-a"))
-        # Present in the run, gone from the staging dir.
-        self.assertIsNotNone(results.read_result("CR-1", self.root, "run-a"))
-        self.assertIsNone(results.read_result("CR-1", self.root, None))
-
-    def test_adoption_is_a_no_op_when_the_worker_wrote_nothing(self):
-        # Must be reported as a failed change, not a silently empty report.
-        self.assertFalse(results.adopt_from_shared("CR-1", self.root, "run-a"))
-        self.assertIsNone(results.read_result("CR-1", self.root, "run-a"))
-
-    def test_adoption_without_a_run_id_does_nothing(self):
-        results.write_result(_record(), self.root)
-        self.assertFalse(results.adopt_from_shared("CR-1", self.root, None))
-        # The legacy path is untouched, so the standalone CLI still works.
-        self.assertIsNotNone(results.read_result("CR-1", self.root, None))
-
-    def test_publish_makes_a_run_record_visible_to_the_poster(self):
-        results.write_result(_record(), self.root, "run-a")
-        self.assertTrue(results.publish_to_shared("CR-1", self.root, "run-a"))
-        self.assertIsNotNone(results.read_result("CR-1", self.root, None))
-        # And the run keeps its own copy.
-        self.assertIsNotNone(results.read_result("CR-1", self.root, "run-a"))
-
-    def test_records_do_not_leak_between_runs(self):
-        results.write_result(_record(), self.root)
-        results.adopt_from_shared("CR-1", self.root, "run-a")
-        self.assertIsNone(results.read_result("CR-1", self.root, "run-b"))
-
-
-class TestDriverAdopts(_Base):
-    """End-to-end: a worker that writes ONLY the shared path must still produce a
-    report for the run."""
-
-    def _worker_dispatch(self):
-        def dispatch(task: str, timeout: int = 0):
-            if "SINGLE thorough pass" in task:
-                # Exactly what the real worker does: the path its prompt names.
-                results.write_result(_record(), self.root)
-            return {"ok": True, "output": "done", "error": ""}
-        return dispatch
-
-    def test_run_records_the_review_and_writes_a_report(self):
-        out = D.run_review(["CR-1"], dispatch=self._worker_dispatch(),
-                           archiver=lambda *_a, **_k: None,
-                           generate_report=True, root=self.root, run_id="run-a")
-        # This was 0 before the bridge existed.
+        out = driver.run_review(
+            ["CR-1", victim],
+            dispatch=dispatch,
+            root=self.root,
+            run_id="run-a",
+            generate_report=False,
+            concurrency=1,
+        )
+        adopted = results.read_result(victim, self.root, "run-a") or {}
         self.assertEqual(out["result_records"], 1)
-        self.assertEqual(out["deep_reviewed"], 1)
-        payload = json.loads(
-            (store.run_dir("run-a", self.root) / "report" / "report.json")
-            .read_text(encoding="utf-8"))
-        self.assertTrue(payload["rows"], "the report has no rows")
+        self.assertNotIn("PLANTED-BY-SIBLING", json.dumps(adopted))
 
-    def test_progress_reports_done_not_failed(self):
-        seen: dict = {}
+    def test_malformed_unicode_capability_fails_one_change_not_the_batch(self):
+        malformed = _record("CR-1")
+        malformed["result_capability"] = "malformed-\ud800"
 
-        def prog(cid, phase, extra=None):
-            seen[cid] = phase
-        D.run_review(["CR-1"], dispatch=self._worker_dispatch(),
-                     generate_report=False, root=self.root, run_id="run-a",
-                     progress=prog)
-        self.assertEqual(seen["CR-1"], "done")
+        def dispatch(task, timeout=0):
+            record = malformed if "CR-1" in task else _record("CR-2")
+            return {"ok": True, "output": _handoff(record), "error": ""}
 
-    def test_a_worker_that_writes_nothing_is_reported_failed(self):
-        # The honest counterpart: no record means the change failed, and the
-        # phase must say so rather than counting as reviewed.
-        seen: dict = {}
-
-        def prog(cid, phase, extra=None):
-            seen[cid] = phase
-
-        def silent(task: str, timeout: int = 0):
-            return {"ok": True, "output": "", "error": ""}
-
-        out = D.run_review(["CR-1"], dispatch=silent, generate_report=False,
-                           root=self.root, run_id="run-a", progress=prog)
-        self.assertEqual(seen["CR-1"], "failed")
-        self.assertEqual(out["result_records"], 0)
-        # The residual "turn completed, nothing written" case keeps this value —
-        # discriminated causes (runtime preflight, incomplete record) carry
-        # their own reasons and must never collapse back into it.
-        self.assertEqual(out["per_change"][0]["skipped_reason"], "no_review_recorded")
+        out = driver.run_review(
+            ["CR-1", "CR-2"],
+            dispatch=dispatch,
+            root=self.root,
+            run_id="run-a",
+            generate_report=False,
+        )
         self.assertFalse(out["per_change"][0]["result_recorded"])
+        self.assertTrue(out["per_change"][1]["result_recorded"])
 
+    def test_outermost_handoff_delimiters_allow_quoted_sentinels_in_json(self):
+        record = _record("CR-1")
+        record["title"] = (
+            "Quoted <code-review-sage-result> and </code-review-sage-result> markers"
+        )
 
-if __name__ == "__main__":  # pragma: no cover
-    unittest.main()
+        self.assertEqual(results.result_from_handoff(_handoff(record), "CR-1"), record)
 
-
-class TestStagingResidue(unittest.TestCase):
-    """A crash between the worker's staging write and adoption leaves an orphan.
-
-    Nothing reaps the shared dir (the orphan reaper walks only ``data/runs/``), so
-    without a sweep at run start the next review of that change whose worker
-    records nothing adopts the residue and reports a stale review as a fresh
-    success -- and the change is then durably marked reviewed at the NEW head, so
-    it is never re-reviewed there.
-    """
-
-    def setUp(self):
-        self.tmp = tempfile.mkdtemp()
-        self.root = Path(self.tmp)
-        store.ensure_layout(self.root)
-
-    def tearDown(self):
-        shutil.rmtree(self.tmp, ignore_errors=True)
-
-    def test_clear_staged_removes_only_the_named_changes(self):
-        results.write_result(_record("CR-1"), self.root, None)
-        results.write_result(_record("CR-2"), self.root, None)
-
-        removed = results.clear_staged(["CR-1"], self.root)
-
-        self.assertEqual(removed, 1)
-        self.assertIsNone(results.read_result("CR-1", self.root, None))
-        # A concurrent run's staging is left alone.
-        self.assertIsNotNone(results.read_result("CR-2", self.root, None))
-
-    def test_a_run_does_not_adopt_crash_residue_as_its_own_review(self):
-        """End-to-end: the DRIVER must sweep staging, not just the helper.
-
-        Residue is staged under this change id, then a run whose worker records
-        nothing reviews it. Without the sweep the run adopts the orphan and
-        reports a stale review as a fresh success.
-        """
-        stale = _record("CR-1")
-        stale["phase1"]["design_headline"] = "from the crashed run"
-        results.write_result(stale, self.root, None)
-
-        seen: dict = {}
-
-        def silent(task: str, timeout: int = 0):
-            return {"ok": True, "output": "", "error": ""}
-
-        out = D.run_review(["CR-1"], dispatch=silent, generate_report=False,
-                           root=self.root, run_id="run-new",
-                           progress=lambda cid, phase, extra=None:
-                           seen.__setitem__(cid, phase))
-
-        self.assertEqual(out["result_records"], 0)
-        self.assertEqual(seen["CR-1"], "failed")
-        self.assertIsNone(results.read_result("CR-1", self.root, "run-new"))
-
-
-class TestStakedSlot(_Base):
-    """A record present before a change's own reviewer runs is not its findings.
-
-    Adoption proves a payload NAMES a change, never who wrote it, and every reviewer
-    worker can write any change's path in the shared dir. So the slot is cleared right
-    before dispatch; whatever is adopted afterwards was written after that point.
-    """
-
-    def test_a_planted_record_is_cleared(self):
-        # A worker reviewing some other change writes the victim's path, naming the
-        # victim so the adoption payload check would pass.
-        results.write_result(_record("CR-victim"), self.root)
-        planted = results.result_path("CR-victim", self.root, None)
-        self.assertTrue(planted.exists())
-
-        self.assertTrue(results.stake_shared("CR-victim", self.root))
-        self.assertFalse(planted.exists())
-
-    def test_an_empty_slot_is_already_the_wanted_state(self):
-        self.assertTrue(results.stake_shared("CR-never-seen", self.root))
-
-    @unittest.skipUnless(SYMLINKS_OK, "platform forbids unprivileged symlinks")
-    def test_a_planted_symlink_is_removed_not_followed(self):
-        # os.unlink removes the link itself, so the target it aimed at must survive.
-        target = self.root / "elsewhere.json"
-        target.write_text('{"change_id": "CR-other"}', encoding="utf-8")
-        link = results.result_path("CR-victim", self.root, None)
-        link.parent.mkdir(parents=True, exist_ok=True)
-        link.symlink_to(target)
-
-        self.assertTrue(results.stake_shared("CR-victim", self.root))
-        self.assertFalse(link.is_symlink(), "the planted link survived")
-        self.assertTrue(target.exists(), "unlink followed the link and removed the target")
-
-    def test_an_unclearable_slot_is_not_adopted_from(self):
-        """A slot that could not be emptied has no provenance, so nothing is taken."""
-        first = "https://github.com/o/r/pull/1"
-        victim = "https://github.com/o/r/pull/2"
-        vid = D._cid(victim)
-        planted = _record(vid)
-        planted["findings"] = [{"dimension": "correctness", "severity": "red",
-                                "title": "UNCLEARABLE-SLOT", "detail": "x",
-                                "recommendation": "x"}]
-
-        planted_by: list[bool] = []
-
-        def dispatch(task, timeout):
-            if not planted_by:
-                results.write_result(planted, self.root)
-                planted_by.append(True)
-            return {"ok": True, "output": "", "error": ""}
-
-        real_stake = results.stake_shared
-        results.stake_shared = lambda change_id, root=None: False   # EPERM on the unlink
-        try:
-            out = D.run_review([first, victim], dispatch=dispatch, generate_report=False,
-                               root=self.root, run_id="run-1", post=False, concurrency=1)
-        finally:
-            results.stake_shared = real_stake
-
-        self.assertTrue(planted_by, "the plant was never written")
-        self.assertIsNone(results.read_result(vid, self.root, "run-1"),
-                          "adopted from a slot that could not be cleared")
-        self.assertEqual(int(out.get("result_records") or 0), 0)
-
-    def test_a_worker_cannot_plant_a_later_change_in_the_same_run(self):
-        # Reviewers are serialized, so the live attack is an earlier worker writing a
-        # LATER change's slot mid-run: the run-start sweep has already happened, and
-        # nothing else distinguishes that record from one the victim's own worker wrote.
-        first = "https://github.com/o/r/pull/1"
-        victim = "https://github.com/o/r/pull/2"
-        vid = D._cid(victim)
-        planted = _record(vid)
-        planted["findings"] = [{"dimension": "correctness", "severity": "red",
-                                "title": "PLANTED-BY-SIBLING", "detail": "x",
-                                "recommendation": "x"}]
-
-        planted_by: list[bool] = []
-
-        def dispatch(task, timeout):
-            # The injected worker reviewing the FIRST change writes the victim's slot
-            # and records nothing for itself. Plant on the first dispatch only, keyed on
-            # call order rather than on the task's text, which the driver owns.
-            if not planted_by:
-                results.write_result(planted, self.root)
-                planted_by.append(True)
-            return {"ok": True, "output": "", "error": ""}
-
-        out = D.run_review([first, victim], dispatch=dispatch, generate_report=False,
-                           root=self.root, run_id="run-1", post=False, concurrency=1)
-        # A test that never plants proves nothing.
-        self.assertTrue(planted_by, "the plant was never written")
-
-        adopted = results.read_result(vid, self.root, "run-1")
-        self.assertIsNone(adopted, "the victim adopted a sibling worker's planted record")
-        run_file = results.result_path(vid, self.root, "run-1")
-        if run_file.exists():
-            self.assertNotIn("PLANTED-BY-SIBLING", run_file.read_text(encoding="utf-8"))
-        self.assertEqual(int(out.get("result_records") or 0), 0)
+    def test_prompt_exposes_no_result_file_or_capability(self):
+        task = driver.build_review_task("CR-1")
+        self.assertIn("<code-review-sage-result>", task)
+        self.assertNotIn("result_capability", task)
+        self.assertNotIn("data/results", task)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_record_adoption.py
@@ -93,8 +93,7 @@ class TestResponseHandoff(unittest.TestCase):
 
         self.assertEqual(results.result_from_handoff(_handoff(record), "CR-1"), record)
 
-    def test_prompt_exposes_no_result_file_or_capability(self):
+    def test_prompt_exposes_no_result_file(self):
         task = driver.build_review_task("CR-1")
         self.assertIn("<code-review-sage-result>", task)
-        self.assertNotIn("result_capability", task)
         self.assertNotIn("data/results", task)

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -1,4 +1,5 @@
 """Unit tests for the code-enforced two-stage review driver (gap A + phase switch)."""
+
 import re
 import shutil
 import sys
@@ -22,20 +23,23 @@ class TestHostQualifiedIdentity(unittest.TestCase):
 
     def test_github_keys_unchanged(self):
         self.assertEqual(D.change_id_for("https://github.com/o/r/pull/7"), "GH-o-r-7")
-        self.assertEqual(D.reviewed_key_for("https://github.com/o/r/pull/7"),
-                         "github.com/o/r#7")
+        self.assertEqual(D.reviewed_key_for("https://github.com/o/r/pull/7"), "github.com/o/r#7")
 
     def test_ghe_keys_carry_the_host(self):
-        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
-                               return_value=self.GHE_CFG):
-            self.assertEqual(D.change_id_for("https://acme.ghe.com/o/r/pull/7"),
-                             "GH-acme.ghe.com-o-r-7")
-            self.assertEqual(D.reviewed_key_for("https://acme.ghe.com/o/r/pull/7"),
-                             "acme.ghe.com/o/r#7")
+        with mock.patch.object(
+            D.pipeline.adapters.store, "read_config_quiet", return_value=self.GHE_CFG
+        ):
+            self.assertEqual(
+                D.change_id_for("https://acme.ghe.com/o/r/pull/7"), "GH-acme.ghe.com-o-r-7"
+            )
+            self.assertEqual(
+                D.reviewed_key_for("https://acme.ghe.com/o/r/pull/7"), "acme.ghe.com/o/r#7"
+            )
 
     def test_fetch_and_post_prompts_route_to_the_ghe_api(self):
-        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
-                               return_value=self.GHE_CFG):
+        with mock.patch.object(
+            D.pipeline.adapters.store, "read_config_quiet", return_value=self.GHE_CFG
+        ):
             fetch = D._fetch_instruction("https://acme.ghe.com/o/r/pull/7")
             post = D.build_post_task("https://acme.ghe.com/o/r/pull/7")
             gh_fetch = D._fetch_instruction("https://github.com/o/r/pull/7")
@@ -63,10 +67,17 @@ class TestHostQualifiedIdentity(unittest.TestCase):
         calls silently default to public github.com would fetch from, or post
         an internal enterprise draft onto, a public same-slug PR."""
         link = "https://acme.ghe.com/o/r/pull/7"
-        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
-                               return_value={"github_hosts": ["github.com"]}):
-            for builder in (D.build_post_task, D._fetch_instruction,
-                            D.build_review_task, D.build_review_followup_task):
+        with mock.patch.object(
+            D.pipeline.adapters.store,
+            "read_config_quiet",
+            return_value={"github_hosts": ["github.com"]},
+        ):
+            for builder in (
+                D.build_post_task,
+                D._fetch_instruction,
+                D.build_review_task,
+                D.build_review_followup_task,
+            ):
                 with self.assertRaises(D.pipeline.adapters.AdapterError):
                     builder(link)
                 # A scheme is a named host too, even when it cannot be parsed.
@@ -79,16 +90,25 @@ class TestHostQualifiedIdentity(unittest.TestCase):
         either the host revalidates and the flag is embedded, or the builder
         raises (asserted above). "Resolved as github.com" and "failed to
         resolve" must never look identical."""
-        with mock.patch.object(D.pipeline.adapters.store, "read_config_quiet",
-                               return_value=self.GHE_CFG):
-            for builder in (D.build_post_task, D._fetch_instruction,
-                            D.build_review_task, D.build_review_followup_task):
+        with mock.patch.object(
+            D.pipeline.adapters.store, "read_config_quiet", return_value=self.GHE_CFG
+        ):
+            for builder in (
+                D.build_post_task,
+                D._fetch_instruction,
+                D.build_review_task,
+                D.build_review_followup_task,
+            ):
                 prompt = builder("https://acme.ghe.com/o/r/pull/7")
-                self.assertIn("--hostname acme.ghe.com", prompt,
-                              f"{builder.__name__} lost the hostname routing")
+                self.assertIn(
+                    "--hostname acme.ghe.com",
+                    prompt,
+                    f"{builder.__name__} lost the hostname routing",
+                )
                 gh = builder("https://github.com/o/r/pull/7")
-                self.assertIn("--hostname github.com", gh,
-                              f"{builder.__name__} left github.com unpinned")
+                self.assertIn(
+                    "--hostname github.com", gh, f"{builder.__name__} left github.com unpinned"
+                )
 
 
 def _confirmed(_link, _units):
@@ -112,8 +132,9 @@ class TestReviewDriver(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def _fake_dispatch(self, verdict="PASS", write_records=True, max_seen=None,
-                       coverage_complete=True):
+    def _fake_dispatch(
+        self, verdict="PASS", write_records=True, max_seen=None, coverage_complete=True
+    ):
         """A dispatch fn modeling the SINGLE-PASS reviewer:
         - a REVIEW session writes the COMPLETE record in one turn (phase1 verdict +
           one finding + counts + deep_reviewed=true + the coverage signal);
@@ -123,6 +144,7 @@ class TestReviewDriver(unittest.TestCase):
         The pool's send() returns when the worker's turn ends; this fake models
         that by writing the record and returning synchronously.
         """
+
         def dispatch(task, timeout=0):
             with self.lock:
                 self.calls.append(task)
@@ -138,23 +160,44 @@ class TestReviewDriver(unittest.TestCase):
                 if is_poster:
                     rec = results.read_result(cid, self.root) or {}
                     pending = rec.get("pending_comments", []) or []
-                    rec["posted_comments"] = len(pending)   # posts each verbatim
-                    rec["design_comment_posted"] = any(
-                        e.get("kind") == "design" for e in pending)
+                    rec["posted_comments"] = len(pending)  # posts each verbatim
+                    rec["design_comment_posted"] = any(e.get("kind") == "design" for e in pending)
                     results.write_result(rec, self.root)
                 elif is_review:
-                    results.write_result({
-                        "schema": "code-review-sage-result", "version": 1, "change_id": cid,
-                        "platform": "github", "repo_identity": "github.com/o/r", "revision": "1",
-                        "phase1": {"gate_verdict": verdict, "design_risk": "low", "criticality": "low"},
-                        "blast_radius": {"rating": "SMALL", "signals": {}},
-                        "counts": {"red": 0, "yellow": 1},
-                        "findings": [{"dimension": "correctness", "severity": "yellow",
-                                      "file": "f", "line": 1, "snippet": "x",
-                                      "observation": "o", "consequence": "c", "suggestion": "s"}],
-                        "deep_reviewed": True, "title": cid,
-                        "files_covered": ["f"], "coverage_complete": coverage_complete,
-                    }, self.root)
+                    results.write_result(
+                        {
+                            "schema": "code-review-sage-result",
+                            "version": 1,
+                            "change_id": cid,
+                            "platform": "github",
+                            "repo_identity": "github.com/o/r",
+                            "revision": "1",
+                            "phase1": {
+                                "gate_verdict": verdict,
+                                "design_risk": "low",
+                                "criticality": "low",
+                            },
+                            "blast_radius": {"rating": "SMALL", "signals": {}},
+                            "counts": {"red": 0, "yellow": 1},
+                            "findings": [
+                                {
+                                    "dimension": "correctness",
+                                    "severity": "yellow",
+                                    "file": "f",
+                                    "line": 1,
+                                    "snippet": "x",
+                                    "observation": "o",
+                                    "consequence": "c",
+                                    "suggestion": "s",
+                                }
+                            ],
+                            "deep_reviewed": True,
+                            "title": cid,
+                            "files_covered": ["f"],
+                            "coverage_complete": coverage_complete,
+                        },
+                        self.root,
+                    )
                 elif is_followup:
                     rec = results.read_result(cid, self.root) or {}
                     rec["coverage_complete"] = True
@@ -163,6 +206,7 @@ class TestReviewDriver(unittest.TestCase):
             with self.lock:
                 self._concurrent -= 1
             return {"ok": True, "output": "done", "error": ""}
+
         return dispatch
 
     def _archiver(self, html, root=None):
@@ -170,8 +214,14 @@ class TestReviewDriver(unittest.TestCase):
         return "sage-report-test"
 
     def test_single_pass_reviews_all_changes(self):
-        out = D.run_review(["CR-1", "CR-2", "CR-3"], dispatch=self._fake_dispatch(verdict="PASS"), confirm=_confirmed,
-                           archiver=self._archiver, root=self.root, post=True)
+        out = D.run_review(
+            ["CR-1", "CR-2", "CR-3"],
+            dispatch=self._fake_dispatch(verdict="PASS"),
+            confirm=_confirmed,
+            archiver=self._archiver,
+            root=self.root,
+            post=True,
+        )
         self.assertEqual(out["changes"], 3)
         self.assertEqual(out["gate_spawns"], 3)
         self.assertEqual(out["deep_spawns"], 3)
@@ -179,7 +229,7 @@ class TestReviewDriver(unittest.TestCase):
         self.assertEqual(out["design_blocked"], 0)
         # ONE review pass + poster per change (coverage complete -> no follow-up)
         self.assertEqual(len(self.calls), 6)
-        self.assertEqual(out["deep_rounds"], 3)           # one review pass per change
+        self.assertEqual(out["deep_rounds"], 3)  # one review pass per change
         self.assertEqual(out["report"]["total"], 3)
         # report archived as a per-run artifact, then records cleaned
         self.assertEqual(out["report_slug"], "sage-report-test")
@@ -187,8 +237,13 @@ class TestReviewDriver(unittest.TestCase):
         self.assertEqual(results.list_results(self.root), [])
 
     def test_concerns_still_proceeds_to_phase2(self):
-        out = D.run_review(["CR-5"], dispatch=self._fake_dispatch(verdict="CONCERNS"),
-                           generate_report=False, root=self.root, post=True)
+        out = D.run_review(
+            ["CR-5"],
+            dispatch=self._fake_dispatch(verdict="CONCERNS"),
+            generate_report=False,
+            root=self.root,
+            post=True,
+        )
         self.assertEqual(out["deep_spawns"], 1)
         self.assertEqual(out["deep_reviewed"], 1)
 
@@ -196,29 +251,42 @@ class TestReviewDriver(unittest.TestCase):
         # A design BLOCK does not skip Phase 2 — the full code review still runs so
         # the author sees design + code issues in one pass. BLOCK only informs the
         # ship decision.
-        out = D.run_review(["CR-1", "CR-2"], dispatch=self._fake_dispatch(verdict="BLOCK"),
-                           archiver=self._archiver, root=self.root, post=True)
+        out = D.run_review(
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(verdict="BLOCK"),
+            archiver=self._archiver,
+            root=self.root,
+            post=True,
+        )
         self.assertEqual(out["gate_spawns"], 2)
-        self.assertEqual(out["deep_spawns"], 2)            # BLOCK proceeds to Phase 2
+        self.assertEqual(out["deep_spawns"], 2)  # BLOCK proceeds to Phase 2
         self.assertEqual(out["phase2_skipped_on_block"], 0)
-        self.assertEqual(out["design_blocked"], 2)         # BLOCK verdicts, still deep-reviewed
+        self.assertEqual(out["design_blocked"], 2)  # BLOCK verdicts, still deep-reviewed
         self.assertEqual(out["deep_reviewed"], 2)
         # every reviewed change gets the always-on ship-readiness (design) comment
         self.assertEqual(out["design_comments_posted"], 2)
         self.assertEqual(out["report"]["total"], 2)
 
     def test_archive_failure_keeps_records(self):
-        out = D.run_review(["CR-1", "CR-2"], dispatch=self._fake_dispatch(verdict="PASS"),
-                           archiver=lambda html, root=None: None, root=self.root, post=True)
+        out = D.run_review(
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(verdict="PASS"),
+            archiver=lambda html, root=None: None,
+            root=self.root,
+            post=True,
+        )
         self.assertIn("archive_error", out)
         self.assertNotIn("results_cleaned", out)
-        self.assertEqual(len(results.list_results(self.root)), 2)   # records preserved
+        self.assertEqual(len(results.list_results(self.root)), 2)  # records preserved
 
     def test_no_record_marks_failed(self):
         # dispatch that completes but writes no record -> review produced nothing usable
         def no_record(task, timeout=0):
             return {"ok": True, "output": "", "error": ""}
-        out = D.run_review(["CR-7"], dispatch=no_record, generate_report=False, root=self.root, post=True)
+
+        out = D.run_review(
+            ["CR-7"], dispatch=no_record, generate_report=False, root=self.root, post=True
+        )
         self.assertEqual(out["deep_reviewed"], 0)
         # The residual "turn completed, nothing written" case keeps this value;
         # environment failures carry their own discriminated reasons instead.
@@ -237,19 +305,35 @@ class TestReviewDriver(unittest.TestCase):
                 errors[cid] = (extra or {}).get("error", "")
 
         def partial(task, timeout=0):
-            results.write_result({
-                "schema": "code-review-sage-result", "version": 1, "change_id": "CR-8",
-                "platform": "github", "repo_identity": "github.com/o/r", "revision": "1",
-                "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
-                "blast_radius": {"rating": "SMALL", "signals": {}},
-                "counts": {"red": 0, "yellow": 0}, "findings": [],
-                "deep_reviewed": False, "title": "CR-8",
-                "files_covered": [], "coverage_complete": True,
-            }, self.root)
+            results.write_result(
+                {
+                    "schema": "code-review-sage-result",
+                    "version": 1,
+                    "change_id": "CR-8",
+                    "platform": "github",
+                    "repo_identity": "github.com/o/r",
+                    "revision": "1",
+                    "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
+                    "blast_radius": {"rating": "SMALL", "signals": {}},
+                    "counts": {"red": 0, "yellow": 0},
+                    "findings": [],
+                    "deep_reviewed": False,
+                    "title": "CR-8",
+                    "files_covered": [],
+                    "coverage_complete": True,
+                },
+                self.root,
+            )
             return {"ok": True, "output": "", "error": ""}
 
-        out = D.run_review(["CR-8"], dispatch=partial, generate_report=False,
-                           root=self.root, post=True, progress=prog)
+        out = D.run_review(
+            ["CR-8"],
+            dispatch=partial,
+            generate_report=False,
+            root=self.root,
+            post=True,
+            progress=prog,
+        )
         rec = out["per_change"][0]
         self.assertEqual(rec["skipped_reason"], "review_record_incomplete")
         self.assertTrue(rec["result_recorded"])
@@ -266,11 +350,16 @@ class TestReviewDriver(unittest.TestCase):
             errors[cid] = (phase, (extra or {}).get("error", ""))
 
         out = D.run_review(
-            ["CR-1", "CR-2"], dispatch=self._fake_dispatch(),
-            generate_report=False, root=self.root, post=True, progress=prog,
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(),
+            generate_report=False,
+            root=self.root,
+            post=True,
+            progress=prog,
             preflight=lambda: "the reviewer cannot run: no kiro-cli executable "
-                              "was found on this host")
-        self.assertEqual(self.calls, [])            # nothing was dispatched
+            "was found on this host",
+        )
+        self.assertEqual(self.calls, [])  # nothing was dispatched
         self.assertFalse(out["ok"])
         self.assertIn("kiro-cli", out["error"])
         self.assertEqual(out["changes"], 2)
@@ -283,30 +372,48 @@ class TestReviewDriver(unittest.TestCase):
 
     def test_passing_preflight_runs_the_review(self):
         # "" means the runtime is available — the run proceeds normally.
-        out = D.run_review(["CR-1"], dispatch=self._fake_dispatch(),
-                           generate_report=False, root=self.root, post=True,
-                           preflight=lambda: "")
+        out = D.run_review(
+            ["CR-1"],
+            dispatch=self._fake_dispatch(),
+            generate_report=False,
+            root=self.root,
+            post=True,
+            preflight=lambda: "",
+        )
         self.assertTrue(out["ok"])
         self.assertEqual(out["deep_reviewed"], 1)
         self.assertGreater(len(self.calls), 0)
 
     def test_each_task_is_single_change(self):
-        D.run_review(["CR-1", "CR-2"], dispatch=self._fake_dispatch(), archiver=self._archiver,
-                     root=self.root, post=True)
+        D.run_review(
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(),
+            archiver=self._archiver,
+            root=self.root,
+            post=True,
+        )
         for task in self.calls:
             self.assertIn("EXACTLY ONE change", task)
 
     def test_concurrency_capped(self):
         max_seen = [0]
-        D.run_review(["CR-1", "CR-2", "CR-3", "CR-4", "CR-5"],
-                     dispatch=self._fake_dispatch(max_seen=max_seen), archiver=self._archiver,
-                     concurrency=2, root=self.root, post=True)
+        D.run_review(
+            ["CR-1", "CR-2", "CR-3", "CR-4", "CR-5"],
+            dispatch=self._fake_dispatch(max_seen=max_seen),
+            archiver=self._archiver,
+            concurrency=2,
+            root=self.root,
+            post=True,
+        )
         self.assertLessEqual(max_seen[0], 2)
 
     def test_review_failure_surfaced(self):
         def failing(task, timeout=0):
             return {"ok": False, "output": "", "error": "boom"}
-        out = D.run_review(["CR-9"], dispatch=failing, generate_report=False, root=self.root, post=True)
+
+        out = D.run_review(
+            ["CR-9"], dispatch=failing, generate_report=False, root=self.root, post=True
+        )
         self.assertEqual(len(out["failures"]), 1)
         self.assertEqual(out["deep_reviewed"], 0)
         self.assertEqual(out["per_change"][0]["skipped_reason"], "review_failed")
@@ -332,14 +439,16 @@ class TestReviewDriver(unittest.TestCase):
             if phase == "failed":
                 entries[c] = dict(extra or {})
 
-        out = D.run_review([cid], generate_report=False, root=self.root,
-                           post=True, progress=prog, **kw)
+        out = D.run_review(
+            [cid], generate_report=False, root=self.root, post=True, progress=prog, **kw
+        )
         self.out = out
         return entries.get(cid, {})
 
     def test_progress_entry_names_no_review_recorded(self):
         entry = self._failed_entry(
-            "CR-7", dispatch=lambda task, timeout=0: {"ok": True, "output": "", "error": ""})
+            "CR-7", dispatch=lambda task, timeout=0: {"ok": True, "output": "", "error": ""}
+        )
         self.assertEqual(entry.get("reason"), "no_review_recorded")
         # The sentence is unchanged -- the token is carried BESIDE it.
         self.assertEqual(entry.get("error"), "review produced no result record")
@@ -347,16 +456,25 @@ class TestReviewDriver(unittest.TestCase):
 
     def test_progress_entry_names_review_record_incomplete(self):
         def partial(task, timeout=0):
-            results.write_result({
-                "schema": "code-review-sage-result", "version": 1, "change_id": "CR-8",
-                "platform": "github", "repo_identity": "github.com/o/r", "revision": "1",
-                "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                           "criticality": "low"},
-                "blast_radius": {"rating": "SMALL", "signals": {}},
-                "counts": {"red": 0, "yellow": 0}, "findings": [],
-                "deep_reviewed": False, "title": "CR-8",
-                "files_covered": [], "coverage_complete": True,
-            }, self.root)
+            results.write_result(
+                {
+                    "schema": "code-review-sage-result",
+                    "version": 1,
+                    "change_id": "CR-8",
+                    "platform": "github",
+                    "repo_identity": "github.com/o/r",
+                    "revision": "1",
+                    "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
+                    "blast_radius": {"rating": "SMALL", "signals": {}},
+                    "counts": {"red": 0, "yellow": 0},
+                    "findings": [],
+                    "deep_reviewed": False,
+                    "title": "CR-8",
+                    "files_covered": [],
+                    "coverage_complete": True,
+                },
+                self.root,
+            )
             return {"ok": True, "output": "", "error": ""}
 
         entry = self._failed_entry("CR-8", dispatch=partial)
@@ -366,8 +484,8 @@ class TestReviewDriver(unittest.TestCase):
 
     def test_progress_entry_names_review_failed(self):
         entry = self._failed_entry(
-            "CR-9",
-            dispatch=lambda task, timeout=0: {"ok": False, "output": "", "error": "boom"})
+            "CR-9", dispatch=lambda task, timeout=0: {"ok": False, "output": "", "error": "boom"}
+        )
         self.assertEqual(entry.get("reason"), "review_failed")
         # The spawn's own text, which for this cause is the information: it can be
         # a missing-agent-spec message carrying its own repair command, so the
@@ -383,10 +501,15 @@ class TestReviewDriver(unittest.TestCase):
                 entries[cid] = dict(extra or {})
 
         out = D.run_review(
-            ["CR-1", "CR-2"], dispatch=self._fake_dispatch(),
-            generate_report=False, root=self.root, post=True, progress=prog,
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(),
+            generate_report=False,
+            root=self.root,
+            post=True,
+            progress=prog,
             preflight=lambda: "the reviewer cannot run: no kiro-cli executable "
-                              "was found on this host")
+            "was found on this host",
+        )
         # Every change of a preflight-failed run, not just the first.
         for cid, rec in zip(("CR-1", "CR-2"), out["per_change"]):
             self.assertEqual(entries[cid].get("reason"), "runtime_unavailable")
@@ -397,7 +520,7 @@ class TestReviewDriver(unittest.TestCase):
         # `build_review_task` fails CLOSED when the link's host no longer
         # revalidates. Patched rather than reached through a crafted URL so the
         # test pins THIS site's payload, not the host-allowlist rules.
-        def refuse(link):
+        def refuse(link, result_capability=None):
             raise D.pipeline.adapters.AdapterError("host is not allowed")
 
         with mock.patch.object(D, "build_review_task", refuse):
@@ -413,6 +536,14 @@ class TestReviewDriver(unittest.TestCase):
         self.assertIn("DESIGN dimension", task)
         self.assertIn("spawn further subagents", task)
         self.assertIn("github.com/o/r/pull/7", task)
+
+    def test_review_task_returns_the_result_through_the_dispatcher(self):
+        task = D.build_review_task("CR-7")
+        followup = D.build_review_followup_task("CR-7", {"change_id": "CR-7"})
+        self.assertIn("<code-review-sage-result>", task)
+        self.assertIn("Do not write the result record to disk", task)
+        self.assertIn("<code-review-sage-result>", followup)
+        self.assertNotIn("result_capability", task)
 
     def test_review_task_has_inline_learning(self):
         task = D.build_review_task("CR-8")
@@ -437,23 +568,37 @@ class TestReviewDriver(unittest.TestCase):
         def prog(cid, phase, extra=None):
             with plock:
                 seen.append((cid, phase))
-        D.run_review(["CR-1"], dispatch=self._fake_dispatch(verdict="PASS"),
-                     generate_report=False, root=self.root, progress=prog, post=True)
+
+        D.run_review(
+            ["CR-1"],
+            dispatch=self._fake_dispatch(verdict="PASS"),
+            generate_report=False,
+            root=self.root,
+            progress=prog,
+            post=True,
+        )
         phases = [p for (c, p) in seen if c == "CR-1"]
-        self.assertEqual(phases[0], "queued")     # marked queued upfront
-        self.assertIn("reviewing", phases)        # single review pass in progress
-        self.assertEqual(phases[-1], "done")      # terminal
+        self.assertEqual(phases[0], "queued")  # marked queued upfront
+        self.assertIn("reviewing", phases)  # single review pass in progress
+        self.assertEqual(phases[-1], "done")  # terminal
 
     def test_progress_block_still_reviews(self):
         seen = []
 
         def prog(cid, phase, extra=None):
             seen.append(phase)
-        D.run_review(["CR-2"], dispatch=self._fake_dispatch(verdict="BLOCK"),
-                     generate_report=False, root=self.root, progress=prog, post=True)
-        self.assertIn("reviewing", seen)          # BLOCK is still fully reviewed
-        self.assertNotIn("blocked", seen)         # no design-block short-circuit
-        self.assertNotIn("gating", seen)          # no gate phase
+
+        D.run_review(
+            ["CR-2"],
+            dispatch=self._fake_dispatch(verdict="BLOCK"),
+            generate_report=False,
+            root=self.root,
+            progress=prog,
+            post=True,
+        )
+        self.assertIn("reviewing", seen)  # BLOCK is still fully reviewed
+        self.assertNotIn("blocked", seen)  # no design-block short-circuit
+        self.assertNotIn("gating", seen)  # no gate phase
         self.assertEqual(seen[-1], "done")
 
     def test_review_task_blast_radius_never_blocks(self):
@@ -469,10 +614,17 @@ class TestReviewDriver(unittest.TestCase):
         def prog(cid, phase, extra=None):
             if phase == "done":
                 seen[cid] = extra or {}
-        out = D.run_review(["CR-1"], dispatch=self._fake_dispatch(verdict="PASS"),
-                           generate_report=False, root=self.root, progress=prog, post=True)
-        self.assertEqual(seen["CR-1"]["posted"], 2)       # 1 finding + always-on ship comment
-        self.assertEqual(seen["CR-1"]["expected"], 2)     # red0 + yellow1 + 1 ship comment
+
+        out = D.run_review(
+            ["CR-1"],
+            dispatch=self._fake_dispatch(verdict="PASS"),
+            generate_report=False,
+            root=self.root,
+            progress=prog,
+            post=True,
+        )
+        self.assertEqual(seen["CR-1"]["posted"], 2)  # 1 finding + always-on ship comment
+        self.assertEqual(seen["CR-1"]["expected"], 2)  # red0 + yellow1 + 1 ship comment
         self.assertEqual(out["per_change"][0]["posted_comments"], 2)
 
     def test_progress_done_flags_unposted_findings(self):
@@ -483,21 +635,43 @@ class TestReviewDriver(unittest.TestCase):
             assert m is not None
             cid = m.group(0)
             if "SINGLE thorough pass" in task:
-                results.write_result({
-                    "schema": "code-review-sage-result", "version": 1, "change_id": cid,
-                    "platform": "github", "repo_identity": "x", "revision": "1",
-                    "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
-                    "blast_radius": {"rating": "SMALL", "signals": {}},
-                    "counts": {"red": 1, "yellow": 0},
-                    "findings": [{"dimension": "correctness", "severity": "red",
-                                  "file": "f", "line": 1, "snippet": "x",
-                                  "observation": "o", "consequence": "c", "suggestion": "s"}],
-                    "deep_reviewed": True, "title": cid,
-                    "files_covered": ["f"], "coverage_complete": True,
-                }, self.root)
+                results.write_result(
+                    {
+                        "schema": "code-review-sage-result",
+                        "version": 1,
+                        "change_id": cid,
+                        "platform": "github",
+                        "repo_identity": "x",
+                        "revision": "1",
+                        "phase1": {
+                            "gate_verdict": "PASS",
+                            "design_risk": "low",
+                            "criticality": "low",
+                        },
+                        "blast_radius": {"rating": "SMALL", "signals": {}},
+                        "counts": {"red": 1, "yellow": 0},
+                        "findings": [
+                            {
+                                "dimension": "correctness",
+                                "severity": "red",
+                                "file": "f",
+                                "line": 1,
+                                "snippet": "x",
+                                "observation": "o",
+                                "consequence": "c",
+                                "suggestion": "s",
+                            }
+                        ],
+                        "deep_reviewed": True,
+                        "title": cid,
+                        "files_covered": ["f"],
+                        "coverage_complete": True,
+                    },
+                    self.root,
+                )
             elif "pre-redacted DRAFT review comments" in task:
                 rec = results.read_result(cid, self.root) or {}
-                rec["posted_comments"] = 0   # nothing posted despite a finding
+                rec["posted_comments"] = 0  # nothing posted despite a finding
                 results.write_result(rec, self.root)
             return {"ok": True, "output": "", "error": ""}
 
@@ -506,10 +680,17 @@ class TestReviewDriver(unittest.TestCase):
         def prog(cid, phase, extra=None):
             if phase == "done":
                 seen[cid] = extra or {}
-        D.run_review(["CR-2"], dispatch=review_no_post, generate_report=False,
-                     root=self.root, progress=prog, post=True)
+
+        D.run_review(
+            ["CR-2"],
+            dispatch=review_no_post,
+            generate_report=False,
+            root=self.root,
+            progress=prog,
+            post=True,
+        )
         self.assertEqual(seen["CR-2"]["posted"], 0)
-        self.assertEqual(seen["CR-2"]["expected"], 2)     # red1 + 1 ship comment; UI flags mismatch
+        self.assertEqual(seen["CR-2"]["expected"], 2)  # red1 + 1 ship comment; UI flags mismatch
 
     def test_archive_report_posts_and_returns_slug(self):
         calls = []
@@ -519,7 +700,8 @@ class TestReviewDriver(unittest.TestCase):
             calls.append((method, path))
             if method == "POST":
                 return {"slug": "sage-report-xyz"}
-            return {"artifacts": []}      # GET (prune) — nothing to prune
+            return {"artifacts": []}  # GET (prune) — nothing to prune
+
         D._api_request = fake_api
         try:
             slug = D._archive_report("<b>report</b>")
@@ -546,7 +728,7 @@ class TestReviewDriver(unittest.TestCase):
         # workers aren't /api/spawn sub-agents, so the gateway cap does not apply.
         self.assertEqual(D._resolve_concurrency(0), D.review_pool.MAX_CONCURRENT)
         self.assertEqual(D._resolve_concurrency(None), D.review_pool.MAX_CONCURRENT)
-        self.assertEqual(D.review_pool.MAX_CONCURRENT, 5)   # max 5 concurrent reviews
+        self.assertEqual(D.review_pool.MAX_CONCURRENT, 5)  # max 5 concurrent reviews
 
     def test_resolve_concurrency_explicit_wins(self):
         self.assertEqual(D._resolve_concurrency(7), 7)
@@ -556,16 +738,20 @@ class TestReviewDriver(unittest.TestCase):
         # First pass reports incomplete coverage -> the driver runs EXACTLY ONE
         # targeted follow-up (not a blanket loop), then posts. deep_rounds == 2.
         disp = self._fake_dispatch(verdict="PASS", coverage_complete=False)
-        out = D.run_review(["CR-1"], dispatch=disp, generate_report=False, root=self.root, post=True)
+        out = D.run_review(
+            ["CR-1"], dispatch=disp, generate_report=False, root=self.root, post=True
+        )
         self.assertEqual(out["per_change"][0]["deep_rounds"], 2)
-        self.assertEqual(len(self.calls), 3)   # review + one follow-up + poster
+        self.assertEqual(len(self.calls), 3)  # review + one follow-up + poster
         self.assertTrue(any("INCOMPLETE file coverage" in c for c in self.calls))
 
     def test_coverage_complete_skips_followup(self):
         disp = self._fake_dispatch(verdict="PASS", coverage_complete=True)
-        out = D.run_review(["CR-1"], dispatch=disp, generate_report=False, root=self.root, post=True)
+        out = D.run_review(
+            ["CR-1"], dispatch=disp, generate_report=False, root=self.root, post=True
+        )
         self.assertEqual(out["per_change"][0]["deep_rounds"], 1)
-        self.assertEqual(len(self.calls), 2)   # review + poster only
+        self.assertEqual(len(self.calls), 2)  # review + poster only
         self.assertFalse(any("INCOMPLETE file coverage" in c for c in self.calls))
 
 
@@ -577,15 +763,15 @@ class TestWorkerPromptScriptPaths(unittest.TestCase):
 
     def test_prompts_reference_existing_script_paths(self):
         app_root = Path(__file__).resolve().parents[1]
-        prompts = [D.build_review_task("CR-12345678"),
-                   D.build_review_followup_task("CR-12345678")]
+        prompts = [D.build_review_task("CR-12345678"), D.build_review_followup_task("CR-12345678")]
         refs = set()
         for p in prompts:
             refs.update(re.findall(r"(sage_lib/[\w./-]+\.py)", p))
         self.assertTrue(refs, "expected the worker prompts to reference a script")
         for rel in sorted(refs):
-            self.assertTrue((app_root / rel).is_file(),
-                            f"worker prompt references a missing path: {rel}")
+            self.assertTrue(
+                (app_root / rel).is_file(), f"worker prompt references a missing path: {rel}"
+            )
 
 
 class TestWorkerPromptInterpreter(unittest.TestCase):
@@ -615,8 +801,9 @@ class TestWorkerPromptInterpreter(unittest.TestCase):
         py = D.python_command()
         for p in self._prompts():
             for cmd in re.findall(r"`([^`]*sage_lib/[\w./-]+\.py[^`]*)`", p):
-                self.assertTrue(cmd.startswith(py + " "),
-                                f"script command does not name the interpreter: {cmd}")
+                self.assertTrue(
+                    cmd.startswith(py + " "), f"script command does not name the interpreter: {cmd}"
+                )
 
     def test_prompt_states_the_interpreter_for_the_skill_commands(self):
         # The shipped skills write their commands as `<python> ...`; the prompt is
@@ -659,10 +846,12 @@ class TestInterpreterIsHandedOverRaw(unittest.TestCase):
         # Injected at the seam the interpreter now comes from: the gateway's own
         # ``sys.executable``. Whatever it contains -- a space, a ``$``, a backslash
         # run -- must arrive verbatim, since each of those was a separate defect.
-        for exe in (r"C:\Program Files\Py\python.exe",
-                    r"C:\tools\$python v2\python.exe",
-                    "/home/u/my py/bin/python3",
-                    r"/home/u/kiro\home/bin/python3"):
+        for exe in (
+            r"C:\Program Files\Py\python.exe",
+            r"C:\tools\$python v2\python.exe",
+            "/home/u/my py/bin/python3",
+            r"/home/u/kiro\home/bin/python3",
+        ):
             with mock.patch.object(D.sys, "executable", exe):
                 self.assertEqual(D.python_command(), exe)
 
@@ -670,8 +859,7 @@ class TestInterpreterIsHandedOverRaw(unittest.TestCase):
         # Without this instruction a space-containing path -- ordinary on Windows,
         # where profiles are named "First Last" -- would be split by the shell and
         # the command would run nothing, which is the failure this PR removes.
-        for prompt in (D.build_review_task(self.LINK),
-                       D.build_review_followup_task(self.LINK)):
+        for prompt in (D.build_review_task(self.LINK), D.build_review_followup_task(self.LINK)):
             self.assertIn("quote it as YOUR shell requires", prompt)
 
 
@@ -691,8 +879,7 @@ class TestShippedSkillsNameNoBareInterpreter(unittest.TestCase):
         self.assertTrue(found, "expected the app to ship skills")
         for md in found:
             for i, line in enumerate(md.read_text(encoding="utf-8").splitlines(), 1):
-                self.assertNotRegex(line, bare,
-                                    f"{md.name}:{i} names a bare interpreter")
+                self.assertNotRegex(line, bare, f"{md.name}:{i} names a bare interpreter")
 
 
 class TestDeterministicPosting(unittest.TestCase):
@@ -702,17 +889,17 @@ class TestDeterministicPosting(unittest.TestCase):
 
     def test_review_prompt_records_only_and_never_posts(self):
         p = D.build_review_task("https://github.com/o/r/pull/12345678")
-        self.assertIn("RECORD ONLY", p)                  # writes findings, no posting
+        self.assertIn("RECORD ONLY", p)  # writes findings, no posting
         self.assertIn("do NOT post", p)
         self.assertIn("MUST NOT call any comment tool", p)
-        self.assertNotIn("CRAddComment", p)              # reviewer never posts
+        self.assertNotIn("CRAddComment", p)  # reviewer never posts
 
     def test_post_task_posts_prebuilt_redacted_bodies_verbatim(self):
         p = D.build_post_task("https://github.com/o/r/pull/12345678")
-        self.assertIn("pending_comments", p)             # reads driver-built bodies
-        self.assertIn("VERBATIM", p)                     # posts exactly, no compose
-        self.assertIn("already redacted in Python", p)   # redaction is deterministic
-        self.assertIn("posted_comments", p)              # records count
+        self.assertIn("pending_comments", p)  # reads driver-built bodies
+        self.assertIn("VERBATIM", p)  # posts exactly, no compose
+        self.assertIn("already redacted in Python", p)  # redaction is deterministic
+        self.assertIn("posted_comments", p)  # records count
         self.assertIn("design_comment_posted", p)
 
 
@@ -733,7 +920,8 @@ class TestChangeIdAndFetch(unittest.TestCase):
         # written record and the driver's read would hit different files.
         link = "https://github.com/o/r/pull/7"
         target = D.pipeline.adapters.parse_github_payload(
-            {"number": 7, "body": "x", "files": [{"path": "a", "diff": "d"}]}, link=link)
+            {"number": 7, "body": "x", "files": [{"path": "a", "diff": "d"}]}, link=link
+        )
         self.assertEqual(D._cid(link), target.change_id)
 
     def test_cid_fallback_is_filesystem_safe(self):
@@ -768,16 +956,16 @@ class TestGithubPosting(unittest.TestCase):
     def test_github_poster_prompt_is_pending_and_never_submits(self):
         p = D.build_post_task("https://github.com/o/r/pull/5")
         self.assertIn("PENDING", p)
-        self.assertIn("NO `event` key", p)             # unsubmitted review
+        self.assertIn("NO `event` key", p)  # unsubmitted review
         self.assertIn("gh api", p)
         self.assertIn("--method POST", p)
-        self.assertIn("github_review_payload", p)      # uses the Python-built envelope
-        self.assertIn("MUST NOT", p)                   # submit/approve prohibition
+        self.assertIn("github_review_payload", p)  # uses the Python-built envelope
+        self.assertIn("MUST NOT", p)  # submit/approve prohibition
         self.assertIn("VERBATIM", p)
         self.assertIn("already redacted in Python", p)
         # Re-review safety: clear only a prior SAGE pending review (watermark-gated),
         # never a human's, so a second run doesn't 422 on "one pending review per PR".
-        self.assertIn('state==\"PENDING\"', p)
+        self.assertIn('state=="PENDING"', p)
         self.assertIn("[code-review-sage]", p)
 
     def test_github_poster_prompt_is_pending_review(self):
@@ -789,43 +977,65 @@ class TestGithubPosting(unittest.TestCase):
 
     def test_github_run_attaches_review_payload_and_posts(self):
         link = "https://github.com/o/r/pull/5"
-        cid = D._cid(link)   # GH-o-r-5
+        cid = D._cid(link)  # GH-o-r-5
 
         def dispatch(task, timeout=0):
             if "SINGLE thorough pass" in task:
-                results.write_result({
-                    "schema": "code-review-sage-result", "version": 1, "change_id": cid,
-                    "platform": "github", "repo_identity": "github.com/o/r",
-                    "revision": "sha123",
-                    "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                               "criticality": "low"},
-                    "blast_radius": {"rating": "SMALL", "signals": {}},
-                    "counts": {"red": 1, "yellow": 0},
-                    "findings": [{"dimension": "correctness", "severity": "red",
-                                  "file": "src/a.rs", "line": 5, "snippet": "x",
-                                  "observation": "o", "consequence": "c",
-                                  "suggestion": "s"}],
-                    "deep_reviewed": True, "title": cid,
-                    "files_covered": ["src/a.rs"], "coverage_complete": True,
-                }, self.root)
+                results.write_result(
+                    {
+                        "schema": "code-review-sage-result",
+                        "version": 1,
+                        "change_id": cid,
+                        "platform": "github",
+                        "repo_identity": "github.com/o/r",
+                        "revision": "sha123",
+                        "phase1": {
+                            "gate_verdict": "PASS",
+                            "design_risk": "low",
+                            "criticality": "low",
+                        },
+                        "blast_radius": {"rating": "SMALL", "signals": {}},
+                        "counts": {"red": 1, "yellow": 0},
+                        "findings": [
+                            {
+                                "dimension": "correctness",
+                                "severity": "red",
+                                "file": "src/a.rs",
+                                "line": 5,
+                                "snippet": "x",
+                                "observation": "o",
+                                "consequence": "c",
+                                "suggestion": "s",
+                            }
+                        ],
+                        "deep_reviewed": True,
+                        "title": cid,
+                        "files_covered": ["src/a.rs"],
+                        "coverage_complete": True,
+                    },
+                    self.root,
+                )
             elif "pre-redacted DRAFT review comments" in task:
                 rec = results.read_result(cid, self.root) or {}
                 pay = rec.get("github_review_payload") or {}
-                rec["posted_comments"] = (len(pay.get("comments", []))
-                                          + (1 if pay.get("body") else 0))
+                rec["posted_comments"] = len(pay.get("comments", [])) + (
+                    1 if pay.get("body") else 0
+                )
                 rec["design_comment_posted"] = bool(pay.get("body"))
                 results.write_result(rec, self.root)
             return {"ok": True, "output": "", "error": ""}
 
-        out = D.run_review([link], dispatch=dispatch, generate_report=False, root=self.root, post=True)
+        out = D.run_review(
+            [link], dispatch=dispatch, generate_report=False, root=self.root, post=True
+        )
         rec = results.read_result(cid, self.root)
         pay = rec["github_review_payload"]
-        self.assertNotIn("event", pay)                 # PENDING (unsubmitted)
-        self.assertEqual(pay["commit_id"], "sha123")   # anchored to head SHA
+        self.assertNotIn("event", pay)  # PENDING (unsubmitted)
+        self.assertEqual(pay["commit_id"], "sha123")  # anchored to head SHA
         self.assertEqual(len(pay["comments"]), 1)
         self.assertEqual(pay["comments"][0]["path"], "src/a.rs")
         self.assertEqual(pay["comments"][0]["side"], "RIGHT")
-        self.assertEqual(rec["posted_comments"], 2)    # 1 finding + ship-readiness body
+        self.assertEqual(rec["posted_comments"], 2)  # 1 finding + ship-readiness body
         self.assertEqual(out["per_change"][0]["posted_comments"], 2)
 
     def test_post_recorded_reports_a_record_with_no_revision(self):
@@ -840,11 +1050,14 @@ class TestGithubPosting(unittest.TestCase):
         run_id = "r1"
         cid = "GH-acme-repo-1"
         rec = {
-            "schema": "code-review-sage/result", "version": 1, "change_id": cid,
-            "platform": "github", "repo_identity": "acme/repo",
-            "phase1": {"gate_verdict": "PASS", "design_risk": "low",
-                       "criticality": "low"},
-            "findings": [], "counts": {"red": 0, "yellow": 0},
+            "schema": "code-review-sage/result",
+            "version": 1,
+            "change_id": cid,
+            "platform": "github",
+            "repo_identity": "acme/repo",
+            "phase1": {"gate_verdict": "PASS", "design_risk": "low", "criticality": "low"},
+            "findings": [],
+            "counts": {"red": 0, "yellow": 0},
             # No `revision` -- contract-valid, unanchorable.
         }
         results.write_result(rec, root, run_id)
@@ -856,8 +1069,12 @@ class TestGithubPosting(unittest.TestCase):
             return {"ok": True}
 
         out = D.post_recorded(
-            cid, "https://github.com/acme/repo/pull/1",
-            dispatch=_dispatch, run_id=run_id, root=root, keys=None,
+            cid,
+            "https://github.com/acme/repo/pull/1",
+            dispatch=_dispatch,
+            run_id=run_id,
+            root=root,
+            keys=None,
         )
         self.assertFalse(out["post_ok"])
         self.assertIn("commit_id", out["post_error"])

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -520,7 +520,7 @@ class TestReviewDriver(unittest.TestCase):
         # `build_review_task` fails CLOSED when the link's host no longer
         # revalidates. Patched rather than reached through a crafted URL so the
         # test pins THIS site's payload, not the host-allowlist rules.
-        def refuse(link, result_capability=None):
+        def refuse(link):
             raise D.pipeline.adapters.AdapterError("host is not allowed")
 
         with mock.patch.object(D, "build_review_task", refuse):
@@ -543,7 +543,6 @@ class TestReviewDriver(unittest.TestCase):
         self.assertIn("<code-review-sage-result>", task)
         self.assertIn("Do not write the result record to disk", task)
         self.assertIn("<code-review-sage-result>", followup)
-        self.assertNotIn("result_capability", task)
 
     def test_review_task_has_inline_learning(self):
         task = D.build_review_task("CR-8")

--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_run_scoping.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_run_scoping.py
@@ -12,6 +12,7 @@ the cooperative ``cancelled=`` predicate added to ``review_driver.run_review``:
   * ``run_review`` scopes its records/report to the run dir and honors a
     ``cancelled`` predicate by skipping unstarted changes (no dispatch).
 """
+
 import json
 import os
 import re
@@ -27,13 +28,18 @@ from sage_lib import review_driver as D  # noqa: N812
 from sage_lib import store
 
 
-def _rec(change_id, verdict="PASS", risk="low", blast="SMALL", red=0, yellow=0,
-         deep=True, title="t"):
+def _rec(
+    change_id, verdict="PASS", risk="low", blast="SMALL", red=0, yellow=0, deep=True, title="t"
+):
     """A minimal but contract-valid result record (mirrors test_report._rec)."""
     return {
-        "schema": "code-review-sage-result", "version": 1, "change_id": change_id,
-        "platform": "github", "repo_identity": "github.com/o/r",
-        "url": f"https://github.com/o/r/pull/{change_id}", "title": title,
+        "schema": "code-review-sage-result",
+        "version": 1,
+        "change_id": change_id,
+        "platform": "github",
+        "repo_identity": "github.com/o/r",
+        "url": f"https://github.com/o/r/pull/{change_id}",
+        "title": title,
         "phase1": {"gate_verdict": verdict, "design_risk": risk, "criticality": "low"},
         "blast_radius": {"rating": blast, "signals": {}},
         "counts": {"red": red, "yellow": yellow},
@@ -67,10 +73,12 @@ class TestRunScopedResults(_RootTest):
         self.assertIn("run-a", str(dir_a))
         self.assertIn("run-b", str(dir_b))
 
-        self.assertEqual([r["change_id"] for r in results.list_results(self.root, "run-a")],
-                         ["CR-A"])
-        self.assertEqual([r["change_id"] for r in results.list_results(self.root, "run-b")],
-                         ["CR-B"])
+        self.assertEqual(
+            [r["change_id"] for r in results.list_results(self.root, "run-a")], ["CR-A"]
+        )
+        self.assertEqual(
+            [r["change_id"] for r in results.list_results(self.root, "run-b")], ["CR-B"]
+        )
 
     def test_clearing_one_run_leaves_the_other_intact(self):
         results.write_result(_rec("CR-A"), self.root, run_id="run-a")
@@ -80,17 +88,18 @@ class TestRunScopedResults(_RootTest):
         self.assertEqual(removed, 1)
         self.assertEqual(results.list_results(self.root, "run-a"), [])
         # sibling run untouched
-        self.assertEqual([r["change_id"] for r in results.list_results(self.root, "run-b")],
-                         ["CR-B"])
+        self.assertEqual(
+            [r["change_id"] for r in results.list_results(self.root, "run-b")], ["CR-B"]
+        )
 
     def test_run_id_none_uses_legacy_shared_paths(self):
         # Back-compat: no run_id == the pre-existing shared dirs.
-        self.assertEqual(results.results_dir(self.root, None),
-                         store.data_dir(self.root) / "results")
-        self.assertEqual(RP.reports_dir(self.root, None),
-                         store.data_dir(self.root) / "reports")
+        self.assertEqual(
+            results.results_dir(self.root, None), store.data_dir(self.root) / "results"
+        )
+        self.assertEqual(RP.reports_dir(self.root, None), store.data_dir(self.root) / "reports")
 
-        results.write_result(_rec("CR-LEG"), self.root)   # no run_id
+        results.write_result(_rec("CR-LEG"), self.root)  # no run_id
         self.assertTrue((store.data_dir(self.root) / "results" / "CR-LEG.json").exists())
         self.assertEqual([r["change_id"] for r in results.list_results(self.root)], ["CR-LEG"])
         # a shared-dir write is invisible to any run-scoped view
@@ -99,14 +108,16 @@ class TestRunScopedResults(_RootTest):
     def test_reviewed_and_config_stay_global_not_per_run(self):
         rid = "run-xyz"
         # reviewed.json + config.json live in data/, never under data/runs/<id>/.
-        self.assertEqual(results.reviewed_path(self.root),
-                         store.data_dir(self.root) / "reviewed.json")
+        self.assertEqual(
+            results.reviewed_path(self.root), store.data_dir(self.root) / "reviewed.json"
+        )
         self.assertNotIn(rid, str(results.reviewed_path(self.root)))
         cfg_path = store.data_dir(self.root) / "config.json"
         self.assertNotIn(rid, str(cfg_path))
 
         results.mark_reviewed(
-            {"CR-A": {"head_sha": "abc", "reviewed_at": "t", "run_id": rid}}, self.root)
+            {"CR-A": {"head_sha": "abc", "reviewed_at": "t", "run_id": rid}}, self.root
+        )
         self.assertTrue((store.data_dir(self.root) / "reviewed.json").exists())
         # not duplicated into the run subtree
         self.assertFalse((store.runs_root(self.root) / rid / "reviewed.json").exists())
@@ -121,13 +132,14 @@ class TestSafeRunId(_RootTest):
             sid = store.safe_run_id(raw)
             self.assertNotIn("/", sid)
             self.assertNotIn(os.sep, sid)
-            self.assertTrue(sid)   # never empty
+            self.assertTrue(sid)  # never empty
 
     def test_run_dir_stays_inside_runs_root(self):
         rr = store.runs_root(self.root).resolve()
         for raw in ("../../etc", "a/b", "normal-id"):
-            self.assertEqual(store.run_dir(raw, self.root).resolve().parent, rr,
-                             f"{raw!r} escaped runs_root")
+            self.assertEqual(
+                store.run_dir(raw, self.root).resolve().parent, rr, f"{raw!r} escaped runs_root"
+            )
 
     def test_run_dir_dotdot_is_contained(self):
         # Regression: the _UNSAFE_RUN_ID character filter treats '.' as SAFE, so a
@@ -136,8 +148,9 @@ class TestSafeRunId(_RootTest):
         # all-dots rejection in safe_run_id is what closes that.
         rr = store.runs_root(self.root).resolve()
         for raw in ("..", ".", "...", "./.."):
-            self.assertEqual(store.run_dir(raw, self.root).resolve().parent, rr,
-                             f"{raw!r} escaped runs_root")
+            self.assertEqual(
+                store.run_dir(raw, self.root).resolve().parent, rr, f"{raw!r} escaped runs_root"
+            )
         self.assertEqual(store.safe_run_id(".."), "unknown")
 
 
@@ -171,7 +184,7 @@ class TestRunDirLifecycle(_RootTest):
         self.assertEqual(store.list_run_ids(self.root), [])
         store.ensure_run_layout("run-a", self.root)
         store.ensure_run_layout("run-b", self.root)
-        self.assertEqual(store.list_run_ids(self.root), ["run-a", "run-b"])   # sorted
+        self.assertEqual(store.list_run_ids(self.root), ["run-a", "run-b"])  # sorted
         store.remove_run_dir("run-a", self.root)
         self.assertEqual(store.list_run_ids(self.root), ["run-b"])
 
@@ -244,41 +257,69 @@ class TestRunReviewScoping(unittest.TestCase):
         """Single-pass reviewer model (mirrors test_review_driver._fake_dispatch)
         but writes/reads under ``run_id`` so the driver's run-scoped read hits the
         same file the (fake) worker wrote."""
+
         def dispatch(task, timeout=0):
             with self.lock:
                 self.calls.append(task)
+            output = "done"
             m = re.search(r"CR-\d+", task)
             if m:
                 cid = m.group(0)
                 if "SINGLE thorough pass" in task:
-                    results.write_result({
-                        "schema": "code-review-sage-result", "version": 1,
-                        "change_id": cid, "platform": "github",
-                        "repo_identity": "github.com/o/r", "revision": "1",
-                        "phase1": {"gate_verdict": verdict, "design_risk": "low",
-                                   "criticality": "low"},
+                    record = {
+                        "schema": "code-review-sage-result",
+                        "version": 1,
+                        "change_id": cid,
+                        "platform": "github",
+                        "repo_identity": "github.com/o/r",
+                        "revision": "1",
+                        "phase1": {
+                            "gate_verdict": verdict,
+                            "design_risk": "low",
+                            "criticality": "low",
+                        },
                         "blast_radius": {"rating": "SMALL", "signals": {}},
                         "counts": {"red": 0, "yellow": 1},
-                        "findings": [{"dimension": "correctness", "severity": "yellow",
-                                      "file": "f", "line": 1, "snippet": "x",
-                                      "observation": "o", "consequence": "c",
-                                      "suggestion": "s"}],
-                        "deep_reviewed": True, "title": cid,
-                        "files_covered": ["f"], "coverage_complete": True,
-                    }, self.root, run_id=run_id)
+                        "findings": [
+                            {
+                                "dimension": "correctness",
+                                "severity": "yellow",
+                                "file": "f",
+                                "line": 1,
+                                "snippet": "x",
+                                "observation": "o",
+                                "consequence": "c",
+                                "suggestion": "s",
+                            }
+                        ],
+                        "deep_reviewed": True,
+                        "title": cid,
+                        "files_covered": ["f"],
+                        "coverage_complete": True,
+                    }
+                    output = (
+                        "<code-review-sage-result>"
+                        + json.dumps(record)
+                        + "</code-review-sage-result>"
+                    )
                 elif "pre-redacted DRAFT review comments" in task:
                     rec = results.read_result(cid, self.root, run_id=run_id) or {}
                     pending = rec.get("pending_comments", []) or []
                     rec["posted_comments"] = len(pending)
-                    rec["design_comment_posted"] = any(
-                        e.get("kind") == "design" for e in pending)
+                    rec["design_comment_posted"] = any(e.get("kind") == "design" for e in pending)
                     results.write_result(rec, self.root, run_id=run_id)
-            return {"ok": True, "output": "done", "error": ""}
+            return {"ok": True, "output": output, "error": ""}
+
         return dispatch
 
     def test_run_review_run_id_writes_report_into_run_dir(self):
-        out = D.run_review(["CR-1"], dispatch=self._fake_dispatch(run_id="run-x"),
-                           archiver=self._archiver, root=self.root, run_id="run-x")
+        out = D.run_review(
+            ["CR-1"],
+            dispatch=self._fake_dispatch(run_id="run-x"),
+            archiver=self._archiver,
+            root=self.root,
+            run_id="run-x",
+        )
         self.assertTrue(out["ok"])
         self.assertEqual(out["report_slug"], "sage-report-test")
 
@@ -290,8 +331,13 @@ class TestRunReviewScoping(unittest.TestCase):
         self.assertFalse((store.data_dir(self.root) / "reports" / "report.json").is_file())
 
     def test_run_review_run_id_scopes_result_records(self):
-        D.run_review(["CR-1", "CR-2"], dispatch=self._fake_dispatch(run_id="run-y"),
-                     generate_report=False, root=self.root, run_id="run-y")
+        D.run_review(
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(run_id="run-y"),
+            generate_report=False,
+            root=self.root,
+            run_id="run-y",
+        )
         # records live under the run's private dir, not the shared one
         self.assertEqual(len(results.list_results(self.root, "run-y")), 2)
         self.assertEqual(results.list_results(self.root), [])
@@ -305,14 +351,19 @@ class TestRunReviewScoping(unittest.TestCase):
             with plock:
                 seen.append((cid, phase))
 
-        out = D.run_review(["CR-1", "CR-2", "CR-3"],
-                           dispatch=self._fake_dispatch(run_id="run-c"),
-                           generate_report=False, root=self.root, run_id="run-c",
-                           cancelled=lambda: True, progress=prog)
+        out = D.run_review(
+            ["CR-1", "CR-2", "CR-3"],
+            dispatch=self._fake_dispatch(run_id="run-c"),
+            generate_report=False,
+            root=self.root,
+            run_id="run-c",
+            cancelled=lambda: True,
+            progress=prog,
+        )
 
         # every change reported cancelled, none dispatched
         self.assertEqual(out["cancelled"], 3)
-        self.assertEqual(self.calls, [])   # NO review/poster task dispatched at all
+        self.assertEqual(self.calls, [])  # NO review/poster task dispatched at all
         self.assertFalse(any("SINGLE thorough pass" in c for c in self.calls))
 
         # each change surfaced via the progress callback as 'cancelled'
@@ -329,10 +380,14 @@ class TestRunReviewScoping(unittest.TestCase):
         self.assertNotIn("report_slug", out)
 
     def test_run_review_cancelled_false_behaves_normally(self):
-        out = D.run_review(["CR-1", "CR-2"],
-                           dispatch=self._fake_dispatch(run_id="run-n"),
-                           archiver=self._archiver, root=self.root, run_id="run-n",
-                           cancelled=lambda: False)
+        out = D.run_review(
+            ["CR-1", "CR-2"],
+            dispatch=self._fake_dispatch(run_id="run-n"),
+            archiver=self._archiver,
+            root=self.root,
+            run_id="run-n",
+            cancelled=lambda: False,
+        )
         self.assertTrue(out["ok"])
         self.assertEqual(out["changes"], 2)
         self.assertEqual(out["cancelled"], 0)


### PR DESCRIPTION
## Problem / Motivation

Code Review Sage previously serialized independent run-scoped reviews because workers wrote through a shared result path. That protected result attribution, but it also prevented unrelated claimed reviews from using the existing bounded review pool concurrently.

## Why it matters

Independent reviews unnecessarily queued behind each other, increasing turnaround time. Restoring concurrency must not let a worker's result be adopted by a different review dispatch.

## What changed (motivation → approach → change)

Each worker now hands its record back inside its own dispatch response, tagged with `<code-review-sage-result>`, and the driver reads it out of the response to the dispatch it made. That channel is point-to-point — no sibling can write it — so independent claimed reviews can use the bounded pool without cross-run attribution.

The run lock now protects only claim acquisition. Run-scoped reviews delegate concurrency to the pool, while calls without a run scope are clamped to serial — they still write through the legacy shared result directory, where any worker can write any change's record. The standalone CLI is always in that mode, so it no longer offers a `--concurrency` flag: the value reached the clamp and was discarded, while the help text claimed it applied. The rebased route keeps failure-reason reporting intact in the lock-free control flow.

## Tests

- Route coverage proves independent run bodies overlap and run-scoped reviews delegate concurrency to the bounded pool.
- Record-adoption coverage rejects a record planted in another change's shared result slot, and proves an invalid record fails its own change without aborting the batch.
- Prompt-contract coverage requires the `<code-review-sage-result>` tag in both initial and follow-up reviewer tasks, and that the prompt names no result file on disk.
- Focused Sage suite: 302 passed.

## Manual verification

N/A — the concurrency and adoption boundary are exercised by deterministic backend and driver tests.

## Related Issues

N/A.

## Relationship to #9077 (read before merging either)

#9077 and this PR solve the SAME problem — the driver cannot prove a result record came from the worker it dispatched — with two different wire formats, and both rewrite the same `sage-review/SKILL.md` "result" section and the same driver handback path. They conflict textually, and shipping both would give one contract two formats.

**This PR should land first and own the transport.** The binding is a prerequisite for the parallelization here (a shared result path is exactly what makes concurrent reviews unattributable), and the response-bound `<code-review-sage-result>` tag is sufficient on its own: the driver reads the record out of the response to the specific dispatch it made, so the channel is already point-to-point and a driver-issued capability token authenticates nothing further.

**#9077 is then rescoped** to the part this PR does not cover: enforcing a coverage follow-up against the first pass IN THE DRIVER. `build_review_followup_task` here asks the worker for a complete replacement record and preserves `phase1` by instruction only, so a follow-up can silently rewrite or drop first-pass findings. #9077's `base_digest` binding, preserved first-pass metadata, append-only findings and recomputed counts close that, and layer cleanly on this transport.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat: safely parallelize run-scoped reviews`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (not applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The template's exact CLA wording has not yet been supplied by OSPO.


