### PR TITLE
fix: draw straight quotes with a scoped font-face, not the curly glyph

### DIFF
--- a/website/src/i18n/scriptFonts.test.ts
+++ b/website/src/i18n/scriptFonts.test.ts
@@ -93,6 +93,12 @@ const ALIASES = [...SC_ALIASES, ...REGIONAL_ALIASES, ...COMMON_ALIASES] as const
  * Ranges that must stay OUT of every alias. Latin proper plus general punctuation:
  * an alias claiming U+2000-206F would take over quotes, dashes and ellipses in
  * Latin text, which is the same class of silent regression as claiming Latin.
+ *
+ * The ONE intentional exception is 'KC Straight Quotes' (#6374): it claims exactly
+ * U+0022 and U+0027 to replace Space Grotesk's miscut straight quotes. It is
+ * deliberately NOT in ALIASES, so the checks above never run on it; instead it is
+ * pinned separately at the bottom of this file to those two code points and nothing
+ * wider, which is what keeps the exception from quietly growing into a Latin claim.
  */
 const FORBIDDEN = [
   { name: 'Latin (Basic through Extended-B)', lo: 0x0000, hi: 0x024f },
@@ -385,5 +391,51 @@ describe('font stack declarations', () => {
       }
     }
     expect(offenders, offenders.join('\n')).toEqual([])
+  })
+})
+
+/**
+ * The straight-quote alias is the deliberate inverse of every alias above: those
+ * exist to add script coverage WITHOUT touching Latin, while this one exists to
+ * REPLACE the Latin body face for exactly two code points. Space Grotesk (the
+ * default body face) draws U+0022 and U+0027 as its closing curly glyph, so a
+ * straight quote in UI copy — or one a user types — renders as ” / ’ on the wrong
+ * side of the word (#6374). The alias leads the sans stack with a local()
+ * straight-quote face and a unicode-range of just those two code points.
+ *
+ * Two properties keep it safe, and both are pinned here because neither is visible
+ * from reading a family list: it may claim ONLY U+0022 and U+0027 (widening it back
+ * into Latin is the regression FORBIDDEN guards for the other aliases), and it must
+ * stay OUT of the mono tokens (JetBrains Mono already draws straight quotes, so the
+ * override is neither needed nor wanted there).
+ */
+describe('KC Straight Quotes (#6374) — the one deliberate Latin-claiming alias', () => {
+  const FAMILY = 'KC Straight Quotes'
+
+  it('exists, is local()-only, and claims EXACTLY U+0022 and U+0027', () => {
+    const block = faceBlock(FAMILY)
+    expect(block, `no @font-face for '${FAMILY}' in index.css`).not.toBe('')
+    expect(block).toMatch(/src:[^;]*local\(/)
+    expect(block, `'${FAMILY}' must not fetch a remote font`).not.toMatch(/url\(/)
+    const ranges = parseUnicodeRange(block).map((r) => [r.lo, r.hi]).sort((a, b) => a[0] - b[0])
+    // The whole safety of a Latin-claiming leading alias is that it claims these
+    // two code points and no others. Any wider range is a silent Latin takeover.
+    expect(ranges).toEqual([[0x22, 0x22], [0x27, 0x27]])
+  })
+
+  it('leads every sans --script-fallbacks and appears in none of the mono ones', () => {
+    const sansSites: Array<[string, string]> = [
+      ['root', ruleBody(/:root\s*\{([^}]*)\}/)],
+      ...REGIONAL.map(({ lang }) => [lang, htmlLangRuleBody(lang)] as [string, string]),
+    ]
+    for (const [label, block] of sansSites) {
+      const sans = scriptToken(block)
+      const mono = scriptToken(block, true)
+      expect(sans, `'${FAMILY}' missing from the ${label} sans token`).toContain(FAMILY)
+      // Leading is what makes it win for U+0022/U+0027 over the body face without a
+      // unicode-range collision changing anything else (see the aliases' rationale).
+      expect(sans.trimStart().startsWith(`'${FAMILY}'`), `'${FAMILY}' must lead the ${label} sans token`).toBe(true)
+      expect(mono, `'${FAMILY}' must not appear in the ${label} mono token`).not.toContain(FAMILY)
+    }
   })
 })

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -207,6 +207,30 @@
        local('NirmalaUI-Bold'), local('Vrinda Bold');
   unicode-range: U+0980-09FF;
 }
