### PR TITLE
refactor(events): dedupe the RawEvent fallback and the tombstone stat

### DIFF
--- a/src/kiro_crew/events/backfill.py
+++ b/src/kiro_crew/events/backfill.py
@@ -344,7 +344,13 @@ def backfill_subagents(home: Path, limit: int | None = None) -> SourceReport:
         outcome: str | None = None
         died_ms: int | None = None
         readable = False
-        if tombstone.exists():
+        # Stat the tombstone once and let both decisions below read the answer.
+        # The terminal branch decides from ``readable`` / ``cause`` / ``died_ms``,
+        # which this block's parse is the only source of, so a second stat that
+        # answered differently would judge the terminal against a file no other
+        # line here ever saw.
+        has_tombstone = tombstone.exists()
+        if has_tombstone:
             try:
                 t = _read_json_no_follow(tombstone)
                 if isinstance(t, dict):
@@ -377,7 +383,7 @@ def backfill_subagents(home: Path, limit: int | None = None) -> SourceReport:
         # subagent is still STREAMING its answer, so its presence alone proves
         # nothing — a run dir with state but no tombstone is in-flight (or was
         # orphaned) and gets only the spawned event.
-        if tombstone.exists():
+        if has_tombstone:
             # A tombstone does NOT mean failure: successful delivery writes a
             # ``cause="delivered"`` tombstone instead of deleting the folder
             # (deferred-TTL cleanup). Only a non-delivered cause is abnormal —

--- a/src/kiro_crew/events/base.py
+++ b/src/kiro_crew/events/base.py
@@ -199,9 +199,10 @@ def parse(line: str) -> Parsed | None:
     """Parse one log line. Returns ``None`` only for non-JSON / non-object input.
 
     Guarantees for well-formed envelopes: never raises. A ``kind`` this build
-    does not know — or a known kind whose required fields are absent — yields
-    a :class:`RawEvent` carrying the payload verbatim. Unknown fields inside
-    ``data`` for a known kind are ignored (additive evolution).
+    does not know — or a known kind whose payload violates a field's declared
+    type, or leaves a required field absent — yields a :class:`RawEvent`
+    carrying the payload verbatim. Unknown fields inside ``data`` for a known
+    kind are ignored (additive evolution).
     """
     try:
         rec = json.loads(line)
@@ -236,21 +237,22 @@ def parse(line: str) -> Parsed | None:
         return None
     data: dict[str, Any] = data_val
     cls = REGISTRY.get(kind)
-    event: Event
+    typed: Event | None = None
     if cls is not None:
         allowed = {f.name for f in dc_fields(cls)} - _BASE_FIELDS
         kwargs = {k: val for k, val in data.items() if k in allowed}
         # A retained value that violates the field's declared type must not
         # reach consumers as a typed event — that would make the dataclass
         # schema a lie. Such lines degrade to RawEvent like unknown kinds.
-        if not _payload_matches(cls, kwargs):
-            event = RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
-        else:
+        if _payload_matches(cls, kwargs):
             try:
-                event = cls(key=key, ts_ms=ts_ms, **kwargs)
+                typed = cls(key=key, ts_ms=ts_ms, **kwargs)
             except TypeError:
-                # Required typed field missing — fall back rather than fail.
-                event = RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
-    else:
-        event = RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
+                # Required typed field missing — leave ``typed`` at ``None`` so
+                # the fallback below applies, rather than failing the parse.
+                pass
+    # One fallback for all three degrade paths: unknown kind, a payload whose
+    # value violates the field's declared type, and a payload missing a
+    # required typed field.
+    event = typed if typed is not None else RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
     return Parsed(event=event, kind=kind, src=src, v=v)


### PR DESCRIPTION
## Problem / Motivation

Two readability defects in `src/kiro_crew/events/`, both found by the
module-simplification sweep's judgment classes (duplicated construction,
duplicated condition):

