### PR TITLE
fix(chat): fire redaction notice on the 7 exception-path assistant persists

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3155,6 +3155,48 @@ def _redaction_notice(count: int) -> str:
     )
 
 
+def _append_redaction_notice(slot: _ChatSlot, redacted: str) -> None:
+    """Append the credential-redaction notice for an already-persisted body.
+
+    ``redacted`` is the SAME string that was just written to the assistant row,
+    so counting composes with per-chunk redaction unchanged: whatever pass wrote
+    the tag (per-chunk in the run loop, or a finalizing re-redact), the artifact
+    is already in the text by the time this runs. The wire-stream redactors are
+    deliberately not in that list: they rewrite only what crosses WS/SSE, and
+    ``assistant_text`` is accumulated independently of them.
+
+    Tell the user the text was altered. Until #6189 this was silent: the
+    redactor's warnings are logged and nothing else, so a user copied a command
+    whose credential had become a placeholder and only found out when it failed
+    downstream.
+
+    The count comes from the TAG in the persisted text, not from the redactor's
+    returned warnings, because on the streaming path that warning list is almost
+    always empty here: the run loop redacts every chunk before it enters
+    ``assistant_text``, so a finalizing re-redact re-redacts already-clean text
+    and reports nothing. Warnings only fire for a credential split across chunk
+    boundaries, the rarer case. Reading the artifact instead of the event answers
+    the question the user actually has -- "is what I am about to copy still what
+    the assistant wrote?" -- and stays correct wherever the substitution happened.
+
+    The count sums every CREDENTIAL tag the redactor can emit, read from
+    ``CREDENTIAL_REDACTION_TAGS`` which ``security.py`` owns beside the passes
+    that write them. Enumerating tags by hand here is what previously left an
+    encoded-credential-only segment silently rewritten and undercounted a mixed
+    one; asking the redactor's own module means a newly added tag cannot escape.
+
+    SCOPE: credentials only. This notice does NOT fire for the
+    ``redact_exfiltration_urls`` pass, which rewrites a URL to
+    ``[REDACTED: suspicious URL to <domain>]`` just as silently. Same root cause,
+    different rewriter -- tracked separately rather than widened into this fix,
+    because issue #6189 reports the credential case and the notice wording
+    ("A credential ... was replaced") would have to change to cover both.
+    """
+    count = sum(redacted.count(tag) for tag in CREDENTIAL_REDACTION_TAGS)
+    if count:
+        slot.append("notice", _redaction_notice(count), "msg msg-info")
+
+
 def _flush_segment(
     state: DashboardState,
     slot: _ChatSlot,
@@ -3236,41 +3278,16 @@ def _flush_segment(
         last_msg["variants"] = pending_list
         last_msg["variant_idx"] = len(pending_list) - 1
         slot._pending_variants = []
-    # Tell the user the text was altered. Until now this was silent: the
-    # `cred_warnings` above are logged and nothing else, so a user copied a
-    # command whose credential had become a placeholder and only found out when
-    # it failed downstream (issue #6189).
-    #
-    # The count comes from the TAG in the persisted text, not from
-    # `cred_warnings`, because on the streaming path that list is almost always
-    # empty HERE: the run loop redacts every chunk before it enters
-    # `assistant_text` (EVENT_TEXT_CHUNK branch), so this call re-redacts
-    # already-clean text and reports nothing. `cred_warnings` only fires for a
-    # credential split across chunk boundaries, which is the rarer case. Reading
-    # the artifact instead of the event answers the question the user actually
-    # has -- "is what I am about to copy still what the assistant wrote?" -- and
-    # stays correct wherever the substitution happened: per-chunk, the
-    # StreamRedactor wire pass, or this call. All three write the same tag.
-    #
-    # Broadcast unconditionally: `quiet_persist` exists to suppress a DUPLICATE
-    # of the pre-steer assistant text that clients already rendered, and a notice
-    # row has no streamed counterpart to duplicate. Suppressing it there would
-    # drop the warning on exactly the path this fix exists to cover.
-    # The count sums every CREDENTIAL tag the redactor can emit, read from
-    # `CREDENTIAL_REDACTION_TAGS` which `security.py` owns beside the passes that
-    # write them. Enumerating tags by hand here is what previously left an
-    # encoded-credential-only segment silently rewritten and undercounted a mixed
-    # one; asking the redactor's own module means a newly added tag cannot escape.
-    #
-    # SCOPE: credentials only, so this notice does NOT fire for the
-    # `redact_exfiltration_urls` pass a few lines above, which rewrites a URL to
-    # `[REDACTED: suspicious URL to <domain>]` just as silently. Same root cause,
-    # same function, different rewriter -- tracked separately rather than widened
-    # into this fix, because issue #6189 reports the credential case and the notice
-    # wording ("A credential ... was replaced") would have to change to cover both.
-    _cred_redactions = sum(redacted.count(tag) for tag in CREDENTIAL_REDACTION_TAGS)
-    if _cred_redactions:
-        slot.append("notice", _redaction_notice(_cred_redactions), "msg msg-info")
+    # Tell the user the text was altered (issue #6189); shared with the
+    # exception-path persists via `_append_redaction_notice` so all eight
+    # persists carry one notice contract. The notice broadcasts unconditionally
+    # even under `quiet_persist`: that flag exists to suppress a DUPLICATE of the
+    # pre-steer assistant text clients already rendered, and a notice row has no
+    # streamed counterpart to duplicate -- suppressing it would drop the warning
+    # on exactly the path this fix exists to cover. See the helper for why the
+    # count reads the persisted TAG rather than the redactor's warnings and why
+    # the scope is credentials only.
+    _append_redaction_notice(slot, redacted)
     # Re-append any stop_event that belongs to this segment's trailing run,
     # placed AFTER the finalized assistant message so the UI shows
     # prose → stop card.
@@ -10509,11 +10526,9 @@ async def _run_chat(
     except asyncio.CancelledError:
         if assistant_text:
             slot.purge_chunks()
-            slot.append(
-                "assistant",
-                redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
-                "msg msg-a",
-            )
+            _redacted = redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0]
+            slot.append("assistant", _redacted, "msg msg-a")
+            _append_redaction_notice(slot, _redacted)
     except AcpAuthRequired as exc:
         # The signed-out CLI is discovered HERE, not by a probe: this is the
         # authoritative logout signal now that readiness is latched at boot.
@@ -10528,11 +10543,9 @@ async def _run_chat(
         needs_session_reset = True
         if assistant_text:
             slot.purge_chunks()
-            slot.append(
-                "assistant",
-                redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
-                "msg msg-a",
-            )
+            _redacted = redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0]
+            slot.append("assistant", _redacted, "msg msg-a")
+            _append_redaction_notice(slot, _redacted)
         _auth_msg = str(exc)
         slot.append("error", _auth_msg, "msg msg-err")
         _mark_kiro_signed_out(state)
@@ -10542,11 +10555,9 @@ async def _run_chat(
         needs_session_reset = True
         if assistant_text:
             slot.purge_chunks()
-            slot.append(
-                "assistant",
-                redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
-                "msg msg-a",
-            )
+            _redacted = redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0]
+            slot.append("assistant", _redacted, "msg msg-a")
+            _append_redaction_notice(slot, _redacted)
         slot._acp_pipe_death_retries += 1
         if _should_suppress_requeue(slot):
             pass
@@ -10582,11 +10593,9 @@ async def _run_chat(
         needs_session_reset = True  # checked in finally block
         if assistant_text:
             slot.purge_chunks()
-            slot.append(
-                "assistant",
-                redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0],
-                "msg msg-a",
-            )
+            _redacted = redact_credentials(redact_exfiltration_urls(assistant_text)[0])[0]
+            slot.append("assistant", _redacted, "msg msg-a")
+            _append_redaction_notice(slot, _redacted)
         slot._prompt_busy_retries += 1
         if _should_suppress_requeue(slot):
             pass
@@ -10661,6 +10670,7 @@ async def _run_chat(
                 _safe, _ = redact_credentials(_safe)
                 slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
+                _append_redaction_notice(slot, _safe)
             # Option Y: pipe-death ("process exited"/"not running") shares the
             # _acp_pipe_death_retries counter with the AcpProcessDied handler;
             # genuine "already in progress" busy uses _prompt_busy_retries.
@@ -10932,6 +10942,7 @@ async def _run_chat(
                 _safe, _ = redact_credentials(_safe)
                 slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
+                _append_redaction_notice(slot, _safe)
             # Surface a brief recovery notice (one append). Tag it ONLY when the
             # requeue below will actually happen, or a terminal notice reads as pending.
             _will_recover = not _should_suppress_requeue(slot) and _prompt_depth == 0
@@ -10973,6 +10984,7 @@ async def _run_chat(
                 _safe, _ = redact_credentials(_safe)
                 slot.purge_chunks()
                 slot.append("assistant", _safe, "msg msg-a")
+                _append_redaction_notice(slot, _safe)
             # ── Poisoned-conversation escalation ────────────────────────────
             # A transient-classified error that reaches this terminal branch
             # with ZERO output means a full retry ladder was exhausted

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -1129,6 +1129,144 @@ class TestFlushSegment:
         assert [m.get("role") for m in slot.messages] == ["assistant"]
 
 
+class TestAppendRedactionNotice:
+    """Unit coverage for the shared notice helper (issue #8311).
+
+    ``_flush_segment`` and the seven exception/teardown persists all route
+    through ``_append_redaction_notice`` so the credential-redaction notice
+    lands wherever a pasteable assistant body is finalized, not only on the
+    happy path. These tests exercise the helper directly: it takes the
+    ALREADY-REDACTED string (the same bytes persisted to the assistant row),
+    counts the artifact tags, and appends one ``msg-info`` notice.
+    """
+
+    def test_a_clean_body_gets_no_notice(self, tmp_path):
+        _state(tmp_path)  # not needed, but keeps the harness parity explicit
+        slot = _slot()
+
+        chat_runner._append_redaction_notice(slot, "here is a plain answer")
+
+        assert [m.get("role") for m in slot.messages] == []
+
+    def test_a_single_credential_gets_one_notice(self, tmp_path):
+        from kiro_crew.security import REDACTED_CREDENTIAL_TAG, redact_credentials
+
+        slot = _slot()
+        secret = "postgresql://user:pass@host:5432/db"
+        redacted, _ = redact_credentials(f"connect with {secret}")
+
+        chat_runner._append_redaction_notice(slot, redacted)
+
+        notices = [m for m in slot.messages if m.get("role") == "notice"]
+        assert len(notices) == 1, f"expected one notice row, got {slot.messages}"
+        assert notices[0]["cls"] == "msg msg-info"
+        assert "Security notice" in notices[0]["content"]
+        assert "will not work if you paste it as-is" in notices[0]["content"]
+        # The notice must never carry the secret it is reporting on.
+        assert "user:pass" not in notices[0]["content"]
+        # Coherence check: the tag the count reads is genuinely present in the body.
+        assert REDACTED_CREDENTIAL_TAG in redacted
+
+    def test_multiple_credentials_are_counted(self, tmp_path):
+        from kiro_crew.security import redact_credentials
+
+        slot = _slot()
+        redacted, _ = redact_credentials("first postgresql://a:b@h1/db then mysql://c:d@h2/db")
+
+        chat_runner._append_redaction_notice(slot, redacted)
+
+        notices = [m for m in slot.messages if m.get("role") == "notice"]
+        assert len(notices) == 1, f"expected exactly one notice row, got {notices}"
+        assert "2 credentials" in notices[0]["content"]
+        assert "were replaced" in notices[0]["content"]
+
+    def test_an_encoded_credential_tag_is_counted(self, tmp_path):
+        """A base64-encoded credential is redacted by a DIFFERENT pass and tag.
+
+        Counting only the plaintext tag would leave this silently rewritten --
+        the same #6189 failure, reached by another pass. The helper reads
+        ``CREDENTIAL_REDACTION_TAGS`` so a newly added tag cannot escape.
+        """
+        import base64
+
+        from kiro_crew.security import (
+            _REDACTED_ENCODED_CREDENTIAL_TAG,
+            REDACTED_CREDENTIAL_TAG,
+            redact_credentials,
+        )
+
+        slot = _slot()
+        blob = base64.b64encode(b"postgresql://user:pass@host:5432/db").decode()
+        redacted, _ = redact_credentials(f"decode this: {blob}")
+
+        chat_runner._append_redaction_notice(slot, redacted)
+
+        # Redacted by pass 2, so ONLY the encoded tag is present.
+        assert _REDACTED_ENCODED_CREDENTIAL_TAG in redacted
+        assert REDACTED_CREDENTIAL_TAG not in redacted
+        notices = [m for m in slot.messages if m.get("role") == "notice"]
+        assert len(notices) == 1, f"expected one notice row, got {slot.messages}"
+        assert "A credential" in notices[0]["content"]
+
+
+class TestExceptionPathRedactionNotice:
+    """The notice must fire on the exception/teardown persists too (issue #8311).
+
+    Seven branches finalize a pasteable assistant body directly via
+    ``slot.append("assistant", <redacted>, "msg msg-a")`` and bypass
+    ``_flush_segment``. This drives a real ``AcpProcessDied`` turn (the same
+    scripted-provider harness the recovery-ladder tests use) with a credential
+    in the streamed text and asserts the notice now lands immediately after the
+    assistant row and BEFORE the subsequent retry/error card. It fails if the
+    ``_append_redaction_notice`` call is removed from that branch, which is the
+    mutation guard the issue asks for.
+    """
+
+    @pytest.mark.asyncio
+    async def test_process_death_persist_warns_about_a_redacted_credential(self, tmp_path):
+        from kiro_crew.acp.client import AcpProcessDied
+        from kiro_crew.security import REDACTED_CREDENTIAL_TAG
+
+        state, client = _runner_state(tmp_path)
+        slot = _slot()
+
+        # Stream a credential-bearing chunk, then die: assistant_text is non-empty
+        # so the AcpProcessDied branch persists the (redacted) partial and, with
+        # this fix, appends the notice.
+        def _stream(*_args, **_kwargs):
+            async def _gen():
+                yield LLMEvent(
+                    kind=EVENT_TEXT_CHUNK,
+                    text="run: psql postgresql://user:pass@host:5432/db",
+                )
+                raise AcpProcessDied("process exited")
+
+            return _gen()
+
+        client.stream = MagicMock(side_effect=_stream)
+
+        await _drive(state, slot)
+
+        roles = [m.get("role") for m in slot.messages]
+        assert "assistant" in roles, f"no assistant row persisted: {slot.messages}"
+        assistant = next(m for m in slot.messages if m.get("role") == "assistant")
+        notice = next((m for m in slot.messages if m.get("role") == "notice"), None)
+        # Redaction still happened on the exception path.
+        assert "user:pass" not in assistant["content"]
+        assert REDACTED_CREDENTIAL_TAG in assistant["content"]
+        # ...and the notice now fires (this is what regresses if the helper call
+        # is removed from the AcpProcessDied branch).
+        assert notice is not None, f"expected a redaction notice row, got {roles}"
+        assert notice["cls"] == "msg msg-info"
+        assert "Security notice" in notice["content"]
+        assert "user:pass" not in notice["content"]
+        # Ordering: notice sits between the assistant body and the retry/error
+        # card, mirroring _flush_segment (notice immediately follows its message).
+        assert roles.index("notice") == roles.index("assistant") + 1
+        assert "error" in roles, f"expected a retry/error card after the notice: {roles}"
+        assert roles.index("notice") < roles.index("error")
+
+
 class TestScheduleWidgetRegistration:
     def test_empty_text_registers_nothing(self, tmp_path):
         state, slot = _state(tmp_path), _slot()


### PR DESCRIPTION
Fixes #8311.

## Summary

The credential-redaction notice (#6189 / PR #8109) previously fired only on the `_flush_segment` path. Seven exception/teardown branches in `src/kiro_crew/dashboard/chat_runner.py` persist the pasteable assistant body directly via `slot.append("assistant", …, "msg msg-a")`, bypassing `_flush_segment` — so a segment finalized through one of those branches got its credentials redacted correctly but never told the user.

This change extracts the count-tags-and-append-notice tail of `_flush_segment` into a module-level helper `_append_redaction_notice(slot, redacted)` and calls it from all 8 assistant-body persist sites so they share one notice contract.

## Changes

- New module-level helper `_append_redaction_notice(slot, redacted)`: sums occurrences of `CREDENTIAL_REDACTION_TAGS` in the exact persisted bytes and appends a single `msg msg-info` notice row when non-zero. Counting is artifact-based (reads tags in the persisted text, not the redactor's warning list), so it composes with the per-chunk redaction already done on the streaming paths.
- `_flush_segment` tail replaced with a call to the helper (behavior unchanged; notice still lands after the assistant row and before the trailing stop card).
- The 7 exception/teardown branches (CancelledError, AcpAuthRequired, AcpProcessDied, PromptBusyExhausted, AcpError transient, post-token transient recovery, terminal else) each call the helper immediately after their assistant persist and before any subsequent error/retry/stop card. The 4 inline-redact sites hoist the redacted value into a `_redacted` local so the helper sees the exact persisted bytes; the 3 `_safe` sites reuse the existing local.

## Scope / divergence from the issue

At the current repo HEAD only the credential notice (#8109) has landed. The exfiltration-URL notice (#8291) referenced in the issue is **not present** in the file, so this fix propagates the existing **credential-only** notice and does not invent a URL notice. The issue's line numbers (from `bbbf77567`) are stale; sites were located by pattern, confirming the count of 7. The URL-exfiltration notice remains the separately-tracked #8291 concern.

## Testing

- `python -m pytest test/test_chat_runner_coverage.py` → 277 passed (Python 3.12.13).
- `black --check` / `isort --check-only` / `flake8` clean on both changed files.
- New tests in `test/test_chat_runner_coverage.py`: `TestAppendRedactionNotice` (helper units: clean → no notice, single/multiple credentials, encoded-credential tag counted, no secret leak) and `TestExceptionPathRedactionNotice` (drives a real AcpProcessDied turn, asserts ordering assistant → notice → error card).
- Mutation guard confirmed: removing the helper call from the AcpProcessDied branch makes `TestExceptionPathRedactionNotice` fail with "expected a redaction notice row", then restored.

## Sequencing note

The issue triage suggested sequencing this after open PR #8291 (URL notice, same file) merges to avoid a conflict. This change is self-contained (adds a helper + call sites) and should compose cleanly with a later URL-notice landing, but reviewers may want to reconcile ordering with #8291 before merging.

## Pattern harvest

Rule candidate: semgrep
Pattern: a user-visible side effect is implemented inline in one persist path while sibling persist paths write the same artifact directly. Concretely: an `slot.append("assistant", ..., "msg msg-a")` call in `chat_runner.py` that is not followed by the shared `_append_redaction_notice(...)` call. The defect class is a cross-cutting notice/audit tail coupled to one function body instead of to the artifact it describes, so every later branch that persists that artifact silently opts out. Extracting the tail into a named helper is what makes the rule expressible at all -- before this change there was no single symbol a linter could require.