+/* ── Straight ASCII quotes (U+0022 " and U+0027 ') ──
+   Space Grotesk — the default body face — has no straight-quote glyph: it draws
+   both code points as its CLOSING curly form, so a straight quote in UI copy, or
+   one a user types, renders as ” / ’ and hangs on the wrong side of the word
+   (issue #6374). This alias draws ONLY those two code points from a locally
+   installed straight-quote face. Like the script aliases above it is
+   unicode-range-restricted, so it is never consulted for any other character and
+   can lead the family list without changing how anything else renders. The curly
+   quotes U+2018-U+201D are deliberately NOT claimed — they keep coming from the
+   body face, unchanged, exactly as the script-fallback note below intends.
+
+   One 400-700 face, not the split 400/700 pair the CJK aliases need: a quotation
+   mark carries no meaningful weight contrast, and the range descriptor covers a
+   bold context with no synthetic bold. src is local()-only, so nothing downloads;
+   if none of the listed faces is installed the code point falls through to the
+   body face — today's rendering, never worse. */
+@font-face {
+  font-family: 'KC Straight Quotes';
+  font-style: normal; font-weight: 400 700;
+  src: local('Arial'), local('ArialMT'), local('Helvetica Neue'), local('Helvetica'),
+       local('Segoe UI'), local('SegoeUI'), local('Roboto'), local('Liberation Sans'),
+       local('DejaVu Sans'), local('Noto Sans'), local('Nimbus Sans');
+  unicode-range: U+0022, U+0027;
+}
 
 /* ─── OpenDyslexic (SIL-OFL) ── accessibility built-in ───
    Registered as its own font-family so the a11y font never leaks into
@@ -268,8 +292,11 @@
      CJK) through the wrong glyph forms. html:lang(zh-CN/ja/ko) below swap
      isolated regional faces for that UI language. A bare :lang(zh) is avoided
      — it also matches zh-TW/zh-HK. They lead each stack; unicode-range is what
-     makes leading safe. */
-  --script-fallbacks:'KC Devanagari Fallback','KC Bengali Fallback';
+     makes leading safe. 'KC Straight Quotes' leads every sans variant for the
+     same reason, fixing the straight-quote glyph (#6374) in every UI language.
+     It is sans-only: the mono stacks resolve to JetBrains Mono, whose straight
+     quotes are already correct. */
+  --script-fallbacks:'KC Straight Quotes','KC Devanagari Fallback','KC Bengali Fallback';
   --script-fallbacks-mono:'KC Devanagari Fallback','KC Bengali Fallback';
   /* An installed theme pack fills --theme-font-sans / --theme-font-mono with its
      own faces (see hooks/themeCss.ts). Reading them here means code surfaces
@@ -285,19 +312,19 @@ html:lang(zh-CN) {
   /* Isolated Simplified aliases for Chinese UI. Not :lang(zh): that also
      matches zh-TW / zh-HK / zh-Hant. Document-level only — :root/--font-body
      and useZoom already resolve var(--script-fallbacks) on <html>. */
-  --script-fallbacks:'KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+  --script-fallbacks:'KC Straight Quotes','KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
   --script-fallbacks-mono:'KC Han Mono Fallback','KC Han Fallback','KC Devanagari Fallback','KC Bengali Fallback';
 }
 html:lang(ja) {
   /* Never retain the SC aliases here. If no named Japanese face is installed,
      falling through lets the browser use its lang-aware Japanese fallback. */
-  --script-fallbacks:'KC Japanese Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+  --script-fallbacks:'KC Straight Quotes','KC Japanese Fallback','KC Devanagari Fallback','KC Bengali Fallback';
   --script-fallbacks-mono:'KC Japanese Mono Fallback','KC Japanese Fallback','KC Devanagari Fallback','KC Bengali Fallback';
 }
 html:lang(ko) {
   /* Never retain the SC or JP aliases here. Neither draws Hangul, so leaving one
      in front only delays resolution to the browser's lang-aware Korean fallback. */
-  --script-fallbacks:'KC Korean Fallback','KC Devanagari Fallback','KC Bengali Fallback';
+  --script-fallbacks:'KC Straight Quotes','KC Korean Fallback','KC Devanagari Fallback','KC Bengali Fallback';
   --script-fallbacks-mono:'KC Korean Mono Fallback','KC Korean Fallback','KC Devanagari Fallback','KC Bengali Fallback';
 }
 /* Dark theme shadows */


### PR DESCRIPTION
## Problem / Motivation

