### PR TITLE
fix(snapshot): report a refused cron merge to the import caller

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -222,7 +222,8 @@ def _read_job_records(path: Path) -> tuple[list[dict[str, Any]], bool]:
     * :func:`~kiro_crew.portability._sanitize_imported_crons` rewrites an
       unreadable import to an empty store and reports it to the caller.
     * :func:`~kiro_crew.snapshot._merge_crons` prints which path it could not
-      read and skips the merge.
+      read, skips the merge, and answers ``False`` so its caller can report
+      the refusal instead of a success.
 
     The latter two still guard on ``(OSError, ValueError)`` only, so a deeply
     nested store aborts an import or a snapshot merge there. That is a real

--- a/src/kiro_crew/dashboard/handlers/portability.py
+++ b/src/kiro_crew/dashboard/handlers/portability.py
@@ -129,13 +129,20 @@ async def api_portability_import(request: web.Request) -> web.Response:
         # whether an import was pinned, mixed or unpinned is a security property of the
         # operation, so the audit trail is where it belongs more than a UI badge does. The
         # response still carries it for whatever renders it later.
+        #
+        # A refused component merge (issue #8217: the cron merge can refuse and
+        # import nothing) is logged as `partial`, not `ok` -- a flat ok here made
+        # the audit trail agree with a summary that claimed a merge that never
+        # happened.
+        refused = summary.get("refused_merges") or []
         _sel().log_api_access(
             caller=caller,
             operation="portability.import",
-            outcome="ok",
+            outcome="partial" if refused else "ok",
             resources=(
                 f"mode={mode},items={len(summary.get('items', []))},"
                 f"staging={summary.get('staging', 'unknown')}"
+                + (f",refused={';'.join(refused)}" if refused else "")
             ),
         )
 

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -542,8 +542,17 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
 
             if (snap / "crons.json").is_file():
                 if (mc / "crons.json").is_file():
-                    _merge_crons(snap / "crons.json", mc / "crons.json")
-                    summary["items"].append("crons (merged)")
+                    if _merge_crons(snap / "crons.json", mc / "crons.json"):
+                        summary["items"].append("crons (merged)")
+                    else:
+                        # A refused merge imported zero jobs. Appending
+                        # "crons (merged)" here regardless was issue #8217: the
+                        # dashboard rendered a success over a restore that
+                        # brought no job back. The refusal is named in the
+                        # items and flagged machine-readably so the handler can
+                        # log the import as partial rather than a flat ok.
+                        summary["items"].append("crons (skipped: unreadable or invalid cron store)")
+                        summary.setdefault("refused_merges", []).append("crons")
                 else:
                     shutil.copy2(str(snap / "crons.json"), str(mc / "crons.json"))
                     summary["items"].append("crons (copied)")

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -2347,21 +2347,32 @@ def _usable_cron_shape(parsed: object, path: Path) -> bool:
     return True
 
 
