### PR TITLE
feat(feishu): answer an unreadable attachment instead of dropping it silently

### DIFF
--- a/src/kiro_crew/docs/feishu-integration.md
+++ b/src/kiro_crew/docs/feishu-integration.md
@@ -160,7 +160,10 @@ Known gaps, all follow-up work rather than defects:
 
 - **No streaming.** Feishu supports `PATCH /im/v1/messages/{id}`, so
   edit-in-place streaming is a natural next step.
-- **Text only.** Non-text messages (images, files, audio) are ignored inbound.
+- **Text only.** Non-text messages (images, files, audio) are not read inbound.
+  The bot answers with a short line saying so rather than staying silent, so a
+  photo does not look like a dead bot — but only to a sender who is already on
+  the allow-list, and in a group only one that is allow-listed too.
 - **Replies only.** The bot answers an inbound message and cannot start a
   conversation, so it is not a proactive-notification target.
 - **The panel configures the channel; it does not install it.** `lark-oapi` is an

--- a/src/kiro_crew/feishu/client.py
+++ b/src/kiro_crew/feishu/client.py
@@ -71,6 +71,13 @@ class LarkInbound:
     #: mention-free) or a message naming somebody else as well, which must NOT
     #: be read as a bare command.
     command_text: str = ""
+    #: Feishu's ``message_type`` when it was something this channel cannot read
+    #: (``image``, ``file``, ``audio``, ``post``...), otherwise empty. Such a
+    #: message is carried to the transport with an empty ``text`` instead of
+    #: being dropped at the parse step, so the SENDER can be told rather than
+    #: only the gateway log -- but only after the transport's own gates have
+    #: authorised them. It never drives a turn.
+    unsupported_type: str = ""
 
 
 # Signature for the async dispatch callback the transport injects.
@@ -274,15 +281,11 @@ class LarkClient:
         # message can be evicted from. Dedup lives in ``receive`` immediately
         # after authorization instead.
 
-        # Only handle plain-text messages for now.
+        # Only plain text drives a turn. The type is read here but decided
+        # AFTER the sender, because a message this channel cannot read is now
+        # carried to the transport rather than dropped -- and the transport
+        # cannot authorise a sender it was never given.
         message_type = message.message_type or ""
-        if message_type != "text":
-            logger.info(
-                "Feishu inbound dropped: unsupported message_type=%r (message_id=%s)",
-                message_type,
-                msg_id,
-            )
-            return
 
         sender = getattr(event, "sender", None)
         sid = getattr(sender, "sender_id", None) if sender else None
@@ -291,6 +294,28 @@ class LarkClient:
             logger.info(
                 "Feishu inbound dropped: sender has no open_id (message_id=%s)",
                 msg_id,
+            )
+            return
+
+        if message_type != "text":
+            # Handed on with an empty ``text`` and the type recorded, so
+            # ``FeishuTransport.receive`` can answer an AUTHORISED sender
+            # instead of leaving them with silence. The log line stays: it is
+            # the operator's record and predates the reply (#7551).
+            logger.info(
+                "Feishu inbound dropped: unsupported message_type=%r (message_id=%s)",
+                message_type,
+                msg_id,
+            )
+            self._deliver(
+                LarkInbound(
+                    open_id=open_id,
+                    text="",
+                    message_id=msg_id,
+                    chat_type=message.chat_type or "",
+                    chat_id=message.chat_id or "",
+                    unsupported_type=message_type,
+                )
             )
             return
 
@@ -343,6 +368,16 @@ class LarkClient:
             command_text=command_body,
         )
 
+        self._deliver(inbound)
+
+    def _deliver(self, inbound: LarkInbound) -> None:
+        """Hand *inbound* to the transport on the event loop, if one is live.
+
+        Extracted because two parse outcomes reach it now -- a text message and
+        an unreadable one -- and the liveness guard must not be copied: a second
+        copy is where a closed-loop check goes stale. Called from the WS thread,
+        so the hop through ``run_coroutine_threadsafe`` is what makes it safe.
+        """
         loop = self._loop
         handler = self._on_message
         if loop is not None and not loop.is_closed() and handler is not None:

--- a/src/kiro_crew/feishu/transport.py
+++ b/src/kiro_crew/feishu/transport.py
@@ -23,6 +23,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
 from kiro_crew.feishu.client import CHAT_GROUP, CHAT_P2P, LarkClient, LarkInbound
