### PR TITLE
fix(desktop): recover the main window from a hung renderer

### DIFF
--- a/website/electron/hang-recovery.js
+++ b/website/electron/hang-recovery.js
@@ -1,0 +1,144 @@
+"use strict";
+//
+// Hang self-healing for the main dashboard window.
+//
+// The problem this solves: `renderer-recovery.js` heals a renderer that DIES
+// (`render-process-gone` → bounded reload), but a renderer that HANGS emits
+// `unresponsive` instead — and the main window never listened for it. A wedged
+// renderer therefore left the window mapped, painted with its last frame, and
+// dead to all input, while the main process stayed healthy (timers, liveness
+// probes and update checks kept running), so nothing anywhere noticed.
+// Observed in the wild on 2026-09-03: the renderer went silent during a macOS
+// sleep dark-wake, the main process ran on for 5+ hours, and the user's only
+// way out of the frozen full-screen window was a power-button reboot
+// (issue #8264).
+//
+// The design converts the hang into the failure mode the app already heals:
+// after a grace period, `forcefullyCrashRenderer()` turns the hang into a
+// `render-process-gone` with reason `crashed`, which renderer-recovery's
+// bounded reload path picks up. The grace period exists because `unresponsive`
+// also fires for transient stalls (a long GC pause, post-wake CPU churn); a
+// `responsive` event within the grace window cancels the kill so a merely-slow
+// page keeps its state instead of losing it to a reload.
+//
+// No second retry budget lives here, deliberately. The loop terminates through
+// renderer-recovery's own bound: a force-crash produces either a bounded
+// reload (at most 3 per minute) or a give-up, and a dead, given-up renderer
+// emits no further `unresponsive` events — so this module can never fire
+// unboundedly on its own.
+//
+// Pure logic + injected dependencies: Electron main is not exercised by the
+// unit test runner, so the decisions have to be testable without a live
+// BrowserWindow (same pattern as renderer-recovery.js / perf-metrics.js).
+//
+
+/** How long a hung renderer gets to come back before it is force-crashed.
+ *  Electron only emits `unresponsive` after the renderer has already been
+ *  stuck for its internal responsiveness deadline, so this is additional
+ *  slack on top of that, not the total. */
+const DEFAULT_GRACE_MS = 15_000;
+
+/**
+ * Create the hang-recovery coordinator.
+ *
+ * @param {object} deps
+ * @param {() => void} deps.forceCrash      Kill the wedged renderer
+ *   (`webContents.forcefullyCrashRenderer()`), handing the failure to the
+ *   existing `render-process-gone` recovery path.
+ * @param {() => boolean} [deps.isQuitting] True while the app is shutting
+ *   down; a teardown-time hang must not race the quit with a forced crash.
+ * @param {(msg: string) => void} [deps.log]
+ * @param {(fn: () => void, ms: number) => any} [deps.setTimer]
+ * @param {(handle: any) => void} [deps.clearTimer]
+ * @param {number} [deps.graceMs]
+ * @returns {{
+ *   handleUnresponsive: () => string,
+ *   handleResponsive: () => string,
+ *   handleGone: () => string,
+ *   armed: boolean,
+ * }}
+ *   `handleUnresponsive` returns "armed" | "already-armed" | "ignored-quitting";
+ *   `handleResponsive` returns "recovered" | "idle";
+ *   `handleGone` returns "disarmed" | "idle".
+ */
+function createHangRecovery({
+  forceCrash,
+  isQuitting = () => false,
+  log = () => {},
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (handle) => clearTimeout(handle),
+  graceMs = DEFAULT_GRACE_MS,
+} = {}) {
+  if (typeof forceCrash !== "function") {
+    throw new Error("createHangRecovery: forceCrash is required");
+  }
+  const grace = Math.max(1, Number(graceMs) || DEFAULT_GRACE_MS);
+  let timer = null;
+
+  function expire() {
+    timer = null;
+    // Re-checked at expiry, not just at arming: a quit can begin during the
+    // grace window, and crashing the renderer mid-quit would fight teardown.
+    if (isQuitting()) {
+      log("renderer still unresponsive at grace expiry, but app is quitting — not crashing it");
+      return;
+    }
+    log(
+      `renderer unresponsive for ${grace}ms — force-crashing it so ` +
+        `render-process-gone recovery can reload the dashboard`,
+    );
+    try {
+      forceCrash();
+    } catch (e) {
+      // Never let a failed kill escape into Electron's event emitter.
+      log(`force-crash of hung renderer failed: ${e && e.message}`);
+    }
+  }
+
+  function handleUnresponsive() {
+    if (isQuitting()) {
+      log("renderer unresponsive during quit — not recovering");
+      return "ignored-quitting";
+    }
+    // Electron may re-emit while a page stays hung; one pending kill is enough.
+    if (timer !== null) return "already-armed";
+    log(`renderer unresponsive — force-crash in ${grace}ms unless it recovers`);
+    timer = setTimer(expire, grace);
+    return "armed";
+  }
+
+  function handleResponsive() {
+    if (timer === null) return "idle";
+    clearTimer(timer);
+    timer = null;
+    log("renderer responsive again within the grace window — hang recovery disarmed");
+    return "recovered";
+  }
+
+  function handleGone() {
+    // The renderer died on its own (or was killed) while the grace timer was
+    // armed. The timer must not survive it: `render-process-gone` reloads the
+    // dashboard into the SAME WebContents, and a fresh renderer never emits
+    // `responsive` (it only pairs with an `unresponsive` from the same
+    // process), so a stale expiry would force-crash the healthy replacement.
+    if (timer === null) return "idle";
+    clearTimer(timer);
+    timer = null;
+    log("renderer gone while hang recovery was armed — disarming the pending force-crash");
+    return "disarmed";
+  }
+
+  return {
+    handleUnresponsive,
+    handleResponsive,
+    handleGone,
+    get armed() {
+      return timer !== null;
+    },
+  };
+}
+
+module.exports = {
+  createHangRecovery,
+  DEFAULT_GRACE_MS,
+};

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -170,6 +170,7 @@
       "gateway-liveness.js",
       "gateway-recovery.js",
       "renderer-recovery.js",
