### PR TITLE
docs: align documented node floor

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -37,7 +37,7 @@ Builds use plain `pip` + `npm`/Vite + `pytest`, driven by the repo-root
 | Requirement | Needed for | Floor |
 |-------------|------------|-------|
 | **Python** | Backend | `>= 3.12` (`requires-python` in `pyproject.toml`; `make build` provisions a 3.12 `.venv` by default) |
-| **Node.js + npm** | Building the dashboard | `>= 22` (`website/package.json` `engines`; Node 24 LTS recommended); the legacy Amazon Linux 2 path drops to 16 where newer official builds need a glibc that host does not have |
+| **Node.js + npm** | Building the dashboard | `>= 22` (`website/package.json` `engines`; Node 24 LTS recommended); on x86_64 Amazon Linux 2, the glibc-217 fallback installs Node 24 because official builds need a newer glibc (no glibc-217 arm64 build is available) |
 | **`kiro-cli`** | Driving the LLM | Required; see below |
 
 Node is only needed to *build* the dashboard. The prebuilt wheel, the DMG, the

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -37,7 +37,7 @@ Builds use plain `pip` + `npm`/Vite + `pytest`, driven by the repo-root
 | Requirement | Needed for | Floor |
 |-------------|------------|-------|
 | **Python** | Backend | `>= 3.12` (`requires-python` in `pyproject.toml`; `make build` provisions a 3.12 `.venv` by default) |
-| **Node.js + npm** | Building the dashboard | `20 \|\| >= 22` (`website/package.json` `engines`); `ensure-node.sh` targets 20, and drops to 16 on Amazon Linux 2 where newer official builds need a glibc that host does not have |
+| **Node.js + npm** | Building the dashboard | `>= 22` (`website/package.json` `engines`; Node 24 LTS recommended); the legacy Amazon Linux 2 path drops to 16 where newer official builds need a glibc that host does not have |
 | **`kiro-cli`** | Driving the LLM | Required; see below |
 
 Node is only needed to *build* the dashboard. The prebuilt wheel, the DMG, the


### PR DESCRIPTION
## Problem / Motivation

The install guide still advertises Node `20 || >=22` for building the dashboard, although `website/package.json` requires `>=22`.

## Why it matters

A contributor following the installation table can select Node 20 and attempt a dashboard build outside the package's declared supported engine range.

## What changed (motivation → approach → change)

Update only the Node.js row in `docs/guides/install.md` to match the existing `>=22` engine and recommend Node 24 LTS. Preserve the documented legacy Amazon Linux 2 caveat. No dependency, runtime behavior, or public API changes.

## Tests

No automated regression test added for this documentation-only line change.

- `git diff --check`: passed before submission.
- `python -m py_compile scripts/docs_lint.py`: passed before submission; this validates the checker syntax, not documentation behavior.
- The broader audit ran `python scripts/docs_lint.py`: passed (248 Markdown files).
- Full pytest was not run. The attempted build-target parity subset was blocked during collection by missing `hypothesis`; this is not a passing test result.

## Manual verification

Compared the changed row with the declared Node engine and existing Node-floor guidance. Reviewed the complete one-line diff. No dashboard build or legacy AL2 installation was performed for this prose correction.

## Related Issues

Fixes #8364.

## Pattern harvest

Rule candidate: review-prompt
Pattern: when a runtime engine floor changes, compare installation tables with the authoritative package manifest, keeping platform-specific legacy caveats separate.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [ ] Existing tests pass and new tests added for new functionality — no new functionality; full suite not run, limitations above
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