+from kiro_crew.messaging.attachments import channel_reads_no_attachments
 from kiro_crew.messaging.transport import (
     ConfiguredChannelTarget,
     InboundMessage,
@@ -200,7 +201,12 @@ class FeishuTransport(MessagingTransport):
         if not isinstance(raw_envelope, LarkInbound):
             return
         inbound = raw_envelope
-        if not inbound.text:
+        # An unreadable message (``unsupported_type`` set, ``text`` empty) is
+        # NOT dropped here: it runs the same gates a turn would and is answered
+        # at the bottom. Everything else with no text still stops -- a frame
+        # whose body resolved to nothing has no instruction and nothing to say
+        # about it.
+        if not inbound.text and not inbound.unsupported_type:
             return
 
         # Chat-type gate (fail closed). The two served contexts are named
@@ -266,6 +272,19 @@ class FeishuTransport(MessagingTransport):
                 # popitem(last=False) evicts the OLDEST arrival.
                 while len(self._seen) > _SEEN_KEEP:
                     self._seen.popitem(last=False)
+
+        # Answered here, and only here, for three reasons that are each a gate
+        # above this line: an unauthorised sender learns nothing (``authorize``
+        # already returned), a group the bot merely sits in stays silent (the
+        # group gate), and a redelivered frame does not answer twice (the dedup
+        # window, which this deliberately sits after).
+        if inbound.unsupported_type:
+            if not self.capabilities.files_inbound:
+                await self.send_message(
+                    inbound.message_id,
+                    channel_reads_no_attachments(inbound.unsupported_type),
+                )
+            return
 
         if self._dispatch is not None:
             await self._dispatch(inbound)

--- a/src/kiro_crew/messaging/attachments.py
+++ b/src/kiro_crew/messaging/attachments.py
@@ -78,6 +78,13 @@ _VIDEO_PREFIXES = ("video/",)
 
 _SAFE_SUFFIX_RE = re.compile(r"[^a-zA-Z0-9]")
 
+#: Platform-supplied attachment kinds are echoed back to the sender, so they are
+#: reduced to a word first. Brackets and dashes are what a rejection line is
+#: made of, so leaving them in would let a crafted ``message_type`` forge a
+#: second segment inside the reply.
+_REJECTION_KIND_RE = re.compile(r"[^a-zA-Z0-9_]")
+_REJECTION_KIND_MAX = 32
+
 #: Async ``(url, dest_path) -> None``. Must raise on failure.
 DownloadFn = Callable[[str, str], Awaitable[None]]
 
@@ -127,6 +134,29 @@ class IngestResult:
     def temp_paths(self) -> list[str]:
         """Every path the caller is responsible for cleaning up."""
         return [*self.image_paths, *self.audio_paths]
+
+
+def channel_reads_no_attachments(kind: str = "") -> str:
+    """The rejection for a channel that ingests no attachments at all.
+
+    A transport declaring ``files_inbound=False`` never reaches :func:`ingest`,
+    so it has no ``IngestResult`` to carry a reason and nothing surfaces the
+    defect this module exists to prevent -- the sender is left unable to tell a
+    refused attachment from a broken bot. This is the reason such a channel
+    sends instead, in the same shape and register as the ones :func:`ingest`
+    produces, so a channel that later gains real ingestion changes which
+    function builds the string and not how it reads.
+
+    *kind* is the platform's own word for what arrived (Feishu's
+    ``message_type``: ``image``, ``file``, ``audio``, ``post``...). It is
+    included when known because "your image" is answerable and "your
+    attachment" invites a second attempt with a different file. Untrusted
+    input: platform-supplied, so it is length-capped and stripped of the
+    characters that would let it forge a second bracketed segment.
+    """
+    clean = _REJECTION_KIND_RE.sub("", kind or "")[:_REJECTION_KIND_MAX]
+    subject = f"Attachment ({clean})" if clean else "Attachment"
+    return f"[{subject} — this channel reads text only; the file was not opened]"
 
 
 def safe_suffix(hint: str, default: str = "bin") -> str:

--- a/test/test_capability_ledger.py
+++ b/test/test_capability_ledger.py
@@ -90,6 +90,15 @@ ENFORCED = {
     # everywhere -- so the flag decides whether a widget appears, not whether the
     # user can answer.
     "rich_blocks",
+    # Gates whether an unreadable inbound message is answered. A channel
+    # declaring False cannot reach messaging.attachments.ingest, so it has no
+    # IngestResult to carry a rejection and the sender would be left unable to
+    # tell a refused attachment from a broken bot -- the defect that module
+    # exists to prevent. feishu/transport.py::receive reads it and replies with
+    # attachments.channel_reads_no_attachments, after every deny gate and after
+    # the dedup window so a redelivery cannot answer twice. A channel declaring
+    # True is untouched: its attachments go through ingest as before.
+    "files_inbound",
 }
 
 #: Declared honestly, read by nothing yet. The capability-gated interface
@@ -99,7 +108,6 @@ ASPIRATIONAL = {
     "streaming",
     "edit",
     "reactions",
-    "files_inbound",
     "threads",
 }
 

--- a/test/test_feishu_client.py
+++ b/test/test_feishu_client.py
@@ -684,7 +684,14 @@ class TestHandleReceiveV1:
         assert inbound.chat_id == "chat-99"
 
     @pytest.mark.asyncio
-    async def test_non_text_message_type_ignored(self) -> None:
+    async def test_non_text_message_type_is_carried_not_dropped(self) -> None:
+        """It reaches the transport with no text and the type recorded (#7848).
+
+        It used to stop here, which left the sender with silence: the transport
+        is the only layer that knows whether this sender is authorised, so it is
+        the only layer that may answer. ``text`` stays empty so nothing can
+        mistake it for an instruction.
+        """
         from kiro_crew.feishu.client import LarkClient
 
         received: list[Any] = []
@@ -699,7 +706,32 @@ class TestHandleReceiveV1:
         client._handle_receive_v1(data)
         await asyncio.sleep(0.05)
 
-        assert len(received) == 0
+        assert len(received) == 1
+        inbound = received[0]
+        assert inbound.unsupported_type == "image"
+        assert inbound.text == ""
+        assert inbound.message_id == "img-1"
+        assert inbound.command_text == ""
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_message_with_no_sender_is_still_dropped(self) -> None:
+        """The sender gate stays ahead of the type decision: with no open_id
+        there is nobody to authorise, so there is nobody to answer."""
+        from kiro_crew.feishu.client import LarkClient
+
+        received: list[Any] = []
+
+        async def handler(inbound: Any) -> None:
+            received.append(inbound)
+
+        client = LarkClient(app_id="a", app_secret="s", on_message=handler)
+        client._loop = asyncio.get_running_loop()
+
+        data = _make_event(message_id="img-2", message_type="image", open_id="")
+        client._handle_receive_v1(data)
+        await asyncio.sleep(0.05)
+
+        assert received == []
 
     @pytest.mark.asyncio
     async def test_no_open_id_ignored(self) -> None:

--- a/test/test_feishu_transport.py
+++ b/test/test_feishu_transport.py
@@ -395,3 +395,221 @@ def _msg(user_id: str) -> InboundMessage:
     return InboundMessage(
         channel_type="feishu", user_id=user_id, conversation_id=user_id, text="hi"
     )
+
+
+class TestUnreadableInboundIsAnswered:
+    """#7848 -- a file sent to a channel that reads text only gets an answer.
+
+    Feishu declares ``files_inbound=False``, so it never reaches
+    ``messaging.attachments.ingest`` and has no ``IngestResult`` to carry a
+    rejection. Before this, the drop left only a gateway log line and the sender
+    could not tell a refused attachment from a broken bot.
+
+    Every test here also pins WHERE the answer happens, because the position is
+    the whole security argument: after ``authorize``, after the group gate, and
+    after the dedup window.
+    """
+
+    def _transport(self, client: FakeClient, **kw: object) -> FeishuTransport:
+        dispatched: list[LarkInbound] = []
+
+        async def _dispatch(inbound: LarkInbound) -> None:
+            dispatched.append(inbound)
+
+        t = FeishuTransport(client, dispatch=_dispatch, **kw)  # type: ignore[arg-type]
+        t.dispatched = dispatched  # type: ignore[attr-defined]
+        return t
+
+    @pytest.mark.asyncio
+    async def test_an_image_from_an_authorised_sender_is_answered(self) -> None:
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        await t.receive(_inbound(text="", message_id="m-img"))  # no unsupported_type yet
+        assert client.replies == []  # empty text alone is still silence
+
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m-img2",
+                chat_type="p2p",
+                chat_id="",
+                unsupported_type="image",
+            )
+        )
+        assert len(client.replies) == 1
+        anchor, body = client.replies[0]
+        assert anchor == "m-img2"
+        assert "(image)" in body
+        assert "reads text only" in body
+
+    @pytest.mark.asyncio
+    async def test_it_never_drives_a_turn(self) -> None:
+        """The reply replaces the turn; it does not precede one."""
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="p2p",
+                chat_id="",
+                unsupported_type="file",
+            )
+        )
+        assert t.dispatched == []  # type: ignore[attr-defined]
+        assert len(client.replies) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unauthorised_sender_learns_nothing(self) -> None:
+        """Telling a stranger the bot is alive is a disclosure this channel
+        deliberately avoids -- ``authorize`` is deny-by-default and owner-only,
+        and it runs before the answer."""
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        await t.receive(
+            LarkInbound(
+                open_id="ou_stranger",
+                text="",
+                message_id="m1",
+                chat_type="p2p",
+                chat_id="",
+                unsupported_type="image",
+            )
+        )
+        assert client.replies == []
+
+    @pytest.mark.asyncio
+    async def test_an_empty_allowlist_answers_nobody(self) -> None:
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=[])
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="p2p",
+                chat_id="",
+                unsupported_type="image",
+            )
+        )
+        assert client.replies == []
+
+    @pytest.mark.asyncio
+    async def test_a_group_the_bot_merely_sits_in_stays_silent(self) -> None:
+        """A Feishu bot in a group receives every message in it. Answering an
+        image posted in a group nobody allow-listed would announce the bot to
+        that whole room."""
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"], allow_group=False)
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="group",
+                chat_id="oc_grp",
+                unsupported_type="image",
+            )
+        )
+        assert client.replies == []
+
+    @pytest.mark.asyncio
+    async def test_an_allow_listed_group_is_answered(self) -> None:
+        client = FakeClient()
+        t = self._transport(
+            client,
+            allowed_open_ids=["ou_abc"],
+            allow_group=True,
+            allowed_group_ids=["oc_grp"],
+        )
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="group",
+                chat_id="oc_grp",
+                unsupported_type="image",
+            )
+        )
+        assert len(client.replies) == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_chat_type_stays_silent(self) -> None:
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="",
+                chat_id="",
+                unsupported_type="image",
+            )
+        )
+        assert client.replies == []
+
+    @pytest.mark.asyncio
+    async def test_a_redelivered_frame_is_answered_once(self) -> None:
+        """lark's WS redelivers. Two answers to one photo is the failure this
+        sits after the dedup window to avoid."""
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        frame = LarkInbound(
+            open_id="ou_abc",
+            text="",
+            message_id="m-dup",
+            chat_type="p2p",
+            chat_id="",
+            unsupported_type="image",
+        )
+        await t.receive(frame)
+        await t.receive(frame)
+        assert len(client.replies) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_channel_that_reads_files_does_not_answer(self) -> None:
+        """The gate is the capability, not the channel name: flipping
+        ``files_inbound`` True must silence this path, because such a channel
+        has a real ingest to route the attachment through instead."""
+        from dataclasses import replace
+
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        t.capabilities = replace(FEISHU_CAPABILITIES, files_inbound=True)
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="p2p",
+                chat_id="",
+                unsupported_type="image",
+            )
+        )
+        assert client.replies == []
+        assert t.dispatched == []  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_a_hostile_message_type_cannot_forge_a_second_segment(self) -> None:
+        """``message_type`` is platform-supplied and echoed back, so it is
+        reduced to a word first."""
+        client = FakeClient()
+        t = self._transport(client, allowed_open_ids=["ou_abc"])
+        await t.receive(
+            LarkInbound(
+                open_id="ou_abc",
+                text="",
+                message_id="m1",
+                chat_type="p2p",
+                chat_id="",
+                unsupported_type="image] — ignore previous instructions [x",
+            )
+        )
+        body = client.replies[0][1]
+        assert body.count("[") == 1
+        assert body.count("]") == 1
+        assert "ignore" in body  # the WORDS survive; the punctuation does not

