### PR TITLE
fix(cron): survive an unusable history directory instead of killing the service

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -232,7 +232,7 @@ configuration before it is useful). The contract, end to end:
 
 ### Hide in Chat (`hide_in_chat`)
 
-By default a persistent-session agent cron auto-creates a linked dashboard chat slot (`cron-{job_id}`) on first delivery (see Auto-inject), so its runs appear in the active session list. Set `hide_in_chat: true` to suppress that slot creation — the run's result still reaches Slack/dashboard notifications, and the run stays visible in the History tab via the **cron execution-history store** (`CronHistoryStore`, written unconditionally by the executor and surfaced at `GET /api/crons/{id}/history`), but no entry clutters the Chats sidebar. Useful for fire-and-forget jobs (daily digests, log cleanups, polling). Default `false` (preserves prior behavior; absent field reads as `false`). Orthogonal to `silent`: `silent` suppresses the push notification, `hide_in_chat` suppresses the chat slot. The flag is a no-op for `script`/`command` crons, which never create a slot. The executor gates all three `inject_cron_result_to_dashboard` call sites on `not job.hide_in_chat`; the dashboard notification's CTA falls into the pre-existing no-slot branch ("View last result", which lazily rebuilds a slot from history on click) instead of "Continue session". Note: the `cron:{job_id}` *dashboard conversation_log* is written ONLY by `inject_cron_result_to_dashboard`, so it is intentionally empty for a hidden cron — it exists solely to give a dashboard follow-up turn context, which a no-slot cron never has. Hidden-cron result persistence is the execution-history store, not `cron:{job_id}`.
+By default a persistent-session agent cron auto-creates a linked dashboard chat slot (`cron-{job_id}`) on first delivery (see Auto-inject), so its runs appear in the active session list. Set `hide_in_chat: true` to suppress that slot creation — the run's result still reaches Slack/dashboard notifications, and the run stays visible in the History tab via the **cron execution-history store** (`CronHistoryStore`, written by the executor whenever the store is usable — see **History is best-effort** below — and surfaced at `GET /api/crons/{id}/history`), but no entry clutters the Chats sidebar. Useful for fire-and-forget jobs (daily digests, log cleanups, polling). Default `false` (preserves prior behavior; absent field reads as `false`). Orthogonal to `silent`: `silent` suppresses the push notification, `hide_in_chat` suppresses the chat slot. The flag is a no-op for `script`/`command` crons, which never create a slot. The executor gates all three `inject_cron_result_to_dashboard` call sites on `not job.hide_in_chat`; the dashboard notification's CTA falls into the pre-existing no-slot branch ("View last result", which lazily rebuilds a slot from history on click) instead of "Continue session". Note: the `cron:{job_id}` *dashboard conversation_log* is written ONLY by `inject_cron_result_to_dashboard`, so it is intentionally empty for a hidden cron — it exists solely to give a dashboard follow-up turn context, which a no-slot cron never has. Hidden-cron result persistence is the execution-history store, not `cron:{job_id}`.
 
 ### Cron Folders (`folder_id`)
 
@@ -289,6 +289,28 @@ attempted and every one was **security-blocked** with none approved, the run
 sets `last_status = "error"` with a redacted reason and calls `record_failure()`,
 so the same 5-failure `_AUTO_PAUSE_THRESHOLD` applies. Any other outcome records
 a success.
+
+**History is best-effort.** `CronHistoryStore` never lets a history failure reach
+the scheduler. Its directory is resolved once by `prepare()`: usable means history
+is fully on, unusable means the store constructs with `enabled` False, where every
+read returns empty and every write is dropped. Usability is decided by the syscalls
+the store's own paths issue — an `os.stat` of the directory plus the lock-file
+`os.open` — because a refused `mkdir` does not imply an unusable directory
+(`Path.mkdir(exist_ok=True)` consults `Path.is_dir()`, and pathlib re-raises
+`EPERM` out of that stat rather than reporting False, so the flag cannot absorb a
+directory that is denied for reading as well as writing). Deciding it is blocking
+I/O, so a loop-bound caller MUST defer it: `CronService.__init__` passes
+`_defer_prepare=_defer_initial_load` and `CronService.create()` runs `prepare()`
+through `asyncio.to_thread`, the same hop it already uses for `_load()`; a deferred
+store reads `enabled` False until that completes, so a read racing the prepare
+degrades rather than touching a directory of unknown state. At runtime `_degrade`
+disables the store only on a DENIAL (`EPERM`/`EACCES`/`EROFS`), which is a standing
+condition; every other `OSError` (a full disk, fd exhaustion) costs one record and
+leaves history on. Callers do not branch on any of this: the store answers
+every read with an empty result, so a denied install and a job that has never run
+are deliberately indistinguishable over the API today, and the `logger.warning`
+above is the operator's signal. Surfacing the state belongs in the change that
+renders it.
 
 Only an unconditional security block counts. A governance `TOOL_DENY` and an
 unattended-approval timeout also arrive unapproved, but they describe the policy

