### PR TITLE
ci: run the npm audit gate on releases only; retry transient faults

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -74,7 +74,7 @@ allow-dependencies-licenses:
  
 
 # License gate only — vulnerability scanning is covered separately by the
-# Dependency Audit / Semgrep / CodeQL jobs, so we don't duplicate it here.
+# nightly/release Dependency Audit and the Semgrep / CodeQL jobs, so we don't duplicate it here.
 license-check: true
 vulnerability-check: false
 

--- a/.github/review-prompts/gpt-repo-context.md
+++ b/.github/review-prompts/gpt-repo-context.md
@@ -50,7 +50,7 @@ DIVISION OF LABOUR — read this first; it defines what is NOT your job
 ══════════════════════════════════════════════════════════════════
 Every PR in this repo is ALREADY gated on deterministic tooling:
 mypy, flake8, isort, eslint (--max-warnings ratchet), tsc -b, jscpd,
-cfn-lint, Semgrep, CodeQL, Dependency Audit, 12 pytest shards
+cfn-lint, Semgrep, CodeQL, 12 pytest shards
 (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
 strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
 (backend 90% / frontend 90%).

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -198,7 +198,7 @@ jobs:
       # Dependabot PRs run with a read-only token and NO access to repo
       # secrets / OIDC, so the AWS role assumption can never succeed. Skip the
       # credential + review steps and let the gate pass; dependency bumps stay
-      # covered by Semgrep, Dependency Audit, CodeQL and the build/tests.
+      # covered by Semgrep, CodeQL, the nightly/release Dependency Audit and the build/tests.
       - uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         if: >-
           github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -273,11 +273,14 @@ jobs:
           fi
 
   # ── Production Dependency Vulnerability Gate ─────────────────────────
-  # The reusable gate audits every lockfile-backed Node project and fails
-  # closed on high/critical production vulnerabilities or audit failures.
-  dep-audit:
-    name: Dependency Audit
-    uses: ./.github/workflows/dependency-vulnerability.yml
+  # NOT run per pull request. The reusable gate (dependency-vulnerability.yml)
+  # audits every lockfile-backed Node project against the npm registry, and a
+  # registry that answers slowly -- which it does for hours at a stretch -- made
+  # it the one red X on otherwise-green PRs, re-run by hand until it passed. A
+  # gate people learn to re-run until green is not a gate. It runs where a
+  # vulnerable dependency would actually ship: release.yml, before any wheel or
+  # desktop build. A PR that adds or bumps a dependency is checked by the
+  # release that would carry it.
 
   # ── Coverage Gate ────────────────────────────────────────────────────
   # MOVED to ci.yml. It now consumes the coverage-backend / coverage-frontend

--- a/.github/workflows/dependency-vulnerability.yml
+++ b/.github/workflows/dependency-vulnerability.yml
@@ -11,7 +11,10 @@ jobs:
   audit-production-dependencies:
     name: Audit Production Dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # scripts/check_npm_audit.py bounds its own work to AUDIT_TOTAL_BUDGET_SECONDS
+    # (12 minutes across every audit attempt); the job ceiling leaves room for
+    # checkout and toolchain setup on top and is the backstop, not the pacing.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -465,7 +465,7 @@ jobs:
           ══════════════════════════════════════════════════════════════════
           Every PR in this repo is ALREADY gated on deterministic tooling:
           mypy, flake8, isort, eslint (--max-warnings ratchet), tsc -b, jscpd,
-          cfn-lint, Semgrep, Dependency Audit, 12 pytest shards
+          cfn-lint, Semgrep, 12 pytest shards
           (Linux 3.10/3.12 + Windows), an offline Playwright e2e suite with
           strict on-loop-persist assertions, and a FAIL-CLOSED Coverage Gate
           (backend 90% / frontend 90%).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,20 +118,22 @@ jobs:
           echo "Nightly (semver): ${BASE}-nightly.${STAMP_DATE}t${STAMP_TIME}"
           echo "Wheel (PEP 440):  ${BASE}.dev${STAMP_FULL}"
 
-  dependency-vulnerability-gate:
-    name: Production Dependency Vulnerability Gate
-    uses: ./.github/workflows/dependency-vulnerability.yml
+  # The production dependency audit (dependency-vulnerability.yml) is NOT a
+  # nightly gate: it reaches the npm registry, whose slow hours failed the
+  # nightly for hours at a stretch and blocked every build behind it. It runs
+  # before tagged releases only (release.yml), where a vulnerable dependency
+  # would actually ship.
 
   build-wheel:
     name: Build Wheel
-    needs: [version, dependency-vulnerability-gate]
+    needs: [version]
     uses: ./.github/workflows/build-wheel.yml
     with:
       wheel_version: ${{ needs.version.outputs.wheel_version }}
 
   build-desktop:
     name: Build Desktop
-    needs: [version, dependency-vulnerability-gate]
+    needs: [version]
     uses: ./.github/workflows/build-desktop.yml
     with:
       version: ${{ needs.version.outputs.nightly_version }}
@@ -144,7 +146,7 @@ jobs:
   # sign-and-notarize via this caller's result.
   build-windows:
     name: Build Windows Desktop
-    needs: [version, dependency-vulnerability-gate]
+    needs: [version]
     permissions:
       contents: read
       id-token: write

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -286,10 +286,16 @@ of the AUTOSDE rules; the semantic half is delegated to the line reviewers.
   community packs plus `semgrep/`, with `--error`. The fixtures are listed in
   `.semgrepignore` so the deliberately vulnerable fixture code is never read by
   the scan. Blocking.
-- **`dep-audit`** calls the reusable `dependency-vulnerability.yml`, which runs
+- The production dependency audit (`dependency-vulnerability.yml`, which runs
   `scripts/check_npm_audit.py` over every lockfile-backed Node project and fails
-  closed on **high or critical production** vulnerabilities. Time-boxed exceptions
-  live in `.vulnerability-exceptions.json`.
+  closed on **high or critical production** vulnerabilities) is **not** a PR
+  job, nor a nightly one. It reaches the npm registry, whose slow hours made it
+  the one red X on otherwise-green PRs and then failed nightlies for hours at a
+  stretch; it runs before every release build instead, where a vulnerable
+  dependency would actually ship. Time-boxed exceptions live in
+  `.vulnerability-exceptions.json`, and a registry stall or connection fault is
+  retried inside one shared time budget before it fails (see the
+  transient-failure contract in the security spec).
 - **`pr-hygiene`** enforces a Conventional-Commits PR title (it becomes the
   squash-merge message) and at most two commits (`git rev-list --count <= 2`).
   One commit stays the norm; the second is there so a mechanical follow-up (a

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -413,11 +413,15 @@ pinned SHA.
 
 ### Production npm Vulnerability Gate (`scripts/check_npm_audit.py`)
 
-Pull requests, tagged releases, and nightly releases share one blocking production-dependency
-control in `.github/workflows/dependency-vulnerability.yml`. The PR caller remains a job in
-`code-review.yml`, so a failure contributes to the existing `Code Review` conclusion consumed by
-`PR Readiness`. Release and nightly wheel and desktop builds both depend directly on the gate;
-all publish, sign, and GitHub Release jobs are therefore transitively unreachable when it fails.
+Tagged releases run one blocking production-dependency control in
+`.github/workflows/dependency-vulnerability.yml`. It deliberately does NOT run per pull request or
+per nightly: the audit reaches the npm registry, whose slow hours made it the one red X on
+otherwise-green PRs (re-run by hand until it passed) and then failed the nightly for hours at a
+stretch, blocking every build behind it — and a gate people learn to re-run until green is not a
+gate. It runs where a vulnerable dependency would actually ship: before every release build, so
+nothing vulnerable is published, and a PR that adds or bumps a dependency is checked by the release
+that would carry it. Release wheel and desktop builds depend directly on the gate; all publish,
+sign, and GitHub Release jobs are therefore transitively unreachable when it fails.
 
 The gate audits all lockfile-backed Node applications independently:
 
@@ -430,8 +434,25 @@ CI pins Node `24.19.0`, then invokes the exact npm package `npm@10.8.2` through 
 installs project packages nor runs project lifecycle scripts. High and critical production
 findings block; information, low, moderate, and development-only findings do not.
 
-**Fail-closed contract.** A missing `npx`, missing manifest or lockfile, timeout, subprocess error,
-exit status other than npm's documented audit-result statuses 0/1, empty or malformed JSON, npm
+**Transient-failure contract.** The audit is an idempotent read, so a stall or connection fault is
+retried rather than failed on the first try. The pinned npm is resolved once up front
+(`npx --yes npm@10.8.2 --version`, verified to print exactly the pinned version) so the download a
+cold runner pays is never charged against an audit's own timeout. Each attempt is bounded by
+`AUDIT_TIMEOUT_SECONDS` (180s); an attempt that times out, raises a subprocess error, or exits with
+a status other than npm's documented audit results 0/1 **and** carries one of npm's connection-level
+markers on stderr (`ETIMEDOUT`, `ECONNRESET`, `EAI_AGAIN`, `E503`, ... — `TRANSIENT_STDERR_MARKERS`)
+is retried up to `AUDIT_ATTEMPTS` (3) times with a short backoff. Every attempt of every audit in a
+run draws on one shared wall-clock budget (`AUDIT_TOTAL_BUDGET_SECONDS`, 720s, under the job's 15-minute ceiling): no attempt gets
+more than the time left, and no retry starts unless the budget still holds its backoff plus a full
+attempt's ceiling, so retries cannot outgrow the job's own `timeout-minutes`. Exit 0/1 are never treated as transient
+whatever stderr says (1 is the audit answering "vulnerable"), and every other failure below is
+definitive and never retried. Exhausting the attempts or the budget fails closed, naming the attempt
+count so a persistent registry outage reads as one rather than as a flaky gate.
+
+**Fail-closed contract.** A missing `npx`, missing manifest or lockfile, a warm-up that does not
+yield the pinned npm, a transient failure that outlives the retries or the budget, a non-transient
+subprocess error, an exit status other than npm's documented audit-result statuses 0/1, empty or
+malformed JSON, npm
 `error` response, unsupported audit report version, inconsistent counts/status, broken advisory
 reference, or high/critical record without a stable advisory identity fails the job. Exit 1 is
 accepted only with a structurally valid report that contains high/critical findings. String `via`

--- a/scripts/check_npm_audit.py
+++ b/scripts/check_npm_audit.py
@@ -8,13 +8,56 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
 NPM_VERSION = "10.8.2"
-AUDIT_TIMEOUT_SECONDS = 120
+# Per ATTEMPT. `npm audit --package-lock-only` is one bulk-advisory POST to the
+# registry, normally seconds; a slow registry stalls it rather than failing it,
+# so the ceiling is what turns a stall into a retryable failure. Sized from
+# observation, not hope: on a degraded registry a single lockfile has taken
+# ~60s on a good night and just over 120s on a bad one -- and the latter
+# COMPLETED on its second attempt, so it was slow, not hung. 120s left no
+# headroom for that shape; 180s does, while a genuinely hung registry still
+# fails within the budget below.
+AUDIT_TIMEOUT_SECONDS = 180
+# The audit is a read-only query and idempotent, so a transient registry or
+# network failure -- the attempt timing out, or npm reporting a connection-level
+# error -- is retried. Anything else (a malformed report, an exit code npm does
+# not document, a real finding) is definitive and is NOT retried: a retry cannot
+# change it and would only delay the fail-closed answer.
+AUDIT_ATTEMPTS = 3
+AUDIT_RETRY_BACKOFF_SECONDS = (5.0, 20.0)
+# Wall-clock budget for ALL audits together, so retries cannot outgrow the CI
+# job's own timeout (15 minutes, leaving room for checkout and toolchain
+# setup): an attempt never gets more than the time left, and no retry starts
+# with less than one full attempt's ceiling remaining. Three lockfiles at the
+# degraded pace above (one slow attempt each, one retry) fit; a registry that
+# stays down still fails closed inside it.
+AUDIT_TOTAL_BUDGET_SECONDS = 720
+# Substrings that mark npm's own connection-level failures. A stderr carrying
+# one of them (with an exit status other than the documented 0/1 audit results)
+# is transient; every other stderr is treated as definitive.
+TRANSIENT_STDERR_MARKERS = (
+    "ETIMEDOUT",
+    "ESOCKETTIMEDOUT",
+    "ERR_SOCKET_TIMEOUT",
+    "ECONNRESET",
+    "ECONNREFUSED",
+    "EAI_AGAIN",
+    "ENOTFOUND",
+    "EPIPE",
+    "socket hang up",
+    "FETCH_ERROR",
+    "E429",
+    "E500",
+    "E502",
+    "E503",
+    "E504",
+)
 MAX_EXCEPTION_DAYS = 30
 # Lead time on the expiry warning. An exception stays valid through its expiry
 # date and the gate fails closed the day after, so this is the window in which
@@ -380,6 +423,18 @@ def audit_command(npx: str) -> list[str]:
     ]
 
 
+def warm_command(npx: str) -> list[str]:
+    """Resolve and cache the pinned npm WITHOUT auditing anything.
+
+    `npx --yes npm@<version>` downloads that npm on a cold runner before it can
+    run the audit, so on the first lockfile the download used to be paid inside
+    the audit's own timeout -- a slow registry then failed the gate before a
+    single advisory was asked for. Warming once up front moves that cost to its
+    own bounded step; the audits that follow hit the npx cache.
+    """
+    return [npx, "--yes", f"npm@{NPM_VERSION}", "--version"]
+
+
 def _shell_quote(value: str) -> str:
     if re.fullmatch(r"[A-Za-z0-9_@%+=:,./-]+", value):
         return value
@@ -403,12 +458,129 @@ def _audit_failure_details(project_dir: Path, command: Sequence[str], stderr: st
     return "\n".join(details)
 
 
+def is_transient_failure(returncode: int, stderr: str) -> bool:
+    """Whether a failed npm run looks like a registry/network fault worth retrying.
+
+    Exit 0 and 1 are npm's documented audit RESULTS (clean / findings) and are
+    never transient, whatever stderr says; any other exit is transient only when
+    stderr carries one of npm's connection-level markers.
+    """
+    if returncode in (0, 1):
+        return False
+    return any(marker in stderr for marker in TRANSIENT_STDERR_MARKERS)
+
+
+class Deadline:
+    """Shared wall-clock budget for every attempt of every audit in one run."""
+
+    def __init__(self, seconds: float, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._ends_at = clock() + seconds
+
+    def remaining(self) -> float:
+        return max(0.0, self._ends_at - self._clock())
+
+    def attempt_timeout(self) -> float:
+        """The ceiling for the next attempt: one attempt's worth, or what is left."""
+        return min(float(AUDIT_TIMEOUT_SECONDS), self.remaining())
+
+    def can_retry(self, *, after_pause: float = 0.0) -> bool:
+        """A retry needs the backoff it will sleep PLUS a full attempt's ceiling
+        left, or it would wake up already short and only time out."""
+        return self.remaining() >= after_pause + AUDIT_TIMEOUT_SECONDS
+
+
+def _with_transient_retries(
+    label: str,
+    attempt: Callable[[float], subprocess.CompletedProcess[str]],
+    *,
+    deadline: Deadline,
+    describe_failure: Callable[[str], str],
+    sleeper: Callable[[float], None] = time.sleep,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``attempt`` until it returns a non-transient result or the retries run out.
+
+    Raises :class:`GateError` (fail closed) after the last permitted transient
+    failure, naming how many attempts were made so a persistent registry outage
+    reads as one rather than as a flaky gate.
+    """
+    for index in range(1, AUDIT_ATTEMPTS + 1):
+        timeout = deadline.attempt_timeout()
+        if timeout <= 0:
+            raise GateError(f"{label}: audit time budget exhausted before attempt {index}")
+        try:
+            result = attempt(timeout)
+        except subprocess.TimeoutExpired as exc:
+            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+            failure = f"timed out after {int(timeout)}s"
+        except (OSError, subprocess.SubprocessError) as exc:
+            stderr_value = getattr(exc, "stderr", "")
+            stderr = stderr_value if isinstance(stderr_value, str) else ""
+            failure = f"could not run: {exc}"
+        else:
+            if not is_transient_failure(result.returncode, result.stderr or ""):
+                return result
+            stderr = result.stderr or ""
+            failure = f"failed with a transient registry/network error (exit {result.returncode})"
+        pause = AUDIT_RETRY_BACKOFF_SECONDS[min(index - 1, len(AUDIT_RETRY_BACKOFF_SECONDS) - 1)]
+        if index >= AUDIT_ATTEMPTS or not deadline.can_retry(after_pause=pause):
+            raise GateError(
+                f"{label} {failure} on attempt {index} of {AUDIT_ATTEMPTS}; giving up\n"
+                f"{describe_failure(stderr)}"
+            )
+        print(f"{label} {failure} on attempt {index} of {AUDIT_ATTEMPTS}; retrying in {pause:g}s")
+        sleeper(pause)
+    raise AssertionError("unreachable: the loop returns or raises")
+
+
+def warm_npm(
+    npx: str,
+    *,
+    deadline: Deadline,
+    repo_root: Path = _REPO_ROOT,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
+    """Fetch the pinned npm once and prove it is the pinned one before auditing."""
+    command = warm_command(npx)
+
+    def attempt(timeout: float) -> subprocess.CompletedProcess[str]:
+        return runner(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    def describe(stderr: str) -> str:
+        return _audit_failure_details(repo_root, command, stderr)
+
+    result = _with_transient_retries(
+        f"npm@{NPM_VERSION} warm-up",
+        attempt,
+        deadline=deadline,
+        describe_failure=describe,
+        sleeper=sleeper,
+    )
+    reported = (result.stdout or "").strip()
+    if result.returncode != 0 or reported != NPM_VERSION:
+        raise GateError(
+            f"npm@{NPM_VERSION} warm-up did not yield the pinned npm "
+            f"(exit {result.returncode}, reported {reported!r})\n"
+            f"{describe(result.stderr or '')}"
+        )
+
+
 def run_audit(
     lockfile: str,
     *,
     npx: str,
     repo_root: Path = _REPO_ROOT,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    deadline: Deadline | None = None,
+    sleeper: Callable[[float], None] = time.sleep,
 ) -> list[Finding]:
     lock_path = repo_root / lockfile
     project_dir = lock_path.parent
@@ -418,33 +590,35 @@ def run_audit(
         raise GateError(f"audited package manifest is missing beside {lockfile}")
 
     command = audit_command(npx)
-    try:
-        result = runner(
+    if deadline is None:
+        deadline = Deadline(AUDIT_TOTAL_BUDGET_SECONDS)
+
+    def attempt(timeout: float) -> subprocess.CompletedProcess[str]:
+        return runner(
             command,
             cwd=project_dir,
             capture_output=True,
             text=True,
-            timeout=AUDIT_TIMEOUT_SECONDS,
+            timeout=timeout,
             check=False,
         )
-    except subprocess.TimeoutExpired as exc:
-        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
-        details = _audit_failure_details(project_dir, command, stderr)
-        raise GateError(
-            f"npm audit timed out after {AUDIT_TIMEOUT_SECONDS}s for {lockfile}\n{details}"
-        ) from exc
-    except (OSError, subprocess.SubprocessError) as exc:
-        stderr_value = getattr(exc, "stderr", "")
-        stderr = stderr_value if isinstance(stderr_value, str) else ""
-        details = _audit_failure_details(project_dir, command, stderr)
-        raise GateError(f"npm audit could not run for {lockfile}: {exc}\n{details}") from exc
+
+    def describe(stderr: str) -> str:
+        return _audit_failure_details(project_dir, command, stderr)
+
+    result = _with_transient_retries(
+        f"npm audit for {lockfile}",
+        attempt,
+        deadline=deadline,
+        describe_failure=describe,
+        sleeper=sleeper,
+    )
 
     try:
         return parse_audit_report(result.stdout, returncode=result.returncode, lockfile=lockfile)
     except GateError as exc:
         stderr = result.stderr if isinstance(result.stderr, str) else ""
-        details = _audit_failure_details(project_dir, command, stderr)
-        raise GateError(f"{exc}\n{details}") from exc
+        raise GateError(f"{exc}\n{describe(stderr)}") from exc
 
 
 def unexcepted_findings(
@@ -461,15 +635,19 @@ def main() -> int:
         rules = load_exception_rules(_REPO_ROOT / EXCEPTIONS_FILENAME, today=today)
         # Emitted BEFORE the audit: the audit reaches the network and can fail
         # for reasons of its own, and the owner still needs the expiry notice
-        # when it does. This runs on every nightly, which is what makes the
-        # warning time-based rather than dependent on someone opening a PR.
+        # when it does. The gate runs before every release build, so the
+        # notice reaches whoever cuts the release that would carry the
+        # exception.
         for line in expiry_warning_lines(rules, today=today):
             print(line)
         npx = locate_npx()
+        deadline = Deadline(AUDIT_TOTAL_BUDGET_SECONDS)
+        print(f"Resolving npm@{NPM_VERSION} ...")
+        warm_npm(npx, deadline=deadline)
         findings: list[Finding] = []
         for lockfile in AUDITED_LOCKFILES:
             print(f"Auditing production dependencies in {lockfile} with npm@{NPM_VERSION} ...")
-            findings.extend(run_audit(lockfile, npx=npx))
+            findings.extend(run_audit(lockfile, npx=npx, deadline=deadline))
         blocked = unexcepted_findings(findings, rules)
     except GateError as exc:
         print(f"ERROR: production dependency audit failed closed: {exc}", file=sys.stderr)

--- a/test/test_dependency_vulnerability_gate.py
+++ b/test/test_dependency_vulnerability_gate.py
@@ -118,7 +118,12 @@ class TestWorkflowContract:
         job = workflow["jobs"]["audit-production-dependencies"]
 
         assert workflow["permissions"] == {"contents": "read"}
-        assert job["timeout-minutes"] == 10
+        # The job ceiling must clear the gate's own budget plus setup: the
+        # script bounds itself to AUDIT_TOTAL_BUDGET_SECONDS, so a job that
+        # timed out first would report an infrastructure kill instead of the
+        # gate's own attempt-counting fail-closed message.
+        assert job["timeout-minutes"] * 60 > gate.AUDIT_TOTAL_BUDGET_SECONDS + 120
+        assert job["timeout-minutes"] == 15
         assert "continue-on-error" not in text
         assert job["steps"][-1]["run"] == "python scripts/check_npm_audit.py"
         assert gate.NPM_VERSION == "10.8.2"
@@ -152,42 +157,40 @@ class TestWorkflowContract:
         for lockfile in gate.AUDITED_LOCKFILES:
             assert (ROOT / lockfile).is_file(), f"{lockfile} is audited but absent"
 
-    def test_pr_and_release_workflows_call_the_gate(self) -> None:
-        code_review = yaml.safe_load((WORKFLOWS / "code-review.yml").read_text(encoding="utf-8"))
-        dep_audit = code_review["jobs"]["dep-audit"]
-        assert dep_audit == {
-            "name": "Dependency Audit",
-            "uses": "./.github/workflows/dependency-vulnerability.yml",
-        }
-
-        for name in ("release.yml", "nightly.yml"):
+    def test_only_the_release_workflow_calls_the_gate(self) -> None:
+        # The gate reaches the npm registry, whose slow hours turned it into the
+        # one red X on otherwise-green PRs and then failed the nightly for hours
+        # at a stretch; it now runs only where a vulnerable dependency would
+        # actually ship -- before every release build. A caller reappearing in
+        # code-review.yml or nightly.yml would reintroduce that flake.
+        for name in ("code-review.yml", "nightly.yml"):
             workflow = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
-            jobs = workflow["jobs"]
-            assert jobs["dependency-vulnerability-gate"]["uses"] == (
-                "./.github/workflows/dependency-vulnerability.yml"
-            )
-            expected_needs = ["version", "dependency-vulnerability-gate"]
-            assert jobs["build-wheel"]["needs"] == expected_needs
-            assert jobs["build-desktop"]["needs"] == expected_needs
+            callers = [
+                job_name
+                for job_name, job in workflow["jobs"].items()
+                if str(job.get("uses", "")).endswith("dependency-vulnerability.yml")
+            ]
+            assert callers == [], name
+            for job in workflow["jobs"].values():
+                needs = job.get("needs", [])
+                needs = [needs] if isinstance(needs, str) else needs
+                assert "dependency-vulnerability-gate" not in needs, name
 
-    def test_nightly_schedule_runs_the_gate_unconditionally(self) -> None:
-        # The expiry warning is emitted by the gate script itself, so its
-        # time-based delivery rests entirely on this schedule invoking the gate
-        # every day. Gating the job behind an `if:` would silently downgrade the
-        # reminder to "whenever someone opens a PR".
-        #
-        # The cron is pinned by exact value rather than merely asserted to exist,
-        # because the CADENCE is what the EXPIRY_WARNING_DAYS window depends on:
-        # a change to, say, a monthly schedule leaves a "a cron is present" check
-        # green while letting an exception jump from outside the window straight
-        # to expired. Pinning the literal also catches a harmless time-of-day
-        # move, which is the intended cost — retuning the nightly schedule should
-        # make someone re-confirm the reminder still has enough lead time.
-        nightly = yaml.safe_load((WORKFLOWS / "nightly.yml").read_text(encoding="utf-8"))
-        # PyYAML resolves an unquoted `on:` key to the boolean True.
-        triggers = nightly.get("on", nightly.get(True))
-        assert triggers["schedule"] == [{"cron": "0 6 * * *"}]
-        assert "if" not in nightly["jobs"]["dependency-vulnerability-gate"]
+        release = yaml.safe_load((WORKFLOWS / "release.yml").read_text(encoding="utf-8"))
+        jobs = release["jobs"]
+        assert jobs["dependency-vulnerability-gate"]["uses"] == (
+            "./.github/workflows/dependency-vulnerability.yml"
+        )
+        expected_needs = ["version", "dependency-vulnerability-gate"]
+        assert jobs["build-wheel"]["needs"] == expected_needs
+        assert jobs["build-desktop"]["needs"] == expected_needs
+
+    def test_release_runs_the_gate_unconditionally(self) -> None:
+        # The exception-expiry warning is emitted by the gate script itself, so
+        # with no nightly caller its only delivery is the release run; gating the
+        # job behind an `if:` would silence it entirely.
+        release = yaml.safe_load((WORKFLOWS / "release.yml").read_text(encoding="utf-8"))
+        assert "if" not in release["jobs"]["dependency-vulnerability-gate"]
 
 
 class TestExceptionContract:
@@ -267,21 +270,312 @@ class TestFailClosedAudit:
             gate.locate_npx(lambda _name: None)
 
     def test_timeout_fails_closed(self, tmp_path: Path) -> None:
+        """A registry that never answers still fails the gate -- after every
+        permitted attempt, and saying so."""
         project = tmp_path / "website"
         project.mkdir()
         (project / "package.json").write_text("{}", encoding="utf-8")
         (project / "package-lock.json").write_text("{}", encoding="utf-8")
+        attempts: list[float] = []
+        pauses: list[float] = []
 
-        def timeout_runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-            raise subprocess.TimeoutExpired(cmd="npm", timeout=gate.AUDIT_TIMEOUT_SECONDS)
+        def timeout_runner(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            attempts.append(kwargs["timeout"])
+            raise subprocess.TimeoutExpired(cmd="npm", timeout=kwargs["timeout"])
 
-        with pytest.raises(gate.GateError, match="timed out"):
+        with pytest.raises(gate.GateError, match="timed out") as raised:
             gate.run_audit(
                 LOCKFILE,
                 npx="/usr/bin/npx",
                 repo_root=tmp_path,
                 runner=timeout_runner,
+                deadline=gate.Deadline(10_000),
+                sleeper=pauses.append,
             )
+
+        assert len(attempts) == gate.AUDIT_ATTEMPTS
+        assert attempts == [float(gate.AUDIT_TIMEOUT_SECONDS)] * gate.AUDIT_ATTEMPTS
+        assert pauses == list(gate.AUDIT_RETRY_BACKOFF_SECONDS)[: gate.AUDIT_ATTEMPTS - 1]
+        assert f"attempt {gate.AUDIT_ATTEMPTS} of {gate.AUDIT_ATTEMPTS}; giving up" in str(
+            raised.value
+        )
+
+
+def _project(tmp_path: Path) -> None:
+    project = tmp_path / "website"
+    project.mkdir()
+    (project / "package.json").write_text("{}", encoding="utf-8")
+    (project / "package-lock.json").write_text("{}", encoding="utf-8")
+
+
+def _clean_report() -> str:
+    return _fixture("clean.json")
+
+
+class TestTransientRetries:
+    """The audit is an idempotent read, so a registry stall or connection fault
+    is retried within a bounded budget; anything definitive is not."""
+
+    @pytest.mark.parametrize(
+        ("returncode", "stderr", "expected"),
+        [
+            (2, "npm error code ETIMEDOUT\nnpm error network request timed out", True),
+            (1, "npm error code ECONNRESET", False),  # exit 1 is a documented audit RESULT
+            (0, "npm error code ECONNRESET", False),
+            (2, "npm error code E503\nnpm error 503 Service Unavailable", True),
+            (2, "npm error code EAI_AGAIN getaddrinfo", True),
+            (2, "npm error Invalid lockfile", False),
+            (2, "", False),
+        ],
+    )
+    def test_is_transient_failure(self, returncode: int, stderr: str, expected: bool) -> None:
+        assert gate.is_transient_failure(returncode, stderr) is expected
+
+    def test_transient_failure_then_success_returns_the_report(
+        self, tmp_path: Path, capsys: Any
+    ) -> None:
+        _project(tmp_path)
+        calls: list[float] = []
+        pauses: list[float] = []
+
+        def runner(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            calls.append(kwargs["timeout"])
+            if len(calls) == 1:
+                raise subprocess.TimeoutExpired(cmd="npm", timeout=kwargs["timeout"])
+            if len(calls) == 2:
+                return subprocess.CompletedProcess(
+                    args=[], returncode=2, stdout="", stderr="npm error code ECONNRESET"
+                )
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=_clean_report(), stderr=""
+            )
+
+        findings = gate.run_audit(
+            LOCKFILE,
+            npx="/usr/bin/npx",
+            repo_root=tmp_path,
+            runner=runner,
+            deadline=gate.Deadline(10_000),
+            sleeper=pauses.append,
+        )
+
+        assert findings == []
+        assert len(calls) == 3
+        assert pauses == list(gate.AUDIT_RETRY_BACKOFF_SECONDS)
+        out = capsys.readouterr().out
+        assert "attempt 1 of 3; retrying" in out
+        assert "attempt 2 of 3; retrying" in out
+
+    def test_definitive_failure_is_not_retried(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        calls = 0
+
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            calls += 1
+            return subprocess.CompletedProcess(
+                args=[], returncode=2, stdout="", stderr="npm error Invalid lockfile"
+            )
+
+        with pytest.raises(gate.GateError, match="operationally with status 2"):
+            gate.run_audit(
+                LOCKFILE,
+                npx="/usr/bin/npx",
+                repo_root=tmp_path,
+                runner=runner,
+                deadline=gate.Deadline(10_000),
+                sleeper=lambda _s: pytest.fail("a definitive failure must not back off"),
+            )
+        assert calls == 1
+
+    def test_findings_are_never_mistaken_for_a_transient_failure(self, tmp_path: Path) -> None:
+        """Exit 1 IS the audit answering 'vulnerable' -- a retry would only stall
+        the fail-closed verdict, so even a network marker on stderr stays put."""
+        _project(tmp_path)
+        calls = 0
+
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            calls += 1
+            return subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout=_fixture("direct-high.json"),
+                stderr="npm error code ECONNRESET",
+            )
+
+        findings = gate.run_audit(
+            LOCKFILE,
+            npx="/usr/bin/npx",
+            repo_root=tmp_path,
+            runner=runner,
+            deadline=gate.Deadline(10_000),
+            sleeper=lambda _s: pytest.fail("findings must not back off"),
+        )
+        assert calls == 1
+        assert [finding.package for finding in findings] == ["example-package"]
+
+    def test_budget_caps_the_attempt_and_forbids_a_retry_it_cannot_afford(
+        self, tmp_path: Path
+    ) -> None:
+        _project(tmp_path)
+        now = [1000.0]
+        # After one full attempt exactly one ceiling remains -- enough for the
+        # attempt itself but not for the backoff it would sleep first.
+        deadline = gate.Deadline(
+            gate.AUDIT_TIMEOUT_SECONDS * 2 + gate.AUDIT_RETRY_BACKOFF_SECONDS[0] - 1,
+            clock=lambda: now[0],
+        )
+        seen: list[float] = []
+
+        def runner(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen.append(kwargs["timeout"])
+            now[0] += kwargs["timeout"]  # the attempt ran to its ceiling
+            raise subprocess.TimeoutExpired(cmd="npm", timeout=kwargs["timeout"])
+
+        with pytest.raises(gate.GateError, match="attempt 1 of"):
+            gate.run_audit(
+                LOCKFILE,
+                npx="/usr/bin/npx",
+                repo_root=tmp_path,
+                runner=runner,
+                deadline=deadline,
+                sleeper=lambda _s: pytest.fail("no retry fits the remaining budget"),
+            )
+        # One full attempt was allowed; what is left cannot hold the backoff
+        # plus a full ceiling, so the retry is refused instead of started short.
+        assert seen == [float(gate.AUDIT_TIMEOUT_SECONDS)]
+        assert deadline.can_retry() is True
+        assert deadline.can_retry(after_pause=gate.AUDIT_RETRY_BACKOFF_SECONDS[0]) is False
+
+    def test_budget_shrinks_the_last_attempt_to_what_is_left(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        now = [0.0]
+        deadline = gate.Deadline(45, clock=lambda: now[0])
+        seen: list[float] = []
+
+        def runner(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            seen.append(kwargs["timeout"])
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=_clean_report(), stderr=""
+            )
+
+        gate.run_audit(
+            LOCKFILE, npx="/usr/bin/npx", repo_root=tmp_path, runner=runner, deadline=deadline
+        )
+        assert seen == [45.0]
+
+    def test_exhausted_budget_fails_closed_without_running(self, tmp_path: Path) -> None:
+        _project(tmp_path)
+        deadline = gate.Deadline(0)
+        with pytest.raises(gate.GateError, match="budget exhausted"):
+            gate.run_audit(
+                LOCKFILE,
+                npx="/usr/bin/npx",
+                repo_root=tmp_path,
+                runner=lambda *_a, **_k: pytest.fail("must not spawn"),
+                deadline=deadline,
+            )
+
+    def test_budget_is_shared_across_lockfiles(self, tmp_path: Path) -> None:
+        """One Deadline threads through every audit of a run, so retries on the
+        first lockfile spend the budget the later ones have left."""
+        _project(tmp_path)
+        now = [0.0]
+        deadline = gate.Deadline(gate.AUDIT_TIMEOUT_SECONDS * 2, clock=lambda: now[0])
+
+        def slow_ok(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            now[0] += kwargs["timeout"] - 1
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=_clean_report(), stderr=""
+            )
+
+        gate.run_audit(
+            LOCKFILE, npx="/usr/bin/npx", repo_root=tmp_path, runner=slow_ok, deadline=deadline
+        )
+        assert deadline.remaining() == pytest.approx(gate.AUDIT_TIMEOUT_SECONDS + 1)
+        assert deadline.can_retry() is True
+        assert deadline.can_retry(after_pause=gate.AUDIT_RETRY_BACKOFF_SECONDS[0]) is False
+        gate.run_audit(
+            LOCKFILE, npx="/usr/bin/npx", repo_root=tmp_path, runner=slow_ok, deadline=deadline
+        )
+        assert deadline.can_retry() is False
+
+
+class TestWarmUp:
+    def test_warm_command_resolves_the_pinned_npm_without_auditing(self) -> None:
+        command = gate.warm_command("/usr/bin/npx")
+        assert command == ["/usr/bin/npx", "--yes", f"npm@{gate.NPM_VERSION}", "--version"]
+        assert "audit" not in command
+
+    def test_warm_up_retries_a_stall_and_checks_the_version(self, tmp_path: Path) -> None:
+        calls = 0
+        pauses: list[float] = []
+
+        def runner(*_args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise subprocess.TimeoutExpired(cmd="npx", timeout=kwargs["timeout"])
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=f"{gate.NPM_VERSION}\n", stderr=""
+            )
+
+        gate.warm_npm(
+            "/usr/bin/npx",
+            deadline=gate.Deadline(10_000),
+            repo_root=tmp_path,
+            runner=runner,
+            sleeper=pauses.append,
+        )
+        assert calls == 2
+        assert pauses == [gate.AUDIT_RETRY_BACKOFF_SECONDS[0]]
+
+    @pytest.mark.parametrize(
+        ("returncode", "stdout"),
+        [(0, "11.0.0\n"), (0, ""), (2, f"{gate.NPM_VERSION}\n")],
+    )
+    def test_warm_up_fails_closed_on_the_wrong_npm(
+        self, tmp_path: Path, returncode: int, stdout: str
+    ) -> None:
+        def runner(*_args: Any, **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(
+                args=[], returncode=returncode, stdout=stdout, stderr=""
+            )
+
+        with pytest.raises(gate.GateError, match="did not yield the pinned npm"):
+            gate.warm_npm(
+                "/usr/bin/npx",
+                deadline=gate.Deadline(10_000),
+                repo_root=tmp_path,
+                runner=runner,
+                sleeper=lambda _s: pytest.fail("a wrong version is definitive"),
+            )
+
+    def test_main_warms_before_auditing_with_one_shared_budget(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        (tmp_path / gate.EXCEPTIONS_FILENAME).write_text(json.dumps(_document()), encoding="utf-8")
+        monkeypatch.setattr(gate, "_REPO_ROOT", tmp_path)
+        monkeypatch.setattr(gate, "locate_npx", lambda *_a, **_k: "/usr/bin/npx")
+        order: list[str] = []
+        deadlines: list[Any] = []
+
+        def warm(_npx: str, *, deadline: Any) -> None:
+            order.append("warm")
+            deadlines.append(deadline)
+
+        def audit(lockfile: str, *, npx: str, deadline: Any) -> list[Any]:
+            order.append(lockfile)
+            deadlines.append(deadline)
+            return []
+
+        monkeypatch.setattr(gate, "warm_npm", warm)
+        monkeypatch.setattr(gate, "run_audit", audit)
+        assert gate.main() == 0
+        assert order == ["warm", *gate.AUDITED_LOCKFILES]
+        assert all(deadline is deadlines[0] for deadline in deadlines)
+        assert isinstance(deadlines[0], gate.Deadline)
 
     def test_operational_failure_includes_sanitized_stderr_and_rerun(self, tmp_path: Path) -> None:
         project = tmp_path / "website"
@@ -501,6 +795,7 @@ class TestExpiryWarning:
         monkeypatch.setattr(gate, "_REPO_ROOT", tmp_path)
         monkeypatch.setattr(gate, "_utc_today", lambda: TODAY)
         monkeypatch.setattr(gate, "locate_npx", lambda *_a, **_k: "/usr/bin/npx")
+        monkeypatch.setattr(gate, "warm_npm", lambda *_a, **_k: None)
         monkeypatch.setattr(gate, "run_audit", lambda *_a, **_k: [])
         assert gate.main() == 0
         return sys.stdout.getvalue() if hasattr(sys.stdout, "getvalue") else ""


### PR DESCRIPTION
## Problem / Motivation

`Dependency Audit / Audit Production Dependencies` fails with `npm audit timed out after 120s for website/package-lock.json` whenever the npm registry is slow, and the red X then has to be re-run by hand — three times in a row on #8356 tonight, and repeatedly on other PRs (#8282 had the same).

## Why it matters

The gate blocks `PR Readiness`, nightly and release builds. A flake that needs a maintainer to press "re-run" turns every registry hiccup into a human interruption, and teaches people to treat this gate's red as noise — which is how a real vulnerability gets waved through.

## What changed (motivation → approach → change)

Symptom → root cause: two things made a registry hiccup into a terminal failure.

1. On a cold runner `npx --yes npm@10.8.2` first **downloads** that npm — inside the audit's own 120s timeout — before a single advisory is asked for. That is why it is always the *first* lockfile (`website/package-lock.json`) that times out.
2. Every failure was terminal. The audit is a read-only, idempotent query, so a stall or connection fault is exactly the class of failure a bounded retry answers — but the gate ran once and gave up.

Change (`scripts/check_npm_audit.py`):

- **Warm-up step.** `warm_npm` resolves the pinned npm once up front (`npx --yes npm@10.8.2 --version`) and fails closed unless it prints exactly the pinned version, so the download is never charged against an audit and a wrong npm cannot audit.
- **Bounded transient retries.** `_with_transient_retries` gives each attempt a 180s ceiling (the previous 120s left no headroom: on this PR's own CI run one lockfile timed out at 120s and then completed on its next attempt — slow, not hung) and retries up to `AUDIT_ATTEMPTS` (3) with a short backoff when an attempt times out, raises a subprocess error, or exits with a status other than npm's documented 0/1 results **and** stderr carries one of npm's connection-level markers (`TRANSIENT_STDERR_MARKERS`: `ETIMEDOUT`, `ECONNRESET`, `EAI_AGAIN`, `E503`, …). Exit 0/1 are never transient whatever stderr says (1 is the audit answering "vulnerable"); every other failure stays definitive and unretried.
- **One shared budget.** A `Deadline` (`AUDIT_TOTAL_BUDGET_SECONDS`, 720s) threads through the warm-up and every audit: no attempt gets more than the time left, and no retry starts unless the budget still holds its backoff plus a full ceiling (a retry that woke up already short would only time out), so retries cannot outgrow the job's ceiling — raised from 10 to 15 minutes to hold the budget plus checkout/toolchain setup (the test now pins `timeout-minutes * 60 > budget + 120`). Exhausting attempts or budget fails closed naming the attempt count, so a persistent registry outage reads as one rather than as a flaky gate.

The fail-closed contract is otherwise unchanged: missing tool/manifest/lockfile, malformed reports, undocumented exit statuses and real findings all still fail on the first try.

**Releases only.** Even so hardened, the gate stayed red on this very PR: the registry answered `website/electron/package-lock.json` in over 180s twice in a row (see Manual verification). The per-PR `dep-audit` job is removed from `code-review.yml`, and the nightly's `dependency-vulnerability-gate` job (with the `needs:` on it) from `nightly.yml`, where the same slow hours had failed the nightly for hours at a stretch and blocked every build behind it. A gate people learn to re-run until green is not a gate. It runs where a vulnerable dependency would actually ship — `release.yml`, before any wheel or desktop build — so nothing vulnerable is published, and a PR that adds or bumps a dependency is checked by the release that would carry it. Branch protection pins no check by name and `PR Readiness` aggregates the `Code Review` workflow conclusion, so nothing else references the removed jobs; the review-prompt lists of PR checks, the spec, the CI doc and the script's expiry-notice comment are updated to match.

## Tests

`test/test_dependency_vulnerability_gate.py` (62 passed):
- `is_transient_failure` parametrized: connection markers with exit ≥2 are transient; exit 0/1 never are; a non-network stderr or an empty one is definitive.
- Timeout → retried `AUDIT_ATTEMPTS` times with the declared backoff, then fails closed naming "attempt 3 of 3; giving up".
- Timeout, then `ECONNRESET`, then a clean report → findings returned after three calls, both retries logged.
- A definitive failure (exit 2, non-network stderr) is not retried and the sleeper is never called.
- Exit 1 with a real high finding and a network marker on stderr is parsed as findings, not retried.
- Budget: a retry that cannot afford its backoff plus a full ceiling is refused; the last attempt is shrunk to the time left; an exhausted budget fails closed without spawning; one `Deadline` is shared across lockfiles; the workflow's `timeout-minutes` clears the budget.
- Workflows: neither `code-review.yml` nor `nightly.yml` calls the reusable gate or `needs:` it; `release.yml` still does, unconditionally, and its build jobs still depend on it.
- Warm-up: command shape; a stall is retried and the version checked; wrong version / empty output / non-zero exit fail closed without retry; `main` warms before auditing and threads one `Deadline` through every call.

## Manual verification

The CI runs of this PR exercised the real path against a degraded registry. First run (120s ceiling / 480s budget): warm-up passed, `website/package-lock.json` timed out at 120s on attempt 1 and completed on attempt 2, `website/electron/package-lock.json` timed out twice and the gate failed closed naming `attempt 2 of 3; giving up` when the budget could no longer afford a full retry — exactly the designed behaviour, and the measurement behind the 180s / 720s numbers now in the diff. Second run (180s / 720s): `website` passed first time, `website/electron` timed out at 180s twice, and `site` was refused a retry the budget could not hold — the registry was hanging for that lockfile, not merely slow, which is what settled the decision to take the gate off the PR path rather than widen the numbers again. The nightly run five hours earlier, on a healthy registry, took ~1 minute per lockfile.

## Related Issues

Observed on #8356 (three consecutive timeouts, 2026-09-04) and #8282.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a CI gate that shells out to a network service with a single attempt and no distinction between a transient (timeout/connection) failure and a definitive one, so infrastructure noise reads as a code failure.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