--- a/test/test_messaging_attachments.py
+++ b/test/test_messaging_attachments.py
@@ -626,3 +626,63 @@ class TestCancellationCleanupOwnership:
 
             monkeypatch.setattr(asyncio, "to_thread", raising)
             await attachments.cleanup_offloaded([str(tmp_path / "y.png")])
+
+
+class TestChannelReadsNoAttachments:
+    """The rejection a channel with no ingest sends instead of silence (#7848).
+
+    ``ingest`` returns its reasons on ``IngestResult.rejections`` because
+    silently dropping an attachment is the defect this module exists to fix. A
+    transport declaring ``files_inbound=False`` never calls ``ingest``, so it has
+    no result to carry one; this builds the same sentence for that case, and the
+    tests pin the shape rather than the prose so a reworded reason stays one
+    bracketed segment.
+    """
+
+    def test_it_names_the_kind_when_known(self) -> None:
+        from kiro_crew.messaging.attachments import channel_reads_no_attachments
+
+        out = channel_reads_no_attachments("image")
+        assert out.startswith("[Attachment (image) — ")
+        assert out.endswith("]")
+
+    def test_it_omits_an_empty_kind_rather_than_printing_brackets(self) -> None:
+        from kiro_crew.messaging.attachments import channel_reads_no_attachments
+
+        out = channel_reads_no_attachments("")
+        assert out.startswith("[Attachment — ")
+        assert "()" not in out
+
+    def test_it_matches_the_shape_ingest_produces(self) -> None:
+        """One bracketed segment, em dash separated -- the form every
+        ``ingest`` rejection already uses, so a channel that later gains real
+        ingestion changes which function builds the string and not how it
+        reads."""
+        from kiro_crew.messaging.attachments import channel_reads_no_attachments
+
+        out = channel_reads_no_attachments("file")
+        assert out.count("[") == 1
+        assert out.count("]") == 1
+        assert " — " in out
+
+    def test_a_platform_kind_cannot_forge_a_second_segment(self) -> None:
+        """The kind is platform-supplied and echoed to the sender, so brackets
+        and dashes -- what a rejection line is made of -- are stripped."""
+        from kiro_crew.messaging.attachments import channel_reads_no_attachments
+
+        out = channel_reads_no_attachments("x] — [injected")
+        assert out.count("[") == 1
+        assert out.count("]") == 1
+
+    def test_a_long_kind_is_capped(self) -> None:
+        from kiro_crew.messaging.attachments import channel_reads_no_attachments
+
+        out = channel_reads_no_attachments("a" * 500)
+        assert len(out) < 200
+
+    def test_it_carries_no_emoji(self) -> None:
+        """AGENTS.md: never an emoji in a user-facing surface."""
+        from kiro_crew.messaging.attachments import channel_reads_no_attachments
+
+        out = channel_reads_no_attachments("image")
+        assert all(ord(ch) < 0x2500 or ch == "\u2014" for ch in out)