--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -1300,12 +1300,31 @@ class CronService:
         self._reaper_task: asyncio.Task[None] | None = None
         self._push_refresh: Callable[[str], None] | None = None  # set externally
         _cfg = KiroCrewConfig.load().cron_history
+        _history_dir = base_dir if base_dir is not None else _default_dir()
+        # Execution history is BEST-EFFORT and must never be load-bearing for
+        # scheduling: a throw HERE would propagate out of CronService.__init__
+        # and take the WHOLE cron subsystem with it — the gateway scheduler, MCP
+        # cron_add/cron_list/cron_trigger and `kirocrew cron list` alike, none of
+        # which need history to work. That guarantee lives in the store itself:
+        # _prepare_dir resolves usability without raising and _degrade absorbs a
+        # later failure, so there is deliberately NO try/except here. One would
+        # guard a raise that cannot occur, and a reader would have to prove that
+        # for themselves before trusting either layer.
+        #
+        # The store's directory setup is synchronous filesystem I/O, so it is
+        # deferred on exactly the same condition as _load() below: a loop
+        # context constructs via create(), which then runs both off the loop in
+        # a worker thread. Without that, preparing the history directory would
+        # stat/open on the gateway's sole event loop — the same
+        # no-blocking-call-on-event-loop violation _defer_initial_load exists
+        # to prevent.
         self._history = CronHistoryStore(
-            base_dir=base_dir if base_dir is not None else _default_dir(),
+            base_dir=_history_dir,
             cron_summary_cap=_cfg.cron_summary_cap,
             cron_trace_cap_kb=_cfg.cron_trace_cap_kb,
             cron_max_records_per_job=_cfg.cron_max_records_per_job,
             cron_max_index_records=_cfg.cron_max_index_records,
+            _defer_prepare=_defer_initial_load,
         )
         # Populate the in-memory snapshot from disk once at construction.
         # The read paths (list_jobs / get_job) are CACHE-ONLY — they perform no
@@ -1362,6 +1381,8 @@ class CronService:
         # re-arm the timer thread-safely — see _arm_timer / __init__ _loop.
         self._loop = asyncio.get_running_loop()
         await asyncio.to_thread(self._load)
+        # Resolve history usability off the loop too (deferred in __init__).
+        await asyncio.to_thread(self._history.prepare)
         return self
 
     async def start(self) -> None:

--- a/src/kiro_crew/cron_history.py
+++ b/src/kiro_crew/cron_history.py
@@ -7,11 +7,21 @@ Storage layout:
     ~/.kiro/crew/cron-history/
         {job_id}.jsonl      — full records (including trace) for one job
         _index.jsonl        — lightweight index (no trace) for list queries
