### PR TITLE
docs: prefer isolated pod over dev-backend.sh for worktree preview

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kirocrew-worktree-dev
-description: "HARD RULE for developing the Kiro Crew source repo ITSELF (not for users' own projects): every change is built and verified inside a git worktree, never against the live gateway. Covers worktree creation, the blocking local build gates (pytest + isort + flake8 + mypy + tsc + vitest), the built-dist gotcha, feature flags, live preview paths (dev-backend.sh or isolated pods), and the PR workflow. Use only when building, testing, switching, or verifying a change to Kiro Crew's own codebase."
+description: "HARD RULE for developing the Kiro Crew source repo ITSELF (not for users' own projects): every change is built and verified inside a git worktree, never against the live gateway. Covers worktree creation, the blocking local build gates (pytest + isort + flake8 + mypy + tsc + vitest), the built-dist gotcha, feature flags, live preview paths (isolated pods, dev-backend.sh as fallback), and the PR workflow. Use only when building, testing, switching, or verifying a change to Kiro Crew's own codebase."
 triggers: kirocrew worktree, kirocrew build gate, kirocrew dev, kirocrew source, contribute to kirocrew, kirocrew repo
 repo_scope: src/kiro_crew
 ---
@@ -241,26 +241,23 @@ the gate that lets you push.
 
 **Build gates green is the floor** — it proves the code compiles and tests pass.
 Actually *running* the worktree to click through it is an **optional** preview
-step with several paths; use whichever your environment supports:
+step. **Prefer the isolated pod over `dev-backend.sh`** — it is hands-off (no
+port/data-home bookkeeping to remember) and disposable (`pod down` leaves zero
+residue), where `dev-backend.sh` leaves a foreground process and a
+`.kirocrew-dev/` directory you manage yourself. Reach for `dev-backend.sh` only
+where a pod cannot run.
 
-1. **`dev-backend.sh` (simplest).** From the worktree root:
-   ```bash
-   ./dev-backend.sh
-   ```
-   Starts the gateway on its own dev port using `.kirocrew-dev/` as its data
-   directory (isolated from your production `~/.kiro/crew/`). It uses
-   `PYTHONPATH=src` so code changes are picked up on restart. Ctrl+C to stop,
-   re-run after changes.
-
-2. **Isolated pod (no cutover, hands-off).** Preview the full stack on its own
-   port without touching the live gateway:
+1. **Isolated pod (preferred).** Preview the full stack on its own port without
+   touching the live gateway:
    ```bash
    kirocrew pod up <worktree-name> --json   # own KIROCREW_HOME, own port, no crons
    kirocrew pod down <worktree-name>        # zero residue
    ```
-   Best for QA agents and end-to-end tests. `kirocrew pod --help` for all verbs
-   (`ls`, `status`, `logs`, `provision`, …). The worktree must be built first
-   (venv + dist); `kirocrew pod up --provision` does the full on-ramp.
+   Best for QA agents and end-to-end tests, but the default for a human
+   iterating on a worktree too — it needs no cleanup discipline of its own.
+   `kirocrew pod --help` for all verbs (`ls`, `status`, `logs`, `provision`,
+   …). The worktree must be built first (venv + dist); `kirocrew pod up
+   --provision` does the full on-ramp.
 
    For behavior that needs existing data, seed a shipped fixture instead of
    clicking state in by hand:
@@ -269,6 +266,23 @@ step with several paths; use whichever your environment supports:
    ```
    A bare name populates the whole isolated home; an unknown name is refused
    with the available names. A path remains the sanitized config-only form.
+
+   Pods need Linux `systemd --user` or macOS `launchd` (`kirocrew pod install`
+   once per machine) — see [`kiro_crew/pod/README.md`](../../../pod/README.md)
+   for the platform gate. Without one of those, fall through to
+   `dev-backend.sh` below.
+
+2. **`dev-backend.sh` (fallback where a pod cannot run).** From the worktree
+   root:
+   ```bash
+   ./dev-backend.sh
+   ```
+   Starts the gateway on its own dev port using `.kirocrew-dev/` as its data
+   directory (isolated from your production `~/.kiro/crew/`). It uses
+   `PYTHONPATH=src` so code changes are picked up on restart. Ctrl+C to stop,
+   re-run after changes. Use this on a host with no `systemd --user` / `launchd`
+   (or before running `kirocrew pod install`), or when you specifically need a
+   foreground process to attach a debugger to.
 
 3. **No preview at all (also valid).** For many changes, the build gate + unit
    tests are enough confidence to cut the PR. Previewing live is optional.


### PR DESCRIPTION
## Problem / Motivation

Rule 5 of the `kirocrew-worktree-dev` skill listed `./dev-backend.sh` and the
isolated pod (`kirocrew pod up`) as two equally-weighted preview options for a
worktree. In practice the pod needs no cleanup discipline of its own (own port,
own `KIROCREW_HOME`, zero residue on `pod down`), while `dev-backend.sh` leaves
a foreground process and a `.kirocrew-dev/` directory the developer manages by
hand — but nothing in the skill said which to reach for by default.

## Why it matters

A contributor (human or agent) following this skill has no signal for which
preview path is the better default, so they either pick arbitrarily or default
to whichever is listed first (`dev-backend.sh`), which is the less hands-off
option for the common case.

## What changed (motivation → approach → change)

Goal: make the pod the default preview path without removing `dev-backend.sh`,
since it is still needed on hosts without `systemd --user` / `launchd`, or when
a foreground process is specifically wanted for attaching a debugger.

- Rule 5: reordered so the isolated pod is option 1 (preferred), with a new
  sentence stating the preference and why, plus a note on the platform gate
  (`systemd --user` / `launchd`) linking to `kiro_crew/pod/README.md`.
- `dev-backend.sh` is now option 2, explicitly framed as the fallback for hosts
  without that platform gate, or when a foreground/debugger-attachable process
  is specifically needed.
- Frontmatter `description` reordered to match ("isolated pods, dev-backend.sh
  as fallback").

## Tests

Docs-only change; no automated tests apply. `./scripts/docs-lint.sh` was run
(see Manual verification) rather than added to, since it already covers
markdown structure/link checks repo-wide.

## Manual verification

- `./scripts/docs-lint.sh` passes: 259 markdown files scanned, no new issues.
- Read through the rendered Rule 5 section manually to confirm the numbered
  list, code blocks, and the new relative link (`../../../pod/README.md`)
  resolve correctly from `src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md`.

## Related Issues

N/A — no tracking issue; raised directly from internal usage feedback.

## Pattern harvest

Not generalizable: this is a one-off reordering of prose/example precedence in
a single skill file, not a defect class.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality — N/A, docs-only
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — this PR *is* the documentation update
- [x] No secrets, credentials, or internal references in the diff