### PR DESCRIPTION
Fixes #7848.

## Problem / Motivation

Send a photo to the Feishu bot and nothing happens. Not an error, not a hint, not a reaction — silence.

`feishu/client.py` dropped any non-text message at the parse step. #7551 added a log line there, and its reasoning was right for the audience it chose:

> Non-text inbound messages (and six other early-return cases) were dropped with no log line anywhere, making a delivered-and-ignored message **indistinguishable from a dead WebSocket, wrong App ID, missing scope, or allowlist rejection**.

That sentence is just as true for the sender, and for them nothing changed. A line in `gateway.log` resolves the ambiguity for whoever runs the gateway; the person who dropped a screenshot into the chat still cannot tell whether the bot is broken, whether their message arrived, or whether images are simply not a thing here. The rational next move is to send it again — or to send "did you get that?", which *does* get answered, making the first look like a bug.

## Why it matters

`messaging/attachments.py` already exists to prevent precisely this, and says so:

> **Why rejections are returned rather than swallowed.** Silently dropping an attachment is **the original defect this module exists to fix**: a user posts a file and the reply simply ignores it, with no explanation. Callers are expected to surface `IngestResult.rejections` to the user.

But a transport declaring `files_inbound=False` never reaches `ingest`, so it has no `IngestResult` to carry a reason and that mechanism never runs for it. The guarantee exists; two channels sit outside it.

