### PR TITLE
fix(chat): withhold Trust from the composer when no slot can record it (#5486)

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -177,8 +177,19 @@ function sameBlocks(a: PasteBlock[], b: PasteBlock[]): boolean {
   return b.every(x => ids.has(x.id))
 }
 
+// Decisions mapped here resolve via the ONE-SHOT `api.resolveApproval`
+// endpoint, which has no trust verb: POST /api/approvals/{id}/{action} honors
+// exactly `approve`, `reject` and `reject_once` (dashboard/handlers/sessions.py),
+// and the next identical call prompts again. Any UI feeding this path must offer
+// only those decisions — mapping a trust verb to `approve` here runs the tool
+// once while the composer reports a standing grant the backend never recorded
+// (#5400 on the spawn-approval card, #5434 on the collapsed tool row, #5486
+// here). The Trust affordances are withheld from this path at their render
+// sites (`approvalTrustGrantable`); this arm stays fail-closed so a trust verb
+// that reaches it anyway is rejected rather than silently upgraded — the same
+// rule ChatPage's `toApiDecision` carries verbatim.
 function toApiDecision(d: string): 'approve' | 'reject' | 'reject_once' {
-  if (d === 'approved' || d === 'trust' || d === 'trust_reads') return 'approve'
+  if (d === 'approved') return 'approve'
   if (d === 'rejected_once') return 'reject_once'
   return 'reject'
 }
@@ -885,6 +896,17 @@ function ChatInput({
     || (pendingApproval?.content || '').match(/^(?:🔧\s*)?\[([a-z_]+)\]/)?.[1]
     || ''
   const approvalIsUnattended = UNATTENDED_APPROVAL_SOURCES.has(approvalSource)
+  /** True when a standing Trust grant can actually be RECORDED for this card.
+   *  FAIL-CLOSED: the Trust affordances are withheld unless this holds, because
+   *  the only other resolve path is the one-shot `api.resolveApproval`, which
+   *  has no trust verb — offering Trust there claims a standing grant the
+   *  backend never records (#5400, #5434, #5486).
+   *  - `activeSlot`: `api.approveChatSlot` is slot-scoped, so with no slot the
+   *    grant has nowhere to land and `handleApprovalAction` falls through to the
+   *    one-shot endpoint.
+   *  - `!approvalIsUnattended`: session trust is incoherent for a job that is
+   *    not this session (see `approvalSource` above). */
+  const approvalTrustGrantable = !!activeSlot && !approvalIsUnattended
   const simplified = useSimplifiedToolNames()
   const uiLang = useLanguage().resolved
   const approvalLabelRaw = sanitizeLlmOutput(pendingApproval?.content || '').replace(/^🔧\s*/, '')
@@ -3076,8 +3098,8 @@ function ChatInput({
                   )}
                   <div className="flex gap-1.5 flex-wrap items-center">
                       <button disabled={approvalSubmitting} className={approvalBtnClass} onClick={() => handleApprovalAction('approved')}><CheckCircle size={12} className="shrink-0" />{i18nT('components.chatInput.allow_once')}</button>
-                      {approvalIsReadOnly && !approvalIsUnattended && <button disabled={approvalSubmitting} className={approvalBtnClass} onClick={() => handleApprovalAction('trust_reads')}><BookOpen size={12} className="shrink-0" />{i18nT('components.chatInput.trust_reads')}</button>}
-                      {!approvalIsUnattended && approvalTrustCommandGrantable && (
+                      {approvalIsReadOnly && approvalTrustGrantable && <button disabled={approvalSubmitting} className={approvalBtnClass} onClick={() => handleApprovalAction('trust_reads')}><BookOpen size={12} className="shrink-0" />{i18nT('components.chatInput.trust_reads')}</button>}
+                      {approvalTrustGrantable && approvalTrustCommandGrantable && (
                         <TrustDropdown
                             fullCommand={approvalFullCommand}
                             baseCommand={approvalBaseCommand}

--- a/website/src/test/ChatInput.approval.test.tsx
+++ b/website/src/test/ChatInput.approval.test.tsx
@@ -224,16 +224,38 @@ describe('ChatInput approval flow', () => {
     expect(screen.queryByText('Trust reads')).not.toBeInTheDocument()
   })
 
-  it('trust action falls back to resolveApproval when no activeSlot', async () => {
+  // #5486: with no slot to grant on, the Trust affordances are WITHHELD rather
+  // than quietly resolved through the one-shot endpoint. `api.approveChatSlot`
+  // is slot-scoped, so a Trust click used to fall through to
+  // `api.resolveApproval` — which has no trust verb — running the tool once
+  // while the composer reported a standing grant. Same fail-closed rule as
+  // #5400 on the spawn card and #5434 on the collapsed tool row: offer only
+  // trust verbs the resolve path honors. The mapping that performed the
+  // downgrade is pinned separately in ChatInput.trustOneShot.test.tsx.
+  //
+  // `activeSlot: null` reaches this through `useSlotId`'s global fallback; a
+  // `<SlotProvider slotId={null}>` cell (an intentionally empty pane) reaches
+  // the same predicate through the provider branch.
+  it('withholds the Trust dropdown when there is no slot to grant on (#5486)', () => {
     const state = stateWithApproval()
     state.chat!.activeSlot = null
     const store = createTestStore(state)
     renderWithProviders(<ChatInput {...defaultProps} />, { store })
-    fireEvent.click(screen.getByText('Trust'))
-    fireEvent.click(screen.getByText('Trust all tools'))
-    await waitFor(() => {
-      expect(api.resolveApproval).toHaveBeenCalledWith('ap-123', 'approve')
-    })
+    expect(screen.queryByText('Trust')).not.toBeInTheDocument()
+    // Withholding the trust tier must not take the approval bar with it: the
+    // decisions the one-shot endpoint CAN honor are still offered.
+    expect(screen.getByText('Allow once')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
+  })
+
+  it('withholds Trust reads when there is no slot to grant on (#5486)', () => {
+    const state = stateWithApproval()
+    state.chat!.activeSlot = null
+    const store = createTestStore(state)
+    renderWithProviders(<ChatInput {...defaultProps} />, { store })
+    // is_read_only is '1' in this fixture, so the button renders whenever the
+    // gate allows it — its absence here is the gate, not a missing precondition.
+    expect(screen.queryByText('Trust reads')).not.toBeInTheDocument()
   })
 
   it('handles API error gracefully without crashing', async () => {

--- a/website/src/test/ChatInput.trustOneShot.test.tsx
+++ b/website/src/test/ChatInput.trustOneShot.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Source contract for #5486: ChatInput's own `toApiDecision` must not map a
+ * trust verb onto the one-shot approval endpoint.
+ *
+ * `POST /api/approvals/{id}/{action}` honors exactly `approve`, `reject` and
+ * `reject_once` (dashboard/handlers/sessions.py) — there is no trust verb, and
+ * the next identical call prompts again. Mapping `trust`/`trust_reads` to
+ * `approve` there ran the tool once while `finish()` dispatched
+ * `decision: 'trust'`, so the composer reported a standing grant the backend
+ * never recorded. Same defect as #5400 (spawn-approval card) and #5434
+ * (collapsed tool row); ChatPage's `toApiDecision` carries the same rule.
+ *
+ * Why a source contract and not a render test: the trust arm is now
+ * unreachable from the DOM. `approvalTrustGrantable` withholds both Trust
+ * affordances unless a slot is present, and `handleApprovalAction` closes over
+ * the `activeSlot` of the render that drew the button — so a rendered Trust
+ * click always reaches the slot-scoped `api.approveChatSlot` branch, never this
+ * mapping. The narrowing is kept as a defensive invariant for the same reason
+ * the sibling keeps it (ChatPage.collapsedGroupTrust.test.tsx): the render gate
+ * is one edit away from being widened, and this arm decides what a widened gate
+ * would authorize. The gate itself is pinned behaviorally in
+ * ChatInput.approval.test.tsx.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const source = readFileSync(resolve(__dirname, '../components/ChatInput.tsx'), 'utf-8')
+
+/** The body of `function toApiDecision(...)`, brace-matched from its signature. */
+function toApiDecisionBody(src: string): string {
+  const at = src.indexOf('function toApiDecision')
+  expect(at).toBeGreaterThan(-1)
+  const open = src.indexOf('{', src.indexOf(')', at))
+  let depth = 0
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++
+    else if (src[i] === '}') {
+      depth--
+      if (depth === 0) return src.slice(open + 1, i)
+    }
+  }
+  throw new Error('unbalanced braces in toApiDecision')
+}
+
+const body = toApiDecisionBody(source)
+// Executed rather than string-matched so the pin is about the MAPPING, not its
+// spelling: any re-ordering, added branch or changed literal is caught. The body
+// carries no type annotations, so it is valid JS as extracted. `new Function` is
+// the subject under test being the source TEXT: the helper is module-private so
+// it cannot be imported, and re-typing it here would pin a copy rather than the
+// code that ships.
+const toApiDecision = new Function('d', body) as (d: string) => string
+
+describe("ChatInput toApiDecision (#5486 contract)", () => {
+  it('maps every trust verb to reject — the one-shot endpoint cannot record a grant', () => {
+    // The full verb set `handleApprovalAction` routes to the slot endpoint. If a
+    // trust verb ever reaches this mapping, fail closed: a rejection tells the
+    // truth, an `approve` claims a standing grant that was a single execution.
+    for (const verb of ['trust', 'trust_reads', 'trust_command', 'trust_base']) {
+      expect(toApiDecision(verb)).toBe('reject')
+    }
+  })
+
+  it('still maps the decisions this endpoint does honor', () => {
+    expect(toApiDecision('approved')).toBe('approve')
+    expect(toApiDecision('rejected_once')).toBe('reject_once')
+    expect(toApiDecision('rejected')).toBe('reject')
+  })
+
+  it('never answers approve for anything but an explicit one-shot approval', () => {
+    // Fail-closed by default: an unknown or future verb must not be upgraded
+    // into an execution. `approved` is the only input that authorizes one.
+    for (const verb of ['', 'zzq-unknown', 'trusted', 'approve', 'allow']) {
+      expect(toApiDecision(verb)).not.toBe('approve')
+    }
+  })
+
+  it('has exactly one call site, on the one-shot endpoint', () => {
+    // A second call site would be a second resolve path with its own grant
+    // semantics — re-verify this contract against it before adding one.
+    const calls = source.match(/(?<!function\s)toApiDecision\(/g) ?? []
+    expect(calls).toHaveLength(1)
+    expect(source).toContain('api.resolveApproval(approvalId, toApiDecision(decision))')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`ChatInput` (the composer's approval bar) kept its own `toApiDecision`, and it mapped `trust` and `trust_reads` to a plain `approve`:

```ts
function toApiDecision(d: string): 'approve' | 'reject' | 'reject_once' {
  if (d === 'approved' || d === 'trust' || d === 'trust_reads') return 'approve'
```

That mapping feeds the one-shot `api.resolveApproval` fallback. `handleApprovalAction` routes a trust verb to the slot-scoped `api.approveChatSlot` **only when `activeSlot` is set**; with no slot it falls through to the one-shot endpoint, which honors exactly `approve | reject | reject_once` and records no standing grant (`dashboard/handlers/sessions.py:1507`). Meanwhile `finish()` dispatches `resolveByApprovalId({ decision: 'trust' })`, so the row renders as a standing grant.

Net effect in that state: the tool runs once, the composer says the user granted standing trust, and the backend recorded nothing. The user's next identical action prompts again, which reads as the grant having been forgotten rather than never made.

Compounding it, the same function already failed CLOSED for the other two verbs from the same dropdown: `trust_command` and `trust_base` fell to `return 'reject'`. Two of four trust verbs rejected, two silently approved, on one code path -- which is what marks the `trust`/`trust_reads` arm as an artifact rather than a policy.

## Why it matters

This is a consent path, and the failure is quiet in the direction that overstates consent. A user who clicks Trust believes they have widened what runs without asking; the dashboard agrees with them; nothing was recorded. The gap is only observable later, as a prompt they thought they had silenced.

It is the third surface to ship this same defect independently -- #5400 (spawn-approval card, PR #5433) and #5434 (collapsed tool row, PR #5485) -- so the rule was evidently not written anywhere a third author had to read it.

## What changed (motivation -> approach -> change)

The issue named two candidate readings and asked an owner to pick: the branch is dead, so delete the trust mapping; or the branch is reachable, so gate the Trust controls. The already-merged sibling resolves that by having done **both**: PR #5485 narrowed `ChatPage`'s `toApiDecision` to `action === 'approved' ? 'approve' : 'reject'` AND made `CollapsibleToolGroup`'s Trust button fail-closed behind an opt-in `canTrust`. This PR mirrors that shape, so nothing here is a fresh policy choice:

1. **`toApiDecision` narrowed** -- `approved -> approve`, `rejected_once -> reject_once`, everything else `reject`. It carries the constraint comment PR #5485 added at `ChatPage`'s copy, which the issue said applies verbatim.
2. **`approvalTrustGrantable`** -- one predicate, `!!activeSlot && !approvalIsUnattended`, gating both Trust affordances (Trust reads; the Trust dropdown carrying trust / trust_command / trust_base). Previously they were gated on `!approvalIsUnattended` alone. So the mapping's trust arm is now unreachable from the DOM, and the narrowing is defence in depth behind a user-visible fail-closed gate.

**What the user sees, before and after.** With a slot present -- every state reachable from the shipped UI -- there is no change at all: Trust still routes to `api.approveChatSlot` and still records a standing grant. With no slot, the Trust affordances are absent and the bar offers Allow once / Reject / Reject once, which are exactly the decisions that path can honor.

**What gets authorized, before and after.** Strictly narrower, never wider. Before, a trust click in the no-slot state authorized one execution while claiming a standing grant. After, it authorizes nothing, because it cannot be clicked. No decision becomes auto-approved, and no set of commands newly runs without a prompt.

**Reachability, stated honestly.** Not reachable from today's grid: `SessionGridView.renderLeaf` mounts `ChatPane` only for `leaf.kind === 'session' && leaf.slot`, and `deleteSlot.fulfilled` clears `state.messages` in the same reducer that nulls `activeSlot`. It is one mount away: `selectSlotPendingApproval(state, null)` falls back to the global `state.chat.messages`, and `SlotContext` documents `<SlotProvider slotId={null}>` as a supported "intentionally empty pane" -- such a pane's composer would show the globally-active slot's pending approval with `activeSlot` null. The fix is fail-closed either way, which is why it does not depend on settling that.

### Deliberate deviations

- **The private `toApiDecision` is kept, not deleted in favour of the canonical one.** It is not a pure duplicate: it also maps `rejected_once -> reject_once`, a third verb `ChatPage`'s copy has no notion of and the only producer of which is `RejectDropdown`'s "Reject once -- keep asking about the rest". Deleting it would silently downgrade that tier to a plain reject. `ChatPage`'s version is also a component-private `useCallback`, so it cannot be imported. The two now agree on trust, and `ChatInput.trustOneShot.test.tsx` pins the agreement.
- **The shared chokepoint is deliberately NOT built here.** `apps/mochi/panel/approvalActions.ts` already holds a canonical routing predicate (`TRUST_ACTIONS` + `approvalRoute`), and promoting it out of `apps/mochi` for `ChatPage` / `ChatInput` / the tool-group row to consume is the right end state -- but it is a cross-app refactor on a consent path, which is a maintainer's call, not a rider on a bug fix. Filed as #8193 with the audit behind it.

## Tests

- `website/src/test/ChatInput.trustOneShot.test.tsx` (new) -- source contract on the narrowed mapping. It brace-matches the shipped `toApiDecision` body out of `ChatInput.tsx` and executes it, so the pin is on the MAPPING rather than its spelling: all four trust verbs answer `reject`, `approved` and `rejected_once` still answer their own verbs, no unknown verb answers `approve`, and there is still exactly one call site and it is the one-shot endpoint. A source contract for the same reason the sibling's `ChatPage.collapsedGroupTrust.test.tsx` is one -- after the render gate the arm is unreachable from the DOM, so a render test could not reach it.
- `website/src/test/ChatInput.approval.test.tsx` -- the pin that locked the old behaviour (`trust action falls back to resolveApproval when no activeSlot`, asserting `resolveApproval('ap-123', 'approve')`) is replaced by two that lock the new one, one per render site: the Trust dropdown is withheld with no slot, and Trust reads is withheld with no slot. The first also asserts Allow once and Reject are still present, so withholding the tier cannot silently take the bar with it.

Replacing that pin is the same contract change PR #5485 made at `ChatPage` and is on the same grounds; it was the second reason #5486 was held for a human, and the sibling merging is what settles it.

**Mutation-verified, one per enforcement site**, each read as a failure MESSAGE rather than an exit code:

| mutation | reddens | failure |
|---|---|---|
| `toApiDecision` maps trust/trust_reads back to `approve` | trust-verb contract, only | `AssertionError: expected 'approve' to be 'reject'` |
| Trust reads gate back to `!approvalIsUnattended` | Trust reads pin, only | `expect(element).not.toBeInTheDocument()`, found the BookOpen "Trust reads" button |
| Trust dropdown gate back to `!approvalIsUnattended` | Trust dropdown pin, only | `expect(element).not.toBeInTheDocument()`, found the Handshake "Trust" button |
| `approvalTrustGrantable` drops `!!activeSlot` | both render pins | as above |

A third candidate pin (nothing is resolved on render) was written and then dropped: it passed with the fix reverted, so it pinned nothing about this defect.

## Manual verification

N/A -- and deliberately so rather than for convenience. The state where behaviour differs cannot be produced from the shipped UI (see Reachability above), so there is no click path to walk. The DOM evidence that the gate is the thing controlling those buttons comes from the mutation runs, which print the exact `<button>` that reappears when each gate is reverted.

Local, on `5c8ddc6`: 26 files / 497 tests across `ChatInput*`, `TrustDropdown`, `ApprovalCard`; 8 files / 340 tests across the remaining Trust-asserting specs (`ActivityViewerCoverage`, `ApprovalModePicker`, `ChannelPageCoverage`, `MochiChatPanel*`, `MochiSettingsPanel`, `mochiTrustGrantability`); `i18nLintExemptions` 43 tests. `eslint` clean on the three files, `tsc -b` exit 0, `check_focus_cue` / `check_feature_map` / `check_changelog_history` / `leaf_test_scope` / `ratchet_scope` / `check_harness_parity` all pass with `BASE_REF` set to the merge-base.

## Screenshots / video

None, and not omitted for convenience: with a slot present the rendered bar is unchanged, and the state that differs is not reachable from the shipped UI, so a capture would either show no difference or show a state a user cannot reach. The reappearing buttons are evidenced as serialized DOM in the mutation table above instead.

## Related Issues

Closes #5486
Refs #5400, #5434, #8193

## Pattern harvest

Rule candidate: review-prompt
Pattern: a decision string crossing into an endpoint that cannot honor every value it can carry, with the UI reporting the value it SENT rather than the one that was recorded. Three surfaces shipped this same shape independently (#5400, #5434, #5486), and the tell each time was an else-approve fallback (`x === 'reject' ? 'reject' : 'approve'`, or an OR-chain onto `approve`) reachable from a richer verb set than the endpoint's. The generalizable question for a reviewer: for each verb this control can emit, does the endpoint it lands on record that verb -- and does the UI report what was recorded or what was clicked? The static form of the guard, plus whether one predicate should own the routing, is #8193.
