### PR TITLE
fix(chat): notice a tool call that leaked after the turn ran tools

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -287,7 +287,6 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     SYNTHETIC_RECOVERY_KIND,
     TRANSIENT_RETRY_KIND,
     RecoveryPayload,
-    has_leaked_tool_call,
     is_promise_only_terminal,
     is_synthetic_payload_item,
     is_synthetic_recovery_item,
@@ -295,6 +294,7 @@ from kiro_crew.dashboard.chat_utils import (  # noqa: E402
     payload_for_replay,
     should_continue_after_compaction,
     should_notice_leaked_tool_call,
+    should_notice_mixed_turn_leak,
     should_recover_promise_only,
     subagents_attached,
 )
@@ -9818,24 +9818,39 @@ async def _run_chat(
                 "msg msg-info",
             )
             _noticed_leak = True
-        elif (
-            _turn_tool_calls > 0
-            and _stop_reason == STOP_REASON_END_TURN
-            and _prompt_depth == 0
-            and has_leaked_tool_call(assistant_text)
+        elif should_notice_mixed_turn_leak(
+            stop_reason=_stop_reason,
+            end_turn_reason=STOP_REASON_END_TURN,
+            final_segment_text=assistant_text,
+            prompt_depth=_prompt_depth,
+            turn_tool_calls=_turn_tool_calls,
         ):
-            # MIXED-TURN diagnostic (advisory gap named by review): the turn
-            # executed tools and THEN leaked a final dispatch as text. The
-            # notice/un-landing path deliberately excludes this shape —
-            # un-landing a turn whose earlier tool calls had real side effects
-            # would misdescribe it — but the stall must stay diagnosable, so
-            # log it. No notice card, no un-landing, no behavior change.
+            # MIXED TURN: the turn dispatched tool calls and THEN leaked a
+            # final one as text. The two halves of the leak response split
+            # here, because only one is unsafe on this shape: UN-LANDING stays
+            # excluded, since earlier calls may already have taken effect, so
+            # `_noticed_leak` is deliberately NOT set and the turn lands, bills
+            # and consolidates exactly as before — while the NOTICE is not
+            # excluded, and used to be, because a logger warning is invisible
+            # to the person in the chat and the leak read as a completed
+            # action. Wording differs from the sibling on purpose: "nothing was
+            # run" is false here. Rationale in full, including why the count is
+            # described as attempted: should_notice_mixed_turn_leak's docstring.
             logger.warning(
                 "Leaked tool call alongside %d executed tool call(s) for slot %s "
                 "— the final segment contains an invoke block as text; the turn "
                 "lands normally (diagnostic only)",
                 _turn_tool_calls,
                 slot.key,
+            )
+            slot.append(
+                "notice",
+                "ℹ️ The last tool call leaked into the reply text instead of "
+                f"executing — the {_turn_tool_calls} call(s) before it were "
+                "attempted and may already have taken effect, so part of this turn "
+                "may have landed and part did not. Check what landed before "
+                "re-sending (an active monitor loop retries on its next cycle).",
+                "msg msg-info",
             )
         # Promise-only guard (#2686): the turn ended NORMALLY with visible text
         # whose FINAL segment only ANNOUNCES an immediate action ("I'll do that

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -1857,9 +1857,12 @@ def has_leaked_tool_call(text: str) -> bool:
 
     Quoted syntax is excluded structurally: fenced code blocks and inline code
     spans are stripped before the scan, so a pasted bug report or an explained
-    example never matches. The caller must additionally require
-    ``turn_tool_calls == 0`` — a turn that executed tools and ALSO printed a
-    block is not the leak shape.
+    example never matches. Callers decide what to DO with a match, and the two
+    turn shapes differ: :func:`should_notice_leaked_tool_call` requires
+    ``turn_tool_calls == 0`` because it un-lands the turn, which would
+    misdescribe a turn whose earlier calls had side effects, while
+    :func:`should_notice_mixed_turn_leak` handles that shape notice-only. A
+    tool-heavy turn IS a leak — it is just not un-landable.
     """
     if not text:
         return False
@@ -1906,8 +1909,11 @@ def should_notice_leaked_tool_call(
     layer can fix honestly.
 
     Gates: the turn ended NORMALLY (cancel/refusal/error paths own their own
-    reporting), made ZERO tool calls (a turn that executed tools and also
-    printed a block is not the leak shape), is top-level, is NOT a
+    reporting), made ZERO tool calls — not because a tool-heavy turn is a
+    different shape (it is the same leak) but because THIS path un-lands the
+    turn, and a turn whose earlier calls had real side effects must not be
+    marked unacted; that shape is noticed without un-landing by
+    :func:`should_notice_mixed_turn_leak` — is top-level, is NOT a
     stage-execution turn (the orchestrator's stage loop reads the turn result
     for stage accounting, and un-landing a stage turn from here would let the
     loop record an unfinished stage as complete — same exclusion as the
@@ -1921,6 +1927,66 @@ def should_notice_leaked_tool_call(
     if turn_tool_calls != 0:
         return False
     if in_stage_execution:
+        return False
+    if stop_reason != end_turn_reason:
+        return False
+    if prompt_depth != 0:
+        return False
+    return has_leaked_tool_call(final_segment_text)
+
+
+def should_notice_mixed_turn_leak(
+    *,
+    stop_reason: str,
+    end_turn_reason: str,
+    final_segment_text: str,
+    prompt_depth: int,
+    turn_tool_calls: int,
+) -> bool:
+    """Decide whether to surface the MIXED-TURN leak notice.
+
+    The shape :func:`should_notice_leaked_tool_call` deliberately declines: the
+    turn dispatched tool calls and THEN leaked a final one as text. Its
+    ``turn_tool_calls == 0`` gate exists to protect UN-LANDING — earlier calls
+    in the turn may already have taken effect, so marking it unacted could
+    misdescribe it — and that reasoning is untouched here. This predicate
+    governs only the user-visible NOTICE, which carries no such hazard: nothing
+    is queued, nothing is un-landed, nothing executes.
+
+    Why the notice is worth a card on a shape that lands normally: the mixed
+    turn hides the gap BETTER than the zero-call one, not worse. The model
+    reads state, announces the write, leaks the write, and the reply lands
+    looking like a completed action — some of the work may already have
+    happened, so there is no stall to notice and no missing output to explain.
+    Before this the only trace was a gateway log line, which the person in the
+    chat does not read.
+
+    Conditions are EXACTLY the ones the runner already used for its diagnostic
+    log, so the set of diagnosed turns does not move — only their visibility:
+    at least one dispatched tool call, a NORMAL end-turn (which excludes the
+    cancelled stop reason), top-level, and a final segment carrying the
+    machine-shaped leak (:func:`has_leaked_tool_call`).
+
+    Deliberately NOT gated on ``in_stage_execution``, unlike its sibling: that
+    exclusion exists so the orchestrator's stage loop cannot read an unfinished
+    stage as complete, and a notice-only card changes no turn result the loop
+    reads. One mismatch follows and is accepted: the card's guidance ("check
+    what landed before re-sending") addresses a human driving the chat, not the
+    stage loop, so on a stage-execution turn it offers advice its reader cannot
+    act on — harmless, and better than hiding the leak on those turns.
+
+    The card says the earlier calls were ATTEMPTED rather than ran, and never
+    "nothing was run" as the sibling does, because ``turn_tool_calls`` counts
+    dispatches at the tool-call event, before approval — a refused call
+    increments it too. The count bounds what may have landed rather than
+    asserting any of it did, and a reader who took "nothing was run" literally
+    here would redo work that already took effect.
+
+    ``turn_tool_calls`` is REQUIRED, unlike the sibling's defaulted parameter:
+    zero is that one's firing shape but this one's refusing shape, so a default
+    here would silently disable the predicate rather than exercise it.
+    """
+    if turn_tool_calls <= 0:
         return False
     if stop_reason != end_turn_reason:
         return False

--- a/test/test_leaked_toolcall_notice.py
+++ b/test/test_leaked_toolcall_notice.py
@@ -30,6 +30,7 @@ from kiro_crew.acp.types import STOP_REASON_CANCELLED, STOP_REASON_END_TURN
 from kiro_crew.dashboard.chat_utils import (
     has_leaked_tool_call,
     should_notice_leaked_tool_call,
+    should_notice_mixed_turn_leak,
 )
 
 _END = STOP_REASON_END_TURN
@@ -208,7 +209,10 @@ def test_adversarial_delimiter_runs_scan_in_linear_time():
 
 
 def test_a_turn_that_made_tool_calls_never_notices():
-    # A turn that executed tools and also printed a block is not the leak shape.
+    # Not because a tool-heavy turn is a different shape — it is the same leak —
+    # but because THIS path un-lands the turn, and a turn whose earlier calls had
+    # side effects must not be marked unacted. That shape is noticed without
+    # un-landing by should_notice_mixed_turn_leak, covered below.
     assert _notice(turn_tool_calls=1) is False
 
 
@@ -234,3 +238,64 @@ def test_stage_execution_turns_never_notice():
 
 def test_non_leak_text_never_notices():
     assert _notice(final_segment_text="All done — the queue is empty.") is False
+
+
+# ── Mixed turn: dispatched tools, THEN leaked its final dispatch ──
+
+
+def _mixed(**over):
+    """should_notice_mixed_turn_leak with firing defaults, so each test flips
+    exactly the one field it is about."""
+    kw = dict(
+        stop_reason=_END,
+        end_turn_reason=_END,
+        final_segment_text=_LEAK,
+        prompt_depth=0,
+        turn_tool_calls=4,
+    )
+    kw.update(over)
+    return should_notice_mixed_turn_leak(**kw)
+
+
+def test_a_turn_that_dispatched_tools_then_leaked_its_last_call_is_noticed():
+    """The observed shape: read state over several calls, announce the write,
+    leak the write itself. The turn lands looking like a completed action, so
+    there is no stall to notice and no missing output to explain — which is why
+    the sibling's silence here read as success.
+    """
+    assert _mixed() is True
+
+
+def test_the_two_predicates_partition_by_tool_count():
+    """Neither shape may fall through both, and neither may claim the other's.
+
+    The runner chains them as if/elif, so an overlap would be an ordering bug
+    and a gap would be a silent stall.
+    """
+    assert _notice(turn_tool_calls=0) is True
+    assert _mixed(turn_tool_calls=0) is False
+    assert _notice(turn_tool_calls=2) is False
+    assert _mixed(turn_tool_calls=2) is True
+
+
+def test_a_cancelled_mixed_turn_is_not_noticed():
+    """Excluded via the stop reason rather than an is_cancelled flag: a cancelled
+    turn never reports end_turn, and the user already knows they cancelled it.
+    """
+    assert _mixed(stop_reason=STOP_REASON_CANCELLED) is False
+
+
+def test_non_end_turn_and_nested_mixed_turns_are_not_noticed():
+    assert _mixed(stop_reason="error: tool stall") is False
+    assert _mixed(prompt_depth=1) is False
+
+
+def test_a_mixed_turn_whose_text_is_prose_is_not_noticed():
+    # The count alone must never fire the card: it takes an actual leak.
+    assert _mixed(final_segment_text="Read four resources; all consistent.") is False
+
+
+def test_a_mixed_turn_quoting_a_fenced_block_is_not_noticed():
+    # Same structural exclusion the sibling gets: explaining a leak is not one.
+    fenced = "Here is what a leak looks like:\n\n```\n" + _LEAK + "\n```\n"
+    assert _mixed(final_segment_text=fenced) is False


### PR DESCRIPTION
## Problem / Motivation

When a turn executes some tool calls and then leaks its **final** call into the text
channel instead of executing it, the user is told nothing.

Observed in a dashboard session: the model re-read live state over two tool calls,
wrote a confident one-line summary of what it had checked, said it was performing the
write — and then emitted the write itself as prose, an `invoke` block with its
parameters rendered as message text. The turn ended there. The write never ran. The
resource was unchanged.

Nothing in the chat said so. The reply reads like a completed action, because the
reads really did happen, so there is no missing output to notice and no stall to
explain. The only trace was a `logger.warning` in the gateway log, which the person
in the chat does not read.

`has_leaked_tool_call` already detects this exactly, and the runner already reaches
the branch. It logs and stops.

## Why it matters

This shape hides the gap **better** than the zero-tool-call one the notice already
covers, not worse.

A turn that leaks its only call produces no work and no output — a user watching an
unattended loop eventually notices nothing happened. A turn that leaks its *last*
call produces real work plus a summary that sounds finished. The failure is silent
and confidently worded, and the user's next action is taken on the belief that the
write landed.

In the observed session the leaked call was the one the user had just explicitly
authorised, so the message said the action was being performed while the state it
described never changed.

## What changed (motivation → approach → change)

**Symptom** → a mixed turn's leak is detected, logged, and never shown to the user.

**Root cause** → the leak response has two halves, and both were gated on the same
condition. `should_notice_leaked_tool_call` requires `turn_tool_calls == 0`, and its
docstring gave the reason as "a turn that executed tools and ALSO printed a block is
not the leak shape". That reason is not the real one. The real one is in the runner's
own comment: un-landing a turn whose earlier calls had **side effects** would
misdescribe it. That reasoning is sound — and it is a reason to withhold
**un-landing**, not a reason to withhold **informing**. A notice card queues nothing,
executes nothing and un-lands nothing.

**Change** → the two halves are separated at that seam.

- The existing mixed-turn branch now appends a notice in addition to its log. It does
  **not** set `_noticed_leak`, so the turn still lands, bills and consolidates exactly
  as before. No landing behaviour changes anywhere.
- Its inline condition is extracted to `should_notice_mixed_turn_leak` in
  `chat_utils.py`, beside its sibling — matching how this file already carries each
  turn-shape decision as a pure predicate with the rationale in its docstring, and
  giving the branch a testable seam it did not have.
- The predicate's conditions are **exactly** the four the runner already used, so the
  set of diagnosed turns does not move — only its visibility. It is deliberately not
  gated on `in_stage_execution` (that exclusion protects the orchestrator's stage
  accounting from a changed turn result, and a card changes no turn result) and needs
  no `is_cancelled` gate, since a cancelled turn never reports `end_turn`.
- The notice wording differs from the sibling's on purpose. "nothing was run" is
  false here, and a user who read it that way would redo work that already took
  effect — so it names the count that ran and says part of the turn landed and part
  did not.
- Two docstrings asserted the claim this change contradicts ("not the leak shape").
  Both now give the un-landing reason instead and point at the new predicate. A
  tool-heavy turn *is* a leak; it is just not un-landable.

## Tests

Added to `test/test_leaked_toolcall_notice.py`, following the file's existing
convention of assembling the machine syntax from fragments rather than writing a raw
`invoke` block as a literal:

- `test_a_turn_that_executed_tools_then_leaked_its_last_call_is_noticed` — the
  observed shape now fires.
- `test_the_two_predicates_partition_by_tool_count` — the two predicates partition on
  tool count, neither overlapping nor leaving a gap. The runner chains them as
  `if`/`elif`, so an overlap is an ordering bug and a gap is a silent stall.
- `test_a_cancelled_mixed_turn_is_not_noticed`,
  `test_non_end_turn_and_nested_mixed_turns_are_not_noticed` — each gate declines.
- `test_a_mixed_turn_whose_text_is_prose_is_not_noticed` — the tool count alone never
  fires the card; it takes an actual leak.
- `test_a_mixed_turn_quoting_a_fenced_block_is_not_noticed` — the new path inherits
  the structural quoted-code exclusion, so explaining a leak is not one.

The comment on the existing `test_a_turn_that_made_tool_calls_never_notices` is
updated to name the un-landing reason; its assertion is unchanged and still passes.

Local: 27 passed in the leak suite; 305 passed across it plus
`test_chat_runner_coverage.py` and `test_error_code_contract.py`. `isort`, `flake8`,
`mypy` and the baselined black gate are clean on the changed files.

A passing suite proves nothing about detection, so the tool-count condition was
mutated (`if turn_tool_calls <= 0` disabled) and the suite re-run: the partition test
failed with `assert True is False`, i.e. for the intended reason — the two predicates
would overlap — and passed again on revert.

## Manual verification

N/A — the decision is a pure predicate and is unit-tested directly, matching how the
sibling notice is covered; the append site is a single `slot.append` reusing the
existing notice row.

The triggering condition cannot be forced on demand: the leak originates in the model
writing to the wrong channel, not in anything this layer controls. That is also why
the fix is notice-only.

## Screenshots / video

N/A — no new or changed UI surface. The card is the existing notice row
(`msg msg-info`) already used by the zero-tool-call path; only its trigger and text
are new.

## Related Issues

Context: #6112 reported the leak, and #6130 shipped the notice for the zero-tool-call
shape while leaving the mixed-turn shape as log-only. This adds the user-visible half
for that shape, without reversing the un-landing exclusion #6130 chose.

## Pattern harvest

Rule candidate: review-prompt

Pattern: when a guard has an *inform* half and an *act* half, a safety condition that
only constrains the act must not gate the inform — the event ends up detected, logged
and invisible to the only person who can respond to it. The tell is a branch whose
comment explains why it must not change state, and which then also declines to say
anything.
