### PR TITLE
feat(acp): select claude models from the provider's advertised list

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -72,9 +72,11 @@ from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
     ACP_BACKEND_CODEX,
     ACP_BACKEND_KIRO,
+    ACP_BACKENDS_ADVERTISED_MODEL_SELECTION,
     ACP_BACKENDS_INTERNAL_SANDBOX,
     ACP_BACKENDS_MEMBER_DISPATCH,
     ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION,
+    ACP_BACKENDS_SEED_LOCAL_SETTINGS,
     ACP_BACKENDS_SESSION_MCP_ARRAY,
     ACP_BACKENDS_STEER,
     ACP_CLIENT_CAPABILITIES,
@@ -128,6 +130,7 @@ from kiro_crew.acp.types import (
     AcpPromptStats,
     JsonRpcMessage,
     JsonRpcRequest,
+    model_registry_namespace,
 )
 from kiro_crew.agent import ensure_agent_materialized
 from kiro_crew.browser_cli.launch import browser_session_env, browser_socket_env
@@ -2521,6 +2524,10 @@ class AcpClient:
         # offers rather than a hardcoded guess. Each entry: {modelId, name,
         # description}.
         self._available_models: list[dict[str, str]] = []
+        # Set by _capture_available_models (claude only) when the discovered ids
+        # changed the cross-session provider-model cache, signalling the async
+        # init path to offload a disk persist. Reset to False after each persist.
+        self._advertised_models_changed: bool = False
         # Mode ids the backend advertised at session init (session/new|load
         # `modes.availableModes`). Empty when the backend omits `modes` (older
         # kiro-cli / offline fake) — the set_mode guard treats empty as "attempt"
@@ -2662,6 +2669,27 @@ class AcpClient:
     @property
     def _is_codex(self) -> bool:
         return self.backend == ACP_BACKEND_CODEX
+
+    @property
+    def _model_registry_namespace(self) -> str:
+        """The model_registry namespace key for this backend (``claude_code`` /
+        ``acp``). A registry index selector, NOT a provider-identity check — see
+        agent_sdk.provider_identity note 3. Used to fold the wire model id and
+        seed the allowlist against the right index for whichever backend is a
+        member of ``ACP_BACKENDS_ADVERTISED_MODEL_SELECTION``."""
+        return model_registry_namespace(self.backend)
+
+    @property
+    def _uses_advertised_model_selection(self) -> bool:
+        """True when this backend sources its wire model id / seed from the
+        provider's advertised list (see ``ACP_BACKENDS_ADVERTISED_MODEL_SELECTION``)."""
+        return self.backend in ACP_BACKENDS_ADVERTISED_MODEL_SELECTION
+
+    @property
+    def _seeds_local_settings(self) -> bool:
+        """True when this backend seeds (and must re-seed) a per-session settings
+        file (see ``ACP_BACKENDS_SEED_LOCAL_SETTINGS``)."""
+        return self.backend in ACP_BACKENDS_SEED_LOCAL_SETTINGS
 
     @property
     def _is_kiro(self) -> bool:
@@ -3014,19 +3042,24 @@ class AcpClient:
             perms["deny"] = list(deny_rules)
         if perms:
             data["permissions"] = perms
-        # "claude_code" is the registry's provider key for this backend (the same
-        # literal model_registry itself indexes by).
-        allowlist = model_registry.available_models("claude_code")
+        # Namespace-keyed (claude_code here), the registry index this backend's ids
+        # live in — see _model_registry_namespace. Provider-first: the ids the
+        # backend actually advertised (cached from a prior session/new) when the
+        # cache is warm, so the seed reflects what the account is served and a
+        # served-but-unregistered model gets its real window; the static registry
+        # allowlist is the cold-cache fallback (first-ever session), which is the
+        # exact list shipped before this cache existed.
+        allowlist = model_registry.seed_available_models(self._model_registry_namespace)
         if allowlist:
             data["availableModels"] = allowlist
         else:
             # Only reachable with a corrupt/missing model registry (which the
-            # registry already warns about at import). Without the allowlist the
-            # adapter can collapse the [1m] id to 200K, so say so here rather
-            # than degrade silently.
+            # registry already warns about at import) AND a cold advertised-model
+            # cache. Without the allowlist the adapter can collapse the [1m] id to
+            # 200K, so say so here rather than degrade silently.
             logger.warning(
-                "model registry availableModels empty (corrupt or missing registry?); "
-                "settings.local.json written without an allowlist — the 1M-token "
+                "availableModels empty (corrupt/missing registry and cold advertised-model "
+                "cache?); settings.local.json written without an allowlist — the 1M-token "
                 "window may not resolve",
             )
         # self._model is a resolved provider id; DEFAULT_MODEL ("auto") is not one,
@@ -3153,6 +3186,17 @@ class AcpClient:
             _rejected_log, _ = redact_exfiltration_urls(str(model_id))
             _rejected_log, _ = redact_credentials(_rejected_log)
             raise AcpModelUnavailable(_rejected_log, self._advertised_model_ids())
+        if self._uses_advertised_model_selection:
+            # Mirror the spawn path (_spawn): fold the requested id onto the exact
+            # spelling the backend advertised, so a warm-pool claim that switches
+            # model sends the versioned [1m] id claude-agent-acp serves at 1M — not
+            # a bare/base spelling that resolves to the 200K window. Without this
+            # the fold happened only at spawn, so a pooled runtime claimed for a
+            # 4.8 chat could send the base id and silently serve 200K. Capability-
+            # gated + namespace-keyed so any future member gets the same fold.
+            model_id = model_registry.resolve_wire_model_id(
+                model_id, self._model_registry_namespace
+            )
         if self.backend in ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION:
             await self.set_config_option("model", model_id)
         else:
@@ -3162,6 +3206,19 @@ class AcpClient:
             )
         self._model = model_id
         self._resolved_model_id = model_id
+        if self._seeds_local_settings:
+            # Re-seed the per-session settings file: a pooled runtime seeded it at
+            # spawn with the POOL DEFAULT model + its allowlist, and the spawn-only
+            # seed left that stale file in place across the claim — so the allowlist
+            # and model key could still describe the pool default (and collapse a
+            # 4.8 pick to 200K). Overwrites only the file Crew authored (ownership
+            # guards inside), refreshing both to the just-claimed selection.
+            # Capability-gated (not ``_is_claude``) so a future settings-seeding
+            # adapter re-seeds on a warm claim by joining the set.
+            try:
+                await asyncio.to_thread(self._write_claude_local_settings)
+            except (OSError, ValueError, TypeError):
+                logger.warning("re-seed of settings.local.json on set_model failed", exc_info=True)
         # The previous model's window (and its authoritative usage_update, if
         # any) no longer describe this session — rebase the meter stats to the
         # new model so the context meter updates without waiting for the next
@@ -3212,6 +3269,36 @@ class AcpClient:
         captured = parse_advertised_models({"models": models})
         if captured:
             self._available_models = captured
+            # Feed the discovered ids into the cross-session provider-model cache
+            # so the next session's settings seed can source availableModels (and
+            # the wire model id) from what this backend actually serves rather
+            # than the static registry. In-memory + synchronous here (cheap, and
+            # this method is sync); the disk persist is offloaded by the async
+            # caller when this reports a change. Gated on capability, not on
+            # ``_is_claude`` (harness-parity H6): kiro-cli reaches its models via
+            # --agent and its windows via the --list-models cache, so it is not a
+            # member and feeds nothing; a future adapter with the same served-vs-
+            # stored spelling gap opts into the set and is fed here automatically,
+            # keyed by its own registry namespace.
+            if self._uses_advertised_model_selection:
+                self._advertised_models_changed = model_registry.refresh_advertised_models(
+                    self._model_registry_namespace, self._advertised_model_ids()
+                )
+
+    async def _persist_advertised_models_if_changed(self) -> None:
+        """Offload a disk persist of the provider-model cache when it changed.
+
+        Mirrors the kiro-window cache's split: :func:`refresh_advertised_models`
+        did the cheap in-memory update synchronously in
+        ``_capture_available_models`` and set ``_advertised_models_changed``;
+        this offloads only the blocking write so the init path never persists on
+        the event loop, and never for an unchanged cache. Best-effort — a write
+        failure is swallowed by ``persist_advertised_models`` itself.
+        """
+        if not self._advertised_models_changed:
+            return
+        self._advertised_models_changed = False
+        await asyncio.to_thread(model_registry.persist_advertised_models)
 
     def available_models(self) -> list[dict[str, str]]:
         """Models advertised by the backend at session init (may be empty)."""
@@ -3492,6 +3579,18 @@ class AcpClient:
             await asyncio.to_thread(assert_voice_runtime_outside_agent_workspace, self._work_dir)
 
         if self._is_claude:
+            # Fold the requested model onto the exact spelling claude-agent-acp
+            # advertised (from the persisted provider-model cache warmed by a
+            # prior session's _capture_available_models), so a model the static
+            # registry does not carry still resolves to the versioned [1m] id the
+            # backend serves rather than a bare form that collapses to the base
+            # window. Done here so BOTH the seed below and _apply_startup_model's
+            # set_model read the same id. No-op on a cold cache (first-ever
+            # session): the registry fallback in the seed still applies and this
+            # session's own capture warms the cache for the next one.
+            self._model = model_registry.resolve_wire_model_id(
+                self._model, self._model_registry_namespace
+            )
             # Per-session settings seed (permissions.defaultMode + the
             # availableModels allowlist that unlocks the 1M-token window). It MUST
             # run on the PRIMARY spawn path — not only the rare model-substitution
@@ -4358,6 +4457,8 @@ class AcpClient:
                         self._session_id = resume_sid
                         self._resumed = True
                         self._capture_available_models(load_resp)
+                        if self._uses_advertised_model_selection:
+                            await self._persist_advertised_models_if_changed()
                         self._store_session_config(load_resp)
                         logger.info("ACP session resumed: %s", resume_sid)
                 except (AcpError, AcpTimeoutError):
@@ -4380,6 +4481,8 @@ class AcpClient:
             session_resp = await self._new_session_following_substitution()
             self._session_id = session_resp.get("sessionId")
             self._capture_available_models(session_resp)
