### PR TITLE
fix(ci): stop fork GPT lane hiding a verdict behind an incomplete run (#8292)

### DIFF
--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -986,12 +986,63 @@ jobs:
               echo "</details>"
             fi
           } > /tmp/fork-codex-comment.md
-          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null | head -n1 || true)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" --field body="$(cat /tmp/fork-codex-comment.md)" >/dev/null || true
+          # Find the bot's existing marker comment (first match wins) and
+          # capture its id. Guards:
+          #   - author filter: only a github-actions[bot] comment can match, so a
+          #     PR commenter cannot plant the marker and have this step PATCH
+          #     their comment with the write-scoped token.
+          #   - per-page jq: with --paginate the --jq filter runs PER PAGE.
+          # An incomplete run never modifies an existing comment (see below), so
+          # only the id is needed here: no body capture, no PATCH decision that
+          # depends on the current body.
+          # Capture the paginated query's FULL output first so its own exit
+          # status alone decides lookup_ok. Piping straight into `head -n1`
+          # would let `head` close the pipe after the first of several matches
+          # (a marker duplicated across API pages) and, under `set -o pipefail`,
+          # make the whole pipeline non-zero -- misreading a successful lookup as
+          # a failure. So select the first id in a second step off the captured
+          # value.
+          lookup_ok=1
+          all_matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null)" || lookup_ok=0
+          existing="$(printf '%s\n' "$all_matches" | head -n1)"
+          if [ "$kind" = "incomplete" ]; then
+            # Stale-read race (#8292): an incomplete run NEVER modifies an
+            # existing comment, whether or not it carries [GPT-REVIEWED].
+            # Overlapping runs for different SHAs can read this comment before a
+            # newer run PATCHes its verdict in; an incomplete run that read first
+            # would otherwise clobber the newer run's just-published verdict with
+            # its own "review incomplete" body, and even a PATCH that only
+            # preserved the verdict and prepended a notice would restore the
+            # stale body it read. So when a comment already exists -- OR the
+            # lookup could not confirm one does not (a transient API error must
+            # not be read as "no comment", which would send this incomplete run
+            # to the create path and post a spurious marker over a live verdict)
+            # -- leave it untouched and emit a diagnostic only. Only when the
+            # lookup SUCCEEDED and found nothing does an incomplete run create
+            # the first "review incomplete" placeholder. The fail-closed
+            # "Finalize check-run" step still gates merge, so an incomplete run
+            # is never mistaken for an approval; the fork lane has no override.
+            if [ "$lookup_ok" -eq 0 ]; then
+              echo "Incomplete run for $HEAD; lookup failed, skipping to avoid posting a spurious marker over a possibly-live verdict"
+            elif [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              echo "Incomplete run for $HEAD; left existing comment #$existing untouched to avoid overwriting a newer verdict"
+            else
+              gh pr comment "$PR" --body-file /tmp/fork-codex-comment.md || true
+            fi
           else
-            gh pr comment "$PR" --body-file /tmp/fork-codex-comment.md || true
+            # A completed verdict (blocked/clear) must become visible. If the
+            # lookup succeeded and found the marker, PATCH it in place; otherwise
+            # -- no existing comment, OR the lookup failed so we cannot confirm
+            # one -- create. A duplicate comment on a transient error is far more
+            # recoverable than a real verdict that never posts, so a completed
+            # run always publishes rather than staying silent.
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat /tmp/fork-codex-comment.md)" >/dev/null || true
+            else
+              gh pr comment "$PR" --body-file /tmp/fork-codex-comment.md || true
+            fi
           fi
 
       # Fail-CLOSED finalize of the required "GPT 5.6 Review" check-run, keyed to

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -766,6 +766,19 @@ of that name -- the same-repo twin renames itself (see the reviewer-job security
 posture above) -- so the protected status can only be reported by a review that
 actually ran.
 
