### PR TITLE
refactor: derive jump-letter exclusions from reserved panel codes

### DIFF
--- a/website/src/hooks/useKeyboardShortcuts.ts
+++ b/website/src/hooks/useKeyboardShortcuts.ts
@@ -367,38 +367,53 @@ export const RESERVED_PANEL_CODES: ReadonlySet<string> = new Set<string>([
 ])
 
 /**
- * Letters usable for chat-jumps 10+ (digit 1–9 stay digits; the 10th session
- * onward gets a letter). a–z minus every letter another unshifted chord owns,
- * so a jump letter can never shadow an existing shortcut:
- *  - c/n/p/s — core panel navigation (CORE_PANEL_MAP)
- *  - k       — shortcuts modal (Alt+K)
- *  - g       — agent monitor (Ctrl+G is literal Ctrl on EVERY platform, so it
- *              collides with the Mac Ctrl-jump mode; excluded uniformly rather
- *              than per-platform so the same session always shows the same
- *              letter on every OS)
- *  - runtime — any code a downstream edition registered via
- *              registerPanelShortcut (EXTRA_PANEL_ROUTES); registration
- *              happens at module init, before any keypress or badge render,
- *              and panels always win over jump letters.
- * Computed per call (not a constant) so the runtime exclusions are honored.
+ * Letters a jump chord must avoid for a reason OTHER than pre-panel routing, so
+ * they are absent from RESERVED_PANEL_CODES and cannot be derived from it: global
+ * Ctrl/⌘ chords that reach hasCommandModifier via plain Ctrl on macOS and would
+ * double-fire with the Mac Ctrl-jump branch. Each is an independent document
+ * listener, so an unexcluded letter fires both actions at once; excluded
+ * uniformly across platforms so a session shows the same letter on every OS.
+ *  - a — select-all in a focusable list (Ctrl/⌘+A)
+ *  - d — split the focused pane (Ctrl/⌘+D)
+ *  - f — message search / Markdown find (Ctrl/⌘+F)
+ *  - g — agent monitor (Ctrl+G, literal Ctrl on every platform)
+ *  - t/w — file-explorer new-folder-tab / close-tab (Ctrl/⌘+T, Ctrl/⌘+W)
  */
