### PR TITLE
fix(crew-companion): close the overlay during an update-install restart

### DIFF
--- a/website/electron/crew-companion/index.js
+++ b/website/electron/crew-companion/index.js
@@ -54,6 +54,13 @@ let fetchLocalToken = null;
 let log = () => {};
 let timer = null;
 let reconciling = false;
+// Latched true by suspendCrewCompanion() while an update install is stopping the
+// gateway and quitting. The reconcile loop treats a gateway it cannot reach as
+// "unknown" and LEAVES every window as-is, so without this latch the overlay
+// would float orphaned over the vanished dashboard during the quit handoff — and
+// a tick firing in the brief window where the gateway is still up (dispatch runs
+// BEFORE stopGateway is awaited) could even reopen a just-closed overlay.
+let suspended = false;
 /**
  * The token this poll reuses across ticks.
  *
@@ -278,6 +285,7 @@ function openDashboardSession(slotKey) {
 }
 
 async function reconcileOnce() {
+  if (suspended) return;
   if (reconciling) return;
   reconciling = true;
   try {
@@ -309,6 +317,11 @@ async function reconcileOnce() {
       }
     }
 
+    // Re-check AFTER the awaited probes: the top-of-function latch cannot stop a
+    // reconcile that was already in flight (past that check, awaiting the gateway)
+    // when suspendCrewCompanion() ran. Without this, that in-flight tick would
+    // resume here and reopen the overlay we just closed for the update quit.
+    if (suspended) return;
     if (state === "unknown") return; // leave every window exactly as it is
     if (state === "disabled") {
       if (petWindowCount() > 0) {
@@ -432,9 +445,36 @@ function shutdownCrewCompanion() {
   closePetWindow();
 }
 
+/**
+ * Close the overlays for an in-flight update install WITHOUT tearing the app
+ * down. Unlike shutdownCrewCompanion this keeps the reconcile timer, IPC
+ * handlers and cached token intact, so an install that FAILS resumes cleanly via
+ * resumeCrewCompanion() with no re-init (re-running initCrewCompanion would stack
+ * a second `crew-companion:focusable`/`turn-off` listener). The latch stops the
+ * still-running loop from reopening what we just closed.
+ */
+function suspendCrewCompanion() {
+  suspended = true;
+  closePanelWindow();
+  closeGalleryWindow();
+  closePetWindow();
+  log("crew-companion: overlays closed for update install");
+}
+
+/** Undo suspendCrewCompanion() when an update install did not proceed. The loop
+ * reopens the overlays on its next tick once the gateway is reachable again. */
+function resumeCrewCompanion() {
+  if (!suspended) return;
+  suspended = false;
+  log("crew-companion: update install did not proceed — resuming");
+  void reconcileOnce();
+}
+
 module.exports = {
   initCrewCompanion,
   shutdownCrewCompanion,
+  suspendCrewCompanion,
+  resumeCrewCompanion,
   // Exported for tests: they drive the tick directly rather than waiting 5s.
   reconcileOnce,
   probeEnabled,

--- a/website/electron/crew-companion/test/updateSuspend.test.js
+++ b/website/electron/crew-companion/test/updateSuspend.test.js
@@ -1,0 +1,161 @@
+"use strict";
+
+/**
+ * An update install stops the gateway and quits the app. suspendCrewCompanion()
+ * must close the overlays AND latch the reconcile loop, because the loop treats a
+ * gateway it cannot reach as "unknown" and leaves every window as-is — so without
+ * the latch the ghost floats orphaned over the vanished dashboard during the quit
+ * handoff, and a tick firing while the gateway is briefly still up (dispatch runs
+ * before stopGateway is awaited) could reopen a just-closed overlay.
+ *
+ * A failed install does NOT quit, so resumeCrewCompanion() must let the loop
+ * reopen the overlay once the restored gateway answers again — WITHOUT re-running
+ * initCrewCompanion (which would stack a second IPC listener).
+ *
+ * These drive the exported reconcile/suspend/resume directly rather than waiting
+ * on the 5-second interval.
+ */
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const Module = require("node:module");
+const path = require("node:path");
+
+const INDEX = path.join(__dirname, "..", "index.js");
+
+function loadCompanion(wiring) {
+  const originalLoad = Module._load;
+  const calls = { open: 0, closePet: 0, closePanel: 0, closeGallery: 0 };
+  let windowOpen = false;
+  const stubs = {
+    electron: {
+      ipcMain: { on() {}, handle() {}, removeHandler() {} },
+      BrowserWindow: { fromWebContents: () => null },
+    },
+  };
+  const noopWindowModule = {
+    setOverlayTarget() {}, setPanelTarget() {}, setGalleryTarget() {},
+    setOverlayLogger() {}, setPanelLogger() {}, setGalleryLogger() {},
+    registerPanelIpc() {}, registerGalleryIpc() {}, registerOverlayIpc() {},
+    setAppearanceChangedHandler() {}, setPanelClosedHandler() {},
+    setGalleryOpenedHandler() {}, setGalleryClosedHandler() {},
+    broadcastToPets() {},
+    openPetWindow() { windowOpen = true; calls.open += 1; },
+    closePetWindow() { windowOpen = false; calls.closePet += 1; },
+    closePanelWindow() { calls.closePanel += 1; },
+    closeGalleryWindow() { calls.closeGallery += 1; },
+    petWindowCount: () => (windowOpen ? 1 : 0),
+    startHitboxPoll() {}, stopHitboxPoll() {},
+  };
+
+  Module._load = function (request, parent, isMain) {
+    if (request === "electron") return stubs.electron;
+    if (request === "node:http" || request === "http") {
+      return {
+        get(_url, _opts, cb) {
+          const statusCode = wiring.status.shift();
+          const res = {
+            statusCode,
+            on(evt, fn) {
+              if (evt === "data") fn(JSON.stringify([{ name: "crew-companion", enabled: true }]));
+              if (evt === "end") fn();
+            },
+          };
+          setImmediate(() => cb(res));
+          return { on() {}, destroy() {} };
+        },
+      };
+    }
+    if (
+      request.startsWith("./pet") || request.startsWith("./panel") ||
+      request.startsWith("./gallery") || request.startsWith("./page")
+    ) {
+      return noopWindowModule;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[require.resolve(INDEX)];
+    const mod = require(INDEX);
+    mod.__calls = calls;
+    return mod;
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+async function settle() {
+  for (let i = 0; i < 10; i += 1) await new Promise((r) => setImmediate(r));
+}
+
+test("suspend closes the overlays and latches the reconcile loop", async () => {
+  // init's own reconcile opens the overlay; the latched tick must NOT reopen it.
+  const mod = loadCompanion({ status: [200] });
+  mod.initCrewCompanion({
+    backendUrl: "http://127.0.0.1:5476",
+    fetchLocalToken: async () => "tok",
+    glog: () => {},
+  });
+  await settle();
+  assert.equal(mod.__calls.open, 1, "init reconcile opens the overlay while enabled");
+
+  mod.suspendCrewCompanion();
+  assert.equal(mod.__calls.closePet, 1, "suspend closes the pet overlay");
+  assert.equal(mod.__calls.closePanel, 1, "suspend closes the panel");
+  assert.equal(mod.__calls.closeGallery, 1, "suspend closes the gallery");
+
+  // A tick during the quit handoff must be a no-op: it must not even probe (so
+  // no status is consumed) and must not reopen the overlay it just closed.
+  await mod.reconcileOnce();
+  assert.equal(mod.__calls.open, 1, "a suspended tick must not reopen the overlay");
+
+  mod.shutdownCrewCompanion();
+});
+
+test("resume lets the loop reopen the overlay after a failed install", async () => {
+  // status: [init probe, resume's own reconcile]. The suspended tick consumes none.
+  const mod = loadCompanion({ status: [200, 200] });
+  mod.initCrewCompanion({
+    backendUrl: "http://127.0.0.1:5476",
+    fetchLocalToken: async () => "tok",
+    glog: () => {},
+  });
+  await settle();
+
+  mod.suspendCrewCompanion();
+  await mod.reconcileOnce();
+  assert.equal(mod.__calls.open, 1, "still latched — no reopen while suspended");
+
+  mod.resumeCrewCompanion();
+  await settle();
+  assert.equal(mod.__calls.open, 2, "resume reopens the overlay once the gateway answers");
+
+  mod.shutdownCrewCompanion();
+});
+
+test("a reconcile already in flight when suspend fires does not reopen the overlay", async () => {
+  // The dangerous race: a tick passed the top-of-function latch and is awaiting
+  // the gateway probe when the update dispatch calls suspend. status: [init, the
+  // in-flight tick]. Both probe "enabled".
+  const mod = loadCompanion({ status: [200, 200] });
+  mod.initCrewCompanion({
+    backendUrl: "http://127.0.0.1:5476",
+    fetchLocalToken: async () => "tok",
+    glog: () => {},
+  });
+  await settle();
+  assert.equal(mod.__calls.open, 1, "init opened the overlay");
+
+  // Start a tick (it clears the top latch — not yet suspended — and awaits the
+  // probe), THEN suspend synchronously before the probe resolves.
+  const inFlight = mod.reconcileOnce();
+  mod.suspendCrewCompanion();
+  await inFlight;
+  await settle();
+
+  assert.equal(mod.__calls.closePet, 1, "suspend closed the overlay");
+  assert.equal(mod.__calls.open, 1, "the in-flight tick must re-check suspended and NOT reopen");
+
+  mod.shutdownCrewCompanion();
+});

--- a/website/electron/ipc-registrar.js
+++ b/website/electron/ipc-registrar.js
@@ -31,6 +31,12 @@ function createIpcRegistrar({
   port,
   detectWsl = detectWsl2,
   glog,
+  // Close/reopen the Crew Companion overlay around an update install so it does
+  // not float orphaned over the vanished dashboard during the quit handoff.
+  // Optional and no-op by default: an updater path must never depend on the
+  // companion being wired.
+  closeCrewCompanionForUpdate = () => {},
+  reopenCrewCompanionAfterUpdate = () => {},
 } = {}) {
   if (!electron) throw new Error("createIpcRegistrar: electron is required");
   if (!store) throw new Error("createIpcRegistrar: store is required");
@@ -304,12 +310,21 @@ function createIpcRegistrar({
         // the intentional shutdown and disarms probing throughout bundle swap.
         // auto-update invokes onInstallDispatched before awaiting stopGateway;
         // keep these as separate callbacks so that ordering remains explicit.
-        onInstallDispatched: () => gateway.onInstallDispatched(),
+        // Closing the companion overlay here — before the gateway stops — keeps a
+        // reconcile tick from reopening it in the window where it is still up.
+        onInstallDispatched: () => {
+          gateway.onInstallDispatched();
+          closeCrewCompanionForUpdate();
+        },
         // WHY failure recovery is active: dispatch stopped both the watchdog and
         // gateway. A failed swap does not quit, so nothing else can restore the
         // dashboard; the supervisor clears the flag, respawns, reconnects, and
-        // re-arms liveness in that order.
-        onInstallFailed: () => gateway.onInstallFailed(),
+        // re-arms liveness in that order. The companion closed at dispatch is
+        // reopened to match — its loop self-heals once the restored gateway answers.
+        onInstallFailed: () => {
+          gateway.onInstallFailed();
+          reopenCrewCompanionAfterUpdate();
+        },
         onUpdateState: broadcastUpdateState,
         log: makeUpdaterLogger(log),
       });

--- a/website/electron/main.js
+++ b/website/electron/main.js
@@ -39,7 +39,25 @@ const { exitImmersiveModes } = require("./blocking-prompt");
 const { createMetricsRecorder } = require("./perf-metrics");
 const { initMochi, shutdownMochi } = require("./mochi/index");
 const { borrowSessionToken } = require("./mochi-session-token");
-const { initCrewCompanion, shutdownCrewCompanion } = require("./crew-companion/index");
+const {
+  initCrewCompanion,
+  shutdownCrewCompanion,
+  suspendCrewCompanion,
+  resumeCrewCompanion,
+} = require("./crew-companion/index");
+
+// An update install stops the gateway and quits the app. Close the Crew
+// Companion overlay at dispatch so it does not float orphaned over the vanished
+// dashboard during the quit handoff, and reopen it if the install fails and the
+// gateway is restored. suspend/resume keep the companion's loop and IPC handlers
+// intact, so the failure path needs no re-init. Both are best-effort — a
+// companion teardown must never block an update or its recovery.
+function closeCrewCompanionForUpdate() {
+  try { suspendCrewCompanion(); } catch { /* best effort */ }
+}
+function reopenCrewCompanionAfterUpdate() {
+  try { resumeCrewCompanion(); } catch { /* best effort */ }
+}
 const { createGatewaySupervisor } = require("./gateway-supervisor");
 const { createWindowLifecycle } = require("./window-lifecycle");
 const { createIpcRegistrar } = require("./ipc-registrar");
@@ -260,6 +278,8 @@ const ipcRegistrar = createIpcRegistrar({
   windows,
   gateway,
   glog,
+  closeCrewCompanionForUpdate,
+  reopenCrewCompanionAfterUpdate,
 });
 
 /**

--- a/website/electron/test/reconnect-focus.test.js
+++ b/website/electron/test/reconnect-focus.test.js
@@ -242,7 +242,7 @@ describe("gateway supervisor wiring (source pins)", () => {
     );
     assert.match(
       IPC_REGISTRAR_JS,
-      /onInstallFailed: \(\) => gateway\.onInstallFailed\(\)/,
+      /onInstallFailed:\s*\(\)\s*=>\s*\{[\s\S]{0,200}?gateway\.onInstallFailed\(\)/,
       "the updater failure hook must still reach supervisor recovery",
     );
   });

--- a/website/electron/test/update-ipc-registration.test.js
+++ b/website/electron/test/update-ipc-registration.test.js
@@ -130,8 +130,13 @@ test("liveness recovery stands down during an update install", () => {
   );
   assert.match(
     REGISTRAR_SOURCE,
-    /onInstallDispatched:\s*\(\)\s*=>\s*gateway\.onInstallDispatched\(\)/,
+    /onInstallDispatched:\s*\(\)\s*=>\s*\{[\s\S]{0,200}?gateway\.onInstallDispatched\(\)/,
     "ipc-registrar.js no longer connects updater dispatch to the gateway liveness owner",
+  );
+  assert.match(
+    REGISTRAR_SOURCE,
+    /onInstallDispatched:\s*\(\)\s*=>\s*\{[\s\S]{0,200}?closeCrewCompanionForUpdate\(\)/,
+    "ipc-registrar.js no longer closes the Crew Companion overlay at update dispatch -- it floats orphaned over the vanished dashboard during the quit handoff",
   );
 });
 
@@ -150,8 +155,13 @@ test("a failed install re-arms gateway recovery", () => {
   );
   assert.match(
     REGISTRAR_SOURCE,
-    /onInstallFailed:\s*\(\)\s*=>\s*gateway\.onInstallFailed\(\)/,
+    /onInstallFailed:\s*\(\)\s*=>\s*\{[\s\S]{0,200}?gateway\.onInstallFailed\(\)/,
     "ipc-registrar.js no longer connects install failure to gateway recovery",
+  );
+  assert.match(
+    REGISTRAR_SOURCE,
+    /onInstallFailed:\s*\(\)\s*=>\s*\{[\s\S]{0,200}?reopenCrewCompanionAfterUpdate\(\)/,
+    "ipc-registrar.js no longer reopens the Crew Companion overlay when a failed install leaves the app running",
   );
 });
 


### PR DESCRIPTION
## Problem / Motivation

When Kiro Crew auto-updates with the **Crew Companion** enabled, the main dashboard window disappears while the companion ghost keeps floating on screen, and the restart looks stuck for several seconds.

Observed in the field (gateway-launch.log, two consecutive installs on 2026-09-03):

```
[update] stopping gateway before install
[update] gateway down — quitAndInstall
[update] installer took over (manual install) — arming the exit failsafe
[update] still alive 5000ms after the installer took over — forcing exit so the swap can proceed
```

## Why it matters

An update install stops the gateway and quits the app so the new bundle can swap in. On macOS the quit after `quitAndInstall` can take up to the 5-second force-exit failsafe. During that window the dashboard window is already torn down, but the Crew Companion overlay — a separate always-on-top window — is left floating over nothing, which reads as a hang. It is the most visible thing on screen exactly when the app looks frozen.

## What changed (motivation → approach → change)

Root cause: the companion overlay is driven by a reconcile loop that treats a gateway it cannot reach as `"unknown"` and, by design, **leaves every window exactly as it is** (to avoid flicker on transient blips). So when the update stops the gateway, nothing closes the overlay — the loop just holds it.

Fix: close the overlay at install *dispatch*, before the gateway stops, and latch the loop so it cannot reopen it.

- `crew-companion/index.js`: add a `suspended` latch consulted at the top of `reconcileOnce`, plus `suspendCrewCompanion()` (close panel/gallery/pet windows + latch) and `resumeCrewCompanion()` (clear latch + kick one reconcile). suspend/resume keep the reconcile timer, IPC handlers and cached token intact.
- `ipc-registrar.js`: on `onInstallDispatched` close the companion (this runs **before** `stopGateway` is awaited, so the latch also prevents a tick reopening it while the gateway is briefly still up); on `onInstallFailed` reopen it.
- `main.js`: wire `closeCrewCompanionForUpdate` / `reopenCrewCompanionAfterUpdate` into the registrar (best-effort — a companion teardown never blocks an update or its recovery).

Because suspend/resume never tear down the loop or re-register IPC, a **failed** install (which does not quit) resumes with no re-init: the loop reopens the overlay once the restored gateway answers again.

Scope is deliberately limited to Crew Companion — Mochi is a separate app and is untouched.

## Tests

- `crew-companion/test/updateSuspend.test.js` (new):
  - suspend closes the overlays and a subsequent reconcile tick does **not** reopen them (the latch holds, and no gateway probe is even issued);
  - resume lets the loop reopen the overlay once the gateway answers again (the failed-install path).
- `test/update-ipc-registration.test.js`, `test/reconnect-focus.test.js`: updated the source-pin assertions for the `onInstallDispatched`/`onInstallFailed` callbacks, which changed from one-liners to blocks, and added pins that the companion close/reopen wiring is present.

## Manual verification

N/A — unit coverage sufficient. The failure only reproduces during a live packaged auto-update restart, which cannot be driven in a dev checkout; the reconcile-loop behavior it depends on is covered by the new unit test.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** window-lifecycle/timing fix (when the overlay window closes during an update quit); no rendered pixel change to any surface.

## Related Issues

no linked issue: reported directly by a user; no tracked GitHub issue exists.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a poll-driven reconcile that no-ops on an "unknown" probe leaves UI attached to a resource being deliberately torn down elsewhere (here, the gateway during an update quit). Lifecycle transitions must **actively** close/latch the dependent UI rather than wait for the next poll, which by contract does nothing when it cannot reach the resource.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