+
+History is BEST-EFFORT.  When the directory cannot be created or written the
+store constructs anyway with ``enabled`` False: reads return empty, writes are
+dropped, and nothing raises.  A runtime failure on a store that DID construct
+degrades the same way (``_degrade``) rather than propagating, so the invariant
+holds at the store itself instead of relying on every caller to wrap it.
+Losing run records must never take scheduling down with it — see
+``_prepare_dir`` for how usability is decided, and ``prepare()`` for why a
+loop-bound caller must resolve that off the event loop.
 """
 
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import logging
 import os
@@ -29,6 +39,10 @@ _SUMMARY_CAP = 200
 _TRACE_CAP = 50 * 1024  # 50KB
 _MAX_RECORDS_PER_JOB = 100
 _MAX_INDEX_RECORDS = 2000
+
+#: Errnos that mean "this store is refused", not "this attempt failed". Only
+#: these disable history for the process's lifetime — see ``_degrade``.
+_DENIAL_ERRNOS = frozenset({errno.EPERM, errno.EACCES, errno.EROFS})
 
 
 @dataclass
@@ -67,14 +81,134 @@ class CronHistoryStore:
         cron_trace_cap_kb: int = _TRACE_CAP // 1024,
         cron_max_records_per_job: int = _MAX_RECORDS_PER_JOB,
         cron_max_index_records: int = _MAX_INDEX_RECORDS,
+        *,
+        _defer_prepare: bool = False,
     ):
         self._dir = (base_dir or config_dir()) / "cron-history"
-        self._dir.mkdir(parents=True, exist_ok=True)
         self._index_path = self._dir / "_index.jsonl"
         self._summary_cap = cron_summary_cap
         self._trace_cap = cron_trace_cap_kb * 1024
         self._max_records_per_job = cron_max_records_per_job
         self._max_index_records = cron_max_index_records
+        # Directory setup does synchronous filesystem I/O, so a caller on an
+        # event loop MUST defer it and run prepare() in a worker thread — see
+        # prepare() and CronService.create(). Deferred starts DISABLED so a read
+        # racing the prepare degrades rather than touching an unprepared store.
+        self._prepared = False
+        self._enabled = False
+        if not _defer_prepare:
+            self.prepare()
+
+    @property
+    def enabled(self) -> bool:
+        """False when the history directory is unusable, or not yet prepared.
+
+        Every read returns empty and every write is dropped, so a caller never
+        has to branch on it: history degrades, scheduling does not.
+        """
+        return self._enabled
+
+    def prepare(self) -> None:
+        """Resolve whether history is usable. Blocking; idempotent.
+
+        Off the event loop only. ``CronService.create()`` runs this via
+        ``asyncio.to_thread``, mirroring how it defers ``_load()``.
+        """
+        if self._prepared:
+            return
+        self._prepared = True
+        self._enabled = self._prepare_dir()
+
+    def _prepare_dir(self) -> bool:
+        """Ensure the history directory is usable. Never raises.
+
+        Returns True when records can be persisted, False to disable history.
+        """
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            return True
+        except OSError as exc:
+            # A denial scoped to this one leaf answers EPERM to BOTH os.mkdir
+            # and the os.stat behind Path.is_dir(), and pathlib consults
+            # is_dir() to decide whether exist_ok applies — so mkdir raises
+            # even though the directory is already there. A failed mkdir
+            # therefore does not by itself mean the store is unusable.
+            if self._probe_usable():
+                logger.debug(
+                    "cron history: mkdir refused for existing %s (%s); the "
+                    "store's own syscalls work, continuing",
+                    self._dir,
+                    exc,
+                )
+                return True
+            logger.warning(
+                "cron history disabled: %s is unusable (%s). Scheduling is "
+                "unaffected; run records will not be persisted.",
+                self._dir,
+                exc,
+            )
+            return False
+
+    def _probe_usable(self) -> bool:
+        """True when the syscalls this store's own paths depend on all work.
+
+        Opening the lock file is NOT sufficient evidence that a store whose
+        mkdir was refused is usable. The read and rotate paths go through
+        ``Path.exists()`` (an ``os.stat``) and ``Path.glob()`` (a directory
+        scan), and pathlib RE-RAISES EPERM out of both rather than reporting
+        False — ``_ignore_error`` covers ENOENT/ENOTDIR/EBADF/ELOOP, not
+        EPERM. A probe that only opened the lock file therefore reported a
+        stat-denied directory as usable, and ``rotate_all()`` — awaited
+        unguarded by ``CronService.start()`` — then raised straight back out
+        of service startup, which is the failure this class exists to prevent.
+
+        So require the two capabilities that discriminate: stat the directory
+        and open the lock file. Both are O(1) and fail fast. Enumerating the
+        directory is deliberately NOT part of the probe — its cost grows with
+        the number of jobs, and ``_degrade()`` already turns a directory-scan
+        failure at runtime into disabled history rather than a raise, so
+        proving ``glob()`` works up front buys nothing.
+        """
+        try:
+            os.stat(self._dir)
+            fd = os.open(str(self._lock_path()), os.O_WRONLY | os.O_CREAT, 0o600)
+        except OSError:
+            return False
+        os.close(fd)
+        return True
+
+    def _degrade(self, operation: str, exc: OSError) -> None:
+        """Handle a runtime failure. Never raises.
+
+        Only a DENIAL disables the store. A denial is a standing condition — the
+        sandbox profile that refused us will refuse us for this process's whole
+        life — so continuing to attempt writes just logs the same error per run.
+
+        Every other ``OSError`` is treated as transient and costs ONE record:
+        a full disk, an fd exhaustion, or a transient I/O error clears on its
+        own, and disabling history for the process's remaining lifetime over a
+        momentary ENOSPC would lose every subsequent run's record for no reason
+        — strictly worse than the pre-existing behaviour, where each call site
+        caught its own failure and the next run wrote normally.
+        """
+        if exc.errno in _DENIAL_ERRNOS:
+            if self._enabled:
+                self._enabled = False
+                logger.warning(
+                    "cron history disabled: %s was denied on %s (%s). Scheduling "
+                    "is unaffected; run records will no longer be persisted.",
+                    operation,
+                    self._dir,
+                    exc,
+                )
+            return
+        logger.warning(
+            "cron history: %s failed on %s (%s); dropping this record and "
+            "staying enabled. Scheduling is unaffected.",
+            operation,
+            self._dir,
+            exc,
+        )
 
     def _job_path(self, job_id: str) -> Path:
         path = (self._dir / f"{job_id}.jsonl").resolve()
@@ -102,7 +236,12 @@ class CronHistoryStore:
         if len(record.trace) > self._trace_cap:
             record.trace = record.trace[:self._trace_cap] + "\n...[truncated]"
 
-        await asyncio.to_thread(self._append_sync, record)
+        if not self._enabled:
+            return
+        try:
+            await asyncio.to_thread(self._append_sync, record)
+        except OSError as exc:
+            self._degrade("append", exc)
 
     def _append_sync(self, record: CronRunRecord) -> None:
         fd = self._lock()
@@ -121,7 +260,13 @@ class CronHistoryStore:
         self, job_id: str, offset: int = 0, limit: int = 20
     ) -> tuple[list[dict[str, Any]], int]:
         """Return (records_without_trace, total_count) for a job, newest first."""
-        return await asyncio.to_thread(self._get_job_history_sync, job_id, offset, limit)
+        if not self._enabled:
+            return [], 0
+        try:
+            return await asyncio.to_thread(self._get_job_history_sync, job_id, offset, limit)
+        except OSError as exc:
+            self._degrade("get_job_history", exc)
+            return [], 0
 
     # Reads are lock-free (eventually-consistent): a concurrent append may
     # produce a partial final line, silently skipped by the JSONDecodeError handler.
@@ -152,7 +297,13 @@ class CronHistoryStore:
         self, offset: int = 0, limit: int = 20, job_id: str | None = None
     ) -> tuple[list[dict[str, Any]], int]:
         """Return records from global index, newest first, optionally filtered."""
-        return await asyncio.to_thread(self._get_all_history_sync, offset, limit, job_id)
+        if not self._enabled:
+            return [], 0
+        try:
+            return await asyncio.to_thread(self._get_all_history_sync, offset, limit, job_id)
+        except OSError as exc:
+            self._degrade("get_all_history", exc)
+            return [], 0
 
     # Reads are lock-free (eventually-consistent): a concurrent append may
     # produce a partial final line, silently skipped by the JSONDecodeError handler.
@@ -187,7 +338,13 @@ class CronHistoryStore:
 
     async def get_run_detail(self, job_id: str, run_id: str) -> dict[str, Any] | None:
         """Return full record (with trace) for a specific run."""
-        return await asyncio.to_thread(self._get_run_detail_sync, job_id, run_id)
+        if not self._enabled:
+            return None
+        try:
+            return await asyncio.to_thread(self._get_run_detail_sync, job_id, run_id)
+        except OSError as exc:
+            self._degrade("get_run_detail", exc)
+            return None
 
     def _get_run_detail_sync(self, job_id: str, run_id: str) -> dict[str, Any] | None:
         job_path = self._job_path(job_id)
@@ -208,7 +365,12 @@ class CronHistoryStore:
 
     async def rotate(self, job_id: str) -> None:
         """Trim job file to last _MAX_RECORDS_PER_JOB records."""
-        await asyncio.to_thread(self._rotate_sync, job_id)
+        if not self._enabled:
+            return
+        try:
+            await asyncio.to_thread(self._rotate_sync, job_id)
+        except OSError as exc:
+            self._degrade("rotate", exc)
 
     def _rotate_sync(self, job_id: str) -> None:
         job_path = self._job_path(job_id)
@@ -230,7 +392,12 @@ class CronHistoryStore:
 
     async def rotate_all(self) -> None:
         """Rotate all job files and trim the global index."""
-        await asyncio.to_thread(self._rotate_all_sync)
+        if not self._enabled:
+            return
+        try:
+            await asyncio.to_thread(self._rotate_all_sync)
+        except OSError as exc:
+            self._degrade("rotate_all", exc)
 
     def _rotate_all_sync(self) -> None:
         fd = self._lock()
@@ -260,7 +427,13 @@ class CronHistoryStore:
 
     async def delete_job_history(self, job_id: str) -> bool:
         """Remove all history for a job."""
-        return await asyncio.to_thread(self._delete_job_history_sync, job_id)
+        if not self._enabled:
+            return False
+        try:
+            return await asyncio.to_thread(self._delete_job_history_sync, job_id)
+        except OSError as exc:
+            self._degrade("delete_job_history", exc)
+            return False
 
     def _delete_job_history_sync(self, job_id: str) -> bool:
         fd = self._lock()

--- a/test/test_cron_history.py
+++ b/test/test_cron_history.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import errno
 import json
+import os
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -553,3 +557,250 @@ class TestRunResultFreshness:
         assert row2["trace"] == ""
         # Context-carry for the next prompt still holds run 1's value.
         assert job.last_result == "run one output"
+
+
+# ── Unusable history directory degrades instead of killing cron ───────────
+#
+# The reported failure is a denial scoped to the ``cron-history`` leaf alone:
+# its sibling job store stays writable in the same process. `_deny_leaf`
+# reproduces that shape by refusing only calls whose path names that leaf.
+#
+# The denial is PERSISTENT, not construction-time: a sandbox profile refuses
+# for the process's whole life. Tests that lift the denial after construction
+# prove nothing about the paths that run later — `rotate_all()` in particular,
+# which `CronService.start()` awaits unguarded.
+#
+# Branch table for `_prepare_dir` / `_probe_usable` (every row is covered
+# below), where "stat" stands for the stat + directory-scan pair that
+# `Path.exists()` and `Path.glob()` need:
+#
+#   mkdir ok                          -> enabled
+#   mkdir denied, stat ok,  open ok   -> enabled  (existing but un-mkdir-able)
+#   mkdir denied, stat DENIED, open ok-> disabled (lock file alone is not proof)
+#   mkdir denied, all denied          -> disabled
+#   constructed enabled, later OSError-> degrades to disabled, never raises
+
+
+def _leaf_denier(func, leaf: str):
+    def _wrapped(path, *a, **kw):
+        if isinstance(path, (str, os.PathLike)) and leaf in os.fspath(path):
+            raise PermissionError(errno.EPERM, "Operation not permitted")
+        return func(path, *a, **kw)
+
+    return _wrapped
+
+
+@contextlib.contextmanager
+def _deny_leaf(*names: str, leaf: str = "cron-history"):
+    """Refuse EPERM for each ``os.<name>`` call that targets *leaf*."""
+    with contextlib.ExitStack() as stack:
+        for name in names:
+            stack.enter_context(patch(f"os.{name}", _leaf_denier(getattr(os, name), leaf)))
+        yield
+
+
+def test_mkdir_denied_but_dir_usable_keeps_history_enabled(tmp_path: Path) -> None:
+    """An existing directory whose mkdir is refused is still usable.
+
+    ``mkdir(parents=True, exist_ok=True)`` raises anyway because pathlib
+    consults ``Path.is_dir()`` to decide whether ``exist_ok`` applies. Without
+    the tolerant construction this raises PermissionError out of
+    ``CronHistoryStore.__init__``.
+    """
+    (tmp_path / "cron-history").mkdir()
+    with _deny_leaf("mkdir"):
+        store = CronHistoryStore(base_dir=tmp_path)
+        assert store.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_mkdir_denied_but_dir_usable_still_persists(tmp_path: Path) -> None:
+    """That tolerated store is a real store, with the denial still in force."""
+    (tmp_path / "cron-history").mkdir()
+    with _deny_leaf("mkdir"):
+        store = CronHistoryStore(base_dir=tmp_path)
+        await store.append(_record(job_id="j1", run_id="r1"))
+        rows, total = await store.get_job_history("j1")
+        assert store.enabled is True
+        assert total == 1
+        assert rows[0]["run_id"] == "r1"
+
+
+def test_stat_denied_disables_history_even_when_lock_opens(tmp_path: Path) -> None:
+    """A stat-denied directory is NOT usable, however well the lock file opens.
+
+    ``Path.exists()`` and ``Path.glob()`` re-raise EPERM (pathlib's
+    ``_ignore_error`` covers ENOENT/ENOTDIR/EBADF/ELOOP, not EPERM), so a
+    probe that only opened the lock file reported this store as enabled and the
+    read/rotate paths then raised.
+    """
+    (tmp_path / "cron-history").mkdir()
+    with _deny_leaf("mkdir", "stat", "scandir", "listdir"):
+        store = CronHistoryStore(base_dir=tmp_path)
+        assert store.enabled is False
+
+
+def test_unwritable_dir_disables_history_without_raising(tmp_path: Path) -> None:
+    """A wholly denied directory disables history instead of raising."""
+    with _deny_leaf("mkdir", "stat", "scandir", "listdir", "open"):
+        store = CronHistoryStore(base_dir=tmp_path)
+        assert store.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_store_operations_are_inert(tmp_path: Path) -> None:
+    """Every entry point no-ops on a disabled store; none of them raise."""
+    with _deny_leaf("mkdir", "stat", "scandir", "listdir", "open"):
+        store = CronHistoryStore(base_dir=tmp_path)
+        assert store.enabled is False
+        await store.append(_record(job_id="j1", run_id="r1"))
+        assert await store.get_job_history("j1") == ([], 0)
+        assert await store.get_all_history() == ([], 0)
+        assert await store.get_run_detail("j1", "r1") is None
+        assert await store.delete_job_history("j1") is False
+        await store.rotate("j1")
+        await store.rotate_all()
+
+
+@pytest.mark.asyncio
+async def test_runtime_oserror_degrades_instead_of_propagating(tmp_path: Path) -> None:
+    """A store that constructed healthy still degrades on a later failure.
+
+    The invariant is enforced at the store, so it does not depend on each of
+    the service's call sites wrapping history in try/except.
+    """
+    store = CronHistoryStore(base_dir=tmp_path)
+    assert store.enabled is True
+    with patch.object(
+        store, "_rotate_all_sync", side_effect=PermissionError(errno.EPERM, "nope")
+    ):
+        await store.rotate_all()
+    assert store.enabled is False
+    # Subsequent operations are inert rather than raising.
+    await store.append(_record(job_id="j1", run_id="r1"))
+    assert await store.get_all_history() == ([], 0)
+
+
+@pytest.mark.asyncio
+async def test_transient_oserror_costs_one_record_and_stays_enabled(tmp_path: Path) -> None:
+    """A full disk must not disable history for the process's lifetime.
+
+    Only a denial is a standing condition. Disabling on any OSError would lose
+    every subsequent run's record over a momentary ENOSPC — strictly worse than
+    the pre-existing behaviour, where each call site caught its own failure and
+    the next run wrote normally.
+    """
+    store = CronHistoryStore(base_dir=tmp_path)
+    with patch.object(
+        store, "_append_sync", side_effect=OSError(errno.ENOSPC, "No space left on device")
+    ):
+        await store.append(_record(job_id="j1", run_id="lost"))
+    assert store.enabled is True, "a transient failure must not disable history"
+    # The next write lands normally.
+    await store.append(_record(job_id="j1", run_id="kept"))
+    rows, total = await store.get_job_history("j1")
+    assert total == 1
+    assert rows[0]["run_id"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_denial_errnos_disable_but_transient_ones_do_not(tmp_path: Path) -> None:
+    """Pin the exact errno split `_degrade` keys on."""
+    for code in (errno.EPERM, errno.EACCES, errno.EROFS):
+        store = CronHistoryStore(base_dir=tmp_path)
+        with patch.object(store, "_append_sync", side_effect=OSError(code, "denied")):
+            await store.append(_record(job_id="j", run_id="r"))
+        assert store.enabled is False, f"errno {code} is a denial and must disable"
+    for code in (errno.ENOSPC, errno.EMFILE, errno.EIO):
+        store = CronHistoryStore(base_dir=tmp_path)
+        with patch.object(store, "_append_sync", side_effect=OSError(code, "transient")):
+            await store.append(_record(job_id="j", run_id="r"))
+        assert store.enabled is True, f"errno {code} is transient and must NOT disable"
+
+
+def test_cron_service_survives_unusable_history_dir(tmp_path: Path) -> None:
+    """CronService still constructs and schedules when history is unusable.
+
+    This is the reported blast radius: the store is built in
+    ``CronService.__init__``, so a throw there takes the whole cron subsystem
+    down — gateway scheduler, MCP ``cron_add``/``cron_list``/``cron_trigger``
+    and ``kirocrew cron list`` alike, none of which need history to work.
+    """
+    from kiro_crew.cron import CronService
+
+    with _deny_leaf("mkdir", "stat", "scandir", "listdir", "open"):
+        svc = CronService(base_dir=tmp_path)
+        assert svc.get_history().enabled is False
+        assert svc.list_jobs() == []
+
+
+def test_cron_service_start_survives_stat_denied_history(tmp_path: Path) -> None:
+    """``start()`` must not raise when the history leaf is stat-denied.
+
+    ``start()`` awaits ``rotate_all()`` WITHOUT a try/except, so a store that
+    wrongly reports itself enabled turns this into a fatal gateway-startup
+    error even though the constructor survived.
+    """
+    from kiro_crew.cron import CronService
+
+    async def _boot() -> None:
+        with _deny_leaf("mkdir", "stat", "scandir", "listdir"):
+            svc = await CronService.create(base_dir=tmp_path)
+            assert svc.get_history().enabled is False
+            try:
+                await svc.start()
+            finally:
+                await svc.stop()
+
+    (tmp_path / "cron-history").mkdir(exist_ok=True)
+    asyncio.run(_boot())
+
+
+def test_create_factory_prepares_history_off_the_event_loop(tmp_path: Path) -> None:
+    """``CronService.create()`` must resolve history usability off the loop.
+
+    Directory setup is synchronous filesystem I/O (an ``os.stat`` and, on the
+    denied path, a lock-file ``os.open``). Running it in the constructor put it
+    on the gateway's sole event loop, which is the
+    no-blocking-call-on-event-loop violation ``_defer_initial_load`` already
+    exists to prevent for ``_load()``. Mechanical proof: ``prepare()`` runs, and
+    never on the loop thread.
+    """
+    import threading
+
+    from kiro_crew.cron import CronService
+
+    async def _boot() -> None:
+        loop_thread = threading.get_ident()
+        prepare_threads: list[int] = []
+        orig = CronHistoryStore.prepare
+
+        def _track(self: CronHistoryStore) -> None:
+            prepare_threads.append(threading.get_ident())
+            return orig(self)
+
+        with patch.object(CronHistoryStore, "prepare", _track):
+            svc = await CronService.create(base_dir=tmp_path)
+
+        assert prepare_threads, "the factory must still prepare the history store"
+        assert all(t != loop_thread for t in prepare_threads), (
+            "history prepare() must run in a worker thread, never on the event loop"
+        )
+        assert svc.get_history().enabled is True
+
+    asyncio.run(_boot())
+
+
+def test_deferred_store_reads_as_disabled_until_prepared(tmp_path: Path) -> None:
+    """A deferred store is disabled until prepare() runs.
+
+    Fail-safe direction: a read racing the prepare degrades to empty history
+    rather than touching a directory whose usability is still unknown.
+    """
+    store = CronHistoryStore(base_dir=tmp_path, _defer_prepare=True)
+    assert store.enabled is False
+    store.prepare()
+    assert store.enabled is True
+    # Idempotent: a second prepare neither re-probes nor flips the verdict.
+    store.prepare()
+    assert store.enabled is True


### PR DESCRIPTION
## Problem / Motivation

Every cron operation fails on affected installs with `[Errno 1] Operation not permitted: <data-home>/cron-history`, and the failure is not confined to history: `cron_add`, `cron_list` and `cron_trigger` over MCP, `kirocrew cron list` on the CLI, and the gateway's own scheduler all die identically. No scheduled or unattended automation runs at all.

`CronHistoryStore.__init__` calls `mkdir(parents=True, exist_ok=True)` with no exception handling, and `CronService.__init__` constructs that store unconditionally, so anything the mkdir raises propagates out of the service constructor and takes the whole cron subsystem with it.

`exist_ok=True` does not cover this, which is the part that is easy to get wrong. pathlib catches the `OSError` from `os.mkdir` and then consults `Path.is_dir()` to decide whether the flag applies. When the directory is denied for **reading** as well as writing, that stat is refused too, and pathlib's `_ignore_error` covers `ENOENT`/`ENOTDIR`/`EBADF`/`ELOOP` but **not** `EPERM` — so `is_dir()` re-raises and `mkdir` raises on a directory that already exists. A mkdir-only denial is absorbed normally; it takes the read denial to make it fatal.

`cron-history` is listed in `sandbox.py`'s `_CREW_HIDDEN_LEAVES`, while its sibling `crons.json` is explicitly carried in `_CREW_SANDBOX_VISIBLE_LEAVES` precisely because `CronService` runs in-sandbox. That asymmetry is why writes to the job store succeed in the same process that cannot touch the history directory.

## Why it matters

Cron is fully non-functional on any install where that leaf is denied — not degraded, dead. Scheduling has no dependency on execution history, so losing history should cost history and nothing else. Whatever the sandbox classification of this one directory ends up being, a store that cannot open its directory must not be able to take down the scheduler.

## What changed (motivation → approach → change)

Symptom: EPERM on an existing `cron-history` directory. Root cause: an unguarded `mkdir` in a constructor the whole cron subsystem is built on, plus an `exist_ok=True` that cannot absorb a read denial. Change: make history best-effort at the store, and decide usability from the syscalls the store's own code paths actually issue.

- `_prepare_dir()` no longer lets directory setup escape. A failed `mkdir` does not by itself mean the store is unusable, so it falls through to a probe.
- `_probe_usable()` requires the two capabilities that discriminate: `os.stat` of the directory and the lock-file `os.open`. Both are O(1) and fail fast. Opening the lock file *alone* is not sufficient evidence — the read and rotate paths go through `Path.exists()` and `Path.glob()`, which re-raise `EPERM` through the same `_ignore_error` gate that `is_dir()` does. A lock-file-only probe reported a stat-denied directory as usable, and `rotate_all()` — which `CronService.start()` awaits **unguarded** — then raised straight back out of gateway startup, relocating the crash rather than removing it.
- **Setup is deferred off the event loop.** It is blocking filesystem I/O, so `CronHistoryStore` takes `_defer_prepare` and `CronService.__init__` passes `_defer_prepare=_defer_initial_load` — deferring on exactly the condition `_load()` already used. `CronService.create()` then runs `await asyncio.to_thread(self._history.prepare)` alongside its existing `await asyncio.to_thread(self._load)`. A deferred store reads `enabled` False until `prepare()` completes, so a read racing it degrades rather than touching a directory of unknown state. Net effect: the gateway path now performs **no** history filesystem I/O on the event loop, which the base branch did via the unguarded `mkdir`.
- When the directory is usable, history stays fully enabled. When it is not, the store constructs with `enabled` False: every read returns empty, every write is dropped, nothing raises.
- `_degrade()` is the runtime floor, and it distinguishes a standing condition from a blip. A **denial** (`EPERM`/`EACCES`/`EROFS`) disables the store, because the profile refusing us will refuse us for the process's whole life. Every other `OSError` — a full disk, fd exhaustion — costs exactly **one record** and leaves history enabled; disabling for the process's remaining life over a momentary ENOSPC would be strictly worse than the pre-existing behaviour, where each call site caught its own failure and the next run wrote normally.
- There is deliberately **no** `try/except` around the store construction in `CronService.__init__`. `_prepare_dir` resolves usability without raising and `_degrade` absorbs later failures, so a wrapper there would guard a raise that cannot occur — and would cost every reader the work of proving that before trusting either layer.

Branch table for the resulting decision, every row covered by a test:

| mkdir | stat | lock open | Result |
|---|---|---|---|
| ok | — | — | enabled |
| denied | ok | ok | enabled (existing but un-mkdir-able) |
| denied | **denied** | ok | disabled (lock file alone is not proof) |
| denied | denied | denied | disabled |
| runtime denial (`EPERM`/`EACCES`/`EROFS`) | | | disabled for the process |
| runtime transient (`ENOSPC`/`EMFILE`/`EIO`) | | | one record lost, history stays on |

## Tests

Eleven tests in `test/test_cron_history.py`, covering each row above. The denial is applied **persistently** rather than only across construction — a sandbox profile refuses for the process's whole life, and a denial lifted after construction proves nothing about `rotate_all()`, which runs later.

- `test_mkdir_denied_but_dir_usable_keeps_history_enabled` / `..._still_persists` — the un-mkdir-able but usable directory stays enabled and still reads back what it wrote, with the denial in force.
- `test_stat_denied_disables_history_even_when_lock_opens` — a stat-denied directory is disabled even though the lock file opens.
- `test_unwritable_dir_disables_history_without_raising` and `test_disabled_store_operations_are_inert` — a wholly denied directory disables rather than raises, and all seven entry points no-op.
- `test_runtime_oserror_degrades_instead_of_propagating` — a denial on a healthy store disables it and leaves it inert.
- `test_transient_oserror_costs_one_record_and_stays_enabled` and `test_denial_errnos_disable_but_transient_ones_do_not` — the errno split, asserted per errno over both sets.
- `test_cron_service_survives_unusable_history_dir` and `test_cron_service_start_survives_stat_denied_history` — the reported blast radius: construction *and* `start()` both survive.
- `test_create_factory_prepares_history_off_the_event_loop` — mechanical proof, mirroring the existing `TestConstructionLoadOffLoop`: `prepare()` runs, and never on the loop thread.
- `test_deferred_store_reads_as_disabled_until_prepared` — the fail-safe direction of deferral, plus idempotence.

Mutation-verified at three levels: all nine original tests fail against the base (five with the exact reported `[Errno 1] Operation not permitted`); the three covering the stat-denied path fail against an earlier revision that probed only the lock file; and the two off-loop tests fail against the revision before deferral (`TypeError: unexpected keyword argument '_defer_prepare'`, `AttributeError: no attribute 'prepare'`).

## Manual verification

N/A — unit coverage sufficient. The reported failure is a macOS Seatbelt denial that cannot be reproduced on Linux, so the denial is simulated at the syscall boundary (`os.mkdir` / `os.stat` / `os.scandir` / `os.listdir` / `os.open` refused for paths naming the leaf) rather than through a real sandbox profile. That exercises the exact pathlib mechanism described above; it does not prove XNU's own ordering, and a macOS run remains worthwhile before assuming the platform behaviour is fully characterised.

Full backend suite: 83,938 passed, zero cron failures. The 93 unrelated failures in this environment reproduce identically against the base branch (deep scratch path exceeding the `AF_UNIX` limit, missing optional deps, no user-level `gh` install).

`docs/system-specs/modules/learn-cron-dashboard.md` is updated in the same commit per AGENTS.md: the store is no longer "written unconditionally by the executor", and a **History is best-effort** section states the contract (how usability is decided, why it must be resolved off the loop, and the errno split). It also records what the API deliberately does NOT express: a denied install and a job that has never run both read as an empty list, and the `logger.warning` is the operator's only signal. Surfacing that state is a follow-up belonging to the change that renders it — see the First Principles disposition.

## Related Issues

no linked issue: #7742 covers this defect but is already claimed by the open PR #7827, so this PR intentionally carries no closing keyword rather than racing that one. Maintainers should decide which lands.

Relationship to #7827, stated plainly because both touch `CronHistoryStore.__init__`: that PR defers the `mkdir` into `_lock()`, which fixes the MCP and CLI read paths (they never call `start()`). Applying its diff and probing shows the constructor survives but `CronService.start()` still raises `PermissionError`, because `start()` awaits `rotate_all()` unguarded and `_rotate_all_sync()` calls `_lock()` first — so the gateway scheduler stays broken. The two approaches are complementary rather than rival, and one PR should carry both.

**Open maintainer decision** (raised by both Design Review and First Principles, answered `needs-a-decision`): the root cause is the sandbox classification — `cron-history` is masked at `sandbox.py:180` while in-sandbox code constructs `CronService` at `mcp_cron.py:1737` — so on sandboxed installs history is now permanently disabled rather than restored. Reclassifying a deliberate `_CREW_HIDDEN_LEAVES` entry is a security-posture call that does not belong in a resilience fix; it is #7742's option 1 and stays open there. The question is whether history-disabled is the intended end state for sandboxed installs. The store is correct under either answer, which is why the floor sits here rather than depending on the classification.

## Pattern harvest

Rule candidate: review-prompt
Pattern: `Path.mkdir(exist_ok=True)`, `Path.exists()` and `Path.is_dir()` are widely assumed to be non-raising existence checks, but all three re-raise `EPERM` because pathlib's `_ignore_error` allowlist excludes it — so "the directory is already there" is not a reason a call cannot fail, and a probe that proves one syscall works proves nothing about a sibling path that uses a different one.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

