### PR TITLE
feat(acp): harness descriptors, registry, and capability gates as config data

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -26,6 +26,7 @@
         "mcp_quarantine_after_failures": 3,
         "acp_backend": "",
         "member_acp_backend": "kas",
+        "default_harness": "",
         "default_agent": "",
         "sweep_agents_backups": false,
         "sandbox": "auto",
@@ -286,6 +287,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": "kas"
+    },
+    {
+      "path": "agent.default_harness",
+      "kind": "core",
+      "type": "string",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Default Harness",
+      "help": "Harness id new sessions start on when no explicit selection is made. Empty means kiro-cli. A value naming a harness that is unknown or unavailable degrades to kiro-cli with a logged reason, so a typo never stops the gateway. Bundled ids: 'kiro', 'kas', 'codex', 'claude'; an operator harness uses its id from harnesses.json.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": ""
     },
     {
       "path": "agent.default_agent",

--- a/docs/system-specs/modules/README.md
+++ b/docs/system-specs/modules/README.md
@@ -13,8 +13,9 @@ agent loads only the one it needs.
 | Spec | Subsystem |
 |---|---|
 | [acp-client.md](acp-client.md) | The ACP JSON-RPC client that drives `kiro-cli`: transport, framing, timeouts, and the backend seam. |
-| [providers.md](providers.md) | The `LLMProvider` interface and the KiroACP-only provider surface. |
+| [providers.md](providers.md) | The `LLMProvider` interface, the single ACP provider surface, and the harness registry that makes the harness behind it data. |
 | [harness-parity.md](harness-parity.md) | The invariants keeping the Kiro harness first-class while other harnesses are adapted, and the test pinning each. |
+| [harness-authoring.md](harness-authoring.md) | Authoring an operator harness descriptor: where the config lives, every field and its validation rule, what the capability flags do, and a worked third-party ACP example. |
 | [harness-onboarding.md](harness-onboarding.md) | The sequence a new ACP harness walks to land: vocabulary, capability decisions, spawn path, handshake, install probe, selectability, and what a live harness additionally touches. |
 | [kas-backend.md](kas-backend.md) | The second, adapted ACP backend: how Crew selects and adapts it (the `kas_wire` seam, harness-parity, ABC defaults) and the deferred hooks / transport / `/clear` items. Crew-side only. |
 | [session.md](session.md) | Sessions, slots, session keys, the warm pool, and PID tracking. |

--- a/docs/system-specs/modules/harness-authoring.md
+++ b/docs/system-specs/modules/harness-authoring.md
@@ -1,0 +1,205 @@
+# Authoring an operator harness descriptor
+
+An **operator descriptor** teaches Kiro Crew to drive a harness Kiro Crew does
+not bundle — any agent process that speaks public ACP over stdio. It is pure
+configuration: an id, an executable, an argv template, a capability set, a model
+source, and an MCP-delivery mode. No code ships with it — an operator descriptor
+gets the generic adapter (`GenericAdapter`), whose every step is the standard
+rule (PATH/absolute resolution, pure template rendering through the same
+attestation seam the bundled harnesses use). A harness whose invocation cannot be
+expressed as data belongs in `acp/harness_adapters.py` as a reviewed bundled
+adapter, not here.
+
+This page is the reference for what a descriptor field means and how it is
+validated; the invariants that keep an added harness from disturbing the Kiro
+path are in [harness-parity.md](harness-parity.md), and the provider/registry
+model it plugs into is in [providers.md](providers.md).
+
+## Where the descriptors live
+
+Operator descriptors live in **`harnesses.json`**, a dedicated file beside
+`config.json` (`~/.kiro/crew/harnesses.json` by default), keyed by harness id:
+
+```jsonc
+{
+  "agy": {
+    "display_name": "AGY",
+    "executable": "agy-acp",
+    "argv": ["{executable}", "acp", "--workdir", "{workdir}"],
+    "model_args": ["--model", "{model}"],
+    "capabilities": {},
+    "model_source": "acp_advertised",
+    "mcp_delivery": "wire_fed"
+  }
+}
+```
+
+A dedicated file rather than a config key, deliberately: a descriptor names a
+binary Kiro Crew spawns as itself, and no loader clamp can bound that value —
+so the file is **write-protected against the agent's own tools on both paths**
+(the file-edit gate and shell redirects alike; reads through the file-read
+tool stay open, the file holds no secret). `config.json` could not carry the
+key safely because it must remain freely shell-readable, which leaves shell
+redirects open there. This is the same relocation the repo applies to every
+value that is an input to a security decision (the browse launch config, the
+computer-use policy, the on-call rotation record). Only an operator editing
+the file directly — outside an agent session — can author a descriptor.
+
+Edit the file, then the descriptor is picked up on the next registry load. The
+consumer surfaces land in the following parts of this stack: `GET
+/api/harnesses` and **Settings → AI Backend** (part 3) list it alongside the
+bundled rows once they ship. A descriptor that fails validation is not
+silently dropped: the registry retains it under its `invalid` map with a
+field-named reason, which those surfaces render inline (R6.1).
+
+To make the harness the default for unselected sessions, set the
+`agent.default_harness` config key to its id (a config key is safe here: it
+only selects among already-registered ids, and an unknown or unavailable value
+degrades to kiro-cli; honored once session selection lands in part 2); to bind
+a single chat, pick it in the chat composer's harness picker
+(part 3 — see [providers.md](providers.md) § Chat composer).
+
+## A worked example: AGY, a third-party ACP adapter server
+
+AGY is a fictional third-party agent shipped as its own ACP adapter binary
+(`agy-acp`) on `PATH`. It speaks public ACP over stdio, advertises its models
+over `session/new`, takes MCP servers on the wire, and has no bespoke Kiro Crew
+adapter — the shape an operator descriptor is for. The descriptor above is
+complete. Reading it field by field:
+
+- **`agy`** (the key) is the harness id. Lowercase letters, digits, and hyphens
+  only, ≤ 32 characters, unique across bundled and operator harnesses. It is the
+  stable handle everything references: `agent.default_harness`, the composer
+  pick, `GET /api/models?harness=agy`, the session-map binding.
+- **`display_name: "AGY"`** is the human-facing name in the picker and Settings.
+  Optional — it falls back to the id.
+- **`executable: "agy-acp"`** is resolved at spawn. A bare name is found on
+  `PATH` (plus Kiro Crew's augmented-PATH helper — mise shims, per-version
+  manager bins); an **absolute path** is honored as-is. A **relative path is
+  refused** — only an absolute path or a bare PATH name is legal, because a
+  relative path resolves against a working directory that is not the operator's
+  and would exec bytes nobody attested.
+- **`argv: ["{executable}", "acp", "--workdir", "{workdir}"]`** is the ordered
+  token list rendered to argv (never through a shell). The **first token must be
+  `{executable}`** so the trust-attested executable is the one that execs — a
+  literal first token would exec bytes the attestation never checked. Placeholders
+  are a closed vocabulary: `{executable}`, `{agent}`, `{model}`, `{workdir}`. An
+  unknown placeholder or an unbalanced brace (`--dir={workdir`) is a
+  registration-time reason, not a half-working spawn.
+- **no `agent_args`** — AGY has no `--agent` convention, so the block is omitted.
+  An omitted convention block is dropped entirely rather than defaulted, so AGY
+  does not inherit kiro-cli's `--agent` flag.
+- **`model_args: ["--model", "{model}"]`** is the optional model convention,
+  emitted **only when a model is pinned**. With no model selected the whole block
+  is dropped — AGY runs on its own default — rather than execing an empty
+  `--model` argument.
+- **`capabilities: {}`** — empty, which means **every capability is off** (see
+  below).
+- **`model_source: "acp_advertised"`** — AGY's models come from what a live
+  session advertised over `session/new`.
+- **`mcp_delivery: "wire"`** — AGY reads no config file of ours, so MCP servers
+  are delivered over `session/new`.
+
+### The placeholder-block rule
+
+`{model}` is only meaningful in `model_args` and `{agent}` only in `agent_args`,
+because those are the blocks `render_argv` gates on a value being present. Using
+either in the ungated `argv` block — or in each other's block — is **refused at
+validation**: outside its gated block the placeholder renders to the empty string
+whenever the value is absent, execing a silent empty argument (`--model=` or a
+bare `""`). `{executable}` and `{workdir}` carry no gating and are legal in every
+block.
+
+So `argv: ["{executable}", "--model", "{model}"]` is rejected — put the model
+flag in `model_args`, where it is emitted only when a model is actually pinned.
+
+## Every descriptor field and its validation rule
+
+| Field | Required | Rule |
+|---|---|---|
+| `id` (map key) | yes | Non-empty; lowercase letters/digits/hyphens; ≤ 32 chars; unique across all harnesses. |
+| `display_name` | no | Any string; falls back to the id when empty. |
+| `executable` | yes | Non-empty. Absolute path, or a bare PATH-resolvable name. Relative paths are refused; resolution + trust attestation happen at spawn. |
+| `argv` | yes | A sequence of string tokens (not a bare string), non-empty, first token exactly `{executable}`. Each token: only closed-vocabulary placeholders, no unbalanced braces, `{model}`/`{agent}` not used here. |
+| `agent_args` | no | Sequence of string tokens; `{agent}` legal here (and only here); emitted only when an agent is selected. |
+| `model_args` | no | Sequence of string tokens; `{model}` legal here (and only here); emitted only when a model is pinned. |
+| `capabilities` | no | An object whose keys are the known capability names, each a strict `true`/`false`. Unknown key or non-bool value is refused. Absent ⇒ all off. |
+| `model_source` | no | One of `acp_advertised` (default) or `static`. `static` **requires** a non-empty `models` list. |
+| `models` | when `static` | Sequence of non-empty strings; consulted only when `model_source` is `static`. |
+| `mcp_delivery` | no | One of the delivery modes (`wire` for a harness that reads no config of ours; default is wire-fed). |
+| `adapter` | — | **Operator descriptors cannot set this.** Naming a bundled adapter is reviewed-code-only, so configuration can never select code. |
+
+A validation failure names the field and the fix (e.g. `harness 'agy': argv
+template must start with {executable} …`), surfaced both at config load and on the
+Settings row — not only in logs (R6.1).
+
+## What the capability flags do, and why undeclared means off
+
+A descriptor's `capabilities` object is opt-in membership. Each flag Kiro Crew
+reads off the session's **bound descriptor** at the call site that gates a
+behavior; an undeclared flag reads `false`, **fail-closed**. The flags:
+
+| Capability | Config-grantable? | When set | When unset (the fail-closed default) |
+|---|---|---|---|
+| `internal_sandbox` | **no — code-only** | Kiro Crew skips its own sandbox in favour of the harness's own | **Kiro Crew wraps the spawn** in its OS sandbox (Linux `unshare`, macOS Seatbelt) |
+| `session_sharing` | **no — code-only** | the harness may host multiplexed subagent sessions on one process | one process per session |
+| `steer` | yes | mid-turn steer messages are delivered | steer is withheld |
+| `acp_runtime_pool` | **no — code-only** | the harness takes effort from the workspace `cli.json` overlay and pools runtimes | one process per session, no overlay |
+| `kiro_identity_store` | **no — code-only** | the harness is retired by an external `kiro-cli logout` (kiro identity sweep) | no identity sweep watches it |
+| `mcp_tool_search` | yes | the Tool Search `cli.json` overlay is written | no overlay |
+| `reasoning_effort` | yes | the effort slider/`/effort` control is offered | no effort control |
+
+**Code-only means an operator descriptor cannot claim it at all**: the four
+flags marked code-only are honoured by machinery written for specific bundled
+harnesses (kiro-cli's internal sandbox, the shared `AcpRuntime`'s kiro dialect,
+kiro's session demux, kiro-cli's login store), so a config grant would not
+light the feature up — it would point trusted machinery at a process that
+never earned it. `internal_sandbox` is the sharpest case: granted to a binary
+with no internal sandbox, the agent process runs with **no sandbox at all**.
+A descriptor whose `capabilities` object names any of them — even as `false` —
+is refused with a per-key reason and excluded from selection, like every other
+validation failure. Granting one to a new harness is a code change in
+`acp/harness_registry.py`, where the honouring code can be reviewed alongside
+the claim.
+
+An empty `capabilities` (AGY's case) therefore gets: Kiro Crew's own sandbox
+wraps every spawn, no session sharing, no steer, no cli.json overlays, and no
+identity sweep. That is the correct default for a harness whose isolation and
+feature support Kiro Crew has not demonstrated: a capability granted by the
+**absence** of a check is exactly the silent-capture failure harness-parity
+exists to prevent (see [harness-parity.md](harness-parity.md) Group B).
+
+## How availability and serviceability render
+
+Two independent gates decide how a row appears in the picker and in Settings:
+
+- **`available`** describes the machine: it is `true` when the executable
+  resolves at listing time. Availability is lazy and non-blocking — installing
+  the binary heals the row on the next listing with no gateway restart, and one
+  unavailable harness never hides the others. An unavailable row stays visible,
+  marked, and unselectable with its reason.
+- **`serviceable`** describes this build. Every operator descriptor that speaks
+  public ACP is serviceable — the row serves as soon as its binary resolves.
+  (The only unserviceable bundled row is Claude Code, held back by the
+  public-build posture; an operator descriptor naming `claude-agent-acp` is
+  itself legal and serviceable.)
+
+Both gates are shown in the picker and in the Settings inventory; a row is
+selectable only when both pass. Invalid descriptors never appear as selectable
+rows — they are listed under `invalid` with their field-named reason.
+
+## Where models come from
+
+`model_source` decides how `GET /api/models?harness=agy` answers:
+
+- **`acp_advertised`** (AGY's case) reads what a **live session on that harness**
+  advertised in its `session/new` response. Before any session has started the
+  catalog is empty (`[]`) — the models appear once the harness has run once. This
+  is the right default for a harness that enumerates its own models over ACP.
+- **`static`** reads the descriptor's own `models` list and requires it to be
+  non-empty. Use it for a harness that cannot enumerate models over ACP; an empty
+  `static` list is a validation error, not an empty dropdown.
+
+A model id belongs to one harness's namespace and is never compared across
+harnesses; picking a harness drops a model carried over from a different one, so
+a session never binds a model the chosen harness never advertised.

--- a/src/kiro_crew/acp/harness_adapters.py
+++ b/src/kiro_crew/acp/harness_adapters.py
@@ -1,0 +1,650 @@
+"""Harness adapters: the reviewed code one bundled harness needs, and no more.
+
+A :class:`~kiro_crew.acp.harness_descriptor.HarnessDescriptor` says what a
+harness IS; an adapter carries the few steps that cannot be said as data —
+resolving an executable that is not simply a PATH name, contributing argv a
+token template cannot express, and mutating the child environment before exec.
+
+Only a bundled descriptor may name an adapter (the ``ADAPTER_*`` vocabulary); an
+operator's descriptor is data and gets :class:`HarnessAdapter`, the base, whose
+every method is the generic rule. That asymmetry is the whole point of the split:
+configuration must never be able to select Python.
+
+Four properties hold across this module, and each method is written to keep them:
+
+- **The attested executable is the one that execs.** :func:`resolve_spawn_executable`
+  resolves a candidate and then attests it; :func:`checked_spawn_argv` refuses an
+  argv whose ``argv[0]`` is anything else. The second half is not redundant:
+  without it a descriptor whose template never mentions ``{executable}`` would
+  attest one path while ``exec`` resolved a bare name through ``PATH`` at spawn
+  time, and the attestation would read as protection while providing none.
+- **Attestation is uniform.** Bundled or operator, every harness executable goes
+  through the same gate kiro-cli has always taken (runnable, non-zero-byte, its
+  launch path pinned), so an operator harness is not a hole in it.
+- **Adapters do blocking work and say so.** Resolution stats the filesystem and
+  ``pre_spawn`` can write an agent spec, so every method here is synchronous and
+  the spawn path calls it from a worker thread.
+- **Nothing here imports the registry.** The registry serves descriptors and
+  derives availability from :func:`resolve_executable`, so the dependency runs one
+  way only: registry -> adapters -> descriptor.
+
+Deliberately NOT here: KAS's per-session custom-agent projection. It is not a
+spawn step — it runs per ``session/new`` — so it stays in ``AcpRuntime``, keyed
+positively off the backend as it is today. :meth:`HarnessAdapter.post_initialize`
+exists so that a harness whose post-handshake step DOES belong here can land
+without editing the spawn path (harness-parity H13).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping
+
+from kiro_crew import platform_compat
+from kiro_crew.acp.harness_descriptor import (
+    ADAPTER_CLAUDE,
+    ADAPTER_GENERIC,
+    ADAPTER_KAS,
+    ADAPTER_KIRO,
+    HarnessDescriptor,
+)
+from kiro_crew.acp.harness_descriptor import render_argv as render_argv_template
+from kiro_crew.acp.protocol_profile import (
+    KAS_PROFILE,
+    KIRO_PROFILE,
+    STANDARD_ACP_PROFILE,
+    ProtocolProfile,
+)
+from kiro_crew.env import augmented_path
+
+logger = logging.getLogger(__name__)
+
+
+class HarnessSpawnRefused(RuntimeError):
+    """A harness cannot be launched, with a reason that names the harness.
+
+    Raised instead of returning an empty argv so a caller cannot proceed with a
+    half-resolved command: every refusal here is terminal for that spawn, and
+    R6.3's rule is refusal over falling back to a different harness.
+    """
+
+
+class HarnessExecutableTrustError(HarnessSpawnRefused):
+    """Resolved harness bytes are not approved for credential-bearing ACP.
+
+    The one lineage for the attestation refusal, and it is harness-neutral: the
+    gate it reports was never kiro-specific (it asks whether a candidate is a
+    runnable, non-empty file) and every harness takes it, so naming one harness
+    in the exception made the others look exempt. ``AcpClient``'s own resolver
+    raises this too, so a caller catching it covers both session paths.
+    """
+
+
+# ── Candidate inspection ──
+
+
+def _is_spawnable_file(resolved: str) -> bool:
+    """Can ``resolved`` be launched as a program on THIS platform?
+
+    This is the spawn-a-binary question, deliberately NOT
+    ``platform_compat.is_executable_file`` — that predicate answers the
+    hooks/scripts question (on Windows it accepts only a known SCRIPT suffix
+    ``.sh/.ps1/.cmd/.bat/.py/.exe``), which would reject a real installed
+    ACP binary such as ``kiro-cli`` / ``agy-acp`` that carries no such suffix.
+
+    POSIX: unchanged — the file must carry an execute bit (``os.access(X_OK)``),
+    so a ``chmod -x`` still refuses it and the interrupted-install branch stays
+    intact.
+
+    Windows: there is NO POSIX execute bit (every file reports the same mode), so
+    an ``X_OK`` check would reject every candidate. Windows determines
+    runnability from the file extension via ``PATHEXT``, and PATH resolution
+    already went through ``shutil.which`` (which honours ``PATHEXT``); for an
+    explicit absolute path there is no bit left to check, so an existing regular
+    file is spawnable. The zero-byte guard (checked before this, below) still
+    refuses a truncated install on every platform.
+    """
+    if platform_compat.IS_WINDOWS:
+        return os.path.isfile(resolved)
+    return os.access(resolved, os.X_OK)
+
+
+def _candidate_problem(resolved: str) -> str:
+    """Why ``resolved`` cannot be spawned, or "" when it can.
+
+    One place for the three questions availability and spawn both ask — the
+    candidate exists, it is not empty, and it is an executable file — so every
+    resolver gives the same verdict for the same file, on every platform. They
+    are ordered so the reason names the actual defect: a path that is simply
+    absent reads as "does not exist" rather than as a permissions problem, which
+    is the difference between "install it" and "chmod it".
+
+    Emptiness is checked BEFORE executability so a zero-byte file gets the
+    "zero-byte file" reason on every platform (a truncated install keeps its
+    execute bit on POSIX, and on Windows there is no bit to distinguish it from a
+    non-executable at all) — the two spawn paths must agree that a truncated
+    binary is refused, and with one reason.
+    """
+    if not os.path.exists(resolved):
+        return f"{resolved} does not exist"
+    try:
+        if os.path.getsize(resolved) <= 0:
+            return f"{resolved} is a zero-byte file"
+    except OSError as exc:
+        return f"{resolved} could not be inspected ({exc.strerror or exc})"
+    if not _is_spawnable_file(resolved):
+        return f"{resolved} is not an executable file"
+    return ""
+
+
+def _resolve_kiro_cli_candidate(descriptor: HarnessDescriptor) -> tuple[str, str]:
+    """``(path, reason)`` for kiro-cli, shared by every harness the CLI serves.
+
+    The same ``kiro_cli.resolve_kiro_cli`` discovery ``AcpClient`` uses, so the
+    operator override, the fixed install locations, and the augmented PATH are
+    honoured identically by every spawn path — a bare ``shutil.which`` regressed
+    the runtime to "not found in PATH" once for a non-login gateway with a
+    ``~/.local/bin`` install.
+
+    That chain's own filter checks the execute bit everywhere but the zero-byte
+    case only on Windows, so the shared check runs here too: a truncated
+    ``~/.local/bin/kiro-cli`` (an interrupted install) is executable on POSIX and
+    would otherwise resolve, then exec into a process that exits with no ACP
+    frame.
+
+    Two harnesses resolve through it — the kiro backend and the KAS relay, which
+    IS a kiro-cli — and they must agree, because an operator who overrode the
+    binary did so for both.
+    """
+    # Deferred: kiro_cli reaches the platform layer and the environment, and this
+    # module is imported by the descriptor/registry side of the package.
+    from kiro_crew.kiro_cli import resolve_kiro_cli
+
+    resolved = resolve_kiro_cli()
+    if not resolved:
+        # Same searched-directories diagnostic AcpClient._spawn gives (#6497), so
+        # the runtime path names WHERE it looked — the fixed install locations and
+        # the KIROCREW_KIRO_BIN override, not just "PATH" — instead of a bare
+        # "not found". Shared with the client through the one canonical message so
+        # the two spawn paths cannot drift. Deferred import: acp.client imports
+        # this module, so a module-level import would be a cycle.
+        from kiro_crew.acp.client import kiro_cli_not_found_message
+
+        return "", kiro_cli_not_found_message(environ=os.environ, home=Path.home())
+    problem = _candidate_problem(resolved)
+    if problem:
+        return "", problem
+    return resolved, ""
+
+
+# ── Adapters ──
+
+
+class HarnessAdapter:
+    """The generic harness: everything an operator descriptor gets.
+
+    Every method is the data-only rule, and a bundled adapter overrides only the
+    ones its harness genuinely needs. Subclassing (rather than a dict of
+    callables) is what makes that partial: an adapter that needs a custom argv
+    does not thereby take over environment handling, so the number of behaviours
+    a harness can accidentally change is bounded by what it actually overrode.
+    """
+
+    #: The ``ADAPTER_*`` name a bundled descriptor selects this with; empty for
+    #: the base itself. No live descriptor resolves to the bare base —
+    #: adapter-less descriptors resolve to :class:`GenericAdapter` (``name`` =
+    #: ``ADAPTER_GENERIC``) — so this stays empty only for the abstract parent.
+    name = ""
+
+    def resolve_executable(self, descriptor: HarnessDescriptor) -> tuple[str, str]:
+        """``(path, reason)`` for the descriptor's executable; one is always empty.
+
+        Resolution only — nothing is executed and nothing is attested here, so a
+        listing can ask this question about every registered harness without
+        launching any of them or pinning a digest for one nobody selected.
+
+        The path a bundled adapter or an operator gave is used as-is when it is
+        absolute; a bare name goes through ``shutil.which``. Either way the
+        candidate must be an executable, non-empty file — a truncated or
+        non-executable candidate execs into an opaque "process exited" with no
+        ACP frame, and naming it here turns that into a readable reason.
+        """
+        candidate = descriptor.executable
+        if not candidate:
+            return "", "no executable is declared"
+        if os.path.isabs(candidate):
+            resolved = candidate
+        else:
+            found = shutil.which(candidate)
+            if not found:
+                return "", f"{candidate!r} was not found on PATH"
+            resolved = found
+        problem = _candidate_problem(resolved)
+        if problem:
+            return "", problem
+        return resolved, ""
+
+    def render_argv(
+        self,
+        descriptor: HarnessDescriptor,
+        *,
+        executable: str,
+        agent: str = "",
+        model: str = "",
+        workdir: str | os.PathLike[str] = "",
+    ) -> list[str]:
+        """The pre-sandbox argv for one spawn.
+
+        The default is pure template rendering, so the harnesses whose invocation
+        IS expressible as data — kiro-cli, Codex, every operator harness — share
+        one implementation and cannot drift from each other.
+        """
+        return render_argv_template(
+            descriptor,
+            executable=executable,
+            agent=agent,
+            model=model,
+            workdir=workdir,
+        )
+
+    def pre_spawn(
+        self,
+        descriptor: HarnessDescriptor,
+        *,
+        env: MutableMapping[str, str],
+        workdir: str,
+        agent: str,
+    ) -> None:
+        """Last chance to prepare the machine and the child environment.
+
+        Runs off the event loop, immediately before the environment scrub, so an
+        adapter may add a variable the scrub then vets — and cannot add one after
+        it.
+
+        The default strips kiro-cli's own API key: a foreign harness must never
+        receive it, and the failure direction of getting this wrong is silent
+        (the harness ignores an unknown variable while the key is exposed to it).
+        """
+        # Deferred: config.loader -> dashboard -> session -> acp would be a cycle
+        # at module scope. Matches the in-file convention in acp/runtime.py.
+        from kiro_crew.config.loader import strip_kiro_cli_api_key
+
+        strip_kiro_cli_api_key(env)
+
+    def post_initialize(self, descriptor: HarnessDescriptor, init_resp: Mapping[str, Any]) -> None:
+        """React to the harness's ACP ``initialize`` response.
+
+        No bundled harness needs this in the ``AcpRuntime`` path yet, and it is
+        declared anyway: an adapter whose post-handshake step lands later must be
+        able to do so without adding a branch to the spawn path, which is what
+        H13 asks of every added harness.
+        """
+
+    @property
+    def protocol_profile(self) -> ProtocolProfile:
+        """The ACP wire dialect this harness speaks.
+
+        The base — every operator descriptor and bundled Codex — speaks the
+        public ACP wire (:data:`STANDARD_ACP_PROFILE`): integer protocol version,
+        standard permission-option field names, ``session/set_config_option`` for
+        model/effort, and ``agent_thought_chunk`` reasoning updates. A bespoke
+        adapter overrides this only when its harness's wire genuinely differs.
+
+        This is a property so a caller reads the profile the same way whichever
+        adapter serves the descriptor, and so the wire decision lives on the
+        adapter rather than in an ``_is_claude`` branch of the client/runtime.
+        """
+        return STANDARD_ACP_PROFILE
+
+
+class KiroAdapter(HarnessAdapter):
+    """kiro-cli: the first-class harness (harness-parity H1, H9).
+
+    Its argv IS the descriptor template, so ``render_argv`` is inherited and the
+    ``--agent`` / ``--model`` conventions live in the descriptor as data. What
+    cannot be data is the two side effects below.
+    """
+
+    name = ADAPTER_KIRO
+
+    def resolve_executable(self, descriptor: HarnessDescriptor) -> tuple[str, str]:
+        """Resolve kiro-cli through its own candidate chain.
+
+        See :func:`_resolve_kiro_cli_candidate`, shared with the KAS relay.
+        """
+        return _resolve_kiro_cli_candidate(descriptor)
+
+    def pre_spawn(
+        self,
+        descriptor: HarnessDescriptor,
+        *,
+        env: MutableMapping[str, str],
+        workdir: str,
+        agent: str,
+    ) -> None:
+        """Materialize the agent spec, then hand kiro-cli its own API key.
+
+        Self-heal: kiro-cli discovers its selectable modes at startup from
+        ``~/.kiro/agents/*.json``, so the managed default agent file must exist
+        BEFORE this ``--agent`` spawn or a later ``set_mode`` fails with "Mode
+        '<agent>' not found". Regenerate it if missing, best-effort — a spec that
+        cannot be written is not a reason to refuse the spawn, and a non-managed
+        agent cannot be materialized here at all (the ``create_session`` guard
+        fails those closed instead).
+
+        The API key is re-injected from the data home's ``.env`` because a
+        post-scrub Docker image has stripped it from the gateway's own
+        environment; only kiro-cli gets it, which is why this overrides the
+        base's strip rather than adding to it.
+        """
+        # Deferred for the same cycle reason as the base implementation.
+        from kiro_crew.agent import ensure_agent_materialized
+        from kiro_crew.config.loader import inject_kiro_cli_api_key
+
+        try:
+            ensure_agent_materialized(agent)
+        except Exception:
+            logger.warning("pre-spawn agent materialization failed", exc_info=True)
+        inject_kiro_cli_api_key(env)
+
+    @property
+    def protocol_profile(self) -> ProtocolProfile:
+        """kiro-cli's wire (:data:`KIRO_PROFILE`).
+
+        Date-string protocol version, kiro-style permission options,
+        ``session/set_model`` + ``set_mode`` (no ``session/set_config_option``),
+        and no dedicated thought-chunk update type.
+        """
+        return KIRO_PROFILE
+
+
+class KasAdapter(HarnessAdapter):
+    """KAS: the v3 engine reached through kiro-cli's own ACP relay.
+
+    The relay means KAS is not a separate process tree Crew assembles — it is a
+    kiro-cli invoked with different arguments. So resolution is kiro-cli's, and
+    the only thing that cannot be said as data is the argv, which
+    :mod:`kiro_crew.acp.kas_transport` owns so that the engine and auth-owner
+    flags live beside the reasoning for each.
+
+    ``pre_spawn`` is deliberately NOT overridden, so KAS takes the base's strip of
+    ``KIRO_API_KEY``: that variable is kiro-cli's credential for its own v2 agent
+    loop, and the v3 engine authenticates from the OIDC store via
+    ``--auth-method cli`` instead. Handing it over would widen credential exposure
+    for a consumer that does not read it.
+    """
+
+    name = ADAPTER_KAS
+
+    def resolve_executable(self, descriptor: HarnessDescriptor) -> tuple[str, str]:
+        """Resolve kiro-cli, since the relay IS kiro-cli.
+
+        Shared with :class:`KiroAdapter` rather than reimplemented: both harnesses
+        must honour the same operator override, fixed install locations, and
+        augmented PATH, and a second copy of that chain is how one of them
+        regresses to "not found in PATH" alone.
+        """
+        return _resolve_kiro_cli_candidate(descriptor)
+
+    def render_argv(
+        self,
+        descriptor: HarnessDescriptor,
+        *,
+        executable: str,
+        agent: str = "",
+        model: str = "",
+        workdir: str | os.PathLike[str] = "",
+    ) -> list[str]:
+        """``kiro-cli acp --agent-engine v3 --auth-method cli``.
+
+        ``executable`` is the ATTESTED kiro-cli path, so it lands as ``argv[0]``
+        and the whole command is anchored on bytes that were vetted. Neither the
+        agent nor the model appears: KAS takes custom agents over the wire in
+        ``session/new`` (``_meta.kiro.customAgents``) and its model is chosen per
+        session, so pinning either at process start would apply it to every
+        session on the process.
+        """
+        # Deferred to keep this module's imports off the KAS wire modules, which
+        # reach the ACP types; the registry side imports this one.
+        from kiro_crew.acp.kas_transport import build_kas_argv
+
+        return build_kas_argv(executable)
+
+    @property
+    def protocol_profile(self) -> ProtocolProfile:
+        """The KAS relay's wire (:data:`KAS_PROFILE`).
+
+        kiro-cli's dialect in every respect — the relay IS a kiro-cli — EXCEPT
+        the ``initialize`` ``protocolVersion``, which the relay expects as the
+        public-ACP integer ``1`` (``runtime.py``'s ``PROTOCOL_VERSION_KAS``), not
+        kiro-cli's date string. Returning :data:`KIRO_PROFILE` here would flip
+        that handshake byte the moment a client/runtime site reads the profile
+        instead of forking on the backend, so KAS carries its own constant.
+        """
+        return KAS_PROFILE
+
+
+class ClaudeAdapter(HarnessAdapter):
+    """The Claude Code seam.
+
+    Registered so the harness is nameable and its capabilities readable. After
+    upstream #7301 the public build genuinely serves it (``acp/client.py`` owns the
+    spawn path and the adapter is a public npm package), so nothing here overrides
+    the generic rules. Its live effort push runs in ``providers.acp`` after the
+    session is ready, which is not a spawn step and does not belong here.
+    """
+
+    name = ADAPTER_CLAUDE
+
+    @property
+    def protocol_profile(self) -> ProtocolProfile:
+        """The public ACP wire (:data:`STANDARD_ACP_PROFILE`).
+
+        Stated explicitly (though identical to the base) so the claude seam's
+        wire is pinned as data rather than inherited by accident: integer
+        protocol version, standard permission options,
+        ``session/set_config_option`` for model/effort, and
+        ``agent_thought_chunk`` reasoning updates.
+        """
+        return STANDARD_ACP_PROFILE
+
+
+class GenericAdapter(HarnessAdapter):
+    """Any harness that speaks standard ACP over stdio, from data alone (R2).
+
+    This is what every adapter-less descriptor resolves to — bundled Codex and
+    every operator harness — so adopting a new provider's ACP server is config,
+    not a code PR. It carries no harness-specific behaviour: ``render_argv`` is
+    the base's pure template rendering (``agent_args`` only when an agent is
+    passed, ``model_args`` only when a model is pinned, no hardcoded flags), and
+    ``pre_spawn`` is the base's strip of kiro-cli's own API key. The one thing it
+    changes from the base is executable resolution, below.
+    """
+
+    name = ADAPTER_GENERIC
+
+    @property
+    def protocol_profile(self) -> ProtocolProfile:
+        """The public ACP wire (:data:`STANDARD_ACP_PROFILE`).
+
+        Stated explicitly (though identical to the base) so the wire dialect for
+        every operator harness and bundled Codex is pinned as data rather than
+        inherited by accident — the same discipline :class:`ClaudeAdapter` keeps.
+        A generic stdio ACP harness speaks the public wire: integer protocol
+        version, standard permission options, ``session/set_config_option`` for
+        model/effort, and ``agent_thought_chunk`` reasoning updates.
+        """
+        return STANDARD_ACP_PROFILE
+
+    def resolve_executable(self, descriptor: HarnessDescriptor) -> tuple[str, str]:
+        """``(path, reason)`` for the descriptor's executable; one is always empty.
+
+        An absolute path is honoured as given — it must still be an executable,
+        non-empty file, or the reason names the defect. A BARE NAME (no path
+        separator) is resolved through PATH, but through the SAME augmented PATH
+        the kiro chain uses (:func:`kiro_crew.env.augmented_path`), not the
+        process's inherited PATH: a gateway launched under systemd or another
+        non-login shell rarely inherits ``~/.local/bin`` and its kin, so a plain
+        ``shutil.which`` would report "not found" for an operator harness
+        installed exactly where the kiro binary is found. Reusing the shared
+        helper keeps the two paths in sync rather than copying its directory list
+        here.
+
+        A RELATIVE path (one that contains a separator but is not absolute, e.g.
+        ``./bin/agy`` or ``bin/agy``) is refused with a reason that names the real
+        rule. ``shutil.which`` short-circuits such a candidate against the
+        process's own working directory and discards the ``path`` argument
+        entirely, so the augmented PATH would never be consulted and the resolved
+        file would depend on wherever the gateway happens to be running (under
+        systemd, ``WorkingDirectory`` or ``/`` — nothing the operator chose).
+        Refusing keeps the diagnostic honest instead of reporting a PATH miss for
+        a PATH that was never searched.
+        """
+        candidate = descriptor.executable
+        if not candidate:
+            return "", "no executable is declared"
+        if os.path.isabs(candidate):
+            resolved = candidate
+        elif os.path.dirname(candidate):
+            # Relative path with a separator: shutil.which would resolve it
+            # against the gateway's cwd and ignore the augmented PATH, so the
+            # bytes that ran would depend on where the gateway was launched.
+            return "", (
+                f"{candidate!r} is a relative path; it would be resolved against "
+                f"the gateway's working directory, not the session workdir or the "
+                f"augmented PATH — give an absolute path or a bare name on PATH"
+            )
+        else:
+            found = shutil.which(candidate, path=augmented_path(os.environ.get("PATH", "")))
+            if not found:
+                return "", f"{candidate!r} was not found on PATH"
+            resolved = found
+        problem = _candidate_problem(resolved)
+        if problem:
+            return "", problem
+        return resolved, ""
+
+
+_GENERIC_ADAPTER = GenericAdapter()
+
+#: Adapter per ``ADAPTER_*`` name. A descriptor with no adapter — every operator
+#: harness, and bundled Codex — resolves to the generic adapter, so "has an
+#: adapter" is never a branch a caller has to write.
+_ADAPTERS: Mapping[str, HarnessAdapter] = {
+    ADAPTER_KIRO: KiroAdapter(),
+    ADAPTER_KAS: KasAdapter(),
+    ADAPTER_CLAUDE: ClaudeAdapter(),
+    ADAPTER_GENERIC: _GENERIC_ADAPTER,
+}
+
+
+def adapter_for(descriptor: HarnessDescriptor) -> HarnessAdapter:
+    """The adapter serving ``descriptor``, never None.
+
+    A descriptor that names no adapter — every operator harness, and bundled
+    Codex — resolves to :class:`GenericAdapter`, the standard-ACP-over-stdio rule
+    (R1.2). A named adapter selects its bespoke instance. An unknown adapter name
+    cannot reach here (``validate_descriptor`` closes the vocabulary and an
+    operator descriptor cannot carry the field at all), so the generic fallback
+    also covers a bundled descriptor mid-rename rather than throwing during a
+    spawn.
+    """
+    if not descriptor.adapter:
+        return _GENERIC_ADAPTER
+    return _ADAPTERS.get(descriptor.adapter, _GENERIC_ADAPTER)
+
+
+def resolve_executable(descriptor: HarnessDescriptor) -> tuple[str, str]:
+    """``(path, reason)`` for ``descriptor``'s executable; one is always empty.
+
+    The listing-side entry point: resolution only, nothing executed and nothing
+    attested (see :meth:`HarnessAdapter.resolve_executable`).
+    """
+    return adapter_for(descriptor).resolve_executable(descriptor)
+
+
+def attest_executable(harness_id: str, resolved: str) -> str:
+    """The launch path for ``resolved``, or raise :class:`HarnessExecutableTrustError`.
+
+    The Trust_Attestation every harness takes: the candidate must be a runnable,
+    non-zero-byte file, and the path returned is the one to exec — anchored with
+    ``abspath`` rather than ``realpath`` so a multiplexer launcher dispatching on
+    its own ``argv[0]`` and a multi-call binary resolving a sibling subcommand
+    both still work.
+
+    Applied to bundled and operator harnesses alike (R2.2). Uniformity is the
+    requirement: gating only the harness that shipped first would leave every
+    later one exec'ing whatever a config value pointed at.
+    """
+    # Deferred: kiro_prerequisite imports the sandbox helpers, which import back
+    # into this side of the package.
+    from kiro_crew.kiro_prerequisite import snapshot_trusted_acp_executable
+
+    try:
+        if platform_compat.IS_WINDOWS:
+            snapshot = snapshot_trusted_acp_executable(
+                resolved,
+                platform_name="win32",
+                environ=os.environ,
+            )
+        else:
+            snapshot = snapshot_trusted_acp_executable(resolved)
+    except OSError as exc:
+        raise HarnessExecutableTrustError(f"harness {harness_id!r}: {exc}") from exc
+    except ValueError as exc:
+        # The snapshot's own refusal text names Kiro CLI, because its other
+        # caller is the kiro-only client path. Restating the verdict against the
+        # candidate keeps an operator harness's refusal about THAT harness:
+        # "harness 'mine': Kiro CLI is not a runnable executable" sends the
+        # operator to reinstall a tool that is not the one that failed. The
+        # shared candidate verdict names the actual defect where it is still
+        # observable, and the original text stays on the chained cause.
+        problem = _candidate_problem(resolved) or (
+            f"{resolved} is not a runnable executable for ACP execution"
+        )
+        raise HarnessExecutableTrustError(f"harness {harness_id!r}: {problem}") from exc
+    return snapshot.launch_path
+
+
+def resolve_spawn_executable(descriptor: HarnessDescriptor) -> str:
+    """Resolve and attest ``descriptor``'s executable, returning the path to exec.
+
+    Blocking (``shutil.which``, ``stat``, and the attestation's own reads), so
+    callers on the event loop run it in a worker thread.
+    """
+    resolved, reason = resolve_executable(descriptor)
+    if reason:
+        raise HarnessSpawnRefused(f"harness {descriptor.id!r} cannot start: {reason}")
+    return attest_executable(descriptor.id, resolved)
+
+
+def checked_spawn_argv(descriptor: HarnessDescriptor, argv: list[str], attested: str) -> list[str]:
+    """``argv``, once it is proven to exec the attested executable.
+
+    This is the second half of attestation, and without it the first half is
+    decoration: a template that never substitutes ``{executable}`` leaves a bare
+    name in ``argv[0]``, which ``exec`` then resolves through ``PATH`` at spawn
+    time — so the bytes that were vetted and the bytes that run need not be the
+    same file. Validation already requires the template to start with
+    ``{executable}``; this catches the other producer, an adapter's own
+    ``render_argv`` override, where no template is involved at all.
+
+    Refuses rather than rewriting ``argv[0]``: a silent rewrite would make a
+    descriptor or adapter bug indistinguishable from a correct spawn, and the
+    mismatch is always a bug in Kiro Crew's own data rather than something an
+    operator can act on.
+    """
+    if not argv:
+        raise HarnessSpawnRefused(
+            f"harness {descriptor.id!r} rendered an empty argv, so there is " f"nothing to exec"
+        )
+    if argv[0] != attested:
+        raise HarnessSpawnRefused(
+            f"harness {descriptor.id!r} would exec {argv[0]!r} but "
+            f"{attested!r} is the executable that was attested; refusing to "
+            f"spawn bytes that were never checked"
+        )
+    return argv

--- a/src/kiro_crew/acp/harness_descriptor.py
+++ b/src/kiro_crew/acp/harness_descriptor.py
@@ -1,0 +1,662 @@
+"""Harness descriptor: the data record describing one ACP-speaking harness.
+
+A harness is an executable that speaks ACP on stdio and drives an LLM with its
+own authentication (kiro-cli, Codex, Claude Code, KAS, or an operator's own ACP
+server). This module owns the DATA and the two pure operations over it —
+validation and argv rendering — so that spawning a harness never needs a
+per-harness code branch.
+
+Three properties are load-bearing and every function here is written to keep
+them:
+
+- **Validation returns reasons, it does not raise.** An operator's descriptor
+  arrives from configuration and may be arbitrary garbage; a malformed one must
+  cost that harness its place in the selection surfaces, never the gateway's
+  boot. So the failure channel is a ``list[str]`` of diagnosable reasons that a
+  caller can record and show, and the parse entry point tolerates any input
+  shape rather than trusting the config layer to have pre-validated it.
+- **Rendering is total and shell-free.** ``render_argv`` returns a ``list[str]``
+  built by token-wise substitution. Nothing here concatenates a command line,
+  quotes an argument, or consults a shell, so an operator-supplied executable,
+  agent name, or model id can never become shell syntax.
+- **Capabilities default OFF.** A descriptor that never mentions a capability
+  does not get it. The alternative fails open: a harness that has demonstrated
+  nothing would inherit a feature (a sandbox waiver, session sharing) the
+  operator never granted it. See docs/system-specs/modules/harness-parity.md.
+- **Code and configuration are not the same authority.** Bundled descriptors are
+  constructed in code and may name an ``adapter``; an operator's descriptor is
+  parsed from ``config.json`` and cannot, because a config key that chose a
+  Python entry point would let configuration select code.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field, fields
+from typing import Any, Collection, Iterable, Mapping
+
+from kiro_crew.acp_backends import (  # noqa: F401 - re-exported for existing importers
+    ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_CODEX,
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+)
+
+# ── Legacy ACP backend identifiers ──
+# The ``acp_backend`` string a session/provider is keyed on while the harness
+# seam is still being wired through. DEFINED in the top-level leaf
+# ``kiro_crew.acp_backends`` (the single owner after upstream's #6593 registry
+# refactor) and re-exported here. ``protocol_profile`` needs them to map a
+# backend string to a wire profile, and ``acp.types`` imports ``harness_registry``
+# which imports ``harness_adapters`` — so a ``protocol_profile`` -> ``acp.types``
+# edge would close a module-scope cycle. ``acp_backends`` imports nothing from
+# this package (it is a true leaf too), so re-exporting from it here is cycle-free
+# and keeps ONE definition of the identifiers. ``acp.types`` re-exports the same
+# names for compatibility, so existing ``from kiro_crew.acp.types import
+# ACP_BACKEND_*`` call sites keep working.
+
+
+# ── Capability vocabulary ──
+# Each name is a feature the code currently assumes kiro-cli has. A capability
+# is an opt-in claim: membership is an explicit decision per harness, never an
+# inference from "this is not some other harness".
+
+CAPABILITY_SESSION_SHARING = "session_sharing"
+CAPABILITY_STEER = "steer"
+CAPABILITY_INTERNAL_SANDBOX = "internal_sandbox"
+CAPABILITY_ACP_RUNTIME_POOL = "acp_runtime_pool"
+CAPABILITY_KIRO_IDENTITY_STORE = "kiro_identity_store"
+CAPABILITY_MCP_TOOL_SEARCH = "mcp_tool_search"
+CAPABILITY_REASONING_EFFORT = "reasoning_effort"
+
+#: Every capability name a descriptor may mention, in declaration order.
+CAPABILITY_NAMES: tuple[str, ...] = (
+    CAPABILITY_SESSION_SHARING,
+    CAPABILITY_STEER,
+    CAPABILITY_INTERNAL_SANDBOX,
+    CAPABILITY_ACP_RUNTIME_POOL,
+    CAPABILITY_KIRO_IDENTITY_STORE,
+    CAPABILITY_MCP_TOOL_SEARCH,
+    CAPABILITY_REASONING_EFFORT,
+)
+
+# ── Model source ──
+
+#: The harness enumerates its own models over ACP (the default).
+MODEL_SOURCE_ACP_ADVERTISED = "acp_advertised"
+#: The descriptor carries a fixed list, for a harness that cannot enumerate.
+MODEL_SOURCE_STATIC = "static"
+MODEL_SOURCES = frozenset({MODEL_SOURCE_ACP_ADVERTISED, MODEL_SOURCE_STATIC})
+
+# ── Adapters (bundled, reviewed code only) ──
+# A harness whose pre-spawn or post-initialize needs cannot be expressed as argv
+# data names an adapter: a Python entry point that ships with Kiro Crew. The
+# vocabulary is closed and lists only adapters that EXIST — naming one that does
+# not is a descriptor that validates and then fails at spawn, which is the
+# failure this module exists to move earlier.
+#
+# Deliberately absent from :data:`DESCRIPTOR_KEYS`: an operator descriptor that
+# could name an adapter would be configuration selecting arbitrary Python, so
+# harness-specific code ships only through review. See the registry module for
+# what each adapter carries.
+ADAPTER_KIRO = "kiro"
+ADAPTER_KAS = "kas"
+ADAPTER_CLAUDE = "claude"
+#: The adapter every adapter-less descriptor resolves to — the generic ACP rule
+#: (PATH/absolute resolution and pure template rendering, no harness-specific
+#: code). It is named so the instance can be registered and referred to like the
+#: bespoke ones, and it is in the vocabulary so a bundled descriptor MAY state it
+#: explicitly; an operator descriptor still cannot name any adapter (``adapter``
+#: is not in :data:`DESCRIPTOR_KEYS`) and reaches the generic rule by leaving the
+#: field unset.
+ADAPTER_GENERIC = "generic"
+ADAPTERS = frozenset({ADAPTER_KIRO, ADAPTER_KAS, ADAPTER_CLAUDE, ADAPTER_GENERIC})
+
+# ── MCP delivery ──
+
+#: The harness loads MCP servers from its own configuration channel.
+MCP_DELIVERY_FILE_FED = "file_fed"
+#: The harness learns its MCP servers only from the ACP session/new request.
+MCP_DELIVERY_WIRE_FED = "wire_fed"
+MCP_DELIVERIES = frozenset({MCP_DELIVERY_FILE_FED, MCP_DELIVERY_WIRE_FED})
+#: Wire-fed is the default for an omitted declaration: the ACP specification
+#: requires every conformant agent to accept the stdio server list at
+#: session/new, so it is the one channel a harness cannot have opted out of.
+MCP_DELIVERY_DEFAULT = MCP_DELIVERY_WIRE_FED
+
+# ── Argv placeholder vocabulary (closed) ──
+
+PLACEHOLDER_EXECUTABLE = "{executable}"
+PLACEHOLDER_AGENT = "{agent}"
+PLACEHOLDER_MODEL = "{model}"
+PLACEHOLDER_WORKDIR = "{workdir}"
+#: The complete set. Anything else brace-wrapped in a template is a validation
+#: failure rather than a literal, because silently passing an unknown
+#: ``{...}`` token through to exec would hand the harness a meaningless
+#: argument and produce a failure far from its cause.
+ARGV_PLACEHOLDERS = frozenset(
+    {
+        PLACEHOLDER_EXECUTABLE,
+        PLACEHOLDER_AGENT,
+        PLACEHOLDER_MODEL,
+        PLACEHOLDER_WORKDIR,
+    }
+)
+
+# ── Identifier shape ──
+
+#: Harness ids are lowercase kebab: they appear in config keys, API query
+#: parameters, session records, and spawn arguments, so the charset is kept to
+#: what is safe and unambiguous in all four.
+HARNESS_ID_MAX_LEN = 32
+_HARNESS_ID_RE = re.compile(r"[a-z0-9-]+")
+#: Any brace-wrapped run in a template token. Matching the whole run (rather
+#: than scanning for known placeholders) is what makes an unknown placeholder
+#: detectable instead of surviving as a literal.
+_BRACED_RE = re.compile(r"\{[^{}]*\}")
+
+#: The mapping keys an operator descriptor may carry. Unknown keys fail
+#: validation: a typo'd key would otherwise be silently ignored, leaving the
+#: operator with a harness that quietly does not do what they configured.
+#:
+#: ``adapter`` is deliberately NOT here, and must never be added. A bundled
+#: descriptor is constructed in code and may name one; an operator's descriptor
+#: arrives from ``config.json`` and gets argv-template semantics only, because a
+#: config key that selected a Python entry point would let configuration choose
+#: code. ``test_harness_registry.py`` pins the literal key's rejection so
+#: extending this set cannot open that path by accident.
+DESCRIPTOR_KEYS: frozenset[str] = frozenset(
+    {
+        "id",
+        "display_name",
+        "executable",
+        "argv",
+        "agent_args",
+        "model_args",
+        "capabilities",
+        "model_source",
+        "models",
+        "mcp_delivery",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CapabilitySet:
+    """Per-harness feature flags, every one defaulting to disabled."""
+
+    session_sharing: bool = False
+    steer: bool = False
+    internal_sandbox: bool = False
+    acp_runtime_pool: bool = False
+    kiro_identity_store: bool = False
+    mcp_tool_search: bool = False
+    reasoning_effort: bool = False
+
+    def has(self, name: str) -> bool:
+        """True when this set claims ``name``.
+
+        An unknown name is a programming error (a capability gate naming a flag
+        that does not exist), not operator data, so it raises rather than
+        answering False — answering False would silently disable a real feature
+        after a rename.
+        """
+        if name not in CAPABILITY_NAMES:
+            raise ValueError(f"unknown harness capability {name!r}")
+        return bool(getattr(self, name))
+
+    def as_dict(self) -> dict[str, bool]:
+        """The flags as a plain mapping, for serialization and listings."""
+        return {name: bool(getattr(self, name)) for name in CAPABILITY_NAMES}
+
+
+@dataclass(frozen=True)
+class HarnessDescriptor:
+    """One harness described as data: command, conventions, capabilities.
+
+    Immutable so a descriptor handed to a session at creation cannot be edited
+    underneath it — a session's binding has to outlive changes to the
+    registry's copy (a persisted default change must never retarget a live
+    session). Sequence fields are tuples for the same reason.
+    """
+
+    id: str
+    display_name: str = ""
+    #: Absolute path or a PATH-resolvable name. Resolution and trust
+    #: attestation happen at spawn time; this is only the rule.
+    executable: str = ""
+    #: Ordered token list: literals and placeholders, always rendered as argv.
+    #: The first token must be ``{executable}`` so the attested executable is the
+    #: one that execs (see :func:`validate_descriptor`).
+    argv: tuple[str, ...] = ()
+    #: Optional convention block, emitted only when an agent is selected.
+    agent_args: tuple[str, ...] = ()
+    #: Optional convention block, emitted only when a model is selected.
+    model_args: tuple[str, ...] = ()
+    capabilities: CapabilitySet = field(default_factory=CapabilitySet)
+    model_source: str = MODEL_SOURCE_ACP_ADVERTISED
+    #: Consulted only when ``model_source`` is ``static``.
+    models: tuple[str, ...] = ()
+    mcp_delivery: str = MCP_DELIVERY_DEFAULT
+    #: Bundled-only: the name of a reviewed Python entry point carrying this
+    #: harness's pre-spawn / post-initialize steps (see :data:`ADAPTERS`). Empty
+    #: for every operator descriptor, and :func:`descriptor_from_mapping` has no
+    #: way to set it — configuration must never be able to select code.
+    adapter: str = ""
+
+    @property
+    def label(self) -> str:
+        """Human-facing name, falling back to the id when none was given."""
+        return self.display_name or self.id
+
+
+def _reason_prefix(harness_id: str) -> str:
+    """Locate a reason on its harness even when the id itself is the problem."""
+    return f"harness {harness_id!r}: " if harness_id else "harness: "
+
+
+def _placeholder_reasons(prefix: str, block: str, tokens: Iterable[Any]) -> list[str]:
+    """Reasons for every bad token in ``tokens``: non-string, unknown placeholder,
+    unbalanced brace, or a convention placeholder used outside its own block.
+
+    ``{agent}`` and ``{model}`` are CONVENTION placeholders: ``render_argv`` emits
+    the ``agent_args`` block only when an agent is selected and the ``model_args``
+    block only when a model is pinned, so those placeholders are only meaningful
+    where that gating applies. In the ungated ``argv`` block — or in each other's
+    block — they render to the empty string whenever the value is absent, execing
+    a silent empty argument (``--model=`` or a bare ``""``). Rejecting them at
+    validation turns that footgun into a registration-time reason instead of a
+    spawn that half-works. ``{executable}`` and ``{workdir}`` carry no gating and
+    stay legal in every block.
+    """
+    # The convention placeholder each gated block owns; every other block that is
+    # not that block's home rejects it.
+    _CONVENTION_HOME = {
+        PLACEHOLDER_AGENT: "agent_args",
+        PLACEHOLDER_MODEL: "model_args",
+    }
+    reasons: list[str] = []
+    for token in tokens:
+        if not isinstance(token, str):
+            reasons.append(f"{prefix}{block} token {token!r} is not a string")
+            continue
+        residue = token
+        for match in _BRACED_RE.finditer(token):
+            placeholder = match.group(0)
+            if placeholder not in ARGV_PLACEHOLDERS:
+                allowed = ", ".join(sorted(ARGV_PLACEHOLDERS))
+                reasons.append(
+                    f"{prefix}{block} token {token!r} uses unknown placeholder "
+                    f"{placeholder} (allowed: {allowed})"
+                )
+            elif placeholder in _CONVENTION_HOME and _CONVENTION_HOME[placeholder] != block:
+                reasons.append(
+                    f"{prefix}{block} token {token!r} uses {placeholder}, which is "
+                    f"only meaningful in {_CONVENTION_HOME[placeholder]} (that block "
+                    f"is emitted only when the value is present; elsewhere "
+                    f"{placeholder} renders to an empty argument)"
+                )
+            residue = residue.replace(placeholder, "", 1)
+        # A leftover brace means the token is neither a placeholder nor a plain
+        # literal — most often a typo like "--dir={workdir" whose rendered form
+        # would reach exec unsubstituted.
+        if "{" in residue or "}" in residue:
+            reasons.append(f"{prefix}{block} token {token!r} has an unbalanced brace")
+    return reasons
+
+
+def _sequence_reasons(prefix: str, block: str, value: Any) -> list[str]:
+    """Reason when ``value`` is not a sequence of tokens.
+
+    A bare string is the case that matters: ``argv="my-tool acp"`` on a
+    code-built descriptor is iterable, so every check downstream happily
+    iterates it ONE CHARACTER AT A TIME and the descriptor validates. The argv
+    it renders is ``["m", "y", "-", …]``, which fails at exec with an unreadable
+    error far from the mistake. :func:`descriptor_from_mapping` already refuses
+    the shape for operator config; this is the same refusal for a descriptor
+    built in code.
+    """
+    if isinstance(value, (tuple, list)):
+        return []
+    kind = "a string" if isinstance(value, str) else f"{type(value).__name__}"
+    return [f"{prefix}{block} must be a sequence of tokens, not {kind}"]
+
+
+def validate_descriptor(
+    descriptor: HarnessDescriptor,
+    *,
+    taken_ids: Collection[str] = (),
+) -> list[str]:
+    """Return every shape problem with ``descriptor``; empty means valid.
+
+    ``taken_ids`` are ids already registered, so the caller gets uniqueness
+    enforced with the same diagnosable-reason channel as everything else
+    instead of having to compare ids itself.
+    """
+    prefix = _reason_prefix(descriptor.id)
+    reasons: list[str] = []
+
+    if not isinstance(descriptor.id, str) or not descriptor.id:
+        reasons.append(f"{prefix}identifier is empty")
+    elif not _HARNESS_ID_RE.fullmatch(descriptor.id):
+        reasons.append(f"{prefix}identifier must use only lowercase letters, digits, and hyphens")
+    elif len(descriptor.id) > HARNESS_ID_MAX_LEN:
+        reasons.append(f"{prefix}identifier is longer than {HARNESS_ID_MAX_LEN} characters")
+    elif descriptor.id in taken_ids:
+        reasons.append(f"{prefix}identifier is already registered")
+
+    if not isinstance(descriptor.executable, str) or not descriptor.executable:
+        reasons.append(f"{prefix}executable is empty")
+
+    # Shape before content: a bare-string argv passes every per-token check by
+    # being iterated character-wise, so the sequence check has to come first and
+    # the token checks have to be skipped when it fails.
+    for block, tokens in (
+        ("argv", descriptor.argv),
+        ("agent_args", descriptor.agent_args),
+        ("model_args", descriptor.model_args),
+    ):
+        shape = _sequence_reasons(prefix, block, tokens)
+        if shape:
+            reasons += shape
+            continue
+        if block == "argv" and not tokens:
+            # Without at least one token there is no program to exec; the harness
+            # would fail at spawn with an empty argv rather than at registration.
+            reasons.append(f"{prefix}argv template is empty")
+        elif block == "argv" and tokens[0] != PLACEHOLDER_EXECUTABLE:
+            # argv[0] IS the program, and ``executable`` is the field that gets
+            # resolved and trust-attested at spawn. A template whose first token
+            # is a literal therefore execs bytes nobody checked: a bare name is
+            # resolved by exec through PATH at spawn time, so the file that was
+            # attested and the file that runs need not be the same one. Requiring
+            # the placeholder is what makes the attestation load-bearing rather
+            # than decorative (the spawn path re-checks the rendered argv, for
+            # the adapters that build one without a template).
+            reasons.append(
+                f"{prefix}argv template must start with {PLACEHOLDER_EXECUTABLE} "
+                f"so the executable that is trust-attested is the one that runs, "
+                f"not {tokens[0]!r}"
+            )
+        reasons += _placeholder_reasons(prefix, block, tokens)
+
+    if descriptor.model_source not in MODEL_SOURCES:
+        allowed = ", ".join(sorted(MODEL_SOURCES))
+        reasons.append(f"{prefix}model_source {descriptor.model_source!r} is not one of: {allowed}")
+    elif descriptor.model_source == MODEL_SOURCE_STATIC and not descriptor.models:
+        # Rejected rather than accepted-and-listed-unavailable: ``static`` is the
+        # declaration "I cannot enumerate my models over ACP, here they are
+        # instead", so an empty list leaves the composer with no model to offer
+        # and no way to obtain one. The harness could never serve a session, and
+        # a validation reason names the actual mistake at registration time
+        # instead of surfacing as an empty dropdown the operator has to explain.
+        reasons.append(f"{prefix}model_source is 'static' but no models are declared")
+
+    if descriptor.mcp_delivery not in MCP_DELIVERIES:
+        allowed = ", ".join(sorted(MCP_DELIVERIES))
+        reasons.append(f"{prefix}mcp_delivery {descriptor.mcp_delivery!r} is not one of: {allowed}")
+
+    shape = _sequence_reasons(prefix, "models", descriptor.models)
+    if shape:
+        reasons += shape
+    else:
+        for model in descriptor.models:
+            if not isinstance(model, str) or not model:
+                reasons.append(f"{prefix}models entry {model!r} is not a non-empty string")
+
+    if not isinstance(descriptor.capabilities, CapabilitySet):
+        reasons.append(f"{prefix}capabilities is not a capability set")
+
+    if descriptor.adapter and descriptor.adapter not in ADAPTERS:
+        allowed = ", ".join(sorted(ADAPTERS))
+        reasons.append(f"{prefix}adapter {descriptor.adapter!r} is not one of: {allowed}")
+
+    return reasons
+
+
+#: Capabilities an OPERATOR DESCRIPTOR may not claim. Each of these is honoured
+#: by code written for a specific bundled harness, so a config grant does not
+#: light the feature up — it points trusted machinery at a process that never
+#: earned it:
+#:
+#: * ``internal_sandbox`` waives Kiro Crew's own OS sandbox in favour of the
+#:   harness's internal one (kiro-cli's). Granted to a binary with no internal
+#:   sandbox, the agent process runs UNCONFINED — the one fail-open in the
+#:   capability set, and a security hole rather than a malfunction.
+#: * ``acp_runtime_pool`` routes the session onto ``AcpRuntime``, which speaks
+#:   kiro-cli's wire dialect (date-string protocolVersion, ``/effort``); a
+#:   foreign harness there fails its handshake or, worse, half-works.
+#: * ``session_sharing`` multiplexes one process across sessions and subagents
+#:   through machinery built for kiro-cli's demux; a foreign process is reused
+#:   across trust contexts it never declared it could separate.
+#: * ``kiro_identity_store`` retires the process when KIRO-CLI's login changes;
+#:   an operator harness authenticates itself, so the sweep would kill sessions
+#:   on an identity store their harness never reads.
+#:
+#: Bundled descriptors construct :class:`CapabilitySet` directly in
+#: ``harness_registry.py`` and never pass through this parser, so the grants
+#: stay expressible where the honouring code actually exists. Rejected per key
+#: with its own reason (not silently dropped): a dropped flag would read as
+#: "Kiro Crew ignored my capability" with nothing to diagnose, and the whole
+#: entry failing closed matches every other validation error's posture.
+_CONFIG_UNGRANTABLE_CAPABILITIES: dict[str, str] = {
+    CAPABILITY_INTERNAL_SANDBOX: (
+        "it waives Kiro Crew's own sandbox in favour of a harness-internal one "
+        "only kiro-cli has — granted from config it leaves the process unconfined"
+    ),
+    CAPABILITY_ACP_RUNTIME_POOL: (
+        "the shared AcpRuntime speaks kiro-cli's wire dialect; a config-declared "
+        "harness runs through the generic per-session client instead"
+    ),
+    CAPABILITY_SESSION_SHARING: (
+        "session multiplexing is built for kiro-cli's demux; a config-declared "
+        "harness gets one process per session"
+    ),
+    CAPABILITY_KIRO_IDENTITY_STORE: (
+        "it ties the process's lifetime to kiro-cli's login; a config-declared "
+        "harness authenticates itself"
+    ),
+}
+
+
+def _capabilities_from_mapping(prefix: str, raw: Any) -> tuple[CapabilitySet, list[str]]:
+    """Parse a capability mapping, defaulting every unmentioned flag to off."""
+    if raw is None:
+        return CapabilitySet(), []
+    if not isinstance(raw, Mapping):
+        return CapabilitySet(), [f"{prefix}capabilities must be an object"]
+    reasons: list[str] = []
+    flags: dict[str, bool] = {}
+    for key, value in raw.items():
+        if key not in CAPABILITY_NAMES:
+            allowed = ", ".join(CAPABILITY_NAMES)
+            reasons.append(f"{prefix}unknown capability {key!r} (allowed: {allowed})")
+            continue
+        # Strict bool: a truthy string such as "false" would otherwise ENABLE
+        # the flag, which is the wrong direction to guess in.
+        if not isinstance(value, bool):
+            reasons.append(f"{prefix}capability {key!r} must be true or false")
+            continue
+        # A code-only capability is refused even as an explicit ``false``: the
+        # key's presence in config is a claim about machinery this descriptor
+        # can never bind, and accepting the spelling at all invites flipping it.
+        if key in _CONFIG_UNGRANTABLE_CAPABILITIES:
+            why = _CONFIG_UNGRANTABLE_CAPABILITIES[key]
+            reasons.append(
+                f"{prefix}capability {key!r} cannot be granted from configuration — {why}"
+            )
+            continue
+        flags[key] = value
+    if reasons:
+        return CapabilitySet(), reasons
+    return CapabilitySet(**flags), []
+
+
+def _string_tuple(prefix: str, key: str, raw: Any) -> tuple[tuple[str, ...], list[str]]:
+    """Coerce a JSON array of strings to a tuple, reporting the shape instead
+    of guessing.
+
+    A bare string is rejected rather than wrapped: ``"argv": "my-tool acp"``
+    reads like a command line, and accepting it would imply the shell splitting
+    that this module exists to avoid.
+    """
+    if raw is None:
+        return (), []
+    if isinstance(raw, str) or not isinstance(raw, (list, tuple)):
+        return (), [f"{prefix}{key} must be an array of strings"]
+    values: list[str] = []
+    reasons: list[str] = []
+    for item in raw:
+        if not isinstance(item, str):
+            reasons.append(f"{prefix}{key} entry {item!r} is not a string")
+            continue
+        values.append(item)
+    return tuple(values), reasons
+
+
+def _optional_string(prefix: str, key: str, raw: Any, default: str) -> tuple[str, list[str]]:
+    """Read an optional string field, keeping ``default`` when it is absent."""
+    if raw is None:
+        return default, []
+    if not isinstance(raw, str):
+        return default, [f"{prefix}{key} must be a string"]
+    return raw, []
+
+
+def descriptor_from_mapping(
+    raw: Any,
+    *,
+    harness_id: str = "",
+    taken_ids: Collection[str] = (),
+) -> tuple[HarnessDescriptor | None, list[str]]:
+    """Parse and validate an operator descriptor.
+
+    ``harness_id`` is the id the descriptor was filed under (the
+    ``harnesses.json`` map); a descriptor may also carry it as an ``id``
+    field, and the two must agree. Returns ``(None, reasons)`` when anything is
+    wrong and never raises, so a registry can record the reasons and keep
+    serving every other harness.
+    """
+    prefix = _reason_prefix(harness_id)
+    if not isinstance(raw, Mapping):
+        return None, [f"{prefix}descriptor must be an object"]
+
+    reasons: list[str] = []
+    unknown = sorted(str(key) for key in raw.keys() if key not in DESCRIPTOR_KEYS)
+    if unknown:
+        allowed = ", ".join(sorted(DESCRIPTOR_KEYS))
+        reasons.append(
+            f"{prefix}unknown field(s) {', '.join(repr(k) for k in unknown)} "
+            f"(allowed: {allowed})"
+        )
+
+    declared_id, id_reasons = _optional_string(prefix, "id", raw.get("id"), harness_id)
+    reasons += id_reasons
+    if harness_id and declared_id and declared_id != harness_id:
+        reasons.append(f"{prefix}declared id {declared_id!r} does not match its registry key")
+        declared_id = harness_id
+    if not declared_id:
+        reasons.append(f"{prefix}identifier is empty")
+
+    display_name, name_reasons = _optional_string(
+        prefix, "display_name", raw.get("display_name"), ""
+    )
+    reasons += name_reasons
+    executable, exe_reasons = _optional_string(prefix, "executable", raw.get("executable"), "")
+    reasons += exe_reasons
+    argv, argv_reasons = _string_tuple(prefix, "argv", raw.get("argv"))
+    reasons += argv_reasons
+    agent_args, agent_reasons = _string_tuple(prefix, "agent_args", raw.get("agent_args"))
+    reasons += agent_reasons
+    model_args, model_arg_reasons = _string_tuple(prefix, "model_args", raw.get("model_args"))
+    reasons += model_arg_reasons
+    models, models_reasons = _string_tuple(prefix, "models", raw.get("models"))
+    reasons += models_reasons
+    capabilities, cap_reasons = _capabilities_from_mapping(prefix, raw.get("capabilities"))
+    reasons += cap_reasons
+    model_source, source_reasons = _optional_string(
+        prefix, "model_source", raw.get("model_source"), MODEL_SOURCE_ACP_ADVERTISED
+    )
+    reasons += source_reasons
+    mcp_delivery, delivery_reasons = _optional_string(
+        prefix, "mcp_delivery", raw.get("mcp_delivery"), MCP_DELIVERY_DEFAULT
+    )
+    reasons += delivery_reasons
+
+    descriptor = HarnessDescriptor(
+        id=declared_id,
+        display_name=display_name,
+        executable=executable,
+        argv=argv,
+        agent_args=agent_args,
+        model_args=model_args,
+        capabilities=capabilities,
+        model_source=model_source,
+        models=models,
+        mcp_delivery=mcp_delivery,
+    )
+    reasons += validate_descriptor(descriptor, taken_ids=taken_ids)
+    if reasons:
+        # Deduplicate while preserving order: a field can be reported by both
+        # the parse step and the shape check, and a listing should show the
+        # reason once.
+        return None, list(dict.fromkeys(reasons))
+    return descriptor, []
+
+
+def _substitute(token: str, values: Mapping[str, str]) -> str:
+    """Replace known placeholders in ``token`` in a SINGLE pass.
+
+    Single-pass matters: a model id or agent name that happens to contain
+    ``{workdir}`` must reach exec as those literal bytes, not as the working
+    directory. Unknown placeholders are left untouched — validation is where
+    they are rejected, and rendering stays total so a caller can never be
+    handed an exception mid-spawn.
+    """
+    return _BRACED_RE.sub(lambda m: values.get(m.group(0), m.group(0)), token)
+
+
+def render_argv(
+    descriptor: HarnessDescriptor,
+    *,
+    executable: str = "",
+    agent: str = "",
+    model: str = "",
+    workdir: str | os.PathLike[str] = "",
+) -> list[str]:
+    """Render ``descriptor``'s template into a concrete argv list.
+
+    ``executable`` overrides ``descriptor.executable`` (spawn resolves a PATH
+    name to an absolute, attested path before rendering). The optional
+    convention blocks are emitted only when their value is non-empty, so a
+    harness with no model selected gets no dangling ``--model`` flag rather
+    than an empty argument, and a descriptor that declares no block for a
+    convention never receives a substituted default from another harness.
+
+    The result is a plain ``list[str]`` for ``subprocess`` with no shell: every
+    value lands as exactly one argv element regardless of the spaces, quotes,
+    or metacharacters it contains.
+    """
+    values = {
+        PLACEHOLDER_EXECUTABLE: executable or descriptor.executable,
+        PLACEHOLDER_AGENT: agent,
+        PLACEHOLDER_MODEL: model,
+        PLACEHOLDER_WORKDIR: os.fspath(workdir) if workdir else "",
+    }
+    rendered = [_substitute(token, values) for token in descriptor.argv]
+    if agent:
+        rendered += [_substitute(token, values) for token in descriptor.agent_args]
+    if model:
+        rendered += [_substitute(token, values) for token in descriptor.model_args]
+    return rendered
+
+
+def capability_names() -> tuple[str, ...]:
+    """The capability vocabulary, derived from the dataclass declaration.
+
+    Kept as a function so a flag added to :class:`CapabilitySet` without a
+    matching entry in :data:`CAPABILITY_NAMES` is caught by the pin test rather
+    than becoming a flag nothing can read.
+    """
+    return tuple(f.name for f in fields(CapabilitySet))

--- a/src/kiro_crew/acp/harness_registry.py
+++ b/src/kiro_crew/acp/harness_registry.py
@@ -1,0 +1,819 @@
+"""Harness registry: which ACP harnesses exist, and whether each can run now.
+
+The registry is the single place that answers "what harnesses are there?" for
+every selection surface (chat composer, spawn tool, cron, Settings) and for the
+provider factory that renders a spawn argv. It serves two populations from one
+interface:
+
+- **Bundled descriptors**, constructed in code below: kiro-cli (the default),
+  KAS, Codex, and the dormant Claude Code seam. Only these may name an
+  ``adapter`` — a reviewed Python entry point carrying pre-spawn /
+  post-initialize steps that argv data cannot express (KAS's token resolution,
+  kiro's ``~/.kiro/agents`` self-heal).
+- **Operator descriptors**, parsed from ``harnesses.json`` beside the config: pure data, no
+  adapter, every capability off unless explicitly enabled. The acceptance case
+  is an ACP server the operator already runs and has already authenticated —
+  executable, argv template, capabilities, and nothing else needed from us.
+
+Four decisions shape this module and are worth stating before the code:
+
+**Availability is evaluated lazily, never at boot.** ``list()`` and the
+selection paths ask; nothing probes at import. Registering a harness is free, so
+a Codex binary the operator has not installed costs a listing row rather than a
+gateway that will not start — and kiro-cli readiness remains the only
+bootstrap-gating check (R6.1). Availability is also never CACHED across calls,
+which is what makes recovery work: the operator installs the binary and the next
+listing says so, with no restart (R6.5).
+
+**Availability never runs the harness.** It asks whether an executable resolves
+and is a non-empty executable file, and whether the descriptor validates.
+Executing a candidate to see whether it answers ACP would turn a listing into N
+child processes, and an unauthenticated harness would fail that probe for a
+reason ("not signed in") that is not what the listing claims to report. A
+spawn-time failure is recorded through :meth:`HarnessRegistry.note_probe_failure`
+instead, and expires (see :data:`_PROBE_FAILURE_TTL_SECS`).
+
+**An invalid operator descriptor is excluded from ``list()`` and reported by
+:meth:`HarnessRegistry.invalid`.** Both halves matter: a selection surface reads
+``list()``, so a descriptor that failed validation is not one ``if`` away from
+being handed to a session (R2.3), while the reasons stay retrievable so Settings
+can show the operator what is wrong with their entry (R6.2). Everything else
+stays registered — one malformed entry costs its own harness and nothing more.
+
+**Harness definitions are not agent-writable.** A descriptor names an executable
+Kiro Crew will spawn, so an agent that could author one would have arbitrary code
+execution in the gateway's own identity — which makes this a three-way guard, and
+each half closes a different reachable path:
+
+- the **file-edit tool**: ``harnesses.json`` is on
+  ``security._WRITE_PROTECTED_HOME_PATHS``, so an ``edit``-kind write there is
+  refused while reads stay allowed;
+- the **shell**: the same leaf is on ``security._WRITE_PROTECTED_BASH_LEAVES``,
+  so a redirect, ``tee``, ``cp``, or any novel write verb naming the file is
+  refused (the matcher is verb-independent — naming the leaf at all is the
+  signal);
+- the **Settings PATCH** surface (``dashboard.handlers.core._EDITABLE_CONFIG``)
+  is an allowlist that never carried a harness key and must not grow one.
+
+``kirocrew config set`` needs no bespoke guard anymore: the descriptors are not
+config keys, so the setter has nothing to author or delete.
+
+This module exposes no writer at all, and ``test_harness_registry.py`` pins all
+three halves.
+
+**Both agent write paths are closed.** Operator descriptors live in
+``harnesses.json`` beside ``config.json`` — a dedicated leaf, present in BOTH
+``security._WRITE_PROTECTED_HOME_PATHS`` (the file-edit tools) and
+``security._WRITE_PROTECTED_BASH_LEAVES`` (shell redirects, anchored form) —
+so neither an agent file-edit nor ``echo '{...}' > ~/.kiro/crew/harnesses.json``
+can plant a descriptor. Reads stay allowed on both paths: the file holds no
+secret and the registry (plus an operator's ``cat``) must read it freely. This
+is the same relocation the repo applied to ``playwright-cli-config.json``, the
+computer-use policy, and the OMC rotation record: a value that is an input to a
+security decision moves OUT of the generally-writable config surface instead of
+growing a bespoke guard. The registry still validates every row as untrusted —
+an entry that fails validation is excluded from every listing with a recorded
+reason — because write protection bounds who can author the file, not what a
+legitimate author may have typo'd.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+# ``resolve_executable`` is the adapters' seam, imported into this namespace
+# rather than reimplemented: an adapter owns its own command resolution
+# (kiro-cli's install-location chain, KAS's Node-plus-script pair) and a
+# descriptor with no adapter gets the generic PATH rule, which is all an operator
+# harness needs. Availability calls it as a module global, so one seam answers
+# for every harness and a test can substitute it once.
+from kiro_crew.acp.harness_adapters import resolve_executable
+from kiro_crew.acp.harness_descriptor import (
+    ADAPTER_CLAUDE,
+    ADAPTER_KAS,
+    ADAPTER_KIRO,
+    MCP_DELIVERY_FILE_FED,
+    MCP_DELIVERY_WIRE_FED,
+    CapabilitySet,
+    HarnessDescriptor,
+    descriptor_from_mapping,
+    validate_descriptor,
+)
+
+#: Leaf name of the operator-descriptor file, resolved against ``config_dir()``.
+#: A module-level constant (not an inline literal) because ``security.py`` names
+#: the same leaf in BOTH write-protection registers and the docs name it for
+#: operators — one spelling, pinned by ``test_harness_registry``.
+OPERATOR_HARNESSES_LEAF = "harnesses.json"
+
+logger = logging.getLogger(__name__)
+
+# ── Bundled harness ids ──
+# Kiro-cli's id is spelled out rather than reusing ``ACP_BACKEND_KIRO`` (the
+# empty string): an id appears in a config key, an API query parameter, a session
+# record, and a spawn argument, and "" is unusable in all four. The empty string
+# remains its ALIAS — see :data:`_ALIASES`.
+
+HARNESS_KIRO = "kiro"
+HARNESS_KAS = "kas"
+HARNESS_CODEX = "codex"
+HARNESS_CLAUDE = "claude"
+
+#: The harness an operator who configures nothing gets, and the one an unusable
+#: configured value degrades to (harness-parity H1/H3).
+DEFAULT_HARNESS = HARNESS_KIRO
+
+
+class UnknownHarness(LookupError):
+    """Raised for a harness id that is not registered.
+
+    ``LookupError`` because that is what the operation is — a failed lookup — so
+    a caller that already handles ``KeyError``-shaped failures keeps working.
+    """
+
+
+class HarnessUnavailable(RuntimeError):
+    """Raised when a registered harness cannot serve a session right now.
+
+    Distinct from :class:`UnknownHarness` on purpose: "you named something that
+    does not exist" and "that harness exists but its binary is missing" are
+    different operator actions, and a surface that collapses them tells the
+    operator to fix the wrong thing.
+    """
+
+    def __init__(self, harness_id: str, reason: str) -> None:
+        super().__init__(f"harness {harness_id!r} is unavailable: {reason}")
+        self.harness_id = harness_id
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class HarnessListing:
+    """One row of :meth:`HarnessRegistry.list` — what a surface needs to render.
+
+    ``reason`` is empty exactly when ``available`` is True, so a surface can show
+    it unconditionally. ``valid`` is False only for the rows
+    :meth:`HarnessRegistry.invalid` returns; ``list()`` never yields one.
+    """
+
+    id: str
+    display_name: str
+    available: bool
+    reason: str
+    bundled: bool
+    valid: bool = True
+
+
+# ── Bundled descriptors ──
+# Capability sets are transcribed from the ``ACP_BACKENDS_*`` frozensets in
+# acp/types.py and from the code paths that gate Tool Search and reasoning
+# effort. Every membership below is a deliberate decision with the evidence in
+# its comment; a capability nobody has demonstrated stays off (harness-parity
+# H6), because the failure direction of a wrong grant is silent.
+
+_KIRO_DESCRIPTOR = HarnessDescriptor(
+    id=HARNESS_KIRO,
+    display_name="Kiro CLI",
+    executable="kiro-cli",
+    # kiro-cli's spawn command is rendered from this template:
+    # ``[kiro_bin, "acp", "--agent", agent]``, plus ``["--model", model]`` when a
+    # model is pinned. A golden test pins those bytes, because the default path's
+    # argv is the one thing no operator opted into and every install depends on.
+    argv=("{executable}", "acp"),
+    agent_args=("--agent", "{agent}"),
+    model_args=("--model", "{model}"),
+    capabilities=CapabilitySet(
+        # Every grant kiro-cli holds now lives on THIS descriptor (the
+        # ACP_BACKENDS_SESSION_SHARING / _STEER / _INTERNAL_SANDBOX / _ACP_RUNTIME
+        # / _KIRO_IDENTITY_STORE frozensets that once all contained
+        # ACP_BACKEND_KIRO are retired — wave-2 T5).
+        session_sharing=True,
+        steer=True,
+        internal_sandbox=True,
+        acp_runtime_pool=True,
+        kiro_identity_store=True,
+        # Tool Search is a kiro-cli feature written into its own workspace
+        # ``cli.json`` overlay (``providers.acp._write_tool_search_overlay``).
+        mcp_tool_search=True,
+        # Effort reaches kiro-cli through the same overlay
+        # (``providers.acp._apply_effort_overlay``) plus its advertised
+        # ``configOptions``.
+        reasoning_effort=True,
+    ),
+    # kiro-cli reads its MCP servers from its own agent spec; ``session/new``
+    # carries only the pooled broker stubs, which shadow same-named spec entries.
+    mcp_delivery=MCP_DELIVERY_FILE_FED,
+    adapter=ADAPTER_KIRO,
+)
+
+_KAS_DESCRIPTOR = HarnessDescriptor(
+    id=HARNESS_KAS,
+    display_name="Kiro Agent Server",
+    # KAS is reached through kiro-cli's OWN ACP relay -- ``kiro-cli acp
+    # --agent-engine v3 --auth-method cli`` -- so the executable it resolves is
+    # kiro-cli, discovered through the same candidate chain the kiro harness uses.
+    # The relay owns both concerns Crew used to hold: locating KAS's extracted
+    # Node bundle, and answering its access-token callback. ``kas_transport``
+    # builds the argv; neither an ``--agent`` nor a ``--model`` block appears
+    # because both are chosen per session over the wire.
+    executable="kiro-cli",
+    argv=("{executable}",),
+    capabilities=CapabilitySet(
+        # The grant now lives on this descriptor (the ACP_BACKENDS_* views are
+        # retired — wave-2 T5). KAS keeps steer + acp_runtime_pool; it
+        # deliberately does NOT get session_sharing (its teardown deletes the
+        # persisted session, so a shared subagent would strand spawn_continue)
+        # and does NOT get internal_sandbox.
+        steer=True,
+        acp_runtime_pool=True,
+        # NOT granted, even though the process on the end of the argv IS
+        # kiro-cli. The relay starts the KAS server with no ``--sandbox``
+        # argument and KAS's sandbox factory resolves an absent config to its
+        # no-op backend, so no OS sandbox starts inside. This capability makes
+        # ``sandbox.wrap_argv`` SKIP Crew's own seatbelt in favour of the
+        # harness's internal one, so claiming it here would trade a real layer
+        # for one that never starts (harness-parity H7 -- the flag that fails
+        # OPEN).
+        internal_sandbox=False,
+        # GRANTED: ``--auth-method cli`` keeps token resolution inside the
+        # kiro-cli process, which holds the OIDC refresh token, so every access
+        # token a KAS session serves comes from kiro-cli's own identity store.
+        # That is the demonstration this capability waits for. It authorizes
+        # retiring a live session's child when the store starts naming a
+        # different account: without it a KAS session would keep serving turns on
+        # a logged-out account's credentials.
+        kiro_identity_store=True,
+        # NOT granted, and both are a deliberate WITHDRAWAL of a write KAS
+        # receives today. The gates used to be spelled ``is_claude_backend``, so
+        # KAS got kiro-cli's ``cli.json`` overlay writes as a consequence of a
+        # negative test rather than of anything it demonstrated (harness-parity
+        # H6). Tool Search and the effort overlay are both written into kiro-cli's
+        # OWN workspace ``cli.json``; the relay does not forward that file's
+        # settings to the v3 engine, so the writes bought nothing and cost a
+        # settings file inside the user's project directory. Effort is the one
+        # with a second channel (the live ``/effort`` command), and it is
+        # withdrawn too rather than half-kept: the spawn path already drops a
+        # per-spawn effort level for KAS and reports the drop, so granting it here
+        # would make one build answer "does KAS honour effort" two different ways.
+        # Either opts in the moment someone shows KAS honours the channel.
+        mcp_tool_search=False,
+        reasoning_effort=False,
+    ),
+    mcp_delivery=MCP_DELIVERY_WIRE_FED,
+    adapter=ADAPTER_KAS,
+)
+
+_CODEX_DESCRIPTOR = HarnessDescriptor(
+    id=HARNESS_CODEX,
+    display_name="Codex CLI",
+    # The ACP server is the ``codex-acp`` npm adapter, NOT the ``codex`` CLI:
+    # per the dormant seam's own spawn path (``_resolve_codex_acp_bin`` in
+    # acp/client.py, upstream #7813), "The 'codex' CLI alone does not serve
+    # ACP" — it would read ``acp`` as a prompt and never answer initialize, so
+    # every selected session would hang at handshake. The adapter is spawned
+    # bare and driven entirely over the pipe (it ships its own Codex binary),
+    # and model selection travels over ``session/set_config_option`` (codex is
+    # in the config-option channel; STANDARD profile), so there are no
+    # model_args either.
+    executable="codex-acp",
+    # Data-only: no adapter class exists for Codex yet, so this entry is exactly
+    # what an operator descriptor would be, validated structurally only (the
+    # binary is not present in CI). A harness whose real convention differs is
+    # corrected here, in data, with no spawn-code change.
+    argv=("{executable}",),
+    capabilities=CapabilitySet(),
+    mcp_delivery=MCP_DELIVERY_WIRE_FED,
+)
+
+_CLAUDE_DESCRIPTOR = HarnessDescriptor(
+    id=HARNESS_CLAUDE,
+    display_name="Claude Code",
+    executable="claude-agent-acp",
+    argv=("{executable}",),
+    capabilities=CapabilitySet(
+        # Grants all withdrawn on THIS descriptor (the ACP_BACKENDS_* sets it
+        # once sat in — or out of — are retired, wave-2 T5): the seam runs one
+        # AcpClient per session, so no runtime pool and no session sharing, and
+        # it authenticates through its own subscription rather than kiro-cli's
+        # identity store.
+        # Effort IS supported, but as a live push after the session is ready
+        # (``AcpProvider._set_claude_effort`` -> ``session/set_config_option``)
+        # rather than through the kiro cli.json overlay.
+        reasoning_effort=True,
+    ),
+    mcp_delivery=MCP_DELIVERY_WIRE_FED,
+    adapter=ADAPTER_CLAUDE,
+)
+
+#: Bundled descriptors in listing order, default first.
+BUNDLED_DESCRIPTORS: tuple[HarnessDescriptor, ...] = (
+    _KIRO_DESCRIPTOR,
+    _KAS_DESCRIPTOR,
+    _CODEX_DESCRIPTOR,
+    _CLAUDE_DESCRIPTOR,
+)
+
+#: The bundled descriptors keyed by id, for the reads that must not touch
+#: configuration. Built once at import from the same tuple, so it cannot name a
+#: harness the listings do not.
+_BUNDLED_BY_ID: Mapping[str, HarnessDescriptor] = {d.id: d for d in BUNDLED_DESCRIPTORS}
+
+#: Bundled harnesses that this BUILD cannot serve at all, mapped to the reason a
+#: listing shows. Empty after upstream #7301 made Claude Code a selectable public
+#: backend: the public build genuinely serves it (``acp/client.py`` owns the whole
+#: spawn path and the adapter is a public npm package), so claude's row moved out
+#: of here. Whether claude is USABLE on a given machine is a separate question,
+#: answered by executable resolution today (and by the install probe once stage 3
+#: wires ``agent_sdk.backend_install`` in) — a missing ``claude-agent-acp`` yields
+#: an "unavailable" listing with the binary reason, not an "unserviceable" one.
+#:
+#: The mechanism is retained deliberately: an edition whose build genuinely cannot
+#: serve a bundled harness registers its refusal here, so the harness stays visible
+#: with an honest reason rather than silently spawning something else under its
+#: label. It is a build-capability gate, distinct from the deployment-policy gate
+#: (``acp_backends.selectable_backends()``) and the machine-availability gate.
+_UNSERVICEABLE: Mapping[str, str] = {}
+
+
+def unserviceable_reason(harness_id: str) -> str:
+    """The ``_UNSERVICEABLE`` reason for ``harness_id``, or ``""`` when it serves.
+
+    The single read of the ``_UNSERVICEABLE`` map for callers outside this
+    module (``acp.harness_selection.unserviceable_reason``, which the selection
+    surfaces consume). Keeping the map private and exposing it only through this
+    function keeps the ownership posture one-directional at the seam: a consumer
+    asks about one harness and cannot enumerate or mutate the table. After wave 2
+    and upstream #7301 the map is EMPTY in the public build — Claude Code is now a
+    selectable public backend, so it no longer sits here — and a harness that
+    merely lacks a legacy ``acp_backend`` spelling (Codex, every operator
+    descriptor) was never here either; all of them answer ``""``. An edition whose
+    build genuinely cannot serve a bundled harness is what would populate it.
+    """
+    return _UNSERVICEABLE.get(harness_id, "")
+
+
+# ── Legacy ``agent.acp_backend`` aliases ──
+# Upstream selects a backend at ``agent.acp_backend``; the empty string means
+# kiro-cli. Those values keep working unchanged by resolving to descriptor ids
+# (R1.6). Resolution is TOTAL and degrades to the default for anything else,
+# mirroring ``_normalize_acp_backend``: an unknown or unselectable persisted
+# value costs a log line, never a gateway that will not start (harness-parity
+# H1/H3).
+_ALIASES: Mapping[str, str] = {
+    "": HARNESS_KIRO,
+    HARNESS_KIRO: HARNESS_KIRO,
+    HARNESS_KAS: HARNESS_KAS,
+    HARNESS_CODEX: HARNESS_CODEX,
+    HARNESS_CLAUDE: HARNESS_CLAUDE,
+}
+
+#: How long a recorded spawn/initialize failure keeps a harness marked
+#: unavailable. It expires rather than sticking, because the failure is a
+#: SNAPSHOT of one attempt: the operator signs in, or reinstalls the binary, and
+#: nothing would clear a permanent verdict short of a gateway restart — which
+#: R6.5 exists to avoid. Short enough that a repaired harness heals on its own,
+#: long enough that a listing does not re-offer a harness that just failed.
+_PROBE_FAILURE_TTL_SECS = 300.0
+
+
+class HarnessRegistry:
+    """Serves harness descriptors, availability, and legacy alias resolution.
+
+    Synchronous throughout: every answer is either in-memory data or a stat-level
+    filesystem question, so an async wrapper would add a hop without removing a
+    blocking call. Callers on the event loop that care route the listing through
+    ``asyncio.to_thread`` the same way the config readers do.
+
+    One process-wide instance is expected (:func:`registry`), so the descriptor
+    cache is guarded by a lock: listings are reached from request handlers and
+    from ``to_thread`` offloads at the same time.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._fingerprint: tuple | None = None
+        self._descriptors: dict[str, HarnessDescriptor] = {}
+        self._invalid: dict[str, list[str]] = {}
+        self._configured_default: str = ""
+        self._probe_failures: dict[str, tuple[float, str]] = {}
+
+    # ── Loading ──
+
+    def _operator_section(self) -> tuple[dict, str]:
+        """``(operator descriptors, agent.default_harness)`` as stored.
+
+        The descriptors are read from ``harnesses.json`` beside ``config.json``
+        — a DEDICATED file, not a config key, because a descriptor names a
+        binary the gateway spawns and no loader clamp can bound that value. A
+        dedicated leaf can be write-protected on BOTH agent write paths
+        (``security._WRITE_PROTECTED_HOME_PATHS`` for the file-edit tools and
+        ``security._WRITE_PROTECTED_BASH_LEAVES`` for shell redirects) without
+        touching how ``config.json`` itself is read, which is the exposure that
+        made the earlier ``agent.harnesses`` config key unshippable: the config
+        file deliberately stays bash-readable, so a raw ``echo '{...}' >
+        config.json`` could plant a shape-valid descriptor there. Same
+        relocation the repo already applied to ``playwright-cli-config.json``,
+        ``computer_use.json``, and the OMC policy for this exact class.
+
+        ``default_harness`` stays a config key: it selects among already
+        registered ids and an unknown or unavailable value degrades to
+        kiro-cli, so the loader-clamp reasoning that protects the rest of the
+        config holds for it.
+
+        Deferred import of the config loader, for the reason
+        ``_normalize_acp_backend`` defers the reverse edge: the loader is imported
+        first by the gateway and desktop entrypoints, and a module-scope import
+        here would put the whole config module behind an ACP vocabulary import.
+        A config that cannot be read at all leaves the bundled harnesses
+        serving — one broken file must not cost the default harness; a
+        ``harnesses.json`` that is absent (the common case) or unparseable
+        likewise costs only the operator rows.
+        """
+        default_harness = ""
+        try:
+            from kiro_crew.config.loader import KiroCrewConfig
+
+            agent = KiroCrewConfig.load().agent
+            default_harness = getattr(agent, "default_harness", "") or ""
+        except Exception:
+            logger.warning("harness registry: config unreadable; default harness is kiro")
+        raw: Any = {}
+        try:
+            from kiro_crew.config.loader import config_dir
+
+            path = config_dir() / OPERATOR_HARNESSES_LEAF
+            if path.is_file():
+                raw = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.warning(
+                "harness registry: %s unreadable; serving bundled harnesses only",
+                OPERATOR_HARNESSES_LEAF,
+            )
+            raw = {}
+        return (raw if isinstance(raw, dict) else {}), str(default_harness)
+
+    @staticmethod
+    def _fingerprint_of(raw: Mapping[str, Any], default_harness: str) -> tuple:
+        """A cheap, total signature of the operator harness configuration.
+
+        Keyed on the CONTENT rather than on the config file's mtime because that
+        is what the parse result depends on: an unrelated settings write must not
+        re-validate every operator descriptor, and an edit to one must.
+        ``repr`` is used rather than JSON so an unserializable value (config is
+        untrusted) still produces a key instead of raising.
+        """
+        return (default_harness, tuple(sorted((str(k), repr(v)) for k, v in raw.items())))
+
+    def _ensure_loaded(self) -> None:
+        """Refresh the descriptor cache when the operator configuration changed."""
+        raw, default_harness = self._operator_section()
+        fingerprint = self._fingerprint_of(raw, default_harness)
+        with self._lock:
+            if self._fingerprint == fingerprint and self._descriptors:
+                return
+            descriptors: dict[str, HarnessDescriptor] = {d.id: d for d in BUNDLED_DESCRIPTORS}
+            invalid: dict[str, list[str]] = {}
+            for key, value in raw.items():
+                harness_id = str(key)
+                descriptor, reasons = descriptor_from_mapping(
+                    value,
+                    harness_id=harness_id,
+                    taken_ids=tuple(descriptors),
+                )
+                if descriptor is None:
+                    # One bad entry costs its own harness and nothing else: the
+                    # loop keeps going, the reasons are retained for the operator,
+                    # and every other harness stays selectable (R2.3).
+                    invalid[harness_id] = reasons
+                    logger.warning(
+                        "harness registry: ignoring operator harness %r (%s)",
+                        harness_id,
+                        "; ".join(reasons),
+                    )
+                    continue
+                descriptors[descriptor.id] = descriptor
+            self._fingerprint = fingerprint
+            self._descriptors = descriptors
+            self._invalid = invalid
+            self._configured_default = default_harness
+
+    def reload(self) -> None:
+        """Drop the cached descriptors so the next call re-reads configuration.
+
+        For the write paths that persist a harness definition (and for tests):
+        the content fingerprint already catches an edit, so this only shortens
+        the window, and it is deliberately the ONLY mutator this class exposes —
+        there is no setter for a harness definition anywhere in this module.
+        """
+        with self._lock:
+            self._fingerprint = None
+            self._descriptors = {}
+            self._invalid = {}
+            self._configured_default = ""
+
+    # ── Reads ──
+
+    def get(self, harness_id: str) -> HarnessDescriptor:
+        """The descriptor for ``harness_id``.
+
+        Raises :class:`UnknownHarness` — including for an operator descriptor
+        that failed validation, which is registered nowhere. Availability is a
+        separate question; see :meth:`require_available`.
+        """
+        self._ensure_loaded()
+        descriptor = self._descriptors.get(harness_id)
+        if descriptor is None:
+            known = ", ".join(sorted(self._descriptors))
+            raise UnknownHarness(f"unknown harness {harness_id!r} (registered: {known})")
+        return descriptor
+
+    def default(self) -> HarnessDescriptor:
+        """The default harness: ``agent.default_harness``, else kiro-cli.
+
+        A configured default that is unknown or unavailable degrades to kiro-cli
+        with a logged reason rather than raising, for the reason H1/H3 give: an
+        operator whose configuration is unusable still gets a working gateway.
+
+        Reads ``agent.default_harness`` ONLY — the legacy ``agent.acp_backend``
+        is not consulted here, and composing
+        ``resolve_alias(config.agent.acp_backend)`` is the caller's
+        responsibility. A consumer wiring session creation MUST compose the two
+        (an explicit ``default_harness`` first, else the resolved alias) for an
+        operator's stored ``acp_backend`` to keep selecting the harness it names;
+        without that composition a config carrying only ``acp_backend: "kas"``
+        silently starts sessions on kiro-cli. Keeping the composition out of
+        here is deliberate: the precedence between the two keys belongs to the
+        surface that knows which one the operator meant, and this method stays
+        the single answer to "what does ``default_harness`` say".
+        """
+        self._ensure_loaded()
+        configured = self._configured_default
+        if configured:
+            try:
+                descriptor = self.get(configured)
+            except UnknownHarness:
+                logger.warning(
+                    "Ignoring agent.default_harness %r (unknown harness); using %r",
+                    configured,
+                    DEFAULT_HARNESS,
+                )
+            else:
+                available, reason = self._availability(descriptor)
+                if available:
+                    return descriptor
+                logger.warning(
+                    "Ignoring agent.default_harness %r (%s); using %r",
+                    configured,
+                    reason,
+                    DEFAULT_HARNESS,
+                )
+        return self.get(DEFAULT_HARNESS)
+
+    def capabilities(self, harness_id: str) -> CapabilitySet:
+        """The capability set ``harness_id`` declares."""
+        return self.get(harness_id).capabilities
+
+    def bound_capabilities(self, harness_id: str) -> CapabilitySet:
+        """Capabilities for a harness a session is already bound to. Non-blocking.
+
+        The read every capability GATE uses, and it is separate from
+        :meth:`capabilities` for one reason: a gate is asked from the event loop —
+        the identity-change sweep walks every live session, ``supports_steer`` is
+        consulted mid-turn — and :meth:`capabilities` goes through
+        :meth:`_ensure_loaded`, which stats and may read ``config.json``. This
+        answers from the loaded cache when there is one and from the bundled table
+        otherwise, so no gate puts a configuration read on the loop.
+
+        A harness this cannot resolve answers with every flag OFF rather than
+        raising. Fail-closed is the correct direction for a gate — the feature
+        does not happen, instead of a harness inheriting a sandbox waiver or
+        session sharing it never declared — and raising would turn an
+        unresolvable id into a broken turn. It is a floor and not a path: an
+        operator harness is resolvable from the cache from the moment a surface
+        selected it (selection loads the registry), and a bundled one needs no
+        cache at all. The warning is what makes the floor diagnosable, since a
+        silently capability-less session presents only as a feature that stopped
+        happening.
+        """
+        with self._lock:
+            descriptor = self._descriptors.get(harness_id)
+        if descriptor is None:
+            descriptor = _BUNDLED_BY_ID.get(harness_id)
+        if descriptor is None:
+            logger.warning(
+                "harness registry: no descriptor for bound harness %r; "
+                "answering every capability as unsupported",
+                harness_id,
+            )
+            return CapabilitySet()
+        return descriptor.capabilities
+
+    def resolve_alias(self, acp_backend_value: object) -> str:
+        """A legacy ``agent.acp_backend`` value as a registered descriptor id.
+
+        Total, and never raises: every value ``_normalize_acp_backend`` accepts
+        today maps to a registered bundled id, and everything else — an unknown
+        string, a non-string a hand-edited config can hold, or a value the code
+        knows but cannot serve — resolves to the default. That is the same
+        degrade-to-default posture the normalizer has, and it is deliberate: a
+        typo must not select a foreign harness, and it must not stop the gateway
+        either (harness-parity H3).
+        """
+        if isinstance(acp_backend_value, str):
+            # Unserviceable is consulted BEFORE the alias table, and the order is
+            # the whole safety of this function: nothing structurally keeps the
+            # two mappings disjoint (a harness that gains a legacy identifier
+            # gains an alias row, while its unserviceable row lives elsewhere in
+            # the module), and with the alias first an id present in both would
+            # resolve to a harness that cannot serve a session — which is exactly
+            # what the unserviceable row exists to prevent.
+            unserviceable = _UNSERVICEABLE.get(acp_backend_value)
+            if unserviceable:
+                logger.warning(
+                    "agent.acp_backend %r names a harness that cannot serve a session (%s); "
+                    "using %r",
+                    acp_backend_value,
+                    unserviceable,
+                    DEFAULT_HARNESS,
+                )
+                return DEFAULT_HARNESS
+            resolved = _ALIASES.get(acp_backend_value)
+            if resolved is not None:
+                return resolved
+        if acp_backend_value not in (None, ""):
+            logger.warning(
+                "Ignoring agent.acp_backend %r (unknown harness); using %r",
+                acp_backend_value,
+                DEFAULT_HARNESS,
+            )
+        return DEFAULT_HARNESS
+
+    # ── Availability ──
+
+    def availability(self, harness_id: str) -> tuple[bool, str]:
+        """``(available, reason)`` for ``harness_id``; ``reason`` is empty when available."""
+        return self._availability(self.get(harness_id))
+
+    def _availability(
+        self, descriptor: HarnessDescriptor, *, honor_recent_failure: bool = True
+    ) -> tuple[bool, str]:
+        """``(available, reason)`` for an already-resolved descriptor.
+
+        Three questions, cheapest first: is the harness serviceable at all, did a
+        recent spawn fail, and does its executable resolve? Nothing here runs the
+        harness (see the module docstring), and nothing is cached — the answer
+        describes the machine as it is right now, which is what lets a newly
+        installed binary appear without a restart (R6.5).
+
+        Takes the descriptor rather than an id so a listing pays one config read
+        for the whole table instead of one per row.
+
+        ``honor_recent_failure=False`` skips the recorded-failure question for a
+        caller that is not making a CHOICE — a resume returning a session to the
+        harness it already has. A recorded failure describes one spawn attempt and
+        only a successful spawn clears it, so a resume that honoured it would be
+        refused for the whole failure window even after the operator fixed the
+        cause, and the refusal is what prevents the spawn that would clear it. The
+        two questions that describe the machine as it is now (serviceable,
+        executable resolves) are always asked.
+        """
+        harness_id = descriptor.id
+        unserviceable = _UNSERVICEABLE.get(harness_id)
+        if unserviceable:
+            return False, unserviceable
+        if honor_recent_failure:
+            probe_reason = self._probe_failure(harness_id)
+            if probe_reason:
+                return False, probe_reason
+        reasons = validate_descriptor(descriptor)
+        if reasons:
+            # Unreachable for an operator descriptor (an invalid one is never
+            # registered) and a bug for a bundled one, so it is reported rather
+            # than swallowed: a bundled descriptor that stops validating must be
+            # visible as itself, not as a missing binary.
+            return False, "; ".join(reasons)
+        _path, reason = resolve_executable(descriptor)
+        if reason:
+            return False, reason
+        return True, ""
+
+    def _probe_failure(self, harness_id: str) -> str:
+        """The recorded spawn failure for ``harness_id``, if it has not expired."""
+        with self._lock:
+            entry = self._probe_failures.get(harness_id)
+            if entry is None:
+                return ""
+            recorded_at, reason = entry
+            if (time.monotonic() - recorded_at) >= _PROBE_FAILURE_TTL_SECS:
+                del self._probe_failures[harness_id]
+                return ""
+            return reason
+
+    def note_probe_failure(self, harness_id: str, reason: str) -> None:
+        """Record that ``harness_id`` failed to start, so listings say so.
+
+        Called by the spawn path when a harness dies during ACP initialize (an
+        unauthenticated harness is the common case). Stored per harness, so one
+        failure never touches another harness's availability (R6.4).
+        """
+        if not harness_id or not reason:
+            return
+        with self._lock:
+            self._probe_failures[harness_id] = (time.monotonic(), reason)
+
+    def clear_probe_failure(self, harness_id: str) -> None:
+        """Forget a recorded failure — called after ``harness_id`` starts cleanly."""
+        with self._lock:
+            self._probe_failures.pop(harness_id, None)
+
+    def require_available(
+        self, harness_id: str, *, honor_recent_failure: bool = True
+    ) -> HarnessDescriptor:
+        """The descriptor for ``harness_id``, or a refusal naming the harness.
+
+        The one entry point for a selection surface: it raises
+        :class:`UnknownHarness` or :class:`HarnessUnavailable` rather than
+        returning a substitute, because every surface's rule is
+        refusal-over-fallback — silently serving a different harness than the one
+        asked for is the failure this whole feature is meant to make impossible.
+
+        ``honor_recent_failure=False`` is for a caller returning a session to the
+        harness it is already bound to rather than choosing one; see
+        :meth:`_availability`.
+        """
+        descriptor = self.get(harness_id)
+        available, reason = self._availability(
+            descriptor, honor_recent_failure=honor_recent_failure
+        )
+        if not available:
+            raise HarnessUnavailable(harness_id, reason)
+        return descriptor
+
+    # ── Listings ──
+
+    def list(self) -> tuple[HarnessListing, ...]:
+        """Every registered harness, each marked available or unavailable.
+
+        Bundled harnesses come first in declaration order (default first), then
+        operator harnesses sorted by id, so a selection surface renders a stable
+        list. Returned as a tuple — the design writes ``list[HarnessListing]``,
+        and a tuple is the same thing to every consumer while keeping a caller
+        from mutating the registry's view of the world.
+
+        Invalid operator descriptors are NOT here; see :meth:`invalid`.
+        """
+        self._ensure_loaded()
+        bundled_ids = [d.id for d in BUNDLED_DESCRIPTORS if d.id in self._descriptors]
+        operator_ids = sorted(set(self._descriptors) - set(bundled_ids))
+        rows: list[HarnessListing] = []
+        for harness_id in [*bundled_ids, *operator_ids]:
+            descriptor = self._descriptors[harness_id]
+            available, reason = self._availability(descriptor)
+            rows.append(
+                HarnessListing(
+                    id=harness_id,
+                    display_name=descriptor.label,
+                    available=available,
+                    reason=reason,
+                    bundled=harness_id in bundled_ids,
+                )
+            )
+        return tuple(rows)
+
+    def invalid(self) -> tuple[HarnessListing, ...]:
+        """Operator descriptors that failed validation, with their reasons.
+
+        Separate from :meth:`list` so a selection surface cannot reach one, while
+        Settings can still render "this entry of yours is broken, here is why" —
+        which is the whole value of recording the reason (R2.3, R6.2).
+        """
+        self._ensure_loaded()
+        return tuple(
+            HarnessListing(
+                id=harness_id,
+                display_name=harness_id,
+                available=False,
+                reason="; ".join(reasons),
+                bundled=False,
+                valid=False,
+            )
+            for harness_id, reasons in sorted(self._invalid.items())
+        )
+
+
+_REGISTRY = HarnessRegistry()
+
+
+def registry() -> HarnessRegistry:
+    """The process-wide registry.
+
+    A function rather than a bare module global so a test can reach the same
+    instance every consumer does, and so the singleton is constructed at import
+    without touching configuration or the filesystem (R6.1).
+    """
+    return _REGISTRY

--- a/src/kiro_crew/acp/protocol_profile.py
+++ b/src/kiro_crew/acp/protocol_profile.py
@@ -1,0 +1,140 @@
+"""Wire-protocol profile: the ACP dialect an adapter speaks, as data.
+
+``AcpClient``/``AcpRuntime`` historically forked on ``_is_claude``-descended
+branches for the handful of ways the public ACP wire differs from kiro-cli's:
+the ``initialize`` ``protocolVersion`` (a date string for kiro, the integer ``1``
+for public ACP), which ``PermissionOption`` field names WE emit/prefer
+(``id``/``label`` vs ``optionId``/``name`` — the *parser* stays tolerant of both
+regardless), whether ``session/set_config_option`` is used (e.g. to set the model
+or an effort level), and whether the harness emits ``agent_thought_chunk``
+reasoning updates.
+
+Those are properties of the *harness*, not of the legacy backend string, so they
+belong on the adapter. A frozen :class:`ProtocolProfile` names them in one place;
+:data:`KIRO_PROFILE` carries today's kiro-cli bytes, :data:`STANDARD_ACP_PROFILE`
+the public-ACP bytes, and :data:`KAS_PROFILE` the KAS relay's (kiro-cli's dialect
+but the public-ACP integer ``protocolVersion``, verified against ``runtime.py``).
+The adapter owns the profile (see :mod:`kiro_crew.acp.harness_adapters`); where
+client/runtime code cannot reach an adapter object it derives the profile from
+the backend string through the single :func:`profile_for_backend` mapping, so the
+string→profile decision lives here and nowhere else.
+
+This is a seam: every value equals the constant the corresponding ``_is_claude``
+branch used, so kiro/kas/claude bytes are unchanged and the golden argv/handshake
+tests pin no difference. The backend-identifier constants
+(:data:`~kiro_crew.acp.harness_descriptor.ACP_BACKEND_KIRO` and its siblings) are
+imported from the descriptor leaf rather than ``acp.types`` so this module has no
+module-scope edge into the ``types`` -> ``harness_registry`` -> ``harness_adapters``
+cycle; ``harness_adapters`` therefore imports the profile constants at module
+scope like any ordinary dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Union
+
+from kiro_crew.acp.harness_descriptor import (
+    ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_CODEX,
+    ACP_BACKEND_KAS,
+)
+
+PermissionOptionStyle = Literal["kiro", "standard"]
+
+
+@dataclass(frozen=True)
+class ProtocolProfile:
+    """The ACP wire dialect a harness speaks.
+
+    Frozen because a profile is a fixed description of a harness's wire, shared
+    by every session on that harness; nothing mutates it per session.
+
+    - ``protocol_version``: the value sent as ``initialize.protocolVersion`` —
+      kiro-cli's date string, or the public-ACP integer.
+    - ``permission_option_style``: which ``PermissionOption`` field spelling WE
+      emit/prefer. The parser reads both spellings regardless; this only decides
+      what we produce. No production code consumes this yet — land its consumer
+      with it, and until then do not gate parsing on it (the parser is
+      deliberately harness-agnostic).
+    - ``supports_set_config_option``: whether ``session/set_config_option`` is the
+      channel for model / effort selection (vs kiro-cli's ``session/set_model``
+      and ``set_mode``).
+    - ``emits_thought_chunks``: whether the harness is OBSERVED to emit
+      ``agent_thought_chunk`` reasoning updates as a dedicated update type. Not
+      consumed in production today; ``False`` for kiro-cli records that we have
+      not observed them, not a guarantee — ``_extract_text_chunk`` handles the
+      update unconditionally, so do NOT gate chunk parsing on this flag or a
+      harness's reasoning text would be silently dropped.
+    """
+
+    protocol_version: Union[str, int]
+    permission_option_style: PermissionOptionStyle
+    supports_set_config_option: bool
+    emits_thought_chunks: bool
+
+
+#: kiro-cli's wire: a date-string protocol version, kiro-style permission options,
+#: no ``session/set_config_option`` (it uses ``session/set_model`` + ``set_mode``),
+#: and no dedicated thought-chunk update type.
+KIRO_PROFILE = ProtocolProfile(
+    protocol_version="2025-08-22",
+    permission_option_style="kiro",
+    supports_set_config_option=False,
+    emits_thought_chunks=False,
+)
+
+#: The KAS relay's wire: kiro-cli's dialect in every respect EXCEPT the
+#: ``initialize`` ``protocolVersion``, which the relay expects as the public-ACP
+#: integer ``1`` (``runtime.py``'s :data:`~kiro_crew.acp.runtime.PROTOCOL_VERSION_KAS`,
+#: selected on the primary v3 path). Verified against the wire in ``runtime.py``,
+#: not inferred from "the relay IS kiro-cli": treating KAS as :data:`KIRO_PROFILE`
+#: would flip its handshake ``protocolVersion`` from ``1`` to the date string the
+#: moment a client/runtime site reads the profile instead of forking on the
+#: backend. The permission-option style, ``set_config_option`` posture, and
+#: thought-chunk behaviour are kiro-cli's, since the relay IS a kiro-cli.
+KAS_PROFILE = ProtocolProfile(
+    protocol_version=1,
+    permission_option_style="kiro",
+    supports_set_config_option=False,
+    emits_thought_chunks=False,
+)
+
+#: The public ACP wire (claude-agent-acp and the generic adapter): integer
+#: protocol version ``1``, standard permission-option field names,
+#: ``session/set_config_option`` for model/effort, and ``agent_thought_chunk``
+#: reasoning updates.
+STANDARD_ACP_PROFILE = ProtocolProfile(
+    protocol_version=1,
+    permission_option_style="standard",
+    supports_set_config_option=True,
+    emits_thought_chunks=True,
+)
+
+
+def profile_for_backend(backend: str) -> ProtocolProfile:
+    """The :class:`ProtocolProfile` for a legacy ``acp_backend`` string.
+
+    The single string→profile mapping, for client/runtime sites that hold a
+    backend string rather than an adapter object. ``claude`` speaks the public
+    ACP wire; the KAS relay speaks kiro-cli's dialect but with the public-ACP
+    integer ``protocolVersion`` (:data:`KAS_PROFILE`); kiro-cli (``""``) and any
+    unrecognized value speak kiro-cli's wire — kiro-cli's profile is the
+    fail-safe default because it is the wire AcpClient's default path already
+    speaks.
+    """
+    if backend == ACP_BACKEND_CLAUDE:  # harness-ok: this IS the string→profile map
+        return STANDARD_ACP_PROFILE
+    if backend == ACP_BACKEND_CODEX:  # harness-ok: this IS the string→profile map
+        # codex-acp speaks the public ACP wire: integer protocolVersion 1 and
+        # ``session/set_config_option`` for model/effort (upstream's
+        # PROTOCOL_VERSION_CODEX and its membership in both
+        # ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION and the effort set) — the
+        # standard profile IS that wire. Mapped even while the seam is dormant,
+        # so the day a provider registers it the handshake is already right.
+        return STANDARD_ACP_PROFILE
+    if backend == ACP_BACKEND_KAS:  # harness-ok: this IS the string→profile map
+        return KAS_PROFILE
+    # ACP_BACKEND_KIRO ("") and any unrecognized value → kiro-cli's wire, the
+    # dialect AcpClient's default path already speaks.
+    return KIRO_PROFILE

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -7,6 +7,14 @@ import re as _re
 from dataclasses import dataclass, field
 from typing import Any
 
+# The bundled-harness ids (our wave-2 registry vocabulary) still live in
+# ``harness_registry`` and back the ``_HARNESS_BACKENDS`` bridge below.
+from kiro_crew.acp.harness_registry import (
+    HARNESS_CLAUDE,
+    HARNESS_KAS,
+    HARNESS_KIRO,
+)
+
 # Backend identifiers, the capability sets and the selectable registry live in the
 # leaf module
 # ``kiro_crew.acp_backends`` (it imports nothing from this package, which is what
@@ -148,14 +156,104 @@ ACP_CLIENT_CAPABILITIES: dict = {
 # The selectable set is no longer a constant either: it is a REGISTRY an edition
 # extends (``register_selectable_backend``). A frozen ``ACP_BACKENDS_SELECTABLE``
 # snapshot here would be read before boot registration and silently miss it.
+# Consumers that need the selectable set call ``selectable_backends()``;
+# the wave-2 ``ACP_BACKENDS_SELECTABLE`` snapshot has been dropped.
 
-# ── Capability membership ──
+# ── Capability membership (harness-parity H6, H7) ──
+# Every capability a backend may claim is an OPT-IN grant, never a negation at
+# the call site. ``not is_claude_backend`` reads correctly with two backends and
+# then silently hands the capability to the third, so a harness that has never
+# demonstrated the capability inherits it — and the operator who never opted into
+# that harness is the one who finds out. Adding a member is a deliberate edit
+# with evidence; inheriting a default is not a decision. See
+# docs/system-specs/modules/harness-parity.md.
+#
 # The ``ACP_BACKENDS_*`` capability sets are DEFINED in the leaf module
 # ``kiro_crew.acp_backends`` and re-exported by the import above, so
-# ``from kiro_crew.acp.types import ACP_BACKENDS_STEER`` still resolves. They moved
-# for the same reason the backend identifiers did: a consumer outside this package
-# must be able to ask a capability question without importing ``kiro_crew.acp``,
-# whose ``__init__`` pulls in the client and runtime.
+# ``from kiro_crew.acp.types import ACP_BACKENDS_STEER`` still resolves. They live
+# in the leaf for the same reason the backend identifiers do: a consumer outside
+# this package must be able to ask a capability question without importing
+# ``kiro_crew.acp``, whose ``__init__`` pulls in the client and runtime.
+#
+# Two disciplines meet here and both hold:
+#
+# * PER-SESSION behavior gates read the session's BOUND DESCRIPTOR
+#   (``binding.descriptor.capabilities``), never a set keyed on the legacy
+#   ``acp_backend`` spelling — an operator harness has no such spelling, so a
+#   set lookup would silently mis-gate it (harness-parity H5/H6).
+# * OUTSIDE-ACP consumers with no session in hand (readiness, prerequisites,
+#   ``session._bg_runtime_backends``) read the leaf sets, whose membership is
+#   the ``acp_backend`` vocabulary — bundled harnesses only, by construction.
+#
+# The leaf sets and the bundled descriptors' ``CapabilitySet`` grants are two
+# spellings of the SAME facts, pinned in agreement by
+# ``test_harness_capability_views.py``: a capability cannot be claimed in one
+# vocabulary and withheld in the other. WHY a harness claims a capability — or
+# deliberately does not — is recorded on its descriptor in
+# ``acp/harness_registry.py``.
+#
+# A bundled harness with no legacy identifier (Codex), and every operator
+# harness, contributes no member to any leaf set: those sets are keyed by the
+# ``acp_backend`` vocabulary, and a harness outside it has nothing to
+# contribute. Such a harness is reached through the registry's capability read
+# instead, which is where every per-session consumer ends up.
+
+#: The legacy ``acp_backend`` spelling of each bundled harness that has one.
+_HARNESS_BACKENDS: dict[str, str] = {
+    HARNESS_KIRO: ACP_BACKEND_KIRO,
+    HARNESS_KAS: ACP_BACKEND_KAS,
+    HARNESS_CLAUDE: ACP_BACKEND_CLAUDE,
+}
+
+
+def legacy_backend_for(harness_id: str) -> str | None:
+    """The ``acp_backend`` spelling of ``harness_id``, or None when it has none.
+
+    The bridge a session binding needs while the provider is still keyed on
+    ``acp_backend``: a surface resolves a harness id, and this says which backend
+    identifier constructs a provider for it. ``None`` is a real answer — Codex and
+    every operator harness have no legacy spelling — and it must NOT be collapsed
+    to ``ACP_BACKEND_KIRO``, which is the empty string: a caller that treated a
+    missing spelling as kiro-cli's would hand a foreign harness kiro's capability
+    answers (session sharing, the identity-store sweep, the cli.json overlays)
+    without it having declared any of them. Callers refuse instead.
+
+    Reading it through a function rather than exporting the dict keeps the mapping
+    one-directional at the seam: consumers ask about one harness and cannot
+    enumerate or mutate the table.
+    """
+    return _HARNESS_BACKENDS.get(harness_id)
+
+
+#: :data:`_HARNESS_BACKENDS` read the other way: which harness a live process's
+#: backend spelling IS. Built from the same table so the two directions cannot
+#: drift, and one-to-one today — a spelling that ever names two harnesses needs
+#: an explicit tie-break here rather than whichever row was written last.
+_BACKEND_HARNESSES: dict[str, str] = {
+    backend: harness_id for harness_id, backend in _HARNESS_BACKENDS.items()
+}
+
+
+def harness_for_backend(acp_backend: str) -> str | None:
+    """The harness id whose legacy spelling is ``acp_backend``, else None.
+
+    The IDENTITY question — "which harness is this running process?" — and it is
+    deliberately not the registry's ``resolve_alias``, which answers the CONFIG
+    question "which harness did the operator's stored key select?". The two differ
+    for any harness that is known but not selectable: ``resolve_alias("codex")``
+    degrades to kiro-cli (with a WARNING naming ``agent.acp_backend``) because
+    selecting the dormant seam must not start a session on it. Read as an identity
+    that is a misattribution — a codex-seam session's usage rows would be
+    credited to kiro-cli, and its auth message would send the user to
+    ``kiro-cli login`` for a harness that never refused — plus a config warning on
+    a read that touched no config.
+
+    ``None`` means the spelling carries no bundled row at all, which provider
+    construction already rejects (``ACP_BACKENDS_KNOWN``); a caller that wants a
+    total answer falls back to the alias table for exactly that case.
+    """
+    return _BACKEND_HARNESSES.get(acp_backend)
+
 
 # ── Provider labels ──
 # The backend identity key persisted in the session map. It indexes three

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -54,6 +54,17 @@ from kiro_crew.computer_use.types import MAX_TREE_DEPTH_LIMIT as _CU_MAX_TREE_DE
 from kiro_crew.computer_use.types import MAX_TREE_NODES_LIMIT as _CU_MAX_TREE_NODES
 from kiro_crew.computer_use.types import MIN_SCREENSHOT_MAX_PX as _CU_MIN_SCREENSHOT_MAX_PX
 
+# Section DTOs and their field-level coercion live in a one-way sibling module.
+# Re-export every historical loader name so existing imports keep working while
+# KiroCrewConfig remains the compatibility facade and owns read/merge/save.
+# The three harness-config helpers (_stash_raw_acp_backend, _stored_acp_backend,
+# _normalize_harness_id) are called QUALIFIED through this module
+# import rather than added to the from-import above: that import list is the
+# loader's frozen compatibility re-export surface, pinned by identity in
+# test_config_module_boundaries — new internals the loader merely CONSUMES must
+# not widen what the facade re-exports.
+from kiro_crew.config import sections as _config_sections
+
 # Pure path primitives live in the leaf module ``config.paths`` (stdlib-only,
 # no ``kiro_crew`` imports) so the modules that only need ``config_dir()`` can
 # import them from there without transitively pulling in the full loader (DTOs,
@@ -93,10 +104,6 @@ from kiro_crew.config.resolution import (  # noqa: F401
     tailnet_effective_allowed_logins,
     tailnet_identity_unknown,
 )
-
-# Section DTOs and their field-level coercion live in a one-way sibling module.
-# Re-export every historical loader name so existing imports keep working while
-# KiroCrewConfig remains the compatibility facade and owns read/merge/save.
 from kiro_crew.config.sections import (  # noqa: F401
     _BOT_NAME_MAX,
     _BOT_NAME_RE,
@@ -2353,7 +2360,14 @@ class KiroCrewConfig:
 
             # Preserve fail-closed security semantics before advisory schema
             # validation can replace malformed input with a missing-field default.
-            # Normalize resource_limits FIRST, for exactly that reason. Its
+            # Record the stored ``agent.acp_backend`` spelling FIRST: validation
+            # blanks a value outside the field's enum, and the harness alias table
+            # is the thing that decides what a stored spelling means. Without this
+            # the enum clamp happens twice over — once here, once in
+            # ``_normalize_acp_backend`` — and the operator's value is gone before
+            # anything can refuse by name (see ``_stash_raw_acp_backend``).
+            _config_sections._stash_raw_acp_backend(data)
+            # Normalize resource_limits next, for exactly that reason. Its
             # fields are declared ``int | None``, so jsonschema reads a
             # hand-edited ``512.5`` as a type violation and
             # ``_apply_field_default`` POPS the key -- deleting a ceiling the
@@ -2561,6 +2575,9 @@ class KiroCrewConfig:
                 acp_backend=_normalize_acp_backend(agent_data.get("acp_backend")),
                 member_acp_backend=_normalize_acp_backend(
                     agent_data.get("member_acp_backend", "kas")
+                ),
+                default_harness=_config_sections._normalize_harness_id(
+                    agent_data.get("default_harness")
                 ),
                 default_agent=agent_data.get("default_agent", ""),
                 sweep_agents_backups=_safe_bool(
@@ -3602,6 +3619,15 @@ class KiroCrewConfig:
         except Exception as e:
             # Migration write-back is best-effort; never block startup.
             logger.warning("Config write-back failed: %s", e)
+
+        # The stored ``acp_backend`` spelling, assigned rather than constructed:
+        # it lives on the non-dataclass base ``_StoredBackendSpelling``, so it is
+        # not a field and cannot travel through __init__. Assigned AFTER the
+        # write-back above for the same reason it is not a field — it is not part
+        # of what gets serialized, so it must not be able to influence it.
+        stored_backend = _config_sections._stored_acp_backend(agent_data)
+        if stored_backend:
+            cfg.agent._acp_backend_stored = stored_backend
 
         return cfg, ticket
 

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -476,8 +476,30 @@ DEFAULT_CWD_ALLOWED_ROOTS = [
 ]
 
 
+class _StoredBackendSpelling:
+    """Non-field carrier for the ``acp_backend`` value as it was STORED.
+
+    A plain (non-dataclass) base, which is what keeps this attribute out of
+    ``dataclasses.fields(AgentConfig)``: the dataclass machinery collects
+    annotations from the class itself and from DATACLASS bases only, so an
+    annotation declared here is a normal class attribute and nothing else. That
+    matters because ``fields()`` is what ``asdict``, ``to_dict``, the JSON-schema
+    walker, and every published section default enumerate — and this value records
+    HOW a value was read, never what the operator set, so a key nobody configured
+    must not appear in ``config.json`` or in the settings schema.
+
+    A ``ClassVar`` would have the same effect on ``fields()`` and cannot be
+    assigned per instance (mypy refuses it, correctly — the loader needs one value
+    per loaded config, not one per process).
+    """
+
+    #: The pre-clamp ``agent.acp_backend`` spelling; assigned by the loader after
+    #: construction, "" for any programmatically built config.
+    _acp_backend_stored: str = ""
+
+
 @dataclass
-class AgentConfig:
+class AgentConfig(_StoredBackendSpelling):
     approval_mode: str = field(
         default="auto",
         metadata=_meta("Approval Mode", "Tool approval mode.", enum=["auto", "interactive"]),
@@ -601,6 +623,30 @@ class AgentConfig:
             # Same no-enum reasoning as acp_backend above: the live selectable
             # set comes from the registry via resolve_selected_backend, never a
             # frozen literal.
+        ),
+    )
+    #: The ``acp_backend`` value as STORED, before the selectable clamp above,
+    #: lives on :class:`_StoredBackendSpelling` rather than here so it is not a
+    #: dataclass field — see that class for why.
+    #:
+    #: It exists because the clamp is lossy in a way that matters to harness
+    #: selection: ``codex`` is a KNOWN-but-unselectable backend, so a stored
+    #: ``acp_backend: "codex"`` reads back as ``""`` — kiro-cli. A surface
+    #: resolving a harness from the clamped field would therefore start the
+    #: session on kiro-cli and report success, never telling the operator their
+    #: value was ignored. Alias resolution reads it instead (see
+    #: :attr:`acp_backend_alias`) so the registry's alias table decides what the
+    #: stored spelling means, and a harness with no binary refuses rather than
+    #: silently degrading.
+    default_harness: str = field(
+        default="",
+        metadata=_meta(
+            "Default Harness",
+            "Harness id new sessions start on when no explicit selection is made. "
+            "Empty means kiro-cli. A value naming a harness that is unknown or "
+            "unavailable degrades to kiro-cli with a logged reason, so a typo "
+            "never stops the gateway. Bundled ids: 'kiro', 'kas', 'codex', "
+            "'claude'; an operator harness uses its id from harnesses.json.",
         ),
     )
     default_agent: str = field(
@@ -1113,6 +1159,23 @@ class AgentConfig:
         effect on reasoning-capable models; on others it is ignored downstream.
         """
         return self.role_efforts.get(role, "")
+
+    @property
+    def acp_backend_alias(self) -> str:
+        """The stored ``acp_backend`` spelling, for harness alias resolution.
+
+        Read this — never :attr:`acp_backend` — when asking the harness registry
+        "which harness does the operator's legacy key name?". The field itself has
+        been clamped to a SELECTABLE backend, which silently turns a stored
+        ``codex`` into kiro-cli; the alias table has to see what was written or
+        that operator's harness is ignored without a word.
+
+        Falls back to the clamped field so a directly-constructed
+        ``AgentConfig(acp_backend="kas")`` — every test double and every
+        programmatic caller — still resolves its backend, rather than answering
+        "unset" because it never went through the loader.
+        """
+        return self._acp_backend_stored or self.acp_backend
 
 
 @dataclass
@@ -3641,6 +3704,72 @@ def _normalize_acp_backend(value: object) -> str:
     module) that the old local import of ``acp.types`` existed to dodge.
     """
     return resolve_selected_backend(value)
+
+
+#: Where the pre-validation ``agent.acp_backend`` spelling is stashed inside the
+#: validated data dict. Leading underscore so both the JSON-schema walker and
+#: ``to_dict`` skip it: it is a record of HOW a value was read, never a setting,
+#: and emitting it would write a key nobody configured into ``config.json``.
+_RAW_ACP_BACKEND_KEY = "_acp_backend_stored"
+
+
+def _stash_raw_acp_backend(data: dict) -> None:
+    """Record ``agent.acp_backend`` as WRITTEN, before validation rewrites it.
+
+    Schema validation replaces an out-of-enum value with the field default, and
+    ``agent.acp_backend``'s enum is the SELECTABLE set — so a stored ``codex``
+    (known to the harness registry, not selectable as a provider key) is gone
+    before any consumer sees it, and the operator is never told their harness was
+    ignored. Stashing the raw spelling here is what lets alias resolution refuse by
+    name instead of silently starting sessions on kiro-cli.
+
+    Written into the same dict the loader caches, so a cache hit answers with the
+    stored spelling too rather than only the first read after a config change.
+
+    Shape-only and total: a non-string (a hand-edited config can hold anything)
+    stashes nothing, and an absent section is left absent rather than created —
+    creating it would turn "unconfigured" into a configured empty section.
+    """
+    agent = data.get("agent")
+    if not isinstance(agent, dict):
+        return
+    raw = agent.get("acp_backend")
+    if isinstance(raw, str) and raw.strip():
+        agent[_RAW_ACP_BACKEND_KEY] = raw.strip()
+
+
+def _stored_acp_backend(agent_data: dict) -> str:
+    """The ``agent.acp_backend`` value as written, for harness alias resolution.
+
+    Reads the stash :func:`_stash_raw_acp_backend` placed before validation, then
+    falls back to the section's own (post-validation) value so a caller that built
+    the dict itself — a test double, a programmatic construction — still resolves
+    its backend rather than answering "unset".
+
+    Deliberately NOT clamped: :func:`_normalize_acp_backend` degrades a
+    known-but-unselectable value like ``codex`` to kiro-cli, which is the right
+    posture for the provider key and the wrong one for "which harness did the
+    operator name". Both are kept, so the provider stays safe and the harness
+    surfaces can refuse by name instead of silently running somewhere else.
+    """
+    for key in (_RAW_ACP_BACKEND_KEY, "acp_backend"):
+        value = agent_data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _normalize_harness_id(value: object) -> str:
+    """Coerce a persisted ``agent.default_harness`` to a string, never raising.
+
+    Shape only: whether the id names a REGISTERED and AVAILABLE harness is the
+    registry's question, answered when the value is used rather than when it is
+    read, because a harness can become available after the config is loaded (the
+    operator installs the binary) and a boot-time verdict would outlive that.
+    A non-string — which a hand-edited ``config.json`` can hold — reads as
+    absent, which means the default harness.
+    """
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _validate_activation(value: str) -> str:

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -6782,6 +6782,9 @@ _WRITE_PROTECTED_HOME_PATHS: list[str] = [
     f"{prefix}/{leaf}"
     for prefix in _CREW_HOME_PREFIXES
     # config.json / config.local.json: security-relevant resource ceilings.
+    # harnesses.json: operator ACP harness descriptors — each row names an
+    # executable the gateway spawns as itself, with no downstream clamp. Paired
+    # with the same leaf in _WRITE_PROTECTED_BASH_LEAVES; reads stay allowed.
     # playwright-cli-config.json: the browse launch config
     # (browser_cli/launch.py). It holds no secret and the CLI must READ it on
     # every invocation, so it is write-protected rather than sensitive. But it is
@@ -6792,7 +6795,7 @@ _WRITE_PROTECTED_HOME_PATHS: list[str] = [
     # directly and does NOT route through this gate, so its own write still works.
     # Paired with the same leaf in _WRITE_PROTECTED_BASH_LEAVES — protected on one
     # path only is not protected.
-    for leaf in ("config.json", "config.local.json", "playwright-cli-config.json")
+    for leaf in ("config.json", "config.local.json", "harnesses.json", "playwright-cli-config.json")
 ] + [
     # Ops Mission Control's on-call schedule. WRITE-protected, not read+write
     # sensitive: it holds no secret and every teammate's instance must READ it to
@@ -7007,13 +7010,15 @@ _WRITE_PROTECTED_HOME_PATHS += [_KIRO_AGENTS_DIR]
 # losing game. Widen this only via the SHARED matcher (so
 # credentials benefit too), not with per-leaf special cases.
 #
-# ONE ENTRY IS EXEMPT from that anchoring limit, and the exemption is about
-# severity rather than parser completeness: the alias ownership record's residual
-# threat is the DELETION of a user-authored alias by Kiro
-# Crew's own trusted writer, so its filename is additionally matched
-# anchor-independently as a bare path segment (see
+# TWO ENTRIES ARE EXEMPT from that anchoring limit, and the exemption is about
+# severity rather than parser completeness: for the alias ownership record the
+# residual threat is the DELETION of a user-authored alias by Kiro
+# Crew's own trusted writer, and for the harness-definition file it is the
+# gateway EXECUTING a planted descriptor's binary, so those filenames are
+# additionally matched
+# anchor-independently as bare path segments (see
 # ``_BARE_TOKEN_PROTECTED_LEAVES`` below). That widening is affordable only
-# because the name is globally distinctive; it is NOT a template for the other
+# because each name is globally distinctive; it is NOT a template for the other
 # leaves, and the anchoring limit above still describes them.
 #
 # ``rotation.yaml`` is the first entry, and it meets the bar the scope note sets rather than
@@ -7055,6 +7060,18 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
     "apps/ops-mission-control/data/rotation.yaml",
     "apps/ops-mission-control/data/incidents/index.json",
     "connections-tool-aliases.json",
+    # Operator ACP harness descriptors (acp/harness_registry.py), paired with the
+    # same leaf in _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths
+    # agree. A descriptor names an executable the GATEWAY spawns as itself, and
+    # no loader clamp bounds that value — an agent that could plant a shape-valid
+    # row would have the gateway persistently exec its bytes outside deny rules
+    # and the SEL audit. Reads stay allowed on both paths: the file holds no
+    # secret and the registry must read it on every listing. Same relocation
+    # pattern as playwright-cli-config.json below, for the same class of value —
+    # but unlike that leaf it is ALSO matched anchor-independently (see
+    # ``_BARE_TOKEN_PROTECTED_LEAVES``): the file is the execution grant, so a
+    # ``cd``-relative spelling must not walk around the anchored forms here.
+    "harnesses.json",
     # The browse launch config (browser_cli/launch.py), paired with the same leaf
     # in _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths agree — a
     # leaf on only one of the two is reachable through the other.
@@ -7094,15 +7111,28 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
 # of the contract — relative, ``cd``-prefixed, subdir-relative, either
 # separator, quoted or not, all refused identically.
 #
-# SCOPE: bare-token matching is for THIS filename ONLY, because it is globally
-# distinctive — a long hyphenated name that occurs nowhere in ordinary command
+# SCOPE: bare-token matching is only for a filename that passes BOTH tests the
+# alias record set — (1) severity: the FILENAME is itself the grant, with no
+# downstream clamp, so anchoring cannot be part of the contract; and
+# (2) distinctiveness: the name occurs nowhere in ordinary command
 # lines, so the false-positive cost is confined to commands that genuinely mean
 # this record. A generic leaf must NEVER be added here: unanchored
 # ``index.json`` or ``config.json`` would refuse a large fraction of routine
 # commands in any repository. The other write-protected leaves are not
 # distinctive at all (their distinguishing part is the ``apps/.../data/``
 # subpath) and must stay anchored.
-_BARE_TOKEN_PROTECTED_LEAVES: tuple[str, ...] = ("connections-tool-aliases.json",)
+#
+# ``harnesses.json`` passes both tests: a shape-valid descriptor row names an
+# executable the gateway spawns as itself (the file IS the execution grant, so
+# a ``cd``-relative redirect walking around the anchored spellings is not a
+# residual to accept), and unlike playwright-cli-config.json there is no
+# env-var override that already concedes the fence, so the wider blast radius
+# buys a real closure. The name is a coined leaf that ordinary command lines
+# do not utter.
+_BARE_TOKEN_PROTECTED_LEAVES: tuple[str, ...] = (
+    "connections-tool-aliases.json",
+    "harnesses.json",
+)
 
 # Whisper weight files, matched as a NAME with no anchor, for the same reason as the
 # alias record above: the filename IS the grant. `stt.models` verifies a file's sha256

--- a/test/test_harness_attestation.py
+++ b/test/test_harness_attestation.py
@@ -1,0 +1,149 @@
+"""The spawn-side Trust_Attestation seam of :mod:`kiro_crew.acp.harness_adapters`.
+
+Every harness — bundled or operator-authored — passes through the same three
+steps before a process exists: resolve the descriptor's executable, attest the
+resolved candidate (runnable, non-zero-byte, path anchored), and prove the
+rendered argv execs the attested bytes. These tests pin each step's verdicts
+directly, because the callers that exercise them end to end live a slice away
+(the serving layer) and a refusal's TEXT is part of the contract: it is what an
+operator reads when a harness will not start.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from kiro_crew.acp.harness_adapters import (
+    HarnessExecutableTrustError,
+    HarnessSpawnRefused,
+    attest_executable,
+    checked_spawn_argv,
+    resolve_spawn_executable,
+)
+from kiro_crew.acp.harness_descriptor import HarnessDescriptor
+
+
+def _executable(tmp_path, name="agy-acp", content="#!/bin/sh\nexit 0\n"):
+    """A runnable, non-empty candidate on this platform."""
+    if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+        path = tmp_path / f"{name}.bat"
+        path.write_text("@echo off\r\nexit /b 0\r\n")
+    else:
+        path = tmp_path / name
+        path.write_text(content)
+        path.chmod(0o755)
+    return path
+
+
+def _descriptor(executable: str) -> HarnessDescriptor:
+    return HarnessDescriptor(
+        id="agy",
+        display_name="Agy",
+        executable=executable,
+        argv=("{executable}", "acp"),
+    )
+
+
+class TestAttestExecutable:
+    def test_a_runnable_candidate_returns_a_launch_path_to_its_own_bytes(self, tmp_path):
+        """The attested path must point at the vetted file — the exec'd bytes
+        and the checked bytes have to be the same file."""
+        candidate = _executable(tmp_path)
+
+        launch = attest_executable("agy", str(candidate))
+
+        assert os.path.samefile(launch, candidate)
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="on Windows the zero-byte refusal lives in resolution "
+        "(_candidate_problem), not the snapshot — covered below via "
+        "resolve_spawn_executable",
+    )
+    def test_a_zero_byte_candidate_is_refused_naming_the_harness_and_the_defect(self, tmp_path):
+        """A truncated install must be refused BEFORE exec, and the refusal must
+        name the operator's harness — not Kiro CLI, which is the shared
+        snapshot's other caller — so the operator debugs the right tool."""
+        path = tmp_path / "empty"
+        path.touch()
+        path.chmod(0o755)
+
+        with pytest.raises(HarnessExecutableTrustError) as excinfo:
+            attest_executable("agy", str(path))
+
+        assert "'agy'" in str(excinfo.value)
+        assert "zero-byte" in str(excinfo.value)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX exec bit does not exist on Windows")
+    def test_a_non_executable_candidate_is_refused_as_not_executable(self, tmp_path):
+        path = tmp_path / "plain"
+        path.write_text("data\n")
+
+        with pytest.raises(HarnessExecutableTrustError) as excinfo:
+            attest_executable("agy", str(path))
+
+        assert "not an executable file" in str(excinfo.value)
+
+
+class TestResolveSpawnExecutable:
+    def test_resolves_and_attests_an_absolute_declared_executable(self, tmp_path):
+        candidate = _executable(tmp_path)
+
+        launch = resolve_spawn_executable(_descriptor(str(candidate)))
+
+        assert os.path.samefile(launch, candidate)
+
+    def test_a_zero_byte_candidate_is_refused_at_resolution_on_every_platform(self, tmp_path):
+        """The zero-byte guard is resolution's (``_candidate_problem``), so it
+        holds on Windows too — where the attestation snapshot deliberately
+        short-circuits and would accept anything."""
+        path = tmp_path / ("truncated.bat" if os.name == "nt" else "truncated")
+        path.touch()
+        if os.name != "nt":
+            path.chmod(0o755)
+
+        with pytest.raises(HarnessSpawnRefused) as excinfo:
+            resolve_spawn_executable(_descriptor(str(path)))
+
+        assert "zero-byte" in str(excinfo.value)
+
+    def test_an_unresolvable_declaration_is_refused_with_the_resolution_reason(self):
+        """A resolution failure surfaces as a spawn refusal that carries the
+        listing-side reason verbatim, so the spawn path and the settings surface
+        tell the operator the same story."""
+        with pytest.raises(HarnessSpawnRefused) as excinfo:
+            resolve_spawn_executable(_descriptor("definitely-not-on-path-4242"))
+
+        assert "'agy' cannot start" in str(excinfo.value)
+        assert "was not found on PATH" in str(excinfo.value)
+
+
+class TestCheckedSpawnArgv:
+    def test_an_argv_execing_the_attested_path_passes_through_unchanged(self, tmp_path):
+        candidate = str(_executable(tmp_path))
+        argv = [candidate, "acp", "--flag"]
+
+        assert checked_spawn_argv(_descriptor(candidate), argv, candidate) is argv
+
+    def test_an_empty_argv_is_refused(self, tmp_path):
+        candidate = str(_executable(tmp_path))
+
+        with pytest.raises(HarnessSpawnRefused) as excinfo:
+            checked_spawn_argv(_descriptor(candidate), [], candidate)
+
+        assert "empty argv" in str(excinfo.value)
+
+    def test_an_argv0_that_is_not_the_attested_path_is_refused_not_rewritten(self, tmp_path):
+        """The second half of attestation: a bare name in ``argv[0]`` would be
+        re-resolved through PATH by exec, so vetted bytes and run bytes could
+        differ. The refusal names both paths and never rewrites."""
+        candidate = str(_executable(tmp_path))
+
+        with pytest.raises(HarnessSpawnRefused) as excinfo:
+            checked_spawn_argv(_descriptor(candidate), ["agy-acp", "acp"], candidate)
+
+        assert "never checked" in str(excinfo.value)
+        assert "'agy-acp'" in str(excinfo.value)

--- a/test/test_harness_capability_views.py
+++ b/test/test_harness_capability_views.py
@@ -1,0 +1,144 @@
+"""The leaf ``ACP_BACKENDS_*`` sets and the bundled descriptors must agree.
+
+Wave-2 T4 rekeyed every PER-SESSION behavior consumer onto
+``binding.descriptor.capabilities`` at its own call site, and T5 deleted the
+derived behavior views from ``acp/types.py``. The merge with origin/main then
+brought in upstream's parallel refactor: the capability sets are DEFINED in the
+leaf ``kiro_crew.acp_backends`` (so a consumer outside the ACP package can ask a
+capability question without importing ``kiro_crew.acp``, whose ``__init__``
+pulls in the client and runtime) and re-exported from ``acp.types`` for existing
+importers — ``test_acp_capability_sets_leaf.py`` pins that placement.
+
+Post-merge, both disciplines hold at once:
+
+* PER-SESSION behavior gates still read the session's bound descriptor
+  (``_declares(<CAPABILITY_*>)``), never a set keyed on the legacy
+  ``acp_backend`` spelling — an operator harness has no such spelling, so a set
+  lookup would silently mis-gate it. The harness-parity added-line gate
+  (``scripts/check_harness_parity.py``) keeps new membership checks out of the
+  gated modules.
+* OUTSIDE-ACP consumers with no session in hand (readiness, prerequisites,
+  ``session._bg_runtime_backends``) read the leaf sets, whose membership is the
+  bundled ``acp_backend`` vocabulary by construction.
+
+That leaves ONE new way to be wrong: the leaf sets and the descriptors'
+``CapabilitySet`` grants are two spellings of the same facts and can drift.
+This module is the pin that keeps them agreeing — each leaf set must equal the
+same membership rebuilt from ``BUNDLED_DESCRIPTORS``, and both must equal the
+shipped literals recorded here (kiro-cli full; KAS steer+runtime+identity;
+claude none), so a drift in either spelling fails by name.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.acp import types as acp_types
+from kiro_crew.acp.harness_descriptor import (
+    CAPABILITY_ACP_RUNTIME_POOL,
+    CAPABILITY_INTERNAL_SANDBOX,
+    CAPABILITY_KIRO_IDENTITY_STORE,
+    CAPABILITY_SESSION_SHARING,
+    CAPABILITY_STEER,
+)
+from kiro_crew.acp.harness_registry import BUNDLED_DESCRIPTORS
+from kiro_crew.acp.types import ACP_BACKEND_KAS, ACP_BACKEND_KIRO
+from kiro_crew.acp_backends import (
+    ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_INTERNAL_SANDBOX,
+    ACP_BACKENDS_KIRO_IDENTITY_STORE,
+    ACP_BACKENDS_SESSION_SHARING,
+    ACP_BACKENDS_STEER,
+    selectable_backends,
+)
+
+#: The vocabulary sets that STAY (the ``acp_backend`` gate, not capability views).
+#: ``ACP_BACKENDS_SELECTABLE`` was dropped in wave-2 for the ``selectable_backends()``
+#: registry function (checked separately below), so only ``ACP_BACKENDS_KNOWN``
+#: remains as a module-level frozenset here.
+_VOCABULARY_SETS = ("ACP_BACKENDS_KNOWN",)
+
+#: capability flag -> (leaf set, shipped membership). The literals are the pin's
+#: independent third leg: with only two spellings, a bug edited into both at once
+#: would still "agree". kiro-cli full; KAS steer+runtime+identity; claude none.
+_CAPABILITY_TRIPLES = {
+    CAPABILITY_SESSION_SHARING: (
+        ACP_BACKENDS_SESSION_SHARING,
+        frozenset({ACP_BACKEND_KIRO}),
+    ),
+    CAPABILITY_STEER: (
+        ACP_BACKENDS_STEER,
+        frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS}),
+    ),
+    CAPABILITY_INTERNAL_SANDBOX: (
+        ACP_BACKENDS_INTERNAL_SANDBOX,
+        frozenset({ACP_BACKEND_KIRO}),
+    ),
+    CAPABILITY_ACP_RUNTIME_POOL: (
+        ACP_BACKENDS_ACP_RUNTIME,
+        frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS}),
+    ),
+    CAPABILITY_KIRO_IDENTITY_STORE: (
+        ACP_BACKENDS_KIRO_IDENTITY_STORE,
+        frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS}),
+    ),
+}
+
+
+def _backends_claiming_locally(capability: str) -> frozenset[str]:
+    """The set-of-backends membership rebuilt from the bundled descriptors.
+
+    Keyed by the legacy ``acp_backend`` spelling, so a bundled harness without
+    one (Codex), and every operator harness, contributes no member — exactly the
+    leaf sets' own membership rule.
+    """
+    return frozenset(
+        acp_types._HARNESS_BACKENDS[d.id]
+        for d in BUNDLED_DESCRIPTORS
+        if d.id in acp_types._HARNESS_BACKENDS and d.capabilities.has(capability)
+    )
+
+
+def test_leaf_sets_descriptors_and_shipped_literals_all_agree() -> None:
+    """Each capability's three spellings are identical.
+
+    A descriptor grant edited without its leaf set (or vice versa) fails here by
+    capability name, which is what keeps "claimed in one vocabulary, withheld in
+    the other" impossible — the property the derived views used to provide by
+    construction.
+    """
+    for capability, (leaf_set, shipped) in _CAPABILITY_TRIPLES.items():
+        rebuilt = _backends_claiming_locally(capability)
+        assert (
+            leaf_set == shipped
+        ), f"{capability}: leaf set {sorted(leaf_set)!r} != shipped {sorted(shipped)!r}"
+        assert (
+            rebuilt == shipped
+        ), f"{capability}: descriptors rebuild {sorted(rebuilt)!r} != shipped {sorted(shipped)!r}"
+
+
+def test_the_collector_is_gone() -> None:
+    """``_backends_claiming`` — which derived the old views — stays deleted.
+
+    Left behind, it is the one call a session-scoped consumer would quietly
+    rebuild a view from; per-session gates read the bound descriptor instead.
+    """
+    assert not hasattr(acp_types, "_backends_claiming")
+
+
+def test_the_vocabulary_gate_survives() -> None:
+    """The ``acp_backend`` vocabulary gate is NOT a view and must remain.
+
+    Config resolution (``_normalize_acp_backend``) and provider construction key
+    on it, so the capability-set placement must not take it with it. Post-merge
+    the gate is two things: the ``ACP_BACKENDS_KNOWN`` frozenset (the closed
+    membership set) and the ``selectable_backends()`` registry function that
+    replaced the dropped ``ACP_BACKENDS_SELECTABLE`` snapshot.
+    """
+    for name in _VOCABULARY_SETS:
+        assert isinstance(
+            getattr(acp_types, name), frozenset
+        ), f"{name} is the acp_backend vocabulary gate and must stay a frozenset"
+    # The selectable set is now a registry function, not a frozen constant, but it
+    # is still part of the vocabulary gate and must still hand back a frozenset.
+    assert isinstance(
+        selectable_backends(), frozenset
+    ), "selectable_backends() is the acp_backend selectable gate and must return a frozenset"

--- a/test/test_harness_descriptor.py
+++ b/test/test_harness_descriptor.py
@@ -1,0 +1,647 @@
+"""Tests for the ACP harness descriptor: shape validation and argv rendering."""
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from kiro_crew.acp.harness_descriptor import (
+    ADAPTERS,
+    CAPABILITY_NAMES,
+    DESCRIPTOR_KEYS,
+    HARNESS_ID_MAX_LEN,
+    MCP_DELIVERY_DEFAULT,
+    MCP_DELIVERY_FILE_FED,
+    MCP_DELIVERY_WIRE_FED,
+    MODEL_SOURCE_ACP_ADVERTISED,
+    MODEL_SOURCE_STATIC,
+    PLACEHOLDER_AGENT,
+    PLACEHOLDER_EXECUTABLE,
+    PLACEHOLDER_MODEL,
+    PLACEHOLDER_WORKDIR,
+    CapabilitySet,
+    HarnessDescriptor,
+    capability_names,
+    descriptor_from_mapping,
+    render_argv,
+    validate_descriptor,
+)
+
+# A descriptor in the shape the bundled kiro-cli entry will take: base argv plus
+# both optional convention blocks.
+KIRO_LIKE = HarnessDescriptor(
+    id="kiro",
+    display_name="Kiro CLI",
+    executable="kiro-cli",
+    argv=("{executable}", "acp"),
+    agent_args=("--agent", "{agent}"),
+    model_args=("--model", "{model}"),
+    mcp_delivery=MCP_DELIVERY_FILE_FED,
+)
+
+
+# ── Defaults ──
+
+
+def test_capabilities_all_default_disabled():
+    caps = CapabilitySet()
+    assert caps.as_dict() == {name: False for name in CAPABILITY_NAMES}
+    assert all(not caps.has(name) for name in CAPABILITY_NAMES)
+
+
+def test_capability_names_match_the_dataclass_fields():
+    assert capability_names() == CAPABILITY_NAMES
+
+
+def test_unknown_capability_lookup_raises_rather_than_answering_false():
+    with pytest.raises(ValueError, match="unknown harness capability"):
+        CapabilitySet().has("teleportation")
+
+
+def test_minimal_mapping_gets_safe_defaults():
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "my-tool", "argv": ["{executable}", "acp"]},
+        harness_id="my-tool",
+    )
+    assert reasons == []
+    assert desc is not None
+    assert desc.mcp_delivery == MCP_DELIVERY_DEFAULT == MCP_DELIVERY_WIRE_FED
+    assert desc.model_source == MODEL_SOURCE_ACP_ADVERTISED
+    assert desc.capabilities == CapabilitySet()
+    assert desc.models == ()
+    assert desc.agent_args == ()
+    assert desc.model_args == ()
+    # Absent display name falls back to the id so a listing is never blank.
+    assert desc.label == "my-tool"
+
+
+def test_capabilities_are_opt_in_one_at_a_time():
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "my-tool",
+            "argv": ["{executable}"],
+            "capabilities": {"steer": True},
+        },
+        harness_id="my-tool",
+    )
+    assert reasons == []
+    assert desc is not None
+    assert desc.capabilities.has("steer") is True
+    assert desc.capabilities.has("internal_sandbox") is False
+
+
+# ── Validation reasons ──
+
+
+def test_unknown_field_is_a_diagnosable_reason():
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}"], "adaptor": "kiro"},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("'adaptor'" in r for r in reasons)
+
+
+def test_unknown_placeholder_names_the_placeholder_and_the_token():
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}", "--home={home}"]},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("{home}" in r and "--home={home}" in r for r in reasons)
+
+
+def test_unbalanced_brace_is_rejected():
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}", "--dir={workdir"]},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("unbalanced brace" in r for r in reasons)
+
+
+def test_placeholder_reasons_cover_every_template_block():
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "x",
+            "argv": ["{executable}"],
+            "agent_args": ["{persona}"],
+            "model_args": ["{llm}"],
+        },
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("agent_args" in r and "{persona}" in r for r in reasons)
+    assert any("model_args" in r and "{llm}" in r for r in reasons)
+
+
+def test_model_placeholder_in_argv_is_rejected():
+    # {model} in the ungated argv block would render to an empty argument when no
+    # model is pinned (e.g. "--model=" or a bare ""), a silent spawn footgun. It
+    # is only legal in model_args, whose emission is gated on a model value.
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}", "--model={model}"]},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("{model}" in r and "model_args" in r for r in reasons)
+
+
+def test_agent_placeholder_in_argv_is_rejected():
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}", "{agent}"]},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("{agent}" in r and "agent_args" in r for r in reasons)
+
+
+def test_convention_placeholders_are_rejected_in_the_other_conventions_block():
+    # {agent} belongs to agent_args and {model} to model_args; each is rejected
+    # in the other's block.
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "x",
+            "argv": ["{executable}"],
+            "agent_args": ["--agent", "{model}"],
+            "model_args": ["--model", "{agent}"],
+        },
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("agent_args" in r and "{model}" in r for r in reasons)
+    assert any("model_args" in r and "{agent}" in r for r in reasons)
+
+
+def test_convention_placeholders_are_legal_in_their_own_block():
+    # {agent} in agent_args and {model} in model_args — where emission is gated —
+    # validate cleanly, as every bundled descriptor uses them.
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "x",
+            "argv": ["{executable}", "acp"],
+            "agent_args": ["--agent", "{agent}"],
+            "model_args": ["--model", "{model}"],
+        },
+        harness_id="x",
+    )
+    assert desc is not None, reasons
+    assert reasons == []
+
+
+def test_executable_and_workdir_placeholders_are_legal_in_argv():
+    # The ungated placeholders carry no per-value gating and stay legal anywhere.
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}", "--cwd={workdir}"]},
+        harness_id="x",
+    )
+    assert desc is not None, reasons
+    assert reasons == []
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    ["Kiro", "my_tool", "my tool", "", "kiro!", "ki.ro", "a" * (HARNESS_ID_MAX_LEN + 1)],
+)
+def test_identifier_charset_and_length_are_enforced(bad_id):
+    reasons = validate_descriptor(
+        HarnessDescriptor(id=bad_id, executable="x", argv=("{executable}",))
+    )
+    assert any("identifier" in r for r in reasons)
+
+
+def test_identifier_uniqueness_is_reported_against_taken_ids():
+    reasons = validate_descriptor(
+        HarnessDescriptor(id="kiro", executable="x", argv=("{executable}",)),
+        taken_ids={"kiro"},
+    )
+    assert any("already registered" in r for r in reasons)
+
+
+def test_empty_executable_is_reported():
+    reasons = validate_descriptor(HarnessDescriptor(id="x", argv=("{executable}",)))
+    assert any("executable is empty" in r for r in reasons)
+
+
+def test_empty_argv_template_is_reported():
+    reasons = validate_descriptor(HarnessDescriptor(id="x", executable="x"))
+    assert any("argv template is empty" in r for r in reasons)
+
+
+@pytest.mark.parametrize(
+    "raw,needle",
+    [
+        ({"capabilities": {"warp_drive": True}}, "unknown capability"),
+        ({"capabilities": {"steer": "true"}}, "must be true or false"),
+        ({"capabilities": ["steer"]}, "capabilities must be an object"),
+        ({"model_source": "guess"}, "model_source"),
+        ({"mcp_delivery": "carrier_pigeon"}, "mcp_delivery"),
+        ({"argv": "my-tool acp"}, "argv must be an array of strings"),
+        ({"models": [3]}, "models entry"),
+        ({"display_name": 7}, "display_name must be a string"),
+    ],
+)
+def test_field_shape_problems_are_reported_not_guessed(raw, needle):
+    payload = {"executable": "x", "argv": ["{executable}"], **raw}
+    desc, reasons = descriptor_from_mapping(payload, harness_id="x")
+    assert desc is None
+    assert any(needle in r for r in reasons), reasons
+
+
+def test_declared_id_must_match_its_registry_key():
+    desc, reasons = descriptor_from_mapping(
+        {"id": "other", "executable": "x", "argv": ["{executable}"]},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("does not match its registry key" in r for r in reasons)
+
+
+def test_every_reason_names_the_harness_it_belongs_to():
+    _, reasons = descriptor_from_mapping({"argv": ["{nope}"]}, harness_id="my-tool")
+    assert reasons
+    assert all("my-tool" in r for r in reasons)
+
+
+def test_a_string_capability_value_never_enables_the_flag():
+    # "false" is truthy in Python; guessing here would enable a capability the
+    # operator meant to disable.
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}"], "capabilities": {"steer": "false"}},
+        harness_id="x",
+    )
+    assert desc is None
+    assert reasons
+
+
+def test_the_literal_adapter_key_is_not_an_operator_field():
+    # A bundled descriptor may name a reviewed Python entry point; configuration
+    # must never be able to. The literal key is rejected as an unknown field, so
+    # extending DESCRIPTOR_KEYS cannot open this path without failing here.
+    assert "adapter" not in DESCRIPTOR_KEYS
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}"], "adapter": "kiro"},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("'adapter'" in r for r in reasons)
+
+
+def test_a_parsed_descriptor_never_carries_an_adapter():
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}"]}, harness_id="x"
+    )
+    assert reasons == []
+    assert desc is not None
+    assert desc.adapter == ""
+
+
+@pytest.mark.parametrize("block", ["argv", "agent_args", "model_args", "models"])
+def test_a_bare_string_sequence_is_rejected_on_a_code_built_descriptor(block):
+    # A string is iterable, so every per-token check passes by iterating ONE
+    # CHARACTER AT A TIME and the descriptor validates — then renders
+    # ["m", "y", "-", ...] and dies at exec. The parse path already refuses the
+    # shape; this is the same refusal for a descriptor built in code.
+    fields_ = {"id": "x", "executable": "x", "argv": ("{executable}",)}
+    fields_[block] = "my-tool acp"
+    reasons = validate_descriptor(HarnessDescriptor(**fields_))
+    assert any(f"{block} must be a sequence" in r for r in reasons), reasons
+
+
+def test_a_static_model_source_with_no_models_is_rejected():
+    # 'static' declares "here are my models"; an empty list leaves the composer
+    # with nothing to offer and no way to obtain anything, so the harness could
+    # never serve a session.
+    reasons = validate_descriptor(
+        HarnessDescriptor(
+            id="x", executable="x", argv=("{executable}",), model_source=MODEL_SOURCE_STATIC
+        )
+    )
+    assert any("no models are declared" in r for r in reasons)
+
+    desc, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}"], "model_source": MODEL_SOURCE_STATIC},
+        harness_id="x",
+    )
+    assert desc is None
+    assert any("no models are declared" in r for r in reasons)
+
+
+def test_a_static_model_source_with_models_is_accepted():
+    reasons = validate_descriptor(
+        HarnessDescriptor(
+            id="x",
+            executable="x",
+            argv=("{executable}",),
+            model_source=MODEL_SOURCE_STATIC,
+            models=("m1",),
+        )
+    )
+    assert reasons == []
+
+
+def test_an_unknown_adapter_is_rejected():
+    reasons = validate_descriptor(
+        HarnessDescriptor(id="x", executable="x", argv=("{executable}",), adapter="teleporter")
+    )
+    assert any("adapter" in r for r in reasons)
+
+
+@pytest.mark.parametrize("adapter", sorted(ADAPTERS))
+def test_every_declared_adapter_validates(adapter):
+    reasons = validate_descriptor(
+        HarnessDescriptor(id="x", executable="x", argv=("{executable}",), adapter=adapter)
+    )
+    assert reasons == []
+
+
+@pytest.mark.parametrize("garbage", [None, "kiro-cli acp", 7, [], ["argv"], True])
+def test_non_object_descriptor_is_a_reason_not_an_exception(garbage):
+    desc, reasons = descriptor_from_mapping(garbage, harness_id="x")
+    assert desc is None
+    assert any("must be an object" in r for r in reasons)
+
+
+# ── Argv rendering ──
+
+
+def test_render_substitutes_executable_agent_and_model():
+    assert render_argv(KIRO_LIKE, agent="default", model="auto") == [
+        "kiro-cli",
+        "acp",
+        "--agent",
+        "default",
+        "--model",
+        "auto",
+    ]
+
+
+def test_render_omits_the_whole_block_for_an_empty_value():
+    assert render_argv(KIRO_LIKE, agent="default") == [
+        "kiro-cli",
+        "acp",
+        "--agent",
+        "default",
+    ]
+    assert render_argv(KIRO_LIKE, model="auto") == ["kiro-cli", "acp", "--model", "auto"]
+    assert render_argv(KIRO_LIKE) == ["kiro-cli", "acp"]
+
+
+def test_render_prefers_the_resolved_executable_over_the_descriptor_rule():
+    argv = render_argv(KIRO_LIKE, executable="/opt/kiro/bin/kiro-cli")
+    assert argv[0] == "/opt/kiro/bin/kiro-cli"
+
+
+def test_render_accepts_a_path_workdir_and_embeds_it_in_a_token():
+    descriptor = HarnessDescriptor(id="x", executable="x", argv=("{executable}", "--cwd={workdir}"))
+    workdir = pathlib.Path("/tmp/work dir")
+    argv = render_argv(descriptor, workdir=workdir)
+    # Build the expectation from the SAME Path object: str(Path) renders the
+    # platform's own separator (``/tmp/work dir`` on POSIX, ``\tmp\work dir`` on
+    # Windows), and the token embeds exactly that, so a literal would only match
+    # on POSIX.
+    assert argv == ["x", f"--cwd={workdir}"]
+
+
+def test_a_descriptor_without_a_model_convention_gets_no_substituted_default():
+    descriptor = HarnessDescriptor(id="x", executable="x", argv=("{executable}", "acp"))
+    assert render_argv(descriptor, model="some-model") == ["x", "acp"]
+
+
+def test_substituted_values_are_not_rescanned_for_placeholders():
+    # A model id containing another placeholder must reach exec as literal bytes.
+    argv = render_argv(KIRO_LIKE, model="{workdir}", workdir="/secret")
+    assert argv == ["kiro-cli", "acp", "--model", "{workdir}"]
+
+
+def test_render_leaves_an_unknown_placeholder_alone_rather_than_raising():
+    # Validation rejects such a descriptor; rendering stays total so a spawn
+    # path can never be handed an exception mid-flight.
+    descriptor = HarnessDescriptor(id="x", executable="x", argv=("{executable}", "{home}"))
+    assert render_argv(descriptor) == ["x", "{home}"]
+
+
+# ── Property 1: rendering is deterministic, shell-free, and total ──
+
+_LITERALS = st.text(
+    alphabet=st.characters(exclude_characters="{}", exclude_categories=("Cs",)),
+    min_size=1,
+    max_size=8,
+)
+
+
+def _block_tokens(placeholders):
+    """Tokens legal in one template block: literals plus only the placeholders
+    that block permits.
+
+    ``{agent}``/``{model}`` are convention placeholders legal ONLY in their own
+    gated block (``agent_args`` / ``model_args``); the ungated ``{executable}``
+    and ``{workdir}`` are legal everywhere. Drawing per-block keeps the generator
+    inside the validator's accepted space so ``test_generated_descriptors_are_valid``
+    pins the real shape rather than a superset the validator now rejects.
+    """
+    ph = st.sampled_from(sorted(placeholders))
+    return st.one_of(
+        _LITERALS,
+        ph,
+        st.builds(lambda lit, p: f"{lit}={p}", _LITERALS, ph),
+    )
+
+
+_ARGV_TOKENS = _block_tokens({PLACEHOLDER_EXECUTABLE, PLACEHOLDER_WORKDIR})
+_AGENT_TOKENS = _block_tokens({PLACEHOLDER_EXECUTABLE, PLACEHOLDER_WORKDIR, PLACEHOLDER_AGENT})
+_MODEL_TOKENS = _block_tokens({PLACEHOLDER_EXECUTABLE, PLACEHOLDER_WORKDIR, PLACEHOLDER_MODEL})
+_IDS = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz0123456789-", min_size=1, max_size=HARNESS_ID_MAX_LEN
+)
+# Values a hostile or merely awkward operator/model name can take. Every one of
+# these would be re-interpreted by a shell, so they are the interesting inputs
+# for "argv is a list, never a command line".
+_SHELL_HOSTILE = st.sampled_from(
+    [
+        "a b",
+        "; rm -rf /",
+        "$(whoami)",
+        "`id`",
+        "&& echo pwned",
+        "| cat /etc/passwd",
+        "'quoted'",
+        '"quoted"',
+        "new\nline",
+        "tab\there",
+        "*",
+        "~",
+        "$HOME",
+        ">out",
+    ]
+)
+_VALUES = st.one_of(
+    _SHELL_HOSTILE,
+    st.text(alphabet=st.characters(exclude_categories=("Cs",)), min_size=1, max_size=10),
+)
+
+
+@st.composite
+def _descriptors(draw):
+    model_source = draw(st.sampled_from([MODEL_SOURCE_ACP_ADVERTISED, MODEL_SOURCE_STATIC]))
+    # A 'static' source with no models fails validation (it could never serve a
+    # model to the composer), so the generator pairs them — otherwise the
+    # properties below would be exercising invalid descriptors.
+    min_models = 1 if model_source == MODEL_SOURCE_STATIC else 0
+    return HarnessDescriptor(
+        id=draw(_IDS),
+        display_name=draw(st.text(max_size=10)),
+        executable=draw(
+            st.text(alphabet=st.characters(exclude_characters="{}"), min_size=1, max_size=10)
+        ),
+        # argv[0] must be the executable placeholder — the attested executable is
+        # the one that has to exec — so the generator pins it and varies the tail.
+        argv=("{executable}", *draw(st.lists(_ARGV_TOKENS, max_size=3))),
+        agent_args=tuple(draw(st.lists(_AGENT_TOKENS, max_size=3))),
+        model_args=tuple(draw(st.lists(_MODEL_TOKENS, max_size=3))),
+        capabilities=CapabilitySet(**{name: draw(st.booleans()) for name in CAPABILITY_NAMES}),
+        model_source=model_source,
+        models=tuple(
+            draw(st.lists(st.text(min_size=1, max_size=8), min_size=min_models, max_size=3))
+        ),
+        mcp_delivery=draw(st.sampled_from([MCP_DELIVERY_FILE_FED, MCP_DELIVERY_WIRE_FED])),
+        adapter=draw(st.sampled_from(["", *sorted(ADAPTERS)])),
+    )
+
+
+@given(_descriptors())
+def test_generated_descriptors_are_valid(descriptor):
+    # Pins the generator to the validator: if a shape the generator produces
+    # ever stops validating, the properties below are testing the wrong space.
+    assert validate_descriptor(descriptor) == []
+
+
+@given(_descriptors(), _VALUES, _VALUES, _VALUES)
+def test_rendering_is_deterministic(descriptor, agent, model, workdir):
+    first = render_argv(descriptor, agent=agent, model=model, workdir=workdir)
+    second = render_argv(descriptor, agent=agent, model=model, workdir=workdir)
+    assert first == second
+    assert isinstance(first, list)
+    assert all(isinstance(token, str) for token in first)
+
+
+@given(_descriptors(), _VALUES, _VALUES)
+def test_rendering_never_splits_or_interprets_a_value(descriptor, agent, model):
+    argv = render_argv(descriptor, agent=agent, model=model)
+    # One template token renders to exactly one argv element: no value can grow
+    # the argument count by containing a space, a pipe, or a substitution.
+    expected = len(descriptor.argv) + len(descriptor.agent_args) + len(descriptor.model_args)
+    assert len(argv) == expected
+    # A bare placeholder token carries the value verbatim — unquoted, unescaped,
+    # and unexpanded.
+    for token, rendered in zip(descriptor.argv, argv):
+        if token == "{agent}":
+            assert rendered == agent
+        elif token == "{model}":
+            assert rendered == model
+
+
+@given(_descriptors(), _VALUES)
+def test_an_empty_model_omits_the_whole_model_block(descriptor, agent):
+    without_model = render_argv(descriptor, agent=agent, model="")
+    base = render_argv(dataclasses.replace(descriptor, model_args=()), agent=agent)
+    # No dangling flag: the argv is exactly what the same descriptor with no
+    # model convention at all would produce.
+    assert without_model == base
+
+
+@given(
+    st.recursive(
+        st.one_of(st.none(), st.booleans(), st.integers(), st.text(max_size=6)),
+        lambda children: st.one_of(
+            st.lists(children, max_size=3),
+            st.dictionaries(st.text(max_size=6), children, max_size=3),
+        ),
+        max_leaves=6,
+    )
+)
+def test_parsing_arbitrary_config_never_raises(raw):
+    # An operator descriptor is untrusted config; a malformed one costs that
+    # harness its listing, never the gateway's boot.
+    descriptor, reasons = descriptor_from_mapping(raw, harness_id="probe")
+    assert (descriptor is None) == bool(reasons)
+
+
+# ── Code-only capabilities are refused from configuration (review finding) ──
+# Local review (2026-09-02, GPT + Opus lanes, both blocking): every name in
+# CAPABILITY_NAMES was config-grantable, so an operator descriptor could claim
+# internal_sandbox (Kiro Crew's own sandbox waived for a binary with no internal
+# one — the process runs UNCONFINED), acp_runtime_pool (routed onto AcpRuntime,
+# which speaks kiro-cli's wire dialect), session_sharing (a foreign process
+# multiplexed across trust contexts), or kiro_identity_store (sessions retired
+# on a login store the harness never reads). All four are honoured by code
+# written for specific bundled harnesses; a config grant points that machinery
+# at a process that never earned it.
+
+_CODE_ONLY_CAPABILITIES = (
+    "internal_sandbox",
+    "acp_runtime_pool",
+    "session_sharing",
+    "kiro_identity_store",
+)
+
+
+@pytest.mark.parametrize("capability", _CODE_ONLY_CAPABILITIES)
+def test_code_only_capabilities_cannot_be_granted_from_config(capability):
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "x",
+            "argv": ["{executable}"],
+            "capabilities": {capability: True},
+        },
+        harness_id="my-tool",
+    )
+    assert desc is None
+    assert any(
+        capability in r and "cannot be granted from configuration" in r for r in reasons
+    ), reasons
+
+
+@pytest.mark.parametrize("capability", _CODE_ONLY_CAPABILITIES)
+def test_code_only_capabilities_are_refused_even_as_false(capability):
+    # The key's PRESENCE is the claim; accepting the spelling at all invites
+    # flipping it, and a dropped-but-accepted key would read as granted.
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "x",
+            "argv": ["{executable}"],
+            "capabilities": {capability: False},
+        },
+        harness_id="my-tool",
+    )
+    assert desc is None
+    assert reasons
+
+
+def test_operator_grantable_capabilities_still_parse():
+    # The refusal is scoped: capabilities an operator adapter can genuinely
+    # implement stay grantable.
+    desc, reasons = descriptor_from_mapping(
+        {
+            "executable": "x",
+            "argv": ["{executable}"],
+            "capabilities": {"steer": True, "reasoning_effort": True, "mcp_tool_search": True},
+        },
+        harness_id="my-tool",
+    )
+    assert reasons == []
+    assert desc is not None
+    assert desc.capabilities.has("steer")
+    assert desc.capabilities.has("reasoning_effort")
+
+
+def test_the_ungrantable_set_only_names_real_capabilities():
+    # A retired/renamed capability lingering here would silently stop gating.
+    from kiro_crew.acp.harness_descriptor import _CONFIG_UNGRANTABLE_CAPABILITIES
+
+    for name in _CONFIG_UNGRANTABLE_CAPABILITIES:
+        assert name in CAPABILITY_NAMES

--- a/test/test_harness_generic_adapter.py
+++ b/test/test_harness_generic_adapter.py
@@ -1,0 +1,252 @@
+"""Tests for the generic ACP adapter (Wave 2, T2 / R1.2, R2).
+
+The generic adapter is what every adapter-less descriptor resolves to — bundled
+Codex and every operator harness — so a new provider's ACP server is config, not
+a code PR. These tests pin three things: its argv is pure template rendering with
+no hardcoded flags, its executable resolution honours an absolute path and falls
+back to the augmented PATH the kiro chain uses, and adapter RESOLUTION sends an
+adapter-less descriptor here while leaving kiro/kas/claude on their bespoke
+adapters.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from kiro_crew.acp.harness_adapters import (
+    ClaudeAdapter,
+    GenericAdapter,
+    KasAdapter,
+    KiroAdapter,
+    adapter_for,
+)
+from kiro_crew.acp.harness_descriptor import (
+    ADAPTER_GENERIC,
+    HarnessDescriptor,
+)
+from kiro_crew.acp.harness_registry import (
+    HARNESS_CLAUDE,
+    HARNESS_CODEX,
+    HARNESS_KAS,
+    HARNESS_KIRO,
+    registry,
+)
+
+
+def _operator_descriptor(**overrides) -> HarnessDescriptor:
+    """An adapter-less descriptor shaped like an operator's own ACP server."""
+    fields = dict(
+        id="agy",
+        display_name="AGY ACP",
+        executable="agy-acp",
+        argv=("{executable}", "acp"),
+    )
+    fields.update(overrides)
+    return HarnessDescriptor(**fields)
+
+
+# ── render_argv matrix (pure template, no hardcoded flags) ──
+
+
+def test_render_argv_emits_neither_block_without_agent_or_model():
+    descriptor = _operator_descriptor(
+        agent_args=("--agent", "{agent}"),
+        model_args=("--model", "{model}"),
+    )
+    argv = GenericAdapter().render_argv(descriptor, executable="/opt/agy-acp")
+    assert argv == ["/opt/agy-acp", "acp"]
+
+
+def test_render_argv_appends_agent_block_only_when_agent_passed():
+    descriptor = _operator_descriptor(
+        agent_args=("--agent", "{agent}"),
+        model_args=("--model", "{model}"),
+    )
+    argv = GenericAdapter().render_argv(descriptor, executable="/opt/agy-acp", agent="kirocrew")
+    assert argv == ["/opt/agy-acp", "acp", "--agent", "kirocrew"]
+
+
+def test_render_argv_appends_model_block_only_when_model_pinned():
+    descriptor = _operator_descriptor(
+        agent_args=("--agent", "{agent}"),
+        model_args=("--model", "{model}"),
+    )
+    argv = GenericAdapter().render_argv(descriptor, executable="/opt/agy-acp", model="fast-1")
+    assert argv == ["/opt/agy-acp", "acp", "--model", "fast-1"]
+
+
+def test_render_argv_appends_both_blocks_when_agent_and_model_given():
+    descriptor = _operator_descriptor(
+        agent_args=("--agent", "{agent}"),
+        model_args=("--model", "{model}"),
+    )
+    argv = GenericAdapter().render_argv(
+        descriptor, executable="/opt/agy-acp", agent="kirocrew", model="fast-1"
+    )
+    assert argv == ["/opt/agy-acp", "acp", "--agent", "kirocrew", "--model", "fast-1"]
+
+
+def test_render_argv_ignores_agent_when_descriptor_declares_no_agent_args():
+    """A descriptor with no ``agent_args`` block gets no agent flag even when an
+    agent is passed — the generic path hardcodes nothing."""
+    descriptor = _operator_descriptor(model_args=("--model", "{model}"))
+    argv = GenericAdapter().render_argv(descriptor, executable="/opt/agy-acp", agent="kirocrew")
+    assert argv == ["/opt/agy-acp", "acp"]
+
+
+# ── resolve_executable ──
+
+
+def test_absolute_executable_is_honored_when_it_is_a_runnable_file(tmp_path):
+    tool = tmp_path / "agy-acp"
+    tool.write_text("#!/bin/sh\n", encoding="utf-8")
+    tool.chmod(0o755)
+    descriptor = _operator_descriptor(executable=str(tool))
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert reason == ""
+    assert resolved == str(tool)
+
+
+def test_absolute_executable_missing_is_refused_with_a_reason(tmp_path):
+    missing = tmp_path / "not-here"
+    descriptor = _operator_descriptor(executable=str(missing))
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert resolved == ""
+    assert str(missing) in reason
+    assert "does not exist" in reason
+
+
+def test_bare_name_resolves_through_augmented_path(tmp_path, monkeypatch):
+    """A PATH name resolves via the augmented PATH the kiro chain uses.
+
+    The tool is placed in ``~/.local/bin`` — a directory ``augmented_path``
+    prepends but a non-login PATH omits — and the process PATH is emptied, so a
+    plain ``shutil.which`` would miss it and only the augmentation finds it.
+    """
+    home = tmp_path / "home"
+    local_bin = home / ".local" / "bin"
+    local_bin.mkdir(parents=True)
+    # ``shutil.which`` on Windows only matches a PATHEXT-suffixed name, so the
+    # planted tool carries one there; the descriptor still says the bare
+    # ``agy-acp`` and which() adds the extension — the same shape a real
+    # Windows install of a provider's launcher has.
+    tool = local_bin / ("agy-acp.bat" if os.name == "nt" else "agy-acp")
+    tool.write_text("#!/bin/sh\n", encoding="utf-8")
+    tool.chmod(0o755)
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))  # expanduser's key on Windows
+    monkeypatch.setenv("PATH", "")
+
+    descriptor = _operator_descriptor(executable="agy-acp")
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert reason == ""
+    # normcase: Windows which() may report the PATHEXT extension in the
+    # case PATHEXT spells it (.BAT), and the filesystem is case-insensitive.
+    assert os.path.normcase(resolved) == os.path.normcase(str(tool))
+
+
+def test_bare_name_not_found_is_refused(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("PATH", "")
+    descriptor = _operator_descriptor(executable="definitely-not-installed-xyz")
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert resolved == ""
+    assert "not found on PATH" in reason
+
+
+def test_relative_path_executable_is_refused_with_an_honest_reason():
+    """A relative path (separator, not absolute) is refused, not silently
+    resolved against the gateway cwd — shutil.which would discard the augmented
+    PATH for it, so the reason must name the real rule, not a PATH miss."""
+    for candidate in ("./bin/agy-acp", "bin/agy-acp"):
+        descriptor = _operator_descriptor(executable=candidate)
+        resolved, reason = GenericAdapter().resolve_executable(descriptor)
+        assert resolved == ""
+        assert "relative path" in reason
+        assert "not found on PATH" not in reason
+
+
+def test_empty_executable_is_refused():
+    descriptor = _operator_descriptor(executable="")
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert resolved == ""
+    assert reason == "no executable is declared"
+
+
+def test_absolute_non_executable_file_is_refused(tmp_path):
+    """The interrupted-install branch: a present but non-executable file.
+
+    The defect class is the POSIX execute BIT missing, so the test probes the
+    mechanism instead of guessing the platform: on Windows ``chmod(0o644)`` is
+    a no-op and every regular file is spawnable, so the refusal this test pins
+    cannot occur there and the test skips itself (conftest's probe-not-guess
+    rule for symlinks, applied to the exec bit).
+    """
+    tool = tmp_path / "agy-acp"
+    tool.write_text("#!/bin/sh\n", encoding="utf-8")
+    tool.chmod(0o644)
+    if os.access(tool, os.X_OK):
+        pytest.skip("this platform has no removable execute bit")
+    descriptor = _operator_descriptor(executable=str(tool))
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert resolved == ""
+    assert "not an executable file" in reason
+
+
+def test_absolute_zero_byte_file_is_refused(tmp_path):
+    """A truncated install: executable bit set, zero bytes."""
+    tool = tmp_path / "agy-acp"
+    tool.write_bytes(b"")
+    tool.chmod(0o755)
+    descriptor = _operator_descriptor(executable=str(tool))
+    resolved, reason = GenericAdapter().resolve_executable(descriptor)
+    assert resolved == ""
+    assert "zero-byte file" in reason
+
+
+# ── pre_spawn: a generic (genuinely foreign) harness never gets kiro's key ──
+
+
+def test_generic_pre_spawn_strips_kiro_clis_api_key(tmp_path):
+    """The base strip is inherited, and the generic adapter is the genuinely
+    foreign harness — an operator ACP server must never receive KIRO_API_KEY."""
+    from kiro_crew.config.loader import CRED_KIRO_API_KEY
+
+    descriptor = _operator_descriptor()
+    env = {CRED_KIRO_API_KEY: "secret", "PATH": "/usr/bin"}
+    GenericAdapter().pre_spawn(descriptor, env=env, workdir=str(tmp_path), agent="kirocrew")
+    assert CRED_KIRO_API_KEY not in env
+    assert env["PATH"] == "/usr/bin"
+
+
+# ── adapter resolution ──
+
+
+def test_adapter_less_descriptor_resolves_to_generic():
+    descriptor = _operator_descriptor()
+    assert descriptor.adapter == ""
+    adapter = adapter_for(descriptor)
+    assert isinstance(adapter, GenericAdapter)
+    assert adapter.name == ADAPTER_GENERIC
+
+
+def test_bundled_codex_is_adapter_less_and_resolves_to_generic():
+    codex = registry().get(HARNESS_CODEX)
+    assert codex.adapter == ""
+    assert isinstance(adapter_for(codex), GenericAdapter)
+
+
+@pytest.mark.parametrize(
+    "harness_id,adapter_cls",
+    [
+        (HARNESS_KIRO, KiroAdapter),
+        (HARNESS_KAS, KasAdapter),
+        (HARNESS_CLAUDE, ClaudeAdapter),
+    ],
+)
+def test_bespoke_harnesses_keep_their_own_adapter(harness_id, adapter_cls):
+    descriptor = registry().get(harness_id)
+    assert isinstance(adapter_for(descriptor), adapter_cls)

--- a/test/test_harness_registry.py
+++ b/test/test_harness_registry.py
@@ -1,0 +1,869 @@
+"""Tests for the ACP harness registry: bundled descriptors, aliases, availability.
+
+The registry is what every selection surface reads, so the pins here are mostly
+about what must NOT happen: a capability nobody granted, an executable probed at
+boot, an operator descriptor that names Python code, or a harness definition an
+agent could author.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import stat
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from kiro_crew.acp import harness_registry
+from kiro_crew.acp.harness_descriptor import (
+    ADAPTER_CLAUDE,
+    ADAPTER_KAS,
+    ADAPTER_KIRO,
+    ADAPTERS,
+    CAPABILITY_NAMES,
+    MCP_DELIVERY_FILE_FED,
+    MCP_DELIVERY_WIRE_FED,
+    CapabilitySet,
+    validate_descriptor,
+)
+from kiro_crew.acp.harness_registry import (
+    BUNDLED_DESCRIPTORS,
+    DEFAULT_HARNESS,
+    HARNESS_CLAUDE,
+    HARNESS_CODEX,
+    HARNESS_KAS,
+    HARNESS_KIRO,
+    OPERATOR_HARNESSES_LEAF,
+    HarnessRegistry,
+    HarnessUnavailable,
+    UnknownHarness,
+    registry,
+    unserviceable_reason,
+)
+from kiro_crew.acp.types import (
+    ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_KAS,
+    ACP_BACKEND_KIRO,
+    ACP_BACKENDS_KNOWN,
+    selectable_backends,
+)
+
+# The legacy ``agent.acp_backend`` value each bundled harness corresponds to.
+# Codex has no legacy identifier in ``acp/types.py`` (upstream adds one), so it is
+# absent here rather than mapped to something it is not.
+_LEGACY_BACKEND = {
+    HARNESS_KIRO: ACP_BACKEND_KIRO,
+    HARNESS_KAS: ACP_BACKEND_KAS,
+    HARNESS_CLAUDE: ACP_BACKEND_CLAUDE,
+}
+
+# Each behavior capability paired with the legacy ``acp_backend`` membership it
+# shipped with. The ``ACP_BACKENDS_*`` views these were transcribed from are
+# retired (wave-2 T5), so the membership is written out as LITERALS here — which
+# is the whole point of a transcription pin: a table derived from the descriptors
+# it checks pins nothing. These are the exact sets that shipped before the rekey
+# (kiro full; KAS steer+runtime+identity; claude none of the five).
+_SHIPPED_MEMBERS = {
+    "session_sharing": frozenset({ACP_BACKEND_KIRO}),
+    "steer": frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS}),
+    "internal_sandbox": frozenset({ACP_BACKEND_KIRO}),
+    "acp_runtime_pool": frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS}),
+    "kiro_identity_store": frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS}),
+}
+
+
+def _write_config(payload: dict) -> None:
+    """Write ``config.json`` under this test's pinned data home."""
+    from kiro_crew.config.loader import config_dir, config_path
+
+    config_dir().mkdir(parents=True, exist_ok=True)
+    config_path().write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_harnesses(payload: object) -> None:
+    """Write ``harnesses.json`` under this test's pinned data home.
+
+    The operator-descriptor file the registry reads — a dedicated leaf, not a
+    config key, so the write-protection fence can cover it without gating
+    config reads (see the module docstring of ``harness_registry``).
+    """
+    from kiro_crew.config.loader import config_dir
+
+    config_dir().mkdir(parents=True, exist_ok=True)
+    (config_dir() / OPERATOR_HARNESSES_LEAF).write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _fresh_registry(harnesses: dict | None = None, default_harness: str = "") -> HarnessRegistry:
+    """A registry reading a ``harnesses.json`` that declares *harnesses*."""
+    if harnesses is not None:
+        _write_harnesses(harnesses)
+    agent: dict = {}
+    if default_harness:
+        agent["default_harness"] = default_harness
+    _write_config({"agent": agent})
+    return HarnessRegistry()
+
+
+def _executable(path) -> str:
+    """Create a non-empty executable file at *path* and return it."""
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(path)
+
+
+def _operator_descriptor(executable: str, **overrides) -> dict:
+    payload = {"executable": executable, "argv": ["{executable}", "acp"]}
+    payload.update(overrides)
+    return payload
+
+
+# ── Bundled descriptors ──
+
+
+def test_every_bundled_descriptor_validates():
+    for descriptor in BUNDLED_DESCRIPTORS:
+        assert validate_descriptor(descriptor) == [], descriptor.id
+
+
+def test_bundled_ids_are_unique():
+    ids = [d.id for d in BUNDLED_DESCRIPTORS]
+    assert len(ids) == len(set(ids))
+
+
+def test_kiro_is_the_default_harness_and_is_listed_first():
+    # An operator who configures nothing gets Kiro (harness-parity H1).
+    assert DEFAULT_HARNESS == HARNESS_KIRO
+    assert BUNDLED_DESCRIPTORS[0].id == HARNESS_KIRO
+    assert _fresh_registry().default().id == HARNESS_KIRO
+
+
+def test_kiro_descriptor_carries_todays_spawn_conventions():
+    kiro = registry().get(HARNESS_KIRO)
+    # AcpRuntime._resolve_spawn_argv builds [bin, "acp", "--agent", agent] and
+    # appends ["--model", model] only when a model is pinned.
+    assert kiro.argv == ("{executable}", "acp")
+    assert kiro.agent_args == ("--agent", "{agent}")
+    assert kiro.model_args == ("--model", "{model}")
+    # kiro-cli reads MCP servers from its own agent spec, not from session/new.
+    assert kiro.mcp_delivery == MCP_DELIVERY_FILE_FED
+    assert kiro.adapter == ADAPTER_KIRO
+
+
+@pytest.mark.parametrize("harness_id", sorted(_LEGACY_BACKEND))
+@pytest.mark.parametrize("capability", sorted(_SHIPPED_MEMBERS))
+def test_bundled_capability_matches_its_frozenset(harness_id, capability):
+    """A bundled flag says exactly what the legacy membership set said.
+
+    This is the transcription pin: the ``ACP_BACKENDS_*`` frozensets it once read
+    are retired (wave-2 T5), so the behaviour shipping before the rekey is written
+    out as literals in ``_SHIPPED_MEMBERS``. A descriptor that disagrees with one
+    silently grants or withdraws a capability, which is exactly what this catches.
+    """
+    backend = _LEGACY_BACKEND[harness_id]
+    expected = backend in _SHIPPED_MEMBERS[capability]
+    assert registry().capabilities(harness_id).has(capability) is expected
+
+
+def test_kas_declares_no_tool_search_or_effort():
+    # Withdrawn deliberately: the old gates were spelled ``is_claude_backend``, so
+    # KAS received kiro-cli's cli.json overlay writes as a consequence of a
+    # negative test rather than of anything it demonstrated (harness-parity H6).
+    # The descriptor states the positive posture, and the consequences are pinned
+    # where they take effect (test_acp_tool_search.py's KAS-skips cases).
+    caps = registry().capabilities(HARNESS_KAS)
+    assert caps.has("mcp_tool_search") is False
+    assert caps.has("reasoning_effort") is False
+    assert registry().get(HARNESS_KAS).adapter == ADAPTER_KAS
+
+
+def test_kiro_declares_tool_search_and_effort():
+    caps = registry().capabilities(HARNESS_KIRO)
+    assert caps.has("mcp_tool_search") is True
+    assert caps.has("reasoning_effort") is True
+
+
+def test_codex_is_data_only_with_every_capability_off():
+    codex = registry().get(HARNESS_CODEX)
+    assert codex.adapter == ""
+    assert codex.mcp_delivery == MCP_DELIVERY_WIRE_FED
+    assert codex.capabilities == CapabilitySet()
+
+
+def test_codex_descriptor_launches_the_acp_adapter_not_the_cli():
+    """Review finding (2026-09-02): ``codex acp`` is NOT an ACP server.
+
+    The ``codex`` CLI reads ``acp`` as a prompt and never answers initialize, so
+    a descriptor spawning it would hang every selected session at handshake. The
+    real server is the ``codex-acp`` npm adapter — the same binary the dormant
+    seam's own spawn path resolves (``_resolve_codex_acp_bin``: "The 'codex' CLI
+    alone does not serve ACP") — spawned bare and driven over the pipe. Model
+    selection travels over ``session/set_config_option`` (codex is in the
+    config-option channel), so there are no model_args either.
+    """
+    codex = registry().get(HARNESS_CODEX)
+    assert codex.executable == "codex-acp"
+    assert codex.argv == ("{executable}",)
+    assert codex.model_args == ()
+
+
+def test_claude_is_registered_and_serviceable_and_the_unserviceable_barrier_still_works(
+    monkeypatch,
+):
+    """Claude is a registered, serviceable public backend (#7301), and the
+    build-refusal barrier still works for a row that IS declared unserviceable.
+
+    #7301 made Claude Code selectable in the public build, so the old
+    ``_UNSERVICEABLE`` refusal posture is gone: claude is registered (a persisted
+    ``acp_backend: "claude"`` is recognized, not silently swapped) and its
+    availability is now driven by executable resolution — the claude-agent-acp
+    adapter binary being present or absent — not by a build-level refusal.
+
+    The regression barrier the old test protected is the ``_UNSERVICEABLE``
+    mechanism itself, not claude's membership in it. So this asserts BOTH: claude
+    now serves when its binary resolves, AND a synthetic row injected into
+    ``_UNSERVICEABLE`` still refuses end to end (availability False with the
+    reason, ``require_available`` raises, the listing shows it False with the
+    reason). An edition whose build genuinely cannot serve a bundled harness is
+    what would populate that map, and this proves the seam it flows through is
+    intact.
+    """
+    reg = registry()
+    claude = reg.get(HARNESS_CLAUDE)
+    assert claude.adapter == ADAPTER_CLAUDE
+    # Serviceable now: no build-level refusal. Availability is whatever the
+    # adapter's executable resolution reports on this machine — never a hardcoded
+    # "not serviceable" refusal.
+    available, reason = reg.availability(HARNESS_CLAUDE)
+    if not available:
+        assert "not serviceable" not in reason
+    assert unserviceable_reason(HARNESS_CLAUDE) == ""
+    # The barrier still bites for a row that IS declared unserviceable: inject a
+    # synthetic bundled-style row and confirm it refuses through every seam.
+    monkeypatch.setitem(
+        harness_registry._UNSERVICEABLE, HARNESS_CLAUDE, "build cannot serve claude"
+    )
+    available, reason = reg.availability(HARNESS_CLAUDE)
+    assert available is False
+    assert reason == "build cannot serve claude"
+    with pytest.raises(HarnessUnavailable) as excinfo:
+        reg.require_available(HARNESS_CLAUDE)
+    assert excinfo.value.harness_id == HARNESS_CLAUDE
+    assert excinfo.value.reason == "build cannot serve claude"
+    # Visible in the listing with its reason (R6.2), never silently dropped.
+    row = next(r for r in reg.list() if r.id == HARNESS_CLAUDE)
+    assert (row.available, row.reason) == (False, "build cannot serve claude")
+
+
+def test_only_bundled_descriptors_may_name_an_adapter():
+    named = {d.adapter for d in BUNDLED_DESCRIPTORS if d.adapter}
+    assert named <= ADAPTERS
+
+
+def test_the_unselectable_set_is_transcribed_from_the_legacy_vocabulary():
+    """What cannot be selected is exactly what ``selectable_backends()`` excludes.
+
+    KNOWN minus selectable is the set of backends the code understands but cannot
+    serve a session with; the registry keeps them registered and refuses
+    selection, so the posture survives the migration instead of a harness
+    quietly becoming selectable.
+    """
+    unselectable_backends = ACP_BACKENDS_KNOWN - selectable_backends()
+    expected = {
+        harness_id
+        for harness_id, backend in _LEGACY_BACKEND.items()
+        if backend in unselectable_backends
+    }
+    assert set(harness_registry._UNSERVICEABLE) == expected
+
+
+# ── Legacy alias resolution (Property 4) ──
+
+
+def test_the_empty_backend_resolves_to_kiro():
+    # ACP_BACKEND_KIRO is spelled "", which is unusable as an id — the alias is
+    # what keeps an existing config working unchanged (R1.6).
+    assert registry().resolve_alias(ACP_BACKEND_KIRO) == HARNESS_KIRO
+
+
+def test_kas_and_codex_resolve_to_their_own_descriptors():
+    assert registry().resolve_alias(ACP_BACKEND_KAS) == HARNESS_KAS
+    assert registry().resolve_alias(HARNESS_CODEX) == HARNESS_CODEX
+
+
+def test_a_serviceable_backend_resolves_to_its_own_harness(caplog):
+    # #7301: claude is serviceable now, so its legacy backend resolves to the
+    # claude harness rather than degrading to the default. No "cannot serve"
+    # warning is emitted for it.
+    with caplog.at_level("WARNING"):
+        assert registry().resolve_alias(ACP_BACKEND_CLAUDE) == HARNESS_CLAUDE
+    assert not any("cannot serve a session" in r.getMessage() for r in caplog.records)
+
+
+def test_a_known_but_unserviceable_backend_degrades_to_the_default(monkeypatch, caplog):
+    # The degrade-on-unserviceable mechanism is unchanged; only claude left the
+    # map. Inject a synthetic unserviceable row for a real backend id and confirm
+    # resolve_alias consults _UNSERVICEABLE and degrades to the default with the
+    # warning — the barrier the old claude row exercised, proven on a live row.
+    monkeypatch.setitem(
+        harness_registry._UNSERVICEABLE, ACP_BACKEND_KAS, "build cannot serve this backend"
+    )
+    with caplog.at_level("WARNING"):
+        assert registry().resolve_alias(ACP_BACKEND_KAS) == DEFAULT_HARNESS
+    assert any("cannot serve a session" in r.getMessage() for r in caplog.records)
+
+
+def test_an_unserviceable_backend_degrades_even_when_it_is_also_an_alias(monkeypatch, caplog):
+    """Unserviceable is consulted before the alias table, and the order matters.
+
+    Nothing structurally keeps the two mappings disjoint: an alias row is what a
+    harness gains when it acquires a legacy ``acp_backend`` identifier, and its
+    unserviceable row lives elsewhere in the module. With the alias consulted
+    first, an id in both resolves to a harness that cannot serve a session —
+    which is the one outcome the unserviceable row exists to prevent.
+
+    Claude is serviceable now (#7301) so it can no longer stand in for the
+    unserviceable side; a synthetic row on a real backend id that is ALSO wired
+    into ``_ALIASES`` proves the same ordering invariant on a live id.
+    """
+    monkeypatch.setitem(harness_registry._UNSERVICEABLE, ACP_BACKEND_KAS, "build cannot serve this")
+    monkeypatch.setitem(harness_registry._ALIASES, ACP_BACKEND_KAS, HARNESS_KAS)
+    with caplog.at_level("WARNING"):
+        assert registry().resolve_alias(ACP_BACKEND_KAS) == DEFAULT_HARNESS
+    assert any("cannot serve a session" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.parametrize("garbage", ["nope", "KIRO", "kiro-cli", "  ", None, 7, [], {"a": 1}, True])
+def test_an_unresolvable_backend_degrades_without_raising(garbage):
+    assert registry().resolve_alias(garbage) == DEFAULT_HARNESS
+
+
+_ALIAS_VALUES = st.one_of(
+    st.sampled_from(
+        sorted(ACP_BACKENDS_KNOWN | selectable_backends() | {HARNESS_CODEX, HARNESS_KIRO})
+    ),
+    st.text(max_size=12),
+    st.none(),
+    st.integers(),
+    st.booleans(),
+    st.lists(st.text(max_size=3), max_size=2),
+)
+
+
+@given(_ALIAS_VALUES)
+def test_alias_resolution_is_total_and_lands_on_a_bundled_descriptor(value):
+    """Property 4: resolution never errors and never leaves the bundled set."""
+    reg = registry()
+    resolved = reg.resolve_alias(value)
+    descriptor = reg.get(resolved)  # raises UnknownHarness if unregistered
+    assert descriptor.id == resolved
+    assert descriptor.id in {d.id for d in BUNDLED_DESCRIPTORS}
+
+
+@given(_ALIAS_VALUES)
+def test_alias_resolution_matches_the_normalizers_degrade_posture(value):
+    """Property 4: anything the normalizer degrades also degrades here.
+
+    ``codex`` is the one deliberate divergence and is excluded: the normalizer
+    does not know it yet (it is absent from ``ACP_BACKENDS_KNOWN``) while R1.6
+    requires it to alias its bundled descriptor. Every other value the normalizer
+    sends to Kiro must land on the default harness here too.
+    """
+    from kiro_crew.config.loader import _normalize_acp_backend
+
+    if value == HARNESS_CODEX:
+        return
+    normalized = _normalize_acp_backend(value)
+    resolved = registry().resolve_alias(value)
+    if normalized == ACP_BACKEND_KIRO:
+        assert resolved == DEFAULT_HARNESS
+    else:
+        assert resolved == registry().resolve_alias(normalized)
+
+
+# ── Operator descriptors ──
+
+
+def test_a_valid_operator_descriptor_is_registered_and_listed(tmp_path):
+    exe = _executable(tmp_path / "my-acp-tool")
+    reg = _fresh_registry({"my-tool": _operator_descriptor(exe, display_name="My ACP Tool")})
+    row = next(r for r in reg.list() if r.id == "my-tool")
+    assert (row.display_name, row.available, row.reason, row.bundled) == (
+        "My ACP Tool",
+        True,
+        "",
+        False,
+    )
+    # Every capability off unless the descriptor enabled it (R2.5).
+    assert reg.capabilities("my-tool") == CapabilitySet()
+
+
+def test_operator_harnesses_are_listed_after_the_bundled_ones(tmp_path):
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry(
+        {"zz-tool": _operator_descriptor(exe), "aa-tool": _operator_descriptor(exe)}
+    )
+    ids = [r.id for r in reg.list()]
+    bundled = [d.id for d in BUNDLED_DESCRIPTORS]
+    assert ids[: len(bundled)] == bundled
+    assert ids[len(bundled) :] == ["aa-tool", "zz-tool"]
+
+
+def test_an_invalid_operator_descriptor_is_excluded_and_reported(tmp_path):
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry(
+        {
+            "broken": {"executable": exe, "argv": ["{executable}", "--home={home}"]},
+            "good": _operator_descriptor(exe),
+        }
+    )
+    # Excluded from every selection surface (R2.3): not in the listing…
+    assert "broken" not in {r.id for r in reg.list()}
+    # …and not gettable either, so nothing can hand it to a session.
+    with pytest.raises(UnknownHarness):
+        reg.get("broken")
+    # The reason is retained so Settings can show what is wrong (R6.2).
+    invalid = {r.id: r for r in reg.invalid()}
+    assert "{home}" in invalid["broken"].reason
+    assert invalid["broken"].valid is False
+    # Every other harness is unaffected.
+    assert "good" in {r.id for r in reg.list()}
+    assert reg.get(DEFAULT_HARNESS).id == DEFAULT_HARNESS
+
+
+def test_an_operator_descriptor_cannot_shadow_a_bundled_harness(tmp_path):
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry({HARNESS_KIRO: _operator_descriptor(exe)})
+    assert reg.get(HARNESS_KIRO).adapter == ADAPTER_KIRO
+    assert "already registered" in {r.id: r.reason for r in reg.invalid()}[HARNESS_KIRO]
+
+
+def test_the_literal_adapter_key_is_refused_on_the_operator_path(tmp_path):
+    """Configuration must never be able to select a Python entry point.
+
+    The parse path rejects the LITERAL key, not merely a typo of it, so extending
+    ``DESCRIPTOR_KEYS`` for a bundled-only field cannot quietly open this door.
+    """
+    from kiro_crew.acp.harness_descriptor import DESCRIPTOR_KEYS, descriptor_from_mapping
+
+    assert "adapter" not in DESCRIPTOR_KEYS
+    descriptor, reasons = descriptor_from_mapping(
+        {"executable": "x", "argv": ["{executable}"], "adapter": ADAPTER_KIRO},
+        harness_id="x",
+    )
+    assert descriptor is None
+    assert any("'adapter'" in r for r in reasons)
+
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry({"sneaky": _operator_descriptor(exe, adapter=ADAPTER_KAS)})
+    assert "sneaky" not in {r.id for r in reg.list()}
+    assert "'adapter'" in {r.id: r.reason for r in reg.invalid()}["sneaky"]
+
+
+def test_a_new_operator_harness_appears_after_the_config_changes(tmp_path):
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry({})
+    assert "later" not in {r.id for r in reg.list()}
+    _write_harnesses({"later": _operator_descriptor(exe)})
+    reg.reload()
+    assert "later" in {r.id for r in reg.list()}
+
+
+def test_a_config_load_failure_degrades_to_bundled_only(monkeypatch, caplog):
+    import kiro_crew.config.loader as loader
+
+    def _explode(*_a, **_kw):
+        raise RuntimeError("config unreadable")
+
+    monkeypatch.setattr(loader.KiroCrewConfig, "load", staticmethod(_explode))
+    with caplog.at_level("WARNING"):
+        ids = {r.id for r in HarnessRegistry().list()}
+    assert ids == {d.id for d in BUNDLED_DESCRIPTORS}
+    assert any("config unreadable" in r.getMessage() for r in caplog.records)
+
+
+# ── Default harness ──
+
+
+def test_the_configured_default_harness_is_honoured(tmp_path):
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry({"mine": _operator_descriptor(exe)}, default_harness="mine")
+    assert reg.default().id == "mine"
+
+
+def test_an_unknown_default_harness_degrades_to_kiro(caplog):
+    reg = _fresh_registry({}, default_harness="ghost")
+    with caplog.at_level("WARNING"):
+        assert reg.default().id == HARNESS_KIRO
+    assert any("default_harness" in r.getMessage() for r in caplog.records)
+
+
+def test_an_unavailable_default_harness_degrades_to_kiro(tmp_path, caplog):
+    missing = str(tmp_path / "never-installed")
+    reg = _fresh_registry({"mine": _operator_descriptor(missing)}, default_harness="mine")
+    with caplog.at_level("WARNING"):
+        assert reg.default().id == HARNESS_KIRO
+    assert any(missing in r.getMessage() for r in caplog.records)
+
+
+# ── Availability ──
+
+
+def test_nothing_is_probed_until_a_caller_asks(monkeypatch):
+    """R6.1: registration is free; the executables are not touched at boot."""
+    calls: list[str] = []
+
+    def _counting(descriptor):
+        calls.append(descriptor.id)
+        return descriptor.executable, ""
+
+    monkeypatch.setattr(harness_registry, "resolve_executable", _counting)
+    reg = HarnessRegistry()
+    assert calls == []
+    # Even loading the descriptors probes nothing — only availability does.
+    reg.get(HARNESS_KIRO)
+    assert calls == []
+    reg.list()
+    assert calls
+
+
+def test_availability_never_executes_a_candidate():
+    # A listing must not become N subprocess spawns, and an unauthenticated
+    # harness must not be reported as a missing binary. Pinned structurally: this
+    # module has no way to run anything.
+    source = inspect.getsource(harness_registry)
+    for forbidden in ("subprocess", "os.system", "asyncio.create_subprocess"):
+        assert forbidden not in source
+
+
+def test_a_missing_executable_is_unavailable_with_a_reason_naming_it(tmp_path):
+    missing = str(tmp_path / "not-installed")
+    reg = _fresh_registry({"mine": _operator_descriptor(missing)})
+    available, reason = reg.availability("mine")
+    assert available is False
+    assert missing in reason
+
+
+def test_a_bare_name_off_path_is_unavailable(tmp_path):
+    reg = _fresh_registry({"mine": _operator_descriptor("definitely-not-on-path-xyz")})
+    available, reason = reg.availability("mine")
+    assert available is False
+    assert "not found on PATH" in reason
+
+
+def test_a_zero_byte_executable_is_refused(tmp_path):
+    path = tmp_path / "truncated"
+    path.write_text("", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    reg = _fresh_registry({"mine": _operator_descriptor(str(path))})
+    available, reason = reg.availability("mine")
+    assert available is False
+    assert "zero-byte" in reason
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows has no execute bit to clear")
+def test_a_non_executable_file_is_refused(tmp_path):
+    path = tmp_path / "not-executable"
+    path.write_text("data\n", encoding="utf-8")
+    path.chmod(0o644)
+    reg = _fresh_registry({"mine": _operator_descriptor(str(path))})
+    available, reason = reg.availability("mine")
+    assert available is False
+    assert "not an executable file" in reason
+
+
+def test_a_path_that_does_not_exist_says_so_rather_than_blaming_permissions(tmp_path):
+    """The reason has to name the actual defect to be actionable.
+
+    An absent path and a present-but-unexecutable one need different fixes
+    ("install it" vs "chmod it"), and the executable-file probe answers False for
+    both — so absence is checked first.
+    """
+    missing = str(tmp_path / "never-installed")
+    reg = _fresh_registry({"mine": _operator_descriptor(missing)})
+    available, reason = reg.availability("mine")
+    assert available is False
+    assert reason == f"{missing} does not exist"
+
+
+def test_a_zero_byte_kiro_cli_is_refused_on_every_platform(tmp_path, monkeypatch):
+    """kiro-cli's own candidate filter checks emptiness only on Windows.
+
+    A truncated ``kiro-cli`` (an interrupted install) keeps its execute bit on
+    POSIX, so without the registry's own check it would list available and then
+    exec into a process that exits with no ACP frame.
+    """
+    truncated = tmp_path / "kiro-cli"
+    truncated.write_text("", encoding="utf-8")
+    truncated.chmod(truncated.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(
+        "kiro_crew.kiro_cli.resolve_kiro_cli", lambda *a, **k: str(truncated), raising=True
+    )
+    available, reason = _fresh_registry({}).availability(HARNESS_KIRO)
+    assert available is False
+    assert reason == f"{truncated} is a zero-byte file"
+
+
+def test_kas_availability_follows_kiro_cli_because_the_relay_is_kiro_cli(tmp_path, monkeypatch):
+    """KAS is reached as ``kiro-cli acp --agent-engine v3``, so it resolves that binary.
+
+    Not an incidental sharing: an operator who overrode the kiro-cli path did so
+    for every harness the CLI serves, and a second resolution chain here is how
+    KAS would report available while the binary it execs is a different file.
+    """
+    resolved = _executable(tmp_path / "kiro-cli")
+    monkeypatch.setattr(
+        "kiro_crew.kiro_cli.resolve_kiro_cli", lambda *a, **k: resolved, raising=True
+    )
+    assert _fresh_registry({}).availability(HARNESS_KAS) == (True, "")
+
+
+def test_kas_is_unavailable_when_kiro_cli_cannot_be_found(monkeypatch):
+    """The relay has nothing to relay THROUGH, and the reason says which binary."""
+    monkeypatch.setattr("kiro_crew.kiro_cli.resolve_kiro_cli", lambda *a, **k: "", raising=True)
+    available, reason = _fresh_registry({}).availability(HARNESS_KAS)
+    assert available is False
+    assert "kiro-cli" in reason
+
+
+def test_a_zero_byte_kiro_cli_is_refused_for_kas_too(tmp_path, monkeypatch):
+    """The shared candidate check covers both harnesses, not just the kiro one.
+
+    Same defect as ``test_a_zero_byte_kiro_cli_is_refused_on_every_platform``,
+    asserted through KAS: a truncated binary keeps its execute bit on POSIX, and
+    the two harnesses must agree about it or the same file is spawnable under one
+    name and not the other.
+    """
+    truncated = tmp_path / "kiro-cli"
+    truncated.write_text("", encoding="utf-8")
+    truncated.chmod(truncated.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(
+        "kiro_crew.kiro_cli.resolve_kiro_cli", lambda *a, **k: str(truncated), raising=True
+    )
+    available, reason = _fresh_registry({}).availability(HARNESS_KAS)
+    assert available is False
+    assert reason == f"{truncated} is a zero-byte file"
+
+
+def test_installing_the_binary_heals_the_listing_without_a_restart(tmp_path):
+    """R6.5: recovery is reflected on the next listing, no gateway restart."""
+    path = tmp_path / "later-installed"
+    reg = _fresh_registry({"mine": _operator_descriptor(str(path))})
+    assert next(r for r in reg.list() if r.id == "mine").available is False
+    _executable(path)
+    row = next(r for r in reg.list() if r.id == "mine")
+    assert (row.available, row.reason) == (True, "")
+
+
+def test_a_recorded_spawn_failure_marks_only_that_harness(tmp_path):
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry({"mine": _operator_descriptor(exe), "other": _operator_descriptor(exe)})
+    reg.note_probe_failure("mine", "exited during ACP initialize (rc=1)")
+    available, reason = reg.availability("mine")
+    assert available is False
+    assert "ACP initialize" in reason
+    # R6.4: another harness's availability is untouched.
+    assert reg.availability("other") == (True, "")
+    reg.clear_probe_failure("mine")
+    assert reg.availability("mine") == (True, "")
+
+
+def test_a_recorded_failure_expires_so_a_repaired_harness_heals(tmp_path, monkeypatch):
+    """A failed attempt is a snapshot, not a verdict.
+
+    Nothing would clear a permanent one short of a gateway restart, which R6.5
+    exists to avoid — so the record ages out and the next listing re-asks.
+    """
+    exe = _executable(tmp_path / "tool")
+    reg = _fresh_registry({"mine": _operator_descriptor(exe)})
+    reg.note_probe_failure("mine", "not signed in")
+    assert reg.availability("mine")[0] is False
+    monkeypatch.setattr(harness_registry, "_PROBE_FAILURE_TTL_SECS", 0.0)
+    assert reg.availability("mine") == (True, "")
+
+
+def test_require_available_refuses_rather_than_substituting(tmp_path):
+    missing = str(tmp_path / "gone")
+    reg = _fresh_registry({"mine": _operator_descriptor(missing)})
+    with pytest.raises(HarnessUnavailable) as excinfo:
+        reg.require_available("mine")
+    assert excinfo.value.harness_id == "mine"
+    assert missing in str(excinfo.value)
+    with pytest.raises(UnknownHarness):
+        reg.require_available("no-such-harness")
+
+
+def test_unknown_harness_error_names_what_is_registered():
+    with pytest.raises(UnknownHarness) as excinfo:
+        _fresh_registry({}).get("ghost")
+    assert HARNESS_KIRO in str(excinfo.value)
+
+
+# ── Write guard: harness definitions are operator-only ──
+
+
+def test_the_file_holding_harness_definitions_is_write_protected_from_agent_tools():
+    """R2.4 on the tool path.
+
+    Operator descriptors live in ``harnesses.json``, which is on the write-only
+    protected tier — the agent's file-edit tool is refused there while reads stay
+    allowed. A descriptor names a binary Kiro Crew spawns, so an agent that could
+    author one would have arbitrary code execution in the gateway's identity.
+    """
+    from kiro_crew import security
+    from kiro_crew.config.loader import config_dir
+
+    assert security.is_sensitive_write_path(str(config_dir() / OPERATOR_HARNESSES_LEAF))
+    # Pinned against the LIST, not just the predicate: removing harnesses.json
+    # from the write-protected tier must fail here rather than silently open the
+    # file, and the leaf spelling must match the one the registry reads.
+    tails = {entry.rsplit("/", 1)[-1] for entry in security.write_protected_home_paths()}
+    assert OPERATOR_HARNESSES_LEAF in tails
+
+
+def test_harness_definitions_are_not_on_the_settings_patch_allowlist():
+    """R2.4 on the API path.
+
+    The generic config PATCH surface is an allowlist; a harness definition is not
+    a scalar preference and must not be writable through it.
+    """
+    from kiro_crew.dashboard.handlers.core import _EDITABLE_CONFIG
+
+    assert "agent.harnesses" not in _EDITABLE_CONFIG
+    assert not any(key.startswith("agent.harnesses.") for key in _EDITABLE_CONFIG)
+
+
+# ── Write guard: the shell path ──
+
+
+def test_harnesses_json_shell_writes_are_denied_and_reads_stay_allowed(tmp_path, monkeypatch):
+    """R2.4 on the bash path.
+
+    A shell redirect is the write path no file-edit gate sees, so the leaf is
+    fenced in ``_WRITE_PROTECTED_BASH_LEAVES`` — protected on one path only is
+    not protected. The bash matcher is verb-INDEPENDENT (naming the leaf at all
+    is refused, so no novel write verb slips through), which takes bash ``cat``
+    with it — the same trade the playwright-cli-config leaf already made.
+    Reads survive on the paths that matter: the registry reads the file
+    in-process, and the agent's file-READ tool is ungated (only the file-EDIT
+    tier lists the leaf).
+    """
+    from pathlib import Path
+
+    from kiro_crew import security
+
+    assert OPERATOR_HARNESSES_LEAF in security._WRITE_PROTECTED_BASH_LEAVES
+    # Also on the bare-token tier: every anchored pattern above is defeated by
+    # one ``cd`` (``cd ~/.kiro/crew; printf … > harnesses.json`` names no home
+    # and no prefix), and for a file that IS the execution grant that gap is
+    # not a residual to accept. Membership here routes the leaf through the
+    # anchor-independent matcher and its shared test grid.
+    assert OPERATOR_HARNESSES_LEAF in security._BARE_TOKEN_PROTECTED_LEAVES
+    assert (
+        security.is_sensitive_bash_command(
+            f"cd ~/.kiro/crew && printf '{{}}' > {OPERATOR_HARNESSES_LEAF}"
+        )
+        is not None
+    )
+
+    for prefix in security.crew_home_prefixes():
+        for record in (
+            f"~/{prefix}/{OPERATOR_HARNESSES_LEAF}",
+            f"$HOME/{prefix}/{OPERATOR_HARNESSES_LEAF}",
+            str(Path.home() / prefix / OPERATOR_HARNESSES_LEAF),
+        ):
+            for cmd in (
+                f"echo '{{}}' > {record}",
+                f"echo '{{}}' >> {record}",
+                f"tee {record}",
+                f"touch {record}",
+                f"rm {record}",
+                f"mv /tmp/forged.json {record}",
+                f"cp /tmp/forged.json {record}",
+                # The verb-independent matcher catches reads too; the sanctioned
+                # read paths are the file-READ tool and the registry itself.
+                f"cat {record}",
+            ):
+                assert security.is_sensitive_bash_command(cmd) is not None, cmd
+        # Unrelated writes under the crew home stay allowed.
+        assert security.is_sensitive_bash_command(f"touch ~/{prefix}/sessions.db") is None
+    # A DIFFERENT file whose name merely ends with the leaf's is not fenced.
+    assert security.is_sensitive_bash_command(f"touch my-{OPERATOR_HARNESSES_LEAF}") is None
+    # The file-READ tool path stays open: the leaf is write-protected, not
+    # read+write sensitive (it holds no secret).
+    from kiro_crew.config.loader import config_dir
+
+    assert not security.is_sensitive_path(str(config_dir() / OPERATOR_HARNESSES_LEAF))
+
+
+# ── Config keys ──
+
+
+def test_the_registry_reads_operator_descriptors_from_harnesses_json(tmp_path):
+    """The store is the dedicated file, named by its pinned leaf constant."""
+    from kiro_crew.config.loader import config_dir
+
+    exe = _executable(tmp_path / "tool")
+    _write_config({"agent": {"default_harness": "mine"}})
+    _write_harnesses({"mine": _operator_descriptor(exe)})
+    assert (config_dir() / OPERATOR_HARNESSES_LEAF).is_file()
+
+    reg = HarnessRegistry()
+    assert reg.get("mine").executable == exe
+    assert reg.default().id == "mine"
+
+
+@pytest.mark.parametrize("garbage", [7, None, [], {"a": 1}, True])
+def test_a_malformed_default_harness_reads_as_absent(garbage):
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    _write_config({"agent": {"default_harness": garbage}})
+    assert KiroCrewConfig.load().agent.default_harness == ""
+
+
+def test_a_non_object_harness_entry_is_served_as_an_invalid_row(caplog):
+    """A non-object entry reaches the registry instead of vanishing at load.
+
+    The file is read un-coerced so the registry's reason channel —
+    the only surface an operator sees — can say ``descriptor must be an object``
+    under the entry's own id. Dropping it at read would leave Settings with no
+    row and no reason for a harness the operator plainly configured.
+    """
+    _write_harnesses({"mine": "kiro-cli acp"})
+
+    with caplog.at_level("WARNING"):
+        reg = HarnessRegistry()
+        invalid = {r.id: r for r in reg.invalid()}
+    assert "must be an object" in invalid["mine"].reason
+    assert invalid["mine"].valid is False
+    # Excluded from every selection surface, like any other invalid descriptor.
+    assert "mine" not in {r.id for r in reg.list()}
+    with pytest.raises(UnknownHarness):
+        reg.get("mine")
+    assert any("ignoring operator harness" in r.getMessage() for r in caplog.records)
+
+
+def test_a_non_object_harnesses_file_reads_as_empty():
+    _write_harnesses(["mine"])
+    reg = HarnessRegistry()
+    assert {r.id for r in reg.list()} == {d.id for d in BUNDLED_DESCRIPTORS}
+
+
+def test_an_unparseable_harnesses_file_costs_only_the_operator_rows(caplog):
+    """A corrupt file must not take the bundled harnesses down with it."""
+    from kiro_crew.config.loader import config_dir
+
+    config_dir().mkdir(parents=True, exist_ok=True)
+    (config_dir() / OPERATOR_HARNESSES_LEAF).write_text("{not json", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        reg = HarnessRegistry()
+    assert {r.id for r in reg.list()} == {d.id for d in BUNDLED_DESCRIPTORS}
+    assert any(OPERATOR_HARNESSES_LEAF in r.getMessage() for r in caplog.records)
+
+
+def test_capability_vocabulary_covers_every_bundled_flag():
+    for descriptor in BUNDLED_DESCRIPTORS:
+        assert set(descriptor.capabilities.as_dict()) == set(CAPABILITY_NAMES)

--- a/test/test_protocol_profile.py
+++ b/test/test_protocol_profile.py
@@ -1,0 +1,134 @@
+"""Unit tests for the ACP ProtocolProfile seam.
+
+These pin the two profile constants byte-for-byte, the backend→profile mapping,
+and that each bundled adapter reports the profile the wave-2 design assigns it.
+The profile is a pure seam over the former ``_is_claude`` wire branches, so these
+values must equal the wire constants (``PROTOCOL_VERSION`` / ``PROTOCOL_VERSION_CLAUDE``)
+the client used before the extraction.
+"""
+
+from __future__ import annotations
+
+from kiro_crew.acp.harness_adapters import (
+    ClaudeAdapter,
+    HarnessAdapter,
+    KasAdapter,
+    KiroAdapter,
+)
+from kiro_crew.acp.protocol_profile import (
+    KAS_PROFILE,
+    KIRO_PROFILE,
+    STANDARD_ACP_PROFILE,
+    ProtocolProfile,
+    profile_for_backend,
+)
+from kiro_crew.acp.types import ACP_BACKEND_CLAUDE, ACP_BACKEND_KAS, ACP_BACKEND_KIRO
+
+
+class TestProfileConstants:
+    def test_kiro_profile_exact_fields(self):
+        assert KIRO_PROFILE.protocol_version == "2025-08-22"
+        assert KIRO_PROFILE.permission_option_style == "kiro"
+        assert KIRO_PROFILE.supports_set_config_option is False
+        assert KIRO_PROFILE.emits_thought_chunks is False
+
+    def test_standard_profile_exact_fields(self):
+        assert STANDARD_ACP_PROFILE.protocol_version == 1
+        assert STANDARD_ACP_PROFILE.permission_option_style == "standard"
+        assert STANDARD_ACP_PROFILE.supports_set_config_option is True
+        assert STANDARD_ACP_PROFILE.emits_thought_chunks is True
+
+    def test_kas_profile_exact_fields(self):
+        # KAS is kiro-cli's dialect EXCEPT the initialize protocolVersion, which
+        # the relay expects as the public-ACP integer 1.
+        assert KAS_PROFILE.protocol_version == 1
+        assert isinstance(KAS_PROFILE.protocol_version, int)
+        assert not isinstance(KAS_PROFILE.protocol_version, bool)
+        assert KAS_PROFILE.permission_option_style == "kiro"
+        assert KAS_PROFILE.supports_set_config_option is False
+        assert KAS_PROFILE.emits_thought_chunks is False
+
+    def test_kas_profile_protocol_version_pins_the_runtime_wire(self):
+        # Drift pin: import runtime's OWN constant so the profile and the wire
+        # cannot silently diverge. If the KAS handshake integer ever changes in
+        # runtime.py, this fails until KAS_PROFILE is updated to match.
+        from kiro_crew.acp.runtime import PROTOCOL_VERSION_KAS
+
+        assert KAS_PROFILE.protocol_version == PROTOCOL_VERSION_KAS
+        assert profile_for_backend(ACP_BACKEND_KAS).protocol_version == PROTOCOL_VERSION_KAS
+
+    def test_kiro_protocol_version_is_a_str(self):
+        # The kiro wire is a date STRING, not the integer the public wire uses;
+        # a regression to int would silently change the initialize handshake.
+        assert isinstance(KIRO_PROFILE.protocol_version, str)
+
+    def test_standard_protocol_version_is_an_int(self):
+        assert isinstance(STANDARD_ACP_PROFILE.protocol_version, int)
+        assert not isinstance(STANDARD_ACP_PROFILE.protocol_version, bool)
+
+    def test_profile_is_frozen(self):
+        import dataclasses
+
+        try:
+            KIRO_PROFILE.supports_set_config_option = True  # type: ignore[misc]
+        except dataclasses.FrozenInstanceError:
+            pass
+        else:  # pragma: no cover - only runs on a regression
+            raise AssertionError("ProtocolProfile must be frozen")
+
+    def test_matches_client_wire_constants(self):
+        # The seam must be byte-identical to the constants the _is_claude
+        # branches used, or the extraction changed the wire.
+        from kiro_crew.acp.client import PROTOCOL_VERSION, PROTOCOL_VERSION_CLAUDE
+
+        assert KIRO_PROFILE.protocol_version == PROTOCOL_VERSION
+        assert STANDARD_ACP_PROFILE.protocol_version == PROTOCOL_VERSION_CLAUDE
+
+
+class TestProfileForBackend:
+    def test_kiro_backend_maps_to_kiro_profile(self):
+        assert profile_for_backend(ACP_BACKEND_KIRO) is KIRO_PROFILE
+
+    def test_empty_string_maps_to_kiro_profile(self):
+        # ACP_BACKEND_KIRO IS the empty string; assert the literal too so a
+        # future change to the constant cannot silently drop the empty case.
+        assert profile_for_backend("") is KIRO_PROFILE
+
+    def test_kas_backend_maps_to_kas_profile(self):
+        # KAS is the kiro-cli relay but with the public-ACP integer
+        # protocolVersion, so it has its own profile (not KIRO_PROFILE).
+        assert profile_for_backend(ACP_BACKEND_KAS) is KAS_PROFILE
+
+    def test_claude_backend_maps_to_standard_profile(self):
+        assert profile_for_backend(ACP_BACKEND_CLAUDE) is STANDARD_ACP_PROFILE
+
+    def test_unknown_backend_falls_back_to_kiro_profile(self):
+        # Fail-safe: an unrecognized backend gets kiro-cli's wire, the dialect
+        # AcpClient's default path already speaks.
+        assert profile_for_backend("something-else") is KIRO_PROFILE
+
+    def test_returns_a_protocol_profile(self):
+        assert isinstance(profile_for_backend(ACP_BACKEND_CLAUDE), ProtocolProfile)
+
+
+class TestAdapterProfiles:
+    def test_kiro_adapter_reports_kiro_profile(self):
+        assert KiroAdapter().protocol_profile is KIRO_PROFILE
+
+    def test_kas_adapter_reports_kas_profile(self):
+        assert KasAdapter().protocol_profile is KAS_PROFILE
+
+    def test_claude_adapter_reports_standard_profile(self):
+        assert ClaudeAdapter().protocol_profile is STANDARD_ACP_PROFILE
+
+    def test_generic_adapter_reports_standard_profile(self):
+        # The generic adapter pins its profile explicitly (identical to the base)
+        # so every operator harness / bundled Codex has the wire nailed as data.
+        from kiro_crew.acp.harness_adapters import GenericAdapter
+
+        assert GenericAdapter().protocol_profile is STANDARD_ACP_PROFILE
+
+    def test_base_adapter_reports_standard_profile(self):
+        # The generic adapter (every operator descriptor, bundled Codex) speaks
+        # the public ACP wire.
+        assert HarnessAdapter().protocol_profile is STANDARD_ACP_PROFILE


### PR DESCRIPTION
<!-- Part 1 of a 3-PR stack. Supersedes #7984, which carried the whole feature
     in one diff — the fork AI-review lanes fail closed above 1 MB, so the work
     ships as three sequential PRs. Parts 2 (consumer wiring + serving) and 3
     (UI + docs) follow as soon as their predecessor merges; each is
     independently green. -->

## Problem / Motivation

**Stack:** part 1 of 3 (supersedes #7984) — part 2 wires the registry into
session serving; part 3 lands the Settings UI, docs, and screenshot evidence.
Each part opens after its predecessor merges.

Adding an AI provider to Kiro Crew today means a code PR: a bespoke adapter,
capability sets edited by hand, and a spawn branch per backend. An operator who
runs an ACP-speaking server that Kiro Crew has never heard of — a vendor
adapter binary, an internal gateway, a house-built agent — cannot use it at
all, even though the conversation protocol on the wire is the same standard
ACP the named backends already speak.

## Why it matters

The set of ACP-capable providers is growing faster than any hand-written
adapter roster can. Making a provider a ROW OF CONFIG DATA instead of a code
change turns "support my provider" from a feature request into an operator
action, while keeping the security posture explicit: a descriptor declares
what its harness may do, and everything it does not declare stays off.

## What changed (motivation → approach → change)

Goal: any ACP provider becomes a row in a dedicated `harnesses.json` beside
the config. Approach: a validated descriptor object rather than free-form
config — every behavioural difference between harnesses becomes a declared
field with a pinned vocabulary, so the serving code (part 2) can be generic.

This part lands the core, with **no consumer wired yet** (behaviour of every
existing session path is unchanged — that is part 2):

- `acp/harness_descriptor.py`: the `HarnessDescriptor` dataclass — executable,
  argv template, capability set, MCP delivery mode, model source — with
  field-level validation. Code-only capabilities (`internal_sandbox`,
  `acp_runtime_pool`, `session_sharing`, `kiro_identity_store`) are REFUSED
  from config with per-key reasons: an operator row can never grant itself a
  sandbox waiver.
- `acp/harness_registry.py`: bundled descriptors for the named backends plus
  operator rows read from `~/.kiro/crew/harnesses.json` — a dedicated file,
  deliberately NOT a `config.json` key; invalid rows are excluded from every
  listing with a recorded reason, never silently trusted.
- `acp/protocol_profile.py`: each wire dialect pinned as data (protocol
  version, permission-option style, model/effort channel).
- `security.py`: `harnesses.json` is write-protected from agent tools on BOTH
  write paths — the file-edit register and the shell register (a descriptor
  row names an executable the gateway spawns as itself; nothing downstream
  clamps that). Because the file is effectively an execution grant, its leaf
  is additionally matched anchor-independently (`_BARE_TOKEN_PROTECTED_LEAVES`),
  so a `cd`-relative redirect cannot walk around the home-anchored spellings.
  Reads stay allowed on both paths: the file holds no secret and the registry
  reads it on every listing. Same relocation pattern as
  `playwright-cli-config.json`, the computer-use policy, and the OMC rotation
  record.
- `acp/harness_adapters.py` spawn-side trust attestation: the resolved
  executable must be a runnable, non-zero-byte file, and the rendered argv is
  refused unless `argv[0]` execs exactly the attested path.

The parity-gate extension (new CI rules that steer added lines onto
descriptor-declared capabilities) and the harness-parity spec updates ship
with part 2, where the capability-view retirement they describe actually
happens.

## Tests

- `test_harness_descriptor.py` — field validation, capability refusal from
  config (per-key reasons), delivery-mode vocabulary.
- `test_harness_registry.py` — bundled + operator rows, invalid-row exclusion
  with reasons, the `harnesses.json` file read (valid, malformed, non-object,
  unparseable), and the write-fence grid: file-edit tier membership, shell
  writes refused across every home-prefix spelling AND the bare `cd`-relative
  form, file-READ tool ungated, Settings-PATCH allowlist pinned.
- `test_harness_generic_adapter.py` — executable resolution (absolute,
  PATH-augmented bare name, relative refused, zero-byte refused,
  platform-correct executability).
- `test_harness_attestation.py` — the spawn-side trust seam: attested launch
  path, zero-byte and non-executable refusals, and the check that `argv[0]`
  execs exactly the attested bytes.
- `test_harness_capability_views.py`, `test_protocol_profile.py`,
  `test_security.py` — leaf/descriptor agreement, dialect profiles, and the
  bare-token fence grid (which is tuple-driven, so `harnesses.json` runs
  through all five probe families automatically).

## Manual verification

N/A for this part — nothing consumes the registry yet, so there is no
user-visible behaviour change; the full stack was hands-on verified in a dev
pod (all three named providers plus a config-authored stub provider serving
real sessions) and that evidence ships with part 3, where the UI lands.

No linked issue: this implements the provider-extensibility work discussed in
#7984, which this stack supersedes.
