### PR TITLE
fix(ci): never let an incomplete review body overwrite a posted verdict (#8292)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1046,23 +1046,70 @@ jobs:
             echo
             echo "False positive or not applicable? A repository writer can comment:"
             echo "\`/ai-review override gpt $HEAD: <one-sentence reason>\`"
-          } > /tmp/codex-comment.md
+          } > "${RUNNER_TEMP:-/tmp}/codex-comment.md"
 
-          # Find the bot's existing marker comment (first match wins). Two guards:
+          # Find the bot's existing marker comment (first match wins) and
+          # capture its CURRENT body in the same query, before any PATCH
+          # decision (#8292). Guards:
           #   - author filter: only a github-actions[bot] comment can match, so a
           #     PR commenter cannot plant the marker and have this step PATCH
           #     their comment with the write-scoped token.
           #   - per-page jq: with --paginate the --jq filter runs PER PAGE.
-          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null \
+          #   - @json: each match arrives as ONE compact line, so `head -n1`
+          #     still selects a whole record even though bodies are multi-line.
+          existing_json="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | {id, body} | @json" 2>/dev/null \
             | head -n1 || true)"
+          existing="$(printf '%s\n' "$existing_json" | jq -r '.id // empty' 2>/dev/null || true)"
+          # GitHub stores comment bodies with CRLF line endings; normalize to LF
+          # so the marker grep and the line-anchored cleanup below see the same
+          # bytes this step originally wrote.
+          printf '%s\n' "$existing_json" | jq -r '.body // empty' 2>/dev/null | tr -d '\r' \
+            > "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md" \
+            || : > "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md"
 
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat /tmp/codex-comment.md)" >/dev/null || true
-            echo "Updated existing GPT 5.6 comment #$existing"
+            if [ "$kind" = "incomplete" ] \
+              && grep -Fq "[GPT-REVIEWED]" "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md"; then
+              # Visibility invariant (#8292): a verdict that exists never
+              # becomes invisible. The REST comments API exposes no edit
+              # history, so an incomplete body PATCHed over a completed verdict
+              # would bury that verdict — including [BLOCK-MERGE] findings — in
+              # GraphQL userContentEdits where no reader or tool looks. Keep
+              # the existing verdict and prepend ONE dated notice, replacing
+              # any notice a previous incomplete run left so they never stack.
+              # Scope: ONLY marker-absent (incomplete) bodies are caught here;
+              # override/blocked/clear kinds still replace the comment, and
+              # "Gate on findings" below stays fail-closed for $HEAD.
+              {
+                echo "$MARKER"
+                echo "<!-- codex-stale-notice-begin -->"
+                echo "> ⚠️ **Stale verdict notice ($(date -u +'%Y-%m-%d %H:%M UTC')):** a later GPT 5.6 run did not produce a completed verdict for \`$HEAD\`; the verdict below is from an earlier completed run. Inspect the GPT 5.6 Review job logs and re-run the workflow, or have a repository writer comment \`/ai-review override gpt $HEAD: <one-sentence reason>\`."
+                echo "<!-- codex-stale-notice-end -->"
+                echo ""
+                # Strip the leading marker and any previous notice block. Both
+                # patterns are LINE-ANCHORED and the notice strip is bounded to
+                # the head window (lines 1-8) where this step's own notice
+                # always sits: the preserved body embeds model-authored review
+                # prose, so an unanchored or unbounded range keyed on these
+                # markers would let a finding that merely QUOTES them delete
+                # the verdict to EOF — the very failure this guard prevents.
+                # Worst case inside the window is a few head lines; the
+                # verdict body below line 8 is untouchable by construction.
+                sed -e '1{/^<!-- codex-ai-review -->$/d;}' \
+                  -e '1,8{/^<!-- codex-stale-notice-begin -->$/,/^<!-- codex-stale-notice-end -->$/d;}' \
+                  "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md"
+              } > "${RUNNER_TEMP:-/tmp}/codex-merged-comment.md"
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "${RUNNER_TEMP:-/tmp}/codex-merged-comment.md")" >/dev/null || true
+              echo "Preserved GPT 5.6 verdict in comment #$existing; prepended incomplete-run notice for $HEAD"
+            else
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "${RUNNER_TEMP:-/tmp}/codex-comment.md")" >/dev/null || true
+              echo "Updated existing GPT 5.6 comment #$existing"
+            fi
           else