- `events/base.py::parse()` constructed the *identical*
  `RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)` at **three**
  separate places — unknown `kind`, a payload value that violates its field's
  declared type, and a payload missing a required typed field — nested three
  levels deep behind an `if not _payload_matches(...): ... else: ...` pair.
- `events/backfill.py::backfill_subagents()` called `tombstone.exists()`
  **twice per run directory**: once to decide whether to skip the run or emit
  `subagent/spawned`, and again to decide whether to emit a terminal event.

## Why it matters

The `RawEvent` fallback is the schema's forward-compatibility contract — a
newer writer's line must never be lost. Three hand-copied constructions of it
is three places for that contract to drift, and the duplication is what makes
the nesting hard to read in the first place.

The double `tombstone.exists()` is worse than redundant. Every value the
*second* decision consumes — `readable`, `cause`, `outcome`, `died_ms` — is
derived from the *first* read. So if the two stats ever disagree, the terminal
event is judged against a file that nothing else in the loop ever saw.

## What changed (motivation → approach → change)

**`base.py::parse()`** — three duplicated constructions, one contract → funnel
them through a single fallback. A `typed: Event | None` local stays `None`
until a typed event is actually built, and one closing line resolves it:

```python
event = typed if typed is not None else RawEvent(key=key, ts_ms=ts_ms, kind=kind, payload=data)
```

The negated `if not _payload_matches(...)` / `else` inverts to the positive
form, one nesting level disappears, and the `RawEvent` construction now exists
once, so it cannot drift between the three paths. `is not None` (not
truthiness) is deliberate: a frozen dataclass with no fields set is falsy, and
a truthiness test would silently discard a validly-constructed typed event.

**`backfill.py::backfill_subagents()`** — one duplicated condition → stat once.
`has_tombstone` is computed where the other tombstone-derived values are, and
both decisions read it.

### The one semantic delta, stated plainly

With a stable filesystem the two forms are identical on every path. They differ
only in the race where `tombstone.json` is created or deleted *between* what
used to be the two stats:

| Race | Before | After |
|---|---|---|
| tombstone vanishes (deferred-TTL cleanup), was readable | `spawned` with **no terminal** — the exact "replays forever as an active run" pathology the comment above it warns about, despite having read a valid `cause` | `spawned` + `completed`/`failed`, derived from the bytes actually read |
| tombstone vanishes, was corrupt | `failures = 0` — the read failure is swallowed and the `rep.fail()` is then skipped by the second stat | `failures = 1`, which is what an unreadable tombstone means |
| tombstone appears (a live gateway writes one mid-run) | `spawned` + a **spurious `rep.fail()`** charged to a file that was never opened — `readable` is `False` only because the read block was skipped | `spawned` only, the documented in-flight outcome |

In all three rows the old outcome is derived from a stat whose answer
contradicts the bytes the loop actually read; the new one is not. I took the
single stat rather than preserving the race bit-for-bit because a run directory
disagreeing with itself inside one loop iteration is not behaviour worth
conserving, and this is a read-only validator whose whole job is to report what
the stores contain.

One nuance in the same window, for completeness: when a vanished tombstone was
readable but carried no `died`, the terminal event is stamped `ts_ms=0`
(`_mtime_ms` returns 0 on `OSError`) and `ts_fallbacks` is incremented.
Degraded, but *counted* — and still better than no terminal at all.

### What I deliberately did NOT change

`backfill.py`'s own module docstring declares it **disposable** — "it is
deleted when the live emit sites land". So I restricted it to the one
duplicated-condition fix and left its control flow alone. In particular the
JSONL row-reading prelude duplicated between `backfill_transcripts` and
`backfill_usage` (bounded-records loop → limit check → strip → blank skip →
`json.loads` → dict check) is genuine duplication, but extracting it would have
to preserve an `early return` that abandons *all remaining files* rather than
just the current one, and rewriting control flow in a module scheduled for
deletion is not a trade worth making.

## Tests

