### PR TITLE
fix(instances): make the gateway run dir owner-only on Windows

### DIFF
--- a/src/kiro_crew/instances/run_marker.py
+++ b/src/kiro_crew/instances/run_marker.py
@@ -167,17 +167,30 @@ def _pid_record(pid: int) -> str:
 
 
 def _run_dir() -> Path:
-    """Return ``<config_dir>/run`` (created ``0700``); mirrors sandbox._ensure_run_dir."""
+    """Return ``<config_dir>/run`` (created owner-only); mirrors sandbox._ensure_run_dir.
+
+    ``restrict_dir_to_owner``, not ``os.chmod(0o700)``: on POSIX the two are the
+    same call, but a mode is meaningless on Windows, where a bare chmod leaves
+    the directory on the inherited DACL. This directory holds the gateway's
+    credential, its pid — the identity a client checks before trusting a port —
+    and the marker naming an executable mint will exec, so it must be owner-only
+    on every platform. The directory helper is also what makes the sidecars
+    safe: its Windows grants carry ``(OI)(CI)``, so files created inside inherit
+    owner-only, which ``atomic_write(mode=0o600)`` cannot deliver there.
+
+    Best-effort by contract, unlike the fail-loud helper it calls: ``_run_dir``
+    is reached through :func:`secret_path` on the dashboard's startup path, and
+    a directory that cannot be tightened (owned by another uid, an unresolvable
+    SID) must not take the gateway down.
+    """
     d = config_dir() / "run"
     d.mkdir(parents=True, exist_ok=True)
     try:
-        # exist_ok does not re-apply mode on an existing dir — enforce 0700 so the
-        # marker (which names an executable mint will exec) isn't world-writable.
-        # 0o700 (owner-only) is deliberate for a dir holding an exec'd path;
-        # semgrep's 0o644 default is wrong for a private dir (mirrors sandbox.py).
-        os.chmod(d, 0o700)  # nosemgrep
+        # exist_ok does not re-apply the mode/DACL to an existing dir, so tighten
+        # unconditionally rather than only on the create.
+        platform_compat.restrict_dir_to_owner(d)
     except OSError:
-        pass
+        logger.debug("could not restrict run dir %s to its owner", d, exc_info=True)
     return d
 
 

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -930,6 +930,45 @@ class TestRunMarker:
         cmd = build_candidate_command("status", marker_port=7000)
         assert '[ -n "$__kb" ] && [ -x "$__kb" ]' in cmd
 
+    def test_run_dir_lockdown_is_the_directory_helper(self, tmp_path, monkeypatch):
+        """``run/`` holds the gateway's credential, pid and launcher marker.
+
+        A bare ``os.chmod(0o700)`` is a silent no-op on Windows, so the
+        directory and everything created inside it keep the inherited DACL.
+        The tightening must go through ``platform_compat.restrict_dir_to_owner``,
+        whose Windows grants carry ``(OI)(CI)`` and so also cover the ``.pid``
+        and ``.bin`` sidecars, which ``atomic_write(mode=0o600)`` cannot.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew import platform_compat
+        from kiro_crew.instances import run_marker
+
+        seen: list[str] = []
+        # Re-patch over the session-wide Windows stub in conftest so this
+        # assertion is not vacuous on the Windows matrix.
+        monkeypatch.setattr(platform_compat, "restrict_dir_to_owner", lambda p: seen.append(str(p)))
+        d = run_marker._run_dir()
+        assert seen == [str(d)]
+
+    def test_run_dir_lockdown_failure_is_best_effort(self, tmp_path, monkeypatch):
+        """A refused lockdown must not break gateway startup.
+
+        ``restrict_dir_to_owner`` is fail-loud by design, but ``_run_dir`` is on
+        the path of ``secret_path()``, which the dashboard calls outside a
+        try/except. The existing contract — tighten if possible, otherwise carry
+        on — is what the caller depends on, so the raise is absorbed here.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+        from kiro_crew import platform_compat
+        from kiro_crew.instances import run_marker
+
+        def _refuse(_path):
+            raise OSError("lockdown refused")
+
+        monkeypatch.setattr(platform_compat, "restrict_dir_to_owner", _refuse)
+        d = run_marker._run_dir()
+        assert d.is_dir()
+
 
 # ── run-marker port discovery (clients find a gateway on a non-default port) ──
 


### PR DESCRIPTION
## Problem / Motivation

`<config_dir>/run` is the gateway's private sidecar directory. It holds:

- `gateway-<port>.secret` — the local API credential (`cli_server` reads it via
  `run_marker.read_secret`);
- `gateway-<port>.pid` — per `read_pid`'s own docstring, *"the identity a client
  checks before trusting the port"*;
- `gateway-<port>.bin` — the launcher path the SSH token mint execs.

`run_marker._run_dir` tightened it with `os.chmod(d, 0o700)`. A POSIX mode is
meaningless on Windows, so the directory simply keeps the DACL it inherited.
Measured on Windows 11 with a data home on a non-profile volume:

```
# os.chmod(d, 0o700) — what _run_dir does today
run                        BUILTIN\Administrators:(I)(OI)(CI)(F)
                           NT AUTHORITY\SYSTEM:(I)(OI)(CI)(F)
                           BUILTIN\Users:(I)(OI)(CI)(RX)
                           NT AUTHORITY\Authenticated Users:(I)(M)
run\gateway-8080.pid       BUILTIN\Users:(I)(RX)
                           NT AUTHORITY\Authenticated Users:(I)(M)

# platform_compat.restrict_dir_to_owner(d)
run                        OWNER RIGHTS:(OI)(CI)(F)
                           <owner>:(OI)(CI)(F)
run\gateway-8080.pid       OWNER RIGHTS:(I)(F)
                           <owner>:(I)(F)
```