+      "hang-recovery.js",
       "native-logging.js",
       "disable-gpu.js",
       "memory-watch-log.js",

--- a/website/electron/test/hang-recovery.test.js
+++ b/website/electron/test/hang-recovery.test.js
@@ -1,0 +1,170 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { createHangRecovery, DEFAULT_GRACE_MS } = require("../hang-recovery");
+
+// A coordinator wired entirely to fakes: Electron main is not available here,
+// and a real hung WebContents cannot be simulated in a unit test at all. Timers
+// are captured, not scheduled, so a test fires expiry deterministically.
+function harness(overrides = {}) {
+  const crashes = [];
+  const logs = [];
+  const timers = new Map();
+  let nextHandle = 1;
+  let quitting = false;
+  const rec = createHangRecovery({
+    forceCrash: () => crashes.push(timers.size),
+    isQuitting: () => quitting,
+    log: (m) => logs.push(m),
+    setTimer: (fn, ms) => {
+      const handle = nextHandle++;
+      timers.set(handle, { fn, ms });
+      return handle;
+    },
+    clearTimer: (handle) => {
+      timers.delete(handle);
+    },
+    ...overrides,
+  });
+  return {
+    rec,
+    crashes,
+    logs,
+    timers,
+    fire: () => {
+      // Run every pending timer, the way expiry would.
+      for (const [handle, { fn }] of [...timers]) {
+        timers.delete(handle);
+        fn();
+      }
+    },
+    setQuitting: (v) => {
+      quitting = v;
+    },
+  };
+}
+
+test("a hang arms the grace timer and expiry force-crashes the renderer", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleUnresponsive(), "armed");
+  assert.strictEqual(h.rec.armed, true);
+  assert.strictEqual(h.crashes.length, 0, "no crash before the grace expires");
+  h.fire();
+  assert.strictEqual(h.crashes.length, 1);
+  assert.match(h.logs.join("\n"), /force-crashing/);
+});
+
+test("responsive within the grace window disarms without crashing", () => {
+  const h = harness();
+  h.rec.handleUnresponsive();
+  assert.strictEqual(h.rec.handleResponsive(), "recovered");
+  assert.strictEqual(h.rec.armed, false);
+  assert.strictEqual(h.timers.size, 0, "the pending timer is cleared");
+  h.fire();
+  assert.strictEqual(h.crashes.length, 0);
+});
+
+test("responsive with nothing armed is an idle no-op", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleResponsive(), "idle");
+  assert.strictEqual(h.crashes.length, 0);
+});
+
+test("repeated unresponsive while armed does not stack timers", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleUnresponsive(), "armed");
+  assert.strictEqual(h.rec.handleUnresponsive(), "already-armed");
+  assert.strictEqual(h.rec.handleUnresponsive(), "already-armed");
+  assert.strictEqual(h.timers.size, 1);
+  h.fire();
+  assert.strictEqual(h.crashes.length, 1, "one hang episode, one crash");
+});
+
+test("a hang during quit is ignored", () => {
+  const h = harness();
+  h.setQuitting(true);
+  assert.strictEqual(h.rec.handleUnresponsive(), "ignored-quitting");
+  assert.strictEqual(h.rec.armed, false);
+  h.fire();
+  assert.strictEqual(h.crashes.length, 0);
+});
+
+test("a quit that begins during the grace window suppresses the crash at expiry", () => {
+  const h = harness();
+  h.rec.handleUnresponsive();
+  h.setQuitting(true);
+  h.fire();
+  assert.strictEqual(h.crashes.length, 0);
+  assert.match(h.logs.join("\n"), /quitting — not crashing/);
+});
+
+test("a throwing forceCrash is contained and logged", () => {
+  const h = harness({
+    forceCrash: () => {
+      throw new Error("boom");
+    },
+  });
+  h.rec.handleUnresponsive();
+  assert.doesNotThrow(() => h.fire());
+  assert.match(h.logs.join("\n"), /force-crash of hung renderer failed/);
+  assert.match(h.logs.join("\n"), /boom/);
+});
+
+test("a new hang after an expiry can arm again", () => {
+  const h = harness();
+  h.rec.handleUnresponsive();
+  h.fire();
+  assert.strictEqual(h.crashes.length, 1);
+  assert.strictEqual(h.rec.handleUnresponsive(), "armed");
+  h.fire();
+  assert.strictEqual(h.crashes.length, 2);
+});
+
+test("a renderer death inside the grace window disarms the pending crash", () => {
+  // The hung renderer can crash on its own before the grace expires;
+  // render-process-gone then reloads the dashboard into the SAME WebContents,
+  // and the fresh renderer never emits `responsive` — so without the disarm
+  // the stale expiry would force-crash the healthy replacement.
+  const h = harness();
+  h.rec.handleUnresponsive();
+  assert.strictEqual(h.rec.handleGone(), "disarmed");
+  assert.strictEqual(h.rec.armed, false);
+  assert.strictEqual(h.timers.size, 0, "the pending timer is cleared");
+  h.fire();
+  assert.strictEqual(h.crashes.length, 0, "the replacement renderer is not killed");
+  assert.match(h.logs.join("\n"), /renderer gone while hang recovery was armed/);
+});
+
+test("renderer death with nothing armed is an idle no-op", () => {
+  const h = harness();
+  assert.strictEqual(h.rec.handleGone(), "idle");
+  assert.strictEqual(h.crashes.length, 0);
+});
+
+test("a hang in the reloaded renderer can re-arm after a mid-grace death", () => {
+  const h = harness();
+  h.rec.handleUnresponsive();
+  h.rec.handleGone();
+  assert.strictEqual(h.rec.handleUnresponsive(), "armed");
+  h.fire();
+  assert.strictEqual(h.crashes.length, 1, "the new hang episode still recovers");
+});
+
+test("forceCrash is required", () => {
+  assert.throws(() => createHangRecovery({}), /forceCrash is required/);
+});
+
+test("the default grace is sane and overridable", () => {
+  assert.ok(DEFAULT_GRACE_MS >= 1000, "default grace is at least a second");
+  const captured = [];
+  const rec = createHangRecovery({
+    forceCrash: () => {},
+    setTimer: (fn, ms) => {
+      captured.push(ms);
+      return 1;
+    },
+    clearTimer: () => {},
+    graceMs: 250,
+  });
+  rec.handleUnresponsive();
+  assert.deepStrictEqual(captured, [250]);
+});

