### PR TITLE
fix: recover a JSON-escaped session-directive marker in tool results

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -351,7 +351,6 @@ src/kiro_crew/service/apparmor.py
 src/kiro_crew/service/common.py
 src/kiro_crew/service/linux.py
 src/kiro_crew/service/macos.py
-src/kiro_crew/session_directive.py
 src/kiro_crew/session_pid_sig.py
 src/kiro_crew/session_workspace.py
 src/kiro_crew/skill_providers/skillsh.py

--- a/docs/system-specs/features/agent-host-contract.md
+++ b/docs/system-specs/features/agent-host-contract.md
@@ -218,6 +218,40 @@ distinguishable, and a remedy named only where this repository actually
 establishes one — the `claude` CLI reports an empty install command rather than an
 invented one.
 
+## 9. Tool-result text fidelity (control markers)
+
+| | kiro-cli | KAS | CC |
+|---|---|---|---|
+| How a tool result arrives | `content[].content.text` blocks, or `rawOutput.items[].Text` / `.Json.stdout` | same shapes, but an MCP result can arrive as an **already-serialised** JSON envelope under a key this repository does not recognise | `content[]` text blocks |
+| Marker survives untouched | yes | **no** — the envelope reaches the consumer through `json.dumps`, which escapes every quote in it | yes |
+| Recovery | not needed | `acp/_dispatch._repair_escaped_marker`, run over the joined output before redaction and the head cut | not needed |
+
+Two consumers read a control marker out of the tool-result TEXT rather than out
+of a structured field: a session directive (`session_directive.peek` — how
+`monitor_start` / `monitor_update` / `autonudge_stop` reach the session that owns
+the loop) and an MCP App render marker (`mcp_apps_render.find_marker`). Both
+sentinels are quote-free, so JSON escaping leaves them perfectly intact while
+mangling the payload behind them. The failure that produces is silent and
+expensive: the frame still looks like it carries a directive, the consumer can no
+longer name the record the MCP stub parked, the tool answers "requested", and no
+loop arms. It cost several gateway restarts to find on KAS precisely because
+every layer looked healthy.
+
+The recovery is keyed on the sentinel, not on any envelope field name, because
+the field differs per backend; and acceptance is the test — a candidate is used
+only when `peek` actually reads a selector from it, so a wrong guess degrades to
+the original text instead of substituting something worse. A frame carrying two
+DIFFERENT markers is refused rather than resolved to the first, since applying
+the wrong directive is worse than applying none.
+
+**A provider must declare:** whether its tool-result text arrives verbatim or
+pre-serialised, and — if any builder it adds can emit an `EVENT_TOOL_RESULT` —
+that the builder runs the repair. This is the one bucket in this document with a
+ratchet instead of a checklist line: `test_session_directive_transport.py` walks
+every `AcpEvent(kind=EVENT_TOOL_RESULT)` construction under `acp/` and fails when
+one of them does not call `_repair_escaped_marker`, because a provider author is
+exactly the person who will not know this constraint exists.
+
 ## Seam status today
 
 | Bucket | Seam |
@@ -231,6 +265,7 @@ invented one.
 | 5 MCP injection | **none** — an overridable method returning `[]` is the whole extension point, and now that CC is selectable that neutral default is what a public build actually runs |
 | 7 Regex-engine parity | **none** — the deny catalog is authored against one engine |
 | 8 Auxiliary runtimes | partial — `agent_sdk/backend_install.py` is a real preflight that names each absent component before a session, but the *requirement* is still declared nowhere a type checker can see: the probe knows CC needs two binaries because it was written to, not because CC declared it |
+| 9 Tool-result marker fidelity | real — one recovery function, and the only bucket whose requirement a test enforces rather than a comment asserting it |
 
 ## New-provider checklist
 
@@ -243,6 +278,10 @@ from 1M to 200K — both documented as comments rather than enforced by an
 interface. Neither is hypothetical any more. CC is selectable on a public build,
 so a public build reaches both, and a comment is not a thing an operator can
 read.
+
+Bucket 9 is the exception worth copying: its requirement is enforced by a
+ratchet, so a new builder that drops the marker recovery fails a test instead of
+shipping a monitor loop that never arms.
 
 ## What supporting one foreign host costs today
 

--- a/docs/system-specs/features/babysit-pr-watch.md
+++ b/docs/system-specs/features/babysit-pr-watch.md
@@ -60,6 +60,20 @@ hook, or subagent from using inherited process identity to arm, rewrite, or
 stop another session's unattended loop; `test_autonudge_stop_auth.py` pins the
 binding-key-only targeting and the non-nudgeable-session refusals.
 