Any authenticated account holds **Modify** on the directory and on the sidecars
created inside it.

The gap is not uniform even within this one directory: `dashboard/server.py`'s
`_write_secret_file` deliberately calls `platform_compat.restrict_to_owner` on
the `.secret` file ("on Windows an owner-only DACL … a raw fchmod would be a
silent no-op"), while `write_marker` writes the `.pid` and `.bin` with
`atomic_write(..., mode=0o600)`, whose mode is exactly that silent no-op. So the
credential is protected and the two files that decide *which* gateway a client
trusts are not.

## Why it matters

On Windows the run directory and its `.pid` / `.bin` sidecars are writable by
any authenticated local account. `read_pid` is the ownership proof `cli_server`
checks before trusting a port, and `prune_markers` uses the same recorded pid to
decide which sibling gateway's marker and credential it must not reap. A
tampered sidecar therefore steers a client's port trust and can direct the live
gateway's prune at a sibling's files.

The exposure is bounded by where the data home sits: under the default
`%USERPROFILE%\.kiro`, the profile's own ACL still keeps other users out. It is
real wherever `KIROCREW_HOME` points outside the profile — a data drive, a
shared volume, a service account's working area — which the measurement above
reproduces. `restrict_dir_to_owner` exists precisely so this does not depend on
where the data home was placed.

## What changed (motivation → approach → change)

Symptom: an "owner-only" directory that is not owner-only on Windows. Root
cause: the wrong half of `AGENTS.md`'s cross-platform pair —

| Need | Use (`platform_compat`) | NOT |
|---|---|---|
| Owner-only secret directory (fail-loud, inheritable) | `restrict_dir_to_owner(path)` | `restrict_to_owner(path)` on a directory (its Windows grants carry no `(OI)(CI)`…) |

Change: `_run_dir` calls `platform_compat.restrict_dir_to_owner(d)`. On POSIX
that helper *is* `os.chmod(path, 0o700)`, so nothing about Linux or macOS
behaviour moves — including the `nosemgrep` suppression, which now lives inside
the helper where it belongs. On Windows it applies the owner-only DACL.

The `(OI)(CI)` inheritance is what makes this one call sufficient: files created
in the directory from then on inherit owner-only, so the `.pid` and `.bin`
sidecars are covered without touching `write_marker` or widening
`atomic_write`'s contract. It is not a retrofit — as the helper's docstring
notes, a file that already exists keeps its own DACL — so an existing install
tightens on the next file write, not on the next `_run_dir` call.

The one deliberate difference from the helper's own contract is failure
handling. `restrict_dir_to_owner` is fail-loud by design, but `_run_dir` is
reached through `secret_path()` from `dashboard/server.py`'s startup path, which
does not guard it; a directory that cannot be tightened (owned by another uid,
an unresolvable SID) must not take the gateway down. The pre-existing
best-effort contract is kept, with the swallowed error now logged rather than
silently `pass`ed.

## Tests

Two tests in `test/test_instances.py::TestRunMarker`:

- `test_run_dir_lockdown_is_the_directory_helper` — `_run_dir()` routes its
  tightening through `platform_compat.restrict_dir_to_owner` for that exact
  path. Red on `997d59421`: `assert [] == ['…\\run']`. It re-patches the symbol
  over `conftest`'s session-wide Windows stub, so the assertion is not vacuous
  on the Windows matrix.
- `test_run_dir_lockdown_failure_is_best_effort` — a raising lockdown still
  returns a usable directory, pinning the contract `secret_path()`'s caller
  depends on. This one passes before and after by construction; it exists so a
  later change to the fail-loud helper cannot silently start taking the gateway
  down at startup.

Green: `test_instances.py` 298 passed, 5 skipped (the single failure,
`test_no_anchored_pattern_uses_a_dollar_anchor`, is a pre-existing `cp950`
decode failure on this Windows box and reproduces identically on `997d59421`).
Siblings that consume the run marker — `test_cli_restart_marker_fallback.py`,
`test_instance_credential_pairing.py`, `test_mcp_api_port_resolution.py`,
`test_governance_self_protection.py` — 215 passed, 1 skipped.

## Manual verification

The `icacls` table under **Problem / Motivation** is the manual verification:
both directories created on the same Windows 11 host on a non-profile volume,
one tightened the old way and one through the helper, each with a
`gateway-8080.pid` created afterwards so the `(OI)(CI)` inheritance is shown
rather than asserted. Unit coverage pins the call routing; only a real DACL read
can show what the call is worth.

## Related Issues

None — found by auditing `AGENTS.md`'s `platform_compat` "use this / NOT that"
table against current `main`.

## Pattern harvest

Rule candidate: `semgrep`

Pattern: `os.chmod(dir, 0o700)` (or `os.chmod(file, 0o600)`) used as a security
control on a path that also exists on Windows, where the mode is a silent no-op.
The greppable shape is a raw `os.chmod` with an owner-only mode outside
`platform_compat`, on a path under the data home; the fix is
`restrict_dir_to_owner` for directories and `restrict_to_owner` for files. The
tell that it is worth a rule rather than a one-off: this repository already
carries the correct call in `mcp_gateway/apps.py`, in
`dashboard/server.py::_write_secret_file`, and in the `AGENTS.md` table — the
knowledge was present and the site still drifted.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
