### PR TITLE
fix(chat): keep new mobile session after drawer closes

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -4106,15 +4106,34 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // host route happens to carry.
     if (noUrlSync) return
     // Our own drawer-entry consumption, not a Back/Forward the user asked for.
-    // Cleared and returned BEFORE the arming block below so the flag can never
-    // outlive its pop and swallow a later genuine one — the `!popReadyRef` and
-    // duplicate-key guards there return early, so a check placed after them
-    // would leave the flag set. `lastLocKeyRef` is still advanced, because this
-    // entry HAS been visited and must not be honored again if the effect re-runs
-    // on it while navigationType is still 'POP'.
+    // Correct the POP's stale outgoing `?sid=` HERE, in the effect that owns the
+    // POP, rather than relying on the separate activeSlot -> URL effect below.
+    // In a real mobile browser those two navigation effects can be committed in
+    // either order: a fast New Chat activates the newborn slot, closes the
+    // drawer, then this POP lands on the duplicate's predecessor naming the old
+    // slot. If the generic sync is still gated by a prior POP claim, the old URL
+    // wins and its reader switches Redux straight back, leaving an empty New
+    // Session row behind. MemoryRouter settles synchronously and hid that race.
+    //
+    // `activeSlotRef` is the render-current value even when the close originated
+    // from createSlot.fulfilled in this same commit. Replacing only this popped
+    // entry also preserves the one-entry drawer invariant: the duplicate is gone,
+    // and the surviving history entry names the session actually on screen.
     if (drawerPopRef.current) {
       drawerPopRef.current = false
       lastLocKeyRef.current = location.key
+      popInFlightRef.current = false
+      const target = activeSlotRef.current
+      const urlSlot = searchParams.get('sid') || searchParams.get('slot')
+      if (target && target !== urlSlot) {
+        const next = new URLSearchParams(searchParams)
+        next.set('sid', target)
+        next.delete('slot')
+        navigate(
+          { pathname: location.pathname, search: `?${next}`, hash: location.hash },
+          { replace: true },
+        )
+      }
       return
     }
     // Embed: host app drives the URL — react to any ?sid change.
@@ -4142,7 +4161,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       popInFlightRef.current = true
       dispatch(switchSlot(urlSid))
     }
-  }, [searchParams, filteredSlots, activeSlot, dispatch, embedMode, navigationType, location.key, connected, noUrlSync])
+  }, [searchParams, filteredSlots, activeSlot, dispatch, embedMode, navigationType, location.key, location.pathname, location.hash, connected, noUrlSync, navigate])
   // Timeout: if slot never appears after 5s, show error.
   // Gated on `connected` so the timer only runs while the gateway is reachable
   // — otherwise an offline tab would burn its 5s while the resolve effects

