### PR TITLE
fix(instances): stop token churn starving the pane load watchdog

### DIFF
--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -1243,6 +1243,10 @@ export function removeAuthBanner(): void {
   // still authenticates for everything the owner gate does not front, so a
   // success proves nothing about the stale-subject denial.
   if (_staleOwnerBanner) return
+  // Auth works again, so a LATER lapse in this same document deserves its own
+  // hand-off. Deliberately after the stale-owner return above: that denial is not
+  // disproved by an unrelated success, and re-asking the hub for it loops forever.
+  _embeddedHandoffPosted = false
   if (!_sessionExpiredShown) return
   _sessionExpiredShown = false
   const el = document.getElementById('mc-session-expired')
@@ -1253,6 +1257,31 @@ export function removeAuthBanner(): void {
 // Reactive warm-path recovery: background-poll 403s funnel here, through the
 // shared single-flight refreshOnce(). True if the 30-day cookie rotated.
 let _silentRefreshExhausted = false
+// One hub hand-off per pane DOCUMENT. Without this every 403 from every
+// background poll posts another `mc-auth-expired`, and the hub answers each one
+// with an SSH token mint (rate-limited, never stopped) — a mint storm behind a
+// loading spinner. A hub re-mint reloads this iframe, which resets this latch,
+// so a pane that can recover still gets a fresh ask on every load.
+let _embeddedHandoffPosted = false
+
+/** Hand auth recovery to the hub, at most once per pane document.
+ *
+ * The wildcard target is deliberate and matches the two call sites' comments:
+ * the hub's origin is not knowable from inside the pane (tunnel hosts vary), and
+ * the message carries only a fixed type string — no secret — while the parent
+ * validates `event.origin` before acting on it (see resolveTunnelOrigin).
+ */
+function postAuthExpiredToHub(): boolean {
+  if (_embeddedHandoffPosted) return true
+  try {
+    // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
+    window.parent.postMessage({ type: 'mc-auth-expired' }, '*')
+  } catch {
+    return false // cross-origin parent unreachable — caller falls back to the banner
+  }
+  _embeddedHandoffPosted = true
+  return true
+}
 
 export function attemptSilentRefresh(): Promise<boolean> {
   return refreshOnce().then((res) => {
@@ -1271,6 +1300,7 @@ export function attemptSilentRefresh(): Promise<boolean> {
 /** Test-only: reset module auth-recovery state between cases. */
 export function __resetAuthRecoveryStateForTests(): void {
   _silentRefreshExhausted = false
+  _embeddedHandoffPosted = false
   _sessionExpiredShown = false
   _staleOwnerBanner = false
   __resetRefreshOnceForTests()
@@ -1332,17 +1362,30 @@ export function checkSessionExpired(r: Response): Response {
     // When this dashboard is running embedded in the Instances pane stack
     // (an <iframe> inside the hub), don't show the paste-token banner here —
     // the user can't easily fetch the remote token from inside the pane, and
-    // the hub owns recovery. Signal the parent, which force-mints a fresh
-    // token and reloads this iframe (mirrors the hub's auto-recovery).
-    // The message carries no secret; the parent validates event.origin before
-    // acting (see InstancesViewport / resolveTunnelOrigin).
+    // the hub owns recovery.
+    //
+    // But try OUR OWN recovery first. This pane holds the same 30-day
+    // `mc_refresh_<port>` cookie the top-level path below uses, and the common
+    // cause of a burst of 403s here is a lapsed access cookie (a laptop that
+    // slept through the proactive refresh) — which one silent refresh fixes, with
+    // no SSH mint, no iframe reload, and no lost pane state. Handing that to the
+    // hub instead costs a remote mint and a full reload of this document.
+    //
+    // Only when the refresh cannot recover do we signal the parent, which
+    // force-mints a fresh token and reloads this iframe. That hand-off is
+    // latched to once per document (see postAuthExpiredToHub): the hub answers
+    // every ask with a mint, so an unrepairable session used to produce one mint
+    // per rate-limit window for as long as the window stayed open.
     if (window.parent && window.parent !== window) {
-      try {
-        window.parent.postMessage({ type: 'mc-auth-expired' }, '*')
-      } catch {
-        /* cross-origin parent unreachable — fall through to the banner below */
+      if (!_silentRefreshExhausted) {
+        void attemptSilentRefresh().then((ok) => {
+          if (ok) removeAuthBanner()
+          else postAuthExpiredToHub()
+        })
+        return r
       }
-      return r
+      if (postAuthExpiredToHub()) return r
+      // Cross-origin parent unreachable — fall through to the banner below.
     }
     // Mid-session the access cookie can lapse (20h TTL, or laptop sleep
     // pausing the proactive refresh timer) while the tab stays open. The
@@ -1382,18 +1425,15 @@ function handleStaleOwnerSession(): void {
   // Embedded in the Instances pane stack: hand recovery to the hub, mirroring
   // checkSessionExpired — the hub force-mints a fresh token (whose subject is
   // derived from the current owner) and reloads this iframe.
+  // No silent refresh attempt here, unlike checkSessionExpired: re-minting from
+  // the incoming subject keeps the stale bootstrap subject, so a "successful"
+  // refresh would rotate the cookie and be denied again. The hand-off is latched
+  // to once per document, and `_staleOwnerBanner` above keeps a later 2xx from
+  // re-opening it — a hub re-mint cannot fix this denial either, so asking twice
+  // only buys another SSH mint.
   if (typeof window !== 'undefined' && window.parent && window.parent !== window) {
-    try {
-      // The wildcard target mirrors checkSessionExpired's hand-off above: the
-      // hub's origin is not knowable from inside the pane (tunnel hosts vary),
-      // and the message carries only a fixed type string — no secret — while
-      // the parent validates event.origin before acting on it.
-      // nosemgrep: javascript.browser.security.wildcard-postmessage-configuration.wildcard-postmessage-configuration
-      window.parent.postMessage({ type: 'mc-auth-expired' }, '*')
-      return
-    } catch {
-      /* cross-origin parent unreachable — fall through to the banner below */
-    }
+    if (postAuthExpiredToHub()) return
+    // Cross-origin parent unreachable — fall through to the banner below.
   }
   showSessionExpiredBanner(i18nT('api.client.stale_owner_session'))
 }

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -35,7 +35,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { api } from '../api/client'
 import { useAppDispatch, useAppSelector } from '../store'
-import { removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
+import { clearPaneReady, removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
 import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin, useCrewSwitcherStableOrder, setStableOrder } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
 import { LINUX_CAPTION_CONTROLS_WIDTH, TRAFFIC_LIGHT_INSET_PX, WIN_CAPTION_OVERLAY_WIDTH } from '../lib/electron'
@@ -62,7 +62,28 @@ const REFRESH_MIN_INTERVAL_MS = 10_000
 // Iframes report no load errors to the parent, and the backend can say
 // "connected" while the browser-side load is dead (tunnel half-up, token
 // rejected, remote gateway mid-restart) — this watchdog is the only signal.
+// NOTE: this is deliberately LONGER than REFRESH_MIN_INTERVAL_MS, so the two
+// cannot be compared to decide whether the watchdog can fire. The countdown is
+// per LOAD, not per iframe src: the token is absent from the watchdog effect's
+// deps below precisely so that a re-mint arriving inside the window cannot
+// postpone it.
 const PANE_LOAD_TIMEOUT_MS = 15_000
+// How many reactive re-mints one pane may ask for before the parent stops
+// answering. The child posts `mc-auth-expired` on EVERY 403 it sees
+// (api/client.ts hands recovery to the hub before it latches its own banner),
+// so a pane whose session cannot be repaired by a fresh token asks forever —
+// one SSH mint per REFRESH_MIN_INTERVAL_MS, for as long as the window stays
+// open. Past this count the reactive path goes quiet and the pane is failed to
+// the error panel, so the user gets Retry (which re-mints on demand) instead of
+// an invisible mint storm.
+//
+// Only Retry resets the count. `mc-embedded-ready` deliberately does NOT:
+// EmbeddedHostBridge posts it from a mount effect, BEFORE the pane's first
+// authenticated request, so it proves the SPA mounted — not that the new token
+// worked. A pane whose shell mounts fine and whose API then 403s posts it on
+// every reload, so resetting there would clear the count once per re-mint and
+// leave the very loop this cap exists to bound running unbounded.
+const MAX_REACTIVE_REMINTS = 3
 
 /** Parse a ``<int>[hm]`` TTL (e.g. "20h", "30m") to seconds; 0 if unparseable. */
 function ttlToSeconds(ttl: string): number {
@@ -136,6 +157,9 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   const paneChromeRef = useRef<Record<string, boolean>>({})
   const refreshingRef = useRef<Set<string>>(new Set())
   const lastRefreshRef = useRef<Map<string, number>>(new Map())
+  // Reactive (mc-auth-expired) re-mints answered per pane since its last Retry
+  // — see MAX_REACTIVE_REMINTS.
+  const reactiveMintsRef = useRef<Map<string, number>>(new Map())
   // Live iframe elements by id, so the parent can postMessage the switcher model
   // into each embedded pane. Set/cleared by the iframe ref cb.
   const iframeRefs = useRef<Map<string, HTMLIFrameElement>>(new Map())
@@ -144,15 +168,23 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   const postModelToRef = useRef<(id: string) => void>(() => {})
   const instancesRef = useRef<Array<{ id: string }>>([])
 
+  // Whether `refreshToken` would actually mint for this id right now: no mint
+  // already in flight, and outside the rate window. Split out of refreshToken so
+  // the reactive path can tell a declined call from an answered one BEFORE it
+  // charges the pane's budget — a call the guards drop mints nothing, so
+  // charging for it would fail the pane early (see MAX_REACTIVE_REMINTS).
+  const canRefreshNow = useCallback((id: string) => {
+    if (refreshingRef.current.has(id)) return false
+    return Date.now() - (lastRefreshRef.current.get(id) || 0) >= REFRESH_MIN_INTERVAL_MS
+  }, [])
+
   // Force a fresh token mint for one instance and reload its iframe by updating
   // warm[id].token (srcFor re-derives the ?token= URL, so changing the token
   // reloads the iframe). Mirrors the gateway's mint-and-load. Concurrency- and
   // rate-guarded so the reactive path can't loop.
   const refreshToken = useCallback(
     async (id: string) => {
-      if (refreshingRef.current.has(id)) return
-      const last = lastRefreshRef.current.get(id) || 0
-      if (Date.now() - last < REFRESH_MIN_INTERVAL_MS) return
+      if (!canRefreshNow(id)) return
       refreshingRef.current.add(id)
       try {
         const res = await api.refreshInstanceToken(id)
@@ -167,7 +199,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         lastRefreshRef.current.set(id, Date.now())
       }
     },
-    [dispatch],
+    [dispatch, canRefreshNow],
   )
 
   // Pre-mint + warm one connected instance without surfacing it. Cheap when the
@@ -225,6 +257,35 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // Force a fresh mint and reload its iframe rather than letting it show
         // the in-pane paste-token banner. No foreground guard here — the active
         // pane is exactly the one the user wants restored.
+        //
+        // Bounded, though: a session a fresh token cannot repair re-asks on
+        // every 403 forever (the child hands off before latching its own
+        // banner), which is one SSH mint every REFRESH_MIN_INTERVAL_MS with
+        // nothing to show for it. Count the mints actually issued and go quiet
+        // once a pane has burned MAX_REACTIVE_REMINTS of them.
+        const spent = reactiveMintsRef.current.get(id) || 0
+        if (spent >= MAX_REACTIVE_REMINTS) {
+          // Going quiet is not enough on its own: this ask can arrive while the
+          // pane is READY (its shell mounted, only its API is 403ing), and both
+          // affordances are off in that state — the load watchdog below skips a
+          // ready pane, and the child has already latched its own hand-off so it
+          // shows no banner either. Dropping the ask silently would leave a
+          // live-looking pane serving stale content with no way out, the same
+          // dead end this fix is about. Retract readiness and record the verdict
+          // so the error panel carrying Retry surfaces instead.
+          dispatch(clearPaneReady(id))
+          setTimedOut(prev => (prev[id] ? prev : { ...prev, [id]: true }))
+          return
+        }
+        // Charge the budget only for asks that are actually answered with a mint.
+        // A pane can post several asks inside one rate window — a 200 landing
+        // mid-reload re-arms the child's hand-off latch, so a 403 from a poll
+        // that started before the reload posts again seconds later — and
+        // refreshToken drops those. Counting them anyway would spend the budget
+        // on mints that never happened and show the panel after one real retry
+        // instead of MAX_REACTIVE_REMINTS.
+        if (!canRefreshNow(id)) return
+        reactiveMintsRef.current.set(id, spent + 1)
         void refreshToken(id)
       } else if (data.type === 'mc-switch-instance') {
         // The embedded pane's inline switcher asks the parent to flip
@@ -284,6 +345,9 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // rather than waiting for the next input-driven broadcast. Also record
         // readiness: this is the parent's only proof the pane actually loaded
         // (drives the loading overlay + load watchdog below).
+        // NOTE: deliberately does NOT clear reactiveMintsRef — this fires on
+        // mount, before the pane's first authenticated request, so it is no
+        // evidence the token works. See MAX_REACTIVE_REMINTS.
         dispatch(setPaneReady(id))
         postModelToRef.current(id)
       } else if (data.type === 'mc-drag-gaps') {
@@ -308,7 +372,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     }
     window.addEventListener('message', onMessage)
     return () => window.removeEventListener('message', onMessage)
-  }, [dispatch, refreshToken])
+  }, [dispatch, refreshToken, canRefreshNow])
 
   // Proactive refresh: when an embedded token passes REFRESH_AT_ELAPSED_FRAC of
   // its TTL, re-mint and reload that iframe ahead of the cap. Skips the active
@@ -372,11 +436,24 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     setFocusChromeVisible(paneChromeRef.current[activeId] ?? true)
   }, [activeId, focusMode])
   // Primitive deps for the watchdog effect (a fresh conn object identity on
-  // every setWarm would defeat the dep comparison; the src only depends on these).
+  // every setWarm would defeat the dep comparison).
   const activeWarmPort = activeWarmConn?.port
-  const activeWarmToken = activeWarmConn?.token
   const activeReady = activeId ? !!ready[activeId] : true
   const activeSeq = activeId ? reloadSeq[activeId] || 0 : 0
+  // The watchdog's countdown is anchored to the identity of the LOAD — (id, port,
+  // reloadSeq) — and NOT to the iframe src. A token re-mint also changes the src,
+  // but the token is deliberately ABSENT from the deps below, so a re-mint neither
+  // clears nor restarts the pending timer: it keeps ticking against the deadline
+  // the load began with. That absence is the fix. Refreshes are rate-limited to
+  // REFRESH_MIN_INTERVAL_MS, which is SHORTER than PANE_LOAD_TIMEOUT_MS, so while
+  // the token WAS a dep a pane stuck in an `mc-auth-expired` -> re-mint loop
+  // restarted a countdown-from-scratch every 10s and could never reach 15s.
+  // Symptom: the loading overlay spun forever and the error panel — the only
+  // affordance carrying Retry and the tab strip — could never surface, stranding
+  // the user on a pane that looked merely slow. An explicit Retry or a real port
+  // change is what legitimately restarts the clock. A re-mint that DOES load still
+  // clears the verdict, because `activeTimedOut` additionally requires
+  // `!activeReady`.
   useEffect(() => {
     if (!activeId || activeWarmPort === undefined || activeReady) return
     const id = activeId
@@ -384,9 +461,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
       setTimedOut(prev => (prev[id] ? prev : { ...prev, [id]: true }))
     }, PANE_LOAD_TIMEOUT_MS)
     return () => window.clearTimeout(t)
-    // Restart the countdown whenever the pane's src (port/token) or forced
-    // reload sequence changes — each of those reloads the iframe.
-  }, [activeId, activeWarmPort, activeWarmToken, activeSeq, activeReady])
+  }, [activeId, activeWarmPort, activeSeq, activeReady])
 
   const retry = useCallback(
     (id: string) => {
@@ -394,6 +469,9 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
       // an identical token (setWarm would be a no-op for the iframe src).
       setTimedOut(prev => ({ ...prev, [id]: false }))
       setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
+      // An explicit user press is a fresh start: re-open the reactive budget so
+      // a pane that recovers on the next token can still self-heal afterwards.
+      reactiveMintsRef.current.delete(id)
       connectMutation.mutate(id)
     },
     [connectMutation],
@@ -409,6 +487,30 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     const victim = [...mru].reverse().find(id => id !== activeId && warm[id])
     if (victim) dispatch(removeWarm(victim))
   }, [warm, warmCap, mru, activeId, dispatch])
