### PR TITLE
fix(snapshot): copy notification records as bytes, not through a locale decode

### DIFF
--- a/src/kiro_crew/jsonl_util.py
+++ b/src/kiro_crew/jsonl_util.py
@@ -45,13 +45,14 @@ stops seeing a prior entry.
 Each has an undecoded twin — :func:`bounded_raw_records` and
 :func:`strict_raw_records` — yielding ``bytes``. The bounded twin has one
 caller, which already iterated a binary handle and prefilters on bytes before
-parsing. The strict twin has no external caller today: it is what
-:func:`strict_records` is built on, and the site that wanted raw strict bytes
-directly — the snapshot notification merge, which copies records into another
-file verbatim — is deliberately NOT converted here. That site needs the reader
-to guarantee something the others do not, namely that what it hands back is
-valid for the DESTINATION file and not merely a faithful copy of the source, so
-it is being done separately rather than inferred from this reader's contract.
+parsing. The strict twin's caller is the snapshot notification merge, which
+copies records into another file verbatim: it needs one guarantee the other
+readers' callers do not, namely that the bytes are valid for the DESTINATION
+file and not merely a faithful copy of the source. That is why it takes the raw
+twin and validates the encoding itself rather than taking
+:func:`strict_records`: a decode whose OUTPUT is what gets written back is the
+non-byte-exact round trip that site is fixing. Its write-side contract is
+stated on :func:`kiro_crew.snapshot._merge_notifications`.
 
 :func:`kiro_crew.session_storage._manifest_records` is a third reader and
 deliberately stays separate: it needs ``str.splitlines`` boundaries, since

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -21,6 +21,12 @@ from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Callable
 
 from kiro_crew import pinned_fs, platform_compat
+from kiro_crew.jsonl_util import (
+    RECORD_CAP,
+    UndecodableRecord,
+    UnreadableRecord,
+    strict_raw_records,
+)
 
 if TYPE_CHECKING:
     from kiro_crew import snapshot_redact
@@ -2370,25 +2376,270 @@ def _merge_crons(src_path: Path, dst_path: Path) -> None:
     print(f"  Cron jobs imported: {imported} (skipped {total - imported} duplicates)")
 
 
+_TERMINATORS = (b"\n", b"\r")
+
+# Longest single notification record either side of the merge will materialise.
+# Both trees are agent-writable and the read feeds an append to a durable file,
+# so an over-cap record aborts rather than being skipped. Named here, and read at
+# call time, so a test can move the dial instead of writing a 128 MiB fixture --
+# the same reason `subagent_cost` names its own.
+_NOTIFICATION_RECORD_CAP = RECORD_CAP
+
+
+def _notification_key(record: bytes, path: Path) -> tuple[Any, ...] | None:
+    """The dedupe key for one raw notification record, or ``None`` if it has none.
+
+    Well-defined and hashable for EVERY record shape, which the previous
+    ``json.loads(line).get("ts") or line.strip()`` was not: a non-object
+    record raised ``AttributeError`` off ``.get``, and a list or dict ``ts``
+    raised ``TypeError`` on set insert. Both escaped as an aborted restore.
+
+    A ``ts`` is used whenever it is truthy AND hashable, which is every JSON
+    scalar. Restricting it to ``str`` would have been a REGRESSION: the
+    predecessor keyed a numeric ``ts`` on the number, so two rows carrying the
+    same numeric ``ts`` with different bytes -- one normalised, one not --
+    deduplicated, and keying them on their raw form instead persists a
+    duplicate. Only an unhashable ``ts``, which cannot be a set member at all,
+    falls through to the raw form.
+
+    The ``ts`` goes into the key under a KIND TAG that is deliberately coarser
+    than its Python type, because two different equalities are in play at once
+    and a naive tag gets one of them wrong:
+
+    * ``True == 1`` and ``hash(True) == hash(1)``, so an untagged key makes a row
+      with ``ts: true`` and a row with ``ts: 1`` one set member and DELETES the
+      second as a duplicate.
+    * ``1 == 1.0`` and they hash equal too, so tagging with
+      ``type(ts).__name__`` splits a row written as an integer here and a float
+      there -- an ordinary serializer artefact -- into two records and PERSISTS a
+      duplicate.
+
+    An earlier revision hit each of those in turn. One tag covers both: integers
+    and floats share ``"num"`` so they still deduplicate exactly as the
+    predecessor's bare-value key did, while ``bool`` is its own tag. ``bool`` is
+    tested first because it is a SUBCLASS of ``int``, so an ``isinstance(ts,
+    int)`` check would swallow it.
+
+    A record with no usable ``ts`` falls back to its RAW BYTES, and a record that
+    does not PARSE gets no key at all. The split is the fix. The predecessor fell
+    back to ``line.strip()`` for both, and stripping is what deleted bytes: it
+    makes two DISTINCT byte sequences share a key. Unstripped bytes cannot --
+    byte-equal records ARE the same record, so collapsing them loses nothing.
+    Withholding a key from an unparseable record covers the remaining case,
+    because the fragments a split record produces are exactly the unparseable
+    ones.
+
+    That is reachable, not theoretical, and it is why the two cases are separated.
+    A crash mid-append leaves a truncated row in the live file -- say ``b'{"a":
+    "x'``. A source record holding a bare carriage return is split at it, because
+    this reader's boundaries are the universal-newline set, yielding ``b'{"a":
+    "x\r'``. Those two are NOT byte-equal, but they STRIP to the same thing, so
+    the predecessor skipped the fragment as a duplicate, appended only the tail,
+    and left the live file with a line parsing as neither while the source's bytes
+    were gone. Measured on real bytes, before and after: stripping loses them,
+    raw bytes do not. The fragment is also unparseable, so it takes the ``None``
+    path and is doubly protected.
+
+    So a ``ts``-less row that parses IS deduplicated, on bytes -- which keeps the
+    predecessor's idempotence for a re-run without keeping the deletion. Only an
+    unparseable record is appended unconditionally.
+    Duplicating a row is recoverable; deleting one is not. ``_merge_notifications``
+    validates the whole source before appending anything so that a FAILED merge
+    does not leave a prefix for a retry to duplicate.
+
+    The kind tag also keeps the two families apart: ``json.loads`` can only
+    produce ``dict``, ``list``, ``str``, ``int``, ``float``, ``bool`` or ``None``,
+    so ``type(ts).__name__`` is never ``"raw"`` and a byte key can never collide
+    with a ``ts`` key.
+
+    Raises :class:`UndecodableRecord` for a record that is not valid UTF-8,
+    which is how the encoding property is enforced: this decode VALIDATES and
+    the result is used only for the key, while what gets appended is always the
+    original bytes. Validating by decoding and then writing the decoded form
+    back is what makes the copy non-byte-exact in the first place.
+    """
+    try:
+        text = record.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise UndecodableRecord(f"record is not valid UTF-8 in {path!r}") from exc
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        # A record that does not PARSE keeps no key, so it is never skipped.
+        # Deliberately not byte-keyed: framing splits a record at a bare
+        # carriage return, and the fragments of a split record are exactly the
+        # unparseable ones. Leaving them unkeyed is what makes "a fragment is
+        # never mistaken for a record already present" structural rather than a
+        # property of whichever collision one happens to think of.
+        return None
+    ts = parsed.get("ts") if isinstance(parsed, dict) else None
+    # Truthiness reproduces the predecessor's `or` fallback: an absent, empty or
+    # zero ts fell through to the line itself, and now falls through to None.
+    if ts:
+        try:
+            hash(ts)
+        except TypeError:
+            pass
+        else:
+            # `bool` first: it is a subclass of `int`, so the numeric arm would
+            # otherwise swallow it and re-create the True/1 collision.
+            if isinstance(ts, bool):
+                kind = "bool"
+            elif isinstance(ts, (int, float)):
+                kind = "num"
+            else:
+                kind = type(ts).__name__
+            return (kind, ts)
+    # No usable ``ts``, but the record PARSED -- so it is a whole record a
+    # producer wrote, not a framing fragment, and its raw bytes are an identity
+    # it is safe to deduplicate on. RAW, and never stripped: the predecessor's
+    # ``line.strip()`` is what deleted bytes, because stripping makes two
+    # DISTINCT byte sequences share a key -- a fragment ending in a carriage
+    # return strips to a crash-truncated row that does not contain one. Keying on
+    # the unstripped bytes cannot do that: byte-equal records ARE the same
+    # record, so a collapse here loses no information, while a stripped key
+    # collapses records that differ. That distinction is the whole fix.
+    #
+    # The key is the bytes that LAND, not the bytes that arrive. The append below
+    # terminates an unterminated record, so keying the arriving form makes a
+    # re-import compare an unterminated source row against the terminated row it
+    # itself wrote, miss, and append a second copy. Normalising here uses the
+    # SAME predicate as that write, so the two cannot drift.
+    #
+    # The direction matters and only one of the two is safe. Normalising by
+    # ADDING the terminator the writer adds is deterministic and merges only
+    # records that land identically. Normalising by REMOVING terminators would be
+    # ``rstrip``, and that is the predecessor's deleter wearing a different name:
+    # it maps ``X\r`` and ``X`` onto one key, which is precisely the fragment and
+    # crash-truncated-row pair above.
+    return ("raw", record if record.endswith(_TERMINATORS) else record + b"\n")
+
+
 def _merge_notifications(src_path: Path, dst_path: Path) -> None:
