### PR TITLE
fix(electron): grant the dashboard the notifications permission so its OS toasts work

### DIFF
--- a/website/electron/permission-handler.js
+++ b/website/electron/permission-handler.js
@@ -86,6 +86,33 @@
 const TRUSTED_PAGE_PERMISSIONS = new Set(["fullscreen", "notifications"]);
 
 /**
+ * Trusted-page permissions that are additionally restricted to the MAIN frame.
+ *
+ * The trust/origin gate above identifies the dashboard's webContents, but a
+ * subframe shares its parent's webContents — and `isAppOrigin` treats any
+ * localhost origin as the app. Without a frame check, an iframe the dashboard
+ * embeds (a scripted localhost preview, a widget) would inherit the grant and
+ * could post OS notifications wearing this app's identity. `notifications` is
+ * therefore granted only when `details.isMainFrame` is exactly true —
+ * fail-closed when the field is absent, since only Electron's real permission
+ * callbacks (which always carry it) should ever be granted.
+ *
+ * `fullscreen` stays frame-agnostic deliberately: an inline <video> inside an
+ * embedded player frame legitimately requests fullscreen, that was the
+ * pre-existing granted behavior this change must not regress, and a fullscreen
+ * takeover is visible and user-initiated where a forged notification is not.
+ */
+const MAIN_FRAME_ONLY_PERMISSIONS = new Set(["notifications"]);
+
+/** Frame gate for MAIN_FRAME_ONLY_PERMISSIONS; true for everything else. */
+function frameOk(permission, details) {
+  return (
+    !MAIN_FRAME_ONLY_PERMISSIONS.has(permission) ||
+    details?.isMainFrame === true
+  );
+}
+
+/**
  * True when the request belongs to the app's own dashboard.
  *
  * Checks TWO sources because neither is always present:
@@ -247,7 +274,8 @@ function createPermissionRequestHandler(deps = {}) {
     // Notification.requestPermission()), never on Chromium's per-navigation
     // re-checks, so it cannot become console noise.
     if (TRUSTED_PAGE_PERMISSIONS.has(permission)) {
-      const allowed = !isUntrusted(wc) && originOk(wc, origin);
+      const allowed =
+        frameOk(permission, details) && !isUntrusted(wc) && originOk(wc, origin);
       if (!allowed) audit("request", permission, wc, origin, details);
       return callback(allowed);
     }
@@ -337,7 +365,9 @@ function createPermissionCheckHandler(deps = {}) {
     // the renderer reads `Notification.permission` (this handler's verdict)
     // and never constructs a toast unless it says 'granted'.
     if (TRUSTED_PAGE_PERMISSIONS.has(permission)) {
-      return !isUntrusted(wc) && originOk(wc, origin);
+      return (
+        frameOk(permission, details) && !isUntrusted(wc) && originOk(wc, origin)
+      );
     }
     const granted =
       !isUntrusted(wc) &&

--- a/website/electron/permission-handler.js
+++ b/website/electron/permission-handler.js
@@ -52,27 +52,38 @@
 "use strict";
 
 /**
- * The permission name Electron uses for DOM fullscreen.
+ * Page permissions granted to the trusted dashboard with no OS (TCC) leg.
  *
- * Electron routes a DOM `element.requestFullscreen()` through the permission
- * handlers as `permission === "fullscreen"`. Because the rules below grant
- * nothing but `media`, every fullscreen request from the dashboard was answered
- * `callback(false)` — so the fullscreen button on an inline `<video>` (a file
- * card, the media viewer) did nothing at all when clicked, with no error
- * surfaced anywhere the user could see it.
+ * Both members share one shape: the dashboard's own code requests them, they
+ * claim no OS resource Electron must broker (so they are answered before the
+ * media path rather than folded into its macOS machinery), and denying them is
+ * SILENT in the renderer — the exact failure mode this module's header
+ * documents for the microphone. The trust gate applies to both: an untrusted
+ * page in the embedded browser view is refused regardless of origin.
  *
- * It is DISPLAY-only: it claims no OS resource and has no macOS TCC leg, which
- * is why it is answered before the media path rather than folded into it. The
- * trust gate is unchanged — an untrusted page in the embedded browser view is
- * still refused, because a third-party page owning the whole screen can repaint
- * it as a convincing fake of this app.
+ * - `fullscreen`: Electron routes a DOM `element.requestFullscreen()` through
+ *   these handlers as `permission === "fullscreen"`. Before it was granted,
+ *   the fullscreen button on an inline `<video>` (a file card, the media
+ *   viewer) did nothing at all when clicked. Denied to untrusted views because
+ *   a third-party page owning the whole screen can repaint it as a convincing
+ *   fake of this app.
  *
- * Deliberately a single named constant rather than an allowlist container: the
- * sibling capabilities routed through the same handler (`pointerLock`,
- * `keyboardLock`) have no consumer in this product, and widening a permission
- * set without one is how a security default quietly erodes.
+ * - `notifications`: the dashboard fires page-context `new Notification()` for
+ *   new unacked notifications (useNativeNotification.ts) and approval requests
+ *   (useWebSocket.ts). In a plain browser Chromium prompts and grants, so
+ *   Chrome-tab users got native OS toasts; under this handler's blanket deny,
+ *   `Notification.permission` was pinned to 'denied' and the SAME code no-oped
+ *   silently in the packaged app — the one surface where OS notifications are
+ *   most expected. Granting here makes Electron render those constructor calls
+ *   as real OS notifications with zero renderer changes. Denied to untrusted
+ *   views so a browsed page cannot post OS toasts wearing this app's identity.
+ *
+ * This set exists because it now has TWO consumers with identical treatment.
+ * Capabilities routed through the same handler with NO consumer in this
+ * product (`pointerLock`, `keyboardLock`) stay out: widening a permission set
+ * without a consumer is how a security default quietly erodes.
  */
