### PR TITLE
docs(skills): give the pipeline conductor its ledger disciplines

### DIFF
--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -39,7 +39,7 @@ The operator's seed message names a spec file (JSON). Fields you consume now:
                    "skip_signals": ["claimed", "in-progress"]},
   "worker_contract": {"branch_pattern": "fix/{slug}-{n}",
                        "worktree_pattern": "../{repo_name}-fix-{n}"},
-  "governance": {"max_in_flight": 8, "max_per_cycle": 3,
+  "governance": {"max_in_flight": 32, "max_per_cycle": 3,
                   "idle_alert_secs": 900, "session_ceiling": 30,
                   "credit_budget_per_item": 100, "topup_ceiling": 2},
   "interface": {"folder_name": "pipeline-{id}", "digest_language": "auto"}
@@ -56,8 +56,14 @@ spec file's directory is your working state home: write the probe config as
 
 1. Read the spec. `chat_folder_create` the pipeline folder.
 2. Build the queue from the work source (or adopt the operator's seeded
-   backlog). Record every item in the session ledger:
-   `{item, state: queued, evidence}`.
+   backlog). **Record the backlog at whatever size it is** — as the queue's
+   PROVENANCE, one entry: the work source, its selector, the count, and the item
+   ids as one list. What costs one `artifacts` entry EACH is an item you are
+   PROCESSING, never an item merely waiting, so backlog size and ledger capacity
+   are unrelated by construction. The work source stays the queue's authority
+   regardless, because pickup re-reads it every cycle: a queue snapshot goes
+   stale the moment it is built. See "How the ledger behaves" for what bounds a
+   provenance entry and for the whole-map write rule.
 3. Open your own status file beside the spec — `conductor-status/v1`, schema
    below. The ledger tracks the items; the status file tracks YOU.
 4. Arm the patrol: `monitor_start` (interval ~90s) with the standing
@@ -68,18 +74,106 @@ spec file's directory is your working state home: write the probe config as
 Standing patrol instruction template (keep it CURRENT — steering edits go here
 via `monitor_update`, see "Live steering"):
 
-> PROBE FIRST: one `fleet_probe.py --config <path>` call. Act only on 🔔/BANNED
+> LEDGER FIRST: one `session_ledger_read` — the injected `[work ledger]` block
+> is a truncated teaser, and every disposition below is a comparison against the
+> recorded item state.
+> THEN PROBE: one `fleet_probe.py --config <path>` call. Act only on 🔔/BANNED
 > lines: ERR → batch resume; PR → record; GREEN → verify independently then
 > digest + backfill; STANDDOWN/PROPOSAL → disposition + backfill; TERMINAL →
 > close it out, never nudge; BLOCKED → adjudicate; IDLE → intervention ladder.
 > Diff each fired line's `i=` against the recorded one: unchanged index is no
 > progress. Mark each acted signal handled.
+> Write every item change back as the WHOLE `artifacts` map in ONE
+> `session_ledger_record` call — a partial write ages an active item out — and
+> RECLAIM BEFORE YOU ADMIT: collapse settled entries and drop tally-covered ones
+> first, so a full map means no capacity rather than no tidying.
 > THEN, every cycle regardless of what fired: review `open_rulings` and deliver
 > any ruling still owed; run the unfiltered merge reconcile.
 > Check budgets on items with open sessions every ~5 cycles. Admission per the
 > delivery counters first, load/memory second. Quiet cycle = one line, end
 > turn. EXIT when queue empty and fleet drained: final tally, then
 > `autonudge_stop`.