--- a/website/src/test/ChatPage.drawerBackClose.test.tsx
+++ b/website/src/test/ChatPage.drawerBackClose.test.tsx
@@ -36,7 +36,8 @@ import { MemoryRouter, Routes, Route, useLocation, useNavigate, useNavigationTyp
 import { createTestStore } from './helpers'
 import { ThemeProvider } from '../hooks/useTheme'
 import { sseSlots, sseConnected } from '../store/dashboardSlice'
-import { setActiveSlot } from '../store/chatSlice'
+import { createSlot, setActiveSlot } from '../store/chatSlice'
+import { api } from '../api/client'
 
 /** Completion callbacks handed to framer's `animate`, fired manually so a close
  *  can be run to completion (the panel unmounts on the settle, not on the
@@ -281,6 +282,27 @@ describe('ChatPage — mobile sessions drawer answers Back (#5795)', () => {
     expect(screen.getByTestId('off-chat')).toBeTruthy()
     expect(probe().dataset.sid).toBe('')
     expect(store.getState().chat.activeSlot).toBe('slot-1')
+  })
+
+  it('creating a session from the drawer consumes the entry without restoring the outgoing chat', async () => {
+    const store = renderChat()
+    openDrawer()
+    vi.mocked(api.createChatSlot).mockResolvedValueOnce({
+      key: 'slot-new', title: 'New Session', messages: 0, running: false,
+    })
+
+    await act(async () => {
+      await store.dispatch(createSlot({ mode: '' })).unwrap()
+    })
+    finishSlide()
+
+    expect(drawerMounted()).toBe(false)
+    expect(store.getState().chat.activeSlot).toBe('slot-new')
+    expect(probe().dataset.sid).toBe('slot-new')
+
+    platformBack()
+    expect(screen.getByTestId('off-chat')).toBeTruthy()
+    expect(store.getState().chat.activeSlot).toBe('slot-new')
   })
 
   it('a backdrop tap consumes the entry too, so the next Back is not an invisible no-op', () => {


### PR DESCRIPTION
## Problem / Motivation

On a mobile dashboard, **+ New** can create and briefly activate a blank session, close the Sessions drawer, and then return the conversation pane to the previously active chat. The successful create leaves an empty **New Session** row behind, making it appear that the new chat loaded old conversation content.

## Why it matters

The previous transcript and composer become active again without an error, so a user can type into the wrong conversation and accumulate orphaned empty sessions while retrying. The defect is intermittent because it depends on browser-history and React effect ordering in a real mobile browser.

## What changed (motivation → approach → change)

The mobile drawer pushes a duplicate history entry so the platform Back gesture can dismiss it. When a newborn session became active, drawer close consumed that entry with `navigate(-1)`, landing on the predecessor URL whose `?sid=` still named the outgoing chat. Repairing that URL in a separate synchronization effect left a browser-ordering window where the stale POP could switch Redux back.

This change makes the effect that owns the drawer POP also repair the surviving history entry immediately:

- clear the drawer-owned POP claim;
- read the render-current active slot;
- replace a stale `?sid=`/legacy `?slot=` with that active slot; and
- preserve the existing one-entry drawer and Back-button invariant.

The generic active-slot URL effect remains responsible for normal session navigation and slug normalization.

## Tests

- Added a mobile drawer regression that creates a session through the real asynchronous `createSlot` path while the drawer owns its duplicate history entry, then verifies:
  - the drawer closes;
  - the newborn session remains active;
  - `?sid=` names the newborn session; and
  - the next Back leaves the chat route instead of resurrecting the outgoing conversation.
- 355 related frontend tests passed across drawer, responsive panel, ChatPage coverage/drafts, chat reducer, and switch-rejection suites.
- `npx tsc -b` passed.
- Full frontend ESLint passed.
- Production frontend build passed.
- Current-head GitHub validation passed all 61 substantive build, test, security, packaging, and coverage checks, plus GPT, Opus, Design, UX, and First Principles reviews at `2dcce1bfde11`.
- The complete frontend test gate was also attempted locally; it exceeded the 20-minute safety bound while still progressing and emitted no Vitest failure markers. CI remains the authoritative full-suite run.

## Manual verification

Reviewed the supplied mobile screen recording frame by frame. It shows the new session becoming selected as the drawer closes, the previous transcript returning, and a later retry successfully opening a blank session. The recording is not published because it contains private session titles and conversation content.

The live gateway was not modified; verification used the isolated worktree and automated frontend harness.

<!-- no-visual-delta -->
**Why no screenshot:** This patch changes only browser-history and session-selection ordering; the rendered drawer, transcript, and composer have no visual delta. The supplied reproduction recording contains private session titles and conversation content and cannot be published.

## Related Issues

Fixes #8207

## Pattern harvest

Rule candidate: review-prompt
Pattern: A component-owned browser-history POP that represents transient view state must repair its destination state in the same effect, rather than relying on a sibling synchronization effect whose navigation can be reordered.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — this corrects internal mobile navigation ordering without changing a documented interface)
- [x] No secrets, credentials, or internal references in the diff
