### PR TITLE
fix: tolerate vanished Personal Shopper sites file

### DIFF
--- a/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py
@@ -481,9 +481,10 @@ def _sites_path() -> Path:
 async def _handle_get_sites(request: web.Request) -> web.Response:
     def _read():
         path = _sites_path()
-        if path.exists():
+        try:
             return json.loads(path.read_text(encoding="utf-8"))
-        return {"sites": []}
+        except FileNotFoundError:
+            return {"sites": []}
 
     data = await asyncio.to_thread(_read)
     return web.json_response(data)

--- a/src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py
@@ -224,6 +224,24 @@ class TestFeedbackIsConstrained(RoutesTestCase):
 
 
 class TestSitesShapeValidation(RoutesTestCase):
+    async def test_get_treats_a_vanished_sites_file_as_empty(self) -> None:
+        """Deleting sites.json during discovery must not turn GET into a 500."""
+        sites_file = routes_mod._sites_path()
+        sites_file.write_text('{"sites": []}', encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def vanish_before_read(path, *args, **kwargs):
+            if path == sites_file:
+                path.unlink()
+                raise FileNotFoundError(path)
+            return real_read_text(path, *args, **kwargs)
+
+        with mock.patch.object(Path, "read_text", vanish_before_read):
+            resp = await self.client.get(f"{_PREFIX}/sites")
+
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(await resp.json(), {"sites": []})
+
     async def test_sites_must_be_an_array_of_objects(self) -> None:
         resp = await self.client.put(f"{_PREFIX}/sites", json={"sites": ["amazon"]})
         self.assertEqual(resp.status, 400)


### PR DESCRIPTION
## Problem / Motivation

The Personal Shopper sites endpoint checked `sites.json` with `exists()` and then opened it in a separate filesystem operation. If the file was removed in that window, the uncaught `FileNotFoundError` escaped the worker thread and the endpoint returned HTTP 500.

## Why it matters

Deleting/resetting this optional user-owned state can race a dashboard read. An absent sites file already means an empty configured-site list; the same state reached a few microseconds later should not turn a routine GET into a server failure.

## What changed (motivation → approach → change)

Remove the check-then-open sequence. The handler now attempts the read once and maps only `FileNotFoundError` to the existing empty-sites fallback. Other failures—including corrupt JSON or permission errors—retain their current error behavior instead of being hidden.

## Tests

- `python -m pytest src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py -q --disable-warnings --no-cov -n 0` — 30 passed
- `python -m isort --check-only src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py`
- `python -m flake8 src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py src/kiro_crew/apps/builtins/personal_shopper/tests/test_routes.py`
- `python -m mypy --follow-imports=skip src/kiro_crew/apps/builtins/personal_shopper/backend/routes.py`
- `python scripts/check_black_formatting.py`
- `python scripts/check_brand_name.py`
- `git diff --check`

## Manual verification

The regression creates `sites.json`, removes it at the exact read boundary, and calls the real aiohttp endpoint. It returned HTTP 500 before the fix and now returns HTTP 200 with `{"sites": []}`.

## Related Issues

None.

## Pattern harvest

Rule candidate: review-prompt
Pattern: Optional-file reads must not probe exists() and then reopen; disappearance between those operations should map to the already-absent state.

## Checklist

- [x] Added a deterministic red-before endpoint regression
- [x] Kept the fallback restricted to the vanished-file state
- [x] Ran focused tests and touched-file quality gates
- [x] Completed a full open-PR changed-file collision scan immediately before creation

## Contribution License Agreement

I agree that my contributions are licensed under the repository's license terms.