-    existing: set[str] = set()
-    with open(dst_path) as f:
-        for line in f:
-            try:
-                existing.add(json.loads(line).get("ts") or line.strip())
-            except (ValueError, TypeError):
-                pass
-    imported = 0
-    with open(dst_path, "a") as out, open(src_path) as f:
-        for line in f:
-            try:
-                key = json.loads(line).get("ts") or line.strip()
-                if key not in existing:
-                    out.write(line)
+    """Append the snapshot's notification records to the live file, byte for byte.
+
+    This is the only merge that COPIES records rather than consuming them, so
+    reading faithfully is not the whole contract -- the bytes must also be valid
+    for the destination. Both handles are BINARY and framing comes from
+    :func:`strict_raw_records`, because the text-mode predecessor was a locale
+    decode followed by a locale encode and neither half was byte-exact:
+
+    * Universal-newline translation on read, ``os.linesep`` on write. A record
+      terminated ``\\r\\n`` was appended as ``\\n`` -- a byte silently dropped --
+      and a bare ``\\r`` INSIDE a record split it in two, so both halves failed
+      ``json.loads``, the ``except`` swallowed both, and the record was lost
+      while the function printed success. Both fire on a pure UTF-8 host with
+      fully valid UTF-8 input, so an explicit ``encoding=`` does not address
+      them; ``newline=`` is a separate axis and binary mode closes both at once.
+    * The locale codec decided whether an invalid-UTF-8 record aborted the
+      restore or was delivered into the live file. ``for line in f`` decodes
+      OUTSIDE the ``try``, so ``UnicodeDecodeError`` -- a ``ValueError`` --
+      escaped the ``except (ValueError, TypeError)`` because the iterator raised
+      it, not ``json.loads``. On a UTF-8 host that aborted the restore with a
+      traceback; under a single-byte locale the decode succeeded, the encode put
+      the same bytes back, and the live file stopped being valid UTF-8 -- after
+      which its loader returns NO rows for the whole file and the next rewrite
+      persists that empty view.
+
+    The posture is ABORT, never skip, because the output feeds a durable write
+    and a skipped record is a deleted one. Abort means RAISE, not warn: this
+    function's callers report an outcome to somebody. ``apply_import_zip``
+    appends ``notifications (merged)`` to its summary and the dashboard handler
+    answers ``ok: True`` with a SEL ``outcome="ok"``, and a printed warning is
+    invisible to both -- so warn-and-return would tell an API caller the import
+    succeeded while records were left behind. The print stays so a CLI operator
+    reads the reason before the traceback. This is why it differs from
+    ``_merge_crons``, which warns and returns: a refused cron merge writes
+    nothing and skips one component, while this one may already have appended a
+    prefix, and the caller has to learn the write is incomplete.
+
+    * A destination-scan failure is still a true no-op -- the destination is not
+      even opened for append until that scan has completed.
+    * The SOURCE is validated whole before the destination is opened for append,
+      so a source-side refusal is also a no-op. Without that pass, a source whose
+      Nth record is undecodable had already appended N-1 records when it aborted,
+      and a retry re-appended every identity-less one of them, since a row with
+      no ``ts`` cannot be deduplicated. The cost is reading the source twice.
+    * A failure DURING the copy is therefore the residual case -- the source
+      changed between the two passes -- and its prefix stays. Rolling it back
+      would be a second unvalidated write to the live file.
+
+    Every appended record ends with a terminator, and an unterminated final
+    record already in the destination gains one before anything is appended
+    after it. Without that, two records glued into one line that parses as
+    neither.
+    """
+    existing: set[tuple[Any, ...]] = set()
+    dst_unterminated = False
+    try:
+        with open(dst_path, "rb") as f:
+            for record in strict_raw_records(f, dst_path, cap=_NOTIFICATION_RECORD_CAP):
+                key = _notification_key(record, dst_path)
+                if key is not None:
                     existing.add(key)
-                    imported += 1
-            except (ValueError, TypeError):
-                pass
+                dst_unterminated = not record.endswith(_TERMINATORS)
+    except (OSError, UnreadableRecord) as exc:
+        # No `_safe_name` here, deliberately: this path is the LIVE data home,
+        # chosen by the operator, not a name that came out of an archive -- which
+        # is the scope `_safe_name`'s own docstring states. The SOURCE prints do
+        # wrap it; see the one below.
+        print(f"  ⚠️  Could not read {dst_path}: {exc} — merge aborted")
+        raise
+    # The ENTIRE source is validated before the destination is opened for append.
+    # Without this pass, a source whose Nth record is undecodable or over-cap has
+    # already appended N-1 records by the time it aborts -- and a retry
+    # re-appends every identity-less one of those, because a row with no ``ts``
+    # cannot be deduplicated by construction. Validating first makes the source
+    # side all-or-nothing in the ordinary case, so there is no prefix to
+    # duplicate.
+    try:
+        with open(src_path, "rb") as f:
+            for record in strict_raw_records(f, src_path, cap=_NOTIFICATION_RECORD_CAP):
+                _notification_key(record, src_path)
+    except (OSError, UnreadableRecord) as exc:
+        # The PATH goes through `_safe_name` because a bundle chooses its own inner
+        # root, so an archive-derived path can carry ANSI controls -- and printing
+        # one raw lets a hostile archive move the cursor and overwrite lines right
+        # above the prompt where the operator decides whether to trust the restore.
+        #
+        # The EXCEPTION deliberately does NOT, and the invariant is worth stating
+        # because it is what makes the wrapper unnecessary rather than forgotten:
+        # both types this arm catches already render an embedded path with
+        # repr-style escaping -- `OSError.__str__` does it for its filename, and
+        # `jsonl_util` uses `{path!r}` for the reason its own comment gives.
+        # Measured: a control character in a directory name reaches neither
+        # exception's `str()` raw. Widening this `except` tuple means re-checking
+        # that, because a type formatting a path with `str()` would need the wrapper.
+        print(f"  ⚠️  Could not read {_safe_name(src_path)}: {exc} — merge aborted")
+        raise
+    imported = 0
+    try:
+        with open(dst_path, "ab") as out, open(src_path, "rb") as f:
+            if dst_unterminated:
+                out.write(b"\n")
+            for record in strict_raw_records(f, src_path, cap=_NOTIFICATION_RECORD_CAP):
+                key = _notification_key(record, src_path)
+                # A `None` key means the record did not PARSE, so it may be a
+                # framing fragment rather than a record -- nothing it could be a
+                # duplicate OF. Both `existing.add` sites refuse `None`, which is
+                # what keeps it out of this membership test; an unconditional
+                # `key is not None` here would be dead, and a mutation proved it
+                # unobservable. A ts-less row that DOES parse is keyed on its raw
+                # bytes and deduplicates normally; see _notification_key for why
+                # raw and not stripped.
+                if key in existing:
+                    continue
+                out.write(record if record.endswith(_TERMINATORS) else record + b"\n")
+                if key is not None:
+                    existing.add(key)
+                imported += 1
+    except (OSError, UnreadableRecord) as exc:
+        # Reached only when the source changed BETWEEN the validation pass and
+        # this one, so the prefix already appended stays: rolling it back would
+        # be a second unvalidated write. Names the count so an operator knows a
+        # prefix landed, and identity-less rows in it will re-append on a retry.
+        print(f"  ⚠️  Stopped merging {_safe_name(src_path)} after {imported} record(s): {exc}")
+        raise
     print(f"  Notifications imported: {imported}")
 
 
