### PR TITLE
feat(session-control): let a cron dispatch the sessions it creates

### DIFF
--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -90,14 +90,15 @@ that is out of bounds is visible after the fact even though nothing happened.
 |---------|--------|-----|
 | Config switch off (`agent.session_control`) | 403 | Operator opted out. **Exception:** a crew-member DM slot (`member-*` caller key) bypasses this switch — see "Member callers" below |
 | Caller session cannot be identified | 403 | An unidentifiable caller makes the self-target guard blind |
-| Caller is an unattended session (`cron-*`, `workflow-*`) | 403 | A scheduled job acting on live conversations is not a handoff |
+| Caller is an unattended session (`workflow-*`) | 403 | A `workflow-<run_id>` slot exists only once its originating tab is gone, so there is no owning session to fence it to. **Exception:** a cron slot (`cron-*` caller key) is admitted and fenced by creator ownership instead — see "Cron callers" below |
 | Caller is itself incognito, temporary, or app-scoped | 403 | Caller-side isolation — the direction the target-side checks cannot see |
-| Caller is channel-linked (`linked_session_key` set) | 403 | The exfiltration direction: a linked caller's conversation IS a channel thread, so a read would hand a private dashboard transcript to that channel's readers. `CHANNEL_AGENT_BLOCKED_TOOLS` keys on the agent identity; a linked slot is a second route to the same surface |
+| Caller is an APP-owned cron (`created_by` starts `app:`), or a cron whose job cannot be found | 403 | `app_owned_cron_caller` / `cron_owner_unverifiable`. A cron tab is minted without `app=`, so the `_app` check above cannot see an app's own scheduled job; ownership is read from the JOB instead, and an unverifiable owner fails closed — see "Cron callers" below |
+| Caller is channel-linked (`linked_session_key` set) | 403 | The exfiltration direction: a linked caller's conversation IS a channel thread, so a read would hand a private dashboard transcript to that channel's readers. `CHANNEL_AGENT_BLOCKED_TOOLS` keys on the agent identity; a linked slot is a second route to the same surface. **Exception:** a `cron:<job_id>` link, which names the job's own run transcript and republishes to nobody |
 | Caller's own session is no longer open | 403 | Nothing to attribute the operation to |
 | Caller changed workspace while a creation was in flight | 403 | Creation resolves the workspace's project directory off-loop, so it suspends between authorizing the caller and allocating the slot. Both decisions that read the caller's workspace -- the memory boundary the child inherits, and whether the answering agent is bound to that workspace -- are invalidated by a move, and re-deciding the binding here is not available: it needs a config load, which must not run on the event loop |
 | Named agent does not resolve to a configured one | 403 | The resolver falls back to the default agent, which passes the workspace check because it is the caller's own default -- so no boundary is crossed, but the created session would store and advertise a name that is not what answers. `ResolvedBindings.requested_resolved` states that contract for callers that store the requested name. Refused rather than rewritten to the effective agent: nothing exists yet, so a corrected name costs one retry, whereas an existing slot keeps its stored name verbatim so a momentarily stale resolution cannot permanently rebind it |
 | Target is the caller | 403 | A session controlling itself has no exit |
-| Target is unattended (`cron-*`, `workflow-*`) | 403 | A `workflow-<run_id>` slot is display-only and a cron's turns are driven by a schedule |
+| Target is unattended (`cron-*`, `workflow-*`) | 403 | A `workflow-<run_id>` slot is display-only and a cron's turns are driven by a schedule. Not exempted for a cron CALLER: a cron may create and drive its own children, never another job's tab |
 | Target is incognito or temporary | 403 | Never addressable, matching `list_sessions` |
 | Target is app-scoped | 403 | App sessions are the app's, not a peer's |
 | Target is channel-linked (`linked_session_key` set) | 403 | Its conversation is mirrored to Slack/Telegram, so reaching it crosses a surface boundary both ways — and its stop cannot be honoured, because the stop path addresses `dashboard:<slot>` while a linked slot's turns run under its linked key |
@@ -129,6 +130,34 @@ operator configuration. Two rules give it that shape:
   to member callers unchanged.
 
 Ordinary (non-member) callers are untouched: they still require the switch.
+
+### The fence propagates to what a fenced caller creates
+
+`_caller_is_ownership_fenced` covers three populations, not two: a member DM slot,
+a cron slot, and **anything either of them created**. The third is the one a key
+prefix cannot see, and without it the fence buys nothing. A created child is minted
+with a plain `chat-` key and INHERITS its creator's agent, so a fenced caller
+running a session-control agent would otherwise get an unfenced deputy for free:
+create a child, seed it, and the child — an ordinary caller by key — reads any
+same-workspace session and reports back through the transcript its creator is
+allowed to read.
+
+`_created_by` is the marker, and it needs no lineage walk: `create_session` is its
+ONLY writer, so a non-empty value means "an agent made this session" at any depth.
+A grandchild carries its parent's key there and is fenced by the same test, and a
+chain whose middle slot has been closed cannot fail open because no chain is
+walked. A person's own tab and a fork reach `get_or_create_slot` directly and stay
+unattributed, so ordinary human use is unaffected.
+
+There is deliberately NO attendance exemption. `_ChatSlot._human_seen` looks like
+the right hatch and is not: it records that a human has EVER driven the slot, is
+monotonic and persisted, and says nothing about who authored the turn running now.
+Releasing the fence on it would hand the creator its deputy back for the price of
+the user glancing at the tab once — cron creates the child, the user types into it,
+and from then on every cron-authored turn in that child runs unfenced. The question
+the predicate can answer is "whose authority is this session", not "is a person at
+the keyboard", so a person working in an agent-created session keeps that session's
+reach rather than their own.
 The member-facing tool surface is the ordinary `kirocrew-dashboard` `session_*`
 tool set, mounted **per session** rather than through the on-disk agent
 template: a member DM session's ACP `session/new` **and `session/load`** carry
@@ -154,6 +183,102 @@ are simply not mounted, never mounted-and-refused. Because the mount is
 session-scoped, no other session on the same agent template gains the tools,
 preserving the two-part grant for ordinary agents (the switch AND the
 per-agent server assignment).