+
+  // Drop the per-pane load facts of a pane that is no longer warm. Both the
+  // reactive budget and the timed-out verdict describe ONE load of ONE
+  // connection; the connection they describe is gone (K-cap eviction above, an
+  // explicit disconnect from InstancesPanel, a crew deleted), and the next
+  // warm is a new load rather than a continuation of the dead one. Retry was
+  // the only thing clearing either, and a re-warm is precisely the path that
+  // does not go through Retry — so without this an exhausted-then-evicted pane
+  // comes back with its budget already spent and its verdict already latched,
+  // and renders "Pane failed to load" before its fresh iframe has had a chance
+  // to load at all, having minted nothing. Keyed on `warm` because that is the
+  // one signal every teardown path shares, whoever dispatched it.
+  useEffect(() => {
+    for (const id of reactiveMintsRef.current.keys()) {
+      if (!warm[id]) reactiveMintsRef.current.delete(id)
+    }
+    setTimedOut(prev => {
+      const stale = Object.keys(prev).filter(id => prev[id] && !warm[id])
+      if (stale.length === 0) return prev
+      const next = { ...prev }
+      for (const id of stale) delete next[id]
+      return next
+    })
+  }, [warm])
 
   // Auto-warm on load: after the first instances poll, pre-mount every
   // currently-connected instance's iframe (up to the warm cap) so panes are