## What changed (motivation → approach → change)

**The reply reuses the existing mechanism's shape rather than inventing a parallel one.** `attachments.channel_reads_no_attachments()` builds the same single bracketed, em-dash-separated segment every `ingest` rejection already produces (`[Attachment {name} — download failed]`). It lives in that module because that module owns rejection wording, so a channel that later gains real ingestion changes *which function builds the string*, not how it reads.

**Three gates decide where the reply happens, and each one is a security property:**

| Position | Why |
|---|---|
| after `authorize` | An unauthorised sender still learns nothing. Telling a stranger the bot is alive is a disclosure this channel deliberately avoids — `authorize` is deny-by-default and owner-only. |
| after the group gate | A Feishu bot added to a group receives every message in it. Answering a photo in a group nobody allow-listed would announce the bot to that whole room. |
| after the dedup window | lark's WS redelivers. Two answers to one photo is the failure this sits behind the window to avoid. |

**The parse step had to change to make that possible.** `_handle_receive_v1` dropped the message *before* extracting `open_id`, and the transport is the only layer that knows whether a sender is authorised — so it cannot answer a message it was never given. The type is now decided after the sender, and an unreadable message is carried on with `text=""` and `unsupported_type` set. Empty text plus no `unsupported_type` still stops in `receive` exactly as before, so a frame whose body resolved to nothing is unchanged. The existing log line is untouched.