+
+## How the ledger behaves
+
+Every rule above and below tells you to record something in the session ledger.
+Three mechanics decide whether that record is still there next cycle, and all
+three fail silently.
+
+**Read the ledger at the TOP of every cycle, before the probe.** The
+`[work ledger]` block prefixed onto a nudge turn is a teaser, not the record:
+**1600 chars total**, every field truncated to **300 chars**, and only the
+**last 3** `tried` entries. A fleet's item table does not fit in that. "PROBE
+FIRST" ranks the probe above worker transcripts, not above the ledger — a fired
+line carries a key, an age and an index, and every row of the action table is a
+comparison against RECORDED state: which item that session owns, what its last
+index was, whether its PR is already recorded. Act first and read after, and you
+have dispositioned a fleet against a 1600-char summary of it. Cadence is not a
+trade-off here: the read is O(record), never O(loop history), which is the whole
+reason a patrol loop's per-cycle cost stops growing.
+
+**The snapshot arrives on nudge turns only** — it is rendered on the patrol wake
+path. An operator steering you mid-run arrives with no block at all, and that is
+exactly the turn where you are about to answer "where are the other N". Read
+before you answer.
+
+**A terminal phase silences the snapshot for the rest of the run.**
+`render_snapshot` returns empty once the phase is terminal (`done`,
+`abandoned`), so `drain` is a MODE and never a phase: keep the ledger's phase
+in-flight until the final tally, or you spend the whole drain blind to your own
+state with no symptom but the absence of a block you stopped expecting.
+
+**Write the item map back WHOLE, in ONE `session_ledger_record` call.** Items
+live in `artifacts`, a string→string map: a nested object is rejected outright
+(`artifacts_not_string_map`) and NOTHING persists, so each item is one
+single-line string. Then two caps bound it, and neither one errors:
+
+- **32 entries — which is the same number as `max_in_flight`, deliberately.**
+  One entry is what one item COSTS while you process it, so the entry cap and the
+  fleet ceiling are one ceiling, not two that can disagree: `max_in_flight`
+  defaults to the cap, and a spec raising it above the cap has configured a fleet
+  whose own worker state cannot fit — honour the cap and tell the operator the
+  spec over-subscribes the ledger. **A backlog costs nothing here**, because a
+  waiting item is one line inside the provenance entry rather than an entry of
+  its own; queue length and ledger capacity are unrelated.
+
+  **Neither number is the fleet size to run.** They are a ceiling; the size is
+  what the host can carry this cycle, read from `resource_status` and the
+  delivery counters (see admission and resource governance). Never write a fleet
+  size into a plan — derive it every cycle, because free CPU and memory are the
+  operator's, not yours, and they move.
+
+  **The cap is not a number you check — it is a step you run.** Past it the map
+  is trimmed by insertion order and the OLDEST entries age out, blind to whether
+  that item is still in flight, and nothing says so: the ledger's age-out has no
+  notion of an active item. So **RECLAIM, THEN ADMIT, in that order, once per
+  cycle before any dispatch write**: collapse every settled item to its one-line
+  outcome, drop the ones the final tally already covers, and write that map back.
+  What still occupies a slot afterwards is an ACTIVE item, and only then does a
+  full map mean "no capacity" rather than "not tidied yet". Run it in that order
+  and the deadlock cannot form; check a slot count without it and a map full of
+  finished work reads as a fleet at capacity, which strands the queue permanently
+  and looks exactly like being busy.
+- **2000 chars per value, 128 per key.** An oversized value is TRUNCATED, not
+  refused, which cuts a one-line entry mid-payload and leaves a record that
+  reads as present and decodes as garbage. Entries carry pointers, never prose:
+  scope, branch, PR number, session key, state. This is also the real bound on
+  the provenance entry, and the reason it carries the SOURCE and the COUNT and
+  not only the ids — a long enough id list is silently cut, so the entry must be
+  the thing that lets you rebuild the queue rather than the queue itself.
+
+A write MERGES rather than replaces, and that is what makes a partial write
+unsafe rather than merely incomplete: an omitted key is NOT deleted, so it looks
+preserved, while every key you DO send is re-inserted as newest. A cycle that
+records only the items that moved therefore pushes every quiet item to the front
+of the eviction queue — the long-running worker nobody has heard from is the
+entry the cap takes first. Read the map, edit it in memory, send all of it. This
+is the one place "write only deltas" does not apply.
+
+Confirm it landed by READING, not from the write's reply: the record tool answers
+with the phase and the next intent only, so an eviction leaves no trace in the
+response to the call that caused it. The next cycle's read is the only place a
+missing item surfaces — which is one more reason that read is not optional.
 
 ## Conductor-owned state: `conductor-status/v1`
 
@@ -128,7 +222,13 @@ saying it. A debt survives only when both hold.
 Dispatch is **idempotent** — every check, every time (skipping them is how two
 sessions end up on one item and mutual-yield deadlock):
 
-1. Ledger state is `queued` — anything else, skip.
+1. The ledger carries no non-`queued` entry for the item — `dispatched`,
+   `green_verified`, `done` or parked means skip. An ABSENT entry means NOT YET
+   ADMITTED, which is eligible: the ledger holds admitted items only, so absence
+   is the normal state of a backlog item and reading it as a veto would strand
+   every item the entry cap could not hold. What prevents a double dispatch is
+   not this check — it is the four-way collision check in step 4 and the atomic
+   forge claim below, which is why the ledger being a cache is safe here.
 2. The backlog/findings store (when the pipeline has one) still says the item
    is open — a queue snapshot goes stale the moment it is built.
 3. `claim_preflight.py` returns `CLAIM` for the item (below). That verdict
