### PR TITLE
fix(chat): recover synthetic backend retry turns

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -168,8 +168,31 @@ send time.
   internal orchestration instruction is never persisted as user-authored
   history or mirrored to linked channels), draining one does not cancel a
   pending synthesis, and the tag is merge-breaking so a nudge is never folded
-  into a `[N queued messages merged]` user turn. At `_prompt_depth > 0` the ladder is disabled entirely (terminal
-  notice on the first empty) to prevent nested-turn re-queue loops.
+  into a `[N queued messages merged]` user turn. At `_prompt_depth > 0` the
+  ladder is disabled entirely (terminal notice on the first empty) to prevent
+  nested-turn re-queue loops.
+- **Kiro CLI synthetic turn-failure recovery** (dashboard chat runner, depth-0
+  turns only): Kiro CLI can finish a failed inner agent loop as ACP
+  `Ok`/`UserTurnEnd` with the exact assistant sentence `I hit an issue while
+  processing your request. Please retry.` after tools already ran. The runner
+  requires positive Kiro-backend identity, at least one tool call in the turn,
+  the exact sentence, and that the current user message did not itself contain
+  that sentence before treating it as provider control output: it removes the
+  trailing live chunks, never persists the sentence as an assistant answer,
+  and replaces any already-streamed browser row with an empty assistant frame
+  before the recovery notice (the terminal authoritative refresh removes that
+  unpersisted blank row). If tools changed files before the failure, file-change
+  snapshots are attached only to a synthetic assistant anchor created by this
+  turn, never to an assistant message from an earlier turn. Completion token
+  counts are deliberately not evidence:
+  Kiro's credit-only accounting reports zero output tokens for legitimate model
+  text as well as for this sentinel. The failed turn is never recorded as
+  successful, and the runner queues one `_POSTTOKEN_RECOVER_MSG` continuation on the same live session. The continuation preserves completed
+  tool results and explicitly forbids replaying them. It shares the post-token
+  one-shot budget, respects Stop, queued user follow-ups, pending steers and
+  stage-execution boundaries, and a repeated sentinel is terminal rather than a
+  loop. Broader `please retry` prose and sentences that merely quote the literal
+  are ordinary model output.
 - **Leaked tool-call notice** (dashboard chat runner, depth-0 turns only,
   issue #6112): a turn that ends normally with an invoke block emitted as
   TEXT and zero tool calls executed — the model wrote its invocation into the

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -287,9 +287,11 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     SYNTHETIC_RECOVERY_KIND,
     TRANSIENT_RETRY_KIND,
     RecoveryPayload,
+    contains_upstream_turn_failure_text,
     is_promise_only_terminal,
     is_synthetic_payload_item,
     is_synthetic_recovery_item,
+    is_upstream_turn_failure_text,
     mint_options_token,
     payload_for_replay,
     should_continue_after_compaction,
@@ -1411,13 +1413,17 @@ def _snapshot_write_target(
     return {"path": path, "content": content}
 
 
-def _flush_file_changes(slot: "_ChatSlot") -> None:
-    """Attach accumulated file changes to the last assistant message.
+def _flush_file_changes(slot: "_ChatSlot", turn_boundary: int = 0) -> None:
+    """Attach accumulated file changes to this turn's last assistant message.
 
     Dedups by path (first before, last after), reads the AFTER content from
     disk, and writes the list to message meta as ``file_changes``. Called on
     every exit path (success / cancel / error) so users always see what was
     modified, even on aborted turns.
+
+    ``turn_boundary`` is ``len(slot.messages)`` captured at turn start. Limiting
+    the reverse scan to that slice prevents an error-only write turn from
+    attaching its changes to the previous turn's assistant row.
     """
     # Defensive: only proceed when a real, non-empty list is present. Tests
     # using MagicMock slots leave _file_changes as a MagicMock attribute
@@ -1463,10 +1469,11 @@ def _flush_file_changes(slot: "_ChatSlot") -> None:
     # would silently discard real changes past the snapshot limit or inside
     # redacted spans.
     fc_list = list(deduped.values())
-    # Attach to the most recent assistant message; if none exists (turn
-    # aborted before any text), create a synthetic message so the chips
-    # still surface.
-    for m in reversed(slot.messages):
+    # Attach to the most recent assistant message created by this turn; if none
+    # exists (turn aborted before any text), create a synthetic message so the
+    # chips still surface without mutating an earlier turn.
+    boundary = max(0, turn_boundary)
+    for m in reversed(slot.messages[boundary:]):
         if m.get("role") == "assistant":
             m.setdefault("meta", {})["file_changes"] = fc_list
             break
@@ -4702,12 +4709,15 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     _stop_since_enqueue = _cur_stop_gen != getattr(slot, "_promise_only_stop_gen", _cur_stop_gen)
     _user_input = bool(getattr(slot, "_pending_steers", None)) or _has_user_queued_followup(slot)
     if _should_suppress_requeue(slot) or slot._stopping or _stop_since_enqueue or _user_input:
-        # Both auto-continuations carry the same hazard and the same fix: the
-        # post-compaction resume would re-drive a request the user has since
-        # stopped or replaced. Purge either one, and reset whichever one-shot
-        # budget was spent (both resets are idempotent, so no need to tell them
-        # apart per item).
-        _purgeable = (_PROMISE_ONLY_CONTINUE_MSG, _COMPACTION_CONTINUE_MSG)
+        # All three auto-continuations carry the same hazard and the same fix:
+        # each would re-drive a request the user has since stopped or replaced.
+        # Purge them, and reset whichever one-shot budget was spent (the resets
+        # are idempotent, so no need to tell them apart per item).
+        _purgeable = (
+            _PROMISE_ONLY_CONTINUE_MSG,
+            _COMPACTION_CONTINUE_MSG,
+            _POSTTOKEN_RECOVER_MSG,
+        )
         superseded = [
             q
             for q in slot._queue
@@ -4726,6 +4736,7 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
             # value cannot re-trigger this block on a later drain.
             slot._promise_only_retries = 0
             slot._compaction_continue_retries = 0
+            slot._posttoken_retry_used = False
             slot._promise_only_stop_gen = _cur_stop_gen
             # The earlier "auto-continuing once" notice and the card's "continuing
             # automatically" detail now stand uncorrected; append a one-line
@@ -4740,7 +4751,7 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
             )
             slot.append("notice", _correction, "msg msg-info")
             logger.info(
-                "Purged %d superseded promise-only continuation(s) before dispatch "
+                "Purged %d superseded auto-continuation(s) before dispatch "
                 "for slot %s (user_input=%s stop_since_enqueue=%s)",
                 len(superseded),
                 slot.key,
@@ -5225,6 +5236,9 @@ async def _run_chat(
     # suspended and reset _stop_state to idle before continuation processing.
     # The monotonic generation preserves that user intent across the whole call.
     _stop_gen_at_entry = slot._stop_generation
+    # Fallback boundary for failures during asynchronous turn setup. Reset at
+    # provider dispatch below after setup-only rows have been appended.
+    _turn_msg_boundary = len(slot.messages)
 
     session_key = effective_session_key(slot)
     sessions = getattr(state, "sessions", None)
@@ -5651,6 +5665,11 @@ async def _run_chat(
     # `getattr(state, "sessions", None)` above).
     _stop_gen_turn_start = getattr(slot, "_stop_generation", 0)
     _retrying_empty = False
+    # Kiro CLI can end a failed inner agent loop with an ordinary Ok/UserTurnEnd
+    # carrying one fixed assistant sentence. That is provider control output, not
+    # an answer; this flag keeps it out of success, consolidation and budget-reset
+    # paths whether the one-shot continuation is eligible or terminal.
+    _upstream_turn_failed = False
     # Set when the turn ended on a promise-only final message and we injected one
     # continuation (see the promise-only guard near turn completion). Like
     # _retrying_empty it suppresses success-recording for this non-landing turn.
@@ -9608,6 +9627,51 @@ async def _run_chat(
         # and the branch below is what decides whether one was given.
         _answer_text = _answer_text_only(assistant_text, _compaction_notice_chunks)
 
+        # Kiro CLI's inner agent loop can fail after tool execution yet close ACP
+        # as a normal Ok/UserTurnEnd with this fixed sentence. Without this
+        # intercept Kiro Crew persists the sentence, records a success and leaves
+        # the user to type the same request again. Treat the exact sentinel as
+        # control output only after real tool activity, and never when the current
+        # request itself quoted or asked for it. The continuation stays on the
+        # SAME live session, whose context contains the completed tool results,
+        # and explicitly forbids replaying them.
+        _upstream_turn_failed = (
+            _stop_reason == STOP_REASON_END_TURN
+            and bool(getattr(client, "is_kiro_backend", False))
+            and _turn_tool_calls > 0
+            and not contains_upstream_turn_failure_text(message)
+            and not _compaction_notice_chunks
+            and is_upstream_turn_failure_text(_answer_text)
+        )
+        if _upstream_turn_failed:
+            logger.warning(
+                "Kiro CLI synthetic turn failure for slot %s "
+                "(tool_calls=%d, posttoken_retry_used=%s)",
+                slot.key,
+                _turn_tool_calls,
+                slot._posttoken_retry_used,
+            )
+            # Remove only the trailing live chunks that rendered the sentinel;
+            # earlier finalized assistant segments and tool cards stay intact.
+            slot.purge_chunks()
+            # purge_chunks is server-only, but StreamRedactor may already have
+            # broadcast the sentinel's safe prefix as chat_chunk frames. Replace
+            # that live browser row with an empty assistant before the recovery
+            # notice arrives; chat_done's authoritative refresh then removes the
+            # blank row because it was deliberately never persisted.
+            state.broadcast_ws(
+                "chat_message",
+                {
+                    "slot": slot.key,
+                    "role": "assistant",
+                    "content": "",
+                    "cls": "msg msg-a",
+                },
+            )
+            _wsred.reset()
+            assistant_text = ""
+            _answer_text = ""
+
         # A turn whose ONLY assistant text was such a notice still has to reach
         # the wire and the transcript, but it must not take the answer branch:
         # the post-compaction continuation is an `elif` UNDER that branch, so
@@ -9676,6 +9740,38 @@ async def _run_chat(
                     )
             _flush_text_stream()
             _flush_segment(state, slot, assistant_text, broadcast=False)
+        elif _upstream_turn_failed:
+            _will_recover = (
+                _prompt_depth == 0
+                and not slot._in_stage_execution
+                and not slot._posttoken_retry_used
+                and not _should_suppress_requeue(slot)
+                and getattr(slot, "_stop_generation", _stop_gen_turn_start) == _stop_gen_turn_start
+                and not _has_user_queued_followup(slot)
+                and not getattr(slot, "_pending_steers", None)
+            )
+            slot.append(
+                "error",
+                (
+                    "⟳ Backend turn failed — recovering…"
+                    if _will_recover
+                    else "⟳ Backend turn failed — please retry."
+                ),
+                "msg msg-err",
+                meta={"kind": TRANSIENT_RETRY_KIND} if _will_recover else None,
+            )
+            if _will_recover:
+                # Share the post-activity one-shot: both paths resume after model
+                # activity, and a sentinel on this synthetic continuation must
+                # terminate rather than enqueue itself forever.
+                slot._posttoken_retry_used = True
+                _queue_recovery(
+                    0,
+                    _POSTTOKEN_RECOVER_MSG,
+                    kind=SYNTHETIC_RECOVERY_KIND,
+                    payload=RecoveryPayload.CONTINUATION,
+                )
+                slot._promise_only_stop_gen = getattr(slot, "_stop_generation", 0)
         elif _stop_reason == STOP_REASON_REFUSAL:
             # Model-side content refusal (kiro-cli passes Anthropic's `refusal`
             # stop reason through verbatim) with no accompanying text. This is
@@ -10122,8 +10218,8 @@ async def _run_chat(
                 turn_boundary=_turn_msg_boundary,
                 model=_turn_model,
             )
-            # Attach accumulated file changes to last assistant message before persist
-            _flush_file_changes(slot)
+            # Attach accumulated file changes to this turn's assistant anchor before persist.
+            _flush_file_changes(slot, turn_boundary=_turn_msg_boundary)
             # Save to history and trigger memory consolidation
             await save_slot_off_loop(state, slot)
         # Reset ALL retry budgets once the cycle completes (success OR the
@@ -10134,6 +10230,7 @@ async def _run_chat(
         # mask the transient-failure retry accounting).
         if (
             not _retrying_empty
+            and not _upstream_turn_failed
             and not _recovering_promise
             and not _recovering_compaction
             and not _noticed_leak
@@ -10207,6 +10304,7 @@ async def _run_chat(
             logger.info("Turn cancelled by user for slot %s", slot.key)
         elif (
             not _retrying_empty
+            and not _upstream_turn_failed
             and not _recovering_promise
             and not _recovering_compaction
             and not _noticed_leak
@@ -10219,6 +10317,7 @@ async def _run_chat(
         if (
             _stop_reason != STOP_REASON_CANCELLED
             and not _retrying_empty
+            and not _upstream_turn_failed
             and not _recovering_promise
             and not _recovering_compaction
             and not _noticed_leak
@@ -10932,14 +11031,18 @@ async def _run_chat(
                 _safe, _ = redact_credentials(_safe)
                 slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
-            # Surface a brief recovery notice (one append). Tag it ONLY when the
-            # requeue below will actually happen, or a terminal notice reads as pending.
-            _will_recover = not _should_suppress_requeue(slot) and _prompt_depth == 0
-            slot.append(
-                "error",
-                "⟳ Backend hiccup — recovering…",
-                "msg msg-err",
-                meta={"kind": TRANSIENT_RETRY_KIND} if _will_recover else None,
+            # Decide eligibility before AND after the backoff. Stop is a
+            # monotonic generation because it can resolve back to idle during the
+            # await; point-in-time state alone forgets that intervention. User
+            # follow-ups and steers get the same precedence as the dispatch-time
+            # purge, so nothing runner-authored jumps ahead of newer intent.
+            _will_recover = (
+                _prompt_depth == 0
+                and not slot._in_stage_execution
+                and not _should_suppress_requeue(slot)
+                and getattr(slot, "_stop_generation", _stop_gen_turn_start) == _stop_gen_turn_start
+                and not _has_user_queued_followup(slot)
+                and not getattr(slot, "_pending_steers", None)
             )
             if _will_recover:
                 _delay = transient_retry_delay(1)  # single short backoff (one-shot)
@@ -10950,12 +11053,31 @@ async def _run_chat(
                     _delay,
                     _msg[:80],
                 )
-                # Back off, then re-queue the CONTINUE instruction onto the SAME
-                # live session (no reset). The partial + notice are already shown;
-                # the model resumes from the preserved context and appends the
-                # continued answer as a new message below. Consume the one-shot
-                # allowance HERE — only a real enqueue burns it.
                 await asyncio.sleep(_delay)
+                _will_recover = (
+                    not slot._in_stage_execution
+                    and not _should_suppress_requeue(slot)
+                    and getattr(slot, "_stop_generation", _stop_gen_turn_start)
+                    == _stop_gen_turn_start
+                    and not _has_user_queued_followup(slot)
+                    and not getattr(slot, "_pending_steers", None)
+                )
+            # Tag only a notice backed by a real queued recovery. A Stop or
+            # follow-up during backoff leaves a terminal, honest receipt.
+            slot.append(
+                "error",
+                (
+                    "⟳ Backend hiccup — recovering…"
+                    if _will_recover
+                    else "⟳ Backend hiccup — recovery cancelled."
+                ),
+                "msg msg-err",
+                meta={"kind": TRANSIENT_RETRY_KIND} if _will_recover else None,
+            )
+            if _will_recover:
+                # Re-queue the CONTINUE instruction onto the SAME live session
+                # (no reset). The model resumes from preserved tool results.
+                # Consume the allowance only when enqueue actually happens.
                 slot._posttoken_retry_used = True
                 _queue_recovery(
                     0,
@@ -10963,10 +11085,11 @@ async def _run_chat(
                     kind=SYNTHETIC_RECOVERY_KIND,
                     payload=RecoveryPayload.CONTINUATION,
                 )
-            # else: Stop active (_should_suppress_requeue) or nested turn
-            # (_prompt_depth != 0) — do NOT requeue; partial + notice already
-            # shown, so the streamed answer survives in the transcript. The
-            # allowance is left UNconsumed so a later turn can still recover once.
+                # Preserve the turn-start generation so dispatch-time purge also
+                # catches a Stop that lands after enqueue.
+                slot._promise_only_stop_gen = _stop_gen_turn_start
+            # else: Stop/user intervention/nested or stage turn — do NOT requeue;
+            # partial output survives and the one-shot remains available.
         else:
             if assistant_text:
                 _safe, _ = redact_exfiltration_urls(assistant_text)
@@ -11253,7 +11376,7 @@ async def _run_chat(
         # a raise here cannot skip the re-arm below and re-introduce the orphan
         # bug this fix prevents.
         try:
-            _flush_file_changes(slot)
+            _flush_file_changes(slot, turn_boundary=_turn_msg_boundary)
         except Exception:
             logger.debug("_flush_file_changes failed", exc_info=True)
         # This turn consumed the one-shot post-compaction re-injection flag but

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1517,6 +1517,25 @@ _POSTTOKEN_RECOVER_MSG = (
     "to finish the original request — do NOT restart from scratch and do NOT "
     "re-run steps or tools that already completed successfully."
 )
+
+# Kiro CLI emits this exact assistant response when its inner agent loop fails
+# after one or more successful tool cycles. The ACP turn still reports Ok +
+# UserTurnEnd, so the dashboard cannot classify it from the stop reason. Keep the
+# match exact: broader "please retry" matching would reinterpret ordinary model
+# prose and user-requested quotations as backend failures.
+_UPSTREAM_TURN_FAILURE_TEXT = "I hit an issue while processing your request. Please retry."
+
+
+def is_upstream_turn_failure_text(text: str) -> bool:
+    """Return whether *text* is Kiro CLI's synthetic turn-failure response."""
+    return text.strip() == _UPSTREAM_TURN_FAILURE_TEXT
+
+
+def contains_upstream_turn_failure_text(text: str) -> bool:
+    """Return whether the current user request quotes or asks for the sentinel."""
+    return _UPSTREAM_TURN_FAILURE_TEXT in text
+
+
 _EMPTY_AUTO_CONTINUE_MSG = (
     f"{EMPTY_RESPONSE_RECOVERY_PREFIX}\n"
     "Your previous turn produced no output (the model returned an empty "

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -16076,6 +16076,299 @@ class TestEmptyResponseRetry:
         mock_client.stream = _stream
         mock_client.stream_command = _stream
 
+    def _make_upstream_failure_stream(
+        self,
+        mock_client,
+        *,
+        with_tool: bool = True,
+        output_tokens: int = 0,
+    ):
+        """Kiro CLI's synthetic Ok/UserTurnEnd failure after optional tool work."""
+        from kiro_crew.acp.types import STOP_REASON_END_TURN, TurnUsage
+        from kiro_crew.dashboard.chat_utils import _UPSTREAM_TURN_FAILURE_TEXT
+        from kiro_crew.providers.base import (
+            EVENT_COMPLETE,
+            EVENT_TEXT_CHUNK,
+            EVENT_TOOL_CALL,
+            LLMEvent,
+        )
+
+        mock_client.is_kiro_backend = True
+
+        async def _stream(msg):
+            if with_tool:
+                yield LLMEvent(
+                    kind=EVENT_TOOL_CALL,
+                    title="shell",
+                    tool_kind="execute",
+                    tool_call_id="tc-completed",
+                )
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text=_UPSTREAM_TURN_FAILURE_TEXT)
+            yield LLMEvent(
+                kind=EVENT_COMPLETE,
+                stop_reason=STOP_REASON_END_TURN,
+                usage=TurnUsage(output_tokens=output_tokens),
+            )
+
+        mock_client.stream = _stream
+        mock_client.stream_command = _stream
+
+    @pytest.mark.asyncio
+    async def test_upstream_failure_after_tool_work_continues_once(self, tmp_path: Path) -> None:
+        """The Kiro CLI sentinel is control output, not a landed assistant answer.
+
+        Completed tool work makes replaying the original request unsafe. The runner
+        removes the sentinel and queues one continuation on the same live session.
+        """
+        from kiro_crew.dashboard.chat_utils import (
+            _POSTTOKEN_RECOVER_MSG,
+            _UPSTREAM_TURN_FAILURE_TEXT,
+            SYNTHETIC_RECOVERY_KIND,
+            TRANSIENT_RETRY_KIND,
+            RecoveryPayload,
+        )
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        self._make_upstream_failure_stream(client)
+
+        with (
+            patch(
+                "kiro_crew.dashboard.chat_runner._start_next_queued_turn",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "kiro_crew.dashboard.chat_runner.save_slot_off_loop",
+                new_callable=AsyncMock,
+            ) as mock_save,
+            patch("kiro_crew.dashboard.chat_runner._maybe_consolidate") as mock_consolidate,
+        ):
+            await _run_chat(state, slot, "perform the task")
+
+        assert [m for m in slot.messages if m.get("content") == _UPSTREAM_TURN_FAILURE_TEXT] == []
+        assert slot._queue == [
+            {
+                "id": slot._queue[0]["id"],
+                "content": _POSTTOKEN_RECOVER_MSG,
+                "kind": SYNTHETIC_RECOVERY_KIND,
+                "payload": RecoveryPayload.CONTINUATION,
+                "meta": slot._queue[0]["meta"],
+            }
+        ]
+        recovery = [
+            m
+            for m in slot.messages
+            if m.get("role") == "error" and "Backend turn failed" in m.get("content", "")
+        ]
+        assert len(recovery) == 1
+        assert "recovering" in recovery[0]["content"]
+        assert (recovery[0].get("meta") or {}).get("kind") == TRANSIENT_RETRY_KIND
+        assert slot._posttoken_retry_used is True
+        mock_save.assert_awaited_once()
+        mock_consolidate.assert_not_called()
+        state.sessions.record_success.assert_not_called()
+        wire = [call.args for call in state.broadcast_ws.call_args_list]
+        reconcile_at = next(
+            i
+            for i, args in enumerate(wire)
+            if args[0] == "chat_message"
+            and args[1].get("role") == "assistant"
+            and args[1].get("content") == ""
+        )
+        chunk_at = next(
+            i
+            for i, args in enumerate(wire)
+            if args[0] == "chat_chunk"
+            and _UPSTREAM_TURN_FAILURE_TEXT.startswith(args[1].get("content", ""))
+        )
+        assert chunk_at < reconcile_at
+
+    @pytest.mark.asyncio
+    async def test_reported_output_tokens_do_not_override_behavioral_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        """Kiro's completion token fields are not an authoritative discriminator."""
+        from kiro_crew.dashboard.chat_utils import _UPSTREAM_TURN_FAILURE_TEXT
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        self._make_upstream_failure_stream(client, output_tokens=17)
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner._start_next_queued_turn",
+            new=AsyncMock(return_value=False),
+        ):
+            await _run_chat(state, slot, "perform the task")
+
+        assert not any(
+            m.get("role") == "assistant" and m.get("content") == _UPSTREAM_TURN_FAILURE_TEXT
+            for m in slot.messages
+        )
+        assert slot._posttoken_retry_used is True
+        assert len(slot._queue) == 1
+        state.sessions.record_success.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upstream_failure_file_changes_use_current_turn_anchor(
+        self, tmp_path: Path
+    ) -> None:
+        """A tool-writing sentinel turn must not mutate the prior assistant row."""
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        prior = slot.append("assistant", "prior turn", "msg msg-a", broadcast=False)
+        changed = tmp_path / "generated.txt"
+        changed.write_text("after\n")
+        slot._file_changes = [{"path": str(changed), "content": "before\n"}]
+        self._make_upstream_failure_stream(client)
+
+        with patch(
+            "kiro_crew.dashboard.chat_runner._start_next_queued_turn",
+            new=AsyncMock(return_value=False),
+        ):
+            await _run_chat(state, slot, "perform the task")
+
+        assert "file_changes" not in (prior.get("meta") or {})
+        anchors = [
+            m
+            for m in slot.messages
+            if m.get("role") == "assistant" and (m.get("meta") or {}).get("file_changes")
+        ]
+        assert len(anchors) == 1
+        assert "stopped" in anchors[0].get("content", "").lower()
+        assert anchors[0]["meta"]["file_changes"][0]["path"] == str(changed)
+        state.sessions.record_success.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_repeated_upstream_failure_is_terminal_not_a_loop(self, tmp_path: Path) -> None:
+        """A sentinel on the synthetic continuation spends no second recovery."""
+        from kiro_crew.dashboard.chat_utils import (
+            _POSTTOKEN_RECOVER_MSG,
+            TRANSIENT_RETRY_KIND,
+        )
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        slot._posttoken_retry_used = True
+        self._make_upstream_failure_stream(client, with_tool=True)
+
+        await _run_chat(
+            state,
+            slot,
+            _POSTTOKEN_RECOVER_MSG,
+            _synthetic_payload=True,
+        )
+
+        assert slot._queue == []
+        failures = [
+            m
+            for m in slot.messages
+            if m.get("role") == "error" and "Backend turn failed" in m.get("content", "")
+        ]
+        assert len(failures) == 1
+        assert "please retry" in failures[0]["content"].lower()
+        assert (failures[0].get("meta") or {}).get("kind") != TRANSIENT_RETRY_KIND
+        state.sessions.record_success.assert_not_called()
+
+    def test_upstream_failure_match_is_exact(self) -> None:
+        """Ordinary prose quoting the sentence remains a legitimate answer."""
+        from kiro_crew.dashboard.chat_utils import (
+            _UPSTREAM_TURN_FAILURE_TEXT,
+            is_upstream_turn_failure_text,
+        )
+
+        assert is_upstream_turn_failure_text(_UPSTREAM_TURN_FAILURE_TEXT)
+        assert is_upstream_turn_failure_text(f"  {_UPSTREAM_TURN_FAILURE_TEXT}\n")
+        assert not is_upstream_turn_failure_text(f"The backend said: {_UPSTREAM_TURN_FAILURE_TEXT}")
+        assert not is_upstream_turn_failure_text("Please retry.")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("non_kiro", [False, True])
+    async def test_exact_text_without_tool_activity_or_from_non_kiro_is_preserved(
+        self, tmp_path: Path, non_kiro: bool
+    ) -> None:
+        """Text alone cannot claim provider control output."""
+        from kiro_crew.dashboard.chat_utils import _UPSTREAM_TURN_FAILURE_TEXT
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        self._make_upstream_failure_stream(
+            client,
+            with_tool=False,
+            output_tokens=0,
+        )
+        if non_kiro:
+            client.is_kiro_backend = False
+        else:
+            # The no-tool half independently proves exact text is insufficient.
+            client.is_kiro_backend = True
+
+        await _run_chat(state, slot, "quote the sentence")
+
+        assert any(
+            m.get("role") == "assistant" and m.get("content") == _UPSTREAM_TURN_FAILURE_TEXT
+            for m in slot.messages
+        )
+        assert not any(
+            m.get("role") == "error" and "Backend turn failed" in m.get("content", "")
+            for m in slot.messages
+        )
+        assert slot._queue == []
+        state.sessions.record_success.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_user_requested_exact_text_after_tool_activity_is_preserved(
+        self, tmp_path: Path
+    ) -> None:
+        """A current request quoting the literal outranks the sentinel heuristic."""
+        from kiro_crew.dashboard.chat_utils import _UPSTREAM_TURN_FAILURE_TEXT
+
+        state, slot, client, _run_chat = self._make_state_and_slot(tmp_path)
+        self._make_upstream_failure_stream(client, with_tool=True, output_tokens=0)
+
+        await _run_chat(
+            state,
+            slot,
+            f"Run a harmless check, then reply exactly: {_UPSTREAM_TURN_FAILURE_TEXT}",
+        )
+
+        assert any(
+            m.get("role") == "assistant" and m.get("content") == _UPSTREAM_TURN_FAILURE_TEXT
+            for m in slot.messages
+        )
+        assert not any(
+            m.get("role") == "error" and "Backend turn failed" in m.get("content", "")
+            for m in slot.messages
+        )
+        assert slot._queue == []
+        state.sessions.record_success.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_late_stop_purges_posttoken_continuation(self, tmp_path: Path) -> None:
+        """A Stop after enqueue but before dispatch cannot resume completed tools."""
+        from kiro_crew.dashboard.chat_runner import _start_next_queued_turn
+        from kiro_crew.dashboard.chat_utils import (
+            _POSTTOKEN_RECOVER_MSG,
+            SYNTHETIC_RECOVERY_KIND,
+            RecoveryPayload,
+        )
+
+        state, slot, _client, _run_chat = self._make_state_and_slot(tmp_path)
+        slot._posttoken_retry_used = True
+        slot._promise_only_stop_gen = slot._stop_generation
+        slot.queue_insert(
+            0,
+            _POSTTOKEN_RECOVER_MSG,
+            kind=SYNTHETIC_RECOVERY_KIND,
+            payload=RecoveryPayload.CONTINUATION,
+        )
+        # The Stop resolves back to idle before the queue drain, so only the
+        # monotonic generation can prove intervention occurred.
+        slot._stop_state = "soft_pending"
+        slot._stop_state = "idle"
+
+        assert await _start_next_queued_turn(state, slot) is False
+        assert slot._queue == []
+        assert slot._posttoken_retry_used is False
+        assert any(
+            m.get("role") == "notice" and "Auto-continue cancelled" in m.get("content", "")
+            for m in slot.messages
+        )
+
     @pytest.mark.asyncio
     async def test_first_empty_response_requeues_message(self, tmp_path: Path) -> None:
         """First empty response at depth 0 → message re-queued silently."""
@@ -16680,6 +16973,49 @@ class TestRunChatTransientRetry:
         # (finding #3, prevents a recovery-turn re-failure from looping).
         state.sessions.reset.assert_not_awaited()
         assert slot._posttoken_retry_used is True
+
+    @pytest.mark.asyncio
+    async def test_stop_during_posttoken_backoff_cancels_recovery(self, tmp_path, monkeypatch):
+        """A Stop that begins and resolves during backoff must still veto enqueue."""
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.dashboard.chat_utils import TRANSIENT_RETRY_KIND
+        from kiro_crew.providers.base import EVENT_TEXT_CHUNK, LLMEvent
+
+        call_count = 0
+
+        async def _stream(msg):
+            nonlocal call_count
+            call_count += 1
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="partial answer")
+            raise AcpError(self._TRANSIENT)
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client = self._client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+
+        async def _stop_during_sleep(_delay):
+            slot._stop_state = "soft_pending"
+            slot._stop_state = "idle"
+
+        with patch("asyncio.sleep", side_effect=_stop_during_sleep):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        assert call_count == 1
+        assert slot._queue == []
+        assert slot._posttoken_retry_used is False
+        assert any("partial answer" in t for t in self._assistant_texts(slot))
+        receipts = [
+            m
+            for m in slot.messages
+            if m.get("role") == "error" and "Backend hiccup" in m.get("content", "")
+        ]
+        assert len(receipts) == 1
+        assert "cancelled" in receipts[0]["content"]
+        assert (receipts[0].get("meta") or {}).get("kind") != TRANSIENT_RETRY_KIND
 
     @pytest.mark.asyncio
     async def test_transient_post_token_suppressed_preserves_partial(self, tmp_path, monkeypatch):


