### PR TITLE
fix(autonudge): treat a merged subject as terminal when a paused loop's cap is raised

### DIFF
--- a/src/kiro_crew/dashboard/session_directive_apply.py
+++ b/src/kiro_crew/dashboard/session_directive_apply.py
@@ -50,7 +50,11 @@ from typing import Any
 from kiro_crew.apps.builtins.auto_research.session_keys import (
     is_owned_research_slot,
 )
-from kiro_crew.autonudge import APPROVAL_STALL_REASON, AUTONUDGE_STOP_REASON
+from kiro_crew.autonudge import (
+    APPROVAL_STALL_REASON,
+    AUTONUDGE_STOP_REASON,
+    MONITOR_TERMINAL_REASON,
+)
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.session_surface import has_dashboard_surface
 
@@ -320,16 +324,55 @@ async def _monitor_update(session_key: str, args: dict[str, Any]) -> str:
         # A budget-raise passed the spent-budget guard above, so any budget in
         # the patch here is beyond the loop's elapsed age (or 0 = unlimited).
         raising_budget = "max_runtime_secs" in patch
-        if stopped_at_cap and raising_cap:
-            patch["active"] = True
-            revived = True
-        elif stopped_at_budget and raising_budget:
+        # A TERMINAL subject outranks every bound, and an OWED terminal turn counts
+        # as one -- the same precedence the expiry notice states, read from the same
+        # two fields, so the agent-facing and user-facing endings cannot disagree.
+        #
+        # A channel-bound loop does not settle on observation: the probe records the
+        # owed final turn in ``monitor.terminal_pending`` and leaves the loop active
+        # with no ``outcome``. If that turn is refused (a busy thread, the ordinary
+        # case) and the retry finds a bound spent, the loop deactivates tagged with
+        # that bound before the settlement that would promote the debt ever runs.
+        # Reading ``stopped_reason`` alone then contradicts a fact already durably on
+        # disk, and here it does more than mis-word a notice: a patch that also
+        # raises the bound REVIVES the loop, re-arming a watch on a subject that has
+        # already merged -- the wasted fresh loop this branch exists to prevent.
+        #
+        # Expressed ONCE, as a term in the revival decision itself, rather than as a
+        # guard per branch: the notice next door lost this same precedence three
+        # times because each new bound was added ahead of it.
+        monitor = getattr(loop, "monitor", None)
+        owed = str(getattr(monitor, "terminal_pending", "") or "") if monitor else ""
+        terminal = reason == MONITOR_TERMINAL_REASON or bool(owed)
+        # A settled outcome wins; the debt is the fallback that keeps the
+        # merged-vs-closed distinction available before the settlement lands. Both
+        # speak the same vocabulary (``success``/``blocked``, matching
+        # ``MonitorOutcome``), so one reading covers either source.
+        settled = getattr(monitor, "outcome", None) if monitor else None
+        decided = str(getattr(settled, "value", settled) or owed or "")
+        revivable = not terminal and (
+            (stopped_at_cap and raising_cap) or (stopped_at_budget and raising_budget)
+        )
+        if revivable:
             patch["active"] = True
             revived = True
         else:
             # Name the bound that actually stopped the loop, so the remedy in
             # the message is the one that will work.
-            if stopped_at_budget:
+            if terminal:
+                if decided == "success":
+                    bound = (
+                        "its subject already merged, so the watch is over and there is "
+                        "nothing left to observe; raising a bound buys cycles with no "
+                        "work in them, so arm monitor_start again only for a NEW subject"
+                    )
+                else:
+                    bound = (
+                        "its subject was closed without merging, so re-arming would only "
+                        "re-observe that; the open question is whether to reopen the "
+                        "subject or abandon the goal, and neither is a bound you can raise"
+                    )
+            elif stopped_at_budget:
                 bound = (
                     f"its {int(getattr(loop, 'max_runtime_secs', 0) or 0)}s wall-clock "
                     "budget ran out; raise max_runtime_secs above the loop's age "

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -39,6 +39,7 @@ from kiro_crew import autonudge_authz, session_directive
 from kiro_crew.autonudge import (
     APPROVAL_STALL_REASON,
     AUTONUDGE_STOP_REASON,
+    MONITOR_TERMINAL_REASON,
     AutoNudgeService,
     binding_key_for,
 )
@@ -242,6 +243,7 @@ class _FakeLoop:
         max_runtime_secs=0,
         stopped_reason="",
         slot_key="",
+        monitor=None,
     ):
         self.id = loop_id
         self.cycle_count = cycle_count
@@ -251,6 +253,20 @@ class _FakeLoop:
         self.max_runtime_secs = max_runtime_secs
         self.stopped_reason = stopped_reason
         self.slot_key = slot_key
