### PR TITLE
fix(connections): isolate warm mint agent specs per process

### DIFF
--- a/docs/architecture/design-notes/connections-warm-table.md
+++ b/docs/architecture/design-notes/connections-warm-table.md
@@ -4,10 +4,13 @@ Cold mint (`kiro_crew.connections.mint`) spawns one kiro-cli process per provide
 approval URL: ~7.5s per card. `kiro_crew.connections.warm` serves the whole gallery from one
 process, and every rule below answers an observed failure.
 
-**Placement.** All warm code is in `src/kiro_crew/connections/warm.py`; the dashboard handler
-adds only endpoint wiring and function-local engine imports -- `expire_dead_mints` on the status
-path, `mintable_providers` plus `warm_mint_all` on the premint path, and `adopt_shared_mint` on
-the mint path -- keeping the mint engine off the gateway's boot path.
+**Placement.** Warm engine code remains in `src/kiro_crew/connections/warm.py`; the dashboard
+handler adds only endpoint wiring -- `expire_dead_mints` on the status path,
+`mintable_providers` plus `warm_mint_all` on the premint path, and `adopt_shared_mint` on the
+mint path. The dashboard server registers two lifecycle hooks in both full and headless modes:
+a tracked startup task that scavenges dead private generations off-loop without delaying the
+listener bind, and a cleanup hook that retires the live runtime. Those hooks import the warm
+module lazily, so importing the server alone still does not construct or spawn the engine.
 
 ## The handoff: how a premint reaches the click it was minted for
 
@@ -147,41 +150,33 @@ what is genuinely per-process. Three adaptations:
 - `_mint_holder_alive` is deliberately **not** reused -- it reads the row's own `client`, which
   a shared row does not own, so it answers False for every warm row. `_warm_row_alive` asks the
   generation/activation pair instead.
-- Warm spec names are fixed (`kirocrew-mint-warm-*`), with no `-<pid>-<8hex>` suffix, keeping
-  them out of the cold engine's manifest sweep. That shared prefix is a hazard in reverse -- a
-  *cold* spec for a server named `warm-*` matches the warm glob -- so `_is_stale_warm_spec`
-  refuses anything matching the cold name shape, and both patterns must share one **character
-  class**: while warm accepted `[A-Za-z]` and cold only `[a-z]`, a mixed-case alias produced a
-  live cold spec the warm sweep read as its own and unlinked.
-- **A name is not ownership.** Those fixed names are predictable and they live in the user's own
-  agents directory, next to the agents they hand-write, so a name says where a spec of ours
-  would *go* and never that the file already there is one. Trusting the name shape alone was a
-  defect in both directions: the write-time sweep unlinked a user's own agent spec sitting at
-  such a path, and the write then clobbered one at a path the current plan wanted.
-  `_warm_spec_is_foreign` proves ownership from the file's CONTENTS, and it takes two halves.
-  The fields the spec body fixes (`model`, `includeMcpJson`, `prompt`, `allowedTools`) are read
-  off `_mint_spec_body` so a change to the body cannot leave the module unable to recognise its
-  own files -- but they are also **stock defaults** a hand-written or scaffolded agent plausibly
-  carries, so on their own they still read a wholly user-authored spec as ours. The
-  discriminating half is `_WARM_SPEC_SENTINEL`, stamped as the description prefix of every spec
-  written here. `description` is the only field free enough to carry a marker while staying
-  schema-legal: kiro-cli rejects an unknown spec key, and the agent-spec migration sweep strips
-  bookkeeping keys. Requiring it orphans nothing, since no warm-spec writer has ever shipped --
-  and a hypothetical unsentinelled file of ours would read as foreign, which means refused and
-  left in place. It fails closed, because the mistakes are not symmetric: reading our own file
-  as foreign leaves one stale spec as clutter, while reading a user's file as ours destroys it.
-  A refusal is audited and skipped -- never raised -- so an occupied path costs one unwarmed
-  provider, not a failed spawn.
-- **The ownership checks guard one directory; kiro-cli reads two.** Everything above protects
-  the user's agents directory, but kiro-cli also resolves PROJECT-LOCAL specs from
-  `<cwd>/.kiro/agents`, and the process is activated BY NAME -- so a spec planted under the
-  warm process's own working directory shadows the guarded one, and its `mcpServers` is what
-  gets initialized and authorized against. No ownership check looks there. The working
-  directory is therefore `<data home>/run/connections-warm`: `run/` is already on
-  `security._SENSITIVE_HOME_DIRS` (it holds the sandbox launchers and run markers the gateway
-  execs outside the sandbox), while `connections/` carries no entry and an agent file tool
-  could write it. The property is asserted through `security.is_sensitive_write_path` rather
-  than a path literal, so a later rename cannot silently leave the fence.
+- Warm mode names remain fixed (`kirocrew-mint-warm-*`) because one process must switch among
+  a known set after spawn. The files do **not** live in `~/.kiro/agents`: every process owns a
+  random direct child under `<data home>/run/connections-warm/generations/`, and its modes are
+  written to `<generation>/.kiro/agents` before spawn. The generation root is the runtime cwd,
+  so kiro-cli resolves the private base mode for the initial `--agent` and the private all-mode
+  for the later `session/set_mode`. The sensitive `run/` boundary also makes the root ineligible
+  for project-agent discovery, keeping both names out of the picker and spawn roster.
+- **A name is not ownership.** `_WARM_SPEC_SENTINEL` remains the content discriminator for every
+  file the writer touches. Inside a new generation it protects against a same-user race; at
+  startup it licenses deletion of sentinel-owned files left in the old global location. The
+  fields the spec body fixes (`model`, `includeMcpJson`, `prompt`, `allowedTools`) are stock
+  defaults a user agent can plausibly carry, so they are necessary but insufficient. An
+  unreadable, linked, oversized, malformed, or unsentinelled file is retained and logged.
+- **Directory lifetime follows process lifetime.** A provisional marker is written before spawn
+  and atomically completed with the runtime PID plus process-start token after spawn. Parking,
+  an interrupted teardown, or a kill timeout retains both the runtime reference and directory.
+  A confirmed kill releases only that runtime's directory. Gateway cleanup retires every live
+  and parked generation; the next startup removes a crash leftover only when both its recorded
+  gateway and runtime identities are provably dead. Missing or ambiguous evidence fails closed
+  to retained clutter, preventing PID reuse or a second live gateway sharing the data home from
+  losing a directory it may still use.
+- **Legacy manual cleanup.** An old global
+  `~/.kiro/agents/kirocrew-mint-warm-*.json` carrying `_WARM_SPEC_SENTINEL` is removed
+  automatically at startup. A file without that sentinel is never auto-deleted because its name
+  cannot prove ownership. The operator must inspect its `name`, `description`, and `mcpServers`
+  and remove it manually only when they recognize it as obsolete generated warm-mint residue;
+  ordinary warm operation no longer reads or writes that global path.
 
 ## Tool-alias key shape
 
@@ -196,13 +191,14 @@ the pre-#3260 rule and those assertions were not carried forward.
 
 ## Filesystem work never runs on the loop
 
-Every flow reads the user's config, the shared agents directory, or kiro-cli's OAuth cache, any
-of which can sit on a network mount where a stat is unbounded, so all of that work lives in
-SYNCHRONOUS helpers and a coroutine reaches them through `asyncio.to_thread` -- enforced by a
-fixed-point drift guard in `test/test_connections_warm.py` that reuses the mint engine's own
-primitive sets so the two cannot drift apart. What the guard pins today is the exact set of
-helpers doing filesystem work, so the lifecycle slice can neither call one from a coroutine nor
-quietly drop the filesystem work the guard's coverage rests on without failing it.
+Every flow reads the user's config, a private generation tree, the old global agents directory,
+or kiro-cli's OAuth cache, any of which can sit on a network mount where a stat is unbounded, so
+all of that work lives in SYNCHRONOUS helpers and a coroutine reaches them through
+`asyncio.to_thread` -- enforced by a fixed-point drift guard in `test/test_connections_warm.py`
+that reuses the mint engine's own primitive sets so the two cannot drift apart. What the guard
+pins today is the exact set of helpers doing filesystem work, so the lifecycle slice can neither
+call one from a coroutine nor quietly drop the filesystem work the guard's coverage rests on
+without failing it.
 
 ## Seams and residuals
 
@@ -280,16 +276,13 @@ generation** rather than anything else:
 
 And one the second review round found, which is not a cancellation bug at all:
 
-- **A refused spec was still activated by name.** The writer declines to overwrite a file at
-  a planned spec path whose contents this module did not write — which protects the file and
-  nothing else, because the spawn is handed `agent=<fixed name>` and kiro-cli resolves that
-  name off the same agents directory. A hand-written agent parked at
-  `kirocrew-mint-warm-base.json` would therefore have been executed, with its own
-  `mcpServers` commands initialized, by the very code that had just refused to own it.
-  `_unowned_plan_specs` now re-verifies, off the loop, that every planned spec exists *and*
-  is sentinel-owned before the runtime is constructed; any refusal aborts warming entirely
-  and is audited. Aborting is safe because the cold path still serves every Connect — it
-  just spawns per provider.
+- **A refused spec must never be activated by name.** Even in the private generation scope,
+  the writer can race a same-user file at a planned path. Refusing to overwrite protects the
+  file but not the spawn: the runtime is handed `agent=<fixed name>` and kiro-cli resolves that
+  name from the same project-local agents directory. `_unowned_plan_specs` therefore re-verifies,
+  off the loop, that every planned spec exists *and* is sentinel-owned before the runtime is
+  constructed; any refusal aborts warming and is audited. Aborting is safe because the cold
+  path still serves every Connect — it just spawns per provider.
 
 One residual remains:
 
@@ -340,9 +333,13 @@ session timeout, which is the right trade: correctness over a warm-cache hit. Cl
 residual entirely would need the backend to expose a session id at request time rather than at
 response time.
 
-- **A hard gateway kill strands warm spec files.** They carry no manifest row, so the cold
-  engine's aged-row sweep cannot see them. The next spawn's write-time sweep removes them, so
-  the exposure is bounded, but it is not a clean teardown.
+**Generation-owned spec cleanup closes the file-lifetime residual.** A hard gateway kill may
+leave a private generation tree, but it no longer publishes agent modes globally. Its owner
+marker carries gateway and runtime PID/start identities; the next gateway removes the tree only
+when both are provably dead. Graceful shutdown removes each tree immediately after its process
+kill succeeds, while a parked or unkillable process retains its own tree. Sentinel-owned files
+from the former global location are cleaned at startup; unsentinelled files remain a documented
+manual decision rather than being deleted on a name match.
 
 ## The one bug class, and the uniform shape that closes it
 

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -85,19 +85,25 @@ which protects the SPAWN. Without the second check the refusal would hand kiro-c
 stranger's spec at our fixed name and initialize its ``mcpServers``. A refusal aborts
 warming entirely, audited: the cold path still serves every Connect.
 
