### PR TITLE
refactor(kiro-prereq): route the three terminal audit labels through one helper

### DIFF
--- a/src/kiro_crew/kiro_prerequisite.py
+++ b/src/kiro_crew/kiro_prerequisite.py
@@ -570,6 +570,23 @@ def _sanitize_detail(text: str) -> str:
     return safe[-_MAX_VISIBLE_DETAIL:]
 
 
+def _terminal_audit_detail(result: ProcessResult, succeeded: bool) -> str:
+    """The terminal audit event's error label for a run that finished or timed out.
+
+    *succeeded* is the verdict the caller already reached, not ``result.ok``, so
+    the label always follows that verdict and can never contradict the
+    ``outcome`` recorded beside it. The update path spells the verdict
+    ``update.ok and not error``, where ``error`` is itself set from this same
+    run, so the two agree there.
+    """
+
+    if succeeded:
+        return ""
+    if result.timed_out:
+        return "timeout"
+    return "nonzero exit"
+
+
 def _canonical_candidate(path: str) -> str:
     try:
         return os.path.realpath(path)
@@ -851,13 +868,12 @@ def _project_identity_database(source: Path, destination: Path) -> bool:
 def _atomic_write_secret_bytes(path: Path, content: bytes) -> None:
     """Atomically stage one bounded Kiro identity file, owner-only from birth.
 
-    ``restrict_to_owner=True`` locks the temp file down BEFORE the identity
-    bytes reach it — the previous post-rename lockdown left them readable
-    under the inherited DACL on Windows for the write window, and a lockdown
-    failure after the rename left the published file unprotected (issue
-    #5285). The default ``restrict_on_error="raise"`` keeps this fail-loud:
-    every failure now happens before the final path is touched, so an
-    unprotectable identity file never exists there at all.
+    ``restrict_to_owner=True`` locks the staged temp file down BEFORE the
+    identity bytes reach it (``0o600`` on POSIX, an owner-only DACL on
+    Windows), so those bytes never sit in a file readable at the parent's
+    inherited DACL. The default ``restrict_on_error="raise"`` keeps that
+    unconditional: a lockdown failure aborts before the final path is touched,
+    so an unprotectable identity file never exists there at all.
     """
 
     atomic_write(path, content, fsync=True, restrict_to_owner=True)
@@ -2984,15 +3000,12 @@ class KiroPrerequisiteService:
                         (update.output or "").strip()
                         or f"kiro-cli update exited with code {update.returncode}"
                     )
+                updated = update.ok and not error
                 await self._set_terminal_audit(
                     "update_cli",
-                    "completed" if update.ok and not error else "failed",
+                    "completed" if updated else "failed",
                     "gateway-setup",
-                    (
-                        ""
-                        if update.ok and not error
-                        else "timeout" if update.timed_out else "nonzero exit"
-                    ),
+                    _terminal_audit_detail(update, updated),
                 )
         if not error:
             # Re-probe so a successful update flips ``acp_supported`` / ``ready``
@@ -3049,17 +3062,11 @@ class KiroPrerequisiteService:
                 "probe execution failed",
             )
             return ProcessResult(ok=False, error="Kiro CLI probe could not run")
-        if result.ok:
-            audit_detail = ""
-        elif result.timed_out:
-            audit_detail = "timeout"
-        else:
-            audit_detail = "nonzero exit"
         await self._set_terminal_audit(
             action,
             "completed" if result.ok else "failed",
             "gateway-status",
-            audit_detail,
+            _terminal_audit_detail(result, result.ok),
         )
         return result
 
@@ -3206,28 +3213,23 @@ class KiroPrerequisiteService:
                 "probe execution failed",
             )
             return ProcessResult(ok=False, error="Kiro identity probe could not run")
-        if result.ok:
-            audit_detail = ""
-        elif result.timed_out:
-            audit_detail = "timeout"
-        else:
-            audit_detail = "nonzero exit"
         await self._set_terminal_audit(
             action,
             "completed" if result.ok else "failed",
             "gateway-status",
-            audit_detail,
+            _terminal_audit_detail(result, result.ok),
         )
         return result
 
     def _mark_setup_complete(self) -> None:
         if self._initial_setup_complete:
             return