@@ -146,7 +246,9 @@ sessions end up on one item and mutual-yield deadlock):
    `worktree_pattern`. The preflight answers the two PR arms; the branch and
    worktree arms are local and yours.
 5. In-flight count < `max_in_flight`, this cycle's dispatches <
-   `max_per_cycle`, and admission admits (see governance).
+   `max_per_cycle`, this cycle's ledger reclaim has run and left a slot for it
+   (see "How the ledger behaves" — reclaim, then admit), and admission admits
+   (see governance).
 
 Then **claim atomically** — the lock label and the assignee in ONE call, never
 two. The forge is the cross-operator lock and your ledger is only a cache of
@@ -560,7 +662,7 @@ cannot deliver, and the failures then present as the workers' fault.
 
 | Signal | Posture | Do |
 | --- | --- | --- |
-| Delivery counters both 0; load and memory healthy | `ample` | Dispatch up to `max_in_flight`. |
+| Delivery counters both 0; load and memory healthy | `ample` | Dispatch up to `max_in_flight`, into what this cycle's ledger reclaim left free (see "How the ledger behaves"). |
 | Either delivery counter ≥2 in one cycle | `saturated` | Stop dispatching until two consecutive clean cycles. In-flight work continues — what is short is delivery, not compute, so stopping the workers would waste their progress for nothing. |
 | Load or memory tight, delivery clean | `tight` | No new dispatches; ask heavy workers to defer gate runs; postpone items marked expensive. |
 | `critical` from `resource_status` | `critical` | Halt admission; `session_stop` the most expensive in-flight items (record as reclaim, not failure); handle violators; wait for recovery before resuming. |
