### PR TITLE
feat(sandbox): give each agent scope an owning-instance slice

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -25,6 +25,7 @@ import ctypes
 import ctypes.util
 import errno
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -6258,6 +6259,59 @@ _CGROUP_FALLBACK_MAX_MEMORY_MB = 8192
 _CGROUP_AGENTS_SLICE = "kirocrew-agents.slice"
 
 
+def _instance_slice_token() -> str:
+    """A short, systemd-safe token identifying THIS instance's data home.
+
+    Hex only, and specifically NO dashes: systemd reads a dash in a slice name
+    as a hierarchy separator, so a token containing one would silently insert
+    another slice level (and two tokens could collide on a shared prefix).
+
+    Keyed on the resolved data home because that is already the ownership key
+    the rest of the codebase uses — ``cleanup_orphaned_session_roots`` reaps
+    from a per-data-home account book, which is exactly why it cannot reach a
+    co-resident instance's children. Deriving the slice from the same key keeps
+    one notion of "whose process is this" instead of adding a second.
+    """
+    return hashlib.sha256(str(config_dir()).encode("utf-8")).hexdigest()[:12]
+
+
+def _agents_slice_name() -> str:
+    """The slice new agent scopes are placed in: one child per instance.
+
+    Every gateway on a host shared ONE slice, because the name was a module
+    constant with no per-instance component. Nothing downstream could then tell
+    one instance's scopes from another's, since a scope's identity is its slice
+    plus a timestamp and neither names an owner. That is a correctness floor
+    for anything operating on scopes as a population: a host routinely runs
+    several gateways at once — ``kirocrew pod up`` creates one per pod by
+    design — so "every scope in the agents slice" is not "my scopes", and a
+    sweep that assumes it is reaches into a live co-resident session.
+
+    Returns a dash-nested CHILD of :data:`_CGROUP_AGENTS_SLICE`, so the parent
+    stays the aggregate enforcement boundary: cgroup v2 bounds a descendant by
+    the minimum effective limit along its ancestor chain, so the MemoryHigh /
+    MemoryMax on the parent keep applying to every instance's scopes exactly as
+    before. Callers that match on the parent's name in a cgroup path (it is a
+    path component of every scope either way) are likewise unaffected.
+
+    Degrades to the bare parent slice if the data home cannot be resolved: a
+    missing ownership component must not fail the spawn, matching how an
+    unavailable cgroup backend is handled.
+    """
+    try:
+        token = _instance_slice_token()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "could not derive a per-instance agent slice (%s); falling back to "
+            "the shared %s — scopes from this instance will not be "
+            "distinguishable from a co-resident gateway's",
+            exc,
+            _CGROUP_AGENTS_SLICE,
+        )
+        return _CGROUP_AGENTS_SLICE
+    return f"{_CGROUP_AGENTS_SLICE[: -len('.slice')]}-{token}.slice"
+
+
 def _default_max_memory_mb() -> int:
     """Return the default cgroup ``memory.max`` in MB: a fixed fraction
     (:data:`_CGROUP_MEMORY_FRACTION`) of physical RAM, so the ceiling scales
@@ -6718,12 +6772,15 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
     the returned argv's eventual PID is the real child — parent PID tracking,
     ``killpg``, and descendant scans are unaffected.
 
-    Every scope is parented under :data:`_CGROUP_AGENTS_SLICE`, and the
-    slice-level soft ceiling (``MemoryHigh``, see
-    :func:`_ensure_agent_slice_memory_high`) — a host-derived constant (75%
-    of RAM) — is ensured before each wrap, throttling the SUM of all
-    concurrent agent trees before the slice's hard ``MemoryMax``
-    (:func:`ensure_agents_slice_limits`) OOM-kills a scope.
+    Every scope is parented under a per-instance child of
+    :data:`_CGROUP_AGENTS_SLICE` (see :func:`_agents_slice_name`, which explains
+    why the owner has to be expressible), and the slice-level soft ceiling
+    (``MemoryHigh``, see :func:`_ensure_agent_slice_memory_high`) — a
+    host-derived constant (75% of RAM) — is ensured before each wrap on the
+    PARENT, throttling the SUM of all concurrent agent trees before the slice's
+    hard ``MemoryMax`` (:func:`ensure_agents_slice_limits`) OOM-kills a scope.
+    cgroup v2 bounds a descendant by the minimum effective limit along its
+    ancestor chain, so nesting one level deeper does not loosen either ceiling.
 
     Layers OUTSIDE the OS-level sandbox: callers pass the already-``wrap_argv``-ed
     argv here so the child is filesystem-isolated AND cgroup-bounded.
@@ -6785,7 +6842,7 @@ def cgroup_scope_argv(argv: list[str]) -> list[str]:
         "--user",
         "--scope",
         "-q",
-        f"--slice={_CGROUP_AGENTS_SLICE}",
+        f"--slice={_agents_slice_name()}",
         *props,
         "--",
         *argv,
@@ -7056,12 +7113,29 @@ def check_agents_slice_pressure() -> str | None:
     if new_kills <= 0:
         return None
     victims: list[str] = []
+
+    def _record_if_killed(scope_dir: Path) -> None:
+        scope_local = _read_cgroup_counters(scope_dir / "memory.events.local")
+        if scope_local.get("oom_kill", 0) > 0:
+            victims.append(scope_dir.name)
+
     try:
+        # Scopes sit one level deeper than they used to: each instance places
+        # its own under a per-instance child slice (_agents_slice_name), so
+        # scanning only direct children would report "(already reaped)" for
+        # every real victim. Both shapes are walked rather than just the nested
+        # one, because the aggregate slice is shared host-wide: a co-resident
+        # gateway still on an older build keeps putting scopes directly here,
+        # and its OOM kills are still worth naming.
         for child in slice_dir.iterdir():
-            if child.suffix == ".scope" and child.is_dir():
-                child_local = _read_cgroup_counters(child / "memory.events.local")
-                if child_local.get("oom_kill", 0) > 0:
-                    victims.append(child.name)
+            if not child.is_dir():
+                continue
+            if child.suffix == ".scope":
+                _record_if_killed(child)
+            elif child.suffix == ".slice":
+                for grandchild in child.iterdir():
+                    if grandchild.suffix == ".scope" and grandchild.is_dir():
+                        _record_if_killed(grandchild)
     except OSError:
         pass
     mem_current = -1

--- a/test/test_sandbox_agent_slice_identity.py
+++ b/test/test_sandbox_agent_slice_identity.py
@@ -1,0 +1,194 @@
+"""Agent scopes must name the instance that owns them.
+
+Every gateway on a host placed its agent scopes in ONE slice whose name was a
+module constant, so a scope's identity was "the agents slice, at time T" and
+neither component named an owner. Anything reasoning about scopes as a
+population therefore could not separate its own from a co-resident gateway's --
+and a host routinely runs several at once, because ``kirocrew pod up`` creates
+one per pod by design. These tests pin the owner being expressible, and pin the
+two properties that made the shared constant safe (aggregate ceiling, cgroup
+path matching) surviving the change.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _slice_arg(argv: list[str]) -> str:
+    """The ``--slice=`` value in a systemd-run argv."""
+    for a in argv:
+        if a.startswith("--slice="):
+            return a.split("=", 1)[1]
+    raise AssertionError(f"no --slice= in {argv!r}")
+
+
+@pytest.fixture
+def wrapped():
+    """Call ``cgroup_scope_argv`` with the cgroup backend forced available.
+
+    ``trusted_system_bin`` is stubbed so the assertions do not depend on the
+    test host having systemd-run in a trusted directory, and the off-thread
+    slice reconciliation is stubbed so no thread or subprocess is started.
+    """
+    import kiro_crew.sandbox as sb
+
+    def _call(argv=None):
+        sb._CGROUP_SCOPE_PROBE = None
+        sb._CGROUP_WARNED = False
+        try:
+            with (
+                patch("kiro_crew.sandbox._probe_cgroup_scope", return_value=(True, "ok")),
+                patch(
+                    "kiro_crew.platform_compat.trusted_system_bin",
+                    return_value="/usr/bin/systemd-run",
+                ),
+                patch("kiro_crew.sandbox._reconcile_slice_memory_high_off_thread"),
+                patch(
+                    "kiro_crew.sandbox._cgroup_limits_from_config",
+                    return_value=(8192, 8192, 50, 0),
+                ),
+                patch("kiro_crew.sandbox._cpu_controller_delegated", return_value=False),
+            ):
+                return sb.cgroup_scope_argv(list(argv or ["kiro-cli", "chat"]))
+        finally:
+            sb._CGROUP_SCOPE_PROBE = None
+            sb._CGROUP_WARNED = False
+
+    return _call
+
+
+class TestAgentSliceIdentity:
+    def test_two_instances_do_not_share_a_slice(self, wrapped, monkeypatch, tmp_path):
+        """The load-bearing property: co-resident gateways get distinct slices.
+
+        Without this, "every scope in the agents slice" reads as "my scopes" to
+        any scope-level sweep, and the sweep reaches into a live session that
+        belongs to another gateway on the same host.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "instance-a"))
+        slice_a = _slice_arg(wrapped())
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "instance-b"))
+        slice_b = _slice_arg(wrapped())
+
+        assert slice_a != slice_b, (
+            "two data homes produced the same slice, so a scope carries no " f"owner: {slice_a}"
+        )
+
+    def test_slice_is_stable_for_one_instance(self, wrapped, monkeypatch, tmp_path):
+        """Recomputable: an owner check is only possible if the name is stable."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "instance-a"))
+        assert _slice_arg(wrapped()) == _slice_arg(wrapped(["git", "status"]))
+
+    def test_slice_nests_under_the_aggregate_parent(self, wrapped, monkeypatch, tmp_path):
+        """The parent stays the aggregate enforcement boundary.
+
+        systemd's dash-hierarchy makes ``kirocrew-agents-<tok>.slice`` a child
+        of ``kirocrew-agents.slice``, so the MemoryHigh / MemoryMax applied to
+        the parent keep bounding every instance's scopes (cgroup v2 bounds a
+        descendant by the minimum effective limit along its ancestor chain), and
+        the parent remains a path component of every scope's cgroup -- which is
+        what callers matching the parent name in ``/proc/self/cgroup`` rely on.
+        """
+        import kiro_crew.sandbox as sb
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "instance-a"))
+        name = _slice_arg(wrapped())
+        parent_stem = sb._CGROUP_AGENTS_SLICE[: -len(".slice")]
+
+        assert name.endswith(".slice")
+        assert name.startswith(f"{parent_stem}-"), (
+            f"{name} is not a dash-child of {sb._CGROUP_AGENTS_SLICE}, so it "
+            "does not inherit the aggregate ceiling"
+        )
+
+    def test_instance_token_carries_no_dash(self, monkeypatch, tmp_path):
+        """A dash in the token would silently add a systemd hierarchy level.
+
+        systemd reads each dash as a separator, so ``...-ab-cd.slice`` would
+        nest under ``...-ab.slice`` -- an extra level, and a prefix two tokens
+        could share.
+        """
+        import kiro_crew.sandbox as sb
+
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "instance-a"))
+        token = sb._instance_slice_token()
+
+        assert token
+        assert "-" not in token
+        assert token.isalnum()
+
+    def test_unresolvable_home_degrades_to_the_shared_slice(self, wrapped, caplog):
+        """A missing owner must not fail the spawn.
+
+        The scope still gets its ceilings; only the ownership component is lost,
+        and the warning says so. Matches how an unavailable cgroup backend is
+        handled rather than raising on the spawn path.
+        """
+        import logging
+
+        import kiro_crew.sandbox as sb
+
+        with patch(
+            "kiro_crew.sandbox._instance_slice_token",
+            side_effect=RuntimeError("no home"),
+        ):
+            with caplog.at_level(logging.WARNING):
+                argv = wrapped()
+
+        assert _slice_arg(argv) == sb._CGROUP_AGENTS_SLICE
+        assert argv[argv.index("--") + 1 :] == ["kiro-cli", "chat"]
+        assert "TasksMax=8192" in argv
+        assert any("co-resident" in r.getMessage() for r in caplog.records)
+
+
+class TestSlicePressureScanFindsNestedScopes:
+    """The OOM-victim scan has to follow the scopes one level down.
+
+    ``check_agents_slice_pressure`` names the scopes that recorded a kill. With
+    scopes now under a per-instance child slice, a scan of direct children only
+    would find none and report "(already reaped)" for every real victim.
+    """
+
+    def _slice_tree(self, tmp_path, *, nested: bool):
+        """Build a fake agents-slice cgroup dir with one OOM-killed scope."""
+        root = tmp_path / "kirocrew-agents.slice"
+        holder = root / "kirocrew-agents-abc123.slice" if nested else root
+        scope = holder / "run-rdeadbeef.scope"
+        scope.mkdir(parents=True)
+        (scope / "memory.events.local").write_text("max 3\noom_kill 2\n")
+        (root / "memory.events").write_text("max 9\noom_kill 4\n")
+        (root / "memory.events.local").write_text("max 9\noom_kill 0\n")
+        (root / "memory.current").write_text("123\n")
+        (root / "memory.max").write_text("456\n")
+        return root, scope.name
+
+    @pytest.mark.parametrize("nested", [True, False])
+    def test_victim_scope_is_named(self, tmp_path, nested):
+        """Both shapes are found.
+
+        Nested is this instance's own layout. Flat still matters because the
+        aggregate slice is shared host-wide: a co-resident gateway on an older
+        build keeps putting scopes directly in it, and its kills are still
+        worth naming.
+        """
+        import kiro_crew.sandbox as sb
+
+        root, scope_name = self._slice_tree(tmp_path, nested=nested)
+        prev = sb._SLICE_OOM_SEEN
+        try:
+            # Baseline below the tree's counters, so the scan sees new kills.
+            sb._SLICE_OOM_SEEN = {"oom_kill": 0, "max": 0}
+            with (
+                patch("kiro_crew.sandbox._agents_slice_cgroup_dir", return_value=root),
+                patch("kiro_crew.sandbox._SLICE_LIMITS_APPLIED", False),
+            ):
+                message = sb.check_agents_slice_pressure()
+        finally:
+            sb._SLICE_OOM_SEEN = prev
+
+        assert message is not None
+        assert scope_name in message
+        assert "already reaped" not in message

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -2487,7 +2487,14 @@ class TestAgentsSliceLimits:
                 patch("kiro_crew.sandbox._cpu_controller_delegated", return_value=False),
             ):
                 out = sb.cgroup_scope_argv(["kiro-cli", "chat"])
