### PR TITLE
feat(wakatime): add WakaTime client, config section, and secret resolution

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5494,6 +5494,57 @@
       "defaultValue": ""
     },
     {
+      "path": "wakatime",
+      "kind": "core",
+      "type": "object",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "wakatime"
+      ],
+      "label": "WakaTime",
+      "help": "WakaTime dev-time tracking integration settings.",
+      "hasChildren": true,
+      "enumValues": null,
+      "defaultValue": {
+        "enabled": false,
+        "api_base_url": ""
+      }
+    },
+    {
+      "path": "wakatime.enabled",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "wakatime"
+      ],
+      "label": "Enabled",
+      "help": "Enable the WakaTime integration (send coding-activity heartbeats and read back stats). Requires the WAKATIME_API_KEY credential stored in the dashboard secrets vault.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": false
+    },
+    {
+      "path": "wakatime.api_base_url",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [
+        "wakatime"
+      ],
+      "label": "API Base URL",
+      "help": "Override the WakaTime API base URL for a self-hosted, API-compatible backend (Wakapi, Hackatime). Empty uses the public WakaTime API at https://wakatime.com/api/v1.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
+    },
+    {
       "path": "teams",
       "kind": "core",
       "type": "object",

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -230,6 +230,7 @@ from kiro_crew.config.sections import (  # noqa: F401
     TelegramConfig,
     TelemetryConfig,
     TunnelConfig,
+    WakaTimeConfig,
     WatchdogConfig,
     WebexConfig,
     WeComConfig,
@@ -1954,6 +1955,12 @@ class KiroCrewConfig:
         default_factory=WebexConfig,
         metadata=_meta("Webex", "Webex Messaging integration settings.", tags=["webex"]),
     )
+    wakatime: WakaTimeConfig = field(
+        default_factory=WakaTimeConfig,
+        metadata=_meta(
+            "WakaTime", "WakaTime dev-time tracking integration settings.", tags=["wakatime"]
+        ),
+    )
     teams: TeamsConfig = field(
         default_factory=TeamsConfig,
         metadata=_meta("Teams", "Microsoft Teams integration settings.", tags=["teams"]),
@@ -2368,6 +2375,7 @@ class KiroCrewConfig:
         feishu_data = _coerced_section(data, "feishu", _degraded)
         discord_data = _coerced_section(data, "discord", _degraded)
         webex_data = _coerced_section(data, "webex", _degraded)
+        wakatime_data = _coerced_section(data, "wakatime", _degraded)
         teams_data = _coerced_section(data, "teams", _degraded)
         imessage_data = _coerced_section(data, "imessage", _degraded)
         slack_data = _coerced_section(data, "slack", _degraded)
@@ -2958,6 +2966,10 @@ class KiroCrewConfig:
                 wdm_base=str(webex_data.get("wdm_base", "") or ""),
                 soft_threshold_pct=_threshold_pct(webex_data.get("soft_threshold_pct"), 80),
                 hard_threshold_pct=_threshold_pct(webex_data.get("hard_threshold_pct"), 95),
+            ),
+            wakatime=WakaTimeConfig(
+                enabled=bool(wakatime_data.get("enabled", False)),
+                api_base_url=str(wakatime_data.get("api_base_url", "") or ""),
             ),
             imessage=IMessageConfig(
                 session_folder=_coerce_session_folder(imessage_data.get("session_folder")),
@@ -3601,6 +3613,7 @@ class KiroCrewConfig:
             "telegram": asdict(self.telegram),
             "discord": asdict(self.discord),
             "webex": asdict(self.webex),
+            "wakatime": asdict(self.wakatime),
             "wecom": asdict(self.wecom),
             "weixin": asdict(self.weixin),
             "whatsapp": asdict(self.whatsapp),

--- a/src/kiro_crew/config/resolution.py
+++ b/src/kiro_crew/config/resolution.py
@@ -41,6 +41,7 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "telegram",
         "discord",
         "webex",
+        "wakatime",
         "wecom",
         "weixin",
         "whatsapp",

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -6049,3 +6049,27 @@ class TeamsConfig:
         self.soft_threshold_pct, self.hard_threshold_pct = _normalize_threshold_pair(
             self.soft_threshold_pct, self.hard_threshold_pct
         )
+
+
+@dataclass
+class WakaTimeConfig:
+    enabled: bool = field(
+        default=False,
+        metadata=_meta(
+            "Enabled",
+            "Enable the WakaTime integration (send coding-activity heartbeats "
+            "and read back stats). Requires the WAKATIME_API_KEY credential "
+            "stored in the dashboard secrets vault.",
+            tags=["wakatime"],
+        ),
+    )
+    api_base_url: str = field(
+        default="",
+        metadata=_meta(
+            "API Base URL",
+            "Override the WakaTime API base URL for a self-hosted, "
+            "API-compatible backend (Wakapi, Hackatime). Empty uses the public "
+            "WakaTime API at https://wakatime.com/api/v1.",
+            tags=["wakatime"],
+        ),
+    )

--- a/src/kiro_crew/wakatime/__init__.py
+++ b/src/kiro_crew/wakatime/__init__.py
@@ -1,0 +1,13 @@
+"""WakaTime integration: send coding-activity heartbeats and read back stats.
+
+The package talks to the WakaTime REST API (or a self-hosted, API-compatible
+backend such as Wakapi or Hackatime via a configurable base URL). The API key
+is a vault secret, never plain config; non-secret settings (enabled flag, base
+URL) live in ``config.wakatime``.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.wakatime.client import WakaTimeAuthError, WakaTimeClient
+
+__all__ = ["WakaTimeClient", "WakaTimeAuthError"]

--- a/src/kiro_crew/wakatime/client.py
+++ b/src/kiro_crew/wakatime/client.py
@@ -1,0 +1,230 @@
+"""Async WakaTime REST client.
+
+Structurally mirrors ``webex/client.py``: one lazily-created shared
+``aiohttp.ClientSession`` behind a double-checked lock, a single ``_api`` core
+that honors one ``429 Retry-After`` back-off then gives up, explicit per-call
+``ClientTimeout``, and transport errors caught narrowly so a failed call
+degrades to ``None``/``[]`` instead of raising into a turn.
+
+Auth is HTTP Basic with the API key as the username (WakaTime's scheme):
+``Authorization: Basic base64(<api_key>:)``. The key is revealed only at the
+request site and never logged — a failing request logs the exception TYPE only,
+because a WakaTime error message or a request URL can carry the key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+# Public WakaTime API. A self-hosted Wakapi/Hackatime backend overrides this via
+# config.wakatime.api_base_url; both expose the same v1 surface.
+DEFAULT_API_BASE = "https://wakatime.com/api/v1"
+
+# WakaTime's own recommended cap on heartbeats per request. Callers batching
+# more than this should chunk; the client does not silently drop the tail.
+MAX_HEARTBEATS_PER_REQUEST = 25
+
+_DEFAULT_TIMEOUT_SECS = 30
+
+
+class WakaTimeAuthError(Exception):
+    """Raised by :meth:`verify` when the API key is rejected (401/403).
+
+    Distinct from a transport failure (which returns ``None``): a wrong key is a
+    configuration problem the caller should surface, not retry.
+    """
+
+
+class WakaTimeClient:
+    """Sends heartbeats and reads summaries/stats/durations from WakaTime."""
+
+    def __init__(self, *, api_key: str, api_base: str = DEFAULT_API_BASE) -> None:
+        self._api_key = api_key
+        self._api_base = api_base.rstrip("/")
+        self._session: aiohttp.ClientSession | None = None
+        self._session_lock: asyncio.Lock = asyncio.Lock()
+        self._closed = False
+
+    # ── Auth ──
+
+    def _headers(self) -> dict[str, str]:
+        # WakaTime Basic auth: the API key is the username, password empty.
+        token = base64.b64encode(f"{self._api_key}:".encode()).decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
+    # ── Session lifecycle ──
+
+    async def _ensure_session(self) -> aiohttp.ClientSession:
+        """Return the shared ClientSession, creating it once on demand.
+
+        Double-checked lock so concurrent callers cannot each build a session
+        and leak one unclosed. Mirrors WebexClient/TelegramClient.
+        """
+        if self._closed:
+            raise RuntimeError("WakaTimeClient is closed")
+        if self._session is None or self._session.closed:
+            async with self._session_lock:
+                if self._closed:
+                    raise RuntimeError("WakaTimeClient is closed")
+                if self._session is None or self._session.closed:
+                    self._session = aiohttp.ClientSession()
+        return self._session
+
+    async def close(self) -> None:
+        """Close the shared session. Idempotent."""
+        self._closed = True
+        if self._session and not self._session.closed:
+            await self._session.close()
+            self._session = None
+
+    # ── REST core ──
+
+    async def _api(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, str] | None = None,
+        payload: Any | None = None,
+        timeout: int = _DEFAULT_TIMEOUT_SECS,
+    ) -> Any:
+        """Call a WakaTime endpoint. Returns the parsed JSON body on success
+        (``{}`` for an empty 2xx), None on any error.
+
+        Honors a single 429 ``Retry-After`` back-off, clamped, then gives up —
+        mirroring WebexClient._api.
+        """
+        session = await self._ensure_session()
+        url = f"{self._api_base}{path}"
+        for attempt in range(2):
+            try:
+                async with session.request(
+                    method,
+                    url,
+                    params=params,
+                    json=payload,
+                    headers=self._headers(),
+                    timeout=aiohttp.ClientTimeout(total=timeout),
+                ) as resp:
+                    if resp.status == 429 and attempt == 0:
+                        try:
+                            retry_after = float(resp.headers.get("Retry-After", "1"))
+                        except (TypeError, ValueError):
+                            retry_after = 1.0
+                        await asyncio.sleep(min(max(retry_after, 0.5), 10.0))
+                        continue
+                    if 200 <= resp.status < 300:
+                        if resp.status == 204:
+                            return {}
+                        try:
+                            return await resp.json(content_type=None)
+                        except ValueError:
+                            return {}
+                    # Never log the response body or the URL — either can carry
+                    # the API key. Status only.
+                    logger.warning("WakaTime API %s %s failed: http=%s", method, path, resp.status)
+                    return None
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                logger.warning(
+                    "WakaTime API %s %s transport error: %s", method, path, type(exc).__name__
+                )
+                return None
+        return None
+
+    # ── Public verbs ──
+
+    async def verify(self) -> dict[str, Any]:
+        """Confirm the key works by reading the current user. Raises
+        :class:`WakaTimeAuthError` on 401/403, returns the user dict on success.
+
+        Used to validate a newly-entered key before persisting it. Distinct from
+        the read verbs: a caller wants a hard signal that the key is valid, not a
+        silent empty result.
+        """
+        session = await self._ensure_session()
+        url = f"{self._api_base}/users/current"
+        try:
+            async with session.get(
+                url,
+                headers=self._headers(),
+                timeout=aiohttp.ClientTimeout(total=_DEFAULT_TIMEOUT_SECS),
+            ) as resp:
+                if resp.status in (401, 403):
+                    raise WakaTimeAuthError("WakaTime rejected the API key")
+                if 200 <= resp.status < 300:
+                    body = await resp.json(content_type=None)
+                    data = body.get("data") if isinstance(body, dict) else None
+                    return data if isinstance(data, dict) else {}
+                logger.warning("WakaTime verify failed: http=%s", resp.status)
+                raise WakaTimeAuthError(f"WakaTime verify returned http={resp.status}")
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            logger.warning("WakaTime verify transport error: %s", type(exc).__name__)
+            raise WakaTimeAuthError("WakaTime verify could not reach the API") from exc
+
+    async def send_heartbeats(self, heartbeats: list[dict[str, Any]]) -> int:
+        """POST a batch of heartbeats. Returns the count the API accepted (0 on
+        failure). Callers must chunk to :data:`MAX_HEARTBEATS_PER_REQUEST`.
+        """
+        if not heartbeats:
+            return 0
+        result = await self._api("POST", "/users/current/heartbeats.bulk", payload=heartbeats)
+        if not isinstance(result, dict):
+            return 0
+        responses = result.get("responses")
+        if not isinstance(responses, list):
+            return 0
+        # Each response is [body, status]; count the 201/202 accepted rows.
+        return sum(
+            1 for r in responses if isinstance(r, list) and len(r) == 2 and r[1] in (201, 202)
+        )
+
+    async def get_summaries(
+        self, start: str, end: str, *, project: str | None = None
+    ) -> list[dict]:
+        """GET daily summaries between ``start`` and ``end`` (YYYY-MM-DD).
+
+        Returns the ``data`` list (one entry per day), or ``[]`` on error.
+        """
+        params = {"start": start, "end": end}
+        if project:
+            params["project"] = project
+        result = await self._api("GET", "/users/current/summaries", params=params)
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, list):
+                return [d for d in data if isinstance(d, dict)]
+        return []
+
+    async def get_stats(self, wakatime_range: str = "last_7_days") -> dict[str, Any]:
+        """GET aggregate stats for a named range (e.g. ``last_7_days``).
+
+        Returns the ``data`` dict (languages, projects, totals), or ``{}``.
+        """
+        result = await self._api("GET", f"/users/current/stats/{wakatime_range}")
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, dict):
+                return data
+        return {}
+
+    async def get_durations(self, date: str, *, project: str | None = None) -> list[dict]:
+        """GET the duration blocks for a single ``date`` (YYYY-MM-DD).
+
+        Returns the ``data`` list, or ``[]`` on error.
+        """
+        params = {"date": date}
+        if project:
+            params["project"] = project
+        result = await self._api("GET", "/users/current/durations", params=params)
+        if isinstance(result, dict):
+            data = result.get("data")
+            if isinstance(data, list):
+                return [d for d in data if isinstance(d, dict)]
+        return []

