### PR TITLE
fix: tolerate vanished cron trigger secrets

### DIFF
--- a/src/kiro_crew/cron_trigger.py
+++ b/src/kiro_crew/cron_trigger.py
@@ -40,8 +40,11 @@ def trigger_cron_job(job_id: str, port: int, secret_path: Path) -> tuple[bool, s
     # caller does that; closing it means this parameter going away, not the order
     # flipping.
     secret = run_marker.read_secret(port)
-    if not secret and secret_path.exists():
-        secret = secret_path.read_text().strip()
+    if not secret:
+        try:
+            secret = secret_path.read_text().strip()
+        except FileNotFoundError:
+            pass
     if secret:
         headers["X-Internal-Secret"] = secret
     try:

--- a/test/test_cron_trigger.py
+++ b/test/test_cron_trigger.py
@@ -115,6 +115,26 @@ class TestTriggerCronJob:
         assert ok is False
         assert "HTTP 403" in msg
 
+    def test_secret_file_disappears_before_read(self, mock_dashboard, monkeypatch):
+        """A concurrent secret cleanup behaves like an already-missing fallback."""
+        port, cfg_dir = mock_dashboard
+        secret_path = cfg_dir / ".local_secret"
+        path_type = type(secret_path)
+        original_read_text = path_type.read_text
+
+        def remove_before_read(path, *args, **kwargs):
+            if path == secret_path:
+                path.unlink()
+                raise FileNotFoundError(path)
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(path_type, "read_text", remove_before_read)
+        with patch("kiro_crew.cron_trigger.run_marker.read_secret", return_value=None):
+            ok, msg = trigger_cron_job("abc12345", port, secret_path)
+
+        assert ok is False
+        assert "HTTP 403" in msg
+
     def test_invalid_job_id_rejected(self, mock_dashboard):
         """Malformed job IDs are rejected before making HTTP request."""
         port, cfg_dir = mock_dashboard


### PR DESCRIPTION
## Problem / Motivation

`trigger_cron_job()` read its fallback credential with a check-then-read pair:

```python
if not secret and secret_path.exists():
    secret = secret_path.read_text().strip()
```

Between the `exists()` probe and the `read_text()` the file can be gone — a
gateway cleanup or a credential replacement lands in that window — and the read
then raises `FileNotFoundError`.

## Why it matters

`trigger_cron_job()` promises a `(success, message)` result to both of its
callers, the CLI and the MCP surface. The exception escaped that contract
through both instead of being reported as a result, so a routine concurrent
credential cleanup surfaced as a crash rather than a handled outcome.

The window is small but it is opened by ordinary maintenance of the very file
being read, not by an exotic failure.

## What changed (motivation → approach → change)

**Symptom** — `FileNotFoundError` out of `cron_trigger.py:44` when the fallback
secret file is removed between the probe and the read.

**Root cause** — a positive existence probe followed by an unguarded read. The
probe's answer is stale by the time it is used, and "the file vanished" is
already a state this function knows how to handle: it is the same state as "the
file was never there".

**Change** — drop the `exists()` probe and let the read itself answer, catching
`FileNotFoundError` and falling through. Disappearance now takes exactly the
path an already-missing secret takes, so there is one behaviour for one
condition instead of two.

## Tests

`test/test_cron_trigger.py::test_secret_file_disappears_before_read` — patches
`Path.read_text` so the secret file is unlinked and `FileNotFoundError` raised at
the moment of the read, which is the only way to land inside the window
deterministically. It pins the outcome, not the mechanism: the call must return
the ordinary `(False, "HTTP 403")` result that an already-missing secret
produces, rather than raising.

Red-before: the new test fails with `FileNotFoundError` at `cron_trigger.py:44`
without the production change.

Validation at this head (rebased onto current main): `test/test_cron_trigger.py`
green (18 tests); `isort --check-only` and `flake8` clean; `mypy src/kiro_crew/`
clean; `git diff --check` clean.

## Manual verification

N/A — unit coverage sufficient. The change is a single exception path, and the
race it closes cannot be triggered by hand reliably; the regression injects the
failure at the exact instruction instead, which is stronger evidence than a
manual attempt at the window.

## Related Issues

no linked issue: found by code inspection during a review of check-then-read
patterns, not reported as an issue; the fix is smaller than a report would be.

Behaviour contract is unchanged: when neither credential source is available the
request is still sent without the internal-secret header and the gateway's
response is returned normally. This PR only stops one way of reaching that state
from raising.

## Pattern harvest

Rule candidate: semgrep
Pattern: positive `path.exists()` probe followed by an unguarded `path.read_text()`/`open()` on the same path — disappearance between probe and read should take the already-missing path, so guard the read instead of probing.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
