### PR TITLE
docs: add errors-use-error-notice frontend review rule

### DIFF
--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -75,6 +75,12 @@ ones (e.g. `typeof Notification !== 'undefined'`).
 - **Icons: `lucide-react` only, with `className="lucide-inline"`.** Never an emoji,
   never a hand-rolled SVG, never `size={N}`. Enforced by `AUTOSDE.yaml`
   (`use-lucide-icons`, `no-emoji-as-icons`).
+- **Errors shown to the user render through `ErrorNotice`, with `askAgent` on
+  wherever the hand-off cannot lose anything.** Never a hand-written
+  `<div className="text-danger">{err}</div>`. The hand-off navigates away and
+  destroys unsaved local state, so next to an unsaved draft leave `askAgent` off
+  and say why in a `{/* No hand-off: … */}` comment — a silent omission reads as
+  "forgot". Enforced by `AUTOSDE.yaml` (`errors-use-error-notice`).
 - **Security: every `dangerouslySetInnerHTML` goes through DOMPurify** via
   `md()` / `sanitize()` / `esc()` in `src/api/helpers.ts`. A bypass is an XSS bug,
   so there is no acceptable pointer for this one.

--- a/website/AUTOSDE.yaml
+++ b/website/AUTOSDE.yaml
@@ -522,3 +522,96 @@ custom-rules:
       <span><AlertTriangle className="lucide-inline" /> {error}</span>
       icon: <Inbox className="lucide-inline" />
       ```
+
+  - id: errors-use-error-notice
+    blocking: true
+    file-patterns:
+      - "src/**/*.tsx"
+    rule: |
+      An error surfaced to the user renders through `ErrorNotice`
+      (`src/components/ErrorNotice.tsx`), and turns on its `askAgent` hand-off
+      wherever the hand-off cannot destroy anything. Never a hand-written
+      `<div className="text-danger">{err}</div>`, a bare `role="alert"` box, or an
+      error string dropped into a `<p>`.
+
+      Why: this is an AI agent app. An error the user cannot fix themselves is
+      usually one the agent can, so an error surface without the hand-off is a
+      dead end. `ErrorNotice` is the ONE place that recovers the structured
+      context (route, failed endpoint, HTTP status, backend `code`) from the
+      error journal and offers it to the agent; a hand-written red div throws
+      that context away and re-implements the visual (icon, `role="alert"`,
+      design tokens, dismiss) slightly differently every time.
+
+      "Error" here means the outcome of something that FAILED: a rejected
+      request, a caught exception, a `useQuery` / `useMutation` `error`, a
+      backend `{ error, code }` body, a job's `last_error`, a boundary fallback.
+      Decide by where the VALUE comes from, not by how it is rendered — a
+      string that originates in one of those is an error however it is shown.
+      It does NOT cover client-side validation hints ("name is required"),
+      empty states, warnings, or status text about something that has not
+      failed — those are not errors and must not be dressed as one.
+
+      `askAgent` is opt-in, and the direction of that default is the safety
+      property (the prop's doc comment says why). The hand-off NAVIGATES to the
+      chat and unmounts the tree that rendered the banner, destroying any
+      unsaved local state in it. The AUTHOR decides per surface:
+      - `askAgent` MUST be on when there is nothing to lose: crash fallbacks,
+        read / list / load failures, action failures on a surface whose inputs
+        are already persisted, log and status panels.
+      - `askAgent` MUST stay off next to an editable field whose value is not
+        yet saved somewhere durable (a half-filled form, a comment draft, a
+        setup wizard) — AND the omission carries a `{/* No hand-off: … */}`
+        comment naming the draft it protects, the established form in
+        `src/pages/settings/RemoteCrewPanel.tsx`.
+      - `onHandoff` lets a dialog close itself before the navigation (the
+        `App.tsx` update-modal form). It does NOT make the navigation safe:
+        the tree beneath the dialog still unmounts, so over an unsaved draft
+        the no-hand-off form applies, `onHandoff` or not.
+
+      On the `askAgent` choice, the REVIEWER blocks on the missing decision,
+      never on the direction of it: an added or touched `ErrorNotice` carrying
+      neither `askAgent` nor a `No hand-off` comment, or a comment that names
+      no concrete draft. (The hand-written-surface ban above is its own
+      blocking trigger.) Whether a subtree holds unsaved state is not visible
+      in a hunk, so a reviewer never demands `askAgent` be turned on — a wrong
+      demand causes exactly the data loss the default prevents. Doubt a
+      comment's claim in a thread; do not overrule it.
+
+      Applies to what the diff ADDS or TOUCHES. The ~100 pre-existing
+      hand-written sites are grandfathered, but a diff that edits one (its
+      message, styling, or condition) migrates it. This is deliberately
+      stricter than `max-two-buttons-per-row`'s growth-only grandfather: the
+      migration is one line — pass the same string the site already had and
+      `ErrorNotice` recovers the structured context by message match — so
+      touch-it-migrate-it is the cheapest way the backlog ever shrinks, where
+      growth-only would leave every site a dead end forever.
+
+      Does NOT flag:
+      - `ErrorBoundary` / `MessageErrorBoundary` fallbacks that mount
+        `AskAgentButton` directly — they are the component's other consumer.
+      - `role: 'error'` rows inside the chat transcript (`ErrorCard`) — the
+        agent is already in that conversation, so a hand-off would be circular.
+      - A `useNotify(msg, { type: 'error' })` toast — the app-sdk seam carries
+        only message + type, so it cannot host the hand-off and is out of this
+        rule's reach. It is transient feedback, not the error surface: when
+        the failure leaves the user in a failed state (a load that did not
+        happen, a save that did not persist), that state is ALSO rendered
+        in-page through `ErrorNotice`; a toast as the ONLY report of it is a
+        violation.
+
+      Bad:
+      ```tsx
+      {err && <div className="text-danger text-sm">{err}</div>}
+      {mutation.error && <p role="alert" className="text-danger">{String(mutation.error)}</p>}
+      <ErrorNotice message={loadErr} />   // neither askAgent nor a No hand-off comment: the decision is missing
+      ```
+
+      Good:
+      ```tsx
+      <ErrorNotice message={err} askAgent />
+      <ErrorNotice message={mutation.error instanceof Error ? mutation.error.message : undefined} variant="inline" askAgent />
+
+      {/* No hand-off: the add-crew form shares this panel — a failed refresh
+          must not offer a navigation that discards it. */}
+      <ErrorNotice message={loadErr} />
+      ```


### PR DESCRIPTION
## Problem / Motivation

The dashboard has one shared error surface, `ErrorNotice`, that renders an error *and* offers to hand it to the agent with the full structured context (route, failed endpoint, HTTP status, backend `code`). Nothing requires anyone to use it. Roughly 100 sites still render an error as a hand-written `<div className="text-danger">{err}</div>`, and new ones keep landing, because no review rule names the component or the `askAgent` decision.

## Why it matters

This is an AI agent app: an error the user cannot fix themselves is usually one the agent can, so every hand-written red div is a dead end that throws away the context the agent would need. It also re-implements the visual (icon, `role="alert"`, tokens, dismiss) slightly differently each time. The hand-off is also destructive (it navigates away and unmounts the tree, destroying unsaved local state), so the `askAgent` choice has to be made deliberately per surface — and today a reviewer cannot tell "protected a draft" from "forgot the prop".

## What changed (motivation → approach → change)

Goal: make "render errors through `ErrorNotice`, decide `askAgent` explicitly" a review-enforced rule rather than tribal knowledge.

Approach: a `blocking: true` rule in `website/AUTOSDE.yaml`, which is what the GPT and Opus review lanes load from the base ref, plus a one-bullet pointer in `website/AGENTS.md`'s "Rules that must not wait for a pointer" list so agents see it before writing code. No CI script — the error-vs-validation split and the "does this subtree hold a draft" question are semantic, so this belongs to the AI lanes, not a grep gate.

The rule (`errors-use-error-notice`):

- Every user-facing error (a rejected request, a caught exception, a `useQuery`/`useMutation` `error`, a backend `{ error, code }` body, a job's `last_error`, a boundary fallback) renders through `ErrorNotice`; classification is by where the value comes from, not how it is rendered. Validation hints, empty states and warnings are out of scope.
- The **author** must turn `askAgent` on where nothing unsaved can be lost, and must leave it off next to an unsaved draft with a `{/* No hand-off: … */}` comment naming the draft (the form already used in `RemoteCrewPanel.tsx`). `onHandoff` lets a dialog close itself but does not make the navigation safe.
- The **reviewer** blocks on the hand-written surface and on the *missing decision* (an added/touched `ErrorNotice` with neither `askAgent` nor a `No hand-off` comment) — never on the direction of the decision, since whether a subtree holds unsaved state is not visible in a hunk and a wrong demand would cause exactly the data loss the prop's default prevents.
- Applies to what a diff adds or touches. Existing sites are grandfathered until edited; this is deliberately stricter than `max-two-buttons-per-row`'s growth-only grandfather because the migration is one line and growth-only would leave the backlog a dead end forever.
- Does not flag `ErrorBoundary`/`MessageErrorBoundary` fallbacks (they mount `AskAgentButton` directly), chat-transcript `ErrorCard` rows (the agent is already in that conversation), or `useNotify(..., { type: 'error' })` toasts — but a toast as the *only* report of a failure that leaves the user in a failed state is a violation, because the app-sdk seam carries only message + type and cannot host the hand-off.

Local adversarial review (GPT and Opus lanes mirrored locally, then one verifier): 0 blocking, 5 advisory findings, all fixed in this commit — the reviewer bright line moved to "missing decision", the `onHandoff` clause no longer counts as enabled over a draft, the toast exception was corrected against the real `useNotify` signature, the stricter grandfather is stated with its reason, and error classification is anchored on the value's source.

## Tests

N/A — the diff is a review rule (YAML) and a doc bullet (markdown); no runtime code path. The YAML was parsed (`custom-rules` still loads, 14 rules, the new one `blocking: true` on `src/**/*.tsx`), and the diff-scoped gates (`check_brand_name.py`, `docs-lint.sh`, `scrub-lint.sh`, `check_focus_cue.py`, `check_harness_parity.py`, `check_changelog_history.py`) exit 0.

## Manual verification

Every factual claim the rule makes about the codebase was checked against the source: `ErrorNotice.askAgent` defaults to `false`; `RemoteCrewPanel.tsx` carries the `No hand-off` comment form; `App.tsx` mounts `AskAgentButton` with `onHandoff`; chat `role: 'error'` rows render through `ErrorCard`; `useNotify` takes `(message, { type })` only.

## Related Issues

no linked issue: the rule was requested directly, not tracked in an issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
