### PR TITLE
perf(chat): bound paginated transcript reads

### DIFF
--- a/docs/system-specs/modules/history.md
+++ b/docs/system-specs/modules/history.md
@@ -34,6 +34,39 @@ parsers, formatters, logging, and atomic I/O remain ordinary module dependencies
 stable helpers still owned by the core facade are resolved lazily rather than
 injected into every component.
 
+### Bounded transcript pages
+
+`ConversationLog.read_messages_chained_page` serves dashboard pagination without
+materializing the complete parsed transcript. `TranscriptReadProjection` keeps a
+bounded in-memory sparse index per transcript revision, mapping every fixed row
+stride to a byte offset. Any file-stamp or invalidation-generation change rebuilds
+the index from byte zero; only an exact revision reuses checkpoints.
+Authoritative full reads performed off the event loop (including restore) warm
+the index so the first dashboard page does not repeat the scan. A page seeks to
+the nearest checkpoint and decodes only the intersecting range plus at most one
+stride. Tab-chain membership and ordering come from the same `_tab_id_index` as
+`read_messages_chained`; there is no second lineage model.
+
+The index stores counts and offsets only, never message content, and never crosses
+a process boundary or trusts agent-writable derived state. In-memory validity
+requires the full file stamp (`mtime_ns`, size, inode, device) and the process-wide
+history invalidation generation. A revision changing during a page read is
+retried; repeated churn falls back to the complete-reader oracle so the endpoint
+never returns a mixed revision. Indexed reads use the strict framing posture
+(`strict_raw_records_with_offsets`): a record over `RECORD_CAP` raises instead of
+being skipped, because a skipped row would shift every cursor above it; the
+endpoint then serves the request from the full reader, which has no per-record cap.
+
+Paginated slot detail composes an indexed durable prefix with the resident disk
+suffix and the existing unflushed/transient window reconciliation. The first
+range read returns an ordered chain revision (`key`, file stamp, invalidation
+generation); every later range in that response must match it, otherwise the
+whole composition retries and ultimately falls back to the full-reader oracle.
+It preserves the legacy exact `total`, `before`, `next_before`, and `has_more`
+fields. The no-limit route and callers requiring complete history remain on
+`read_messages_chained`. Display redaction remains at `_prepare_messages`; neither
+the sparse index nor page projection stores a redacted or alternate transcript.
+
 ## ConversationLog (`history.py` facade)
 
 Per-thread JSONL files at `~/.kiro/crew/sessions/{safe_key}.jsonl`. First line is metadata, subsequent lines are messages with `role`, `content`, `ts`, `tools`, `source_thread`, `source_user`. A writer can also supply `cls` (presentation class) and `mid` — persisted as `meta.mid`, the same field shape the dashboard slot save writes, so a dual-write injector's durable copy carries the SAME delivery identity as its in-memory window copy and a bounded slot-detail read reconciles the two as one message instead of re-appending the injection. A row appended without an id carries no `meta` at all (the pre-id shape readers keep an id-less fallback for; existing transcripts are never migrated).

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -133,6 +133,7 @@ from kiro_crew.dashboard.state import (
 from kiro_crew.dashboard.system_notices import SESSION_RELOAD_KIND, is_system_notice
 from kiro_crew.dashboard.turn_dispatch import spawn_guarded_turn
 from kiro_crew.history import carry_provenance, is_incognito_transcript, transcript_stems
+from kiro_crew.history_projection import TranscriptRevisionChanged
 from kiro_crew.messaging.link import is_channel_session_key
 from kiro_crew.providers.acp import AcpProvider
 from kiro_crew.providers.base import LLMProvider
@@ -1658,10 +1659,11 @@ def _snapshot_slot_window(slot: "_ChatSlot") -> tuple[int, list[dict]]:
     return disk_older_count, window
 
 
-def _append_unflushed_tail(
+def _append_unflushed_tail_from_offset(
     slot: "_ChatSlot",
     all_msgs: list[dict],
     *,
+    disk_offset: int,
     snapshot: tuple[int, list[dict]] | None = None,
 ) -> list[dict]:
     """Append window messages that are not yet on disk to a chained disk read.
@@ -1770,7 +1772,8 @@ def _append_unflushed_tail(
     if snapshot is None:
         snapshot = _snapshot_slot_window(slot)
     disk_older_count, window = snapshot
-    window_disk = all_msgs[disk_older_count:]
+    local_older_count = max(0, disk_older_count - disk_offset)
+    window_disk = all_msgs[local_older_count:]
     disk_mid_positions: dict[str, list[int]] = {}
     every_row_has_an_id = bool(window_disk)
     for i, m in enumerate(window_disk):
@@ -1816,7 +1819,7 @@ def _append_unflushed_tail(
             pending.append(m)
         if not owed_before and not pending:
             return all_msgs
-        merged: list[dict] = list(all_msgs[:disk_older_count])
+        merged: list[dict] = list(all_msgs[:local_older_count])
         for i, m in enumerate(window_disk):
             merged.extend(owed_before.get(i, ()))
             merged.append(m)
@@ -1824,7 +1827,7 @@ def _append_unflushed_tail(
         return merged
     else:
         start = 0
-        d = min(disk_older_count, len(all_msgs))
+        d = min(local_older_count, len(all_msgs))
         # An owed row is one the disk slice does not already carry, and this arm walks
         # the WHOLE window so that a single owed row cannot strand the rows behind it.
         # There are two ways to be owed, and both route to ``owed_rows``:
@@ -1913,6 +1916,92 @@ def _append_unflushed_tail(
             merged_idless.append(row)
         merged_idless.extend(tail)
         return merged_idless
+
+
+def _append_unflushed_tail(
+    slot: "_ChatSlot",
+    all_msgs: list[dict],
+    *,
+    snapshot: tuple[int, list[dict]] | None = None,
+) -> list[dict]:
+    """Compatibility wrapper for reconciliation against a complete disk read."""
+    return _append_unflushed_tail_from_offset(
+        slot,
+        all_msgs,
+        disk_offset=0,
+        snapshot=snapshot,
+    )
+
+
+def _bounded_slot_page(
+    conversation_log: Any,
+    slot: "_ChatSlot",
+    history_key: str,
+    *,
+    limit: int,
+    before: int | None,
+    snapshot: tuple[int, list[dict]],
+    durable_prefix_count: int,
+    pending_rewrite: bool,
+) -> tuple[list[dict], int, bool, int]:
+    """Compose one display page from an indexed durable prefix and live suffix.
+
+    The sparse history projection owns durable row ranges. This helper reads at
+    most the resident disk/window suffix, applies the established reconciliation
+    oracle there, and fetches only the older range intersecting the requested
+    page. Unlimited callers keep using the complete-reader path.
+    """
+    disk_older_count, _window = snapshot
+    if disk_older_count != durable_prefix_count:
+        raise TranscriptRevisionChanged("raw and durable history prefix counters differ")
+
+    total_probe = conversation_log.read_messages_chained_page(history_key, limit=1)
+    durable_total = total_probe.total
+    revision = total_probe.revision
+    prefix_total = min(disk_older_count, durable_total)
+
+    if pending_rewrite:
+        disk_suffix: list[dict] = []
+    else:
+        suffix_count = durable_total - prefix_total
+        disk_suffix = (
+            conversation_log.read_messages_chained_page(
+                history_key,
+                limit=suffix_count,
+                before=durable_total,
+                expected_revision=revision,
+            ).messages
+            if suffix_count > 0
+            else []
+        )
+
+    merged_suffix = _append_unflushed_tail_from_offset(
+        slot,
+        disk_suffix,
+        disk_offset=prefix_total,
+        snapshot=snapshot,
+    )
+    collapsed_suffix = _collapse_wire_rows(merged_suffix)
+    total = prefix_total + len(collapsed_suffix)
+    end = total if before is None else max(0, min(before, total))
+    start = max(0, end - limit)
+
+    messages: list[dict] = []
+    prefix_end = min(end, prefix_total)
+    if start < prefix_end:
+        messages.extend(
+            conversation_log.read_messages_chained_page(
+                history_key,
+                limit=prefix_end - start,
+                before=prefix_end,
+                expected_revision=revision,
+            ).messages
+        )
+    suffix_start = max(start, prefix_total) - prefix_total
+    suffix_end = max(0, end - prefix_total)
+    if suffix_start < suffix_end:
+        messages.extend(collapsed_suffix[suffix_start:suffix_end])
+    return messages, total, start > 0, start
 
 
 async def api_chat_slot_detail(request: web.Request) -> web.Response:
@@ -2169,65 +2258,106 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
                     next_before = rotated_count
                     total += rotated_count
     else:
-        # Legacy pagination path (retained for programmatic callers).
-        # Always reads from chained disk history; no in-memory offset math.
-        # The FULL corpus — size-rotated archive heads included — so paging can
-        # walk past a rotation boundary instead of declaring the transcript
-        # complete at it (the reader's oldest messages live in archive/ after
-        # a big session rotates, and this path is their only way back in).
         history_key = slot_history_key(slot)
-        try:
-            all_msgs = (
-                await asyncio.to_thread(
-                    state.conversation_log.read_messages_chained_full, history_key
+        bounded_page: tuple[list[dict], int, bool, int] | None = None
+        requires_full_reader = False
+        if state.conversation_log:
+            try:
+                rotated = await asyncio.to_thread(
+                    state.conversation_log.read_rotated_messages_chained,
+                    history_key,
                 )
-                if state.conversation_log
-                else []
-            )
-        except Exception:
-            # NOT `all_msgs = []`. This is the legacy pagination path and the only
-            # way back into a rotated archive, so folding the failure into an empty
-            # corpus answers 200 with the live tail and `has_more` false -- the
-            # reader is told their older history does not exist. See
-            # `history_corpus_unreadable` for why all three sites share one answer.
-            logger.warning("read_messages_chained_full failed for %s", history_key, exc_info=True)
-            return history_corpus_unreadable()
-        # Append any un-flushed in-memory tail messages beyond what's on disk.
-        # Snapshot on the LOOP, after the disk read: the two reads inside the helper
-        # have no await between them, so a synchronous finalization cannot be caught
-        # half-done the way a worker thread can catch it.
-        tail_snapshot = _snapshot_slot_window(slot)
-        all_msgs = await asyncio.to_thread(
-            _append_unflushed_tail, slot, all_msgs, snapshot=tail_snapshot
-        )
-        # One row must mean one displayed message BEFORE `limit` is applied. The
-        # owed rows above can include `chunk`/`streaming`, and a segment still
-        # streaming is hundreds of rows that render as one message, so slicing
-        # first spends the caller's budget on rows the response will not carry
-        # and returns a mid-sentence fragment.
-        #
-        # Reduce the whole corpus, not a trailing slice: the helper places owed
-        # rows at the disk index they belong to, so they are not a contiguous
-        # suffix and a slice-scoped fold would miss the interleaved ones. In a
-        # thread for the same reason the append is -- whole-corpus work does not
-        # belong on the event loop.
-        #
-        # `done` is already excluded upstream (`_UNOWED_WINDOW_ROLES`), so on
-        # this path the reduction's remaining job is folding the chunk runs.
-        all_msgs = await asyncio.to_thread(_collapse_wire_rows, all_msgs)
-        total = len(all_msgs)
-        if before is not None:
-            end = max(0, min(before, total))
+            except Exception:
+                logger.warning("rotated-archive read failed for %s", history_key, exc_info=True)
+                return history_corpus_unreadable()
+            requires_full_reader = bool(rotated)
+
+        if not requires_full_reader:
+            for _attempt in range(_FLUSH_SNAPSHOT_RETRIES):
+                tail_snapshot = _snapshot_slot_window(slot)
+                durable_prefix_count = int(
+                    getattr(slot, "_disk_older_durable_count", tail_snapshot[0]) or 0
+                )
+                version = (
+                    getattr(slot, "_dirty_gen", 0),
+                    slot._disk_older_count,
+                    durable_prefix_count,
+                )
+                try:
+                    candidate = await asyncio.to_thread(
+                        _bounded_slot_page,
+                        state.conversation_log,
+                        slot,
+                        history_key,
+                        limit=limit,
+                        before=before,
+                        snapshot=tail_snapshot,
+                        durable_prefix_count=durable_prefix_count,
+                        pending_rewrite=bool(getattr(slot, "_pending_rewrite", False)),
+                    )
+                except Exception:
+                    logger.debug(
+                        "bounded slot history revision changed or read failed for %s; retrying",
+                        history_key,
+                        exc_info=True,
+                    )
+                    continue
+                current_version = (
+                    getattr(slot, "_dirty_gen", 0),
+                    slot._disk_older_count,
+                    int(getattr(slot, "_disk_older_durable_count", tail_snapshot[0]) or 0),
+                )
+                if current_version == version:
+                    bounded_page = candidate
+                    break
+
+        if bounded_page is not None and state.conversation_log:
+            # The bounded reader walks only the live tab chain. A size rotation
+            # landing between the archive probe above and the range reads moves
+            # the head of this transcript into archive/ where the bounded index
+            # cannot see it, so the page would omit those rows and could report
+            # `has_more` false. Re-probe after composing: an archive that
+            # appeared means the archive-including full reader must serve this
+            # request instead.
+            try:
+                rotated_after = await asyncio.to_thread(
+                    state.conversation_log.read_rotated_messages_chained,
+                    history_key,
+                )
+            except Exception:
+                logger.warning("rotated-archive re-probe failed for %s", history_key, exc_info=True)
+                return history_corpus_unreadable()
+            if rotated_after:
+                bounded_page = None
+
+        if bounded_page is not None:
+            messages, total, has_more, next_before = bounded_page
         else:
-            end = total
-        start = max(0, end - limit)
-        messages = all_msgs[start:end]
-        has_more = start > 0
-        # The cursor the client should send next, in the RAW index space this
-        # slice was taken in. The client cannot derive it from the response:
-        # `_prepare_messages` drops `done`, so the returned row count is not
-        # the span consumed here.
-        next_before = start
+            try:
+                all_msgs = (
+                    await asyncio.to_thread(
+                        state.conversation_log.read_messages_chained_full,
+                        history_key,
+                    )
+                    if state.conversation_log
+                    else []
+                )
+            except Exception:
+                logger.warning(
+                    "read_messages_chained_full failed for %s", history_key, exc_info=True
+                )
+                return history_corpus_unreadable()
+            tail_snapshot = _snapshot_slot_window(slot)
+            all_msgs = await asyncio.to_thread(
+                _append_unflushed_tail, slot, all_msgs, snapshot=tail_snapshot
+            )
+            all_msgs = await asyncio.to_thread(_collapse_wire_rows, all_msgs)
+            total = len(all_msgs)
+            end = max(0, min(before, total)) if before is not None else total
+            start = max(0, end - limit)
+            messages = all_msgs[start:end]
+            has_more = start > 0
+            next_before = start
 
     # Snapshot every slot field the response needs BEFORE leaving the event
     # loop: the render below runs in a worker thread, and it must not read

--- a/src/kiro_crew/history.py
+++ b/src/kiro_crew/history.py
@@ -41,6 +41,7 @@ from kiro_crew.history_cache import (
     _FileChangeCacheEntry,
     _LRUCache,
     _SearchTextCache,
+    _TranscriptRowIndexEntry,
 )
 from kiro_crew.history_consolidation import (  # noqa: F401 - facade re-exports
     _CONSOLIDATION_BACKOFF_BASE_SECS,
@@ -67,7 +68,9 @@ from kiro_crew.history_consolidation import (  # noqa: F401 - facade re-exports
     _strip_skill_frontmatter,
 )
 from kiro_crew.history_projection import (
+    ChainRevision,
     SessionMetadataProjection,
+    TranscriptPage,
     TranscriptReadProjection,
 )
 from kiro_crew.history_rewrite import HistoryRewriteCoordinator
@@ -1353,6 +1356,10 @@ class ConversationLog:
         #: parsed transcript corpus. The file stamp includes inode and size in
         #: addition to nanosecond mtime so rotations and atomic rewrites miss.
         self._file_change_cache: _LRUCache[_FileChangeCacheEntry] = _LRUCache(cache_max)
+        #: Sparse row-to-byte indexes for paginated transcript reads. Entries
+        #: contain offsets and counts only, never message content, so a bounded
+        #: page does not retain the complete parsed transcript in memory.
+        self._page_index_cache: _LRUCache[_TranscriptRowIndexEntry] = _LRUCache(cache_max)
         #: Bounded memo of ``(mtime, gen, doc_chars, casefolded_blob)`` per
         #: session, consumed only by :meth:`search_sessions`. ``gen`` is the
         #: invalidation generation (:meth:`_cache_gen`) the entry was folded
@@ -2685,6 +2692,21 @@ class ConversationLog:
     def chain_mid_rotation(self, key: str) -> bool:
         """See ``HistoryReadProjection.chain_mid_rotation``."""
         return self._read_projection.chain_mid_rotation(key)
+
+    def read_messages_chained_page(
+        self,
+        key: str,
+        *,
+        limit: int,
+        before: int | None = None,
+        expected_revision: ChainRevision | None = None,
+    ) -> TranscriptPage:
+        return self._read_projection.read_messages_chained_page(
+            key,
+            limit=limit,
+            before=before,
+            expected_revision=expected_revision,
+        )
 
     def _rebuild_tab_id_index(self) -> None:
         self._read_projection._rebuild_tab_id_index()

--- a/src/kiro_crew/history_cache.py
+++ b/src/kiro_crew/history_cache.py
@@ -40,6 +40,23 @@ _TRANSCRIPT_CACHE_MAX = 256
 #: rate collapses to ~0. Measured on an 810-session store: a warm
 #: ``list_sessions`` re-opened and re-parsed ~554 first lines on every call
 #: (57.9 ms); with the cache able to hold the corpus the same call costs 24.5 ms,
+
+
+class _TranscriptRowIndexEntry(NamedTuple):
+    """Sparse byte offsets for one immutable transcript revision.
+
+    ``checkpoints`` stores ``(logical_row, byte_offset)`` pairs for valid,
+    non-metadata message rows. The file stamp and process-wide generation are
+    both required: atomic replacement changes the inode, while a rewrite that
+    restores mtime is exposed by the generation.
+    """
+
+    stamp: tuple[int, int, int, int]
+    generation: int
+    row_count: int
+    checkpoints: tuple[tuple[int, int], ...]
+
+
 #: all of it the unavoidable ``glob`` + one ``stat`` per file.
 #:
 #: This is the same failure mode ``_SearchTextCache`` already documents and
@@ -364,18 +381,24 @@ class HistoryCacheCoordinator:
             cache.pop(entry_key, None)
 
     def _invalidate_cache(self, key: str) -> None:
-        """Invalidate every facade-held cache spelling after a write."""
+        """Invalidate content caches and advance generations after a write.
+
+        Sparse page indexes are revision-specific derived state, so they are
+        invalidated with content caches. A later bounded read rebuilds from byte
+        zero unless the exact file stamp and generation still match.
+        """
         idents = self._log._cache_key_identities(key)
         # Bump BEFORE dropping entries: a fill publishing between a pop and a
         # later bump would pass its re-check and resurrect the entry just
         # dropped. Bump-first makes every fill storing after a pop self-discard.
         self._log._bump_cache_gen(key, idents)
-        # Pops must be exactly as wide as the generation bump. The writer and
-        # reader may use different logical, sanitized, canonical, or legacy
-        # spellings for the same transcript; under-popping one spelling leaves
-        # a warm entry permanently stale after an mtime-preserving rewrite.
+        # Content-cache pops must be exactly as wide as the generation bump. The
+        # writer and reader may use different logical, sanitized, canonical, or
+        # legacy spellings for the same transcript; under-popping one spelling
+        # leaves content or derived offsets stale after a rewrite.
         for ident in idents:
             self._log._msg_cache.pop(ident, None)
+            self._log._page_index_cache.pop(ident, None)
             self._log._meta_cache.pop(ident, None)
             self._log._file_change_cache.pop(ident, None)
             self._log._tab_id_by_key.pop(ident, None)

--- a/src/kiro_crew/history_projection.py
+++ b/src/kiro_crew/history_projection.py
@@ -13,15 +13,17 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import time as _time
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, AbstractSet, Any, Literal, overload
 
 from kiro_crew.atomic_write import atomic_write, replace_with_retry
-from kiro_crew.history_cache import _FileChangeCacheEntry
-from kiro_crew.jsonl_util import bounded_raw_records
+from kiro_crew.history_cache import _FileChangeCacheEntry, _TranscriptRowIndexEntry
+from kiro_crew.jsonl_util import bounded_raw_records, strict_raw_records_with_offsets
 
 if TYPE_CHECKING:
     from kiro_crew.history import ConversationLog
@@ -48,6 +50,27 @@ def _history_facade() -> Any:
 def _facade_flock_acquire_timeout() -> float:
     """Read the one timeout with an established facade rebind seam."""
     return float(_history_facade()._FLOCK_ACQUIRE_TIMEOUT_S)
+
+
+_TRANSCRIPT_PAGE_INDEX_STRIDE = 128
+_TRANSCRIPT_PAGE_READ_ATTEMPTS = 2
+
+ChainRevision = tuple[tuple[str, tuple[int, int, int, int], int], ...]
+
+
+class TranscriptRevisionChanged(RuntimeError):
+    """A chained transcript changed between reads composing one response."""
+
+
+@dataclass(frozen=True)
+class TranscriptPage:
+    """One exact page in chained durable-message index space."""
+
+    messages: list[dict]
+    total: int
+    next_before: int
+    has_more: bool
+    revision: ChainRevision
 
 
 def _facade_strip_markdown_preview(text: str) -> str:
@@ -300,6 +323,19 @@ class TranscriptReadProjection:
                 gen=generation,
             )
         return messages
+
+    def _chain_keys(self, key: str) -> list[str]:
+        """Return the established chronological tab chain for *key*."""
+        metadata = self._log.get_metadata(key)
+        tab_id = metadata.get("tab_id")
+        if not tab_id:
+            return [key]
+        with self._log._lock:
+            if self._log._tab_id_index is None:
+                self._log._rebuild_tab_id_index()
+            index = self._log._tab_id_index or {}
+            keys = list(index.get(tab_id, []))
+        return keys or [key]
 
     def read_messages_chained(self, key: str) -> list[dict]:
         """Concatenate chronologically ordered files sharing the same tab id."""
@@ -644,6 +680,185 @@ class TranscriptReadProjection:
                 ) from exc
         return False
 
+    @staticmethod
+    def _message_record(raw: bytes) -> dict | None:
+        """Decode one record using the full-reader's skip semantics."""
+        try:
+            data = json.loads(raw)
+        except ValueError:
+            return None
+        if not isinstance(data, dict) or data.get("_type") == "metadata":
+            return None
+        return data
+
+    @staticmethod
+    def _file_stamp(path: Path) -> tuple[int, int, int, int] | None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+        return (stat.st_mtime_ns, stat.st_size, stat.st_ino, stat.st_dev)
+
+    def _row_index(self, key: str) -> _TranscriptRowIndexEntry:
+        """Return a sparse valid-message-row index for one file revision."""
+        path = self._log._path(key)
+        generation = self._log._cache_gen(key)
+        stamp = self._file_stamp(path)
+        if stamp is None:
+            self._log._page_index_cache.pop(key, None)
+            return _TranscriptRowIndexEntry((0, 0, 0, 0), generation, 0, ())
+        cached = self._log._page_index_cache.get(key)
+        if cached is not None and cached.stamp == stamp and cached.generation == generation:
+            return cached
+
+        row_count = 0
+        checkpoints: list[tuple[int, int]] = []
+        try:
+            with open(path, "rb") as handle:
+                records = strict_raw_records_with_offsets(handle, path)
+                for start, _end, raw in records:
+                    if self._message_record(raw) is None:
+                        continue
+                    if row_count % _TRANSCRIPT_PAGE_INDEX_STRIDE == 0:
+                        checkpoints.append((row_count, start))
+                    row_count += 1
+        except OSError:
+            raise
+
+        entry = _TranscriptRowIndexEntry(
+            stamp,
+            generation,
+            row_count,
+            tuple(checkpoints),
+        )
+        if self._file_stamp(path) == stamp:
+            self._log._publish_if_current(
+                self._log._page_index_cache,
+                key,
+                entry,
+                key=key,
+                gen=generation,
+            )
+        return entry
+
+    def _read_message_range(
+        self,
+        key: str,
+        start: int,
+        end: int,
+        index: _TranscriptRowIndexEntry,
+    ) -> list[dict]:
+        """Read ``[start, end)`` while decoding at most one extra index stride."""
+        if start >= end or index.row_count == 0:
+            return []
+        checkpoint_row = 0
+        checkpoint_offset = 0
+        for row, offset in index.checkpoints:
+            if row > start:
+                break
+            checkpoint_row, checkpoint_offset = row, offset
+
+        path = self._log._path(key)
+        messages: list[dict] = []
+        logical_row = checkpoint_row
+        with open(path, "rb") as handle:
+            handle.seek(checkpoint_offset)
+            records = strict_raw_records_with_offsets(handle, path)
+            for _record_start, _record_end, raw in records:
+                message = self._message_record(raw)
+                if message is None:
+                    continue
+                if logical_row >= end:
+                    break
+                if logical_row >= start:
+                    messages.append(message)
+                logical_row += 1
+        return messages
+
+    def _read_messages_chained_page_once(
+        self,
+        key: str,
+        *,
+        limit: int,
+        before: int | None,
+    ) -> tuple[TranscriptPage, list[tuple[str, _TranscriptRowIndexEntry]]]:
+        keys = self._chain_keys(key)
+        indexed = [(chained_key, self._row_index(chained_key)) for chained_key in keys]
+        total = sum(index.row_count for _chained_key, index in indexed)
+        end = total if before is None else max(0, min(before, total))
+        start = max(0, end - limit)
+
+        messages: list[dict] = []
+        base = 0
+        for chained_key, index in indexed:
+            file_end = base + index.row_count
+            overlap_start = max(start, base)
+            overlap_end = min(end, file_end)
+            if overlap_start < overlap_end:
+                messages.extend(
+                    self._read_message_range(
+                        chained_key,
+                        overlap_start - base,
+                        overlap_end - base,
+                        index,
+                    )
+                )
+            base = file_end
+            if base >= end:
+                break
+        revision: ChainRevision = tuple(
+            (chained_key, index.stamp, index.generation) for chained_key, index in indexed
+        )
+        return TranscriptPage(messages, total, start, start > 0, revision), indexed
+
+    def read_messages_chained_page(
+        self,
+        key: str,
+        *,
+        limit: int,
+        before: int | None = None,
+        expected_revision: ChainRevision | None = None,
+    ) -> TranscriptPage:
+        """Read one exact chained page without materialising complete transcripts.
+
+        A stable revision decodes the requested page plus at most one sparse-index
+        stride per intersecting file. A file changing during the read is retried.
+        ``expected_revision`` pins the several range reads composing one HTTP
+        response to the same chain membership, file stamps, and generations.
+        """
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+        for _attempt in range(_TRANSCRIPT_PAGE_READ_ATTEMPTS):
+            page, indexed = self._read_messages_chained_page_once(key, limit=limit, before=before)
+            stable = all(
+                self._file_stamp(self._log._path(chained_key)) == index.stamp
+                and self._log._cache_gen(chained_key) == index.generation
+                for chained_key, index in indexed
+            )
+            if stable and (expected_revision is None or page.revision == expected_revision):
+                return page
+        if expected_revision is not None:
+            raise TranscriptRevisionChanged("chained transcript changed during page composition")
+
+        for _attempt in range(_TRANSCRIPT_PAGE_READ_ATTEMPTS):
+            keys = self._chain_keys(key)
+            indexed = [(chained_key, self._row_index(chained_key)) for chained_key in keys]
+            revision: ChainRevision = tuple(
+                (chained_key, index.stamp, index.generation) for chained_key, index in indexed
+            )
+            messages = self.read_messages_chained(key)
+            stable = self._chain_keys(key) == keys and all(
+                self._file_stamp(self._log._path(chained_key)) == index.stamp
+                and self._log._cache_gen(chained_key) == index.generation
+                for chained_key, index in indexed
+            )
+            if stable:
+                total = len(messages)
+                end = total if before is None else max(0, min(before, total))
+                start = max(0, end - limit)
+                return TranscriptPage(messages[start:end], total, start, start > 0, revision)
+        raise TranscriptRevisionChanged("chained transcript changed during full-read fallback")
+
     def _rebuild_tab_id_index(self) -> None:
         """Rebuild the tab-id chain index while the owner lock is held."""
         index: dict[str, list[str]] = {}
@@ -777,7 +992,18 @@ class TranscriptReadProjection:
                 cached = self._log._msg_cache.get(key)
                 if cached and cached[0] == mtime and cached[1] == self._log._cache_gen(key):
                     return cached[2]
-                with open(path, encoding="utf-8") as handle:
+                with open(path, encoding="utf-8", newline="") as handle:
+                    # Stamp the HANDLE, not the path: an atomic replace swaps
+                    # the inode, so a stamp taken through the path after the
+                    # read can describe a different file than the bytes below.
+                    # fstat on the open descriptor names the exact revision read.
+                    read_stat = os.fstat(handle.fileno())
+                    read_stamp = (
+                        read_stat.st_mtime_ns,
+                        read_stat.st_size,
+                        read_stat.st_ino,
+                        read_stat.st_dev,
+                    )
                     raw = handle.read()
             except FileNotFoundError:
                 # A delete racing the read is a definitive empty answer, not a
@@ -797,9 +1023,20 @@ class TranscriptReadProjection:
                 )
                 raise
 
+            try:
+                asyncio.get_running_loop()
+                warm_page_index = False
+            except RuntimeError:
+                warm_page_index = True
             messages: list[dict] = []
-            for line in raw.splitlines():
-                line = line.strip()
+            checkpoints: list[tuple[int, int]] = []
+            row_count = 0
+            byte_offset = 0
+            for frame in raw.splitlines(keepends=True):
+                record_offset = byte_offset
+                if warm_page_index:
+                    byte_offset += len(frame.encode("utf-8"))
+                line = frame.strip()
                 if not line:
                     continue
                 try:
@@ -810,6 +1047,10 @@ class TranscriptReadProjection:
                     continue
                 if data.get("_type") != "metadata":
                     messages.append(data)
+                    if warm_page_index:
+                        if row_count % _TRANSCRIPT_PAGE_INDEX_STRIDE == 0:
+                            checkpoints.append((row_count, record_offset))
+                        row_count += 1
 
             entry_generation = self._log._cache_gen(key) if gen is None else gen
             if gen is None or (
@@ -818,6 +1059,24 @@ class TranscriptReadProjection:
                 and flock_witness == self._log._flock_hold_witness(key)
             ):
                 self._log._msg_cache[key] = (mtime, entry_generation, messages)
+            if warm_page_index and read_stamp[1] == byte_offset:
+                # Offsets belong to `read_stamp`'s revision. Publish only if the
+                # path STILL names that revision: an equal-size rewrite landing
+                # after the read would otherwise be blessed with stale offsets.
+                if self._file_stamp(path) == read_stamp:
+                    entry = _TranscriptRowIndexEntry(
+                        read_stamp,
+                        entry_generation,
+                        row_count,
+                        tuple(checkpoints),
+                    )
+                    self._log._publish_if_current(
+                        self._log._page_index_cache,
+                        key,
+                        entry,
+                        key=key,
+                        gen=entry_generation,
+                    )
             return messages
         return []
 

--- a/src/kiro_crew/jsonl_util.py
+++ b/src/kiro_crew/jsonl_util.py
@@ -257,8 +257,35 @@ def _frames(handle: IO[bytes], cap: int) -> Iterator[bytes | _Oversized]:
     stops consuming this generator, and generators are lazy, so the work of
     discarding a multi-GB tail is never done for it. That is the same guarantee
     the old explicit flag gave, with no flag to pass or get wrong.
+
+    Implemented as a thin projection of :func:`_frames_with_offsets`, which owns
+    the buffer walk; the two readers therefore frame identically by construction
+    rather than by parallel maintenance.
+    """
+    for _start, _end, frame in _frames_with_offsets(handle, cap):
+        yield frame
+
+
+def _frames_with_offsets(
+    handle: IO[bytes], cap: int
+) -> Iterator[tuple[int, int, bytes | _Oversized]]:
+    """Frame *handle* into complete records with absolute byte offsets.
+
+    This is the single framing implementation: :func:`_frames` projects it.
+    Offsets name exact record boundaries, so they are safe seek targets for a
+    later bounded read of the same stamped file revision. Everything the
+    :func:`_frames` docstring says about boundaries, the cap, drops, and peak
+    memory holds here verbatim.
     """
     buf = b""
+    # Absolute offset of buf[0]. Seeded from the handle's position when it has
+    # one (callers may hand a pre-seeked file) and advanced by bytes CONSUMED,
+    # so a readline-only handle with no `tell` frames identically.
+    try:
+        buf_offset = handle.tell()
+    except (AttributeError, OSError):
+        buf_offset = 0
+    consumed = buf_offset
     # True while discarding the remainder of an over-cap record, whose own
     # terminator is what ends the discard.
     dropping = False
@@ -275,21 +302,26 @@ def _frames(handle: IO[bytes], cap: int) -> Iterator[bytes | _Oversized]:
         if not chunk:
             break
         buf += chunk
+        consumed += len(chunk)
         # Walk by offset and slice the remainder ONCE at the end of the chunk:
         # re-slicing per record copies the whole tail each time, which is
         # quadratic in the number of records a single read holds.
         start = 0
         while (idx := _boundary_end(buf, start)) is not None:
+            piece_start = start
             piece, start = buf[start:idx], idx
+            absolute_start = buf_offset + piece_start
+            absolute_end = buf_offset + idx
             if dropping:
                 dropping = False  # this piece's terminator ended the dropped record
                 continue
             if _body_len(piece) > cap:
                 # Already terminated, so there is nothing left to discard and
                 # `dropping` must stay clear -- the next piece is a real record.
-                yield _OVERSIZED
+                yield absolute_start, absolute_end, _OVERSIZED
                 continue
-            yield piece
+            yield absolute_start, absolute_end, piece
+        buf_offset += start
         buf = buf[start:]
         # A trailing \r is a pending TERMINATOR half, not body: it was left
         # unsplit above in case its \n is in the next read, so counting it would
@@ -297,18 +329,40 @@ def _frames(handle: IO[bytes], cap: int) -> Iterator[bytes | _Oversized]:
         pending_cr = buf.endswith(b"\r")
         if len(buf) - pending_cr > cap:
             if not dropping:
-                yield _OVERSIZED
+                yield buf_offset, buf_offset + len(buf), _OVERSIZED
                 dropping = True
             # KEEP a pending \r. It is the dropped record's own terminator, and
             # dropping it would leave the NEXT record's terminator to end the
             # discard -- silently consuming a valid record.
-            buf = b"\r" if pending_cr else b""
+            if pending_cr:
+                buf_offset = consumed - 1
+                buf = b"\r"
+            else:
+                buf_offset = consumed
+                buf = b""
     if buf and not dropping:
         # A crash mid-append leaves a final record with no terminator. Its BODY
         # is within the cap because the per-read check above reported and dropped
         # any longer tail; the piece itself may be one byte longer, when the file
         # ends on a bare \r that is a terminator here rather than a pending half.
-        yield buf
+        yield buf_offset, buf_offset + len(buf), buf
+
+
+def strict_raw_records_with_offsets(
+    handle: IO[bytes], path: Path, *, cap: int = RECORD_CAP
+) -> Iterator[tuple[int, int, bytes]]:
+    """Yield ``(start, end, record)``, aborting on an oversized record.
+
+    The pagination index is an INDEX SPACE: every row it counts positions the
+    rows above it, so a skipped record does not merely go missing, it shifts
+    every later cursor. That is the strict posture, so an over-cap record raises
+    :class:`OversizedRecord` and the caller falls back to the authoritative full
+    reader, which has no per-record cap.
+    """
+    for start, end, frame in _frames_with_offsets(handle, cap):
+        if isinstance(frame, _Oversized):
+            raise OversizedRecord(f"record over {cap} bytes in {path!r}")
+        yield start, end, frame
 
 
 def _decode(raw: bytes) -> str:

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -1316,29 +1316,155 @@ class TestSlotDetailPagination:
             assert data["has_more"] is True
 
     @pytest.mark.asyncio
-    async def test_cursor_branch_reads_disk_off_the_loop_thread(self, tmp_path, monkeypatch):
-        """The read must not run on the loop thread that serves every other request.
+    async def test_bounded_request_never_calls_full_chained_reader(self, tmp_path, monkeypatch):
+        state = await self._slot_with_history(tmp_path, monkeypatch, "bounded-reader", count=30)
 
-        Asserts only that the call executed on a different thread. It does not
-        measure loop latency, so it cannot prove the loop was never blocked for
-        some other reason — but it does fail if the ``to_thread`` hop is removed.
-        """
+        def full_read_forbidden(_key):
+            raise AssertionError("bounded slot detail called the full chained reader")
+
+        monkeypatch.setattr(state.conversation_log, "read_messages_chained", full_read_forbidden)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/bounded-reader?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        assert [message["content"] for message in data["messages"]] == [
+            f"msg {i}" for i in range(20, 30)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_rotation_racing_bounded_page_falls_back_to_archive_reader(
+        self, tmp_path, monkeypatch
+    ):
+        """An archive appearing mid-request must not be hidden by the bounded page."""
+        state = await self._slot_with_history(tmp_path, monkeypatch, "rotate-race", count=30)
+        log = state.conversation_log
+        archived = [
+            {"role": "user", "content": f"old {i}", "ts": "2026-09-03T00:00:00+00:00"}
+            for i in range(5)
+        ]
+        probes: list[int] = []
+
+        def rotated_probe(_key):
+            # Empty before the bounded read (no archive yet), populated after it:
+            # the size rotation landed while the page was being composed.
+            probes.append(len(probes))
+            return [] if len(probes) == 1 else list(archived)
+
+        full_reads: list[str] = []
+        real_full = log.read_messages_chained_full
+
+        def full_reader(key):
+            full_reads.append(key)
+            return list(archived) + real_full(key)
+
+        monkeypatch.setattr(log, "read_rotated_messages_chained", rotated_probe)
+        monkeypatch.setattr(log, "read_messages_chained_full", full_reader)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/rotate-race?limit=10&before=12")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        assert len(probes) >= 2, "archive state must be re-probed after composition"
+        assert full_reads, "an archive that appeared mid-request must route to the full reader"
+        assert data["total"] == 35
+        assert [message["content"] for message in data["messages"]] == [
+            f"old {i}" for i in range(2, 5)
+        ] + [f"msg {i}" for i in range(7)]
+        assert data["has_more"] is True
+        assert data["next_before"] == 2
+
+    @pytest.mark.asyncio
+    async def test_raw_and_durable_prefix_mismatch_uses_full_reader(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("mixed-prefix")
+        state.conversation_log.append("dashboard:mixed-prefix", "done", "")
+        state.conversation_log.append("dashboard:mixed-prefix", "user", "msg 1")
+        state.conversation_log.append("dashboard:mixed-prefix", "user", "msg 2")
+        slot.append("user", "msg 2")
+        slot.drain()
+        slot._disk_older_count = 2
+        slot._disk_older_durable_count = 1
+
+        real = state.conversation_log.read_messages_chained_page
+        bounded_calls = 0
+
+        def counting_page(*args, **kwargs):
+            nonlocal bounded_calls
+            bounded_calls += 1
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(state.conversation_log, "read_messages_chained_page", counting_page)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/mixed-prefix?limit=10")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        assert bounded_calls == 0
+        assert data["total"] == 2
+        assert [message["content"] for message in data["messages"]] == [
+            "msg 1",
+            "msg 2",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_bounded_composition_retries_on_chain_revision_change(
+        self, tmp_path, monkeypatch
+    ):
+        state = await self._slot_with_history(tmp_path, monkeypatch, "revision-race", count=30)
+        log = state.conversation_log
+        real = log.read_messages_chained_page
+        inserted = False
+
+        def append_between_ranges(key, *, limit, before=None, expected_revision=None):
+            nonlocal inserted
+            page = real(
+                key,
+                limit=limit,
+                before=before,
+                expected_revision=expected_revision,
+            )
+            if not inserted:
+                inserted = True
+                log.append(key, "assistant", "foreign mid-read")
+            return page
+
+        monkeypatch.setattr(log, "read_messages_chained_page", append_between_ranges)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.get("/api/chat/slots/revision-race?limit=50")
+            assert resp.status == 200, await resp.text()
+            data = await resp.json()
+
+        contents = [message["content"] for message in data["messages"]]
+        assert contents == [f"msg {i}" for i in range(30)] + ["foreign mid-read"]
+
+    @pytest.mark.asyncio
+    async def test_cursor_branch_reads_bounded_page_off_the_loop_thread(
+        self, tmp_path, monkeypatch
+    ):
+        """The bounded reader must run away from the loop serving other requests."""
         state = await self._slot_with_history(tmp_path, monkeypatch, "offloop")
         log = state.conversation_log
-        real = log.read_messages_chained_full
+        real = log.read_messages_chained_page
         seen: list[int] = []
 
-        def recording(key):
+        def recording(key, *, limit, before=None, expected_revision=None):
             seen.append(threading.get_ident())
-            return real(key)
+            return real(
+                key,
+                limit=limit,
+                before=before,
+                expected_revision=expected_revision,
+            )
 
-        monkeypatch.setattr(log, "read_messages_chained_full", recording)
+        monkeypatch.setattr(log, "read_messages_chained_page", recording)
         loop_thread = threading.get_ident()
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.get("/api/chat/slots/offloop?limit=5")
             assert resp.status == 200
-        assert seen, "read_messages_chained_full was never called"
+        assert seen, "read_messages_chained_page was never called"
         assert loop_thread not in seen
 
     @pytest.mark.asyncio
@@ -2193,13 +2319,13 @@ class TestSlotDetailPagination:
 
         loop_thread = threading.get_ident()
         seen: dict[str, int] = {}
-        original = ch._append_unflushed_tail
+        original = ch._append_unflushed_tail_from_offset
 
         def spy(*args, **kwargs):
             seen["thread"] = threading.get_ident()
             return original(*args, **kwargs)
 
-        monkeypatch.setattr(ch, "_append_unflushed_tail", spy)
+        monkeypatch.setattr(ch, "_append_unflushed_tail_from_offset", spy)
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.get("/api/chat/slots/offloop?limit=10")
@@ -21145,7 +21271,7 @@ class TestUnflushedTailOrderingAndSnapshot:
         slot.messages.append(owed)
         assert owed["meta"]["mid"] not in disk_mids, "fixture row must be un-persisted"
 
-        original = ch._append_unflushed_tail
+        original = ch._append_unflushed_tail_from_offset
         seen: dict[str, object] = {}
 
         def worker_entered(slot_arg, all_msgs_arg, **kwargs):
@@ -21157,7 +21283,7 @@ class TestUnflushedTailOrderingAndSnapshot:
             ]
             return original(slot_arg, all_msgs_arg, **kwargs)
 
-        monkeypatch.setattr(ch, "_append_unflushed_tail", worker_entered)
+        monkeypatch.setattr(ch, "_append_unflushed_tail_from_offset", worker_entered)
 
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.get("/api/chat/slots/loopsnap?limit=10")

--- a/test/test_history_pagination_projection.py
+++ b/test/test_history_pagination_projection.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import functools
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import history_projection
+from kiro_crew.history import ConversationLog
+from kiro_crew.jsonl_util import OversizedRecord, strict_raw_records_with_offsets
+
+
+def _write_transcript(
+    log: ConversationLog,
+    key: str,
+    count: int,
+    *,
+    tab_id: str | None = None,
+    start: int = 0,
+) -> None:
+    path = log._path(key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {"_type": "metadata", "created_at": "2026-09-03T00:00:00+00:00"}
+    if tab_id is not None:
+        metadata["tab_id"] = tab_id
+    lines = [json.dumps(metadata)]
+    lines.extend(
+        json.dumps(
+            {
+                "role": "user" if row % 2 == 0 else "assistant",
+                "content": f"message-{row}",
+                "ts": f"2026-09-03T00:00:{row % 60:02d}+00:00",
+            }
+        )
+        for row in range(start, start + count)
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    log._invalidate_cache(key)
+    log.invalidate_tab_id_cache()
+
+
+def test_offset_reader_reports_exact_universal_newline_boundaries(tmp_path: Path) -> None:
+    path = tmp_path / "records.jsonl"
+    path.write_bytes(b'{"a":1}\r\n{"a":2}\r{"a":3}\n{"a":4}')
+
+    with path.open("rb") as handle:
+        records = list(strict_raw_records_with_offsets(handle, path))
+
+    assert records == [
+        (0, 9, b'{"a":1}\r\n'),
+        (9, 17, b'{"a":2}\r'),
+        (17, 25, b'{"a":3}\n'),
+        (25, 32, b'{"a":4}'),
+    ]
+    for start, end, raw in records:
+        assert path.read_bytes()[start:end] == raw
+
+
+def test_chained_page_matches_full_projection(tmp_path: Path) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    _write_transcript(log, "dashboard:chat-a", 120, tab_id="shared-tab", start=0)
+    _write_transcript(log, "dashboard:chat-b", 140, tab_id="shared-tab", start=120)
+
+    expected = log.read_messages_chained("dashboard:chat-b")
+    newest = log.read_messages_chained_page("dashboard:chat-b", limit=100)
+    older = log.read_messages_chained_page("dashboard:chat-b", limit=100, before=newest.next_before)
+    oldest = log.read_messages_chained_page("dashboard:chat-b", limit=100, before=older.next_before)
+
+    assert newest.total == 260
+    assert newest.has_more is True
+    assert newest.next_before == 160
+    assert older.next_before == 60
+    assert oldest.next_before == 0
+    assert oldest.has_more is False
+    assert oldest.messages + older.messages + newest.messages == expected
+
+
+def test_page_index_updates_after_append(tmp_path: Path) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:append"
+    _write_transcript(log, key, 20)
+    first = log.read_messages_chained_page(key, limit=5)
+    assert [row["content"] for row in first.messages] == [f"message-{i}" for i in range(15, 20)]
+
+    log.append(key, "assistant", "new-tail")
+    second = log.read_messages_chained_page(key, limit=5)
+
+    assert second.total == 21
+    assert [row["content"] for row in second.messages] == [
+        "message-16",
+        "message-17",
+        "message-18",
+        "message-19",
+        "new-tail",
+    ]
+
+
+def test_warm_page_decodes_only_page_plus_one_index_stride(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:large"
+    _write_transcript(log, key, 10_000)
+    log.read_messages_chained_page(key, limit=100)
+
+    real = history_projection.strict_raw_records_with_offsets
+    reads: list[int] = []
+
+    def counting_records(*args, **kwargs):
+        reads.append(0)
+        at = len(reads) - 1
+        for record in real(*args, **kwargs):
+            reads[at] += 1
+            yield record
+
+    monkeypatch.setattr(history_projection, "strict_raw_records_with_offsets", counting_records)
+    page = log.read_messages_chained_page(key, limit=100, before=9_000)
+
+    assert len(page.messages) == 100
+    assert reads
+    assert max(reads) <= 100 + history_projection._TRANSCRIPT_PAGE_INDEX_STRIDE + 1
+    assert len(log._msg_cache) == 0, "bounded paging must not retain the full parsed transcript"
+
+
+def test_larger_same_inode_rewrite_rebuilds_index_from_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:larger-rewrite"
+    _write_transcript(log, key, 1_000)
+    log.read_messages_chained_page(key, limit=100)
+    inode = log._path(key).stat().st_ino
+
+    _write_transcript(log, key, 1_200, start=5_000)
+    assert log._path(key).stat().st_ino == inode
+
+    real = history_projection.strict_raw_records_with_offsets
+    reads: list[int] = []
+
+    def counting_records(*args, **kwargs):
+        reads.append(0)
+        at = len(reads) - 1
+        for record in real(*args, **kwargs):
+            reads[at] += 1
+            yield record
+
+    monkeypatch.setattr(history_projection, "strict_raw_records_with_offsets", counting_records)
+    page = log.read_messages_chained_page(key, limit=100)
+
+    assert page.total == 1_200
+    assert [row["content"] for row in page.messages] == [
+        f"message-{row}" for row in range(6_100, 6_200)
+    ]
+    assert reads
+    assert max(reads) >= 1_200, "a changed revision must rebuild from byte zero"
+
+
+def test_expected_revision_rejects_between_read_rewrite(tmp_path: Path) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:revision"
+    _write_transcript(log, key, 20)
+    first = log.read_messages_chained_page(key, limit=5)
+
+    _write_transcript(log, key, 8)
+
+    with pytest.raises(history_projection.TranscriptRevisionChanged):
+        log.read_messages_chained_page(
+            key,
+            limit=5,
+            expected_revision=first.revision,
+        )
+
+
+def test_fallback_retries_when_chain_changes_after_full_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:chat-fallback-base"
+    _write_transcript(log, key, 10, tab_id="fallback-tab")
+    projection = log._read_projection
+
+    real_once = projection._read_messages_chained_page_once
+
+    def unstable_page_once(*args, **kwargs):
+        page, indexed = real_once(*args, **kwargs)
+        stale = [
+            (chained_key, index._replace(stamp=(0, 0, 0, 0))) for chained_key, index in indexed
+        ]
+        return page, stale
+
+    monkeypatch.setattr(projection, "_read_messages_chained_page_once", unstable_page_once)
+
+    real_full = projection.read_messages_chained
+    inserted = False
+
+    def full_then_insert(chained_key: str) -> list[dict]:
+        nonlocal inserted
+        messages = real_full(chained_key)
+        if not inserted:
+            _write_transcript(
+                log,
+                "dashboard:chat-fallback-later",
+                1,
+                tab_id="fallback-tab",
+                start=10,
+            )
+            inserted = True
+        return messages
+
+    monkeypatch.setattr(projection, "read_messages_chained", full_then_insert)
+
+    page = log.read_messages_chained_page(key, limit=20)
+
+    assert page.total == 11
+    assert [row["content"] for row in page.messages] == [f"message-{row}" for row in range(11)]
+    assert [revision_key for revision_key, _stamp, _generation in page.revision] == [
+        "dashboard:chat-fallback-base",
+        "dashboard:chat-fallback-later",
+    ]
+
+
+def test_index_scan_oserror_is_not_a_valid_empty_page(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:index-io-error"
+    _write_transcript(log, key, 3)
+
+    def fail_scan(*_args, **_kwargs):
+        raise OSError("transient read failure")
+
+    monkeypatch.setattr(history_projection, "strict_raw_records_with_offsets", fail_scan)
+
+    with pytest.raises(OSError, match="transient read failure"):
+        log.read_messages_chained_page(key, limit=3)
+    assert key not in log._page_index_cache
+
+
+def test_invalid_utf8_is_not_a_valid_truncated_page(tmp_path: Path) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:index-invalid-utf8"
+    path = log._path(key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b'{"_type":"metadata","created_at":"2026-09-03T00:00:00+00:00"}\n'
+        b'{"role":"user","content":"before","ts":"2026-09-03T00:00:00+00:00"}\n'
+        b'{"role":"assistant","content":"\xff","ts":"2026-09-03T00:00:01+00:00"}\n'
+        b'{"role":"user","content":"after","ts":"2026-09-03T00:00:02+00:00"}\n'
+    )
+    log._invalidate_cache(key)
+
+    with pytest.raises(UnicodeDecodeError):
+        log.read_messages_chained_page(key, limit=3)
+    assert key not in log._page_index_cache
+
+
+def test_equal_size_rewrite_during_full_read_does_not_publish_stale_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:equal-size-rewrite"
+    _write_transcript(log, key, 300)
+    path = log._path(key)
+    original = path.read_bytes()
+    # Same byte length, shifted record boundaries: row 1 grows by one byte and
+    # the last row shrinks by one, so every checkpoint offset between them moves
+    # while the size the old code compared against stays identical.
+    rewritten = original.replace(b'"message-1"', b'"message-1X"', 1)
+    rewritten = rewritten.replace(b'"message-299"', b'"message-29"', 1)
+    assert len(rewritten) == len(original) and rewritten != original
+
+    real_get_running_loop = history_projection.asyncio.get_running_loop
+    original_stamp = history_projection.TranscriptReadProjection._file_stamp(path)
+    landed = False
+
+    def replace_then_report_off_loop():
+        # Called by the full reader immediately AFTER the bytes were read and
+        # BEFORE the warmed index is stamped and published. Other callers probe
+        # the loop too (metadata reads), so gate on the reader's own frame.
+        nonlocal landed
+        caller = sys._getframe(1).f_code.co_name
+        if not landed and caller == "_read_messages_locked":
+            landed = True
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_bytes(rewritten)
+            tmp.replace(path)
+        return real_get_running_loop()
+
+    published: list[tuple[tuple, tuple]] = []
+    real_publish = log._publish_if_current
+
+    def recording_publish(cache, cache_key, entry, *args, **kwargs):
+        if cache is log._page_index_cache:
+            published.append((entry.stamp, entry.checkpoints))
+        return real_publish(cache, cache_key, entry, *args, **kwargs)
+
+    monkeypatch.setattr(
+        history_projection.asyncio, "get_running_loop", replace_then_report_off_loop
+    )
+    monkeypatch.setattr(log, "_publish_if_current", recording_publish)
+    messages = log.read_messages_chained(key)
+    monkeypatch.undo()
+
+    assert landed and len(messages) == 300
+    current_stamp = history_projection.TranscriptReadProjection._file_stamp(path)
+    log._page_index_cache.pop(key, None)
+    fresh = log._read_projection._row_index(key)
+    assert fresh.stamp == current_stamp
+    for stamp, checkpoints in published:
+        assert stamp != original_stamp, "the replaced revision must never be published"
+        if stamp == current_stamp:
+            assert checkpoints == fresh.checkpoints, "new stamp paired with stale offsets"
+
+    page = log.read_messages_chained_page(key, limit=5)
+    on_disk = [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line and json.loads(line).get("_type") != "metadata"
+    ]
+    assert page.total == 300
+    assert page.messages == on_disk[-5:]
+    assert page.messages[-1]["content"] == "message-29"
+
+
+def test_oversized_row_aborts_indexed_page_instead_of_undercounting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:oversized-row"
+    _write_transcript(log, key, 5)
+    log.append(key, "assistant", "x" * 2_000)
+    log.append(key, "user", "after-big")
+
+    real = history_projection.strict_raw_records_with_offsets
+    monkeypatch.setattr(
+        history_projection,
+        "strict_raw_records_with_offsets",
+        functools.partial(real, cap=1_000),
+    )
+
+    with pytest.raises(OversizedRecord):
+        log.read_messages_chained_page(key, limit=3)
+    assert key not in log._page_index_cache
+    # The authoritative reader has no per-record cap and still serves every row.
+    assert [row["content"] for row in log.read_messages_chained(key)][-2:] == [
+        "x" * 2_000,
+        "after-big",
+    ]
+
+
+def test_off_loop_full_read_warms_first_page_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = ConversationLog(base_dir=tmp_path)
+    key = "dashboard:restore-warm"
+    _write_transcript(log, key, 10_000)
+
+    real = history_projection.strict_raw_records_with_offsets
+    reads: list[int] = []
+
+    def counting_records(*args, **kwargs):
+        reads.append(0)
+        at = len(reads) - 1
+        for record in real(*args, **kwargs):
+            reads[at] += 1
+            yield record
+
+    monkeypatch.setattr(history_projection, "strict_raw_records_with_offsets", counting_records)
+    assert len(log.read_messages_chained(key)) == 10_000
+    assert reads == [], "the authoritative full parse must not scan the file twice"
+    entry = log._page_index_cache.get(key)
+    assert entry is not None and entry.row_count == 10_000
+
+    page = log.read_messages_chained_page(key, limit=100)
+
+    assert len(page.messages) == 100
+    assert reads
+    assert max(reads) <= 100 + history_projection._TRANSCRIPT_PAGE_INDEX_STRIDE + 1


### PR DESCRIPTION
## Problem / Motivation

Chat history is paginated at the API boundary but not at the storage boundary. Each bounded slot-detail request currently parses the complete chained JSONL history before selecting the requested rows.

This makes gateway work scale with total conversation length and repeats complete-history parsing as users load older pages.

## Why it matters

Long agent conversations commonly contain thousands of messages and large tool results. Repeated complete-history parsing increases page latency, gateway CPU, and peak memory despite the browser requesting only a bounded window.

For a 10,000-row transcript, the existing full-read baseline was approximately 97.7 ms and 10.7 MiB. The bounded restore-warmed reader completes in approximately 3.77 ms and 70 KiB.

## What changed (motivation → approach → change)

This change keeps JSONL as the authoritative transcript while adding a gateway-owned sparse read projection:

- Adds offset-preserving bounded JSONL framing.
- Maintains trusted in-memory row checkpoints keyed by full file stamp and history generation.
- Builds checkpoints during authoritative off-loop full reads instead of scanning restored transcripts twice.
- Rebuilds the sparse index from byte zero on any file-stamp (mtime_ns, size, inode, device) or invalidation-generation change; only an exact revision reuses checkpoints.
- Adds `ConversationLog.read_messages_chained_page` with existing `total`, `before`, `next_before`, and `has_more` semantics.
- Pins all durable ranges composing one HTTP response to an exact ordered chain revision.
- Retries complete page composition after concurrent mutation and falls back to the legacy full-reader oracle after repeated churn.
- Reconciles bounded durable ranges with the existing event-loop-captured resident and unflushed tail.
- Switches only explicitly paginated slot-detail requests to the bounded path.
- Leaves unlimited reads and callers requiring complete history unchanged.
- Keeps redaction at the existing response-preparation boundary.
- Documents the index, invalidation, revision, fallback, and trust contracts.

The sparse index is deliberately not persisted. It contains only row counts and byte offsets and never trusts agent-writable derived state.

This change is independent of #7916: that PR handles archive reachability and browser scroll stability, while this PR bounds gateway storage work for the current chained transcript. If archive pagination lands later, its archive segments should be incorporated into this bounded projection rather than returning to complete-corpus reads.

## Tests

Added and updated coverage for:

- exact page equivalence across transcript chains;
- boundary, `before`, `next_before`, `has_more`, and total semantics;
- universal newline and byte-offset framing;
- bounded warm reads over a 10,000-row transcript;
- restore-time index warming without a second scan;
- rebuild-from-zero after appends and after larger same-inode rewrites (no stale checkpoint reuse);
- rebuilds after rewrites and invalidation;
- concurrent revision changes between response ranges;
- complete-response retry and legacy fallback;
- live and unflushed tail ordering;
- loop-captured tail snapshots;
- shared cached-list identity;
- fork, rewind, cache, and locking compatibility.

Validation:

- 838 affected tests passed
- Targeted mypy passed
- Targeted Flake8 passed
- Black and isort checks passed
- Documentation lint passed
- Subprocess-encoding, agent-SDK boundary, sync-I/O, lockdown, brand, harness, lock, testpath, changelog, focus, vendor-manifest, scrub-lint, and CloudFormation gates passed
- Frontend scoped tests, TypeScript, ESLint, i18n, phantom-class, duplication, production build, and bundle-size gates passed
- Electron gate: 1,558 passed with zero assertion failures; one unrelated gateway-stop timing test remained pending on this host and Node cancelled it plus 25 descendants
- Full backend run: 83,756 passed; remaining failures were unrelated host-isolation, inherited command-environment, ownership-topology, and AF_UNIX path limitations. No changed history, JSONL, pagination, fork, or dashboard-chat test failed.

## Manual verification

Reader-level profiling:

| Rows | Full read + index | Process-cold page | Warm page |
|---:|---:|---:|---:|
| 100 | 2.428 ms / 118 KiB | 5.308 ms / 75 KiB | 2.765 ms / 69 KiB |
| 1,000 | 14.629 ms / 1.05 MiB | 23.155 ms / 76 KiB | 3.014 ms / 70 KiB |
| 10,000 | 141.661 ms / 10.47 MiB | 201.805 ms / 85 KiB | **3.766 ms / 70 KiB** |

A first-ever process-cold page still performs O(total rows) index construction. This PR does not claim constant-time process-cold opening.

## Related Issues

Fixes #8234.

## Checklist

- [x] One commit with a Conventional Commits title
- [x] Existing affected tests pass and new tests cover the new behavior
- [x] Self-review completed; code follows project style guidelines
- [x] History-system documentation updated
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The exact CLA wording will be supplied by OSPO before the first public PR.