-OWNERSHIP: these specs carry FIXED, predictable names in the user's own agents directory,
-so a name is where a spec of ours would GO and never proof that the file there is one.
-Every spec written here is stamped with :data:`_WARM_SPEC_SENTINEL` on its description --
-the stock defaults a spec body also fixes are values a user's own agent plausibly carries,
-so the sentinel is what actually discriminates. Neither :func:`_write_warm_mint_specs` nor
-:func:`_remove_warm_mint_specs` unlinks or overwrites a path whose contents this module did
-not write -- see :func:`_warm_spec_is_foreign`.
+OWNERSHIP: mode names remain fixed, but their files live only in one random, owner-only
+PROJECT scope under ``<data home>/run/connections-warm/generations``. That generation root is
+the runtime cwd, so both the initial ``--agent`` and later ``session/set_mode`` resolve the
+private ``.kiro/agents`` files before the user's global scope; the picker refuses the sensitive
+run tree. Every spec is still stamped with :data:`_WARM_SPEC_SENTINEL`, because content proof
+protects same-user races and licenses one-time cleanup of sentinel-owned global leftovers.
+An unsentinelled global file is never auto-deleted: a name cannot prove ownership.
+
+GENERATION LIFETIME follows the process. Its PID-reuse-resistant owner marker is written
+before spawn and completed with the child identity after spawn. Parking or a failed kill keeps
+the directory attached; a confirmed kill releases it. Gateway startup scavenges only roots
+whose gateway and runtime identities are both provably dead, while graceful cleanup retires the
+live singleton. Missing, malformed or unreadable evidence fails closed to retained clutter.
 
 INVARIANT: no coroutine here touches the filesystem directly. The spec helpers read the
-user's config, the shared agents dir, or kiro-cli's OAuth cache, and the credential gate
-reads the operator's OAuth-endpoint extension -- any of which can sit on a network mount
-where a stat is unbounded -- so they are synchronous, and a coroutine reaches them through
-``asyncio.to_thread``. Enforced by a fixed-point drift guard in
+user's config, private generation tree, global legacy agents dir, or kiro-cli's OAuth cache,
+and the credential gate reads the operator's OAuth-endpoint extension -- any of which can sit
+on a network mount where a stat is unbounded -- so they are synchronous, and a coroutine
+reaches them through ``asyncio.to_thread``. Enforced by a fixed-point drift guard in
 ``test/test_connections_warm.py``, not merely described here.
 
 REQUEST PATH: :func:`warm_mint_all` is driven by ``POST /api/connections/premint``, which the
@@ -130,17 +136,22 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
+import shutil
+import stat
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from kiro_crew import agent as _agent
-from kiro_crew import hooks
+from kiro_crew import hooks, platform_compat
 from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.agent_files import AGENT_FILENAME
 from kiro_crew.config.loader import data_home