-            assert f"--slice={sb._CGROUP_AGENTS_SLICE}" in out
+            # Still placed under the aggregate boundary, now via a per-instance
+            # child of it (see _agents_slice_name) — cgroup v2 bounds a
+            # descendant by the minimum effective limit along its ancestor
+            # chain, so the aggregate layer of the two-level model is intact.
+            parent_stem = sb._CGROUP_AGENTS_SLICE[: -len(".slice")]
+            assert any(
+                a.startswith(f"--slice={parent_stem}") and a.endswith(".slice") for a in out
+            ), out
             assert "MemoryMax=4096M" in out
             assert "TasksMax=8192" in out
         finally:
@@ -3497,7 +3504,13 @@ class TestAgentSliceMemoryHigh:
             ):
                 out = sb.cgroup_scope_argv(["kiro-cli", "chat"])
             ensure.assert_called_once_with()
-            assert "--slice=kirocrew-agents.slice" in out
+            # The slice is a per-instance child of the aggregate parent (see
+            # _agents_slice_name), so match the parent stem rather than an exact
+            # name: the reconciliation this test is about still targets the
+            # parent, which is what the ceiling is applied to.
+            assert any(
+                a.startswith("--slice=kirocrew-agents") and a.endswith(".slice") for a in out
+            ), out
         finally:
             sb._CGROUP_SCOPE_PROBE = None
 


