### PR TITLE
docs: add worktree verification recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ in the **same commit** when you change what it documents.
 | user-facing strings, dates, numbers, sort order | [i18n-catalog](website/docs/i18n-catalog.md) (authoring) + [i18n-gates](docs/ci/i18n-gates.md) (CI) |
 | tests: flakes, speed, fixtures, sharding, side effects, conftest isolation | [testing-conventions](docs/system-specs/common/testing-conventions.md) + the [writing-tests](src/kiro_crew/builtin_skills/kirocrew-dev/writing-tests/SKILL.md) skill |
 | browser E2E | [e2e-gate](docs/ci/e2e-gate.md) |
+| proving a worktree change against an isolated running gateway | [worktree-verification-recipes](docs/guides/worktree-verification-recipes.md) |
 | CI, PR flow, review gates | [ci-and-reviews](docs/ci/ci-and-reviews.md) + [CONTRIBUTING.md](CONTRIBUTING.md) |
 | constants, magic numbers, where a limit lives | [code-style](docs/system-specs/common/code-style.md) |
 | injected `[Cron notification]` / `[Subagent completion event]` | [injected-messages](docs/system-specs/common/injected-messages.md) |

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -6,6 +6,7 @@ system is built, see [../architecture/](../architecture/README.md).
 | Guide | Covers |
 |---|---|
 | [install.md](install.md) | Installing and building Kiro Crew: source, wheel, and first run. |
+| [worktree-verification-recipes.md](worktree-verification-recipes.md) | Copy-pasteable backend, frontend, agent-driving, diagnosis, and reclamation traces against an isolated worktree pod. |
 | [windows-install.md](windows-install.md) | Native Windows setup, and the per-feature status on Windows. |
 | [macos-troubleshooting.md](macos-troubleshooting.md) | macOS desktop app issues — a CLI that resolves in Terminal but is `command not found` inside the app, and the `launchctl setenv PATH` recipe that fixes it. |
 | [docker.md](docker.md) | Running Kiro Crew as a container. |

