### PR TITLE
refactor: correct false comments and flatten conditionals in service

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -1113,9 +1113,12 @@ on crash, and starts on boot. Implemented in `src/kiro_crew/service/`.
     ship no `sudo` binary — and a non-root caller with no `sudo` fails
     with a clear `ServiceInstallError` rather than an uncaught
     `FileNotFoundError`.
-  - The gateway runs as `User=$USER Group=$(id -gn)` — kirocrew
-    code never runs under sudo. Only `install` and `systemctl` invocations
-    are elevated.
+  - The gateway runs as `User=$USER Group=$(id -gn)`. Every elevated
+    executable is a stock system program, not a kirocrew one; the module
+    docstring in `service/linux.py` sits next to the call sites, names the
+    current set, and records what escalating the AppArmor step's
+    interpreter does and does not guarantee. [security](security.md)
+    carries the reasoning behind that step's four tools.
   - **Environment**: values are captured from the installer's environment
     into the unit's `Environment=` lines at install time
     (`service_environment()` in `service/common.py`) — this is how

--- a/src/kiro_crew/service/controller.py
+++ b/src/kiro_crew/service/controller.py
@@ -77,7 +77,7 @@ def installed_service_has_managed_marker() -> "bool | None":
         if plat == Platform.SYSTEMD:
             expected = 'Environment="KIROCREW_SERVICE_MANAGED=1"'
             lines = path.read_text(encoding="utf-8").splitlines()
-            return expected in {line.strip() for line in lines}
+            return any(line.strip() == expected for line in lines)
         if plat == Platform.LAUNCHD:
             # Reuse the launchd reader so malformed XML (which plistlib exposes
             # as an ExpatError) fails closed just like every other service
@@ -127,7 +127,7 @@ def install_service() -> int:
         # started — the directive only applies at service start. Deliberately
         # non-fatal: a failure warns and leaves the service running.
         if profile.message:
-            print(f"   {'⚠️ ' if not profile.ok else ''}{profile.message}")
+            print(f"   {'' if profile.ok else '⚠️ '}{profile.message}")
         _print_headless_auth_warning()
         print()
         print("   Status: kirocrew service status")
@@ -170,7 +170,7 @@ def uninstall_service() -> int:
             return 1
         print("✅ kirocrew service stopped and removed.")
         if profile.message:
-            print(f"   {'⚠️ ' if not profile.ok else ''}{profile.message}")
+            print(f"   {'' if profile.ok else '⚠️ '}{profile.message}")
         return 0
     if plat == Platform.LAUNCHD:
         macos.uninstall()
@@ -209,7 +209,7 @@ def install_launcher_profile(exec_path: str | None = None) -> int:
         return 0
     outcome = linux.install_launcher_profile(exec_path)
     if outcome.message:
-        print(f"{'⚠️  ' if not outcome.ok else '✅ '}{outcome.message}")
+        print(f"{'✅ ' if outcome.ok else '⚠️  '}{outcome.message}")
     return 0 if outcome.ok else 1
 
 
@@ -219,11 +219,10 @@ def remove_launcher_profile() -> int:
         print("ℹ️  Nothing to remove — the AppArmor sandbox profile is Linux-only.")
         return 0
     outcome = linux.remove_launcher_profile()
-    print(
-        f"{'⚠️  ' if not outcome.ok else '✅ '}{outcome.message}"
-        if outcome.message
-        else "✅ No AppArmor sandbox profile was installed."
-    )
+    if outcome.message:
+        print(f"{'✅ ' if outcome.ok else '⚠️  '}{outcome.message}")
+    else:
+        print("✅ No AppArmor sandbox profile was installed.")
     return 0 if outcome.ok else 1
 
 

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -12,9 +12,39 @@ per-user systemd manager — ``systemctl --user`` fails with
 uniformly across any distro shipping systemd >= 219, which is
 everything since 2015.
 