+A directive travels to the consumer as a marker inside the tool's own RESULT
+TEXT, and the marker's payload is the only thing that names the record the MCP
+stub parked out of band. A backend whose tool results arrive already serialised
+as JSON escapes every quote in that payload while leaving the quote-free sentinel
+intact, so the frame still looks like it carries a directive and names nothing:
+the tool answers "requested" and no loop arms. `acp/_dispatch._repair_escaped_marker`
+recovers it at every `EVENT_TOOL_RESULT` builder, `test_session_directive_transport.py`
+pins that recovery and ratchets it over any builder a new provider adds, and
+[agent-host-contract.md](agent-host-contract.md) §9 states the requirement a
+provider must declare. The consumer-side failure paths log at `warning`
+(`session-directive NOT APPLIED`, `SELECTOR UNREADABLE`, `CLAIM MISS`, `DENIED`),
+which is what makes this class of drop visible in `gateway.log` instead of
+silent.
+
 `monitor_start` binds one loop to the calling session. `AutoNudgeService._add_unserialized`
 replaces an existing loop on that binding before it persists and arms the new
 one. `test_autonudge_stop_auth.py::test_applier_monitor_start_arms_via_the_session_binding_key`

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -21,7 +21,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import mcp_apps_render
+from kiro_crew import mcp_apps_render, session_directive
 from kiro_crew.acp.types import (
     EVENT_PERMISSION_REQUEST,
     EVENT_TEXT_CHUNK,
@@ -1143,6 +1143,165 @@ def _mcp_content_text(payload: dict[str, Any]) -> str | None:
     return "\n".join(parts)
 
 
+def _marker_bearing_text(payload: dict[str, Any], _max_nodes: int = 512) -> str | None:
+    """Return the ONE string inside *payload* that carries the directive sentinel.
+
+    The last-resort companion to :func:`_mcp_content_text`, for a tool-result
+    envelope this module does not recognise as a pure text envelope. Such a
+    payload currently reaches the consumer through ``json.dumps``, which escapes
+    every quote in it -- so a directive marker embedded in one of its string
+    values arrives with ``\"kind\"`` instead of ``"kind"`` and
+    ``session_directive.peek`` can no longer parse the selector. The sentinel
+    itself survives that escaping unchanged, so the frame still LOOKS like it
+    carries a directive while naming no record: observed on the KAS backend as
+    ``json-unparseable (JSONDecodeError)`` with the envelope's own ``"}`` still
+    attached to the payload's tail.
+
+    Keyed on the SENTINEL rather than on any envelope field name, because the
+    field differs per backend and the sentinel is a fixed control token this
+    process emitted itself. Requires EXACTLY ONE match: zero means there is no
+    directive here and the caller should keep dumping the envelope, while two or
+    more means the frame is ambiguous about which string is the directive, and
+    guessing between them could apply the wrong payload. Bounded walk
+    (``_max_nodes``, depth 6) so a pathological envelope cannot spin here.
+    """
+    hits: list[str] = []
+    budget = [_max_nodes]
+
+    def _walk(node: Any, depth: int) -> None:
+        if budget[0] <= 0 or depth > 6 or len(hits) > 1:
+            return
+        budget[0] -= 1
+        if isinstance(node, str):
+            if session_directive.has_marker(node):
+                hits.append(node)
+        elif isinstance(node, dict):
+            for value in node.values():
+                _walk(value, depth + 1)
+        elif isinstance(node, list):
+            for value in node:
+                _walk(value, depth + 1)
+
+    _walk(payload, 0)
+    return hits[0] if len(hits) == 1 else None
+
+
+ELIDED_MARKER_VALUE = "[[directive marker emitted on its own line above]]"
+
+
+def _elide_marker_value(payload: Any, marker: str) -> Any:
+    """Copy *payload* with the one *marker*-bearing string replaced by a note.
+
+    The marker has to leave the envelope on its OWN line for
+    ``session_directive.peek`` to read it, but the envelope's other fields are
+    real tool output the user is owed -- dropping them to make room for the
+    marker loses transcript content (an exit status, a second text block). So
+    the marker goes out verbatim and this copy carries everything ELSE, with the
+    one value that already went out replaced by a short note instead of
+    duplicated.
+    """
+    if isinstance(payload, str):
+        return ELIDED_MARKER_VALUE if payload == marker else payload
+    if isinstance(payload, dict):
+        return {k: _elide_marker_value(v, marker) for k, v in payload.items()}
+    if isinstance(payload, list):
+        return [_elide_marker_value(v, marker) for v in payload]
+    return payload
+
+
+def _repair_escaped_marker(text: str) -> str | None:
+    """Recover a directive marker whose payload arrived JSON-ESCAPED, or None.
+
+    Some backends (observed on KAS) hand the whole tool result back already
+    serialised as JSON, so the text this module receives is the DUMP of an
+    envelope rather than the envelope itself. Every quote in the embedded
+    directive is then ``\\"`` and the envelope's own ``"}`` is glued to the
+    payload's tail, so the sentinel still arrives intact while
+    ``session_directive.peek`` can no longer read a selector out of it -- the
+    frame names a directive it cannot identify, and the parked record is never
+    claimed.
+
+    Two recoveries, tried in order, because the escaping can wrap the WHOLE text
+    or just reach the marker:
+
+    1. The whole text parses as JSON -- take the one string inside it that
+       carries the sentinel (:func:`_marker_bearing_text` for a container, the
+       value itself for a bare string).
+    2. Only the marker line is escaped -- unescape it and ``raw_decode`` the
+       first JSON value, which ignores the envelope's trailing punctuation.
+
+    ACCEPTANCE IS THE TEST, not the shape: a candidate is returned only when
+    ``peek`` actually reads a selector from it, so a wrong guess degrades to
+    None and leaves the original text untouched rather than substituting
+    something worse.
+    """
+    if not text or not session_directive.has_marker(text):
+        return None
+    if session_directive.peek(text) is not None:
+        return None  # already readable -- nothing to repair
+    if text.count(session_directive.SENTINEL) > 1:
+        # Ambiguous: recovery (2) below reads the FIRST marker line, which would
+        # be a GUESS about which directive the frame meant. Applying the wrong
+        # directive is worse than applying none, and a real frame carries one
+        # marker (a second directive arrives under its own toolCallId), so refuse.
+        return None
+
+    # (1) the entire text is a JSON dump.
+    try:
+        outer = json.loads(text)
+    except (ValueError, TypeError):
+        outer = None
+    if isinstance(outer, str):
+        if session_directive.peek(outer) is not None:
+            return outer
+    elif isinstance(outer, (dict, list)):
+        inner = _marker_bearing_text(outer if isinstance(outer, dict) else {"_": outer})
+        if inner is not None and session_directive.peek(inner) is not None:
+            # Siblings FIRST, marker LAST. Both placements keep peek working, but
+            # only this one survives display: session_directive.strip_marker cuts
+            # from the sentinel to the END of the string, so anything after the
+            # marker is dropped from the transcript the user actually reads.
+            siblings = json.dumps(_elide_marker_value(outer, inner), default=str)
+            return siblings + "\n" + inner
+
+    # (2) The escaped dump is only PART of the text -- another output part, or a
+    # line of prose, sits beside it -- so (1) cannot parse the whole thing. Undo
+    # the escaping on the marker's own line by decoding it AS the JSON string it
+    # came from: prepend the opening quote the dump's own key/colon consumed and
+    # raw_decode, which stops at that string's real closing quote and therefore
+    # ignores whatever the envelope glued onto the tail.
+    #
+    # A plain str.replace of \\" -> " CANNOT do this: a quote that was already
+    # escaped inside the directive (a message quoting a word) arrives as \\\\"
+    # and collapses to a dangling \\" that terminates the JSON string early, so
+    # every directive whose text contains a quote failed to recover.
+    idx = text.find(session_directive.SENTINEL)
+    if idx < 0:
+        return None
+    head = text[:idx]
+    rest = text[idx + len(session_directive.SENTINEL) :]
+    line, newline, following = rest.partition("\n")
+    try:
+        unescaped, _end = json.JSONDecoder().raw_decode('"' + line)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(unescaped, str):
+        return None
+    # Whatever the envelope glued on after the marker's own string (its closing
+    # `"}`, or real trailing text) is preserved BEFORE the marker, not after it.
+    # Two constraints pin that position: peek parses the marker's line as one
+    # JSON value, so the bytes cannot stay on that line; and strip_marker cuts
+    # from the sentinel to the END of the string, so a later line would be
+    # dropped from the transcript. Ahead of the marker satisfies both.
+    # `_end` indexes the quote-prefixed copy, so one char of it is our prefix.
+    suffix = line[_end - 1 :]
+    preserved = head + "".join(
+        part + "\n" for part in (suffix, following if newline else "") if part
+    )
+    candidate = preserved + session_directive.SENTINEL + unescaped
+    return candidate if session_directive.peek(candidate) is not None else None
+
+
 def _build_tool_result_event(update: dict[str, Any], cache_scope: str = "") -> AcpEvent | None:
     """Build an ``EVENT_TOOL_RESULT`` from a ``tool_call_update`` carrying output.
 
@@ -1201,13 +1360,70 @@ def _build_tool_result_event(update: dict[str, Any], cache_scope: str = "") -> A
                             output_parts.append(str(j["stdout"]))
                         else:
                             _mcp_text = _mcp_content_text(j)
+                            # Track provenance explicitly. Re-deriving it by
+                            # object identity (`_mcp_text is _mcp_content_text(j)`)
+                            # is wrong: a recognised text envelope with >=2 blocks
+                            # returns a FRESH join each call, so the identity test
+                            # reports "marker-bearing" for an ordinary result and
+                            # emits its whole envelope a second time.
+                            _marker_envelope = False
+                            if _mcp_text is None:
+                                # Not a recognised text envelope. Before dumping
+                                # it -- which would escape every quote and
+                                # destroy an embedded directive payload -- check
+                                # whether one of its strings IS the directive.
+                                _mcp_text = _marker_bearing_text(j)
+                                if _mcp_text is not None:
+                                    _marker_envelope = True
+                                    logger.warning(
+                                        "tool-result envelope is not a text envelope but "
+                                        "carries a session-directive marker; using that "
+                                        "string verbatim instead of json.dumps, which "
+                                        "would escape its payload. Envelope keys: %s",
+                                        sorted(j.keys()),
+                                    )
                             if _mcp_text is not None:
+                                if _marker_envelope:
+                                    # The envelope's other fields are real output.
+                                    # They go BEFORE the marker: strip_marker cuts
+                                    # from the sentinel to the end of the string,
+                                    # so anything after it is lost from display.
+                                    output_parts.append(
+                                        json.dumps(_elide_marker_value(j, _mcp_text), default=str)
+                                    )
                                 output_parts.append(_mcp_text)
                             else:
                                 output_parts.append(json.dumps(j, default=str))
     if not output_parts:
         return None
     joined = "\n".join(output_parts)
+    # Repair a marker that arrived JSON-escaped, BEFORE redaction and the head
+    # cut: the consumer reads its selector out of this exact string, and an
+    # escaped payload names no parked record (see _repair_escaped_marker).
+    _repaired = _repair_escaped_marker(joined)
+    if _repaired is not None:
+        # No payload excerpt: this text is PRE-redaction (redaction runs on the
+        # join below) and these warnings land in the persistent log ring that
+        # /api/logs serves, so an excerpt here would publish credentials that
+        # the transcript itself never shows. Length is the diagnostic.
+        logger.warning(
+            "tool-result text carried a JSON-ESCAPED session-directive marker; "
+            "repaired it so the selector is readable (payload %d chars).",
+            len(joined),
+        )
+        joined = _repaired
+    elif session_directive.has_marker(joined) and session_directive.peek(joined) is None:
+        # The frame names a directive whose selector cannot be read and the
+        # repair could not recover it either. Logged HERE because a silent None
+        # from the repair is indistinguishable downstream from a transport that
+        # never carried a marker at all -- which is what made this class of
+        # failure invisible.
+        logger.warning(
+            "tool-result carries a session-directive marker whose selector is "
+            "UNREADABLE and could not be repaired: %s (payload %d chars).",
+            session_directive.peek_failure_reason(joined),
+            len(joined),
+        )
     final_output = _redact(joined)[:8000]
     # An MCP App render marker lives at offset 0 of its own text part, but the
     # 8000-char join cut is applied to the CONCATENATION of all parts: when the

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -46,6 +46,8 @@ from kiro_crew import agent_scratch, model_registry, platform_compat
 from kiro_crew.acp._dispatch import (
     _kiro_mcp_server_name,
     _kiro_tool_name,
+    _marker_bearing_text,
+    _repair_escaped_marker,
     build_permission_event,
     derive_edit_diff,
     extract_tool_purpose,
@@ -168,6 +170,7 @@ from kiro_crew.sandbox import (
 )
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
+from kiro_crew.session_directive import content_free_digest
 from kiro_crew.skill_usage import get_global_skill_read_observer
 
 logger = logging.getLogger(__name__)
@@ -6685,12 +6688,45 @@ class AcpClient:
                             if "stdout" in j and j.get("stdout"):
                                 output_parts.append(str(j["stdout"])[:4000])
                             else:
-                                output_parts.append(json.dumps(j, default=str)[:4000])
+                                # An unrecognised structured envelope reaches the
+                                # consumer through json.dumps, which escapes every
+                                # quote in it. That is lossless for display but
+                                # fatal for a session-directive marker: the
+                                # sentinel survives while its payload becomes
+                                # \\"kind\\", so peek() can no longer name the
+                                # parked record and the directive is dropped. Emit
+                                # that one string verbatim instead.
+                                _marker = _marker_bearing_text(j)
+                                if _marker is not None:
+                                    logger.warning(
+                                        "tool-result rawOutput Json envelope carries a "
+                                        "session-directive marker; using that string "
+                                        "verbatim instead of json.dumps, which would "
+                                        "escape its payload. Envelope keys: %s",
+                                        sorted(j.keys()),
+                                    )
+                                    output_parts.append(_marker[:4000])
+                                else:
+                                    output_parts.append(json.dumps(j, default=str)[:4000])
 
         if not output_parts:
             return None
 
-        final_output = "\n".join(output_parts)[:8000]
+        final_output = "\n".join(output_parts)
+        # Repair a marker that arrived JSON-escaped, BEFORE redaction and the
+        # head cut: the consumer reads its selector out of this exact string.
+        _repaired = _repair_escaped_marker(final_output)
+        if _repaired is not None:
+            logger.warning(
+                "tool-result text carried a JSON-ESCAPED session-directive "
+                "marker; repaired it so the selector is readable. "
+                "Original: %dB sha=%s (content withheld -- this runs BEFORE "
+                "redaction, so the frame is unredacted here).",
+                len(final_output),
+                content_free_digest(final_output),
+            )
+            final_output = _repaired
+        final_output = final_output[:8000]
         final_output, _ = redact_exfiltration_urls(final_output)
         final_output, _ = redact_credentials(final_output)
         return AcpEvent(
@@ -6856,7 +6892,16 @@ class AcpClient:
                                     if out:
                                         output_parts.append(out[:4000])
                                 else:
-                                    output_parts.append(json.dumps(d, indent=2)[:4000])
+                                    # See the rawOutput Json branch above: a dump
+                                    # escapes an embedded directive marker beyond
+                                    # what peek() can read.
+                                    _marker = (
+                                        _marker_bearing_text(d) if isinstance(d, dict) else None
+                                    )
+                                    if _marker is not None:
+                                        output_parts.append(_marker[:4000])
+                                    else:
+                                        output_parts.append(json.dumps(d, indent=2)[:4000])
                             elif rc.get("kind") == "text":
                                 output_parts.append(str(rc.get("data", ""))[:4000])
                         if output_parts:
@@ -6864,7 +6909,10 @@ class AcpClient:
                                 AcpEvent(
                                     kind=EVENT_TOOL_RESULT,
                                     tool_call_id=tool_use_id,
-                                    tool_output="\n".join(output_parts)[:8000],
+                                    tool_output=(
+                                        _repair_escaped_marker("\n".join(output_parts))
+                                        or "\n".join(output_parts)
+                                    )[:8000],
                                 )
                             )
         except Exception:

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -471,6 +471,19 @@ class AcpEvent:
     #: the original bytes never ride this display event.  Approval surfaces use
     #: it to refuse a durable command grant for a value the user could not see.
     tool_input_redacted: bool = False
+    #: The tool's result text, VERBATIM enough that a control marker embedded in
+    #: it still parses. Two consumers read markers out of this string rather than
+    #: out of a structured field: a session directive (``session_directive.peek``,
+    #: which arms/stops a monitor loop) and an MCP App render marker
+    #: (``mcp_apps_render.find_marker``). A builder that serialises an
+    #: unrecognised result envelope with ``json.dumps`` escapes every quote in it,
+    #: which leaves both sentinels intact while destroying the payload behind
+    #: them -- so the frame still looks like it carries a directive and names
+    #: nothing. EVERY builder must therefore run
+    #: ``acp/_dispatch._repair_escaped_marker`` over its joined output before
+    #: redaction and the head cut; a new provider's builder is pinned to that by
+    #: ``test_session_directive_transport.py``. See
+    #: docs/system-specs/features/agent-host-contract.md §9.
     tool_output: str = ""
     tool_final: bool = False  # True when this tool_result is the final (status=completed) update
     usage: TurnUsage = field(default_factory=TurnUsage)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -7460,12 +7460,30 @@ async def _run_chat(
                             "(tool_call_id=%s, mcp_server_name=%r, tool_name=%r, "
                             "expected mcp_server_name=%r). Either a forged marker, "
                             "or this ACP backend emits no _meta.kiro identity AND "
-                            "could not reach the gateway to park the payload.",
+                            "could not reach the gateway to park the payload. "
+                            "CLAIM was attempted for session_key=%r selector=%r; "
+                            "that session's queue currently holds %d parked "
+                            "record(s) — a non-zero depth here means a record WAS "
+                            "parked but did not match this frame's (kind, args) or "
+                            "fell outside this turn, while zero means nothing ever "
+                            "reached /api/session-directive for this key.",
                             event.tool_call_id,
                             _seen_tool_identity.get(event.tool_call_id, ("", ""))[0],
                             _seen_tool_identity.get(event.tool_call_id, ("", ""))[1],
                             session_directive.CORE_MCP_SERVER,
+                            session_key,
+                            (_sel_pair[0] if _sel_pair else None),
+                            directive_queue.depth(session_key),
                         )
+                        if _sel_pair is None:
+                            logger.warning(
+                                "session-directive SELECTOR UNREADABLE for %s: the "
+                                "frame carries the marker sentinel but peek() could "
+                                "not turn it into a (kind, args) selector, so no "
+                                "parked record can be named. Reason: %s",
+                                session_key,
+                                session_directive.peek_failure_reason(event.tool_output),
+                            )
                 if not _dir_tool and event.tool_call_id in _dir_consumed_out:
                     # A LATER frame for a directive we already consumed: replay
                     # the output we produced instead of letting the raw marker

--- a/src/kiro_crew/dashboard/directive_queue.py
+++ b/src/kiro_crew/dashboard/directive_queue.py
@@ -66,7 +66,7 @@ import time
 import uuid
 from typing import Any
 
-from kiro_crew.session_directive import DIRECTIVE_TOOLS
+from kiro_crew.session_directive import DIRECTIVE_TOOLS, content_free_digest
 
 logger = logging.getLogger(__name__)
 
@@ -217,6 +217,13 @@ def claim(
     the same session cannot both apply it. Returns ``None`` when nothing matches.
     """
     if not session_key or kind not in DIRECTIVE_TOOLS:
+        logger.warning(
+            "session-directive CLAIM REFUSED before lookup: session_key=%r kind=%r "
+            "(empty session key, or kind is not a known directive tool). Nothing "
+            "was claimed.",
+            session_key,
+            kind,
+        )
         return None
     now = time.monotonic()
     want = _canonical(args)
@@ -226,10 +233,14 @@ def claim(
             return None
         hit: dict[str, Any] | None = None
         keep: list[dict[str, Any]] = []
+        misses: list[str] = []
         for record in queue:
             at = float(record.get("at", 0.0))
             age = now - at
             if age > MAX_AGE_SECS:
+                misses.append(
+                    "stale(kind=%r age=%.1fs > %.1fs)" % (record.get("kind"), age, MAX_AGE_SECS)
+                )
                 logger.info(
                     "session-directive dropped as stale for %s: %s (age %.0fs > %.0fs)",
                     session_key,
@@ -243,16 +254,58 @@ def claim(
             # equal records, and each frame must consume its OWN. The queue is
             # oldest-first, so taking the first match pairs frame N with record N
             # while `keep` retains the rest for the sibling frames.
+            _rec_kind = record.get("kind")
+            _rec_args = _canonical(record.get("args"))
             if (
                 hit is None
-                and record.get("kind") == kind
-                and _canonical(record.get("args")) == want
+                and _rec_kind == kind
+                and _rec_args == want
                 and (not_before is None or at >= not_before)
             ):
                 hit = record
                 continue
+            if hit is None:
+                # Name the ONE reason this candidate was passed over. Ordered so
+                # the first true predicate is the decisive one, because a record
+                # failing on kind is a different bug from one failing only on the
+                # turn bound -- and the old silent None could not tell them apart.
+                if _rec_kind != kind:
+                    misses.append("kind-differs(parked=%r wanted=%r)" % (_rec_kind, kind))
+                elif _rec_args != want:
+                    # Digests, not the args themselves: the parked record carries
+                    # the payload the tool validated and `want` came off
+                    # model-visible marker text, so printing either publishes
+                    # directive content to the dashboard log. A digest still
+                    # answers the question this line exists for -- are these two
+                    # the same payload -- and pairs with the other side's log.
+                    misses.append(
+                        "args-differ(parked_sha=%s/%dB wanted_sha=%s/%dB)"
+                        % (
+                            content_free_digest(_rec_args),
+                            len(_rec_args),
+                            content_free_digest(want),
+                            len(want),
+                        )
+                    )
+                elif not_before is not None and at < not_before:
+                    misses.append(
+                        "parked-before-this-turn(at=%.1f < turn_start=%.1f, %.1fs earlier)"
+                        % (at, not_before, not_before - at)
+                    )
+                else:
+                    misses.append("already-matched-a-sibling-frame(kind=%r)" % (_rec_kind,))
             keep.append(record)
         if hit is None:
+            if misses:
+                logger.warning(
+                    "session-directive CLAIM MISS for session_key=%r kind=%r: %d "
+                    "parked record(s) were examined and none matched -> %s. The "
+                    "record stays parked; the directive is NOT applied.",
+                    session_key,
+                    kind,
+                    len(misses),
+                    "; ".join(misses),
+                )
             # Nothing matched. Keep what survived the staleness sweep so a
             # sibling frame in this same turn can still find its own record.
             if keep:

--- a/src/kiro_crew/dashboard/handlers/sessions.py
+++ b/src/kiro_crew/dashboard/handlers/sessions.py
@@ -1549,12 +1549,23 @@ async def api_session_directive(request: web.Request) -> web.Response:
     # either one is positive proof of a local caller, and a cookie carries
     # neither. Same predicate as ``handlers/updates.py``'s host-locality gate.
     if not (request.get("internal_auth") or request.get("peer_verified")):
+        logger.warning(
+            "session-directive REFUSED (not_local_caller): neither internal_auth nor "
+            "peer_verified was set, so the caller could not be proven local. "
+            "Nothing was parked."
+        )
         return web.json_response(
             {"error": "local caller required", "code": "not_local_caller"},
             status=403,
         )
     session_key = request.headers.get("X-Session-Key", "").strip()
     if not session_key:
+        logger.warning(
+            "session-directive REFUSED (session_key_required): the caller sent no "
+            "X-Session-Key, so no session could be named and nothing was parked. On a "
+            "backend that emits no _meta.kiro identity this is fatal: the marker cannot "
+            "be trusted either, so the directive is dropped entirely."
+        )
         return web.json_response(
             {"error": "X-Session-Key required", "code": "session_key_required"},
             status=400,
@@ -1576,6 +1587,13 @@ async def api_session_directive(request: web.Request) -> web.Response:
     try:
         record_id = directive_queue.publish(session_key, kind, args)
     except ValueError as exc:
+        logger.warning(
+            "session-directive REFUSED (invalid_directive) for session_key=%r kind=%r: "
+            "%s. Nothing was parked.",
+            session_key,
+            kind,
+            exc,
+        )
         return web.json_response({"error": str(exc), "code": "invalid_directive"}, status=400)
     return web.json_response({"ok": True, "id": record_id})
 

--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -179,6 +179,12 @@ async def apply_session_directive(
             return f"Error: unknown session directive {kind!r}."
     except _DirectiveDenied as exc:
         _audit(session_key, kind, "denied")
+        logger.warning(
+            "session-directive DENIED at apply for session_key=%r kind=%r: %s",
+            session_key,
+            kind,
+            exc,
+        )
         return str(exc)
     except Exception as exc:  # never propagate into the turn loop
         logger.warning("apply_session_directive(%s) failed", kind, exc_info=True)

--- a/src/kiro_crew/session_directive.py
+++ b/src/kiro_crew/session_directive.py
@@ -43,6 +43,7 @@ directive tool and is ignored.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from typing import Any
@@ -87,6 +88,10 @@ CORE_MCP_SERVER = "kirocrew-core"
 # A machine-facing framing token must not depend on characters that sanitisers,
 # Unicode normalisers and transports all legitimately rewrite.
 _SENTINEL = "[[KIROCREW_SESSION_DIRECTIVE]]"
+# Public alias. The transport layer (acp/_dispatch) has to locate the marker in a
+# raw frame to repair a payload that arrived JSON-escaped, and reaching for the
+# private name from another module would make that dependency invisible here.
+SENTINEL = _SENTINEL
 
 # The ACP tool-result parser truncates each output part at 4000 chars
 # (``acp/_dispatch.py`` ``str(text)[:4000]``). The marker is the TAIL of the
@@ -175,7 +180,7 @@ def decode(text: str, expected_tool: str) -> dict[str, Any] | None:
     idx = text.find(_SENTINEL)
     if idx < 0:
         return None
-    line = text[idx + len(_SENTINEL):].split("\n", 1)[0]
+    line = text[idx + len(_SENTINEL) :].split("\n", 1)[0]
     try:
         block = json.loads(line)
     except (ValueError, TypeError):
@@ -207,7 +212,7 @@ def peek(text: str) -> tuple[str, dict[str, Any]] | None:
     idx = text.find(_SENTINEL)
     if idx < 0:
         return None
-    line = text[idx + len(_SENTINEL):].split("\n", 1)[0]
+    line = text[idx + len(_SENTINEL) :].split("\n", 1)[0]
     try:
         block = json.loads(line)
     except (ValueError, TypeError):
@@ -272,6 +277,72 @@ def directive_tool_for(mcp_server_name: str, tool_name: str) -> str:
     if mcp_server_name != CORE_MCP_SERVER:
         return ""
     return match_tool(tool_name or "")
+
+
+def content_free_digest(payload: str, _len: int = 12) -> str:
+    """Short stable digest of *payload* that reveals none of its content.
+
+    Directive diagnostics are logged on the failure path, where the payload is
+    either malformed or came from model-visible text -- so the log line must not
+    carry the bytes themselves. A digest keeps the one question those lines exist
+    to answer: two logs naming the same digest saw the same payload, and two
+    naming different digests did not. It is deliberately truncated: this is a
+    correlation handle, not a signature, and a full hash only makes the line
+    harder to read.
+
+    Returns a marker instead of a digest for empty input, so a caller can print
+    the result unconditionally without a special case.
+    """
+    if not payload:
+        return "empty"
+    return hashlib.sha256(payload.encode("utf-8", "replace")).hexdigest()[:_len]
+
+
+def peek_failure_reason(text: str | None) -> str:
+    """Name WHY :func:`peek` returned ``None`` for *text* -- diagnostics only.
+
+    ``has_marker`` true with ``peek`` returning ``None`` is a real observed state
+    and, until this existed, an undiagnosable one: the consumer could report that
+    no record matched without being able to say whether the sentinel arrived
+    without its payload, the payload was truncated mid-JSON, or the payload named
+    a kind this build does not know. Mirrors :func:`peek`'s branches exactly, so a
+    reason here is the branch peek actually took. Returns ``"ok"`` when peek
+    succeeds, so a caller can log it unconditionally.
+
+    The reason names the failure SHAPE only -- never the payload. The payload is
+    model-visible text that reaches the dashboard log before anything has
+    redacted it, and a malformed frame is exactly the case where the bytes are
+    least trustworthy, so an excerpt here would publish unvalidated content to
+    diagnose a parse error. Shape plus length is what actually distinguishes the
+    failures; ``payload_sha`` correlates two log lines without revealing either.
+    """
+    if not text:
+        return "empty-output"
+    idx = text.find(_SENTINEL)
+    if idx < 0:
+        return "no-sentinel"
+    line = text[idx + len(_SENTINEL) :].split("\n", 1)[0]
+    if not line:
+        return "sentinel-present-but-payload-empty (marker is the last thing in the frame)"
+    try:
+        block = json.loads(line)
+    except (ValueError, TypeError) as exc:
+        return "json-unparseable (%s); payload_len=%d payload_sha=%s" % (
+            exc.__class__.__name__,
+            len(line),
+            content_free_digest(line),
+        )
+    if not isinstance(block, dict):
+        return "json-not-an-object (%s)" % type(block).__name__
+    kind = block.get("kind")
+    if not isinstance(kind, str):
+        return "kind-missing-or-not-a-string"
+    if kind not in DIRECTIVE_TOOLS:
+        # Shape, not the value: `kind` is read straight out of model-visible
+        # marker text, so echoing it here would publish unvalidated content on
+        # the same pre-redaction path as the excerpt above.
+        return "unknown-kind (len=%d sha=%s)" % (len(kind), content_free_digest(kind))
+    return "ok"
 
 
 def strip_marker(text: str) -> str:

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -14,12 +14,31 @@ Each test here drives a REAL boundary end-to-end:
 * ``_build_tool_result_event`` — the ACP result parser, whose ``rawOutput``
   ``Json`` branch used to ``json.dumps`` the MCP content envelope, escaping the
   payload's quotes and non-ASCII so the marker line could not be parsed.
+* the same parser again, for an envelope it does NOT recognise as a text
+  envelope, or a result the backend hands back ALREADY serialised (observed on
+  KAS). Both reach ``json.dumps`` too, and the escaping leaves the quote-free
+  sentinel intact while destroying the payload behind it — so the frame still
+  looks like it carries a directive and names no parked record. The last class
+  here is a ratchet over every ``EVENT_TOOL_RESULT`` builder, because the person
+  who adds the next one is a new provider's author, who will not know this
+  constraint exists.
 """
 
+import ast
 import json
+import types
+
+from source_corpus import parsed_candidates, src_root
 
 from kiro_crew import session_directive as sd
-from kiro_crew.acp._dispatch import _build_tool_result_event, _mcp_content_text
+from kiro_crew.acp._dispatch import (
+    _build_tool_result_event,
+    _mcp_content_text,
+    _repair_escaped_marker,
+    parse_session_update,
+)
+from kiro_crew.acp.client import AcpClient
+from kiro_crew.acp.types import EVENT_TOOL_RESULT, JsonRpcMessage
 from kiro_crew.mcp_apps_render import find_marker
 from kiro_crew.mcp_gateway.apps import append_marker
 from kiro_crew.validation import build_tool_response, strip_hidden_unicode
@@ -220,3 +239,405 @@ class TestMcpAppMarkerSurvivesResultCuts:
         event = _build_tool_result_event(update)
         assert event is not None
         assert find_marker(event.tool_output) == self._id()
+
+
+# A quote INSIDE the directive's own text is the point of this fixture, not
+# decoration: encode escapes it once and the envelope's dump escapes it again, so
+# a recovery that merely replaces ``\"`` with ``"`` collapses it into a dangling
+# backslash-quote that ends the JSON string early. Every real monitor_start
+# message quotes its stop reason, so a fixture without a quote would pass against
+# a repair that cannot handle a single actual directive.
+MONITOR_ARGS = {
+    "message": 'Report the cycle. After cycle 3 call autonudge_stop with reason "done".',
+    "idle_secs": 60,
+    "max_cycles": 3,
+    "max_runtime_secs": 0,
+}
+
+
+def _monitor() -> str:
+    text = sd.encode("monitor_start", MONITOR_ARGS, "Armed: fires every 60s, 3 cycles.")
+    assert sd.peek(text) is not None, "fixture must start readable"
+    return text
+
+
+def _pre_serialised(text: str) -> str:
+    """The result as a backend hands it back: inside a serialised envelope."""
+    dumped = json.dumps({"stdout": text})
+    assert sd.has_marker(dumped), "the sentinel survives the dump"
+    assert sd.peek(dumped) is None, "but the selector does not"
+    return dumped
+
+
+def _update(**extra: object) -> dict[str, object]:
+    return {
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-1",
+        "status": "completed",
+        **extra,
+    }
+
+
+def _runtime_output(update: dict[str, object]) -> str | None:
+    """Drive the live consumer path: AcpRuntime -> handle -> parse_session_update."""
+    results = [
+        e for e in parse_session_update(update, cache_scope="scope") if e.kind == EVENT_TOOL_RESULT
+    ]
+    return results[0].tool_output if results else None
+
+
+class TestSurvivesUnrecognisedResultEnvelope:
+    """Defect 3: an envelope with no recognised text field must not be dumped
+    over a directive. The recovery keys on the SENTINEL, not on a field name,
+    because the field differs per backend."""
+
+    def test_directive_survives_any_envelope_key(self):
+        for key in ("output", "Ok", "result", "content"):
+            out = _runtime_output(_update(rawOutput={"items": [{"Json": {key: _monitor()}}]}))
+            assert sd.peek(out) == ("monitor_start", MONITOR_ARGS), key
+
+    def test_marker_free_envelope_is_still_serialised(self):
+        payload = {"exit_status": 0, "note": "hi"}
+        out = _runtime_output(_update(rawOutput={"items": [{"Json": payload}]}))
+        assert out == json.dumps(payload, default=str)
+
+    def test_two_competing_directives_are_not_guessed_between(self):
+        # Applying the WRONG directive is worse than applying none, so a frame
+        # naming two DIFFERENT directives must degrade rather than pick one --
+        # including at the join-point recovery, which reads the first marker line.
+        other = sd.encode("monitor_start", {**MONITOR_ARGS, "idle_secs": 900}, "Armed: every 900s.")
+        out = _runtime_output(
+            _update(rawOutput={"items": [{"Json": {"a": _monitor(), "b": other}}]})
+        )
+        assert sd.peek(out) is None
+        assert out is not None and out.startswith("{")
+
+
+class TestSurvivesPreSerialisedResultText:
+    """Defect 3b: the backend hands the result back already JSON-encoded, so the
+    text this parser receives is the DUMP of an envelope rather than the
+    envelope. Observed on KAS as ``json-unparseable (JSONDecodeError)`` with the
+    envelope's own ``"}`` still glued to the payload's tail."""
+
+    def test_recovered_from_every_output_shape(self):
+        escaped = _pre_serialised(_monitor())
+        shapes = {
+            "Json.stdout": _update(rawOutput={"items": [{"Json": {"stdout": escaped}}]}),
+            "Text": _update(rawOutput={"items": [{"Text": escaped}]}),
+            "content block": _update(content=[{"content": {"type": "text", "text": escaped}}]),
+        }
+        for label, update in shapes.items():
+            assert sd.peek(_runtime_output(update)) == (
+                "monitor_start",
+                MONITOR_ARGS,
+            ), label
+
+    def test_recovered_when_it_is_only_one_of_several_parts(self):
+        # The live shape: prose beside the escaped envelope, so the JOINED text
+        # does not parse as JSON and the recovery must work from the marker's own
+        # line. This is what a whole-text json.loads alone cannot reach.
+        out = _runtime_output(
+            _update(
+                content=[
+                    {"content": {"type": "text", "text": "tool ran"}},
+                    {"content": {"type": "text", "text": _pre_serialised(_monitor())}},
+                ]
+            )
+        )
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS)
+        assert out is not None and out.startswith("tool ran")
+
+    def test_a_readable_directive_is_passed_through_byte_identical(self):
+        marker = _monitor()
+        out = _runtime_output(_update(content=[{"content": {"type": "text", "text": marker}}]))
+        assert out == marker
+
+    def test_plain_text_output_is_untouched(self):
+        out = _runtime_output(_update(content=[{"content": {"type": "text", "text": "ok"}}]))
+        assert out == "ok"
+
+
+class TestSurvivesTheAcpClientParser:
+    """``providers/acp.py``'s own builder, ``AcpClient._extract_tool_call_update``:
+    a second, independent parser with the same envelope shapes and the same
+    defect class."""
+
+    @staticmethod
+    def _output(update: dict[str, object]) -> str | None:
+        fake = types.SimpleNamespace(_session_id="sess-1")
+        msg = JsonRpcMessage(method="session/update", params={"update": update})
+        event = AcpClient._extract_tool_call_update(fake, msg)
+        return event.tool_output if event else None
+
+    def test_directive_survives_unrecognised_envelope(self):
+        out = self._output(_update(rawOutput={"items": [{"Json": {"result": _monitor()}}]}))
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS)
+
+    def test_directive_survives_pre_serialised_text(self):
+        out = self._output(_update(rawOutput={"items": [{"Text": _pre_serialised(_monitor())}]}))
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS)
+
+    def test_a_readable_directive_is_passed_through_byte_identical(self):
+        marker = _monitor()
+        out = self._output(_update(content=[{"content": {"type": "text", "text": marker}}]))
+        assert out == marker
+
+    def test_marker_free_envelope_is_still_serialised(self):
+        payload = {"exit_status": 0}
+        out = self._output(_update(rawOutput={"items": [{"Json": payload}]}))
+        assert out == json.dumps(payload, default=str)
+
+
+class TestEveryToolResultBuilderRepairsTheMarker:
+    """Ratchet: a NEW builder cannot skip the recovery.
+
+    The defect was never one bad builder -- it was that several independent
+    builders can emit an ``EVENT_TOOL_RESULT`` and the fix has to hold at each.
+    The requirement is enforced here rather than left in a comment because the
+    author who adds the next builder is a new provider's, and
+    docs/system-specs/features/agent-host-contract.md §9 is the declaration they
+    are meant to answer."""
+
+    REQUIRED = "_repair_escaped_marker"
+
+    @classmethod
+    def _builders(cls) -> list[tuple[str, str, bool]]:
+        """``(file, function, repairs?)`` per ``EVENT_TOOL_RESULT`` construction."""
+        found: list[tuple[str, str, bool]] = []
+        acp_dir = src_root() / "acp"
+        for path, _text, tree in parsed_candidates(require_all=("EVENT_TOOL_RESULT",)):
+            if acp_dir not in path.parents:
+                continue
+            for func in ast.walk(tree):
+                if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                builds = any(
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "AcpEvent"
+                    and any(
+                        kw.arg == "kind"
+                        and isinstance(kw.value, ast.Name)
+                        and kw.value.id == "EVENT_TOOL_RESULT"
+                        for kw in node.keywords
+                    )
+                    for node in ast.walk(func)
+                )
+                if not builds:
+                    continue
+                repairs = any(
+                    isinstance(node, ast.Name) and node.id == cls.REQUIRED
+                    for node in ast.walk(func)
+                )
+                found.append((path.name, func.name, repairs))
+        return found
+
+    def test_every_builder_runs_the_repair(self):
+        offenders = [f"{file}::{func}" for file, func, repairs in self._builders() if not repairs]
+        assert not offenders, (
+            f"these EVENT_TOOL_RESULT builders never call {self.REQUIRED} over "
+            "their joined output, so a JSON-escaped session-directive marker "
+            f"reaching them is dropped silently: {offenders}. See "
+            "docs/system-specs/features/agent-host-contract.md §9."
+        )
+
+    def test_the_gate_sees_the_builders_it_is_meant_to_cover(self):
+        # Without this, renaming AcpEvent (or breaking the AST match) would make
+        # the gate above pass over an empty set.
+        seen = {(file, func) for file, func, _ in self._builders()}
+        assert ("_dispatch.py", "_build_tool_result_event") in seen
+        assert ("client.py", "_extract_tool_call_update") in seen
+        assert len(seen) >= 3, seen
+
+
+# A value that appears NOWHERE else, so finding it in a log line proves the
+# payload itself leaked rather than some incidental substring.
+CANARY = "canary-9f3e2a-directive-body"
+
+
+class TestRecoveryPreservesSurroundingOutput:
+    """Finding 2: repairing the marker must not discard the rest of the frame.
+
+    The marker has to leave on its own line for ``peek`` to read it, but the
+    other fields are real tool output -- an exit status, a second text block --
+    that the transcript is owed. A recovery that returns only the marker silently
+    drops them, which is data loss the user cannot see or recover.
+    """
+
+    def test_json_branch_keeps_sibling_fields(self):
+        # A marker-bearing envelope whose SIBLINGS carry real output.
+        out = _runtime_output(
+            _update(
+                rawOutput={
+                    # NOT `stdout`: that key takes the envelope's own
+                    # long-standing shortcut, which drops siblings for every
+                    # envelope and is not the marker path under test here.
+                    "items": [{"Json": {"out": _monitor(), "exit_status": 7, "stderr": CANARY}}]
+                }
+            )
+        )
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS), "selector still readable"
+        assert "exit_status" in out and "7" in out, "sibling field survived the repair"
+        assert CANARY in out, "sibling output survived the repair"
+
+    def test_escaped_dump_keeps_sibling_fields(self):
+        # The whole frame is one escaped dump: recovery path (1).
+        repaired = _repair_escaped_marker(json.dumps({"out": _monitor(), "note": CANARY}))
+        assert repaired is not None
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+        assert CANARY in repaired, "the sibling field is not dropped for the marker"
+
+    def test_partial_escape_keeps_head_and_tail(self):
+        # An escaped dump sitting BESIDE other text: recovery path (2). Both the
+        # prose before it and whatever trails the marker must survive.
+        head = "step 1 done\n"
+        tail = "\nstep 3 done: %s" % CANARY
+        frame = head + json.dumps({"out": _monitor()})[1:-1] + tail
+        repaired = _repair_escaped_marker(frame)
+        assert repaired is not None
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+        assert repaired.startswith(head), "leading output preserved"
+        assert CANARY in repaired, "trailing output preserved"
+
+    def test_marker_line_stays_a_single_json_value(self):
+        # The suffix must land on a LATER line: peek parses the marker's own line
+        # as one JSON value, so trailing bytes there would re-break the selector
+        # this repair exists to restore.
+        repaired = _repair_escaped_marker(
+            json.dumps({"out": _monitor(), "note": CANARY})[1:-1] + "\ntrailing"
+        )
+        assert repaired is not None
+        marker_line = [ln for ln in repaired.split("\n") if sd.SENTINEL in ln]
+        assert len(marker_line) == 1
+        payload = marker_line[0].split(sd.SENTINEL, 1)[1]
+        json.loads(payload)  # raises if anything was glued onto the marker's line
+
+
+class TestFailurePathDiagnosticsWithholdPayload:
+    """Finding 1: the failure-path warnings run BEFORE redaction, so they must
+    name the failure shape and never the payload bytes."""
+
+    def test_peek_failure_reason_withholds_the_payload(self):
+        reason = sd.peek_failure_reason(sd.SENTINEL + '{"kind": "monitor_start", ' + CANARY)
+        assert "json-unparseable" in reason, reason
+        assert "payload_len=" in reason and "payload_sha=" in reason, reason
+        assert CANARY not in reason, "the malformed payload must not be echoed"
+
+    def test_digest_is_stable_and_content_free(self):
+        a = sd.content_free_digest(CANARY)
+        assert a == sd.content_free_digest(CANARY), "same payload -> same handle"
+        assert a != sd.content_free_digest(CANARY + "!"), "different payload -> different handle"
+        assert CANARY not in a
+        assert sd.content_free_digest("") == "empty", "printable without a special case"
+
+    def test_repair_warning_withholds_the_frame(self, caplog):
+        with caplog.at_level("WARNING"):
+            out = _runtime_output(_update(rawOutput={"items": [{"Json": {"o": _monitor()}}]}))
+        assert sd.peek(out) is not None, "the repair itself still works"
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert MONITOR_ARGS["message"] not in logged, "directive args reached the log"
+        assert sd.SENTINEL not in logged, "the marker itself reached the log"
+
+    def test_claim_miss_withholds_the_args(self, caplog):
+        from kiro_crew.dashboard import directive_queue
+
+        key = "sess-canary-1"
+        directive_queue.reset()
+        directive_queue.publish(key, "monitor_start", {"message": CANARY})
+        with caplog.at_level("WARNING"):
+            claimed = directive_queue.claim(key, "monitor_start", {"message": "something else"})
+        assert claimed is None, "the mismatched record must not be claimed"
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert "args-differ" in logged, "the operator still learns WHY it missed"
+        assert CANARY not in logged, "the parked payload reached the log"
+
+
+class TestOrdinaryResultsAreNotDuplicated:
+    """A recognised MCP text envelope must pass through ONCE.
+
+    The marker-envelope branch is selected by an explicit flag, not by comparing
+    ``_mcp_content_text``'s return to itself: a >=2-block envelope returns a
+    fresh ``"\\n".join`` each call, so an identity test reports "marker-bearing"
+    for an ordinary result and emits the whole envelope a second time. A
+    single-block envelope hides the bug (join returns the stored object), which
+    is why the multi-block case is the one pinned here.
+    """
+
+    @staticmethod
+    def _envelope(*texts: str) -> dict[str, object]:
+        return {"content": [{"type": "text", "text": t} for t in texts]}
+
+    def test_two_text_blocks_are_not_emitted_twice(self):
+        out = _runtime_output(_update(rawOutput={"items": [{"Json": self._envelope("A", "B")}]}))
+        assert out == "A\nB", out
+        assert out.count("A") == 1 and out.count("B") == 1
+        assert "content" not in out, "the envelope was dumped alongside its own text"
+
+    def test_single_text_block_is_not_emitted_twice(self):
+        out = _runtime_output(_update(rawOutput={"items": [{"Json": self._envelope("only")}]}))
+        assert out == "only", out
+
+    def test_multi_block_envelope_carrying_a_marker_still_resolves(self):
+        out = _runtime_output(
+            _update(rawOutput={"items": [{"Json": self._envelope("preamble", _monitor())}]})
+        )
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS)
+        assert "preamble" in out
+        assert out.count("preamble") == 1, "duplicated on the marker path"
+
+
+class TestPreservedOutputSurvivesDisplay:
+    """Preserved output must survive ``strip_marker``, not just the repair.
+
+    ``strip_marker`` truncates from the sentinel to the END of the string, so
+    output placed AFTER the marker is recovered into ``tool_output`` and then
+    dropped from the transcript the user actually reads -- preserved in the data
+    and invisible in the product. Everything therefore goes BEFORE the marker,
+    which keeps peek's line intact and keeps the bytes on the surviving side.
+    """
+
+    def test_json_branch_siblings_survive_strip(self):
+        out = _runtime_output(
+            _update(rawOutput={"items": [{"Json": {"out": _monitor(), "stderr": CANARY}}]})
+        )
+        assert sd.peek(out) is not None, "selector readable before display"
+        shown = sd.strip_marker(out)
+        assert CANARY in shown, "sibling output was cut by strip_marker"
+        assert sd.SENTINEL not in shown, "the marker itself must not be displayed"
+
+    def test_escaped_dump_siblings_survive_strip(self):
+        repaired = _repair_escaped_marker(json.dumps({"out": _monitor(), "note": CANARY}))
+        assert repaired is not None
+        assert sd.peek(repaired) is not None
+        assert CANARY in sd.strip_marker(repaired), "sibling output was cut by strip_marker"
+
+    def test_partial_escape_head_and_suffix_survive_strip(self):
+        head = "step 1 done\n"
+        frame = head + json.dumps({"out": _monitor()})[1:-1] + "\nstep 3: %s" % CANARY
+        repaired = _repair_escaped_marker(frame)
+        assert repaired is not None
+        assert sd.peek(repaired) is not None
+        shown = sd.strip_marker(repaired)
+        assert "step 1 done" in shown, "leading output was cut"
+        assert CANARY in shown, "trailing output was cut by strip_marker"
+
+    def test_marker_is_the_last_line(self):
+        # The invariant that makes the two above hold, stated once directly.
+        repaired = _repair_escaped_marker(json.dumps({"out": _monitor(), "note": CANARY}))
+        assert repaired is not None
+        lines = repaired.split("\n")
+        assert sd.SENTINEL in lines[-1], "marker must be last, or strip_marker eats the rest"
+
+
+class TestUnknownKindWithholdsThePayload:
+    """`kind` is read out of model-visible marker text, so the diagnostic names
+    its shape rather than echoing it -- the same rule as the excerpt beside it."""
+
+    def test_unknown_kind_is_not_echoed(self):
+        hostile = "not-a-tool-" + CANARY
+        reason = sd.peek_failure_reason(
+            sd.SENTINEL + json.dumps({"kind": hostile, "args": {}, "human": "x"})
+        )
+        assert reason.startswith("unknown-kind"), reason
+        assert CANARY not in reason, "the payload's kind reached the log"
+        assert "len=" in reason and "sha=" in reason, reason


### PR DESCRIPTION
## Problem / Motivation

A session directive (`monitor_start`, `monitor_update`, `autonudge_stop`,
`ask_question`) reaches its consumer as a marker embedded in the tool's own
**result text**, and the marker's one-line JSON payload is the only thing that
names the record the MCP stub parked out of band. On a backend that hands an MCP
tool result back **already serialised as JSON** (observed on KAS), the ACP result
parser did not recognise the envelope and fell through to `json.dumps`, escaping
every quote in the payload. The sentinel contains no quotes, so it survived
untouched: the frame still *looked* like it carried a directive while naming no
record.

What a user saw: `monitor_start` answered "Monitor loop requested", the model
reported "Armed", the dashboard showed no loop, and no cycle ever fired.
`~/.kiro/crew/autonudge.json` had not been written in weeks.

## Why it matters

Every unattended-monitoring feature is dead on that backend, silently. There is
no error anywhere in the normal path — the tool reports success, the record sits
parked, the consumer cannot name it, and the drop is invisible. Finding it took
several gateway restarts and hand-added logging because no layer said anything.
Any workflow that leans on `monitor_start` (the `babysit` and `prepare-pr` CI
loops, conductor patrol) simply never ran.

## What changed (motivation → approach → change)

**Symptom** → `session_directive.peek` returned `None` for a frame that carried
the sentinel, so `directive_queue.claim` had no `(kind, args)` selector and the
parked record was never claimed.

**Root cause** → `acp/_dispatch._build_tool_result_event` (and the two builders
in `acp/client.py`) serialise an unrecognised structured result with
`json.dumps`. That is lossless for display but fatal for a control marker: the
quote-free sentinel survives, the payload behind it does not.

**Change** →

- `_marker_bearing_text` — before dumping an unrecognised envelope, emit the one
  string inside it that carries the sentinel, verbatim. Keyed on the **sentinel**,
  not on a field name, because the field differs per backend. Requires exactly
  one match; two competing markers fall back rather than guess.
- `_repair_escaped_marker` — recover a payload that arrived JSON-escaped, at the
  join point so every output shape is covered (content blocks, `rawOutput.Text`,
  `rawOutput.Json.stdout`, and an escaped envelope sitting beside plain prose).
  **Acceptance is the test**: a candidate is returned only when `peek` actually
  reads a selector from it, so a wrong guess degrades to the original text. A
  frame naming two *different* directives is refused rather than resolved to the
  first — applying the wrong directive is worse than applying none.
- Both run at every `EVENT_TOOL_RESULT` builder, **before** redaction and the
  8000-char head cut, since the consumer reads the selector out of that exact
  string.
- **Observability**: the consumer-side paths that drop a directive now log at
  `warning` (`NOT APPLIED` with the claim key and queue depth, `SELECTOR
  UNREADABLE` with the parse reason, `CLAIM REFUSED`, `CLAIM MISS` with the
  per-record reason, `REFUSED`, `DENIED`). Success paths stay silent — the SEL
  audit already records them. Their absence is what made this class of drop
  invisible.
- **Provider requirement, not folklore**: `agent-host-contract.md` gains bucket 9
  (tool-result text fidelity) with the per-backend table and the "a provider must
  declare" line; `AcpEvent.tool_output` documents the constraint at the field
  every builder fills; `babysit-pr-watch.md` names the transport hop in the
  monitor contract.

## Tests

All in `test/test_session_directive_transport.py` (the existing transport-level
regression file for this defect class — defects 1 and 2 were already covered
there; these are defect 3):

- `TestSurvivesUnrecognisedResultEnvelope` — a directive survives an envelope
  under any of four plausible key names; a marker-free envelope is still
  `json.dumps`'d; two *competing* directives are refused rather than guessed
  between.
- `TestSurvivesPreSerialisedResultText` — recovery from a pre-serialised result
  via `Json.stdout`, `Text`, and a content block, and when the escaped envelope
  is only one of several output parts (the live shape); a readable marker passes
  through byte-identical; plain text is untouched.
- `TestSurvivesTheAcpClientParser` — the same shapes through
  `AcpClient._extract_tool_call_update`, the second independent builder.
- `TestEveryToolResultBuilderRepairsTheMarker` — an AST ratchet over every
  `AcpEvent(kind=EVENT_TOOL_RESULT)` construction under `acp/`: a builder that
  does not call `_repair_escaped_marker` fails the gate, plus a vacuous-green
  guard pinning the three known builders. A new provider's builder trips it on
  the first run.

The fixture deliberately quotes a word inside the directive's own message, since
that double-escapes and is what a naive `\"` → `"` unescape breaks on — every
real `monitor_start` message quotes its stop reason.

Mutation-verified: disabling the join-point repair fails 3 tests; restoring the
naive unescape fails 1; removing the two-marker refusal fails 1.

## Manual verification

Verified end-to-end against the live gateway on the KAS backend: before the fix,
arming a 3-cycle monitor logged `SELECTOR UNREADABLE … json-unparseable
(JSONDecodeError)` and no loop existed. After the fix and a restart, the same arm
produced `PARKED` → claim → apply, and the loop fired all three cycles and
stopped itself. That is what this PR was written from.

## Related Issues

no linked issue: found while debugging a live arming failure, no tracked issue exists.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a control marker embedded in human-readable text is destroyed by a
serialisation step that preserves the sentinel — any transform that may
`json.dumps` a payload carrying a sentinel must be checked for it, because the
surviving sentinel makes the frame look intact while the payload behind it is
unparseable. The generalised guard shipped here is the AST ratchet over
`EVENT_TOOL_RESULT` builders.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