--- a/website/electron/window-lifecycle.js
+++ b/website/electron/window-lifecycle.js
@@ -5,6 +5,7 @@ const path = require("path");
 
 const { createTokenRetryHandler, dashboardRetryPath } = require("./token-retry");
 const { createRendererRecovery } = require("./renderer-recovery");
+const { createHangRecovery } = require("./hang-recovery");
 const { armSplashHistoryClear } = require("./splash-history");
 const { hideToTray, cancelPendingTrayHide } = require("./hide-to-tray");
 const { attachHtmlFullScreen } = require("./html-fullscreen");
@@ -990,12 +991,31 @@ function createWindowLifecycle(options) {
       },
     });
 
+    // A renderer that HANGS never reaches the `render-process-gone` handler
+    // below: it emits `unresponsive` instead, and with no listener the window
+    // stayed frozen until the user rebooted (#8264). Convert a sustained hang
+    // into the crash the bounded recovery already heals; `responsive` within
+    // the grace window cancels the kill so a transient stall keeps its state.
+    const hangRecovery = createHangRecovery({
+      isQuitting,
+      log: glog,
+      forceCrash: () => {
+        if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return;
+        mainWindow.webContents.forcefullyCrashRenderer();
+      },
+    });
+    mainWindow.webContents.on("unresponsive", () => hangRecovery.handleUnresponsive());
+    mainWindow.webContents.on("responsive", () => hangRecovery.handleResponsive());
+
     mainWindow.webContents.on("render-process-gone", (_event, details) => {
       // Flush the trajectory before the terminal event so the log stays causal.
       // An in-flight content trace is write-or-lose: stopRecording is the only
       // operation that lands it, and a renderer death is its most useful end.
       for (const line of memoryWatchLog.flush()) glog(line);
       void cageTrace.stopForCrash();
+      // A hung renderer can die on its own inside the grace window; the armed
+      // force-crash must not survive into the reloaded replacement renderer.
+      hangRecovery.handleGone();
       rendererRecovery.handleGone(details || {});
     });
 