### PR DESCRIPTION
**Status: this ships an ownership scheme whose only consumer is its own defining site.** `cgroup_scope_argv` writes the per-instance slice name; nothing reads it back to answer "is this scope mine". The sweep that would consume it is **not implemented** -- it is one of the open remedies on #8133 and no code in `src/` enumerates scopes for that purpose. Reviewers should not have to derive that from the diff, so it is stated here.

This is therefore preparation, not a repair: it does **not** fix the leak reported in #8133, and nothing in it reclaims a single orphaned scope. The trailer is `Refs`, and the type is `feat` rather than `fix` because the change adds a property that did not exist (and `refactor` would be wrong -- cgroup placement changes and new host state appears). An earlier revision of this description was titled `fix(`, which a reviewer correctly called a contradiction with the sentence above; that is corrected rather than merely annotated.

**Whether it should land now or alongside its first consumer is an open architectural question**, raised as CONCERNS by the First Principles reviewer and answered in a [reply on this PR](https://github.com/kirodotdev/KiroCrew/issues/8351#issuecomment-5534689651). The case for landing it first is in section 2 and rests on a measurement; the case for deferring is that an abstraction with no reader has not yet earned its place. That is a maintainer's call, not mine.

What is deliberately absent: no reaping, no timeout, no grace period, and no definition of "orphaned". Those are #8133's open policy decisions and inventing any of them here would pre-empt a maintainer.
## 1. What is the problem?

Every gateway on a host put its agent scopes in the same slice. `_CGROUP_AGENTS_SLICE` (`sandbox.py:6258`) was a module constant with exactly one use site (`sandbox.py:6788`, in `cgroup_scope_argv`) and no per-instance component, so a scope's identity amounted to "the agents slice, at time T". Neither component named an owner.

A host routinely runs several gateways at once. `kirocrew pod up` creates one per pod by design, and this repo's own development workflow mandates pods, so co-residency is the normal case rather than an unusual deployment.

## 2. Why this issue matters to the user

Without ownership, "every scope in the agents slice" reads as "my scopes" to anything that operates on scopes as a population, and it is wrong. The remedy recommended on #8133 is a startup sweep that stops every `run-*.scope` older than the gateway's own start stamp, justified as sound rather than heuristic because "a live scope always post-dates it, and the comparison cannot false-positive on a live session". That justification silently assumes one gateway per host.

Measured at 2026-09-04T00:52:43Z against main 711544f3d87a838657349849ad0e9c3883e882d4, on a host running five gateway units (two of them pods):

| | count |
|---|---|
| active scopes in the slice | 94 |
| pre-date the gateway start stamp, so would be swept | 57 |
| of those, reparented to the user manager (genuine orphan candidates) | 51 |
| of those, **owned by a live co-resident gateway** | **6** |

Six live scopes would be killed, one of them a pod's live agent session. The reporter's own two-sided check (`total=28 live=23 would_reap=0`) is consistent with this rather than contradicting it: it ran where only one gateway existed, so it is a control that cannot fail on the healthy case.

So the danger this addresses is not the current leak, which this change does not touch. It is that the next person to implement that sweep correctly-as-written destroys live work. Landing ownership first is what makes any of the candidate remedies safe to write, and it is needed identically by all of them: `BindsTo=` has to name which gateway to bind to, and a sweep has to name whose scopes it may touch.

## 3. How the change works

Each instance's scopes now go in a dash-nested child, `kirocrew-agents-<token>.slice`, where the token is a 12-hex-character digest of the resolved data home.

The data home is deliberately not a new notion of ownership. It is the one the codebase already uses: `cleanup_orphaned_session_roots` (`session_pid.py:777`) reaps from a per-data-home account book keyed on the recorded owning gateway pid plus a start token, which is precisely why it cannot reach a co-resident instance's children. Deriving the slice from the same key keeps one answer to "whose process is this" instead of adding a second that could disagree.

Three properties that made the shared constant safe are preserved, and each is pinned by a test:

- **The aggregate ceiling still applies.** systemd's dash-hierarchy makes the new slice a child of `kirocrew-agents.slice`, and cgroup v2 bounds a descendant by the minimum effective limit along its ancestor chain. `MemoryHigh` / `MemoryMax` stay applied to the parent and keep bounding the sum across all instances exactly as before. Verified against real systemd: a scope created by the argv this code emits landed at `kirocrew.slice/kirocrew-agents.slice/kirocrew-agents-<token>.slice/<scope>`, with the per-scope `TasksMax=8192` and `MemoryMax` applied and the parent's `memory.max` unchanged.
- **Cgroup-path matching still works.** The parent remains a path component of every scope's cgroup, so the check at `dev_fleet/gateway_service.py:634` that looks for `kirocrew-agents.slice` in `/proc/self/cgroup` is unaffected.
- **The token cannot perturb the hierarchy.** It is hex only, with no dash, because systemd reads a dash as a hierarchy separator: a dash would silently insert another slice level and give two tokens a shared prefix.

One consequential follow-on: the OOM-victim scan in `check_agents_slice_pressure` names the scopes that recorded a kill by listing the slice's children, and scopes now sit one level deeper, so it would have reported `(already reaped)` for every real victim. It now descends into child slices. It still walks direct children as well, because the aggregate slice is shared host-wide and a co-resident gateway on an older build keeps placing scopes directly in it; those kills are still worth naming.

If the data home cannot be resolved, the slice degrades to the bare parent and logs a warning that says ownership was lost. A missing ownership component must not fail a spawn, matching how an unavailable cgroup backend is already handled.

## 4. What tests we did

New file `test/test_sandbox_agent_slice_identity.py`, 7 cases. Verified red-before by reverting only `sandbox.py` and keeping the tests: **5 failed, 2 passed** at the base commit; all 7 pass with the change. The 2 that pass either way are deliberate guards rather than regression tests (a constant is trivially stable, and the flat-shape scan already worked).

- two data homes produce different slices (the load-bearing property)
- the slice is stable for one data home, so an owner check can recompute it
- the slice is a dash-child of the aggregate parent, so it inherits the ceiling
- the token carries no dash
- an unresolvable data home degrades to the shared slice, still emits the ceilings, and warns
- the OOM-victim scan names a killed scope in both the nested and flat shapes (parametrized)

Two existing assertions pinned the old exact slice string and were updated to match the parent stem instead; both keep their original intent (`test_cgroup_scope_argv_reconciles_when_available` is about reconciliation firing, and the `test_per_scope_property_still_emitted_ratchet` ratchet is about the per-scope layer surviving). The hand-written argv in `test_host_service_guard.py` was left alone: it feeds the host-service guard, which does not parse the slice, and it remains exactly the shape the degradation path emits.

Suites run serially (`-n 0`): the new file plus `test_sandbox_argv.py`, `test_host_service_guard.py`, `test_resource_pressure_notify.py`, `test_spawn_audit.py`, `test_sandbox_absent_ceiling_seal.py`, `test_sandbox_first_party_exec.py`, `test_agent_home_isolation.py` -> **389 passed, 3 skipped**. Gates clean: black (repo gate, 3 files in scope), isort, flake8, mypy.

Every transient unit created while verifying was torn down; the host's `run-*.scope` count was 94 before and after.

## 5. Any other suggestions on the work

**One cost to weigh, disclosed rather than hidden.** An empty child slice is not garbage-collected: after its last scope exits the slice unit stays loaded until the user manager restarts. I measured this directly. Because the slice is per *instance* and not per spawn, the count is bounded by distinct data homes rather than by sessions, so this does not reintroduce the unbounded growth #8133 is about. It does mean a host that runs many throwaway pods accumulates one idle slice unit per pod data home. Reclaiming those is cleanup of units this code created, not orphan policy, so it could be added later without touching any of the open decisions.

**Three findings from investigating #8133 that this PR deliberately does not act on**, recorded in full in [a comment on the issue](https://github.com/kirodotdev/KiroCrew/issues/8133#issuecomment-5534116907):

1. The `reset-failed` thread in the report is a red herring. Measured with two throwaway scopes: SIGKILLing a scope's only process leaves `LoadState=not-found`, and so does a clean exit. Transient scopes are collected when the cgroup empties, so `grep reset-failed src/` returning 0 does not contribute to the accumulation. They pile up because the cgroup never empties.
2. The dominant leak on the measured host is not the non-exiting `kiro-cli acp` the report names. 48 of the 94 active scopes held exactly one process, a long-lived helper daemon, with no agent process present; the same helper also appears inside 29 live session scopes, so it is spawned within a session and outlives it.
3. Consequently 0 of the 51 orphan candidates appeared in the account book, so `cleanup_orphaned_session_roots` structurally cannot reach them, and killing the recorded session root does not empty the scope.

Whether a scope holding only a surviving helper daemon counts as "orphaned" is a definition that needs a number invented for it, so it is left to a maintainer.

**Not included on purpose:** the hardcoded `_LIVE_GATEWAY_UNIT` at `dev_fleet/live.py:196`, which two triage comments asked to split out. It is a real and independent defect (I saw a failed scope on the measured host recording exactly that probe), but a PR fixing a precondition should not also carry a second finding.

## Pattern harvest

Rule candidate: grep/semgrep (repo-local lint)
Pattern: a module-level constant holding a systemd unit name (`*.slice`, `*.service`, `*.scope`) that is then used to PLACE or SELECT a per-instance resource, in a program built to run several instances on one host.

The defect here was not the slice name being wrong. It was a host-global namespace keyed on a compile-time constant inside a program whose own tooling starts additional instances (`kirocrew pod up`). The constant makes every instance's resources occupy one namespace, and from inside that namespace no caller can recover which instance owns what. The failure only shows up on a multi-instance host, which is exactly why it survived: a single-instance check passes, so the bug is invisible to the healthy case.

This class has at least two members in this repo, which is what makes it worth a rule rather than a one-off note. The second is `_LIVE_GATEWAY_UNIT = "kirocrew-gateway.service"` at `dev_fleet/live.py:196`, which assumes the live gateway's unit is named that literal; on an install whose unit is named anything else the probe queries a unit that does not exist, and per its own docstring the caller then degrades silently. Same shape, same assumption, different consequence.

A rule cannot simply ban the literals, because a deliberately shared name is legitimate: the aggregate parent slice in this change stays a constant precisely because it is the host-wide enforcement boundary. So the useful form is to flag the constant and require the author to say which one it is -- a per-instance derivation, or an explicit note that host-global sharing is intended and why. That distinction is exactly what was missing at both sites.

Not folded into this PR: the `_LIVE_GATEWAY_UNIT` fix. It is an independent defect and a PR that ships a precondition should not also carry a second finding.

Refs #8133