@@ -729,7 +831,8 @@ autonudge_stop.`
 
 Queue empty + fleet drained: final tally (dispatched / merged / open-green /
 proposals / standdowns / skips, with URLs), close remaining sessions,
-`autonudge_stop`.
+`autonudge_stop`. That tally is also the first moment the ledger's phase may go
+terminal — see "How the ledger behaves".
 
 ## Known limits (state them, don't hide them)
 


### PR DESCRIPTION
## 1. What is the problem?

The `pipeline-conductor` skill instructs the conductor to record something in
the session ledger in about twenty separate places, and never once says how the
ledger behaves. Three of its mechanics fail silently, so each one had to be
rediscovered by the model at runtime:

- The `[work ledger]` block prefixed onto a nudge turn is a **truncated
  snapshot**, not the record: 1600 chars total, each field cut to 300, only the
  last 3 `tried` entries. A fleet's item table does not fit in it. The skill
  never said the block is not the authority, and its armed patrol instruction
  opened with `PROBE FIRST`, which reads as "the probe is step one".
- The `artifacts` map is capped at **32 entries** and trims by insertion order,
  ageing out the oldest entry with no notion of whether that item is still in
  flight. The skill never mentioned a cap at all.
- The skill also predicated dispatch on the ledger reading `queued` for an item
  ("Ledger state is `queued` -- anything else, skip") while telling startup to
  record the whole backlog there. Those two instructions are only compatible
  below the cap: a 33-item backlog leaves 32 entries on disk and one item that
  silently never existed, and the dispatch predicate then skips it forever.
- A write **merges** rather than replaces. An omitted key is not deleted -- so it
  looks preserved -- while every key you do send is re-inserted as newest. A
  cycle that records only the items that moved therefore pushes every quiet item
  to the front of the eviction queue.

A three-day conductor run of 538 patrol cycles and 11 automatic context
compactions shows what an undocumented discipline costs. `session_ledger_record`
was called 235 times; `session_ledger_read` 14 times. The first read happened 59%
of the way through the run, so **all of the first five compactions happened
before the conductor ever read its ledger back**. Nudge cycles between a
compaction and the next read: 416, then 270, then 131, then 50, then 26. The run
then pivoted -- five consecutive compactions each followed by a read within zero
cycles, the model having worked the discipline out for itself -- and then
regressed, the final compaction followed by 17 cycles with no read to the end of
the run.

The skill's own `conductor-status/v1` file, which the skill says to "rewrite
whole each cycle", was written 7 times inside one narrow window and never again
across the remaining cycles. In its place the conductor grew a hand-rolled
replacement state store mid-run: TSV files and shell scripts it wrote itself, one
brief file reaching 425 KB.

That curve is the argument. With no written discipline the behaviour is
discovered, partially held, then lost.

## 2. Why this issue matters to the user

The ledger is the only conductor state that survives compaction. When it is
written but not read, the conductor's answer to "where are the other N" comes
from a 1600-char summary of a fleet, and the operator gets a tally that is
missing items with no error anywhere to say so. Every downstream row of the
action table is a comparison against recorded state -- which item owns a session,
what its last probe index was, whether its PR is already recorded -- so a cycle
that acts before it reads dispositions a fleet against the teaser.

The cap makes it worse than stale. The live fleet does not reach 32 entries
(`max_in_flight` defaults to 8); finished items do, so on a multi-day run history
occupies the slots and the eviction lands on an active item's only surviving
state. The conductor then has a worker running with no record that it exists.

And the 425 KB hand-rolled state store is the tell: absent guidance, the model
does not fail loudly, it reinvents -- burning cycles and disk on a worse copy of a
primitive it already had.

## 3. How our fix solves it

The root cause is not conductor diligence, it is that the skill documents an
obligation ("record it") without documenting the mechanics that decide whether
the record survives. The fix is to write the mechanics down where the obligation
lives.

A new `How the ledger behaves` section states all three, with the reason inline
in the file's existing voice:

- **Read at the top of every cycle, before the probe.** The section says plainly
  that `PROBE FIRST` ranks the probe above worker *transcripts*, not above the
  ledger, which removes the ordering ambiguity that the old wording created. The
  reason cadence is affordable is stated too: the read is O(record), never
  O(loop history). Two adjacent mechanics come with it -- the snapshot is
  rendered only on the patrol wake path, so an operator steering mid-run gets no
  block at all on precisely the turn they ask for the tally; and
  `render_snapshot` returns empty on a terminal phase, so `drain` is a mode and
  never a phase.
- **Write the whole map back in one call.** The merge semantics are given as the
  reason a partial write is unsafe rather than merely incomplete, ending on the
  explicit exception: this is the one place "write only deltas" does not apply.
  Finished items get collapsed to a one-line outcome so history cannot occupy a
  slot an active item needs, because the ledger's own age-out cannot make that
  distinction.
- **One ceiling, not two.** An `artifacts` entry is what one item COSTS while it
  is being processed, so the 32-entry cap and the fleet ceiling are the same number
  by construction: `max_in_flight`'s documented default moves from 8 to 32 to match
  the cap, and a spec raising it above the cap is named as an over-subscription to
  report rather than a fleet to run. A BACKLOG costs nothing against it -- a waiting
  item is one line inside a single provenance entry (source, selector, count, ids),
  never an entry of its own -- so queue length and ledger capacity are unrelated and
  a backlog may be any size.
- **Neither number is the fleet size to run.** The ceiling is a ceiling; the size is
  what the host can carry this cycle, derived every cycle from `resource_status` and
  the delivery counters the admission table already keys on. The skill says not to
  write a fleet size into a plan, because free CPU and memory are the operator's and
  they move.
- **The cap is a step the conductor runs, not a number it checks.** RECLAIM, THEN
  ADMIT, once per cycle before any dispatch write: collapse every settled item to
  its one-line outcome, drop the ones the final tally already covers, write that map
  back. What still occupies a slot afterwards is an active item, and only then does a
  full map mean "no capacity" rather than "not tidied yet". Stating it as an order is
  what makes it safe -- a slot count checked without the reclaim lets a map full of
  finished work read as a fleet at capacity, stranding the queue permanently in a
  state indistinguishable from being busy. The two operative sites, the per-dispatch
  predicate and the `ample` posture row, name that step rather than carrying a bound
  of their own, and the re-injected patrol instruction carries it too.
- **A waiting item never costs a slot.** The queue's authority stays the work
  source, which pickup already re-reads every cycle because "a queue snapshot goes
  stale the moment it is built", so the two instructions above are compatible at any
  backlog size. Its consequence is followed through: an ABSENT ledger entry now means
  "not yet admitted", which is eligible, rather than a skip -- and the reason
  that is safe is stated where the change lands, because what prevents a double
  dispatch is the four-way collision check and the atomic forge claim, not the
  ledger, exactly as the skill's own closing note already says (labels and
  assignees are the cross-operator lock; the ledger is a cache).
- **The numbers, from the source.** 32 entries, 2000 chars per value, 128 per
  key, and the snapshot's 1600 / 300 / last-3. Each is stated with what it does
  on overflow, because neither cap errors: the map trims oldest-first and an
  oversized value is truncated, not refused, which cuts a one-line entry
  mid-payload and leaves a record that reads as present and decodes as garbage.

Three small edits make the section operative rather than reference material: the
armed patrol instruction now opens `LEDGER FIRST` and closes with the whole-map
write rule, so the discipline is in the text that is re-injected every cycle;
startup's ledger write points at the caps; and the exit tally is named as the
first moment the phase may go terminal.

The `goal-conductor` skill is a different consumer of the same ledger and has
already learned all three. This mirrors that prior art rather than reinventing
it, so the two consumers of one primitive now describe it the same way.

**One thing this PR deliberately does not claim.** The ledger's own files were
not inspected, so there is no evidence that entries were actually aged out in
the measured run. Discipline 2 is framed as "the skill never warns about a cap
the ledger documents", not as an observed loss.

## 4. What tests we did

Every number in the new prose was read out of the ledger module rather than
copied from the sibling skill, and the sibling's mirrored constants were checked
against it in the same pass:

| Claim in the new prose | Source constant |
| --- | --- |
| 32 entries, oldest age out by insertion order | `_MAX_ARTIFACTS = 32`, "Cap by insertion order: oldest pointers age out first" |
| 2000 chars per value | `_MAX_TEXT = 2000` |
| 128 chars per key | `_clamp(k, 128)` in the artifacts merge |
| snapshot 1600 chars total | `_SNAPSHOT_MAX_CHARS = 1600` |
| 300 chars per field | `_SNAPSHOT_FIELD_MAX = 300` |
| last 3 `tried` entries | `_SNAPSHOT_TRIED_TAIL = 3` |
| terminal phase silences the snapshot | `render_snapshot` returns `""` for `TERMINAL_PHASES = {done, abandoned}` |
| a write merges; a written key becomes newest | the merge is `dict(state["artifacts"])` plus a pop-before-reassign, whose own comment explains the re-insertion |
| an oversized value truncates rather than refuses | `_clamp` is `value[:limit]` |
| a nested value is rejected outright | the record handler returns 400 `artifacts_not_string_map` before any write |

`goal-conductor`'s bundled codec documents its constants as "mirrored from" the
ledger module. They still agree (2000 / 128 / 32), and its prose figure of 1600
chars is correct, so there is **no disagreement to report** -- but the numbers now
live in the skill that acts on them rather than only in a sibling's script.

Tests, scoped to what a markdown change in this tree can affect (627 passed):

```
python3 -m pytest -n0 -q \
  test/test_pipeline_conductor_skill_contract.py \
  test/test_pipeline_conductor_agent.py \
  test/test_builtin_skill_scope.py \
  test/test_builtin_skill_packaging.py \
  test/test_builtin_skill_sync_safety.py \
  test/test_frontmatter.py \
  test/test_brand_name_gate.py
