### PR TITLE
fix: publish official catalog cache atomically

### DIFF
--- a/src/kiro_crew/apps/official_catalog.py
+++ b/src/kiro_crew/apps/official_catalog.py
@@ -45,6 +45,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew.apps.manifest import KEBAB_RE, app_name_error
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 
 logger = logging.getLogger(__name__)
@@ -110,8 +111,7 @@ def _read_cache() -> dict[str, Any] | None:
 def _write_cache(doc: dict[str, Any]) -> None:
     path = _cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(doc), encoding="utf-8")
+        atomic_write(path, json.dumps(doc))
     except OSError:
         logger.debug("could not cache the official catalog", exc_info=True)
 

--- a/test/test_official_catalog.py
+++ b/test/test_official_catalog.py
@@ -83,6 +83,32 @@ class TestLoadRefusals:
 
 
 class TestCache:
+    def test_interrupted_write_keeps_the_previous_cache(self, monkeypatch):
+        """A failed refresh must not expose a truncated catalog to readers."""
+        path = oc._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        previous = doc(revision="previous")
+        replacement = doc(revision="replacement")
+        path.write_text(json.dumps(previous), encoding="utf-8")
+
+        real_write_text = type(path).write_text
+
+        def interrupted_write(self, data, *args, **kwargs):
+            if self == path:
+                real_write_text(self, data[:8], *args, **kwargs)
+                raise OSError("simulated interrupted cache write")
+            return real_write_text(self, data, *args, **kwargs)
+
+        def interrupted_atomic_write(*args, **kwargs):
+            raise OSError("simulated interrupted cache write")
+
+        monkeypatch.setattr(type(path), "write_text", interrupted_write)
+        monkeypatch.setattr(oc, "atomic_write", interrupted_atomic_write, raising=False)
+
+        oc._write_cache(replacement)
+
+        assert json.loads(path.read_text(encoding="utf-8")) == previous
+
     def test_a_second_load_does_not_refetch(self, tmp_path, monkeypatch):
         calls = []
 


### PR DESCRIPTION
## Problem / Motivation

The official app catalog cache was written directly to its published path. If that write was interrupted after truncation, concurrent readers (and subsequent starts) observed invalid JSON instead of the previous valid catalog.

## Why it matters

A torn refresh unnecessarily discards a usable catalog and forces the app store onto its fallback/fetch path. Concurrent reads can also race the in-place write and observe a transient partial document.

## What changed (motivation → approach → change)

Keep cache readers on an all-or-nothing view by routing the best-effort catalog cache write through the repository's shared unique-temp-file + replace helper. The existing error policy is preserved: write failures are logged at debug level and do not fail the request.

## Tests

- `python -m pytest test/test_official_catalog.py -q --disable-warnings --no-cov -n 0` — 109 passed
- `python -m isort --check-only src/kiro_crew/apps/official_catalog.py test/test_official_catalog.py`
- `python -m flake8 src/kiro_crew/apps/official_catalog.py test/test_official_catalog.py`
- `python -m mypy --follow-imports=skip src/kiro_crew/apps/official_catalog.py`
- `python scripts/check_black_formatting.py`
- `python scripts/check_brand_name.py`
- `git diff --check`

## Manual verification

The regression installs a prior valid cache, injects an interrupted refresh that truncates the direct writer, and asserts the prior JSON remains intact. It failed before the fix with `JSONDecodeError` on the truncated `{"schema` prefix and passes through the atomic writer.

## Related Issues

None.

## Pattern harvest

Rule candidate: review-prompt
Pattern: JSON caches read concurrently must be published by atomic replace rather than direct write_text to the published path.

## Checklist

- [x] Added a deterministic red-before regression
- [x] Kept the implementation minimal and preserved failure semantics
- [x] Ran focused tests and touched-file quality gates
- [x] Completed a full open-PR changed-file collision scan immediately before creation

## Contribution License Agreement

I agree that my contributions are licensed under the repository's license terms.