@@ -4080,6 +4331,19 @@ def restore_main(argv: list[str] | None = None, *, parsed: argparse.Namespace | 
             # as one rather than letting a traceback out -- the same contract every other
             # refusal on this path already follows.
             print(f"❌ {e}")
+            return 1
+        except UnreadableRecord as exc:
+            # The notification merge aborts on a record it cannot deliver intact, so
+            # that a partial copy is never reported as a success -- see
+            # `_merge_notifications`. That refusal is as deliberate as the two above and
+            # belongs in this list; while it was missing, it left this command as a
+            # TRACEBACK, which tells the operator their tool broke rather than that their
+            # data was rejected. Deliberately narrower than `(OSError, UnreadableRecord)`,
+            # which is what the merge itself catches: an `OSError` here could come from
+            # any copy in the restore, and labelling one of those a refused notification
+            # record would be a wrong message rather than a missing one.
+            _audit("state_restore_rejected", f"reason=unreadable_notification_record detail={exc}")
+            print(f"❌ {exc}")
             return 1
         except SourceComponentUnsound as e:
             # `_allocate_rollback_dir` raises this when every candidate name for the current

--- a/test/test_jsonl_util.py
+++ b/test/test_jsonl_util.py
@@ -607,17 +607,13 @@ _KERNEL_PSEUDO_FILE_READERS = {
 # if it is ever bounded the posture must be abort/count, never skip.
 _FENCED_READERS = {"sel.py"}
 
-# DEFERRED, not excused: this one is a known live bug, tracked separately, and
-# listed here so the scanner records it instead of going quiet about it.
-#
-# `snapshot._merge_notifications` copies records from one file into another
-# verbatim, which makes it the only site in the #6345 audit where reading
-# faithfully is not the whole contract -- the bytes must also be VALID FOR THE
-# DESTINATION. Converting it needs that write-side contract stated up front
-# (record boundary, dedupe-key type, framing, and encoding), and four successive
-# review rounds on PR #7651 each found one more property of it, so it is being
-# done as its own change rather than inferred from the read-side contract here.
-_DEFERRED_READERS = {"snapshot.py"}
+# DEFERRED, not excused: nothing is deferred today. `snapshot._merge_notifications`
+# was the one entry, and it is converted -- it reads both the destination and the
+# source through `strict_raw_records`, validates each record's encoding without
+# transforming it, and appends the original bytes. See #7771 for the write-side
+# contract that conversion needed (record boundary, dedupe-key type, framing,
+# encoding, abort-not-skip posture) and which is stated on the function itself.
+_DEFERRED_READERS: set[str] = set()
 
 _ALLOWED_UNBOUNDED_FILES = (
     {path for path, _ in _KERNEL_PSEUDO_FILE_READERS} | _FENCED_READERS | _DEFERRED_READERS

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -13,6 +13,7 @@ import pytest
 
 from conftest import requires_symlinks
 from kiro_crew import snapshot as snapshot_mod
+from kiro_crew.jsonl_util import OversizedRecord, UndecodableRecord, UnreadableRecord
 from kiro_crew.snapshot import restore_main, snapshot_main
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -404,6 +405,42 @@ class TestRestoreMerge:
         ).fetchone()[0]
         assert val == '"modified"'
         conn.close()
+
+    def test_a_refused_notification_record_exits_1_instead_of_tracebacking(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """The CLI must report a refusal, not crash with it.
+
+        ``_merge_notifications`` aborts on a record it cannot deliver intact so a
+        partial copy is never reported as success. That refusal had nowhere to
+        land on this path: ``restore_main`` contains a ``try`` whose whole stated
+        purpose is that "a traceback would read like a crash and bury the one
+        sentence saying what to do about it", and ``UnreadableRecord`` was simply
+        missing from its list of arms.
+
+        Drives the real command end to end rather than calling the merge
+        directly, because the defect was entirely in what the BOUNDARY does with
+        the exception -- a unit test on the merge passes either way.
+        """
+        src, out, dst = tmp_path / "src9", tmp_path / "out9", tmp_path / "dst9"
+        _setup_fake_kirocrew(src)
+        # Both sides must have the file or the merge is never reached: a missing
+        # destination takes the copy branch instead.
+        (src / "notifications.jsonl").write_bytes(b'{"ts":1,"msg":"from snapshot"}\n')
+        monkeypatch.setenv("KIROCREW_HOME", str(src))
+        tarball = _make_snapshot(src, out)
+
+        _setup_fake_kirocrew(dst)
+        # 0xff is invalid UTF-8 anywhere, which is how a real file gets here.
+        (dst / "notifications.jsonl").write_bytes(b'{"ts":2,"msg":"\xff"}\n')
+        monkeypatch.setenv("KIROCREW_HOME", str(dst))
+
+        ret = restore_main([str(tarball), "--mode", "merge", "--force"] + unpinnable_argv())
+
+        assert ret == 1, "a refusal must be an exit code, not an exception"
+        out_text = capsys.readouterr().out
+        assert "not valid UTF-8" in out_text, "the refusal must say WHY"
+        assert out_text.count("❌") >= 1, "reported through the same channel as its neighbours"
 
     def test_merge_cron_dedup(self, env, monkeypatch):
         """TEST 8"""
@@ -1301,3 +1338,516 @@ class TestMergeRestoreLocksBeforePublish:
         monkeypatch.setattr(snapshot_mod.os, "close", _close)
         snapshot_mod._do_merge(snap, home, ["security"], allow_unpinned=bool(unpinnable_argv()))
         assert not (home / "telemetry_salt").exists()
+
+
+class TestNotificationMergeWriteSideContract:
+    """The notification merge copies records, so its bytes must be valid FOR THE DESTINATION.
+
+    Every fixture here is real BYTES written to a real file. A synthesized
+    ``UnicodeDecodeError`` would route the merge down a healthy path and prove
+    nothing: the defect was that the decode happened at ``for line in f``,
+    OUTSIDE the ``try``, so the failure never took the branch a fake exception
+    would have taken.
+    """
+
+    LIVE = b'{"ts":"2026-02-01T00:00:00Z","msg":"local"}\n'
+    GOOD = b'{"ts":"2026-03-01T00:00:00Z","msg":"snap"}\n'
+    # 0xff is invalid UTF-8 anywhere; a truncated multi-byte lead is the
+    # ordinary way a real file gets there.
+    BAD_UTF8 = b'{"ts":"2026-03-02T00:00:00Z","msg":"\xff"}\n'
+
+    def _files(self, tmp_path, src_bytes: bytes, dst_bytes: bytes):
+        src = tmp_path / "snap-notifications.jsonl"
+        dst = tmp_path / "live-notifications.jsonl"
+        src.write_bytes(src_bytes)
+        dst.write_bytes(dst_bytes)
+        return src, dst
+
+    @staticmethod
+    def _merge_must_not_abort(src, dst) -> None:
+        """Call the merge, turning an escaping exception into a NAMED failure.
+
+        Several properties here are "a record of this shape must not abort the
+        restore", and the pre-fix behaviour was an escaping exception. Letting it
+        surface raw would report the red as an incidental error; ``pytest.fail``
+        makes the red say which property broke.
+        """
+        try:
+            snapshot_mod._merge_notifications(src, dst)
+        except Exception as exc:  # noqa: BLE001 — the subject is that it does not
+            pytest.fail(f"the merge aborted instead of handling the record: {exc!r}")
+
+    # ── encoding ──────────────────────────────────────────────────────────
+
+    def test_an_invalid_utf8_source_record_never_reaches_the_live_file(self, tmp_path, capsys):
+        """The whole point: the live file must stay loadable.
+
+        Its loader decodes the WHOLE file and returns no rows at all on one bad
+        byte, after which the next rewrite persists that empty view -- so a
+        single appended bad record costs every record that was already there.
+        """
+        src, dst = self._files(tmp_path, self.GOOD + self.BAD_UTF8, self.LIVE)
+        with pytest.raises(UndecodableRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert b"\xff" not in after
+        after.decode("utf-8")  # the property that matters: still loadable
+        out = capsys.readouterr().out
+        assert "Notifications imported:" not in out, "reported success on a failed merge"
+        assert "not valid UTF-8" in out
+
+    def test_the_failure_reaches_the_caller_and_is_not_only_printed(self, tmp_path):
+        """A warn-and-return would tell an API caller the import succeeded.
+
+        ``apply_import_zip`` appends ``notifications (merged)`` to its summary
+        unconditionally, and the dashboard handler answers ``ok: True`` with a
+        SEL ``outcome="ok"``. Neither sees stdout. So the merge has to raise, or
+        an import that left records behind is reported as one that did not.
+        Pinned separately from the byte-level assertions because it is a
+        contract with the CALLER, not with the file.
+        """
+        for label, src_bytes, dst_bytes in (
+            ("source", self.GOOD + self.BAD_UTF8, self.LIVE),
+            ("destination", self.GOOD, self.LIVE + self.BAD_UTF8),
+        ):
+            src, dst = self._files(tmp_path, src_bytes, dst_bytes)
+            with pytest.raises(UnreadableRecord):
+                snapshot_mod._merge_notifications(src, dst)
+            assert True, label
+
+    def test_an_invalid_utf8_record_already_in_the_live_file_is_a_true_no_op(
+        self, tmp_path, capsys
+    ):
+        """The destination scan is its own failure domain and must write nothing.
+
+        This is the site the issue's own criterion required and did not name.
+        The scan used to run in text mode too, so pre-existing live corruption
+        aborted the merge with a traceback before the copy loop was reached; it
+        still aborts, but now with a named reason and without having touched the
+        destination.
+        """
+        src, dst = self._files(tmp_path, self.GOOD, self.LIVE + self.BAD_UTF8)
+        before = dst.read_bytes()
+        with pytest.raises(UndecodableRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == before, "destination-scan failure was not a no-op"
+        out = capsys.readouterr().out
+        assert "Notifications imported:" not in out
+        assert "merge aborted" in out
+
+    def test_the_success_line_is_printed_exactly_once(self, tmp_path, capsys):
+        """A count, not a membership test, because a duplicate is invisible to `in`.
+
+        The restructure that added the raising posture left the pre-existing
+        success print in place below the new one, so the CLI reported the import
+        count twice. Every other assertion here spells the check
+        ``"Notifications imported:" in out``, which passes just as happily on two
+        copies as on one -- and no linter or type check sees a doubled print
+        either. Found by the First Principles lane, pinned here.
+        """
+        src, dst = self._files(tmp_path, self.GOOD, self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        out = capsys.readouterr().out
+        assert out.count("Notifications imported:") == 1, f"success line not printed once:\n{out}"
+
+    # ── boundary and byte-exactness ───────────────────────────────────────
+
+    def test_a_crlf_terminated_record_keeps_its_carriage_return(self, tmp_path):
+        """Row D of the measurement: text mode DROPPED the ``\\r``.
+
+        Universal newlines translated ``\\r\\n`` to ``\\n`` on read and
+        ``os.linesep`` put back only ``\\n`` on write, so the appended record
+        was one byte shorter than the record on disk. This fires on a pure UTF-8
+        host with fully valid UTF-8 input, which is why an explicit
+        ``encoding=`` does not address it -- ``newline=`` is a separate axis.
+        """
+        src_bytes = b'{"ts":"2026-03-03T00:00:00Z","msg":"crlf"}\r\n'
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes
+
+    def test_a_record_holding_a_bare_carriage_return_is_not_silently_lost(self, tmp_path, capsys):
+        """Row E: the strongest demonstration, and it needs no bad encoding.
+
+        A VALID UTF-8 record containing a bare ``\\r`` was split by universal
+        newlines, both halves then failed ``json.loads``, the
+        ``except (ValueError, TypeError): pass`` swallowed both, and the merge
+        printed ``imported: 0`` and returned success. The record was gone from
+        the live file permanently. Data loss on the default configuration.
+        """
+        src_bytes = b'{"ts":"2026-03-04T00:00:00Z","msg":"a\rb"}\n'
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        self._merge_must_not_abort(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes
+        assert "Notifications imported: 0" not in capsys.readouterr().out
+
+    # ── framing ───────────────────────────────────────────────────────────
+
+    def test_an_unterminated_live_record_gains_a_terminator_before_any_append(self, tmp_path):
+        """A crash mid-append leaves the live file without a final terminator.
+
+        Appending onto it glued two records into one line that parses as
+        neither, so both were lost to the loader.
+        """
+        unterminated = b'{"ts":"2026-02-02T00:00:00Z","msg":"torn"}'
+        src, dst = self._files(tmp_path, self.GOOD, unterminated)
+        snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert after == unterminated + b"\n" + self.GOOD
+        rows = [json.loads(line) for line in after.splitlines() if line.strip()]
+        assert [r["msg"] for r in rows] == ["torn", "snap"]
+
+    def test_an_unterminated_source_record_is_terminated_as_it_is_appended(self, tmp_path):
+        """Otherwise the NEXT append glues onto it, moving the same defect."""
+        src, dst = self._files(tmp_path, b'{"ts":"2026-03-05T00:00:00Z"}', self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + b'{"ts":"2026-03-05T00:00:00Z"}\n'
+
+    # ── dedupe key type ───────────────────────────────────────────────────
+
+    def test_a_non_object_record_does_not_abort_the_merge(self, tmp_path, capsys):
+        """``json.loads(raw).get("ts")`` raised AttributeError on a JSON array.
+
+        The record is unparseable AS A NOTIFICATION but its bytes are still
+        history, so it is copied and keyed by its raw form -- not dropped, which
+        would delete it.
+        """
+        src_bytes = b"[1, 2]\n" + self.GOOD
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        self._merge_must_not_abort(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes
+        assert "Notifications imported: 2" in capsys.readouterr().out
+
+    def test_an_unhashable_ts_does_not_abort_the_merge(self, tmp_path, capsys):
+        """A list or dict ``ts`` raised TypeError on set insert."""
+        src_bytes = b'{"ts":[1,2],"msg":"weird"}\n' + b'{"ts":{"a":1},"msg":"weirder"}\n'
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        self._merge_must_not_abort(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes
+        assert "Notifications imported: 2" in capsys.readouterr().out
+
+    def test_a_numeric_ts_still_deduplicates_on_its_value(self, tmp_path, capsys):
+        """Keying only `str` would REGRESS against the predecessor.
+
+        `json.loads(line).get("ts") or line.strip()` keyed a numeric ts on the
+        number, so two rows carrying the same numeric ts with different bytes --
+        one normalised, one not -- deduplicated. Falling back to the raw form for
+        them instead persists a duplicate, which is the loss class this whole
+        change is about. Found by the GPT lane.
+        """
+        live = b'{"ts":1767225600,"msg":"same row, live spelling"}\n'
+        src_bytes = b'{"msg":"same row, snapshot spelling","ts":1767225600}\n'
+        src, dst = self._files(tmp_path, src_bytes, live)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == live, "a numeric ts stopped deduplicating"
+        assert "Notifications imported: 0" in capsys.readouterr().out
+
+    def test_an_int_and_an_equal_float_ts_deduplicate(self, tmp_path, capsys):
+        """`1` and `1.0` are equal and hash equal, so they are ONE row.
+
+        The kind tag is `"num"` for both, deliberately coarser than the Python
+        type: tagging with `type(ts).__name__` split a row written as an integer
+        on one side and a float on the other -- an ordinary serializer artefact
+        -- into two records and persisted the duplicate. Found by the GPT lane.
+        """
+        live = b'{"ts":1767225600,"msg":"one row"}\n'
+        src_bytes = b'{"ts":1767225600.0,"msg":"one row, float spelling"}\n'
+        src, dst = self._files(tmp_path, src_bytes, live)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == live, "an int and an equal float ts stopped deduplicating"
+        assert "Notifications imported: 0" in capsys.readouterr().out
+
+    def test_a_boolean_ts_does_not_collide_with_the_number_one(self, tmp_path, capsys):
+        """`True == 1` and `hash(True) == hash(1)`, so `bool` is its own kind.
+
+        Widening the predicate to any hashable `ts` is what exposes this: without
+        a distinct tag these two records are one set member and the second is
+        DELETED as a duplicate -- the loss class this change closes, re-created by
+        the fix for it. `bool` is checked before the numeric arm because it is a
+        subclass of `int`.
+        """
+        src_bytes = b'{"ts":true,"msg":"boolean"}\n{"ts":1,"msg":"number"}\n'
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes, "a boolean ts collided with 1"
+        assert "Notifications imported: 2" in capsys.readouterr().out
+
+    def test_a_fragment_of_a_split_record_is_not_skipped_against_a_truncated_live_row(
+        self, tmp_path
+    ):
+        """Content is not identity, and using it as identity DELETES bytes.
+
+        A crash mid-append leaves a truncated row in the live file. A source
+        record holding a bare carriage return is split at it, because the
+        reader's boundaries are the universal-newline set -- and the source's
+        first piece can strip to exactly that truncated live row. Keyed on
+        content, that piece was skipped as a duplicate while the second piece was
+        appended, so the live file gained a dangling line and the source's
+        carriage return was gone, while the merge printed success. Measured on
+        these exact bytes. Found by the GPT lane.
+        """
+        live = b'{"ts":"2026-01-01T00:00:00Z","msg":"a\n'
+        src_bytes = b'{"ts":"2026-01-01T00:00:00Z","msg":"a\rb"}\n'
+        src, dst = self._files(tmp_path, src_bytes, live)
+        snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert after == live + src_bytes, "a record fragment was skipped as a duplicate"
+        assert b"\r" in after, "the source carriage return was lost"
+
+    def test_two_distinct_records_with_no_ts_both_land(self, tmp_path, capsys):
+        """The add-guards are what keep `None` out of the seen-set.
+
+        If either `existing.add` accepted a `None` key, the FIRST identity-less
+        record would seed it and every later one would match -- so a source
+        holding several such rows would append one and silently drop the rest.
+        Two rows are the smallest input that observes it; one row cannot.
+        """
+        src_bytes = b'{"msg":"first with no ts"}\n{"msg":"second with no ts"}\n'
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes, "an identity-less row was dropped"
+        assert "Notifications imported: 2" in capsys.readouterr().out
+
+    def test_a_parsing_ts_less_row_deduplicates_on_its_raw_bytes(self, tmp_path, capsys):
+        """A ts-less row that PARSES is a whole record, so bytes are its identity.
+
+        Rewritten rather than adjusted: the predecessor of this test pinned a
+        re-append as declared behaviour, and that premise is gone. Keying such a
+        row on its unstripped bytes restores idempotence for a re-run without
+        restoring the deletion, because byte-equal records ARE the same record.
+        """
+        src_bytes = b'{"msg":"no ts at all"}\n'
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes
+        assert "Notifications imported: 1" in capsys.readouterr().out
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + src_bytes, "a re-run must NOT re-append it"
+        assert "Notifications imported: 0" in capsys.readouterr().out
+
+    def test_an_UNTERMINATED_ts_less_row_also_deduplicates_on_re_import(self, tmp_path, capsys):
+        """The key must be the bytes that LAND, not the bytes that arrive.
+
+        The test above uses a source row that already ends in a newline, so it
+        cannot see this: an UNTERMINATED row is written with a terminator
+        appended, so keying the arriving form makes a second import compare the
+        source's unterminated bytes against the terminated row the first import
+        itself wrote, miss, and append a second copy. Reproduced before the fix --
+        two copies after two imports, with "imported: 1" both times.
+
+        Asserted by COUNT rather than by membership, because membership is
+        structurally blind to duplication, which is the whole defect here.
+        """
+        src_bytes = b'{"msg":"no ts, unterminated"}'  # deliberately no terminator
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        landed = self.LIVE + src_bytes + b"\n"
+
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == landed
+        assert "Notifications imported: 1" in capsys.readouterr().out
+
+        snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert after.count(src_bytes) == 1, "the row must appear exactly ONCE"
+        assert after == landed, "a re-import must append nothing"
+        assert "Notifications imported: 0" in capsys.readouterr().out
+
+    def test_two_parsed_rows_differing_ONLY_in_terminator_both_survive(self, tmp_path):
+        """Pins the DIRECTION of the normalization, not merely its presence.
+
+        Found by mutation: replacing the ``+ b"\\n"`` normalization with
+        ``rstrip(b"\\r\\n")`` left the whole suite green, so nothing distinguished
+        the safe direction from the predecessor's deleter. The existing
+        strip-alike test cannot catch it -- its fragment is UNPARSEABLE, so it
+        takes the ``None`` path and never reaches the raw key at all.
+
+        These two rows PARSE, so both are byte-keyed. They land as distinct bytes
+        (``...\\r`` is kept as-is, ``...`` gains ``\\n``), so both must survive.
+        Under ``rstrip`` they collapse to one key and the second is deleted.
+        """
+        cr_row = b'{"msg":"same payload"}\r'
+        bare_row = b'{"msg":"same payload"}'
+        src, dst = self._files(tmp_path, cr_row + bare_row, self.LIVE)
+        snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert after == self.LIVE + cr_row + bare_row + b"\n", "both rows must land"
+        assert after.count(b'{"msg":"same payload"}') == 2, "neither may be skipped"
+
+    def test_an_unterminated_DESTINATION_row_keeps_its_identity(self, tmp_path):
+        """The destination side takes the same normalization, so the two agree.
+
+        A crash leaves the live file's final record unterminated; the merge
+        terminates it before appending. Its key therefore has to be the
+        terminated form too, or the row it becomes stops matching the row it was
+        and a later import of the same content duplicates it.
+        """
+        row = b'{"msg":"crash-truncated tail"}'
+        src, dst = self._files(tmp_path, row + b"\n", self.LIVE + row)
+        snapshot_mod._merge_notifications(src, dst)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes().count(row) == 1, "one row, not two"
+
+    def test_two_rows_that_only_STRIP_alike_both_survive(self, tmp_path):
+        """Round 5's deletion, pinned against the key that caused it.
+
+        A crash truncates a live row to ``b'{"a": "x'``; framing splits a source
+        record at its bare carriage return, yielding ``b'{"a": "x\\r'``. Those two
+        are NOT byte-equal but they strip alike, which is exactly how the
+        predecessor deleted the source's bytes. Both must survive.
+        """
+        truncated = b'{"a": "x'
+        src, dst = self._files(tmp_path, b'{"a": "x\ry"}\n', self.LIVE + truncated)
+        snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert truncated in after, "the live truncated row must remain"
+        assert b'{"a": "x\r' in after, "the source fragment must not be skipped"
+        assert b'y"}' in after, "the source tail must be appended"
+
+    def test_a_byte_key_can_never_collide_with_a_ts_key(self, tmp_path):
+        """``json.loads`` cannot produce a value whose type is named ``raw``.
+
+        The kind tag is what keeps the two key families apart, so this pins the
+        claim the docstring makes rather than leaving it as prose.
+        """
+        k = lambda b: snapshot_mod._notification_key(b, tmp_path / "x.jsonl")  # noqa: E731
+
+        # A HASHABLE ts always tags with its kind, never "raw" -- json.loads can
+        # only yield str/int/float/bool here, so type(ts).__name__ cannot be "raw"
+        # and the string "raw" as a VALUE tags as `str`, not as the byte family.
+        for value in (b'{"ts": "raw"}', b'{"ts": 1}', b'{"ts": 1.0}', b'{"ts": true}'):
+            key = k(value + b"\n")
+            assert key is not None and key[0] != "raw", f"{value!r} collided"
+        # An UNHASHABLE ts has no usable identity of its own, so it takes the byte
+        # key. Safe for the same reason: byte-equal records are the same record.
+        for value in (b'{"ts": [1]}', b'{"ts": {"n": 1}}'):
+            key = k(value + b"\n")
+            assert key is not None and key[0] == "raw", f"{value!r} should byte-key"
+        # Parsed but no ts -> byte key. Unparseable -> no key at all.
+        assert k(b'{"m":1}\n')[0] == "raw"
+        assert k(b"not json\n") is None
+
+    # ── bound ─────────────────────────────────────────────────────────────
+
+    def test_an_over_cap_record_aborts_instead_of_being_skipped(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """A skipped record here is a permanently deleted one, so it aborts.
+
+        The cap is moved rather than writing a 128 MiB fixture; the read is a
+        global lookup at call time for exactly that reason.
+        """
+        monkeypatch.setattr(snapshot_mod, "_NOTIFICATION_RECORD_CAP", 64)
+        oversized = b'{"ts":"2026-03-06T00:00:00Z","msg":"' + b"x" * 200 + b'"}\n'
+        src, dst = self._files(tmp_path, self.GOOD + oversized, self.LIVE)
+        with pytest.raises(OversizedRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert b"x" * 200 not in after
+        out = capsys.readouterr().out
+        assert "Notifications imported:" not in out
+        assert "record over 64 bytes" in out
+
+    # ── failure posture ───────────────────────────────────────────────────
+
+    def test_an_archive_derived_path_cannot_forge_terminal_output(self, tmp_path, capsys):
+        """A bundle chooses its own inner root, so a path can carry ANSI controls.
+
+        `_safe_name` exists for exactly this and is used at nineteen sites in this
+        module; its docstring names archive root directories. These three prints
+        are new code and were bypassing it, so a crafted root printed raw would
+        move the cursor and overwrite lines right above the prompt where the
+        operator decides whether to trust the restore. Found by the GPT lane.
+        """
+        hostile = tmp_path / "kirocrew-snapshot-\x1b[2K\x1b[1Aevil"
+        hostile.mkdir()
+        src = hostile / "notifications.jsonl"
+        dst = tmp_path / "live.jsonl"
+        src.write_bytes(self.BAD_UTF8)
+        dst.write_bytes(self.LIVE)
+        with pytest.raises(UndecodableRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        out = capsys.readouterr().out
+        assert "\x1b" not in out, f"a raw escape reached the terminal:\n{out!r}"
+        assert "evil" in out, "the name was suppressed rather than escaped"
+
+    def test_the_residual_copy_failure_also_escapes_its_archive_path(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        """The SECOND source print needs its own test or its sanitizer is untested.
+
+        `_safe_name` guards two source prints, and a mutation of this one could not
+        redden while only the pre-validation path had coverage. Reaching it needs
+        the residual condition -- the source changing between the validation pass
+        and the copy -- which cannot be produced by file content alone, so the
+        reader is made to succeed once and refuse once.
+
+        The injected refusal is legitimate HERE, unlike elsewhere in this class,
+        because the property under test is that the print escapes its path. The
+        exception is only the trigger that reaches the print; it is not the thing
+        being verified, so it does not have to be a real undecodable byte.
+        """
+        real = snapshot_mod.strict_raw_records
+        calls = {"n": 0}
+
+        def flaky(handle, path, **kw):
+            calls["n"] += 1
+            if calls["n"] >= 3:  # 1 = destination scan, 2 = validation, 3 = the copy
+                raise UnreadableRecord("source changed under the merge")
+            yield from real(handle, path, **kw)
+
+        hostile = tmp_path / "kirocrew-snapshot-\x1b[2K-forged"
+        hostile.mkdir()
+        src = hostile / "notifications.jsonl"
+        dst = tmp_path / "live.jsonl"
+        src.write_bytes(self.GOOD)
+        dst.write_bytes(self.LIVE)
+        monkeypatch.setattr(snapshot_mod, "strict_raw_records", flaky)
+        with pytest.raises(UnreadableRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        out = capsys.readouterr().out
+        assert "Stopped merging" in out, f"the copy-loop print was not reached:\n{out!r}"
+        assert "\x1b" not in out, f"a raw escape reached the terminal:\n{out!r}"
+        assert "forged" in out, "the name was suppressed rather than escaped"
+
+    def test_a_ts_less_row_before_a_bad_one_is_not_duplicated_by_a_retry(self, tmp_path, capsys):
+        """The source is validated WHOLE before the destination is opened.
+
+        An identity-less row cannot be deduplicated, by construction. So if a
+        later record aborts the copy, the rows already appended include ones a
+        retry has no way to recognise -- and the retry appends them again. The
+        pre-validation pass is what removes the prefix entirely, which is the only
+        fix that does not require identity for rows that have none. Found by the
+        GPT lane.
+        """
+        src_bytes = b'{"msg":"no ts, would double"}\n' + self.BAD_UTF8
+        src, dst = self._files(tmp_path, src_bytes, self.LIVE)
+        for attempt in ("first", "retry"):
+            with pytest.raises(UndecodableRecord):
+                snapshot_mod._merge_notifications(src, dst)
+            assert dst.read_bytes() == self.LIVE, f"{attempt}: a prefix was appended"
+        out = capsys.readouterr().out
+        assert "Notifications imported:" not in out
+        assert "after 1 record(s)" not in out, "the copy loop ran despite a bad source"
+
+    def test_a_bad_source_record_leaves_the_live_file_untouched(self, tmp_path, capsys):
+        """A source-side refusal is a no-op now, not an abort with a prefix.
+
+        Earlier revisions appended everything up to the bad record and kept it,
+        relying on the seen-set rebuilt from the destination to make a re-run
+        idempotent. That reasoning only holds for rows that HAVE identity, and
+        identity-less rows are exactly the ones this function may not deduplicate,
+        so the prefix was a retry-duplication hazard. Validating the whole source
+        first removes it. A prefix can still survive the residual case -- the
+        source changing between the two passes -- which is why the copy loop keeps
+        its own handler.
+        """
+        src, dst = self._files(tmp_path, self.GOOD + self.BAD_UTF8, self.LIVE)
+        with pytest.raises(UndecodableRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE, "a prefix was appended before the refusal"
+        out = capsys.readouterr().out
+        assert "merge aborted" in out
+        assert "Notifications imported:" not in out
+        with pytest.raises(UndecodableRecord):
+            snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE, "the retry appended something"


### PR DESCRIPTION
## 1. What is the problem?

`snapshot._merge_notifications` appends the snapshot's notification records into the live `notifications.jsonl` verbatim. Both handles were text mode:

```python
with open(dst_path) as f:                                # destination scan
    for line in f:
        try:
            existing.add(json.loads(line).get("ts") or line.strip())
        except (ValueError, TypeError):
            pass
with open(dst_path, "a") as out, open(src_path) as f:    # the copy
    for line in f:
        try:
            key = json.loads(line).get("ts") or line.strip()
            ...
```

So a verbatim byte copy was running through a locale decode followed by a locale encode, with universal-newline translation on top. Neither half is byte-exact, and the issue's own framing -- an "encoding-validation gap" -- names a symptom rather than the defect.

### Read this before prescribing `encoding="utf-8"`

The obvious remedy is an explicit `encoding=` on both `open()` calls. **It does not fix this.** Two of the measured failures are locale-INDEPENDENT and fire on a pure UTF-8 host with fully valid UTF-8 input, because `newline=` is a separate axis from `encoding=`. Measured on `2d75835f3`, UTF-8 locale, `PYTHONUTF8=1`:

**A valid record is silently and permanently lost.** A record containing a bare carriage return:

```
src  in : b'{"ts":"2026-03-04T00:00:00Z","msg":"a\rb"}\n'
printed : Notifications imported: 0        <-- reported as success
dst out : (unchanged -- the record is gone)
```

Universal newlines split the record in two, both halves then failed `json.loads`, and `except (ValueError, TypeError): pass` swallowed both. No encoding was involved.

**A valid record loses a byte.** A record terminated with a carriage return plus line feed:

```
src  in : b'{"ts":"2026-01-05T00:00:00Z"}\r\n'
appended: b'{"ts":"2026-01-05T00:00:00Z"}\n'   <-- one byte shorter than the source
```

The remaining failures are locale-dependent, and the locale decides which one you get. `for line in f` decodes OUTSIDE the `try`, so `UnicodeDecodeError` -- a `ValueError` subclass -- escaped `except (ValueError, TypeError)` because the ITERATOR raised it, not `json.loads`. The escaping traceback's innermost frame is `<frozen codecs>:322`.

| input | locale | measured |
|---|---|---|
| invalid UTF-8 in the source | utf-8 | restore aborts with a traceback; nothing appended |
| invalid UTF-8 in the LIVE file | utf-8 | aborts at the destination scan, before any append |
| invalid UTF-8 in the source | ISO-8859-1 | merge SUCCEEDS, bytes land verbatim, live file is no longer valid UTF-8 |
| unterminated final record either side | any | two records glued into one line that parses as neither |

On the single-byte-locale row: latin-1 and cp1252 are byte-BIJECTIONS on decode-then-encode. All 256 byte values were checked; zero differ for either codec, and cp1252 rejects exactly five (`0x81 0x8D 0x8F 0x90 0x9D`) and round-trips the other 251 identically. So that path does not garble the bytes -- it faithfully delivers invalid UTF-8 into a file whose reader demands UTF-8, which is the harm.

## 2. Why this issue matters to the user

The live file's loader decodes the whole file inside one `try` whose `except Exception` returns `[]`, so one bad byte costs every record, not the bad row. Measured with `KIROCREW_HOME` on a temp dir:

```
5 valid records + 1 invalid-UTF-8 record on disk
  _load_notifications()    -> 0 rows        (not 5)
  _rewrite_notifications() -> file is 0 bytes; all 5 valid records gone
```

Any delete, acknowledge or clear triggers that rewrite. So the user's outcome is a restore that reported success, then total loss of notification history the next time they dismiss a notification. And the two locale-independent failures lose records on the default configuration with no bad bytes anywhere.

## 3. How our fix solves it

Symptom to root cause: records were lost or garbled -> because the appended bytes were not the source bytes -> because a verbatim copy was being decoded, re-encoded and newline-translated -> because both handles were text mode. So the fix is to stop being in text mode.

Both reads now go through `jsonl_util.strict_raw_records` on BINARY handles. That module's own docstring names this caller and says it was left unconverted pending exactly this contract, and `strict_raw_records` says "use where the record must survive byte-for-byte: a reader that copies records into another file cannot go through a lossy decode and re-encode". Records come back with their terminators, undecoded and byte-exact.

The write-side contract the issue asked for, stated up front and now on the function itself:

- **Boundary** -- the universal-newline set, which is what the text-mode iteration split on, with the pending-carriage-return half-pair handled inside the framing layer.
- **Encoding** -- validated by decoding, but the decode's RESULT is used only for the dedupe key; what gets appended is always the original bytes. Validating by decoding and writing the decoded form back is precisely the round trip being removed.
- **Framing** -- every appended record ends with a terminator, and an unterminated final record already in the destination gains one before anything is appended after it.
- **Key type** -- well-defined and hashable for every record shape. A non-object record no longer raises `AttributeError` off `.get`, and a list or dict `ts` no longer raises `TypeError` on set insert. A `ts` is used whenever it is truthy AND hashable, under a kind tag deliberately coarser than its Python type, because two equalities are in play at once: `True == 1` and they hash equal, so an untagged key DELETES a `ts: true` row as a duplicate of a `ts: 1` row; `1 == 1.0` and they hash equal too, so tagging with `type(ts).__name__` SPLITS an integer-versus-float spelling of one row and persists a duplicate. One tag covers both -- `int` and `float` share `"num"` so they deduplicate exactly as the predecessor's bare-value key did, while `bool` is its own tag and is tested FIRST because it is a subclass of `int`. A record with NO usable `ts` yields no key and is never deduplicated: the predecessor fell back to `line.strip()`, which is content used as identity, and for a row that does not parse that is not identity -- two different records whose stripped bytes coincide collapse and the loser is deleted.
- **Failure posture** -- abort, never skip, because the output feeds a durable append and a skipped record is a deleted one. Abort means RAISE, not warn: `apply_import_zip` appends `notifications (merged)` to its summary unconditionally and the dashboard handler answers `ok: True` with a SEL `outcome="ok"`, and neither sees stdout, so a printed warning alone would tell an API caller that an import which left records behind had finished. The print stays so a CLI operator reads the reason before the traceback. Both scans are no-ops on refusal: the destination is not opened for append until its scan completes, and the ENTIRE source is validated before it is opened, because an identity-less row cannot be deduplicated so any prefix left by an aborted copy is one a retry would append again. A failure DURING the copy is the residual case -- the source changed between the two passes -- and only there does a prefix survive, since rolling it back would be a second unvalidated write.
- **Bound** -- a per-record cap that aborts. It arrives with the reader.

**The destination scan is converted too, and that is not scope creep.** The issue's own acceptance criterion "destination-scan failure must be a true no-op" is about that site, even though neither the issue body nor its triage comment names it. It had the same defect: an invalid record already in the LIVE file aborted the merge with a traceback before the copy loop was reached.

**The bound is in scope for the same reason it could not be left out.** `snapshot.py` held exactly two `for <var> in <handle>:` loops and both were in this function, so converting them removes the file's last instance of the shape -- at which point `test_the_scanner_actually_detects_the_pattern` requires it to leave `_DEFERRED_READERS`, since that test asserts every excused file still contains the shape. And the byte-exactness fix requires a binary framing reader, which is `strict_raw_records`, whose `cap` is a defaulted keyword. `Refs #6345` is here so that issue's owner sees a part landed; this does not claim to close it.

## 4. What tests we did

Twenty-one new tests in `test/test_snapshot.py::TestNotificationMergeWriteSideContract`, one per contract property. Every fixture is real BYTES written to a real file: a synthesized `UnicodeDecodeError` would route the merge down a healthy path and prove nothing, because the whole defect was that the decode happened at `for line in f`, outside the `try`, so the real failure never took the branch a fake exception takes.

Mutation-verified one enforcement SITE at a time, twenty-four mutations, each reverted with the file asserted restored byte-for-byte:

| property | how the mutation failed |
|---|---|
| encoding, source side | `Failed: DID NOT RAISE UndecodableRecord` |
| encoding, destination side | `Failed: DID NOT RAISE UndecodableRecord` |
| a destination-scan failure must not fall through to the copy | `Failed: DID NOT RAISE UndecodableRecord` |
| abort, not skip, on an undecodable source record | `Failed: DID NOT RAISE UndecodableRecord` |
| the failure reaches the caller, both sites | `Failed: DID NOT RAISE UnreadableRecord` |
| byte-exactness against newline translation | byte equality, both carriage-return tests |
| framing, destination terminator | `At index 42 diff: b'{' != b'\n'` -- the records glued |
| framing, source terminator | byte equality |
| key type, non-object row | `Failed: the merge aborted ... AttributeError("'list' object has no attribute 'get'")` |
| key type, unhashable `ts` | `Failed: ... TypeError("unhashable type: 'list'")` |
| the per-record cap | `Failed: DID NOT RAISE OversizedRecord` |
| a numeric `ts` still deduplicates | `AssertionError: a numeric ts stopped deduplicating` |
| an int and an equal float `ts` deduplicate | `AssertionError: an int and an equal float ts stopped deduplicating` |
| `ts: true` does not collide with `ts: 1` | `AssertionError: a boolean ts collided with 1` |
| `bool` is not swallowed by the numeric arm | `AssertionError: a boolean ts collided with 1` |
| a split record's fragment is not skipped | `AssertionError: a record fragment was skipped as a duplicate` |
| an identity-less row is never skipped | `AssertionError: the declared re-append` |
| both `existing.add` guards keep `None` out of the seen-set | `AssertionError: an identity-less row was dropped` |
| the source pre-validation pass | `AssertionError: first: a prefix was appended` |
| the pre-pass must call the operation that DECODES | `AssertionError: first: a prefix was appended` |
| the success line prints exactly once | `assert 2 == 1`, with both copies in the message |
| an archive-derived path is escaped before printing, pre-validation site | `AssertionError: a raw escape reached the terminal` |
| the same, at the residual copy-failure site | `AssertionError: a raw escape reached the terminal` |

Every red is on pytest's assertion channel -- `AssertionError`, or `Failed` from `DID NOT RAISE` or from a `_merge_must_not_abort` helper that names the property instead of surfacing an incidental exception.

Two of those deserve calling out because they are not obvious. The success-line mutation exists because a restructure re-emitted that `print` and no linter, formatter or type checker sees a doubled print -- and every other assertion here spells the check `"Notifications imported:" in out`, which is structurally blind to duplication whatever suffix it carries, so the test counts instead of testing membership. And the pre-validation pass has two mutations because removing the pass and keeping the pass while not calling the key function fail identically: `strict_raw_records` does not decode, so draining the reader proves nothing about encoding.

Suites, one named file per invocation, serially (`-n 0`), with `PYTHONPATH` pinned to the worktree so main's installed copy could not be the thing under test:

- `test/test_snapshot.py` -- 92 passed (71 pre-existing, including the two pre-existing notification-merge tests, which pass unchanged)
- `test/test_jsonl_util.py` -- 40 passed, including the audit scanner with `snapshot.py` removed from the excused set
- `test/test_portability.py` -- 51 passed (the second caller of this function)

Gates: `isort`, `flake8`, `mypy`, `scripts/check_black_formatting.py`, `scripts/check_subprocess_encoding.py`, `scripts/check_lockdown_before_publish.py`, `scripts/check_testpaths_coverage.py`, `scripts/check_loop_bound_locks.py` -- all clean. Mergeability computed rather than polled: `git merge-tree --write-tree kirocrew/main HEAD` exits 0, and main's delta since the merge-base overlaps none of these four files.

## 5. Any other suggestions on the work

**A bundle chooses its own inner root, so the two SOURCE-path prints escape it.** `_safe_name` exists in this module for exactly that -- its docstring names archive root directories, and nineteen sites already use it -- and the prints this change adds were bypassing it, so a crafted root could move the cursor and overwrite lines right above the prompt where the operator decides whether to trust the restore. Both source prints now wrap the path. The destination print deliberately does not: that path is the live data home, chosen by the operator, not a name out of an archive.

The exception text is deliberately left unwrapped, and the invariant is stated on the code because it is what makes the wrapper unnecessary rather than forgotten: both types the arm catches already render an embedded path with repr-style escaping -- `OSError.__str__` for its filename, and `jsonl_util` via `{path!r}`. Measured: a control character in a directory name reaches neither exception's `str()` raw. Wrapping it as well was over-delivery, and no mutation of it could redden.

**The `blocked` label is stale and can be dropped.** It was applied because `strict_raw_records` and `_DEFERRED_READERS` did not exist on main. Both shipped in #7651, merged 2026-09-02 as `4c288169029ddea1f0522d90243fe39e029cfa7c`, and both were read on main before this change was written.

**One correction to the issue's triage comment**, because it bears on the remedy. That comment identifies the silent path as one where "the destination gets different bytes than the source had". Measured, that is not the mechanism: under a single-byte locale the copy is byte-faithful, and the bytes that really do change change from universal-newline translation, which is locale-independent. Its headline conclusion -- that the non-byte-exact round trip is the root defect rather than an encoding-validation gap -- is right, and stronger than its own reasoning.

**Two residues, both filed rather than folded in.** #8181: both callers fall back to `shutil.copy2` when the live file does not exist, which is byte-exact and validates nothing, so it delivers the same total-loss outcome on every locale including UTF-8 on a fresh install. Not in this PR because `copy2` never decoded anything, so leaving text mode does not touch it -- closing it means ADDING a validation pass rather than converting a pipeline. #8217: `_merge_crons` warns and returns on three refusal paths while `portability.py` appends `crons (merged)` unconditionally, so a refused cron merge is reported as merged -- the same summary-honesty defect this PR fixes for notifications, in the neighbouring component, and its fix needs a judgement about whether one refused component should abort a multi-component restore.

**One inherited quirk, declared rather than silently carried.** `ts: true` and `ts: 1` are equal and hash equal in Python; the kind tag separates them, but the underlying identity is the language's and is inherited from the code being replaced. It is not a regression this PR introduces and not among the acceptance criteria.

Trailer: `Closes #7771` rather than a bare `Refs`, because all four acceptance criteria are met by this diff and both residues have their own tracked owners.

## Scope: one finding acknowledged and tracked rather than fixed here

A review round raised that identity-less notification rows can evict live history. The
finding is real and half of it is fixed in this change: a `ts`-less row that PARSES is now
deduplicated on its raw unstripped bytes, which restores the predecessor's idempotence for a
re-run without restoring the deletion it caused. Stripping made two distinct byte sequences
share a key; raw bytes cannot, because byte-equal records are the same record.

The remaining half is deliberately not fixed here, and is tracked in #8313:

- A record that does not PARSE gets no key by design, so it appends on every merge. That is
  correct, not a shortcoming: `jsonl_util` frames on the universal-newline set, so a record
  containing a bare carriage return is split into fragments, and those fragments are exactly
  the unparseable records. Giving them a content key lets one collide with a crash-truncated
  row and be deleted. The docstring records that framing on newline alone was considered and
  rejected for the mirror-image reason, so this is a reviewed tradeoff rather than an
  oversight.
- Genuinely distinct rows defeat any per-record identity, and `dashboard/state.py`'s trim
  keeps the newest rows while deliberately retaining unparseable ones -- which is what turns
  an append into an eviction. That is a second owner's file.
- Whether the merge should refuse a malformed or non-object row outright is a behaviour
  change, not a bug fix: `main` imports them, and refusing would make one bad row cost an
  entire snapshot restore under this change's validate-whole-source-first posture.

The vector is pre-existing: `main` keys a `ts`-less row by `line.strip()`, which collapses
only identical rows, so it appends N rows for N distinct rows exactly as this branch does.
Nothing here is a regression from this change.

## Two reviewers, the same lines, different questions

`_notification_key`'s raw-key return was examined twice with opposite outcomes, and both
readings are honest. Recording it so nobody has to reconstruct why.

**Opus 4.8** considered the append's terminator handling and dropped it. Its question was
whether adding a terminator to an unterminated final record HARMS the destination, and the
answer is no: terminating it is correct hygiene, the operation is idempotent, no record is
lost, and nothing becomes unloadable.

**GPT 5.6** asked a different question -- whether the added terminator changes the row's
DEDUPLICATION KEY -- and found that it does. An unterminated parsed row without `ts` was
keyed on its arriving bytes while the append wrote it with `\n` appended, so a second import
compared the source's unterminated bytes against the terminated row the first import itself
wrote, missed, and appended a second copy.

Reproduced before the fix: two copies after two imports, with `Notifications imported: 1`
printed both times. Fixed by normalizing the raw key to the bytes that LAND rather than the
bytes that arrive, using the same predicate as the write so the two cannot drift.

**The direction of that normalization is load-bearing.** Adding the terminator the writer
adds is deterministic and merges only records that land identically. Normalizing the other
way -- `rstrip` -- would be the predecessor's `line.strip()` under a new name, mapping `X\r`
and `X` onto one key, which is exactly the fragment / crash-truncated-row pair this change
exists to keep apart. A mutation test pins the direction, not merely the presence, because
substituting `rstrip` left the whole suite green until that test was added.

The general form worth keeping: an earlier "no findings" is not evidence of absence. It is
evidence about the question that reviewer asked.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a loop that iterates a file handle in TEXT mode while its body copies the line into another file. The decode sits on the `for` statement, so it is outside any `try` in the body, and `UnicodeDecodeError` being a `ValueError` makes an `except ValueError` look like it covers a case it cannot reach. Independently, text mode applies universal-newline translation, so the copy is not byte-exact even when every byte is valid UTF-8. Two questions worth asking of any such loop: does an `except ValueError` in the body actually catch the decode, and is the handle text mode when the contract is a verbatim copy.

Second candidate, from this PR's own review history: when a change adds a discriminator to a dedupe key, ask what the discriminator JOINS as well as what it SPLITS. Two revisions here each fixed one equality class and broke the other, because `True == 1` and `1 == 1.0` both hold and hash equal.

Not a semgrep rule: the shape is easy to match but the judgement -- whether a site's contract is verbatim-copy or consume -- is not, so a syntactic rule would be mostly false positives on consumer reads.

Closes #7771
Refs #6345
Refs #8181
Refs #8217


