### PR TITLE
fix(spawn): record an unresolved-owner marker instead of an empty session key

### DIFF
--- a/src/kiro_crew/mcp_tools/spawn.py
+++ b/src/kiro_crew/mcp_tools/spawn.py
@@ -52,6 +52,35 @@ from kiro_crew.validation import (
 # self-correction for a few dozen characters, not a full agent listing.
 _MAX_ROSTER_NAMES = 8
 
+# Owner recorded on an audit record when the resolver named no session. An empty
+# owner is ambiguous by construction: a resolver whose every identity source
+# failed and a spawn with genuinely no owning session both produce ``""``, and
+# nothing downstream can recover which one it was. This marker names the failed
+# resolution where it happens, so the audit trail says "the owner was lost"
+# rather than naming no session at all.
+#
+# Same ``unresolved:<pid>`` wire format the computer-use shim already writes
+# (``mcp_computer.UNRESOLVED_SESSION_PREFIX``), so one audit-reader vocabulary
+# covers both producers. Deliberately NOT trustworthy attribution -- the prefix
+# says it is not, so a reader cannot mistake a pid for a session identity.
+_OWNER_UNRESOLVED_PREFIX = "unresolved:"
+
+
+def _audit_owner(parent_session: str) -> str:
+    """The owner to record on an audit record for *parent_session*.
+
+    A resolved key is recorded verbatim. An empty one becomes the unresolved
+    marker for THIS process, read at call time so a forked child cannot report
+    its parent's pid.
+
+    Audit-only. The spawn REQUEST keeps the empty owner, because
+    ``parent_session_key`` addresses per-slot frame delivery and a synthetic key
+    there would route frames at a slot that does not exist.
+    """
+    if parent_session:
+        return parent_session
+    return f"{_OWNER_UNRESOLVED_PREFIX}{os.getpid()}"
+
 
 def _agent_roster_hint() -> str:
     """Valid agent names, for the ``agent``/``agents`` parameter descriptions.
@@ -963,7 +992,7 @@ def spawn_sub_agents(name: str, args: dict[str, Any]) -> str:
             entry["agent_or_mode"] = a[:MAX_SHORT_STRING]
 
     mcp_core.sel().log_tool_invocation(
-        session_key=parent_session or "",
+        session_key=_audit_owner(parent_session),
         source="mcp_core",
         tool_name="spawn_sub_agents",
         outcome="attempt",
@@ -1096,7 +1125,7 @@ def spawn_sub_agents(name: str, args: dict[str, Any]) -> str:
     if sa_errors:
         sa_results.append(json.dumps({"status": "spawn_errors", "errors": sa_errors}))
     mcp_core.sel().log_tool_invocation(
-        session_key=parent_session or "",
+        session_key=_audit_owner(parent_session),
         source="mcp_core",
         tool_name="spawn_sub_agents",
         outcome="completed" if not timed_out and not errored else "partial",

--- a/test/test_mcp_core_spawn_sub_agents.py
+++ b/test/test_mcp_core_spawn_sub_agents.py
@@ -518,3 +518,78 @@ class TestSpawnList:
             result = _call_tool("spawn_list", {})
 
             assert "No subagents running" in result
+
+
+class TestSpawnSubAgentsAuditOwner:
+    """The audit trail must distinguish a LOST owner from an absent one.
+
+    ``_resolve_session_key`` returns ``""`` when every identity source fails,
+    which is the same value a spawn with genuinely no owning session carries.
+    Recording that empty string leaves the run's audit entries naming no
+    session and the two cases indistinguishable afterwards, so a failed
+    resolution is recorded under an explicit unresolved marker instead.
+    """
+
+    @staticmethod
+    def _audit_owners(mock_sel):
+        """Every ``session_key`` the tool wrote to the audit trail, in order."""
+        return [
+            call.kwargs["session_key"]
+            for call in mock_sel.return_value.log_tool_invocation.call_args_list
+        ]
+
+    def test_unresolved_owner_is_marked_in_audit_records(self):
+        with patch("kiro_crew.mcp_core._post") as mock_post, \
+             patch("kiro_crew.mcp_core._get") as mock_get, \
+             patch("kiro_crew.mcp_core._resolve_session_key", return_value=""), \
+             patch("kiro_crew.mcp_core.sel") as mock_sel:
+            mock_post.return_value = {"id": "a1"}
+            mock_get.return_value = {"done": True, "agent": "w", "result": "ok"}
+
+            _call_tool("spawn_sub_agents", {"agents": [{"prompt": "task"}]})
+
+            owners = self._audit_owners(mock_sel)
+            # Both the attempt and the outcome record are written.
+            assert len(owners) == 2
+            for owner in owners:
+                assert owner != ""
+                # Wire format an audit reader filters on. Never presented as
+                # trustworthy attribution -- the prefix says it is not.
+                assert owner.startswith("unresolved:")
+                assert owner.removeprefix("unresolved:").isdigit()
+
+    def test_resolved_owner_is_recorded_verbatim(self):
+        # The marker must not displace a real owner: attribution that resolves
+        # is still recorded exactly as resolved.
+        with patch("kiro_crew.mcp_core._post") as mock_post, \
+             patch("kiro_crew.mcp_core._get") as mock_get, \
+             patch("kiro_crew.mcp_core._resolve_session_key", return_value="dashboard:tab7"), \
+             patch("kiro_crew.mcp_core.sel") as mock_sel:
+            mock_post.return_value = {"id": "a1"}
+            mock_get.return_value = {"done": True, "agent": "w", "result": "ok"}
+
+            _call_tool("spawn_sub_agents", {"agents": [{"prompt": "task"}]})
+
+            assert self._audit_owners(mock_sel) == ["dashboard:tab7", "dashboard:tab7"]
+
+    def test_unresolved_owner_does_not_reach_the_spawn_request(self):
+        # Producer scope only: the marker is an audit value. The run's
+        # parent_session_key still carries the empty owner, because it feeds
+        # per-slot frame routing and a synthetic key there would address a
+        # slot that does not exist.
+        with patch("kiro_crew.mcp_core._post") as mock_post, \
+             patch("kiro_crew.mcp_core._get") as mock_get, \
+             patch("kiro_crew.mcp_core._resolve_session_key", return_value=""), \
+             patch("kiro_crew.mcp_core.sel"):
+            mock_post.return_value = {"id": "a1"}
+            mock_get.return_value = {"done": True, "agent": "w", "result": "ok"}
+
+            _call_tool("spawn_sub_agents", {"agents": [{"prompt": "task"}]})
+
+            spawn_bodies = [
+                call.args[1] for call in mock_post.call_args_list
+                if call.args and call.args[0] == "/api/spawn"
+            ]
+            assert spawn_bodies
+            for body in spawn_bodies:
+                assert body["parent_session"] == ""


### PR DESCRIPTION
## Problem / Motivation

`_resolve_session_key()` (`mcp_core.py:606`) returns `""` after all four identity sources fail. The three spawn entry points call it and continue unconditionally, and the two audit records in `spawn_sub_agents` write `session_key=parent_session or ""`.

So an empty owner is ambiguous by construction: a resolver whose every identity source failed, and a spawn with genuinely no owning session, both produce `""`. Nothing downstream can recover which one it was, and the audit trail names no session for a subagent that did run.

## Why it matters

The audit trail is the record of who caused what. An entry with no owner cannot be attributed, and — worse — cannot be distinguished from an entry that legitimately has no owner, so a resolver regression leaves no trace at all. It looks like normal traffic.

## What changed

The audit records now name the failed resolution instead of naming nothing:

- `_OWNER_UNRESOLVED_PREFIX` + `_audit_owner()` in `src/kiro_crew/mcp_tools/spawn.py`
- applied at the two `log_tool_invocation` call sites in `spawn_sub_agents`

The wire format is `unresolved:<pid>` — deliberately the same format the computer-use shim already writes into this same audit trail (`mcp_computer.UNRESOLVED_SESSION_PREFIX`), so one audit-reader vocabulary covers both producers rather than two spellings of the same condition.

The prefix states that it is not trustworthy attribution, so a reader cannot mistake the pid for a session identity. The pid is read at call time, so a forked child cannot report its parent's.

Deliberately unchanged: owner resolution itself, and the spawn **request** body. `parent_session_key` addresses per-slot frame delivery, and a synthetic key there would route frames at a slot that does not exist — so the request keeps the empty owner. One of the added tests pins that boundary.

This follows the option the triage comment selected ("a marker (option 2) looks lowest-risk and keeps the audit trail honest"); resolver hardening and fail-closed refusal are not attempted here.

## Tests

`test/test_mcp_core_spawn_sub_agents.py` gains `TestSpawnSubAgentsAuditOwner` — three tests: a resolved owner is recorded verbatim, an unresolved owner is marked, and the marker does not reach the request body.

With the source change reverted the second fails on `assert '' != ''`. After: `32 passed`. flake8, isort and mypy clean on the changed files.

## Manual verification

None beyond the tests — the change is observable only in the SEL audit record, which the tests read directly.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** a backend audit-record change with no UI surface.

## Related Issues

Fixes #8108

## Pattern harvest

Rule candidate: review-prompt

Pattern: a resolver that returns an empty string on total failure, whose callers then store that empty value in a field where "absent" is also a legal value. The two states become permanently indistinguishable at the point of storage, not at the point of failure.