### PR DESCRIPTION

## Problem / Motivation

Kiro CLI can fail its inner agent loop after several successful tool cycles yet close ACP as a normal `Ok` / `UserTurnEnd` result whose only assistant text is:

> I hit an issue while processing your request. Please retry.

Kiro Crew treated that provider-generated sentence as a real answer. It persisted the text, recorded success, reset recovery budgets, and required the user to repeat a request whose tools may already have produced side effects.

## Why it matters

Long-running work can stop after minutes of successful execution with no actionable diagnosis. Blindly replaying the original request is unsafe because completed tools may run twice. The recovery must continue from the live session context, preserve tool results, and remain cancellable before dispatch.

## What changed (motivation → approach → change)

- Added an exact classifier for Kiro CLI's synthetic turn-failure sentence. Broad `please retry` matching is deliberately avoided.
- Require positive `is_kiro_backend` identity, at least one tool call in the turn, and confirmation that the current user message did not itself contain the sentence before treating it as provider control output. Exact answers without tool activity, quoted/requested literals, and non-Kiro output remain ordinary assistant text.
- Remove the synthetic sentence's trailing chunks, replace any already-streamed browser row with an empty assistant reconciliation, and then show one transcript-visible recovery notice; the terminal authoritative refresh removes the unpersisted blank row.
- Scope file-change snapshot attachment to the current turn boundary, so a sentinel/error turn with completed writes creates its own established synthetic assistant anchor instead of mutating the previous turn's assistant row.
- Queue the existing post-token continuation on the same live session, preserving completed tool results and explicitly forbidding replay.
- Share the existing post-token one-shot so a repeated sentinel terminates instead of looping.
- Extend dispatch-time intervention cancellation to post-token continuations. A late Stop, queued user follow-up, or steer removes the continuation and restores its one-shot budget before anything can run.
- Recheck monotonic Stop generation, queued follow-ups, and pending steers after the post-token retry backoff and before consuming the one-shot, so an intervention that begins and resolves during the await cannot be forgotten.
- Keep sentinel turns out of success recording, consolidation, landed-turn state, and retry-budget resets.
- Document the recovery contract in the session specification.

