### PR TITLE
fix: bound design tweak startup log reads

### DIFF
--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -267,6 +267,10 @@ _HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
 _LSOF_TIMEOUT = 4
 _PROBE_TIMEOUT = 1.5
 _START_TIMEOUT = 45
+_DEV_LOG_TAIL_CHARS = 800
+# UTF-8 uses at most four bytes per character, so this preserves the character
+# contract without letting a noisy child choose the diagnostic read size.
+_DEV_LOG_TAIL_BYTES = _DEV_LOG_TAIL_CHARS * 4
 _STOP_GRACE = 3
 _RELAY_TIMEOUT = 30
 _WS_IDLE = 3600
@@ -656,6 +660,19 @@ class _DevProxyHandler(dev_preview.DevProxyHandlerBase):
     timeout = _CLIENT_READ_TIMEOUT
 
 
+def _read_dev_log_tail(log: Path) -> str:
+    """Return the bounded diagnostic tail of a failed dev-server launch."""
+
+    try:
+        with log.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            handle.seek(max(0, handle.tell() - _DEV_LOG_TAIL_BYTES))
+            raw = handle.read(_DEV_LOG_TAIL_BYTES)
+    except OSError:
+        return ""
+    return raw.decode("utf-8", errors="replace")[-_DEV_LOG_TAIL_CHARS:]
+
+
 def _start_dev_proc(project_id: str, root: Path) -> dict:
     """Start an owned project dev server and discover the port it selected."""
 
@@ -736,11 +753,7 @@ def _start_dev_proc(project_id: str, root: Path) -> dict:
     deadline = time.time() + _START_TIMEOUT
     while time.time() < deadline:
         if proc.poll() is not None:
-            tail = ""
-            try:
-                tail = log.read_text("utf-8", errors="replace")[-800:]
-            except OSError:
-                pass
+            tail = _read_dev_log_tail(log)
             _DEV_PROCS.pop(project_id, None)
             return {
                 "ok": False,

--- a/test/test_design_tweak_devproc.py
+++ b/test/test_design_tweak_devproc.py
@@ -437,6 +437,37 @@ class TestStartDevProc:
         assert result["ok"] is False
         assert "exited" in result["error"]
 
+    def test_process_exit_reads_only_a_bounded_log_tail(self, tmp_path, monkeypatch):
+        """A noisy child cannot force the error path to load its whole log."""
+        _make_pkg_json(tmp_path, {"dev": "vite"})
+        (tmp_path / "node_modules").mkdir()
+        monkeypatch.setattr(server, "_resolve_bin", lambda n: Path("/usr/bin/npm"))
+        monkeypatch.setattr(server, "DATA_DIR", tmp_path)
+
+        payload = "noise-" * 1_000 + "界" * 900 + "END"
+        fake = FakePopen(pid=201, returncode=1)
+
+        def fake_popen(*args, **kwargs):
+            handle = kwargs["stdout"]
+            handle.write(payload.encode("utf-8"))
+            handle.flush()
+            return fake
+
+        original_read_text = Path.read_text
+
+        def reject_whole_log_read(path, *args, **kwargs):
+            if path.name == "devserver-proj-tail.log":
+                raise AssertionError("startup diagnostics must not read the whole log")
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(Path, "read_text", reject_whole_log_read)
+
+        result = server._start_dev_proc("proj-tail", tmp_path)
+
+        assert result["ok"] is False
+        assert result["log"] == payload[-server._DEV_LOG_TAIL_CHARS :]
+
     def test_spawn_oserror(self, tmp_path, monkeypatch):
         """Popen failure (e.g. ENOENT) returns an error dict, not an exception."""
         _make_pkg_json(tmp_path, {"dev": "vite"})


### PR DESCRIPTION
## Problem / Motivation

When an owned project's dev server exits during the 45-second startup window,
Design Tweak reports the failure with the last 800 characters of the server's
log. It obtained them by loading the **whole** file and slicing:

```python
tail = log.read_text("utf-8", errors="replace")[-800:]
```

The size of that read is chosen by the child process, not by the backend.

## Why it matters

A dev server can emit an arbitrarily large log inside that 45-second window — a
build loop, a stack-trace flood, a dependency resolver in a retry cycle. Because
the failure path reads the file in full before discarding all but the last 800
characters, a noisy child turns an ordinary launch failure into backend memory
exhaustion.

The bad case is reached precisely when something has already gone wrong, so the
diagnostic path is at its least robust exactly when it is needed.

## What changed (motivation → approach → change)

**Symptom** — the startup failure path at `server.py:739` loads an entire
child-controlled log to produce an 800-character diagnostic.

**Root cause** — the read is unbounded because the bound was applied *after*
reading, as a slice. The 800-character contract was expressed at the wrong end
of the operation.

**Change** — extract `_read_dev_log_tail()`, which seeks to the end of the file
and reads only the bytes the diagnostic can need, then decodes that window:

- `_DEV_LOG_TAIL_BYTES = _DEV_LOG_TAIL_CHARS * 4`, because UTF-8 encodes a
  character in at most four bytes. The byte bound therefore cannot cut the
  character contract short, while the child no longer chooses the read size.
- Decoding uses `errors="replace"` on the window, so a multibyte character
  straddling the seek boundary degrades to a replacement character instead of
  raising.
- The final `[-_DEV_LOG_TAIL_CHARS:]` keeps the existing 800-character contract
  exact after decode.
- `OSError` still yields `""`, preserving the previous behaviour when the log
  cannot be read at all.

The response shape and the 800-character diagnostic are unchanged; only the
amount read from disk is bounded.

## Tests

`test/test_design_tweak_devproc.py::test_process_exit_reads_only_a_bounded_log_tail`
— writes a large payload ending in 900 multibyte characters, then patches
`Path.read_text` to raise `AssertionError` if the dev log is ever read whole.
That inversion is what makes the test meaningful: it pins the *absence* of the
unbounded read rather than merely observing an output that a whole-file read
would also produce. It then asserts the returned tail equals the last
`_DEV_LOG_TAIL_CHARS` of the payload, so the multibyte boundary is exercised
rather than assumed.

Red-before: the regression fails on `Path.read_text()` at `server.py:739`
without the production change.

Validation at this exact head (`21717fcbf`), the focused suite re-run to confirm
it still holds: `test/test_design_tweak_devproc.py` green (53 passed, 3 platform
skips); repository-scoped Black gate clean; `isort` and `flake8` clean on both
touched files; isolated mypy on `server.py` clean; subprocess-encoding gate,
feature-map gate and brand gate clean; `git diff --check` clean.

## Manual verification

N/A — unit coverage sufficient. Reproducing the unbounded read by hand means
driving a real dev server into emitting a multi-gigabyte log; the regression
asserts the whole-file read never happens, which is the property at issue and is
checked directly rather than inferred from memory behaviour.

## Related Issues

No linked issue.

## Pattern harvest

Review prompt: inspect other diagnostic-tail call sites for whole-file reads
followed by a slice, especially child-process logs whose producer controls file
size.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented behaviour changes
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