-Sudo scope: only the systemctl/tee invocations in this file run under
-sudo. The Python interpreter that imports MCP / LLM / agent code never
-runs as root. The actual gateway runs as ``User=$USER`` once started.
+Sudo scope: this file escalates ``systemctl``, ``install``, ``mkdir``,
+``rm``, ``rmdir`` and ``test`` directly, and lends its privileged helpers
+to ``service/apparmor.py``, which adds ``apparmor_parser``, ``aa-exec``,
+and — inside ``aa-exec`` — ``setpriv`` plus a trusted system ``python3``.
+
+What each mechanism here buys is narrower than it reads, and for ``setpriv`` it
+depends on which install path is running — that gap is where an audit of this
+module goes wrong.
+
+Trusted resolution buys one thing, on both paths: the interpreter is root-owned,
+resolved from a fixed list of trusted system directories, and never
+``sys.executable`` — which rules out escalating the venv python, the one that is
+user-writable. It says nothing about what that interpreter then loads. Invoked
+without ``-I``/``-S``, CPython prepends the caller's working directory to
+``sys.path`` and imports ``site``, so code from that working directory,
+``PYTHONPATH``, a user-site ``.pth`` line, ``sitecustomize`` or ``usercustomize``
+runs before or during the payload's own first import — ``ctypes``, which a planted
+module on any of those paths shadows.
+
+WHOSE privileges that loaded code gets is what ``setpriv`` decides, and both
+install paths are live. It reuids to the account the INSTALLER was invoked as
+(``os.getuid()``): started as an ordinary user — the default, where this module
+escalates individual commands through ``sudo`` — it reuids from sudo's root back
+to that user, so the probe and anything it loads stay unprivileged; started as
+``sudo kirocrew service install`` it reuids to 0, which is a no-op, and only on
+that path does the loaded code run as root.
+
+What IS bounded on both paths is the PAYLOAD: a constant stdlib snippet importing
+no ``kiro_crew``, so no MCP / LLM / agent code is reached deliberately.
+
+``docs/system-specs/modules/security.md`` carries the reasoning behind the
+AppArmor step's four tools. The actual gateway runs as ``User=$USER`` once
+started.
 """
 
 from __future__ import annotations
@@ -150,8 +180,8 @@ def render_unit() -> str:
     systemd instance is also wired up explicitly — see the ``XDG_RUNTIME_DIR`` /
     ``DBUS_SESSION_BUS_ADDRESS`` lines below.
 
-    The unit deliberately carries no ``AppArmorProfile=`` directive (#3463):
-    the profile is attached by PATH to the resolved launcher script instead
+    The unit deliberately carries no ``AppArmorProfile=`` directive: the
+    profile is attached by PATH to the resolved launcher script instead
     (:func:`install_apparmor_profile`), and when both mechanisms are present
     systemd's ``change_onexec`` transition silently wins over the kernel's
     automatic path attachment, defeating it.
@@ -287,9 +317,10 @@ def _require_privilege() -> None:
     """
     if not sys.platform.startswith("linux"):
         return
