### PR TITLE
docs: scope the touch exception to the components that make it

### DIFF
--- a/website/docs/page-layout.md
+++ b/website/docs/page-layout.md
@@ -793,9 +793,14 @@ Inline within a `Card`, built from the shared primitives:
   reliably hand a finger drag to that shape — Settings → Voice → Language showed
   7 of its ~41 codes with the rest unreachable. A themed list nobody can scroll
   is worse than an OS-drawn list that works. Because the choice lives inside
-  `SimpleSelect`, no call site makes it: keep reaching for the components above
-  and the touch case is already handled. `NativeSelect` is the single file
-  exempted from the `no-restricted-syntax` rule; do not add a second.
+  `SimpleSelect`, no call site makes it — and `SettingsSelect` inherits it by
+  wrapping `SimpleSelect`. It goes no further: `SearchableSelect`,
+  `DropdownMenu` and `AgentSelector` keep the themed popup on a coarse pointer,
+  since a native `<select>` cannot host a filter box, per-option sublabels or a
+  command menu. Reaching for one of those does not mean the touch case has been
+  handled for you; whether that scroller is a real defect on a phone is
+  unresolved in #5551. `NativeSelect` is the single file exempted from the
+  `no-restricted-syntax` rule; do not add a second.
 - `Toggle` for a boolean switch. It carries `role="switch"`, `aria-checked` and
   `aria-disabled` itself, so do not re-add them.
 


### PR DESCRIPTION
## Problem / Motivation

`website/docs/page-layout.md`'s Forms section lists five dropdown components to
pick between -- `SettingsSelect`, `SimpleSelect`, `SearchableSelect`,
`DropdownMenu`, `AgentSelector` -- and then tells the reader:

> Because the choice lives inside `SimpleSelect`, no call site makes it: keep
> reaching for the components above and the touch case is already handled.

That is true for two of the five. Measured on the source:

| component | routes to `NativeSelect` on a coarse pointer |
|---|---|
| `SimpleSelect` | yes -- the only component that does |
| `SettingsSelect` (`components/settings.tsx`) | yes, inherited: it wraps `SimpleSelect` (import at `:5`, render at `:110`) |
| `SearchableSelect` | no |
| `ui/dropdown-menu.tsx` | no |
| `AgentSelector` | no |

`components/SimpleSelect.tsx` and `components/ui/native-select.tsx` are the only
files under `website/src` that mention `NativeSelect` at all.

## Why it matters

This is a normative style guide, and the sentence is an instruction not to think
about the touch case when reaching for any component in that list. #5551 exists
precisely because `SearchableSelect` keeps the themed fixed-position scroller on
a phone, and a guide that says the case is handled is what stops the next author
from noticing. The same applies to `DropdownMenu` and `AgentSelector`.

## What changed (motivation -> approach -> change)

Symptom: guidance that reads as covering five components while describing a
mechanism that exists in one.

Root cause: the sentence was written when the exception was introduced for
`SimpleSelect` (#5525), and its scope claim generalised to the whole bullet list
sitting above it rather than staying with the component that carries the routing.

Change: name which components carry the exception and which do not, give the
reason the same remedy cannot transfer (a native `<select>` cannot host a filter
box, per-option sublabels or a command menu), and point at the open question
instead of presuming its answer -- whether that scroller is a real defect on a
phone is unresolved.

Deliberately NOT changed: the mechanism sentence immediately above, which
attributes the failure to a `position:fixed` overflow scroller inside
react-remove-scroll's lock. It describes `SimpleSelect`'s Radix Select, where it
is #5525's documented rationale. It does not obviously hold for
`SearchableSelect`, whose `<Popover>` at `SearchableSelect.tsx:172-175` carries
no `modal` prop while this repo's own note at `AgentSelector.tsx:40` attributes
react-remove-scroll to modal mode -- but that is a claim for whoever answers
#5551 with a device check, not something to rewrite from inference here.

Nothing about which component is correct to use changes, and no behaviour
changes: this is prose only.

## Tests

No new tests. The change is prose in a docs file, and there is no gate that
asserts this section's content, so there is nothing here a test could lock in
that would not just restate the sentence.

Two existing specs read this file from disk and both pass:

- `website/src/test/mobilePanels.compositor.test.ts` -- 27 tests
- `website/src/test/narrowFirstBaseline.test.ts` -- 8 tests

Stated honestly, neither is cover for this change: they assert on the
`data-owns-swipe` gesture section and on a `px-N md:px-N pb-8 overflow-y-auto`
skeleton match respectively, not on the Forms block. They are reported because
they parse the edited file, so they would catch a structural break.

`BRAND_BASE_REF=origin/main scripts/check_brand_name.py` passes on the added
lines. The added lines carry no term in `.woke.yml`'s ruleset.

## Manual verification

Verified every component claim in the table above by reading the source rather
than the doc: grepped `website/src` for `NativeSelect` references and for
coarse-pointer routing per component, and read `components/settings.tsx` to
confirm `SettingsSelect` reaches the exception by wrapping `SimpleSelect`. Then
re-read the edited paragraph in place to confirm it still flows from the
mechanism sentence it follows.

## Related Issues

Refs #5551

This does not close it. The titled defect -- whether `SearchableSelect`'s
scroller is unscrollable on real iOS Safari -- needs a physical device check that
cannot be run in this repository (`website/playwright.config.ts` ships only
`setup` and `chromium`/Desktop Chrome), and then a design decision with split
precedent: #5525 handed the touch case to the OS, while #7186 deliberately kept a
themed fixed overflow scroller for the short-viewport case. This PR only removes
the false statement that the question is already settled.

## Pattern harvest

Pattern: a normative doc claim whose scope generalised past the mechanism that
justified it -- one component gained a behaviour, and the sentence describing it
was attached to the list the component was chosen from.

Rule candidate: review-prompt. When a change gives ONE member of a documented
set a new guarantee, the doc sentence recording it has to name that member, not
the set.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