--- a/docs/guides/worktree-verification-recipes.md
+++ b/docs/guides/worktree-verification-recipes.md
@@ -1,0 +1,249 @@
+# Worktree verification recipes
+
+These traces prove a Kiro Crew change against an isolated gateway running the
+changed worktree. They do not touch the live gateway or its data home. Run them
+from the worktree root after the normal build and test gates pass.
+
+## Command availability
+
+The pod lifecycle, packaged scenarios, diagnostic commands, and pod-e2e harness
+are on `main` today:
+
+- `kirocrew pod scenarios [--json]`
+- `kirocrew pod up/down/ls/status/logs/prune`
+- `src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh`
+
+`kirocrew pod api` is not on `main` yet. It arrives with PR #8218. This guide is
+sequenced after #8218: do not merge it first, and update recipes 1 and 3 in the
+same review round if #8218's interface changes. Recipes that use `pod api`
+deliberately fail their preflight until that command is installed:
+
+```bash
+kirocrew pod --help | grep -qw api || {
+  echo "This recipe requires kirocrew pod api from PR #8218" >&2
+  exit 1
+}
+```
+
+`pod api` prints a stable JSON object with `name`, `method`, `path`, `status`,
+`ok`, and `body`. It permits `GET` and `HEAD` by default; `POST`, `PUT`, `PATCH`,
+and `DELETE` require `--allow-write`. It mints the selected pod's dashboard token
+internally, so do not add a `token` query parameter.
+
+Only three packaged scenarios exist: `empty`, `minimal`, and `rich`.
+`kirocrew pod scenarios` prints each name plus its description. Use the smallest
+one that establishes the state under test. The fixture job names asserted below
+are owned by [`minimal/crons.json`](../../src/kiro_crew/tests_fixtures/minimal/crons.json).
+Ten specialized payloads remain deferred until a verification recipe
+demonstrates that one is needed; do not invent a fourth scenario in a feature
+branch.
+
+## Find the verification surface without searching the repository
+
+Start at [`../feature-map/README.md`](../feature-map/README.md). Its row for a
+user-facing feature gives the page, backend handler, and HTTP endpoint. That is
+the trace from the product surface to the assertion target; do not rediscover it
+with a repository-wide search.
+
+For example, the **Schedule** row maps the schedule page to
+`handlers/cron.py` and `GET /api/crons`. The backend recipe below therefore
+asserts that endpoint against the `minimal` scenario, which contains one active
+and one paused cron.
+
+## Recipe 1: prove a backend change
+
+This concrete trace proves the Schedule read path. Change only `PATH` and the
+`jq` assertion when the feature-map row for your change names a different
+endpoint.
+
+```bash
+set -euo pipefail
+WT="$(basename "$PWD")"
+PATH_TO_ASSERT=/api/crons
+
+kirocrew pod scenarios
+kirocrew pod --help | grep -qw api || {
+  echo "This recipe requires kirocrew pod api from PR #8218" >&2
+  exit 1
+}
+
+HANDLE="$(kirocrew pod up "$WT" --seed minimal --json)"
+trap 'kirocrew pod down "$WT"' EXIT
+printf '%s\n' "$HANDLE" | jq -e --arg wt "$WT" '
+  .name == $wt and
+  .status == "up" and
+  (.base_url | startswith("http://127.0.0.1:"))
+' >/dev/null
+
+RESPONSE="$(kirocrew pod api "$WT" GET "$PATH_TO_ASSERT")"
+printf '%s\n' "$RESPONSE" | jq -e '
+  .status == 200 and
+  .ok == true and
+  ([.body.jobs[].name] | sort) ==
+    (["daily minimal fixture ping", "paused weekly recap"] | sort)
+' >/dev/null
+
+kirocrew pod down "$WT"
+trap - EXIT
+```
+
+This asserts all of the following:
+
+1. the isolated gateway started from this worktree and returned its loopback
+   `base_url`;
+2. the feature-map endpoint answered HTTP 200 through `pod api`;
+3. the handler read the seeded pod home rather than an empty or live data home;
+4. `pod down` reclaimed the isolated home.
+
+A successful boot without the `jq` API assertion is not backend verification.
+
+## Recipe 2: prove a frontend change
+
+The [pod-e2e skill](../../src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/SKILL.md)
+owns the harness flags, manifest syntax, authenticated Playwright context, and
+artifact contract. Follow that skill for harness details. This recipe adds the
+worktree-specific proof delta: a seeded boot, a passing verdict assertion, and
+non-empty screenshot evidence. Use `--no-suppress-first-run` only when the
+changed surface includes onboarding or another first-run overlay.
+
+```bash
+set -euo pipefail
+WT="$(basename "$PWD")"
+HARNESS="$PWD/src/kiro_crew/apps/builtins/dev_fleet/skills/pod-e2e/scripts/pod-e2e.sh"
+ARTIFACT_DIR="$HOME/.kirocrew-pods/.e2e-artifacts/$WT"
+
+HANDLE="$(kirocrew pod up "$WT" --seed rich --json)"
+trap 'kirocrew pod down "$WT"' EXIT
+printf '%s\n' "$HANDLE" | jq -e '
+  .status == "up" and (.base_url | startswith("http://127.0.0.1:"))
+' >/dev/null
+
+bash "$HARNESS" "$WT" --fe-only --no-suppress-first-run
+
+jq -se '
+  any(.[]; .phase == "smoke" and .status == "pass") and
+  all(.[]; .status == "pass")
+' "$ARTIFACT_DIR/verdict.jsonl" >/dev/null
+test -s "$ARTIFACT_DIR/fe-smoke.png"
+
+kirocrew pod down "$WT"
+trap - EXIT
+printf 'Evidence: %s\n' "$ARTIFACT_DIR/fe-smoke.png"
+```
+
+The built-in smoke phase proves the authenticated SPA shell, not the changed
+feature. A feature-specific frontend change also needs the branch-local
+Playwright assertion and screenshot described by the pod-e2e skill. Inspect the
+resulting image before using it as PR evidence; a green verdict with a stale or
+unrelated frame is not proof.
+
+## Recipe 3: drive an agent inside the pod
+
+The existing routes and payloads are:
+
+| Operation | Route | Payload |
+|---|---|---|
+| Create | `POST /api/session-control/create` | optional `title`, `agent`, `folder_id` |
+| Send | `POST /api/session-control/send` | required `target`, `message` |
+| Read | `GET /api/session-control/read` | query `target`; optional integer `limit`, `since` |
+| Stop | `POST /api/session-control/stop` | required `target` |
+| Close | `POST /api/session-control/close` | required `target` |
+
+The create response returns the new session key as `body.target`. Send returns
+`body.started`; read returns `body.running`, `body.next_since`, and
+`body.messages`.
+
+**This recipe is not executable through PR #8218 as currently implemented.**
+The session-control routes require a validated `X-Internal-Secret` and identify
+the caller from `X-Session-Key`. PR #8218's `pod api` sends only a dashboard
+query token and has no caller-session option. A live probe returns HTTP 403 with
+`code: internal_secret_required`; even adding internal authentication alone
+would leave create without a caller workspace. Do not claim that an agent was
+driven through `pod api` until both requirements have a supported interface.
+
+The intended trace below records the exact routes and bodies, but the first
+request is expected to fail under the current #8218 implementation. It is kept
+here as the acceptance trace for closing that compatibility gap, not as a green
+recipe:
+
+```bash
+set -euo pipefail
+WT="$(basename "$PWD")"
+
+CREATED="$(kirocrew pod api "$WT" POST /api/session-control/create \
+  --data '{"title":"cron verification agent"}' --allow-write)"
+TARGET="$(printf '%s\n' "$CREATED" | jq -er \
+  '.status == 200 and .body.ok == true and .body.target')"
+
+SENT="$(kirocrew pod api "$WT" POST /api/session-control/send \
+  --data "$(jq -nc --arg target "$TARGET" \
+    --arg message 'list my cron jobs' '{target:$target,message:$message}')" \
+  --allow-write)"
+printf '%s\n' "$SENT" | jq -e \
+  '.status == 200 and .body.ok == true and (.body.started | type == "boolean")' \
+  >/dev/null
+
+while :; do
+  READ="$(kirocrew pod api "$WT" GET \
+    "/api/session-control/read?target=$TARGET&limit=20")"
+  printf '%s\n' "$READ" | jq -e '.status == 200 and .body.ok == true' >/dev/null
+  [ "$(printf '%s\n' "$READ" | jq -r '.body.running')" = false ] && break
+  sleep 1
+done
+printf '%s\n' "$READ" | jq -e '
+  any(.body.messages[];
+      .role == "assistant" and
+      (.content | ascii_downcase | contains("cron")))
+' >/dev/null
+
+kirocrew pod api "$WT" POST /api/session-control/stop \
+  --data "$(jq -nc --arg target "$TARGET" '{target:$target}')" \
+  --allow-write >/dev/null
+kirocrew pod api "$WT" POST /api/session-control/close \
+  --data "$(jq -nc --arg target "$TARGET" '{target:$target}')" \
+  --allow-write >/dev/null
+```
+
+The acceptance assertion is not merely that send returned 200: read must show
+an assistant reply about cron jobs, and close must archive the temporary
+session. `stop` is a safe no-op if the reply already finished.
+
+## Recipe 4: diagnose and reclaim
+
+Use the non-destructive views first:
+
+```bash
+set -euo pipefail
+WT="$(basename "$PWD")"
+
+kirocrew pod ls
+STATUS="$(kirocrew pod status "$WT" --json)"
+printf '%s\n' "$STATUS" | jq -e --arg wt "$WT" \
+  '.name == $wt and .status == "up" and (.health == 200 or .health == 401 or .health == 403)' \
+  >/dev/null
+kirocrew pod logs "$WT" --lines 100
+kirocrew pod prune --dry-run --json | jq .
+```
+
+`pod ls` distinguishes running pods from orphaned pod homes. `pod status`
+asserts that this named pod is active and that its own gateway answered the
+health probe. `pod logs` shows the last 100 service lines. `pod prune --dry-run`
+classifies bulk-reclaim candidates without deleting anything.
+
+Reclaim one known pod with the same stop-drain-delete-verify path used by every
+recipe:
+
+```bash
+kirocrew pod down "$WT"
+```
+
+After reviewing the dry-run, reclaim orphaned homes older than the default three
+days with:
+
+```bash
+kirocrew pod prune
+```
+
+Use `kirocrew pod prune --all` only when every reported orphan should be
+removed regardless of age. Reclamation is destructive to the isolated pod home,
+so keep a fresh crash home until its logs and sessions are no longer needed.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -287,6 +287,19 @@ where a pod cannot run.
 3. **No preview at all (also valid).** For many changes, the build gate + unit
    tests are enough confidence to cut the PR. Previewing live is optional.
 
