### PR TITLE
fix(dashboard): stop refusal recovery re-answering an answered turn

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5453,6 +5453,16 @@ async def _run_chat(
     # backend 5xx is only retried while this is False, so a re-prompt can't
     # double-stream text or re-run a side-effecting tool.
     _turn_emitted = False
+    # Did this turn stream text the user has ALREADY READ, which a later tool
+    # boundary then flushed out of `assistant_text`? The three tool-boundary
+    # flushes below (post-tool-group text, EVENT_TOOL_CALL, the permission flow)
+    # persist the segment and reset the buffer, so a turn that answered and THEN
+    # hit a blocked tool call reaches end-of-turn with an empty `assistant_text`
+    # even though its answer is on screen. Kept separate from
+    # `_produced_visible_output`, whose narrower meaning (only the paths that
+    # reset the buffer WITHOUT a tool boundary — steer cut, compaction, clear,
+    # agent switch) is load-bearing for the promise-only guard below.
+    _turn_flushed_visible_text = False
     # Was this turn's prompt CONSUMED by the model? Reported to whoever armed the
     # turn (a queued sub-agent completion's retention clock -- see
     # ``_arm_queued_delivery_settlement``), because every handled-failure path
@@ -6900,6 +6910,7 @@ async def _run_chat(
                     if assistant_text:
                         _flush_segment(state, slot, assistant_text)
                         assistant_text = ""
+                        _turn_flushed_visible_text = True
                     else:
                         # No accumulated text, but still tell frontend to
                         # finalize any streaming message before tools.
@@ -6992,6 +7003,7 @@ async def _run_chat(
                 if not in_tool_group and assistant_text:
                     _flush_segment(state, slot, assistant_text, broadcast=False)
                     assistant_text = ""
+                    _turn_flushed_visible_text = True
                 in_tool_group = True
                 _turn_emitted = True  # tool side effect — transient retry now unsafe
                 await _report_consumed(irreversible=True)
@@ -7686,6 +7698,7 @@ async def _run_chat(
                 if assistant_text:
                     _flush_segment(state, slot, assistant_text)
                     assistant_text = ""
+                    _turn_flushed_visible_text = True
                 _pre_tool_hooks_fired = False
                 # Backend-subagent request whose SECURITY context is absent
                 # (structured params missing, or shell with no recoverable
@@ -10263,6 +10276,26 @@ async def _run_chat(
         # No turn cap by design: the model decides when to stop, and the user's
         # Stop button stays the hard breaker. The finally block's dequeue loop
         # picks this up and dispatches it.
+        #
+        # `answered` decides WHICH body is sent. A turn that produced its own
+        # answer despite the block did not end early, so telling it to "continue
+        # where you left off" makes it answer the same question a second time —
+        # once per blocked call, each a full billed turn. The reason still has to
+        # be delivered (without steer this turn is its only channel), so the
+        # answered variant carries it as awareness and forbids the restatement
+        # instead of suppressing the turn. `_answer_text` is the turn's own answer
+        # with backend control notices removed; `_produced_visible_output` covers
+        # the paths that reset `assistant_text` after emitting (steer cut,
+        # compaction, clear, agent switch) — the same pair every other
+        # "did this turn say anything" check in this function uses.
+        # That pair alone is NOT enough here, because unlike those checks this one
+        # can be reached with the answer BEFORE the block: the model answers, then
+        # calls a tool, and the tool boundary flushes the answer out of
+        # `assistant_text` (EVENT_TOOL_CALL / the permission flow) while the user
+        # has already read it on screen. `_turn_flushed_visible_text` carries that
+        # third case, so the ordering answer-then-block gets the same awareness
+        # body as block-then-answer instead of being told to continue and
+        # re-deriving what is already on screen.
         if should_queue_refusal_recovery(
             _refusal_reasons,
             slot._stopping,
@@ -10279,7 +10312,13 @@ async def _run_chat(
                 if _recovery_hint:
                     break
             _recovery_body = build_refusal_recovery_prompt(
-                _refusal_reasons, credential_tool_hint=_recovery_hint
+                _refusal_reasons,
+                credential_tool_hint=_recovery_hint,
+                answered=(
+                    bool(_answer_text.strip())
+                    or _produced_visible_output
+                    or _turn_flushed_visible_text
+                ),
             )
             if _recovery_body:
                 _queue_recovery(

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2710,7 +2710,7 @@ def parse_hook_continuations(stdouts: list[str]) -> list[str]:
 
 
 def build_refusal_recovery_prompt(
-    refusals: list[tuple[str, str]], *, credential_tool_hint: str = ""
+    refusals: list[tuple[str, str]], *, credential_tool_hint: str = "", answered: bool = False
 ) -> str:
     """Build the body of an automatic continuation after a recoverable tool refusal.
 
@@ -2735,6 +2735,25 @@ def build_refusal_recovery_prompt(
     different tool) or stop on its own with a reason. The caller prepends
     :data:`REFUSAL_RECOVERY_PREFIX`. Returns "" if there is nothing to recover.
 
+    ``answered`` says the turn ALREADY streamed text the user has read, despite
+    the block. The premise of the default wording — "the turn ended early, pick up
+    where you left off" — is then false, and acting on it makes the model re-answer
+    a question the user has already read, once per blocked call and at full turn
+    cost. So the body flips to awareness-only: same block reasons, same
+    remediation, but an explicit instruction not to restate what was sent.
+
+    That flag deliberately does NOT claim the turn *finished* — no caller can tell
+    a delivered answer from a one-line preamble ("Let me check the logs.") before
+    the blocked call, because the two are indistinguishable prose flushed at the
+    same point in the stream. So this branch conditions its instruction on whether
+    the task is done rather than asserting it: continue-from-there is the default
+    and stopping is the narrow case. Asserting a finished answer here would tell a
+    turn that had only narrated its intent to stop with the work undone.
+    The reason still has to be delivered rather than dropped, because on a backend
+    without mid-turn steer this turn is the ONLY channel for it — without it the
+    model's last word on the subject is kiro-cli's "User denied tool execution",
+    and it will keep attributing the block to the user in later turns.
+
     Lives here (a leaf module that owns the prefix) rather than in context.py so
     chat_runner can import it at module top without a circular import. There is
     deliberately no retry cap: the model decides when to stop, and the user's
@@ -2743,9 +2762,18 @@ def build_refusal_recovery_prompt(
     if not refusals:
         return ""
     lines = [
-        "One or more tool calls in your previous turn were blocked by a Kiro Crew "
-        "safety policy, which ended the turn early. This was NOT a user action — "
-        "do not treat it as a cancellation or interruption by the user.",
+        (
+            "One or more tool calls in your previous turn were blocked by a Kiro "
+            "Crew safety policy. This was NOT a user action — do not treat it as a "
+            "cancellation or interruption by the user. That turn already put text "
+            "on screen for the user, so this note is for awareness: carry on from "
+            "there rather than starting over."
+            if answered
+            else "One or more tool calls in your previous turn were blocked by a "
+            "Kiro Crew safety policy, which ended the turn early. This was NOT a "
+            "user action — do not treat it as a cancellation or interruption by "
+            "the user."
+        ),
         "",
         "Blocked:",
     ]
@@ -2753,10 +2781,19 @@ def build_refusal_recovery_prompt(
         lines.append(f"  - {title}: {reason}" if reason else f"  - {title}")
     lines += [
         "",
-        "Decide how to proceed: use an allowed alternative (for a shell command, "
-        "a read-only variant), a different tool, or — if the block is correct and "
-        "you genuinely cannot proceed — say so and stop. Otherwise continue the "
-        "task where you left off.",
+        (
+            "Do NOT repeat, restate or re-derive what you already sent — the user "
+            "has read it. If the task is NOT finished, continue from there: use an "
+            "allowed alternative (for a shell command, a read-only variant) or a "
+            "different tool, and say what it changed. Only if the task IS finished "
+            "and the block left nothing missing, reply with one short line noting "
+            "the block and stop."
+            if answered
+            else "Decide how to proceed: use an allowed alternative (for a shell "
+            "command, a read-only variant), a different tool, or — if the block is "
+            "correct and you genuinely cannot proceed — say so and stop. Otherwise "
+            "continue the task where you left off."
+        ),
     ]
     # Per-class remediation, de-duplicated across the turn's refusals: several
     # blocked calls in one turn are usually the same wall hit from different

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -1263,6 +1263,117 @@ class TestRefusalRecovery:
         client.reject_tool.assert_called()
 
     @pytest.mark.asyncio
+    async def test_deny_after_an_answer_injects_awareness_not_a_redo(self, tmp_path):
+        """A denied call followed by a real answer must not ask for a resume.
+
+        The regression this pins: the turn answered the user's question despite
+        the block, then the continuation told it to "continue the task where you
+        left off" — so it answered the same question again, at full turn cost,
+        once per blocked call.
+        """
+        cb = _context_builder(
+            ToolHookResult.deny("Blocked by security policy: git push")
+        )
+        state, client = _make_state(tmp_path, context_builder=cb)
+        slot = _make_slot()
+        client.context_usage_pct = MagicMock(return_value=0.0)
+        client._client = client
+        client.last_prompt_stats = None
+
+        calls = {"n": 0}
+
+        def _stream(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Blocked, then the model answers anyway from what it already had.
+                return _async_iter(
+                    [
+                        _permission_event(),
+                        LLMEvent(kind=EVENT_TEXT_CHUNK, text="Here is the answer."),
+                        _complete_event(),
+                    ]
+                )
+            return _async_iter([_complete_event()])
+
+        client.stream = MagicMock(side_effect=_stream)
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+            if slot.task:
+                await slot.task
+
+        recovery = [
+            m["content"]
+            for m in slot.messages
+            if m.get("role") == "inject"
+            and m.get("content", "").startswith(REFUSAL_RECOVERY_PREFIX)
+        ]
+        assert recovery, "the block reason must still reach the model"
+        body = recovery[-1]
+        # Awareness is kept …
+        assert "security policy: git push" in body.lower()
+        assert "NOT a user action" in body
+        # … the redo instruction is not.
+        assert "continue the task where you left off" not in body
+        assert "Do NOT repeat" in body
+
+    @pytest.mark.asyncio
+    async def test_answer_before_the_block_also_gets_awareness_not_a_redo(self, tmp_path):
+        """The answer-THEN-block ordering must reach the same awareness body.
+
+        The sibling above covers block-then-answer, where the answer is still in
+        ``assistant_text`` at end of turn. Here the model answers FIRST and then
+        calls the blocked tool, and the tool boundary flushes that answer out of
+        ``assistant_text`` — so the end-of-turn buffer is empty even though the
+        user has already read the answer on screen. Keying the body on that buffer
+        alone sent the resume instruction for this ordering, which is the same
+        duplicate answer at full turn cost (GPT round on #8275).
+        """
+        cb = _context_builder(
+            ToolHookResult.deny("Blocked by security policy: git push")
+        )
+        state, client = _make_state(tmp_path, context_builder=cb)
+        slot = _make_slot()
+        client.context_usage_pct = MagicMock(return_value=0.0)
+        client._client = client
+        client.last_prompt_stats = None
+
+        calls = {"n": 0}
+
+        def _stream(*a, **kw):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # The answer lands first; the blocked call ends the turn after it.
+                return _async_iter(
+                    [
+                        LLMEvent(kind=EVENT_TEXT_CHUNK, text="Here is the answer."),
+                        _permission_event(),
+                        _complete_event(),
+                    ]
+                )
+            return _async_iter([_complete_event()])
+
+        client.stream = MagicMock(side_effect=_stream)
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+            if slot.task:
+                await slot.task
+
+        recovery = [
+            m["content"]
+            for m in slot.messages
+            if m.get("role") == "inject"
+            and m.get("content", "").startswith(REFUSAL_RECOVERY_PREFIX)
+        ]
+        assert recovery, "the block reason must still reach the model"
+        body = recovery[-1]
+        assert "security policy: git push" in body.lower()
+        assert "NOT a user action" in body
+        assert "continue the task where you left off" not in body
+        assert "Do NOT repeat" in body
+
+    @pytest.mark.asyncio
     async def test_clean_turn_does_not_enqueue_recovery(self, tmp_path):
         """An auto-approved tool with no refusal must not trigger recovery."""
         cb = _context_builder(ToolHookResult.auto_approve())
@@ -1316,6 +1427,43 @@ class TestBuildRefusalRecoveryPrompt:
         # The caller prepends REFUSAL_RECOVERY_PREFIX; the body must not.
         out = build_refusal_recovery_prompt([("bash", "reason")])
         assert REFUSAL_RECOVERY_PREFIX not in out
+
+    def test_answered_turn_gets_awareness_body_not_a_continuation(self):
+        """A turn that already answered must not be told to resume the task.
+
+        Same reasons, same remediation — but "continue the task where you left
+        off" is what made the model re-answer a question the user had already
+        read, once per blocked call.
+        """
+        out = build_refusal_recovery_prompt(
+            [("bash", "command accesses sensitive credential path")], answered=True
+        )
+        # The reason still reaches the model: on a backend without mid-turn steer
+        # this turn is the only channel for it.
+        assert "bash" in out
+        assert "sensitive credential path" in out
+        assert "NOT a user action" in out
+        # …but the premise flips from "ended the turn early" to awareness-only.
+        assert "ended the turn early" not in out
+        assert "this note is for awareness" in out
+        assert "continue the task where you left off" not in out
+        assert "Do NOT repeat" in out
+
+    def test_unanswered_turn_keeps_the_continuation_body(self):
+        out = build_refusal_recovery_prompt([("bash", "reason")], answered=False)
+        assert "ended the turn early" in out
+        assert "continue the task where you left off" in out
+        assert "this note is for awareness" not in out
+
+    def test_answered_keeps_per_class_remediation(self):
+        # The awareness variant drops the resume instruction, not the guidance:
+        # "how to do this properly" is the awareness the user is owed.
+        reason = "Blocked by security policy: cat ~/.aws/credentials"
+        assert build_refusal_recovery_prompt(
+            [("Running: cat creds", reason)], answered=True
+        ).count("How to do this properly:") == build_refusal_recovery_prompt(
+            [("Running: cat creds", reason)]
+        ).count("How to do this properly:")
 
 
 class TestPendingProjectReset:

--- a/test/test_deny_guidance.py
+++ b/test/test_deny_guidance.py
@@ -1276,5 +1276,27 @@ class TestNoticeIntegration:
         )
         assert "How to do this properly" not in body
 
+    def test_answered_body_never_tells_an_unfinished_turn_to_stop(self):
+        """`answered=True` means text was SENT, never that the task is DONE.
+
+        No caller can tell a delivered answer from a one-line preamble ("Let me
+        check the logs.") before the blocked call: both are plain prose flushed at
+        the same point in the stream. So the awareness body must not assert a
+        finished answer — a turn that had only narrated its intent would read that
+        as licence to stop with the work undone. Continue-from-there is the
+        default here; stopping is the narrow, explicitly conditional case.
+        """
+        body = build_refusal_recovery_prompt(
+            [("Running: git push", "Blocked by security policy: git push")], answered=True
+        )
+        # The anti-repeat guarantee, which is the whole point of the flag.
+        assert "Do NOT repeat" in body
+        assert "continue the task where you left off" not in body
+        # ...but it must not claim the turn answered, nor stop unconditionally.
+        assert "you already gave" not in body
+        assert "If the answer stands as given" not in body
+        assert "If the task is NOT finished, continue from there" in body
+        assert "Only if the task IS finished" in body
+
     def test_empty_refusals_still_yield_nothing(self):
         assert build_refusal_recovery_prompt([]) == ""


### PR DESCRIPTION
## Problem / Motivation

When a tool call is blocked by a Kiro Crew safety policy, the chat runner queues a
`[Tool refusal — automatic recovery]` continuation so the model learns the real
reason — the backend's own tool result for a rejected permission is the fixed
string `User denied tool execution`, and on a backend without mid-turn steer
(`ACP_BACKENDS_STEER` omits the claude backend, so `supports_steer` is `False` and
`notices_sent` is always 0) that continuation is the *only* channel for it.

The body of that continuation asserts the block "ended the turn early" and closes
with "continue the task where you left off". Both are false for a turn that went on
to answer anyway — the model routed around the block, or already had enough
evidence without the blocked call. Acting on the instruction makes it re-answer a
question the user has already read.

Observed in a live session: three separate blocked calls in one investigation
produced three recovery turns, and the user saw the same verdict written out three
times.

## Why it matters

Every duplicate is a full billed turn, and the count scales with the number of
blocked calls in the turn rather than with the number of open questions. The
user-visible damage is worse than the cost: an answer restated three times reads as
the agent losing track of the conversation, and it buries the one thing the recovery
turn exists to deliver — the block reason.

## What changed (motivation → approach → change)

**Symptom:** a turn that answered despite a policy block answers again, once per
blocked call.

**Root cause:** the recovery body has exactly one wording, and its premise ("the
turn ended early") is true in only one of the two cases that reach it. The decision
to queue was right; the *text* was wrong about what had happened.

**Change:** `build_refusal_recovery_prompt()` in
`src/kiro_crew/dashboard/state.py` gains an `answered` flag. When it is set, the
blocked-call list and the whole per-class `remediation_for` guidance block still go
out unchanged, but the framing becomes awareness rather than resumption, and the
closing instruction becomes an explicit prohibition on restating what was already
sent. The unanswered wording is reproduced byte-for-byte, so no existing recovery is
altered.

The flag means *text was sent*, never *the task is done*, and the body is worded to
match: continuing from there is the default, and the one-line-and-stop case is
conditioned explicitly on the task being finished. That distinction is load-bearing
because there is no way to tell a delivered answer from a one-line preamble ("Let me
check the logs.") before the blocked call — both are plain prose flushed at the same
point in the stream — so a body that asserted a finished answer would tell a turn
that had only narrated its intent to stop with the work undone.

The single call site in `src/kiro_crew/dashboard/chat_runner.py` passes
`answered=bool(_answer_text.strip()) or _produced_visible_output or
_turn_flushed_visible_text`. `_answer_text` is the turn's own answer with backend
control notices removed; `_produced_visible_output` covers the paths that reset
`assistant_text` after emitting it *without* a tool boundary (steer cut, compaction,
clear, agent switch); `_turn_flushed_visible_text` is new and covers the three
tool-boundary flushes (post-tool-group text, `EVENT_TOOL_CALL`, the permission flow),
which persist the segment and reset the buffer — so *answer → blocked call → turn
end* would otherwise reach the predicate with an empty `assistant_text` and be scored
unanswered. It is a separate flag rather than a widening of `_produced_visible_output`
because that flag's narrow meaning is what the promise-only guard below it depends on.

**Two things deliberately NOT done**, because the existing design rules them out:

- **No turn cap.** There has never been one on this path (`git log -S` for
  `refusal_recovery_depth`, `max_refusal`, `recovery_depth` finds nothing), and the
  absence is a choice rather than an omission: `should_queue_refusal_recovery`'s
  docstring records the asymmetry it was written for — skipping wrongly leaves the
  model with `User denied tool execution` and no correction, while queueing wrongly
  costs one turn the model would otherwise have been told twice. A cap is the
  *skipping* direction, and it bites hardest exactly when the model is most confused
  (after several blocks in a row). The sibling Stop-hook path does have
  `agent.max_stop_hook_nudges`, for a reason that does not transfer: a hook is an
  external program that can return `block` unconditionally forever with zero model
  agency, whereas a refusal chain requires the model to freely choose a fresh
  blocked call each turn.
- **No suppression of the recovery turn.** Dropping it would take the block reason
  with it, leaving the model's last word on the subject as `User denied tool
  execution` — which is how it starts attributing policy blocks to the user in later
  turns. Awareness-without-redo delivers the reason at the same one-turn cost the
  design already accepted.

No frontend change is needed: `RecoveryCard.tsx` dispatches on the prefix and counts
`- ` bullets, both unchanged, and the default body is byte-identical, so the
`capture-recovery-card.mjs` and `RecoveryCard.test.tsx` fixtures still match.

## Tests

`test/test_dashboard_approval.py`:

- `test_answered_turn_gets_awareness_body_not_a_continuation` — the reason is still
  present, `"ended the turn early"` and `"continue the task where you left off"` are
  gone, the awareness framing and `"Do NOT repeat"` are present.
- `test_unanswered_turn_keeps_the_continuation_body` — pins the default wording so a
  later edit cannot collapse the two modes into one.
- `test_answered_keeps_per_class_remediation` — equal `"How to do this properly:"`
  counts in both modes, so the awareness path cannot quietly drop the remediation
  guidance that is the reason the turn is dispatched at all.
- `test_deny_after_an_answer_injects_awareness_not_a_redo` — drives the real
  `_run_chat` with a `ToolHookResult.deny(...)` and a first stream that emits text,
  then asserts the injected recovery row carries the reason and the prohibition but
  not the redo instruction. This is the one that proves `answered=True` is reached on
  the production path, not only in the builder.
- `test_answer_before_the_block_also_gets_awareness_not_a_redo` — the ordering the
  predicate previously missed: text streamed *before* the blocked call, so the
  tool-boundary flush has emptied `assistant_text` by end of turn. Reverting
  `or _turn_flushed_visible_text` fails it with
  `assert 'continue th...you left off' not in ...`.

`test/test_deny_guidance.py`:

- `test_answered_body_never_tells_an_unfinished_turn_to_stop` — locks the
  sent-vs-finished distinction into the body itself: the awareness branch keeps
  `"Do NOT repeat"`, still avoids the resume instruction, and must make
  continue-from-there the default with the stop case explicitly conditioned on the
  task being finished. Without it, a turn that only narrated its intent before the
  block could be told to stop with the work undone.

## Manual verification

N/A — unit coverage sufficient: the last test drives the real `_run_chat` deny path
end to end, which is the integration this change lives on.

Local pre-push review, stated so the server lanes are read with it in mind: the
`opus` lane ran on its pinned `claude-opus-4.8` against the extracted
`claude-review.yml` contract and returned no findings. **The `gpt` lane did not
run.** This gateway rejects `gpt-5.6-sol`, `gpt-5.6-terra` and `gpt-5.6-luna` with
`Invalid value for config option model`, and `grok-4.6` too, so no model in or near
the `gpt-5.x` tier was reachable; the retry on `claude-opus-4.8` was stopped before
it finished. The server-side `codex-review` lane is therefore the first GPT pass on
this diff — treat its verdict as unpreviewed rather than as a re-run of a local
green.

## Related Issues

no linked issue: found while triaging a live session, not tracked.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: an automatic continuation whose text asserts a precondition ("the turn
ended early", "you were interrupted") that the code queuing it never checked — the
decision to queue and the claim about *why* it was queued need the same evidence.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
