### PR TITLE
fix(apps): write the surrogate escape as a literal so docstrings encode on 3.13+

### DIFF
--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -1195,7 +1195,7 @@ def _mirrored_len(text: str) -> int:
     title cap that "a cap that only one side enforces is not a cap"; that holds for the
     UNIT as well as for the number, so the caps are measured the host's way.
     UNPAIRED surrogates are why this passes ``surrogatepass``: JSON can carry a lone
-    ``\ud800`` escape, ``json.loads`` accepts it, and a plain ``utf-16-le`` encode then
+    ``\\ud800`` escape, ``json.loads`` accepts it, and a plain ``utf-16-le`` encode then
     raises ``UnicodeEncodeError`` -- so a manifest would CRASH validation instead of
     being told what is wrong with it. With the flag the count still matches the host
     exactly: a lone surrogate is one unit in both languages, an astral character two.

--- a/test/test_source_corpus.py
+++ b/test/test_source_corpus.py
@@ -26,6 +26,8 @@ filters on the bare keyword and why that spelling is asserted below.
 from __future__ import annotations
 
 import ast
+from collections.abc import Sequence
+from pathlib import Path
 
 import pytest
 import test_no_blocking_call_on_loop as blocking
@@ -41,6 +43,39 @@ _MIN_FILES = 800
 #: The census filter, which lives in ``test_security_posture`` as a literal at
 #: its one call site because that gate has no class to hang it on.
 _CENSUS_REQUIRE_ALL = ("redact",)
+
+#: The nodes CPython attaches ``__doc__`` to, and so the only strings it encodes
+#: on its own account rather than on the program's.
+_DOCSTRING_NODES = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+#: Necessary condition for an unencodable docstring, so the gate below parses 15
+#: files instead of the tree. A surrogate must have been WRITTEN as an escape:
+#: no UTF-8 byte sequence decodes to one, so a literal surrogate would make the
+#: file unreadable (pinned above) rather than parseable. Surrogates are
+#: U+D800-U+DFFF, so every spelling is ``\u`` or ``\U0000`` followed by a ``d``,
+#: and ``\N{...}`` has no name for an unpaired one.
+_SURROGATE_ESCAPES = ("\\ud", "\\uD", "\\U0000d", "\\U0000D")
+
+
+def _unencodable_docstrings(sources: Sequence[tuple[Path, str]]) -> list[tuple[Path, str, str]]:
+    """``(path, owner, reason)`` for every docstring UTF-8 cannot represent.
+
+    ``clean=False`` because de-indenting cannot change whether a character is
+    encodable, and the whole point is to answer that question cheaply.
+    """
+    found: list[tuple[Path, str, str]] = []
+    for path, text in sources:
+        for node in ast.walk(ast.parse(text, filename=str(path))):
+            if not isinstance(node, _DOCSTRING_NODES):
+                continue
+            doc = ast.get_docstring(node, clean=False)
+            if doc is None:
+                continue
+            try:
+                doc.encode("utf-8")
+            except UnicodeEncodeError as exc:
+                found.append((path, getattr(node, "name", "<module>"), str(exc)))
+    return found
 
 
 class TestCorpusHealth:
@@ -64,6 +99,27 @@ class TestCorpusHealth:
         assert unreadable_files() == (), (
             "The corpus could not decode these files, so no ratchet can see them: "
             f"{[str(p) for p in unreadable_files()]}"
+        )
+
+    def test_no_docstring_holds_a_character_utf_8_cannot_encode(self):
+        """An unpaired surrogate in a docstring is an unimportable module.
+
+        The compiler de-indents docstrings and encodes ``__doc__`` as strict
+        UTF-8, so from 3.13 on a docstring carrying an unpaired surrogate raises
+        ``UnicodeEncodeError`` on IMPORT. Nothing else in the suite survives that:
+        it lands during collection, so every gate here reports zero tests rather
+        than one failure, and the corpus never gets read at all.
+
+        Asserted rather than left to the compiler because the property has to
+        hold on every interpreter the project supports -- an older one compiles
+        such a docstring happily, which is exactly how one reaches a tree whose
+        gates all look green.
+        """
+        offenders = _unencodable_docstrings(candidate_sources(require_any=_SURROGATE_ESCAPES))
+        assert offenders == [], (
+            "These docstrings hold a character UTF-8 cannot encode, so their "
+            "modules do not import on 3.13+ -- write the escape as a literal "
+            f"(``\\\\ud800``) instead: {[(str(p), owner) for p, owner, _why in offenders]}"
         )
 
     def test_sources_are_the_real_file_contents(self):