-const FULLSCREEN_PERMISSION = "fullscreen";
+const TRUSTED_PAGE_PERMISSIONS = new Set(["fullscreen", "notifications"]);
 
 /**
  * True when the request belongs to the app's own dashboard.
@@ -166,9 +177,9 @@ function logDeny(kind, permission, wc, origin, details) {
 /**
  * Build the handler for session.setPermissionRequestHandler().
  *
- * Grants `media` for the app origin unless video is explicitly requested.
- * Denies every other permission type (geolocation, clipboard, notifications,
- * MIDI, …).
+ * Grants `media` for the app origin unless video is explicitly requested, plus
+ * the TRUSTED_PAGE_PERMISSIONS set (fullscreen, notifications). Denies every
+ * other permission type (geolocation, clipboard, MIDI, …).
  *
  * ── The macOS (TCC) leg ──────────────────────────────────────────────────────
  *
@@ -227,14 +238,15 @@ function createPermissionRequestHandler(deps = {}) {
     // otherwise inherit the dashboard's microphone grant. A page never gets a
     // capability just for being served from loopback.
     //
-    // Display-only capabilities are answered HERE, before the media rule: they
-    // need the same trust gate but none of the macOS TCC machinery below, and
-    // letting one fall through would put a fullscreen click behind a microphone
-    // prompt. Logged unconditionally on refusal rather than via
-    // isNoteworthyDenial: this branch only runs on a real request (a user
-    // gesture), never on Chromium's per-navigation re-checks, so it cannot
-    // become console noise.
-    if (permission === FULLSCREEN_PERMISSION) {
+    // Non-OS page capabilities (fullscreen, notifications) are answered HERE,
+    // before the media rule: they need the same trust gate but none of the
+    // macOS TCC machinery below, and letting one fall through would put a
+    // fullscreen click or a notification behind a microphone prompt. Logged
+    // unconditionally on refusal rather than via isNoteworthyDenial: this
+    // branch only runs on a real request (a user gesture or an explicit
+    // Notification.requestPermission()), never on Chromium's per-navigation
+    // re-checks, so it cannot become console noise.
+    if (TRUSTED_PAGE_PERMISSIONS.has(permission)) {
       const allowed = !isUntrusted(wc) && originOk(wc, origin);
       if (!allowed) audit("request", permission, wc, origin, details);
       return callback(allowed);
@@ -318,11 +330,13 @@ function createPermissionCheckHandler(deps = {}) {
     // handler (which does the actual granting) is always frame-originated and
     // therefore always has a webContents to match.
     //
-    // The fullscreen branch mirrors the request handler's for the reason in this
+    // This branch mirrors the request handler's for the reason in this
     // module's header: a check that disagrees with the async grant is exactly
     // what made permissions.query() report one verdict while the real request
-    // took another.
-    if (permission === FULLSCREEN_PERMISSION) {
+    // took another. For notifications the check IS the user-visible surface:
+    // the renderer reads `Notification.permission` (this handler's verdict)
+    // and never constructs a toast unless it says 'granted'.
+    if (TRUSTED_PAGE_PERMISSIONS.has(permission)) {
       return !isUntrusted(wc) && originOk(wc, origin);
     }
     const granted =

--- a/website/electron/test/permission-handler.test.js
+++ b/website/electron/test/permission-handler.test.js
@@ -470,6 +470,9 @@ describe("HTML fullscreen — the dead fullscreen button", () => {
 });
 
 describe("notifications — the silent desktop-notification gap", () => {
+  // Electron's real permission callbacks always carry isMainFrame; the grant
+  // is fail-closed without it (see MAIN_FRAME_ONLY_PERMISSIONS).
+  const MAIN = { isMainFrame: true };
   // The dashboard fires page-context `new Notification()` (useNativeNotification,
   // useWebSocket approval toasts). Chromium prompts and grants in a plain
   // browser, so Chrome-tab users got native OS toasts; the blanket deny here
@@ -477,9 +480,9 @@ describe("notifications — the silent desktop-notification gap", () => {
   // same code no-oped silently. Issue #8308.
   it("GRANTS notifications to the dashboard", () => {
     const req = createPermissionRequestHandler(quiet);
-    assert.equal(grant(req, APP, "notifications", {}), true);
+    assert.equal(grant(req, APP, "notifications", MAIN), true);
     const check = createPermissionCheckHandler(quiet);
-    assert.equal(check(APP, "notifications", ORIGIN, {}), true);
+    assert.equal(check(APP, "notifications", ORIGIN, MAIN), true);
   });
 
   it("the CHECK verdict alone unblocks the renderer hook", () => {
@@ -487,7 +490,7 @@ describe("notifications — the silent desktop-notification gap", () => {
     // which reflects THIS handler's synchronous check — a request-side grant
     // with a denying check would leave the hook dead. Pin the check directly.
     const check = createPermissionCheckHandler(quiet);
-    assert.equal(check(null, "notifications", ORIGIN, {}), true, "null-wc check must pass on origin");
+    assert.equal(check(null, "notifications", ORIGIN, MAIN), true, "null-wc check must pass on origin");
   });
 
   it("DENIES notifications to the untrusted embedded browser view", () => {
@@ -495,16 +498,16 @@ describe("notifications — the silent desktop-notification gap", () => {
     // an OS notification is trusted chrome, ideal phishing surface.
     const untrusted = { isUntrusted: (wc) => wc === APP, onDeny: () => {} };
     const req = createPermissionRequestHandler(untrusted);
-    assert.equal(grant(req, APP, "notifications", {}), false);
+    assert.equal(grant(req, APP, "notifications", MAIN), false);
     const check = createPermissionCheckHandler(untrusted);
-    assert.equal(check(APP, "notifications", ORIGIN, {}), false);
+    assert.equal(check(APP, "notifications", ORIGIN, MAIN), false);
   });
 
   it("DENIES notifications to a foreign origin", () => {
     const foreign = wcAt("https://evil.example/");
-    assert.equal(grant(createPermissionRequestHandler(quiet), foreign, "notifications", {}), false);
+    assert.equal(grant(createPermissionRequestHandler(quiet), foreign, "notifications", MAIN), false);
     assert.equal(
-      createPermissionCheckHandler(quiet)(foreign, "notifications", "https://evil.example", {}),
+      createPermissionCheckHandler(quiet)(foreign, "notifications", "https://evil.example", MAIN),
       false,
     );
   });
@@ -519,14 +522,43 @@ describe("notifications — the silent desktop-notification gap", () => {
       askForMicAccess: boom,
       onMicBlocked: boom,
     });
-    assert.equal(grant(req, APP, "notifications", {}), true);
+    assert.equal(grant(req, APP, "notifications", MAIN), true);
+  });
+
+  it("DENIES notifications to a SUBFRAME of the dashboard", () => {
+    // A subframe shares the dashboard's webContents and isAppOrigin treats any
+    // localhost origin as the app — without the frame gate, an embedded
+    // localhost iframe would inherit the grant and could post OS toasts
+    // wearing this app's identity. GPT review finding on #8312.
+    const sub = { isMainFrame: false };
+    const req = createPermissionRequestHandler(quiet);
+    assert.equal(grant(req, APP, "notifications", sub), false);
+    const check = createPermissionCheckHandler(quiet);
+    assert.equal(check(APP, "notifications", ORIGIN, sub), false);
+  });
+
+  it("FAILS CLOSED when isMainFrame is absent", () => {
+    const req = createPermissionRequestHandler(quiet);
+    assert.equal(grant(req, APP, "notifications", {}), false);
+    assert.equal(grant(req, APP, "notifications", undefined), false);
+    const check = createPermissionCheckHandler(quiet);
+    assert.equal(check(APP, "notifications", ORIGIN, {}), false);
+  });
+
+  it("fullscreen stays FRAME-AGNOSTIC (pre-existing behavior preserved)", () => {
+    // An inline <video> in an embedded player frame legitimately requests
+    // fullscreen; the main-frame gate is scoped to notifications only.
+    const req = createPermissionRequestHandler(quiet);
+    assert.equal(grant(req, APP, "fullscreen", { isMainFrame: false }), true);
+    const check = createPermissionCheckHandler(quiet);
+    assert.equal(check(APP, "fullscreen", ORIGIN, { isMainFrame: false }), true);
   });
 
   it("request and check handlers AGREE on notifications", () => {
     for (const isUntrusted of [() => false, () => true]) {
       const deps = { ...quiet, isUntrusted };
-      const fromRequest = grant(createPermissionRequestHandler(deps), APP, "notifications", {});
-      const fromCheck = createPermissionCheckHandler(deps)(APP, "notifications", ORIGIN, {});
+      const fromRequest = grant(createPermissionRequestHandler(deps), APP, "notifications", MAIN);
+      const fromCheck = createPermissionCheckHandler(deps)(APP, "notifications", ORIGIN, MAIN);
       assert.equal(fromRequest, fromCheck);
     }
   });

--- a/website/electron/test/permission-handler.test.js
+++ b/website/electron/test/permission-handler.test.js
@@ -121,7 +121,7 @@ describe("createPermissionCheckHandler", () => {
 
   it("denies non-media permissions and foreign origins", () => {
     const h = createPermissionCheckHandler(quiet);
-    for (const p of ["geolocation", "notifications", "midi", "clipboard-read", "unknown"]) {
+    for (const p of ["geolocation", "midi", "clipboard-read", "unknown"]) {
       assert.equal(h(APP, p, ORIGIN, {}), false, `${p} must be denied`);
     }
     assert.equal(h(wcAt("http://evil.example/"), "media", "http://evil.example", { mediaType: "audio" }), false);
@@ -361,7 +361,7 @@ describe("denial logging", () => {
     const seen = [];
     const deps = { isAppOrigin: () => true, onDeny: (...a) => seen.push(a) };
     const check = createPermissionCheckHandler(deps);
-    for (const p of ["geolocation", "web-app-installation", "background-sync", "notifications", "midi"]) {
+    for (const p of ["geolocation", "web-app-installation", "background-sync", "midi"]) {
       check(APP, p, ORIGIN, {});
     }
     check(APP, "media", ORIGIN, { mediaType: "video" }); // camera, by design
@@ -463,8 +463,71 @@ describe("HTML fullscreen — the dead fullscreen button", () => {
 
   it("does not widen anything else — geolocation stays denied", () => {
     const req = createPermissionRequestHandler(quiet);
-    for (const p of ["geolocation", "notifications", "midi", "clipboard-read", "pointerLock"]) {
+    for (const p of ["geolocation", "midi", "clipboard-read", "pointerLock"]) {
       assert.equal(grant(req, APP, p, {}), false, `${p} must stay denied`);
+    }
+  });
+});
+
+describe("notifications — the silent desktop-notification gap", () => {
+  // The dashboard fires page-context `new Notification()` (useNativeNotification,
+  // useWebSocket approval toasts). Chromium prompts and grants in a plain
+  // browser, so Chrome-tab users got native OS toasts; the blanket deny here
+  // pinned `Notification.permission` to 'denied' in the packaged app and the
+  // same code no-oped silently. Issue #8308.
+  it("GRANTS notifications to the dashboard", () => {
+    const req = createPermissionRequestHandler(quiet);
+    assert.equal(grant(req, APP, "notifications", {}), true);
+    const check = createPermissionCheckHandler(quiet);
+    assert.equal(check(APP, "notifications", ORIGIN, {}), true);
+  });
+
+  it("the CHECK verdict alone unblocks the renderer hook", () => {
+    // useNativeNotification only fires on Notification.permission === 'granted',
+    // which reflects THIS handler's synchronous check — a request-side grant
+    // with a denying check would leave the hook dead. Pin the check directly.
+    const check = createPermissionCheckHandler(quiet);
+    assert.equal(check(null, "notifications", ORIGIN, {}), true, "null-wc check must pass on origin");
+  });
+
+  it("DENIES notifications to the untrusted embedded browser view", () => {
+    // A browsed page must not post OS toasts wearing this app's identity —
+    // an OS notification is trusted chrome, ideal phishing surface.
+    const untrusted = { isUntrusted: (wc) => wc === APP, onDeny: () => {} };
+    const req = createPermissionRequestHandler(untrusted);
+    assert.equal(grant(req, APP, "notifications", {}), false);
+    const check = createPermissionCheckHandler(untrusted);
+    assert.equal(check(APP, "notifications", ORIGIN, {}), false);
+  });
+
+  it("DENIES notifications to a foreign origin", () => {
+    const foreign = wcAt("https://evil.example/");
+    assert.equal(grant(createPermissionRequestHandler(quiet), foreign, "notifications", {}), false);
+    assert.equal(
+      createPermissionCheckHandler(quiet)(foreign, "notifications", "https://evil.example", {}),
+      false,
+    );
+  });
+
+  it("answers notifications WITHOUT entering the macOS mic path", () => {
+    // Same rationale as fullscreen: no OS resource Electron must broker, so a
+    // notification must never be gated on — or prompt for — the microphone.
+    const boom = () => { throw new Error("TCC leg must not run for notifications"); };
+    const req = createPermissionRequestHandler({
+      ...quiet,
+      getMicAccessStatus: boom,
+      askForMicAccess: boom,
+      onMicBlocked: boom,
+    });
+    assert.equal(grant(req, APP, "notifications", {}), true);
+  });
+
+  it("request and check handlers AGREE on notifications", () => {
+    for (const isUntrusted of [() => false, () => true]) {
+      const deps = { ...quiet, isUntrusted };
+      const fromRequest = grant(createPermissionRequestHandler(deps), APP, "notifications", {});
+      const fromCheck = createPermissionCheckHandler(deps)(APP, "notifications", ORIGIN, {});
+      assert.equal(fromRequest, fromCheck);
     }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #8308.

The dashboard already fires page-context `new Notification()` toasts — `useNativeNotification.ts` for new unacked notifications, `useWebSocket.ts` for approval requests — and they work in a plain browser, where Chromium prompts and grants. In the Electron app the permission handlers denied `notifications` wholesale, pinning `Notification.permission` to `'denied'`, so the exact same code no-oped silently. Desktop users got *fewer* OS notifications than browser-tab users.

## Change

`electron/permission-handler.js`: generalize the existing fullscreen grant into a `TRUSTED_PAGE_PERMISSIONS` set (`fullscreen`, `notifications`). Both members share one shape — requested by the dashboard's own code, no OS resource Electron must broker, silent renderer failure when denied. The grant is:

- **trust-gated** — the untrusted embedded browser view stays denied (an OS toast is trusted chrome; a browsed page must not post one wearing the app's identity), and the separate `persist:kirocrew-browser` partition keeps its own deny-all handlers;
- **origin-gated** — foreign origins stay denied;
- **TCC-free** — answered before the media rule, so a notification is never gated on or prompts for the microphone.

Zero renderer changes: with permission granted, Electron renders the existing constructor calls as real OS notifications.

## Tests

New `notifications` describe block in `electron/test/permission-handler.test.js` mirroring the fullscreen-grant pattern: dashboard grant (request + check), null-`wc` check on origin (the verdict `Notification.permission` reflects), untrusted-view denial, foreign-origin denial, no-TCC-path guard, request/check agreement. The untrusted-view sweep in `permission-untrusted.test.js` passes unchanged — the identity gate outranks the new grant, which is exactly what it pins.

`node --test test/permission-handler.test.js test/permission-untrusted.test.js`: 50/50 pass. Full electron suite matches the clean-main host baseline (failures identical on pristine HEAD, all in unrelated auto-update/petOverlays files).

## Not in scope

#4667's broader feature asks (per-category config, click-to-navigate) — this PR only unblocks the notification code that already ships.


## Pattern harvest
Rule candidate: audit checklist
Pattern: a renderer calls a permission-gated Web API (`new Notification()`) that the Electron permission handlers deny by default, so the feature silently no-ops only in the packaged app. When adding or reviewing page-context Web API usage in `website/src/`, cross-check `electron/permission-handler.js` grants (TRUSTED_PAGE_PERMISSIONS / media rule) so the app-origin allowlist stays in sync with the APIs the dashboard actually uses.