### PR DESCRIPTION
<!-- no-visual-delta -->

## Problem / Motivation

A main-window renderer that **hangs** (as opposed to crashing) is terminal: the window stays mapped, painted with its last frame, and dead to all input, while the main process stays healthy — timers, gateway liveness probes, and update checks keep running, so nothing anywhere notices. Observed in the wild on 2026-09-03: the renderer went silent during a macOS sleep dark-wake and the app ran on frozen for 5+ hours; the only way out of the frozen full-screen window was a power-button reboot.

## Why it matters

`renderer-recovery.js` already heals a renderer that *dies* (`render-process-gone` → bounded reload), but the main window had no `unresponsive` handler — only the Mochi panel window did (`mochi/panelWindow.js`). So the app's most visible surface had a failure mode with no recovery and no user escape short of killing the process or rebooting. Any user whose renderer wedges (GPU compositor faults around sleep/wake are one documented trigger) loses their session to a hard reboot.

## What changed (motivation → approach → change)

Symptom: frozen, input-dead main window with a healthy main process. Root cause: Electron reports a hung renderer via `unresponsive`, and the main window never listened for it, so the hang never entered any recovery path.

Approach: rather than build a second recovery mechanism, convert the hang into the failure mode the app already heals. New `website/electron/hang-recovery.js` (pure logic + injected dependencies, same testability pattern as `renderer-recovery.js`):

- On `unresponsive`: arm a 15s grace timer (re-emits while armed are deduped; hangs during quit are ignored).
- On `responsive` within the window: disarm — a transient stall (long GC pause, post-wake CPU churn) keeps its page state.
- On `render-process-gone` within the window: disarm — the hung renderer can die on its own mid-grace, and the reloaded replacement in the same `WebContents` never emits `responsive`, so a stale expiry would force-crash the healthy new renderer.
- At expiry (quit re-checked): `webContents.forcefullyCrashRenderer()`, which raises `render-process-gone` with reason `crashed` — a reason `renderer-recovery.js` treats as recoverable — handing the failure to the existing bounded reload (≤3 attempts/minute, then give-up).

Deliberately no second retry budget here: a force-crash lands in renderer-recovery's bound, and a dead, given-up renderer emits no further `unresponsive`, so the loop terminates through the existing bound.

`window-lifecycle.js` wires the three events on the main window's `WebContents` (which survives reloads, so re-arming after recovery works without re-registration).

Note on the `package.json` change: it adds `"hang-recovery.js"` to the electron-builder `files` allowlist so the new module ships in the packaged app — no dependency added or changed.

## Tests

`website/electron/test/hang-recovery.test.js` — 13 tests on a fully-faked harness (captured timers, deterministic expiry):

- hang → grace → force-crash fires exactly once
- `responsive` within grace disarms without crashing; idle `responsive` is a no-op
- repeated `unresponsive` doesn't stack timers (one episode, one crash)
- hang during quit is ignored; quit beginning mid-grace suppresses the crash at expiry
- a throwing `forceCrash` is contained and logged, never escapes into the emitter
- a new hang after expiry re-arms
- renderer death mid-grace disarms the pending crash (the reloaded replacement is not killed); idle death is a no-op; a hang in the reloaded renderer re-arms
- `forceCrash` is required; default grace ≥1s and overridable

Full electron suite passes locally (`npm run test:electron`).

## Manual verification

The original incident is reproducible only via a real renderer wedge (e.g. around macOS sleep/wake), which a unit test cannot simulate. The unit tests cover every decision the module makes; the Electron-side contract (`forcefullyCrashRenderer()` → `render-process-gone` reason `crashed` → recoverable) is documented Electron behavior and matches `renderer-recovery.js`'s existing `RECOVERABLE_REASONS`.

**Why no screenshot:** main-process hang-recovery logic, no pixel changes.

## Related Issues

Fixes #8264

## Pattern harvest

Rule candidate: review-prompt
Pattern: a window wiring `render-process-gone` without also wiring `unresponsive`/`responsive` leaves the hung-renderer failure mode unrecoverable.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — module-level docs in the new file
- [x] No secrets, credentials, or internal references in the diff
