### PR TITLE
docs(prepare-pr): pin the babysit loop interval at 300s

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -395,6 +395,17 @@ inside a run whose conclusion reads `cancelled`.
 
      **`max_cycles` is a poll budget, not a round budget.** One 20–40 minute round costs several 5-minute cycles, so the default expires after two or three rounds — silently. `max_cycles=80` is roughly ten rounds; raise it via `monitor_update` if the work is still live near the cap. See `babysit` for the loop's own semantics.
 
+     **`interval_secs=300` is FIXED for the whole run — raise `max_cycles`, never
+     the interval.** Lengthening it is the wrong lever for every state this loop
+     reaches. When the PR is holding for a user decision it looks like an "idle
+     tick", and the generic wake-up guidance for idle ticks (1200–1800s) is
+     *about a different mechanism* — it does not apply here, because a PR is
+     never idle: CI lanes and review bots post on their own schedule, so a
+     20–30 minute gap means findings that are already actionable sit unread for
+     up to half an hour. If the loop needs to survive longer, that is a
+     `max_cycles` / `max_runtime_secs` change. The only sanctioned interval
+     change is *downward*, and only on explicit user request.
+
 ### Phase 4 — Converge or escalate
 
 **Converged** — `pr_status.py` = 0 **and** no unanswered concern remains (re-check


### PR DESCRIPTION
## Problem / Motivation

A `prepare-pr` run armed its `monitor_start` babysit loop at the prescribed `interval_secs=300`, then later called `monitor_update(interval_secs=1800)` once the PR entered a *holding for a user decision* state. Nothing rechecked the value, so the loop polled every 30 minutes for the remainder of the run.

## Why it matters

A PR is not idle while it waits on a human. CI lanes and review bots post on their own schedule, independent of whatever the loop is nominally blocked on. At a 30-minute gap, review findings that were already actionable sat unread for up to half an hour per round — exactly the latency the 5-minute interval exists to avoid.

## What changed (motivation → approach → change)

Symptom: the loop's effective cadence silently grew 6× mid-run.

Root cause: the skill prescribes `interval_secs=300` in its `monitor_start` example but never says the value is fixed. That leaves "the PR is waiting on a human, so this is an idle tick" open as a plausible reading of the loop's state — and the generic wake-up guidance for idle ticks names 1200–1800s as its default. The number was reachable through a reading the skill did not close off. The adjacent `max_cycles` paragraph already establishes the correct knob for making a loop last longer; it just never says that knob is the *only* one.

Change: one paragraph after the `max_cycles` note stating that `interval_secs=300` is fixed for the whole run, that a PR is never idle and why, that a longer-lived loop is a `max_cycles` / `max_runtime_secs` change, and that the only sanctioned interval change is downward on explicit user request.

## Tests

None. Prose-only change to a skill document; no code path, script, or exit code is touched.

## Manual verification

- `git diff origin/main --stat` → a single file, `src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md`, one paragraph added and nothing removed.
- Re-read the surrounding Phase 3 block to confirm the new paragraph sits inside the same indented list item as the `monitor_start` example and the `max_cycles` note it builds on, so the markdown nesting is unchanged.

## Related Issues

no linked issue: found while reviewing a live loop's own interval, not tracked beforehand.

## Pattern harvest

Pattern: a skill prescribes a value in an example but not as a constraint, so a state change makes a generic default from elsewhere in the prompt look applicable and the value drifts silently.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
