### PR TITLE
fix(auth): publish the token signing key whole, never a 0-byte one

### DIFF
--- a/src/kiro_crew/dashboard/token_secret.py
+++ b/src/kiro_crew/dashboard/token_secret.py
@@ -21,6 +21,7 @@ commands like ``kirocrew --help``.
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import threading
@@ -28,6 +29,7 @@ import time
 from pathlib import Path
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write, fsync_dir
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +44,46 @@ _MIN_KEY_BYTES = 32
 # an unbounded hang.
 _CREATE_MAX_ATTEMPTS = 50
 _CREATE_BACKOFF_SECONDS = 0.02
+
+#: Errors that mean the FILESYSTEM has no hard links, as opposed to a link that
+#: failed for a reason retrying could fix. Only these may send the publish onto
+#: the in-place fallback, because that fallback creates the destination empty and
+#: so carries the truncation window this module exists to close: a transient
+#: refusal must never be mistaken for a missing filesystem feature. POSIX
+#: specifies EPERM for "the filesystem does not support links"; the *NOTSUP pair
+#: and ENOSYS are the explicit spellings.
+#:
+#: Deliberately EXCLUDED: EACCES (a Windows sharing violation while another
+#: handle holds the path -- transient, and the one this most needs to keep out),
+#: ENOSPC, EDQUOT, EIO and EROFS. Each of those exhausts the retry budget and
+#: degrades to an ephemeral secret with the destination untouched. EXDEV is
+#: excluded too, for the opposite reason: the staged file is a same-directory
+#: sibling, so a cross-device link cannot arise and listing it would only suggest
+#: the staging path is allowed to move.
+_LINK_UNSUPPORTED_ERRNOS = frozenset(
+    {
+        getattr(errno, name)
+        for name in ("EPERM", "EOPNOTSUPP", "ENOTSUP", "ENOSYS")
+        if hasattr(errno, name)
+    }
+)
+
+#: Windows reports a hard link on FAT/exFAT through a Win32 code whose errno
+#: translation is not one of the POSIX names above, so match it directly:
+#: ERROR_INVALID_FUNCTION (1) and ERROR_NOT_SUPPORTED (50).
+_LINK_UNSUPPORTED_WINERRORS = frozenset({1, 50})
+
+
+def _is_link_unsupported(exc: OSError) -> bool:
+    """Whether *exc* says this filesystem cannot hard-link at all.
+
+    False for anything a retry might clear, which keeps a transient failure from
+    routing the key through the in-place create -- see
+    :data:`_LINK_UNSUPPORTED_ERRNOS` for why that distinction is the whole point.
+    """
+    if exc.errno in _LINK_UNSUPPORTED_ERRNOS:
+        return True
+    return getattr(exc, "winerror", None) in _LINK_UNSUPPORTED_WINERRORS
 
 
 def _enforce_owner_only(key_path: Path) -> None:
@@ -64,6 +106,20 @@ def _enforce_owner_only(key_path: Path) -> None:
             key_path,
             exc_info=True,
         )
+
+
+def _unlink_quietly(path: Path) -> None:
+    """Remove *path* if present, swallowing any error.
+
+    Used only for THIS process's private staging file, which no other writer
+    can name, so there is no identity check to make and no failure worth
+    propagating -- a leftover staging file is inert (the key is published under
+    its own name) and must never mask the outcome of the publish itself.
+    """
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _unlink_if_same_file(key_path: Path, created_stat: os.stat_result) -> None:
@@ -108,6 +164,110 @@ def _unlink_if_same_file(key_path: Path, created_stat: os.stat_result) -> None:
             )
 
 