```

`test_pipeline_conductor_skill_contract.py` is the load-bearing one: it pins the
skill's clauses by exact section heading, so it proves the new section neither
renamed an existing heading nor dropped a pinned rule. The two gates that apply
to a shipped skill body were also run directly: `check_builtin_skill_scope.py`
passes (no source-checkout path, test path or repository slug in the new prose --
the mechanics are named by symbol, not by file), and the brand-name gate passes
on the added lines.

No script was added, no test was modified, and no other skill was touched.

## 5. Any other suggestions on the work

**Surface the post-write artifacts state in `session_ledger_record`'s reply.**
The tool answers `Recorded. phase=<...> next=<...>`. The underlying `record()`
already returns the post-write document -- deliberately, so a caller's view is
what landed on disk -- but the MCP surface discards it, so an eviction leaves no
trace in the response to the call that caused it. A conductor cannot learn it
lost an item until the next read. Returning the surviving entry count, or the
keys that aged out, would make the cap observable at the moment it bites. The
new section documents the workaround (confirm by reading, never from the reply);
the better fix is in the tool. Out of scope here, so it is written as a
suggestion rather than done.

**The cap discipline wants a codec, not prose.** `goal-conductor` ships a
`rotate` mode that collapses terminal entries and refuses to drop an active one,
returning a structured `cap_exceeded_all_active` error instead. This PR states
the same rule as prose because the codec lives in the sibling skill's directory
and cross-skill script references do not resolve for an installed reader. Either
promoting that codec to a shared location or bundling an equivalent under
`pipeline-conductor/scripts/` would put the rule back under test -- which is the
skill's own stated principle, that a decision a script computes can be tested
while one stated as prose rots silently.

**The status file has the same disease one level down.** The measured run wrote
`conductor-status/v1` seven times and then stopped, while the skill says to
rewrite it whole each cycle. That is a second undocumented-discipline failure
with the same shape and is not addressed here.

---

no linked issue: this was dispatched directly as a skill-documentation task, not
filed as an issue first. The failure it closes is stated in full in section 1
above, with the measured run that evidences it, so an issue would carry no
information this body does not.