+from kiro_crew.config.paths import project_agents_dir
 from kiro_crew.connections.mint import (
     _MINT_AGENT_PREFIX,
     _MINT_GRANT_POLL_SECONDS,
@@ -185,6 +196,15 @@ _WARM_ALL_AGENT = f"{_WARM_AGENT_PREFIX}all"
 #: ``description`` is the only schema-legal field free enough to carry a marker: kiro-cli
 #: rejects an unknown spec key, and the agent-spec migration sweep strips bookkeeping keys.
 _WARM_SPEC_SENTINEL = "Kiro Crew warm mint spec (machine-written; safe to delete)"
+#: Each helper process resolves its internal modes from one private project scope. The
+#: directory name is random rather than a provider or agent name, so no stable internal
+#: mode appears under the user's global ``~/.kiro/agents`` scope.
+_WARM_GENERATION_PREFIX = "generation-"
+_WARM_GENERATION_MARKER = ".owner.json"
+_WARM_GENERATION_SENTINEL = "kirocrew.connections.warm.generation"
+_WARM_GENERATION_MARKER_VERSION = 1
+_WARM_GENERATION_MARKER_MAX_BYTES = 4096
+_WARM_RUNTIME_DIR_ATTR = "_kirocrew_warm_generation_dir"
 _WARM_SPAWN_TIMEOUT_SECONDS = 90.0
 _WARM_SESSION_TIMEOUT_SECONDS = 90.0
 _WARM_SESSION_DESTROY_TIMEOUT_SECONDS = 10.0
@@ -642,31 +662,62 @@ def _warm_ownership_marks(name: str) -> dict[str, Any]:
     return {key: probe[key] for key in ("model", "includeMcpJson", "prompt", "allowedTools")}
 
 
+def _private_warm_spec_work_dir(path: Path) -> Path | None:
+    """Return the owned generation root for a project-local spec, or ``None``.
+
+    The ordinary agent reader rejects ``data_home/run`` by design. These files live there
+    deliberately, so a separate reader is allowed only after the path is proved to be a
+    direct child of a sentinel-owned generation scope.
+    """
+    agents_dir = path.parent
+    if agents_dir.name != "agents" or agents_dir.parent.name != ".kiro":
+        return None
+    work_dir = agents_dir.parent.parent
+    if not _is_plain_warm_generation_dir(work_dir):
+        return None
+    return work_dir if _read_warm_generation_owner(work_dir) is not None else None
+
+
+def _read_warm_spec_body(path: Path) -> dict[str, Any] | None:
+    """Read one spec through the correct trust boundary for its scope."""
+    if _private_warm_spec_work_dir(path) is None:
+        return _read_agent_spec(
+            path,
+            operation="connections_warm_mint",
+            source="dashboard",
+        )
+    try:
+        if platform_compat.is_link_or_junction(path):
+            return None
+        info = path.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_size > hooks.MAX_FILE_BYTES:
+            return None
+        body = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    return body if isinstance(body, dict) else None
+
+
 def _warm_spec_is_foreign(path: Path) -> bool:
     """True when ``path`` exists but no warm plan wrote it, so this module must not touch it.
 
-    Warm spec names are FIXED and predictable and they sit in the user's OWN agents
-    directory, so the name shape :func:`_is_stale_warm_spec` checks says where a spec of
-    ours would GO -- never that the file already there is one. Ownership is proved from the
-    contents instead, and it takes BOTH halves: the declared ``name`` matches the file with
-    every field the writer fixes still holding, AND the description carries the sentinel.
-    The marks alone are generic defaults, so a wholly user-authored spec that happens to
-    carry them was read as ours and clobbered; the sentinel is the half that discriminates.
+    Warm mode names are FIXED and predictable, so the name shape
+    :func:`_is_stale_warm_spec` checks says where a spec of ours would GO -- never that the
+    file already there is one. Production writes them inside a private generation, while
+    startup also applies this predicate to old global paths. Ownership is proved from the
+    contents in both scopes: the declared ``name`` matches the file with every field the
+    writer fixes still holding, AND the description carries the sentinel. The marks alone
+    are generic defaults, so the sentinel is the half that discriminates.
 
     Fails closed, because the two mistakes are not symmetric. Reading a file of ours as
     foreign costs one stale spec left as clutter; reading a user's hand-written agent as
     ours deletes it, or overwrites it with a spec they never asked for. So a file that is
     unreadable, not a JSON object, or shaped like anything but our own is foreign.
     """
-    # Through the hardened reader, like the planner read: a raw ``_load_json`` FOLLOWS a
-    # symlink planted at this warm path and parses whatever it lands on, so a link aimed at
-    # a sensitive file was read uncapped and unaudited -- and the ownership verdict this
-    # function returns is what decides whether that path gets unlinked or overwritten.
-    body = _read_agent_spec(
-        path,
-        operation="connections_warm_mint",
-        source="dashboard",
-    )
+    # Global/user files go through the hardened discovery reader. Private generation files
+    # use the equally bounded non-link reader above only after their sentinel-owned run root
+    # is proved; the general reader correctly rejects that sensitive path.
+    body = _read_warm_spec_body(path)
     if not body:
         # A refusal reads as an empty body: absent, unreadable, non-object, oversized and a
         # sensitive-target symlink all land here, and only the ABSENT one is a path we may
@@ -680,20 +731,290 @@ def _warm_spec_is_foreign(path: Path) -> bool:
     marks = _warm_ownership_marks(path.stem)
     if body.get("name") != path.stem or any(body.get(key) != value for key, value in marks.items()):
         return True
-    # No legacy exposure: no warm-spec writer has ever shipped, so no unsentinelled file of
-    # ours exists anywhere to be orphaned by requiring this. Were one to exist it would read
-    # as foreign, which means refused and left in place -- the safe direction.
+    # An unsentinelled global file remains foreign even if an early/dev build produced it.
+    # Startup logs and retains that path because its name cannot prove ownership; the design
+    # note gives the operator the manual inspection/removal rule. Private generation specs
+    # always carry the sentinel before their process starts.
     return not str(body.get("description") or "").startswith(_WARM_SPEC_SENTINEL)
 
 
-def _write_warm_mint_specs(plan: _WarmSpecPlan) -> None:
-    """Write the whole spec set, removing warm specs no longer in it.
+def _warm_work_dir() -> Path:
+    """Managed root for private warm generations, inside the protected run tree.
 
-    Every unlink and every write is gated on ownership, so a file this module did not write
-    survives both. A refusal is audited and skipped, never raised: a provider whose spec
-    path is occupied is a provider that goes unwarmed, not a failed spawn.
+    Specs never live directly here. Each process gets one direct child under
+    :func:`_warm_generations_dir`, and that child becomes its cwd so kiro-cli resolves
+    ``<cwd>/.kiro/agents`` before the user's global agent directory.
     """
-    agents_dir = _agent.kiro_agents_dir_path()
+    return data_home() / "run" / "connections-warm"
+
+
+def _warm_generations_dir() -> Path:
+    """Root whose direct children are independently owned helper generations."""
+    return _warm_work_dir() / "generations"
+
+
+def _warm_generation_agents_dir(work_dir: Path) -> Path:
+    """The project-local agent scope kiro-cli resolves for one helper process."""
+    return project_agents_dir(work_dir)
+
+
+def _warm_generation_marker_path(work_dir: Path) -> Path:
+    return work_dir / _WARM_GENERATION_MARKER
+
+
+def _warm_generation_owner(runtime: Any | None = None) -> dict[str, Any]:
+    """Ownership record for one generation, with PID-reuse-resistant identities.
+
+    Both identities are taken from ``process_start_time`` because that is the helper
+    ``_process_identity_live`` compares them against on read. The neighbouring
+    ``own_process_start_time`` answers a deliberately different, reboot-unique format --
+    start ticks joined to the boot UUID on Linux, a ``proc_pidinfo`` microtime on macOS --
+    so a gateway token taken from it could never equal what the reader recomputes, and the
+    live gateway would read as dead. Scavenging removes a generation only once BOTH
+    identities are proven dead, so that mismatch would not merely lose a signal: it would
+    forfeit the gateway's veto and delete a directory still in use the moment its
+    short-lived runtime exited.
+    """
+    gateway_pid = os.getpid()
+    runtime_pid = int(getattr(runtime, "pid", 0) or 0)
+    runtime_started = platform_compat.process_start_time(runtime_pid) if runtime_pid > 0 else None
+    return {
+        "sentinel": _WARM_GENERATION_SENTINEL,
+        "version": _WARM_GENERATION_MARKER_VERSION,
+        "gateway_pid": gateway_pid,
+        "gateway_started": platform_compat.process_start_time(gateway_pid) or "",
+        "runtime_pid": runtime_pid,
+        "runtime_started": runtime_started or "",
+    }
+
+
+def _write_warm_generation_owner(work_dir: Path, runtime: Any | None = None) -> None:
+    """Atomically publish the process identities that make boot scavenging safe."""
+    _agent._atomic_json_write(
+        _warm_generation_marker_path(work_dir), _warm_generation_owner(runtime)
+    )
+
+
+def _read_warm_generation_owner(work_dir: Path) -> dict[str, Any] | None:
+    """Read a small plain ownership marker; malformed or linked input is unowned."""
+    marker = _warm_generation_marker_path(work_dir)
+    try:
+        if platform_compat.is_link_or_junction(marker):
+            return None
+        info = marker.lstat()
+        if not stat.S_ISREG(info.st_mode) or info.st_size > _WARM_GENERATION_MARKER_MAX_BYTES:
+            return None
+        body = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    if body.get("sentinel") != _WARM_GENERATION_SENTINEL:
+        return None
+    if body.get("version") != _WARM_GENERATION_MARKER_VERSION:
+        return None
+    return body
+
+
+def _is_plain_warm_generation_dir(work_dir: Path) -> bool:
+    """Whether *work_dir* is one direct, non-link child of the managed root."""
+    if work_dir.parent != _warm_generations_dir() or not work_dir.name.startswith(
+        _WARM_GENERATION_PREFIX
+    ):
+        return False
+    try:
+        if platform_compat.is_link_or_junction(work_dir):
+            return False
+        return stat.S_ISDIR(work_dir.lstat().st_mode)
+    except OSError:
+        return False
+
+
+def _remove_warm_generation_dir(work_dir: Path) -> bool:
+    """Remove one sentinel-owned generation tree without following a link.
+
+    ``False`` means ownership or removal could not be proved. That direction leaves clutter
+    but never deletes an arbitrary run-tree entry.
+    """
+    try:
+        work_dir.lstat()
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    if not _is_plain_warm_generation_dir(work_dir):
+        return False
+    if _read_warm_generation_owner(work_dir) is None:
+        return False
+    try:
+        shutil.rmtree(work_dir)
+    except OSError:
+        logger.debug("warm generation removal failed for %s", work_dir.name, exc_info=True)
+        return False
+    return True
+
+
+def _create_warm_generation_dir() -> Path:
+    """Create one owner-only project root and its private ``.kiro/agents`` scope.
+
+    ``make_owner_only_dir``'s tighten step is best-effort by contract, so it alone cannot
+    carry this module's owner-only guarantee: on a filesystem where the ACL write fails the
+    directory would exist but be open to other local users, and the agent specs written into
+    it are injectable. Each level is therefore re-tightened with the fail-loud
+    :func:`platform_compat.restrict_dir_to_owner` — a refused ACL raises, the cleanup below
+    removes the loose directory, and the caller gets an error instead of a false private
+    scope.
+    """
+    generations = _warm_generations_dir()
+    platform_compat.make_owner_only_dir(generations)
+    platform_compat.restrict_dir_to_owner(generations)
+    work_dir = generations / f"{_WARM_GENERATION_PREFIX}{uuid.uuid4().hex}"
+    try:
+        platform_compat.make_owner_only_dir(work_dir)
+        platform_compat.restrict_dir_to_owner(work_dir)
+        platform_compat.make_owner_only_dir(work_dir / ".kiro")
+        platform_compat.restrict_dir_to_owner(work_dir / ".kiro")
+        agents_dir = _warm_generation_agents_dir(work_dir)
+        platform_compat.make_owner_only_dir(agents_dir)
+        platform_compat.restrict_dir_to_owner(agents_dir)
+        _write_warm_generation_owner(work_dir)
+    except BaseException:
+        # The path was generated in this call and has not been handed to a process. Cleanup
+        # may therefore remove it without the marker proof normal retirement requires.
+        shutil.rmtree(work_dir, ignore_errors=True)
+        raise
+    return work_dir
+
+
+def _bind_warm_generation(runtime: Any, work_dir: Path) -> None:
+    """Attach a spawned process to its directory and publish its runtime identity."""
+    setattr(runtime, _WARM_RUNTIME_DIR_ATTR, str(work_dir))
+    _write_warm_generation_owner(work_dir, runtime)
+
+
+def _runtime_generation_dir(runtime: Any) -> Path | None:
+    raw = getattr(runtime, _WARM_RUNTIME_DIR_ATTR, "")
+    return Path(raw) if raw else None
+
+
+def _recorded_runtime_is_dead(work_dir: Path) -> bool:
+    """Whether the marker positively proves its runtime is gone.
+
+    Mirrors the scavenger's ``is not False`` test, so only proof of death releases a tree and
+    both "still running" and "cannot tell" keep it. An absent or unreadable marker answers
+    ``True`` here only because :func:`_remove_warm_generation_dir` independently refuses an
+    unowned directory, which keeps the ownership refusal in one place. A marker still
+    carrying ``runtime_pid: 0`` is the PROVISIONAL write from
+    :func:`_create_warm_generation_dir` whose post-spawn rewrite in
+    :func:`_bind_warm_generation` never landed -- the spawned process may be alive with no
+    recorded identity to check, so pid 0 answers ``False`` (unproved keeps the tree), exactly
+    as :func:`_process_identity_live` answers ``None`` for the same marker on the scavenge
+    path.
+    """
+    owner = _read_warm_generation_owner(work_dir)
+    if owner is None:
+        return True
+    try:
+        pid = int(owner.get("runtime_pid") or 0)
+    except (TypeError, ValueError):
+        return False
+    if pid <= 0:
+        return False
+    return _process_identity_live(pid, str(owner.get("runtime_started") or "")) is False
+
+
+def _release_runtime_generation(runtime: Any) -> bool:
+    """Release a killed process's generation tree, once that death is actually proven.
+
+    ``_kill_quietly`` answering ``True`` is not that proof. ``AcpRuntime`` reports a survivor
+    by LOGGING one and returning normally -- both of its ``kill_process_tree`` calls swallow
+    ``OSError`` by design, so a signal-delivery failure (EPERM through a launcher wrapper,
+    pgid drift) is indistinguishable from success at that layer, and it deliberately leaves
+    the PID tracked for a sweep rather than raising. Removing on the caller's word alone
+    would therefore ``rmtree`` the cwd and private agent scope of a process still reading
+    them, which is the one loss this whole ownership marker exists to prevent.
+
+    ``False`` leaves the tree attached. Startup scavenging reclaims it once both recorded
+    identities are dead, so an unkillable child costs clutter until the next gateway start
+    instead of costing the running process its specs.
+    """
+    work_dir = _runtime_generation_dir(runtime)
+    if work_dir is None:
+        return True
+    if not _recorded_runtime_is_dead(work_dir):
+        return False
+    removed = _remove_warm_generation_dir(work_dir)
+    if removed:
+        try:
+            delattr(runtime, _WARM_RUNTIME_DIR_ATTR)
+        except AttributeError:
+            pass
+    return removed
+
+
+def _process_identity_live(pid: int, started: str) -> bool | None:
+    """Tri-state PID identity: live, dead/reused, or unprovable."""
+    if pid <= 0 or not started:
+        return None
+    liveness = platform_compat.pid_liveness(pid)
+    if liveness == platform_compat.PID_DEAD:
+        return False
+    current = platform_compat.process_start_time(pid)
+    if current is None:
+        return None
+    if current != started:
+        return False
+    if liveness in (platform_compat.PID_ALIVE, platform_compat.PID_UNSIGNALABLE):
+        return True
+    return None
+
+
+def _scavenge_warm_generation_dirs() -> int:
+    """Remove crash leftovers only when both recorded process identities are dead."""
+    root = _warm_generations_dir()
+    try:
+        candidates = list(root.iterdir())
+    except FileNotFoundError:
+        return 0
+    except OSError:
+        logger.debug("warm generation startup scan failed", exc_info=True)
+        return 0
+    removed = 0
+    for work_dir in candidates:
+        if not _is_plain_warm_generation_dir(work_dir):
+            continue
+        owner = _read_warm_generation_owner(work_dir)
+        if owner is None:
+            logger.warning(
+                "Keeping unproved warm generation directory %s; inspect it manually",
+                work_dir.name,
+            )
+            continue
+        try:
+            gateway_live = _process_identity_live(
+                int(owner.get("gateway_pid") or 0), str(owner.get("gateway_started") or "")
+            )
+            runtime_live = _process_identity_live(
+                int(owner.get("runtime_pid") or 0), str(owner.get("runtime_started") or "")
+            )
+        except (TypeError, ValueError):
+            gateway_live = runtime_live = None
+        if gateway_live is not False or runtime_live is not False:
+            continue
+        if _remove_warm_generation_dir(work_dir):
+            removed += 1
+    if removed:
+        logger.info("Removed %d stale private warm generation directorie(s)", removed)
+    return removed
+
+
+def _write_warm_mint_specs(plan: _WarmSpecPlan, agents_dir: Path) -> None:
+    """Write the complete plan into one private project-local agent scope.
+
+    Every unlink and write is still ownership-gated. The directory is generation-private,
+    but preserving the content proof closes same-user races and keeps the legacy cleanup
+    predicate identical to the writer predicate.
+    """
     agents_dir.mkdir(parents=True, exist_ok=True)
     plan_names = frozenset(plan.specs)
     try:
@@ -714,19 +1035,8 @@ def _write_warm_mint_specs(plan: _WarmSpecPlan) -> None:
         _agent._atomic_json_write(path, spec)
 
 
-def _unowned_plan_specs(plan: _WarmSpecPlan) -> list[str]:
-    """The planned spec names whose file is missing, or is not one this module wrote.
-
-    Activation happens BY NAME: the runtime is handed ``agent=<fixed name>`` and kiro-cli
-    resolves that name off this same agents directory. So the write's refusal protects the
-    FILE and nothing else -- a hand-written agent sitting at a name we declined to
-    overwrite would be spawned, and its ``mcpServers`` commands would initialize. This is
-    what protects the SPAWN.
-
-    Existence is tested as well as ownership, because :func:`_warm_spec_is_foreign` answers
-    False for an absent path: a spec that is not there is equally not ours to activate.
-    """
-    agents_dir = _agent.kiro_agents_dir_path()
+def _unowned_plan_specs(plan: _WarmSpecPlan, agents_dir: Path) -> list[str]:
+    """Planned names missing from, or foreign to, this generation's private scope."""
     unowned: list[str] = []
     for name in plan.specs:
         path = agents_dir / f"{name}.json"
@@ -735,40 +1045,33 @@ def _unowned_plan_specs(plan: _WarmSpecPlan) -> list[str]:
     return unowned
 
 
-def _remove_warm_mint_specs() -> None:
-    """Unlink every warm spec THIS module wrote. Called when the process is retired."""
+def _remove_warm_mint_specs(agents_dir: Path) -> int:
+    """Unlink every sentinel-owned warm spec from one explicit agent scope."""
+    removed = 0
     try:
-        for path in _agent.kiro_agents_dir_path().glob(f"{_WARM_AGENT_PREFIX}*.json"):
+        for path in agents_dir.glob(f"{_WARM_AGENT_PREFIX}*.json"):
             if not _is_stale_warm_spec(path.stem, frozenset()):
                 continue
             if _warm_spec_is_foreign(path):
                 _log_warm_event("warm_mint_spec_removal", path.name, outcome="refused")
                 continue
             path.unlink(missing_ok=True)
-    except Exception:  # noqa: BLE001 — spec files; the write-time sweep catches leftovers
+            removed += 1
+    except Exception:  # noqa: BLE001 — startup cleanup is best-effort and fail-closed
         logger.debug("warm mint spec removal failed", exc_info=True)
+    return removed
 
 
-def _warm_work_dir() -> Path:
-    """The shared process's working directory, inside the agent-write-protected run tree.
+def scavenge_warm_mint_artifacts() -> int:
+    """Boot cleanup for private crash leftovers and sentinel-owned global legacy specs.
 
-    NOT under ``connections/``, and the reason is the spawn. kiro-cli resolves PROJECT-LOCAL
-    agent specs from ``<cwd>/.kiro/agents`` as well as the user's agents dir, and this module
-    activates BY NAME -- so a spec planted at ``<cwd>/.kiro/agents/<mode>.json`` shadows the
-    warm spec :func:`_write_warm_mint_specs` wrote, on a path every ownership check here
-    (:func:`_warm_spec_is_foreign`, :func:`_unowned_plan_specs`) looks straight past. The
-    injected body's ``mcpServers`` would then be what the process initializes and authorizes
-    against.
-
-    ``connections/`` carries no entry in ``security._SENSITIVE_HOME_DIRS``, so an agent file
-    tool could write that tree; ``run/`` is already fenced read+write for precisely this
-    class of reason -- it holds the sandbox launchers and run markers the gateway execs
-    outside the sandbox. Putting the cwd there makes the injection unwritable through any
-    Kiro Crew-mediated channel instead of merely unlikely.
-
-    No ``mkdir`` here: the runtime creates its work dir at spawn.
+    An unsentinelled global file is deliberately retained: its name does not prove Kiro Crew
+    owns it. The design note documents the manual inspection/removal path for that legacy
+    residue.
     """
-    return data_home() / "run" / "connections-warm"
+    removed = _scavenge_warm_generation_dirs()
+    removed += _remove_warm_mint_specs(_agent.kiro_agents_dir_path())
+    return removed
 
 
 def _runtime_alive(runtime: Any) -> bool:
@@ -1124,14 +1427,17 @@ class _WarmMintRuntime:
         await self._park_or_kill_locked()
 
         runtime: Any = None
+        work_dir: Path | None = None
         handed_over = False
         try:
-            await asyncio.to_thread(_write_warm_mint_specs, plan)
+            work_dir = await asyncio.to_thread(_create_warm_generation_dir)
+            agents_dir = _warm_generation_agents_dir(work_dir)
+            await asyncio.to_thread(_write_warm_mint_specs, plan, agents_dir)
             # The write REFUSES a path it does not own rather than clobbering it, and the
             # spawn below activates by NAME -- so without this the refusal would hand
             # kiro-cli a stranger's spec to execute. Aborting is safe and honest: the cold
             # path still serves every Connect, it just spawns per provider.
-            unowned = await asyncio.to_thread(_unowned_plan_specs, plan)
+            unowned = await asyncio.to_thread(_unowned_plan_specs, plan, agents_dir)
             if unowned:
                 logger.warning(
                     "Not warming: %d planned mint spec(s) are not ours to activate", len(unowned)
@@ -1144,14 +1450,17 @@ class _WarmMintRuntime:
                 )
                 return None
             runtime = _acp_runtime_factory()(
-                work_dir=await asyncio.to_thread(_warm_work_dir),
+                work_dir=work_dir,
                 agent=_WARM_BASE_AGENT,
                 sandbox_mode="auto",
             )
+            # Attach before spawn so a cancelled/failed spawn still carries the only path its
+            # cleanup may remove. The marker remains provisional until spawn returns a PID.
+            setattr(runtime, _WARM_RUNTIME_DIR_ATTR, str(work_dir))
             await asyncio.wait_for(runtime.spawn(), timeout=_WARM_SPAWN_TIMEOUT_SECONDS)
-            # No await between the spawn returning and the flag: the handover is a run of
-            # plain assignments plus a synchronous ``create_task``, so there is no window
-            # in which the process is ours but the ``finally`` would still tear it down.
+            await asyncio.to_thread(_bind_warm_generation, runtime, work_dir)
+            # No await between the ownership marker landing and the handover: the runtime,
+            # plan and reaper become visible as one event-loop-atomic state transition.
             self._runtime, self._plan, self._digest = runtime, plan, plan.digest
             self._generation += 1
             self._reaper = asyncio.get_running_loop().create_task(
@@ -1166,9 +1475,9 @@ class _WarmMintRuntime:
             # parked the old generation AND cancelled its reaper, so a CancelledError in the
             # spec write or the spawn would otherwise leave that process with nothing that
             # will ever sweep it -- the parked-generation leak by a third route -- plus a
-            # forked child and a set of specs nobody owns.
+            # forked child and a private spec tree nobody owns.
             if not handed_over:
-                await self._abandon_spawn_locked(runtime)
+                await self._abandon_spawn_locked(runtime, work_dir)
         await asyncio.to_thread(
             _log_warm_event,
             "connections_warm_mint_spawn",
@@ -1176,24 +1485,35 @@ class _WarmMintRuntime:
         )
         return plan
 
-    async def _abandon_spawn_locked(self, runtime: Any) -> None:
+    async def _abandon_spawn_locked(
+        self,
+        runtime: Any,
+        work_dir: Path | None = None,
+    ) -> None:
         """Undo a spawn attempt that never became this object's process.
 
-        Reached from a ``finally``, so it covers cancellation as well as failure.
+        Reached from a ``finally``, so it covers cancellation as well as failure. A process
+        that may still live keeps its directory attached while the parked-generation drain
+        retries the kill; a directory created before any runtime existed can be released
+        immediately.
         """
         if self._retiring:
             # Armed BEFORE any await, because ``create_task`` is synchronous: the parked
             # generation then has its sweeper even if the teardown below is interrupted.
             # Stored as the reaper so a later spawn's own reaper replaces it.
             self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
-        if runtime is not None and not await _kill_quietly(runtime):
+        if runtime is None:
+            if work_dir is not None:
+                await asyncio.to_thread(_remove_warm_generation_dir, work_dir)
+            return
+        if not await _kill_quietly(runtime):
             # This attempt never became ``self._runtime``, so it owns no generation and no
             # rows. Tracked under a key no row can carry, which makes every sweep read it as
             # needed by nobody and retry the kill until it takes -- rather than dropping the
             # last reference to a child that outlived the spawn we gave up on.
             self._retain_unkilled_locked(_WARM_UNKEYED_GENERATION, runtime)
-        if not self._retiring:
-            await asyncio.to_thread(_remove_warm_mint_specs)
+            return
+        await asyncio.to_thread(_release_runtime_generation, runtime)
 
     async def _abandon_session_creation_locked(self, create: Any) -> None:
         """Reap a session the backend may have created after we stopped waiting for it.
@@ -1420,19 +1740,18 @@ class _WarmMintRuntime:
             raise
 
     async def _kill_generation(self, generation: int, runtime: Any) -> bool:
-        """Kill one process and expire the links only it could have redeemed.
+        """Kill one process, expire its links, then release its private spec tree.
 
         ``False`` when the kill did not take, and the caller must keep the pair tracked. The
         rows are expired either way -- this generation is being retired, so its URLs must
-        stop being served -- but the spec sweep is WITHHELD: a spec removed under a process
-        that is still running strands it without the file it was spawned on, which is the
-        same rule the parked path follows.
+        stop being served -- while the generation directory stays attached until a confirmed
+        kill. A parked or unkillable process therefore never loses the modes it still owns.
         """
         killed = await _kill_quietly(runtime)
         self._drop_generation_sessions(generation)
         await _expire_shared_mints("mint_process_gone", generation=generation)
-        if killed and self._runtime is None and not self._retiring:
-            await asyncio.to_thread(_remove_warm_mint_specs)
+        if killed:
+            await asyncio.to_thread(_release_runtime_generation, runtime)
         return killed
 
     def _retain_unkilled_locked(self, generation: int, runtime: Any) -> None:
@@ -1454,7 +1773,6 @@ class _WarmMintRuntime:
         pending = list(self._retiring)
         if runtime is not None:
             pending.append((generation, runtime))
-        had_work = bool(pending)
         self._retiring = []
         self._reaper = self._runtime = None
         self._plan, self._digest = None, ""
@@ -1468,9 +1786,11 @@ class _WarmMintRuntime:
                 await _expire_shared_mints("mint_process_gone", generation=doomed_generation)
                 if not killed:
                     # A hard teardown that could not kill a child must not report it retired:
-                    # left in ``pending`` for the ``finally`` below to re-track.
+                    # left in ``pending`` for the ``finally`` below to re-track, with its
+                    # private agent scope still attached.
                     break
-                # Popped only once this generation is fully retired.
+                await asyncio.to_thread(_release_runtime_generation, doomed_runtime)
+                # Popped only once this generation and its private scope are fully retired.
                 pending.pop(0)
         finally:
             if pending:
@@ -1479,10 +1799,6 @@ class _WarmMintRuntime:
                 # lists above were emptied synchronously, so this is the only reference left.
                 self._retiring = pending
                 self._reaper = asyncio.get_running_loop().create_task(_drain_parked_generations())
-        if had_work and not self._retiring:
-            # Only once nothing is left: a spec removed under a still-running parked process
-            # strands it without the file it was spawned on.
-            await asyncio.to_thread(_remove_warm_mint_specs)
 
 
 async def _destroy_session_quietly(handle: Any) -> bool:
@@ -1532,6 +1848,11 @@ async def _kill_quietly(runtime: Any) -> bool:
 
 
 _warm_mint = _WarmMintRuntime()
+
+
+async def shutdown_warm_mint() -> None:
+    """Gateway cleanup hook: retire every live or parked warm generation."""
+    await _warm_mint.shutdown()
 
 
 def _warm_row_alive(entry: MintState) -> bool:

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2317,6 +2317,59 @@ def _dispatch_owner_dm(state: DashboardState, text: str) -> None:
     task.add_done_callback(state._background_tasks.discard)
 
 
+def _register_connections_warm_lifecycle(app: web.Application, state: DashboardState) -> None:
+    """Retire warm generations on cleanup; startup scavenging is kicked post-bind.
+
+    The import sits inside the hook deliberately, against ``top-level-imports``, because
+    ``no-new-work-on-gateway-boot-path`` governs this file and wins: importing
+    ``connections.warm`` at module scope would pull its whole dependency graph -- the mint
+    table, the provider registry, tool aliases, MCP discovery -- onto the one ordered thread
+    between process start and the socket accepting requests. Startup scavenging is NOT an
+    ``on_startup`` hook for the same reason: aiohttp runs those inside ``runner.setup()``,
+    BEFORE the listener binds, so even a hook that only created the scavenge task put the
+    synchronous import in front of the bind. Both entrypoints instead call
+    ``_kick_connections_warm_scavenge`` strictly after ``_start_site`` returns.
+
+    The cleanup hook is registered here, before ``runner.setup()`` freezes aiohttp's signal
+    lists; it resolves the import only when a gateway is already stopping.
+    """
+
+    async def _connections_warm_shutdown(_app: web.Application) -> None:
+        try:
+            from kiro_crew.connections.warm import shutdown_warm_mint
+
+            await shutdown_warm_mint()
+        except Exception:  # noqa: BLE001 — one cleanup hook must not suppress later hooks
+            logger.warning("Connections warm shutdown failed", exc_info=True)
+
+    app.on_cleanup.append(_connections_warm_shutdown)
+
+
+def _kick_connections_warm_scavenge(state: DashboardState) -> None:
+    """Start the crash-residue scavenge as a tracked background task, post-bind.
+
+    Called by both gateway entrypoints only after ``_start_site`` has returned, so the
+    listener is already accepting requests. The deferred ``connections.warm`` import
+    happens INSIDE the worker thread: resolving that dependency graph on the event loop
+    would stall in-flight requests just as it would have stalled the bind.
+    """
+
+    def _scavenge_in_thread() -> None:
+        from kiro_crew.connections.warm import scavenge_warm_mint_artifacts
+
+        scavenge_warm_mint_artifacts()
+
+    async def _connections_warm_scavenge() -> None:
+        try:
+            await asyncio.to_thread(_scavenge_in_thread)
+        except Exception:  # noqa: BLE001 — fail closed by retaining unproved residue
+            logger.warning("Connections warm artifact scavenging failed", exc_info=True)
+
+    task = asyncio.create_task(_connections_warm_scavenge())
+    state._background_tasks.add(task)
+    task.add_done_callback(state._background_tasks.discard)
+
+
 def _register_browser_view_cleanup(app: web.Application) -> None:
     """Stop the CLI dashboard process when the gateway shuts down.
 
@@ -3641,6 +3694,7 @@ async def start_dashboard(
     # ``_register_instances_hooks`` for why ordering matters.
     _register_instances_hooks(app, state, port)
     _register_browser_view_cleanup(app)
+    _register_connections_warm_lifecycle(app, state)
 
     # Unix-socket cleanup hook — registered before runner.setup freezes the
     # signal lists; the path itself only becomes known after the site starts
@@ -3681,6 +3735,13 @@ async def start_dashboard(
     except OSError:
         await runner.cleanup()
         raise
+
+    # Listener is bound and credentials are published — now kick the warm
+    # crash-residue scavenge. Deliberately NOT an on_startup hook: those run
+    # inside runner.setup(), before the bind, and the scavenge's deferred
+    # import must never sit in front of the listener
+    # (no-new-work-on-gateway-boot-path).
+    _kick_connections_warm_scavenge(state)
 
     # Event-loop heartbeat: proves the asyncio loop is live (the off-loop /proc
     # sampler can't — it runs in a subprocess). Sleeps 10s, then logs actual
@@ -4398,6 +4459,7 @@ async def start_api_server(
     # is what makes headless --slack-only keep the host awake during a long
     # Slack task, identically to the full dashboard.
     _register_prevent_sleep_shutdown(app, state)
+    _register_connections_warm_lifecycle(app, state)
 
     # Unix-socket cleanup hook — same holder pattern as start_dashboard,
     # registered before runner.setup freezes the signal lists.
@@ -4442,6 +4504,11 @@ async def start_api_server(
     except OSError:
         await runner.cleanup()
         raise
+
+    # Listener is bound — kick the warm crash-residue scavenge (parity with
+    # start_dashboard: never an on_startup hook, which would run the deferred
+    # import before the bind).
+    _kick_connections_warm_scavenge(state)
 
     logger.info("API-only server listening on %s:%d", bind_addr, port)
 

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -7,6 +7,7 @@ import asyncio
 import inspect
 import json
 import logging
+import os
 import textwrap
 import time
 from pathlib import Path
@@ -263,11 +264,24 @@ def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
         "mintable_providers",
         "_audited_mintable_providers",
         "_warm_spec_plan",
+        "_private_warm_spec_work_dir",
+        "_read_warm_spec_body",
         "_warm_spec_is_foreign",
+        "_warm_work_dir",
+        "_warm_generations_dir",
+        "_write_warm_generation_owner",
+        "_read_warm_generation_owner",
+        "_is_plain_warm_generation_dir",
+        "_remove_warm_generation_dir",
+        "_create_warm_generation_dir",
+        "_bind_warm_generation",
+        "_recorded_runtime_is_dead",
+        "_release_runtime_generation",
+        "_scavenge_warm_generation_dirs",
         "_unowned_plan_specs",
         "_write_warm_mint_specs",
         "_remove_warm_mint_specs",
-        "_warm_work_dir",
+        "scavenge_warm_mint_artifacts",
         "_credential_bearing_slugs",
     }
 
@@ -398,6 +412,391 @@ def _agents_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     return agents
 
 
+@pytest.fixture
+def _private_warm_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Keep generation roots out of both the checkout and the operator's data home."""
+    home = tmp_path / "crew-home"
+    monkeypatch.setattr(warm, "data_home", lambda: home)
+    return home
+
+
+def test_generation_specs_live_only_in_the_private_project_scope(
+    _agents_dir: Path, _private_warm_home: Path
+):
+    """The warm helper must never publish its internal modes into the user's agent list."""
+    work_dir = warm._create_warm_generation_dir()
+    private_agents = warm._warm_generation_agents_dir(work_dir)
+
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), private_agents)
+
+    assert not list(_agents_dir.glob(f"{warm._WARM_AGENT_PREFIX}*.json"))
+    assert (private_agents / f"{warm._WARM_BASE_AGENT}.json").is_file()
+    assert work_dir.parent == warm._warm_generations_dir()
+
+
+def test_private_generation_specs_are_not_offered_by_agent_discovery(
+    _agents_dir: Path,
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The picker refuses the sensitive run tree even when it is passed as a project."""
+    from kiro_crew import agent_discovery
+
+    work_dir = warm._create_warm_generation_dir()
+    private_agents = warm._warm_generation_agents_dir(work_dir)
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), private_agents)
+    monkeypatch.setattr(
+        agent_discovery,
+        "is_sensitive_path",
+        lambda value: str(value).startswith(str(_private_warm_home / "run")),
+    )
+    agent_discovery.clear_list_agents_cache()
+
+    names = {
+        item.name
+        for item in agent_discovery.list_agents(
+            agents_dir=_agents_dir,
+            project_dir=work_dir,
+        )
+    }
+
+    assert not names & {warm._WARM_BASE_AGENT, warm._WARM_ALL_AGENT}
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_session_mode_both_resolve_from_one_private_generation(
+    _agents_dir: Path,
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The process starts on the private base mode and session/new switches to its all mode."""
+    built: list[dict[str, Any]] = []
+    activated: list[str] = []
+
+    class _Handle:
+        def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
+            return []
+
+        async def drain_init(self, **kwargs: Any) -> None:
+            return None
+
+        async def destroy(self) -> None:
+            return None
+
+    class _Spawnable:
+        pid = 4242
+
+        def __init__(self, **kwargs: Any) -> None:
+            built.append(kwargs)
+
+        async def spawn(self) -> None:
+            return None
+
+        def is_alive(self) -> bool:
+            return True
+
+        async def create_session(self, **kwargs: Any) -> _Handle:
+            activated.append(str(kwargs.get("agent")))
+            return _Handle()
+
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _Spawnable)
+    monkeypatch.setattr(warm.platform_compat, "process_start_time", lambda pid: f"start-{pid}")
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+
+    plan = await warm._warm_mint._ensure_locked([_provider("linear")])
+    assert plan is not None
+    activation, _requests = await warm._warm_mint._activate_locked(
+        plan.all_agent,
+        frozenset(),
+    )
+
+    work_dir = Path(built[0]["work_dir"])
+    assert built[0]["agent"] == warm._WARM_BASE_AGENT
+    assert (work_dir / ".kiro" / "agents" / f"{warm._WARM_BASE_AGENT}.json").is_file()
+    assert (work_dir / ".kiro" / "agents" / f"{warm._WARM_ALL_AGENT}.json").is_file()
+    assert activated == [warm._WARM_ALL_AGENT]
+    assert activation > 0
+
+
+@pytest.mark.asyncio
+async def test_generation_directory_is_removed_only_after_a_confirmed_kill(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class _Process:
+        pid = 5151
+
+        def __init__(self, failures: int) -> None:
+            self.failures = failures
+            self.kill_attempts = 0
+
+        async def kill(self) -> None:
+            self.kill_attempts += 1
+            if self.failures:
+                self.failures -= 1
+                raise TimeoutError("still alive")
+
+    monkeypatch.setattr(warm.platform_compat, "process_start_time", lambda pid: f"start-{pid}")
+    monkeypatch.setattr(warm, "_WARM_KILL_TIMEOUT_SECONDS", 1)
+    work_dir = warm._create_warm_generation_dir()
+    runtime = _Process(failures=1)
+
+    def _liveness(pid: int) -> str:
+        """Report the runtime dead only once its kill has actually taken.
+
+        Stated rather than left to the host: releasing the tree requires positive proof the
+        runtime is gone, and an arbitrary fake PID can collide with a real process on the
+        machine running the suite -- which would otherwise make this test's outcome depend
+        on who happens to own PID 5151.
+        """
+        if pid != runtime.pid:
+            return warm.platform_compat.PID_ALIVE
+        return (
+            warm.platform_compat.PID_DEAD
+            if runtime.kill_attempts > 1
+            else warm.platform_compat.PID_ALIVE
+        )
+
+    monkeypatch.setattr(warm.platform_compat, "pid_liveness", _liveness)
+    warm._bind_warm_generation(runtime, work_dir)
+
+    assert await warm._warm_mint._kill_generation(3, runtime) is False
+    assert work_dir.is_dir(), "a process that may still live still owns its specs"
+
+    assert await warm._warm_mint._kill_generation(3, runtime) is True
+    assert not work_dir.exists(), "a confirmed kill releases the generation tree"
+
+
+def test_generation_creation_refuses_a_dir_whose_acl_tighten_failed(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A silently loose generation dir must be refused, not handed agent specs.
+
+    ``make_owner_only_dir`` documents its tighten step as best-effort, so on a filesystem
+    where the ACL write fails the directory exists but is not provably owner-only --
+    contradicting the private-scope guarantee this module exists to provide. Creation must
+    fail loud (and clean up) rather than return a loose directory that will be handed
+    injectable agent specs.
+    """
+
+    def _failing_restrict(path):  # noqa: ANN001 — mirrors platform_compat's signature
+        raise PermissionError(f"ACL write refused for {path}")
+
+    monkeypatch.setattr(warm.platform_compat, "restrict_dir_to_owner", _failing_restrict)
+
+    with pytest.raises(PermissionError):
+        warm._create_warm_generation_dir()
+
+    generations = warm._warm_generations_dir()
+    leftovers = [p for p in generations.iterdir()] if generations.is_dir() else []
+    assert leftovers == [], "a refused generation dir must not survive on disk"
+
+
+def test_a_provisional_marker_does_not_prove_the_runtime_dead(
+    _private_warm_home: Path,
+):
+    """A marker still carrying pid 0 keeps the tree: the bind rewrite may have failed.
+
+    ``_create_warm_generation_dir`` writes a provisional owner marker with no runtime
+    identity, and ``_bind_warm_generation`` rewrites it after spawn. If that rewrite fails,
+    the marker says ``runtime_pid: 0`` while the spawned process lives -- so reading pid 0
+    as proof of death would delete a surviving runtime's cwd and private specs. Unproved
+    must keep, exactly as the scavenger's tri-state treats the same marker.
+    """
+
+    class _Process:
+        pid = 7373
+
+    work_dir = warm._create_warm_generation_dir()
+    runtime = _Process()
+    # Attach the directory WITHOUT _bind_warm_generation: this is the failed-rewrite
+    # state, where the provisional pid-0 marker from _create_warm_generation_dir is
+    # all that exists on disk.
+    setattr(runtime, warm._WARM_RUNTIME_DIR_ATTR, str(work_dir))
+
+    assert warm._release_runtime_generation(runtime) is False
+    assert work_dir.is_dir(), "a provisional marker (pid 0) must keep the tree"
+
+
+def test_startup_scavenging_deletes_only_proven_dead_owned_generations(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    dead = warm._create_warm_generation_dir()
+    live = warm._create_warm_generation_dir()
+    unproved = warm._warm_generations_dir() / "generation-unproved"
+    unproved.mkdir()
+
+    class _Process:
+        def __init__(self, pid: int) -> None:
+            self.pid = pid
+
+    monkeypatch.setattr(warm.platform_compat, "process_start_time", lambda pid: f"start-{pid}")
+    warm._bind_warm_generation(_Process(101), dead)
+    warm._bind_warm_generation(_Process(202), live)
+    monkeypatch.setattr(
+        warm,
+        "_process_identity_live",
+        lambda pid, started: {101: False, 202: True}.get(pid, False),
+    )
+
+    assert warm._scavenge_warm_generation_dirs() == 1
+    assert not dead.exists()
+    assert live.is_dir()
+    assert unproved.is_dir(), "absence of an ownership marker must fail closed"
+
+
+def test_recorded_gateway_identity_reads_back_as_live(_private_warm_home: Path):
+    """The gateway token the writer stores must round-trip through the reader.
+
+    Writer and reader have to agree on ONE token format, and two different
+    ``platform_compat`` helpers do not: ``own_process_start_time()`` answers
+    ``"{ticks}:{boot_uuid}"`` on Linux and a ``proc_pidinfo`` microtime on macOS,
+    while ``process_start_time(pid)`` -- what the reader compares against --
+    answers bare ticks and a 1s ``ps`` string respectively. Storing one and
+    comparing the other classifies this very much alive gateway as dead on both
+    platforms, and only coincidentally agrees on Windows, where both helpers
+    return the same creation ``FILETIME``.
+    """
+    owner = warm._warm_generation_owner()
+
+    assert owner["gateway_pid"] == os.getpid()
+    assert owner["gateway_started"], "a readable host must record a gateway token"
+    assert warm._process_identity_live(owner["gateway_pid"], owner["gateway_started"]) is True
+
+
+def test_scavenging_keeps_a_generation_whose_gateway_is_still_alive(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A live gateway must veto scavenging even once its runtime has exited.
+
+    This is the consequence of the format mismatch rather than a restatement of
+    it: removal needs BOTH identities proven dead, so a gateway that cannot
+    prove its own liveness silently forfeits its half of that guard, and the
+    directory it is still using is deleted underneath it as soon as its
+    short-lived runtime goes away. Neither identity is stubbed here -- the
+    existing scavenging test replaces ``_process_identity_live`` outright, which
+    is why it cannot observe a wrong token reaching that function.
+    """
+    real_start_time = warm.platform_compat.process_start_time
+    dead_pid = 424242
+
+    monkeypatch.setattr(
+        warm.platform_compat,
+        "process_start_time",
+        lambda pid: "runtime-token" if pid == dead_pid else real_start_time(pid),
+    )
+    monkeypatch.setattr(
+        warm.platform_compat,
+        "pid_liveness",
+        lambda pid: (
+            warm.platform_compat.PID_DEAD if pid == dead_pid else warm.platform_compat.PID_ALIVE
+        ),
+    )
+
+    class _Process:
+        pid = dead_pid
+
+    work_dir = warm._create_warm_generation_dir()
+    warm._bind_warm_generation(_Process(), work_dir)
+
+    assert warm._scavenge_warm_generation_dirs() == 0
+    assert work_dir.is_dir(), "the generation its live gateway still owns must survive"
+
+
+def test_release_keeps_the_tree_when_the_killed_runtime_survived(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A kill that REPORTED success but left the PID alive must not delete the specs.
+
+    ``AcpRuntime._kill_inner`` handles its own survivor by logging and returning: both
+    ``kill_process_tree`` calls swallow ``OSError`` by design, so a signal-delivery failure
+    (EPERM through a launcher wrapper, pgid drift) is indistinguishable from success at that
+    layer, and it deliberately leaves the PID tracked for a sweep instead of raising.
+    ``_kill_quietly`` therefore answers True while the child is still running, and releasing
+    on that word alone rmtree's the cwd and the private agent scope out from under a process
+    still reading them. The recorded runtime identity is the proof that exists; consult it.
+    """
+    survivor_pid = 525252
+    real_start_time = warm.platform_compat.process_start_time
+
+    monkeypatch.setattr(
+        warm.platform_compat,
+        "process_start_time",
+        lambda pid: "runtime-token" if pid == survivor_pid else real_start_time(pid),
+    )
+    monkeypatch.setattr(
+        warm.platform_compat, "pid_liveness", lambda pid: warm.platform_compat.PID_ALIVE
+    )
+
+    class _Process:
+        pid = survivor_pid
+
+    runtime = _Process()
+    work_dir = warm._create_warm_generation_dir()
+    warm._bind_warm_generation(runtime, work_dir)
+
+    assert warm._release_runtime_generation(runtime) is False
+    assert work_dir.is_dir(), "a runtime that outlived its kill still owns its specs"
+
+
+def test_release_removes_the_tree_once_the_runtime_is_provably_dead(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The ordinary confirmed kill must still reclaim the tree.
+
+    Paired with the survivor case on purpose: a gate that refused whenever liveness was
+    merely unproven would trade a deletion bug for a directory that accumulates on every
+    activation, so this pins that a dead runtime is still released promptly rather than
+    waiting for the next gateway start to scavenge it.
+    """
+    gone_pid = 636363
+    real_start_time = warm.platform_compat.process_start_time
+
+    monkeypatch.setattr(
+        warm.platform_compat,
+        "process_start_time",
+        lambda pid: "runtime-token" if pid == gone_pid else real_start_time(pid),
+    )
+    monkeypatch.setattr(
+        warm.platform_compat,
+        "pid_liveness",
+        lambda pid: (
+            warm.platform_compat.PID_DEAD if pid == gone_pid else warm.platform_compat.PID_ALIVE
+        ),
+    )
+
+    class _Process:
+        pid = gone_pid
+
+    runtime = _Process()
+    work_dir = warm._create_warm_generation_dir()
+    warm._bind_warm_generation(runtime, work_dir)
+
+    assert warm._release_runtime_generation(runtime) is True
+    assert not work_dir.exists()
+
+
+def test_startup_removes_owned_global_legacy_specs_but_keeps_unsentinelled_files(
+    _agents_dir: Path,
+    _private_warm_home: Path,
+):
+    ours = _agents_dir / f"{warm._WARM_BASE_AGENT}.json"
+    ours.write_text(
+        json.dumps(warm._warm_spec_body(warm._WARM_BASE_AGENT, {}, "legacy")),
+        encoding="utf-8",
+    )
+    foreign, body = _mimic_spec(_agents_dir, f"{warm._WARM_AGENT_PREFIX}manual")
+
+    assert warm.scavenge_warm_mint_artifacts() == 1
+    assert not ours.exists()
+    assert foreign.read_text(encoding="utf-8") == body
+
+
 def _foreign_spec(agents: Path, stem: str) -> tuple[Path, str]:
     """A user's OWN agent spec, planted at a path a warm plan would claim."""
     path = agents / f"{stem}.json"
@@ -420,7 +819,7 @@ def test_the_sweep_refuses_to_unlink_a_foreign_file_at_a_warm_spec_path(_agents_
     write-time sweep unlinked a user's own agent spec that happened to sit there."""
     planted, body = _foreign_spec(_agents_dir, "kirocrew-mint-warm-notion")
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
 
     assert planted.is_file(), "the sweep deleted a file no warm plan ever wrote"
     assert planted.read_text(encoding="utf-8") == body
@@ -463,7 +862,7 @@ def test_a_mimic_carrying_only_our_generic_defaults_survives_the_write(_agents_d
     clobbered a spec whose description, mcpServers and tools were entirely the user's."""
     planted, body = _mimic_spec(_agents_dir, warm._WARM_BASE_AGENT)
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
 
     assert planted.read_text(encoding="utf-8") == body, "the write clobbered a mimic"
 
@@ -475,10 +874,10 @@ def test_a_mimic_carrying_only_our_generic_defaults_survives_sweep_and_teardown(
     the write-time sweep and teardown."""
     planted, body = _mimic_spec(_agents_dir, "kirocrew-mint-warm-notion")
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
     assert planted.is_file(), "the sweep deleted a mimic"
 
-    warm._remove_warm_mint_specs()
+    warm._remove_warm_mint_specs(_agents_dir)
 
     assert planted.is_file(), "teardown deleted a mimic"
     assert planted.read_text(encoding="utf-8") == body
@@ -513,7 +912,7 @@ def test_a_dangling_symlink_at_the_spec_path_reads_as_foreign(_agents_dir: Path)
 
 def test_every_spec_a_warm_plan_writes_carries_the_ownership_sentinel(_agents_dir: Path):
     """Whole-plan coverage: the base spec and the all-providers spec alike."""
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
 
     written = list(_agents_dir.glob(f"{warm._WARM_AGENT_PREFIX}*.json"))
     assert written
@@ -528,7 +927,7 @@ def test_the_write_refuses_to_clobber_a_foreign_file_at_a_planned_spec_path(_age
     path the CURRENT plan wants was overwritten rather than skipped."""
     planted, body = _foreign_spec(_agents_dir, warm._WARM_BASE_AGENT)
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
 
     assert planted.read_text(encoding="utf-8") == body, "the write clobbered a foreign file"
 
@@ -537,7 +936,7 @@ def test_the_teardown_refuses_to_unlink_a_foreign_file_at_a_warm_spec_path(_agen
     """RED before the ownership check: teardown swept the whole warm glob by name."""
     planted, body = _foreign_spec(_agents_dir, "kirocrew-mint-warm-notion")
 
-    warm._remove_warm_mint_specs()
+    warm._remove_warm_mint_specs(_agents_dir)
 
     assert planted.is_file(), "teardown deleted a file no warm plan ever wrote"
     assert planted.read_text(encoding="utf-8") == body
@@ -551,17 +950,17 @@ def test_the_sweep_still_unlinks_a_stale_spec_a_warm_plan_did_write(_agents_dir:
         encoding="utf-8",
     )
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
 
     assert not stale.exists(), "a spec this module wrote survived the sweep"
     assert (_agents_dir / f"{warm._WARM_BASE_AGENT}.json").is_file()
 
 
 def test_teardown_unlinks_every_spec_a_warm_plan_did_write(_agents_dir: Path):
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
     assert (_agents_dir / f"{warm._WARM_BASE_AGENT}.json").is_file()
 
-    warm._remove_warm_mint_specs()
+    warm._remove_warm_mint_specs(_agents_dir)
 
     assert not list(_agents_dir.glob(f"{warm._WARM_AGENT_PREFIX}*.json"))
 
@@ -574,7 +973,7 @@ def test_a_spec_this_module_wrote_is_rewritten_in_place(_agents_dir: Path):
         encoding="utf-8",
     )
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
 
     description = json.loads(path.read_text(encoding="utf-8"))["description"]
     assert description.startswith(warm._WARM_SPEC_SENTINEL)
@@ -586,8 +985,8 @@ def test_an_unreadable_file_at_a_warm_spec_path_is_left_alone(_agents_dir: Path)
     path = _agents_dir / "kirocrew-mint-warm-notion.json"
     path.write_text("{ this is not json", encoding="utf-8")
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
-    warm._remove_warm_mint_specs()
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), _agents_dir)
+    warm._remove_warm_mint_specs(_agents_dir)
 
     assert path.read_text(encoding="utf-8") == "{ this is not json"
 
@@ -605,7 +1004,7 @@ def test_a_refusal_is_audited_rather_than_raised(monkeypatch: pytest.MonkeyPatch
     )
     _foreign_spec(agents, warm._WARM_BASE_AGENT)
 
-    warm._write_warm_mint_specs(warm._warm_spec_plan([]))
+    warm._write_warm_mint_specs(warm._warm_spec_plan([]), agents)
 
     assert events, "a refusal to touch a user's file was silent"
     assert all(outcome == "refused" for _, _, outcome in events)
@@ -705,7 +1104,7 @@ def test_a_sensitive_symlink_at_a_warm_spec_path_is_never_judged_ours(
     assert warm._warm_spec_is_foreign(link) is True
 
     # The verdict's whole purpose: the sweep must leave both the link and its target alone.
-    warm._remove_warm_mint_specs()
+    warm._remove_warm_mint_specs(_agents_dir)
 
     assert link.is_symlink(), "the sweep unlinked a symlink it was refused"
     assert target.is_file(), "the sweep reached a file outside the agents dir"
@@ -724,7 +1123,7 @@ def test_an_oversized_spec_at_a_warm_spec_path_is_never_judged_ours(
 
     assert warm._warm_spec_is_foreign(planted) is True
 
-    warm._remove_warm_mint_specs()
+    warm._remove_warm_mint_specs(_agents_dir)
 
     assert planted.is_file(), "the sweep unlinked a file it could not read"
 
@@ -1502,7 +1901,7 @@ async def test_a_failed_respawn_still_drains_the_generation_it_parked(
 
     monkeypatch.setattr(warm, "_kill_quietly", _record_kill)
     monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
-    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan, agents_dir: None)
     monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _explode)
     monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 0)
     monkeypatch.setattr(warm._warm_mint, "_runtime", None)
@@ -1528,24 +1927,34 @@ async def test_a_failed_respawn_still_drains_the_generation_it_parked(
 
 
 @pytest.mark.asyncio
-async def test_a_foreign_spec_at_a_planned_path_aborts_warming_instead_of_being_activated(
-    monkeypatch: pytest.MonkeyPatch, _agents_dir: Path
+async def test_a_global_same_name_agent_never_blocks_the_private_generation(
+    monkeypatch: pytest.MonkeyPatch,
+    _agents_dir: Path,
 ):
-    """The refusal has to reach the SPAWN, not just the write."""
-    _foreign_spec(_agents_dir, warm._WARM_BASE_AGENT)
-    constructed: list[str] = []
+    """A user-owned global file survives while the helper activates its private twin."""
+    planted, body = _foreign_spec(_agents_dir, warm._WARM_BASE_AGENT)
+    constructed: list[dict[str, Any]] = []
 
-    def _factory():
-        def _build(**kwargs):
-            constructed.append(str(kwargs.get("agent")))
-            raise AssertionError("a refused spec must never be activated")
+    class _Spawnable:
+        def __init__(self, **kwargs: Any) -> None:
+            constructed.append(kwargs)
 
-        return _build
+        async def spawn(self) -> None:
+            return None
 
-    monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
+        def is_alive(self) -> bool:
+            return True
 
-    assert await warm._warm_mint._ensure_locked([_provider("linear")]) is None
-    assert constructed == [], "the runtime was constructed on a spec we refused to own"
+    monkeypatch.setattr(warm, "_acp_runtime_factory", lambda: _Spawnable)
+    monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
+
+    served = await warm._warm_mint._ensure_locked([_provider("linear")])
+
+    assert served is not None
+    assert constructed and constructed[0]["agent"] == warm._WARM_BASE_AGENT
+    assert planted.read_text(encoding="utf-8") == body
+    private = warm._warm_generation_agents_dir(Path(constructed[0]["work_dir"]))
+    assert (private / f"{warm._WARM_BASE_AGENT}.json").is_file()
 
 
 @pytest.mark.asyncio
@@ -1555,7 +1964,9 @@ async def test_a_missing_planned_spec_also_aborts_warming(
     """Absence and foreignness are the same answer here: an unreadable spec path is not a
     spec of ours, and `_warm_spec_is_foreign` answers False for an absent file, so the
     verification has to test existence as well as ownership."""
-    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)  # writes nothing
+    monkeypatch.setattr(
+        warm, "_write_warm_mint_specs", lambda plan, agents_dir: None
+    )  # writes nothing
     constructed: list[str] = []
 
     def _factory():
@@ -1615,7 +2026,7 @@ async def test_a_cancel_during_the_spec_write_still_arms_the_drain(
     monkeypatch.setattr(warm._warm_mint, "_generation", 5)
     monkeypatch.setattr(warm._warm_mint, "_retiring", [(5, parked_runtime)])
 
-    def _cancel(plan):
+    def _cancel(plan, agents_dir):
         raise asyncio.CancelledError()
 
     monkeypatch.setattr(warm, "_write_warm_mint_specs", _cancel)
@@ -1871,21 +2282,42 @@ async def test_an_abandoned_spawn_whose_kill_times_out_is_tracked_not_dropped(
 
 
 @pytest.mark.asyncio
-async def test_a_spec_sweep_is_withheld_while_an_unkilled_child_still_needs_its_spec():
-    """A spec removed under a process that is still running strands it -- the same rule the
-    parked path follows, and the reason the sweep is gated on the kill having taken."""
-    removed: list[bool] = []
+async def test_a_spec_scope_is_retained_while_an_unkilled_child_still_needs_it(
+    _private_warm_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A spec tree removed under a process that still runs strands that process."""
     doomed = _UnkillableRuntime(failures=1)
-    with pytest.MonkeyPatch.context() as patch:
-        patch.setattr(warm, "_remove_warm_mint_specs", lambda: removed.append(True))
-        patch.setattr(warm._warm_mint, "_runtime", None)
-        patch.setattr(warm._warm_mint, "_retiring", [])
+    doomed.pid = 6060
+    monkeypatch.setattr(warm.platform_compat, "process_start_time", lambda pid: f"start-{pid}")
 
-        assert await warm._warm_mint._kill_generation(3, doomed) is False
-        assert not removed, "the surviving child's spec was unlinked underneath it"
+    def _liveness(pid: int) -> str:
+        """Report the doomed child dead only once its kill has actually taken.
 
-        assert await warm._warm_mint._kill_generation(3, doomed) is True
-        assert removed == [True]
+        Stated rather than left to the host: releasing the tree now requires positive proof
+        the runtime is gone, and an arbitrary fake PID can collide with a real process on
+        the machine running the suite -- which would otherwise make this test's outcome
+        depend on who happens to own PID 6060.
+        """
+        if pid != doomed.pid:
+            return warm.platform_compat.PID_ALIVE
+        return (
+            warm.platform_compat.PID_DEAD
+            if doomed.kill_attempts > 1
+            else warm.platform_compat.PID_ALIVE
+        )
+
+    monkeypatch.setattr(warm.platform_compat, "pid_liveness", _liveness)
+    work_dir = warm._create_warm_generation_dir()
+    warm._bind_warm_generation(doomed, work_dir)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", None)
+    monkeypatch.setattr(warm._warm_mint, "_retiring", [])
+
+    assert await warm._warm_mint._kill_generation(3, doomed) is False
+    assert work_dir.is_dir(), "the surviving child's private specs were removed"
+
+    assert await warm._warm_mint._kill_generation(3, doomed) is True
+    assert not work_dir.exists(), "a confirmed kill must release its private specs"
 
 
 # ── the invariant itself, pinned where it is mechanically checkable ──
@@ -2295,8 +2727,8 @@ async def test_an_unaddressable_abandoned_session_quarantines_its_generation(
     monkeypatch.setattr(warm, "_WARM_SESSION_REAP_TIMEOUT_SECONDS", 0.01)
     monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
     monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
-    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan: None)
-    monkeypatch.setattr(warm, "_unowned_plan_specs", lambda plan: [])
+    monkeypatch.setattr(warm, "_write_warm_mint_specs", lambda plan, agents_dir: None)
+    monkeypatch.setattr(warm, "_unowned_plan_specs", lambda plan, agents_dir: [])
 
     class _NeverReturnsAHandle:
         def is_alive(self) -> bool:
@@ -2609,20 +3041,24 @@ def _mount_spy(monkeypatch: pytest.MonkeyPatch, _agents_dir: Path):
 
     def _factory():
         def _build(**kwargs: Any) -> _SpecEnumeratingRuntime:
-            return _SpecEnumeratingRuntime(_agents_dir, mounted, **kwargs)
+            work_dir = Path(kwargs["work_dir"])
+            return _SpecEnumeratingRuntime(
+                warm._warm_generation_agents_dir(work_dir),
+                mounted,
+                **kwargs,
+            )
 
         return _build
 
     monkeypatch.setattr(warm, "_acp_runtime_factory", _factory)
     monkeypatch.setattr(warm, "_MINT_GRANT_POLL_SECONDS", 3600)
     monkeypatch.setattr(warm, "_WARM_OAUTH_SETTLE_ROUNDS", 1)
-    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
     return mounted
 
 
 async def _spawned_on(agents_dir: Path, plan: warm._WarmSpecPlan, mounted: list[Any]) -> Any:
     """A live process that enumerated ``plan``'s specs, the way a resident one did."""
-    warm._write_warm_mint_specs(plan)
+    warm._write_warm_mint_specs(plan, agents_dir)
     runtime = _SpecEnumeratingRuntime(agents_dir, mounted)
     await runtime.spawn()
     return runtime

--- a/test/test_dashboard_server_coverage.py
+++ b/test/test_dashboard_server_coverage.py
@@ -18,6 +18,7 @@ Everything stays inside ``tmp_path``: no network, no subprocess, no fixed port
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import os
 from pathlib import Path
@@ -442,6 +443,75 @@ class TestReviveIntendedInstances:
             "degraded",
             "ok",
         ]
+
+
+# ── _register_connections_warm_lifecycle ────────────────────────────────
+
+
+class TestConnectionsWarmLifecycle:
+    @pytest.mark.asyncio
+    async def test_kick_tracks_scavenging_without_blocking_and_cleanup_retires_runtime(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from kiro_crew.connections import warm
+
+        calls: list[str] = []
+        scavenge_started = asyncio.Event()
+        scavenge_release = asyncio.Event()
+
+        def _scavenge() -> int:
+            calls.append("scavenge")
+            return 0
+
+        async def _to_thread(func: Any, *args: Any) -> Any:
+            scavenge_started.set()
+            await scavenge_release.wait()
+            return func(*args)
+
+        async def _shutdown() -> None:
+            calls.append("shutdown")
+
+        # Patched on ``connections.warm``, which is where the deferred imports resolve both
+        # names: the scavenge import happens inside the kick's worker thread and the
+        # shutdown import inside the cleanup hook, to keep the warm dependency graph off
+        # the gateway boot path, so this module's globals never hold them.
+        monkeypatch.setattr(warm, "scavenge_warm_mint_artifacts", _scavenge)
+        monkeypatch.setattr(warm, "shutdown_warm_mint", _shutdown)
+        monkeypatch.setattr(asyncio, "to_thread", _to_thread)
+        app = web.Application()
+        state = _state()
+        srv._register_connections_warm_lifecycle(app, state)
+        assert not any(
+            hook.__name__.startswith("_connections_warm") for hook in app.on_startup
+        ), "scavenging must not ride on_startup: those hooks run before the listener binds"
+        cleanup = next(
+            hook for hook in app.on_cleanup if hook.__name__ == "_connections_warm_shutdown"
+        )
+
+        srv._kick_connections_warm_scavenge(state)
+        await scavenge_started.wait()
+
+        assert calls == []
+        assert len(state._background_tasks) == 1
+
+        scavenge_release.set()
+        await asyncio.gather(*state._background_tasks)
+        await cleanup(app)
+
+        assert calls == ["scavenge", "shutdown"]
+
+    def test_both_gateway_modes_register_the_same_lifecycle(self) -> None:
+        registration = "_register_connections_warm_lifecycle(app, state)"
+        kick = "_kick_connections_warm_scavenge(state)"
+        for entrypoint in (srv.start_dashboard, srv.start_api_server):
+            source = inspect.getsource(entrypoint)
+            assert registration in source
+            assert kick in source
+            # The kick must run strictly AFTER the listener binds: an on_startup hook (or
+            # any pre-bind call) puts the scavenge's deferred import in front of the bind,
+            # which no-new-work-on-gateway-boot-path forbids.
+            assert source.index("_start_site(site, port)") < source.index(kick)
 
 
 # ── _register_prevent_sleep_shutdown ────────────────────────────────────

--- a/test/test_dashboard_server_startup_coverage.py
+++ b/test/test_dashboard_server_startup_coverage.py
@@ -431,6 +431,7 @@ class TestStartDashboardWiring:
 
         later_hooks = (
             "_instances_shutdown",
+            "_connections_warm_shutdown",
             "_prevent_sleep_shutdown",
             "_status_sink_shutdown",
             "_contrib_shutdown",
@@ -443,8 +444,16 @@ class TestStartDashboardWiring:
         tunnel_at = cleanup.index("_tunnel_shutdown")
         for name in later_hooks:
             assert tunnel_at < cleanup.index(name), f"{name} would starve the tunnel teardown"
-        for name in ("_instances_startup", "_contrib_startup", "_hooks_startup"):
+        for name in (
+            "_instances_startup",
+            "_contrib_startup",
+            "_hooks_startup",
+        ):
             assert name in startup, f"missing on_startup hook: {name}"
+        # The warm scavenge is deliberately ABSENT from on_startup: those hooks run
+        # inside runner.setup(), before the listener binds, so the scavenge is kicked
+        # explicitly after _start_site instead (no-new-work-on-gateway-boot-path).
+        assert "_connections_warm_startup" not in startup
 
     @pytest.mark.asyncio
     async def test_a_cross_origin_post_is_refused(self, tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Problem / Motivation

Connections warm mint modes were written into the user's global agent directory. That exposed internal process-only modes in the user agent roster and left global artifacts behind when a helper or gateway crashed.

## Why it matters

Internal warm modes are runtime implementation details, not user-selectable agents. Publishing them globally pollutes discovery and allows stale files to outlive the process that owns their OAuth sessions, making the visible roster and the actual runtime lifecycle disagree.

## What changed (motivation → approach → change)

The warm helper now gives every ACP process a random, owner-only generation root under the protected Connections run tree and writes both warm modes to that root's project-local `.kiro/agents` scope. The generation root is also the runtime working directory, so the initial `--agent` spawn and later session mode selection resolve the same private specs without publishing either mode globally.

Each generation carries an ownership marker with gateway/runtime PIDs and process-start identities. Confirmed process teardown releases only that generation; parked, failed-to-kill, and otherwise ambiguous generations are retained. Startup schedules a tracked off-loop scavenger without delaying listener binding, and removes a private generation only when both recorded identities are provably dead. Graceful cleanup retires live and parked generations in both full-dashboard and headless API gateways.

Startup also removes sentinel-owned legacy global warm specs. Unsentinelled legacy files remain untouched and are documented for manual inspection because their names alone cannot prove ownership. Internal generation scopes remain excluded from discovery and agent pickers.

## Tests

- Added/updated warm-engine tests for private project scope, initial/later mode resolution, per-generation ownership, confirmed-kill cleanup, failed-kill retention, fail-closed scavenging, legacy cleanup, and discovery exclusion.
- Added dashboard lifecycle coverage proving both gateway modes schedule scavenging without blocking startup and retire the warm singleton on cleanup.
- Final affected backend slice: 383 passed, 2 skipped.
- Full frontend Vitest: 28,472 passed across 1,805 files; scoped cross-surface guard: 5,682 passed across 208 files.
- Electron: 1,587 passed, 1 skipped. Production/analyze builds, TypeScript, ESLint, i18n, phantom-class, duplication, and bundle-size gates passed.
- Full isort, flake8, mypy (1,282 source files), baseline-aware Black, docs, encoding, SDK-boundary, async-I/O, harness-parity, feature-map, vendor, scrub, and related repository gates passed.
- The full backend suite collected 84,378 tests. Its remaining 21 failures reproduced unchanged on clean current `main` in the same synthetic HOME/temp environment, so they are not PR-11 regressions.

## Manual verification

N/A — this is backend/runtime lifecycle behavior with no visual surface. The automated tests exercise filesystem placement, process ownership, cleanup, startup scheduling, and both gateway registrations directly.

## Related Issues

no linked issue: this is PR-11 in the pre-G2 Connections hardening sequence.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Process-only agent specs must use a process-owned project scope, never a globally discovered user-agent scope.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff


