### PR TITLE
fix(chat): give each same-tick tool row its own disclosure identity

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -556,6 +556,25 @@ export function messageRowKey(m: ChatMessage, i: number): string {
   return keyTs ? `${role}-${keyTs}` : `${role}-${i}`
 }
 
+/** Disclosure-map identity for a tool row (#8204). messageRowKey is
+ *  `${role}-${clientTs ?? ts}` and tool rows are never clientTs-stamped, so a
+ *  burst of tool rows appended in one server tick all share `tool-<tick>` —
+ *  expanding one expanded them all, because the row key doubled as the
+ *  toolDisclosure map key. Fold `meta.tool_call_id` in when present (ACP-issued,
+ *  globally unique) so each row owns its disclosure entry.
+ *
+ *  Deliberately NOT folded into messageRowKey: the React-key role is not at
+ *  stake (each renderMessage element is the sole child of a separately keyed
+ *  wrapper), and the key-stability suite pins messageRowKey(tool) === 'tool-<ts>'.
+ *  Scoped to role 'tool' and identity when the id is absent, so every other
+ *  role's in-session disclosure state keeps its existing key shape.
+ *  Exported for tests. */
+export function toolDisclosureKey(m: ChatMessage, key: string): string {
+  if (m.role !== 'tool') return key
+  const tcid = m.meta?.tool_call_id
+  return typeof tcid === 'string' && tcid ? `${key}-${tcid}` : key
+}
+
 /** Render user message content with file chips and image markdown. Handles:
  *  - Fresh messages: meta.files present, displayTxt has @relative/path tokens
  *  - Replayed history: no meta.files, content has [attached_file N] /full/path
@@ -6841,7 +6860,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       if (spawnLaunch) return <SubagentRunCard key={key} launch={spawnLaunch} slot={activeSlot || ''} />
       // Animate tools in the trailing group (after last assistant/streaming text)
       const isInTrailingGroup = slotStateRef2.current === 'tool_running' && i > lastTextIdxRef.current
-      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} disclosure={toolDisclosure[key]} disclosureKey={key} onDisclosureChange={setToolDisclosureFor} appInPanel={mcpAppPanel} onOpenApp={revealAppInPanel} transcriptHot={transcriptHot} />
+      // Disclosure identity folds in tool_call_id (#8204) — same-tick tool rows
+      // share the row key, and keying the disclosure map by it made one row's
+      // expand/collapse hit them all. React key stays the row key on purpose:
+      // sibling uniqueness is owned by the keyed wrapper, and remounting on a
+      // key change here would drop measured heights for nothing.
+      const dKey = toolDisclosureKey(m, key)
+      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} disclosure={toolDisclosure[dKey]} disclosureKey={dKey} onDisclosureChange={setToolDisclosureFor} appInPanel={mcpAppPanel} onOpenApp={revealAppInPanel} transcriptHot={transcriptHot} />
     }
     if (m.role === 'file') {
       try {

--- a/website/src/test/toolDisclosureKey.collision.test.ts
+++ b/website/src/test/toolDisclosureKey.collision.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tool-row disclosure identity collision regression (#8204).
+ *
+ * messageRowKey is `${role}-${clientTs ?? ts}` and tool rows are never
+ * clientTs-stamped, so a burst of tool rows appended in one server tick all
+ * key as `tool-<tick>`. ChatPage used that string as BOTH the React key and
+ * the toolDisclosure map key, so expanding one same-tick tool row expanded
+ * all of them. The React-key role is not at stake (each renderMessage element
+ * is the sole child of a separately keyed wrapper); the load-bearing role is
+ * the disclosure map identity — which toolDisclosureKey now disambiguates by
+ * folding meta.tool_call_id in when present.
+ *
+ * Probe adapted from the issue (credit @chenmingwei23): driven through the
+ * REAL refreshSlot reducer rather than synthesized state, with per-item
+ * pairing assertions — a set-size check alone cannot express cross-attribution.
+ */
+import { describe, it, expect } from 'vitest'
+import reducer, { refreshSlot } from '../store/chatSlice'
+import { messageRowKey, toolDisclosureKey } from '../pages/ChatPage'
+import type { ChatMessage } from '../types'
+
+const SLOT = 'disclosure-key-slot'
+const initial = reducer(undefined, { type: '@@INIT' })
+const withSlot = { ...initial, activeSlot: SLOT }
+
+// Payload shape per chatSlice.streamingKeyStability.test.ts
+const detailPayload = (key: string, messages: ChatMessage[]) => ({
+  key, messages, running: false, stopping: false, hasMore: false, total: messages.length,
+  queue: [] as { content: string; queueId: string; ts: string }[], context: undefined,
+})
+
+describe('tool-row disclosure identity (#8204)', () => {
+  it('gives same-tick tool rows with distinct tool_call_ids distinct disclosure keys', () => {
+    const server: ChatMessage[] = [
+      { role: 'tool', content: '🔧 alpha', cls: '', ts: 'tick', meta: { tool_call_id: 'tc1' } },
+      { role: 'tool', content: '🔧 bravo', cls: '', ts: 'tick', meta: { tool_call_id: 'tc2' } },
+      { role: 'tool', content: '🔧 charlie', cls: '', ts: 'tick', meta: { tool_call_id: 'tc3' } },
+    ]
+    const state = reducer(withSlot, refreshSlot.fulfilled(detailPayload(SLOT, server), 'r1', SLOT))
+    const tools = state.messages.filter(m => m.role === 'tool')
+
+    // Controls: the reducer really ingested 3 rows, they carry 3 distinct
+    // tool_call_ids, and none stole a clientTs stamp.
+    expect(tools.length).toBe(3)
+    expect(new Set(tools.map(t => t.meta?.tool_call_id)).size).toBe(3)
+    expect(tools.every(t => t.meta?.clientTs === undefined)).toBe(true)
+
+    // NOTE: deliberately no assertion that the row keys THEMSELVES collide —
+    // whether messageRowKey ever stops colliding (e.g. tool rows gain a
+    // clientTs stamp) is the key-stability suite's contract, not this one's.
+    // This suite pins only the property under test: distinct disclosure keys.
+
+    // The fix: per-item pairing — each tool_call_id maps to its OWN disclosure
+    // key, and that key embeds the id so the pairing is attributable.
+    const pairing = tools.map((t, i) => ({
+      tcid: t.meta?.tool_call_id as string,
+      dKey: toolDisclosureKey(t, messageRowKey(t, i)),
+    }))
+    for (const { tcid, dKey } of pairing) {
+      expect(dKey).toBe(`tool-tick-${tcid}`)
+    }
+    expect(new Set(pairing.map(p => p.dKey)).size).toBe(3)
+  })
+
+  it('leaves the disclosure key unchanged when a tool row has no tool_call_id', () => {
+    // Legacy/replayed tool rows may lack the id; their disclosure identity must
+    // stay the row key so nothing about their behavior shifts.
+    const m: ChatMessage = { role: 'tool', content: '🔧 legacy', cls: '', ts: 'tick' }
+    expect(toolDisclosureKey(m, messageRowKey(m, 0))).toBe('tool-tick')
+  })
+
+  it('leaves non-tool roles unchanged (key shape preservation)', () => {
+    // Only the tool path is re-keyed: an assistant row carrying a stray
+    // tool_call_id (never produced today) still keeps its plain row key, so
+    // persisted-in-session disclosure state for every other role is untouched.
+    const m: ChatMessage = { role: 'assistant', content: 'a', cls: '', ts: 'tick', meta: { tool_call_id: 'tcX' } }
+    expect(toolDisclosureKey(m, messageRowKey(m, 0))).toBe('assistant-tick')
+  })
+
+  it('keeps the messageRowKey contract itself untouched for tool rows', () => {
+    // The key-stability suite pins messageRowKey(tool) === 'tool-tick' — the
+    // fix must not alter messageRowKey, only the disclosure identity built on it.
+    const m: ChatMessage = { role: 'tool', content: '🔧 x', cls: '', ts: 'tick', meta: { tool_call_id: 'tc9' } }
+    expect(messageRowKey(m, 0)).toBe('tool-tick')
+  })
+})

