### PR TITLE
fix(tests): anchor bare-interpreter assertion on its code-span backtick

### DIFF
--- a/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
+++ b/src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py
@@ -510,8 +510,14 @@ class TestWorkerPromptInterpreter(unittest.TestCase):
         return [D.build_review_task(self.LINK), D.build_review_followup_task(self.LINK)]
 
     def test_no_prompt_names_a_bare_interpreter(self):
+        # Both needles are anchored on the opening backtick of an inline code
+        # span: python_command() legitimately embeds the absolute
+        # sys.executable, which can itself end in "python3" (issue #8205), so
+        # an unanchored needle would fire on the correct path. Unbackticked
+        # prose is covered only by the span test below
+        # (test_every_script_command_carries_the_resolved_interpreter).
         for p in self._prompts():
-            self.assertNotIn("python3 ", p)
+            self.assertNotIn("`python3 ", p)
             self.assertNotIn("`python ", p)
 
     def test_every_script_command_carries_the_resolved_interpreter(self):


### PR DESCRIPTION
## Problem / Motivation

`test_no_prompt_names_a_bare_interpreter` in
`src/kiro_crew/apps/builtins/code_review_sage/tests/test_review_driver.py`
passes or fails depending on how pytest was launched — on clean main
(verified at 74eab0c). Launch pytest through an interpreter whose executable
name ends in `python3` and the test fails; launch it through one named
`python` and it passes. CI never hits it (its workflow launches pytest bare),
so it only bites developers and agents running the file directly.

## Why it matters

A test whose verdict depends on the launcher spelling is a false alarm
generator: every developer or agent whose venv exposes the interpreter as
`python3` sees a failure on pristine code, wastes time bisecting a phantom
regression, and learns to distrust the file's verdicts — which is how the real
failure the guard exists to catch (a prompt naming a bare interpreter that is
a dead Microsoft Store alias on Windows) would eventually slip through a
habitually-ignored red.

## What changed (motivation → approach → change)

Symptom: the test fails only under a `python3`-named launcher. Root cause: the
guard's first assertion checked for the substring `python3 ` with no
inline-code-span anchor, while its sibling on the next line was correctly
anchored on the opening backtick. `python_command()` in
`sage_lib/review_driver.py` deliberately embeds the ABSOLUTE `sys.executable`
path in prompts inside an inline code span, so when that path ends in
`python3` the correct absolute path contains the flagged substring and the
unanchored assertion fires on the very value the function exists to produce.

Change: one line — anchor the first assertion the same way its sibling already
is, prefixing the needle with the opening backtick of the code span
(`` assertNotIn("`python3 ", p) ``). The anchor is what distinguishes a
genuinely bare interpreter name at the start of a code span from an absolute
path that merely ends in that name: the absolute path always has a slash
directly before the name, never a backtick. A short comment on the test
records why the needle is anchored and where unbackticked-prose coverage
lives (the sibling span test), so the coverage boundary is explicit.

Diagnosis and fix are the reporter's (@chenmingwei23) — credited as
co-author on the commit.

## Tests

This PR is itself a test-only change. Verified red-before-green on the
launcher dependence:

- Pre-fix: `<venv>/bin/python3 -m pytest test_review_driver.py` → 1 failed
  (`'python3 ' unexpectedly found in ...`), 53 passed; the same file under
  `<venv>/bin/python` → 54 passed.
- Post-fix: 54 passed under BOTH launcher spellings.
- Mutation check: deliberately injecting `` `python3 check.py` `` into
  `build_review_task`'s prompt reddens the test — a genuinely bare
  interpreter at the start of a code span still matches.

## Manual verification

N/A — unit coverage sufficient: the change is one assertion needle inside the
test itself, exercised directly by the runs above.

## Related Issues

Closes #8205

## Pattern harvest

Rule candidate: review-prompt
Pattern: "substring assertion on a command fragment without its delimiter anchor fires on absolute paths that merely end in that fragment"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