-        # restrict_to_owner=True locks the temp file down before the content
-        # reaches it and implies 0o600, replacing the previous mode= plus
-        # post-rename restrict_to_owner pair, whose lockdown landed only after
-        # the marker was already published under the inherited DACL on Windows
-        # (issue #5285).
+        # restrict_to_owner=True locks the staged temp file down before any
+        # content reaches it (0o600 on POSIX, an owner-only DACL on Windows), so
+        # the published marker is owner-only from the instant the rename makes
+        # it visible. The default restrict_on_error="raise" is what makes that
+        # unconditional: a lockdown that fails aborts before the rename instead
+        # of publishing the marker under the parent's inherited DACL.
         atomic_write(
             self._setup_marker,
             "complete\n",


### PR DESCRIPTION
## Problem / Motivation

`kiro_prerequisite.py` maps a finished `kiro-cli` child process onto the SEL
terminal-audit event's `error` label — `""` on success, `"timeout"`, or
`"nonzero exit"` — in **three** places, in two different spellings:

- `update_cli` spelled it as a chained ternary
  (`"" if update.ok and not error else "timeout" if update.timed_out else "nonzero exit"`),
  which has to be read right-to-left and re-states the success test that the
  `outcome` argument on the line above already evaluates.
- `_audited_probe` and `_audited_identity_probe` spelled the identical
  three-way decision as a six-line `if/elif/else` ladder assigning a local,
  once each.

The chained ternary is what the module-simplification detector flags in this
module; the two ladders are the duplication it sits next to.

## Why it matters

These three labels are what an operator reads in the SEL audit log to tell a
hung `kiro-cli` from one that exited nonzero. Three copies of one mapping is
three places a future edit can drift, and the drift is invisible: the suite
asserts the paired `(action, outcome)` sequence for these events but never
reads the `error` field, so a label that silently changed value would not turn
a test red. Collapsing them to one definition is what makes the mapping
reviewable at all.

## What changed (motivation → approach → change)

Three copies of one decision → one definition, with the caller's own verdict
kept as a parameter rather than re-derived.

- **New** module-level `_terminal_audit_detail(result: ProcessResult, succeeded: bool) -> str`,
  a pure leaf function returning one of the same three literals in the same
  precedence order (`succeeded` → `""`; else `timed_out` → `"timeout"`; else
  `"nonzero exit"`). It reads only `result.timed_out`, never `output`, `error`
  or `returncode`, so no unsanitized child-process text can reach the audit
  field through it.
- **`update_cli`** binds `updated = update.ok and not error` once and passes it
  to both the `outcome` argument and the helper, replacing the chained ternary
  and removing the duplicated success test.
- **The two probe sites** drop their `audit_detail` ladders and call
  `_terminal_audit_detail(result, result.ok)`.

`succeeded` stays a parameter instead of being derived from `result.ok` inside
the helper, for two reasons. It is behaviour-preserving: the update path's
verdict is `update.ok and not error`, so deriving from `result.ok` would change
the label in the `ok and timed_out` construction. And it is the property worth
keeping — the detail label and the `outcome` recorded beside it are now driven
by the same single expression, so they cannot contradict each other.

**Comment hygiene**, on *both* of this file's `restrict_to_owner` comments —
`_mark_setup_complete` and `_atomic_write_secret_bytes`. Each narrated the
argument pair it replaced ("the previous post-rename lockdown…", "replacing the
previous `mode=` plus post-rename `restrict_to_owner` pair"), which `AGENTS.md`
forbids, and each used an issue number as its only anchor. Both are now stated
in the present tense, and both are made accurate on the two points they each
left out, verified against `atomic_write.py`: `restrict_to_owner` implies
`0o600` **on POSIX** while Windows gets an owner-only DACL, and the guarantee
is unconditional only because `restrict_on_error` defaults to `"raise"` (with
`"warn"`, `atomic_write`'s own docstring says a Windows file genuinely
publishes under its inherited ACL).

Fixing them together is deliberate. Doing one and not the other is the
inconsistency this repo's simplification convention calls out by name — decide
the criterion once, then grep for every site it reaches — and it is what the
First Principles reviewer flagged on the first push.

**Behaviour is identical at every site.** Enumerated over all combinations of
`(update.ok, bool(error), update.timed_out)` for the update path and
`(result.ok, result.timed_out)` for the probes: 0 mismatches. `ProcessResult`
is a plain `@dataclass` with `ok: bool` / `timed_out: bool` — no property, no
`__getattr__`, no subclass — so the reads cannot raise or side-effect, and
`timed_out` is still evaluated only on the failure path. No import was added,
moved, or deleted; no `self._run(...)` argument changed, so `sandbox_mode`,
`extra_hidden_dirs` and `extra_visible_dirs` are untouched at every spawn; and
every `_audit(outcome="invoked", critical=True)` / `_set_terminal_audit` pairing
is unchanged.

This file is **not** in the simplification detector's keystone set, and neither
keystone file that could have hosted a twin does: `safety_override.py` passes
SEL outcomes as literals at each call site (its ternaries are TTL arithmetic),
and `platform/governance.py` passes a signature sentinel. There is no
equivalent hunk left behind.

## Tests

No test changes. This is a behaviour-preserving refactor, and the enumeration
above — not a new test — is what establishes equivalence.

Worth recording for a follow-up rather than widening this PR: these three
labels are **unpinned**. `test/test_kiro_prerequisite.py` asserts the
`(action, outcome)` sequence and the redaction of these events, but never reads
`item["error"]`, so no test would fail if the mapping changed value. That gap
is pre-existing; adding coverage for it is a test-only change that belongs in
its own PR, where it can be reviewed as new coverage instead of as a claim
about this diff.

## Manual verification

N/A — unit coverage sufficient. Backend-only refactor of a pure label mapping,
gated by the existing 226 tests over `kiro_prerequisite` and its auth/spawn
neighbours, plus a full-tree `mypy` and `flake8`.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only — the diff touches one Python module and no
frontend path, so nothing rendered changes.

## Related Issues

no linked issue: routine module-simplification sweep, not a reported defect.

## Pattern harvest

Not generalizable as a new rule: the duplication here is three hand-written
copies of one three-way mapping, which is already covered by the existing
module-simplification sweep (chained ternary + duplicated condition) rather
than by a shape a linter can name. The one transferable observation is recorded
in "Tests" above — an audit-label mapping with no round-trip assertion — which
is already the third bullet of the `recurring-defect-patterns` rule.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
