### PR TITLE
fix(diagnostics): reject a junctioned log dir, not just a symlinked one

### DIFF
--- a/src/kiro_crew/diagnostics.py
+++ b/src/kiro_crew/diagnostics.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import quote, urlencode
 
-from kiro_crew import __version__, release_channel
+from kiro_crew import __version__, platform_compat, release_channel
 from kiro_crew.config.loader import config_dir
 from kiro_crew.security import (
     is_sensitive_path,
@@ -211,8 +211,15 @@ def _usable_dir(p: Path) -> bool:
     themselves symlinks — they sail past the per-file guard and get packaged.
     The guard therefore has to sit one level up, at every directory this module
     globs.
+
+    ``is_link_or_junction``, not ``Path.is_symlink()``: a Windows junction is a
+    reparse point ``is_symlink`` does not report, and it is the only directory
+    link an unprivileged Windows user can create (a symlink needs
+    ``SeCreateSymbolicLinkPrivilege``). A symlink-only guard is therefore open
+    on exactly the platform where planting one is easiest, and what leaks
+    through it is a bundle the user then attaches to a public issue.
     """
-    return p.is_dir() and not p.is_symlink()
+    return p.is_dir() and not platform_compat.is_link_or_junction(p)
 
 
 def _kiro_cli_chat_log() -> Path | None:

--- a/test/test_diagnostics.py
+++ b/test/test_diagnostics.py
@@ -23,7 +23,7 @@ from urllib.parse import parse_qs, urlsplit
 import pytest
 import yaml
 
-from conftest import requires_symlinks
+from conftest import make_dir_link, requires_symlinks
 from kiro_crew import beacon, diagnostics
 from kiro_crew.dashboard.handlers import diagnostics as dh
 from kiro_crew.diagnostics import BundleResult
@@ -612,6 +612,52 @@ def test_triage_workflow_maps_every_channel_dropdown_answer():
             f"issue-triage.yml never applies {label!r}, but the dashboard flow "
             "attaches it -- the two paths must agree on the vocabulary"
         )
+
+
+# ── collector link guard ──────────────────────────────────────────
+
+
+class TestUsableDirRejectsEveryDirLink:
+    """``_usable_dir`` is the collector's one guard against enumerating THROUGH a
+    linked log directory: ``Path.is_dir()`` follows the link, and the real files
+    found on the other side are not themselves links, so they sail past the
+    per-file check and get packaged into a bundle destined for a public issue.
+
+    ``Path.is_symlink()`` does not report a Windows junction, and a junction is
+    the only directory link an unprivileged Windows user can create — a symlink
+    needs ``SeCreateSymbolicLinkPrivilege`` — so a symlink-only guard is open on
+    exactly the platform where planting one is easiest.
+    """
+
+    def test_a_real_directory_link_is_not_usable(self, tmp_path: Path) -> None:
+        # A junction on Windows, a directory symlink on POSIX — the same
+        # traversal either way, and no privilege needed on either.
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "id_rsa").write_text("secret", encoding="utf-8")
+        link = tmp_path / "kiro-log"
+        make_dir_link(link, outside)
+
+        assert link.is_dir()  # the link resolves — this is what makes it dangerous
+        assert list(link.glob("*"))  # and enumerating it reaches the target's files
+        assert diagnostics._usable_dir(link) is False
+
+    def test_a_plain_directory_stays_usable(self, tmp_path: Path) -> None:
+        # The guard must not reject the ordinary case it exists to allow.
+        real = tmp_path / "kiro-log"
+        real.mkdir()
+        assert diagnostics._usable_dir(real) is True
+
+    def test_guard_routes_through_the_shared_link_predicate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pinned at the seam as well as end to end: the junction-aware predicate
+        # is the shared one, so this guard cannot drift from the rest of the
+        # tree on which reparse types count as a link.
+        real = tmp_path / "kiro-log"
+        real.mkdir()
+        monkeypatch.setattr(diagnostics.platform_compat, "is_link_or_junction", lambda p: True)
+        assert diagnostics._usable_dir(real) is False
 
 
 # ── API handlers (mode-independent: stub request + asyncio.run) ──────────────


### PR DESCRIPTION
## Problem / Motivation

`diagnostics._usable_dir` is the support-bundle collector's one guard against
enumerating *through* a linked log directory. Its own docstring states the
reason precisely:

> Rejecting only symlinked *files* is not enough: `Path.is_dir()` follows links,
> so a symlinked `crash-dumps` (or DiagnosticReports) directory is walked
> through to its target, and the real files found there are not themselves
> symlinks — they sail past the per-file guard and get packaged.

The guard is in the right place. Its predicate is not: it tested
`p.is_symlink()`, which does **not** report a Windows junction.

This is worse than an even trade on Windows, because the two link types are not
equally available to an attacker there. A directory *symlink* needs
`SeCreateSymbolicLinkPrivilege` — the repo's own test fixtures document this and
skip on it (`requires_symlinks`). A *junction* needs no privilege at all, and is
followed by the same reparse machinery: `is_dir()`, `glob` and `resolve` all
traverse it identically. So on Windows the only directory link an unprivileged
process can plant is precisely the one the guard did not see.

## Why it matters

Everything `_usable_dir` protects is then enumerated and packaged. The three
directories this module globs all route through it:

- the kiro-log directories (`_kiro_log_dirs` → `_usable_dir` at the dedup step),
- macOS `DiagnosticReports`,
- `<data home>/logs/crash-dumps`.

A junction planted at any of them makes the collector read the *target's* files
and write them into `kirocrew-diagnostics-*.zip`. That bundle is not a private
artifact: the dashboard flow hands it to the user to attach to a public issue,
and the module already treats this as the threat model it is defending —
`_kiro_cli_chat_log` refuses a `KIRO_CHAT_LOG_FILE` pointing at a sensitive path
with the comment *"would copy plaintext logins into a bundle destined for a
public issue. Redaction is not a backstop for that."* A junction reaches the
same outcome without touching that env var.

## What changed (motivation → approach → change)

Symptom: a link guard that a Windows junction walks straight past. Root cause:
`Path.is_symlink()` where `AGENTS.md`'s cross-platform table names a
`platform_compat` predicate —

| Need | Use (`platform_compat`) | NOT |
|---|---|---|
| Detect/remove a dir link | `is_link_or_junction(path)` / `unlink_link_or_junction(path)` | `path.is_symlink()` (misses a Windows junction) |

Change: `_usable_dir` returns `p.is_dir() and not
platform_compat.is_link_or_junction(p)`. One predicate, one line — and because
every globbed directory in this module already funnels through this single
function, the gap closes at all three sites at once rather than needing a guard
added per call site.

Deliberately not widened here: `platform_compat.first_linked_ancestor` covers
the neighbouring case where the path itself is a real directory but an
*ancestor* is a link. That is a different defect with a different blast radius
(an ancestor link to `\\host\share` turns an `is_dir()` into an authenticated
outbound SMB connection), it needs its own reasoning about which of the
collector's paths are attacker-influenced, and folding it in would make this
diff a survey rather than a fix. It is named under **Pattern harvest** instead.

The per-*file* checks (`_usable_log`, the `.ips` filter, the crash-dump filter)
are left on `is_symlink()`: a file symlink IS reported on Windows, and a
junction is a directory-only reparse point, so there is nothing for the wider
predicate to add there.

## Tests

`TestUsableDirRejectsEveryDirLink` in `test/test_diagnostics.py`, three tests:

- `test_a_real_directory_link_is_not_usable` — the end-to-end one, and it uses a
  **real** link, not a mock: `conftest.make_dir_link` creates an actual junction
  on Windows (`_winapi.CreateJunction`) and a real directory symlink on POSIX,
  so the behaviour is exercised on Windows instead of skipped there. It first
  asserts the two facts that make the link dangerous — `link.is_dir()` is `True`
  and `link.glob("*")` reaches the target's files — and then that `_usable_dir`
  refuses it. Red on `997d59421` with a live junction on Windows 11:
  `AssertionError: assert True is False`.
- `test_a_plain_directory_stays_usable` — the guard does not reject the ordinary
  case it exists to allow (passes before and after; it is what stops the fix
  from being "return False").
- `test_guard_routes_through_the_shared_link_predicate` — pins the seam as well
  as the behaviour, so this guard cannot drift from the rest of the tree on
  which reparse types count as a link. Red on `997d59421`.

Green: `test_diagnostics.py` 46 passed, 3 skipped. Directly relevant siblings
`test_strict_identity_diagnostics.py` + `test_portability.py`: 61 passed, 3
skipped. `black` measured against a regenerated control at this PR's own base —
both files carry a pre-existing 224-line baseline and this diff adds **no** new
finding; `flake8`, `isort`, `git diff --check`, module `mypy` and the
diff-scoped brand-name gate are clean.

## Manual verification

N/A — unit coverage sufficient, and it is not the usual "unit tests are enough"
claim: the Windows leg is verified against a real junction created by
`_winapi.CreateJunction` on a Windows 11 host, which is the exact artifact the
defect turns on. A mocked `isjunction` would have proved nothing about whether
`is_dir()` and `glob` actually traverse it.

## Related Issues

None — found by auditing `AGENTS.md`'s `platform_compat` "use this / NOT that"
table against current `main`.

## Pattern harvest

Rule candidate: `semgrep`

Pattern: `path.is_symlink()` (or `os.path.islink`) used as a *directory* link
guard — the shape is an `is_dir()`/`iterdir()`/`glob()` gated on `not
is_symlink()`. It is only ever correct for files; for directories it is blind to
the one reparse type an unprivileged Windows user can create. Two adjacent
residuals this diff deliberately leaves alone, both worth their own look:

- the ancestor case — `platform_compat.first_linked_ancestor`, for a real
  directory reached *through* a linked parent;
- other `is_dir() and not is_symlink()` sites still on `main`, e.g.
  `dashboard/theme_validate.py:1159` and
  `apps/builtins/pptx_maker/backend/engine_source.py:413`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

---

Merge note: open PR #7692 also touches `src/kiro_crew/diagnostics.py` and
`test/test_diagnostics.py`. The two are semantically independent — #7692 rewrites
`_kiro_cli_version` (line ~276) and appends tests at the end of the file, and
does not touch `_usable_dir` or any of its call sites. The only textual contact
is the `from kiro_crew import ...` line, two lines above where #7692 inserts its
new imports; whichever lands second may need that one-line import merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