-def _merge_crons(src_path: Path, dst_path: Path) -> None:
+def _merge_crons(src_path: Path, dst_path: Path) -> bool:
+    """Merge the archive's cron jobs into the live store.
+
+    Returns ``True`` when the merged store was written, ``False`` when the
+    merge was refused: an unreadable source, an unreadable destination, or an
+    unusable cron shape on either side. The refusal diagnostics stay on
+    stdout, but a print is invisible to a caller with no terminal — the
+    dashboard import reported "crons (merged)" over a refusal that imported
+    zero jobs — so the outcome is also returned for the caller to report.
+    A failing WRITE of the merged store is not a refusal: the ``OSError``
+    propagates, which is the loud behavior the caller's error path expects.
+    """
     # Cron job names are operator-authored text and routinely non-ASCII, so the
     # locale codepage is the wrong decoder for this file on any host.
     try:
         src = json.loads(src_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         print(f"  ⚠️  Could not read {src_path}: {exc} — skipping cron merge")
-        return
+        return False
     try:
         dst = json.loads(dst_path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as exc:
         print(f"  ⚠️  Could not read {dst_path}: {exc} — skipping cron merge")
-        return
+        return False
     if not _usable_cron_shape(src, src_path) or not _usable_cron_shape(dst, dst_path):
-        return
+        return False
     existing = {j.get("name") for j in dst.get("jobs", [])}
     imported = 0
     for job in src.get("jobs", []):
@@ -2374,6 +2385,7 @@ def _merge_crons(src_path: Path, dst_path: Path) -> None:
     dst_path.write_text(json.dumps(dst, indent=2), encoding="utf-8")
     total = len(src.get("jobs", []))
     print(f"  Cron jobs imported: {imported} (skipped {total - imported} duplicates)")
+    return True
 
 
 _TERMINATORS = (b"\n", b"\r")
@@ -3870,13 +3882,17 @@ def _do_merge(
 
     if _want(components, "crons"):
         sc, dc = snap / "crons.json", mc / "crons.json"
+        crons_ok = True
         if sc.is_file():
             if dc.is_file():
-                _merge_crons(sc, dc)
+                crons_ok = _merge_crons(sc, dc)
             else:
                 shutil.copy2(str(sc), str(dc))
                 print("  Crons: copied (no existing crons)")
-        print("  ✅ crons")
+        if crons_ok:
+            print("  ✅ crons")
+        else:
+            print("  ⚠️  crons: merge skipped (see warning above) — no jobs imported")
 
     if _want(components, "config"):
         for f in CORE_FILES["config"]:

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -934,3 +934,178 @@ def test_a_malformed_job_cannot_reach_the_cron_loader(tmp_path):
     svc._reset_fingerprint = lambda: None
     svc._load()
     assert [j.name for j in svc._jobs] == ["survivor"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #8217: a refused cron merge must not be reported as a successful one.
+# `apply_import_zip` used to append "crons (merged)" unconditionally, so an
+# import whose merge was refused (imported ZERO jobs) was returned to the
+# dashboard as a success listing "crons (merged)", and the SEL audit agreed.
+# The only trace of the refusal was a print no dashboard import can see.
+# ---------------------------------------------------------------------------
+
+
+def _import_into_target_with_live_crons(zip_path, tmp_path, live_store_text):
+    """Apply a merge import into a target that already has a crons.json."""
+    import kiro_crew.portability as port
+
+    target = tmp_path / "target_mc"
+    target.mkdir()
+    (target / "crons.json").write_text(live_store_text)
+    with patch.object(port, "config_dir", return_value=target):
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+            summary = port.apply_import_zip(zip_path, mode="merge")
+    return summary, target
+
+
+@pytest.mark.parametrize(
+    "live_store_text",
+    [
+        pytest.param("{not json", id="live-store-unreadable"),
+        pytest.param("[]", id="live-store-not-an-object"),
+        pytest.param(json.dumps({"jobs": ["not-an-object"]}), id="live-job-list-unusable"),
+    ],
+)
+def test_a_refused_cron_merge_is_not_reported_as_merged(tmp_path, live_store_text):
+    # The snapshot side is mostly sanitized by `_sanitize_imported_crons`
+    # before the merge, so from `apply_import_zip` the reachable refusals are
+    # the LIVE store's side -- unreadable bytes, a non-object top level, or an
+    # unusable job list -- plus one archive-side shape the sanitizer passes
+    # through (a lone-surrogate job name, covered separately below). Each one
+    # must surface in the summary as a skip, not as "crons (merged)".
+    z = _make_cron_import_zip(
+        tmp_path / "ok.zip", [_cron_job("c1", "restored-job", message="check")]
+    )
+    summary, target = _import_into_target_with_live_crons(z, tmp_path, live_store_text)
+
+    assert "crons (merged)" not in summary["items"], summary
+    assert "crons (skipped: unreadable or invalid cron store)" in summary["items"], summary
+    assert summary.get("refused_merges") == ["crons"]
+    # Nothing was imported: the live store is byte-identical to before.
+    assert (target / "crons.json").read_text() == live_store_text
+
+
+def test_an_archive_side_refusal_is_not_reported_as_merged(tmp_path):
+    # The one archive-side refusal reachable end-to-end: a lone-surrogate job
+    # name survives `_sanitize_imported_crons` (which only checks the name is
+    # a str, and rewrites nothing when no job was dropped or paused), and
+    # `_usable_cron_shape` then refuses the SOURCE side inside `_merge_crons`.
+    z = _make_cron_import_zip(
+        tmp_path / "surrogate.zip", [_cron_job("c1", "bad\ud800name", message="check")]
+    )
+    live = json.dumps({"jobs": [_cron_job("l1", "local-job", message="local")]})
+    summary, target = _import_into_target_with_live_crons(z, tmp_path, live)
+
+    assert "crons (merged)" not in summary["items"], summary
+    assert "crons (skipped: unreadable or invalid cron store)" in summary["items"], summary
+    assert summary.get("refused_merges") == ["crons"]
+    assert (target / "crons.json").read_text() == live
+
+
+def test_a_genuine_cron_merge_still_reports_merged(tmp_path):
+    z = _make_cron_import_zip(
+        tmp_path / "ok.zip", [_cron_job("c1", "restored-job", message="check")]
+    )
+    live = json.dumps({"jobs": [_cron_job("l1", "local-job", message="local")]})
+    summary, target = _import_into_target_with_live_crons(z, tmp_path, live)
+
+    assert "crons (merged)" in summary["items"], summary
+    assert "refused_merges" not in summary, summary
+    names = [j["name"] for j in json.loads((target / "crons.json").read_text())["jobs"]]
+    assert sorted(names) == ["local-job", "restored-job"]
+
+
+def test_merge_crons_returns_the_outcome_on_every_path(tmp_path):
+    """The three refusal paths answer False and write nothing; a merge answers True.
+
+    Two of the source-side refusals are unreachable through `apply_import_zip`
+    (the sanitizer rewrites the snapshot's store first) but fully reachable from
+    the snapshot restore path, so they are locked here at the merger itself.
+    """
+    from kiro_crew.snapshot import _merge_crons
+
+    good = json.dumps({"jobs": [_cron_job("d1", "existing", message="m")]})
+    src, dst = tmp_path / "src.json", tmp_path / "dst.json"
+
+    # Refusal 1: unreadable source.
+    src.write_text("{not json")
+    dst.write_text(good)
+    assert _merge_crons(src, dst) is False
+    assert dst.read_text() == good
+
+    # Refusal 2: unreadable destination.
+    src.write_text(good)
+    dst.write_text("{not json")
+    assert _merge_crons(src, dst) is False
+    assert dst.read_text() == "{not json"
+
+    # Refusal 3: unusable cron shape (source side; the guard is symmetric).
+    src.write_text(json.dumps({"jobs": ["not-an-object"]}))
+    dst.write_text(good)
+    assert _merge_crons(src, dst) is False
+    assert dst.read_text() == good
+
+    # A real merge answers True and writes the merged store.
+    src.write_text(json.dumps({"jobs": [_cron_job("s1", "imported", message="m")]}))
+    dst.write_text(good)
+    assert _merge_crons(src, dst) is True
+    names = [j["name"] for j in json.loads(dst.read_text())["jobs"]]
+    assert sorted(names) == ["existing", "imported"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "summary,expected_outcome,expect_refused_tag",
+    [
+        pytest.param(
+            {
+                "items": ["crons (skipped: unreadable or invalid cron store)"],
+                "refused_merges": ["crons"],
+                "staging": "unpinned",
+            },
+            "partial",
+            True,
+            id="refused-merge-logs-partial",
+        ),
+        pytest.param(
+            {"items": ["crons (merged)"], "staging": "unpinned"},
+            "ok",
+            False,
+            id="clean-import-logs-ok",
+        ),
+    ],
+)
+async def test_import_handler_outcome_reflects_a_refused_merge(
+    tmp_path, summary, expected_outcome, expect_refused_tag
+):
+    # The dashboard handler used to log outcome="ok" unconditionally, so the
+    # audit trail confirmed the false success. A summary carrying a refused
+    # merge must land as "partial" with the refused component named.
+    from aiohttp.test_utils import make_mocked_request
+
+    import kiro_crew.dashboard.handlers.portability as ph
+
+    events = []
+
+    class _FakeSel:
+        def log_api_access(self, **kw):
+            events.append(kw)
+
+    upload = tmp_path / "upload.zip"
+    upload.write_bytes(b"")
+
+    async def _fake_read_upload(request):
+        return upload, None
+
+    req = make_mocked_request("POST", "/api/portability/import?mode=merge")
+    req["user"] = "tester"
+    with patch.object(ph, "_read_upload_file", _fake_read_upload):
+        with patch.object(ph, "validate_import_zip", lambda p: (True, "", {"version": 2})):
+            with patch.object(ph, "apply_import_zip", lambda p, m: summary):
+                with patch.object(ph, "_sel", lambda: _FakeSel()):
+                    resp = await ph.api_portability_import(req)
+
+    assert resp.status == 200
+    assert len(events) == 1, events
+    assert events[0]["outcome"] == expected_outcome
+    assert ("refused=crons" in events[0]["resources"]) is expect_refused_tag

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -1851,3 +1851,55 @@ class TestNotificationMergeWriteSideContract:
         with pytest.raises(UndecodableRecord):
             snapshot_mod._merge_notifications(src, dst)
         assert dst.read_bytes() == self.LIVE, "the retry appended something"
+
+
+# ── Issue #8217: the restore status line must not claim success over a refused
+# cron merge ───────────────────────────────────────────────────────────────────
+
+
+class TestARefusedCronMergeIsVisibleInTheRestoreStatus:
+    """`_do_merge` printed "✅ crons" whatever `_merge_crons` decided.
+
+    The terminal shows the merger's own warning right above, but the status
+    line is the summary an operator scans — a checkmark over a refusal is the
+    same false success the import summary had (#8217).
+    """
+
+    @staticmethod
+    def _job(name: str) -> dict:
+        return {
+            "id": "j1",
+            "name": name,
+            "message": "check",
+            "schedule": {"kind": "cron", "cron_expr": "0 9 * * *"},
+        }
+
+    def test_a_refused_merge_prints_a_skip_not_a_checkmark(self, tmp_path, capsys):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "crons.json").write_text(json.dumps({"jobs": [self._job("imported")]}))
+        (home / "crons.json").write_text("{not json")
+
+        snapshot_mod._do_merge(snap, home, ["crons"], allow_unpinned=bool(unpinnable_argv()))
+
+        out = capsys.readouterr().out
+        assert "✅ crons" not in out, out
+        assert "crons: merge skipped" in out, out
+        # The refusal wrote nothing.
+        assert (home / "crons.json").read_text() == "{not json"
+
+    def test_a_genuine_merge_still_prints_the_checkmark(self, tmp_path, capsys):
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir()
+        home.mkdir()
+        (snap / "crons.json").write_text(json.dumps({"jobs": [self._job("imported")]}))
+        (home / "crons.json").write_text(json.dumps({"jobs": [self._job("existing")]}))
+
+        snapshot_mod._do_merge(snap, home, ["crons"], allow_unpinned=bool(unpinnable_argv()))
+
+        out = capsys.readouterr().out
+        assert "✅ crons" in out, out
+        assert "crons: merge skipped" not in out, out


### PR DESCRIPTION
## Problem / Motivation

A snapshot import whose cron merge was refused is reported to the caller as a successful one. `_merge_crons` (`src/kiro_crew/snapshot.py`) has three refusal paths -- unreadable source JSON, unreadable destination JSON, and an unusable cron shape on either side -- and each returned `None` with only a `print` to show for it. `apply_import_zip` (`src/kiro_crew/portability.py`) then appended `"crons (merged)"` to the summary unconditionally, and the dashboard handler logged the import with `outcome="ok"`. Net effect: an import that restored ZERO cron jobs answered `{ok: true}` with a summary listing `"crons (merged)"`, and the SEL audit trail agreed. The only trace of the refusal was a print a dashboard import has no terminal to show.

## Why it matters

A user restoring a backup expecting their scheduled jobs back is told it worked when no job was imported. They discover the loss later, when a job silently never fires -- and the audit trail, the one place that should contradict the false success, confirms it instead.

## What changed (motivation -> approach -> change)

Symptom: false "crons (merged)" over a refused merge. Root cause: the merge's outcome existed only on stdout, so no caller could distinguish a merge from a refusal. Fix: make the refusal observable at each caller, minimally:

- `_merge_crons` now returns `bool`: `True` only after the merged store is written, `False` on all three refusal paths. Diagnostics stay on stdout; a failing write still raises (`OSError` propagates to the handler's error path, which is the correct loud behavior).
- `apply_import_zip` gates the summary item on that return: a refusal appends `"crons (skipped: unreadable or invalid cron store)"` plus a machine-readable `refused_merges: ["crons"]`, instead of `"crons (merged)"`.
- The dashboard handler (`src/kiro_crew/dashboard/handlers/portability.py`) logs `outcome="partial"` naming the refused component in `resources`, instead of a flat `ok`. `"partial"` follows the established convention (`connections.py`, `security.py`, `hooks_integration.py`).
- The CLI restore path (`_do_merge`) prints an explicit `crons: merge skipped` line instead of `"OK checkmark" crons status line` over a refusal.

Known, deliberately out-of-scope siblings (this PR stops the cron-merge false positive at its root, per the issue; each of these is the same *shape* but a different surface):

- `PortabilityTab.tsx` renders only `summary.items.length` with a green check, so the human-visible toast is unchanged; the API payload and audit trail are now truthful, and `refused_merges` is in the response for the UI to render. Precedent: `rejected_crons` / `paused_crons` are equally unrendered today. Frontend surfacing is a small follow-up (this change is backend-only by design).
- An archive whose own cron store is unreadable is rewritten to an empty store by `_sanitize_imported_crons` before the merge, so that case still reports `"crons (merged)"` over zero restored jobs -- the truth for that path lives in `rejected_crons`, which the sanitizer already reports. Pre-existing, not introduced or widened here.
- `_merge_memory` and `_merge_notifications` append `"(merged)"` under the same unconditional pattern; left alone deliberately to keep this root-cause scoped to the component the issue names.
- The CLI restore's machine-readable terminal event (`state_restored`) does not yet reflect a refused component; `_do_merge` returns `None` today and propagating it is a second contract change.

## Tests

- `test_merge_crons_returns_the_outcome_on_every_path`: all three refusal paths answer `False` and write nothing; a genuine merge answers `True` and writes the merged store.
- `test_a_refused_cron_merge_is_not_reported_as_merged` (parametrized x3): every live-store refusal reachable through `apply_import_zip` (unreadable bytes, non-object top level, unusable job list) yields the skip item + `refused_merges`, never `"crons (merged)"`, and leaves the live store byte-identical.
- `test_an_archive_side_refusal_is_not_reported_as_merged`: the one archive-side refusal that survives the sanitizer end-to-end (a lone-surrogate job name) is reported as a skip.
- `test_a_genuine_cron_merge_still_reports_merged`: no regression on the success path.
- `test_import_handler_outcome_reflects_a_refused_merge` (parametrized x2): the handler logs `partial` + `refused=crons` for a refused merge and `ok` for a clean one.
- `TestARefusedCronMergeIsVisibleInTheRestoreStatus` (2 tests): `_do_merge` prints the skip line, not `"OK checkmark" crons status line`, over a refusal -- and still prints the checkmark on a genuine merge.

Local gates: isort / flake8 / mypy clean; `test/test_portability.py` + `test/test_snapshot.py` 132 passed; full backend suite run -- the only failures are pre-existing host-environment classes (NFS `/local/home` ownership, `AF_UNIX path too long`) that reproduce identically on a pristine `origin/main` worktree on this host.

## Manual verification

N/A -- unit coverage sufficient: both production callers of `_merge_crons` and the handler outcome are exercised directly by the new tests, and the change has no UI surface.

Closes #8217

## Pattern harvest

Rule candidate: a helper that can refuse its work (merge/restore/import) must return the outcome, and a caller MUST NOT append a success item to a user-facing summary (or log outcome=ok) unless that return says the work happened. Two sibling instances of the same shape exist today (`_merge_memory`, `_merge_notifications` append "(merged)" unconditionally) and are named in the out-of-scope list above -- candidate for an AUTOSDE reviewer rule on `summary["items"].append(...(merged)...)` sites adjacent to an ungated helper call; a semgrep rule is likely too syntactic to avoid false positives.