--- a/website/src/store/instancesSlice.ts
+++ b/website/src/store/instancesSlice.ts
@@ -183,6 +183,15 @@ const instancesSlice = createSlice({
       if (!state.ready) state.ready = {}
       state.ready[action.payload] = true
     },
+    /**
+     * The parent no longer believes this pane is loaded, without a src change.
+     * `mc-embedded-ready` fires on mount, so a pane whose shell mounted but
+     * whose session is unrecoverable counts as ready while showing nothing
+     * usable; retracting that is what lets the load verdict surface.
+     */
+    clearPaneReady(state, action: PayloadAction<string>) {
+      if (state.ready) delete state.ready[action.payload]
+    },
     setUnread(state, action: PayloadAction<{ id: string; count: number }>) {
       state.unread[action.payload.id] = action.payload.count
     },
@@ -220,6 +229,7 @@ export const {
   setActiveId,
   removeWarm,
   setPaneReady,
+  clearPaneReady,
   setUnread,
   setHostModel,
   setCrewAddForm,

--- a/website/src/test/ApiClient.coverage.test.tsx
+++ b/website/src/test/ApiClient.coverage.test.tsx
@@ -493,40 +493,76 @@ describe('session-expired banner', () => {
     })
   })
 
-  it('hands recovery to the hub instead of bannering when embedded in the Instances pane', () => {
-    // Inside the hub's iframe the user cannot fetch the REMOTE token, so the
-    // parent is signalled and re-mints instead. The message carries no secret.
-    const post = vi.fn()
+  function withMockedParent(post: (...args: unknown[]) => unknown, body: () => Promise<void>) {
     const original = Object.getOwnPropertyDescriptor(window, 'parent')
     Object.defineProperty(window, 'parent', {
       value: { postMessage: post },
       writable: true,
       configurable: true,
     })
-    try {
-      checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
-      expect(post).toHaveBeenCalledWith({ type: 'mc-auth-expired' }, '*')
-      expect(banner()).toBeNull()
-      expect(fetchMock).not.toHaveBeenCalled()
-    } finally {
+    return body().finally(() => {
       if (original) Object.defineProperty(window, 'parent', original)
-    }
+    })
+  }
+
+  const embedded403 = () =>
+    checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))
+
+  it('recovers an embedded pane with its OWN silent refresh before troubling the hub', async () => {
+    // The pane holds the same 30-day refresh cookie as the top-level path. A
+    // lapsed access cookie (laptop slept through the proactive refresh) is fixed
+    // by one refresh call — no SSH mint, no iframe reload, no lost pane state.
+    const post = vi.fn()
+    fetchMock.mockResolvedValue(okJson({ ok: true }))
+    await withMockedParent(post, async () => {
+      embedded403()
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+      expect(post).not.toHaveBeenCalled()
+      expect(banner()).toBeNull()
+    })
+  })
+
+  it('hands recovery to the hub — ONCE — when the pane cannot refresh itself', async () => {
+    // A terminal 401 means the refresh chain is gone, so the hub must re-mint.
+    // Every later 403 in this document is the SAME unrepaired session: the hub
+    // answers each ask with an SSH mint, so asking once is the whole budget.
+    const post = vi.fn()
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    await withMockedParent(post, async () => {
+      embedded403()
+      await vi.waitFor(() => expect(post).toHaveBeenCalledWith({ type: 'mc-auth-expired' }, '*'))
+      for (let i = 0; i < 5; i++) embedded403()
+      await Promise.resolve()
+      expect(post).toHaveBeenCalledTimes(1)
+      // Still no banner: the hub owns recovery inside a pane.
+      expect(banner()).toBeNull()
+    })
+  })
+
+  it('re-opens the hub hand-off after auth is restored', async () => {
+    // The latch is about one UNREPAIRED session, not the lifetime of the
+    // document: a 2xx proves recovery, so a later genuine lapse may ask again.
+    const post = vi.fn()
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    await withMockedParent(post, async () => {
+      embedded403()
+      await vi.waitFor(() => expect(post).toHaveBeenCalledTimes(1))
+      removeAuthBanner() // what a successful response does
+      embedded403()
+      await vi.waitFor(() => expect(post).toHaveBeenCalledTimes(2))
+    })
   })
 
   it('falls through to the banner path when the parent frame is unreachable', async () => {
-    const original = Object.getOwnPropertyDescriptor(window, 'parent')
-    Object.defineProperty(window, 'parent', {
-      value: { postMessage: () => { throw new Error('cross-origin') } },
-      writable: true,
-      configurable: true,
+    fetchMock.mockResolvedValue(res(401, 'revoked'))
+    // Exhaust the pane's own refresh first (terminal 401), so the 403 below goes
+    // straight to the hand-off — which throws. The throw is swallowed and the
+    // banner is the documented fallback.
+    await expect(attemptSilentRefresh()).resolves.toBe(false)
+    await withMockedParent(() => { throw new Error('cross-origin') }, async () => {
+      expect(() => embedded403()).not.toThrow()
+      await vi.waitFor(() => expect(banner()).not.toBeNull())
     })
-    try {
-      // The postMessage throw is swallowed; the call still returns the response.
-      expect(() => checkSessionExpired(res(403, '', { headers: { 'X-Auth-Required': 'true' } }))).not.toThrow()
-    } finally {
-      if (original) Object.defineProperty(window, 'parent', original)
-      await Promise.resolve()
-    }
   })
 
   it('attemptSilentRefresh reports false on a terminal 401 and true on a rotation', async () => {

--- a/website/src/test/InstancesViewport.test.tsx
+++ b/website/src/test/InstancesViewport.test.tsx
@@ -3,7 +3,7 @@ import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithProviders, createTestStore } from './helpers'
 import InstancesViewport from '../components/InstancesViewport'
-import { setActiveId } from '../store/instancesSlice'
+import { removeWarm, setActiveId, setWarm } from '../store/instancesSlice'
 import {
   consumeChatHandoff,
   installSoftNavigate,
@@ -696,6 +696,204 @@ describe('InstancesViewport', () => {
     expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
   })
 
+  it('stops re-minting after MAX_REACTIVE_REMINTS unanswered mc-auth-expired asks', async () => {
+    // A pane whose session a fresh token cannot repair posts mc-auth-expired on
+    // EVERY 403 it sees, forever. Without a budget that is one SSH mint every
+    // REFRESH_MIN_INTERVAL_MS for as long as the window stays open — and each
+    // re-mint used to postpone the load watchdog, so the user saw only a
+    // spinner. The reactive path must go quiet and let the verdict stand.
+    mockConnectedCd1()
+    // Retry reconnects, and the pane keeps its loopback port — so pin the
+    // connect mock to 7778 like every other mock here. The module default
+    // answers 7777, which would move the pane's expected origin mid-test and
+    // make the posts below cross-origin (silently dropped) rather than capped.
+    vi.mocked(api.connectInstance).mockResolvedValue({ state: 'connected', local_port: 7778, token: 'tok' })
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+
+      const expire = async () => {
+        await act(async () => {
+          window.dispatchEvent(
+            new MessageEvent('message', {
+              data: { type: 'mc-auth-expired' },
+              origin: 'http://127.0.0.1:7778',
+            }),
+          )
+        })
+        // Past the per-instance rate guard, so the throttle is never what stops us.
+        await act(async () => { vi.advanceTimersByTime(11_000) })
+      }
+
+      for (let i = 0; i < 6; i++) await expire()
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(3)
+
+      // `mc-embedded-ready` must NOT re-open the budget. EmbeddedHostBridge
+      // posts it from a mount effect, BEFORE the pane's first authenticated
+      // request, so a pane whose shell mounts and whose API then 403s posts it
+      // on every reload — crediting it would clear the count once per re-mint
+      // and leave the loop this cap exists to bound running forever.
+      const ready = async () => {
+        await act(async () => {
+          window.dispatchEvent(
+            new MessageEvent('message', {
+              data: { type: 'mc-embedded-ready', v: 1 },
+              origin: 'http://127.0.0.1:7778',
+            }),
+          )
+        })
+      }
+      await ready()
+      await expire()
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(3)
+
+      // Only Retry re-opens it, and it does.
+      await act(async () => { screen.getByRole('button', { name: /retry/i }).click() })
+      await expire()
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('surfaces the error panel when the reactive budget runs out on a READY pane', async () => {
+    // The exhausted ask can land while the pane counts as ready: its shell
+    // mounted (mc-embedded-ready) and only its API is 403ing. The load watchdog
+    // skips a ready pane and the child has latched its own hand-off, so simply
+    // dropping the ask would leave a live-looking pane on stale content with no
+    // affordance at all. Exhaustion must retract readiness and show Retry.
+    mockConnectedCd1()
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+
+      const post = async (data: unknown) => {
+        await act(async () => {
+          window.dispatchEvent(new MessageEvent('message', { data, origin: 'http://127.0.0.1:7778' }))
+        })
+      }
+
+      // Every cycle re-announces readiness, exactly as a real reload does.
+      for (let i = 0; i < 4; i++) {
+        await post({ type: 'mc-embedded-ready', v: 1 })
+        await post({ type: 'mc-auth-expired' })
+        await act(async () => { vi.advanceTimersByTime(11_000) })
+      }
+
+      // Capped at 3 mints even though the pane reported ready before every ask.
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(3)
+      // And the pane is no longer passing for loaded — Retry is reachable.
+      expect(store.getState().instances.ready['cd-1']).toBeUndefined()
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not spend the reactive budget on asks the rate guard drops', async () => {
+    // The budget bounds MINTS, not asks. A pane can post several asks inside one
+    // rate window — a 200 landing mid-reload re-arms the child's hand-off latch,
+    // so a 403 from a poll that started before the reload posts again seconds
+    // later — and refreshToken drops those. Charging for a mint that never
+    // happened would fail the pane after one real retry instead of three.
+    mockConnectedCd1()
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+
+      const post = async (data: unknown) => {
+        await act(async () => {
+          window.dispatchEvent(new MessageEvent('message', { data, origin: 'http://127.0.0.1:7778' }))
+        })
+      }
+      const nextWindow = async () => { await act(async () => { vi.advanceTimersByTime(11_000) }) }
+
+      // Ready throughout, so the 15s load watchdog is never what shows the panel
+      // — only the budget can. The mock re-mints the SAME token, so setWarm does
+      // not clear readiness between asks.
+      await post({ type: 'mc-embedded-ready', v: 1 })
+
+      // Three asks inside ONE rate window: the first mints, the other two are
+      // dropped by the guard and must cost nothing.
+      await post({ type: 'mc-auth-expired' })
+      await post({ type: 'mc-auth-expired' })
+      await post({ type: 'mc-auth-expired' })
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(1)
+
+      // Two more windows spend the rest of the budget. Six asks, three mints.
+      await nextWindow()
+      await post({ type: 'mc-auth-expired' })
+      await nextWindow()
+      await post({ type: 'mc-auth-expired' })
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(3)
+      // Still alive: the dropped asks did not bring the panel forward.
+      expect(store.getState().instances.ready['cd-1']).toBe(true)
+      expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+
+      // The next ask is the one that finds the budget spent.
+      await nextWindow()
+      await post({ type: 'mc-auth-expired' })
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(3)
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('re-warming a pane restores its budget instead of failing on the first ask', async () => {
+    // Both the budget and the timed-out verdict describe ONE load of ONE
+    // connection. Eviction and disconnect end that connection, and a re-warm is
+    // a new load — but only Retry used to clear either, and a re-warm is exactly
+    // the path that skips Retry. Left stale, a healthy re-warm renders "Pane
+    // failed to load" before its fresh iframe has had a chance to load at all.
+    mockConnectedCd1()
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+
+      const post = async (data: unknown) => {
+        await act(async () => {
+          window.dispatchEvent(new MessageEvent('message', { data, origin: 'http://127.0.0.1:7778' }))
+        })
+      }
+      await post({ type: 'mc-embedded-ready', v: 1 })
+      for (let i = 0; i < 4; i++) {
+        await post({ type: 'mc-auth-expired' })
+        await act(async () => { vi.advanceTimersByTime(11_000) })
+      }
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(3)
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+
+      // The same teardown InstancesPanel and the K-cap eviction dispatch, then a
+      // fresh warm for the same id.
+      await act(async () => { store.dispatch(removeWarm('cd-1')) })
+      await act(async () => { store.dispatch(setWarm({ id: 'cd-1', conn: { port: 7778, token: 'tok2' } })) })
+      await act(async () => { store.dispatch(setActiveId('cd-1')) })
+
+      // The stale verdict is gone: the new load gets its loading overlay, not the
+      // error panel it never earned.
+      expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+      expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
+      // And its first ask is answered with a mint rather than instant exhaustion.
+      await post({ type: 'mc-auth-expired' })
+      expect(vi.mocked(api.refreshInstanceToken).mock.calls.length).toBe(4)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('ignores mc-switch-instance to an unknown target id even from a trusted origin', async () => {
     // The inbound switcher validates the TARGET (known instance OR warm) after
     // resolving the SENDER origin. A trusted pane must NOT be able to flip the
@@ -795,6 +993,46 @@ describe('InstancesViewport', () => {
     // The iframe was remounted (new element) to force the reload.
     const after = document.querySelector('iframe') as HTMLIFrameElement
     expect(after).not.toBe(before)
+  })
+
+  it('still times out when a re-mint churns the token faster than the watchdog window', async () => {
+    // Regression: the watchdog's countdown used to restart on every token change.
+    // Re-mints are rate-limited to REFRESH_MIN_INTERVAL_MS (10s), which is SHORTER
+    // than PANE_LOAD_TIMEOUT_MS (15s), so a pane stuck in an auth-expired -> re-mint
+    // loop reset the clock before it could ever fire: the loading overlay spun
+    // forever and Retry was unreachable. The deadline is now absolute per load.
+    mockConnectedCd1()
+    vi.useFakeTimers()
+    try {
+      const store = createTestStore({
+        instances: { warm: { 'cd-1': { port: 7778, token: 'tok-0' } }, activeId: 'cd-1', mru: ['cd-1'], unread: {}, ready: {} },
+      })
+      renderWithProviders(<InstancesViewport />, { store })
+      expect(screen.getByText(/Loading pane/i)).toBeInTheDocument()
+
+      // Two re-mints inside the 15s window, 10s apart — same port, new token each
+      // time (exactly what the auth-expired path dispatches).
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
+        store.dispatch(setWarm({ id: 'cd-1', conn: { port: 7778, token: 'tok-1' } }))
+      })
+      expect(screen.queryByText(/Pane failed to load/i)).toBeNull()
+      await act(async () => {
+        vi.advanceTimersByTime(4_000)
+        store.dispatch(setWarm({ id: 'cd-1', conn: { port: 7778, token: 'tok-2' } }))
+      })
+      // 14s elapsed: still inside the ORIGINAL deadline, so not yet a failure.
+      expect(screen.queryByText(/Pane failed to load/i)).toBeNull()
+
+      // Crossing 15s of real elapsed time fires, despite the churn.
+      await act(async () => {
+        vi.advanceTimersByTime(1_000)
+      })
+      expect(screen.getByText(/Pane failed to load/i)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('a late mc-embedded-ready clears a timed-out verdict without Retry', async () => {


### PR DESCRIPTION
## Problem / Motivation

A connected remote crew pane could spin on its loading overlay forever. The error
panel that carries **Retry** never appeared, and because the local header is
`display:none` while a remote tab is active, neither did the tab strip — so the
window was stuck with no affordance at all.

Restarting the remote gateway and reconnecting the tunnel changed nothing. Only a
full quit+restart of the app cleared it, because the stuck state lived in the
dashboard window's own in-memory Redux (`warm` is not persisted).

## Why it matters

The pane's own 15s watchdog exists precisely so a failed load degrades into an
error panel with a Retry button. In this state the watchdog never fired, so the
degradation path was unreachable: a user whose access cookie lapsed lost the whole
dashboard window until they quit the app, and the pane kept minting a fresh SSH
token every 10 seconds for as long as the window stayed open.

## What changed (motivation → approach → change)

Three defects, one chain.

**1. The load watchdog restarted on every re-mint.** `activeWarmToken` sat in the
effect's deps with a cleanup that cleared the pending timer, so each re-mint began
a fresh countdown. With `REFRESH_MIN_INTERVAL_MS` (10s) < `PANE_LOAD_TIMEOUT_MS`
(15s), a pane in a re-mint loop could never reach its own timeout.

The token is now **absent from the deps**, so a re-mint neither clears nor restarts
the pending timer — it keeps ticking against the deadline the load began with. Only
an explicit Retry or a real port change restarts the clock. That absence *is* the
fix; there is no new machinery.

**2. Nothing bounded the reactive re-mint path.** The child posts `mc-auth-expired`
on every 403 it sees and the parent answered each one with an SSH token mint.
`REFRESH_MIN_INTERVAL_MS` is a *pacer, not a stop* — one mint per 10s, indefinitely.

`MAX_REACTIVE_REMINTS = 3` caps the mints issued per pane; past that the reactive
path goes quiet and the pane is failed to the error panel that carries Retry.

It counts **mints, not asks.** A pane can post several asks inside one rate window —
a 200 landing mid-reload re-arms the child's hand-off latch, so a 403 from a poll that
started before the reload posts again seconds later — and `refreshToken` drops those.
Charging for a mint that never happened would show the panel after one real retry
instead of three, so the reactive path consults the rate guard (`canRefreshNow`) and
charges only asks it actually answers.

**Only Retry resets the count.** `mc-embedded-ready` deliberately does *not*:
`EmbeddedHostBridge` posts it from a **mount** effect, before the pane's first
authenticated request, so it proves the SPA mounted — not that the new token worked.
A pane whose shell mounts fine and whose API then 403s posts it on every reload, so
crediting it would clear the count once per re-mint and leave the very loop this cap
exists to bound running unbounded.

And going quiet is not sufficient on its own. The exhausted ask can arrive while the
pane counts as **READY** — its shell mounted, only its API is 403ing — and both
affordances are off in that state: the load watchdog skips a ready pane, and the child
has already latched its own hand-off so it shows no banner either. Dropping the ask
there would leave a live-looking pane serving stale content with no way out, the same
dead end this PR is about. Exhaustion therefore **retracts readiness** (a new
`clearPaneReady` reducer in `instancesSlice`) and latches the timed-out verdict, so
the error panel with Retry surfaces.

Both the budget and the timed-out verdict are **dropped when a pane stops being warm.**
They describe one load of one connection; K-cap eviction and an explicit disconnect end
that connection, and the next warm is a new load rather than a continuation. Retry was
the only thing clearing either, and a re-warm is exactly the path that skips Retry — so
a stale pair made a healthy re-warm render "Pane failed to load" before its fresh iframe
had had a chance to load at all, having minted nothing. The prune is keyed on `warm`,
which is the one signal every teardown path shares whoever dispatched it. (The verdict
half of that staleness predates this PR; the budget half would have been new, so both are
closed here rather than leaving the new mechanism with the same gap.)

**Known tradeoff:** the count does not decay, so a pane whose token legitimately lapses a
4th time within one long-lived window is failed to the error panel rather than re-minting.
That is deliberate — a time-based reset needs another constant and another window to
reason about, while this state is visible (the panel says so) and clears in one Retry
click. A pane that recovers and is later evicted or reconnected starts fresh either way.

**3. The pane escalated too eagerly and too often.** `checkSessionExpired` returned
*before* latching `_sessionExpiredShown`, so every background poll's 403 was another
hub ask — and the embedded path skipped the pane's own `attemptSilentRefresh()`
against its 30-day `mc_refresh_<port>` cookie, turning a merely-lapsed access cookie
into an SSH mint plus a full iframe reload.

The pane now tries its own refresh first, and hands off to the hub **at most once per
document** (`_embeddedHandoffPosted`). A hub re-mint reloads the iframe, which resets
the latch, so a pane that can still recover gets a fresh ask on every load. A
cross-origin parent that cannot be reached returns `false` and falls through to the
session-expired banner, preserving the guard the old inline `try/catch` provided.

## Tests

Both are red before this change and green after.

- `website/src/test/InstancesViewport.test.tsx`
  - **`still times out when a re-mint churns the token faster than the watchdog
    window`** — drives repeated token changes inside the 15s window and asserts
    `timedOut` still latches on the original deadline. Verified non-vacuous: putting
    `activeWarmToken` back into the dep array makes this test fail.
  - **`stops re-minting after MAX_REACTIVE_REMINTS unanswered mc-auth-expired asks`** —
    posts 6 asks and asserts exactly 3 mints, so the extras are dropped rather than
    paced; then posts `mc-embedded-ready` and one more ask and asserts *still* 3, so
    a mount announcement cannot re-open the budget; then clicks Retry and asserts a
    4th, so the one intended reset does work.
  - **`surfaces the error panel when the reactive budget runs out on a READY pane`** —
    announces readiness before each ask, so exhaustion lands on a pane the watchdog
    would skip, and asserts readiness is retracted and the Retry button is on screen.
    This is the test that fails if exhaustion merely goes quiet.
  - **`does not spend the reactive budget on asks the rate guard drops`** — fires three
    asks inside one rate window (1 mint), then one per window twice more, and asserts
    six asks bought exactly 3 mints with the pane still ready and no Retry on screen;
    the 7th ask is what surfaces the panel. Fails if the budget counts asks.
  - **`re-warming a pane restores its budget instead of failing on the first ask`** —
    exhausts the budget, dispatches the real `removeWarm` teardown, re-warms the same
    id, and asserts the loading overlay (not the error panel) plus a 4th mint on the
    next ask. Fails if either per-pane fact survives the teardown.
- `website/src/test/ApiClient.coverage.test.tsx`
  - a `withMockedParent` / `embedded403` rewrite covering four cases, including
    hand-off-once: **6 × 403 → exactly 1 `mc-auth-expired` post**, plus the silent
    refresh being attempted before any hub ask, and the cross-origin fall-through to
    the banner.

## Manual verification

Reproduced against a real remote crew whose access cookie had lapsed: the pane now
surfaces the error panel with Retry at 15s instead of spinning, and Retry recovers
the pane in place — no app restart. The unbounded mint loop is otherwise only
observable in logs, which the unit tests cover directly.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** this diff changes only *when* two already-existing states are
entered (the pane's error panel and its loading overlay) — it adds no component, no
layout, no styling and no user-visible string, so a before/after of the rendered UI
is pixel-identical.

## Related Issues

no linked issue: found and diagnosed directly from a stuck session, no tracking issue was filed.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a watchdog/timeout effect whose dependency list includes the very signal it
is timing, so each retry of that signal restarts the deadline it is supposed to be
racing — latent whenever the retry interval is shorter than the timeout.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
