### PR TITLE
fix(chat): fold every sub-agent wave in a user turn, not just the first

### DIFF
--- a/website/src/pages/chat/groupDisplayItems.ts
+++ b/website/src/pages/chat/groupDisplayItems.ts
@@ -77,6 +77,28 @@ const isSynthesisInjection = (msg: ChatMessage): boolean =>
   (msg.meta as Record<string, unknown> | undefined)?.injectKind === 'synthesis'
 
 /**
+ * The last assistant row of a COMPLETED turn, identified by the per-turn stats
+ * the runner stamps on exactly that row (`_attach_turn_stats`, chat_runner.py).
+ *
+ * This is how the region walk finds where a synthesis turn ENDED. A synthesis
+ * row opens a turn whose answer is real, user-facing content no later synthesis
+ * restates, so that answer must stay outside every later fold — but the rows
+ * after it, which belong to the NEXT wave, are interim work that should fold.
+ * Nothing else in the display layer marks a turn boundary: the runner's
+ * `chat_segment` finalize is a live wire event, not a property of a persisted
+ * row, so a reload has only this meta to go on.
+ *
+ * A turn that produced no assistant message carries no stats, and neither does
+ * an answer still streaming. Both are handled by the caller degrading to the
+ * previous behaviour (leave the region unfolded) rather than guessing a
+ * boundary, because a wrong guess hides an answer behind a toggle that promises
+ * a repeat below.
+ */
+const isTurnEnd = (msg: ChatMessage): boolean =>
+  msg.role === 'assistant' &&
+  !!(msg.meta as Record<string, unknown> | undefined)?.turn_stats
+
+/**
  * An injected row that is NOT part of the fan-out, and whose presence therefore
  * disqualifies the region from being folded.
  *
@@ -188,6 +210,10 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
   // UNFOLDED — degrading to the pre-fold rendering is always safe, whereas
   // folding it would hide unrelated content behind the fan-out's toggle.
   let regionHasForeign = false
+  // Set while the batch being accumulated still holds an un-flushed synthesis
+  // ANSWER, which `settlePendingSynthesisAnswer` below splits off before any
+  // later fold can reach it.
+  let pendingSynthesisAnswer = false
   const hasWorkingSteps = (items: TurnItem[]) =>
     items.some(t =>
       (t.kind === 'single' && (t.msg.role === 'tool' || t.msg.role === 'assistant' || t.msg.role === 'streaming')) ||
@@ -220,6 +246,46 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
       turns.push(...items)
     }
   }
+  /**
+   * Settle an un-flushed synthesis ANSWER sitting at the head of the open batch.
+   *
+   * A synthesis row opens a turn whose answer is real, user-facing content that
+   * no later synthesis restates, so it must never end up inside a later wave's
+   * fold. Splitting it off at its turn boundary and re-anchoring the region
+   * behind it is what lets the rows AFTER it — the next wave's interim work —
+   * fold normally.
+   *
+   * Called at EVERY flush site that can be holding such an answer: the synthesis
+   * branch, and the `subagent` turn-opener a queue-drained completion arrives
+   * as. Missing the second one let the next synthesis mistake that wave's own
+   * per-completion reply for the answer boundary and leave the wave unfolded.
+   *
+   * With no locatable turn end the answer cannot be separated, so the region is
+   * marked foreign and degrades to UNFOLDED — the pre-fix rendering. Showing
+   * interim prose is a cosmetic cost; hiding an answer behind a toggle that
+   * promises a repeat below is a correctness one.
+   */
+  const settlePendingSynthesisAnswer = () => {
+    if (!pendingSynthesisAnswer) return
+    const end = turnItems.findIndex(t => t.kind === 'single' && isTurnEnd(t.msg))
+    if (end >= 0) {
+      flushTurn(turnItems.slice(0, end + 1), true)
+      turnItems = turnItems.slice(end + 1)
+      regionStart = turns.length
+      // A fresh region starts after the answer, so a foreign row that
+      // disqualified the PREVIOUS one must not disqualify this one too —
+      // otherwise one cron reply in wave 1 suppresses every later wave's fold.
+      // RE-DERIVED, never simply cleared: the retained batch can itself hold the
+      // foreign row the old flag was set for (a cron drained AFTER the answer),
+      // and clearing on that would fold an unrelated prompt's reply behind the
+      // fan-out toggle — the exact outcome the foreign guard exists to prevent.
+      // A foreign row arriving later still raises the flag on its own.
+      regionHasForeign = turnItems.some(t => t.kind === 'single' && isForeignInjection(t.msg))
+    } else {
+      regionHasForeign = true
+    }
+    pendingSynthesisAnswer = false
+  }
   for (const item of raw) {
     // The synthesis injection closes a fan-out: flush what is open, then fold
     // everything since the user's prompt into ONE interim turn. Checked BEFORE
@@ -227,6 +293,9 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
     // would be swallowed into the region it is supposed to terminate, and the
     // synthesis answer would fold away with the summaries it replaces.
     if (item.kind === 'single' && isSynthesisInjection(item.msg)) {
+      // A previous synthesis in this same user turn left its answer inside the
+      // open batch; get it out before the fold below runs.
+      settlePendingSynthesisAnswer()
       if (turnItems.length > 0) { flushTurn(turnItems, true); turnItems = [] }
       if (!regionHasForeign) foldInterimRegion(turns, regionStart)
       // The synthesis row leads the turn that carries the answer, so it opens
@@ -237,12 +306,13 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
       // answer no LATER synthesis restates. A synthesis turn can itself spawn a
       // wave (the gateway re-arms `_pending_synthesis` whenever a wave's last
       // agent finishes, whichever turn spawned it), putting a second synthesis
-      // row in the same user turn — and the batch opened here does not reach
-      // `turns` until that second row flushes it, so an unguarded fold would
-      // collapse round one's answer behind round two's toggle. Marking the new
-      // region foreign keeps it unfolded: a nested wave's interim work then
-      // renders as it did before this change, which is the safe direction.
-      regionHasForeign = true
+      // row in the same user turn. That answer must stay outside round two's
+      // fold — but the rows AFTER it are round two's interim work and must fold,
+      // which is why this no longer disqualifies the whole region: doing so left
+      // every wave after the first rendering its per-completion prose in full,
+      // beside a synthesis that restates it — the duplication the fold exists
+      // to remove.
+      pendingSynthesisAnswer = true
       continue
     }
     if (item.kind === 'single' && isForeignInjection(item.msg)) regionHasForeign = true
@@ -252,11 +322,23 @@ export function groupDisplayItems(messages: ChatMessage[]): GroupedTurns {
     // completion is the same case: the gateway injects it as the next turn's
     // input, so the agent's reply belongs BELOW the card, not beside it.
     if (item.kind === 'single' && TURN_OPENER_ROLES.has(item.msg.role)) {
+      // A `subagent` completion opener flushes the open batch WITHOUT resetting
+      // the region (the completions are part of the interim work), so an answer
+      // still sitting in that batch has to be settled here too -- otherwise it
+      // is flushed into the region a later synthesis folds, and that synthesis
+      // then reads the next wave's own reply as the answer boundary.
+      settlePendingSynthesisAnswer()
       if (turnItems.length > 0) { flushTurn(turnItems, true); turnItems = [] }
       turns.push(item)
       // A user/nudge prompt begins a fresh interim region; a sub-agent
       // completion belongs to the one already open.
-      if (item.msg.role !== 'subagent') { regionStart = turns.length; regionHasForeign = false }
+      if (item.msg.role !== 'subagent') {
+        regionStart = turns.length
+        regionHasForeign = false
+        // The prompt ends the previous fan-out outright: any synthesis answer it
+        // left behind is now in a region no later fold can reach.
+        pendingSynthesisAnswer = false
+      }
       continue
     }
     turnItems.push(item)

--- a/website/src/test/groupDisplayItems.test.ts
+++ b/website/src/test/groupDisplayItems.test.ts
@@ -190,6 +190,144 @@ describe('groupDisplayItems', () => {
       .toContain('resumed and summarised agent 1')
   })
 
+  it('folds a SECOND wave in the same user turn, keeping round one\'s answer out', () => {
+    // The reported bug: every wave after the first rendered its per-completion
+    // prose in full, right beside a synthesis that restated it. The region a
+    // synthesis row opens used to be disqualified wholesale to protect that
+    // row's answer; now the answer is split off at its turn boundary (the
+    // `turn_stats` meta the runner stamps) and only it stays outside the fold.
+    const answer = (content: string): ChatMessage =>
+      ({ role: 'assistant', content, cls: '',
+         meta: { turn_stats: { elapsed_ms: 1200 } } } as unknown as ChatMessage)
+    const { turns } = groupDisplayItems([
+      msg('user', 'judge both stacks'),
+      msg('assistant', 'spawning wave 1'),
+      synthesisRow(),
+      answer('ANSWER ONE'),
+      msg('assistant', 'spawning wave 2'),
+      msg('tool', '🔧 @kirocrew-core/spawn_run'),
+      msg('assistant', 'wave 2 per-completion prose'),
+      synthesisRow(),
+      answer('ANSWER TWO'),
+    ])
+    const interim = turns.filter(t => isTurn(t) && t.interim) as { items: { msg: ChatMessage }[] }[]
+    // One fold per wave.
+    expect(interim).toHaveLength(2)
+    const folded = interim.flatMap(t => t.items.map(i => i.msg.content))
+    expect(folded).toContain('spawning wave 1')
+    expect(folded).toContain('wave 2 per-completion prose')
+    // Neither synthesis answer is behind a toggle.
+    expect(folded).not.toContain('ANSWER ONE')
+    expect(folded).not.toContain('ANSWER TWO')
+  })
+
+  it('folds a second wave reached through a queue-drained completion opener', () => {
+    // A completion delivered while the slot is busy drains from the queue as a
+    // `subagent` row, which opens a turn and flushes the open batch WITHOUT
+    // resetting the region. Round one's answer is in that batch, so it has to be
+    // settled at this site too: without it the next synthesis reads wave two's
+    // own per-completion reply as the answer boundary and re-anchors past the
+    // whole wave, leaving it unfolded.
+    const answer = (content: string): ChatMessage =>
+      ({ role: 'assistant', content, cls: '',
+         meta: { turn_stats: { elapsed_ms: 900 } } } as unknown as ChatMessage)
+    const completion = ({ ...msg('subagent', COMPLETION), meta: { subagentCompletion: {} } } as ChatMessage)
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'),
+      msg('assistant', 'spawning wave 1'),
+      synthesisRow(),
+      answer('ANSWER ONE'),
+      msg('assistant', 'spawning wave 2'),
+      completion,
+      answer('wave 2 per-completion prose'),
+      synthesisRow(),
+      answer('ANSWER TWO'),
+    ])
+    const interim = turns.filter(t => isTurn(t) && t.interim) as { items: { msg: ChatMessage }[] }[]
+    const folded = interim.flatMap(t => t.items.map(i => i.msg.content))
+    expect(folded).toContain('wave 2 per-completion prose')
+    expect(folded).not.toContain('ANSWER ONE')
+    expect(folded).not.toContain('ANSWER TWO')
+  })
+
+  it('lets a later wave fold even though a cron reply disqualified an earlier one', () => {
+    // `regionHasForeign` is scoped to ONE region. A cron notification that
+    // drained during wave 1 must not suppress wave 2's fold as well, or a single
+    // unrelated inject silently disables the feature for the rest of the turn.
+    const answer = (content: string): ChatMessage =>
+      ({ role: 'assistant', content, cls: '',
+         meta: { turn_stats: { elapsed_ms: 700 } } } as unknown as ChatMessage)
+    const cron = ({ role: 'inject', content: '[cron]', cls: '',
+                    meta: { injectKind: 'cron' } } as unknown as ChatMessage)
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'),
+      msg('assistant', 'spawning wave 1'),
+      cron,
+      msg('assistant', 'cron answer'),
+      synthesisRow(),
+      answer('ANSWER ONE'),
+      msg('assistant', 'wave 2 per-completion prose'),
+      synthesisRow(),
+      answer('ANSWER TWO'),
+    ])
+    const folded = turns
+      .filter(t => isTurn(t) && t.interim)
+      .flatMap(t => (t as unknown as { items: { msg: ChatMessage }[] }).items.map(i => i.msg.content))
+    // Wave 1 stays unfolded (the cron reply is in it), wave 2 folds.
+    expect(folded).toContain('wave 2 per-completion prose')
+    expect(folded).not.toContain('cron answer')
+    expect(folded).not.toContain('ANSWER ONE')
+  })
+
+  it('keeps a cron reply that landed AFTER a synthesis answer out of the next fold', () => {
+    // The foreign flag must be RE-DERIVED when the region is re-anchored, not
+    // cleared: the retained batch can still hold the very row the flag was set
+    // for. Clearing it here would fold an unrelated prompt's reply behind the
+    // fan-out toggle, which promises a repeat below that never comes.
+    const answer = (content: string): ChatMessage =>
+      ({ role: 'assistant', content, cls: '',
+         meta: { turn_stats: { elapsed_ms: 800 } } } as unknown as ChatMessage)
+    const cron = ({ role: 'inject', content: '[cron]', cls: '',
+                    meta: { injectKind: 'cron' } } as unknown as ChatMessage)
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'),
+      msg('assistant', 'spawning wave 1'),
+      synthesisRow(),
+      answer('ANSWER ONE'),
+      cron,
+      msg('assistant', 'cron answer'),
+      msg('assistant', 'wave 2 per-completion prose'),
+      synthesisRow(),
+      answer('ANSWER TWO'),
+    ])
+    const folded = turns
+      .filter(t => isTurn(t) && t.interim)
+      .flatMap(t => (t as unknown as { items: { msg: ChatMessage }[] }).items.map(i => i.msg.content))
+    expect(folded).not.toContain('cron answer')
+    expect(folded).not.toContain('ANSWER ONE')
+    expect(folded).not.toContain('ANSWER TWO')
+  })
+
+  it('leaves a second wave unfolded when round one\'s answer has no turn boundary', () => {
+    // No `turn_stats` anywhere (a turn that errored, an older transcript, or an
+    // answer still streaming): the answer cannot be separated, so the region
+    // degrades to the pre-fix rendering instead of risking swallowing it.
+    const { turns } = groupDisplayItems([
+      msg('user', 'u'),
+      msg('assistant', 'spawning wave 1'),
+      synthesisRow(),
+      msg('assistant', 'ANSWER ONE'),
+      msg('assistant', 'spawning wave 2'),
+      synthesisRow(),
+      msg('assistant', 'ANSWER TWO'),
+    ])
+    const folded = turns
+      .filter(t => isTurn(t) && t.interim)
+      .flatMap(t => (t as unknown as { items: { msg: ChatMessage }[] }).items.map(i => i.msg.content))
+    expect(folded).not.toContain('ANSWER ONE')
+    expect(folded).not.toContain('ANSWER TWO')
+  })
+
   it('never folds an emitted synthesis answer behind a later wave toggle', () => {
     // A synthesis turn can itself spawn a wave, so two synthesis rows can land
     // in ONE user turn. Round one's answer is a real answer that round two's


### PR DESCRIPTION
## Problem / Motivation

A chat turn that fans out sub-agents more than once renders every wave after the
first **in full**: the per-completion prose the agent writes as each result lands
sits in the transcript immediately above a synthesis turn that restates it. The
user reads the same report twice, at full length.

Reported from a live session judging two large PR stacks — a collapsed
`Worked through N steps` toggle, the `2 agents finished` run card, then a
full-length verdict, then `Sub-agents finished · consolidated summary requested`
followed by a synthesis saying the same thing again.

## Why it matters

Folding that interim region is the whole remedy for post-fan-out duplication
(#7231). Wave 1 got it; waves 2..N never did — and a second wave inside one user
turn is the *normal* shape for the work this feature was built for, because the
gateway re-arms `_pending_synthesis` whenever a wave's last agent finishes,
whichever turn spawned it. So the duplication the fold exists to remove came back
for the majority of real fan-out sessions, while looking fixed.

## What changed (motivation → approach → change)

**Symptom:** only the first wave in a user turn folds.

**Root cause:** the region a synthesis row opens was disqualified wholesale with
`regionHasForeign = true`. That flag exists to keep unrelated content (a cron
reply, a note) out of a fold, and it was borrowed here to protect one specific
row — the synthesis turn's own answer, which is real user-facing content no later
synthesis restates. Protecting one row by poisoning the whole region meant no
wave after the first could ever fold, and the flag stayed sticky until the next
user prompt.

**Change:** carve out just the answer instead of the region.

- `isTurnEnd` identifies a completed turn's last assistant row by the
  `turn_stats` meta the runner already stamps there (`_attach_turn_stats`,
  `chat_runner.py`). Nothing else in the display layer marks a turn boundary —
  `chat_segment` is a live wire event, not a property of a persisted row — so
  this is what a reload has to go on.
- `settlePendingSynthesisAnswer()` splits an un-flushed synthesis answer off at
  that boundary, flushes it as its own **visible** (non-interim) turn, and
  re-anchors `regionStart` behind it. The rows after it belong to the next wave
  and fold normally.
- It runs at **both** flush sites that can hold a pending answer: the synthesis
  branch, and the `subagent` turn-opener — a completion row drained through the
  slot queue flushes the batch there, and skipping it let the next synthesis
  mistake that wave's own reply for the answer boundary and leave the wave
  unfolded.
- Re-anchoring **re-derives** `regionHasForeign` from the batch it retains rather
  than clearing it. Clearing is what lets a cron reply in wave 1 stop
  disqualifying waves 2..N; re-deriving is what keeps a cron reply that landed
  *after* the answer — and is therefore still inside the new region —
  disqualifying it, instead of folding an unrelated prompt's reply behind the
  fan-out toggle.

Every failure path still degrades toward **unfolded**: with no locatable turn
boundary (an errored turn, a pre-`turn_stats` transcript, an answer still
streaming) the region renders exactly as it did before this change rather than
guessing where the answer ended. Hiding an answer behind a toggle that promises a
repeat below is the one outcome that must stay impossible.

Display-only. No message content, no wire shape, and no backend behaviour
changes — the model still receives every result in full.

## Tests

`website/src/test/groupDisplayItems.test.ts`, five new cases:

- **a second wave in the same user turn folds, with round one's answer outside
  it** — two interim regions, both synthesis answers visible. This is the
  reported bug; it fails on the pre-fix module.
- **a second wave reached through a queue-drained `subagent` completion opener
  folds** — the second flush site. Removing the `settlePendingSynthesisAnswer()`
  call there turns this red, so the call is not decorative.
- **a later wave folds even though a cron reply disqualified an earlier one** —
  the re-anchor's foreign reset. Dropping that reset turns this red.
- **a cron reply that landed AFTER a synthesis answer stays out of the next
  fold** — the other half of the same rule: re-derived, not cleared. This one
  fails if the reset is unconditional.
- **no turn boundary anywhere leaves the region unfolded** — pins the safe
  degradation, so a future change cannot turn a missing `turn_stats` into a
  hidden answer.

The pre-existing case asserting a synthesis answer is never folded behind a later
wave's toggle still passes unchanged.

## Manual verification

N/A — `groupDisplayItems` is a pure function over the message list and the
regression is a grouping decision, which the unit tests assert directly. The
reported transcript shape is reproduced verbatim as a test fixture.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** grouping logic only — the fold's rendered appearance
(`TurnBlock`'s interim branch, its toggle and collapsed sections) is untouched;
this change only decides which rows enter that already-shipped fold.

## Related Issues

no linked issue: reported directly in chat from a live session, not filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a broad disqualifier flag reused to protect one narrow row, which then
suppresses the feature for every later region in the same scope — and, on the way
out, a reset of that flag that must be re-derived from the retained state rather
than cleared.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
