### PR TITLE
fix(ci): retry the collaborator permission read so a 5xx cannot drop a disposition

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -393,9 +393,7 @@ jobs:
           # transient class with a bounded retry; a COMMENTS read that never
           # succeeds fails this run CLOSED while naming the read as the cause
           # -- re-running the job is cheaper than re-litigating disposed
-          # findings. (The collaborator-permission read below still fail-opens
-          # to "not a writer"; that residual half is tracked separately and
-          # needs 404-vs-transport handling, not this mechanical shape.)
+          # findings.
           ledger_comments=""
           ledger_read_ok=""
           for attempt in 1 2 3; do
@@ -416,16 +414,54 @@ jobs:
           disp_authors="$(printf '%s' "$comments_json" \
             | jq -r '.[] | select((.body // "") | startswith("<!-- ai-review-disposition ")) | (.user.login // empty)' 2>/dev/null \
             | sort -u || true)"
+          # The authority read that decides whose dispositions this ledger
+          # trusts. A permission read that FAILED is not a read that answered
+          # "no": an empty `perm` matches no `case` arm below, so a transient
+          # 5xx resolves a repository writer to non-writer and drops the
+          # records they already ruled on. The two are split, the same contract
+          # ai-review-human-override.yml applies to this API:
+          #   HTTP 404 -> the API answering "not a collaborator". A legitimate
+          #     negative; resolves to non-writer, no retry.
+          #   any other failure -> unknown. The common case is transient, so
+          #     absorb it with a bounded three attempts and a short backoff
+          #     (<= 3s added), then fail this run CLOSED while NAMING the read.
+          #     The bound is what keeps a fail-closed read from wedging the
+          #     lane: a permanently failing API cannot hold the job open.
+          # The read's stderr goes to an absolute `mktemp` file rather than a
+          # workspace path, so nothing committed at that name can capture the
+          # write or abort the step.
           writers="[]"
+          perm_err="$(mktemp)"
           for author in $disp_authors; do
-            perm="$(gh api "repos/$REPO/collaborators/$author/permission" \
-              --jq '.permission' 2>/dev/null || true)"
+            perm=""
+            perm_read_ok=""
+            for attempt in 1 2 3; do
+              if perm="$(gh api "repos/$REPO/collaborators/$author/permission" \
+                --jq '.permission' 2>"$perm_err")"; then
+                perm_read_ok=1
+                break
+              fi
+              if grep -qiE 'HTTP 404|Not Found' "$perm_err"; then
+                perm=""
+                perm_read_ok=1
+                break
+              fi
+              echo "Reading $author's collaborator permission failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            if [ -z "$perm_read_ok" ]; then
+              echo "::error::Could not read $author's collaborator permission after 3 attempts, so this step cannot tell a non-writer from an unreadable permission API and would drop a writer's dispositions from the round-convergence ledger. Failing closed -- re-run this job."
+              exit 1
+            fi
             case "$perm" in
               admin|maintain|write)
                 writers="$(printf '%s' "$writers" | jq --arg a "$author" '. + [$a]' 2>/dev/null || printf '[]')"
                 ;;
             esac
           done
