### PR TITLE
fix: tolerate app storage delete races

### DIFF
--- a/src/kiro_crew/apps/app_storage.py
+++ b/src/kiro_crew/apps/app_storage.py
@@ -72,7 +72,10 @@ class AppStorage:
         """Delete a key. Returns True if existed."""
         path = self._key_path(key)
         if path.is_file():
-            path.unlink()
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                return False
             sel().log_api_access(
                 caller=f"app:{self._app_name}",
                 operation="app_storage.delete",

--- a/test/test_app_storage.py
+++ b/test/test_app_storage.py
@@ -81,6 +81,25 @@ class TestAppStorageKeyIsolation:
         storage = AppStorage("test-app", tmp_path)
         assert storage.delete(key) is False
 
+    def test_delete_returns_false_when_key_vanishes_after_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A concurrent delete is the same observable state as an absent key."""
+        storage = AppStorage("test-app", tmp_path)
+        storage.set("shared", {"value": 1})
+        key_path = storage._key_path("shared")
+        real_is_file = Path.is_file
+
+        def _remove_after_probe(path: Path) -> bool:
+            present = real_is_file(path)
+            if path == key_path and present:
+                path.unlink()
+            return present
+
+        monkeypatch.setattr(Path, "is_file", _remove_after_probe)
+
+        assert storage.delete("shared") is False
+
     @settings(max_examples=50, suppress_health_check=[HealthCheck.function_scoped_fixture])
     @given(keys=st.lists(_valid_key(), min_size=1, max_size=10, unique=True))
     def test_list_keys_returns_all_set_keys(self, keys: list[str], tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem / Motivation

`AppStorage.delete()` first checked whether the key file existed and then unlinked it. If another caller deleted the same key between those operations, the second caller raised `FileNotFoundError` instead of returning the method's documented boolean result.

## Why it matters

App backends can issue overlapping storage requests. A harmless concurrent delete should settle on an absent key, not turn into an unhandled storage failure.

## What changed (motivation → approach → change)

The deletion path now treats `FileNotFoundError` from the unlink as the same outcome as a key that was already absent. Other deletion errors still propagate, and SEL records success only when this call actually removes the key.

## Tests

Added a deterministic regression that removes the key immediately after the positive file probe and verifies that `delete()` returns `False`. The complete AppStorage and directly related app-context suites pass (36 tests).

## Manual verification

N/A — the deterministic filesystem regression exercises the complete race window and the existing property tests cover normal deletion.

## Related Issues

No linked issue: this is an independently reproduced current-main race.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Boolean delete APIs should treat a file vanishing after an existence probe as an already-absent result.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff