### PR TITLE
fix: cache empty slack channel refreshes

### DIFF
--- a/src/kiro_crew/slack/channel_resolver.py
+++ b/src/kiro_crew/slack/channel_resolver.py
@@ -130,8 +130,8 @@ class ChannelNameResolver:
                 merged = dict(self._names)
                 merged.update(new_names)
                 self._names = merged
-                self._fetched_at = time.time()
-                self._save_to_disk()
+            self._fetched_at = time.time()
+            self._save_to_disk()
         except Exception as exc:
             logger.warning("Failed to refresh channel name cache: %s", exc)
         finally:

--- a/src/kiro_crew/slack/client.py
+++ b/src/kiro_crew/slack/client.py
@@ -804,6 +804,7 @@ class RealSlackClient(SlackClientOps):
         """
         out: list[dict] = []
         cursor: str | None = None
+        completed_pages = 0
         for _ in range(_CONVERSATIONS_LIST_MAX_PAGES):
             try:
                 kwargs: dict[str, Any] = {
@@ -817,11 +818,14 @@ class RealSlackClient(SlackClientOps):
                 data: dict = resp.data if hasattr(resp, "data") else dict(resp)  # type: ignore[assignment,call-overload]
                 channels: list[dict] = data.get("channels", [])
                 out.extend(channels)
+                completed_pages += 1
                 cursor = data.get("response_metadata", {}).get("next_cursor", "")
                 if not cursor:
                     break
             except (SlackClientError, aiohttp.ClientError, asyncio.TimeoutError):
                 logger.debug("conversations_list page failed", exc_info=True)
+                if completed_pages == 0:
+                    raise
                 break
         return out
 

--- a/test/test_channel_resolver.py
+++ b/test/test_channel_resolver.py
@@ -6,6 +6,7 @@ import json
 import time
 from unittest.mock import AsyncMock
 
+import aiohttp
 import pytest
 
 from kiro_crew.slack.channel_resolver import (
@@ -13,6 +14,7 @@ from kiro_crew.slack.channel_resolver import (
     _CACHE_TTL_SECS,
     ChannelNameResolver,
 )
+from kiro_crew.slack.client import RealSlackClient
 
 
 def _make_slack(channels: list[dict] | Exception | None = None) -> AsyncMock:
@@ -96,6 +98,43 @@ class TestResolveMany:
         assert await resolver.resolve_many(slack, ["C111"]) == {"C111": "C111"}
 
         slack.conversations_list.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_real_client_first_page_failure_stays_retryable(self, tmp_path):
+        resolver = ChannelNameResolver(cache_path=tmp_path / _CACHE_FILENAME)
+        web = AsyncMock()
+        web.conversations_list = AsyncMock(
+            side_effect=[
+                aiohttp.ClientError("temporary Slack failure"),
+                {"channels": [], "response_metadata": {}},
+            ]
+        )
+        slack = RealSlackClient.__new__(RealSlackClient)
+        slack._web = web
+
+        assert await resolver.resolve_many(slack, ["C111"]) == {"C111": "C111"}
+        assert await resolver.resolve_many(slack, ["C111"]) == {"C111": "C111"}
+        assert await resolver.resolve_many(slack, ["C111"]) == {"C111": "C111"}
+
+        assert web.conversations_list.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_real_client_keeps_channels_when_a_later_page_fails(self):
+        channel = {"id": "C111", "name": "engineering"}
+        web = AsyncMock()
+        web.conversations_list = AsyncMock(
+            side_effect=[
+                {
+                    "channels": [channel],
+                    "response_metadata": {"next_cursor": "next"},
+                },
+                aiohttp.ClientError("second page failed"),
+            ]
+        )
+        slack = RealSlackClient.__new__(RealSlackClient)
+        slack._web = web
+
+        assert await slack.conversations_list() == [channel]
 
 
 class TestDiskCache:

--- a/test/test_channel_resolver.py
+++ b/test/test_channel_resolver.py
@@ -87,6 +87,16 @@ class TestResolveMany:
         # Failed refresh — falls through to id fallback
         assert result == {"C111": "C111"}
 
+    @pytest.mark.asyncio
+    async def test_successful_empty_refresh_is_cached(self, tmp_path):
+        resolver = ChannelNameResolver(cache_path=tmp_path / _CACHE_FILENAME)
+        slack = _make_slack([])
+
+        assert await resolver.resolve_many(slack, ["C111"]) == {"C111": "C111"}
+        assert await resolver.resolve_many(slack, ["C111"]) == {"C111": "C111"}
+
+        slack.conversations_list.assert_called_once()
+
 
 class TestDiskCache:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

The resolver must cache a successful empty Slack `conversations.list` response, but `RealSlackClient.conversations_list` also collapsed a first-page API/network/timeout failure into the same empty list. The resolver therefore could not tell authoritative emptiness from a fetch that never completed and marked both fresh.

## Why it matters

A transient first-page Slack failure could suppress channel-name refreshes for the full cache TTL. Conversely, treating every empty list as failure would restore the original request-on-every-resolution bug for genuinely empty workspaces.

## What changed (motivation → approach → change)

`RealSlackClient.conversations_list` now re-raises a handled Slack/API/timeout exception only when zero pages completed. Once any page completed, existing partial-pagination behavior is preserved. The resolver's existing exception path leaves first-page failures stale and retryable, while a successful zero-channel response still advances freshness and is cached.

## Tests

- `python -m pytest test/test_channel_resolver.py test/test_slack_client.py -q --disable-warnings --no-cov -n 0` — 31 passed
- `python -m isort --check-only src/kiro_crew/slack/client.py src/kiro_crew/slack/channel_resolver.py test/test_channel_resolver.py`
- `python -m flake8 src/kiro_crew/slack/client.py src/kiro_crew/slack/channel_resolver.py test/test_channel_resolver.py`
- `python -m mypy --follow-imports=skip src/kiro_crew/slack/client.py src/kiro_crew/slack/channel_resolver.py`
- `python scripts/check_black_formatting.py`
- `python scripts/check_brand_name.py`
- `git diff --check`

## Manual verification

The deterministic real-client regression makes the first Slack call raise `aiohttp.ClientError`, the retry return a successful empty page, and a third lookup hit the fresh empty cache. Before the repair only one transport call occurred because the first failure was marked fresh; the repaired seam makes exactly two. A direct sibling test confirms a later-page failure still returns the first page's channels.

## Related Issues

N/A — independently identified correctness defect.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Collection clients must distinguish successful empty responses from zero-page transport failures so cache freshness advances only for completed fetches.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository template contains no CLA text to complete.