### PR TITLE
fix(ci): make jscpd exit non-zero on any clone

### DIFF
--- a/website/.jscpd.json
+++ b/website/.jscpd.json
@@ -1,4 +1,5 @@
 {
+  "exitCode": 1,
   "threshold": 0,
   "minTokens": 180,
   "reporters": [

--- a/website/scripts/capture-topbar-badge-overhang.mjs
+++ b/website/scripts/capture-topbar-badge-overhang.mjs
@@ -31,6 +31,8 @@
 import { chromium } from 'playwright'
 import { mkdirSync } from 'node:fs'
 
+import { diffPngs } from './lib/diff-pngs.mjs'
+
 const BASE = process.argv[2] || 'http://127.0.0.1:6811'
 const OUT = process.argv[3] || '../temp-screenshots/topbar-badge-overhang'
 mkdirSync(OUT, { recursive: true })
@@ -58,40 +60,6 @@ const near = (a, b) => Math.abs(a - b) <= 0.5
  *  and `rawN` is reported so the noise stays visible rather than discarded. */
 const TOL = 24
 
-async function diffPngs(page, aB64, bB64) {
-  return page.evaluate(async ([a, b, tol]) => {
-    const load = (b64) => new Promise((res) => {
-      const img = new Image()
-      img.onload = () => {
-        const c = document.createElement('canvas')
-        c.width = img.naturalWidth; c.height = img.naturalHeight
-        c.getContext('2d').drawImage(img, 0, 0)
-        res(c.getContext('2d').getImageData(0, 0, c.width, c.height))
-      }
-      img.src = `data:image/png;base64,${b64}`
-    })
-    const [ia, ib] = await Promise.all([load(a), load(b)])
-    let n = 0, rawN = 0, minX = Infinity, maxX = -1, minY = Infinity, maxY = -1
-    for (let y = 0; y < ia.height; y++) {
-      for (let x = 0; x < ia.width; x++) {
-        const i = (ia.width * y + x) << 2
-        // Alpha compared too: the glow's edge differs in alpha before opacity is
-        // flattened onto the page background.
-        let d = 0
-        for (let k = 0; k < 4; k++) d = Math.max(d, Math.abs(ia.data[i + k] - ib.data[i + k]))
-        if (d > 0) rawN++
-        if (d > tol) {
-          n++
-          if (x < minX) minX = x
-          if (x > maxX) maxX = x
-          if (y < minY) minY = y
-          if (y > maxY) maxY = y
-        }
-      }
-    }
-    return { n, rawN, minX, maxX, minY, maxY }
-  }, [aB64, bB64, TOL])
-}
 
 /** Boxes that decide whether the badge is clipped. `.tb-right` carries no
  *  border, so its client rect IS its padding box — the clip box for `overflow`. */
@@ -157,7 +125,7 @@ for (const w of WIDTHS) {
 
   const dp = await browser.newPage({ viewport: { width: 400, height: 300 } })
   await dp.goto(PAGE('on', w), { waitUntil: 'domcontentloaded' })
-  const d = await diffPngs(dp, shots.off, shots.on)
+  const d = await diffPngs(dp, shots.off, shots.on, TOL)
   await dp.close()
   console.log(`  diff: ${d.n}px over tol=${TOL} (raw ${d.rawN}px incl. rasterisation noise) x=[${d.minX},${d.maxX}] y=[${d.minY},${d.maxY}]`)
   if (d.n === 0) {

--- a/website/scripts/capture-topbar-metrics-pending.mjs
+++ b/website/scripts/capture-topbar-metrics-pending.mjs
@@ -63,6 +63,8 @@ import { chromium } from 'playwright'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { diffPngs } from './lib/diff-pngs.mjs'
+
 const BASE = process.argv[2] || 'http://127.0.0.1:6812'
 const OUT = process.argv[3] || '../temp-screenshots/topbar-metrics-pending'
 mkdirSync(OUT, { recursive: true })
@@ -95,38 +97,6 @@ const near = (a, b, tol = 0.5) => Math.abs(a - b) <= tol
  *  noise stays visible rather than silently discarded. */
 const TOL = 24
 
-async function diffPngs(page, aB64, bB64) {
-  return page.evaluate(async ([a, b, tol]) => {
-    const load = (b64) => new Promise((res) => {
-      const img = new Image()
-      img.onload = () => {
-        const c = document.createElement('canvas')
-        c.width = img.naturalWidth; c.height = img.naturalHeight
-        c.getContext('2d').drawImage(img, 0, 0)
-        res(c.getContext('2d').getImageData(0, 0, c.width, c.height))
-      }
-      img.src = `data:image/png;base64,${b64}`
-    })
-    const [ia, ib] = await Promise.all([load(a), load(b)])
-    let n = 0, rawN = 0, minX = Infinity, maxX = -1, minY = Infinity, maxY = -1
-    for (let y = 0; y < ia.height; y++) {
-      for (let x = 0; x < ia.width; x++) {
-        const i = (ia.width * y + x) << 2
-        let d = 0
-        for (let k = 0; k < 4; k++) d = Math.max(d, Math.abs(ia.data[i + k] - ib.data[i + k]))
-        if (d > 0) rawN++
-        if (d > tol) {
-          n++
-          if (x < minX) minX = x
-          if (x > maxX) maxX = x
-          if (y < minY) minY = y
-          if (y > maxY) maxY = y
-        }
-      }
-    }
-    return { n, rawN, minX, maxX, minY, maxY }
-  }, [aB64, bB64, TOL])
-}
 
 /** Boxes of the three things every claim here is about. */
 const measure = (page) => page.evaluate(() => {
@@ -208,12 +178,12 @@ for (const w of WIDTHS) {
   } else ok(`${w}: header height unchanged (${m.loaded.header.h.toFixed(1)}px)`)
 
   // --- pixels: the fix is not inert ----------------------------------------
-  const dBefore = await diffPngs(page, shots[`${w}-pending-before`], shots[`${w}-pending-after`])
+  const dBefore = await diffPngs(page, shots[`${w}-pending-before`], shots[`${w}-pending-after`], TOL)
   if (dBefore.n === 0) fail(`${w}: before and after renders are identical — the fix did not apply`)
   else ok(`${w}: ${dBefore.n} pixels differ before vs after (${dBefore.rawN} raw incl. backdrop noise)`)
 
   // --- pixels: pending sits in the loaded layout ----------------------------
-  const dLoaded = await diffPngs(page, shots[`${w}-pending-after`], shots[`${w}-loaded`])
+  const dLoaded = await diffPngs(page, shots[`${w}-pending-after`], shots[`${w}-loaded`], TOL)
   const segBox = m.loaded.metrics
   if (dLoaded.n === 0) {
     // Legitimate on the icon-collapsed rung: with the readings hidden, the two

--- a/website/scripts/lib/diff-pngs.mjs
+++ b/website/scripts/lib/diff-pngs.mjs
@@ -1,0 +1,58 @@
+/** Pixel-diff two base64 PNGs inside the page, returning the changed extent.
+ *
+ * Runs in the page rather than in Node because the decode is `Image` +
+ * `<canvas>`: a harness that shells out to a Node image library would add a
+ * dependency to compare two screenshots it already holds as data URLs.
+ *
+ * `tol` is a per-channel threshold, and it is a parameter rather than a constant
+ * because it is a property of the surface under test, not of the diff. Subpixel
+ * antialiasing shifts a text run by a few units across the whole header while the
+ * element under assertion differs by many tens, so counting the noise would let
+ * the bounding box swallow the header and make a "confined to X" assertion
+ * vacuous. Alpha is compared alongside RGB: a glow's edge differs in alpha before
+ * opacity is flattened onto the page background.
+ *
+ * Both counts are returned on purpose. `n` is the thresholded signal the caller
+ * asserts on; `rawN` is every pixel that differs at all, reported so the noise
+ * the threshold discards stays visible instead of silently vanishing.
+ *
+ * @param {import('playwright').Page} page
+ * @param {string} aB64 base64 PNG, without a data-URL prefix
+ * @param {string} bB64
+ * @param {number} tol per-channel tolerance, in 0-255 units
+ * @returns {Promise<{n: number, rawN: number, minX: number, maxX: number,
+ *   minY: number, maxY: number}>} `min`/`max` bound the thresholded pixels, and
+ *   stay at their initial `Infinity`/`-1` when nothing crossed the threshold.
+ */
+export async function diffPngs(page, aB64, bB64, tol) {
+  return page.evaluate(async ([a, b, t]) => {
+    const load = (b64) => new Promise((res) => {
+      const img = new Image()
+      img.onload = () => {
+        const c = document.createElement('canvas')
+        c.width = img.naturalWidth; c.height = img.naturalHeight
+        c.getContext('2d').drawImage(img, 0, 0)
+        res(c.getContext('2d').getImageData(0, 0, c.width, c.height))
+      }
+      img.src = `data:image/png;base64,${b64}`
+    })
+    const [ia, ib] = await Promise.all([load(a), load(b)])
+    let n = 0, rawN = 0, minX = Infinity, maxX = -1, minY = Infinity, maxY = -1
+    for (let y = 0; y < ia.height; y++) {
+      for (let x = 0; x < ia.width; x++) {
+        const i = (ia.width * y + x) << 2
+        let d = 0
+        for (let k = 0; k < 4; k++) d = Math.max(d, Math.abs(ia.data[i + k] - ib.data[i + k]))
+        if (d > 0) rawN++
+        if (d > t) {
+          n++
+          if (x < minX) minX = x
+          if (x > maxX) maxX = x
+          if (y < minY) minY = y
+          if (y > maxY) maxY = y
+        }
+      }
+    }
+    return { n, rawN, minX, maxX, minY, maxY }
+  }, [aB64, bB64, tol])
+}


### PR DESCRIPTION
## Problem / Motivation

The copy/paste gate has never been able to fail. `website/.jscpd.json` sets no `exitCode`, and
jscpd's own default is `exitCode: 0` — its CLI does
`if (clones.length > 0) exitCallback(options.exitCode)`, i.e. `process.exit(0)`. So it
detects duplication, prints it, and passes.

Verified on `main`:

```
$ cd website && npx jscpd .
Clone found (javascript):
 - scripts/capture-topbar-badge-overhang.mjs [59:1 - 78:74] (19 lines, 367 tokens)
   scripts/capture-topbar-metrics-pending.mjs [96:1 - 115:4]
Found 1 clones.
$ echo $?
0
```

## Why it matters

`npm test` runs this as a `pretest` hook specifically so copy-paste fails before a single test
executes. That protection has been inert, and the clone it was reporting landed anyway — the
PR that introduced it printed `Clone found` and exited 0.

## What changed (motivation → approach → change)

`"exitCode": 1` in `website/.jscpd.json`.

**`threshold: 0` stays.** It is not dead config: it is the separate path that still fires on
bulk duplication if `exitCode` is ever dropped again.

Landing the gate requires the existing clone gone, so it goes in the same change. Both topbar
capture harnesses carried `diffPngs` — 19 lines, 367 tokens, differing only by a two-line
comment — so it moves to `website/scripts/lib/diff-pngs.mjs` alongside the 32 helpers already
there. `TOL` becomes a **parameter** rather than a captured module constant: the tolerance is a
property of the surface under assertion, not of the diff, and both callers already declared
their own copy of it.

**Not taken:** adding the pair to `.jscpd.json`'s `ignore`. That is the silencing option, and
the duplication is real.

## Tests

The gate is its own test, and it is now mutation-checked in both directions:

| state | result |
|---|---|
| clean tree | exit **0**, `Found 0 clones.` |
| helper re-inlined into the second harness | exit **1**, `Found 1 clones.` |

No unit test is added: a test that shells out to jscpd would duplicate the gate CI already
runs, and the behaviour that regressed is the exit code, which only the gate observes.

## Manual verification

| check | result |
|---|---|
| `npx jscpd .` clean / with clone re-inlined | 0 / 1 |
| `node --check` on all three touched `.mjs` files | ok |
| `npx eslint scripts/lib/diff-pngs.mjs` | 0 |
| `npx tsc -b` | 0 |
| `scrub-lint.sh --no-history`, `check_brand_name.py` | 0 |

<!-- no-visual-delta -->
**Why no screenshot:** a CI config key and a helper hoist in two screenshot harnesses. No
application source is touched; the harnesses produce byte-identical diffs, since the extracted
function is the same code with `TOL` passed in rather than closed over.

## Pattern harvest

Rule candidate: a fail-open CI gate — a checker wired into CI whose underlying tool defaults to
`exitCode: 0`, so it detects and prints the very defect it exists to block yet still passes.
Here it was jscpd (no `exitCode` set → duplication reported, process exits 0); the same shape
recurs wherever a tool's "report" and "enforce" behaviours are separate switches and only the
report one is enabled. The generalizable check: for every gate, verify it can actually go red
against a seeded violation, not just that it runs.

## Related Issues

no linked issue: found by auditing which CI gates can pass while the thing they name is broken.

## Checklist

- [x] Single commit with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
