### PR TITLE
fix: inject current user's display name into WeCom prompts

### DIFF
--- a/src/kiro_crew/messaging/dispatch.py
+++ b/src/kiro_crew/messaging/dispatch.py
@@ -222,6 +222,10 @@ class ChannelTurn:
     the spool and its refusal path is byte-identical to before.
     """
 
+    user_display_name: Optional[str] = None
+    """Human name of the sender, injected as ``[CURRENT USER]`` so the agent
+    knows who it is talking to. ``None`` omits the block (byte-identical to before)."""
+
 
 #: Every spelling a channel accepts for "abort the running turn". The union of
 #: the per-channel command tables (``/stop`` and ``/cancel`` everywhere, plus
@@ -644,6 +648,7 @@ async def drive_turn(turn: ChannelTurn, *, sessions: Any, ctx_builder: Any) -> N
             resumed=resumed,
             minimal_context=turn.minimal_context,
             runtime_source=turn.channel_type,
+            user_display_name=turn.user_display_name,
         )
 
         driver = TurnDriver(

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -274,6 +274,7 @@ class WeComDispatcher:
                     notice=lambda sk, provider: self._maybe_notice(inbound, sk, provider),
                     audit_caller=f"wecom:{userid}",
                     after_persist=_surface_new_session,
+                    user_display_name=self._display_name(userid),
                 ),
                 sessions=self.sessions,
                 ctx_builder=self.ctx_builder,
@@ -347,6 +348,17 @@ class WeComDispatcher:
 
     def _resolve_agent(self) -> str:
         return self.agent or self.cfg.agent.default_agent or _DEFAULT_KIROCREW_AGENT
+
+    def _display_name(self, userid: str) -> str:
+        """Sender's name from ``wecom.allowed_users``, else the raw userid.
+
+        WeCom's inbound frame carries only an opaque userid, so resolve the
+        operator-set name for ``[CURRENT USER]``, mirroring Slack's name fallback.
+        """
+        for u in getattr(self.cfg.wecom, "allowed_users", []):
+            if u.get("userid") == userid and u.get("name"):
+                return u["name"]
+        return userid
 
     def _session_key(self, userid: str) -> str:
         gen = self._conv.current_gen(userid)

--- a/src/kiro_crew/wecom/transport_dispatch.py
+++ b/src/kiro_crew/wecom/transport_dispatch.py
@@ -356,8 +356,17 @@ class WeComDispatcher:
         operator-set name for ``[CURRENT USER]``, mirroring Slack's name fallback.
         """
         for u in getattr(self.cfg.wecom, "allowed_users", []):
-            if u.get("userid") == userid and u.get("name"):
-                return u["name"]
+            if u.get("userid") == userid:
+                # Return the operator-set name ONLY when it is a non-empty
+                # string. A truthy non-string (e.g. YAML ``name: 123`` coerced
+                # to int) would otherwise flow into ``[CURRENT USER]`` marker
+                # scrubbing, which assumes ``str`` and raises — crashing every
+                # turn for that user. The loader type-checks ``userid`` but not
+                # ``name``, so guard it here.
+                name = u.get("name")
+                if isinstance(name, str) and name:
+                    return name
+                return userid
         return userid
 
     def _session_key(self, userid: str) -> str:

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -240,7 +240,7 @@ class FakeConvLog:
 def _cfg(default_agent: str = "", approval_mode: str = "interactive"):
     return SimpleNamespace(
         agent=SimpleNamespace(default_agent=default_agent, approval_mode=approval_mode),
-        wecom=SimpleNamespace(hard_threshold_pct=95.0, soft_threshold_pct=80.0),
+        wecom=SimpleNamespace(hard_threshold_pct=95.0, soft_threshold_pct=80.0, allowed_users=[]),
         messaging=SimpleNamespace(
             dm_scope="per-channel-peer",
             idle_reset_minutes=0,
@@ -718,3 +718,33 @@ class TestWeComMidTurn:
         assert not any("合并" in content for content in client.said)
         assert any("重发" in content for content in client.said)
         assert sessions.successes == []
+
+
+class TestWeComDisplayName:
+    """``_display_name`` resolves the ``[CURRENT USER]`` label from the allow-list."""
+
+    @staticmethod
+    def _cfg_with_users(users):
+        cfg = _cfg()
+        cfg.wecom.allowed_users = users
+        return cfg
+
+    def test_resolves_name_from_allowed_users(self) -> None:
+        cfg = self._cfg_with_users(
+            [{"userid": "ZhuQiang", "name": "朱强"}, {"userid": "chrishe", "name": "小碗"}]
+        )
+        d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient(), cfg=cfg)
+        assert d._display_name("ZhuQiang") == "朱强"
+        assert d._display_name("chrishe") == "小碗"
+
+    def test_falls_back_to_userid_when_unknown(self) -> None:
+        cfg = self._cfg_with_users([{"userid": "ZhuQiang", "name": "朱强"}])
+        d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient(), cfg=cfg)
+        # Not in the allow-list -> the raw userid, never an empty label.
+        assert d._display_name("stranger") == "stranger"
+
+    def test_falls_back_to_userid_when_name_missing(self) -> None:
+        cfg = self._cfg_with_users([{"userid": "NoName"}])
+        d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient(), cfg=cfg)
+        # No name on the entry -> the raw userid, never an empty label.
+        assert d._display_name("NoName") == "NoName"

