### PR TITLE
fix(dashboard): carry the client sendId through a requeued steer

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -822,9 +822,31 @@ decline-to-guess default. `sendId` is additive optional meta everywhere it
 travels — no schema bump, and a send without one keeps the exact prior row,
 payload, and scan behavior. Pinned by the sendId tests in
 `test_chat_steer.py`, `chatThinkingSteerBoundary.test.ts`, and
-`ChatSliceCoverageSecondPass.test.tsx`. Known residual: the `STEER_REQUEUED`
-paths do not thread the id into the requeued queue entry, so a steer that
-requeues keeps today's behavior (over-keep — the bubble reconciles on reload).
+`ChatSliceCoverageSecondPass.test.tsx`.
+
+**Send identity through the REQUEUE path (#6751).** A steer whose turn dies
+before kiro-cli confirms it does not persist its own row: the teardown degrades
+it into a queue card and the DRAIN writes the row. That path is covered by the
+same id, threaded one step further. `steer_into_running_turn` records the
+normalized value in `slot._steer_send_ids` (keyed by the message text, like
+`slot._steer_delivery_ids`, and removed in LOCKSTEP with it at every site --
+the unwind, the terminal persisting tail, the hard-kill discard, and the requeue
+itself -- so an entry in one always implies an entry in the other),
+`_requeue_unconsumed_steers` moves it onto the queue entry's meta beside
+`steer_delivery_id`, and the drain's union over every consumed entry's meta
+carries it onto the row it appends. The three `STEER_REQUEUED` returns are
+deliberately NOT the write site: two of them cannot be, because one returns
+before the teardown has requeued anything and the other after the drain has
+already written the row, so the requeue is the only writer common to all three.
+The resulting row is a non-steer user row carrying `meta.sendId` -- the same
+shape `api_chat`'s new-turn path already persists -- so `mergePreservedThinking`
+reads it as a new-turn boundary for that id and the finished turn's chip drops
+with coverage instead of stranding at the tail until a reload. No client change.
+Known residual: `_drained_meta` accumulates only `steer_delivery_id` (into
+`steer_delivery_ids`) and is last-writer-wins for every other key, so a row that
+MERGES two requeued steers keeps one `sendId` and the other send keeps the
+over-keep default. Pinned by the requeue sendId tests in
+`test_steer_requeue.py`.
 
 ### Wait countdown and early end (`/api/session-keepalive` as a control channel)
 

--- a/src/kiro_crew/dashboard/chat_delivery.py
+++ b/src/kiro_crew/dashboard/chat_delivery.py
@@ -219,6 +219,18 @@ async def steer_into_running_turn(
     # through a merge.
     delivery_id = uuid.uuid4().hex
     slot._steer_delivery_ids[message] = delivery_id
+    # Recorded HERE, next to the delivery id, because the requeue is what needs it
+    # and the requeue runs in the TURN's teardown -- another coroutine, which never
+    # sees this call's arguments. The three `STEER_REQUEUED` returns below cannot
+    # do this themselves: two of them have no queue entry to write to at the moment
+    # they run (one returns before the teardown has requeued anything, the other
+    # after the drain already wrote the row), so the only common writer is
+    # `_requeue_unconsumed_steers`. Normalized value, not the raw argument -- the
+    # entry meta is persisted with the queue and reaches the row, so it must clear
+    # the same gate the row stamp does. Absent id stores nothing, which keeps the
+    # requeued entry's meta byte-identical to its pre-#6751 shape.
+    if send_id:
+        slot._steer_send_ids[message] = send_id
     slot._pending_steers.append(message)
     try:
         steered = await client.steer(message)
@@ -241,6 +253,7 @@ async def steer_into_running_turn(
         # writing a second one. Checked first: it is the one signal that survives
         # every intermediate transition, including a merged row.
         slot._steer_delivery_ids.pop(message, None)
+        slot._steer_send_ids.pop(message, None)
         logger.info(
             "steer for slot %s was requeued and drained during the RPC; row already " "persisted",
             slot.key,
@@ -259,6 +272,7 @@ async def steer_into_running_turn(
             # plain remove and not an index dance over possible duplicates.
             slot._pending_steers.remove(message)
             slot._steer_delivery_ids.pop(message, None)
+            slot._steer_send_ids.pop(message, None)
             return STEER_UNAVAILABLE
         if stopped:
             # Still registered means the teardown has not run yet and will
@@ -332,6 +346,10 @@ async def steer_into_running_turn(
     # deliberately keep theirs because `chat_runner`'s drain still has to match it,
     # and that entry is bounded by the queue.
     slot._steer_delivery_ids.pop(message, None)
+    # Same lockstep, same reason: this delivery stamps `sendId` onto its own row a
+    # few lines below, so nothing will read the map entry again and leaving it
+    # would hold a full message string for the slot's lifetime.
+    slot._steer_send_ids.pop(message, None)
 
     ts = datetime.now(timezone.utc).isoformat()
     # Cut the in-flight text segment at the steer boundary BEFORE persisting the

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2761,6 +2761,10 @@ async def stop_slot_turn(
         # of having a row persisted for a message that never ran.
         for _discarded in slot._pending_steers:
             slot._steer_delivery_ids.pop(_discarded, None)
+            # Lockstep with the line above (see `_ChatSlot._steer_send_ids`): a hard
+            # kill discards the text, so there is no requeued entry left to carry
+            # the client's send id onto.
+            slot._steer_send_ids.pop(_discarded, None)
         slot._pending_steers.clear()
         state.push_slots_update()
         logger.info("Stop (force): hard-killing session for slot %s", name)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4101,6 +4101,19 @@ def _requeue_unconsumed_steers(state: "DashboardState", slot: "_ChatSlot") -> No
         _did = getattr(slot, "_steer_delivery_ids", {}).pop(steer_msg, "")
         if _did:
             _meta["steer_delivery_id"] = _did
+        # Carry the client's `sendId` the same way, for the same reason one step
+        # further on (#6751). The drain unions this meta onto the row it writes, so
+        # this is what gives a REQUEUED steer's row the `meta.sendId` an ACCEPTED
+        # steer's row already gets from `steer_into_running_turn` -- without it the
+        # row is id-less, `mergePreservedThinking` has no id to resolve the
+        # optimistic bubble against, and the pre-steer thinking chip strands at the
+        # tail until a reload. Popped in lockstep with the delivery id above so the
+        # two maps never disagree about what is still in flight. Additive: a steer
+        # whose POST carried no id stores nothing here and its entry meta keeps the
+        # exact prior shape.
+        _sid = getattr(slot, "_steer_send_ids", {}).pop(steer_msg, "")
+        if _sid:
+            _meta["sendId"] = _sid
         # Provenance is derivable, not guessed: `steer_into_running_turn` has
         # exactly one caller (the api_chat composer branch), and app isolation
         # confines app-surface requests to app-scoped slots — so every steer

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3191,6 +3191,7 @@ class _ChatSlot:
         "_native_subagent_output",
         "_pending_steers",
         "_steer_delivery_ids",
+        "_steer_send_ids",
         "_wait_state",
         "_end_wait_request",
         "_wait_last_ping",
@@ -3790,6 +3791,15 @@ class _ChatSlot:
         # persisted from one the running turn consumed — a distinction the bare
         # text cannot make.
         self._steer_delivery_ids: dict[str, str] = {}
+        # The client's `sendId` for an in-flight steer that supplied one, keyed by
+        # the same message text as `_steer_delivery_ids`. Kept in LOCKSTEP with
+        # that map -- every site that removes a delivery id removes this too -- so
+        # "present here" always implies "present there" and no reader has to ask
+        # which of the two a half-finished path left behind. Only the requeue reads
+        # it: it moves the id onto the queue entry's meta so the drained row
+        # carries `meta.sendId` like an accepted steer's row does (#6751). A steer
+        # that persists its own row stamps the id directly and drops this entry.
+        self._steer_send_ids: dict[str, str] = {}
         # In-flight `wait` tool sleep, as reported by the tool's own keepalive
         # ping: {"wait_id": str, "seconds": int, "deadline_ts": float}. The
         # deadline is on the dashboard's clock (see api_session_keepalive) so

--- a/test/test_steer_requeue.py
+++ b/test/test_steer_requeue.py
@@ -48,6 +48,11 @@ class TestDeliveryIdLifecycle:
     on purpose -- the drain in `chat_runner` still has to match the id, and that
     entry is bounded by the queue -- but a delivery that persists its own row is
     terminal here and nothing downstream will read it again.
+
+    `_steer_send_ids` (#6751) is the same shape with the same failure mode, and is
+    removed in LOCKSTEP with the delivery id at every site, so these pins assert
+    BOTH maps rather than growing a parallel test class. Each POST below carries a
+    `meta.sendId`, without which the second assertion would be vacuous.
     """
 
     @pytest.mark.asyncio
@@ -63,13 +68,27 @@ class TestDeliveryIdLifecycle:
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post(
-                "/api/chat", json={"slot": "test", "message": "fix sw.js", "steer": True}
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "fix sw.js",
+                    "steer": True,
+                    # Carries a send id so the `_steer_send_ids` assertion below is a
+                    # real pin rather than a vacuous one: without it that map is
+                    # never populated and the assertion holds even with the pop
+                    # removed (#6751).
+                    "meta": {"sendId": "s-m4k2p1-9x7"},
+                },
             )
             assert resp.status == 200
 
         assert slot._steer_delivery_ids == {}, (
             "a delivered steer that persisted its own row is terminal; its id has "
             "no later reader, so keeping it holds the message text for the slot's life"
+        )
+        assert slot._steer_send_ids == {}, (
+            "same for the send id (#6751): this delivery stamped it onto its own "
+            "row, so nothing downstream reads the map entry again"
         )
 
     @pytest.mark.asyncio
@@ -86,10 +105,19 @@ class TestDeliveryIdLifecycle:
 
         async with TestClient(TestServer(_make_app(state))) as client:
             await client.post(
-                "/api/chat", json={"slot": "test", "message": "fix sw.js", "steer": True}
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": "fix sw.js",
+                    "steer": True,
+                    "meta": {"sendId": "s-m4k2p1-9x7"},
+                },
             )
 
         assert slot._steer_delivery_ids == {}
+        # The unwind hands delivery to the queue fallback, which mints no steer, so
+        # nothing will read this entry either (#6751).
+        assert slot._steer_send_ids == {}
 
     @pytest.mark.asyncio
     async def test_many_successful_steers_do_not_accumulate(
@@ -109,10 +137,18 @@ class TestDeliveryIdLifecycle:
             for n in range(5):
                 await client.post(
                     "/api/chat",
-                    json={"slot": "test", "message": f"unique message {n}", "steer": True},
+                    json={
+                        "slot": "test",
+                        "message": f"unique message {n}",
+                        "steer": True,
+                        # A distinct id per send: the growth shape is what makes this
+                        # a leak, so each send must contribute its own key (#6751).
+                        "meta": {"sendId": f"s-m4k2p1-{n}"},
+                    },
                 )
 
         assert slot._steer_delivery_ids == {}
+        assert slot._steer_send_ids == {}
 
 
 class TestSteerPendingTracking:
@@ -576,3 +612,407 @@ class TestHardKillDiscardsSteers:
 
         assert slot._queue == []
         assert slot._pending_steers == []
+
+
+class TestRequeuedSteerCarriesTheClientSendId:
+    """A steer the turn never confirmed must reach its ROW with the client id.
+
+    An ACCEPTED steer persists its own row and stamps `meta.sendId` there
+    (#6075). A REQUEUED steer does not persist anything: the teardown degrades it
+    into a queue card and the DRAIN writes the row. So the id has to travel one
+    step further -- registration, queue entry meta, drained row -- or the row is
+    id-less and `mergePreservedThinking` has nothing to resolve the tab's
+    optimistic bubble against, leaving the pre-steer thinking chip stranded at the
+    tail until a reload (#6751).
+
+    The three `STEER_REQUEUED` returns are deliberately NOT the write site, which
+    is why no test here asserts against them: one of them returns BEFORE the
+    teardown has requeued anything and another AFTER the drain already wrote the
+    row, so neither has an entry to stamp at the moment it runs. The requeue is
+    the only writer common to all three, so that is what these tests drive.
+    """
+
+    _TEXT = "use the cached build"
+    #: Same shape the client mints (`s-<base36>-<base36>`), so the value under
+    #: test passes the real `normalize_send_id` gates rather than a stand-in.
+    _SEND_ID = "s-m4k2p1-9x7"
+
+    def _steer_client(self, on_steer):
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = on_steer
+        return client_mock
+
+    @pytest.mark.asyncio
+    async def test_requeued_entry_meta_carries_the_send_id(self, tmp_path, monkeypatch, _patch_sel):
+        """End to end from the POST: register, requeue, read the entry meta.
+
+        The requeue runs INSIDE the steer RPC's await, driving the real
+        `_requeue_unconsumed_steers` rather than a hand-rolled stand-in, so the
+        entry meta asserted here is the one production writes.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+
+        async def _steer(message):
+            from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+            _requeue_unconsumed_steers(state, slot)
+            return True
+
+        slot._acp_client = self._steer_client(_steer)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": self._TEXT,
+                    "steer": True,
+                    "meta": {"sendId": self._SEND_ID},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        assert [i["content"] for i in slot._queue] == [self._TEXT]
+        assert slot._queue[0]["meta"].get("sendId") == self._SEND_ID, (
+            "the requeued entry must carry the client's sendId -- the drain unions "
+            "entry meta onto the row it writes, so this is the only place the id "
+            "can be put for a steer that never persists its own row"
+        )
+        # The delivery id still rides along: this fix ADDS a key, it does not
+        # displace the one the drain already matches on.
+        assert slot._queue[0]["meta"].get("steer_delivery_id")
+
+    @pytest.mark.asyncio
+    async def test_drained_row_carries_the_send_id(self, tmp_path, monkeypatch):
+        """The leg the fix RELIES on rather than changes: entry meta -> row meta.
+
+        Asserted end to end because "the id is on the queue entry" is worth
+        nothing on its own -- the row is what the frontend reads. The drain's
+        union already carries arbitrary entry meta (it is how a merged row names
+        its steer delivery ids), and this pins that `sendId` is not filtered out
+        of it.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.subagents = None
+        slot = state.get_or_create_slot("test")
+        slot._pending_steers = [self._TEXT]
+        slot._steer_delivery_ids = {self._TEXT: "did-1"}
+        slot._steer_send_ids = {self._TEXT: self._SEND_ID}
+
+        from kiro_crew.dashboard import chat_runner
+
+        chat_runner._requeue_unconsumed_steers(state, slot)
+
+        with (
+            patch.object(chat_runner, "spawn_guarded_turn", return_value=MagicMock()),
+            patch.object(chat_runner, "_run_chat", return_value=MagicMock()),
+        ):
+            assert await chat_runner._start_next_queued_turn(state, slot) is True
+
+        rows = [m for m in slot.messages if m.get("role") == "user"]
+        assert rows, "the drain must have written a user row for the requeued steer"
+        assert (rows[-1].get("meta") or {}).get("sendId") == self._SEND_ID, (
+            "the drained row is what mergePreservedThinking reads; without the id "
+            "on it the optimistic bubble cannot be resolved by identity"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_steer_without_a_send_id_keeps_the_prior_entry_shape(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """Additive, not mandatory: an old client's POST carries no id.
+
+        Pinned as an ABSENT KEY rather than a falsy value -- an empty string would
+        travel to the row and give the frontend an id that matches nothing.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+
+        async def _steer(message):
+            from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+            _requeue_unconsumed_steers(state, slot)
+            return True
+
+        slot._acp_client = self._steer_client(_steer)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat", json={"slot": "test", "message": self._TEXT, "steer": True}
+            )
+            assert resp.status == 200
+
+        assert [i["content"] for i in slot._queue] == [self._TEXT]
+        assert "sendId" not in slot._queue[0]["meta"]
+
+    @pytest.mark.asyncio
+    async def test_an_unusable_send_id_is_treated_as_absent(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """The requeue must inherit `normalize_send_id`, not the raw POST value.
+
+        The entry meta is persisted with the queue and reaches the row, so a value
+        that fails the id gates must not get there by the requeue door after being
+        refused at the row door.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+
+        async def _steer(message):
+            from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+            _requeue_unconsumed_steers(state, slot)
+            return True
+
+        slot._acp_client = self._steer_client(_steer)
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": self._TEXT,
+                    "steer": True,
+                    # A JWT dot and base64 padding: outside the id alphabet, which
+                    # is exactly what that alphabet exists to exclude.
+                    "meta": {"sendId": "a.b/c+d="},
+                },
+            )
+            assert resp.status == 200
+
+        assert "sendId" not in slot._queue[0]["meta"]
+
+
+class TestSendIdMapLifecycle:
+    """The pop sites the extended `TestDeliveryIdLifecycle` pins do not reach.
+
+    `_steer_send_ids` is keyed by message TEXT, so a leaked entry holds a full
+    message for the slot's lifetime. It is removed in LOCKSTEP with
+    `_steer_delivery_ids` at FIVE sites, and a property enforced at five sites
+    needs five proofs. Two of them -- the terminal persisting tail and the unwind
+    -- are already pinned above by the delivery-id lifecycle tests now that their
+    POSTs carry a send id. The remaining three are here: the requeue, the hard
+    kill, and the already-drained return.
+    """
+
+    _TEXT = "fix sw.js"
+    _SEND_ID = "s-m4k2p1-9x7"
+
+    @pytest.mark.asyncio
+    async def test_the_requeue_moves_the_entry_out(self, tmp_path, monkeypatch):
+        """Moved onto the queue entry, not copied -- the map must not keep it."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")
+        slot._pending_steers = [self._TEXT]
+        slot._steer_delivery_ids = {self._TEXT: "did-1"}
+        slot._steer_send_ids = {self._TEXT: self._SEND_ID}
+
+        from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+        _requeue_unconsumed_steers(state, slot)
+
+        assert slot._queue[0]["meta"].get("sendId") == self._SEND_ID
+        assert slot._steer_send_ids == {}
+        assert slot._steer_delivery_ids == {}
+
+    @pytest.mark.asyncio
+    async def test_many_requeued_steers_neither_accumulate_nor_cross_attribute(
+        self, tmp_path, monkeypatch
+    ):
+        """The growth shape for the REQUEUE loop, which one steer cannot show.
+
+        Every other test here requeues a SINGLE pending steer, and with one entry
+        the loop variable and any fixed index into the batch are the same value. So
+        a classic loop-variable slip -- popping `requeued[0]` rather than
+        `steer_msg` -- is invisible to all of them: measured, the whole file stays
+        green under exactly that mutation.
+
+        It has two consequences and this pins both. The map keeps an entry per
+        extra steer, which is the leak the accumulation pin exists for. Worse, the
+        later entries get the FIRST steer's id stamped on them, so the drained row
+        for steer B would name steer A's send and the client would reconcile the
+        wrong bubble -- a correctness fault, not just memory. Asserting each entry
+        against its OWN id catches that direction; asserting only that the map
+        emptied would not.
+
+        The existing accumulation pin drives five ACCEPTED steers, which take the
+        terminal tail and enter the requeue loop zero times, so it cannot cover
+        this even though it is the same failure mode one layer up.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("test")
+        texts = ["steer alpha", "steer beta", "steer gamma"]
+        slot._pending_steers = list(texts)
+        slot._steer_delivery_ids = {t: f"did-{n}" for n, t in enumerate(texts)}
+        slot._steer_send_ids = {t: f"s-m4k2p1-{n}" for n, t in enumerate(texts)}
+
+        from kiro_crew.dashboard.chat_runner import _requeue_unconsumed_steers
+
+        _requeue_unconsumed_steers(state, slot)
+
+        # Requeued at the HEAD in reversed order, so the queue preserves the
+        # original pending order (pinned by the ordering test above).
+        assert [item["content"] for item in slot._queue] == texts
+        paired = {item["content"]: item["meta"].get("sendId") for item in slot._queue}
+        assert paired == {t: f"s-m4k2p1-{n}" for n, t in enumerate(texts)}, (
+            "each requeued entry must carry ITS OWN send id; a shared or shifted id "
+            "makes the drained row name a different send and the client reconcile "
+            "the wrong optimistic bubble"
+        )
+        assert slot._steer_send_ids == {}, (
+            "one leaked entry per requeued steer is the growth shape a single-steer "
+            "test cannot see"
+        )
+        assert slot._steer_delivery_ids == {}
+
+    @pytest.mark.asyncio
+    async def test_a_hard_kill_drops_the_entry(self, tmp_path, monkeypatch, _patch_sel):
+        """A force stop discards the text, so no requeued entry will carry it."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.push_slots_update = MagicMock()
+        state.sessions.stop_turn = AsyncMock()
+        slot = _running_slot(state)
+        slot._stop_state = "soft_pending"  # first press already happened
+        slot._pending_steers = [self._TEXT]
+        slot._steer_delivery_ids = {self._TEXT: "did-1"}
+        slot._steer_send_ids = {self._TEXT: self._SEND_ID}
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/stop?force=true")
+            assert resp.status == 200
+
+        assert slot._steer_send_ids == {}, (
+            "the hard kill discarded the text, so nothing downstream will ever "
+            "read this id -- keeping it holds the message for the slot's lifetime"
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_real_already_drained_path_finds_the_maps_already_clean(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """Why the fifth pop needs a CONSTRUCTED state to observe: it is defensive.
+
+        The `_row_has_delivery_id` return is reached only when the whole
+        requeue-then-drain sequence completed during the steer RPC -- and the
+        requeue is what pops both maps, so by the time that return runs they are
+        already empty. This drives the REAL sequence (real requeue, real drain) and
+        records that precondition, so the constructed pin below is honestly
+        labelled a defensive-invariant pin rather than a production-path one.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.subagents = None
+        slot = _running_slot(state)
+        observed: dict[str, object] = {}
+
+        async def _requeue_and_drain(message):
+            from kiro_crew.dashboard import chat_runner
+
+            chat_runner._requeue_unconsumed_steers(state, slot)
+            with (
+                patch.object(chat_runner, "spawn_guarded_turn", return_value=MagicMock()),
+                patch.object(chat_runner, "_run_chat", return_value=MagicMock()),
+            ):
+                await chat_runner._start_next_queued_turn(state, slot)
+            # Snapshot BEFORE the steer path resumes and runs its own pop.
+            observed["delivery"] = dict(slot._steer_delivery_ids)
+            observed["send"] = dict(slot._steer_send_ids)
+            return True
+
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = _requeue_and_drain
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": self._TEXT,
+                    "steer": True,
+                    "meta": {"sendId": self._SEND_ID},
+                },
+            )
+            assert resp.status == 200
+            # `queued` is the STEER_REQUEUED receipt: the row was already written
+            # by the drain, so this is the return under discussion.
+            assert (await resp.json()).get("queued") is True
+
+        assert observed["send"] == {}, (
+            "the requeue already emptied the map, which is why removing the pop at "
+            "this return cannot redden a production-path test"
+        )
+        assert observed["delivery"] == {}, "same precondition for the delivery id"
+        # The row the drain wrote carries the id, which is the whole point of the
+        # threading -- this return is not a path where the id is lost.
+        rows = [m for m in slot.messages if m.get("role") == "user"]
+        assert rows and (rows[-1].get("meta") or {}).get("sendId") == self._SEND_ID
+
+    @pytest.mark.asyncio
+    async def test_the_already_drained_return_clears_a_populated_map(
+        self, tmp_path, monkeypatch, _patch_sel
+    ):
+        """Defensive-invariant pin for the fifth pop site.
+
+        The state is CONSTRUCTED, not produced: the test above shows the real path
+        reaches this return with both maps already empty. The pop is kept anyway
+        because the lockstep rule -- an entry in one map implies an entry in the
+        other -- is what every reader of these two maps relies on, and the existing
+        `_steer_delivery_ids` pop at this same return is defensive for exactly the
+        same reason. This pin is what makes removing either of them fail.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = _running_slot(state)
+
+        async def _write_row_only(message):
+            # The drain's effect WITHOUT the requeue's bookkeeping: a durable row
+            # carrying this steer's delivery id, both maps left populated. That is
+            # what forces `_row_has_delivery_id` true with entries still present.
+            did = slot._steer_delivery_ids[message]
+            slot.append("user", message, "msg msg-u", meta={"steer_delivery_id": did})
+            return True
+
+        client_mock = MagicMock()
+        client_mock.supports_steer = True
+        client_mock.steer = _write_row_only
+        slot._acp_client = client_mock
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat",
+                json={
+                    "slot": "test",
+                    "message": self._TEXT,
+                    "steer": True,
+                    "meta": {"sendId": self._SEND_ID},
+                },
+            )
+            assert resp.status == 200
+            assert (await resp.json()).get("queued") is True
+
+        assert slot._steer_send_ids == {}, (
+            "the already-drained return must clear the send id in lockstep with the "
+            "delivery id, or a reader cannot assume the two maps agree"
+        )
+        assert slot._steer_delivery_ids == {}


### PR DESCRIPTION
## What is the problem?

A steer that reaches kiro-cli persists its own transcript row and stamps the
client's `meta.sendId` on it, which is how the initiating tab resolves its
optimistic bubble by identity instead of by text (#6075).

A steer whose turn dies before kiro-cli confirms it persists nothing. The
turn's teardown degrades it into an ordinary queue card
(`_requeue_unconsumed_steers`) and the queue DRAIN writes the row. That path
carried the steer's delivery id but not the client's send id, so the drained
row was id-less.

## Why this issue matters to the user

`mergePreservedThinking` resolves an optimistic steer bubble's
accepted-vs-new-turn ambiguity from the covered page's row with that id. With
no id on the row there is nothing to resolve against, so the scan falls back
to its decline-to-guess default and the pre-steer "Thinking" chip stays pinned
at the transcript tail until the user reloads the page.

The direction is safe (over-keep, never over-drop) and there is no regression
against pre-#6075 behaviour, which is why this was accepted as a documented
residual rather than a blocker. It is still a visibly wrong transcript on a
race the user did not cause.

## How our fix solves it

The chain from symptom to root cause:

- Symptom: a requeued steer's row renders with a stranded thinking chip.
- Because: the row carries no `meta.sendId`, so the id-first resolution has no
  key.
- Because: the row is written by the DRAIN, not by `steer_into_running_turn`,
  and the requeued queue entry the drain consumes carried only
  `steer_delivery_id`.
- Because: the send id lived only in `steer_into_running_turn`'s arguments, and
  the requeue runs in the TURN's teardown - a different coroutine that never
  sees them.

So the fix threads the id one step further, at the only site that can:

1. `steer_into_running_turn` records the value in `slot._steer_send_ids`
   immediately after `slot._steer_delivery_ids[message] = delivery_id`.
2. `_requeue_unconsumed_steers` pops it and stamps `meta["sendId"]` onto the
   queue entry beside `steer_delivery_id`.
3. The drain's existing union over every consumed entry's meta carries it onto
   the row it appends. This leg is relied on, not changed - it already filters
   only `QUEUED_CONTAINMENT_META_KEY`, and a test now pins that `sendId`
   survives it.

Three choices worth a reviewer's attention:

**The three `STEER_REQUEUED` returns are not the write site**, although the
issue's suggested fix names them. Two of them cannot be: the one at the
`stopped`-with-registration branch returns BEFORE the teardown has requeued
anything, and the one guarded by `_row_has_delivery_id` returns AFTER the drain
already wrote the row. Neither has an entry to stamp at the moment it runs.
`_requeue_unconsumed_steers` is the single writer common to all three, and
stamping there covers the `_row_has_delivery_id` return too, because that
return's row was appended by a drain that had already unioned the entry meta.
This is a deliberate departure from the issue's wording, not an oversight of
it: a diff that instead stamped at the three returns would leave two of them
writing to a queue entry that does not exist yet or no longer matters.

**The stored value is the normalized one.** `normalize_send_id` gates the raw
client value on an id alphabet plus the canonical credential scan, precisely
because the value is persisted and broadcast without the outbound redaction the
message text goes through. A queue entry's meta is persisted with the queue and
reaches the row, so it has to clear the same gate - recording the raw argument
would let a refused value in by the requeue door after being refused at the row
door.

**The lockstep set is five sites, and all five are covered.**
`_steer_delivery_ids` is removed in production code at five places: the
already-drained return, the unwind, and the terminal persisting tail in
`chat_delivery.py`; the hard-kill discard in `chat_handlers.py`; and the
requeue in `chat_runner.py`. `_steer_send_ids` is keyed by message text, so
missing any one of them leaks a full message string for the slot's lifetime.
Each site has a sibling pop, which gives readers the invariant that an entry in
one map always implies an entry in the other.

No frontend change. The resulting row is a non-steer user row carrying
`meta.sendId` - the same shape `api_chat`'s new-turn path already persists - so
`rowIdentityKeys` produces `send:<id>` for it and the existing scan handles it.
Verified that no history or hydration reducer marks a server row
`optimistic: true`: all three `optimistic: true` assignments in `chatSlice.ts`
are in client-side optimistic append reducers (`appendMessage`,
`appendSlotMessage`, `sideOptimisticAppend`), so a persisted row carrying a
send id cannot be mistaken for an unconfirmed bubble.

## What tests we did

All runs used `PYTHONPATH=<worktree>/src` so the worktree's source is what
executes rather than the shared venv's editable install pointing at another
checkout, and one named file per invocation.

Three EXISTING leak pins in `TestDeliveryIdLifecycle` were extended rather than
duplicated, because they already encode when the slot must be clean. Their
POSTs now carry a `meta.sendId` and each asserts both maps - without the send id
the added assertion would have been vacuously true and would have passed with
the pop removed.

New end-to-end tests, driving the real `POST /api/chat` with the real
`_requeue_unconsumed_steers` invoked inside the steer RPC's await rather than a
hand-rolled stand-in:

- the requeued entry's meta carries the send id, and still carries the delivery
  id (this adds a key, it does not displace one)
- the DRAINED ROW's meta carries it, driven through the real
  `_start_next_queued_turn` with the turn dispatch patched out
- a POST with no id leaves `sendId` ABSENT from the entry meta, not present as
  an empty string that would reach the row and match nothing
- an id failing the gates (`a.b/c+d=`) is treated as absent

On the fifth pop site, honestly labelled. The `_row_has_delivery_id` return is
reached only after the requeue has ALREADY emptied both maps, so removing its
pop cannot redden a production-path test. One test drives that real sequence and
records the precondition; a second constructs the populated state directly and
pins the pop. The pop is kept rather than deleted because the lockstep invariant
is what every reader of these two maps relies on, and the existing
`_steer_delivery_ids` pop at that same return is defensive for the same reason.

One more pin exists because a hole was MEASURED rather than guessed. Every
requeue test drove a SINGLE pending steer, and with one entry the loop variable
and a fixed index into the batch are the same value -- so a classic
loop-variable slip (popping `requeued[0]` instead of `steer_msg`) left the whole
file green. That slip has two effects: an entry leaks per extra steer, and the
later entries get the FIRST steer's id stamped on them, so steer B's drained row
would name steer A's send and the client would reconcile the wrong bubble. The
new multi-steer requeue test asserts each entry against its OWN id, which catches
that second direction; asserting only that the map emptied would not. The
existing accumulation pin cannot cover this: its five steers are all ACCEPTED, so
they take the terminal tail and enter the requeue loop zero times.

Mutation-verified, 10 mutations: five for the five pop sites, four for the write
sites, and one for that growth shape. All ten reddened exactly their targets, and
each failure was confirmed to be an `AssertionError` by reading the failure line
rather than the exit status:

| mutation | site | reddened |
| --- | --- | --- |
| registration write removed | `chat_delivery` write | entry-meta test |
| requeue stamp removed | `chat_runner` stamp | entry-meta, drained-row, requeue-moves-it |
| requeue stamp made unconditional | `chat_runner` stamp | both absent-key tests (`sendId: ''` appears) |
| normalize call removed above the registration | ordering | unusable-id-is-absent (`a.b/c+d=` reaches the entry) |
| already-drained return pop removed | pop 1 | constructed defensive pin |
| unwind pop removed | pop 2 | existing refused-steer pin |
| terminal-tail pop removed | pop 3 | existing successful-steer and accumulation pins |
| hard-kill pop removed | pop 4 | hard-kill-drops-it |
| requeue pop downgraded to a read | pop 5 | requeue-moves-the-entry-out |
| requeue pops a FIXED key, not the loop variable | growth shape | multi-steer requeue pin (cross-attribution assertion) |

Two SOURCE-TEXT pins that a safe-looking refactor would break were read before
editing and both still pass: `spec_builder/tests/test_routes.py` asserts the
literal string `_requeue_unconsumed_steers` appears in the runner source (the
function is not renamed here), and `test_steer_requeue.py` asserts call ORDER
inside `_run_chat`'s finally by `src.index` (no code is moved in that block).

Regression suites: `test_steer_requeue.py` 36 passed, `test_chat_steer.py` 19
passed, `test_queue_drain_revalidation.py` 32 passed,
`test_chat_runner_coverage.py` 267 passed, `test_session_control.py` 142
passed, plus the one spec_builder source-text pin. `black --check`,
`isort --check-only` and `flake8` clean on all changed files. `mypy` on the four
changed modules reports 2 errors, both in `src/kiro_crew/transcribe.py`, which
this PR does not touch - they are main-owned.

One piece of pre-existing noise, measured rather than assumed: the drain test
emits a `PytestUnraisableExceptionWarning` about a never-awaited AsyncMock
coroutine. The unmodified existing `TestStartNextQueuedTurn` class in
`test_chat_runner_coverage.py` emits the same warning from the same house
pattern (`patch.object(chat_runner, "_run_chat", return_value=MagicMock())`
against an async function), so it is inherent to that pattern rather than
introduced here.

Mergeability computed rather than polled: `git merge-tree --write-tree
kirocrew/main HEAD` exits 0 (clean) against main
`2d75835f364f38fddc88efa103f5cc465b97af13`.

## Any other suggestions on the work

**The `blocked` label on #6751 is now stale and a maintainer should drop it.**
The issue was labelled `blocked` on 2026-08-29 with the explicit note "Blocked
on a prerequisite PR, not on a decision" - the prerequisite being PR #6753,
which touched the same file. #6753 merged on 2026-08-30 (merge commit
`1da8e3cb9ed29d81df8f8e6a32f999298fa131ba`, confirmed an ancestor of main), so
the blocker expired four days before this PR. Nothing removed the label.

**Known residual, which is why the trailer is `Refs` and not `Closes`.**
`_dequeue_next_message` merges consecutive queued entries into one row, and the
drain's `_drained_meta` accumulates only `steer_delivery_id` (into
`steer_delivery_ids`); every other key is last-writer-wins. So a row folding
TWO requeued steers keeps one `sendId` and the other send keeps the over-keep
default. Making it accumulate would mean the frontend reading a list of send
ids, which is a client change the issue explicitly scopes out ("The frontend
id-resolution then covers this path with no client change"). Left as a separate
concern; happy to file it as its own issue if a reviewer wants it owned.

**Overlap with open PR #7997.** That PR (`fix/steer-midturn-consume-7246`)
modifies both `chat_delivery.py` and `chat_runner.py`, and one of its hunks is
inside `_requeue_unconsumed_steers`. I read its diff: its requeue hunk is a
pure insertion of a `_mark_steer_row_state` call at the TOP of the
`for steer_msg in reversed(requeued)` loop body, roughly twenty lines above the
`_meta` construction this PR edits, and its `chat_delivery.py` hunks are at the
persisting tail and the top of the file rather than the registration site. The
two are disjoint today. Whichever lands second should re-check.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a correlation id threaded onto the row that ONE path writes, while a
sibling path hands the write to a different component. The send id was stamped
by `steer_into_running_turn` for the path that persists its own row, and the
requeue path - which delegates the write to the queue drain - silently produced
an id-less row. The generalizable check is: when a value is stamped at a write
site, enumerate every OTHER component that writes a row for the same logical
event, and confirm the value reaches each of them. Here that meant asking who
writes the row on each of the three `STEER_REQUEUED` returns, which is also
what showed that the returns themselves are the wrong place to stamp.

Second, narrower candidate for the same class: when a value is added alongside
an existing one in a map-per-message pattern, the new map's removal sites must
be enumerated from the OLD map's removal sites rather than from the paths the
change happens to touch. Grepping every mutation of `_steer_delivery_ids` is
what turned "the requeue and the hard kill" into the correct set of five.

Refs #6751