--- a/website/src/test/toolDisclosureKey.renderSite.test.tsx
+++ b/website/src/test/toolDisclosureKey.renderSite.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Render-site pin for #8204: the disclosure identity ChatPage passes to
+ * ToolCallLine must be the id-folded toolDisclosureKey, not the bare row key.
+ *
+ * The pure-helper suite (toolDisclosureKey.collision.test.ts) proves the
+ * helper disambiguates; this file proves the RENDER SITE actually uses it.
+ * Reverting `disclosure={toolDisclosure[dKey]}` / `disclosureKey={dKey}` back
+ * to the bare `key` restores the defect (same-tick tool pills expand together)
+ * while every helper-level test stays green — so the wiring needs its own pin.
+ *
+ * Arrangement note: exactly two tool rows are used on purpose — the
+ * "Worked through N steps" turn fold requires items.length > 2, so two pills
+ * render directly and the test needs no fold expansion.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import { configureStore } from '@reduxjs/toolkit'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
+import chatReducer from '../store/chatSlice'
+import dashboardReducer from '../store/dashboardSlice'
+import notificationsReducer from '../store/notificationsSlice'
+import { ThemeProvider } from '../hooks/useTheme'
+import type { RootState } from '../store'
+
+interface VirtuosoMockProps {
+  data?: unknown[]
+  itemContent: (index: number, item: unknown) => ReactNode
+}
+vi.mock('react-virtuoso', () => ({ Virtuoso: ({ data, itemContent }: VirtuosoMockProps) => <div data-testid="virtuoso">{data?.map((d: unknown, i: number) => <div key={i}>{itemContent(i, d)}</div>)}</div> }))
+
+// The mount fetch REPLACES chat.messages, so the mock must serve the same
+// transcript the store preloads (see ChatPage.continueGate.test.tsx).
+const detail = vi.hoisted(() => ({ messages: [] as { role: string; content: string; cls?: string; ts?: string; meta?: Record<string, unknown> }[] }))
+vi.mock('../api/client', () => ({
+  api: {
+    chatSlots: vi.fn().mockResolvedValue([]),
+    chatSlotDetail: vi.fn(async () => ({ messages: detail.messages, running: false, has_more: false, total: detail.messages.length })),
+    chatHistory: vi.fn().mockResolvedValue({ sessions: [] }),
+    models: vi.fn().mockResolvedValue([]),
+    agents: vi.fn().mockResolvedValue([]),
+    agentDetail: vi.fn().mockResolvedValue({}),
+    workspaces: vi.fn().mockResolvedValue({ workspaces: [] }),
+    slackChannels: vi.fn().mockResolvedValue([]),
+    spawnList: vi.fn().mockResolvedValue({ agents: [] }),
+  },
+  SEARCH_MIN_CHARS: 2,
+}))
+vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
+vi.mock('../hooks/useBranding', () => ({ useBranding: () => ({ botName: 'Test', avatar: '' }) }))
+vi.mock('../hooks/useAgents', () => ({ useAgents: () => ({ agents: [], defaultAgent: 'default' }) }))
+vi.mock('../components/MarkdownRenderer', () => ({ default: ({ content }: { content: string }) => <span>{content}</span> }))
+vi.mock('../components/WelcomeView', () => ({ default: () => null }))
+vi.mock('../components/MarkdownPanel', () => ({ default: () => null }))
+vi.mock('../pages/chat/ActivityViewer', () => ({ default: () => null }))
+vi.mock('../components/DetailPanel', () => ({ default: () => null }))
+vi.mock('../hooks/useWebSocket', () => ({ useWebSocket: () => ({ subscribeLogs: () => {} }) }))
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+})
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+
+import ChatPage from '../pages/ChatPage'
+
+type Msg = { role: string; content: string; cls?: string; ts?: string; meta?: Record<string, unknown> }
+
+function makeStore(messages: Msg[]) {
+  return configureStore({
+    reducer: { dashboard: dashboardReducer, chat: chatReducer, notifications: notificationsReducer },
+    preloadedState: {
+      dashboard: {
+        status: null,
+        slots: [{ key: 'slot-a', messages: messages.length, running: false, mode: '', pending_approval: false, waiting_for_input: false, last_activity_ts: undefined }],
+        unreadSlots: [], refreshTrigger: 0, approvalMode: 'normal',
+        subagentRunning: {}, subagentDetails: {}, subagentText: {},
+      } as unknown as RootState['dashboard'],
+      chat: {
+        activeSlot: 'slot-a', messages,
+        slotRunning: false, slotStopping: false, slotState: 'idle',
+        history: [], historyHasMore: false, pendingInput: null,
+        subagents: {}, toolLog: [], activityOpen: false, activityTab: 'tools',
+        slotHasMore: false, slotOldestIndex: 0, loadingOlder: false,
+        slotStatusDetail: {}, slotContextPct: {}, slotActivity: {}, slotHistory: [],
+        historyOffset: 0, _wsChunkedDuringFetch: false,
+        slotMessages: {}, slotLoading: false,
+      } as unknown as RootState['chat'],
+      notifications: { items: [] } as unknown as RootState['notifications'],
+    },
+  })
+}
+
+async function renderWith(messages: Msg[]) {
+  detail.messages = messages
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  await act(async () => {
+    render(
+      <QueryClientProvider client={qc}>
+        <Provider store={makeStore(messages)}>
+          <ThemeProvider>
+            <MemoryRouter><ChatPage /></MemoryRouter>
+          </ThemeProvider>
+        </Provider>
+      </QueryClientProvider>,
+    )
+  })
+  await waitFor(() => expect(screen.getByLabelText('Message input')).toBeTruthy())
+}
+
+/** The tool pills' own disclosure buttons: aria-expanded buttons wrapping the
+ *  tool-pill-label testid — page chrome (sidebar toggles, dropdowns) also
+ *  carries aria-expanded, so the label anchor is what scopes this to pills. */
+const pills = () => screen.getAllByRole('button').filter(
+  b => b.hasAttribute('aria-expanded') && b.querySelector('[data-testid="tool-pill-label"]'),
+)
+
+beforeEach(() => {
+  sessionStorage.clear()
+  localStorage.clear()
+})
+
+describe('ChatPage tool-row disclosure identity (#8204 render site)', { timeout: 15_000 }, () => {
+  it('expands only the clicked pill when two same-tick tool rows share a row key', async () => {
+    // Same server tick ('tick'), no clientTs stamp, distinct tool_call_ids —
+    // the exact shape #8204 measured. Their messageRowKey collides ('tool-tick');
+    // only the id-folded disclosure key tells them apart.
+    await renderWith([
+      { role: 'user', content: 'do two things', cls: '', ts: 'u1' },
+      { role: 'tool', content: '🔧 Running: alpha', cls: '', ts: 'tick', meta: { tool_call_id: 'tc1', purpose: 'first' } },
+      { role: 'tool', content: '🔧 Running: bravo', cls: '', ts: 'tick', meta: { tool_call_id: 'tc2', purpose: 'second' } },
+    ])
+
+    await waitFor(() => expect(pills().length).toBe(2))
+    const [a, b] = pills()
+    expect(a.getAttribute('aria-expanded')).toBe('false')
+    expect(b.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(a)
+
+    // Before the fix both pills expanded here: the disclosure map was keyed by
+    // the (colliding) row key, so one row's entry was every sibling's entry.
+    const [a2, b2] = pills()
+    expect(a2.getAttribute('aria-expanded')).toBe('true')
+    expect(b2.getAttribute('aria-expanded')).toBe('false')
+
+    // And the mirror: collapsing A must not collapse an expanded B.
+    fireEvent.click(b2)
+    fireEvent.click(pills()[0])
+    const [a3, b3] = pills()
+    expect(a3.getAttribute('aria-expanded')).toBe('false')
+    expect(b3.getAttribute('aria-expanded')).toBe('true')
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

Two or more tool rows appended in the same server tick share a single disclosure entry: expanding one tool pill expands every same-tick sibling, and collapsing one collapses them all.

Root cause (verified on main): `messageRowKey` (`website/src/pages/ChatPage.tsx`) returns `${role}-${clientTs ?? ts}`, and tool rows are never `clientTs`-stamped — so a coarse OS clock maps a burst of tool rows onto one key. The render site passed that same string as BOTH the React key and the `toolDisclosure` map key, and the disclosure-map role is the load-bearing one (each `renderMessage` element is the sole child of a separately keyed wrapper, so sibling uniqueness was never at stake).

Split out of #4394 as the measured residue after #7207 closed the primary site.

## Why it matters

Any turn where the agent fires several fast tool calls (the common case: parallel reads, batched checks) lands multiple tool rows on one tick. A user trying to inspect ONE tool's output gets every sibling's panel flung open at once, and cannot collapse one without collapsing all — the disclosure control is effectively broken for exactly the busy turns where it is most needed.

## What changed (motivation → approach → change)

Symptom → root cause: same-tick tool rows collide on `messageRowKey`, and the disclosure map was keyed by it.

Approach: disambiguate the **disclosure identity only**, leaving `messageRowKey` and the React key untouched. Two constraints picked this seam:
- The key-stability contract (`chatSlice.streamingKeyStability.test.ts`) pins `messageRowKey(tool)` to exactly `tool-<ts>` — folding the id into `messageRowKey` itself would break that adjudicated contract.
- The React-key role is not at stake, and re-keying it would remount rows (dropping measured heights) for no benefit.

Change: a new exported `toolDisclosureKey(m, key)` appends `meta.tool_call_id` (ACP-issued, globally unique) to the row key for `role === 'tool'` rows that carry one, and returns the key unchanged for every other role and for id-less tool rows. The ToolCallLine render site now reads and writes the `toolDisclosure` map under that key. The sibling SDK render path (`app-sdk/ChatMessageList.tsx`) needs no change — its `msgKey` is index-bearing and never collides.

**Residual scope, deliberately not covered:** tool rows persisted with no `tool_call_id` (the backend's `_tool_meta()` returns `None` when the ACP event carries no id) keep the pre-existing colliding behavior. Both alternatives fail against evidence: `meta.mid` never appears on tool rows (measured in #8204 with a control mutation), and an index-based fallback would break disclosure identity across a history prepend — a worse defect than the one it patches. This PR closes the defect for all id-carrying rows, which is every live-path tool row.

## Tests

- `website/src/test/toolDisclosureKey.collision.test.ts` — adapts #8204's reducer-driven probe (credit @chenmingwei23): 3 same-tick tool rows with distinct `tool_call_id`s through the real `refreshSlot` reducer yield 3 distinct disclosure keys, with per-item pairing assertions (not set-size). Plus: id-less tool rows and non-tool roles keep their exact existing key shape, and `messageRowKey`'s own contract is untouched.
- `website/src/test/toolDisclosureKey.renderSite.test.tsx` — pins the render-site wiring through the real ChatPage: two same-tick tool pills, click one, only that one expands (and the mirror: collapsing one leaves the other open). Verified red against a revert of the wiring (`dKey` → `key`): the test fails with both pills expanded, so the exact line that regressed is covered.
- Full frontend suite green: 1805 files / 28463 tests. `npx tsc -b` clean. Backend isort/flake8/mypy clean (no backend files changed).

## Manual verification

N/A — the render-site test drives the real ChatPage render path end to end (real reducer, real ToolCallLine, real disclosure state), which is the exact user interaction.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** no at-rest pixel change — the delta is interaction-state only (which pill's panel opens on click), pinned by the committed render-site test; same evidence basis as the merged sibling fix #7207.

## Related Issues

Closes #8204

## Pattern harvest

Rule candidate: review-prompt
Pattern: a string passed as both a React key and a state-map key couples two identities with different uniqueness requirements — check that a colliding render key cannot alias user-visible state.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