**`files_inbound` moves ASPIRATIONAL → ENFORCED** in `test_capability_ledger.py`, with its read site cited inline, per the migration contract that module documents (*"A field moving from ASPIRATIONAL to ENFORCED must move sets here in the same change"*). A channel declaring `True` is untouched: its attachments go through `ingest` as before, and the test pins that by flipping the flag.

**The echoed `message_type` is treated as untrusted.** It is platform-supplied and goes back to the sender, so it is stripped to `[a-zA-Z0-9_]` and length-capped: brackets and dashes are what a rejection line is made of, and leaving them in would let a crafted type forge a second bracketed segment inside the reply.

### Scope: Feishu only, deliberately

iMessage also declares `files_inbound=False` and still drops silently. Its `receive` checks `text` *ahead of* `is_own_echo`, whose position carries this comment:

> LAST gate, and its position is load-bearing in both directions … consuming it there would restore the loop while looking fixed.

Reordering a gate whose own comment warns it can silently restore a message loop belongs in its own change, with its own reasoning and its own tests. The doc note records that iMessage is the remaining reader.

## Tests

**24 new tests.** `TestUnreadableInboundIsAnswered` (10) pins the reply and, one test per gate, the three deny paths that must stay silent — unauthorised sender, empty allow-list, unlisted group, unknown chat type — plus answered-once on redelivery, never-drives-a-turn, an allow-listed group *is* answered, and a `files_inbound=True` transport answering nothing. `TestChannelReadsNoAttachments` (6) pins the string's shape rather than its prose, so a reworded reason stays one segment. Two client tests replace the old "ignored" assertion with the new carry-through contract, including that a message with no sender is still dropped.

**Mutation-checked**, so each test fails for the reason it claims:

| mutation | reds |
|---|---|
| answer before `authorize` (leaks the bot to a stranger) | 3 |
| ignore the `files_inbound` gate | 1 |
| answer before the dedup window (double reply) | 1 |
| stop sanitising the platform-supplied kind | 3 |
| drop unreadable messages again (the original bug) | 5 |

## Manual verification

N/A — unit coverage is sufficient and the alternative is not available to me: reaching the real drop path needs a Feishu app plus `lark-oapi`, and every branch this change adds is reachable with the `FakeClient` the suite already uses. The tests drive `transport.receive` and `client._handle_receive_v1` directly, which is where all five decisions live.

Gates run on Linux (parity with CI):

```
black --check (touched files)          7 files unchanged
scripts/check_black_formatting.py      passed
isort --check-only src/kiro_crew test  clean
flake8 src/kiro_crew test              clean
mypy --platform linux src/kiro_crew    no issues in 1280 source files
scripts/docs-lint.sh                   259 files, all checks passed
scripts/check_brand_name.py            passed
pytest (the four touched suites)       166 passed
pytest -k "messaging or feishu or capability or channel"   3640 passed, 2 skipped
```

## Related Issues

Fixes #7848.

On the one question that issue held for — where a backend-owned user-facing string lives — the answer turned out to be in the tree rather than a decision still owed, and it is the reason this is implementable: `messaging/commands.py` already returns hardcoded English reply text to users (`"No subagents running."`, `"No cron jobs scheduled."`, `"No task running."`, and three more), the backend has no catalog, no `.po`, and no `gettext` anywhere, and `website/src/i18n/` is frontend-only. So *"backend-owned strings have no catalog path yet"* is literal. This string is English for consistency with those six, and when a backend catalog arrives it migrates with them.

That remains the reviewable choice here, and it is a product call as much as an engineering one: on Feishu the likely reader is Chinese-speaking, and so are the six precedents. If you would rather this class of string wait for a catalog, say so and I will drop the reply and keep only the carry-through plumbing.