## Tests

- Exact Kiro sentinel after tool activity queues one continuation and records no success; reported output-token counts do not override the behavioral evidence because Kiro's credit-only accounting also reports zero for legitimate output.
- A repeated sentinel is terminal and cannot loop.
- Exact Kiro text without tool activity remains a normal assistant response.
- Non-Kiro exact text remains a normal assistant response.
- Broader prose and quoted forms do not match.
- A Stop that begins and resolves between enqueue and dispatch purges the continuation and restores the one-shot.
- Full `TestEmptyResponseRetry`: 19 passed.
- Full `TestRunChatTransientRetry`: 20 passed.
- File-change, flush, and post-compaction contract suites: 113 passed.
- Full `test_dashboard_chat.py`: 759 passed on the final rebased head.
- Cross-surface frontend suite: 5,682 passed.
- Electron suite under CI's Node 24 runtime: 1,587 passed, 1 skipped.
- Production build, TypeScript, ESLint, i18n check/render, phantom classes, duplication, bundle-size analysis, Black, isort, flake8, mypy, docs, harness, policy, vendor, scrub, and CloudFormation gates passed.

The local full-backend profile run reached 84,065 passes. Its remaining failures are unrelated host-topology failures caused by the dashboard sandbox exposing the live `KIROCREW_HOME`, `/local/home` ownership, and overlong AF_UNIX scratch paths. The two failures related to this diff's answer-branch source contract were fixed and rerun green. Hosted CI provides the authoritative isolated full-backend result.

