### PR TITLE
test(autonudge): pin the gate premise the paused-loop tests rely on

### DIFF
--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -680,6 +680,28 @@ def test_applier_monitor_update_budget_stopped_denial_names_the_budget(monkeypat
     assert "max_cycles" not in result
 
 
+def test_a_probe_state_double_is_a_legacy_loop_only_while_it_carries_the_gate():
+    """Pin ``_FakeLoop``'s premise against the production predicate itself.
+
+    ``monitor_update`` splits on record KIND before it reads a single bound, and a
+    ``monitor`` object alone does not decide that kind. So every paused-loop test
+    below depends on ``gate=True`` putting its double on the LEGACY side — a
+    dependency the class docstring states but nothing executes, so an edit to
+    ``is_structured_monitor_loop`` reports itself only as five assertion failures
+    against a refusal string that names neither the flag nor the routing. This one
+    fails alongside them naming the predicate, so the batch has a cause in it.
+    """
+    from kiro_crew.autonudge import is_structured_monitor_loop
+
+    gated_prompt_loop = _FakeLoop("loop-gated", monitor=_FakeMonitor(), gate=True)
+    controller_record = _FakeLoop("loop-structured", monitor=_FakeMonitor())
+    plain_prompt_loop = _FakeLoop("loop-plain")
+
+    assert not is_structured_monitor_loop(gated_prompt_loop)
+    assert is_structured_monitor_loop(controller_record)
+    assert not is_structured_monitor_loop(plain_prompt_loop)
+
+
 def test_applier_owed_terminal_turn_is_not_reported_as_a_spent_cap(monkeypatch):
     """A channel loop whose subject MERGED must not be told it ran out of cycles.
 


### PR DESCRIPTION
## Problem / Motivation

`main`'s five `monitor_update` paused-loop tests in
`test/test_autonudge_stop_auth.py` went red for several hours today, and the
failure told nobody why. All five reported the same thing:

```
AssertionError: assert 'merged' in 'monitor_update cannot apply legacy fields
to a structured monitor: max_cycles'
```

That string is a **production refusal**, so the batch reads as a bug in the
wording under test. The actual cause was one level up: `monitor_update` splits
on record **kind** before it reads a single bound, and
`is_structured_monitor_loop` decides that kind with
`monitor is not None and not gate`. The tests' `_FakeLoop` predated `gate`, so
the moment they gave it the `monitor` holding the terminal state they are about,
it classified as a controller record and the legacy branch under test became
unreachable. #8317 has since fixed the doubles.

The premise those five now rest on — `gate=True` puts a probe-state double on
the legacy side — is stated in `_FakeLoop`'s docstring and **executed nowhere**.

## Why it matters

The premise is load-bearing for five tests and invisible in all five. Nothing
observes it, so the next edit to `is_structured_monitor_loop` reproduces exactly
the diagnosis cost that just happened: five assertion failures against a refusal
string that names neither the flag nor the routing, in a file whose diff is
clean. It cost this repo a red shard inherited by every PR on that tip, plus two
independent agents reaching the same diagnosis from scratch.

It is also a live risk rather than a hypothetical one, because the classification
straddles two subsystems that ship separately: the discriminator lives in
`autonudge.py`, the split that reads it in `dashboard/session_directive_apply.py`,
and the tests that depend on it name neither in their own diff. That is precisely
the pairing no path-based or file-overlap check can make — it is only visible
through the predicate.

## What changed (motivation → approach → change)

**Goal:** make the premise fail *as itself*, so the batch carries its own cause.

**Approach considered and rejected:** restating the invariant in more prose next
to each of the five. Prose is what is already there, and it is what did not fire.

**The change:** one test,
`test_a_probe_state_double_is_a_legacy_loop_only_while_it_carries_the_gate`,
asserting the three classifications the doubles rely on against the **production
predicate itself**:

| double | `is_structured_monitor_loop` |
|---|---|
| `monitor=_FakeMonitor(), gate=True` — gated prompt loop | `False` (legacy) |
| `monitor=_FakeMonitor()` — controller record | `True` (structured) |
| no monitor — plain prompt loop | `False` (legacy) |

Those three are the invariant production already enforces in both directions: the
prompt-loop arming path (`AutoNudgeService.add` → `_add_unserialized`) attaches a
monitor only `if gate`; `add_monitor` builds its controller record on the
dataclass default (`gate=False`); and `_monitor_tick_is_quiet` — the **only**
writer of `monitor.terminal_pending` and of the `outcome` /
`MONITOR_TERMINAL_REASON` settlement these tests assert on — returns early on
`if not loop.gate`. It is also what the spec says, in
`docs/system-specs/modules/learn-cron-dashboard.md`: *"A prompt-driven zero-token
gate may also carry probe state, but it remains a legacy loop (`gate=true`) on
the AutoNudge control surfaces; only controller records (`gate=false`) use the
structured monitor APIs"*. Nothing documented changes, so no spec edit is owed.

Test-only. No production line moves.

## Tests

- The one test above. `test/test_autonudge_stop_auth.py`: `51 passed`.
- **Verified it fires.** Dropping the `gate` term from
  `is_structured_monitor_loop` (`return getattr(loop, "monitor", None) is not
  None`) takes the module from `5 failed, 45 passed` to `6 failed, 45 passed` —
  the sixth being this test, which names the predicate and the flag rather than a
  refusal string. Reverted after measuring; the production file is untouched in
  this diff.

## Manual verification

N/A — the change is a test, and the suite is the observation. The mutation check
above is the substantive verification.

## Related Issues

no linked issue: this is the harvest of a main regression already fixed by #8317,
not a tracked defect of its own.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a hand-rolled test double whose attribute set predates a production
discriminator silently answers that discriminator's *default*. The test then
routes to the wrong branch and asserts against the **other** branch's error
string — so the failure names a real production refusal and reads as a bug in the
code under test, while the double is the last place anyone looks.

A checkable form, for a reviewer or a review prompt: **when a diff adds a field
that a `getattr(x, "field", default)` predicate splits on, the review has to look
for doubles of `x` in the test tree, not only for callers in `src/`.**

And the reason this PR exists rather than a comment: **an invariant a test
depends on but does not assert is not covered.** When N tests share an unasserted
premise, a break in it costs N confusing failures and zero informative ones, so
the premise earns its own assertion against the production symbol.

Not a lint rule: the trigger is "this double stands in for that dataclass", which
nothing in the source states.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: the spec already states the
      `gate` discriminator this pins; no documented behaviour changes.
- [x] No secrets, credentials, or internal references in the diff