-// a: Ctrl/⌘+A select-all (knowledge list, pages/knowledge/index.tsx; plus the
-//    OS-level select-all expectation in any focusable list). d: Ctrl/⌘+D splits
-//    the focused pane (ChatPage.tsx + SessionGridView.tsx). Both collide with
-//    the Mac Ctrl jump branch — and since each is an independent document
-//    listener, an unexcluded chord would fire BOTH actions at once. Excluded
-//    uniformly (like g) so letter assignments match across platforms.
-// f: message search + Markdown find (useMessageSearch.ts, MarkdownPanel.tsx).
-// t/w: file-explorer new-folder-tab / close-tab (FileExplorerPage.tsx). All
-//    three listen via hasCommandModifier — an XOR (metaKey !== ctrlKey), so a
-//    plain Ctrl+letter satisfies it on macOS and would double-fire with the
-//    Mac Ctrl-jump branch. Same class and same fix as a/d above.
-const JUMP_LETTER_STATIC_EXCLUDE = new Set(['a', 'c', 'd', 'f', 'g', 'k', 'n', 'p', 's', 't', 'w'])
+const JUMP_LETTER_GLOBAL_EXCLUDE = new Set(['a', 'd', 'f', 'g', 't', 'w'])
+
+/**
+ * Lowercase letters a pre-panel chord owns, read straight from
+ * RESERVED_PANEL_CODES so the two never drift: a panel or pre-panel Alt+<letter>
+ * chord added to that set — which the extension-seams drift test already forces —
+ * drops its jump letter in the same edit instead of being silently shadowed by
+ * one. Only single-letter Key* codes name a jump letter; the Comma, Enter,
+ * Backquote, Arrow, and Digit codes are not letters and contribute nothing here.
+ */
+function reservedPanelLetters(): Set<string> {
+  const out = new Set<string>()
+  for (const code of RESERVED_PANEL_CODES) {
+    const m = /^Key([A-Z])$/.exec(code)
+    if (m) out.add(m[1].toLowerCase())
+  }
+  return out
+}
+
+/**
+ * Letters usable for chat-jumps 10+ (digit 1–9 stay digits; the 10th session
+ * onward gets a letter). a–z minus every letter another unshifted chord owns —
+ * the pre-panel chords (`reservedPanelLetters`), the global editor chords
+ * (`JUMP_LETTER_GLOBAL_EXCLUDE`), and any code a downstream edition registered
+ * via registerPanelShortcut (`EXTRA_PANEL_ROUTES`, resolved at module init before
+ * any keypress or badge render, panels winning over jump letters). Computed per
+ * call, not a constant, so the runtime exclusions are honored.
+ */
 export function jumpLetters(): string[] {
+  const panelLetters = reservedPanelLetters()
   const out: string[] = []
   for (let i = 0; i < 26; i++) {
     const ch = String.fromCharCode(97 + i)
-    if (JUMP_LETTER_STATIC_EXCLUDE.has(ch)) continue
+    if (panelLetters.has(ch)) continue
+    if (JUMP_LETTER_GLOBAL_EXCLUDE.has(ch)) continue
     if (('Key' + ch.toUpperCase()) in EXTRA_PANEL_ROUTES) continue
     out.push(ch)
   }

--- a/website/src/test/useKeyboardShortcuts.test.tsx
+++ b/website/src/test/useKeyboardShortcuts.test.tsx
@@ -1031,6 +1031,23 @@ describe('letter jumps reach sessions 10+', () => {
     expect(jumpIndexForCode('Digit1')).toBe(0)
   })
 
+  it('excludes every letter a pre-panel code reserves, so a future panel chord is never shadowed', () => {
+    // The pre-panel exclusions are derived from RESERVED_PANEL_CODES, not
+    // restated, so a single-letter Key* code added there later drops its jump
+    // letter automatically. Today: KeyC/KeyK/KeyN/KeyP/KeyS.
+    const letters = jumpLetters()
+    const reservedLetters = [...RESERVED_PANEL_CODES]
+      .map(code => /^Key([A-Z])$/.exec(code)?.[1].toLowerCase())
+      .filter((letter): letter is string => letter !== undefined)
+    // Pin today's baseline so a shared regex/source bug can't pass by re-deriving
+    // the same wrong answer here and in the code under test.
+    expect([...reservedLetters].sort()).toEqual(['c', 'k', 'n', 'p', 's'])
+    for (const letter of reservedLetters) {
+      expect(letters).not.toContain(letter)
+      expect(jumpIndexForCode('Key' + letter.toUpperCase())).toBe(-1)
+    }
+  })
+
   it('Alt+B picks the 10th displayed row', () => {
     const store = setupMany()
     fireEvent.keyDown(document, { code: 'KeyB', altKey: true })


### PR DESCRIPTION
## Problem / Motivation

`jumpLetters()` — the letters offered as chat-jump shortcuts for sessions 10 and beyond — excluded its letters via a hardcoded set, `JUMP_LETTER_STATIC_EXCLUDE`. Five of those letters (`c/k/n/p/s`) are the letters of panel shortcuts that are *also* declared in `RESERVED_PANEL_CODES`: the same fact written in two places. The parallel list is drift-prone in a dangerous direction — a future pre-panel `Alt+<letter>` chord updates `RESERVED_PANEL_CODES` (the extension-seams drift test enforces that), but nothing forces the hardcoded exclude list to follow. Because the jump-letter branch runs *before* panel routing, the new panel chord would then be silently shadowed by a jump letter.

## Why it matters

A silently shadowed panel chord is a keyboard shortcut that stops working with no error and no test failure — a regression that ships unnoticed and is hard to trace back. Deriving the exclusions from the single authoritative source closes the gap by construction, so a contributor who adds a panel chord the normal way cannot accidentally break it.

## What changed (motivation → approach → change)

- **Symptom → cause:** the exclusion list duplicates panel letters already in `RESERVED_PANEL_CODES`, and nothing keeps the two in sync.
- **Approach:** read the panel-owned exclusions from `RESERVED_PANEL_CODES` at the point of use instead of restating them, so there is one source of truth; keep a small literal set only for the letters excluded for a reason *other* than panel routing (global editor chords), which are not in that set and cannot be derived from it.
- **Change:** added `reservedPanelLetters()` (pulls the single-letter `Key*` codes out of `RESERVED_PANEL_CODES` via `/^Key([A-Z])$/`) and `JUMP_LETTER_GLOBAL_EXCLUDE` (`a/d/f/g/t/w` — select-all, split-pane, find, agent-monitor, new-tab, close-tab). `jumpLetters()` now skips a letter if it is a reserved-panel letter, a global-chord letter, or a runtime-registered panel route. Output is byte-identical today: derived `{c,k,n,p,s}` ∪ literal `{a,d,f,g,t,w}` equals the previous 11-letter set exactly.

## Tests

Added a test in `useKeyboardShortcuts.test.tsx` asserting that every single-letter `Key*` code in `RESERVED_PANEL_CODES` is excluded from `jumpLetters()` and returns `-1` from `jumpIndexForCode()`, and pinning today's derived baseline (`c/k/n/p/s`) so a shared regex/source bug cannot pass by re-deriving the same wrong answer on both sides. The pre-existing test that asserts the exact excluded set and the first three jump letters (`b/e/h`) is unchanged and still passes, which is what confirms output preservation.

## Manual verification

N/A — unit coverage is sufficient. `jumpLetters()` is a pure function fully exercised by the vitest suite, and its output is unchanged, so there is no new runtime behavior to verify by hand. Locally `tsc -b`, `eslint`, the `jscpd` duplication pretest, and `npm run build` all pass.

## Related Issues

Fixes #4875.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — in-code JSDoc on the helpers updated; no spec doc covers this function
- [x] No secrets, credentials, or internal references in the diff