No new tests. Both changes are behavior-preserving restructures of code whose
branches are already covered — `test/test_events_base.py` exercises all four
`parse()` outcomes (typed happy path, unknown kind, type-violating payload,
missing required field) and `test/test_events_backfill.py` exercises the
tombstone branches (delivered, failed, stopped, `gateway_restart`, unreadable).
93 tests pass across `test_events_base.py`, `test_events_backfill.py` and
`test_events_forward.py`.

Worth noting for the reviewer: the `events` package has **zero production
consumers** — `test_events_backfill.py` contains a test that fails the moment
it gains one — so the blast radius of this diff is those two test files.

## Manual verification

N/A — unit coverage sufficient. `parse()` is pure and the validator is
read-only, so there is no integration surface a manual run would exercise that
the tests do not.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff (two files under `src/kiro_crew/events/`),
no frontend path touched and no rendered surface — the `events` package has no
UI consumer at all.

## Related Issues

no linked issue: routine readability sweep, not tracked by an issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (none needed — no new functionality)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no spec documents these internals
- [x] No secrets, credentials, or internal references in the diff

## Pre-review fleet

Before opening, I ran three parallel review agents with distinct lenses,
grounded in this repo's own `AUTOSDE.yaml` and `.github/workflows/*.yml` rather
than generic taste. **No blocking findings from any lens.** What they produced:

- **AUTOSDE + security + import semantics** — checked all ten `file-patterns`
  blocks by glob rather than assumption: of the blocking rules, only
  `backend-security-controls` and `no-blocking-call-on-event-loop` match these
  paths, and both pass (the diff *removes* one `stat(2)` per run dir and adds
  none; the two-pass redaction sink at `backfill.py` and the `O_NOFOLLOW` guard
  are outside the diff and unchanged). Zero imports added, deleted, or moved.
  `harness-parity` does not match `events/`.
- **Behavior preservation** — re-created both pre-change function bodies in the
  live module's globals and diffed outputs. `parse()`: **2,084 inputs, 0
  divergences** (604 typed / 1,468 RawEvent / 12 `None`), including a
  purpose-registered `kw_only` class to reach the otherwise-unreachable
  `TypeError` branch — none of the seven shipped kinds has a required field.
  `backfill_subagents()`: **440 stable-filesystem scenarios, 0 divergences**,
  with the race above as the only delta.
- **Comments, spec obligations, coverage** — no spec under `docs/system-specs/`
  covers this package, so none is owed. Existing tests already cover all four
  `parse()` outcomes and every `has_tombstone` branch. Neither file is in
  `.github/coverage-baselines/backend.txt`.

**Findings I acted on** (all comment-accuracy, all from the third lens): the
`except TypeError` comment said "leave `typed` unset" when `typed` is bound to
`None`; `parse()`'s docstring named only two degrade causes and omitted the
type-violation path, which now sits seventeen lines from a comment naming
three; the `has_tombstone` comment conflated the *stat* with the *read* and was
wedged between two other comment blocks, detaching one from its code. All four
are fixed in the single commit.

**Findings I did not act on:** a suggestion to extract a
`_typed_event(cls, ...)` helper out of `parse()` — it moves the sentinel behind
a call on a per-log-line hot path without removing it, so it trades one
readability cost for another. And the eager-`RawEvent` alternative (construct
it up front, overwrite on success) was rejected for the same reason it was not
written that way: it allocates on every happy-path line.

## Gates run locally

Python 3.12 CI-parity venv, all exit 0: `flake8`, `isort --check-only`, `mypy`
(1281 files), `check_black_formatting`, `check_subprocess_encoding`,
`check_harness_parity`, `check_brand_name`, `docs_lint --test`, `docs-lint.sh`,
`check_per_file_coverage --test`, `check_sync_io_in_async`,
`check_loop_bound_locks`, `check_agent_sdk_boundary`, `scrub-lint --no-history`,
`verify_vendor_manifest`, plus the three `events` test files. Re-run in full
after the rebase onto `9af882186`.