+def _create_key_in_place(key_path: Path) -> bytes | None:
+    """Create the key by exclusive create AT *key_path*, the historical path.
+
+    Reached only when the filesystem cannot hard-link, so the stage-then-link
+    publish in :func:`_load_or_create_secret` is unavailable. Returns the new
+    key, or ``None`` when another process won the create (the caller retries).
+
+    This carries the pre-existing truncation window with it: the destination is
+    created EMPTY and only then written, so a kill between the two leaves a
+    0-byte key. That is deliberate -- on a filesystem with no hard links the
+    alternative is no persisted key at all -- and it is why the linked publish
+    is the default rather than this.
+    """
+    # O_EXCL guarantees exactly one process across all sharers of this data
+    # home wins the create; everyone else hits FileExistsError and loops back
+    # to read the winner's bytes. This is what eliminates the divergence: only
+    # one key is ever generated.
+    try:
+        # os.O_BINARY is REQUIRED on Windows: os.open() there defaults
+        # to TEXT mode, so the os.write() below would translate any
+        # 0x0A ('\n') byte in the random key to 0x0D 0x0A ('\r\n'),
+        # persisting a longer, corrupted key that the creator's
+        # in-memory bytes (and every sibling read) no longer match ->
+        # silent auth divergence. getattr(..., 0) makes it a no-op on
+        # POSIX, where os.O_BINARY does not exist and there is no text
+        # mode. Evaluated at call time so tests can simulate the flag.
+        fd = os.open(
+            str(key_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+    except FileExistsError:
+        # Someone else created it (possibly not yet written). Give the
+        # writer a beat, then loop back to read their bytes.
+        return None
+    except OSError:
+        # On Windows the winner may hold the freshly-created file open
+        # while it writes; a racer's exclusive-create can then hit a
+        # sharing violation (PermissionError / WinError 32) INSTEAD of
+        # FileExistsError. Treat it as contention — back off and retry
+        # within the bounded loop rather than propagating to the outer
+        # ephemeral fallback, which would make this racer diverge from
+        # the winner's persisted key (silent auth corruption). POSIX does
+        # not raise here; a genuinely unwritable dir still degrades to an
+        # ephemeral secret once the retry budget is exhausted.
+        logger.debug(  # nosemgrep: python-logger-credential-disclosure -- logs the path only, never key bytes
+            "token signing key exclusive-create contended at %s; retrying",
+            key_path,
+        )
+        return None
+
+    # We hold the exclusive create. Capture the created file's identity
+    # (device + inode) NOW, while we still hold the fd, so that if we
+    # later have to remove a half-written file we unlink ONLY the exact
+    # file this process created — never a valid key a racing sibling may
+    # have substituted at the same path in the meantime.
+    created_stat = os.fstat(fd)
+    wrote_durable_key = False
+    # Lock the DACL down BEFORE writing the secret bytes: on Windows the
+    # lockdown replaces an existing DACL rather than being applied at
+    # create time, so writing first would leave a window during which
+    # another local principal could slurp the bytes; on POSIX it
+    # collapses to an in-process chmod. Create empty
+    # → tighten → write → fsync.
+    try:
+        _enforce_owner_only(key_path)
+        key = os.urandom(_MIN_KEY_BYTES)
+        # os.write() may return a SHORT count (notably on a nearly-full
+        # disk). Loop until every byte lands; a 0-byte write is an error.
+        mv = memoryview(key)
+        while mv:
+            n = os.write(fd, mv)
+            if n == 0:
+                raise OSError(
+                    "short write persisting token signing key (wrote 0 bytes)"
+                )
+            mv = mv[n:]
+        # Cross-restart persistence is the entire reason this file
+        # exists, so flush the bytes to stable storage before we treat
+        # the key as durable and hand it back. A failing fsync means the
+        # key is not reliably persisted — fall into the cleanup path.
+        os.fsync(fd)
+        wrote_durable_key = True
+    finally:
+        os.close(fd)
+        if not wrote_durable_key:
+            # The exclusive create succeeded but we failed to persist a
+            # full, durable key (ENOSPC, quota, fsync failure, ...). The
+            # on-disk file is now short/empty; leaving it PERMANENTLY
+            # poisons every future boot — the fast-path read sees
+            # <32 bytes, the O_EXCL create then hits FileExistsError, the
+            # retry budget exhausts, and every gateway falls back to a
+            # fresh ephemeral key (tokens die on each restart, concurrent
+            # gateways cannot validate one another) until a human deletes
+            # it. Remove OUR incomplete file so the next init can create a
+            # valid key cleanly. The identity guard ensures we never
+            # delete a valid key a sibling has since substituted.
+            _unlink_if_same_file(key_path, created_stat)
+    # Reaching here means the write + fsync completed; a failure would
+    # have propagated the OSError to the outer handler (the ephemeral
+    # fallback) after the cleanup above ran.
+    return key
+
+
 def _load_or_create_secret() -> bytes:
     """Return the HMAC signing secret, persisted across restarts.
 
@@ -125,12 +285,25 @@ def _load_or_create_secret() -> bytes:
     keep an in-memory key that no longer matches the persisted file, silently
     corrupting every token it issues for sibling instances / after a restart.
 
-    The fix: only ONE key may ever be created. We attempt an exclusive create
-    (``O_CREAT | O_EXCL``); exactly one process wins and writes the fresh key,
-    and every other process takes the ``FileExistsError`` branch and READS the
-    winner's bytes instead of generating its own. A small bounded retry loop
-    covers the create-then-read interleaving (a racing reader can momentarily
-    see the just-created, not-yet-written empty file).
+    The fix: only ONE key may ever be created, and it is only ever PUBLISHED
+    whole. The fresh key is staged into a private sibling file (the shared
+    :func:`kiro_crew.atomic_write.atomic_write` helper -- owner-only before the
+    first byte, fsynced, cleaned up on failure) and then linked into place with
+    ``os.link``. The link is atomic and non-clobbering: exactly one process
+    wins, and every other process takes the ``FileExistsError`` branch and READS
+    the winner's bytes instead of generating its own.
+
+    ``os.link`` rather than ``os.replace`` is what keeps the single-creator
+    election -- a last-writer-wins rename would let each racer install its own
+    key, leaving the losers signing with bytes no longer on disk. Staging rather
+    than creating in place is what keeps the destination name from ever
+    resolving to a partial file: creating it empty and writing afterwards means
+    a kill in between (an update completing during shutdown, a reboot) persists
+    a 0-byte key, and because the fast-path read then sees <32 bytes forever,
+    every later boot degrades to an ephemeral secret -- a dashboard that loads
+    while every signed action fails, which a restart cannot fix.
+
+    A small bounded retry loop still covers the publish-then-read interleaving.
     """
     # Local import: config.loader pulls in modules that import token_auth
     # (which re-exports this module), so a top-level import here risks a
@@ -141,6 +314,12 @@ def _load_or_create_secret() -> bytes:
     try:
         key_path = config_dir() / _SECRET_KEY_FILE
         key_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Set only by a link failure that says this filesystem HAS no hard
+        # links. It is what unlocks the in-place fallback after the loop, so a
+        # transient failure leaves it False and never reaches code that creates
+        # the destination empty.
+        link_unsupported = False
 
         for _attempt in range(_CREATE_MAX_ATTEMPTS):
             # 1) Fast path: an already-populated key file. Read the persisted
@@ -172,106 +351,178 @@ def _load_or_create_secret() -> bytes:
                 _enforce_owner_only(key_path)
                 return existing
 
-            # 2) Try to become the SOLE creator. O_EXCL guarantees exactly one
-            #    process across all sharers of this data home wins the create;
-            #    everyone else hits FileExistsError and loops back to read the
-            #    winner's bytes. This is what eliminates the divergence: only
-            #    one key is ever generated.
+            # 2) Publish a WHOLE key, or lose the race and read the winner's.
+            #    The key is staged into a private sibling first and only then
+            #    linked into place, because the destination name must never
+            #    exist in a partial state. An interrupted update -- or a reboot
+            #    that kills this process between an in-place create and the
+            #    write -- otherwise leaves a 0-byte key on disk, and every
+            #    later boot then reads <32 bytes, exhausts the retry budget and
+            #    degrades to an ephemeral secret: a dashboard that loads while
+            #    every signed action fails, which a restart cannot fix because
+            #    it re-reads the same empty file.
+            #
+            #    os.link is the publish step, not os.replace, because exactly
+            #    ONE key may ever exist. link fails with FileExistsError once a
+            #    sibling has published, which keeps the single-creator election
+            #    the in-place O_EXCL create used to provide; os.replace would
+            #    let each racer install its own key and leave the losers
+            #    signing with bytes that are no longer on disk.
+            # The suffix is load-bearing, not cosmetic. This file holds the FULL
+            # key until the publish link lands, and a kill between that link and
+            # the cleanup unlink below leaves it on disk. security.py's keystone
+            # fence protects a publish artifact by SHAPE -- a direct child of a
+            # keystone leaf's own directory whose name ends in one of
+            # _KEYSTONE_ARTIFACT_SUFFIXES -- so ".tmp" is what puts a leftover
+            # copy of the signing key behind the same fence as the key itself,
+            # rather than leaving it readable to agent tools (a forged-token
+            # path). It also matches the suffix atomic_write's own mkstemp temp
+            # already uses. test_token_auth.py pins this against the real
+            # predicate so a rename cannot silently leave the fence behind.
+            staged = key_path.with_name(
+                f".{key_path.name}.{os.getpid()}.{os.urandom(8).hex()}.tmp"
+            )
+            key = os.urandom(_MIN_KEY_BYTES)
             try:
-                # os.O_BINARY is REQUIRED on Windows: os.open() there defaults
-                # to TEXT mode, so the os.write() below would translate any
-                # 0x0A ('\n') byte in the random key to 0x0D 0x0A ('\r\n'),
-                # persisting a longer, corrupted key that the creator's
-                # in-memory bytes (and every sibling read) no longer match ->
-                # silent auth divergence. getattr(..., 0) makes it a no-op on
-                # POSIX, where os.O_BINARY does not exist and there is no text
-                # mode. Evaluated at call time so tests can simulate the flag.
-                fd = os.open(
-                    str(key_path),
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0),
-                    0o600,
+                # restrict_to_owner (rather than mode=0o600 alone) is what
+                # _enforce_owner_only applies today, and the helper applies it
+                # BEFORE any key byte reaches the file, so the secret never
+                # exists under a wider mode. restrict_on_error="warn" preserves
+                # this call site's fail-soft permission policy, and fsync=True
+                # carries the os.fsync() the in-place writer performed.
+                atomic_write(
+                    staged,
+                    key,
+                    fsync=True,
+                    restrict_to_owner=True,
+                    restrict_on_error="warn",
                 )
-            except FileExistsError:
-                # Someone else created it (possibly not yet written). Give the
-                # writer a beat, then loop back to read their bytes.
-                time.sleep(_CREATE_BACKOFF_SECONDS)
-                continue
             except OSError:
-                # On Windows the winner may hold the freshly-created file open
-                # while it writes; a racer's exclusive-create can then hit a
-                # sharing violation (PermissionError / WinError 32) INSTEAD of
-                # FileExistsError. Treat it as contention — back off and retry
-                # within the bounded loop rather than propagating to the outer
-                # ephemeral fallback, which would make this racer diverge from
-                # the winner's persisted key (silent auth corruption). POSIX does
-                # not raise here; a genuinely unwritable dir still degrades to an
-                # ephemeral secret once the retry budget is exhausted.
+                # Staging failed. No destination file was ever created, so
+                # key_path is untouched. On Windows this can be a TRANSIENT
+                # sharing violation, so retry within the budget rather than
+                # degrading immediately; a genuinely unwritable directory
+                # exhausts the loop and lands on the fallback below.
+                _unlink_quietly(staged)
                 logger.debug(  # nosemgrep: python-logger-credential-disclosure -- logs the path only, never key bytes
-                    "token signing key exclusive-create contended at %s; retrying",
-                    key_path,
+                    "token signing key staging failed at %s; retrying", key_path
                 )
                 time.sleep(_CREATE_BACKOFF_SECONDS)
                 continue
-
-            # We hold the exclusive create. Capture the created file's identity
-            # (device + inode) NOW, while we still hold the fd, so that if we
-            # later have to remove a half-written file we unlink ONLY the exact
-            # file this process created — never a valid key a racing sibling may
-            # have substituted at the same path in the meantime.
-            created_stat = os.fstat(fd)
-            wrote_durable_key = False
-            # Lock the DACL down BEFORE writing the secret bytes: on Windows the
-            # lockdown replaces an existing DACL rather than being applied at
-            # create time, so writing first would leave a window during which
-            # another local principal could slurp the bytes; on POSIX it
-            # collapses to an in-process chmod. Create empty
-            # → tighten → write → fsync.
             try:
-                _enforce_owner_only(key_path)
-                key = os.urandom(_MIN_KEY_BYTES)
-                # os.write() may return a SHORT count (notably on a nearly-full
-                # disk). Loop until every byte lands; a 0-byte write is an error.
-                mv = memoryview(key)
-                while mv:
-                    n = os.write(fd, mv)
-                    if n == 0:
-                        raise OSError(
-                            "short write persisting token signing key (wrote 0 bytes)"
-                        )
-                    mv = mv[n:]
-                # Cross-restart persistence is the entire reason this file
-                # exists, so flush the bytes to stable storage before we treat
-                # the key as durable and hand it back. A failing fsync means the
-                # key is not reliably persisted — fall into the cleanup path.
-                os.fsync(fd)
-                wrote_durable_key = True
-            finally:
-                os.close(fd)
-                if not wrote_durable_key:
-                    # The exclusive create succeeded but we failed to persist a
-                    # full, durable key (ENOSPC, quota, fsync failure, ...). The
-                    # on-disk file is now short/empty; leaving it PERMANENTLY
-                    # poisons every future boot — the fast-path read sees
-                    # <32 bytes, the O_EXCL create then hits FileExistsError, the
-                    # retry budget exhausts, and every gateway falls back to a
-                    # fresh ephemeral key (tokens die on each restart, concurrent
-                    # gateways cannot validate one another) until a human deletes
-                    # it. Remove OUR incomplete file so the next init can create a
-                    # valid key cleanly. The identity guard ensures we never
-                    # delete a valid key a sibling has since substituted.
-                    _unlink_if_same_file(key_path, created_stat)
-            # Reaching here means the write + fsync completed; a failure would
-            # have propagated the OSError to the outer handler (the ephemeral
-            # fallback) after the cleanup above ran.
+                os.link(staged, key_path)
+            except FileExistsError:
+                # A sibling published first. Drop our candidate and loop back to
+                # read theirs; never install it over the winner.
+                _unlink_quietly(staged)
+                time.sleep(_CREATE_BACKOFF_SECONDS)
+                continue
+            except OSError as exc:
+                # Retry either way -- a transient sharing violation (Windows,
+                # while another handle holds the destination) succeeds on a
+                # later attempt, and a filesystem with no hard links simply
+                # fails every attempt. What differs is what the exhausted budget
+                # is allowed to do next: ONLY an unsupported-link error may fall
+                # back to creating the destination in place, because that path
+                # reintroduces the truncation window. A transient error must
+                # degrade to an ephemeral secret with key_path untouched.
+                if _is_link_unsupported(exc):
+                    link_unsupported = True
+                _unlink_quietly(staged)
+                logger.debug(  # nosemgrep: python-logger-credential-disclosure -- logs the path only, never key bytes
+                    "token signing key publish link failed at %s (errno=%s); retrying",
+                    key_path,
+                    exc.errno,
+                )
+                time.sleep(_CREATE_BACKOFF_SECONDS)
+                continue
+            # Linked: the name now resolves to the fully-written inode. The key
+            # BYTES were fsynced during staging, but the new NAME lives in the
+            # parent directory, so the entry is not durable until that directory
+            # is synced -- and the next statement would remove the only other
+            # name pointing at the inode.
+            #
+            # Strict, NOT best_effort: best_effort downgrades even EIO to a
+            # warning, which is right for a caller whose work is already
+            # committed and wrong here, where a swallowed failure followed by the
+            # unlink can leave a power loss with neither name. Then the inode is
+            # unreachable, the next boot mints a fresh key, and every outstanding
+            # cookie and link signed by the old one is invalid.
+            #
+            # A real failure is caught rather than propagated: raising would hit
+            # the outer handler and hand back an EPHEMERAL secret while a valid
+            # key sits at key_path, which is the divergence this function exists
+            # to prevent. So keep the recoverable second name and return the key
+            # that IS on disk. Keeping it is only safe because the staging name
+            # ends in ".tmp": the leftover stays behind security.py's keystone
+            # fence instead of becoming a readable copy of the signing key.
+            #
+            # fsync_dir returns quietly where a directory sync cannot be
+            # EXPRESSED (Windows has no directory descriptor; some network mounts
+            # reject it) and raises only where the device refused the write, so
+            # the normal and unsupported paths still reach the unlink below.
+            try:
+                fsync_dir(key_path.parent)
+            except OSError:
+                logger.warning(  # nosemgrep: python-logger-credential-disclosure -- logs the path only, never key bytes
+                    "could not sync %s after publishing the token signing key; "
+                    "keeping the staging copy as a recoverable second name",
+                    key_path.parent,
+                    exc_info=True,
+                )
+            else:
+                _unlink_quietly(staged)
+            _enforce_owner_only(key_path)
             return key
 
-        # Retries exhausted: a persistently short/empty file (external
-        # corruption, or a creator that crashed after O_EXCL but before the
-        # write). Do NOT truncate-and-regenerate — that reintroduces the exact
-        # divergence race this function exists to prevent. Degrade to an
-        # ephemeral secret (works this session, not across restart), matching
-        # the unwritable-file fallback below. An operator can remove the stale
-        # file to let a fresh key be created cleanly.
+        # Retries exhausted. The in-place fallback below creates the
+        # destination EMPTY and writes afterwards, so it carries the very
+        # truncation window this fix removes -- it is worth that only where the
+        # alternative is no persisted key on any boot, i.e. a filesystem that
+        # genuinely cannot hard-link (FAT/exFAT, some network mounts). Anything
+        # else that exhausted the budget -- a transient sharing violation, a
+        # policy refusal, a short/empty file already at key_path -- skips it and
+        # degrades to the ephemeral secret with key_path untouched, exactly as
+        # the pre-PR code did.
+        #
+        # Fall back under its OWN bounded loop.
+        #
+        # The loop is what makes this converge, and a single attempt would not.
+        # Two gateways booting concurrently on a link-less home both exhaust the
+        # publish loop above and reach here; O_EXCL lets exactly one create the
+        # key, and the LOSER gets None back. Without the re-read below it would
+        # fall through to an ephemeral secret while the winner persisted a real
+        # one, leaving the pair unable to validate each other's tokens -- the
+        # divergence the exclusive create exists to prevent. So the loser loops,
+        # reads the winner's bytes, and returns those instead.
+        if link_unsupported:
+            for _attempt in range(_CREATE_MAX_ATTEMPTS):
+                try:
+                    existing = key_path.read_bytes()
+                except FileNotFoundError:
+                    existing = b""
+                except OSError:
+                    # Windows sharing violation while the winner holds the file
+                    # open; transient, so retry rather than degrade.
+                    time.sleep(_CREATE_BACKOFF_SECONDS)
+                    continue
+                if len(existing) >= _MIN_KEY_BYTES:
+                    _enforce_owner_only(key_path)
+                    return existing
+                created = _create_key_in_place(key_path)
+                if created is not None:
+                    return created
+                # Lost the create (or it failed): give the winner a beat, then
+                # loop back and read what they persisted.
+                time.sleep(_CREATE_BACKOFF_SECONDS)
+
+        # A persistently short/empty file (external corruption, or a creator
+        # that was killed mid-publish on a filesystem with no hard links). Do
+        # NOT truncate-and-regenerate — that reintroduces the exact divergence
+        # race this function exists to prevent. Degrade to an ephemeral secret
+        # (works this session, not across restart), matching the
+        # unwritable-file fallback below. An operator can remove the stale file
+        # to let a fresh key be created cleanly.
         # Logs only the key PATH (key_path) and an attempt count, never the key
         # bytes; the Semgrep rule fires on the credential-adjacent wording in
         # the static message string, not on any secret value.

--- a/test/test_token_auth.py
+++ b/test/test_token_auth.py
@@ -1359,32 +1359,333 @@ def test_signing_secret_read_contention_retries_not_ephemeral(tmp_path, monkeypa
 
 
 def test_signing_secret_create_contention_retries_not_ephemeral(tmp_path, monkeypatch) -> None:
-    """A TRANSIENT sharing violation on the EXCLUSIVE-CREATE of the key file must
-    be retried, not degraded to an ephemeral secret.
+    """A TRANSIENT sharing violation on the PUBLISH of the key file must be
+    retried, not degraded to an ephemeral secret.
 
-    On Windows a racer's ``os.open(..., O_CREAT|O_EXCL)`` can hit a sharing
-    violation (``PermissionError`` / WinError 32) while the winner holds the
-    freshly-created file open — landing on ``os.open``, not the read. The
-    create-side companion to ``test_signing_secret_read_contention_retries_not_ephemeral``;
-    reproduced deterministically with the ``os.open`` simulator so it is caught
+    On Windows the publishing link can hit a sharing violation
+    (``PermissionError`` / WinError 32) while another handle holds the
+    destination open — landing on ``os.link``, not the read. The publish-side
+    companion to ``test_signing_secret_read_contention_retries_not_ephemeral``;
+    reproduced deterministically with the ``os.link`` simulator so it is caught
     on the POSIX dev loop.
     """
-    from windows_sim import open_sharing_violation
+    from windows_sim import link_sharing_violation
 
     from kiro_crew.dashboard import token_secret as ts
 
     monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
     key_file = tmp_path / ts._SECRET_KEY_FILE
 
-    # Fault the FIRST exclusive-create of the key file; the retry must succeed.
-    with open_sharing_violation(match=ts._SECRET_KEY_FILE, times=1) as state:
+    # Fault the FIRST publish of the key file; the retry must succeed.
+    with link_sharing_violation(match=ts._SECRET_KEY_FILE, times=1) as state:
         secret = ts._load_or_create_secret()
 
-    assert state["n"] >= 2, "the contended exclusive-create was not retried"
+    assert state["n"] >= 2, "the contended publish was not retried"
     assert key_file.exists(), "key must be persisted after retrying the create"
     on_disk = key_file.read_bytes()
     assert len(on_disk) >= ts._MIN_KEY_BYTES, "retry wrote a short/incomplete key"
     assert secret == on_disk, "must return the persisted key, not an ephemeral one"
+
+
+def test_signing_secret_destination_never_exists_while_incomplete(tmp_path, monkeypatch) -> None:
+    """Regression (Mesh-3720): ``token_signing.key`` must never exist on disk in a
+    partial state, so an interrupted update cannot leave a 0-byte key.
+
+    The old creator opened the DESTINATION with ``O_CREAT|O_EXCL`` and only then
+    wrote the 32 random bytes. Its ``finally`` cleaned up an exception, but a
+    kill has no ``finally``: an update completing during shutdown, or a reboot,
+    that ended the process between the create and the write persisted a 0-byte
+    key. Every later boot then read <32 bytes, exhausted the retry budget and
+    fell back to a fresh ephemeral secret — a dashboard that loads while every
+    signed action fails, and a plain restart cannot fix it because it re-reads
+    the same empty file.
+
+    The fix stages the whole key into a private sibling and publishes it with
+    ``os.link``, so the destination name only ever appears already-complete.
+    This samples the destination on every ``os.write`` that carries key bytes:
+    with the fix it is absent throughout; before it, it is present at 0 bytes.
+    """
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+    assert not key_file.exists()
+
+    # Sizes the destination had at each point a key byte was being written.
+    # ``None`` means "did not exist", which is the only acceptable value.
+    sizes_during_write: list[int | None] = []
+    real_write = os.write
+
+    def _spy(fd, data):  # type: ignore[no-untyped-def]
+        try:
+            sizes_during_write.append(key_file.stat().st_size)
+        except OSError:
+            sizes_during_write.append(None)
+        return real_write(fd, data)
+
+    monkeypatch.setattr(os, "write", _spy)
+    secret = ts._load_or_create_secret()
+    monkeypatch.undo()
+
+    on_disk = key_file.read_bytes()
+    assert secret == on_disk, "returned key must be the persisted one"
+    assert len(on_disk) >= ts._MIN_KEY_BYTES
+
+    partial = [n for n in sizes_during_write if n is not None and n < ts._MIN_KEY_BYTES]
+    assert not partial, (
+        "the destination existed in a partial state during the write "
+        f"(observed sizes {partial}); a kill there would persist a truncated key"
+    )
+
+
+def test_signing_secret_transient_publish_failure_never_creates_the_destination(
+    tmp_path, monkeypatch
+) -> None:
+    """A publish failure that is NOT "no hard links" must leave the key path alone.
+
+    The in-place fallback creates the destination empty and writes afterwards, so
+    it carries the truncation window this fix removes. Reaching it on a *transient*
+    error — a Windows sharing violation, a security product holding the path, a
+    policy refusal — would recreate exactly the 0-byte key the PR exists to
+    prevent, on a filesystem that can hard-link perfectly well. Only an
+    unsupported-link error may unlock that fallback; anything else degrades to an
+    ephemeral secret with the destination untouched.
+    """
+    from windows_sim import link_sharing_violation
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+
+    # A sharing violation (EACCES / WinError 32) on EVERY publish attempt: never
+    # cleared, but never evidence about hard-link support either.
+    with link_sharing_violation(match=ts._SECRET_KEY_FILE, times=10**6) as state:
+        secret = ts._load_or_create_secret()
+
+    assert state["n"] >= ts._CREATE_MAX_ATTEMPTS, "the publish was not retried"
+    assert len(secret) >= ts._MIN_KEY_BYTES, "no usable secret for this session"
+    assert not key_file.exists(), (
+        "a transient publish failure created the destination anyway — a kill in "
+        "that write window persists the 0-byte key this fix removes"
+    )
+    # Nothing of ours is left in the config dir either.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_signing_secret_persists_on_a_filesystem_without_hard_links(tmp_path, monkeypatch) -> None:
+    """A volume that cannot hard-link must still get a PERSISTED key.
+
+    The publish step is ``os.link``, which FAT/exFAT and some network mounts
+    reject outright. Degrading those hosts to an ephemeral secret would trade
+    one breakage for another (tokens dying on every restart), so the loader
+    falls back to the historical in-place create once the publish budget is
+    spent.
+    """
+    from windows_sim import link_unsupported
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+
+    with link_unsupported(match=ts._SECRET_KEY_FILE) as state:
+        secret = ts._load_or_create_secret()
+
+    assert state["n"] >= 1, "the publish link was never attempted"
+    assert key_file.exists(), "no key was persisted on a link-less filesystem"
+    on_disk = key_file.read_bytes()
+    assert len(on_disk) >= ts._MIN_KEY_BYTES, "persisted a short key"
+    assert secret == on_disk, "returned an ephemeral key instead of the persisted one"
+
+
+def test_signing_secret_concurrent_first_init_converges_without_hard_links(
+    tmp_path, monkeypatch
+) -> None:
+    """Concurrent first boots on a LINK-LESS home must still converge on one key.
+
+    The publish path is ``os.link``, so a filesystem that cannot hard-link sends
+    every racing gateway down the in-place fallback instead. ``O_EXCL`` lets
+    exactly one of them create the key; the loser must read the winner's bytes,
+    not mint its own. A loser that returns an ephemeral secret while the winner
+    persists a real one leaves the pair unable to validate each other's tokens —
+    the divergence the exclusive create exists to prevent, and what a single
+    post-loop create attempt with no re-read reintroduces.
+    """
+    from windows_sim import link_unsupported
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+    assert not key_file.exists()
+
+    n = 8
+    barrier = threading.Barrier(n)
+    results: list[bytes] = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def _worker() -> None:
+        try:
+            barrier.wait()
+            secret = ts._load_or_create_secret()
+        except BaseException as exc:  # noqa: BLE001 - surfaced via assert below
+            with lock:
+                errors.append(exc)
+            return
+        with lock:
+            results.append(secret)
+
+    with link_unsupported(match=ts._SECRET_KEY_FILE):
+        threads = [threading.Thread(target=_worker) for _ in range(n)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+
+    assert not errors, f"workers raised: {errors!r}"
+    assert len(results) == n
+    on_disk = key_file.read_bytes()
+    assert len(on_disk) >= ts._MIN_KEY_BYTES, "no full key was persisted"
+    assert set(results) == {on_disk}, (
+        "racing first inits diverged on a link-less filesystem: "
+        f"{len(set(results))} distinct secrets for one persisted key"
+    )
+
+
+def test_signing_secret_failed_dir_sync_keeps_a_recoverable_name(tmp_path, monkeypatch) -> None:
+    """A directory sync that FAILS must not be followed by dropping the second name.
+
+    The key bytes are fsynced during staging, but the published NAME lives in the
+    parent directory and is not durable until that directory is synced. Unlinking
+    the staging name after a failed sync leaves a power loss with neither name
+    pointing at the inode: the key becomes unreachable, the next boot mints a
+    fresh one, and every outstanding cookie and link signed by the old key is
+    invalid — the same class of breakage this fix exists to remove.
+
+    So a genuine sync failure keeps the staging name as a recoverable second
+    reference, and still returns the key that is on disk rather than degrading to
+    an ephemeral secret (which would diverge from the persisted key). The kept
+    leftover is safe precisely because it ends in ``.tmp`` and so stays behind the
+    keystone fence.
+    """
+    import errno as _errno
+
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+
+    def _failing_sync(path, **kwargs):  # type: ignore[no-untyped-def]
+        # best_effort would swallow this; strict must let it surface here.
+        assert not kwargs.get("best_effort"), (
+            "the publish must sync the directory STRICTLY — best_effort hides the "
+            "very EIO that makes dropping the second name unsafe"
+        )
+        raise OSError(_errno.EIO, "simulated: device refused the directory sync")
+
+    monkeypatch.setattr(ts, "fsync_dir", _failing_sync)
+    secret = ts._load_or_create_secret()
+    monkeypatch.undo()
+
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+    assert key_file.exists(), "the key was not published"
+    assert key_file.read_bytes() == secret, (
+        "returned an ephemeral secret while a valid key sits on disk — the "
+        "divergence the exclusive publish exists to prevent"
+    )
+
+    leftovers = [p for p in tmp_path.iterdir() if p.name != ts._SECRET_KEY_FILE]
+    assert len(leftovers) == 1, (
+        "a failed directory sync must keep exactly one recoverable second name, "
+        f"found {[p.name for p in leftovers]}"
+    )
+    kept = leftovers[0]
+    assert kept.read_bytes() == secret, "the kept name does not resolve to the key"
+    assert kept.stat().st_ino == key_file.stat().st_ino, (
+        "the kept name is a separate inode, so it is a second COPY of the signing "
+        "key rather than a second name for it"
+    )
+    # And it is still fenced, which is what makes keeping it acceptable.
+    from kiro_crew import security
+
+    assert kept.name.endswith(security._KEYSTONE_ARTIFACT_SUFFIXES)
+
+
+def test_signing_secret_staging_file_is_covered_by_the_keystone_fence(
+    tmp_path, monkeypatch
+) -> None:
+    """A leftover staging file must be fenced exactly like the key it copies.
+
+    The staging sibling holds the FULL signing key until the publish link lands,
+    and a kill between that link and the cleanup unlink leaves it on disk. The
+    keystone fence in ``security.py`` protects a publish artifact by SHAPE — a
+    direct child of a keystone leaf's own directory whose name ends in one of
+    ``_KEYSTONE_ARTIFACT_SUFFIXES`` — so a staging name outside those suffixes
+    leaves a readable copy of the key for an agent tool to fetch and forge tokens
+    with.
+
+    Asserted against the real predicate rather than against the literal suffix, so
+    the coupling survives a rename on either side. The name is tested in the
+    directory the key actually lives in: the fence resolves its parent set from
+    the real crew-home prefixes, so pointing ``KIROCREW_HOME`` at a temp dir would
+    move the key without moving the fence and prove nothing.
+    """
+    from kiro_crew import security
+    from kiro_crew.dashboard import token_secret as ts
+
+    captured: list[str] = []
+    real_link = os.link
+
+    def _spy_link(src_path, dst_path, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append(str(src_path))
+        return real_link(src_path, dst_path, **kwargs)
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(os, "link", _spy_link)
+    ts._load_or_create_secret()
+    monkeypatch.undo()
+
+    assert captured, "the publish never linked, so no staging name was observed"
+    staged_name = os.path.basename(captured[0])
+    assert staged_name.endswith(
+        security._KEYSTONE_ARTIFACT_SUFFIXES
+    ), f"staging name {staged_name!r} is outside the keystone artifact suffixes"
+
+    # Now ask the fence about that same name where the key really sits.
+    parents = security._home_dir_targets(security._KEYSTONE_ARTIFACT_PARENTS)
+    assert parents, "the fence resolved no keystone artifact parents"
+    for parent in sorted(parents):
+        candidate = os.path.join(parent, staged_name)
+        assert security._is_keystone_publish_artifact(candidate), (
+            f"a leftover {staged_name!r} in {parent} would not be fenced — it "
+            "holds a full copy of the signing key and agent tools could read it"
+        )
+
+
+def test_signing_secret_publish_leaves_no_staging_file_behind(tmp_path, monkeypatch) -> None:
+    """The staging sibling is this process's private file and must not survive.
+
+    A leftover staging file is inert (the key is published under its own name)
+    but it holds a full copy of the signing secret, so the config directory must
+    contain exactly the key file after a successful publish -- and after a
+    publish this process LOST to a sibling, where its candidate is dropped
+    rather than installed.
+    """
+    from kiro_crew.dashboard import token_secret as ts
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    key_file = tmp_path / ts._SECRET_KEY_FILE
+
+    secret = ts._load_or_create_secret()
+    assert key_file.read_bytes() == secret
+    assert [p.name for p in tmp_path.iterdir()] == [ts._SECRET_KEY_FILE]
+
+    # Now the losing path: a key already exists, so a second loader must read it
+    # and leave nothing of its own candidate behind.
+    again = ts._load_or_create_secret()
+    assert again == secret, "second loader diverged from the persisted key"
+    assert [p.name for p in tmp_path.iterdir()] == [ts._SECRET_KEY_FILE]
 
 
 def test_signing_secret_binary_write_survives_windows_text_mode(tmp_path, monkeypatch) -> None:
@@ -1457,19 +1758,21 @@ def test_signing_secret_write_failure_cleans_up_incomplete_file(tmp_path, monkey
     """Regression (PR #338 / GPT 5.6 HIGH): a write failure DURING exclusive
     creation must NOT leave a poisoned short key file behind.
 
-    The exclusive creator opens ``token_signing.key`` with ``O_CREAT|O_EXCL``
-    then writes 32 bytes. If that write fails partway (ENOSPC, quota) the file
-    exists but is < 32 bytes. Previously the incomplete file was left on disk:
-    every future boot's fast-path read saw < 32 bytes, the O_EXCL create then
-    hit FileExistsError, the bounded retry budget exhausted, and the gateway
-    fell back to a FRESH ephemeral key on EVERY restart (tokens die on each
-    restart; concurrent gateways cannot validate one another) until a human
+    A creator that writes 32 bytes and fails partway (ENOSPC, quota) must leave
+    NOTHING short or empty where the key belongs. Previously the incomplete file
+    was left on disk: every future boot's fast-path read saw < 32 bytes, the
+    create then hit FileExistsError, the bounded retry budget exhausted, and the
+    gateway fell back to a FRESH ephemeral key on EVERY restart (tokens die on
+    each restart; concurrent gateways cannot validate one another) until a human
     deleted the file by hand.
 
-    The fix removes the creator's OWN incomplete file (guarded by a
-    device+inode identity check so a racing sibling's valid key is never
-    deleted) before degrading to an ephemeral secret, so the NEXT init can
-    create a valid, persisted key.
+    Two mechanisms now hold that invariant. The publish path stages the key in a
+    private sibling, so a failed write never touches the destination at all; the
+    in-place fallback (a filesystem with no hard links) removes the creator's OWN
+    incomplete file, guarded by a device+inode identity check so a racing
+    sibling's valid key is never deleted. This faults EVERY key-persist write, so
+    the loader exhausts the publish budget, reaches the fallback, and has to
+    clean up after itself before degrading to an ephemeral secret.
     """
     from kiro_crew.dashboard import token_secret as ts
 
@@ -1481,11 +1784,15 @@ def test_signing_secret_write_failure_cleans_up_incomplete_file(tmp_path, monkey
     calls = {"n": 0}
 
     def _failing_write(fd, data):  # type: ignore[no-untyped-def]
-        # Fail the FIRST os.write (the key-persist write inside the
-        # exclusive-create path) with ENOSPC; delegate every other write to the
-        # real syscall so the second init below can persist a real key.
-        calls["n"] += 1
-        if calls["n"] == 1:
+        # Fail every KEY-PERSIST write with ENOSPC, identified by its payload
+        # length -- both the staged publish and the in-place fallback write the
+        # key in one 32-byte call. Narrowing by length rather than by call count
+        # leaves pytest's own writes alone AND makes the fault persistent, which
+        # is what drives the loader through the publish retries into the cleanup
+        # path. Every other write delegates, so the second init below can
+        # persist a real key.
+        if len(data) == ts._MIN_KEY_BYTES:
+            calls["n"] += 1
             raise OSError(errno.ENOSPC, "No space left on device")
         return real_write(fd, data)
 

--- a/test/windows_sim.py
+++ b/test/windows_sim.py
@@ -39,6 +39,7 @@ in its docstring, and add a self-test in ``test_windows_sim.py``.
 from __future__ import annotations
 
 import datetime as _dt
+import errno
 import os
 import pathlib
 from contextlib import contextmanager
@@ -272,6 +273,64 @@ def open_sharing_violation(
         return real_open(path, flags, mode, *args, **kwargs)
 
     with mock.patch("os.open", _patched):
+        yield state
+
+
+@contextmanager
+def link_sharing_violation(
+    *, match: Optional[str] = None, times: int = 1
+) -> Iterator[dict]:
+    """Make ``os.link()`` raise a Windows-style sharing violation.
+
+    A hard link is how a writer that staged its content elsewhere PUBLISHES it
+    under the real name without clobbering a sibling's. On Windows that create
+    can hit a sharing violation (``PermissionError`` / ``WinError 32``) while
+    another handle holds the destination open, exactly as an exclusive create
+    can; POSIX permits it, so an un-retried publish passes locally and degrades
+    on Windows. Raises for the first *times* matching links, then delegates, so
+    a bounded retry loop succeeds. *match* filters on the DESTINATION path
+    (basename-equality or substring); ``None`` faults every link. Yields a
+    ``{"n": count}`` dict.
+    """
+    real_link = os.link
+    state = {"n": 0}
+
+    def _patched(src, dst, **kwargs):  # type: ignore[no-untyped-def]
+        p = str(dst)
+        if match is None or os.path.basename(p) == match or match in p:
+            state["n"] += 1
+            if state["n"] <= times:
+                raise PermissionError(
+                    f"[WinError 32] simulated sharing violation linking {p}"
+                )
+        return real_link(src, dst, **kwargs)
+
+    with mock.patch("os.link", _patched):
+        yield state
+
+
+@contextmanager
+def link_unsupported(*, match: Optional[str] = None) -> Iterator[dict]:
+    """Make ``os.link()`` fail as it does on a filesystem with no hard links.
+
+    FAT/exFAT volumes and several network mounts reject ``link`` outright with
+    ``EPERM``/``EOPNOTSUPP`` for every call, not transiently. A writer that
+    publishes by link must still leave a persisted file on such a host rather
+    than silently degrading, and this makes that path reachable from a POSIX
+    dev loop. *match* filters on the destination path as above. Yields a
+    ``{"n": count}`` dict.
+    """
+    real_link = os.link
+    state = {"n": 0}
+
+    def _patched(src, dst, **kwargs):  # type: ignore[no-untyped-def]
+        p = str(dst)
+        if match is None or os.path.basename(p) == match or match in p:
+            state["n"] += 1
+            raise OSError(errno.EPERM, "simulated: filesystem does not support links")
+        return real_link(src, dst, **kwargs)
+
+    with mock.patch("os.link", _patched):
         yield state
 
 


### PR DESCRIPTION
## Problem / Motivation

`~/.kiro/crew/token_signing.key` can end up **0 bytes on disk**. It was created
at its final path and only then written:

```python
fd = os.open(str(key_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL | ..., 0o600)
...
os.write(fd, key)   # 32 random bytes
os.fsync(fd)
```

The `finally` block cleans up when the write *raises*. A kill has no `finally`:
an update that completes during shutdown, or a reboot, ending the process
between the create and the write leaves an empty file behind.

Observed on a real host after a reboot that finished a pending update — the key,
`.env` and `refresh_chains.json` were all sitting at 0 bytes shortly after
startup. A watchdog restored them from backup minutes later, so the window is
survivable, but during it the product is unusable and the failure is opaque.

## Why it matters

The empty file is self-poisoning, not a one-time blip. On every later boot the
fast-path read sees `< 32` bytes, the exclusive create then hits
`FileExistsError`, the bounded retry budget exhausts, and the gateway degrades to
a **fresh ephemeral secret**. The dashboard still loads and serves, but every
signed action — creating a session, opening a past one, submitting a prompt — is
rejected, and a plain restart does not help because it re-reads the same empty
file. Nothing recovers it but deleting the file by hand.

The existing code already predicts this outcome in a comment, which is what
makes it worth fixing rather than monitoring:

> Retries exhausted: a persistently short/empty file (external corruption, or a
> creator that crashed after O_EXCL but before the write) … using ephemeral secret

## What changed (motivation → approach → change)

**Symptom** — a 0-byte `token_signing.key` after an interrupted update, and every
signed action failing from then on. **Root cause** — the destination name is
created before the content exists, so the file is observable in a partial state
and a kill makes that state permanent.

**Change** — the key is staged into a private sibling through this repo's shared
`atomic_write` helper and then **published with `os.link`**, so the destination
name only ever resolves to a complete file.

`os.link`, not `os.replace`, is the load-bearing choice. Exactly one key may ever
exist: `warm_auth_singletons()` primes the secret before the port bind, so two
fresh gateways sharing one data home can both observe the key as absent. `link`
fails with `FileExistsError` once a sibling has published, which is the same
single-creator election the exclusive create provided; a last-writer-wins rename
would let each racer install its own key and leave the losers signing with bytes
that are no longer on disk.

Carried through unchanged from the old call site: `restrict_to_owner=True`
(`0o600` on POSIX, owner-only DACL on Windows, applied *before* the first key
byte), `restrict_on_error="warn"` (the site's fail-soft permission policy), and
`fsync=True` for the key bytes.

**Two details that are load-bearing rather than cosmetic**, both found in review:

- **The staging file is suffixed `.tmp`.** It holds the full key until the link
  lands, and a kill in between leaves it on disk. `security.py`'s keystone fence
  protects a publish artifact *by shape* — a direct child of a keystone leaf's own
  directory whose name ends in one of `_KEYSTONE_ARTIFACT_SUFFIXES` — so any other
  suffix leaves a readable copy of the signing key for an agent tool to fetch and
  forge tokens with. It is also the suffix `atomic_write`'s own mkstemp temp uses.
- **The parent directory is synced STRICTLY, and a failure keeps the second name.**
  The key bytes are fsynced during staging, but the published *name* is not durable
  until the directory is — and the next step removes the only other name for that
  inode. `best_effort=True` downgrades even `EIO` to a warning, so a swallowed
  failure followed by that unlink can leave a power loss with neither name: the
  inode unreachable, the next boot minting a fresh key, every outstanding cookie
  and link invalid. A real failure is therefore caught locally and the staging name
  is *kept* as a recoverable second reference, while the on-disk key is still
  returned (propagating would hand back an ephemeral secret while a valid key sits
  at the path — the divergence this function exists to prevent). Where a directory
  sync cannot be *expressed* at all — Windows has no directory descriptor, some
  network mounts refuse it — `fsync_dir` returns quietly, so those platforms still
  reach the unlink and do not accumulate key copies.

**The in-place create survives as a fallback**, for a filesystem that genuinely
has no hard links (FAT/exFAT, some network mounts). There an in-place key —
truncation window and all — beats no persisted key on any boot. Every branch:

| Branch | Reached when | Why it is correct |
|---|---|---|
| publish (`os.link`) | normal | destination never partial |
| in-place fallback | link error says the filesystem cannot link (`EPERM`, `EOPNOTSUPP`/`ENOTSUP`, `ENOSYS`, Win32 `1`/`50`) | only case where the alternative is no persisted key at all |
| ephemeral | any other exhausted failure — transient sharing violation, policy refusal, short/empty file already at the path | destination left untouched, as pre-PR |

The errno gate matters because a transient refusal reaching the in-place path
would recreate the 0-byte key on a filesystem that can link perfectly well. The
fallback also runs under its own bounded read → create → read-the-winner loop:
two gateways booting concurrently on a link-less home both reach it, `O_EXCL`
lets one win, and the loser must read the winner's bytes — a single create
attempt would hand the loser an ephemeral secret while the winner persisted a
real one.

**Scope.** The other two files named in the report already write atomically at
every site, so nothing there changed:

| File | Writers | Status |
|---|---|---|
| `token_signing.key` | `dashboard/token_secret.py` | **not atomic — converted** |
| `.env` | `cli_setup.py`, `secrets/migrate.py`, `dashboard/handlers/messaging.py`, `dashboard/handlers/weixin_qr.py` | already `atomic_write` (all four under one advisory lock) |
| `refresh_chains.json` | `dashboard/refresh_tokens.py` | already `atomic_write` |

**Deliberately deferred.** The report also asks that startup detect an empty
`token_signing.key` and regenerate or restore it before serving the dashboard,
with an operator-facing error. Regenerating a signing key invalidates every live
session and outstanding link, and restoring from backup picks one of several
possible sources — that is a product and security decision for a maintainer, not
something to land alongside a write-path fix. Left out on purpose.

**One sibling defect raised in review and put to the maintainer**, not fixed
here: `secrets/vault.py` creates `.vault_key` the same way and its fast-path read
has no length check, so the same kill wedges the vault. Answered as
`needs-a-decision` in a PR comment — the read-path half collides with that file's
deliberate "refuse to create a new key when a store exists" invariant, and
picking wrong turns a recoverable wedge into a silently re-keyed, undecryptable
vault. Pre-existing on `main`; this PR neither introduces nor worsens it.

## Tests

New, in `test/test_token_auth.py`:

- **`…destination_never_exists_while_incomplete`** — samples the destination on
  every `os.write` carrying key bytes and asserts it is never present at
  `< 32` bytes. This is the reported defect: reverting the source makes it fail
  with an observed size of 0.
- **`…failed_dir_sync_keeps_a_recoverable_name`** — injects `EIO`, asserts the sync
  was requested *without* `best_effort`, then asserts the kept name resolves to the
  same **inode** as the key (a second name, not a second copy), that the returned
  secret equals the on-disk bytes, and that the leftover is still fence-covered.
- **`…staging_file_is_covered_by_the_keystone_fence`** — captures the real staging
  path handed to `os.link` and asserts `security._is_keystone_publish_artifact()`
  accepts it in every directory the fence resolves — the predicate, not a literal
  suffix, so a rename on either side cannot silently drop the fence.
- **`…transient_publish_failure_never_creates_the_destination`** — a sharing
  violation on every publish attempt must leave the destination absent rather than
  falling onto the in-place path.
- **`…concurrent_first_init_converges_without_hard_links`** — 8 racing first boots
  on a link-less home must all return the one persisted key.
- **`…persists_on_a_filesystem_without_hard_links`** — the fallback still lands a
  full, persisted key rather than an ephemeral one.
- **`…publish_leaves_no_staging_file_behind`** — on a successful publish the staging
  sibling must not survive, won race or lost.

Two existing tests move to the new fault-injection point, keeping the property
they pinned:

- `…create_contention_retries_not_ephemeral` — a transient Windows sharing
  violation now lands on `os.link`, not on the destination's `os.open`.
- `…write_failure_cleans_up_incomplete_file` — faults every key-persist write (by
  payload length) instead of only the first, so the loader still reaches the
  cleanup path the test exists to protect. A single failed write no longer
  degrades at all, since the publish retries.

`test/windows_sim.py` gains `link_sharing_violation` and `link_unsupported` so
every new path is reachable deterministically from a POSIX dev loop.

Mutation-verified per behaviour: reverting the publish change fails 3 of the 4
publish-path tests; reverting the errno gate fails the transient test; reducing
the fallback loop to one attempt fails the convergence test with
`2 distinct secrets for one persisted key`; restoring `best_effort=True` plus the
unconditional unlink fails the directory-sync test; restoring the `.new` suffix
fails the fence test.

## Manual verification

N/A — unit coverage is sufficient and strictly better than a manual attempt here:
every defect is a kill or a device error between two syscalls, which the tests
reproduce deterministically (fault-injected write, link, errno and directory-sync
paths) whereas a real reboot or an `EIO` cannot be aimed at that window on demand.

Local gates green on this head: `isort`, `flake8`, `mypy`, the `black` ratchet,
`check_sync_io_in_async`, `check_lockdown_before_publish`, `check_loop_bound_locks`,
`docs-lint`, `scrub-lint`, and the auth / refresh-token / windows-sim /
security-path / `atomic_write` suites together — 456 tests.

## Related Issues

no linked issue: reported through an internal bug tracker, which has no public
issue to close.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a file created at its final path before its content exists — an
exclusive-create used as a lock, then written in place, so a kill between the two
leaves a valid-looking empty file that later reads treat as authoritative

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