+### Turn a preview into proof
+
+A pod being healthy proves only that a gateway answered. To prove changed
+behavior, run the copy-pasteable trace in
+`docs/guides/worktree-verification-recipes.md` for the changed surface. The
+recipes use the feature map to select the owning endpoint, assert seeded backend
+state, run the packaged pod-e2e Playwright harness and preserve screenshot
+evidence, or diagnose and reclaim a failed pod.
+
+The recipes distinguish pod commands already on `main` from `pod api`, which
+arrives with PR #8218. They also record the current session-control compatibility
+gap rather than presenting an HTTP 403 as an agent-driving proof.
+
 ### Agent specs + MCP servers are a SEPARATE isolation axis from the data home
 
 `KIROCREW_HOME` isolates config, DB, sessions and workspace. It does **not**


### PR DESCRIPTION
# Add worktree verification recipes and discoverability wiring

Slice 5 — the final slice — of the verification-controller plan. An agent that changed Kiro Crew code can now follow a documented, copy-pasteable trace to prove the change against a real running Kiro Crew instead of rediscovering the command sequence. No new verbs, no new CLI code, no new fixtures: documentation and discoverability only.

## The doc

`docs/guides/worktree-verification-recipes.md` — four end-to-end traces, each stating what it *asserts*, not just what it runs:

1. **Prove a backend change** — `pod scenarios` → `pod up --seed minimal --json` → `pod api GET <endpoint>` with a `jq` assertion against the seeded state → `pod down`. Shows how the feature map turns a user-facing feature into the handler and endpoint to hit, with the Schedule → `/api/crons` row as the worked example.
2. **Prove a frontend change** — same boot with `rich`, then the pod-e2e harness (real invocation, including `--no-suppress-first-run` from #8087), verdict-file and screenshot-evidence assertions, and the `PLAYWRIGHT_SPEC` hook for feature-specific assertions.
3. **Drive an agent inside the pod** — the pre-existing `/api/session-control/{create,send,read,stop,close}` routes with payload shapes verified against the dashboard server source.
4. **Diagnose and reclaim** — `pod ls/status/logs/prune`.

Discoverability: a root `AGENTS.md` "Read before you touch" row, the `docs/guides/README.md` index entry, and a section in the packaged `kirocrew-worktree-dev` skill (under `src/kiro_crew/builtin_skills/`, the path that reaches installed users).

## Honest finding recorded in the doc

Recipe 3 is **not executable through #8218 as implemented**: the session-control routes require a validated `X-Internal-Secret` and take the caller from `X-Session-Key`, while `pod api` sends only the dashboard query token. A live probe returned HTTP 403 `internal_secret_required`. The doc says so plainly and keeps the trace as the acceptance criteria for closing that gap, rather than presenting it as working. Whether to extend `pod api` for it is a scope decision deliberately not made here.

## Accuracy discipline

Every command was verified against CLI source; the lifecycle and diagnostic traces were additionally **executed live**: scenario listing, seeded `minimal` boot, `/api/crons` returning 200 with both fixture jobs, health 200, zero-residue teardown. `pod api` syntax was verified against PR #8218's implementation; because this doc may merge first, it states which commands are on main today and which arrive with #8218, and its recipes preflight for the verb's presence. Only the three packaged scenarios (`empty`, `minimal`, `rich`) are used; the ten specialized payloads stay deferred until a recipe demonstrates need.

## Verification

Docs lint (259 files), brand, and harness-parity gates green; all seven bash blocks pass `bash -n`; the 33 skill-wiring tests pass. 4 files, +273/−0, docs and skill only.