+        self.monitor = monitor
+
+
+class _FakeMonitor:
+    """The two monitor fields the paused-loop branch reads about a subject.
+
+    ``terminal_pending`` is the owed final turn (``"success"``/``"blocked"``) a
+    channel loop records on observing a terminal subject; ``outcome`` is the
+    settled classification written once that turn lands.
+    """
+
+    def __init__(self, *, terminal_pending="", outcome=None):
+        self.terminal_pending = terminal_pending
+        self.outcome = outcome
 
 
 class _FakeSvc:
@@ -650,6 +666,173 @@ def test_applier_monitor_update_budget_stopped_denial_names_the_budget(monkeypat
     assert not update_calls
     assert "wall-clock" in result and "max_runtime_secs" in result
     assert "max_cycles" not in result
+
+
+def test_applier_owed_terminal_turn_is_not_reported_as_a_spent_cap(monkeypatch):
+    """A channel loop whose subject MERGED must not be told it ran out of cycles.
+
+    A channel-bound loop does not settle on observation: the probe records the owed
+    final turn in ``monitor.terminal_pending`` and leaves the loop active with no
+    ``outcome``. If that turn is refused (a busy thread) and the retry finds the cap
+    spent, the loop deactivates with ``stopped_reason="cycle_cap"`` before the
+    settlement that would promote the debt ever runs. Reading the reason alone then
+    contradicts a fact already durably on disk — and because the cap is also being
+    raised here, the loop would be REVIVED to watch a subject that already merged,
+    which is the wasted fresh loop this costs.
+    """
+    loop = _FakeLoop(
+        "loop-owed-merged",
+        cycle_count=24,
+        max_cycles=24,
+        active=False,
+        stopped_reason="cycle_cap",
+        slot_key="slack:C123:170.5",
+        monitor=_FakeMonitor(terminal_pending="success"),
+    )
+    svc = _FakeSvc(loop)
+    _install_svc(monkeypatch, svc)
+    update_calls = _record_update(monkeypatch)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(),
+            _fake_slot(),
+            _SESSION,
+            "monitor_update",
+            {"patch": {"max_cycles": 48}},
+        )
+    )
+    assert not update_calls, "a terminal subject must not be re-armed by a cap raise"
+    assert "cycle cap" not in result, result
+    assert "merged" in result
+    assert "monitor_start" in result
+
+
+def test_applier_owed_blocked_turn_is_not_reported_as_a_merge(monkeypatch):
+    """A subject closed WITHOUT merging is terminal but is not good news.
+
+    It stopped on a question the operator has to answer — reopen, or abandon — so it
+    must not be worded as a finish. The debt carries the distinction in the same
+    vocabulary the settled outcome uses (``success``/``blocked``).
+    """
+    loop = _FakeLoop(
+        "loop-owed-closed",
+        cycle_count=24,
+        max_cycles=24,
+        active=False,
+        stopped_reason="cycle_cap",
+        slot_key="slack:C123:170.5",
+        monitor=_FakeMonitor(terminal_pending="blocked"),
+    )
+    svc = _FakeSvc(loop)
+    _install_svc(monkeypatch, svc)
+    update_calls = _record_update(monkeypatch)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(),
+            _fake_slot(),
+            _SESSION,
+            "monitor_update",
+            {"patch": {"max_cycles": 48}},
+        )
+    )
+    assert not update_calls
+    assert "cycle cap" not in result, result
+    assert "without merging" in result
+    assert "merged" not in result.replace("without merging", "")
+
+
+def test_applier_settled_terminal_loop_is_not_reported_as_a_manual_pause(monkeypatch):
+    """A SETTLED terminal loop had no branch here either, so it fell to the
+    generic wording and was announced as if a human had pressed Stop."""
+    from kiro_crew.monitoring.models import MonitorOutcome
+
+    loop = _FakeLoop(
+        "loop-settled",
+        cycle_count=7,
+        max_cycles=24,
+        active=False,
+        stopped_reason=MONITOR_TERMINAL_REASON,
+        monitor=_FakeMonitor(outcome=MonitorOutcome.SUCCESS),
+    )
+    svc = _FakeSvc(loop)
+    _install_svc(monkeypatch, svc)
+    update_calls = _record_update(monkeypatch)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(),
+            _fake_slot(),
+            _SESSION,
+            "monitor_update",
+            {"patch": {"message": "revised"}},
+        )
+    )
+    assert not update_calls
+    assert "paused manually" not in result, result
+    assert "merged" in result
+
+
+def test_applier_a_settled_outcome_outranks_a_stale_owed_turn(monkeypatch):
+    """The settled ``outcome`` is authoritative; the debt is only the fallback.
+
+    Both fields can be populated at once — the settlement writes ``outcome`` and
+    clears the debt in the same pass — so a reader that preferred the debt could
+    announce a stale classification.
+    """
+    from kiro_crew.monitoring.models import MonitorOutcome
+
+    loop = _FakeLoop(
+        "loop-both",
+        cycle_count=24,
+        max_cycles=24,
+        active=False,
+        stopped_reason="cycle_cap",
+        monitor=_FakeMonitor(terminal_pending="success", outcome=MonitorOutcome.BLOCKED),
+    )
+    svc = _FakeSvc(loop)
+    _install_svc(monkeypatch, svc)
+    update_calls = _record_update(monkeypatch)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(),
+            _fake_slot(),
+            _SESSION,
+            "monitor_update",
+            {"patch": {"max_cycles": 48}},
+        )
+    )
+    assert not update_calls
+    assert "without merging" in result
+
+
+def test_applier_a_spent_cap_with_no_terminal_news_still_revives(monkeypatch):
+    """Control: the terminal carve-out must not swallow a genuine cap.
+
+    A cap-stopped loop with a monitor that saw nothing terminal keeps the revival
+    affordance a raised cap is supposed to give it.
+    """
+    loop = _FakeLoop(
+        "loop-plain-cap",
+        cycle_count=24,
+        max_cycles=24,
+        active=False,
+        stopped_reason="cycle_cap",
+        monitor=_FakeMonitor(),
+    )
+    svc = _FakeSvc(loop)
+    _install_svc(monkeypatch, svc)
+    update_calls = _record_update(monkeypatch, loop=loop)
+    result = asyncio.run(
+        apply_session_directive(
+            _fake_state(),
+            _fake_slot(),
+            _SESSION,
+            "monitor_update",
+            {"patch": {"max_cycles": 48}},
+        )
+    )
+    assert len(update_calls) == 1
+    assert update_calls[0]["active"] is True
+    assert "re-armed" in result
 
 
 def test_applier_monitor_update_without_a_loop_is_a_clean_noop(monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

Merged #8122 fixed the user-facing expiry notice: it now derives `terminal` from `stopped_reason == monitor_terminal` **or** an outstanding `monitor.terminal_pending`. It deliberately left `_timer`'s ordering, `max_cycles` semantics and `stopped_reason` alone.

`monitor_update`'s paused-loop branch in `src/kiro_crew/dashboard/session_directive_apply.py` still read `stopped_reason` on its own. Two consequences on a loop whose subject has already reached a terminal state:

- the agent is told the loop "hit its cycle cap", and a **settled** terminal loop is reported as "paused manually" — the opposite of what the expiry notice says about the same loop;
- if the same patch also raises `max_cycles`, the branch injects `active=True` and **silently re-arms a watch on an already-merged pull request**.

## Why it matters

The second one costs real work: a fresh loop wakes repeatedly to watch something that is finished, and nothing in the reply says the subject already merged. It is also a disagreement between two surfaces reading the same state — the notice says merged, the directive says out of cycles.

## What changed

The paused-loop branch now reads the same two fields the expiry notice reads, with the same precedence, so the agent-facing and user-facing endings cannot diverge:

- a terminal subject outranks every bound, and an **owed** terminal turn counts as one
- a settled `outcome` outranks a stale owed turn
- revival is confined to the genuinely bound cases — a spent cap or budget with no terminal news

The reply now names the actual ending (merged, or closed without merging) instead of a bound that was not what stopped it.

Scope: `_timer` delivery, `max_cycles` semantics and `stopped_reason` itself are untouched, which is why this is `Refs` rather than `Closes` — the contested delivery half of the issue remains open.

## Tests

`test/test_autonudge_stop_auth.py` gains five tests (it already owns the paused-loop revival and denial cases):

- an owed terminal turn is not reported as a spent cap
- an owed blocked turn is not reported as a merge
- a settled terminal loop is not reported as a manual pause
- a settled outcome outranks a stale owed turn
- **control:** a spent cap with no terminal news still revives — this one passes pre-fix, and guards the cap-raise revival affordance #8122 relies on

Pre-fix, four fail: the loop is revived with `active: True` on a merged subject, and a settled terminal loop reports "paused manually". After: `50 passed`. Neighbouring directive suites: `100 passed`. black, isort, flake8 clean; `mypy 1.14.1` reports no issues in 1279 source files.

## Manual verification

None beyond the tests — the behaviour is a directive reply string and a patch payload, both asserted directly.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** a backend directive-reply change; no UI surface is touched.

## Related Issues

Refs #8060

Not `Closes`: this fixes the `monitor_update` half. The `_timer` delivery-ordering question the issue also raises is untouched and should keep the issue open.

## Pattern harvest

Rule candidate: review-prompt

Pattern: two surfaces deriving the same user-visible verdict from the same state, where only one is updated. The fix that lands in the notice leaves the directive reading a single field, and the two then disagree about the same loop.
