### PR TITLE
fix(slack): re-hydrate thread agent overrides after an inline reroute

### DIFF
--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -3117,6 +3117,14 @@ async def handle_message(
         # mapping with it. So the asker becomes the session key outright.
         if asker_key:
             session_key = asker_key
+            # Same reason as the linked-thread reroute below: overrides are keyed
+            # BY SESSION and the hydration at entry ran for the PREVIOUS key, so
+            # without this the agent re-resolution reads a key nobody hydrated and
+            # falls through to the channel or default agent -- discarding a binding
+            # the asker's own metadata records correctly. The pinned path needs it
+            # exactly as much: `asker_key` is a different conversation, which is
+            # the whole reason it is substituted here.
+            _hydrate_thread_overrides(session_key, conversation_log)
     elif thread_owner_key and thread_owner_key != session_key:
         logger.info(
             "🔗 Slack thread %s linked to dashboard session %s — routing there",
@@ -3124,6 +3132,14 @@ async def handle_message(
             thread_owner_key,
         )
         session_key = thread_owner_key
+        # Thread overrides are keyed BY SESSION, and the hydration at entry ran
+        # for the previous key. Re-hydrate for the new owner in the same breath
+        # as the reroute -- otherwise the agent re-resolution below reads a key
+        # that was never hydrated and falls through to the channel or default
+        # agent, discarding a binding the session's own metadata records
+        # correctly. Same shape as transport_dispatch._resolve_thread_owner.
+        # The helper guards repeated I/O per session, so this is cheap.
+        _hydrate_thread_overrides(session_key, conversation_log)
 
     client: LLMProvider | None = None
     try:

--- a/test/test_slack_handler.py
+++ b/test/test_slack_handler.py
@@ -1788,6 +1788,112 @@ class TestPerThreadAgent:
         assert switched
         assert "thread" not in switched[0][1]["text"].lower()
 
+    @pytest.mark.asyncio
+    async def test_reroute_to_a_linked_session_keeps_its_agent(self):
+        """A reroute must carry the new owner's persisted agent, not the default.
+
+        Hydration at entry runs for the ENTRY key. When the thread turns out to
+        be owned by a linked dashboard session, ``session_key`` is reassigned to
+        that owner — and the agent re-resolution immediately after then reads a
+        key that was never hydrated, so a binding the session's own metadata
+        records correctly is silently replaced by the channel or default agent.
+        ``transport_dispatch._resolve_thread_owner`` re-hydrates in the same
+        breath as the reroute; this asserts the inline handler does too.
+        """
+        from unittest.mock import MagicMock
+
+        from kiro_crew.slack.handler import _hydrated_sessions
+
+        owner_key = "dashboard:chat-7-1785861270"
+
+        class LinkedSessions(FakeSessionManager):
+            """The thread index resolves this thread to a dashboard session."""
+
+            def get_session_for_thread(self, thread_ts):
+                return owner_key
+
+        log = MagicMock()
+        log.get_metadata.side_effect = lambda key: (
+            {"agent": "sisyphus"} if key == owner_key else {}
+        )
+
+        slack = MockSlackClient()
+        sessions = LinkedSessions()
+        try:
+            await handle_message(
+                slack,
+                sessions,
+                "C1",
+                "hello",
+                "thread1",
+                "msg1",
+                "U_OWNER",
+                conversation_log=log,
+            )
+
+            assert (
+                owner_key in sessions.keys_seen
+            ), "the turn never rerouted to the session that owns this thread"
+            assert sessions.last_agent == "sisyphus", (
+                f"rerouted turn ran under {sessions.last_agent!r} — the linked "
+                "session's persisted agent binding was discarded"
+            )
+        finally:
+            _hydrated_sessions.discard(owner_key)
+            _hydrated_sessions.discard("slack:thread1")
+            _hydrated_sessions.discard("thread1")
+
+    @pytest.mark.asyncio
+    async def test_a_pinned_reroute_keeps_the_askers_agent(self):
+        """The sibling reassignment, same defect.
+
+        ``route_pinned`` substitutes ``asker_key`` for the entry key on the branch
+        immediately above the linked-thread reroute, and feeds the same agent
+        re-resolution. Hydration at entry ran for the ENTRY key, so without a
+        re-hydration here the pinned answer runs under the channel or default
+        agent instead of the binding the ASKING conversation recorded — and a
+        pinned asker is by construction a different conversation, which is the
+        whole reason its key is substituted.
+        """
+        from unittest.mock import MagicMock
+
+        from kiro_crew.slack.handler import _hydrated_sessions
+
+        asker_key = "cron:9f2c1d40"
+
+        log = MagicMock()
+        log.get_metadata.side_effect = lambda key: (
+            {"agent": "sisyphus"} if key == asker_key else {}
+        )
+
+        slack = MockSlackClient()
+        sessions = FakeSessionManager()
+        try:
+            await handle_message(
+                slack,
+                sessions,
+                "C1",
+                "hello",
+                "thread1",
+                "msg1",
+                "U_OWNER",
+                conversation_log=log,
+                route_pinned=True,
+                asker_key=asker_key,
+            )
+
+            assert (
+                asker_key in sessions.keys_seen
+            ), "the pinned turn never ran under the asking conversation's key"
+            assert sessions.last_agent == "sisyphus", (
+                f"pinned turn ran under {sessions.last_agent!r} — the asking "
+                "conversation's persisted agent binding was discarded"
+            )
+        finally:
+            _hydrated_sessions.discard(asker_key)
+            _hydrated_sessions.discard("slack:thread1")
+            _hydrated_sessions.discard("thread1")
+
 
 class TestStopCommand:
     """Tests for the !stop kill switch."""


### PR DESCRIPTION
## Problem / Motivation

A Slack turn in a thread that is linked to a dashboard session runs under the **generic default agent** instead of the agent that session is bound to. The binding is persisted correctly in the session's own conversation-log metadata; the turn just never reads it, so the user's chosen agent is silently ignored and they get the default persona's answer.

## Why it matters

An agent binding is the whole point of binding a session to an agent. Silently substituting the default persona is worse than an error: the reply looks plausible, so the user has no signal that their configured agent ΓÇö its tools, its instructions, its model ΓÇö was never used. Anyone driving a bound dashboard session from Slack is hit on the first reroute in a gateway process.

## What changed (motivation ΓåÆ approach ΓåÆ change)

**Symptom** ΓÇö a rerouted Slack turn resolves to the default agent.

**Root cause** ΓÇö the per-thread override maps are keyed BY SESSION. `handle_message` hydrates them once at entry, under the pre-link session key derived from the Slack thread timestamp. When the thread turns out to be owned by a linked dashboard session, the reroute reassigns `session_key = thread_owner_key`, and the agent re-resolution on the very next lines reads `_thread_agents.get(session_key)` under a key that was never hydrated. It misses, and falls through to `channel_agent or _get_default_agent()`.

**Change** ΓÇö re-hydrate for the new owner in the same breath as the reroute, which is exactly what the sibling transport path already does: `transport_dispatch._resolve_thread_owner` calls `_hydrate_thread_overrides(session_key, conversation_log)` immediately after its own `session_key = owner`, with a comment explaining why it belongs inside the reroute rather than beside it. Rather than invent a second mechanism, this mirrors that one call. `_hydrate_thread_overrides` guards repeated I/O per session, so it costs nothing when the key is already hydrated.

**Both inline reassignments, not one.** The Design and First Principles reviewers each flagged the same undeclared sibling, and they were right: the `route_pinned` branch immediately above performs the *other* inline reassignment (`session_key = asker_key`) and feeds the very same `_thread_agents.get(session_key)` lookup, under a key hydration never saw. Verified in the code before changing it — entry hydration runs once for the entry key, and a pinned asker is by construction a different conversation, which is the whole reason its key is substituted there. So the pinned branch had the identical defect and now gets the identical call. Both sites are covered by a test.

## Tests

`test/test_slack_handler.py::TestPerThreadAgent::test_reroute_to_a_linked_session_keeps_its_agent` ΓÇö drives the real `handle_message` with a thread index that resolves the thread to a dashboard session key, and a conversation log holding that session's persisted agent. It asserts the observable outcome, the agent the turn is acquired with, not the internals.

Written first and confirmed failing for the right reason on the unfixed code ΓÇö the reroute assertion passed, so the test was exercising the intended branch, while the agent came back `None`:

```
E   AssertionError: rerouted turn ran under None ΓÇö the linked session's persisted agent binding was discarded
E   assert None == 'sisyphus'
1 failed, 184 deselected, 1 warning in 3.22s
```

`test/test_slack_handler.py::TestPerThreadAgent::test_a_pinned_reroute_keeps_the_askers_agent` — the same shape for the `route_pinned` sibling, driving `handle_message` with `route_pinned=True` and an `asker_key` whose log holds the persisted agent. Also confirmed red first, for the right reason — the reroute assertion passed while the agent came back `None`:

```
E   AssertionError: pinned turn ran under None — the asking conversation's persisted agent binding was discarded
```

After the fix, `186 passed` for that file, and `742 passed` across the 14 files covering this path (`test_slack_handler.py`, `test_slack_thread_session_binding.py`, `test_slack_transport_dispatch.py`, the three handler-coverage files, `test_thread_override_persistence.py`, `test_slack_agent_passthrough.py`, `test_slack_dashboard_live_sync.py`, `test_close_guard_parity.py`, `test_slack_options_lifecycle.py`, `test_slack_mirror_unlink.py`, `test_chat_slack.py`, `test_slack_golden_transcript.py`).

`scripts/check_black_formatting.py`, `isort --check-only`, `flake8` and `mypy` all pass on the two changed files.

## Manual verification

N/A ΓÇö unit coverage sufficient. The test drives the real `handle_message` through the real reroute branch, so the assertion sits on the same code path a live Slack reply takes; the only doubles are the session manager and the conversation log, which is how every existing test in this file exercises the handler.

<!-- no-visual-delta -->

**Why no screenshot:** this is one inserted call inside the Slack inbound handler plus a regression test. There is no UI surface in the diff ΓÇö the only observable difference is which agent a rerouted turn runs under, which is precisely what the test asserts.

## Related Issues

Refs #2795 ΓÇö deliberately **not** `Closes`.

That issue bundles two defects and this PR addresses only the second: the agent binding lost on an inline-handler reroute. Left out on purpose:

- **Defect A**, the additive effective-session context block. It is an undecided design question ΓÇö what the block asserts, whether it re-injects on every follow-up turn, and how it composes with the existing per-turn transport line. Three commenters have recommended splitting the issue; that split is a maintainer's call, so this PR neither pre-empts it nor closes the issue.
- The **parallel privacy-flag miss** at the same reroute: `_hydrate_conv_flags` also runs only under the entry key. The transport sibling re-runs both, but the inline path has its own flag-hydration ordering, and widening into it here would fold a second concern into a one-line fix.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a cache hydrated once at entry, then read after the key it is indexed by has been reassigned ΓÇö the lookup misses silently and falls through to a default instead of failing.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) ΓÇö N/A, no doc describes this path
- [x] No secrets, credentials, or internal references in the diff

