### PR TITLE
fix: prefer the pending Jira fix version for the milestone chip (#7595)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/source_providers.py
+++ b/src/kiro_crew/dashboard/handlers/source_providers.py
@@ -4105,6 +4105,25 @@ def _jira_fix_versions(fields: dict[str, Any]) -> list[dict[str, Any]]:
     return usable
 
 
+def _jira_version_is_done(version: dict[str, Any]) -> bool:
+    """A released or archived version no longer takes new work."""
+    return bool(version.get("released")) or bool(version.get("archived"))
+
+
+def _jira_pick_fix_version(fix_versions: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Pick the fix version that fills the one-slot milestone contract.
+
+    The Issue panel's milestone chip renders only the version's name, with no
+    released/archived signal, so surfacing a shipped release reads as if it
+    were the pending one (issue #7595).  Prefer the first version that is
+    neither released nor archived; when every version has shipped, fall back
+    to the first usable entry so the ticket still shows a release rather than
+    dropping to no milestone at all.
+    """
+    pending = [v for v in fix_versions if not _jira_version_is_done(v)]
+    return (pending or fix_versions)[0] if fix_versions else None
+
+
 def _jira_fix_version_milestone(version: dict[str, Any]) -> dict[str, str]:
     """Map one Jira fix version onto the ``IssueMilestone`` contract.
 
@@ -4117,7 +4136,7 @@ def _jira_fix_version_milestone(version: dict[str, Any]) -> dict[str, str]:
     is done, and an archived one no longer takes work, so both map to
     ``closed`` and everything else stays ``open``.
     """
-    released = bool(version.get("released")) or bool(version.get("archived"))
+    released = _jira_version_is_done(version)
     return {
         "title": str(version.get("name") or "").strip(),
         "state": "closed" if released else "open",
@@ -4315,10 +4334,12 @@ async def _fetch_jira_issue(ref: SourceRef) -> dict[str, Any]:
         )
 
     # Fix versions -> the milestone slot. The contract holds exactly one, so a
-    # ticket scheduled for several releases surfaces the first and declares the
-    # rest partial rather than dropping them silently.
+    # ticket scheduled for several releases surfaces the pending one (falling
+    # back to the first when all have shipped) and declares the rest partial
+    # rather than dropping them silently.
     fix_versions = _jira_fix_versions(fields)
-    milestone = _jira_fix_version_milestone(fix_versions[0]) if fix_versions else None
+    chosen = _jira_pick_fix_version(fix_versions)
+    milestone = _jira_fix_version_milestone(chosen) if chosen else None
     if len(fix_versions) > 1:
         _mark_partial(partial_sections, "fix versions")
 

--- a/test/test_source_providers.py
+++ b/test/test_source_providers.py
@@ -9746,6 +9746,44 @@ class TestJiraFixVersionMilestone:
         assert set(source._jira_fix_version_milestone(version)) == {"title", "state", "dueOn"}
 
 
+class TestJiraPickFixVersion:
+    """Tests for _jira_pick_fix_version (issue #7595)."""
+
+    def test_mixed_versions_prefer_the_unreleased_one(self) -> None:
+        """A pending release wins over an already-shipped one ahead of it."""
+        fix_versions = [
+            {"name": "2.3.0", "released": True},
+            {"name": "2.4.0", "released": False},
+        ]
+        chosen = source._jira_pick_fix_version(fix_versions)
+        assert chosen is not None
+        assert chosen["name"] == "2.4.0"
+
+    def test_all_released_falls_back_to_the_first(self) -> None:
+        """A ticket whose versions all shipped still shows one milestone."""
+        fix_versions = [
+            {"name": "2.2.0", "released": True},
+            {"name": "2.3.0", "archived": True},
+        ]
+        chosen = source._jira_pick_fix_version(fix_versions)
+        assert chosen is not None
+        assert chosen["name"] == "2.2.0"
+
+    def test_empty_list_yields_none(self) -> None:
+        """No usable fix versions means no milestone."""
+        assert source._jira_pick_fix_version([]) is None
+
+    def test_archived_is_not_pending(self) -> None:
+        """An archived-but-unreleased version does not count as pending."""
+        fix_versions = [
+            {"name": "1.0.0", "released": False, "archived": True},
+            {"name": "1.1.0", "released": False},
+        ]
+        chosen = source._jira_pick_fix_version(fix_versions)
+        assert chosen is not None
+        assert chosen["name"] == "1.1.0"
+
+
 class _JiraFakeContent:
     """Minimal ``StreamReader`` stand-in for the capped-response reader."""
 
@@ -9843,6 +9881,26 @@ class TestJiraFixVersionInPayload:
             },
         )
         assert issue["milestone"]["title"] == "2.4.0"
+        assert "fix versions" in issue["partialSections"]
+
+    @pytest.mark.asyncio
+    async def test_pending_version_wins_over_a_shipped_one(self, monkeypatch) -> None:
+        """A released version ahead of a pending one does not steal the chip (#7595)."""
+        issue, _seen = await _jira_fetch(
+            monkeypatch,
+            {
+                "summary": "Fixed in the next release",
+                "fixVersions": [
+                    {"name": "2.3.0", "releaseDate": "2026-06-30", "released": True},
+                    {"name": "2.4.0", "releaseDate": "2026-09-30", "released": False},
+                ],
+            },
+        )
+        assert issue["milestone"] == {
+            "title": "2.4.0",
+            "state": "open",
+            "dueOn": "2026-09-30",
+        }
         assert "fix versions" in issue["partialSections"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The Jira → Issue panel mapping (`_fetch_jira_issue`) filled the one-slot milestone contract with the **first** usable fix version. A ticket carrying `[2.3.0 released, 2.4.0 unreleased]` therefore showed 2.3.0 — the already-shipped release — in the milestone chip, which renders only the title with no released/archived signal, reading as if the fix were already out.

This PR replaces the take-first pick with a pending-first pick:

- New helper `_jira_pick_fix_version`: prefer the first version that is neither released nor archived; when **every** version has shipped, fall back to the first usable entry so the ticket still shows a release rather than dropping to no milestone.
- New shared predicate `_jira_version_is_done` used by both the picker and `_jira_fix_version_milestone`, so the pick and the chip's `state` can never disagree if the definition of "done" is later refined.
- The `partialSections` "fix versions" disclosure behavior is unchanged (still fires when more than one usable version exists).

## Tests

- Unit (`TestJiraPickFixVersion`): mixed released+unreleased picks the unreleased one; all-released falls back to the first; empty list yields `None`; archived-but-unreleased does not count as pending.
- End-to-end (`TestJiraFixVersionInPayload`): a released version ahead of a pending one no longer steals the chip — full milestone dict plus the partial-sections entry pinned.
- Local gates: isort, flake8, mypy (clean on 1282 files), diff-scoped black/brand/sync-io/subprocess-encoding/loop-bound-locks gates all pass. Test execution deferred to CI per host policy.

## Out of scope (kept deliberately)

The issue floats two adjacent questions, both left out of this PR:

1. **Whether Jira's fixVersions array order is trustworthy at all** — this PR keeps first-of-filtered semantics and only changes which subset is preferred; re-ordering (e.g. by release date) is a separate design decision.
2. **Whether the side-panel chip should render released/archived state** — a frontend contract change (`IssueMilestone` already carries `state`, the chip just doesn't render it). Related residual: a ticket whose *single* fix version has shipped still shows that version with no released signal, and with only one version no "fix versions" partial disclosure fires; that is the documented fallback, recorded here as a decision rather than an oversight.

Both are resolvable independently; the headline defect — a pending release being hidden behind a shipped one — is resolved here.

## Pattern harvest

Not generalizable: semantic pick-priority error — mapping a multi-valued upstream field (`fixVersions`) onto a one-slot contract by taking the first element without asking which element best represents the slot's meaning. Whether "first" is right depends on what the slot communicates, so no lint/semgrep pattern can decide it. The fix is locked in by unit tests on the picker and an end-to-end payload test instead, and the shared `_jira_version_is_done` predicate prevents the picker and the chip-state mapping from drifting apart.

Closes #7595