+`fork-gpt-review.yml` publishes its GPT verdict by editing one marker comment in
+place, so an incomplete run must never bury a posted verdict (the class of bug tracked
+as #8292). It goes further than a preserve-and-prepend approach: an incomplete run never
+modifies an existing comment at all. Overlapping runs for different SHAs can read the
+comment before a newer run publishes its verdict, so an incomplete run that read verdict
+V1 first must not PATCH V1 back over a newer run's V2 that landed in between -- and even
+a PATCH that only preserved the verdict and prepended a notice would restore that stale
+body. So when an existing bot comment is present, an incomplete run leaves it entirely
+untouched (a diagnostic log line only), whether or not it carries a `[GPT-REVIEWED]`
+verdict. Completed and blocked verdicts still replace the comment as before, and the
+fail-closed `Finalize check-run` step is unchanged, so an incomplete run is never
+mistaken for an approval and merge safety is unaffected.
+
 Nothing the fork controls can influence these reviews:
 
 - `workflow_run` **always** runs the workflow definition from the **default branch**,

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -4191,3 +4191,361 @@ class TestGptVerdictVisibility:
         assert 'if ! grep -Fq "$reviewed" codex-review-output.md; then' in gate
         assert "Failing closed" in gate
         assert "stale-notice" not in gate
+
+
+# The fork step writes its comment body to the workflow's hardcoded
+# `/tmp/fork-codex-comment.md` (a fork-lane idiom that is safe on an isolated CI
+# runner). These host-side cases exercise the REAL step, so `_run` rewrites that
+# absolute path under each test's own `tmp_path` before executing it: the writes
+# stay off the operator's machine and never race each other across xdist workers.
+class TestForkGptVerdictVisibility:
+    """The fork GPT lane must never bury a posted verdict under an incomplete body.
+
+    ``fork-gpt-review.yml``'s ``Post/update summary comment`` step publishes its
+    verdict by editing ONE marker comment in place. A later incomplete run used
+    to PATCH that slot unconditionally, so a real ``[BLOCK-MERGE]`` verdict got
+    overwritten by a short "review incomplete" body -- recoverable only through
+    GraphQL ``userContentEdits``, which no REST reader or tool consults (#8292).
+    An incomplete run therefore NEVER modifies an existing comment: not even to
+    preserve the verdict and prepend a stale notice, because the preserving
+    PATCH is itself a stale-read overwrite (#8350) -- an incomplete run that
+    read verdict V1 would PATCH V1 back over a newer run's V2 that landed in
+    between. So when an existing bot comment is present, an incomplete run
+    leaves it entirely untouched (a diagnostic echo only); only blocked/clear
+    runs PATCH it. Each contract case runs the REAL fork step bash with a
+    stubbed ``gh``.
+
+    The fork lane differs from the same-repo lane: the step runs under
+    ``set -uo pipefail`` with ``if: always()``, reads a cwd-relative
+    ``codex-review-output.md`` to decide ``kind`` (incomplete/blocked/clear --
+    there is NO human-override kind and NO override footer), and swallows gh
+    errors with ``|| true``.
+    """
+
+    MARKER = "<!-- codex-ai-review -->"
+    HEAD = "f" * 40
+    OLD_HEAD = "a" * 40
+    BOT_COMMENT_ID = "555"
+    IMPOSTOR_COMMENT_ID = "666"
+
+    def _step(self) -> str:
+        return _step_script(_workflow("fork-gpt-review.yml"), "Post/update summary comment")
+
+    def _gh_stub(
+        self, comments_json: Path, patch_log: Path, created_log: Path, *, lookup_fails: bool = False
+    ) -> str:
+        """A gh stub that answers the three calls this step makes.
+
+        ``gh api .../comments --paginate --jq <f>``: runs the step's own jq
+        filter over an array fixture that holds both an impostor ``mallory``
+        comment and the ``github-actions[bot]`` comment, so the author guard is
+        exercised for real. ``gh api --method PATCH ...``: records the target id
+        and stdin body. ``gh pr comment ...``: records the created body.
+        """
+        return (
+            "#!/usr/bin/env bash\n"
+            'if [ "${1:-}" = "api" ] && [ "${2:-}" = "--method" ] && [ "${3:-}" = "PATCH" ]; then\n'
+            f'  printf \'%s\\n\' "$4" >> "{patch_log}"\n'
+            "  # --field body=<value> follows; find it and record the value.\n"
+            "  shift 4\n"
+            '  while [ "$#" -gt 0 ]; do\n'
+            '    case "$1" in\n'
+            f'      body=*) printf \'%s\' "${{1#body=}}" >> "{patch_log}" ;;\n'
+            '      --field) shift; printf \'%s\' "${1#body=}" >> "' + str(patch_log) + '" ;;\n'
+            "    esac\n"
+            "    shift\n"
+            "  done\n"
+            "  exit 0\n"
+            "fi\n"
+            'if [ "${1:-}" = "api" ]; then\n'
+            # A lookup FAILURE: the comments-list API errors (network/5xx).
+            # The step must not treat the empty output as "no comment".
+            + ("  echo 'gh: API error' >&2\n  exit 1\n" if lookup_fails else "")
+            + "  # Locate the --jq filter and apply it to the array fixture.\n"
+            "  # `gh api --jq` emits RAW output (like `jq -r`), so an @json\n"
+            "  # record prints as compact JSON with no surrounding quotes --\n"
+            "  # the step's `jq -r '.id'` then reparses that line as an object.\n"
+            '  filter=""\n'
+            '  while [ "$#" -gt 0 ]; do\n'
+            '    if [ "$1" = "--jq" ]; then shift; filter="$1"; fi\n'
+            "    shift\n"
+            "  done\n"
+            f'  jq -r "$filter" "{comments_json}"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; then\n'
+            "  # --body-file <path> is the last pair.\n"
+            '  file=""\n'
+            '  while [ "$#" -gt 0 ]; do\n'
+            '    if [ "$1" = "--body-file" ]; then shift; file="$1"; fi\n'
+            "    shift\n"
+            "  done\n"
+            f'  cat "$file" >> "{created_log}"\n'
+            "  exit 0\n"
+            "fi\n"
+            'echo "unexpected gh call: $*" >&2\n'
+            "exit 9\n"
+        )
+
+    def _run(
+        self,
+        tmp_path: Path,
+        *,
+        comments: list[dict],
+        review_output: str | None,
+        lookup_fails: bool = False,
+    ) -> tuple[subprocess.CompletedProcess, Path, Path]:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the step is Bash; skip where Bash is absent")
+        if shutil.which("jq") is None:
+            pytest.skip("the step shells out to jq")
+
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        comments_json = tmp_path / "comments.json"
+        comments_json.write_text(json.dumps(comments), encoding="utf-8")
+        patch_log = tmp_path / "patch.log"
+        patch_log.touch()
+        created_log = tmp_path / "created.log"
+        created_log.touch()
+
+        (bin_dir / "gh").write_text(
+            self._gh_stub(comments_json, patch_log, created_log, lookup_fails=lookup_fails),
+            encoding="utf-8",
+        )
+        (bin_dir / "gh").chmod(0o755)
+
+        # The step reads a cwd-relative codex-review-output.md to decide `kind`.
+        # Absent/empty output => incomplete; markers present => blocked/clear.
+        if review_output is not None:
+            (tmp_path / "codex-review-output.md").write_text(review_output, encoding="utf-8")
+
+        runner_temp = tmp_path / "runner-temp"
+        runner_temp.mkdir()
+
+        # The step writes its new comment body to the workflow's HARDCODED
+        # `/tmp/fork-codex-comment.md` (a fork-lane idiom that is safe on an
+        # isolated CI runner). A test must not touch the operator's machine, so
+        # redirect that absolute path under `tmp_path` before running the real
+        # step (AGENTS.md: no test side effects, a spawn's writes stay under
+        # `tmp_path`). The step's other temp files already honour RUNNER_TEMP.
+        comment_file = tmp_path / "fork-codex-comment.md"
+        step = self._step().replace("/tmp/fork-codex-comment.md", str(comment_file))
+        assert "/tmp/fork-codex-comment.md" not in step
+
+        proc = subprocess.run(
+            # GitHub executes run-blocks as `bash -e {0}`.
+            [bash, "-e", "-c", step],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env={
+                **os.environ,
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": "stub",
+                "REPO": "o/r",
+                "PR": "1",
+                "HEAD": self.HEAD,
+                "RUNNER_TEMP": str(runner_temp),
+            },
+            cwd=tmp_path,
+        )
+        assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+        return proc, patch_log, created_log
+
+    def _fixture_comments(self, bot_body: str) -> list[dict]:
+        """An array with an impostor first, then the bot's marker comment.
+
+        The impostor plants the marker under a non-bot login: the author guard
+        (`.user.login == "github-actions[bot]"`) must reject it, so a match on
+        it would prove the guard is not exercised.
+        """
+        return [
+            {
+                "id": int(self.IMPOSTOR_COMMENT_ID),
+                "user": {"login": "mallory"},
+                "body": f"{self.MARKER}\nnice try",
+            },
+            {
+                "id": int(self.BOT_COMMENT_ID),
+                "user": {"login": "github-actions[bot]"},
+                "body": bot_body,
+            },
+        ]
+
+    def _blocking_verdict_body(self, head: str, *, extra: str = "") -> str:
+        """A prior completed BLOCK-MERGE verdict comment body, CRLF like GitHub."""
+        lines = [
+            self.MARKER,
+            "## GPT 5.6 Review (fork) — 🔴 changes requested (blocking)",
+            "",
+            f"_Reviewed `{head}` via the fork AI-review pipeline; updated in place on each push._",
+            "",
+            f"[GPT-REVIEWED] {head}",
+            f"[BLOCK-MERGE] {head}",
+            "",
+            "A real blocking finding lives here.",
+        ]
+        if extra:
+            lines.append(extra)
+        # GitHub returns bodies with CRLF; the step must normalize before grep.
+        return "\r\n".join(lines)
+
+    def test_incomplete_run_never_overwrites_a_posted_verdict(self, tmp_path: Path) -> None:
+        # A completed BLOCK-MERGE verdict already sits in the bot comment. An
+        # incomplete run must leave that comment ENTIRELY untouched: no PATCH,
+        # no create. Even a PATCH that "only" preserved the verdict and
+        # prepended a notice is itself the stale-read overwrite (#8350): the
+        # incomplete run read verdict V1, and PATCHing V1 (with a notice) back
+        # would clobber a newer run's V2 that landed in between. So no edit of
+        # any kind may target this comment.
+        verdict_body = self._blocking_verdict_body(self.OLD_HEAD)
+        comments = self._fixture_comments(verdict_body)
+        # review_output=None => the step's `kind` stays "incomplete".
+        _proc, patch_log, created_log = self._run(
+            tmp_path, comments=comments, review_output=None
+        )
+
+        # No PATCH targeted the bot comment (nor the impostor's), and no new
+        # comment was created. A revert to the old preserve-and-prepend PATCH
+        # would record a PATCH here and fail this assertion.
+        assert patch_log.read_text(encoding="utf-8") == ""
+        assert created_log.read_text(encoding="utf-8") == ""
+
+    def test_completed_verdict_still_replaces_the_comment_wholesale(self, tmp_path: Path) -> None:
+        # A completed run for the new HEAD must replace the old body outright:
+        # no stale-notice, old markers gone, new HEAD markers present.
+        old_body = self._blocking_verdict_body(self.OLD_HEAD)
+        comments = self._fixture_comments(old_body)
+        review_output = (
+            f"[GPT-REVIEWED] {self.HEAD}\n"
+            f"[BLOCK-MERGE] {self.HEAD}\n"
+            "Fresh blocking finding.\n"
+        )
+        _proc, patch_log, created_log = self._run(
+            tmp_path, comments=comments, review_output=review_output
+        )
+
+        patched = patch_log.read_text(encoding="utf-8")
+        # PATCH still targets the bot comment.
+        assert self.BOT_COMMENT_ID in patched
+        # New HEAD markers present; old HEAD markers gone.
+        assert f"[BLOCK-MERGE] {self.HEAD}" in patched
+        assert self.OLD_HEAD not in patched
+        # No stale-notice on a wholesale replace.
+        assert "codex-stale-notice-begin" not in patched
+        assert "did not produce a completed verdict" not in patched
+        assert created_log.read_text(encoding="utf-8") == ""
+
+    def test_incomplete_run_never_overwrites_a_marker_absent_comment(self, tmp_path: Path) -> None:
+        # Stale-read race (#8292): overlapping runs for different SHAs. An older
+        # incomplete run reads the bot comment BEFORE a newer run PATCHes its
+        # verdict in, so at read time the body carries no `[GPT-REVIEWED]`
+        # marker yet. The older incomplete run must NOT PATCH -- doing so would
+        # clobber the newer run's just-published verdict with a "review
+        # incomplete" body, re-hiding the finding. An incomplete body never
+        # overwrites an existing comment, marker-present or not.
+        marker_absent_body = "\r\n".join(
+            [
+                self.MARKER,
+                "## GPT 5.6 Review (fork) — ⏳ review incomplete",
+                "",
+                "_No completed GPT verdict for this commit; see the Fork GPT 5.6 Review job logs._",
+            ]
+        )
+        comments = self._fixture_comments(marker_absent_body)
+        # review_output=None => the step's `kind` stays "incomplete".
+        _proc, patch_log, created_log = self._run(
+            tmp_path, comments=comments, review_output=None
+        )
+
+        # The incomplete run left the existing comment untouched: no PATCH, no
+        # new comment. A revert of the workflow fix (unconditional PATCH in the
+        # else branch) would record a PATCH here and fail this assertion.
+        assert patch_log.read_text(encoding="utf-8") == ""
+        assert created_log.read_text(encoding="utf-8") == ""
+
+    def test_incomplete_run_with_no_existing_comment_creates_as_before(self, tmp_path: Path) -> None:
+        # No bot comment exists (only the impostor). An incomplete run creates a
+        # fresh comment carrying the marker and the incomplete verdict, with no
+        # stale-notice and no PATCH.
+        comments = [
+            {
+                "id": int(self.IMPOSTOR_COMMENT_ID),
+                "user": {"login": "mallory"},
+                "body": f"{self.MARKER}\nnice try",
+            },
+        ]
+        _proc, patch_log, created_log = self._run(
+            tmp_path, comments=comments, review_output=None
+        )
+
+        created = created_log.read_text(encoding="utf-8")
+        assert created.startswith(self.MARKER)
+        assert "⚠️ review incomplete" in created
+        assert "codex-stale-notice-begin" not in created
+        # No PATCH happened -- nothing to edit.
+        assert patch_log.read_text(encoding="utf-8") == ""
+
+    def test_step_source_carries_the_fix_and_leaves_finalize_untouched(self) -> None:
+        # Static guards: an incomplete run over an existing comment does NOTHING
+        # to it, and the fail-closed finalize step (the fork analogue of
+        # codex-review.yml's "Gate on findings") is untouched by the fix.
+        workflow = _workflow("fork-gpt-review.yml")
+        comment_step = _step_script(workflow, "Post/update summary comment")
+        # The incomplete branch leaves the comment untouched (diagnostic only),
+        # so only the else branch (blocked/clear) PATCHes the existing comment.
+        assert 'if [ "$kind" = "incomplete" ]; then' in comment_step
+        assert "left existing comment #$existing untouched" in comment_step
+        # No stale-notice construction survives anywhere in the step: nothing
+        # writes a notice, builds a merged body, or strips one with sed.
+        assert "codex-stale-notice" not in comment_step
+        assert "fork-codex-merged-comment" not in comment_step
+        assert "fork-codex-existing-comment" not in comment_step
+        # The fork lane has NO human-override footer.
+        assert "/ai-review override" not in comment_step
+
+        finalize_step = _step_script(workflow, "Finalize check-run (fail closed)")
+        assert "stale-notice" not in finalize_step
+
+    def test_incomplete_run_on_lookup_failure_neither_patches_nor_creates(
+        self, tmp_path: Path
+    ) -> None:
+        # An INCOMPLETE run: a transient comments-list API failure must NOT be
+        # read as "no existing comment", which would send it down the create
+        # path and post a fresh "review incomplete" marker over a verdict that
+        # is really still there. So an incomplete run whose lookup failed makes
+        # no edit of any kind (diagnostic only); the fail-closed finalize step
+        # still gates merge.
+        verdict_body = self._blocking_verdict_body(self.OLD_HEAD)
+        comments = self._fixture_comments(verdict_body)
+        proc, patch_log, created_log = self._run(
+            tmp_path, comments=comments, review_output=None, lookup_fails=True
+        )
+
+        assert patch_log.read_text(encoding="utf-8") == ""
+        assert created_log.read_text(encoding="utf-8") == ""
+        assert "lookup failed" in proc.stdout.lower() or "skipping" in proc.stdout.lower()
+
+    def test_completed_run_on_lookup_failure_still_publishes_the_verdict(
+        self, tmp_path: Path
+    ) -> None:
+        # A COMPLETED verdict (blocked/clear) must become visible. The lookup
+        # failure guard is scoped to the incomplete case ONLY: suppressing a
+        # completed verdict on a transient lookup error would trade away the
+        # very visibility this fix restores. A duplicate comment is far more
+        # recoverable than a real verdict that never posts, so a completed run
+        # whose lookup failed falls through to CREATE rather than staying
+        # silent.
+        review_output = f"[GPT-REVIEWED] {self.HEAD}\n[BLOCK-MERGE] {self.HEAD}\nblocking finding"
+        comments = self._fixture_comments(self._blocking_verdict_body(self.OLD_HEAD))
+        _proc, patch_log, created_log = self._run(
+            tmp_path, comments=comments, review_output=review_output, lookup_fails=True
+        )
+
+        # No PATCH (the lookup could not confirm a target), but the verdict WAS
+        # published via create -- not silently dropped.
+        assert patch_log.read_text(encoding="utf-8") == ""
+        assert created_log.read_text(encoding="utf-8") != ""


### PR DESCRIPTION
## Summary

Follow-up to #8342. The same verdict-visibility bug (#8292) also affects the fork lane: `fork-gpt-review.yml`'s `Post/update summary comment` step PATCHed the bot's marker comment **unconditionally**, so an incomplete rerun overwrote a posted `[GPT-REVIEWED]`/`[BLOCK-MERGE]` verdict with a short "review incomplete" body. The prior verdict survives only in the GraphQL `userContentEdits` edit history, which the REST comments API (what tooling and `gh api` reach for) does not expose. The finding becomes recoverable in principle and invisible in practice.

This is a visibility bug, not a data-loss or merge-safety bug: the fail-closed check-run gate already refuses to pass on an incomplete verdict.

## What changed

`.github/workflows/fork-gpt-review.yml` — `Post/update summary comment` step only:

- **An incomplete run never modifies an existing comment.** When a `github-actions[bot]` marker comment already exists and this run's `kind` is `incomplete`, the step emits a diagnostic log line and makes **no edit of any kind** — no PATCH, no create — regardless of whether the existing body carries `[GPT-REVIEWED]`.
- This is stricter than a preserve-and-prepend approach on purpose: overlapping runs for different SHAs can read the comment before a newer run PATCHes its verdict in, so an incomplete run that read verdict V1 must not PATCH V1 back over a newer run's V2 that landed in between — and even a PATCH that only preserved the verdict and prepended a notice would restore the stale body it read.
- Only `blocked`/`clear` kinds PATCH the full new body; the create-new `gh pr comment` path (no existing marker) is unchanged.
- **Lookup-failure handling (incomplete-only).** The bot-comment lookup captures the paginated query's full output before selecting the first id (so `head -n1` cannot SIGPIPE the API call under `set -o pipefail` and be misread as a failure). A genuine lookup failure suppresses the update **only for an incomplete run** — where posting would risk a spurious marker over a live verdict. A completed (`blocked`/`clear`) run whose lookup fails falls through to **create** and publishes the verdict rather than staying silent, since a duplicate comment is more recoverable than an unposted verdict.
- The existing `github-actions[bot]` author filter on the comment lookup is preserved, so a PR commenter cannot plant the marker and have this step PATCH their comment with the write-scoped token.

The `Finalize check-run (fail closed)` step (the fork analogue of `Gate on findings`) is **untouched**, so the merge gate stays fail-closed and decoupled from the comment — an incomplete run is never mistaken for an approval.

`docs/ci/ci-and-reviews.md` — a paragraph documenting this lane's no-touch-on-incomplete behavior and why the overlapping-run race makes even a preserving PATCH unsafe.

`test/test_ai_review_workflows.py` — new `TestForkGptVerdictVisibility` running the **real** step bash with a stubbed `gh`; the step's hardcoded `/tmp/fork-codex-comment.md` write is redirected under `tmp_path` so the test touches no shared host file.

## Scope

This PR changes **only the fork lane** (`fork-gpt-review.yml`). It does not touch `codex-review.yml` — that same-repo lane's #8292 fix is sibling PR #8342, which owns it.

## Testing

- `python -m pytest test/test_ai_review_workflows.py -q` => all green (adjudication tests from main coexist with the new fork-lane class).
- `test/test_workflow_secret_and_cache_scope.py` => all green (the workflow edit does not alter secret/cache scope).
- Test-quality check: reverting the workflow guard makes the new contract cases fail (a PATCH is recorded), confirming they are load-bearing.
- flake8 / isort clean on the test file; YAML parse of `fork-gpt-review.yml` OK.

## Follow-up (not in this PR's scope)

The same unconditional-PATCH-on-incomplete construct still lives in **seven** other review lanes: `fork-opus-review.yml`, `design-review.yml`, `fork-design-review.yml`, `ux-review.yml`, `fork-ux-review.yml`, `first-principles-review.yml`, and `fork-first-principles-review.yml` (plus `codex-review.yml`, owned by sibling PR #8342; `claude-review.yml` already posts nothing on an incomplete run). Sweeping those sibling lanes is a tracked follow-up, kept out of this PR to hold its diff to the fork GPT lane and avoid re-arming the Fork workflow-change guard on unrelated workflow files.

## Pattern harvest

Rule candidate: when one lane of a duplicated CI mechanism is fixed, sweep every sibling lane that carries the same construct in the same or an immediately-tracked follow-up — a fix landing on only one of N copies leaves the invariant false everywhere else while reading as "fixed." Here the unconditional `PATCH .../issues/comments/$existing` on an `incomplete` run is shared by `fork-gpt-review.yml` (this PR), `codex-review.yml` (sibling PR #8342), and `fork-opus-review.yml` (tracked follow-up). A cross-lane census at fix time (grep the shared `Post/update` comment step and the unconditional PATCH) surfaces every copy up front rather than relying on a hand-filed note.

## Not in scope

The gate's fail-closed behaviour on an incomplete verdict is correct and is unchanged.

no linked issue: #8292 is closed by sibling PR #8342 (the same-repo lane); this fork-lane follow-up intentionally carries no closing keyword to avoid a duplicate/premature close.