@@ -131,6 +187,12 @@ class TestFilterLiteralsStillMatchWhatTheGatesReject:
             "    logger.error('install failed: %s', redact(stderr.decode()))\n"
         )
         assert self._admits(violating, _CENSUS_REQUIRE_ALL)
+
+    def test_a_lone_surrogate_docstring_survives_the_encodability_filter(self):
+        """The one filter whose literals are prose, so nothing else would notice."""
+        violating = 'def f():\n    """A lone \\ud800 escape, quoted as prose."""\n'
+        assert self._admits(violating, require_any=_SURROGATE_ESCAPES)
+        assert _unencodable_docstrings([(Path("planted.py"), violating)]), "gate must flag this"
 
 
 class TestFiltersStillNarrowTheTree:


### PR DESCRIPTION
## Problem / Motivation

`import kiro_crew.apps.manifest` fails on Python 3.13 and 3.14:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 843: surrogates not allowed
```

The `_mirrored_len` docstring explains why `surrogatepass` is needed and quotes a lone surrogate escape in its prose. Because the docstring is not raw, that escape becomes a real unpaired surrogate in the string. From 3.13 the compiler de-indents docstrings and encodes `__doc__` as strict UTF-8, which an unpaired surrogate cannot survive — so the module raises at import time.

## Why it matters

`pyproject.toml` declares `requires-python >= 3.10`, but on 3.13+ the package is unimportable, and `pytest` aborts during collection with zero tests run rather than reporting a failure.

CI does not see it: the test matrix is 3.10 and 3.12 and lint is 3.12, and on those interpreters the same docstring compiles happily.

## What changed

One character in `src/kiro_crew/apps/manifest.py` — the escape is now written `\\ud800`, matching how three sibling docstrings in the same file already quote prose backslashes. The rendered `__doc__` is unchanged: the reader still sees ``\ud800``.

## Tests

Added `test_no_docstring_holds_a_character_utf_8_cannot_encode` to the existing whole-tree gate in `test/test_source_corpus.py`, beside `test_no_file_was_skipped_as_unreadable` — the same shape of property, one whose violation silently blinds every other gate.

It asserts encodability directly rather than calling `compile()`, because a `compile()` sweep passes on 3.10 and 3.12 and so would not protect this repository's CI. Verified on 3.12, where the import succeeds: with the fix reverted, the new test is the only failure.

It filters to files containing a surrogate escape (15 of 1296) — a sound necessary condition, since no UTF-8 byte sequence decodes to a surrogate, so a literal one would make the file unreadable and trip the adjacent gate instead. 0.38s versus roughly 7s unfiltered.

`test_source_corpus.py` plus `test_app_manifest.py`: 219 passed on 3.13.2 and on 3.12.10. `mypy src/kiro_crew/` clean across 1279 source files; isort, flake8 and the black gate all green.

## Manual verification

`python -c "import kiro_crew.apps.manifest"` — fails on 3.13.2 before the change, succeeds after.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** a docstring change with no runtime or UI behaviour; the only observable difference is whether the module imports.

## Related Issues

None open for this — no existing issue or pull request matched a search for `UnicodeEncodeError`, `surrogates not allowed`, `\ud800`, or pytest collection failures. Happy to file one if you would prefer the bug tracked separately.

## Pattern harvest

Rule candidate: review-prompt

Pattern: prose inside a non-raw docstring that quotes an escape sequence. It is indistinguishable from an intended character to every reader, and to every interpreter older than the one that breaks on it.
