### PR TITLE
test(autonudge): gate the prompt-loop double that carries probe state

### DIFF
--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -232,6 +232,16 @@ def test_autonudge_stop_short_circuits_for_non_nudgeable_session(monkeypatch):
 
 
 class _FakeLoop:
+    """Prompt-loop double.
+
+    ``gate`` mirrors ``NudgeLoop.gate``: a prompt loop carries probe state in
+    ``monitor`` only when it is gated, and ``is_structured_monitor_loop`` reads
+    ``monitor is not None and not gate`` to tell a controller-owned structured
+    monitor apart from a prompt loop. A double that sets ``monitor`` without
+    ``gate=True`` is therefore routed to the structured ``monitor_update`` path,
+    which refuses ``message``/``max_cycles``/``active`` as legacy fields.
+    """
+
     def __init__(
         self,
         loop_id,
@@ -244,6 +254,7 @@ class _FakeLoop:
         stopped_reason="",
         slot_key="",
         monitor=None,
+        gate=False,
     ):
         self.id = loop_id
         self.cycle_count = cycle_count
@@ -254,6 +265,7 @@ class _FakeLoop:
         self.stopped_reason = stopped_reason
         self.slot_key = slot_key
         self.monitor = monitor
+        self.gate = gate
 
 
 class _FakeMonitor:
@@ -688,6 +700,7 @@ def test_applier_owed_terminal_turn_is_not_reported_as_a_spent_cap(monkeypatch):
         stopped_reason="cycle_cap",
         slot_key="slack:C123:170.5",
         monitor=_FakeMonitor(terminal_pending="success"),
+        gate=True,
     )
     svc = _FakeSvc(loop)
     _install_svc(monkeypatch, svc)
@@ -722,6 +735,7 @@ def test_applier_owed_blocked_turn_is_not_reported_as_a_merge(monkeypatch):
         stopped_reason="cycle_cap",
         slot_key="slack:C123:170.5",
         monitor=_FakeMonitor(terminal_pending="blocked"),
+        gate=True,
     )
     svc = _FakeSvc(loop)
     _install_svc(monkeypatch, svc)
@@ -753,6 +767,7 @@ def test_applier_settled_terminal_loop_is_not_reported_as_a_manual_pause(monkeyp
         active=False,
         stopped_reason=MONITOR_TERMINAL_REASON,
         monitor=_FakeMonitor(outcome=MonitorOutcome.SUCCESS),
+        gate=True,
     )
     svc = _FakeSvc(loop)
     _install_svc(monkeypatch, svc)
@@ -787,6 +802,7 @@ def test_applier_a_settled_outcome_outranks_a_stale_owed_turn(monkeypatch):
         active=False,
         stopped_reason="cycle_cap",
         monitor=_FakeMonitor(terminal_pending="success", outcome=MonitorOutcome.BLOCKED),
+        gate=True,
     )
     svc = _FakeSvc(loop)
     _install_svc(monkeypatch, svc)
@@ -817,6 +833,7 @@ def test_applier_a_spent_cap_with_no_terminal_news_still_revives(monkeypatch):
         active=False,
         stopped_reason="cycle_cap",
         monitor=_FakeMonitor(),
+        gate=True,
     )
     svc = _FakeSvc(loop)
     _install_svc(monkeypatch, svc)


### PR DESCRIPTION
## Problem / Motivation

`main` is red: `Backend Tests (3.12, 1)` and `Backend Tests (Windows) (1)` fail 5 tests in `test/test_autonudge_stop_auth.py` (`test_applier_owed_terminal_turn_is_not_reported_as_a_spent_cap`, `test_applier_owed_blocked_turn_is_not_reported_as_a_merge`, `test_applier_settled_terminal_loop_is_not_reported_as_a_manual_pause`, `test_applier_a_settled_outcome_outranks_a_stale_owed_turn`, `test_applier_a_spent_cap_with_no_terminal_news_still_revives`) with

```
AssertionError: assert 'without merging' in 'monitor_update cannot apply legacy fields to a structured monitor: max_cycles'
```

Reproduces on a pure `origin/main` checkout.

## Why it matters

Every open PR inherits the two red backend shards, so `PR Readiness` cannot pass for anyone until this is fixed.

## What changed (motivation → approach → change)

The five tests (from #8201) build a prompt loop whose `monitor` carries `terminal_pending` / `outcome`, but the `_FakeLoop` double never sets `gate`. `is_structured_monitor_loop` (from #5184) reads `monitor is not None and not gate`, so an ungated loop with probe state is classified as a controller-owned structured monitor, and `apply_session_directive("monitor_update", ...)` routes to `_structured_monitor_update`, which refuses `message` / `max_cycles` / `active` as legacy fields. The assertions then run against that refusal string.

A real prompt loop only ever carries probe state when it is gated — the service infers a `MonitorState` only when `loop.gate` is true, and the `NudgeLoop.monitor` field documents that `gate=True` records belong to the prompt path. The double was violating the invariant the discriminator relies on. Fix: `_FakeLoop` gains a `gate` parameter (default `False`, matching `NudgeLoop`) and the five tests pass `gate=True`. No production code changes.

## Tests

`test/test_autonudge_stop_auth.py`: 50 passed locally (was 45 passed / 5 failed on `origin/main`). black / isort / flake8 clean on the file.

## Manual verification

N/A — unit coverage sufficient; the change is confined to a test double.

## Related Issues

no linked issue: main-red introduced by the interaction of #8201 and #5184, caught by CI on open PRs.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a hand-rolled test double omits a field a production discriminator reads via `getattr(obj, name, default)`, so the default silently selects the wrong code path.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