-    geteuid = getattr(os, "geteuid", None)
-    is_root = geteuid is not None and geteuid() == 0
-    if not is_root and shutil.which("sudo") is None:
+    # Ask :func:`_privilege_prefix` rather than re-reading ``os.geteuid``: a
+    # non-empty prefix IS "this call will shell out through sudo", so the two
+    # functions cannot drift into disagreeing about whether escalation is needed.
+    if _privilege_prefix() and shutil.which("sudo") is None:
         raise ServiceInstallError(
             "This action needs root to manage the system service at "
             f"{UNIT_PATH}, but 'sudo' was not found. Re-run as root, or install "
@@ -463,8 +494,10 @@ def install() -> apparmor.ProfileOutcome:
     Calls ``sudo`` to write the unit and to invoke ``systemctl``. Sudo
     will prompt for a password the first time (or when the cached
     ticket has expired) — that prompt appears on the user's terminal.
-    No kirocrew / LLM / agent code runs under sudo: only ``tee`` and
-    ``systemctl`` are invoked.
+    No kirocrew / LLM / agent code runs under sudo deliberately — see the module
+    docstring's sudo scope for the full set of escalated programs, including
+    the ones the AppArmor step adds, and for what the escalated interpreter can
+    still load on its own.
 
     Raises :class:`ServiceInstallError` with a human-readable message if
     a step fails. The CLI catches this and prints the message instead
@@ -558,7 +591,7 @@ def install_apparmor_profile(expected_uid: int | None) -> apparmor.ProfileOutcom
 
     Attaches the profile to ``kirocrew_bin()`` — the same resolved path
     ``render_unit()`` uses for ``ExecStart`` — instead of relying on
-    ``AppArmorProfile=`` (#3463; see the module docstring in ``apparmor.py``).
+    ``AppArmorProfile=`` (see the module docstring in ``apparmor.py``).
 
     ``expected_uid`` is the numeric uid of the account the SERVICE runs as
     (``_current_uid(_current_user())``, resolved once by the caller): the
@@ -635,8 +668,12 @@ def remove_launcher_profile() -> apparmor.ProfileOutcome:
 
 def uninstall() -> None:
     """Stop, disable, and remove the unit. Idempotent."""
-    # Use a non-sudo `test -e` so we don't prompt for a password
-    # when the unit isn't even present.
+    # Probe unprivileged so we don't prompt for a password when the unit isn't
+    # even present: a stock `/etc/systemd/system` is traversable by every user,
+    # so a plain stat answers this. Unlike `_seed_env_file`'s probe, this one
+    # does not need the privileged `test -e` — that path targets a directory an
+    # operator may have locked down, where an unprivileged stat cannot answer
+    # trustworthily (see that function's own docstring for the failure it takes).
     if not UNIT_PATH.exists():
         return
     _require_privilege()

--- a/src/kiro_crew/service/live_target.py
+++ b/src/kiro_crew/service/live_target.py
@@ -186,8 +186,9 @@ def write_target(checkout: Path | str) -> Path:
     path = pointer_path()
     # ``restrict_to_owner=True`` locks the temp file down BEFORE the payload
     # reaches it: the pointer is a code-execution input read at every startup,
-    # and the previous post-rename lockdown left it inheriting the directory's
-    # ACL on Windows for the whole write window (issue #5285). It implies the
+    # so it must never be readable by another account, not even for the width
+    # of the write window — locking down only after the rename would leave it
+    # inheriting the directory's ACL on Windows until then. It implies the
     # owner-only POSIX mode, so the pointer is owner-only on every platform,
     # and a lockdown failure refuses the write before the final path is
     # touched. ``atomic_write`` also creates the parent directory itself,
@@ -227,13 +228,13 @@ def restore(prior: str | None) -> bool:
             # the pointer is a code-execution input read at every startup, and
             # a rollback must not be the step that widens access to it.
             # ``restrict_to_owner=True`` locks the temp file down before the
-            # content reaches it (the previous post-rename lockdown left the
-            # restored pointer inheriting the directory's ACL on Windows for
-            # the write window, issue #5285), and a lockdown failure surfaces
-            # as the OSError this except already maps to ``False`` — before
-            # the final path is touched, so a failed rollback never publishes
-            # an unprotected pointer. The parent mkdir lives inside
-            # ``atomic_write``, after its planted-link check.
+            # content reaches it, so the restored pointer never inherits the
+            # directory's ACL on Windows even for the width of the write
+            # window, and a lockdown failure surfaces as the OSError this
+            # except already maps to ``False`` — before the final path is
+            # touched, so a failed rollback never publishes an unprotected
+            # pointer. The parent mkdir lives inside ``atomic_write``, after
+            # its planted-link check.
             atomic_write(path, prior, restrict_to_owner=True)
         return True
     except OSError:

--- a/src/kiro_crew/service/macos.py
+++ b/src/kiro_crew/service/macos.py
@@ -161,25 +161,21 @@ class ServiceInstallError(RuntimeError):
 def _write_plist_atomic(contents: str) -> None:
     """Write the plist atomically.
 
-    Writes to a sibling temp file in the same directory, then
-    ``os.replace`` to swap into place. ``os.replace`` is atomic on POSIX
-    when source and destination are on the same filesystem, so a SIGINT
-    or crash mid-write leaves either the old plist or no plist at all —
-    never a partial XML document that ``launchctl load`` would reject.
+    Delegates to :func:`kiro_crew.atomic_write.atomic_write`: it writes a
+    sibling temp file in the same directory, then ``os.replace``s it into
+    place. ``os.replace`` is atomic on POSIX when source and destination are
+    on the same filesystem, so a SIGINT or crash never leaves a partial XML
+    document that ``launchctl load`` would reject: the final path holds the old
+    plist before the rename, the new one after it, or nothing where there was no
+    plist to begin with. The shared helper also cleans the temp file up on
+    ``BaseException`` (so that SIGINT leaves no scratch file) and retries the
+    rename past a Windows sharing violation. ``fsync`` is off.
 
-    Delegates to :func:`kiro_crew.atomic_write.atomic_write`, which is that
-    exact shape. Two deliberate strengthenings come with it: the temp cleanup
-    moves from ``except Exception`` to ``except BaseException``, so the SIGINT
-    this docstring already promised to survive also stops leaving a scratch
-    file behind, and the shared helper adds the Windows sharing-violation
-    rename retry. ``fsync`` stays off, as before.
-
-    ``mode=0o600`` preserves rather than tightens: ``mkstemp`` creates its file
-    owner-only and the hand-rolled form never chmod'd it, so the plist has
-    always landed at ``0o600``. It has to be explicit, because ``atomic_write``
-    with no *mode* applies the umask default and would publish the plist
-    world-readable instead. launchd loads the agent as the owning user, so
-    nothing else needs to read it.
+    ``mode=0o600`` has to be explicit: with no *mode*, ``atomic_write`` applies
+    the umask default, so the plist's permissions would follow the operator's
+    umask — world-readable under a common ``022``, owner-only only if they happen
+    to run something as tight as ``077``. launchd loads the agent as the owning
+    user, so nothing else needs to read it.
     """
     atomic_write(PLIST_PATH, contents, mode=0o600)
 
@@ -234,12 +230,12 @@ def write_live_program(contents: str, path: Path | None = None) -> None:
     disagree about which file is authoritative.
 
     Atomic because the agent may be kickstarted at any moment: a partially
-    written launcher would exec a truncated script. The mode is applied to the
-    temp file BEFORE the rename so the file is never visible at the final path
-    without its exec bit -- :func:`kiro_crew.atomic_write.atomic_write` applies
-    *mode* to the descriptor before any content reaches it, which is if anything
-    tighter than the ``os.chmod``-after-write this used to hand-roll. The temp
-    cleanup also widens from ``except Exception`` to ``except BaseException``.
+    written launcher would exec a truncated script.
+    :func:`kiro_crew.atomic_write.atomic_write` applies *mode* to the
+    descriptor before any content reaches it, so the file is never visible at
+    the final path without its exec bit — and never visible anywhere with
+    content but a wider mode. It also cleans the temp file up on
+    ``BaseException``.
 
     ``0o700``, not ``0o755``: launchd runs the agent as the owning user, so
     nobody else needs to read or execute it, and it lives in that user's own
@@ -429,12 +425,12 @@ def restart() -> bool:
     and the respawn ITSELF, so this is safe to call from inside the process being
     restarted.
 
-    The previous implementation (``unload`` then ``load``) could not do that. Run
-    from the gateway, the ``unload`` half SIGTERMs the caller, so the ``load``
-    half never executes and the agent stays down — the exact failure mode that
-    made Dev Fleet's Restart unimplementable on macOS. ``launchctl restart`` is
-    deprecated and behaves like ``stop``; ``KeepAlive`` immediately respawns the
-    loaded job definition rather than re-reading anything.
+    ``unload`` + ``load`` cannot: run from the gateway, the ``unload`` half
+    SIGTERMs the caller, so the ``load`` half never executes and the agent stays
+    down — which is what makes Dev Fleet's Restart unimplementable that way on
+    macOS. ``launchctl restart`` is deprecated and behaves like ``stop``;
+    ``KeepAlive`` immediately respawns the loaded job definition rather than
+    re-reading anything.
 
     Returns False when the plist is absent or launchd rejects the kickstart, so
     callers never report a restart that never happened.


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/service/` carries comment debt that `AGENTS.md` § Code style
explicitly forbids, and two of the comments are outright **false** — which is
worse than stale, because a reader auditing the sudo surface from them reaches
the wrong conclusion:

- `service/linux.py`'s module docstring and `install()` docstring both claimed
  the privileged writer is **`tee`**. `tee` appears nowhere in the module; the
  unit is written with `sudo install`. A reader tracing "what runs as root here"
  was being pointed at a program that does not exist on the path.
- `service/linux.py`'s `uninstall()` said it used a "non-sudo `test -e`". The
  code calls `Path.exists()`; the only privileged `test -e` in the module is
  `_seed_env_file`'s, for a different reason.
- Four task-log citations (`#3463` ×2, `#5285` ×2) and four
  "previously / used to / the previous implementation" narrations, both of which
  `AGENTS.md` names as prohibited comment content.

Alongside that, the module had a handful of small readability items: a
double-negated ternary idiom written four different ways, one `print()` built
from a conditional expression wrapping a nested ternary inside an f-string, a
set comprehension materialised for a single membership test, and a root check
open-coded in two functions that must never disagree.

## Why it matters

A false comment on a privilege boundary is a security-review hazard: it is
exactly the text a reviewer or an auditor reads *instead of* re-deriving the
sudo surface, so an incomplete list becomes an incorrect audit. The `tee` claim
had already survived long enough that the spec (`docs/system-specs/modules/cli.md`)
had copied the same narrow claim.

The task-log citations are the reason `AGENTS.md` bans them: `#3463` tells a
reader nothing at the point of use, while the rationale it stands in for is
already written out two lines away.

## What changed (motivation → approach → change)

One module, one commit, behaviour-preserving throughout. Nothing in
`service/apparmor.py` is touched (see *Scope* below).

**Comment accuracy** — 3 false claims corrected:

- `linux.py` module docstring: replaced the `systemctl`/`tee` claim with the
  actual escalated set — `systemctl`, `install`, `mkdir`, `rm`, `rmdir`, `test`
  directly, plus `apparmor_parser`, `aa-exec`, and the `setpriv` + trusted
  system `python3` that `service/apparmor.py` runs through the privileged
  helpers this module lends it. The load-bearing part is stated as the
  *mechanism* rather than as a list to be trusted, and it is pinned to the thing
  that actually secures the escalation: WHICH interpreter runs — root-owned,
  resolved from a fixed list of trusted system directories, never
  `sys.executable`, and running a constant stdlib snippet that does not import
  `kiro_crew`, so no MCP / LLM / agent code is reached **deliberately** — and the
  docstring now stops the claim exactly there, because the interpreter is not
  isolated. Invoked without `-I`/`-S`, CPython prepends the caller's working
  directory to `sys.path` and imports `site`, so code from that working
  directory, `PYTHONPATH`, a user-site `.pth` line, `sitecustomize` or
  `usercustomize` can run as root before or during the payload's own first import
  of `ctypes`. That is measured rather than assumed (see *Local review*), and the
  invocation itself lives in `service/apparmor.py`, which this commit leaves
  alone (see *Scope*) — the docstring records the boundary rather than moving it.
  `setpriv` is stated separately and without any de-privileging implication: it
  reuids to the account the *installer* was invoked as, which under
  `sudo kirocrew service install` is root, so it does not by itself make the
  probe unprivileged. Cites
  `docs/system-specs/modules/security.md` for the reasoning behind the AppArmor
  step's four tools.
- `linux.py` `install()`: drops its own (stale) enumeration and defers to that
  paragraph.
- `linux.py` `uninstall()`: names the check that actually runs, and states the
  operative permission — a stock `/etc/systemd/system` is *traversable*, so a
  plain stat answers without escalating — and contrasts it with
  `_seed_env_file`'s privileged probe, which exists because `Path.exists()`
  raises `PermissionError` on a locked-down directory rather than answering.
- `docs/system-specs/modules/cli.md` carried the same narrow "Only `install` and
  `systemctl` invocations are elevated" claim. Corrected in this commit: fixing
  one half of a duplicated false claim and leaving the other is how it comes
  back. It now **defers** to the `linux.py` module docstring that sits beside the
  call sites rather than keeping a second copy of the set to drift — the same
  mechanism-plus-pointer form `install()` was given — and its own claim narrows
  to the elevated **executables** being stock system programs, which is what is
  actually true of them.

**Comment hygiene** — the 4 `#NNNN` citations and the 4 historical narrations
(`macos.py` `_write_plist_atomic` / `write_live_program` / `restart`,
`live_target.py` `write_target` / `restore`) are restated in present tense. Each
rewritten comment keeps its constraint and drops only the ticket number or the
"what it used to be": the `atomic_write` guarantees, the `restrict_to_owner`
ordering versus the planted-link check, the `mode`-before-content property, and
the reason `unload` + `load` cannot restart the agent from inside it are all
still there.

**Structural** — 5 sites, all behaviour-identical:

- `controller.py` `remove_launcher_profile`: `print(X if cond else Y)` with a
  nested ternary inside `X` → a plain `if`/`else`, matching its sibling
  `install_launcher_profile`.
- `controller.py` ×4: the warning-prefix ternaries all read `A if not ok else B`;
  inverted to test `ok` positively. The two prefix spellings differ in trailing
  width (`'⚠️  '` two spaces vs `'⚠️ '` one), and each stayed on its own side of
  the flipped condition — verified byte-for-byte.
- `controller.py` `installed_service_has_managed_marker`: a set comprehension
  built solely for one `in` test → `any(line.strip() == expected for line in …)`.
- `linux.py` `_require_privilege`: the open-coded `os.geteuid` root check now
  asks `_privilege_prefix()`, whose non-empty return **is** "this call will shell
  out through sudo". The two functions can no longer drift into disagreeing
  about whether escalation is needed. Equivalence holds in all four input states
  (`geteuid` absent → `["sudo"]` → truthy, matching the old `not is_root`;
  `geteuid() == 0` → `[]` → falsy; `geteuid() != 0` → truthy; non-Linux hits the
  unchanged early `return` above). `os.geteuid` is still reached through this
  module's global `os`, which is what the existing tests monkeypatch, and
  `shutil.which` is still short-circuited away when already root — so a
  root-with-no-sudo container still does not raise.

## Scope

`service/apparmor.py` is deliberately **untouched**, though it holds 12 of the
module's `#NNNN` citations. It is the module's one security-control generator,
and there the ticket numbers carry a design-failure narrative (two earlier
attachment designs and why each was wrong) rather than being bare task-log
noise — rewriting that prose is a judgment call that deserves its own review,
not a line item in a readability sweep. The criterion is a property of the file,
so it is applied to the file as a whole rather than hunk by hunk.

The mechanical detector (shadow-import / chained-ternary) reports **0**
actionable sites in this module on current `origin/main`, so everything here is
judgment-class work under the campaign's rules.

## Tests

No test changes. This is a behaviour-preserving sweep, so the existing tests are
the assertion that nothing moved — in particular `test/test_service.py`'s four
`_privilege_prefix` / `_require_privilege` cases, which patch `svc_linux.os.geteuid`
and therefore still drive the real logic through the new indirection.

- Targeted: `test_service.py`, `test_live_target.py`, `test_spawn_audit.py`,
  `test_host_service_guard.py`, `test_doctor_sandbox_verdict.py`,
  `test_pod_launchd.py` — **474 passed**, and **365 passed** again on the final
  tree after the review fixes.
- Full backend suite on Python 3.12: 84157 passed, 87 failed. Every failure is
  pre-existing on this host and none is in `service/`. Attribution was done by
  failure **set**, not count: the same 13 files fail identically on a pristine
  detached `origin/main` worktree (87 failed there). The single set difference
  (`auto_improvement/tests/test_github_profile.py::TestSuiteMeasurement::test_canary_produces_a_correctly_signed_win`)
  passes standalone on **both** trees and did not fail in the branch's own full
  run, so it is order-dependent on this host and not attributable to the diff.
  The host lacks a usable user-namespace sandbox, which is what reds the
  subprocess-spawning families listed.

## Manual verification

N/A — unit coverage sufficient. There is no reachable behaviour change to
exercise: after stripping docstrings, `live_target.py` and `macos.py` are
AST-identical to `origin/main`, and the five remaining rewrites are
expression-level and output-identical.

## Local review

Four parallel reviewers ran before this PR opened, each on a distinct lens
(AUTOSDE blocking rules; behaviour equivalence; comment accuracy; security
keystone / boot path / import semantics).

**Acted on — 3 findings, all in text this PR itself introduced:**

1. The first draft of the `linux.py` sudo-scope paragraph asserted an
   *exhaustive* list that omitted `aa-exec`, `apparmor_parser`, `setpriv` and
   `python3`. Raised independently by three of the four lenses, verified against
   `apparmor.py`'s `verify_enforcement` argv and `security.md`, and fixed — the
   paragraph now names them and states the de-privileging mechanism, which is
   the part the incomplete list was hiding. Replacing one wrong claim with a
   differently-wrong one would have been the worst outcome here.
2. The `uninstall()` comment said "world-readable" where the operative
   permission is the traverse bit, and did not acknowledge that `Path.exists()`
   propagates `PermissionError`. Corrected.
3. `docs/system-specs/modules/cli.md` mirrored the same stale claim. Corrected
   in this commit rather than deferred.

A verifier then re-checked those three fixes and found **two new inaccuracies
that the fixes themselves had introduced**, both confirmed against the code and
both fixed in the same commit:

4. The fix for (1) claimed `security.md` was "the authoritative list". It is not:
   it names the four AppArmor tools and `sudo install` / `sudo systemctl`, and
   never `mkdir`, `rmdir` or `test`. Both new pointers (`linux.py` and `cli.md`)
   now cite it for the *reasoning*, which is what it actually carries. Pointing a
   reader at a subset while calling it authoritative is the same defect class as
   the `tee` claim this PR started from.
5. The fix for (2) dropped a version scope. `_seed_env_file`'s own docstring
   scopes the `PermissionError` claim to Python 3.12, and on 3.14 `Path.exists()`
   swallows the error and answers `False` instead — so the unscoped restatement
   was false on a supported interpreter (`requires-python = ">=3.12"`). Reworded
   to state the consequence ("cannot answer trustworthily") and defer the
   mechanism to that docstring.

**Dropped — none.** Both behaviour lenses returned no findings with per-rewrite
equivalence proofs (independently confirming the byte-width of the two `⚠️`
prefixes and the four-state truth table for `_require_privilege`), and the
AUTOSDE lens returned no findings.

**One finding I initially deferred and then fixed.** The verifier noted that
`setpriv --reuid=<uid>` does not actually drop privilege under
`sudo kirocrew service install`, where `os.getuid()` is already 0, so
"setpriv drops back to the invoking uid/gid" reads as a de-privileging
guarantee it does not give. I first deferred it as pre-existing (the same claim
sits unchanged in `apparmor.py`, `install_apparmor_profile`, and `security.md`).
GPT 5.6 then raised it independently on the PR against text *this PR wrote* —
which settles it the other way: rebutting an accuracy finding on a technicality,
in a PR whose entire premise is making these comments true, would have been
inconsistent. The docstring now separates the guarantee (stated on what actually
secures it: a root-owned, trusted-directory interpreter that is never
`sys.executable`, running a constant snippet that does not import `kiro_crew`)
from `setpriv` (stated without the implication). The underlying behaviour —
that `apparmor.py`'s "the probe must run unprivileged" constraint is unmet under
a `sudo`-invoked install — is a real pre-existing defect flagged for a
maintainer; fixing it is a behaviour change and does not belong in a
behaviour-preserving sweep.

**Round 2 — 3 more findings in this PR's own text, all fixed.** GPT 5.6 passed
the previous head with no blocking findings but left two advisory ones, and both
were legitimate on exactly the axis this PR exists to fix, so both were fixed
rather than rebutted:

6. `linux.py` asserted `"no user-writable code ... ever runs as root"`. False:
   the escalated interpreter runs without `-I`/`-S`, so CPython's own startup
   imports `site`. **Measured** on `/usr/bin/python3`: with a `sitecustomize.py`
   and a `usercustomize.py` planted on a relocated per-user site path, both
   executed *before* the `-c` payload, and adding `-S -I` suppressed both.
7. `macos.py` `_write_plist_atomic` enumerated the interruption outcomes as
   "either the old plist or no plist at all", omitting the complete **new** plist
   that an interruption after `os.replace` leaves. All three are now named.

A re-review of fix (6) then found it still overstated — the same
one-wrong-claim-for-another trap as (1) and (4):

8. Scoping the guarantee to the payload is not enough, because the payload's own
   first line is `import ctypes`. With `sys.path[0] == ''` under `-c`, a planted
   `ctypes.py` in the caller's working directory **is** what that import
   resolves to — measured, and `-I` restores the stdlib module — and a user-site
   `.pth` line is a further omitted hook. The docstring now names all four
   vectors (working directory, `PYTHONPATH`, `.pth`, `sitecustomize` /
   `usercustomize`) and claims only that no MCP / LLM / agent code is reached
   *deliberately*. `cli.md`'s "never kirocrew code" narrowed with it.

Both behaviour lenses again returned no findings on the final tree, one of them
re-deriving the `_require_privilege` / `_privilege_prefix` equivalence
independently, and both judged that disclosing the residual exposure is the
right call for a comment-accuracy PR rather than an obligation to change the
invocation.

**Round 3 — the paragraph was restructured, not patched again.** GPT passed the
next head with no blocking findings and one advisory: the phrase `"safe to
escalate"` contradicts the root execution the same paragraph goes on to
acknowledge. Correct — and it was the **fourth** round on that one paragraph
(`span=95458d4eeff1`, whose identity is path + lane, so all four share it).
All four had one shape rather than four causes: an affirmative safety claim
broader than the code supports. Round 1 read `setpriv` as a de-privileging
guarantee; round 2 asserted no user-writable code ever runs as root; round 3
scoped that to the payload, missing that the payload's own first line is
`import ctypes`; round 4 was the word `safe`. So the invariant changed rather
than the sentence: the paragraph now makes **no safety claim at all**, stating
only what each mechanism buys — trusted resolution rules out escalating the
user-writable venv interpreter and says nothing about what it then loads,
`setpriv` buys nothing under a sudo-invoked install, the payload is what is
bounded — with the four open import hooks named as facts rather than as caveats
on a promise.

**Flagging for a maintainer, second item.** The working-directory vector is a
concrete *unprivileged* trigger, unlike the site-path ones: `_sudo_capture` pins
no `cwd`, so `cd /tmp && sudo kirocrew service install` resolves the probe's
`import ctypes` against a world-writable directory. Passing `-I` to the trusted
`python3` in `apparmor.verify_enforcement` closes all four vectors in one token
and the payload is pure stdlib, but that edits a file this PR declares out of
scope and changes a security control's invocation, so it wants its own commit,
its own test, and its own review — not a line in a behaviour-preserving sweep.

## CI

`Backend Tests (Windows)` was red on an earlier head for a reason that was
`main`'s, not this diff's — all 5 failures were in `test/test_autonudge_stop_auth.py`,
reproducing byte-identically in a pristine detached `origin/main` worktree. All four
Windows shards are **green** on the current head after the rebase, so nothing is
outstanding there and nothing was weakened, skipped, or re-run to get it.

`Dependency Audit / Audit Production Dependencies` is the one red left, and it
is **not this diff's**. Every attempt fails identically on `npm audit timed out
after 120s for website/package-lock.json` — a tool timeout that the gate turns
into a failure by failing closed, never a reported advisory. Three independent
lines of evidence put it on `main`:

- **This diff cannot reach it.** It touches five files — one spec markdown and
  four modules under `src/kiro_crew/service/` — and no `package.json`,
  `package-lock.json`, or Python dependency manifest. The audited tree is
  `main`'s own; this PR's merge ref is a strict *subset* of it (it predates
  `html-to-image`, which `main` added after this branch's base).
- **The same job is red repo-wide right now** — PRs #8306, #8310, #8318, #8319
  and #8321 all carry the identical failure, and the successes on #8312, #8307
  and #8315 all land inside one good 01:00–01:26 window. Identical input,
  different outcome, is timing.
- **The lockfile itself is over budget.** Running the job's exact command
  (`npm audit --omit=dev --package-lock-only --ignore-scripts
  --audit-level=high`) against this merge ref's lockfile and against current
  `main`'s produces the *same* result — both exceed even a 220s budget. So the
  120s ceiling is marginal for this lockfile against the live registry, which is
  what makes the gate flaky for everyone rather than wrong about this PR.

The job was re-run 10 times rather than touched. The two things that would turn
it green from here — raising the timeout, or adding a
`.vulnerability-exceptions.json` entry — both weaken a security gate, so neither
belongs in a behaviour-preserving comment sweep. Flagging for a maintainer: this
ceiling needs raising (or the audit needs a retry) in its own change.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only — the diff touches four Python files under
`src/kiro_crew/service/` plus one spec markdown file, renders no UI, and changes
no user-visible string; the four `print()` rewrites are byte-identical in output.

## Related Issues

no linked issue: this is a scheduled module-simplification sweep, not the fix for
a tracked report, so nothing here should close on merge.

It *files* one, though: #8414 tracks the cause-level fix for the escalation
boundary this PR only documents (`deferred-finding`, assignee @bolichen97,
`Due: 2026-09-18`). It must **not** be closed by this PR — the remedy it names
edits `service/apparmor.py`, which this commit declares out of scope.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (N/A — no new functionality)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — `docs/system-specs/modules/cli.md`
- [x] No secrets, credentials, or internal references in the diff


