### PR TITLE
docs: credit timwukp in the README contributors block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,7 @@ make this tool possible:
 <a href="https://github.com/thor4" title="Bryan Conklin"><img src="https://github.com/thor4.png?size=64" width="64" height="64" alt="Bryan Conklin" /></a>
 <a href="https://github.com/ThR3742" title="ThR3742"><img src="https://github.com/ThR3742.png?size=64" width="64" height="64" alt="ThR3742" /></a>
 <a href="https://github.com/Tiger-0512" title="Taiga Matsunaga"><img src="https://github.com/Tiger-0512.png?size=64" width="64" height="64" alt="Taiga Matsunaga" /></a>
+<a href="https://github.com/timwukp" title="Tim WU"><img src="https://github.com/timwukp.png?size=64" width="64" height="64" alt="Tim WU" /></a>
 <a href="https://github.com/tjdwlsdlaek" title="seongjin"><img src="https://github.com/tjdwlsdlaek.png?size=64" width="64" height="64" alt="seongjin" /></a>
 <a href="https://github.com/tlauda" title="Tomasz Lauda"><img src="https://github.com/tlauda.png?size=64" width="64" height="64" alt="Tomasz Lauda" /></a>
 <a href="https://github.com/tlobinger" title="Thomas Lobinger"><img src="https://github.com/tlobinger.png?size=64" width="64" height="64" alt="Thomas Lobinger" /></a>


### PR DESCRIPTION
Measured at 2026-09-04T00:45:52Z against main `711544f3d87a838657349849ad0e9c3883e882d4`.

## Problem / Motivation

[#8137](https://github.com/kirodotdev/KiroCrew/issues/8137) is a credit request
filed through the path `CONTRIBUTING.md` documents: "Open an issue naming the
person (yourself is fine), and a maintainer records it," with the exact command
to run. The request is for the investigation and design behind the remote-crew
DNS-shadowing preflight now on `main` (reported as
[#7522](https://github.com/kirodotdev/KiroCrew/issues/7522), implemented via
[#7553](https://github.com/kirodotdev/KiroCrew/pull/7553), merged as
[#7888](https://github.com/kirodotdev/KiroCrew/pull/7888)).

The issue also reports that the *automatic* reporter-credit rule did not fire
for #7522. **That second claim does not survive the code: the rule fired.** The
detail is under "What changed"; it is not fixed here, and it is not fixable in
this repository's code.

## Why it matters

A person asked to be credited by a path the project publishes and told them to
use. The document fixes both the path and the value, so recording it is a lookup,
not a judgement.

## What changed (motivation -> approach -> change)

One line in the README Contributors block, produced by running the documented
command rather than hand-editing:

```sh
python3 scripts/update_contributors.py --login timwukp --name "Tim WU"
```

**Why this is not a workaround for a broken rule.** The reporter half of the
automatic rule is working. Run `33725275383` (2026-09-03T06:52:23Z, the run the
issue cites) logs:

```
PR authors: 156; reporters of closed issues: 189; union: 269.
Collected 269 candidate author(s).
```

`closingIssuesReferences` on merged #7888 resolves #7522 to `timwukp` / `User`,
which is exactly the input `add-contributor.yml` credits, and the login **is
already present** in the README on the pushed rolling branch
`chore/add-contributors` (`3aaa1140a6d91195d79c5ae4ca930031673810fb`, pushed
2026-09-03T06:53:42Z).

What did not happen is delivery. The same run then logs:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create
or approve pull requests (createPullRequest)
```

The workflow takes its documented handoff path there, keeps the run green on
purpose, and comments the compare link on
[#6741](https://github.com/kirodotdev/KiroCrew/issues/6741), which it has now
done on six consecutive daily runs (2026-08-30 through 2026-09-03) with no human
action since 2026-08-29. So the visible symptom the issue reports is real, the
run really was green, and the README really lacks the entry; the inference that
the issue-reporter half is silently not running is the part that does not hold.
It is one un-opened pull request withholding **every** contributor discovered
since 2026-08-29, PR authors and issue reporters alike, not reporters
specifically.

That blocker is deliberately not addressed here. Resolving it needs either a
human to open the contributors PR, or a repo admin to enable "Allow GitHub
Actions to create and approve pull requests", one switch that also grants
workflows PR **approval** and so weakens `main`'s required-human-approval gate.
The workflow's own comment forbids the third option (`Do not "fix" that by
making the step fail again -- it did, daily, unnoticed for weeks`). #6741 is
already routed `needs-human` with that exact ruling recorded.

## Tests

No new test: the input the issue believed was non-firing demonstrably fires, so
there is no non-firing input to pin. The behaviour this change depends on, that
a manually-added entry is never re-added or duplicated by the later automated
sweep, is already covered and was re-run against this diff.

```
python3 -m pytest test/test_update_contributors.py -q   ->  55 passed
python3 scripts/update_contributors.py --test          ->  PASS
```

## Manual verification

Against this branch, on top of `711544f3d`:

- Re-running the manual command: `No new contributors; README already up to date.`
- Feeding the workflow's own stdin path, including a case variant
  `[{"login":"timwukp",...},{"login":"TIMWUKP",...}]`:
  `No new contributors; README already up to date.`
- `grep -c 'github.com/timwukp"' README.md` returns `1`
- `git status --short` shows `M README.md` only.

So when the rolling PR in #6741 does land, it will not produce a second entry.

## Screenshots / video

None: one text line in a list, no rendered surface change beyond an added avatar.

## Related Issues

Refs #8137
Refs #6741

## Pattern harvest

A green scheduled run and a correct observation of its *absent* output can
coexist without the derivation being at fault. This workflow ends in a
best-effort `gh pr create` that is expected to be refused, so its success
conclusion says nothing about whether its result reached `main`. When a
credit/report/sync job "did not fire", read the pushed branch and the job log
before the deriving code: the branch carries the answer, and here it already
held the entry.

## Checklist

- [x] Change is limited to the requested credit
- [x] Produced by the documented script, not a hand edit
- [x] Idempotence against the automated job verified
- [x] Related tests re-run

## Contribution License Agreement

By submitting this pull request I confirm that my contribution is made under the
terms of the project's license.