+            if self._uses_advertised_model_selection:
+                await self._persist_advertised_models_if_changed()
             self._store_session_config(session_resp)
             if not self._session_id:
                 # Both the initial attempt and the substitution retry failed to

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -19,6 +19,7 @@ from kiro_crew.acp_backends import (  # noqa: F401 - re-exported for existing im
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_ADVERTISED_MODEL_SELECTION,
     ACP_BACKENDS_COMPACT,
     ACP_BACKENDS_EFFORT_VIA_CONFIG_OPTION,
     ACP_BACKENDS_INTERNAL_SANDBOX,
@@ -27,9 +28,11 @@ from kiro_crew.acp_backends import (  # noqa: F401 - re-exported for existing im
     ACP_BACKENDS_KNOWN,
     ACP_BACKENDS_MEMBER_DISPATCH,
     ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION,
+    ACP_BACKENDS_SEED_LOCAL_SETTINGS,
     ACP_BACKENDS_SESSION_MCP_ARRAY,
     ACP_BACKENDS_SESSION_SHARING,
     ACP_BACKENDS_STEER,
+    model_registry_namespace,
     selectable_backends,
 )
 

--- a/src/kiro_crew/acp_backends.py
+++ b/src/kiro_crew/acp_backends.py
@@ -409,6 +409,51 @@ ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION = frozenset({ACP_BACKEND_CLAUDE, ACP_BACKEN
 # never advertised.
 ACP_BACKENDS_EFFORT_VIA_CONFIG_OPTION = frozenset({ACP_BACKEND_CLAUDE, ACP_BACKEND_CODEX})
 
+# Backends that resolve the WIRE model id from the provider's OWN advertised list
+# (captured from ``session/new`` and cached across sessions) rather than trusting
+# the stored id verbatim. Needed where the spelling a backend SERVES differs from
+# the one Crew stored: claude-agent-acp advertises versioned ``…[1m]`` ids whose
+# bare form collapses to the base (200K) context window. A member both FEEDS the
+# advertised-model cache on capture and FOLDS the id onto it — at spawn and on a
+# warm-pool ``set_model`` — so a switched model lands on the served spelling.
+# Opt-in (harness-parity H6): a future adapter with the same spelling gap joins
+# here; one whose wire ids are already exact (kiro-cli serves its ids verbatim and
+# gets windows from the ``--list-models`` cache) never needs to.
+ACP_BACKENDS_ADVERTISED_MODEL_SELECTION = frozenset({ACP_BACKEND_CLAUDE})
+
+# Backends that seed a per-session settings file — claude-agent-acp's
+# ``settings.local.json`` — to lock the model + permission surface. The file is
+# written once at spawn, but a warm-pool claim switches model on a process that
+# has ALREADY read it, so a member must RE-SEED it on ``set_model``: the
+# spawn-time write alone leaves a stale allowlist/model behind, which is what let
+# a switched model collapse to its base window on a claimed pool runtime. Opt-in
+# for the same reason as every set here — a harness with no such file is not a
+# member and takes no re-seed.
+ACP_BACKENDS_SEED_LOCAL_SETTINGS = frozenset({ACP_BACKEND_CLAUDE})
+
+# Which model-registry NAMESPACE a backend's ids live in. This is a registry index
+# key, NOT a provider-identity check (see agent_sdk.provider_identity, note 3): a
+# context window is a property of the MODEL, so the same model reached via two
+# backends shares one namespace. Consulted only for
+# ``ACP_BACKENDS_ADVERTISED_MODEL_SELECTION`` members — to pick the registry index
+# the wire id folds against — but mapped for every known backend so a future
+# member already has an entry. Defaults to the ``acp`` (kiro) namespace, where
+# every non-claude id the registry carries lives today. The literals are the
+# model_registry's own provider keys, spelled here rather than imported to keep
+# this load-path leaf free of a ``kiro_crew.model_registry`` dependency.
+_MODEL_REGISTRY_NAMESPACE_BY_BACKEND: dict = {
+    ACP_BACKEND_CLAUDE: "claude_code",
+    ACP_BACKEND_KIRO: "acp",
+    ACP_BACKEND_KAS: "acp",
+    ACP_BACKEND_CODEX: "acp",
+}
+
+
+def model_registry_namespace(backend: str) -> str:
+    """The model-registry namespace key for *backend* (default ``acp``)."""
+    return _MODEL_REGISTRY_NAMESPACE_BY_BACKEND.get(backend, "acp")
+
+
 # Backends implementing ``_kiro.dev/commands/execute`` — the kiro extension that
 # runs a slash command as an RPC. Non-members have no equivalent verb, so their
 # slash commands go through ``session/prompt`` and are interpreted by the adapter

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -255,6 +256,234 @@ def persist_kiro_windows() -> None:
         atomic_write(path, json.dumps(snapshot))
     except OSError:  # pragma: no cover - disk full / perms
         logger.debug("Could not persist kiro window cache", exc_info=True)
+
+
+# ── Provider advertised-model cache (the authoritative per-provider id list) ──
+# The same principle as the kiro-window cache above, applied one level up: the
+# committed registry is a hand-maintained fallback and drifts from what a
+# provider actually serves, so the provider's OWN advertised model list is the
+# ground truth. kiro-cli advertises via ``chat --list-models``; claude-agent-acp
+# advertises its versioned list in the ``session/new`` response
+# (``AcpClient._capture_available_models``). This cache records those advertised
+# provider ids per provider so the consumers that used to read the static
+# ``available_models(provider)`` allowlist can read what the provider served
+# instead — chiefly the claude_code ``settings.local.json`` ``availableModels``
+# seed, which unlocks a model's real window and previously carried only the
+# registry's Anthropic ids (so a served-but-unlisted model, e.g. a new Opus,
+# collapsed to the base window).
+#
+# Runtime state, not committed data (like ``_KIRO_WINDOWS`` / session_map). A
+# corrupt/missing cache degrades silently to the registry allowlist and can
+# never brick import.
+_ADVERTISED_MODELS: dict[str, list[str]] = {}
+
+# Inference-profile prefixes stripped when folding an advertised provider id to
+# a comparison key. Longest-first so ``global.anthropic.`` wins over a bare
+# ``anthropic.`` that is a suffix of it.
+_PROVIDER_ID_PREFIXES: tuple[str, ...] = (
+    "global.anthropic.",
+    "us.anthropic.",
+    "eu.anthropic.",
+    "apac.anthropic.",
+    "anthropic.",
+)
+
+
+def _advertised_models_cache_path() -> Path:
+    """Path to the persisted advertised-model sidecar under the data home.
+
+    Resolved lazily (not at import), for the same reasons as
+    :func:`_kiro_windows_cache_path`: honour ``KIROCREW_HOME`` / test overrides
+    and never let home resolution break module import.
+    """
+    from kiro_crew.config.paths import config_dir
+
+    return config_dir() / "provider_models.json"
+
+
+def _load_advertised_models() -> None:
+    """Load the persisted advertised-model cache into ``_ADVERTISED_MODELS``.
+
+    Called once at import. A missing file is normal (first run); a corrupt file
+    is logged and ignored (degrade to the registry allowlist), never raised.
+    """
+    try:
+        path = _advertised_models_cache_path()
+        if not path.is_file():
+            return
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            for provider, ids in data.items():
+                if isinstance(provider, str) and isinstance(ids, list):
+                    clean = [i for i in ids if isinstance(i, str) and i.strip()]
+                    if clean:
+                        _ADVERTISED_MODELS[provider] = clean
+    except (OSError, ValueError, TypeError):  # pragma: no cover - corrupt/absent cache
+        logger.debug("advertised-model cache unreadable; using registry allowlist", exc_info=True)
+
+
+_load_advertised_models()
+
+
+def refresh_advertised_models(provider: str, ids: Sequence[str]) -> bool:
+    """Ingest a provider's advertised model ids into the cache.
+
+    In-memory only (cheap, non-blocking) so it is safe to call from an async
+    handler and the cache is immediately consistent for callers on the same
+    tick. Returns ``True`` when the cache changed (a persist is warranted): the
+    async caller should then offload :func:`persist_advertised_models` to an
+    executor rather than block the event loop on disk I/O.
+
+    An empty ``ids`` is a no-op (a backend that advertised nothing must not wipe
+    a good cached list from a prior session) and returns ``False``. The stored
+    list is deduped preserving order.
+    """
+    clean: list[str] = []
+    seen: set[str] = set()
+    for i in ids:
+        if isinstance(i, str) and i.strip() and i not in seen:
+            seen.add(i)
+            clean.append(i)
+    if not clean:
+        return False
+    if _ADVERTISED_MODELS.get(provider) == clean:
+        return False
+    _ADVERTISED_MODELS[provider] = clean
+    return True
+
+
+def persist_advertised_models() -> None:
+    """Write the in-memory advertised-model cache to disk (best-effort, blocking).
+
+    Separated from :func:`refresh_advertised_models` so an async caller can
+    offload ONLY the filesystem step to an executor while keeping the in-memory
+    update synchronous. Atomic via :func:`kiro_crew.atomic_write.atomic_write`; a
+    persist failure is logged, not raised. Snapshot with ``dict(...)`` before
+    serializing so a concurrent refresh on the event-loop thread cannot raise
+    ``RuntimeError: dictionary changed size during iteration`` — mirrors
+    :func:`persist_kiro_windows`.
+    """
+    try:
+        snapshot = {p: list(v) for p, v in dict(_ADVERTISED_MODELS).items()}
+        path = _advertised_models_cache_path()
+        atomic_write(path, json.dumps(snapshot))
+    except OSError:  # pragma: no cover - disk full / perms
+        logger.debug("Could not persist advertised-model cache", exc_info=True)
+
+
+def advertised_models(provider: str) -> list[str]:
+    """The provider ids ``provider`` last advertised, or ``[]`` on a cold cache."""
+    return list(_ADVERTISED_MODELS.get(provider, ()))
+
+
+def _normalize_advertised_key(provider_id: str) -> str:
+    """Reduce a provider id to a spelling-agnostic comparison key.
+
+    Strips a leading inference-profile prefix and a trailing ``[1m]`` / ``-1m``
+    window marker, unifies ``.``/``-`` separators, and lowercases — so the
+    versioned id a backend advertises (``global.anthropic.claude-opus-5[1m]``)
+    and the bare id a caller may hold (``claude-opus-5``) fold to the same key
+    (``claude-opus-5``). Used only to match a stored id against the advertised
+    set; never persisted or sent on the wire.
+    """
+    s = provider_id.strip().lower()
+    for pfx in _PROVIDER_ID_PREFIXES:
+        if s.startswith(pfx):
+            s = s[len(pfx) :]
+            break
+    s = s.replace("[1m]", "")
+    s = re.sub(r"[-.]1m$", "", s)
+    s = s.replace(".", "-")
+    return s.strip("-")
+
+
+def _is_1m_id(model_id: str) -> bool:
+    """True if ``model_id`` names a 1M-window variant (``[1m]`` suffix or a
+    standalone ``1m`` token)."""
+    low = model_id.lower()
+    return "[1m]" in low or _has_1m_token(low)
+
+
+def _dedup_window_siblings(ids: Sequence[str]) -> list[str]:
+    """Drop a base-window id when a 1M-window sibling with the same base is present.
+
+    claude-agent-acp reads the ``[1m]`` suffix as a context-window MODIFIER on one
+    base model, not a distinct model, and merges ``availableModels``
+    union+dedup by base name. Seeding BOTH
+    ``global.anthropic.claude-opus-4-8[1m]`` (1M) and its 200K sibling
+    ``global.anthropic.claude-opus-4-8`` therefore lets the adapter's dedup pick
+    the base spelling and serve 200K for an Opus 4.8 pick. When two ids share a
+    normalized base key, keep only the 1M one; otherwise preserve order and drop
+    exact duplicates. Order-preserving, so ``available_models``' default-first head
+    (the 1M flagship) survives.
+    """
+    has_1m = {_normalize_advertised_key(m) for m in ids if _is_1m_id(m)}
+    out: list[str] = []
+    seen: set[str] = set()
+    for mid in ids:
+        key = _normalize_advertised_key(mid)
+        if key and not _is_1m_id(mid) and key in has_1m:
+            continue  # a 1M sibling supersedes this base-window spelling
+        if mid in seen:
+            continue
+        seen.add(mid)
+        out.append(mid)
+    return out
+
+
+def seed_available_models(provider: str) -> list[str]:
+    """The ``availableModels`` allowlist to seed for ``provider``.
+
+    Provider-first: the ids ``provider`` actually advertised (cached from a live
+    session) when the cache is warm, so the seed reflects what the account is
+    served rather than the static Anthropic-only registry. Falls back to
+    :func:`available_models` on a cold cache (first-ever session, before any
+    ``session/new`` has been captured) — the static registry list, which is then
+    window-deduplicated below just like the warm list.
+
+    The result is passed through :func:`_dedup_window_siblings` so a base-window
+    id never rides alongside its 1M sibling: seeding both is what lets the adapter
+    collapse a versioned pick (e.g. Opus 4.8 ``[1m]``) back to 200K. Applied to
+    the advertised list too, since a backend can advertise both spellings.
+    """
+    cached = advertised_models(provider)
+    base = cached if cached else available_models(provider)
+    return _dedup_window_siblings(base)
+
+
+def resolve_wire_model_id(model_id: str, provider: str) -> str:
+    """Fold a stored provider-model id onto the spelling ``provider`` advertised.
+
+    An id the static registry does not carry (a newly-served model) reaches this
+    module as a bare passthrough from :func:`to_provider_id`; sent as-is it can
+    collapse to the base window because it never matches the versioned id in the
+    seeded ``availableModels``. When the provider advertised a matching id, this
+    returns that id instead, so the wire value and the seed agree on one exact
+    spelling.
+
+    Returns ``model_id`` UNCHANGED when it is empty / the ``auto`` sentinel, when
+    the provider advertised nothing (cold cache), when it is already an
+    advertised id, or when no advertised id shares its normalized key — i.e. it
+    only ever tightens a bare id onto an advertised versioned one, never rewrites
+    an id the provider does not serve. When several advertised ids match, a 1M
+    window variant wins over a base one.
+    """
+    if not model_id or model_id == "auto":
+        return model_id
+    adv = advertised_models(provider)
+    if not adv or model_id in adv:
+        return model_id
+    want = _normalize_advertised_key(model_id)
+    if not want:
+        return model_id
+    matches = [a for a in adv if _normalize_advertised_key(a) == want]
+    if not matches:
+        return model_id
+    matches.sort(
+        key=lambda a: (0 if ("[1m]" in a.lower() or _has_1m_token(a.lower())) else 1, len(a))
+    )
+    return matches[0]
 
 
 # ── Precomputed indices (built once; the registry is immutable after import) ──

--- a/test/test_acp_capability_sets_leaf.py
+++ b/test/test_acp_capability_sets_leaf.py
@@ -24,14 +24,18 @@ import pytest
 
 from kiro_crew.acp_backends import (
     ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_CODEX,
     ACP_BACKEND_KAS,
     ACP_BACKEND_KIRO,
     ACP_BACKENDS_ACP_RUNTIME,
+    ACP_BACKENDS_ADVERTISED_MODEL_SELECTION,
     ACP_BACKENDS_COMPACT,
     ACP_BACKENDS_INTERNAL_SANDBOX,
     ACP_BACKENDS_KIRO_IDENTITY_STORE,
+    ACP_BACKENDS_SEED_LOCAL_SETTINGS,
     ACP_BACKENDS_SESSION_SHARING,
     ACP_BACKENDS_STEER,
+    model_registry_namespace,
 )
 from kiro_crew.subprocess_utf8 import UTF8_TEXT
 
@@ -39,9 +43,11 @@ SRC = Path(__file__).resolve().parent.parent / "src" / "kiro_crew"
 
 CAPABILITY_SETS = (
     "ACP_BACKENDS_ACP_RUNTIME",
+    "ACP_BACKENDS_ADVERTISED_MODEL_SELECTION",
     "ACP_BACKENDS_COMPACT",
     "ACP_BACKENDS_INTERNAL_SANDBOX",
     "ACP_BACKENDS_KIRO_IDENTITY_STORE",
+    "ACP_BACKENDS_SEED_LOCAL_SETTINGS",
     "ACP_BACKENDS_SESSION_SHARING",
     "ACP_BACKENDS_STEER",
 )
@@ -127,6 +133,23 @@ def test_membership_is_unchanged_by_the_move() -> None:
     assert ACP_BACKENDS_STEER == frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
     assert ACP_BACKENDS_ACP_RUNTIME == frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
     assert ACP_BACKENDS_KIRO_IDENTITY_STORE == frozenset({ACP_BACKEND_KIRO, ACP_BACKEND_KAS})
+    # The provider-advertised-model seams: claude only today. A future adapter
+    # with the same served-vs-stored spelling gap (or its own settings seed) opts
+    # in here — a deliberate edit this pin forces to be seen.
+    assert ACP_BACKENDS_ADVERTISED_MODEL_SELECTION == frozenset({ACP_BACKEND_CLAUDE})
+    assert ACP_BACKENDS_SEED_LOCAL_SETTINGS == frozenset({ACP_BACKEND_CLAUDE})
+
+
+def test_model_registry_namespace_maps_every_known_backend() -> None:
+    """The namespace is a registry index selector, mapped for every backend so a
+    future ADVERTISED_MODEL_SELECTION member already has an entry. Non-claude ids
+    live in the ``acp`` namespace; only claude uses ``claude_code``."""
+    assert model_registry_namespace(ACP_BACKEND_CLAUDE) == "claude_code"
+    assert model_registry_namespace(ACP_BACKEND_KIRO) == "acp"
+    assert model_registry_namespace(ACP_BACKEND_KAS) == "acp"
+    assert model_registry_namespace(ACP_BACKEND_CODEX) == "acp"
+    # An unknown/unregistered backend defaults to the kiro namespace, never crashes.
+    assert model_registry_namespace("something-new") == "acp"
 
 
 def test_acp_runtime_is_a_superset_of_session_sharing() -> None:

--- a/test/test_acp_client_more_coverage.py
+++ b/test/test_acp_client_more_coverage.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import kiro_crew.acp.client as acp_client
+from kiro_crew import model_registry as mr
 from kiro_crew.acp.client import (
     AcpAuthRequired,
     AcpClient,
@@ -44,6 +45,7 @@ from kiro_crew.acp.client import (
 )
 from kiro_crew.acp.types import (
     ACP_BACKEND_CLAUDE,
+    ACP_BACKEND_CODEX,
     EVENT_AGENT_SWITCHED,
     EVENT_COMPLETE,
     EVENT_MCP_OAUTH_REQUEST,
@@ -1584,3 +1586,103 @@ class TestToolInterruptedAudit:
 
         messages = " ".join(r.getMessage() for r in caplog.records)
         assert "SEL audit failed for tool_interrupted" in messages
+
+
+# ── Provider-advertised model cache wiring (client side) ──
+
+
+class TestAdvertisedModelCacheWiring:
+    """The client half of sourcing model selection from the provider's own
+    advertised list: the seed reads the cache, and a capture feeds it.
+
+    The module-global ``mr._ADVERTISED_MODELS`` is isolated per test.
+    """
+
+    def _read_seed(self, tmp_path: Path) -> dict:
+        return json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
+
+    def test_seed_availableModels_from_advertised_cache(self, tmp_path, monkeypatch):
+        served = [
+            "global.anthropic.claude-opus-5[1m]",
+            "global.anthropic.claude-opus-4-8[1m]",
+        ]
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": served})
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client._write_claude_local_settings()
+        assert self._read_seed(tmp_path)["availableModels"] == served
+
+    def test_seed_falls_back_to_registry_on_cold_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client._write_claude_local_settings()
+        assert self._read_seed(tmp_path)["availableModels"] == mr.seed_available_models(
+            "claude_code"
+        )
+
+    def test_claude_capture_feeds_and_flags_the_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client._capture_available_models(
+            {"models": {"availableModels": [{"modelId": "global.anthropic.claude-opus-5[1m]"}]}}
+        )
+        assert mr.advertised_models("claude_code") == ["global.anthropic.claude-opus-5[1m]"]
+        assert client._advertised_models_changed is True
+
+    def test_non_claude_capture_does_not_feed_the_cache(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        client = _client(tmp_path)  # default backend is kiro-cli
+        client._capture_available_models(
+            {"models": {"availableModels": [{"modelId": "claude-opus-4.8"}]}}
+        )
+        assert mr.advertised_models("claude_code") == []
+        assert client._advertised_models_changed is False
+
+    @pytest.mark.asyncio
+    async def test_set_model_folds_bare_id_onto_advertised_spelling(self, tmp_path, monkeypatch):
+        # The warm-pool 4.8 fix: a claim that switches model must send the
+        # versioned [1m] id the backend serves at 1M, not the bare spelling.
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-4-8[1m]"]}
+        )
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client._session_id = "sid"
+        client._send_request = AsyncMock(return_value=1)
+        client.set_config_option = AsyncMock(return_value=None)
+        await client.set_model("claude-opus-4-8")
+        assert client._model == "global.anthropic.claude-opus-4-8[1m]"
+        assert client._resolved_model_id == "global.anthropic.claude-opus-4-8[1m]"
+
+    @pytest.mark.asyncio
+    async def test_set_model_reseeds_settings_on_claude(self, tmp_path, monkeypatch):
+        # The re-seed half: set_model refreshes settings.local.json so a pooled
+        # runtime's stale spawn-time seed is overwritten with the claimed model.
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-4-8[1m]"]}
+        )
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client._session_id = "sid"
+        client._send_request = AsyncMock(return_value=1)
+        client.set_config_option = AsyncMock(return_value=None)
+        await client.set_model("claude-opus-4-8")
+        seed = json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
+        assert seed["model"] == "global.anthropic.claude-opus-4-8[1m]"
+        assert "global.anthropic.claude-opus-4-8[1m]" in seed["availableModels"]
+
+    @pytest.mark.asyncio
+    async def test_set_model_on_non_member_backend_neither_folds_nor_reseeds(
+        self, tmp_path, monkeypatch
+    ):
+        # codex is a MODEL_VIA_CONFIG_OPTION backend but NOT a member of
+        # ADVERTISED_MODEL_SELECTION / SEED_LOCAL_SETTINGS, so a warm claim must
+        # switch the model verbatim: no fold onto a cached [1m] spelling, no
+        # settings.local.json. Guards the capability gating against a regression to
+        # "any config-option backend".
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-4-8[1m]"]}
+        )
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CODEX)
+        client._session_id = "sid"
+        client.set_config_option = AsyncMock(return_value=None)
+        await client.set_model("gpt-5-codex")
+        assert client._model == "gpt-5-codex"  # sent verbatim, no fold
+        assert not (tmp_path / ".claude" / "settings.local.json").exists()

--- a/test/test_acp_session_mcp.py
+++ b/test/test_acp_session_mcp.py
@@ -647,8 +647,11 @@ class TestLocalSettingsSeed:
         client._write_claude_local_settings()
         data = json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
         # Without the allowlist the adapter can collapse a versioned [1m] id back
-        # to the 200K window.
-        assert data["availableModels"] == model_registry.available_models("claude_code")
+        # to the 200K window. The seed writes the window-deduped list (a 200K base
+        # id is dropped when its 1M sibling is present), so it can differ from the
+        # raw registry list — compare against seed_available_models, the deduped
+        # source the seed actually uses.
+        assert data["availableModels"] == model_registry.seed_available_models("claude_code")
 
     def test_no_permission_mode_leaves_the_adapter_default(self, tmp_path):
         client = self._client(tmp_path)

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -440,3 +440,145 @@ class TestCorruptRegistryFallback:
             mr.to_provider_id("opus-4.8-1m", "claude_code")
             == "global.anthropic.claude-opus-4-8[1m]"
         )
+
+
+class TestAdvertisedModelCache:
+    """The provider-advertised model cache: seed source + wire-id folding.
+
+    Uses monkeypatch to isolate the module-global ``_ADVERTISED_MODELS`` per
+    test (it is process-wide runtime state, like ``_KIRO_WINDOWS``).
+    """
+
+    def test_seed_falls_back_to_registry_on_cold_cache(self, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        # The registry allowlist, deduped so a base-window id never rides next to
+        # its 1M sibling (the pre-dedup list still shipped both).
+        assert mr.seed_available_models("claude_code") == mr._dedup_window_siblings(
+            mr.available_models("claude_code")
+        )
+
+    def test_seed_drops_base_window_sibling_of_a_1m_id(self, monkeypatch):
+        # The 4.8 fix: the registry emits both the [1m] and the 200K spelling of
+        # Opus 4.8; the seed must carry only the 1M one so the adapter cannot
+        # collapse a 4.8 pick to the base window.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        seed = mr.seed_available_models("claude_code")
+        assert "global.anthropic.claude-opus-4-8[1m]" in seed
+        assert "global.anthropic.claude-opus-4-8" not in seed
+
+    def test_seed_dedups_advertised_siblings_too(self, monkeypatch):
+        # A backend that advertises BOTH spellings is deduped the same way.
+        monkeypatch.setattr(
+            mr,
+            "_ADVERTISED_MODELS",
+            {
+                "claude_code": [
+                    "global.anthropic.claude-opus-4-8[1m]",
+                    "global.anthropic.claude-opus-4-8",
+                    "global.anthropic.claude-sonnet-5",
+                ]
+            },
+        )
+        assert mr.seed_available_models("claude_code") == [
+            "global.anthropic.claude-opus-4-8[1m]",
+            "global.anthropic.claude-sonnet-5",
+        ]
+
+    def test_dedup_keeps_order_and_drops_exact_dupes(self):
+        # No 1M sibling to collapse against → only exact duplicates removed,
+        # order preserved.
+        assert mr._dedup_window_siblings(["a", "b", "a", "c"]) == ["a", "b", "c"]
+
+    def test_dedup_keeps_distinct_base_models(self):
+        # Two different 1M models are both kept — dedup is per normalized base.
+        ids = ["global.anthropic.claude-opus-5[1m]", "global.anthropic.claude-opus-4-8[1m]"]
+        assert mr._dedup_window_siblings(ids) == ids
+
+    def test_seed_prefers_advertised_when_warm(self, monkeypatch):
+        served = [
+            "global.anthropic.claude-opus-5[1m]",
+            "global.anthropic.claude-opus-4-8[1m]",
+        ]
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": served})
+        assert mr.seed_available_models("claude_code") == served
+
+    def test_refresh_reports_change_and_dedupes(self, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        assert mr.refresh_advertised_models("claude_code", ["a", "b", "a"]) is True
+        assert mr.advertised_models("claude_code") == ["a", "b"]
+        # Same set again → no change.
+        assert mr.refresh_advertised_models("claude_code", ["a", "b"]) is False
+
+    def test_refresh_empty_never_wipes_a_good_cache(self, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": ["a"]})
+        assert mr.refresh_advertised_models("claude_code", []) is False
+        assert mr.advertised_models("claude_code") == ["a"]
+
+    def test_persist_round_trips(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        monkeypatch.setattr(mr, "_advertised_models_cache_path", lambda: tmp_path / "pm.json")
+        mr.refresh_advertised_models("claude_code", ["global.anthropic.claude-opus-5[1m]"])
+        mr.persist_advertised_models()
+        # Reload into a fresh dict and confirm the sidecar was written.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        mr._load_advertised_models()
+        assert mr.advertised_models("claude_code") == ["global.anthropic.claude-opus-5[1m]"]
+
+    def test_wire_id_folds_bare_onto_advertised_versioned(self, monkeypatch):
+        # The core fix: a bare id the registry does not carry folds onto the
+        # versioned [1m] id the backend advertised, so it stops collapsing to
+        # the base window.
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-5[1m]"]}
+        )
+        assert (
+            mr.resolve_wire_model_id("claude-opus-5", "claude_code")
+            == "global.anthropic.claude-opus-5[1m]"
+        )
+
+    def test_wire_id_prefers_1m_when_both_spellings_advertised(self, monkeypatch):
+        monkeypatch.setattr(
+            mr,
+            "_ADVERTISED_MODELS",
+            {
+                "claude_code": [
+                    "global.anthropic.claude-opus-5",
+                    "global.anthropic.claude-opus-5[1m]",
+                ]
+            },
+        )
+        assert (
+            mr.resolve_wire_model_id("claude-opus-5", "claude_code")
+            == "global.anthropic.claude-opus-5[1m]"
+        )
+
+    def test_wire_id_passthrough_when_cold_or_unmatched(self, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        # Cold cache → unchanged.
+        assert mr.resolve_wire_model_id("claude-opus-5", "claude_code") == "claude-opus-5"
+        # Warm but no normalized match → unchanged (never rewrites to a model
+        # the provider does not serve).
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-sonnet-4-6[1m]"]}
+        )
+        assert mr.resolve_wire_model_id("claude-opus-5", "claude_code") == "claude-opus-5"
+
+    def test_wire_id_leaves_auto_and_empty_alone(self, monkeypatch):
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-5[1m]"]}
+        )
+        assert mr.resolve_wire_model_id("auto", "claude_code") == "auto"
+        assert mr.resolve_wire_model_id("", "claude_code") == ""
+
+    def test_wire_id_keeps_an_already_advertised_id(self, monkeypatch):
+        served = "global.anthropic.claude-opus-4-8[1m]"
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": [served]})
+        assert mr.resolve_wire_model_id(served, "claude_code") == served
+
+    def test_to_provider_id_unknown_still_passes_through(self, monkeypatch):
+        # Guard: the pure translation is unchanged — folding lives in
+        # resolve_wire_model_id, not to_provider_id.
+        monkeypatch.setattr(
+            mr, "_ADVERTISED_MODELS", {"claude_code": ["global.anthropic.claude-opus-5[1m]"]}
+        )
+        assert mr.to_provider_id("claude-opus-5", "claude_code") == "claude-opus-5"


### PR DESCRIPTION
## Problem / Motivation

Selecting **Opus 4.8** sometimes left a session pinned to the **200K** context window instead of the model's **1M** window — silently, with no UX signal. Two independent, intermittent causes:

- **(A) Allowlist sibling collision.** The per-session `settings.local.json` allowlist carried *both* the versioned `...claude-opus-4-8[1m]` id and its bare 200K base sibling `...claude-opus-4-8`. The claude-agent-acp adapter dedups `availableModels` by base name and could resolve to the 200K spelling.
- **(B) Stale warm-pool seed.** A pooled runtime seeds `settings.local.json` at spawn with the pool's *default* model. On claim, `set_model` switched the model on the wire but never re-seeded the file, so the spawn-time window stuck.

## Why it matters

The context window is the single most consequential per-session setting. A silent halving to 200K truncates long sessions with no indication the selected model's full window was lost — the user picks 4.8 (1M) and unknowingly runs at a fifth of the capacity.

## What changed (motivation → approach → change)

Root cause was that model selection was reconstructed from the static registry rather than reconciled with what the provider actually advertises, and the warm-pool re-apply was claude-special-cased at the call site.

- **`model_registry`** — add `_dedup_window_siblings`: drop a base-window id when a 1M sibling with the same advertised key is present (order-preserving; also drops exact dupes). `seed_available_models` routes **both** the advertised (warm) list and the static (cold) fallback through it, so the seeded allowlist can no longer carry both spellings (fixes A).
- **`acp_backends`** — introduce two opt-in capability frozensets, `ACP_BACKENDS_ADVERTISED_MODEL_SELECTION` (feed the advertised cache + fold the wire id at spawn and on `set_model`) and `ACP_BACKENDS_SEED_LOCAL_SETTINGS` (re-seed `settings.local.json` on a warm claim, fixing B), plus `model_registry_namespace(backend)` mapping every known backend to its registry index key. **Claude is the sole member today**; a future provider opts in with one edit rather than a `not is_claude` inference (harness-parity H5/H6).
- **`acp/client`** — `set_model` folds the bare id onto the advertised spelling and re-seeds the settings file (both gated on membership); `_capture_available_models`, the `_spawn` fold, and `_write_claude_local_settings` read the capability sets + `_model_registry_namespace` instead of `_is_claude`/`"claude_code"`.
- **`acp/types`** — re-export the new names for existing importers.

Net effect for non-claude backends is **zero behavior change** (the added init-path call early-returns unless the membership-gated capture flagged a change).

## Tests

- **`test_model_registry`** — dedup drops the base-window sibling of a 1M id, dedups the advertised list too, preserves order, drops exact dupes, keeps distinct base models; cold-cache fallback compares against the deduped list.
- **`test_acp_client_more_coverage`** — `set_model` folds the bare id onto the advertised spelling, re-seeds settings on claude, and a non-member backend (codex) neither folds nor re-seeds.
- **`test_acp_capability_sets_leaf`** — pins the two new members and the `model_registry_namespace` map for every known backend, so opting a harness in stays a visible, deliberate edit.
- **`test_acp_session_mcp`** — updated the settings-seed assertion to compare against the deduped `seed_available_models` (the source the seed now uses), locking in that the written allowlist no longer carries the 200K base sibling.

## Manual verification

N/A — unit coverage sufficient. The seed/fold/re-seed paths are asserted directly (settings file contents, wire id folding, membership gating); no integration or external service is involved.

## Related Issues

N/A — no tracked issue; found and fixed while unifying provider-advertised model selection.

## Pattern harvest

Pattern: a silent capability downgrade from a **stored-vs-served spelling gap** (a versioned `[1m]` id and its bare base sibling both present, dedup-by-base picking the weaker one) combined with a **spawn-time seed never re-applied on mutation**. Rule candidate (review-prompt / agents-md): a per-session settings artifact seeded at spawn must be re-seeded on any wire-level mutation of the same field, and an allowlist must not carry two spellings that a downstream dedup can collapse to the weaker one.

## Checklist

- [x] At most two commits (one here), Conventional Commits title
- [x] Existing tests pass and new tests added
- [x] Self-review completed; follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No secrets, credentials, or internal references in the diff