-            gh pr comment "$PR" --body-file /tmp/codex-comment.md
+            gh pr comment "$PR" --body-file "${RUNNER_TEMP:-/tmp}/codex-comment.md"
             echo "Created new GPT 5.6 comment"
           fi
 

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -502,6 +502,17 @@ no-output review must not look clean. A BLOCKING-labelled finding without the
 `[BLOCK-MERGE]` marker is only a non-gating **advisory warning**, since a coherence
 check on that pairing mis-fires whenever the model quotes prior text.
 
+The GPT summary comment is upserted in place, which once let a failed run's
+"review incomplete" body replace a posted verdict — the REST comments API
+exposes no edit history, so a `[BLOCK-MERGE]` finding vanished from every
+surface a reader or tool checks (#8292). The same-repo GPT lane's post step
+now refuses exactly that transition: an incomplete body never overwrites a
+marker-present verdict; it keeps the existing verdict and prepends one dated
+stale-verdict notice instead. Completed verdicts and human overrides still
+replace the comment, and the fail-closed gate above is unchanged. The fork
+GPT lane (`fork-gpt-review.yml`) still PATCHes unconditionally and is tracked
+separately.
+
 ### Security posture of the reviewer jobs
 
 - Explicit fork guards (`head.repo.full_name == github.repository`) on **every

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -3950,3 +3950,244 @@ class TestBlockAdjudicationExtraction:
         assert "trailing space" not in findings
         assert "[BLOCK-MERGE]" not in findings
         assert "[GPT-REVIEWED]" not in findings
+
+
+class TestGptVerdictVisibility:
+    """An incomplete run must never make a posted GPT verdict invisible (#8292).
+
+    The GPT summary comment is upserted in place, so an unconditional PATCH let
+    a "review incomplete" body replace a posted ``[BLOCK-MERGE]`` verdict; the
+    REST comments API exposes no edit history, so the verdict survived only in
+    GraphQL userContentEdits. The post step now refuses exactly that one
+    transition. These tests run the step's real bash body with a stubbed ``gh``
+    for the three contract cases.
+    """
+
+    HEAD = "1234567890abcdef1234567890abcdef12345678"
+    OLD = "aaaa567890abcdef1234567890abcdef1234aaaa"
+    MARKER = "<!-- codex-ai-review -->"
+
+    def _verdict_body(self, sha: str) -> str:
+        return (
+            f"{self.MARKER}\n"
+            "## GPT 5.6 Review — 🔴 changes requested (blocking)\n"
+            "\n"
+            f"GPT 5.6 found at least one blocking issue that must be resolved before merging `{sha}`.\n"
+            "\n"
+            f"[GPT-REVIEWED] {sha}\n"
+            f"[BLOCK-MERGE] {sha}\n"
+        )
+
+    def _run_step(
+        self,
+        tmp_path: Path,
+        *,
+        existing_body: str | None,
+        review_output: str | None,
+    ) -> tuple[Path, "subprocess.CompletedProcess[bytes]"]:
+        bash = _bash()
+        if bash is None or shutil.which("jq") is None:
+            pytest.skip("GPT comment upsert test requires Bash and jq")
+        if os.name == "nt":
+            pytest.skip("stubbed-PATH gh interception is exercised on POSIX runners")
+
+        stub_dir = tmp_path / "stub"
+        stub_dir.mkdir()
+        calls_dir = tmp_path / "calls"
+        calls_dir.mkdir()
+        runner_temp = tmp_path / "runner-temp"
+        runner_temp.mkdir()
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+
+        finder_file = tmp_path / "finder-comments.json"
+        if existing_body is None:
+            finder_file.write_text("[]", encoding="utf-8")
+        else:
+            finder_file.write_text(
+                json.dumps(
+                    [
+                        {"id": 999, "user": {"login": "mallory"}, "body": existing_body},
+                        {"id": 123, "user": {"login": "github-actions[bot]"}, "body": existing_body},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+        if review_output is not None:
+            (cwd / "codex-review-output.md").write_text(review_output, encoding="utf-8")
+
+        gh_stub = stub_dir / "gh"
+        gh_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            "# Emulates the two gh surfaces the step uses; records mutations.\n"
+            "# The finder branch runs the step's REAL --jq filter with real jq\n"
+            "# over an array fixture, so a drift in the filter (dropped @json,\n"
+            "# changed author guard) fails these tests instead of hiding.\n"
+            'if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "PATCH" ]; then\n'
+            '  printf \'%s\\n\' "$4" >> "$STUB_CALLS/patch-calls.txt"\n'
+            '  for a in "$@"; do\n'
+            '    case "$a" in body=*) printf \'%s\' "${a#body=}" > "$STUB_CALLS/patched-body.md";; esac\n'
+            "  done\n"
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "api" ]; then\n'
+            "  filter=\"\"\n"
+            "  grab=0\n"
+            '  for a in "$@"; do\n'
+            '    if [ "$grab" = 1 ]; then filter="$a"; grab=0; fi\n'
+            '    [ "$a" = "--jq" ] && grab=1\n'
+            "  done\n"
+            '  jq -r "$filter" < "$FINDER_COMMENTS_FILE"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then\n'
+            "  shift 3\n"
+            '  if [ "$1" = "--body-file" ]; then cp "$2" "$STUB_CALLS/created-body.md"; fi\n'
+            "  exit 0\n"
+            "fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        gh_stub.chmod(0o755)
+
+        script = _step_script(_workflow("codex-review.yml"), "Post/update review comment")
+        script_file = tmp_path / "step.sh"
+        script_file.write_text(script, encoding="utf-8")
+
+        env = {
+            **os.environ,
+            "PATH": f"{stub_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "REPO": "example/repo",
+            "PR": "1",
+            "HEAD": self.HEAD,
+            "HUMAN_OVERRIDE": "false",
+            "OVERRIDE_ACTOR": "",
+            "OVERRIDE_SOURCE": "",
+            "GH_TOKEN": "stub-token",
+            "RUNNER_TEMP": str(runner_temp),
+            "STUB_CALLS": str(calls_dir),
+            "FINDER_COMMENTS_FILE": str(finder_file),
+        }
+        # GitHub runs `run:` blocks with `bash -e {0}` when no shell is set.
+        result = subprocess.run(
+            [bash, "-e", str(script_file)],
+            check=False,
+            capture_output=True,
+            cwd=cwd,
+            env=env,
+        )
+        return calls_dir, result
+
+    def test_incomplete_run_never_overwrites_a_posted_verdict(self, tmp_path: Path) -> None:
+        # The existing comment already carries a notice from an earlier
+        # incomplete run: the new notice must REPLACE it, not stack.
+        existing = (
+            f"{self.MARKER}\n"
+            "<!-- codex-stale-notice-begin -->\n"
+            "> ⚠️ **Stale verdict notice (2026-01-01 00:00 UTC):** a later GPT 5.6 run did not produce a completed verdict for `feedbead`; the verdict below is from an earlier completed run. Inspect the GPT 5.6 Review job logs and re-run the workflow.\n"
+            "<!-- codex-stale-notice-end -->\n"
+            "\n" + self._verdict_body(self.OLD).removeprefix(f"{self.MARKER}\n")
+        )
+        calls, result = self._run_step(tmp_path, existing_body=existing, review_output=None)
+
+        assert result.returncode == 0, result.stderr.decode()
+        patched = (calls / "patched-body.md").read_text(encoding="utf-8")
+        # The comment finder keys on startswith(marker): the merged body must
+        # keep the marker as its first line.
+        assert patched.startswith(f"{self.MARKER}\n")
+        # The old verdict stays visible, markers included.
+        assert f"[BLOCK-MERGE] {self.OLD}" in patched
+        assert f"[GPT-REVIEWED] {self.OLD}" in patched
+        assert "🔴 changes requested (blocking)" in patched
+        # Exactly ONE dated notice, naming the sha whose run failed.
+        assert patched.count("<!-- codex-stale-notice-begin -->") == 1
+        assert f"did not produce a completed verdict for `{self.HEAD}`" in patched
+        assert "feedbead" not in patched
+        # The incomplete body itself must not have replaced the verdict.
+        assert "## GPT 5.6 Review — ⚠️ review incomplete" not in patched
+        assert not (calls / "created-body.md").exists()
+        # The author guard ran inside the real filter: the PATCH must target
+        # the bot's comment (123), not the marker-planting impostor's (999).
+        patch_calls = (calls / "patch-calls.txt").read_text(encoding="utf-8")
+        assert "/comments/123" in patch_calls
+        assert "/comments/999" not in patch_calls
+
+    def test_a_verdict_that_quotes_the_notice_markers_is_not_truncated(self, tmp_path: Path) -> None:
+        # The preserved body embeds model-authored review prose. A finding
+        # that QUOTES the notice markers — inline or as a bare fenced line —
+        # must not start an unbounded delete: the notice strip is
+        # line-anchored and bounded to the head window, so quoted markers in
+        # the verdict text survive and the trailing [BLOCK-MERGE] marker
+        # stays visible.
+        existing = (
+            f"{self.MARKER}\n"
+            "## GPT 5.6 Review — 🔴 changes requested (blocking)\n"
+            "\n"
+            "GPT 5.6 found at least one blocking issue that must be resolved"
+            f" before merging `{self.OLD}`.\n"
+            "\n"
+            "_This comment is updated in place on each push._\n"
+            "\n"
+            "BLOCKING — .github/workflows/codex-review.yml:727 — the sed range"
+            " keyed on <!-- codex-stale-notice-begin --> can over-delete\n"
+            "Quoted reproduction of the notice block:\n"
+            "```\n"
+            "<!-- codex-stale-notice-begin -->\n"
+            "> a quoted notice line\n"
+            "```\n"
+            f"[GPT-REVIEWED] {self.OLD}\n"
+            f"[BLOCK-MERGE] {self.OLD}\n"
+        )
+        calls, result = self._run_step(tmp_path, existing_body=existing, review_output=None)
+
+        assert result.returncode == 0, result.stderr.decode()
+        patched = (calls / "patched-body.md").read_text(encoding="utf-8")
+        # The verdict and its markers survive the notice cleanup.
+        assert f"[GPT-REVIEWED] {self.OLD}" in patched
+        assert f"[BLOCK-MERGE] {self.OLD}" in patched
+        assert "can over-delete" in patched
+        assert "> a quoted notice line" in patched
+        # And the fresh notice was still prepended exactly once.
+        assert f"did not produce a completed verdict for `{self.HEAD}`" in patched
+
+    def test_completed_verdict_still_replaces_the_comment(self, tmp_path: Path) -> None:
+        review_output = f"FINDINGS\n[GPT-REVIEWED] {self.HEAD}\n[BLOCK-MERGE] {self.HEAD}\n"
+        calls, result = self._run_step(
+            tmp_path,
+            existing_body=self._verdict_body(self.OLD),
+            review_output=review_output,
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        patched = (calls / "patched-body.md").read_text(encoding="utf-8")
+        # A completed verdict replaces the comment wholesale, exactly as before.
+        assert patched.startswith(f"{self.MARKER}\n")
+        assert f"[BLOCK-MERGE] {self.HEAD}" in patched
+        assert f"[GPT-REVIEWED] {self.OLD}" not in patched
+        assert "<!-- codex-stale-notice-begin -->" not in patched
+        assert not (calls / "created-body.md").exists()
+
+    def test_incomplete_with_no_existing_comment_creates_as_before(self, tmp_path: Path) -> None:
+        calls, result = self._run_step(tmp_path, existing_body=None, review_output=None)
+
+        assert result.returncode == 0, result.stderr.decode()
+        created = (calls / "created-body.md").read_text(encoding="utf-8")
+        assert created.startswith(f"{self.MARKER}\n")
+        assert "⚠️ review incomplete" in created
+        assert "<!-- codex-stale-notice-begin -->" not in created
+        assert not (calls / "patched-body.md").exists()
+
+    def test_guard_is_scoped_to_the_post_step_and_gate_is_untouched(self) -> None:
+        workflow = _workflow("codex-review.yml")
+
+        # The body is captured in the SAME query that finds the id, before any
+        # PATCH decision, one compact line per match.
+        assert "| {id, body} | @json" in workflow
+        # The guard tests the marker against a FILE with grep -Fq, mirroring
+        # the step's existing marker checks — bodies never enter shell strings.
+        assert 'grep -Fq "[GPT-REVIEWED]"' in workflow
+        # The gate's fail-closed contract is byte-identical to before.
+        gate = _step_script(workflow, "Gate on findings")
+        assert 'if ! grep -Fq "$reviewed" codex-review-output.md; then' in gate
+        assert "Failing closed" in gate
+        assert "stale-notice" not in gate


### PR DESCRIPTION
## Problem / Motivation

The `Post/update review comment` step in `.github/workflows/codex-review.yml` publishes the GPT review verdict by PATCHing a single comment in place, keyed by the hidden `<!-- codex-ai-review -->` marker. The step defaults `kind="incomplete"` and unconditionally PATCHes, so a run that fails to produce `codex-review-output.md` replaces a posted `[BLOCK-MERGE]` verdict with a short "review incomplete" body. The REST comments API exposes no edit history, so the buried verdict survives only in GraphQL `userContentEdits` — invisible everywhere a normal reader or tool looks. Verified by the reporter on PR #8184 comment 5528347174: 3 of its 10 revisions were incomplete bodies, each replacing a marker-present blocking verdict, including a security finding.

## Why it matters

A blocking security finding silently vanishing from the one comment reviewers read defeats the purpose of the review lane. Merge safety was never at risk (the `Gate on findings` step fails closed on the output file, not the comment), but a human scanning the PR sees "review incomplete" where a red verdict used to be, and nothing says a verdict ever existed.

## What changed (motivation → approach → change)

Symptom: incomplete bodies overwrite completed verdicts. Root cause: the upsert PATCHes unconditionally, never looking at what it is replacing. Change, scoped to the `Post/update review comment` step only:

- The finder query now captures the existing comment's **body in the same query** that finds its id (`{id, body} | @json` — one compact line per match, so `head -n1` still selects a whole record; author guard unchanged). Captured before any PATCH decision, so there is no find/fetch race. The fetched body is CRLF-normalized (`tr -d '\r'`) before matching, because GitHub stores comment bodies with CRLF line endings and the guard's grep and line-anchored cleanup must see the bytes the step originally wrote.
- **One guarded transition**: if the new body is the `incomplete` kind AND the existing body contains `[GPT-REVIEWED]` (tested with `grep -Fq` against a file, never in a shell string), the step does NOT replace the verdict. It re-posts the existing verdict with one dated stale-verdict notice prepended (with the `/ai-review override` escape hatch), replacing any notice a previous incomplete run left so notices never stack. Invariant: a verdict that exists never becomes invisible.
- The notice cleanup is **line-anchored and bounded to the head window** (lines 1–8, where the step's own notice always sits by construction): the preserved body embeds model-authored review prose, so an unanchored range keyed on the notice markers would let a finding that merely quotes them delete the verdict to EOF — found by both pre-push reviewers, locked in by a dedicated test.
- `override` / `blocked` / `clear` kinds still replace the comment exactly as before. The `Gate on findings` step is byte-identical: fail-closed on incomplete stays, and a preserved stale verdict is SHA-scoped so no consumer reads it as fresh (`sha_matches()` rejects the old SHA).
- Comment scratch files moved from hardcoded `/tmp` to `"${RUNNER_TEMP:-/tmp}"` (always set on GitHub runners; behavior-identical there) so the step's bash body is hermetically testable.
- `docs/ci/ci-and-reviews.md` documents the new upsert semantics, scoped to the same-repo GPT lane.

Known remaining gaps (out of scope per the issue): two fork lanes carry the same defect class — `fork-gpt-review.yml`'s `Post/update summary comment` and `fork-opus-review.yml`'s comment upsert both PATCH an incomplete body over a posted verdict unconditionally. Both are tracked in follow-up #8344. (`claude-review.yml` is already safe: it posts nothing on incomplete. That skip shape was considered and not chosen here because the issue names the dated notice as the preferred form — see the First Principles disposition on this PR.)

## Tests

New `TestGptVerdictVisibility` class in `test/test_ai_review_workflows.py` runs the **real step bash** (extracted via the file's existing `_step_script` helper) with a stubbed `gh` whose finder branch executes the step's **real `--jq` filter** through real `jq` over an array fixture — so filter drift (dropped `@json`, lost author guard) fails the tests instead of hiding:

- (a) incomplete-over-verdict → verdict + markers preserved, exactly one dated notice, PATCH targets the bot's comment (not a marker-planting impostor's)
- (b) completed verdict over anything → replaced wholesale, as before
- (c) incomplete with no existing comment → created, as before
- (d) verdict prose that quotes the notice markers (inline and as a bare fenced line) → never truncated, `[BLOCK-MERGE]` survives
- static scope assertion: same-query capture present, `Gate on findings` untouched

Mutation-verified: disabling the guard condition, dropping the notice-dedup, reverting to the unanchored sed, and dropping the author guard each make the suite fail. Full backend suite: 84,514 passed; fail-set byte-identical to a clean-main control on the same host (all host-env classes).

## Manual verification

Three-case transcript from running the step's bash body with stubbed `gh` (sha `1234…5678` = new head whose run failed; `aaaa…aaaa` = old completed verdict):

### CASE (a): incomplete run over existing BLOCKING verdict → verdict preserved + dated notice
gh-stub: PATCH repos/example/repo/issues/comments/123
Preserved GPT 5.6 verdict in comment #123; prepended incomplete-run notice for 1234567890abcdef1234567890abcdef12345678
```markdown
<!-- codex-ai-review -->
<!-- codex-stale-notice-begin -->
> ⚠️ **Stale verdict notice (2026-09-04 00:50 UTC):** a later GPT 5.6 run did not produce a completed verdict for `1234567890abcdef1234567890abcdef12345678`; the verdict below is from an earlier completed run. Inspect the GPT 5.6 Review job logs and re-run the workflow, or have a repository writer comment `/ai-review override gpt 1234567890abcdef1234567890abcdef12345678: <one-sentence reason>`.
<!-- codex-stale-notice-end -->

## GPT 5.6 Review — 🔴 changes requested (blocking)

GPT 5.6 found at least one blocking issue that must be resolved before merging `aaaa567890abcdef1234567890abcdef1234aaaa`.

SECURITY finding: example.
[GPT-REVIEWED] aaaa567890abcdef1234567890abcdef1234aaaa
[BLOCK-MERGE] aaaa567890abcdef1234567890abcdef1234aaaa```

### CASE (b): completed BLOCKING verdict over existing comment → replaced wholesale (as before)
gh-stub: PATCH repos/example/repo/issues/comments/123
Updated existing GPT 5.6 comment #123
```markdown
<!-- codex-ai-review -->
## GPT 5.6 Review — 🔴 changes requested (blocking)

GPT 5.6 found at least one blocking issue that must be resolved before merging `1234567890abcdef1234567890abcdef12345678`.

_This comment is updated in place on each push._

FINDINGS...
...
```

### CASE (c): incomplete run, no existing comment → created (as before)
gh-stub: CREATE comment
Created new GPT 5.6 comment
```markdown
<!-- codex-ai-review -->
## GPT 5.6 Review — ⚠️ review incomplete

GPT 5.6 did not produce a complete verdict for `1234567890abcdef1234567890abcdef12345678`; inspect the workflow logs and re-run it.
...
```

## Related Issues

Closes #8292

## Pattern harvest

Rule candidate: review-prompt — Pattern: "in-place upsert of a status artifact must compare old and new state class before replacing; a lower-information state never overwrites a higher-information one". Second and third instances of the class: `fork-gpt-review.yml` and `fork-opus-review.yml` carry the same unconditional PATCH (follow-up #8344); `claude-review.yml` already avoids it by posting nothing on incomplete.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

<!-- no-visual-delta -->
**Why no screenshot:** CI workflow + backend test + doc change only; no UI surface is touched.

