### PR TITLE
ci: make gradients a UX review finding

### DIFF
--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -494,6 +494,19 @@ jobs:
                - Theme tokens and existing ui/ primitives over hand-rolled
                  components or hardcoded colors; platform convention over novel
                  widgets for standard jobs.
+               - Flat fills: the brand system is flat, so a NEW decorative
+                 gradient fill (linear-, radial-, or conic-gradient as a
+                 background or surface color) on chrome, a dialog, or an
+                 exported image such as a share card is a finding. A fill is
+                 one solid token (or the brand purple #7c3aed on an
+                 outward-facing artifact). "Looks premium" is not an
+                 exception; a gradient also bands under every social
+                 platform's re-encode. NOT a finding: functional gradients
+                 (mask-image scroll-edge fades, loading shimmer, streaming
+                 glow) and shipped gradient mechanisms (appstore gradient art
+                 in components/appstore/gradient.ts, the session 'gradient'
+                 color mode) — the rule is documented in
+                 website/docs/theming-contract.md.
                - Habituation: flag diffs that MOVE or REORDER existing controls
                  without functional need (breaks muscle memory), and duplicate
                  new paths to an already-reachable action.

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -369,6 +369,19 @@ jobs:
                - Theme tokens and existing ui/ primitives over hand-rolled
                  components or hardcoded colors; platform convention over novel
                  widgets for standard jobs.
+               - Flat fills: the brand system is flat, so a NEW decorative
+                 gradient fill (linear-, radial-, or conic-gradient as a
+                 background or surface color) on chrome, a dialog, or an
+                 exported image such as a share card is a finding. A fill is
+                 one solid token (or the brand purple #7c3aed on an
+                 outward-facing artifact). "Looks premium" is not an
+                 exception; a gradient also bands under every social
+                 platform's re-encode. NOT a finding: functional gradients
+                 (mask-image scroll-edge fades, loading shimmer, streaming
+                 glow) and shipped gradient mechanisms (appstore gradient art
+                 in components/appstore/gradient.ts, the session 'gradient'
+                 color mode) — the rule is documented in
+                 website/docs/theming-contract.md.
                - Habituation: flag diffs that MOVE or REORDER existing controls
                  without functional need (breaks muscle memory), and duplicate
                  new paths to an already-reachable action.

--- a/website/docs/theming-contract.md
+++ b/website/docs/theming-contract.md
@@ -32,6 +32,18 @@ with the theme CSS custom properties or Tailwind classes mapped to them,
 
 The 54 CSS variables are the single source of truth for color. They are the
 customization surface a theme (built-in, custom, or installed) can set.
+
+**Fills are flat.** The brand system is flat: a new decorative gradient fill
+(`linear-`, `radial-`, or `conic-gradient` used as a background or surface
+color) on chrome, a dialog, or an exported image such as a share card is a UX
+review finding. A fill is one solid token, or the brand purple `#7c3aed` on an
+outward-facing artifact. "Looks premium" is not an exception; a gradient also
+bands under every social platform's re-encode. Functional gradients are not
+fills and are fine: `mask-image` scroll-edge fades, loading shimmer, and the
+streaming glow. So are the shipped gradient mechanisms — the appstore gradient
+art in `components/appstore/gradient.ts` (which reads as content, not chrome)
+and the session `'gradient'` color mode. The UX review lane
+(`.github/workflows/ux-review.yml` and its fork variant) applies this rule.
 Theme blocks in `index.css` also set a few non-color properties that are
 deliberately NOT on the allowlist: the font tokens (`--font-body`, `--mono`)
 and radii are injected as fixed defaults by `buildCustomThemeCss` (fonts are a


### PR DESCRIPTION
## Summary

Adds a **flat-fill rule** to the UX review lane (main + fork variants): a NEW decorative gradient fill (`linear-`, `radial-`, `conic-gradient` used as a background or surface color) on chrome, a dialog, or an exported image such as a share card is a finding. The expected fill is one solid theme token, or the brand purple `#7c3aed` on an outward-facing artifact.

The rule is scoped to the defect class it comes from. It explicitly does **not** flag functional gradients (`mask-image` scroll-edge fades, loading shimmer, streaming glow) or the shipped gradient mechanisms (appstore gradient art in `components/appstore/gradient.ts`, which reads as content rather than chrome, and the session `'gradient'` color mode) — those are deliberate and test-pinned, and an "any gradient" rule would misfire on every PR that touches them.

The rule is stated once in `website/docs/theming-contract.md` (next to the existing "never a hardcoded `#hex`" rule, reachable from `website/AGENTS.md`), so an author sees it before review; both reviewer prompts cite that doc.

## Why

The brand system is flat. A gradient background on a share card in #8040 went through the UX lane without comment because no lens named gradients; it was caught by a human instead. This puts the rule where the reviewer will apply it every time — lens 7 (Consistency & Habituation), next to the existing "theme tokens over hardcoded colors" bullet.

Prompt + doc change, no new lane/gate/script. Both `ux-review.yml` and `fork-ux-review.yml` get the identical bullet so fork PRs are held to the same bar.

## Tested

- Both workflow files parse as YAML
- `scripts/check_brand_name.py` (added lines) and `scripts/docs-lint.sh` pass locally
- CI runs the workflow-shape and docs tests

no linked issue: prompt-only reviewer tightening surfaced during #8040 review.