--- a/test/test_wecom_dispatch.py
+++ b/test/test_wecom_dispatch.py
@@ -748,3 +748,18 @@ class TestWeComDisplayName:
         d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient(), cfg=cfg)
         # No name on the entry -> the raw userid, never an empty label.
         assert d._display_name("NoName") == "NoName"
+
+    def test_falls_back_to_userid_when_name_not_a_string(self) -> None:
+        # YAML ``name: 123`` loads as an int; the loader type-checks only
+        # ``userid``, so a non-string name reaches here. It must NOT be returned
+        # (it would crash [CURRENT USER] marker scrubbing, which assumes str) --
+        # fall back to the userid instead.
+        cfg = self._cfg_with_users([{"userid": "IntName", "name": 123}])
+        d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient(), cfg=cfg)
+        assert d._display_name("IntName") == "IntName"
+
+    def test_falls_back_to_userid_when_name_is_empty_string(self) -> None:
+        cfg = self._cfg_with_users([{"userid": "Blank", "name": ""}])
+        d = _dispatcher(FakeSessions(FakeProvider([])), FakeCtx(), FakeClient(), cfg=cfg)
+        # Empty string is not a usable label -> the raw userid.
+        assert d._display_name("Blank") == "Blank"


### PR DESCRIPTION
## Problem / Motivation

On WeCom, the agent cannot tell **which** allow-listed user it is talking to.
WeCom's inbound frame carries only an opaque `userid`, and `[CURRENT USER]` is
never injected for WeCom (only Slack/Telegram set `user_display_name`, and the
`[WORKSPACE IDENTITY]` block is skipped for custom agents). With nothing in the
prompt identifying the sender, the agent infers identity from memory and can
address one user by another user's remembered name.

Repro:
1. Configure `wecom.allowed_users` with two users, each `{userid, name}`.
2. Run a **custom agent** (`agent create --kiro-agent ...`).
3. Have user B message the bot — the agent may greet them as user A.

## Why it matters

Identity is silently wrong on a per-user basis: any non-primary user can be
misidentified as another, which is both confusing and a privacy concern (the
agent may surface the wrong person's context). It affects every WeCom
deployment that admits more than one user.

## What changed (motivation → approach → change)

- **Symptom:** agent greets/addresses the wrong user on WeCom.
- **Root cause:** WeCom never populates `[CURRENT USER]`; the sender's identity
  never reaches the prompt, so the model fills the gap from memory.
- **Change:** resolve the operator-set `name` from `wecom.allowed_users`
  (falling back to the raw `userid`) and pass it through `ChannelTurn` as
  `user_display_name`, which `drive_turn` already threads into `build_message`
  → `[CURRENT USER]`. This mirrors Slack's existing `allowed_users` name
  fallback (`slack/events.py`), rather than inventing a new mechanism.

## Tests

`test/test_wecom_dispatch.py::TestWeComDisplayName`:
- name resolved from the allow-list,
- falls back to the userid for an unknown sender,
- falls back to the userid when the entry has no name.

Full `test_wecom_dispatch.py` and `test_messaging_dispatch.py` pass;
black / flake8 / isort clean.

## Manual verification

N/A — unit coverage exercises the resolver and its fallbacks directly; the
`build_message` threading is an existing, Slack-exercised path.

## Related Issues

N/A

## Pattern harvest

Not generalizable: this is a single missing channel wiring (WeCom did not set
`user_display_name` the way Slack/Telegram do). The fix aligns WeCom with the
existing pattern rather than introducing a new one.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
(`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, `[CURRENT USER]` injection is not documented for any channel
- [x] No secrets, credentials, or internal references in the diff