+          rm -f "$perm_err"
           ledger_full="$(printf '%s' "$comments_json" \
             | jq -r --argjson writers "$writers" '[.[]
                 | select((.user.login == "github-actions[bot]" and ((.body // "") | startswith("<!-- ai-review-human-override ")))

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -3573,6 +3573,111 @@ class TestForkReviewersAreStageTwoOfFastGate:
         assert "never a security" in flat, name
 
 
+class TestLedgerWriterGateFailsClosed:
+    """Execute the ACTUAL ledger writer-gating permission read with ``gh`` stubbed.
+
+    An empty ``perm`` matches no ``case`` arm, so a permission read that FAILED
+    resolves its author to non-writer and drops that writer's disposition
+    records from the ledger -- the reviewer then re-litigates findings a
+    repository writer already ruled on, on a green run with no annotation.
+    """
+
+    DISPOSITION = (
+        '[{"body":"<!-- ai-review-disposition target=gpt head=abc -->",'
+        '"user":{"login":"someone"}}]'
+    )
+
+    def _writer_gate_block(self) -> str:
+        script = _step_script(_workflow("codex-review.yml"), "Write review prompt")
+        start = script.index('disp_authors="')
+        end = script.index('ledger_full="')
+        return script[start:end]
+
+    def _run_gate(self, tmp_path: Path, perm_mode: str):
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the writer gate is Bash; skip where Bash is absent")
+        attempts = tmp_path / "gh-attempts"
+        gh = tmp_path / "gh"
+        stub = f'#!/bin/sh\nprintf x >> "{attempts}"\n'
+        if perm_mode == "write":
+            stub += "printf 'write\\n'\n"
+        elif perm_mode == "notfound":
+            stub += 'echo "gh: Not Found (HTTP 404)" >&2\nexit 1\n'
+        else:
+            stub += 'echo "gh: Internal Server Error (HTTP 500)" >&2\nexit 1\n'
+        gh.write_text(stub, encoding="utf-8", newline="\n")
+        gh.chmod(0o755)
+        sleep_stub = tmp_path / "sleep"
+        sleep_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8", newline="\n")
+        sleep_stub.chmod(0o755)
+        out_file = tmp_path / "writers.json"
+        script = (
+            f"comments_json='{self.DISPOSITION}'\n"
+            + self._writer_gate_block()
+            + f'\nprintf \'%s\' "$writers" > "{out_file}"\n'
+        )
+        result = subprocess.run(
+            [bash, "-e", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                "PATH": _stub_path(tmp_path),
+                "GH_TOKEN": "",
+                "GITHUB_TOKEN": "",
+                "GH_CONFIG_DIR": str(tmp_path),
+                "LC_ALL": "C",
+                "REPO": "example/repo",
+                "PR": "1",
+                "TMPDIR": str(tmp_path),
+            },
+            cwd=tmp_path,
+        )
+        return result, attempts, out_file
+
+    def test_a_readable_writer_is_gated_in(self, tmp_path: Path):
+        result, attempts, out_file = self._run_gate(tmp_path, "write")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(out_file.read_text(encoding="utf-8")) == ["someone"]
+        assert attempts.read_text(encoding="utf-8") == "x"
+
+    def test_a_404_stays_a_legitimate_non_writer(self, tmp_path: Path):
+        # The API answering "not a collaborator" is a real negative: exclude the
+        # author, without a retry and without failing the step.
+        result, attempts, out_file = self._run_gate(tmp_path, "notfound")
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert json.loads(out_file.read_text(encoding="utf-8")) == []
+        assert attempts.read_text(encoding="utf-8") == "x"
+
+    def test_an_unreadable_permission_fails_closed(self, tmp_path: Path):
+        result, attempts, out_file = self._run_gate(tmp_path, "transient")
+        assert result.returncode != 0, "an unreadable permission passed as non-writer"
+        assert "::error::" in result.stdout
+        # Bounded: a permanently failing API must not hold the job open.
+        assert attempts.read_text(encoding="utf-8") == "xxx"
+        assert not out_file.exists(), "the ledger was gated on a permission never read"
+
+    def test_permission_read_no_longer_swallows_its_status(self):
+        block = "\n".join(
+            line
+            for line in self._writer_gate_block().splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "collaborators/$author/permission" in block
+        # The read spans a continuation line and its redirection sits on the
+        # SECOND one, so judge THAT line: a check scoped to the line naming the
+        # endpoint passes while the exit status is still swallowed.
+        redirection = _line_containing(block, "--jq '.permission'")
+        assert "2>/dev/null" not in redirection
+        assert "|| true" not in redirection
+        # An explicit 404 stays a legitimate negative, so it must be matched by
+        # name rather than folded into the unknown-failure arm.
+        assert "HTTP 404|Not Found" in block
+        assert "for attempt in 1 2 3; do" in block
+
+
 class TestProtectedCheckNameHasOnePublisherPerPrType:
     """A required review status must never be satisfied by the OTHER lane's run.
 


### PR DESCRIPTION
## Problem / Motivation

The round-convergence ledger gates which authors' dispositions it trusts by reading each author's collaborator permission. That read swallows its exit status:

```
perm="$(gh api "repos/$REPO/collaborators/$author/permission" --jq '.permission' 2>/dev/null || true)"
```

An empty `perm` matches no `case` arm below, so a read that **failed** is indistinguishable from the API answering "not a collaborator". A transient 5xx therefore resolves a repository writer to non-writer and drops the disposition records they already ruled on — on a green run, with no annotation.

Line 352 of the same file already named this as the known residual after #7854.

## Why it matters

The failure is silent and it discards human decisions. A reviewer with write access disposes of findings; one transient API error later the ledger behaves as though they never did, and the next round re-litigates findings a writer had already settled. Nothing in the run output says so.

## What changed

The permission read is split along the same contract `ai-review-human-override.yml` already applies to this API:

- **HTTP 404** — the API answering "not a collaborator". A legitimate negative: resolve to non-writer, no retry, no failure.
- **Any other failure** — unknown. Absorb it with a bounded three attempts and a short backoff (≤3s added), then fail the run **closed** while naming the read in an `::error::` annotation.

The bound is what keeps a fail-closed read from wedging the lane: a permanently failing API cannot hold the job open.

Shape mirrors merged #7904, which applied the same treatment to this same API — `mktemp` stderr file, three attempts, `sleep "$attempt"`. The stderr file is an absolute `mktemp` path rather than a workspace-relative one, so nothing committed at that name can capture the write or abort the step.

## Tests

`test/test_ai_review_workflows.py` gains `TestLedgerWriterGateFailsClosed`, which executes the actual workflow shell block with `gh` and `sleep` stubbed:

| permission read | before | after |
|---|---|---|
| writer | rc=0, 1 attempt, `["someone"]` | unchanged |
| 404 | rc=0, 1 attempt, `[]` | unchanged, no retry |
| 5xx | **rc=0, 1 attempt, `[]` — writer dropped, job green** | rc=1, 3 attempts, `::error::` |

A fourth test pins the source: the redirection sits on the continuation line, so it asserts against *that* line — a check scoped to the line naming the endpoint passes while the exit status is still swallowed.

`232 passed, 28 skipped` in that file; `196 passed, 35 skipped` across the nine workflow test files; isort and flake8 clean; YAML parses with `jobs=['codex-review']`.

## Manual verification

The three executable cases were driven locally with a `jq` stub, since `jq` is not installed on this machine — they run natively on the ubuntu runner. The table above is that run.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** a CI workflow change with no UI surface; the observable difference is a job's exit status and its annotation.

## Related Issues

Fixes #7853

Note: PR #7876 previously addressed this and was closed by its author without merging. This is not a re-post of that diff — it is based on current `main` (so it has #7854 and #7904), and it avoids the two objections raised on that attempt: the stderr path is absolute rather than workspace-relative, and the unknown-failure arm retries before failing closed.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a shell command whose failure is swallowed with `2>/dev/null || true`, whose empty output then flows into a `case` or `if` that treats "no answer" as a specific answer. The absent branch is invisible at the call site.