Two independent local reviews found missing dispatch-time cancellation and missing positive Kiro identity; both were fixed. A GPT round then showed that output-token counts are non-authoritative for Kiro's credit-only accounting, so that discriminator was removed in favor of backend identity, tool activity, exact-text, and current-request guards. Later GPT rounds identified the live-browser reconciliation gap and then exposed a broader cross-turn file-change attachment bug. The former now replaces an already-streamed sentinel row before recovery; the latter was restructured globally so file changes scan only assistant rows created after the turn boundary and synthesize a current-turn anchor when needed. On the final current head, GPT restated the inherent text-signal ambiguity as a security blocker, but Opus adjudication downgraded it as disproportionate: the continuation is visible, same-session, one-shot, admission-restamped, and subject to the same tool gates, while Kiro CLI exposes no out-of-band failure event to consume.

## Manual verification

N/A — this is backend recovery control flow with deterministic event-stream and queue-dispatch coverage. The triggering upstream failure cannot be induced on demand; the test event shape comes from three observed raw Kiro CLI records.

## Related Issues

Fixes #8285

Related but independent:

- #6850 covers false progress prose after a completed turn and intentionally does not continue mixed tool turns.
- #8215 covers KAS compaction throttling and structured compaction failure recovery.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a provider-owned synthetic failure sentence returned under a success envelope must require positive provider identity plus out-of-band failure evidence before changing control flow.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


### CI retry note

The first two dependency-audit attempts for current-head validation timed out after 120 seconds while waiting for `npm audit`; neither produced a vulnerability finding. This description update retriggers the repository's `pull_request: edited` review/audit path without changing the reviewed commit.