+
+### Cron callers: unattended admission, bounded by the same fence
+
+A cron job's own slot (`cron-<job_id>`, minted by
+`inject_cron_result_to_dashboard`) is admitted to the surface even though nobody
+is watching it, so a scheduled run can enumerate work and dispatch a session per
+item. Three refusals had to move for that, and one deliberately did not:
+
+- **The unattended caller refusal now covers `workflow-*` only.** What must not
+  happen is a scheduled job reaching the user's OWN conversations, which is a
+  question about scope, not attendance — an unattended job already starts a turn
+  in the session that owns it every time it delivers with
+  `send_message(session="origin")`. A cron can be held to that scope; a workflow
+  result slot cannot, because it is minted only once its originating tab is gone
+  and so has no owner to fence it to. Membership of `UNATTENDED_SLOT_PREFIXES` is
+  the fail direction for any prefix added later: a new unattended surface is
+  refused as a source until it is given a fence of its own.
+- **A `cron:<job_id>` link is exempt from the caller-side channel-link
+  refusals.** Those exist for channel links, where a read lands in front of a
+  Slack or Telegram audience. A cron tab's link names the job's own run
+  transcript and republishes to nobody. The TARGET-side refusal is not exempted.
+- **The `created_by` fence binds a cron caller exactly as it binds a member**
+  (`_caller_is_ownership_fenced` is the single predicate both admissions and the
+  fence read, so they cannot drift). A cron reaches the sessions it created and
+  nothing else, fail-closed on an unowned slot. `unattended_target` still stands,
+  so a cron cannot reach another job's tab.
+- **The global switch still gates a cron.** Unlike a member, a cron gets no
+  bypass: the switch is the user's statement that agents may open and drive
+  sessions at all, and a job running while they are asleep is the last caller
+  that should be exempt from it.
+
+**An APP-owned cron is refused, and ownership is read from the job.** This is the
+one place admitting a cron would otherwise open something. `_app` is how every
+other isolation decision recognises an app, but `inject_cron_result_to_dashboard`
+mints the cron tab WITHOUT `app=`, so an app's own scheduled job arrives with
+`_app == ""` and would pass the check beside it. An app could then create a
+persistent, sidebar-visible session that is not app-scoped, which is exactly the
+confinement escape the `_app` refusal exists to prevent, reached through the app's
+cron instead of its session. `_app_owned_cron_refusal` therefore reads ownership off the job, which has **two
+spellings** because two writers record it differently: the app cron SDK tags
+`created_by = "app:{app_name}"`, while `mcp_cron`'s own `cron_add` records the
+calling session in `session_key` and never writes `created_by` at all — so an
+app-scoped session's job carries its authority only in the second. Both are
+checked, and the second delegates to `_app` on the owning slot (resolved through
+`caller_slot_key`, not a naive `removeprefix`) rather than re-deriving app-ness, so
+there is one definition of "is this an app". **A new job field that can name a
+principal is a hole until it is added to that function.** The refusal code is
+`app_owned_cron_caller`, distinct from `app_scoped_caller` because callers render
+that one with app-session wording that would misdescribe a cron. A job the registry
+cannot produce, or a registry that cannot answer, refuses with
+`cron_owner_unverifiable`: "could not verify the owner" must not read as "has no
+owner", and nothing legitimate is refused by it because a cron whose job is gone is
+not running.
+
+One residual is accepted rather than closed. When `session_key` names a session that
+is no longer open its `_app` cannot be read, and the refusal returns nothing for it.
+Refusing instead would disable dispatch for the ordinary case — a user-created job
+whose authoring tab has since been closed, which is most of them — so the
+fail-closed direction is wrong here in a way it is not for a missing job. What
+bounds the exposure is that the slot has to be gone: while an app's session is live,
+its jobs are refused.
+
+Applied at both
+caller-side sites so the two halves stay mirrors, and scoped to cron callers so no
+other caller pays for the lookup.
+
+In `authorize_target` this refusal sits **before** `_resolve_slot`, unlike the other
+caller-side refusals. A caller refused for its own identity must learn nothing from
+the attempt, and resolving first makes the refusal an existence oracle: a guessed
+target answers `target_not_found` (404) when it does not exist and the refusal (403)
+when it does, so a caller allowed to touch nothing could enumerate the user's
+session keys and titles by the shape of the error. The unattended prefix gate is
+already on that side of the resolution for the same reason. The pre-existing
+caller-side block below the resolution (`app_scoped_caller`, `ephemeral_caller`,
+`linked_session_caller`, `mirrored_caller`) has the same shape and is left as it is
+here: moving those changes refusal precedence for callers that exist today.
+
+A session a cron creates is tagged `SlotOrigin.CRON`, not `USER`. A cron's own
+slot carries that tag so its output stays outside the `slots:user` WS scope, and
+a USER-labelled child would hand it that exposure by the route of creating a
+session and writing there instead. The tag follows the caller's AUTHORITY rather
+than its key prefix, for the same reason the fence does: a child inherits its
+creator's agent, so a cron's child can itself call `create_session`, and a
+prefix-only test mints THAT grandchild `USER` because its caller key is a plain
+`chat-`. `create_session` therefore reads the caller slot's own `_origin` as well,
+which carries the tag transitively to any depth. Only app tokens are filtered by
+origin (`_serialize_for_client` returns the unfiltered payload to a dashboard
+user), so a CRON-origin descendant stays in the sidebar exactly as a cron tab does.
+
+Capability remains bounded per agent, which the slot-key prefix could not see:
+`@kirocrew-dashboard` is an opt-in per-agent server, absent from the default
+agent's spec, so a job whose agent does not mount it never has the verbs at all.
+A cron whose fan-out must run without an approval prompt needs the write verbs in
+its own agent's `allowedTools`; `_CONDUCTOR_DASHBOARD_GRANTS` deliberately
+withholds them, because a conductor agent also runs in dashboard sessions where
+no ownership fence applies.
 
 Two notes on scope:
 

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -219,13 +219,17 @@ def _app_owned_cron_refusal(state: "DashboardState", caller_key: str) -> tuple[s
     an app" and not a third. **A new field on the job that can name a principal is
     a hole here until it is added to this function.**
 
-    Known residual, deliberately not closed by refusing: when ``session_key``
-    names a session that is no longer open, its ``_app`` cannot be read, and this
-    returns ``None`` for it. Refusing instead would disable dispatch for the
-    ordinary case -- a user-created job whose authoring tab has since been closed,
-    which is most of them -- so the fail-closed direction is wrong here in a way it
-    is not for the missing-job case below. What bounds the exposure is that the
-    slot has to be gone: while an app's session is live, its jobs are refused.
+    Fail-CLOSED when ``session_key`` names a session that is no longer open: its
+    ``_app`` cannot be read, and "could not verify the owner is not an app" must
+    not read as "has no owner". ``mcp_cron``'s ``cron_add`` records an app's
+    authority ONLY in ``session_key`` -- so once that slot is gone, allowing the
+    job would let an app escape confinement through a cron it authored and then
+    abandoned by closing its session. The cost is a genuinely user-created
+    dispatching cron whose authoring tab has closed is refused too; that caller
+    can reopen a tab, whereas an app session minted outside its confinement cannot
+    be undone. This is the same fail-closed direction the missing-job case below
+    takes, and what still bounds the app case beyond it is that a LIVE app session
+    has its jobs refused directly by the ``_app`` read.
 
     Fail-CLOSED on a job that cannot be found, or a registry that cannot answer:
     "could not verify the owner" must not read as "has no owner", the same
@@ -271,7 +275,32 @@ def _app_owned_cron_refusal(state: "DashboardState", caller_key: str) -> tuple[s
         # is wrong for every non-dashboard session key, and the resolver already
         # matches on the identity each slot actually writes.
         owning_slot = state.get_slot(caller_slot_key(state, owning_key))
-        if owning_slot is not None and str(getattr(owning_slot, "_app", None) or ""):
+        if owning_slot is None:
+            # The job names an owning session, but no live slot carries that key
+            # any more -- the authoring tab was closed or evicted. Its ``_app``
+            # tag lived only on that slot (``mcp_cron``'s ``cron_add`` records the
+            # caller in ``session_key`` and never writes ``created_by``), so the
+            # one place app-ness could be read is gone. That is precisely the
+            # confinement escape: an app creates a cron through ``cron_add``,
+            # closes its session, and its scheduled job then dispatches a
+            # persistent, non-app, sidebar-visible session this gate can no longer
+            # recognise as the app's.
+            #
+            # "Could not verify the owner is not an app" therefore fails CLOSED,
+            # the same direction the missing-job and unreadable-registry cases
+            # above take. This narrows the docstring's former "known residual":
+            # the residual was an accepted fail-OPEN, and a fail-open on an
+            # unresolvable owner is a security-gate defect (anchor
+            # backend-security-controls). The cost is that a genuinely
+            # user-created dispatching cron whose authoring tab has closed is
+            # refused too -- but that caller can reopen a tab, whereas nothing can
+            # undo an app session minted outside its confinement.
+            return (
+                "the session that authored this scheduled job is no longer open, "
+                "so its ownership cannot be verified",
+                "cron_owner_unverifiable",
+            )
+        if str(getattr(owning_slot, "_app", None) or ""):
             return refusal
     return None
 

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -72,15 +72,47 @@ DEFAULT_READ_MESSAGES = 20
 # a multi-megabyte tool payload verbatim.
 MAX_READ_CONTENT_CHARS = 4000
 
-# Slot-key prefixes for sessions no human is watching: a cron run's own slot
-# (``cron-<job_id>``) and a background workflow's result slot
-# (``workflow-<run_id>``, created by ``workflow_inject`` only when the
-# originating tab is gone). They are refused as BOTH source and target. As a
-# target, a message would start a fresh agent turn in a display-only slot nobody
-# reads; as a source, a scheduled job would be able to type into the user's live
-# conversations unattended. Notifications are the supported path for those
-# (``send_message``), not session control.
-UNATTENDED_SLOT_PREFIXES = ("cron-", "workflow-")
+# A cron run's own slot (``cron-<job_id>``, minted by ``inject_cron_result_to_dashboard``).
+CRON_SLOT_PREFIX = "cron-"
+
+# A background workflow's result slot (``workflow-<run_id>``, minted by
+# ``workflow_inject`` only when the originating tab is gone).
+WORKFLOW_SLOT_PREFIX = "workflow-"
+
+# Slot-key prefixes for sessions no human is watching. As a TARGET both are
+# always refused: a message would start a fresh agent turn in a display-only slot
+# nobody reads.
+#
+# As a SOURCE the two differ, and the difference is ownership. What must not
+# happen is a scheduled job reaching the user's OWN conversations, which is a
+# question about scope rather than about attendance -- an unattended job already
+# starts turns in the session that owns it every time it delivers with
+# ``send_message(session="origin")``. A cron slot can be held to that scope,
+# because `authorize_target` fences it to slots carrying its own
+# ``_created_by`` (see :func:`_cron_caller`), so it is admitted as a source. A
+# workflow result slot cannot: it exists only when the originating tab is already
+# gone, so there is no owning session to fence it to and nothing it would
+# legitimately dispatch. It stays refused.
+#
+# Membership here is the fail direction for a prefix added later: a new
+# unattended surface is refused as a source until it is given a fence of its own.
+UNATTENDED_SLOT_PREFIXES = (CRON_SLOT_PREFIX, WORKFLOW_SLOT_PREFIX)
+
+# The ``linked_session_key`` a cron slot carries (``cron:<job_id>``), written by
+# ``inject_cron_result_to_dashboard`` to bind the run's transcript to the tab.
+# It is NOT a channel link, and the caller-side linked refusals exist for channel
+# links: they keep a session whose conversation is mirrored to Slack/Telegram from
+# reading a peer's transcript into that thread. A cron link mirrors nothing and
+# has no audience, so it is exempted where the caller is judged. The TARGET-side
+# refusal is deliberately not exempted -- a cron tab is already unreachable as a
+# target by prefix, and the exemption would otherwise widen to every linked slot.
+CRON_LINK_PREFIX = "cron:"
+
+# The ``created_by`` tag an app's own cron job carries (``app:<app_name>``,
+# written by ``apps/cron_sdk.py``). Spelled here rather than imported: this
+# module sits below the apps package, and the value is a persisted data format
+# rather than something that package exports.
+APP_CRON_OWNER_PREFIX = "app:"
 
 
 def _member_caller(caller_key: str) -> bool:
@@ -100,6 +132,148 @@ def _member_caller(caller_key: str) -> bool:
     from kiro_crew.members import DM_SLOT_KEY_PREFIX
 
     return caller_key.startswith(DM_SLOT_KEY_PREFIX)
+
+
+def _cron_caller(caller_key: str) -> bool:
+    """Whether *caller_key* is a cron job's own slot.
+
+    A cron caller is admitted to the surface DESPITE being unattended, and is
+    bounded the same way a crew member is: :func:`authorize_target` refuses it on
+    any slot it did not create itself, so its reach covers the sessions it
+    dispatched and never the user's own conversations.
+
+    It differs from a member caller in one way that matters. A member bypasses
+    the global ``agent.session_control`` switch, because dispatching into workers
+    is the member operating model rather than an opt-in. A cron does NOT: the
+    switch is the user's statement that agents may open and drive sessions at
+    all, and a job running while they are asleep is the last caller that should
+    be exempt from it.
+
+    Keyed on the slot-key prefix rather than on the slot's ``linked_session_key``
+    or its ``SlotOrigin``, so the answer is available before the slot is resolved
+    and cannot change under a caller: a slot key is immutable, while both of the
+    others are fields a later write could alter.
+    """
+    return caller_key.startswith(CRON_SLOT_PREFIX)
+
+
+def _caller_is_ownership_fenced(state: "DashboardState", caller_key: str) -> bool:
+    """Whether *caller_key* may only reach slots it created itself.
+
+    Three populations, one predicate, so the fence and the admissions that depend
+    on it cannot drift apart:
+
+    * a crew member's DM slot, which bypasses the config switch;
+    * a cron job's own slot, which bypasses the unattended refusal;
+    * **anything either of them created**, which is the part a key prefix cannot
+      see. A created child is minted with a plain ``chat-`` key and INHERITS the
+      creator's agent, so a fenced caller running a session-control agent would
+      otherwise get an unfenced deputy for free: create a child, seed it, and the
+      child -- an ordinary caller by key -- reads any same-workspace session and
+      reports back through the transcript its creator is allowed to read. The
+      fence has to follow authority, not spelling.
+
+    ``_created_by`` is the marker for that third population and needs no lineage
+    walk: :func:`create_session` is its ONLY writer (a person's own tab and a fork
+    reach ``get_or_create_slot`` directly and stay unattributed), so a non-empty
+    value means "an agent made this session" at any depth. A grandchild carries
+    its parent's key there and is fenced by the same test, and a chain whose
+    middle slot has been closed cannot fail open because no chain is walked.
+
+    There is deliberately NO attendance exemption. ``_ChatSlot._human_seen`` looks
+    like the right hatch and is not: it records that a human has EVER driven the
+    slot, is monotonic and persisted, and says nothing about who authored the turn
+    running now. Releasing the fence on it would hand the creator its deputy back
+    for the price of the user glancing at the tab once -- cron creates the child,
+    the user types into it, and from then on every cron-authored turn in that child
+    runs unfenced. The question this predicate can answer is "whose authority is
+    this session", not "is a person at the keyboard", so a person working in an
+    agent-created session keeps that session's reach rather than their own.
+    """
+    if _member_caller(caller_key) or _cron_caller(caller_key):
+        return True
+    slot = state.get_slot(caller_key)
+    if slot is None:
+        return False
+    return bool(getattr(slot, "_created_by", ""))
+
+
+def _app_owned_cron_refusal(state: "DashboardState", caller_key: str) -> tuple[str, str] | None:
+    """``(message, code)`` when *caller_key* is an APP's cron, else ``None``.
+
+    An app-scoped SESSION is refused by the ``_app`` check that sits beside every
+    call site of this one, but a cron tab does not carry that tag:
+    ``inject_cron_result_to_dashboard`` mints it without ``app=``, so an app's own
+    scheduled job reaches this surface with ``_app == ""`` and would pass. Left
+    unchecked, an app could create a persistent, sidebar-visible session that is
+    NOT app-scoped -- precisely the confinement escape the ``_app`` refusal exists
+    to prevent, reached through the app's scheduled job instead of its session.
+
+    App ownership therefore has to be read from the JOB, and it has TWO spellings
+    there because two writers record it differently: the app cron SDK tags
+    ``created_by = "app:{app_name}"``, while ``mcp_cron``'s own ``cron_add``
+    records the calling session in ``session_key`` and never writes ``created_by``
+    at all -- so an app-scoped session's job carries its authority only in the
+    second. Both are checked, and the second delegates to ``_app`` on the owning
+    slot rather than re-deriving app-ness, so there is one definition of "is this
+    an app" and not a third. **A new field on the job that can name a principal is
+    a hole here until it is added to this function.**
+
+    Known residual, deliberately not closed by refusing: when ``session_key``
+    names a session that is no longer open, its ``_app`` cannot be read, and this
+    returns ``None`` for it. Refusing instead would disable dispatch for the
+    ordinary case -- a user-created job whose authoring tab has since been closed,
+    which is most of them -- so the fail-closed direction is wrong here in a way it
+    is not for the missing-job case below. What bounds the exposure is that the
+    slot has to be gone: while an app's session is live, its jobs are refused.
+
+    Fail-CLOSED on a job that cannot be found, or a registry that cannot answer:
+    "could not verify the owner" must not read as "has no owner", the same
+    direction ``agent_unverifiable`` takes on its own unreadable input. Nothing
+    legitimate is refused by it, because a cron whose job is gone is not running.
+
+    Returns rather than raises so each call site keeps its own idiom -- the create
+    path raises ``SessionControlError`` directly, while ``authorize_target`` must
+    go through its ``deny`` closure to get the audit record and the 403.
+    """
+    if not _cron_caller(caller_key):
+        return None
+    job_id = caller_key[len(CRON_SLOT_PREFIX) :]
+    found: Any = None
+    try:
+        for job in state.crons.list_jobs(include_disabled=True):
+            if str(getattr(job, "id", "")) == job_id:
+                found = job
+                break
+    except Exception:
+        logger.warning(
+            "session_control: cron owner lookup failed for %s -- refusing",
+            caller_key,
+            exc_info=True,
+        )
+        found = None
+    if found is None:
+        return (
+            "the scheduled job behind this session could not be found, so its "
+            "ownership cannot be verified",
+            "cron_owner_unverifiable",
+        )
+    refusal = (
+        "app-owned scheduled jobs cannot create or control sessions",
+        "app_owned_cron_caller",
+    )
+    if str(getattr(found, "created_by", "") or "").startswith(APP_CRON_OWNER_PREFIX):
+        return refusal
+    owning_key = str(getattr(found, "session_key", "") or "")
+    if owning_key:
+        # Resolved through this module's own :func:`caller_slot_key` rather than a
+        # ``removeprefix("dashboard:")``: chat_utils documents that the naive strip
+        # is wrong for every non-dashboard session key, and the resolver already
+        # matches on the identity each slot actually writes.
+        owning_slot = state.get_slot(caller_slot_key(state, owning_key))
+        if owning_slot is not None and str(getattr(owning_slot, "_app", None) or ""):
+            return refusal
+    return None
 
 
 # Roles a read must not count, taken from the persistence layer's own list rather
@@ -544,6 +718,11 @@ def _refuse_ineligible_creator(state: "DashboardState", caller_slot: "_ChatSlot"
         raise SessionControlError(
             "app-scoped sessions cannot create sessions", code="app_scoped_caller"
         )
+    if (refusal := _app_owned_cron_refusal(state, getattr(caller_slot, "key", ""))) is not None:
+        # The same confinement, reached through an app's cron rather than its
+        # session -- a cron tab carries no ``_app`` tag for the check above to
+        # read. See :func:`_app_owned_cron_refusal`.
+        raise SessionControlError(refusal[0], code=refusal[1])
     if getattr(caller_slot, "memory_mode", "persistent") != "persistent":
         # An incognito/temporary caller is defined by leaving nothing behind.
         # A persistent child it owns would outlive it, carrying its work into
@@ -552,7 +731,10 @@ def _refuse_ineligible_creator(state: "DashboardState", caller_slot: "_ChatSlot"
             "incognito and temporary sessions cannot create sessions",
             code="ephemeral_caller",
         )
-    if getattr(caller_slot, "linked_session_key", ""):
+    caller_link = getattr(caller_slot, "linked_session_key", "")
+    if caller_link and not caller_link.startswith(CRON_LINK_PREFIX):
+        # A cron tab's link is its own run transcript, not a channel thread, and
+        # is exempt -- see CRON_LINK_PREFIX. Everything else is a channel link.
         raise SessionControlError(
             "channel-linked sessions cannot create sessions",
             code="linked_session_caller",
@@ -665,7 +847,7 @@ async def create_session(
             "session control is disabled in config (agent.session_control)",
             code="session_control_disabled",
         )
-    if caller_key.startswith(UNATTENDED_SLOT_PREFIXES):
+    if caller_key.startswith(UNATTENDED_SLOT_PREFIXES) and not _cron_caller(caller_key):
         raise SessionControlError(
             "unattended sessions (scheduled runs) cannot create sessions",
             code="unattended_caller",
@@ -783,6 +965,32 @@ async def create_session(
     # ordinary session, because the point of creating it here is that the user
     # can see and take over the work. SYSTEM-origin slots fall outside the
     # `slots:user` WS scope, which would hide it from the sidebar.
+    #
+    # A CRON caller is the exception, and it is the one case where USER would be
+    # wrong rather than merely coarse. `inject_cron_result_to_dashboard` tags a
+    # cron's own slot CRON precisely so its output stays out of `slots:user` ("a
+    # USER label would expose it to any app holding `slots:user`"), and the trust
+    # model states the same rule from the other side: inferring USER for a
+    # background caller "put cron output inside `slots:user`". Minting a
+    # USER-labelled child would hand a cron the exposure its own slot is denied,
+    # by the simple route of creating a session and writing there instead.
+    #
+    # The tag therefore follows the caller's AUTHORITY, not its key prefix, and
+    # for the same reason the ownership fence does: a created child INHERITS its
+    # creator's agent, so a cron's child can itself call this verb, and a
+    # prefix-only test mints that grandchild USER (its caller key is a plain
+    # `chat-`) -- the two-hop version of the very route this comment says must be
+    # denied. Reading the caller slot's own ``_origin`` closes it transitively: the
+    # child carries CRON, so ITS children do too, at any depth.
+    #
+    # Nothing is lost by the narrower tag: only APP tokens are filtered by origin
+    # (`_serialize_for_client` returns the unfiltered payload to a dashboard
+    # user), so a CRON-origin descendant stays in the sidebar exactly as today's
+    # cron tabs do -- which is the property the paragraph above is protecting.
+    #
+    # Computed from the RE-RESOLVED caller below rather than here, because it is a
+    # decision input to the allocation and everything above this point was read
+    # before the coroutine suspended.
 
     if folder_id:
         # Confirmed under the folder-store lock -- the only place existence
@@ -837,6 +1045,14 @@ async def create_session(
             code="caller_workspace_changed",
         )
     _refuse_ineligible_creator(state, live_caller)
+    # The child's origin tag, read off the caller that is live NOW -- see the
+    # reasoning above the folder gate. `_cron_caller` covers a cron's own tab;
+    # `_origin` carries the tag onward to every descendant of one.
+    child_origin = (
+        SlotOrigin.CRON
+        if _cron_caller(caller_key) or getattr(live_caller, "_origin", "") == SlotOrigin.CRON
+        else SlotOrigin.USER
+    )
     # The RATE guard, ahead of the capacity ceilings below. Those bound how many
     # sessions can exist; this bounds how fast one caller may open them, which is
     # the property an auto-approved verb loses -- a waived prompt leaves a loop
@@ -884,7 +1100,7 @@ async def create_session(
     # move path uses ("file the slot before the coalesced broadcast").
     with state.suspend_slots_push():
         slot = state.get_or_create_slot(
-            None, agent=agent_name, workspace=workspace, origin=SlotOrigin.USER
+            None, agent=agent_name, workspace=workspace, origin=child_origin
         )
         # Attribute the slot to the caller that asked for it, which is what makes the
         # per-creator ceiling above countable. Written here, inside the synchronous
@@ -1086,11 +1302,25 @@ def authorize_target(
             "session control is disabled in config (agent.session_control)",
             "session_control_disabled",
         )
-    if caller_key.startswith(UNATTENDED_SLOT_PREFIXES):
+    if caller_key.startswith(UNATTENDED_SLOT_PREFIXES) and not _cron_caller(caller_key):
         raise deny(
             "unattended sessions (scheduled runs) cannot control other sessions",
             "unattended_caller",
         )
+    if (refusal := _app_owned_cron_refusal(state, caller_key)) is not None:
+        # The app-confinement refusal, reached through an app's cron rather than
+        # its session -- a cron tab carries no ``_app`` tag for the check further
+        # down to read. See :func:`_app_owned_cron_refusal`.
+        #
+        # Placed BEFORE `_resolve_slot`, unlike the other caller-side refusals: a
+        # caller refused for its own identity must not learn anything from the
+        # attempt, and resolving first makes the refusal an existence oracle -- a
+        # guessed target answers `target_not_found` (404) when it does not exist
+        # and this refusal (403) when it does, so a caller allowed to touch
+        # NOTHING could enumerate the user's session keys and titles by the shape
+        # of the error. The prefix gate above is already on this side of the
+        # resolution for the same reason.
+        raise deny(refusal[0], refusal[1])
 
     try:
         slot = _resolve_slot(state, target)
@@ -1158,7 +1388,8 @@ def authorize_target(
             "incognito and temporary sessions cannot control other sessions",
             "ephemeral_caller",
         )
-    if getattr(caller_slot, "linked_session_key", ""):
+    caller_link = getattr(caller_slot, "linked_session_key", "")
+    if caller_link and not caller_link.startswith(CRON_LINK_PREFIX):
         # The exfiltration direction, and the reason this is not merely the
         # mirror of the target-side check: a linked caller's own conversation is
         # a channel thread, so anything it reads lands in front of whoever is in
@@ -1168,6 +1399,11 @@ def authorize_target(
         # `CHANNEL_AGENT_BLOCKED_TOOLS` already blocks these tools for channel
         # AGENTS, but that guard keys on the agent identity; a linked SLOT is a
         # second route to the same surface and has to be closed on its own.
+        #
+        # A cron tab's link is exempt because it is not a channel: it names the
+        # job's own run transcript and republishes to nobody, so a read through it
+        # reaches no audience the caller did not already have. See
+        # CRON_LINK_PREFIX.
         raise deny(
             "channel-linked sessions cannot control other sessions",
             "linked_session_caller",
@@ -1185,14 +1421,31 @@ def authorize_target(
         # Workspaces are the memory boundary; reaching across one would let a
         # session act on work it cannot see.
         raise deny("target session belongs to a different workspace", "workspace_mismatch")
-    if _member_caller(caller_key) and getattr(slot, "_created_by", "") != caller_key:
-        # The member's automatic authorization reaches ONLY the workers it
-        # created itself (`created_by` is written at birth and rehydrated on
-        # restart). Always enforced for member callers — even when the global
-        # switch is on — so a member's reach never silently widens to the
-        # user's own sessions because of an unrelated opt-in.
+    if (
+        _caller_is_ownership_fenced(state, caller_key)
+        and getattr(slot, "_created_by", "") != caller_key
+    ):
+        # The fence every exempted caller class is bounded by, plus anything they
+        # created. It reaches ONLY the sessions the caller made itself
+        # (`created_by` is written at birth and rehydrated on restart). Always
+        # enforced -- even when the global switch is on -- so no exemption
+        # silently widens to the user's own sessions because of an unrelated
+        # opt-in.
+        #
+        # For a cron caller this is the whole of what replaced the old
+        # `unattended_caller` refusal: a scheduled job reaches the sessions it
+        # dispatched and nothing else. Fail-closed on an unowned slot, which is
+        # what an ownerless rehydrate looks like.
         raise deny(
-            "a crew member can only control worker sessions it created itself",
+            (
+                "a scheduled run can only control sessions it created itself"
+                if _cron_caller(caller_key)
+                else (
+                    "a crew member can only control worker sessions it created itself"
+                    if _member_caller(caller_key)
+                    else "an agent-created session can only control sessions it " "created itself"
+                )
+            ),
             "not_creator",
         )
 

--- a/test/test_cron_session_control.py
+++ b/test/test_cron_session_control.py
@@ -281,6 +281,34 @@ class TestAppOwnedCron:
         ]
         sc._refuse_ineligible_creator(state, caller)
 
+    def test_a_job_whose_authoring_session_has_closed_fails_closed(self, tmp_path):
+        """The confinement escape GPT flagged (backend-security-controls).
+
+        ``mcp_cron.cron_add`` records an app's authority ONLY in ``session_key``
+        (it never writes ``created_by``). The app then closes its session, so the
+        owning slot is gone and its ``_app`` tag is unreadable. Before this fix the
+        ``owning_slot is not None`` guard failed open and returned ``None``, so the
+        app's own cron could mint a persistent, non-app, sidebar-visible session --
+        precisely the confinement the ``_app`` refusal exists to prevent, reached
+        through a closed session the gate can no longer inspect.
+
+        "Cannot verify the owner is not an app" must fail closed, the same
+        direction the missing-job and unreadable-registry cases already take.
+
+        Mutation guard: restore the ``owning_slot is not None and`` short-circuit
+        (drop the unresolvable-owner refusal) and this passes silently, letting the
+        escape back in.
+        """
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state, created_by="")
+        # The job names a session that no longer has a live slot.
+        state.crons.list_jobs.return_value = [
+            SimpleNamespace(id=JOB_ID, created_by="", session_key="dashboard:chat-gone")
+        ]
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, caller)
+        assert exc.value.code == "cron_owner_unverifiable"
+
     def test_an_unfindable_job_fails_closed(self, tmp_path):
         """A tab whose job the registry cannot produce proves no ownership."""
         state = _make_state(tmp_path)

--- a/test/test_cron_session_control.py
+++ b/test/test_cron_session_control.py
@@ -1,0 +1,458 @@
+"""Cron callers on the session-control surface (issue #8332).
+
+A cron job's own slot is admitted as a SOURCE even though nobody is watching it,
+and is bounded by the same ``created_by`` fence a crew member is. These tests pin
+the four halves of that contract:
+
+* the admission (a ``cron-`` caller passes the unattended refusal; a
+  ``workflow-`` caller still does not),
+* the fence (a cron reaches the sessions it created and nothing else, including
+  another job's tab),
+* the link exemption (a ``cron:<job_id>`` link is not a channel link, while a
+  real channel link still refuses),
+* the origin of what it creates (``SlotOrigin.CRON``, so a cron cannot launder
+  its output into the ``slots:user`` scope its own slot is kept out of).
+
+Assertions run against REAL slot objects for the same reason the rest of the
+suite does: the guards read ``linked_session_key`` / ``_created_by`` / ``_origin``
+off the production class, and a permissive double would let a dead guard look
+alive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from chat_test_helpers import _make_state
+
+from kiro_crew.dashboard import create_rate_limit
+from kiro_crew.dashboard import session_control as sc
+from kiro_crew.dashboard.chat_utils import slot_history_key
+from kiro_crew.dashboard.state import SlotOrigin
+from kiro_crew.members import DM_SLOT_KEY_PREFIX
+
+JOB_ID = "2c3b2e25"
+CRON_SLOT = f"cron-{JOB_ID}"
+CRON_KEY = f"cron:{JOB_ID}"
+
+
+@pytest.fixture(autouse=True)
+def _enabled(monkeypatch):
+    """Default to the shipped (enabled) state without reading config."""
+    monkeypatch.setattr(sc, "session_control_enabled", lambda: True)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_create_budget():
+    """The per-caller create-rate window is process-wide module state."""
+    create_rate_limit.reset_for_tests()
+    yield
+    create_rate_limit.reset_for_tests()
+
+
+def _cron_tab(state, job_id: str = JOB_ID, *, created_by: str = ""):
+    """A cron job's own tab, as ``inject_cron_result_to_dashboard`` mints it.
+
+    Registers the owning job too, because ownership is read from the JOB and an
+    unfindable one is refused (`cron_owner_unverifiable`) -- a cron tab whose job
+    the registry cannot produce is not a caller. Note what the mint does NOT pass:
+    no ``app=``, which is exactly why the `_app` check cannot see an app's cron.
+
+    The agent is left empty on purpose: the child inherits the caller's, and a
+    name that does not resolve in the test config is refused (``agent_unresolved``)
+    before the gates under test are reached.
+    """
+    jobs = list(state.crons.list_jobs.return_value or [])
+    jobs.append(SimpleNamespace(id=job_id, created_by=created_by))
+    state.crons.list_jobs.return_value = jobs
+    return state.get_or_create_slot(
+        f"cron-{job_id}",
+        linked_session_key=f"cron:{job_id}",
+        origin=SlotOrigin.CRON,
+    )
+
+
+# ── Predicates ───────────────────────────────────────────────────────────────
+
+
+class TestCronCallerPredicate:
+    def test_a_cron_slot_key_is_a_cron_caller(self):
+        assert sc._cron_caller(CRON_SLOT)
+
+    def test_workflow_and_ordinary_and_member_slots_are_not(self):
+        assert not sc._cron_caller("workflow-run7")
+        assert not sc._cron_caller("chat-1-abc")
+        assert not sc._cron_caller(DM_SLOT_KEY_PREFIX + "radar")
+        assert not sc._cron_caller("")
+
+    def test_workflow_is_still_an_unattended_prefix(self):
+        """The refusal set keeps workflow, so a later prefix is refused by default."""
+        assert "workflow-" in sc.UNATTENDED_SLOT_PREFIXES
+        assert "cron-" in sc.UNATTENDED_SLOT_PREFIXES
+
+
+class TestOwnershipFencedPredicate:
+    """One predicate covers every fenced caller, so admission cannot outrun the fence."""
+
+    def test_both_exempted_caller_classes_are_fenced(self, tmp_path):
+        state = _make_state(tmp_path)
+        assert sc._caller_is_ownership_fenced(state, CRON_SLOT)
+        assert sc._caller_is_ownership_fenced(state, DM_SLOT_KEY_PREFIX + "radar")
+
+    def test_a_human_created_caller_is_not_fenced(self, tmp_path):
+        """A person's own tab reaches get_or_create_slot directly and stays unattributed."""
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("chat-1")
+        assert not sc._caller_is_ownership_fenced(state, "chat-1")
+
+    def test_a_session_a_fenced_caller_created_is_fenced_too(self, tmp_path):
+        """The deputy hole: the child has a chat- key but inherits the creator's agent."""
+        state = _make_state(tmp_path)
+        child = state.get_or_create_slot("chat-9")
+        child._created_by = CRON_SLOT
+        assert sc._caller_is_ownership_fenced(state, "chat-9")
+
+    def test_a_grandchild_is_fenced_without_walking_the_chain(self, tmp_path):
+        """`_created_by` is written only by create_session, so depth needs no walk."""
+        state = _make_state(tmp_path)
+        child = state.get_or_create_slot("chat-9")
+        child._created_by = CRON_SLOT
+        grandchild = state.get_or_create_slot("chat-10")
+        grandchild._created_by = "chat-9"
+        assert sc._caller_is_ownership_fenced(state, "chat-10")
+
+    def test_sticky_attendance_does_not_release_the_fence(self, tmp_path):
+        """`_human_seen` records that a human EVER typed, not who authored this turn.
+
+        Releasing on it would hand the creator its deputy back for the price of the
+        user glancing at the tab once: cron creates the child, the user types into
+        it, and every later cron-authored turn in that child runs unfenced.
+        """
+        state = _make_state(tmp_path)
+        child = state.get_or_create_slot("chat-9")
+        child._created_by = CRON_SLOT
+        child._human_seen = True
+        assert sc._caller_is_ownership_fenced(state, "chat-9")
+
+
+class TestCreatedChildIsNotAnUnfencedDeputy:
+    """A cron must not get an unfenced deputy by creating one (GPT, head a0c88b594)."""
+
+    def test_the_child_cannot_reach_a_session_it_did_not_create(self, tmp_path):
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        child = state.get_or_create_slot("chat-9", workspace=caller.workspace)
+        child._created_by = CRON_SLOT
+        state.get_or_create_slot("chat-2", workspace=caller.workspace)
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state, caller_session_key="chat-9", target="chat-2", operation="read"
+            )
+        assert exc.value.code == "not_creator"
+        assert "agent-created session" in exc.value.message
+
+    def test_the_child_still_reaches_its_own_children(self, tmp_path):
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        child = state.get_or_create_slot("chat-9", workspace=caller.workspace)
+        child._created_by = CRON_SLOT
+        grandchild = state.get_or_create_slot("chat-10", workspace=caller.workspace)
+        grandchild._created_by = "chat-9"
+
+        resolved = sc.authorize_target(
+            state, caller_session_key="chat-9", target="chat-10", operation="send"
+        )
+        assert resolved is grandchild
+
+
+# ── Creator eligibility ──────────────────────────────────────────────────────
+
+
+class TestRefuseIneligibleCreator:
+    def test_a_cron_link_does_not_refuse(self, tmp_path):
+        """A cron tab's link names its own run transcript, not a channel thread."""
+        state = _make_state(tmp_path)
+        sc._refuse_ineligible_creator(state, _cron_tab(state))
+
+    def test_a_real_channel_link_still_refuses(self, tmp_path):
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("chat-9", linked_session_key="slack:C123:171.2")
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, slot)
+        assert exc.value.code == "linked_session_caller"
+
+    def test_an_app_scoped_cron_tab_is_still_refused(self, tmp_path):
+        """The link exemption widens one refusal, not the set."""
+        state = _make_state(tmp_path)
+        slot = _cron_tab(state)
+        slot._app = "some-app"
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, slot)
+        assert exc.value.code == "app_scoped_caller"
+
+
+class TestAppOwnedCron:
+    """An app must not escape its confinement through its own scheduled job.
+
+    ``inject_cron_result_to_dashboard`` mints the tab without ``app=``, so the
+    ``_app`` refusal cannot see an app's cron. Ownership is read from the job.
+    """
+
+    def test_an_app_owned_cron_cannot_create_a_session(self, tmp_path):
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state, created_by="app:issue-radar")
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, caller)
+        assert exc.value.code == "app_owned_cron_caller"
+
+    def test_an_app_owned_cron_cannot_control_a_session_it_created(self, tmp_path):
+        """Refused on the control path too, so the two caller halves stay mirrors."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state, created_by="app:issue-radar")
+        worker = state.get_or_create_slot("chat-7", workspace=caller.workspace)
+        worker._created_by = CRON_SLOT
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state, caller_session_key=CRON_KEY, target="chat-7", operation="send"
+            )
+        assert exc.value.code == "app_owned_cron_caller"
+
+    def test_an_app_owned_cron_is_refused_before_the_target_is_resolved(self, tmp_path):
+        """A caller refused for its own identity must learn nothing from the attempt.
+
+        Resolving first makes the refusal an existence oracle: a guessed target
+        answers `target_not_found` when it does not exist and this refusal when it
+        does, so a caller allowed to touch nothing could enumerate session keys and
+        titles by the shape of the error. Same code either way is the assertion.
+
+        Mutation guard: move the refusal back below `_resolve_slot` and the
+        nonexistent-target case answers `target_not_found` instead.
+        """
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state, created_by="app:issue-radar")
+        state.get_or_create_slot("chat-7", workspace=caller.workspace)
+
+        codes = []
+        for target in ("chat-7", "chat-does-not-exist"):
+            with pytest.raises(sc.SessionControlError) as exc:
+                sc.authorize_target(
+                    state, caller_session_key=CRON_KEY, target=target, operation="read"
+                )
+            codes.append(exc.value.code)
+        assert codes == ["app_owned_cron_caller", "app_owned_cron_caller"]
+
+    def test_a_user_owned_cron_is_unaffected(self, tmp_path):
+        """`created_by` also carries a Slack user id, which is not an app."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state, created_by="U0123ABCD")
+        sc._refuse_ineligible_creator(state, caller)
+
+    def test_a_job_authored_by_an_app_session_is_refused(self, tmp_path):
+        """The second spelling of app ownership.
+
+        `mcp_cron.cron_add` records the calling session in `session_key` and never
+        writes `created_by`, so an app-scoped session's job carries its authority
+        only there. Reading `created_by` alone let it through.
+
+        Mutation guard: drop the session_key branch and this passes silently.
+        """
+        state = _make_state(tmp_path)
+        app_session = state.get_or_create_slot("chat-42", app="issue-radar")
+        caller = _cron_tab(state, created_by="")
+        state.crons.list_jobs.return_value = [
+            SimpleNamespace(id=JOB_ID, created_by="", session_key="dashboard:chat-42")
+        ]
+        assert app_session._app == "issue-radar"
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, caller)
+        assert exc.value.code == "app_owned_cron_caller"
+
+    def test_a_job_authored_by_an_ordinary_session_is_unaffected(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("chat-42")
+        caller = _cron_tab(state, created_by="")
+        state.crons.list_jobs.return_value = [
+            SimpleNamespace(id=JOB_ID, created_by="", session_key="dashboard:chat-42")
+        ]
+        sc._refuse_ineligible_creator(state, caller)
+
+    def test_an_unfindable_job_fails_closed(self, tmp_path):
+        """A tab whose job the registry cannot produce proves no ownership."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot(
+            CRON_SLOT, linked_session_key=CRON_KEY, origin=SlotOrigin.CRON
+        )
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, slot)
+        assert exc.value.code == "cron_owner_unverifiable"
+
+    def test_an_unreadable_registry_fails_closed(self, tmp_path):
+        """ "Could not verify" must not read as "has no owner"."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        state.crons.list_jobs.side_effect = RuntimeError("registry unavailable")
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc._refuse_ineligible_creator(state, caller)
+        assert exc.value.code == "cron_owner_unverifiable"
+
+    def test_an_ordinary_caller_needs_no_job_lookup(self, tmp_path):
+        """The lookup is scoped to cron callers; nothing else pays for it."""
+        state = _make_state(tmp_path)
+        state.crons.list_jobs.side_effect = AssertionError("must not be consulted")
+        sc._refuse_ineligible_creator(state, state.get_or_create_slot("chat-1"))
+
+
+class TestCreateSessionAdmission:
+    def test_a_workflow_caller_is_still_refused_as_unattended(self, tmp_path):
+        state = _make_state(tmp_path)
+        state.get_or_create_slot("workflow-run7", linked_session_key="workflow:run7")
+        with pytest.raises(sc.SessionControlError) as exc:
+            asyncio.run(sc.create_session(state, caller_session_key="workflow:run7"))
+        assert exc.value.code == "unattended_caller"
+
+    def test_a_cron_caller_passes_the_unattended_refusal(self, tmp_path, monkeypatch):
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: caller.workspace)
+
+        result = asyncio.run(sc.create_session(state, caller_session_key=CRON_KEY))
+
+        assert state.get_slot(result["target"]) is not None
+
+    def test_the_global_switch_still_gates_a_cron_caller(self, tmp_path, monkeypatch):
+        """Unlike a member, a cron gets no bypass of ``agent.session_control``."""
+        state = _make_state(tmp_path)
+        _cron_tab(state)
+        monkeypatch.setattr(sc, "session_control_enabled", lambda: False)
+        with pytest.raises(sc.SessionControlError) as exc:
+            asyncio.run(sc.create_session(state, caller_session_key=CRON_KEY))
+        assert exc.value.code == "session_control_disabled"
+
+    def test_the_created_session_is_attributed_to_the_job(self, tmp_path, monkeypatch):
+        """``_created_by`` is the fence's only input, so the create must write it."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: caller.workspace)
+
+        result = asyncio.run(sc.create_session(state, caller_session_key=CRON_KEY))
+
+        assert state.get_slot(result["target"])._created_by == CRON_SLOT
+
+
+class TestCreatedSessionOrigin:
+    """A cron must not reach ``slots:user`` by creating a session and writing there."""
+
+    def test_a_cron_creates_a_cron_origin_child(self, tmp_path, monkeypatch):
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: caller.workspace)
+
+        result = asyncio.run(sc.create_session(state, caller_session_key=CRON_KEY))
+
+        child = state.get_slot(result["target"])
+        assert child._origin == SlotOrigin.CRON, "a USER label would enter slots:user"
+
+    def test_an_ordinary_caller_still_creates_a_user_origin_child(self, tmp_path, monkeypatch):
+        """The narrowing is scoped to cron lineage; nothing else changes."""
+        state = _make_state(tmp_path)
+        caller = state.get_or_create_slot("chat-1", origin=SlotOrigin.USER)
+        monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: caller.workspace)
+
+        result = asyncio.run(sc.create_session(state, caller_session_key=slot_history_key(caller)))
+
+        assert state.get_slot(result["target"])._origin == SlotOrigin.USER
+
+    def test_a_grandchild_of_a_cron_stays_cron_origin(self, tmp_path, monkeypatch):
+        """The tag must follow authority, not the caller's key prefix.
+
+        A child inherits its creator's agent, so a cron's child can itself call
+        this verb -- and its caller key is a plain `chat-`. Keying only on the
+        prefix mints that grandchild USER, which `ws_event_scope` then delivers to
+        any app holding `slots:user`: the two-hop version of the laundering route
+        the CRON tag exists to close.
+
+        Mutation guard: drop the `_origin` half of the condition and this fails.
+        """
+        state = _make_state(tmp_path)
+        cron = _cron_tab(state)
+        child = state.get_or_create_slot("chat-9", workspace=cron.workspace, origin=SlotOrigin.CRON)
+        child._created_by = CRON_SLOT
+        monkeypatch.setattr(sc, "_workspace_name_for_dir", lambda cfg, ws_dir: child.workspace)
+
+        result = asyncio.run(sc.create_session(state, caller_session_key="chat-9"))
+
+        grandchild = state.get_slot(result["target"])
+        assert grandchild._origin == SlotOrigin.CRON, "cron output would enter slots:user"
+
+
+# ── The fence ────────────────────────────────────────────────────────────────
+
+
+class TestAuthorizeTargetCronPath:
+    def _authorize(self, state, target: str, operation: str = "send"):
+        return sc.authorize_target(
+            state, caller_session_key=CRON_KEY, target=target, operation=operation
+        )
+
+    def test_a_cron_reaches_a_session_it_created(self, tmp_path):
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        worker = state.get_or_create_slot("chat-7", workspace=caller.workspace)
+        worker._created_by = CRON_SLOT
+
+        assert self._authorize(state, "chat-7") is worker
+
+    def test_a_cron_cannot_reach_a_session_it_did_not_create(self, tmp_path):
+        """The user's own conversation, which is what the old refusal protected."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        state.get_or_create_slot("chat-7", workspace=caller.workspace)
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            self._authorize(state, "chat-7")
+        assert exc.value.code == "not_creator"
+        assert "scheduled run" in exc.value.message
+
+    def test_a_cron_cannot_reach_another_jobs_tab(self, tmp_path):
+        """``unattended_target`` stands: a cron tab is never addressable."""
+        state = _make_state(tmp_path)
+        _cron_tab(state)
+        other = _cron_tab(state, "99887766")
+        other._created_by = CRON_SLOT  # even if it somehow carried our attribution
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            self._authorize(state, other.key)
+        assert exc.value.code == "unattended_target"
+
+    def test_a_cron_tab_with_a_real_channel_link_is_still_refused(self, tmp_path):
+        """The exemption is the cron link, not the field being non-empty."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        caller.linked_session_key = "slack:C123:171.2"
+        worker = state.get_or_create_slot("chat-7", workspace=caller.workspace)
+        worker._created_by = CRON_SLOT
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            sc.authorize_target(
+                state,
+                caller_session_key=caller.key,
+                target="chat-7",
+                operation="send",
+            )
+        assert exc.value.code == "linked_session_caller"
+
+    def test_an_unowned_target_fails_closed(self, tmp_path):
+        """An ownerless rehydrate must not read as ours."""
+        state = _make_state(tmp_path)
+        caller = _cron_tab(state)
+        worker = state.get_or_create_slot("chat-7", workspace=caller.workspace)
+        worker._created_by = ""
+
+        with pytest.raises(sc.SessionControlError) as exc:
+            self._authorize(state, "chat-7")
+        assert exc.value.code == "not_creator"

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -15,6 +15,7 @@ import asyncio
 import dataclasses
 import re
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -613,14 +614,43 @@ def test_scheduled_target_is_refused(tmp_path):
     assert "unattended" in exc.value.message
 
 
-def test_scheduled_caller_cannot_control_anyone(tmp_path):
+def test_scheduled_caller_cannot_control_a_session_it_did_not_create(tmp_path):
+    """A cron caller is admitted but fenced to its own children (issue #8332).
+
+    The refusal it used to get was ``unattended_caller``, keyed on the slot-key
+    prefix. That was replaced by the ``created_by`` fence, which refuses the case
+    the prefix check existed for -- a scheduled job reaching the user's own
+    conversation -- while letting it drive the sessions it dispatched. The
+    positive half, and a cron's other gates, are in
+    ``test_cron_session_control.py``.
+    """
     state = _make_state(tmp_path)
     caller = _slot(state, "cron-abc123")
+    # Ownership is read from the JOB, and an unfindable one fails closed, so the
+    # fence is only reached once the registry can produce a non-app owner.
+    state.crons.list_jobs.return_value = [SimpleNamespace(id="abc123", created_by="U0123ABCD")]
     _slot(state, "chat-2")
     with pytest.raises(sc.SessionControlError) as exc:
         sc.authorize_target(
             state, caller_session_key=_key(caller), target="chat-2", operation="read"
         )
+    assert exc.value.code == "not_creator"
+
+
+def test_workflow_caller_cannot_control_anyone(tmp_path):
+    """The unattended refusal still stands for the caller class with no fence.
+
+    A ``workflow-<run_id>`` slot is minted only once its originating tab is gone,
+    so there is no owning session to bound it to.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "workflow-run7")
+    _slot(state, "chat-2")
+    with pytest.raises(sc.SessionControlError) as exc:
+        sc.authorize_target(
+            state, caller_session_key=_key(caller), target="chat-2", operation="read"
+        )
+    assert exc.value.code == "unattended_caller"
     assert "cannot control other sessions" in exc.value.message
 
 


### PR DESCRIPTION
## What is the problem?

A cron job cannot use session control, and the refusal does not depend on which agent the job runs as. A job mapped to `kirocrew-conductor`, an agent installed specifically for session control with no `fs_write` and no `code`, was refused exactly like a job running as the default agent, because the gate reads the slot's NAME.

Three refusals fired, all keyed on the `cron-` slot-key prefix or on a field a cron borrowed:

| gate | code |
|---|---|
| `create_session` | `unattended_caller` (`UNATTENDED_SLOT_PREFIXES`) |
| `_refuse_ineligible_creator` | `linked_session_caller`, because `inject_cron_result_to_dashboard` sets `linked_session_key = cron:<job_id>` |
| `authorize_target` | `unattended_caller`, the one that gates `session_send` / `read` / `stop` |

`agent.session_control` did not reach any of them: the config gate sits above the prefix check. "View last result" was not a way around it either, because `api_cron_to_chat` reuses the same `cron-<job_id>` slot.

## Why this issue matters to the user

The blocked workflow is a morning dispatch: a 06:30 job enumerates the tasks due today, the user replies "work on 1, 2 and 6", and each task should get its own session so the three run in parallel with separate context. The fan-out needs `session_create` plus `session_send`, and both were refused.

Beyond that one workflow, the gate was checking the wrong property and its stated reason was already contradicted.

**Wrong property.** Capability is bounded per agent already: `@kirocrew-dashboard` is an opt-in per-agent MCP server, deliberately absent from the default agent's spec, and `_install_conductor_agent()` mounting it IS the explicit assignment. That layer is fail-closed by construction, since an agent without the mount never sees the verbs. The prefix check added a gate on top that cannot tell a session-control agent from a general-purpose one.

**Contradicted reason.** The comment said a cron must not "type into the user's live conversations unattended", and named `send_message` as the supported alternative. But `send_message(session="origin")` resolves the originating dashboard slot and, when it is idle, calls `spawn_guarded_turn` -> `_run_chat`. That is an unattended scheduled job starting a turn in the user's live conversation, through a documented path. What actually separates the two is SCOPE: `_resolve_session_target` accepts only the literal `"origin"` and rejects arbitrary slot keys, so a cron can talk back to its owner and nothing else.

Scope is a defensible line. It was not the line the code stated, and it does not justify refusing `create_session` at all: a session the cron just created is empty, so there is no third party's turn to interrupt and nothing to clobber.

## How our fix solves it

The chain runs symptom, then stated reason, then real invariant, then the mechanism that already expresses it.

The real invariant is "a scheduled job must not reach the user's own sessions", and this repo already has a fence for exactly that shape. `authorize_target` refuses a crew member on any slot it did not create (`_created_by`, 403), and that fence is precisely why `_MEMBER_DASHBOARD_GRANTS` may auto-approve the write verbs while `_CONDUCTOR_DASHBOARD_GRANTS` withholds them; the tuple comments state the reasoning. So:

1. **`create_session` and `authorize_target` admit a `cron-` caller**, and the fence binds it. Both admissions and the fence read one predicate (`_caller_is_ownership_fenced`) so they cannot drift apart. Fail-closed on an unowned slot, which is what an ownerless rehydrate looks like.
2. **`workflow-` stays refused.** It is minted only once its originating tab is gone, so there is no owning session to fence it to. Membership of `UNATTENDED_SLOT_PREFIXES` is now the fail direction for any prefix added later: a new unattended surface is refused as a source until it is given a fence of its own.
3. **A `cron:<job_id>` link is exempt from the caller-side channel-link refusals.** Those exist for links that republish to a Slack or Telegram audience; a cron link names the job's own run transcript and republishes to nobody. Both caller-side sites are exempted together, keeping `_refuse_ineligible_creator` an exact mirror of `authorize_target`'s caller half as its docstring requires. The TARGET-side refusal is untouched.
4. **`unattended_target` stands.** A cron drives its own children, never another job's tab.
5. **The global switch still gates a cron.** Unlike a member it gets no bypass: the switch is the user's statement that agents may open and drive sessions at all, and a job running while they are asleep is the last caller that should be exempt from it.
6. **A session a cron creates is tagged `SlotOrigin.CRON`, not `USER`.** This is the one place the change would otherwise open something. A cron's own slot is tagged CRON so its output stays outside the `slots:user` WS scope ("a USER label would expose it to any app holding `slots:user`"), and the trust model states the same rule from the other side: inferring USER for a background caller "put cron output inside `slots:user`". A USER-labelled child would hand a cron that exposure by the route of creating a session and writing there. Nothing is lost, because only app tokens are filtered by origin (`_serialize_for_client` returns the unfiltered payload to a dashboard user), so the child stays in the sidebar exactly as a cron tab does.

Runaway creation needed no new work. The existing guards were written for this caller: `create_rate_limited` (5-minute window), `slot_cap_reached`, and `creator_slot_cap_reached` keyed on the caller so each job gets its own share, whose comment already reasons about "an automated creator looping on it".

## What tests we did

New `test/test_cron_session_control.py`, 19 tests against REAL slot objects (the suite's own doctrine, since the guards read `linked_session_key` / `_created_by` / `_origin` off the production class and a permissive double would let a dead guard look alive):

- admission: a cron caller passes the unattended refusal and creates a session; a `workflow-` caller still gets `unattended_caller`; the global switch still refuses a cron with `session_control_disabled`.
- the fence: a cron reaches a session it created, gets `not_creator` on one it did not, gets `unattended_target` on another job's tab, and fails closed on an unowned slot.
- the link exemption: a cron link passes, a `slack:` link on the same slot still gets `linked_session_caller`, and an app-scoped cron tab still gets `app_scoped_caller`, so the exemption widens one refusal rather than the set.
- origin: a cron caller's child is `SlotOrigin.CRON`; an ordinary caller's child is still `SlotOrigin.USER`.

Updated `test_scheduled_caller_cannot_control_anyone`, which asserted the old contract, to assert the fence instead, and added `test_workflow_caller_cannot_control_anyone` beside it so the surviving refusal keeps a test of its own.

238 tests green across `test_cron_session_control.py`, `test_session_control.py`, `test_member_session_control.py`, `test_session_control_boundaries.py`, `test_queue_drain_revalidation.py` and `test_session_pulse_session_count.py`. black, isort, flake8 and mypy clean on the changed files.

The spec (`docs/system-specs/modules/session-control.md`) moves with the code: two refusal-table rows and a new "Cron callers" section stating the admission, the fence, the link exemption, the origin rule, and the per-agent capability layer the prefix could not see.

## Any other suggestions on the work

Two things I found while doing this and deliberately did not fold in.

**A cron's caller identity resolves only through its live tab, and that tab is minted after the first run's result is injected.** `caller_slot_key` walks live slots, and the only creator site for a `cron-<job_id>` slot is the post-run injection path. So a brand-new job's FIRST run has no tab, resolves to no caller, and is refused `caller_unidentified`: the capability lands from its second run onward. Jobs with `persistent_session=False` or `hide_in_chat=True` never get a tab and so never become eligible, which is coherent and fail-closed, but the first-run gap is a bad first impression for exactly the person testing a new job. Fixing it means ensuring the tab exists at run start, which has to move `hydrate_slot_from_history` along with it, because the injection hydrates under `if not slot.linked_session_key` and pre-linking the slot without moving the hydration would silently skip it. That belongs in its own PR against the cron delivery path, not bundled with an authorization change. Filed separately.

**Approval, not authorization, is the remaining step for a hands-off fan-out.** `_CONDUCTOR_DASHBOARD_GRANTS` withholds `session_send`, correctly, because a conductor agent also runs in dashboard sessions where no ownership fence applies. A cron whose dispatch must run without an approval prompt needs the write verbs in its own agent's `allowedTools`. That is the existing per-agent extension point and needs no code change, so it is documented in the spec rather than widened here.

Closes #8332