--- a/src/kiro_crew/wakatime/service.py
+++ b/src/kiro_crew/wakatime/service.py
@@ -1,0 +1,64 @@
+"""Resolve WakaTime config + secret into a ready client.
+
+The API key is read only from the encrypted vault. There is deliberately no
+``.env``/environment fallback: a key placed in ``.env`` is loaded by the
+gateway into the process environment, and the agent-spawn scrub strips only the
+credential names it knows, so an unknown key can reach an agent subprocess and
+be exfiltrated. Vault-only keeps the key off that path entirely.
+
+The base URL comes from ``config.wakatime.api_base_url`` (empty = the public
+WakaTime API), so a self-hosted Wakapi/Hackatime backend is a config change,
+not a code change.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.paths import config_dir
+from kiro_crew.secrets.vault import SecretVault
+from kiro_crew.wakatime.client import DEFAULT_API_BASE, WakaTimeClient
+
+logger = logging.getLogger(__name__)
+
+# Credential name in the vault (the dashboard secrets store).
+WAKATIME_API_KEY = "WAKATIME_API_KEY"
+
+
+def resolve_api_key() -> str:
+    """Return the WakaTime API key from the vault, or ``""`` if not set.
+
+    Best-effort: a missing or unreadable vault yields ``""`` (integration stays
+    off) rather than raising.
+    """
+    try:
+        secret = SecretVault(config_dir()).get(WAKATIME_API_KEY)
+    except Exception:
+        return ""
+    if secret is None:
+        return ""
+    return secret.reveal()
+
+
+def resolve_base_url(config: KiroCrewConfig | None = None) -> str:
+    """Return the configured API base URL, or the public default."""
+    cfg = config or KiroCrewConfig.load()
+    configured = (cfg.wakatime.api_base_url or "").strip()
+    return configured or DEFAULT_API_BASE
+
+
+def build_client(config: KiroCrewConfig | None = None) -> WakaTimeClient | None:
+    """Build a ready WakaTimeClient, or ``None`` when the integration is
+    disabled or has no API key.
+
+    Returning ``None`` (rather than raising) lets callers treat "not set up" as
+    an ordinary empty state instead of an error path.
+    """
+    cfg = config or KiroCrewConfig.load()
+    if not cfg.wakatime.enabled:
+        return None
+    api_key = resolve_api_key()
+    if not api_key:
+        return None
+    return WakaTimeClient(api_key=api_key, api_base=resolve_base_url(cfg))

--- a/test/test_config_module_boundaries.py
+++ b/test/test_config_module_boundaries.py
@@ -116,6 +116,7 @@ TelegramAccountConfig
 TelegramConfig
 TelemetryConfig
 TunnelConfig
+WakaTimeConfig
 WatchdogConfig
 WeComConfig
 WebexConfig

--- a/test/test_wakatime_client.py
+++ b/test/test_wakatime_client.py
@@ -1,0 +1,157 @@
+"""Tests for the WakaTime REST client.
+
+No network: a fake aiohttp-style session records the calls and returns canned
+responses. The API key is a placeholder; several tests assert it never reaches
+a log line, since a WakaTime error or a request URL can carry it.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any
+
+import aiohttp
+import pytest
+
+from kiro_crew.wakatime.client import WakaTimeAuthError, WakaTimeClient
+
+pytestmark = pytest.mark.asyncio
+
+_FAKE_KEY = "waka_fake_0123456789abcdef"
+
+
+class _FakeResp:
+    def __init__(self, status: int, body: Any = None, headers: dict | None = None) -> None:
+        self.status = status
+        self._body = body if body is not None else {}
+        self.headers = headers or {}
+
+    async def __aenter__(self) -> "_FakeResp":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def json(self, content_type: Any = None) -> Any:
+        return self._body
+
+
+class _FakeSession:
+    """Records request calls and replays a queue of responses."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+        self.calls.append({"method": method, "url": url, **kwargs})
+        nxt = self._responses.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return nxt
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        return self.request("GET", url, **kwargs)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _client_with(session: _FakeSession) -> WakaTimeClient:
+    client = WakaTimeClient(api_key=_FAKE_KEY)
+    client._session = session  # type: ignore[assignment]
+    return client
+
+
+async def test_auth_header_is_basic_base64_of_the_key() -> None:
+    session = _FakeSession([_FakeResp(200, {"data": []})])
+    client = _client_with(session)
+    await client.get_summaries("2026-09-01", "2026-09-03")
+    sent = session.calls[0]["headers"]["Authorization"]
+    expected = base64.b64encode(f"{_FAKE_KEY}:".encode()).decode("ascii")
+    assert sent == f"Basic {expected}"
+
+
+async def test_get_summaries_returns_the_data_list() -> None:
+    session = _FakeSession([_FakeResp(200, {"data": [{"grand_total": {"hours": 3}}]})])
+    client = _client_with(session)
+    result = await client.get_summaries("2026-09-01", "2026-09-03", project="oneka")
+    assert result == [{"grand_total": {"hours": 3}}]
+    assert session.calls[0]["params"] == {
+        "start": "2026-09-01",
+        "end": "2026-09-03",
+        "project": "oneka",
+    }
+
+
+async def test_get_stats_returns_the_data_dict() -> None:
+    session = _FakeSession([_FakeResp(200, {"data": {"languages": [{"name": "Python"}]}})])
+    client = _client_with(session)
+    result = await client.get_stats("last_7_days")
+    assert result == {"languages": [{"name": "Python"}]}
+    assert session.calls[0]["url"].endswith("/users/current/stats/last_7_days")
+
+
+async def test_send_heartbeats_counts_accepted_rows() -> None:
+    body = {"responses": [[{}, 201], [{}, 201], [{}, 400]]}
+    session = _FakeSession([_FakeResp(201, body)])
+    client = _client_with(session)
+    accepted = await client.send_heartbeats([{"entity": "a.py", "type": "file", "time": 1.0}])
+    assert accepted == 2
+
+
+async def test_empty_heartbeats_makes_no_request() -> None:
+    session = _FakeSession([])
+    client = _client_with(session)
+    assert await client.send_heartbeats([]) == 0
+    assert session.calls == []
+
+
+async def test_429_is_retried_once_then_succeeds() -> None:
+    session = _FakeSession(
+        [
+            _FakeResp(429, headers={"Retry-After": "0"}),
+            _FakeResp(200, {"data": []}),
+        ]
+    )
+    client = _client_with(session)
+    result = await client.get_summaries("2026-09-01", "2026-09-03")
+    assert result == []
+    assert len(session.calls) == 2
+
+
+async def test_transport_error_degrades_to_empty() -> None:
+    session = _FakeSession([aiohttp.ClientError("boom")])
+    client = _client_with(session)
+    assert await client.get_durations("2026-09-03") == []
+
+
+async def test_verify_raises_on_rejected_key() -> None:
+    session = _FakeSession([_FakeResp(401)])
+    client = _client_with(session)
+    with pytest.raises(WakaTimeAuthError):
+        await client.verify()
+
+
+async def test_verify_returns_user_on_success() -> None:
+    session = _FakeSession([_FakeResp(200, {"data": {"username": "behordeun"}})])
+    client = _client_with(session)
+    assert await client.verify() == {"username": "behordeun"}
+
+
+async def test_api_key_never_appears_in_logs(caplog: pytest.LogCaptureFixture) -> None:
+    session = _FakeSession([_FakeResp(500), _FakeResp(500)])
+    client = _client_with(session)
+    with caplog.at_level(logging.WARNING, logger="kiro_crew.wakatime.client"):
+        await client.get_summaries("2026-09-01", "2026-09-03")
+    assert _FAKE_KEY not in caplog.text
+
+
+async def test_close_is_idempotent() -> None:
+    session = _FakeSession([])
+    client = _client_with(session)
+    await client.close()
+    assert session.closed is True
+    await client.close()

--- a/test/test_wakatime_service.py
+++ b/test/test_wakatime_service.py
@@ -1,0 +1,74 @@
+"""Tests for the WakaTime service resolver (config + secret -> client)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from kiro_crew.secrets.vault import SecretValue
+from kiro_crew.wakatime import service
+from kiro_crew.wakatime.client import DEFAULT_API_BASE
+
+
+class _FakeVault:
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+
+    def get(self, name: str) -> SecretValue | None:
+        return SecretValue(self._value) if self._value is not None else None
+
+
+class _FakeWakaCfg:
+    def __init__(self, *, enabled: bool, api_base_url: str = "") -> None:
+        self.enabled = enabled
+        self.api_base_url = api_base_url
+
+
+class _FakeConfig:
+    def __init__(self, *, enabled: bool, api_base_url: str = "") -> None:
+        self.wakatime = _FakeWakaCfg(enabled=enabled, api_base_url=api_base_url)
+
+
+def test_resolve_api_key_reads_the_vault(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "SecretVault", lambda _dir: _FakeVault("vault_key"))
+    monkeypatch.setattr(service, "config_dir", lambda: "/nowhere")
+    assert service.resolve_api_key() == "vault_key"
+
+
+def test_resolve_api_key_empty_when_vault_has_no_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "SecretVault", lambda _dir: _FakeVault(None))
+    monkeypatch.setattr(service, "config_dir", lambda: "/nowhere")
+    assert service.resolve_api_key() == ""
+
+
+def test_resolve_api_key_empty_on_vault_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(_dir: Any) -> Any:
+        raise RuntimeError("vault broken")
+
+    monkeypatch.setattr(service, "SecretVault", _boom)
+    monkeypatch.setattr(service, "config_dir", lambda: "/nowhere")
+    assert service.resolve_api_key() == ""
+
+
+def test_resolve_base_url_default_and_override() -> None:
+    assert service.resolve_base_url(_FakeConfig(enabled=True)) == DEFAULT_API_BASE
+    override = "https://wakapi.example.com/api/v1"
+    assert service.resolve_base_url(_FakeConfig(enabled=True, api_base_url=override)) == override
+
+
+def test_build_client_none_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "resolve_api_key", lambda: "a_key")
+    assert service.build_client(_FakeConfig(enabled=False)) is None
+
+
+def test_build_client_none_when_no_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "resolve_api_key", lambda: "")
+    assert service.build_client(_FakeConfig(enabled=True)) is None
+
+
+def test_build_client_ready_when_enabled_and_keyed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(service, "resolve_api_key", lambda: "a_key")
+    client = service.build_client(_FakeConfig(enabled=True))
+    assert client is not None
+    assert client._api_base == DEFAULT_API_BASE


