### PR TITLE
fix(tests): gate _FakeLoop fakes that carry probe monitor state

### DIFF
--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -254,6 +254,15 @@ class _FakeLoop:
         self.stopped_reason = stopped_reason
         self.slot_key = slot_key
         self.monitor = monitor
+        # Mirror production: probe state only ever exists on a GATED prompt loop
+        # (the probe runs behind ``if not loop.gate`` in autonudge.py, and
+        # ``is_structured_monitor_loop`` reads ``monitor and not gate`` as a
+        # structured controller record). A fake carrying ``monitor`` without
+        # ``gate=True`` is a shape production never stores, and it misroutes
+        # ``monitor_update`` into the structured branch, which rejects legacy
+        # fields -- exactly how these tests broke on main when #8201 (branched
+        # before #5184's dispatcher landed) merged with green-but-stale CI.
+        self.gate = monitor is not None
 
 
 class _FakeMonitor:


### PR DESCRIPTION
## Symptom (main breakage — blocks every open PR's backend shards)

The five terminal-subject tests #8201 added in `test/test_autonudge_stop_auth.py` fail on current main (`b2320e02c`) and on every branch cut from it, with `monitor_update cannot apply legacy fields to a structured monitor` (or `0 == 1` update-call counts). First seen as `Backend Tests (Windows) (1)` red on PR #8291; reproduced locally on a pristine `origin/main` worktree on Linux — it is platform-independent main breakage, not a shard flake.

## Root cause: a merge race, not a bad fix

- #5184 (merged 2026-09-03 17:00Z) introduced `is_structured_monitor_loop`: a loop with `monitor` set and `gate` falsy is read as a structured controller record, and `_monitor_update` routes it to `_structured_monitor_update`, which rejects legacy fields (`message`, `max_cycles`, `active`).
- #8201 branched **before** #5184 landed (`git merge-base --is-ancestor` confirms #5184 is not in #8201's branch) and merged at 20:08Z with green-but-stale CI, so the semantic conflict never ran.
- #8201's `_FakeLoop` fixtures carry probe `monitor` state but never set `gate` — a shape production never stores: the observation probe only runs on **gated** prompt loops (`autonudge.py:2916`), so any real loop with `monitor.terminal_pending` has `gate=True`. The un-gated fakes misroute into the structured branch and the legacy patch is refused.

## Fix (test-only, one invariant)

`_FakeLoop` now sets `gate = monitor is not None`, mirroring the production invariant, with a comment explaining why. No `src/` change; #8201's production behaviour is correct once the fixture has the shape real loops have.

## Verification

- Red: the 5 tests fail on pristine `origin/main` (`b2320e02c`) locally, identical to CI.
- Green: with this change, `test/test_autonudge_stop_auth.py` passes 50/50 (was 45 passed + 5 failed).
- `_FakeLoop` is module-local (no cross-file imports); black (26.3.1) + flake8 clean.

## Pattern harvest

Rule candidate: a test fake that carries a state field must also carry every invariant production couples to that field (here: probe `monitor` state exists only on `gate=True` loops) — otherwise a later dispatcher keyed on the coupled field silently reroutes the fake down a branch production never takes. Knowingly out-of-scope sibling: the general "PR merged with green-but-stale CI across a semantic conflict" class (merge-queue/re-run-on-merge policy) is a process question, not fixable in this test file.
