### PR TITLE
fix(dashboard): sort the project tree listing before the 10k cap

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -4951,7 +4951,25 @@ async def api_project_tree(request: web.Request) -> web.Response:
                 timeout=15,
             )
             if ls_rc == 0:
-                listed = [p for p in ls_out.split("\0") if p]
+                # SORT BEFORE THE CAP. `ls-files --cached --others` is not one
+                # sorted stream: git emits every untracked entry as a complete
+                # block and only then the tracked ones (its own emission order
+                # -- unchanged if the flags are written the other way round, and
+                # git-ls-files(1) documents no order at all). A prefix cut of
+                # that therefore never reaches the tracked block once untracked
+                # alone fill the cap, and the whole source tree loses its rows:
+                # the dashboard infers a directory row only from the file paths
+                # present, so those folders go absent rather than collapsed.
+                # Sorting spends the budget by path instead of by whichever
+                # block git happened to emit first. It does NOT make the two
+                # branches emit the same order: the fallback walk below sorts
+                # within each level but is depth-first overall, so it yields a
+                # root `z.txt` before `a/x` where sorted() orders them the other
+                # way. What the branches share is narrower and is the actual
+                # warrant for sorting here -- this handler establishes its own
+                # path order rather than passing through a source's arbitrary
+                # emission order.
+                listed = sorted(p for p in ls_out.split("\0") if p)
                 truncated = len(listed) > _PROJECT_TREE_MAX_ENTRIES
                 return {
                     "root": base,

--- a/test/test_project_tree.py
+++ b/test/test_project_tree.py
@@ -237,3 +237,48 @@ class TestProjectTree:
             data = await resp.json()
         assert data["truncated"] is True
         assert len(data["paths"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_cap_does_not_drop_the_whole_tracked_block(self, tmp_path, mock_sel, monkeypatch):
+        """A fat UNTRACKED subtree must not evict every tracked file.
+
+        ``git ls-files --cached --others`` emits all untracked entries as one
+        complete block and only then the tracked ones, so capping with a plain
+        prefix cut never reaches the tracked block once untracked alone fill it
+        -- the whole source tree loses its rows. The listing is sorted before
+        the cut so the budget is spent by path, not by which block git happened
+        to emit first.
+        """
+        from kiro_crew.dashboard.handlers import files as files_mod
+
+        monkeypatch.setattr(files_mod, "_PROJECT_TREE_MAX_ENTRIES", 20)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git(repo, "init", "-q", ".")
+        tracked = ("README.md", "docs/real.py", "src/real.py")
+        for rel in tracked:
+            p = repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("x")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "init")
+        # Untracked (NOT ignored) and larger than the cap on its own. Named to
+        # sort after every tracked path, so a sorted cut reaches them all.
+        fat = repo / "zz_vendor" / "deep"
+        fat.mkdir(parents=True)
+        for i in range(40):
+            (fat / f"u{i:04d}.txt").write_text("x")
+
+        async with TestClient(TestServer(_make_app(str(repo)))) as client:
+            resp = await client.get(f"/api/project/tree?path={repo}")
+            data = await resp.json()
+
+        assert data["repo"] is True
+        assert data["truncated"] is True
+        assert len(data["paths"]) == 20
+        # The point of the fix: every tracked file keeps a row.
+        for rel in tracked:
+            assert rel in data["paths"], f"{rel} was evicted by the untracked block"
+        # ...and the fix does not merely invert the loss: the untracked subtree
+        # still spends the remaining budget, so it keeps a row too.
+        assert any(p.startswith("zz_vendor/") for p in data["paths"])


### PR DESCRIPTION
## Problem / Motivation

`api_project_tree` caps its listing at 10,000 entries with a plain prefix cut. That
is only safe if the list is ordered by path. On the git branch it is not.

`git ls-files --cached --others` does not emit one sorted stream. It emits **every
untracked entry as a complete block, and only then the tracked ones**:

```
zz_vendor/deep/u0000.txt     <- untracked block, in full
...
README.md                    <- tracked block, only after
src/real.py
```

So once untracked files alone fill the cap, the cut never reaches the tracked
block and **every tracked file is dropped**. The dashboard infers a directory row
only from the file paths present (`PierreWorkspaceTreeImpl.tsx` hands the array
straight to `model.resetPaths`, with no directory manifest), so those folders go
*absent* rather than collapsed: no row, nothing to click, subtree unreachable.

This is git's own emission order, not something the call site chose. I get the
identical order with `--others` written before `--cached` (git 2.50.1), and
`git-ls-files(1)` documents no output order at all.

## Why it matters

Today any repository with 10,000+ unignored untracked files shows **no source tree
at all** in the Files panel. It is total loss rather than degradation, and the
directory whose size caused it is the one thing that survives.

An unignored `build/`, `out/`, or a folder of nested clones is enough. Nobody
decided this: the cap's own comment says it "bounds response size and walk time,
not the UI", so it does not claim to select anything.

## What changed (motivation -> approach -> change)

Sort the listing before applying the cap, so the budget is spent by path instead
of by whichever block git happened to emit first.

I chose sorting rather than any smarter selection because this handler already
establishes its own path order rather than passing through a source's arbitrary
emission order: the non-git fallback walk sorts at both levels
(`sorted(dirnames)`, `sorted(filenames)`). Sorting the git branch brings it under
that same principle instead of inventing a new strategy.

**To be exact about what that does and does not claim: the two branches still do
not emit the same order after this change.** The fallback sorts within each level
but is depth-first overall, so it yields a root `z.txt` before `a/x` where
`sorted()` orders them the other way. An earlier revision of this PR and its code
comment claimed the sort "matches the sorted output the fallback walk already
produces" -- that was false and is corrected in both places. What the branches
share is the narrower principle above, which is the actual warrant here; making
the two orders agree is not a goal of this PR and is not achieved by it.

One line of behaviour change plus the comment explaining why:

```python
listed = sorted(p for p in ls_out.split("\0") if p)
```

### Scope -- please read before reviewing

**This does not resolve #8173, and the trailer is `Refs`, not `Fixes`.**

It stops the *total* loss of the tracked tree. It does **not** give #8173 what that
issue asks for: a root-level folder sorting after the fat directory still loses its
row, because a lexicographic prefix cut is still not breadth-fair. #8173 asks for
lazy per-level truncation with every ancestor keeping a clickable row, which needs
a per-directory endpoint, frontend lazy expansion and per-node truncation markers
-- a feature and a wire-format change, and a policy call on whether the 10k cap
survives. That decision is left to a maintainer; #8173 stays open and carries the
measured analysis.

I deliberately did **not** switch to depth-ordered fill (sort by depth, then path),
which *would* restore root rows for realistic trees. It substitutes a strategy
nobody asked for, and it would falsify the shipped string
`pages.chat.activityViewer.workspace_truncated` -- "Large workspace [em dash]
showing the first 10,000 files" -- across twelve locale files, since the kept
entries would be the shallowest rather than the first.

The non-git fallback walk is also not breadth-fair (it is depth-first and `break`s
out of the whole walk, so the first heavy subtree spends the budget). That is the
same class as #8173 and its fix is the same policy call, so it is untouched here.

### Unverified, and flagged deliberately

The wrapper's comment names `appendPresortedPaths`, so sorted input may well be a
precondition of `@pierre/trees` (`1.0.0-beta.6`) that this change happens to
satisfy. **I could not verify that**: the package is not vendored in-tree and I had
no installed copy to read, and an existing test
(`website/src/test/PierreWorkspaceTreeImpl.test.tsx:293`) asserts an *unsorted*
`resetPaths` payload, which suggests the wrapper deliberately does not sort. So I
am not claiming conformance to that contract, and the fix is not justified on it.
If the sort does satisfy an undocumented precondition, that is luck, and whoever
next touches this should know it was not designed for.

## Tests

`test/test_project_tree.py::TestProjectTree::test_cap_does_not_drop_the_whole_tracked_block`
-- a git repo with 3 tracked files and 40 untracked files under `zz_vendor/deep/`,
with `_PROJECT_TREE_MAX_ENTRIES` monkeypatched to 20.

Fails before the change, on the mechanism itself:

```
AssertionError: README.md was evicted by the untracked block
```

Passes after. It also asserts the fix does not merely invert the loss -- the
untracked subtree still spends the remaining budget and keeps its own row.

```
$ python -m pytest test/test_project_tree.py -q
9 passed
```

All 8 pre-existing tests in the file still pass, so the ordering change breaks no
existing assertion. Black gate passes (`scripts/check_black_formatting.py`).

## Manual verification

Measured by driving the real handler (not a simulation) with the cap lowered to 20
so the effect is observable, against main
`711544f3d87a838657349849ad0e9c3883e882d4`:

| | before | after |
|---|---|---|
| root rows returned | `['zz_vendor']` | `['README.md', 'docs', 'src', 'zz_vendor']` |
| tracked files present | `[]` | all 3 |

Also confirmed no consumer depends on the position of entries in `paths`: no
`paths[0]`, `paths.slice`, or `paths.at(` anywhere in `website/src`.

## Related Issues

Refs #8173

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: prefix-truncating a sequence whose ordering came from an external tool's
undocumented emission order rather than one the call site established.

The instance here was `git ls-files`, but nothing about the defect is git-specific:
any `subprocess` output that gets sliced carries it. The tell is a cap or a
`[:N]` applied to a list the call site did not order, where the source documents
no order and is free to change one. The truncation then silently encodes the
tool's internal grouping as a selection policy -- and it fails hardest exactly
when the data is large, which is when nobody is watching closely.
