### PR TITLE
fix(dashboard): log the caller binding and active slot keys on an autonudge_stop miss

### DIFF
--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -389,11 +389,24 @@ def _no_loop_message(svc: Any, binding: str) -> str:
     loop; naming other sessions' loops here would hand the model the
     identifiers that schema withholds. Cross-session enumeration stays on the
     token-authed dashboard API. A count is all this branch needs, because the
-    caller's question is whether ITS OWN stop took effect.
+    caller's question is whether ITS OWN stop took effect. The keys themselves
+    go to the log instead, which no model reads.
     """
     active = [lp for lp in svc.list_all() if getattr(lp, "active", True)]
     if not active:
         return "No active auto-nudge loop on this session — nothing to stop."
+    # SERVER-SIDE ONLY, and the reason this branch logs at all: a miss has two
+    # candidate causes — a slot-key spelling the binding lookup does not model,
+    # or an arming path that registered a key this session later resolves
+    # differently — and they are distinguishable only from the caller's binding
+    # next to the keys the store actually holds. A slot key can carry a channel
+    # or user identifier, so the pair stays out of the return value and out of
+    # every user-facing string.
+    logger.warning(
+        "AutoNudge: stop resolved no loop for binding %r; active loop slot keys: %s",
+        binding,
+        ", ".join(sorted(repr(getattr(lp, "slot_key", "")) for lp in active)),
+    )
     return (
         "NOTHING WAS STOPPED. No auto-nudge loop is bound to this session "
         f"(binding: {binding}), but {len(active)} auto-nudge loop(s) are running on "

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -30,6 +30,7 @@ the tools are stateless and the loop mutation happens in-process in the applier.
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -893,6 +894,82 @@ def test_applier_autonudge_stop_ignores_inactive_loops_in_the_miss_diagnostic(mo
     assert "loop-dead" not in result
     assert svc.removed == []
     assert svc.updated == []
+
+
+# The miss message is asserted here as a LITERAL, not rebuilt from the applier's
+# own f-string: the diagnostic below must stay server-side, so a change that
+# leaks a slot key into the model's tool result has to fail this comparison
+# rather than be recomputed into agreement with itself.
+_MISS_MESSAGE = (
+    "NOTHING WAS STOPPED. No auto-nudge loop is bound to this session "
+    "(binding: chat-3-1700000000), but 2 auto-nudge loop(s) are running on "
+    "other sessions. A loop can only be stopped from the session it is bound "
+    "to, so this call could not reach them."
+)
+
+
+def test_applier_autonudge_stop_miss_logs_caller_binding_and_active_slot_keys(monkeypatch, caplog):
+    """The miss branch records the pair that identifies WHICH miss this is.
+
+    A miss has two possible causes — a slot-key spelling the lookup does not
+    model, or an arming path that registered a key the session later resolves
+    differently — and they are told apart only by the caller's resolved binding
+    next to the slot keys the store actually holds. Nothing else captures that
+    pair, so the diagnostic has to be emitted where the miss is detected.
+
+    Server-side ONLY: the log carries the slot keys, the returned message must
+    stay byte-identical and keep reporting a count.
+    """
+    loops = [
+        _FakeLoop("loop-a", slot_key="chat-91-1700009991"),
+        _FakeLoop("loop-b", slot_key="slack:T1/C2/1700009992"),
+    ]
+    svc = _FakeSvc(None, all_loops=loops)
+    _install_svc(monkeypatch, svc)
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.session_directive_apply"):
+        result = asyncio.run(
+            apply_session_directive(
+                _fake_state(), _fake_slot(), _SESSION, "autonudge_stop", {"reason": "done"}
+            )
+        )
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == "kiro_crew.dashboard.session_directive_apply"
+    ]
+    assert len(warnings) == 1
+    logged = warnings[0].getMessage()
+    assert binding_key_for(_SESSION) in logged
+    for lp in loops:
+        assert lp.slot_key in logged
+
+    # The model-visible half is unchanged, and the keys stay out of it.
+    assert result == _MISS_MESSAGE
+    for lp in loops:
+        assert lp.slot_key not in result
+    assert svc.removed == []
+    assert svc.updated == []
+
+
+def test_applier_autonudge_stop_logs_nothing_when_no_loop_exists(monkeypatch, caplog):
+    """No loop anywhere is an idempotent success, not a resolution failure.
+
+    Warning on it would fire on every ordinary duplicate stop and bury the miss
+    the log exists to catch.
+    """
+    svc = _FakeSvc(None)
+    _install_svc(monkeypatch, svc)
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.dashboard.session_directive_apply"):
+        result = asyncio.run(
+            apply_session_directive(
+                _fake_state(), _fake_slot(), _SESSION, "autonudge_stop", {"reason": "done"}
+            )
+        )
+    assert "nothing to stop" in result.lower()
+    assert [
+        r for r in caplog.records if r.name == "kiro_crew.dashboard.session_directive_apply"
+    ] == []
 
 
 def test_autonudge_stop_directive_does_not_read_as_confirmation(default_install):


### PR DESCRIPTION
## Problem / Motivation

When `autonudge_stop` resolves no loop for the calling session, nothing records which kind of miss it was, so each occurrence is as undiagnosable as the last.

#6799 merged as a diagnostic rather than a fix: it made `_no_loop_message` discriminate the miss branch and report a count, and deliberately did not widen the lookup, because a guess that stops the wrong loop is worse than a miss. Two candidate causes remain undistinguished — a slot-key spelling the binding lookup does not model, or an arming path registering a key the session later resolves differently — and they are separable only from the caller's binding next to the keys the store actually holds.

## Why it matters

That evidence exists only at the moment of the miss, and today it is discarded. Until it is captured the underlying bug cannot be fixed without guessing, and the wrong guess stops someone else's loop.

## What changed

One `logger.warning` in the miss branch, recording the caller binding and the active loops' `slot_key`s.

Deliberately out of scope: `binding_key_for` and `_find_by_slot` are untouched, no third lookup is added, and the model-visible `NOTHING WAS STOPPED` message is byte-identical. The test asserts that message against a hand-written literal rather than recomputing the applier's own f-string, so a future leak of a slot key into the tool result fails the test instead of quietly agreeing with itself.

The keys stay server-side. Widening the lookup remains a maintainer decision.

## Tests

`pytest test/test_autonudge_stop_auth.py -q` — 43 passed. With the source change reverted: `1 failed, 42 passed`, the new miss-logging case failing on `assert 0 == 1`.

The second added case (no loop anywhere logs nothing) passes either way, because the zero-loops early return fires before the warning in both versions. It is kept as a guard against the warning being moved above that return, not as a discriminator.

Those results were measured at base `03d7737cf`. Re-running them after rebasing onto current `main` was not possible on my machine: `pytest` now aborts during collection with `UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800'` while importing `kiro_crew.apps.manifest`, before any test executes. That reproduces on a clean checkout of `main` at the same base and is unrelated to this branch, so CI is the verification for the rebased commit. Reported separately.

## Screenshots

<!-- no-visual-delta -->

**Why no screenshot:** log-only backend change with no UI surface — the only observable difference is a line in the server log.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a diagnostic that withholds identifiers from the model for good reason, then discards them entirely instead of routing them to the server log.

Fixes #6838