Every straight quote in the dashboard renders as a **closing** curly quote
(#6374). A straight `"` (U+0022) or `'` (U+0027) is drawn as `”` / `’`, so an
opening quote leans the wrong way: `"untitled"` reads as `”untitled”`. It affects
all UI copy that uses straight quotes (error strings, placeholder tips) and any
straight quote a user types or pastes into a message.

Root cause, proven at the pixel: the body webfont **Space Grotesk has no
straight-quote glyph** — it draws U+0022/U+0027 using its closing-curly shape.
Rasterised and compared per-pixel across Firefox, Chromium and WebKit (Safari's
engine), straight U+0022 is **100%** identical to the closing curly `”` and only
~50–57% like the opening `“`. A same-method comparison of every Latin font the app
ships shows **only Space Grotesk is affected** — JetBrains Mono, OpenDyslexic,
OpenDyslexicMono and the system faces all draw straight quotes straight. So this is
a font-file property, not app logic, and no OpenType feature toggles it.

## Why it matters

Quotation marks appear throughout the UI and in user content. A reversed opening
quote reads as a typo in the product's own copy, and it corrupts the appearance of
anything a user quotes. It is locale-independent and affects every dashboard user
on the default theme.

## What changed

`website/src/index.css` — two edits, no component/string/logic change:

1. A `unicode-range` `@font-face` (`KC Straight Quotes`) scoped to **exactly**
   U+0022 and U+0027, backed by a `local()` straight-quote face (Arial / Helvetica
   / Segoe UI / Liberation Sans / DejaVu Sans / …). `local()`-only, so nothing is
   downloaded.
2. It leads each sans `--script-fallbacks` variant (default + zh-CN/ja/ko). Because
   it is unicode-range-restricted it is never consulted for any other character, so
   leading is safe — this is the identical idiom the file's CJK/Devanagari/Bengali
   aliases already use. The intentional curly quotes U+2018–U+201D and the mono
   stack (JetBrains Mono, already correct) are untouched.

This is **not** a content-aware substitution — no character is rewritten, so pasted
JSON/code is byte-identical; only the glyph used to draw U+0022/U+0027 changes.

## Tests

`website/src/i18n/scriptFonts.test.ts` — that file forbids any alias from claiming
Latin/General-Punctuation. This alias is the one deliberate exception, so it is
pinned: a new test asserts it claims **exactly** U+0022 and U+0027 (nothing wider),
is `local()`-only, leads every sans variant, and is absent from every mono variant.
Suite: 44 passing (was 42). `eslint` clean.

## Manual verification

Before/after in the actual dashboard — real shipped catalog strings, real i18n
pipeline, the app's own Space Grotesk webfont, each frame carrying an in-browser
live font check ("Space Grotesk loaded: YES", measured glyph verdict). Before:
U+0022 = 100% the closing curly (bug). After: 40% (drawn straight), same Space
Grotesk letterforms, only the two quote code points changed.

## Screenshots / video

![Before and after in the dashboard](https://raw.githubusercontent.com/k33bz/KiroCrew/evidence-6374/sidebyside.png)

<details><summary>Full-resolution before / after</summary>

**Before — current main** (U+0022 drawn as the closing curly)

![before](https://raw.githubusercontent.com/k33bz/KiroCrew/evidence-6374/before.png)

**After — this fix** (U+0022 drawn straight; letterforms unchanged)

![after](https://raw.githubusercontent.com/k33bz/KiroCrew/evidence-6374/after.png)

</details>

## Related Issues

Closes #6374

## Pattern harvest

Rule candidate: when the UI **body** webfont mis-draws a specific Unicode code
point (here Space Grotesk draws U+0022/U+0027 as its closing-curly glyph), fix it
by prepending a `unicode-range`-scoped `@font-face` for **exactly** those code
points to `--script-fallbacks`, backed by `local()` faces — never by content-aware
character substitution, which would rewrite pasted literals (JSON, code). This is
the same mechanism the file's CJK/Devanagari aliases already use; and any such
Latin-claiming alias should be pinned in `scriptFonts.test.ts` to its exact code
points, so the one deliberate exception to "no alias claims Latin" cannot silently
widen.

## Checklist

- [x] `cd website && npm run check` scope for the change (scriptFonts test + lint) is green
- [x] No new user-facing string, color literal, CSS variable, or class
- [x] No documented-behavior change beyond the in-file comments
- [x] Change is limited to the font-fallback layer; curly quotes and mono are untouched