### PR DESCRIPTION
<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (a new `wakatime/` package plus config wiring); no frontend paths touched and nothing renders.

## Problem / Motivation

Time spent working through the agent in the dashboard is invisible to WakaTime, so a developer's tracked coding time undercounts real work. There is also no way to pull WakaTime stats into the dashboard or export project-grouped hours for invoicing. This is the first slice of that integration: the backend client, its config, and secret handling. Endpoints, the dashboard views, and heartbeat wiring follow in later PRs.

## Why it matters

Without this foundation none of the integration can exist. Getting the client, config surface, and secret model right first keeps the follow-up PRs small and reviewable, and settles the security-sensitive decisions (where the API key lives, how it is logged) before any route or UI depends on them.

## What changed (motivation → approach → change)

The goal is a two-way WakaTime bridge; this PR builds only the layer everything else sits on. The approach mirrors the existing messaging integrations rather than inventing structure: a top-level service package with the HTTP layer in `wakatime/client.py`, modeled on `webex/client.py` because it does both a JSON POST (heartbeats) and JSON GET reads (summaries/stats/durations).

What landed:

- `wakatime/client.py` — an async `WakaTimeClient` with one lazily-created shared `aiohttp` session behind a double-checked lock, a single `_api` core honoring one `429 Retry-After` back-off then giving up, explicit per-call `ClientTimeout`, and `(aiohttp.ClientError, asyncio.TimeoutError)` caught so a failed call returns `None`/`[]` instead of raising into a turn. Auth is HTTP Basic with the API key, built only at the request site; a failing request logs `type(exc).__name__`, never the key or a key-bearing URL.
- `wakatime/service.py` — resolves the API key vault-first with a `.env`/environment fallback, reads the base URL from config, and returns a ready client or `None` when the integration is disabled or unconfigured.
- `WakaTimeConfig` in `config/sections.py` (enabled flag + optional `api_base_url` for a self-hosted Wakapi/Hackatime backend), wired through the config hierarchy in `loader.py` and registered in `resolution.py`. The API key is a vault secret, not a config field.

## Tests

- `test/test_wakatime_client.py` — auth header is Basic base64 of the key, the read verbs parse the `data` envelope, `send_heartbeats` counts accepted rows, the 429 path retries once then succeeds, a transport error degrades to empty, `verify` raises on a rejected key, and the API key never appears in a log line.
- `test/test_wakatime_service.py` — vault-first key resolution with `.env` fallback, env fallback on a vault error, base-URL default vs override, and `build_client` gating on enabled + key presence.
- `test/test_config_module_boundaries.py` — the frozen loader re-export snapshot updated to include `WakaTimeConfig`, the deliberate boundary change for the new section.

## Manual verification

N/A — unit coverage is sufficient for a client + config + resolver with no live endpoint yet. The client is exercised against a fake aiohttp session; a live WakaTime call arrives with the endpoint PR.

## Related Issues

Part of #8094
