### PR TITLE
fix(babysit): name the PR by URL in the guidance, since that is what gates the loop

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md
@@ -185,7 +185,12 @@ not write it off as flakiness.
   you ACT most cycles (fixing findings, pushing revisions) → `monitor_start`.
 - **Pure-watch phase of a PR babysit** — waiting on CI or reviewers, nothing to
   do until a signal → still `monitor_start`, and name the pull request in the
-  instruction. A loop naming one public GitHub pull request is gated by default:
+  instruction **by full URL** — `https://github.com/<owner>/<repo>/pull/<N>`.
+  That form is the only one that selects a subject: a bare `PR #123`, or the
+  `owner/name#123` shorthand, deliberately refuses inference, so the loop stays
+  on the plain timer and every interval spends a turn. The user will usually say
+  "babysit PR #123"; you write the URL. A loop naming one public GitHub pull
+  request that way is gated by default:
   quiet cycles cost no agent turn, and it wakes only on a real change. The
   `pr_watch` script cron (below) is now only for what that cannot reach --
   an enterprise host, or detection with no owning loop.
@@ -625,9 +630,13 @@ Two limits worth knowing before you trust it on an arbitrary PR:
 
 User: "babysit PR #247 until it's review-ready"
 
+Note what the message does with that: the user said `PR #247`, and the armed
+instruction names the pull request by FULL URL. That is what makes the loop
+observation-gated -- copy the user's bare number into the message and it is not.
+
 ```
 monitor_start(
-  message="Check PR #247. FIRST read
+  message="Check https://github.com/owner/repo/pull/247. FIRST read
            gh pr view 247 --json mergeable,mergeStateStatus,reviewDecision —
            rules 6 and 7 of the babysit skill govern what each value means.
            Then run

--- a/src/kiro_crew/config/prompt.md
+++ b/src/kiro_crew/config/prompt.md
@@ -115,7 +115,7 @@ When the user asks you to submit code for review and address automated comments 
 - You need to poll an external system until a condition is met (CR analysis, deployment, ticket resolution)
 
 **Using monitor_start:**
-1. Put the full check instructions AND the exit condition in the message, e.g.: `Check PR #123 for new CI results and review comments. Fix legitimate findings and push. When the PR is review-ready (checks green, threads resolved), tell the user and call autonudge_stop.`
+1. Put the full check instructions AND the exit condition in the message. When the subject is a GitHub pull request, name it BY FULL URL, e.g.: `Check https://github.com/owner/repo/pull/123 for new CI results and review comments. Fix legitimate findings and push. When the PR is review-ready (checks green, threads resolved), tell the user and call autonudge_stop.` The URL is what makes the loop observation-gated, so quiet cycles cost no model turn; a bare `PR #123` leaves the loop on the plain timer and every interval spends a turn. The user will usually say "babysit PR #123" — you write the URL.
 2. Call `monitor_start` with a sensible interval (300s for CI/review polling), then tell the user monitoring is active and END YOUR TURN — the loop wakes you.
 3. Each cycle: do the check, act on findings, report only real signals (don't post "nothing new" every cycle). Every cycle appends a full turn to this same session, so keep per-cycle output small — a chatty loop burns its own context.
 4. When the exit condition is met or the user says stop, call `autonudge_stop`. **This is on you**: `max_cycles` (default 24) is a runaway backstop, and a loop that coasts into its cap did not finish — it ran out of rope. Check the exit condition every cycle and stop deliberately.

--- a/test/test_babysit_guidance_gates.py
+++ b/test/test_babysit_guidance_gates.py
@@ -1,0 +1,64 @@
+"""The guidance an agent copies must demonstrate a form that actually gates.
+
+Every place that teaches an agent to arm a babysit loop used to show the subject
+as a bare ``PR #123``. Inference deliberately refuses that form, so a loop armed
+from the example stayed on the plain timer and every interval spent a turn -- the
+saving read as zero while the mechanism worked perfectly. Measured on a live
+gateway: of six loops that asked to be gated, five had written a bare number and
+only the one that wrote a URL was gated.
+
+These tests assert the shipped text against the real inference function rather
+than against a spelling, so they fail if an example is ever reworded back into a
+form that cannot select a subject -- including the ``<owner>/<repo>`` placeholder
+style, which reads fine to a human and does not infer.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from kiro_crew.probes.targets import infer
+
+ROOT = Path(__file__).resolve().parents[1]
+PROMPT = ROOT / "src" / "kiro_crew" / "config" / "prompt.md"
+BABYSIT_SKILL = (
+    ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "babysit" / "SKILL.md"
+)
+
+_URL = re.compile(r"https://github\.com/\S+?/pull/\d+")
+
+
+def _gating_urls(text: str) -> list[str]:
+    """Every pull-request URL in ``text`` that inference actually accepts."""
+    return [url for url in _URL.findall(text) if infer("Check %s now." % url) is not None]
+
+
+def test_the_monitor_start_guidance_demonstrates_a_gating_subject() -> None:
+    body = PROMPT.read_text(encoding="utf-8")
+    start = body.index("**Using monitor_start:**")
+    block = body[start : start + 1200]
+    assert _gating_urls(block), (
+        "the monitor_start guidance in prompt.md must show the subject as a pull-request "
+        "URL that inference accepts; a bare 'PR #123' leaves the loop ungated"
+    )
+
+
+def test_the_babysit_example_message_names_its_subject_by_url() -> None:
+    body = BABYSIT_SKILL.read_text(encoding="utf-8")
+    # Anchor on the Example section: ``monitor_start(`` also appears far above it
+    # as the tool's signature in the Overview, which carries no subject at all.
+    example = body.index("## Example")
+    start = body.index("monitor_start(", example)
+    message = body[start : start + 400]
+    assert _gating_urls(message), (
+        "the babysit skill's worked example must name the pull request by a URL "
+        "inference accepts, since the armed message is what agents copy"
+    )
+
+
+def test_a_bare_number_is_still_refused_so_the_ratchet_means_something() -> None:
+    # Guards the guard: if inference ever started accepting a bare reference, the
+    # two tests above would pass on the old wording and stop protecting anything.
+    assert infer("Babysit PR #8184 (kirodotdev/KiroCrew), branch fix/x") is None
+    assert infer("Check https://github.com/<owner>/<repo>/pull/123 now.") is None


### PR DESCRIPTION
## Problem / Motivation

A monitor loop is observation-gated only when its instruction names a pull request
by explicit public URL. Inference deliberately refuses a bare `PR #123` and the
`owner/name#123` shorthand, because a loop's own subject and a blocker it merely
mentions cannot be told apart, and gating on the wrong one retires a loop whose
real work is unfinished.

Both places that teach an agent to draft that instruction showed the subject as a
bare number:

- `src/kiro_crew/config/prompt.md` -- the `monitor_start` guidance injected into
  every agent's prompt: `Check PR #123 for new CI results ...`
- `src/kiro_crew/builtin_skills/kirocrew-dev/babysit/SKILL.md` -- the decision
  table said only "name the pull request in the instruction", and the worked
  example armed `message="Check PR #247. ..."`

The tool description already said to use a full URL, but the tool description is
read when calling the tool; the examples are what get copied when composing the
message. So agents wrote the form that refuses gating.

## Why it matters

Measured on a live gateway with the feature merged: of six loops that had asked
to be gated, five had written a bare number and were running on the plain timer,
spending a turn every interval. Only the one loop whose instruction carried a URL
was actually gated -- ten quiet ticks, zero wakes charged to the fallback path,
zero gate fallbacks.

The mechanism worked exactly as designed while the saving read as one sixth of
what was available. That is the same failure mode this line of work exists to
prevent: a correct feature whose adoption is quietly zero. Here the counters
surfaced it, which is the only reason it was found.

## What changed

Guidance only -- no behaviour change, no production code touched.

1. `config/prompt.md`: the example names the subject by URL, and one clause says
   why -- the URL is what makes the loop gated, a bare `PR #123` leaves it on the
   plain timer, and the user will usually say "babysit PR #123" so you write the
   URL.
2. `babysit/SKILL.md`: the decision-table rule now names the required form
   instead of saying "name the pull request", and the worked example arms a URL
   while keeping the user's realistic bare-number request above it -- the point
   being the translation from what the user says to what you arm.
3. `test/test_babysit_guidance_gates.py`: a ratchet that extracts the URLs from
   the shipped text and asserts `probes.targets.infer` accepts them, so a reword
   back into a non-gating form fails instead of silently costing turns. A third
   test guards the guard: it pins that a bare reference is still refused, so the
   other two cannot start passing vacuously if inference ever loosened.

One detail worth recording because it nearly shipped: the placeholder style
matters. `https://github.com/<owner>/<repo>/pull/123` does NOT infer -- the angle
brackets are not valid in an owner or repo segment -- so an example written that
way is as ungated as the bare number it replaced. The samples use bracket-free
placeholders (`owner/repo`), which infer, and the ratchet pins that too.

## Tests

- `test/test_babysit_guidance_gates.py` -- 3 new assertions, each
  mutation-verified: reverting `prompt.md`'s example to `PR #123` reddens the
  first, reverting the skill example to `PR #247` reddens the second, and both
  return green when restored.
- 286 passed across `test_babysit_guidance_gates.py`, `test_acp_prompt_blocks.py`,
  `test_builtin_skill_packaging.py`, `test_builtin_skill_scope.py`,
  `test_builtin_skill_sync_safety.py`, `test_babysit_pr_watch.py` and
  `test_probe_targets.py`.
- `flake8`, `black --check` and `isort --check-only` clean on the new file.

## Manual verification

Ran `probes.targets.infer` against the real strings rather than reasoning about
the regex: the old prompt example is refused, the new one selects
`github.com`, the babysit example still gates with a bare `247` appearing later
in the same message (same number, so no ambiguity refusal), a URL alongside a
DIFFERENT bare `PR #99` is refused as designed, and one of the five live loop
instructions is refused verbatim.

## Related Issues

Refs #7634, which shipped the gate this guidance failed to demonstrate.

## Pattern harvest

Rule candidate: when a feature's behaviour depends on how an instruction is
WORDED, the guidance that teaches the wording must be asserted against the real
predicate, not reviewed by eye -- and the EXAMPLE is what gets copied, so fixing
the prose while leaving a wrong example fixes nothing.

**An example is an interface, and it outranks the prose beside it.** The
`monitor_start` tool description already required a full URL. It lost anyway,
because the agent reads the tool description when CALLING the tool and copies the
EXAMPLE when composing the argument. Five of six live loops copied the example.
When a correct rule and a wrong example disagree, assume the example wins and fix
the example.

**When behaviour depends on how a string is worded, test the shipped words
against the real predicate.** Reviewing guidance by eye is what let this survive:
`Check PR #123` looks like it names a pull request, and a human reader cannot see
that inference refuses it. The new test does not assert a spelling; it runs
`probes.targets.infer` over the text that ships, so the guard tracks the predicate
even if the predicate changes. The third test guards the guard by pinning that a
bare reference is still refused -- without it, loosening inference would make the
other two pass vacuously.

**A placeholder can fail the predicate it is illustrating.**
`https://github.com/<owner>/<repo>/pull/123` reads as a perfectly good generic
URL and does not infer, because angle brackets are not valid in an owner or repo
segment. A placeholder that cannot survive being copied is the same defect as the
bare number, one level more subtle. Bracket-free placeholders (`owner/repo`)
both read as generic and satisfy the predicate.

**A feature can be correct, adopted, and still saving nothing.** The gate worked
exactly as designed from the day it merged; what was missing was that anything
reached it. The counters shipped in #7634 are the only reason the one-in-six ratio
was visible at all -- without a number that distinguishes "gated and quiet" from
"never gated", this would have read as a feature that simply did not help.
