### PR TITLE
feat(telegram): resume dashboard sessions from chat

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -999,7 +999,6 @@ test/test_session_health.py
 test/test_session_keepalive.py
 test/test_session_map_locking.py
 test/test_session_map_migration.py
-test/test_session_map_mirror.py
 test/test_session_memory.py
 test/test_session_more_coverage.py
 test/test_session_mtime_ordering.py

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -64,7 +64,7 @@ Slack's transport path is gated behind the `messaging.use_transport` config flag
 | `messaging/session_trust.py` | The per-session tool-Trust grant store: `is_session_trusted`, `add_trusted_session(key, sessions=)`, `clear_trusted_sessions`. In memory only, so an ad-hoc auto-approve grant dies with the process. The grant has TWO halves and both are load-bearing: the in-memory mapping the driver reads, and the session's approval policy set to `auto`, because a spawned subagent reads its parent's policy and never this mapping. So it is a `key -> SessionManager` MAPPING rather than a set, which is what lets `clear_trusted_sessions` undo the policy half too (back to `""`, the same value the dashboard's untrust toggle writes) without its caller having to hand a manager back. **Every mutation goes through the API**: reaching the container directly is how a revoke came to drop one half and leave subagents trusted, and a mapping has no `.add`, so a half-grant is not expressible either. Named `session_trust`, not `trust`, so it cannot be confused with a connection-admission roster: this grant is about what ONE session's tools may skip, not about which principals may attach. Consumed only through `TurnDriver`'s `auto_approve_session` predicate, which runs BEHIND the keystone, governance and deny-list gates, so a hard DENY still refuses |
 | `messaging/link.py` | **Layer 3** — session-key namespacing (`session_key`/`canonical_key`/`legacy_key`/`is_legacy_slack_key`) + `ChannelLink` + DM-scope key derivation / `should_rotate_generation`, plus the in-channel `/link` ⇄ `/unlink` pair (`rebind_conversation_location` / `release_conversation_location`) |
 | `messaging/conversation.py` | `ConversationState` — per-conversation rotating *generation* bookkeeping (advanced by `/new` and idle/daily reset), seeded from the persisted session map |
-| `messaging/session_resume.py` | **Layer 3** — the channel-neutral half of dashboard-session resume. `SessionResumeController` consumes a bound `ResumeSurface` (including its exact durable expectation identity, which may be narrower than `ChannelLink.channel_id`) and owns the complete SHOW-PICKER flow (eligibility/search, audit, nonce/TTL/owner/message scoping, and registration only after a successful post) plus the CHOOSE/BIND transaction (history existence, conflict checks around the awaited settlement, durable expectation before success, atomic inbound claim, lost-claim/storage outcomes, dashboard push, and audit). `SessionBinder` owns inbound routing, settlement, and release. Discord and Teams retain only address/identity derivation, widgets/cards, exact wording and display redaction, callback parsing, and channel-local replay. |
+| `messaging/session_resume.py` | **Layer 3** — the channel-neutral half of dashboard-session resume. `SessionResumeController` consumes a bound `ResumeSurface` (including its exact durable expectation identity, which may be narrower than `ChannelLink.channel_id`) and owns the complete SHOW-PICKER flow (eligibility/search, audit, nonce/TTL/owner/message scoping, and registration only after a successful post) plus the CHOOSE/BIND transaction (history existence, conflict checks around the awaited settlement, durable expectation before success, atomic inbound claim, lost-claim/storage outcomes, dashboard push, and audit). `SessionBinder` owns inbound routing, settlement, and release. Discord, Telegram, and Teams retain only address/identity derivation, widgets/cards, exact wording and display redaction, callback parsing, and channel-local replay. |
 | `messaging/resume_expectation.py` | The durable conversation-keyed shadow of those bindings, ONE file per channel (`store_filename`), because a Discord channel id and a Teams conversation id are unrelated address spaces |
 | `teams/service_urls.py` | `ServiceUrlStore` — durable `conversation_id -> serviceUrl` (plus the authorized identity owning each conversation), because the Bot Framework offers no lookup and a lost reference leaves every proactive path with nowhere to send. `forget` drops a route the Connector permanently refuses |
 | `teams/cards.py` | Adaptive Card construction + `parse_submit` — the strict, total validation of an untrusted card payload. Mints no nonce of its own: every clickable widget's token comes from `messaging.renderer.new_approval_nonce` |
@@ -84,6 +84,7 @@ Channel-neutral inbound/outbound contract. A new channel = implement this interf
 - **Lifecycle (default no-op, override as needed)**: `connect()` (lazy-import client libs HERE), `maintain()` (poll/heartbeat), `disconnect()`.
 - **Inbound adapter (abstract)**: `receive(raw_envelope)` (ack → filter → authorize → normalize → dispatch) and `authorize(msg) -> bool`. `authorize` MUST be **deny-by-default** — an unconfigured transport authorizes nobody.
 - **Outbound authorization**: `may_send_to(conversation_id, thread_id=None, *, principal="") -> bool` re-decides recipient authorization for a **proactive** send. `authorize` gates a turn the user drove; this gates the messages nobody asked for (a cron result, a compaction notice, a subagent completion), which resolve their destination from a *persisted* `ChannelLink`. A link records a conversation but **not the principal that authorized it**, so without this a recipient removed from a channel's allow-list kept receiving proactive traffic after a restart: the roster changed and nothing re-read it. Only the transport can answer, because the roster holds principals while the link holds a conversation id and whether those are the same string is a per-platform fact. `principal` carries the peer's platform id when the session key names one, which is what lets a transport with an opaque conversation id (Discord, Webex) reach its roster at all; empty means the key names no single person (a room route, a unified bucket), NOT that nobody is authorized. MUST stay **synchronous and in-memory**, because it runs on every proactive send: a network round trip there is unbounded work on the send path, and a check that can time out is a check that fails open under load. See § Proactive sends for where it is enforced and which channels answer how.
+- **Resume-target authorization**: `may_resume_from(conversation_id, thread_id=None) -> bool` applies target- and roster-specific ownership after `supports_session_resume` proves the transport has a correct inbound resolver. The default follows the capability. Telegram narrows it to exactly one configured operator's private DM, so a multi-user allow-list can still receive an outbound dashboard mirror without granting either user inbound control of that dashboard session. The dashboard asks this once after resolving the configured target and threads the answer unchanged through both its occupancy precheck and binding write. It is synchronous and in-memory for the same reason as `may_send_to`.
 
 ### `TransportCapabilities`
 
@@ -849,6 +850,53 @@ Four properties are load-bearing:
   `test_channel_transport_outbound_authz.py` requires every shipped transport to
   override the method rather than inherit the permissive ABC default, so a new
   channel cannot skip the question.
+
+## Telegram dashboard-session resume
+
+A private Telegram DM can take over an existing dashboard conversation without
+opening the dashboard:
+
+- `/session <words>` (plural `/sessions` remains an alias) runs the dashboard's
+  ranked title-and-content search and posts up to ten owner-scoped inline buttons.
+  The command is exposed in Telegram's command menu under its singular spelling.
+- A button carries only a bounded nonce and index. The shared
+  `SessionResumeController` rechecks owner, picker, message, history existence and
+  binding conflicts before marking the selected session's `ChannelLink` as
+  `accepts_inbound=True`. Telegram declares `supports_session_resume=True` because
+  every ordinary inbound message resolves that binding before choosing a native
+  Telegram session key.
+- The common native Telegram session may already hold an **outbound-only** mirror
+  to the DM. Selection replaces that mirror transactionally so the first click is
+  sufficient; a live inbound owner or a selected session active on another channel
+  is never displaced. A failed claim restores the outbound mirror.
+- Session-scoped commands (`/stop`, `/compact`, `/model`, `/title`, `/spawn`,
+  `/task`, and privacy modifiers) use the resolved dashboard key. `/link` also
+  resolves first, but refuses while a resumed session owns the conversation and
+  directs the user to `/unlink`. Recovery and host-level commands stay native so
+  a stale or ambiguous binding cannot block `/new`, `/unlink`, `/session`, `/help`,
+  `/status`, `/ping`, `/cron`, `/yolo`, `/kirocrew dashboard`, `/voice`, or
+  `/agent`.
+- `/new` and `/unlink` call `SessionBinder.release`, which atomically clears the
+  inbound link and retires its durable expectation. `/new` then advances the native
+  Telegram generation; `/unlink` returns to the existing native conversation. A
+  durability failure changes nothing and is reported instead of silently splitting
+  history.
+- A message queued while a native Telegram turn is busy keeps native affinity when
+  it drains (`interpret_commands=False` skips resume resolution). A `/session` bind
+  created after enqueue therefore cannot redirect already-queued text into the
+  selected dashboard conversation. Busy resumed sessions refuse a second message
+  instead of queuing it, so the exception cannot strand resumed work.
+- Every `/model` picker records its exact target session and re-resolves the current
+  binding on press. `/new`, `/unlink`, an agent switch, or any rebind invalidates the
+  old picker before `session/set_model`; only a native picker stores the route-level
+  preference used by later Telegram generations.
+- Listing and selection are limited to exactly one configured operator in a private
+  DM. Dashboard-created Telegram links apply the same rule through
+  `may_resume_from`: with several allowed users they remain outbound-only. The
+  dispatcher rechecks ownership on every inbound route and callback, so a binding
+  written under an earlier single-owner configuration cannot survive a roster
+  change as an authorization bypass. Forum Topics cannot enumerate or resume
+  dashboard history.
 
 ## Telegram forum topics (per-Topic sessions)
 
@@ -1986,14 +2034,12 @@ worse than one clean bubble followed by its pictures. The picture send is
   text bubble has already landed, so re-posting the source would deliver the
   answer twice. The markup is rebuilt from each `OutboundFile`'s own alt and path
   and sent as one short follow-up, display-redacted.
-- **Two gates, one of them not yet reachable.** `files_outbound` is read before
-  extracting. The second is `messaging/upload_gate.uploads_restricted`, which
-  denies an incognito or temporary dashboard session — and today it cannot fire
-  on this channel: it keys on a `dashboard:` session key, and Telegram derives
-  its key from the route alone (`supports_session_resume` is False), so no
-  Telegram turn ever carries one. It is wired anyway, because the gate is shared
-  with Discord where it DOES fire, and because the day inbound resume lands here
-  the ceiling has to already be in the path rather than be remembered.
+- **Two gates, both reachable.** `files_outbound` is read before extracting.
+  The second is `messaging/upload_gate.uploads_restricted`, which denies an
+  incognito or temporary dashboard session. Telegram session resume can carry a
+  `dashboard:` key, so the gate applies to those turns exactly as it does on
+  Discord; native Telegram session keys remain outside that restricted-dashboard
+  branch.
 
 ### Telegram's display-form redaction
 

--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -60,7 +60,7 @@ Slack's transport path is gated behind the `messaging.use_transport` config flag
 | `messaging/sessions_view.py` | The channel-neutral recent-sessions collector (`_collect_recent_sessions` + its off-loop form). Takes an explicit `sessions_dir` so a surface owning its own data-home override threads it in rather than shadowing this module's; `slack/sessions_view.py` does exactly that and keeps the Block Kit rendering |
 | `messaging/privacy_mode.py` | The `!temporary` / `!incognito` session privacy modes, keyed by **session key** — two bounded LRUs, the durable `SessionMap` flag, one `is_restricted` predicate, the token strippers, and the SEL audit with the channel as a parameter. See [Session privacy modes](#session-privacy-modes-privacy_modepy) |
 | `messaging/auto_title.py` | Conversation auto-titling — the claim-early LRU, the tool-free bounded background turn, the prompt, and the title-cleaning rules. Renaming the platform conversation is a caller-supplied callback. See [Auto-titling](#auto-titling-auto_titlepy) |
-| `messaging/upload_gate.py` | `uploads_restricted(dashboard_state, session_key, channel_type=)` — the restricted-session ceiling on outbound file uploads, plus `live_dashboard_slot`. Three-state ladder (non-`dashboard:` key allows, a LIVE slot answers off `is_restricted`, otherwise the PERSISTED transcript mode answers and an unreadable one DENIES), audited per channel. Discord and Telegram both route here |
+| `messaging/upload_gate.py` | `session_is_restricted(dashboard_state, session_key, persisted_probe=, unknown_denies=True)` — the shared incognito/temporary decision, `session_blocks_reads(...)` — its READ counterpart (only `temporary` blocks reads; `incognito` still reads), plus `uploads_restricted(...)` which adds the per-channel upload audit, plus `live_dashboard_slot`. Three-state ladder (non-`dashboard:` key answers off `privacy_mode`, a LIVE slot answers off `is_restricted`/`blocks_reads`, otherwise the PERSISTED transcript mode answers). `unknown_denies` decides an unreadable mode: uploads DENY it outright (bytes cannot be recalled), while the durable-history gate denies only when a transcript EXISTS but its mode cannot be resolved (an ambiguous stem, a header no normal session wrote) — that is where an incognito session can hide. A legacy header with no `memory_mode` reads `persistent` rather than unknown, so the only unknown history allows is a truly ABSENT record, where nothing on disk claims the session is restricted. Discord and Telegram both route uploads here; both resumed-turn paths also use it to gate live projection and durable history, and Telegram uses it for `/title` |
 | `messaging/session_trust.py` | The per-session tool-Trust grant store: `is_session_trusted`, `add_trusted_session(key, sessions=)`, `clear_trusted_sessions`. In memory only, so an ad-hoc auto-approve grant dies with the process. The grant has TWO halves and both are load-bearing: the in-memory mapping the driver reads, and the session's approval policy set to `auto`, because a spawned subagent reads its parent's policy and never this mapping. So it is a `key -> SessionManager` MAPPING rather than a set, which is what lets `clear_trusted_sessions` undo the policy half too (back to `""`, the same value the dashboard's untrust toggle writes) without its caller having to hand a manager back. **Every mutation goes through the API**: reaching the container directly is how a revoke came to drop one half and leave subagents trusted, and a mapping has no `.add`, so a half-grant is not expressible either. Named `session_trust`, not `trust`, so it cannot be confused with a connection-admission roster: this grant is about what ONE session's tools may skip, not about which principals may attach. Consumed only through `TurnDriver`'s `auto_approve_session` predicate, which runs BEHIND the keystone, governance and deny-list gates, so a hard DENY still refuses |
 | `messaging/link.py` | **Layer 3** — session-key namespacing (`session_key`/`canonical_key`/`legacy_key`/`is_legacy_slack_key`) + `ChannelLink` + DM-scope key derivation / `should_rotate_generation`, plus the in-channel `/link` ⇄ `/unlink` pair (`rebind_conversation_location` / `release_conversation_location`) |
 | `messaging/conversation.py` | `ConversationState` — per-conversation rotating *generation* bookkeeping (advanced by `/new` and idle/daily reset), seeded from the persisted session map |
@@ -895,8 +895,68 @@ opening the dashboard:
   `may_resume_from`: with several allowed users they remain outbound-only. The
   dispatcher rechecks ownership on every inbound route and callback, so a binding
   written under an earlier single-owner configuration cannot survive a roster
-  change as an authorization bypass. Forum Topics cannot enumerate or resume
+  change as an authorization bypass. The gate covers the durable expectation store
+  as well as the live map: a detached binding whose expectation survives resolves
+  no key and no ambiguity, yet the binder still builds a notice from the dashboard
+  session's TITLE, so for a non-owner ANY non-empty `RoutingDecision` becomes the
+  generic refusal, which names nothing. Its settlement is deliberately left OWED
+  rather than acknowledged by a message never delivered, so the real owner still
+  receives the notice. Forum Topics cannot enumerate or resume
   dashboard history.
+- **A restricted dashboard session resumed here writes no transcript.** The turn's
+  durable write is skipped when `upload_gate.session_is_restricted` reports the
+  resumed session incognito or temporary — the same predicate the upload ceiling
+  reads, so one conversation cannot refuse the file and then record the text.
+  `privacy_mode.is_restricted` is **not** sufficient on this path: it answers off a
+  process-local tracker that only an inbound CHANNEL message populates, so for a
+  `dashboard:` key it reports unrestricted and fails open. It remains the gate
+  inside `_persist_turn` for Telegram's own native conversations. The decision is
+  made on the loop, before either writer, because the live slot registry and the
+  persisted-transcript fallback are not reachable from the worker thread. A
+  restricted turn skips BOTH direct persistence and `project_channel_turn_live`:
+  projection marks the dashboard slot dirty, and a later dirty-slot flush would
+  otherwise persist the rows the direct writer refused. `/title` uses the same
+  dashboard-aware predicate because its metadata write creates the transcript. On
+  an unrestricted LIVE slot it updates `slot.title`, `_titled`, `_title_origin`
+  and `_title_epoch`, persists through the dashboard's epoch-aware title writer,
+  and broadcasts `slot_title`; writing only transcript metadata would let the
+  slot's next save restore its old title. `/temporary` and `/incognito` are
+  refused while resumed (including a modifier carrying a message, which is NOT
+  processed): runtime memory-mode switching is not a dashboard capability, and
+  marking only Telegram's channel tracker would promise privacy while the live
+  persistent slot kept recording. The user must `/unlink` or `/new` first.
+  The two ceilings deliberately differ on an UNREADABLE persisted mode
+  (`unknown_denies`): an upload denies every unknown, because shipping bytes
+  cannot be taken back, while history denies only an unknown whose transcript
+  EXISTS — an ambiguous stem matching several transcripts, or a header no normal
+  session wrote, which is exactly where an incognito session can hide. A legacy
+  header missing `memory_mode` reads `persistent`, not unknown, so the sole
+  unknown history allows is a truly absent record: nothing on disk claims the
+  session is restricted, and denying there would stop recording every
+  conversation whose transcript has not been written yet.
+- **Dashboard link claims BEFORE it announces.** `POST .../mirror-link` writes the
+  binding first, then sends "Session linked from dashboard" and the catch-up
+  transcript. The old order announced first and claimed last, which left a window
+  as long as the backfill takes — delivery is inline and one message per unit
+  against the transport's rate limit, roughly a second each on Telegram — during
+  which an inbound reply resolved no binding and ran in the channel's NATIVE
+  session, the one the notice had just said the user left. Claiming first follows
+  the endpoint's own reasoning that a binding can be unwound while posted messages
+  cannot: every failure path after the claim (a governance narrowing at the send
+  boundary or mid-backfill, a failed announcement) releases it, restoring the prior
+  link and opt-out rather than unlinking a session that was merely being rebound.
+  The claim and its release run in a worker thread, like the resume binder's, since
+  `batched_save` rewrites the whole map file on exit. A `ConversationOwnershipConflict`
+  now surfaces before anything is posted.
+- **A temporary resumed session reads no memory either.** `temporary` blocks memory
+  and lesson READS as well as writes, while `incognito` deliberately still reads —
+  that is the whole difference between the modes. `upload_gate.session_blocks_reads`
+  answers on the same three rungs (the channel tracker for a native key, the live
+  slot's `blocks_reads`, else the persisted mode, with unknown-on-an-existing-record
+  failing closed). `privacy_mode.is_temporary` cannot answer alone: it reads a
+  process tracker a dashboard slot never populates, so a resumed temporary session
+  would take yesterday's memories into today's prompt. The write ceiling does not
+  cover this — the leak is inbound, into the model, not outbound to disk.
 
 ## Telegram forum topics (per-Topic sessions)
 
@@ -1941,6 +2001,41 @@ An inbound resume binding lives on the bound session's `session_map.json` row. A
 **Store.** `$KIROCREW_HOME/trust/discord_resume_expectations.json` holds channel-id → `{key, title, version, retired}` rows under agent-blocked `trust/`, with an owner-only directory and `restrict_to_owner` file write because modes do not protect files on Windows. `retired` defaults false when loading an older row. Every filesystem step, including `config_dir()`, runs in a worker; an `asyncio.Lock` serializes read-modify-write without spanning Discord I/O.
 
 **Refuse before route.** `DiscordSessionResume.route` returns one `RoutingDecision` containing either the session key or a refusal. Plain turns and session-targeting commands use that decision once; drained turns keep their enqueue-time native decision. `!new`/`!unlink` release every exact-channel binding, `!sessions`/`!help` remain reachable for recovery, and tool approval dispatches no turn while retaining its nonce-keyed visible failure path. Four states run: no owner/no record; no owner/retired record; one owner/no record (bootstrap); one matching owner/active record. Four refuse: active record without owner (lost link, retire after notice), any owner different from the active record or present beside a retired record (announce and adopt after delivery), multiple owners, or a resolution that keeps changing.
+
+**Restricted resumed sessions.** Discord uses the same
+`upload_gate.session_is_restricted` decision as Telegram before both post-turn
+writers. A restricted dashboard turn skips the direct history append AND
+`project_channel_turn_live`; projection is a writer too because it marks the live
+slot dirty for a later flush. The LIVE slot is authoritative. With no open tab, a
+persisted incognito/temporary marker restricts, and so does an unknown mode whose
+transcript EXISTS (an ambiguous stem, or a header no normal session wrote) — that
+is where an incognito session hides. Unlike uploads, which deny every unknown,
+history allows only a truly ABSENT record, since a legacy header with no marker
+reads `persistent` and an absent one claims nothing. Discord offers no rename
+command, so there is no separate title writer to gate.
+
+**A failed pick restores what it displaced.** `SessionResumeController.choose`
+snapshots the channel's expectation before `record` overwrites it, and every
+failed bind path (settlement failure, a conflict re-check, a batch-write failure)
+compare-and-sets that snapshot back on the replacement's own version. Retiring the
+replacement instead would leave a DETACHED marker where an ACTIVE record used to
+be, and that record is the evidence a lost link still owes the user a notice — so
+the next message would route natively and the notice would never arrive. With no
+prior record, or an already-retired one, retiring remains the faithful undo.
+
+**The binding transaction runs off the event loop, and decides under the lock.**
+`batched_save` holds `session_map._MAP_LOCK` across its block and rewrites the whole
+map file on the way out, so both the commit and its rollback go through
+`asyncio.to_thread` — on the loop that write stalls every task, including the
+gateway and heartbeat. Each closure is await-free, because the lock is per-thread
+reentrant and an await inside a batch would let another coroutine into the critical
+section; `binder.lock` still serializes concurrent pickers. Because the dashboard
+and other channels bind WITHOUT that lock, the conflict/displaced decision and both
+restore snapshots are re-derived INSIDE the batch rather than reused from the loop:
+a rebind landing in the hand-off window would otherwise clear a key whose newer
+mirror the pick never saw. The rollback is conditional for the same reason — it runs
+in a second critical section, so it undoes a row only while that row still looks
+like this transaction's own work.
 
 **Versioned acknowledgement.** Settlement follows a confirmed send and compare-and-sets the quoted version, so a newer picker/dashboard record wins and failed delivery settles nothing. A delivered detach replaces the active record with a durable retired marker in one write: no owner may route natively, while an owner racing the write still meets retained evidence and is refused before adoption. This avoids a clear-then-restore transaction whose compensating write could fail after evidence was deleted. **Persistence is fail-closed.** Memory publishes only after a durable write; only an absent file means empty, while I/O, UTF-8, JSON, shape, non-integer version, or non-boolean retired errors refuse routing. A pick records before binding. `!unlink`/`!new` serialize map removal, forced off-loop write, and versioned expectation retirement against pickers. Failed forced writes remain owed, keep the active expectation, and visibly fail the command; a later retirement failure costs one self-retiring notice rather than a silent resume.
 

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -134,6 +134,65 @@ def _redact_assistant(content: str) -> str:
     return content
 
 
+def project_channel_turn_live(
+    dashboard_state: Any,
+    session_key: str,
+    user_text: str,
+    reply_text: str,
+    *,
+    broadcast_user: bool = False,
+) -> tuple[str, str] | None:
+    """Append one resumed turn to its open dashboard slot and return both row ids.
+
+    This is loop-side by contract: user then assistant append without an await between
+    them, so the live window observes one ordered pair. ``broadcast_user`` is explicit
+    because Telegram has no optimistic dashboard copy for its channel-originated row,
+    while Discord's established projection path does not broadcast that row.
+    """
+    from kiro_crew.dashboard.state import row_mid
+    from kiro_crew.messaging.upload_gate import live_dashboard_slot
+
+    slot = live_dashboard_slot(dashboard_state, session_key)
+    if slot is None:
+        return None
+    try:
+        user_mid = (
+            row_mid(
+                slot.append(
+                    "user",
+                    user_text,
+                    "msg msg-u",
+                    broadcast_user=broadcast_user,
+                )
+            )
+            or ""
+        )
+    except Exception:
+        logger.debug(
+            "channel turn projection: user append failed for %s", session_key, exc_info=True
+        )
+        return None
+
+    assistant_mid = ""
+    if reply_text:
+        try:
+            assistant_mid = row_mid(slot.append("assistant", reply_text, "msg msg-a")) or ""
+        except Exception:
+            logger.debug(
+                "channel turn projection: assistant append failed for %s",
+                session_key,
+                exc_info=True,
+            )
+
+    push = getattr(dashboard_state, "push_slots_update", None)
+    if callable(push):
+        try:
+            push()
+        except Exception:
+            logger.debug("channel turn projection: slot push failed", exc_info=True)
+    return user_mid, assistant_mid
+
+
 def _close_time(meta: dict[str, Any], file_mtime: float | None) -> float | None:
     """Best-known epoch instant *meta*'s ``closed`` flag was written.
 

--- a/src/kiro_crew/dashboard/channel_slots.py
+++ b/src/kiro_crew/dashboard/channel_slots.py
@@ -61,11 +61,13 @@ from itertools import islice
 from typing import TYPE_CHECKING, Any
 
 from kiro_crew.dashboard.channel_folders import lookup_channel_folder
+from kiro_crew.dashboard.chat_title import _persist_title
 from kiro_crew.dashboard.chat_utils import effective_session_key
-from kiro_crew.dashboard.state import _normalize_slot_key, durable_row_count
+from kiro_crew.dashboard.state import _normalize_slot_key, durable_row_count, row_mid
 from kiro_crew.history import carry_provenance, is_incognito_transcript
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.messaging.link import channel_namespace_of, is_channel_session_key
+from kiro_crew.messaging.upload_gate import live_dashboard_slot
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -149,9 +151,6 @@ def project_channel_turn_live(
     because Telegram has no optimistic dashboard copy for its channel-originated row,
     while Discord's established projection path does not broadcast that row.
     """
-    from kiro_crew.dashboard.state import row_mid
-    from kiro_crew.messaging.upload_gate import live_dashboard_slot
-
     slot = live_dashboard_slot(dashboard_state, session_key)
     if slot is None:
         return None
@@ -191,6 +190,47 @@ def project_channel_turn_live(
         except Exception:
             logger.debug("channel turn projection: slot push failed", exc_info=True)
     return user_mid, assistant_mid
+
+
+async def rename_channel_title_live(
+    dashboard_state: Any,
+    session_key: str,
+    title: str,
+) -> bool:
+    """Rename the open dashboard slot for *session_key* and keep every view aligned.
+
+    Returns ``False`` when no live slot owns the session, so the channel can fall
+    back to its conversation-log-only path. A live slot is authoritative once it
+    exists: changing only transcript metadata lets its later save rewrite the old
+    in-memory title over the new one. Match the dashboard's own manual-rename
+    ordering instead — update the slot synchronously, bump its title epoch so a
+    background titler stands down, persist through the epoch-aware helper, then
+    broadcast the exact value every dashboard client must render.
+
+    ``_persist_title`` is best-effort by dashboard contract. A failed immediate
+    metadata write leaves the updated live slot authoritative and a later slot
+    save can recover it; the dashboard's own rename endpoint makes the same trade.
+    """
+    slot = live_dashboard_slot(dashboard_state, session_key)
+    if slot is None:
+        return False
+
+    slot.title = title
+    slot._titled = True
+    slot._title_origin = "user"
+    slot._title_epoch = int(getattr(slot, "_title_epoch", 0)) + 1
+    persisted = await _persist_title(dashboard_state, slot)
+    if not persisted:
+        logger.warning("channel title update is live but not yet durable for %s", session_key)
+
+    push_title = getattr(dashboard_state, "push_slot_title", None)
+    if callable(push_title):
+        push_title(slot.key, title)
+    else:
+        push_slots = getattr(dashboard_state, "push_slots_update", None)
+        if callable(push_slots):
+            push_slots()
+    return True
 
 
 def _close_time(meta: dict[str, Any], file_mtime: float | None) -> float | None:

--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -97,23 +97,32 @@ async def api_channel_targets(request: web.Request) -> web.Response:
     return web.json_response(targets)
 
 
-def _resumes_inbound(transport: Any) -> bool:
-    """Does a binding on this transport actually route replies back to the session?
+def _resumes_inbound(
+    transport: Any,
+    conversation_id: str,
+    thread_id: str | None,
+) -> bool:
+    """Whether this resolved target may route replies back to the session.
 
-    Only a transport whose inbound path resolves the mirror binding may claim
-    ``accepts_inbound``. Discord's dispatcher looks the conversation up; the
-    others build a session key from the route and never consult the binding, so
-    a reply there runs in a SEPARATE session no matter what the binding says.
-    Claiming inbound for them would not make replies come back — it would only
-    make the dashboard say they do, and the slot row would report
-    ``direction: both`` on a promise nothing keeps.
-
-    Reads the capability rather than testing ``channel_type == "discord"``, so a
-    transport earns the claim by declaring it next to its own inbound path. The
-    ``getattr`` chain is the conservative branch: a transport with no capability
-    object at all degrades to outbound-only.
+    The capability proves the transport has an inbound binding resolver. The
+    transport's target hook then applies roster- and topology-specific ownership
+    policy; Telegram, for example, permits only its single configured owner DM.
+    A missing hook keeps legacy test doubles capability-driven, while a real hook
+    error fails closed to outbound-only.
     """
-    return bool(getattr(getattr(transport, "capabilities", None), "supports_session_resume", False))
+    capable = bool(
+        getattr(getattr(transport, "capabilities", None), "supports_session_resume", False)
+    )
+    if not capable:
+        return False
+    check = getattr(transport, "may_resume_from", None)
+    if not callable(check):
+        return True
+    try:
+        return bool(check(conversation_id, thread_id))
+    except Exception:
+        logger.warning("mirror-link: target resume policy failed", exc_info=True)
+        return False
 
 
 async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
@@ -290,6 +299,7 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         channel_id=conversation_id,
         thread_id=thread_id,
     )
+    accepts_inbound = _resumes_inbound(transport, conversation_id, thread_id)
 
     # Refuse an occupied conversation BEFORE anything is posted into it. The
     # authoritative check is the atomic one inside ``set_mirror_link`` at the
@@ -314,7 +324,7 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
     # refusal would look like a real conflict. Only an actual list is an answer.
     try:
         rivals = state.sessions.mirror_claim_blockers(
-            session_key, link, accepts_inbound=_resumes_inbound(transport)
+            session_key, link, accepts_inbound=accepts_inbound
         )
     except Exception:
         logger.debug("mirror-link: occupancy precheck unavailable", exc_info=True)
@@ -504,7 +514,7 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
                 # writes an outbound-only binding, ``resumed_session`` skips it,
                 # and the user's reply starts a brand-new session with none of
                 # this transcript.
-                accepts_inbound=_resumes_inbound(transport),
+                accepts_inbound=accepts_inbound,
             )
     except ConversationOwnershipConflict:
         # The precheck above covers the common case; this is the genuine race —

--- a/src/kiro_crew/dashboard/chat_mirror.py
+++ b/src/kiro_crew/dashboard/chat_mirror.py
@@ -346,11 +346,153 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
             status=409,
         )
 
+    # Claim the binding BEFORE anything is posted into the conversation.
+    #
+    # The notice announces a link that does not exist yet, and the catch-up
+    # transcript after it is delivered one message at a time against the
+    # transport's rate limit — Telegram is roughly one per second — so the gap
+    # between the announcement and the claim is as many seconds as there are
+    # backfill messages, not an instant. An inbound reply arriving in it resolves
+    # no binding and runs in the channel's NATIVE session: the very session the
+    # notice just said the user had left, with none of this transcript.
+    #
+    # Claiming first is what this module's own precheck reasoning argues for — a
+    # binding can be unwound, posted messages cannot — so the unwindable half goes
+    # first and every failure path below releases it. The prior state is captured
+    # rather than assumed, because linking is also how an EXISTING mirror is
+    # rebound: a failed rebind must leave the old binding exactly as it was, not
+    # unlink the session.
+    previous_link = state.sessions.get_mirror_link(session_key)
+    previous_inbound = False
+    if previous_link is not None:
+        try:
+            previous_inbound = session_key in state.sessions.find_mirror_sessions(
+                previous_link, inbound_only=True
+            )
+        except Exception:
+            logger.debug("mirror-link: could not read the prior inbound flag", exc_info=True)
+    previous_opt_out: bool | None
+    try:
+        # Off the loop: this READ writes. On a legacy row ``mirror_opt_out``
+        # promotes it inside ``batched_save``, which rewrites the whole map file —
+        # the same synchronous stall the claim below is offloaded to avoid.
+        previous_opt_out = bool(await asyncio.to_thread(state.sessions.mirror_opt_out, session_key))
+    except Exception:
+        # UNKNOWN, not False. A failed read must not mutate state: defaulting here
+        # would let the rollback below write an opt-out the user never chose,
+        # silently clearing a standing refusal to mirror. Unknown means the
+        # rollback leaves that flag alone.
+        logger.debug("mirror-link: could not read the prior opt-out", exc_info=True)
+        previous_opt_out = None
+
+    def _claim_binding() -> None:
+        # Off the loop, and one critical section: ``batched_save`` holds the map
+        # lock across the block and rewrites the whole map file on the way out, so
+        # on the loop this write stalls every other task. Await-free by
+        # construction, because the lock is per-thread reentrant.
+        with state.sessions.batched_save():
+            # The LINK first, deliberately. ``set_mirror_link`` is the call that can
+            # refuse (``ConversationOwnershipConflict``), and it refuses before
+            # mutating, so ordering it first means a refused claim leaves nothing
+            # behind. Withdrawing the opt-out first would flip a standing refusal
+            # for a link that never happened. Both writes share this one critical
+            # section and one file write, so the order costs nothing.
+            state.sessions.set_mirror_link(
+                session_key,
+                link,
+                # Mark the binding inbound-capable only where the transport's
+                # inbound path actually resolves it. Without this the connect
+                # writes an outbound-only binding, ``resumed_session`` skips it,
+                # and the user's reply starts a brand-new session with none of
+                # this transcript.
+                accepts_inbound=accepts_inbound,
+            )
+            # An explicit bind is explicit intent to mirror, so it withdraws any
+            # standing refusal of the AUTOMATIC bind. Without this the two
+            # disagree: a channel that re-asserts its own conversation every turn
+            # would keep declining while the user is looking at a link they just
+            # made, and a later automatic pass would have to guess which of the
+            # two the user meant.
+            state.sessions.set_mirror_opt_out(session_key, False)
+
+    def _release_binding() -> None:
+        with state.sessions.batched_save():
+            # Conditional, and the check shares this critical section with the
+            # writes below so it cannot go stale between them. A rebind — from the
+            # dashboard, another channel, or a second link request — may have landed
+            # between the claim and this failure, and it takes no lock of ours. Undo
+            # only while the binding is still THIS request's claim; anything newer is
+            # deliberate state and outranks a stale restore, the opt-out included.
+            if state.sessions.get_mirror_link(session_key) != link:
+                logger.info(
+                    "mirror-link: leaving a newer binding for %s in place after a failed link",
+                    session_key,
+                )
+                return
+            if previous_opt_out is not None:
+                state.sessions.set_mirror_opt_out(session_key, previous_opt_out)
+            if previous_link is None:
+                state.sessions.clear_mirror_link(session_key, reason=UNBIND_REASON_DASHBOARD_UNLINK)
+            else:
+                state.sessions.set_mirror_link(
+                    session_key,
+                    previous_link,
+                    accepts_inbound=previous_inbound,
+                    reason=UNBIND_REASON_DASHBOARD_UNLINK,
+                )
+
+    async def _release_after_failure() -> None:
+        """Undo the claim, best-effort: the caller is already returning an error."""
+        try:
+            await asyncio.to_thread(_release_binding)
+        except Exception:
+            logger.warning(
+                "mirror-link: could not release the claim for %s after a failed link",
+                session_key,
+                exc_info=True,
+            )
+
+    try:
+        await asyncio.to_thread(_claim_binding)
+    except ConversationOwnershipConflict:
+        # The precheck above covers the common case; this is the genuine race —
+        # someone claimed the conversation while this request was resolving. Report
+        # the same conflict rather than a 500, so the client offers "unlink there
+        # first" instead of inviting a retry of a request that is behaving
+        # correctly. Nothing has been posted, so there is nothing to take back.
+        logger.info("mirror-link refused: conversation claimed before the notice")
+        sel().log_api_access(
+            caller="dashboard",
+            operation="chat.mirror_link",
+            outcome="denied",
+            source="dashboard",
+            resources=f"{slot.key} -> {channel_type}:{conversation_id} (raced)",
+        )
+        return web.json_response(
+            {
+                "error": "another session claimed this conversation",
+                "code": "conversation_occupied",
+            },
+            status=409,
+        )
+    except Exception:
+        # A batch mutates memory inside the block and writes the file on the way
+        # OUT, so a failed write leaves a binding that is live but not durable:
+        # inbound routing would resolve a session whose link no restart can
+        # recover. Put the pre-claim state back and fail with a controlled error
+        # rather than letting the 500 leave that binding standing.
+        logger.warning("mirror-link: the claim for %s did not persist", session_key, exc_info=True)
+        await _release_after_failure()
+        return web.json_response(
+            {"error": "failed to create channel link", "code": "channel_link_failed"}, status=502
+        )
+
     try:
         # Recheck at the actual send boundary as well: target resolution can
         # yield while governance is updated.
         governed = await asyncio.to_thread(_resolve_channel_target, state, session_key, link)
         if governed is None:
+            await _release_after_failure()
             return web.json_response(
                 {"error": "channel is not permitted", "code": "channel_not_permitted"}, status=403
             )
@@ -362,6 +504,7 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         )
     except Exception:
         logger.debug("mirror-link initial delivery failed", exc_info=True)
+        await _release_after_failure()
         return web.json_response(
             {"error": "failed to create channel link", "code": "channel_link_failed"}, status=502
         )
@@ -479,11 +622,11 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
             # Stop immediately if policy narrows while the loop is yielding.
             governed = await asyncio.to_thread(_resolve_channel_target, state, session_key, link)
             if governed is None:
-                # Policy narrowed mid-delivery: fail closed. Do NOT fall
-                # through to set_mirror_link (which would persist a link the
-                # latest governance decision denied) and do NOT report
-                # success. The denial is already SEL-audited inside
+                # Policy narrowed mid-delivery: fail closed. Release the claim so
+                # no binding outlives the latest governance decision, and do NOT
+                # report success. The denial is already SEL-audited inside
                 # _resolve_channel_target via vet_and_audit.
+                await _release_after_failure()
                 return web.json_response(
                     {"error": "channel is not permitted", "code": "channel_not_permitted"},
                     status=403,
@@ -497,46 +640,6 @@ async def api_chat_slot_mirror_link(request: web.Request) -> web.Response:
         except Exception:
             logger.debug("mirror-link context delivery failed", exc_info=True)
 
-    try:
-        with state.sessions.batched_save():
-            # An explicit bind is explicit intent to mirror, so it withdraws any
-            # standing refusal of the AUTOMATIC bind. Without this the two
-            # disagree: a channel that re-asserts its own conversation every turn
-            # would keep declining while the user is looking at a link they just
-            # made, and a later automatic pass would have to guess which of the
-            # two the user meant.
-            state.sessions.set_mirror_opt_out(session_key, False)
-            state.sessions.set_mirror_link(
-                session_key,
-                link,
-                # Mark the binding inbound-capable only where the transport's
-                # inbound path actually resolves it. Without this the connect
-                # writes an outbound-only binding, ``resumed_session`` skips it,
-                # and the user's reply starts a brand-new session with none of
-                # this transcript.
-                accepts_inbound=accepts_inbound,
-            )
-    except ConversationOwnershipConflict:
-        # The precheck above covers the common case; this is the genuine race —
-        # someone claimed the conversation while we were delivering. Report the
-        # same conflict rather than a 500, so the client offers "unlink there
-        # first" instead of inviting a retry of a request that is behaving
-        # correctly.
-        logger.info("mirror-link refused: conversation claimed during delivery")
-        sel().log_api_access(
-            caller="dashboard",
-            operation="chat.mirror_link",
-            outcome="denied",
-            source="dashboard",
-            resources=f"{slot.key} -> {channel_type}:{conversation_id} (raced)",
-        )
-        return web.json_response(
-            {
-                "error": "another session claimed this conversation",
-                "code": "conversation_occupied",
-            },
-            status=409,
-        )
     sel().log_api_access(
         caller="dashboard",
         operation="chat.mirror_link",

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -30,7 +30,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 from kiro_crew.config.loader import KiroCrewConfig
-from kiro_crew.dashboard.state import row_mid
 from kiro_crew.discord.attachments import (
     append_attachment_context,
     process_discord_attachments,
@@ -82,8 +81,9 @@ from kiro_crew.messaging.link import (
     seed_generation,
 )
 from kiro_crew.messaging.renderer import Renderer, SilentRenderer
+from kiro_crew.messaging.session_resume import persisted_session_agent
 from kiro_crew.messaging.transport import InboundMessage
-from kiro_crew.messaging.upload_gate import live_dashboard_slot, uploads_restricted
+from kiro_crew.messaging.upload_gate import uploads_restricted
 from kiro_crew.monitoring.completion import MonitorCompletionHook
 from kiro_crew.monitoring.models import MonitorDispatchResult
 from kiro_crew.safety_override import describe_grant_lifetime, safety_override
@@ -128,12 +128,6 @@ class _MonitorGenerationChanged(Exception):
 # Canonical kiro-cli agent fallback so Discord sessions load kirocrew-core
 # (spawn_run etc.) — mirrors the Slack/Telegram paths.
 _DEFAULT_KIROCREW_AGENT = "kirocrew"
-
-#: Values that mean "let the backend pick" rather than naming an agent. The
-#: dashboard writes ``"default"`` into most session metadata, and ``"auto"`` is
-#: its sibling sentinel (see ``dashboard/handlers/agents.py``). Neither is a
-#: kiro-cli mode, so neither may reach ACP ``session/set_mode``.
-_AGENT_SENTINELS = frozenset({"default", "auto"})
 
 # Keep queue collapse within the shared ingestion layer's per-turn file cap.
 _MAX_COLLAPSED_ATTACHMENTS = IngestLimits().max_attachments
@@ -569,7 +563,7 @@ class DiscordDispatcher:
             # not just a tone change. get_metadata touches the filesystem, so it
             # goes off-loop. Fall back to the Discord agent only when the
             # conversation recorded none.
-            persisted = await asyncio.to_thread(self._persisted_agent, resumed_key)
+            persisted = await asyncio.to_thread(persisted_session_agent, self.conv_log, resumed_key)
             if persisted:
                 agent = persisted
 
@@ -835,7 +829,14 @@ class DiscordDispatcher:
                 # Loop-side: put the turn in the live dashboard window FIRST so
                 # the dashboard's own save serializes it in chronological
                 # position instead of appending it to the foreign tail.
-                mirror_mids = self._mirror_turn_to_live_slot(session_key, text, accumulated)
+                from kiro_crew.dashboard.channel_slots import project_channel_turn_live
+
+                mirror_mids = project_channel_turn_live(
+                    getattr(self._session_resume, "dashboard_state", None),
+                    session_key,
+                    text,
+                    accumulated,
+                )
                 await asyncio.to_thread(
                     self._persist_turn,
                     session_key,
@@ -1404,33 +1405,6 @@ class DiscordDispatcher:
     def _resolve_agent(self) -> str:
         return self.agent or self.cfg.agent.default_agent or _DEFAULT_KIROCREW_AGENT
 
-    def _persisted_agent(self, session_key: str) -> str:
-        """The agent a session was recorded with, or "" when unknown.
-
-        Blocking (reads the conversation log's metadata) — call via
-        ``asyncio.to_thread``. Returns "" on any failure so the caller falls back
-        to the channel's own agent rather than the turn failing.
-
-        ``"default"``/``"auto"`` are dashboard sentinels meaning "let the backend
-        pick", NOT agent names -- most dashboard sessions record ``"default"``.
-        Forwarding one reaches ACP ``session/set_mode``, which rejects it with
-        ``Mode 'default' not found`` and fails every resumed turn, so they are
-        normalized to "" and the channel's own agent is used instead.
-        """
-        if self.conv_log is None:
-            return ""
-        try:
-            meta = self.conv_log.get_metadata(session_key)
-        except Exception:
-            logger.debug(
-                "discord: could not read persisted agent for %s", session_key, exc_info=True
-            )
-            return ""
-        recorded = str((meta or {}).get("agent") or "").strip()
-        if recorded.lower() in _AGENT_SENTINELS:
-            return ""
-        return recorded
-
     @staticmethod
     def _scope_id(user_id: str, thread_id: str = "") -> str:
         return f"thread:{thread_id}" if thread_id else f"user:{user_id}"
@@ -1596,12 +1570,6 @@ class DiscordDispatcher:
             self._session_resume._push_slots()
         await self.client.send_message(channel_id, reply)
 
-    def _live_dashboard_slot(self, session_key: str) -> Any | None:
-        """The OPEN dashboard slot for *session_key*, or ``None``."""
-        return live_dashboard_slot(
-            getattr(self._session_resume, "dashboard_state", None), session_key
-        )
-
     async def _uploads_restricted(self, session_key: str) -> bool:
         """True when this session must not ship local file bytes to Discord.
 
@@ -1625,52 +1593,6 @@ class DiscordDispatcher:
             persisted_probe=_probe_persisted_session,
         )
 
-    def _mirror_turn_to_live_slot(
-        self, session_key: str, user_text: str, reply_text: str
-    ) -> tuple[str, str] | None:
-        """Land a resumed turn in the live dashboard window. Loop-side only.
-
-        A disk-only append is not enough. The dashboard save writes
-        ``meta + frozen prefix + its own window + foreign tail``, so a line
-        appended to disk BEFORE a later dashboard turn is re-serialized AFTER
-        it, and the transcript reads back out of chronological order. Appending
-        to the live window puts the turn in the region the save re-serializes,
-        so ordering is preserved. Mirrors ``dashboard/cron_inject.py``, which
-        appends to the slot and persists idempotently for the same reason.
-
-        Returns the ``(user_mid, assistant_mid)`` the slot minted when the
-        in-memory window took the turn, else ``None``. The caller hands those to
-        the durable write so both copies of one row share ONE identity -- the
-        dual-writer shape ``cron_inject`` uses (``row_mid(slot.append(...))`` ->
-        ``append_if_absent(..., mid=...)``). Minting a SECOND id there instead
-        would defeat the idempotency check the mirrored write exists for:
-        ``append_if_absent`` only skips a body-equal row carrying the SAME mid,
-        so an unrelated id can never match the copy the slot save already landed
-        and the turn would be persisted twice. An empty string stands for a row
-        the slot did not mint an id for (a reply that was not written).
-        """
-        slot = self._live_dashboard_slot(session_key)
-        if slot is None:
-            return None
-        try:
-            user_mid = row_mid(slot.append("user", user_text, "msg msg-u")) or ""
-            assistant_mid = ""
-            if reply_text:
-                assistant_mid = row_mid(slot.append("assistant", reply_text, "msg msg-a")) or ""
-        except Exception:
-            logger.debug(
-                "discord: could not mirror turn into live slot %s", session_key, exc_info=True
-            )
-            return None
-        state = getattr(self._session_resume, "dashboard_state", None)
-        push = getattr(state, "push_slots_update", None)
-        if callable(push):
-            try:
-                push()
-            except Exception:
-                logger.debug("discord: slots push after resumed turn failed", exc_info=True)
-        return (user_mid, assistant_mid)
-
     def _persist_turn(
         self,
         session_key: str,
@@ -1682,7 +1604,7 @@ class DiscordDispatcher:
     ) -> None:
         """Record the turn to conversation_log (dashboard visibility + restart).
 
-        *mirror_mids* is what ``_mirror_turn_to_live_slot`` returned: the ids the
+        *mirror_mids* is what ``project_channel_turn_live`` returned: the ids the
         live dashboard window minted for this turn's rows, or ``None`` when there
         was no live slot to mirror into. It carries BOTH facts, so there is no
         separate ``mirrored`` flag -- the presence of the tuple IS the flag, and a

--- a/src/kiro_crew/discord/transport_dispatch.py
+++ b/src/kiro_crew/discord/transport_dispatch.py
@@ -83,7 +83,7 @@ from kiro_crew.messaging.link import (
 from kiro_crew.messaging.renderer import Renderer, SilentRenderer
 from kiro_crew.messaging.session_resume import persisted_session_agent
 from kiro_crew.messaging.transport import InboundMessage
-from kiro_crew.messaging.upload_gate import uploads_restricted
+from kiro_crew.messaging.upload_gate import session_is_restricted, uploads_restricted
 from kiro_crew.monitoring.completion import MonitorCompletionHook
 from kiro_crew.monitoring.models import MonitorDispatchResult
 from kiro_crew.safety_override import describe_grant_lifetime, safety_override
@@ -829,23 +829,33 @@ class DiscordDispatcher:
                 # Loop-side: put the turn in the live dashboard window FIRST so
                 # the dashboard's own save serializes it in chronological
                 # position instead of appending it to the foreign tail.
+                #
+                # Circular import: the dashboard package imports the channel
+                # transports on its boot path, so this edge only exists at call time.
                 from kiro_crew.dashboard.channel_slots import project_channel_turn_live
 
-                mirror_mids = project_channel_turn_live(
-                    getattr(self._session_resume, "dashboard_state", None),
-                    session_key,
-                    text,
-                    accumulated,
-                )
-                await asyncio.to_thread(
-                    self._persist_turn,
-                    session_key,
-                    text,
-                    accumulated,
-                    is_new_own_session,
-                    agent=agent,
-                    mirror_mids=mirror_mids,
-                )
+                # A resumed ``dashboard:`` key carries the dashboard slot's privacy
+                # mode, not a Discord-local one. Decide on the loop before either
+                # writer: project_channel_turn_live marks the slot dirty, so even
+                # skipping the direct append would let a later slot flush persist
+                # the restricted rows.
+                dashboard_restricted = await self._session_restricted(session_key)
+                if not dashboard_restricted:
+                    mirror_mids = project_channel_turn_live(
+                        getattr(self._session_resume, "dashboard_state", None),
+                        session_key,
+                        text,
+                        accumulated,
+                    )
+                    await asyncio.to_thread(
+                        self._persist_turn,
+                        session_key,
+                        text,
+                        accumulated,
+                        is_new_own_session,
+                        agent=agent,
+                        mirror_mids=mirror_mids,
+                    )
             except Exception:
                 logger.warning(
                     "Discord: persist_turn failed session=%s",
@@ -1569,6 +1579,36 @@ class DiscordDispatcher:
             # binding mutation does.
             self._session_resume._push_slots()
         await self.client.send_message(channel_id, reply)
+
+    async def _session_restricted(self, session_key: str) -> bool:
+        """True when this resumed session must leave no durable transcript.
+
+        Discord can carry a ``dashboard:`` key, whose restriction lives on the
+        dashboard slot rather than in a channel-local tracker. The shared
+        predicate is also the upload ceiling's answer, so a conversation cannot
+        refuse the file and then persist the text.
+
+        With the tab closed, history restricts on an incognito/temporary marker and
+        on an unreadable mode whose transcript EXISTS (an ambiguous stem, or a
+        header no normal session wrote) — that is where an incognito session hides.
+        ``unknown_denies`` is deliberately false here (and true for uploads) only
+        so a truly ABSENT record still records: nothing on disk claims that session
+        is restricted, and denying there would stop recording every conversation
+        whose transcript is not yet written. A legacy header missing the field
+        reads ``persistent``, so it never reaches the unknown case.
+
+        The persisted probe is injected to keep ``messaging`` from importing
+        ``dashboard``. This import stays local because dashboard boot imports the
+        channel transports.
+        """
+        from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
+
+        return await session_is_restricted(
+            getattr(self._session_resume, "dashboard_state", None),
+            session_key,
+            persisted_probe=_probe_persisted_session,
+            unknown_denies=False,
+        )
 
     async def _uploads_restricted(self, session_key: str) -> bool:
         """True when this session must not ship local file bytes to Discord.

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -65,9 +65,12 @@ At startup the bot publishes the menu commands from `COMMAND_SPEC` through `setM
 - `/model` (or `/models`) — pick the model from an inline-button list. Button-only on purpose:
   the choices are what this account's backend actually advertised, so there is
   no model name to guess and no typo to reject mid-conversation. The pick is
-  applied to the running session in place when one is idle, and is remembered
-  for the conversation's later sessions (it outlives `/new`, and is held in
-  memory, so a gateway restart returns to the configured default).
+  applied to the running session in place when one is idle. In a native Telegram
+  conversation it is also remembered for later sessions (it outlives `/new`, and
+  is held in memory, so a gateway restart returns to the configured default). In
+  a resumed dashboard session it changes only that session, and the button is
+  refused if `/new`, `/unlink`, or another binding change moved the chat before
+  the press.
 - `/yolo [on|off|renew]` — report or change the auto-approve grant. This is the
   SAME process-wide grant the dashboard toggle and Slack's `/kirocrew yolo`
   drive, so it expires on one clock everywhere. There is deliberately no
@@ -92,16 +95,18 @@ At startup the bot publishes the menu commands from `COMMAND_SPEC` through `setM
 - `/status` — uptime, message counts, tool decisions, sessions
 - `/ping` — answers `pong`. Answered by the gateway itself, never by the model,
   so it still works when the thing that is wedged is the model.
-- `/sessions [search words]` (or `/session [search words]`) — with no words, the ten
-  most recent conversations, newest first, with a mark for whichever is live. Add
-  words to use the same title-and-message-content ranking as dashboard history search;
-  incognito and temporary transcripts stay excluded. Results remain read-only and
-  open through `/kirocrew dashboard`. **Direct message only**, like `/kirocrew
-  dashboard`: either form can name conversations from across the host, and a forum
-  Topic is readable by the whole supergroup, so answering there would show titles to
-  members who are not on `allowed_user_ids` at all. In a Topic it refuses and points
-  you to a DM. It also refuses when `allowed_user_ids` contains several people,
-  because the bot cannot tell which one owns the host-wide history.
+- `/session [search words]` (or `/sessions [search words]`) — with no words,
+  show the ten most recent eligible conversations; with words, use the same ranked
+  title-and-message-content search as dashboard history. Results are inline buttons:
+  tap one and ordinary messages in this DM immediately continue that dashboard
+  conversation. The bot replaces its outbound-only native mirror automatically, so
+  no preparatory `/unlink` is required. `/new` leaves the resumed session and starts
+  a fresh Telegram conversation; `/unlink` returns to the existing Telegram
+  conversation. Incognito and temporary transcripts stay excluded. **Direct message
+  only**: a forum Topic is readable by the whole supergroup, so listing or resuming
+  there would expose host-wide titles to members outside `allowed_user_ids`. It also
+  refuses when `allowed_user_ids` contains several people, because the bot cannot
+  tell which one owns the host-wide history.
 - `/title <text>` — rename this conversation, so its dashboard sidebar row reads
   as something other than the first forty characters you happened to type.
 - `/cron` (or `/crons`) `list | pause <id> | resume <id> | remove <id>|all` — manage scheduled

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -108,7 +108,9 @@ At startup the bot publishes the menu commands from `COMMAND_SPEC` through `setM
   refuses when `allowed_user_ids` contains several people, because the bot cannot
   tell which one owns the host-wide history.
 - `/title <text>` — rename this conversation, so its dashboard sidebar row reads
-  as something other than the first forty characters you happened to type.
+  as something other than the first forty characters you happened to type. On a
+  resumed dashboard session the live sidebar row and durable metadata change
+  together, so a later dashboard save cannot restore the old name.
 - `/cron` (or `/crons`) `list | pause <id> | resume <id> | remove <id>|all` — manage scheduled
   jobs. The same jobs the dashboard and Slack see.
 - `/spawn <task>` (or `/bg`) — run a task in a background subagent.
@@ -118,7 +120,11 @@ At startup the bot publishes the menu commands from `COMMAND_SPEC` through `setM
 - `/temporary` — this conversation reads and saves no memory: no memories or
   lessons are added to the prompt, and nothing is written to the transcript. A bare
   `/temporary` just marks the conversation; `/temporary <question>` marks it and
-  answers, the same as Slack's `!temporary`.
+  answers, the same as Slack's `!temporary`. While a dashboard session is resumed,
+  `/temporary` and `/incognito` are refused and any attached question is **not
+  processed**: the dashboard slot owns its memory mode, so changing only Telegram's
+  channel state would claim privacy while the persistent slot kept recording. Use
+  `/unlink` or `/new` first.
 - `/incognito` — this conversation MAY read memory but saves nothing. That is the
   whole difference from `/temporary`, and it is the reason for two commands:
   incognito keeps the context you have built up and leaves no trace, temporary does

--- a/src/kiro_crew/messaging/session_resume.py
+++ b/src/kiro_crew/messaging/session_resume.py
@@ -859,6 +859,30 @@ class SessionResumeController:
                 await surface.settle_picker(message_id, conflict)
                 return None
 
+            # Snapshot what this pick is about to overwrite. ``record`` replaces the
+            # channel's expectation outright, so on a failed bind, retiring the
+            # replacement is not a rollback: it leaves a DETACHED marker where an
+            # ACTIVE record used to be, and that record was the evidence a lost
+            # link owes the user a notice. The next message would then route
+            # natively and the notice would never be delivered.
+            #
+            # Guarded for the same reason the ``record`` call below is: the choice
+            # has already been CONSUMED from the picker registry, so an escaping
+            # store error would discard the press with no reply at all and leave
+            # the button dead. A store this read cannot parse is also one the
+            # write could not have trusted, so it settles fail-closed.
+            try:
+                prior = await self.binder.expectations.get(surface.expectation_id)
+            except Exception:
+                logger.warning(
+                    "%s resume: could not read the expectation store for %s",
+                    self.channel_type,
+                    choice.key,
+                    exc_info=True,
+                )
+                await surface.settle_picker(message_id, surface.choice_expectation_failed)
+                return None
+
             try:
                 expectation = await self.binder.expectations.record(
                     surface.expectation_id,
@@ -879,13 +903,32 @@ class SessionResumeController:
                 return None
 
             async def retire_failed_expectation() -> None:
+                """Undo this pick's expectation write, restoring what it displaced.
+
+                Compare-and-set on the replacement's own version throughout, so a
+                newer picker or dashboard record that landed meanwhile wins instead
+                of being reverted to this pick's view.
+                """
                 try:
-                    await self.binder.expectations.retire_if(
-                        surface.expectation_id, expectation.version
-                    )
+                    if prior is not None and not prior.retired:
+                        # An ACTIVE record was displaced: put it back, so the
+                        # refusal or adopt notice it owed is still owed.
+                        await self.binder.expectations.record_if(
+                            surface.expectation_id,
+                            expectation.version,
+                            prior.key,
+                            prior.title,
+                        )
+                    else:
+                        # Nothing meaningful to restore — no record, or an already
+                        # detached one. A retired marker is the same "detached"
+                        # state either way, so retiring is the faithful undo.
+                        await self.binder.expectations.retire_if(
+                            surface.expectation_id, expectation.version
+                        )
                 except Exception:
                     logger.warning(
-                        "%s resume: could not retire failed expectation for %s",
+                        "%s resume: could not undo failed expectation for %s",
                         self.channel_type,
                         choice.key,
                         exc_info=True,
@@ -903,40 +946,81 @@ class SessionResumeController:
 
             cleared: list[str] = []
             claimed = False
-            selected_original = self.sessions.get_mirror_link(choice.key)
-            selected_was_inbound = choice.key in self.sessions.find_mirror_sessions(
-                link, inbound_only=True
-            )
-            try:
+            selected_original: ChannelLink | None = None
+            selected_was_inbound = False
+            late_conflict: str | None = None
+
+            # Both batches run in a WORKER THREAD. ``batched_save`` holds
+            # ``session_map._MAP_LOCK`` across the block and rewrites the whole map
+            # file on the way out, so leaving it on the loop stalls every task —
+            # gateway, heartbeat and unrelated channels — on that disk write. The
+            # map documents itself as callable from any thread, and off the loop its
+            # writes are inline and synchronous, which is exactly what a
+            # transactional batch needs.
+            #
+            # Each closure is deliberately await-free: the lock is per-thread
+            # reentrant, so an await inside a batch would let another coroutine walk
+            # into the critical section. ``self.binder.lock`` is still held around
+            # both, so a second PICKER cannot interleave with this transaction.
+            def commit_binding() -> None:
+                nonlocal claimed, selected_original, selected_was_inbound, late_conflict
                 with self.sessions.batched_save():
-                    for displaced_key in displaced:
+                    # Re-derived INSIDE the lock, not reused from the loop. Anything
+                    # read before this thread acquired ``_MAP_LOCK`` may already be
+                    # stale: the dashboard and other channels bind without taking
+                    # ``binder.lock``, so a rebind of a displaced session can land in
+                    # that window. Acting on the loop-side view would clear a key
+                    # whose newer, deliberate mirror we never saw.
+                    conflict_now, displaced_now = conflict_and_displaced()
+                    if conflict_now is not None:
+                        late_conflict = conflict_now
+                        return
+                    selected_original = self.sessions.get_mirror_link(choice.key)
+                    selected_was_inbound = choice.key in self.sessions.find_mirror_sessions(
+                        link, inbound_only=True
+                    )
+                    for displaced_key in displaced_now:
                         if self.sessions.clear_mirror_link(
                             displaced_key, reason=UNBIND_REASON_ORIGIN_REBIND
                         ):
                             cleared.append(displaced_key)
                     self.sessions.set_mirror_link(choice.key, link, accepts_inbound=True)
                     claimed = True
-            except Exception as exc:
-                try:
-                    with self.sessions.batched_save():
-                        if claimed:
-                            self.sessions.clear_mirror_link(
-                                choice.key, reason=UNBIND_REASON_ORIGIN_REBIND
+
+            def rollback_binding() -> None:
+                # Conditional, for the same reason the commit re-derives: this runs
+                # in a SECOND critical section, so between the two a rebind may have
+                # taken either row. Undo only what still looks like this
+                # transaction's own work; anything newer is deliberate state.
+                with self.sessions.batched_save():
+                    if claimed and self.sessions.get_mirror_link(choice.key) == link:
+                        self.sessions.clear_mirror_link(
+                            choice.key, reason=UNBIND_REASON_ORIGIN_REBIND
+                        )
+                        if selected_original == link:
+                            self.sessions.set_mirror_link(
+                                choice.key,
+                                link,
+                                accepts_inbound=selected_was_inbound,
+                                reason=UNBIND_REASON_ORIGIN_REBIND,
                             )
-                            if selected_original == link:
-                                self.sessions.set_mirror_link(
-                                    choice.key,
-                                    link,
-                                    accepts_inbound=selected_was_inbound,
-                                    reason=UNBIND_REASON_ORIGIN_REBIND,
-                                )
-                        for displaced_key in cleared:
+                    for displaced_key in cleared:
+                        if self.sessions.get_mirror_link(displaced_key) is None:
                             self.sessions.set_mirror_link(
                                 displaced_key,
                                 link,
                                 accepts_inbound=False,
                                 reason=UNBIND_REASON_ORIGIN_REBIND,
                             )
+
+            try:
+                await asyncio.to_thread(commit_binding)
+            except Exception as exc:
+                try:
+                    # ``claimed``, ``cleared`` and both snapshots are read after the
+                    # commit thread joined, so the awaited future is the barrier that
+                    # publishes how far the failed transaction actually got.
+                    await asyncio.to_thread(rollback_binding)
                 except Exception:
                     logger.warning(
                         "%s resume: could not roll back failed binding for %s",
@@ -954,6 +1038,11 @@ class SessionResumeController:
                 else:
                     logger.exception("%s resume: failed to persist binding", self.channel_type)
                     await surface.settle_picker(message_id, surface.choice_binding_failed)
+                return None
+            if late_conflict is not None:
+                # The re-check under the lock refused, so nothing was written.
+                await retire_failed_expectation()
+                await surface.settle_picker(message_id, late_conflict)
                 return None
             self.push_slots()
 

--- a/src/kiro_crew/messaging/session_resume.py
+++ b/src/kiro_crew/messaging/session_resume.py
@@ -34,7 +34,11 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 from kiro_crew.history import is_incognito_transcript, needles_match_text, parse_search_query
-from kiro_crew.messaging.link import UNBIND_REASON_USER_UNLINK, ChannelLink
+from kiro_crew.messaging.link import (
+    UNBIND_REASON_ORIGIN_REBIND,
+    UNBIND_REASON_USER_UNLINK,
+    ChannelLink,
+)
 from kiro_crew.messaging.renderer import new_approval_nonce
 from kiro_crew.messaging.resume_expectation import (
     ExpectationStoreError,
@@ -69,6 +73,30 @@ SETTLE_ADOPT = "adopt"  # link moved; adopt the new session
 #: Re-decide budget for ``route``. A conversation whose owner keeps changing under us
 #: is refused rather than routed on a guess.
 _MAX_ROUTE_ATTEMPTS = 3
+
+#: Dashboard metadata values that delegate agent selection to the current surface.
+#: They are not kiro-cli agent names and must never reach ``session/set_mode``.
+_AGENT_SENTINELS = frozenset({"default", "auto"})
+
+
+def persisted_session_agent(conv_log: Any | None, session_key: str) -> str:
+    """Return a resumed session's recorded agent, or ``""`` to use the route agent.
+
+    Metadata access is blocking; async callers run this helper off the event loop. Missing,
+    unreadable, blank, and dashboard-sentinel values all degrade to the caller's route agent
+    rather than failing the turn or forwarding a non-agent mode to ACP.
+    """
+    if conv_log is None:
+        return ""
+    try:
+        meta = conv_log.get_metadata(session_key)
+    except Exception:
+        logger.debug("resume: could not read persisted agent for %s", session_key, exc_info=True)
+        return ""
+    recorded = str((meta or {}).get("agent") or "").strip()
+    if recorded.casefold() in _AGENT_SENTINELS:
+        return ""
+    return recorded
 
 
 class ResumeReleaseError(RuntimeError):
@@ -782,6 +810,7 @@ class SessionResumeController:
         nonce: str,
         index: int,
         link: ChannelLink,
+        replace_outbound_keys: frozenset[str] = frozenset(),
     ) -> SessionChoice | None:
         """Consume one picker press and atomically claim its inbound binding."""
         if not is_owner:
@@ -806,13 +835,32 @@ class SessionResumeController:
             return None
 
         async with self.binder.lock:
-            conflict = self.binder.binding_conflict(choice.key, choice.title, link)
+
+            def conflict_and_displaced() -> tuple[str | None, list[str]]:
+                conflict = self.binder.binding_conflict(choice.key, choice.title, link)
+                if conflict is None or not replace_outbound_keys:
+                    return conflict, []
+                existing = self.sessions.get_mirror_link(choice.key)
+                inbound = self.sessions.find_mirror_sessions(link, inbound_only=True)
+                occupants = [
+                    key for key in self.sessions.find_mirror_sessions(link) if key != choice.key
+                ]
+                # A channel adapter may identify its own native session generations
+                # as replaceable. Every occupant must be in that explicit set: an
+                # unrelated dashboard mirror is deliberate user state and cannot be
+                # inferred from sharing the same destination.
+                replaceable = occupants and set(occupants) <= replace_outbound_keys
+                if (existing is None or existing == link) and not inbound and replaceable:
+                    return None, occupants
+                return conflict, []
+
+            conflict, displaced = conflict_and_displaced()
             if conflict is not None:
                 await surface.settle_picker(message_id, conflict)
                 return None
 
             try:
-                await self.binder.expectations.record(
+                expectation = await self.binder.expectations.record(
                     surface.expectation_id,
                     choice.key,
                     choice.title,
@@ -830,26 +878,82 @@ class SessionResumeController:
                 await surface.settle_picker(message_id, surface.choice_expectation_failed)
                 return None
 
+            async def retire_failed_expectation() -> None:
+                try:
+                    await self.binder.expectations.retire_if(
+                        surface.expectation_id, expectation.version
+                    )
+                except Exception:
+                    logger.warning(
+                        "%s resume: could not retire failed expectation for %s",
+                        self.channel_type,
+                        choice.key,
+                        exc_info=True,
+                    )
+
             if not await surface.settle_picker(message_id, surface.choice_success(choice)):
+                await retire_failed_expectation()
                 return None
 
-            conflict = self.binder.binding_conflict(choice.key, choice.title, link)
+            conflict, displaced = conflict_and_displaced()
             if conflict is not None:
+                await retire_failed_expectation()
                 await surface.settle_picker(message_id, conflict)
                 return None
 
+            cleared: list[str] = []
+            claimed = False
+            selected_original = self.sessions.get_mirror_link(choice.key)
+            selected_was_inbound = choice.key in self.sessions.find_mirror_sessions(
+                link, inbound_only=True
+            )
             try:
-                self.sessions.set_mirror_link(choice.key, link, accepts_inbound=True)
-            except ConversationOwnershipConflict:
-                logger.debug(
-                    "%s resume: lost the claim race for this conversation",
-                    self.channel_type,
-                )
-                await surface.settle_picker(message_id, surface.choice_claim_lost)
-                return None
-            except Exception:
-                logger.exception("%s resume: failed to persist binding", self.channel_type)
-                await surface.settle_picker(message_id, surface.choice_binding_failed)
+                with self.sessions.batched_save():
+                    for displaced_key in displaced:
+                        if self.sessions.clear_mirror_link(
+                            displaced_key, reason=UNBIND_REASON_ORIGIN_REBIND
+                        ):
+                            cleared.append(displaced_key)
+                    self.sessions.set_mirror_link(choice.key, link, accepts_inbound=True)
+                    claimed = True
+            except Exception as exc:
+                try:
+                    with self.sessions.batched_save():
+                        if claimed:
+                            self.sessions.clear_mirror_link(
+                                choice.key, reason=UNBIND_REASON_ORIGIN_REBIND
+                            )
+                            if selected_original == link:
+                                self.sessions.set_mirror_link(
+                                    choice.key,
+                                    link,
+                                    accepts_inbound=selected_was_inbound,
+                                    reason=UNBIND_REASON_ORIGIN_REBIND,
+                                )
+                        for displaced_key in cleared:
+                            self.sessions.set_mirror_link(
+                                displaced_key,
+                                link,
+                                accepts_inbound=False,
+                                reason=UNBIND_REASON_ORIGIN_REBIND,
+                            )
+                except Exception:
+                    logger.warning(
+                        "%s resume: could not roll back failed binding for %s",
+                        self.channel_type,
+                        choice.key,
+                        exc_info=True,
+                    )
+                await retire_failed_expectation()
+                if isinstance(exc, ConversationOwnershipConflict):
+                    logger.debug(
+                        "%s resume: lost the claim race for this conversation",
+                        self.channel_type,
+                    )
+                    await surface.settle_picker(message_id, surface.choice_claim_lost)
+                else:
+                    logger.exception("%s resume: failed to persist binding", self.channel_type)
+                    await surface.settle_picker(message_id, surface.choice_binding_failed)
                 return None
             self.push_slots()
 

--- a/src/kiro_crew/messaging/transport.py
+++ b/src/kiro_crew/messaging/transport.py
@@ -60,12 +60,14 @@ class TransportCapabilities:
       dashboard marks the binding as an INBOUND resume target
       (``accepts_inbound``), and therefore whether the slot row reports
       ``direction: both``. Only a transport whose inbound path actually resolves
-      the mirror binding may declare it: Discord's dispatcher looks the
-      conversation up (``DiscordSessionResume.resumed_session``), while Telegram
-      and the rest derive a session key from the route alone and never consult
-      the binding. Declaring it where it is not honoured makes the dashboard
-      promise a two-way link whose replies silently start a separate session —
-      which is exactly what this flag exists to prevent. Slack is out of scope
+      the mirror binding may declare it: Discord and Telegram both resolve the
+      conversation through their channel-specific session-resume adapters. The
+      remaining transports derive a session key from the route alone and never
+      consult the binding. Declaring it where it is not honoured makes the
+      dashboard promise a two-way link whose replies silently start a separate
+      session — which is exactly what this flag exists to prevent. The dashboard
+      then calls ``may_resume_from`` on the resolved target, so a capable transport
+      may still narrow inbound ownership per conversation. Slack is out of scope
       here: it routes inbound through its own ``_thread_to_session`` index and
       never sets the marker.
 
@@ -348,6 +350,16 @@ class MessagingTransport(ABC):
         whose principal is no longer on the roster.
         """
         return True
+
+    def may_resume_from(self, conversation_id: str, thread_id: str | None = None) -> bool:
+        """Whether this exact target may drive a dashboard session inbound.
+
+        The capability says the transport has a correct resolver; this hook applies
+        target- and roster-specific ownership policy after target resolution. The
+        default follows the capability. A transport with a stricter owner model
+        overrides synchronously and in memory, matching :meth:`may_send_to`.
+        """
+        return bool(self.capabilities.supports_session_resume)
 
     # -- Inbound adapter ----------------------------------------------------
     @abstractmethod

--- a/src/kiro_crew/messaging/upload_gate.py
+++ b/src/kiro_crew/messaging/upload_gate.py
@@ -39,13 +39,20 @@ logger = logging.getLogger(__name__)
 #: restricted by the channel's own privacy mode.
 _DASHBOARD_PREFIX = "dashboard:"
 
+#: The one memory mode that blocks READS as well as writes. ``incognito`` is
+#: deliberately absent: it reads and writes nothing new, which is the documented
+#: difference between the two modes.
+_TEMPORARY_MEMORY_MODE = "temporary"
+
 #: ``slot_name -> (file_exists, memory_mode_or_None)``. Blocking filesystem I/O;
 #: this module hands it to a worker thread. ``None`` for the mode means "could
 #: not tell", which denies.
 PersistedProbe = Callable[[str], "tuple[bool, str | None]"]
 
 
-def _persisted_mode_is_restricted(session_key: str, probe: PersistedProbe) -> bool:
+def _persisted_mode_is_restricted(
+    session_key: str, probe: PersistedProbe, unknown_denies: bool = True
+) -> bool:
     """Whether ``dashboard:<slot>``'s PERSISTED transcript says it is restricted.
 
     Blocking (it reads the transcript's metadata line), so callers run it off the
@@ -55,24 +62,40 @@ def _persisted_mode_is_restricted(session_key: str, probe: PersistedProbe) -> bo
     ``<name>.jsonl`` and an archived ``dashboard_<name>.jsonl``), and the
     memory-mode helper answers from the FIRST candidate — letting a persistent
     file answer for an incognito session. The probe refuses to guess and reports
-    unknown, which denies, as does a header no normal session wrote. Existence is
-    ignored: unknown denies either way.
+    unknown, as does a header no normal session wrote.
 
-    A probe that raises denies, so a caller cannot open the gate by handing in
-    something broken.
+    *unknown_denies* decides what an unreadable mode means, because the two
+    ceilings are not symmetric. For an UPLOAD (the default) unknown always
+    denies: shipping bytes into a DM or a supergroup-readable Topic cannot be
+    taken back, and refusing one file costs nothing recoverable.
+
+    For durable HISTORY unknown denies only when a transcript EXISTS. That is
+    where an incognito session can hide — an ambiguous stem matching several
+    transcripts, or a header no normal session wrote — so a write there could
+    persist a conversation that promised to leave none. A legacy header whose
+    ``memory_mode`` field is simply absent does NOT reach this case: it reads
+    ``persistent``. So the only record-present unknowns are genuinely
+    unresolvable, and denying them costs a cold resume nothing.
+
+    A truly ABSENT record is the remaining case, and history allows it: nothing
+    on disk claims the session is restricted, and denying there would silently
+    stop recording every conversation whose transcript has not been written yet.
+
+    A probe that raises denies regardless, so a caller cannot open the gate by
+    handing in something broken.
     """
     slot_name = session_key.split(":", 1)[-1]
     try:
-        _exists, mode = probe(slot_name)
+        exists, mode = probe(slot_name)
     except Exception:
         logger.warning(
-            "could not resolve the persisted memory mode for %s; denying uploads",
+            "could not resolve the persisted memory mode for %s; denying",
             session_key,
             exc_info=True,
         )
         return True
     if mode is None:
-        return True
+        return True if unknown_denies else bool(exists)
     return is_incognito_transcript(mode)
 
 
@@ -93,51 +116,55 @@ def live_dashboard_slot(dashboard_state: Any, session_key: str) -> Any | None:
         return None
 
 
-async def uploads_restricted(
+async def session_is_restricted(
     dashboard_state: Any,
     session_key: str,
     *,
-    channel_type: str,
     persisted_probe: PersistedProbe,
+    unknown_denies: bool = True,
 ) -> bool:
-    """True when *session_key* must not ship local file bytes to *channel_type*.
+    """True when *session_key* is an incognito or temporary conversation.
+
+    The decision only, with no audit and no per-caller wording, because more than
+    one ceiling asks it: file uploads ask before shipping local bytes
+    (:func:`uploads_restricted`), and a channel that can RESUME a dashboard
+    session asks before appending that turn to durable history. Both must read the
+    same answer — a conversation that refuses to write a transcript but ships the
+    file, or refuses the file but writes the transcript, keeps neither promise.
 
     Three inputs, in the order their evidence is strongest:
 
     * A key that is not ``dashboard:`` is a channel-native conversation. It never
       had a dashboard slot, so the slot rungs below cannot answer for it — but it
-      CAN be restricted, by the channel's own ``/temporary`` or ``/incognito``, so
-      that predicate is what answers instead. Returning a flat ``False`` here was
-      correct only while no channel-native conversation had a privacy mode, and it
-      became a hole the moment one did: the same conversation that refuses to write
-      a transcript, read memory or save a title would still ship local file bytes
-      into a DM or a supergroup-readable Topic. It is not a blanket fail-closed
-      either — an unrestricted conversation is allowed, which is the common case,
-      and a channel with no modes at all reads ``False`` exactly as before. The
-      DURABLE flags are restored first, because that predicate reads process-local
-      trackers that only an INBOUND channel message populates: a turn no inbound
-      message drove — a cron, a webhook-resumed session, a monitor/auto-nudge
-      re-injection, an explicit ``file_send`` — would otherwise read empty
-      trackers after a gateway restart and ship the bytes the user's
-      ``!incognito`` forbids. Same canonical restore, for the same reason, as
+      CAN be restricted by the channel's own ``/temporary`` or ``/incognito``, so
+      that predicate answers instead. The DURABLE flags are restored first,
+      because that predicate reads process-local trackers that only an INBOUND
+      channel message populates: a turn no inbound message drove — a cron, a
+      webhook-resumed session, a monitor/auto-nudge re-injection, an explicit
+      ``file_send`` — would otherwise read empty trackers after a gateway restart
+      and act on a mode the user's ``!incognito`` forbids. Same canonical restore,
+      for the same reason, as
       ``dashboard.handlers._shared._is_restricted_session``.
     * A LIVE slot answers directly, off the same ``slot.is_restricted`` signal as
       the artifact gate, so the two cannot drift.
-    * No live slot, but a ``dashboard:`` binding still resolved. This is a real
-      state, not a defensive branch: closing the tab pops the slot from the
-      dashboard's ``_slots`` AND discards its key from ``_restricted_keys``,
-      while the mirror binding lives in the persisted session map, which only an
-      explicit unlink clears. So the next message into that conversation resolves
-      an incognito session whose in-memory restriction is gone. The transcript
-      keeps its ``memory_mode`` marker, so resolve the PERSISTED mode instead —
-      and deny when it cannot be read.
+    * No live slot, but a ``dashboard:`` key still resolved. This is a real state,
+      not a defensive branch: closing the tab pops the slot from the dashboard's
+      ``_slots`` AND discards its key from ``_restricted_keys``, while a resume
+      binding lives in the persisted session map, which only an explicit unlink
+      clears. So the next message into that conversation resolves an incognito
+      session whose in-memory restriction is gone. The transcript keeps its
+      ``memory_mode`` marker, so resolve the PERSISTED mode instead. What an
+      UNREADABLE mode means is the caller's call, via *unknown_denies* — the two
+      ceilings are not symmetric there, and ``_persisted_mode_is_restricted``
+      carries the reasoning.
+
+    ``privacy_mode.is_restricted`` is NOT a substitute for the two slot rungs: it
+    reads a process-local tracker that a dashboard slot never populates, so it
+    answers ``False`` for an incognito dashboard session and fails OPEN.
 
     *persisted_probe* is only consulted on the third rung, and is a parameter
     rather than an import so this module keeps its one-way dependency on
     ``dashboard`` (see the module docstring).
-
-    The denial is SEL-audited so the ceiling is observable, mirroring how each
-    transport audits its authorization denials.
     """
     if not session_key.startswith(_DASHBOARD_PREFIX):
         # Restore the durable flags before reading the process-local trackers (see
@@ -149,15 +176,95 @@ async def uploads_restricted(
         # The channel's own mode, on the same predicate its transcript, memory and
         # title writes use, so one conversation cannot be private for three of them
         # and public for the fourth.
-        restricted = privacy_mode.is_restricted(session_key)
-    else:
-        slot = live_dashboard_slot(dashboard_state, session_key)
-        if slot is not None:
-            restricted = bool(getattr(slot, "is_restricted", True))
-        else:
-            restricted = await asyncio.to_thread(
-                _persisted_mode_is_restricted, session_key, persisted_probe
-            )
+        return privacy_mode.is_restricted(session_key)
+    slot = live_dashboard_slot(dashboard_state, session_key)
+    if slot is not None:
+        return bool(getattr(slot, "is_restricted", True))
+    return await asyncio.to_thread(
+        _persisted_mode_is_restricted, session_key, persisted_probe, unknown_denies
+    )
+
+
+async def session_blocks_reads(
+    dashboard_state: Any,
+    session_key: str,
+    *,
+    persisted_probe: PersistedProbe,
+) -> bool:
+    """True when *session_key* must have NO memory or lessons read into its prompt.
+
+    The read half of :func:`session_is_restricted`, and a strictly narrower
+    question: only ``temporary`` blocks reads. ``incognito`` deliberately still
+    reads — keeping the context already built up while writing nothing is the whole
+    documented difference between the two modes.
+
+    Same three rungs, and the same reason a channel-local predicate cannot answer
+    alone: ``privacy_mode.is_temporary`` reads a process tracker that a dashboard
+    slot never populates, so a temporary dashboard session resumed from a channel
+    would read False and take yesterday's memories into today's prompt. Refusing to
+    WRITE does not cover that — the leak is inbound, into the model.
+
+    Unknown fails closed whenever a transcript EXISTS, matching the write gate: an
+    ambiguous stem or an unwritable header is where a temporary session hides. A
+    truly ABSENT record reads False, because nothing on disk claims otherwise.
+    """
+    if not session_key.startswith(_DASHBOARD_PREFIX):
+        privacy_mode.hydrate(getattr(dashboard_state, "sessions", None), session_key)
+        return privacy_mode.is_temporary(session_key)
+    slot = live_dashboard_slot(dashboard_state, session_key)
+    if slot is not None:
+        # Same signal the dashboard's own runner and artifact gate read, so the
+        # surfaces cannot disagree about one slot. Absent attribute fails closed.
+        return bool(getattr(slot, "blocks_reads", True))
+    return await asyncio.to_thread(_persisted_mode_blocks_reads, session_key, persisted_probe)
+
+
+def _persisted_mode_blocks_reads(session_key: str, probe: PersistedProbe) -> bool:
+    """Whether ``dashboard:<slot>``'s PERSISTED transcript says ``temporary``.
+
+    Blocking, so callers run it off the event loop. A probe that raises, or an
+    unreadable mode on a transcript that EXISTS, denies reads; a truly absent
+    record allows them.
+    """
+    slot_name = session_key.split(":", 1)[-1]
+    try:
+        exists, mode = probe(slot_name)
+    except Exception:
+        logger.warning(
+            "could not resolve the persisted memory mode for %s; blocking reads",
+            session_key,
+            exc_info=True,
+        )
+        return True
+    if mode is None:
+        return bool(exists)
+    return mode.strip().lower() == _TEMPORARY_MEMORY_MODE
+
+
+async def uploads_restricted(
+    dashboard_state: Any,
+    session_key: str,
+    *,
+    channel_type: str,
+    persisted_probe: PersistedProbe,
+) -> bool:
+    """True when *session_key* must not ship local file bytes to *channel_type*.
+
+    The decision itself is :func:`session_is_restricted`, shared with the durable
+    history gate so the two ceilings cannot drift: a conversation that refuses to
+    write a transcript must not ship the file either. Returning a flat ``False``
+    for a channel-native key was correct only while no channel-native conversation
+    had a privacy mode, and it became a hole the moment one did. It is not a
+    blanket fail-closed either — an unrestricted conversation is allowed, which is
+    the common case, and a channel with no modes at all reads ``False`` exactly as
+    before.
+
+    This wrapper adds only the upload-specific denial audit, so the ceiling is
+    observable, mirroring how each transport audits its authorization denials.
+    """
+    restricted = await session_is_restricted(
+        dashboard_state, session_key, persisted_probe=persisted_probe
+    )
     if restricted:
         sel().log_api_access(
             caller=session_key,

--- a/src/kiro_crew/telegram/commands.py
+++ b/src/kiro_crew/telegram/commands.py
@@ -11,7 +11,7 @@ Commands:
   /stop        — stop the current reply and clear the queue (alias: /cancel)
   /status      — runtime stats (uptime, messages, tool decisions, sessions)
   /ping        — liveness check (answers "pong")
-  /sessions    — list recent conversations; add words to search (alias: /session)
+  /session     — find and resume a conversation (alias: /sessions)
   /title       — rename this conversation
   /cron        — list / pause / resume / remove scheduled jobs
   /spawn       — run a task in a background subagent (alias: /bg)
@@ -257,7 +257,7 @@ COMMAND_SPEC: tuple[tuple[str, str], ...] = (
     ("model", "Choose the model from a list"),
     ("agent", "Choose the agent from a list"),
     ("status", "Show runtime stats"),
-    ("sessions", "List recent conversations; add words to search"),
+    ("session", "Find and resume a conversation"),
     ("cron", "Manage scheduled jobs (list / pause / resume / remove)"),
     ("voice", "Speak the answers here too (on / off)"),
     ("temporary", "This conversation reads and saves no memory"),

--- a/src/kiro_crew/telegram/session_resume.py
+++ b/src/kiro_crew/telegram/session_resume.py
@@ -11,6 +11,7 @@ from kiro_crew.messaging.renderer import display_safe
 from kiro_crew.messaging.session_resume import ResumeReleaseError  # noqa: F401  (re-export)
 from kiro_crew.messaging.session_resume import (
     PICKER_LIMIT,
+    SETTLE_NOTHING,
     InboundResolution,
     ResumeCopy,
     RoutingDecision,
@@ -175,8 +176,26 @@ class _TelegramResumeSurface:
         )
 
 
+def _decision_says_anything(decision: RoutingDecision) -> bool:
+    """Whether the binder produced anything beyond "run natively, nothing owed".
+
+    Enumerated rather than compared against a pristine ``RoutingDecision``, so a
+    field added later is a visible edit here instead of silently reading as empty.
+    ``observed`` is excluded on purpose: it is the live map state this side already
+    holds, not something the binder disclosed.
+    """
+    return bool(
+        decision.resumed_key is not None
+        or decision.refusal is not None
+        or decision.settle != SETTLE_NOTHING
+        or decision.described is not None
+        or decision.adopt_key
+        or decision.adopt_title
+    )
+
+
 class TelegramSessionResume:
-    """List dashboard sessions and bind one to a Telegram chat or Topic."""
+    """List dashboard sessions and bind one to the single operator's private DM."""
 
     def __init__(
         self,
@@ -240,15 +259,29 @@ class TelegramSessionResume:
     ) -> RoutingDecision:
         link = self.link_for(chat_id, thread_id)
         resolution = self._binder.resolve_inbound(link)
-        if (resolution.key is not None or resolution.ambiguous) and not self.is_owner(
-            user_id, chat_id, chat_type
-        ):
+        owner = self.is_owner(user_id, chat_id, chat_type)
+        if (resolution.key is not None or resolution.ambiguous) and not owner:
             return RoutingDecision(refusal=_ROUTE_OWNER_REFUSAL, observed=resolution)
-        return await self._binder.route(
+        decision = await self._binder.route(
             self.expectation_id(chat_id, thread_id),
             link,
             self._title_of,
         )
+        # The live-binding check above cannot stand alone: the binder ALSO answers
+        # from the durable expectation store, so a binding that was detached while
+        # its expectation survives resolves no key and no ambiguity, yet still
+        # produces a notice built from the dashboard session's TITLE. Reached by a
+        # non-owner — a single-owner binding detached, then a multi-user allow-list
+        # configured — that notice discloses host-wide history to someone the
+        # single-owner rule exists to exclude.
+        #
+        # So a non-owner gets the generic refusal for ANY non-empty decision, which
+        # names nothing. Deliberately including a settlement obligation: it stays
+        # OWED rather than being acknowledged by a message that was never
+        # delivered, so the owner still receives it.
+        if not owner and _decision_says_anything(decision):
+            return RoutingDecision(refusal=_ROUTE_OWNER_REFUSAL, observed=resolution)
+        return decision
 
     async def settle(
         self,
@@ -282,16 +315,26 @@ class TelegramSessionResume:
                 logger.debug("Telegram resume: title lookup failed", exc_info=True)
         return title or session_key.removeprefix("dashboard:")
 
-    def _native_origin_keys(self, link: ChannelLink) -> frozenset[str]:
+    def _native_origin_keys(self, link: ChannelLink, native_key: str = "") -> frozenset[str]:
         """Outbound occupants that are native generations of this Telegram DM.
 
         A dashboard session explicitly mirrored to the same DM is not an origin
         mirror and must remain protected. Legacy origin rows are resolved through
         ``channel_key_for_stem`` before applying the same canonical-key test.
+
+        *native_key* is the dispatcher's own key for this chat and is matched
+        DIRECTLY, because the namespace test below cannot recognise every scope: with
+        ``dm_scope="unified"`` the native bucket is a ``unified:`` key, so without
+        this a one-click takeover would refuse and demand a preparatory ``/unlink``.
+        Only an occupant of THIS link qualifies, so supplying a key that is not
+        bound here grants nothing.
         """
         keys: set[str] = set()
         stem_resolver = getattr(self.sessions, "channel_key_for_stem", None)
         for stored_key in self.sessions.find_mirror_sessions(link):
+            if native_key and stored_key == native_key:
+                keys.add(stored_key)
+                continue
             candidate = stored_key
             parsed = parse_session_key(candidate)
             if parsed is None and stored_key.startswith("dashboard:") and callable(stem_resolver):
@@ -323,7 +366,21 @@ class TelegramSessionResume:
             query=query,
         )
 
-    async def choose(self, client: "TelegramClient", callback: "TelegramCallback") -> None:
+    async def choose(
+        self,
+        client: "TelegramClient",
+        callback: "TelegramCallback",
+        *,
+        native_key: str = "",
+    ) -> None:
+        """Bind the pressed session, replacing this DM's own native mirror.
+
+        *native_key* is the dispatcher's own session key for this chat. It is
+        supplied rather than derived because only the dispatcher knows the
+        configured ``dm_scope``: under ``unified`` the native bucket is a
+        ``unified:`` key, which no amount of namespace matching here would
+        recognise as this DM's own outbound mirror.
+        """
         nonce, index = self._parse_choice(callback.data)
         link = self.link_for(callback.chat_id, callback.message_thread_id)
         await self._controller.choose(
@@ -339,7 +396,7 @@ class TelegramSessionResume:
             nonce=nonce,
             index=index,
             link=link,
-            replace_outbound_keys=self._native_origin_keys(link),
+            replace_outbound_keys=self._native_origin_keys(link, native_key),
         )
 
     @staticmethod

--- a/src/kiro_crew/telegram/session_resume.py
+++ b/src/kiro_crew/telegram/session_resume.py
@@ -1,0 +1,350 @@
+"""Telegram's session picker and inbound binding adapter over the shared resume core."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from kiro_crew.messaging.link import ChannelLink, parse_session_key
+from kiro_crew.messaging.renderer import display_safe
+from kiro_crew.messaging.session_resume import ResumeReleaseError  # noqa: F401  (re-export)
+from kiro_crew.messaging.session_resume import (
+    PICKER_LIMIT,
+    InboundResolution,
+    ResumeCopy,
+    RoutingDecision,
+    SessionChoice,
+    SessionResumeController,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from kiro_crew.history import ConversationLog
+    from kiro_crew.session import SessionManager
+    from kiro_crew.telegram.client import TelegramCallback, TelegramClient
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_COPY = ResumeCopy(
+    sessions_command="/session",
+    unlink_command="/unlink",
+    conversation_noun="Telegram conversation",
+)
+_CALLBACK_DATA_MAX_BYTES = 64
+_BUTTON_LABEL_MAX_CHARS = 80
+_QUERY_LABEL_MAX_CHARS = 100
+_ROUTE_OWNER_REFUSAL = (
+    "🔒 This Telegram chat cannot resume a dashboard session because session "
+    "resume requires exactly one configured operator in a private DM. Your "
+    "message was NOT processed."
+)
+
+
+def _safe_telegram_text(text: str, max_chars: int) -> str:
+    """Redact the complete rendered string before applying its display budget."""
+    return display_safe(text)[:max_chars]
+
+
+def _picker_keyboard(nonce: str, choices: tuple[SessionChoice, ...]) -> dict:
+    """One Telegram button per row, carrying only an ASCII nonce and index."""
+    rows: list[list[dict[str, str]]] = []
+    for index, choice in enumerate(choices):
+        callback_data = f"s:{nonce}:{index}"
+        if (
+            not callback_data.isascii()
+            or len(callback_data.encode("ascii")) > _CALLBACK_DATA_MAX_BYTES
+        ):
+            raise ValueError("session picker callback_data exceeds Telegram's limit")
+        label = _safe_telegram_text(f"{index + 1}. {choice.title}", _BUTTON_LABEL_MAX_CHARS)
+        rows.append([{"text": label, "callback_data": callback_data}])
+    return {"inline_keyboard": rows}
+
+
+def _picker_owner(user_id: int, chat_id: int, thread_id: int | None) -> str:
+    return f"{user_id}:{TelegramSessionResume.expectation_id(chat_id, thread_id)}"
+
+
+class _TelegramResumeSurface:
+    owner_refusal = (
+        "🔒 /session can resume dashboard conversations only from the single "
+        "operator's private chat. Configure exactly one telegram.allowed_user_ids entry."
+    )
+    choice_owner_refusal = "🔒 Session resume is owner-only."
+    choice_expired = "⌛ This session picker expired. Run /session again."
+    choice_missing = "That session is no longer available. Run /session again."
+    choice_expectation_failed = (
+        "⚠️ Couldn't save which conversation this chat is linked to, so the session "
+        "was NOT resumed. Run /session to try again."
+    )
+    choice_claim_lost = (
+        "🧵 Another session just connected here. Run /session again after freeing "
+        "the current binding."
+    )
+    choice_binding_failed = "⚠️ Couldn't resume that session. Run /session to try again."
+
+    def __init__(
+        self,
+        client: "TelegramClient",
+        chat_id: int,
+        thread_id: int | None,
+    ) -> None:
+        self.client = client
+        self.chat_id = chat_id
+        self.thread_id = thread_id
+        self.expectation_id = TelegramSessionResume.expectation_id(chat_id, thread_id)
+
+    def display_safe(self, text: str, max_chars: int) -> str:
+        return _safe_telegram_text(text, max_chars)
+
+    def no_choices(self, query: str) -> str:
+        normalized = " ".join(query.casefold().split())
+        if normalized:
+            label = _safe_telegram_text(" ".join(query.split()), _QUERY_LABEL_MAX_CHARS)
+            return (
+                f"No dashboard sessions matched “{label}”. Try fewer words, or run "
+                f"/session to see up to {PICKER_LIMIT} recent sessions."
+            )
+        return "No recent dashboard sessions."
+
+    def picker_heading(self, query: str, total: int) -> str:
+        shown = min(total, PICKER_LIMIT)
+        normalized = " ".join(query.casefold().split())
+        if normalized:
+            label = _safe_telegram_text(" ".join(query.split()), _QUERY_LABEL_MAX_CHARS)
+            if total > PICKER_LIMIT:
+                summary = f"Showing {PICKER_LIMIT} of {total} matching sessions"
+            else:
+                summary = f"Showing {shown} matching session{'s' if shown != 1 else ''}"
+            return (
+                f"🔎 Dashboard session search\n{summary} for “{label}”, ranked over "
+                "titles and message content."
+            )
+        if total > PICKER_LIMIT:
+            summary = f"Showing {PICKER_LIMIT} of {total} most recent dashboard sessions."
+        else:
+            summary = (
+                f"Showing {shown} most recent dashboard session" f"{'s' if shown != 1 else ''}."
+            )
+        return f"🧵 Recent dashboard sessions\n{summary}"
+
+    def choice_success(self, choice: SessionChoice) -> str:
+        return (
+            f"🔄 Resumed: {choice.title}\n"
+            "Ordinary messages here now continue that dashboard conversation."
+        )
+
+    async def post_picker(
+        self,
+        heading: str,
+        nonce: str,
+        choices: tuple[SessionChoice, ...],
+    ) -> str:
+        try:
+            keyboard = _picker_keyboard(nonce, choices)
+        except ValueError:
+            logger.error("Telegram resume: picker callback payload exceeded the platform cap")
+            await self.say("⚠️ Couldn't build the session picker. Run /session again.")
+            return ""
+        message_id = await self.client.send_message(
+            self.chat_id,
+            f"{heading}\nChoose one to continue here.",
+            reply_markup=keyboard,
+            message_thread_id=self.thread_id,
+        )
+        return str(message_id) if message_id is not None else ""
+
+    async def settle_picker(self, message_id: str, text: str) -> bool:
+        try:
+            numeric_id = int(message_id)
+        except (TypeError, ValueError):
+            return False
+        return bool(
+            await self.client.edit_message(
+                self.chat_id,
+                numeric_id,
+                text,
+                reply_markup={"inline_keyboard": []},
+            )
+        )
+
+    async def say(self, text: str) -> None:
+        await self.client.send_message(
+            self.chat_id,
+            text,
+            message_thread_id=self.thread_id,
+        )
+
+
+class TelegramSessionResume:
+    """List dashboard sessions and bind one to a Telegram chat or Topic."""
+
+    def __init__(
+        self,
+        sessions: "SessionManager",
+        conv_log: "ConversationLog | None",
+        allowed_user_ids: set[int],
+    ) -> None:
+        self.sessions = sessions
+        self.conv_log = conv_log
+        self.owner_id = next(iter(allowed_user_ids)) if len(allowed_user_ids) == 1 else 0
+        self._controller = SessionResumeController(
+            sessions,
+            conv_log,
+            channel_type="telegram",
+            copy=_TELEGRAM_COPY,
+            title_display=_safe_telegram_text,
+        )
+        self.pickers = self._controller.pickers
+        self._binder = self._controller.binder
+        self.expectations = self._binder.expectations
+
+    @property
+    def dashboard_state(self) -> object | None:
+        return self._controller.dashboard_state
+
+    @dashboard_state.setter
+    def dashboard_state(self, state: object | None) -> None:
+        self._controller.dashboard_state = state
+
+    @staticmethod
+    def expectation_id(chat_id: int, thread_id: int | None) -> str:
+        if thread_id is not None:
+            return f"topic:{chat_id}:{thread_id}"
+        return f"chat:{chat_id}"
+
+    @staticmethod
+    def link_for(chat_id: int, thread_id: int | None) -> ChannelLink:
+        return ChannelLink(
+            channel_type="telegram",
+            channel_id=str(chat_id),
+            thread_id=str(thread_id) if thread_id is not None else None,
+        )
+
+    def is_owner(self, user_id: int, chat_id: int, chat_type: str) -> bool:
+        return bool(self.owner_id) and (
+            chat_type == "private" and user_id == self.owner_id and chat_id == user_id
+        )
+
+    def resolve_inbound(self, chat_id: int, thread_id: int | None) -> InboundResolution:
+        return self._binder.resolve_inbound(self.link_for(chat_id, thread_id))
+
+    def resumed_session(self, chat_id: int, thread_id: int | None) -> str | None:
+        return self._binder.resumed_session(self.link_for(chat_id, thread_id))
+
+    async def route(
+        self,
+        user_id: int,
+        chat_id: int,
+        chat_type: str,
+        thread_id: int | None,
+    ) -> RoutingDecision:
+        link = self.link_for(chat_id, thread_id)
+        resolution = self._binder.resolve_inbound(link)
+        if (resolution.key is not None or resolution.ambiguous) and not self.is_owner(
+            user_id, chat_id, chat_type
+        ):
+            return RoutingDecision(refusal=_ROUTE_OWNER_REFUSAL, observed=resolution)
+        return await self._binder.route(
+            self.expectation_id(chat_id, thread_id),
+            link,
+            self._title_of,
+        )
+
+    async def settle(
+        self,
+        chat_id: int,
+        thread_id: int | None,
+        decision: RoutingDecision,
+    ) -> None:
+        await self._binder.settle(
+            self.expectation_id(chat_id, thread_id),
+            self.link_for(chat_id, thread_id),
+            decision,
+        )
+
+    async def leave_resumed_session(self, chat_id: int, thread_id: int | None) -> str | None:
+        released = await self._binder.release(
+            self.expectation_id(chat_id, thread_id),
+            self.link_for(chat_id, thread_id),
+            self._title_of,
+        )
+        if released is not None:
+            self._controller.push_slots()
+        return released
+
+    async def _title_of(self, session_key: str) -> str:
+        title = ""
+        if self.conv_log is not None:
+            try:
+                meta = await asyncio.to_thread(self.conv_log.get_metadata, session_key)
+                title = str((meta or {}).get("title") or "")
+            except Exception:
+                logger.debug("Telegram resume: title lookup failed", exc_info=True)
+        return title or session_key.removeprefix("dashboard:")
+
+    def _native_origin_keys(self, link: ChannelLink) -> frozenset[str]:
+        """Outbound occupants that are native generations of this Telegram DM.
+
+        A dashboard session explicitly mirrored to the same DM is not an origin
+        mirror and must remain protected. Legacy origin rows are resolved through
+        ``channel_key_for_stem`` before applying the same canonical-key test.
+        """
+        keys: set[str] = set()
+        stem_resolver = getattr(self.sessions, "channel_key_for_stem", None)
+        for stored_key in self.sessions.find_mirror_sessions(link):
+            candidate = stored_key
+            parsed = parse_session_key(candidate)
+            if parsed is None and stored_key.startswith("dashboard:") and callable(stem_resolver):
+                candidate = str(stem_resolver(stored_key.removeprefix("dashboard:")) or "")
+                parsed = parse_session_key(candidate)
+            if (
+                parsed is not None
+                and parsed.surface == "telegram"
+                and parsed.chat_type == "direct"
+                and parsed.scope == (link.channel_id,)
+            ):
+                keys.add(stored_key)
+        return frozenset(keys)
+
+    async def show_picker(
+        self,
+        client: "TelegramClient",
+        user_id: int,
+        chat_id: int,
+        chat_type: str,
+        thread_id: int | None,
+        query: str = "",
+    ) -> None:
+        await self._controller.show_picker(
+            _TelegramResumeSurface(client, chat_id, thread_id),
+            caller=str(user_id) or "unknown",
+            picker_owner=_picker_owner(user_id, chat_id, thread_id),
+            is_owner=self.is_owner(user_id, chat_id, chat_type),
+            query=query,
+        )
+
+    async def choose(self, client: "TelegramClient", callback: "TelegramCallback") -> None:
+        nonce, index = self._parse_choice(callback.data)
+        link = self.link_for(callback.chat_id, callback.message_thread_id)
+        await self._controller.choose(
+            _TelegramResumeSurface(client, callback.chat_id, callback.message_thread_id),
+            caller=str(callback.user_id) or "unknown",
+            picker_owner=_picker_owner(
+                callback.user_id,
+                callback.chat_id,
+                callback.message_thread_id,
+            ),
+            is_owner=self.is_owner(callback.user_id, callback.chat_id, callback.chat_type),
+            message_id=str(callback.message_id),
+            nonce=nonce,
+            index=index,
+            link=link,
+            replace_outbound_keys=self._native_origin_keys(link),
+        )
+
+    @staticmethod
+    def _parse_choice(data: str) -> tuple[str, int]:
+        parts = data.split(":")
+        if len(parts) != 3 or parts[0] != "s" or not parts[2].isdigit():
+            return "", -1
+        return parts[1], int(parts[2])

--- a/src/kiro_crew/telegram/transport.py
+++ b/src/kiro_crew/telegram/transport.py
@@ -119,6 +119,9 @@ TELEGRAM_CAPABILITIES = TransportCapabilities(
     max_message_chars=TELEGRAM_CHUNK_LIMIT,
     max_buttons=25,
     supports_proactive_send=True,
+    # /session binds this exact Telegram DM back to a dashboard session, and
+    # every ordinary inbound message resolves that durable binding first.
+    supports_session_resume=True,
 )
 
 
@@ -322,6 +325,10 @@ class TelegramTransport(MessagingTransport):
                 is None
             )
         return conversation_id in self._allowed
+
+    def may_resume_from(self, conversation_id: str, thread_id: str | None = None) -> bool:
+        """Only one unambiguous owner DM may drive a dashboard session inbound."""
+        return thread_id is None and len(self._allowed) == 1 and conversation_id in self._allowed
 
     # -- Lifecycle ----------------------------------------------------------
     async def connect(self) -> None:

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -84,7 +84,11 @@ from kiro_crew.messaging.session_resume import (
 )
 from kiro_crew.messaging.session_trust import add_trusted_session, is_session_trusted
 from kiro_crew.messaging.transport import InboundMessage
-from kiro_crew.messaging.upload_gate import uploads_restricted
+from kiro_crew.messaging.upload_gate import (
+    session_blocks_reads,
+    session_is_restricted,
+    uploads_restricted,
+)
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact, redact_local_paths
 from kiro_crew.sel import sel
@@ -535,8 +539,16 @@ class TelegramDispatcher:
             else None
         )
         decision = RoutingDecision()
-        wants_routing = (interpret_commands or bool(origin_tag)) and (
-            cmd not in _DETACH_EXEMPT_COMMANDS
+        # A HOST-scoped listing is not conversation work: `/spawn list` and
+        # `/task status` report on the whole box, so routing them through a resumed
+        # binding lets a stale or refused one withhold output that has nothing to do
+        # with that session. Asked of the argument, not the command name, because
+        # the same verb is conversation-scoped with a different argument.
+        lists_host = cmd is not None and lists_host_state(cmd, parse_command_argument(text))
+        wants_routing = (
+            (interpret_commands or bool(origin_tag))
+            and (cmd not in _DETACH_EXEMPT_COMMANDS)
+            and not lists_host
         )
         if wants_routing:
             async with self._routing_turn(routing_id) as queued:
@@ -611,6 +623,20 @@ class TelegramDispatcher:
         # apply below is the one place that can still honour it.
 
         if cmd in (privacy_mode.MODE_TEMPORARY, privacy_mode.MODE_INCOGNITO):
+            if resumed_key is not None:
+                # A dashboard slot owns its memory_mode. Marking only Telegram's
+                # process-local tracker would announce privacy while the persistent
+                # live slot kept recording the next turn. Runtime mode switching is
+                # not a dashboard capability, so fail visibly instead of inventing
+                # a second authority. This covers both a bare modifier and
+                # `/temporary <message>`: the message is NOT processed.
+                await self._reply(
+                    chat_id,
+                    "🔒 Privacy mode can't be changed while a dashboard session is "
+                    "resumed. Your message was NOT processed. Use /unlink or /new first.",
+                    thread=reply_thread,
+                )
+                return
             rest = parse_command_argument(text)
             if not rest:
                 applied = await privacy_mode.apply_mode(
@@ -838,7 +864,14 @@ class TelegramDispatcher:
                 # means "as if never picked". get_or_create gates its own model
                 # resolution on `model is None`, so passing "" would skip that
                 # and land on the provider factory's narrower fallback instead.
-                model=self._model_pref.get(route) or None,
+                #
+                # Scoped to a NATIVE turn. ``_model_pref`` is this Telegram route's
+                # own choice, and a resumed dashboard session already has a model of
+                # its own; handing the route's preference to a cold start would run
+                # that conversation under a model its owner never picked, silently
+                # and for every later turn. A resumed session therefore passes None
+                # and lets its own persisted model resolve.
+                model=(None if resumed_key is not None else self._model_pref.get(route) or None),
             )
             _acquired = True
             # Extraction's approved root is the provider's OWN resolved cwd, so a
@@ -882,7 +915,9 @@ class TelegramDispatcher:
                 # gate cannot cover: refusing to WRITE still leaves yesterday's
                 # memories and lessons in today's prompt. Incognito deliberately
                 # still reads — that is the documented difference between the two.
-                blocks_reads=privacy_mode.is_temporary(session_key),
+                # Resolved dashboard-aware, because a RESUMED session carries its
+                # mode on the slot rather than in this channel's tracker.
+                blocks_reads=await self._blocks_memory_reads(session_key),
                 # Who is speaking. Slack has always passed this; without it the
                 # model cannot address the user or tell two participants of a
                 # forum Topic apart. Already narrowed to Telegram's own username
@@ -996,24 +1031,37 @@ class TelegramDispatcher:
                     exc_info=True,
                 )
             try:
+                # Circular import: the dashboard package imports the channel
+                # transports on its boot path, so this edge only exists at call
+                # time. Same reason as the ``surface_dispatcher_session`` import
+                # below.
                 from kiro_crew.dashboard.channel_slots import project_channel_turn_live
 
-                mirror_mids = project_channel_turn_live(
-                    self.dashboard_state,
-                    session_key,
-                    text,
-                    accumulated,
-                    broadcast_user=True,
-                )
-                await asyncio.to_thread(
-                    self._persist_turn,
-                    session_key,
-                    text,
-                    accumulated,
-                    is_new_own_session,
-                    agent=agent,
-                    mirror_mids=mirror_mids,
-                )
+                # Decided HERE, on the loop, because a resumed dashboard session's
+                # restriction lives on its live slot (or, with the tab closed, in
+                # the persisted transcript) — neither is reachable from the worker
+                # thread the write runs in. BOTH paths below must be gated: the
+                # projection appends to a dashboard slot and marks it dirty, so a
+                # later slot flush would persist those rows even if this direct
+                # writer were skipped.
+                dashboard_restricted = await self._session_restricted(session_key)
+                if not dashboard_restricted:
+                    mirror_mids = project_channel_turn_live(
+                        self.dashboard_state,
+                        session_key,
+                        text,
+                        accumulated,
+                        broadcast_user=True,
+                    )
+                    await asyncio.to_thread(
+                        self._persist_turn,
+                        session_key,
+                        text,
+                        accumulated,
+                        is_new_own_session,
+                        agent=agent,
+                        mirror_mids=mirror_mids,
+                    )
             except Exception:
                 logger.warning(
                     "Telegram: persist_turn failed session=%s", session_key, exc_info=True
@@ -2009,6 +2057,58 @@ class TelegramDispatcher:
             return None
         return getattr(msg, "message_id", 0) or None
 
+    async def _blocks_memory_reads(self, session_key: str) -> bool:
+        """True when this session must take NO memory or lessons into its prompt.
+
+        The read counterpart of :meth:`_session_restricted`. ``temporary`` is the
+        only mode that blocks reads, and for a RESUMED ``dashboard:`` key that fact
+        lives on the slot, not in this channel's tracker — so
+        ``privacy_mode.is_temporary`` alone would let stored memories into the
+        model for a temporary dashboard session.
+        """
+        from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
+
+        return await session_blocks_reads(
+            self.dashboard_state,
+            session_key,
+            persisted_probe=_probe_persisted_session,
+        )
+
+    async def _session_restricted(self, session_key: str) -> bool:
+        """True when this session is incognito or temporary, so nothing may persist.
+
+        The same predicate the upload ceiling reads
+        (:func:`kiro_crew.messaging.upload_gate.session_is_restricted`), asked here
+        before the durable history write. A resumed Telegram turn can carry a
+        ``dashboard:`` key whose restriction lives on its live slot rather than in
+        this process's channel trackers, which is exactly the case
+        ``privacy_mode.is_restricted`` cannot see.
+
+        The LIVE slot is the authoritative rung and the one the exposure needs: a
+        restricted tab that is open is exactly the case that would otherwise write.
+        With the tab closed this falls back to the persisted ``memory_mode``, which
+        restricts on an incognito/temporary marker AND on an unreadable mode whose
+        transcript EXISTS — an ambiguous stem or a header no normal session wrote,
+        where an incognito session can hide. ``unknown_denies`` is off here, unlike
+        the upload ceiling, only so a truly ABSENT record still records: nothing on
+        disk claims that session is restricted, and denying there would stop
+        recording every conversation not yet written. A legacy header missing the
+        field reads ``persistent``, so it never reaches the unknown case.
+
+        The persisted-transcript probe is passed IN for the same reason as in
+        :meth:`_uploads_restricted`: ``messaging`` may not import ``dashboard``, so
+        the import lives here and stays function-local because the dashboard
+        gateway imports the channel transports.
+        """
+        from kiro_crew.dashboard.handlers._shared import _probe_persisted_session
+
+        return await session_is_restricted(
+            self.dashboard_state,
+            session_key,
+            persisted_probe=_probe_persisted_session,
+            unknown_denies=False,
+        )
+
     async def _uploads_restricted(self, session_key: str) -> bool:
         """True when this session must not ship local file bytes to Telegram.
 
@@ -2166,14 +2266,15 @@ class TelegramDispatcher:
         # metadata write CREATES the transcript file, so on a `/temporary` or
         # `/incognito` conversation this one command would persist user-authored
         # content for a mode that promised not to. `_persist_turn` gates the same
-        # way, and so does Slack's own `/title`; this is the third write on the same
+        # way, and so does Slack's own `/title`; this is another write on the same
         # promise rather than a new rule.
         #
-        # The predicate is the channel's in-process tracker, NOT the transcript's
-        # `memory_mode` header: the dashboard deliberately writes an incognito
-        # transcript and marks it, discarding on close, so a gate down in
-        # `ConversationLog` would refuse a write that path is entitled to make.
-        if privacy_mode.is_restricted(titled_key):
+        # The shared predicate is required here because *titled_key* may be a
+        # RESUMED ``dashboard:`` key. ``privacy_mode.is_restricted`` is only the
+        # answer for Telegram-native conversations; it reads a channel-local
+        # process tracker that a dashboard slot never populates and therefore
+        # fails open for an incognito dashboard session.
+        if await self._session_restricted(titled_key):
             await self._reply(
                 chat_id,
                 "🔒 This conversation is private, so its name isn't saved.",
@@ -2181,7 +2282,17 @@ class TelegramDispatcher:
             )
             return
         try:
-            await asyncio.to_thread(self.conv_log.set_title, titled_key, title)
+            # Circular dependency: dashboard boot imports channel transports, so
+            # the channel-to-slot bridge stays local like the turn projection.
+            from kiro_crew.dashboard.channel_slots import rename_channel_title_live
+
+            renamed_live = await rename_channel_title_live(
+                self.dashboard_state,
+                titled_key,
+                title,
+            )
+            if not renamed_live:
+                await asyncio.to_thread(self.conv_log.set_title, titled_key, title)
         except Exception:
             logger.warning("telegram /title: set_title failed", exc_info=True)
             await self._reply(chat_id, "⚠️ Couldn't rename this conversation.", thread=thread)
@@ -2333,7 +2444,28 @@ class TelegramDispatcher:
             return
 
         if data.startswith("s:"):
-            await self._session_resume.choose(self.client, cb)
+            # The native session key is supplied by the DISPATCHER because only it
+            # knows this DM's dm_scope. Under ``dm_scope="unified"`` the native
+            # bucket is a ``unified:`` key, not a ``telegram:`` one, so the resume
+            # adapter cannot recognise its own outbound mirror by namespace and
+            # would demand a preparatory /unlink for one-click takeover.
+            press_route = self._route_key(
+                chat_type=cb.chat_type,
+                user_id=cb.user_id,
+                chat_id=cb.chat_id,
+                thread=cb.message_thread_id,
+            )
+            # Under the SAME per-route lock a message takes for its routing
+            # decision. A press and the message that follows it are independent
+            # Telegram tasks, so without this the message can resolve its session
+            # before the press has committed the binding — and its turn, with its
+            # transcript, lands in the native session the user just left.
+            async with self._routing_turn(
+                self._session_resume.expectation_id(cb.chat_id, self._route_thread(press_route))
+            ):
+                await self._session_resume.choose(
+                    self.client, cb, native_key=self._session_key(press_route)
+                )
             return
 
         # Route the callback to the same conversation identity its turn used so
@@ -2924,7 +3056,21 @@ class TelegramDispatcher:
         agent: str | None = None,
         mirror_mids: tuple[str, str] | None = None,
     ) -> None:
-        """Persist one atomic turn, deduplicating rows already projected live."""
+        """Persist one atomic turn, deduplicating rows already projected live.
+
+        ``privacy_mode.is_restricted`` is this channel's OWN privacy gate and is
+        checked here, at the only writer, so it covers the turn, the drained queue
+        and the steered continuation alike.
+
+        It is NOT the whole ceiling for a RESUMED dashboard session. That
+        predicate reads a process-local tracker which only an inbound CHANNEL
+        message populates, so it answers ``False`` for an incognito dashboard slot
+        and fails open. That rung is decided by the CALLER, through
+        :meth:`_session_restricted`, which skips this call entirely — it needs the
+        live slot registry and, failing that, an await on the persisted transcript,
+        neither reachable from the worker thread this runs in. A second caller must
+        make the same check before calling.
+        """
         if self.conv_log is None or privacy_mode.is_restricted(session_key):
             return
         with self.conv_log.atomic_appends(session_key):

--- a/src/kiro_crew/telegram/transport_dispatch.py
+++ b/src/kiro_crew/telegram/transport_dispatch.py
@@ -29,6 +29,7 @@ import logging
 import os
 import re
 import time
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -36,7 +37,7 @@ from kiro_crew.acp.client import AcpError
 from kiro_crew.agent_discovery import list_agents
 from kiro_crew.config.loader import ACTIVATION_MENTION, ACTIVATION_OFF
 from kiro_crew.executors import run_in_embed_pool
-from kiro_crew.history import is_incognito_transcript, mint_row_mid
+from kiro_crew.history import mint_row_mid
 from kiro_crew.hooks import TOOL_AUTO_APPROVE, TOOL_DENY
 from kiro_crew.messaging import auto_title, privacy_mode
 from kiro_crew.messaging.attachments import IngestLimits, append_attachment_context
@@ -76,15 +77,19 @@ from kiro_crew.messaging.renderer import (
     display_safe,
     session_provenance_tag,
 )
-from kiro_crew.messaging.session_resume import SEARCH_FETCH_LIMIT, history_dashboard_key
+from kiro_crew.messaging.session_resume import (
+    ResumeReleaseError,
+    RoutingDecision,
+    persisted_session_agent,
+)
 from kiro_crew.messaging.session_trust import add_trusted_session, is_session_trusted
-from kiro_crew.messaging.sessions_view import collect_recent_sessions_audited
 from kiro_crew.messaging.transport import InboundMessage
 from kiro_crew.messaging.upload_gate import uploads_restricted
 from kiro_crew.safety_override import safety_override
 from kiro_crew.security import redact, redact_local_paths
 from kiro_crew.sel import sel
 from kiro_crew.session_allocation import SessionClosingError
+from kiro_crew.session_map import ConversationOwnershipConflict
 from kiro_crew.stats import Stats
 from kiro_crew.telegram.attachments import process_telegram_attachments
 from kiro_crew.telegram.commands import (
@@ -101,6 +106,7 @@ from kiro_crew.telegram.renderer import (
     TelegramRenderer,
     md_to_telegram_html_safe,
 )
+from kiro_crew.telegram.session_resume import TelegramSessionResume
 from kiro_crew.telegram.transport import (
     TELEGRAM_CAPABILITIES,
     TelegramInboundMessage,
@@ -109,6 +115,8 @@ from kiro_crew.telegram.transport import (
 from kiro_crew.voice_reply import synthesis_settings, synthesize_and_deliver
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from kiro_crew.config.loader import KiroCrewConfig
     from kiro_crew.context import ContextBuilder
     from kiro_crew.cron import CronService
@@ -153,6 +161,31 @@ _UNTAGGED_OPTIONS_REFUSAL = (
 _BUSY_OPTIONS_REFUSAL = (
     "🔘 That conversation is busy with another turn, so your choice was NOT "
     "applied. Type it as a message once the turn finishes."
+)
+
+_RELEASE_FAILURE = (
+    "⚠️ Could not leave the resumed session safely, so nothing changed. "
+    "Try again before sending another message."
+)
+
+# Commands that must remain usable even when a remembered binding is stale or
+# ambiguous. Everything else that acts on a conversation resolves the resumed
+# session first, so /stop, /compact, /model, /title, /spawn and /task cannot
+# silently operate on Telegram's native conversation instead.
+_DETACH_EXEMPT_COMMANDS = frozenset(
+    {
+        "new",
+        "unlink",
+        "sessions",
+        "help",
+        "status",
+        "ping",
+        "cron",
+        "yolo",
+        "dashboard",
+        "voice",
+        "agent",
+    }
 )
 
 
@@ -215,12 +248,6 @@ _MODEL_PICKER_MAX = 50
 #: catalogues, so one bound fits both.
 _PICKER_LIMIT = 24
 
-#: ``/sessions`` rows, matching the Slack surfaces' own default.
-_SESSIONS_LIMIT = 10
-#: Per-row caps, so one pathological title cannot consume the whole message.
-_SESSION_TITLE_CHARS = 60
-_SESSION_AGENT_CHARS = 24
-_SESSION_QUERY_CHARS = 100
 #: ``/title`` ceiling. The dashboard sidebar row truncates well before this; the
 #: cap is here so a persisted transcript never carries an unbounded title.
 _TITLE_MAX_CHARS = 80
@@ -240,6 +267,11 @@ class _Picker:
     #: ``(value, label)`` in button order. A ``""`` value is the row that means
     #: "no explicit pick" — Auto for a model, the configured default for an agent.
     choices: tuple[tuple[str, str], ...]
+    # Exact session the picker may mutate; revalidated on press.
+    session_key: str = ""
+    # Native Telegram model choices persist across /new; resumed-session choices
+    # switch only the selected dashboard session.
+    store_route_preference: bool = False
 
 
 #: Answers shorter than this are not spoken. Speaking "Done." spends a message
@@ -343,7 +375,7 @@ class TelegramDispatcher:
         # Injected by ``DashboardState.register_channel_transport`` through the
         # transport's ``dispatcher`` property, so a first turn can surface its
         # session to an open tab immediately instead of waiting for the reconciler.
-        self.dashboard_state: Any = None
+        self._dashboard_state: Any = None
         self.client: "TelegramClient | None" = None
         # This bot's own registered username (no leading @), from getMe().
         # Empty until the gateway's startup call resolves -- see
@@ -363,6 +395,14 @@ class TelegramDispatcher:
         # end-of-turn drain. Both now live in messaging/queue_receipt.py so
         # Telegram and Discord cannot drift on the lock discipline.
         self._queue = ReceiptQueue()
+        self._session_resume = TelegramSessionResume(sessions, conv_log, self._allowed)
+        # Full route identity -> (lock, queued deciders). A Topic is independent from
+        # every sibling Topic in the same supergroup, while one route serializes
+        # route -> refusal delivery -> settlement.
+        self._routing_locks: dict[str, tuple[asyncio.Lock, list[int]]] = {}
+        # A message still evaluating governance predates a refusal but is not yet a
+        # routing decider. Settlement waits until none remain for this exact route.
+        self._routing_checks: dict[str, int] = {}
         # session_key -> the running turn's renderer, so a concurrent mid-turn
         # steer (handled in a separate _handle_busy task) can hand it the user's
         # typed steer text for the inline "↪️ steered: …" chip. Set on turn
@@ -396,6 +436,15 @@ class TelegramDispatcher:
         self._model_pickers: dict[str, _Picker] = {}
         self._agent_pickers: dict[str, _Picker] = {}
 
+    @property
+    def dashboard_state(self) -> Any:
+        return self._dashboard_state
+
+    @dashboard_state.setter
+    def dashboard_state(self, state: Any) -> None:
+        self._dashboard_state = state
+        self._session_resume.dashboard_state = state
+
     # ── Turn dispatch (transport's dispatch callback) ──────────────────────
 
     async def handle_message(
@@ -421,25 +470,33 @@ class TelegramDispatcher:
         queued or steered, because those paths retain text but not provenance.
         """
         assert self.client is not None, "TelegramDispatcher.client must be set"
-        # Inbound channels-governance gate (off-loop) — recheck per message so a
-        # host-profile deny added after connect stops dispatch without a restart
-        # (the startup gate only blocks CONNECTING). Silently drop on deny.
-        if not await channel_inbound_permitted("telegram"):
+        user_id = int(msg.user_id)
+        chat_id = int(msg.conversation_id)
+        thread = getattr(msg, "thread_id", None)
+        route = self._route_key(
+            chat_type=getattr(msg, "chat_type", "private"),
+            user_id=user_id,
+            chat_id=chat_id,
+            thread=thread,
+        )
+        reply_thread = self._route_thread(route)
+        routing_id = self._session_resume.expectation_id(chat_id, reply_thread)
+        self._routing_checks[routing_id] = self._routing_checks.get(routing_id, 0) + 1
+        try:
+            permitted = await channel_inbound_permitted("telegram")
+        finally:
+            remaining = self._routing_checks[routing_id] - 1
+            if remaining:
+                self._routing_checks[routing_id] = remaining
+            else:
+                self._routing_checks.pop(routing_id)
+        if not permitted:
             logger.info("telegram inbound dropped: denied by channels governance policy")
             return
         # Counted here, matching where Slack counts it: an inbound message the
         # governance gate refused never happened as far as the operator's own
-        # traffic figures go, but everything past this point did. Without these
-        # three counters `/status` — a command this channel offers — reports
-        # "msgs 0 (ok 0 / fail 0)" forever on a Telegram-only install, and
-        # Stats.daily_report says "no messages" for a bot that has been answering
-        # all day.
+        # traffic figures go, but everything past this point did.
         Stats().inc_message_received()
-        # Forum activation gate: whether the bot should ANSWER here, as opposed to
-        # whether it MAY (that is the transport's fail-closed forum authZ, already
-        # passed). Slack has had this per channel since before the transport path
-        # existed; without it an allow-listed Topic cannot host a conversation
-        # between humans, because every message starts a turn.
         _activation = self._activation_outcome(msg)
         if _activation is not None:
             sel().log_api_access(
@@ -450,31 +507,7 @@ class TelegramDispatcher:
                 resources=f"chat={msg.conversation_id}",
             )
             return
-        user_id = int(msg.user_id)
-        chat_id = int(msg.conversation_id)
         text = msg.text
-        # Route to the conversation identity. DM (private) -> (direct, user_id),
-        # reproducing the pre-forum key EXACTLY; an authorized supergroup forum
-        # message always carries a Topic thread -> (forum, "chat:thread"). A
-        # threadless General message never reaches here (the forum gate in
-        # transport.receive / on_callback denies it); the threadless (forum,
-        # "chat") branch below is defensive dead code, not a served path.
-        # ``thread`` is the raw Topic id passed to the renderer so its outbound
-        # messages thread into the Topic. Everything downstream (session key,
-        # generation counter, awaiting flag) keys on ``route`` so /new, idle
-        # rotation and /compact are per-topic, not per-user.
-        route = self._route_key(
-            chat_type=getattr(msg, "chat_type", "private"),
-            user_id=user_id,
-            chat_id=chat_id,
-            thread=getattr(msg, "thread_id", None),
-        )
-        thread = getattr(msg, "thread_id", None)
-        # The Topic id (int) used to thread EVERY dispatcher-originated reply for
-        # this turn back into the user's Topic (command confirmations, receipts,
-        # the soft-threshold notice); None only for a DM (an authorized forum
-        # turn always carries a Topic — General is denied at the gate).
-        reply_thread = self._route_thread(route)
 
         # Per-message mid-turn override: "/queue …" / "/steer …" let the user
         # choose how THIS message is handled if it lands while a turn is running
@@ -501,16 +534,49 @@ class TelegramDispatcher:
             if interpret_as_command and override_mode is None
             else None
         )
+        decision = RoutingDecision()
+        wants_routing = (interpret_commands or bool(origin_tag)) and (
+            cmd not in _DETACH_EXEMPT_COMMANDS
+        )
+        if wants_routing:
+            async with self._routing_turn(routing_id) as queued:
+                decision = await self._session_resume.route(
+                    user_id,
+                    chat_id,
+                    getattr(msg, "chat_type", "private"),
+                    reply_thread,
+                )
+                if decision.refusal is not None:
+                    landed = await self._reply(chat_id, decision.refusal, thread=reply_thread)
+                    if (
+                        landed is not None
+                        and len(queued) == 1
+                        and not self._routing_checks.get(routing_id)
+                    ):
+                        await self._session_resume.settle(chat_id, reply_thread, decision)
+                    return
+        resumed_key = decision.resumed_key
+
         if cmd == "new":
+            try:
+                left_resumed = await self._session_resume.leave_resumed_session(
+                    chat_id, reply_thread
+                )
+            except ResumeReleaseError:
+                await self._reply(chat_id, _RELEASE_FAILURE, thread=reply_thread)
+                return
             self._conv.bump_gen(route)
-            await self._reply(chat_id, "✅ New conversation started.", thread=reply_thread)
+            message = "✅ New conversation started."
+            if left_resumed is not None:
+                message = "✅ New conversation started — left the resumed session."
+            await self._reply(chat_id, message, thread=reply_thread)
             return
         if cmd == "compact":
             self._conv.clear_awaiting(route)
-            await self._handle_compact(route, chat_id)
+            await self._handle_compact(route, chat_id, session_key=resumed_key)
             return
         if cmd == "link":
-            await self._handle_link(route, chat_id)
+            await self._handle_link(route, chat_id, resumed_key=resumed_key)
             return
         if cmd == "unlink":
             await self._handle_unlink(route, chat_id)
@@ -519,10 +585,15 @@ class TelegramDispatcher:
             await self._reply(chat_id, _HELP_TEXT, thread=reply_thread)
             return
         if cmd == "stop":
-            await self._handle_stop(route, chat_id)
+            await self._handle_stop(route, chat_id, session_key=resumed_key)
             return
         if cmd == "model":
-            await self._handle_model(route, chat_id, parse_command_argument(text))
+            await self._handle_model(
+                route,
+                chat_id,
+                parse_command_argument(text),
+                session_key=resumed_key,
+            )
             return
         if cmd == "agent":
             await self._handle_agent(route, chat_id, parse_command_argument(text))
@@ -547,7 +618,7 @@ class TelegramDispatcher:
                     # Rotation FIRST: a bare modifier returns before the turn path
                     # would have rotated, so keying on the un-rotated generation
                     # protects a session the next message abandons.
-                    self._rotated_session_key(route),
+                    resumed_key or self._rotated_session_key(route),
                     source="telegram",
                     caller=str(user_id),
                     sessions=self.sessions,
@@ -579,15 +650,19 @@ class TelegramDispatcher:
                 cmd, route, chat_id, user_id, thread=reply_thread, subject="conversation list"
             ):
                 return
-            await self._handle_sessions(
+            await self._session_resume.show_picker(
+                self.client,
+                user_id,
                 chat_id,
-                parse_command_argument(text),
-                caller=str(user_id),
-                thread=reply_thread,
+                getattr(msg, "chat_type", "private"),
+                reply_thread,
+                query=parse_command_argument(text),
             )
             return
         if cmd == "title":
-            await self._handle_title(route, chat_id, parse_command_argument(text))
+            await self._handle_title(
+                route, chat_id, parse_command_argument(text), session_key=resumed_key
+            )
             return
         if cmd == "cron":
             if not await self._require_direct_chat(
@@ -611,9 +686,21 @@ class TelegramDispatcher:
             ):
                 return
             if cmd == "spawn":
-                await self._handle_spawn(route, chat_id, arg, thread=reply_thread)
+                await self._handle_spawn(
+                    route,
+                    chat_id,
+                    arg,
+                    thread=reply_thread,
+                    session_key=resumed_key,
+                )
             else:
-                await self._handle_task(chat_id, arg, route=route, thread=reply_thread)
+                await self._handle_task(
+                    chat_id,
+                    arg,
+                    route=route,
+                    thread=reply_thread,
+                    session_key=resumed_key,
+                )
             return
         if cmd == "yolo":
             await self._handle_yolo(
@@ -640,23 +727,22 @@ class TelegramDispatcher:
             )
             return
 
-        # ── Mid-turn concurrency: check the CURRENT-generation key for an
-        # in-flight turn BEFORE any idle/daily rotation. Rotating first could
-        # mint a new key and miss the running turn, letting a second concurrent
-        # turn bypass steer/queue. Surface the message (steer or queue) instead
-        # of a silent block.
-        session_key = self._session_key(route)
+        session_key = resumed_key or self._session_key(route)
         if origin_tag and session_provenance_tag(session_key) != origin_tag:
-            # The button belongs to a session this route no longer targets. This
-            # gate precedes the busy read so a stale press neither queues nor
-            # reveals whether the replacement conversation is running a turn.
             await self._reply(chat_id, _STALE_OPTIONS_REFUSAL, thread=reply_thread)
             return
         if self.sessions.is_busy(session_key):
             if origin_tag:
-                # Queue and steer paths store only text. Letting a tagged choice
-                # enter either path would replay it later with no tag to validate.
                 await self._reply(chat_id, _BUSY_OPTIONS_REFUSAL, thread=reply_thread)
+                return
+            if resumed_key is not None:
+                await self._reply(
+                    chat_id,
+                    "⏳ That session is busy with a turn started elsewhere. Send your "
+                    "message again once it finishes, or /unlink to return to your "
+                    "Telegram conversation.",
+                    thread=reply_thread,
+                )
                 return
             await self._handle_busy(
                 session_key,
@@ -669,22 +755,13 @@ class TelegramDispatcher:
             )
             return
 
-        session_key = self._rotated_session_key(route)
+        if resumed_key is None:
+            session_key = self._rotated_session_key(route)
         if origin_tag and session_provenance_tag(session_key) != origin_tag:
-            # Idle/daily rotation can change the native key after the pre-busy
-            # check. Revalidate the final key so the choice cannot cross it.
             await self._reply(chat_id, _STALE_OPTIONS_REFUSAL, thread=reply_thread)
             return
-        # Restore a privacy mode set before a restart. The in-memory trackers are
-        # empty on a cold process, so without this a session the operator marked
-        # incognito yesterday reads as unrestricted today and this turn's transcript
-        # is written. The durable flag lives on the session map; this is the only
-        # place that reads it back onto the final key.
         privacy_mode.hydrate(self.sessions, session_key)
         if privacy_request:
-            # Applied AFTER the rotation, so it lands on the key this turn actually
-            # runs under. Notified through the same adapter the bare-command branch
-            # uses, so a deferred modifier confirms exactly like an immediate one.
             await privacy_mode.apply_mode(
                 privacy_request,
                 session_key,
@@ -694,12 +771,11 @@ class TelegramDispatcher:
                 notify=lambda note: self._notify(chat_id, note, thread=reply_thread),
             )
         channel_id = f"telegram:{user_id}"
-        # Resolve the kiro-cli agent: this route's /agent pick wins, else an
-        # explicit override, else the configured default, else the canonical
-        # "kirocrew" agent — so the session loads kirocrew-core (spawn_run)
-        # instead of kiro-cli's bare built-in default. Mirrors
-        # slack/transport_dispatch.py.
         agent = self._resolve_agent(route)
+        if resumed_key is not None:
+            persisted = await asyncio.to_thread(persisted_session_agent, self.conv_log, resumed_key)
+            if persisted:
+                agent = persisted
 
         decider = (
             TelegramApprovalDecider(session_key=session_key)
@@ -711,7 +787,7 @@ class TelegramDispatcher:
             chat_id,
             TELEGRAM_CAPABILITIES,
             session_key=session_key,
-            message_thread_id=int(thread) if thread else None,
+            message_thread_id=reply_thread,
             show_thinking=self.cfg.telegram.show_thinking,
             uploads_allowed=not await self._uploads_restricted(session_key),
             reply_to_message_id=self._reply_target(msg, interpret_commands=interpret_commands),
@@ -775,16 +851,13 @@ class TelegramDispatcher:
             # than passed at construction, because the provider does not exist
             # until the session is acquired.
             renderer.attach_context_client(getattr(provider, "client", None))
-            if is_new:
+            is_new_own_session = is_new and resumed_key is None
+            if is_new_own_session:
                 await self.sessions.set_channel(session_key, channel_id)
-            # Bind this chat as the session's outbound mirror so a turn the user
-            # later takes from the dashboard is delivered back here. Slack gets
-            # this from its own per-turn thread binding; Telegram had it only
-            # behind an explicit /link. Called ON the loop, like every other
-            # session-map mutation: `_MAP_LOCK` is what orders it against a
-            # concurrent mutation, and the write is bounded — one whole-map
-            # rewrite, on a conversation's first turn only.
-            self._bind_origin_mirror(session_key, route, chat_id)
+            if resumed_key is None:
+                # A resumed dashboard session already owns its surface and binding.
+                # Reassert only Telegram's native conversation mirror.
+                self._bind_origin_mirror(session_key, route, chat_id)
             # ── Attachment ingestion (mirrors Discord) ──
             if msg.attachments:
                 attachment_result = await process_telegram_attachments(self.client, msg.attachments)
@@ -899,7 +972,8 @@ class TelegramDispatcher:
             # SPAWN the task never re-records this successful turn as a failure.
             try:
                 if (
-                    accumulated
+                    resumed_key is None
+                    and accumulated
                     and not privacy_mode.is_restricted(session_key)
                     and auto_title.try_claim(session_key)
                 ):
@@ -922,14 +996,29 @@ class TelegramDispatcher:
                     exc_info=True,
                 )
             try:
+                from kiro_crew.dashboard.channel_slots import project_channel_turn_live
+
+                mirror_mids = project_channel_turn_live(
+                    self.dashboard_state,
+                    session_key,
+                    text,
+                    accumulated,
+                    broadcast_user=True,
+                )
                 await asyncio.to_thread(
-                    self._persist_turn, session_key, text, accumulated, is_new, agent
+                    self._persist_turn,
+                    session_key,
+                    text,
+                    accumulated,
+                    is_new_own_session,
+                    agent=agent,
+                    mirror_mids=mirror_mids,
                 )
             except Exception:
                 logger.warning(
                     "Telegram: persist_turn failed session=%s", session_key, exc_info=True
                 )
-            if is_new:
+            if is_new_own_session:
                 try:
                     # Circular import: dashboard boot imports channel packages.
                     from kiro_crew.dashboard.channel_slots import (
@@ -1018,6 +1107,19 @@ class TelegramDispatcher:
                 chat_type=getattr(msg, "chat_type", "private"),
                 thread=thread,
             )
+
+    @asynccontextmanager
+    async def _routing_turn(self, route_id: str) -> "AsyncIterator[list[int]]":
+        """Serialize decision settlement for one exact DM or Topic, never provider work."""
+        lock, deciders = self._routing_locks.setdefault(route_id, (asyncio.Lock(), []))
+        deciders.append(1)
+        try:
+            async with lock:
+                yield deciders
+        finally:
+            deciders.pop()
+            if not deciders:
+                self._routing_locks.pop(route_id, None)
 
     async def _handle_busy(
         self,
@@ -1494,7 +1596,13 @@ class TelegramDispatcher:
         if not spoken:
             logger.info("telegram: voice reply produced no audio for %s", route)
 
-    async def _handle_stop(self, route: tuple[str, str], chat_id: int) -> None:
+    async def _handle_stop(
+        self,
+        route: tuple[str, str],
+        chat_id: int,
+        *,
+        session_key: str | None = None,
+    ) -> None:
         """Hard cancel: abort the in-flight turn and clear everything.
 
         The cooperative-cancel contract, the lock ordering across
@@ -1508,7 +1616,7 @@ class TelegramDispatcher:
         assert self.client is not None
         reply = await stop_running_turn(
             self.sessions,
-            self._session_key(route),
+            session_key or self._session_key(route),
             queue=self._queue,
             surface=self._receipt_surface(chat_id, None),
         )
@@ -1621,7 +1729,14 @@ class TelegramDispatcher:
         value, label = picker.choices[index]
         return picker, value, label
 
-    async def _handle_model(self, route: tuple[str, str], chat_id: int, arg: str) -> None:
+    async def _handle_model(
+        self,
+        route: tuple[str, str],
+        chat_id: int,
+        arg: str,
+        *,
+        session_key: str | None = None,
+    ) -> None:
         """Post the model keyboard (or report the current pick for a bare arg).
 
         Deliberately button-only: a free-text model id means guessing at names
@@ -1630,9 +1745,9 @@ class TelegramDispatcher:
         list" rather than parsed.
         """
         assert self.client is not None
-        session_key = self._session_key(route)
+        target_key = session_key or self._session_key(route)
         thread = self._route_thread(route)
-        choices = self._model_choices(session_key)
+        choices = self._model_choices(target_key)
         if len(choices) <= 1:
             await self._reply(
                 chat_id,
@@ -1666,10 +1781,21 @@ class TelegramDispatcher:
         now = time.time()
         self._prune_pickers(self._model_pickers, now)
         self._model_pickers[f"{chat_id}:{message_id}"] = _Picker(
-            route=route, created_at=now, choices=choices
+            route=route,
+            created_at=now,
+            choices=choices,
+            session_key=target_key,
+            store_route_preference=session_key is None,
         )
 
-    async def _apply_model(self, route: tuple[str, str], model_id: str) -> str:
+    async def _apply_model(
+        self,
+        route: tuple[str, str],
+        model_id: str,
+        session_key: str | None = None,
+        *,
+        store_route_preference: bool | None = None,
+    ) -> str:
         """Record *model_id* for *route* and push it to the live session.
 
         *model_id* comes verbatim from the session's advertised list, so it is
@@ -1686,9 +1812,12 @@ class TelegramDispatcher:
         Returns the user-facing outcome line.
         """
         label = model_id or "Auto"
-        self._model_pref[route] = model_id
-        session_key = self._session_key(route)
-        live = self.sessions.has_session(session_key)
+        if store_route_preference is None:
+            store_route_preference = session_key is None
+        if store_route_preference:
+            self._model_pref[route] = model_id
+        target_key = session_key or self._session_key(route)
+        live = self.sessions.has_session(target_key)
         # Two different promises, because the preference reaches a session only
         # at creation: ``get_or_create`` returns a reused session from its fast
         # path before it consults ``model=``. With nothing live the next message
@@ -1703,17 +1832,22 @@ class TelegramDispatcher:
         # recorded; the next session start resolves it from config. Claiming a
         # live switch here would be a lie.
         if not model_id:
+            if not store_route_preference:
+                return (
+                    "⚠️ Auto can only be selected when starting a new Telegram "
+                    "conversation; the resumed session was not changed."
+                )
             return next_new if live else deferred
         if not live:
             return deferred
-        if not await self.sessions.try_acquire(session_key):
+        if not await self.sessions.try_acquire(target_key):
             return (
                 f"✅ Model set to {label}, but a reply is still running — this "
                 f"conversation keeps its current model; the switch applies to "
                 f"your next one (/new)."
             )
         try:
-            provider = self.sessions.get_provider(session_key)
+            provider = self.sessions.get_provider(target_key)
             set_model = getattr(getattr(provider, "client", None), "set_model", None)
             if set_model is None:
                 return next_new
@@ -1721,19 +1855,23 @@ class TelegramDispatcher:
         except Exception as exc:
             logger.warning(
                 "telegram /model: live set_model failed for %s: %s",
-                session_key,
+                target_key,
                 type(exc).__name__,
                 exc_info=True,
             )
-            # The stored preference still stands, so the next session gets it —
-            # but do not claim the running conversation switched when it did not.
+            # A native-route preference still stands; a resumed session has no
+            # deferred Telegram preference to apply later.
+            suffix = (
+                "it applies to your next conversation (/new)."
+                if store_route_preference
+                else "the resumed session was not changed."
+            )
             return (
                 f"⚠️ Couldn't switch this conversation to {label} "
-                f"({type(exc).__name__}) — it applies to your next "
-                f"conversation (/new)."
+                f"({type(exc).__name__}) — {suffix}"
             )
         finally:
-            self.sessions.release(session_key)
+            self.sessions.release(target_key)
         return f"✅ Now using {label}."
 
     def _addresses_this_bot(self, msg: InboundMessage) -> bool:
@@ -1879,12 +2017,10 @@ class TelegramDispatcher:
         Discord dispatcher; this supplies Telegram's dashboard state and audit
         label.
 
-        It cannot fire here YET, and that is worth stating rather than implying:
-        the gate keys on a ``dashboard:`` session key, and this channel derives
-        its key from the route alone (``supports_session_resume`` is False), so no
-        Telegram turn carries one. Wired regardless — a forum Topic is readable by
-        every member of its supergroup, so the day inbound resume lands the
-        ceiling has to already be on the path rather than be remembered.
+        A resumed Telegram turn can carry a ``dashboard:`` key, so this gate is
+        active rather than preparatory. A forum Topic is readable by every member
+        of its supergroup, making the restricted-session ceiling mandatory before
+        any local file bytes are inspected or delivered.
 
         The persisted-transcript probe is passed IN because ``messaging`` may not
         import ``dashboard``; this package may, so the import lives here, and stays
@@ -1998,126 +2134,16 @@ class TelegramDispatcher:
             f"Switch back to return to the previous one."
         )
 
-    # ── /sessions, /title and the service-backed commands ──────────────────
+    # ── /title and the service-backed commands ─────────────────────────────
 
-    async def _handle_sessions(
+    async def _handle_title(
         self,
+        route: tuple[str, str],
         chat_id: int,
-        query: str = "",
+        arg: str,
         *,
-        caller: str = "",
-        thread: int | None = None,
+        session_key: str | None = None,
     ) -> None:
-        """List recent conversations, or search their titles and message content.
-
-        Still read-only. A Resume button would need per-chat inbound rerouting (the
-        machinery Discord carries in ``discord/session_resume.py``) which this
-        channel does not have, and a button that binds a session the next typed
-        message then bypasses is worse than no button. Search uses ConversationLog's
-        dashboard ranking rather than a Telegram-only title filter, but renders the
-        same bounded title/agent rows as the recent list.
-
-        *caller* is the requesting user's id, and the audit record's subject. It was
-        the constant ``"telegram"``, which is the SOURCE, not the subject: with more
-        than one entry in ``allowed_user_ids`` — the forum case this channel serves —
-        a read of every conversation's titles must be attributable to a participant.
-        """
-        normalized_query = " ".join(query.split())
-        rows: list[dict] | None
-        if normalized_query:
-            operation = "telegram.sessions_data_access"
-            if self.conv_log is None:
-                sel().log_api_access(
-                    caller=caller or "telegram",
-                    operation=operation,
-                    outcome="error",
-                    source="telegram",
-                    resources="0 sessions read (conversation log unavailable)",
-                )
-                await self._reply(chat_id, "Sessions unavailable.", thread=thread)
-                return
-            try:
-                found = await asyncio.to_thread(
-                    self.conv_log.search_sessions,
-                    query,
-                    SEARCH_FETCH_LIMIT,
-                )
-                rows = [
-                    row
-                    for row in found
-                    if isinstance(row, dict) and not is_incognito_transcript(row.get("memory_mode"))
-                ][:_SESSIONS_LIMIT]
-            except Exception as exc:
-                sel().log_api_access(
-                    caller=caller or "telegram",
-                    operation=operation,
-                    outcome="error",
-                    source="telegram",
-                    resources="0 sessions read (search failed)",
-                    error=display_safe(str(exc))[:200],
-                )
-                logger.exception("telegram: session search failed")
-                await self._reply(chat_id, "Sessions unavailable.", thread=thread)
-                return
-            sel().log_api_access(
-                caller=caller or "telegram",
-                operation=operation,
-                outcome="allowed",
-                source="telegram",
-                resources=f"{len(rows)} sessions read",
-            )
-        else:
-            rows = await collect_recent_sessions_audited(
-                self.sessions,
-                caller=caller or "telegram",
-                source="telegram",
-                limit=_SESSIONS_LIMIT,
-                with_messages=False,
-            )
-            if rows is None:
-                await self._reply(chat_id, "Sessions unavailable.", thread=thread)
-                return
-
-        query_label = display_safe(normalized_query)[:_SESSION_QUERY_CHARS]
-        if not rows:
-            if normalized_query:
-                await self._reply(
-                    chat_id,
-                    f"No conversations matched “{query_label}”. Try fewer words, "
-                    "or use /sessions to see the most recent conversations.",
-                    thread=thread,
-                )
-            else:
-                await self._reply(chat_id, "No recent conversations.", thread=thread)
-            return
-
-        if normalized_query:
-            lines = [f"🔎 Conversation search for “{query_label}”:"]
-        else:
-            lines = ["🧵 Recent conversations:"]
-        for row in rows:
-            key = str(row.get("key") or "")
-            if normalized_query:
-                logical_key = (
-                    history_dashboard_key(key) or self.sessions.channel_key_for_stem(key) or key
-                )
-                active = bool(logical_key and self.sessions.has_session(logical_key))
-            else:
-                active = bool(row["active"])
-            mark = "🟢" if active else "⚫"
-            title = redact(str(row.get("title") or key or "Untitled session"))[
-                :_SESSION_TITLE_CHARS
-            ]
-            agent = redact(str(row.get("agent") or "kirocrew"))[:_SESSION_AGENT_CHARS]
-            lines.append(f"{mark} {title} — {agent}")
-        lines.append("")
-        if normalized_query:
-            lines.append("Open one with /kirocrew dashboard.")
-        else:
-            lines.append("Search with /sessions <words>, or open one with /kirocrew dashboard.")
-        await self._reply(chat_id, "\n".join(lines), thread=thread)
-
-    async def _handle_title(self, route: tuple[str, str], chat_id: int, arg: str) -> None:
         """Rename this conversation, so the dashboard sidebar row is legible.
 
         Without this the title is frozen at the first 40 characters of the first
@@ -2135,7 +2161,7 @@ class TelegramDispatcher:
         # The rotated key, because a title is DURABLE: renaming the generation the
         # idle window has just retired leaves the next message in a different,
         # untitled session and the rename looks like it was lost.
-        titled_key = self._rotated_session_key(route)
+        titled_key = session_key or self._rotated_session_key(route)
         # A restricted session writes NOTHING, and a title is not an exception: the
         # metadata write CREATES the transcript file, so on a `/temporary` or
         # `/incognito` conversation this one command would persist user-authored
@@ -2187,7 +2213,13 @@ class TelegramDispatcher:
         await self._reply_markdown(chat_id, reply, thread=thread)
 
     async def _handle_spawn(
-        self, route: tuple[str, str], chat_id: int, arg: str, *, thread: int | None = None
+        self,
+        route: tuple[str, str],
+        chat_id: int,
+        arg: str,
+        *,
+        thread: int | None = None,
+        session_key: str | None = None,
     ) -> None:
         """Run a task in a background subagent, or list the running ones."""
         if self.subagent_manager is None:
@@ -2198,7 +2230,9 @@ class TelegramDispatcher:
         # Rotated: the subagent's completion arrives later and is routed by this
         # key, so binding it to a generation the next message abandons sends the
         # result to a conversation nobody is reading.
-        reply = spawn_task_reply(arg, self.subagent_manager, self._rotated_session_key(route))
+        reply = spawn_task_reply(
+            arg, self.subagent_manager, session_key or self._rotated_session_key(route)
+        )
         if reply is None:
             await self._reply(chat_id, "Usage: /spawn <task>  ·  /spawn list", thread=thread)
             return
@@ -2211,6 +2245,7 @@ class TelegramDispatcher:
         *,
         route: tuple[str, str],
         thread: int | None = None,
+        session_key: str | None = None,
     ) -> None:
         """Drive the task runner: ``run <spec>`` / ``status`` / ``cancel``.
 
@@ -2226,7 +2261,9 @@ class TelegramDispatcher:
         # Rotated, for the same reason as /spawn: the approval notice comes back
         # later and is routed by this key.
         reply = await task_arg_reply(
-            arg, self.task_runner, session_key=self._rotated_session_key(route)
+            arg,
+            self.task_runner,
+            session_key=session_key or self._rotated_session_key(route),
         )
         if reply is None:
             await self._reply(
@@ -2295,6 +2332,10 @@ class TelegramDispatcher:
             logger.info("telegram callback dropped: denied by channels governance policy")
             return
 
+        if data.startswith("s:"):
+            await self._session_resume.choose(self.client, cb)
+            return
+
         # Route the callback to the same conversation identity its turn used so
         # an approval/[OPTIONS:] press resolves against the correct session key:
         # a private press -> (direct, user_id); an allow-listed forum press ->
@@ -2321,7 +2362,13 @@ class TelegramDispatcher:
             rid, _, nonce = rest.rpartition(":")
             trust = flag == "t"
             approved = flag in ("1", "t")
-            session_key = self._session_key(route)
+            session_key = self._callback_session_key(
+                route,
+                cb.chat_id,
+                cb_thread,
+                cb.user_id,
+                cb.chat_type,
+            )
             key = TelegramApprovalDecider.key(session_key, rid)
             # Asked BEFORE the grant, because Trust is the one press with a side
             # effect that OUTLIVES the prompt: it auto-approves every later tool in
@@ -2381,13 +2428,12 @@ class TelegramDispatcher:
         # applying, and the wording that must not claim "expired" for a picker that
         # was simply used) is one decision, and two copies of it means a fix to
         # double-press or eviction handling reaches one picker.
-        for prefix, table, noun, command, apply, operation, resource in (
+        for prefix, table, noun, command, operation, resource in (
             (
                 "m:",
                 self._model_pickers,
                 "model",
                 "/model",
-                self._apply_model,
                 "telegram.set_model",
                 "model",
             ),
@@ -2396,7 +2442,6 @@ class TelegramDispatcher:
                 self._agent_pickers,
                 "agent",
                 "/agent",
-                self._apply_agent,
                 "telegram.set_agent",
                 "agent",
             ),
@@ -2407,7 +2452,39 @@ class TelegramDispatcher:
             if taken is None:
                 return
             picker, value, label = taken
-            outcome = await apply(picker.route, value)
+            if prefix == "m:":
+                current_target = self._callback_session_key(
+                    route,
+                    cb.chat_id,
+                    cb_thread,
+                    cb.user_id,
+                    cb.chat_type,
+                )
+                if not current_target or current_target != picker.session_key:
+                    sel().log_api_access(
+                        caller=str(cb.user_id) or "unknown",
+                        operation=operation,
+                        outcome="denied",
+                        source="telegram",
+                        resources=f"{resource}={label}",
+                        error="session_binding_changed",
+                    )
+                    await self.client.edit_message(
+                        cb.chat_id,
+                        cb.message_id,
+                        "⌛ This model list belongs to a session this chat no longer "
+                        "controls. Send /model again.",
+                        reply_markup={"inline_keyboard": []},
+                    )
+                    return
+                outcome = await self._apply_model(
+                    picker.route,
+                    value,
+                    picker.session_key,
+                    store_route_preference=picker.store_route_preference,
+                )
+            else:
+                outcome = await self._apply_agent(picker.route, value)
             sel().log_api_access(
                 caller=str(cb.user_id) or "unknown",
                 operation=operation,
@@ -2488,6 +2565,24 @@ class TelegramDispatcher:
             )
 
     # ── Helpers ────────────────────────────────────────────────────────────
+
+    def _callback_session_key(
+        self,
+        route: tuple[str, str],
+        chat_id: int,
+        thread_id: int | None,
+        user_id: int,
+        chat_type: str,
+    ) -> str:
+        """The current callback target, or ``""`` when routing is unsafe."""
+        resolution = self._session_resume.resolve_inbound(chat_id, thread_id)
+        if resolution.ambiguous:
+            return ""
+        if resolution.key is not None and not self._session_resume.is_owner(
+            user_id, chat_id, chat_type
+        ):
+            return ""
+        return resolution.key or self._session_key(route)
 
     def _authorized(self, user_id: int) -> bool:
         # Deny-by-default (callbacks bypass transport.receive, so re-check here).
@@ -2719,24 +2814,8 @@ class TelegramDispatcher:
         )
 
     def _origin_mirror_link(self, route: tuple[str, str], chat_id: int) -> ChannelLink:
-        """The mirror location for the chat a conversation is being read in.
-
-        One definition shared by the automatic bind, ``/link`` and ``/unlink``:
-        an unlink matches an occupied location by VALUE, so a second spelling of
-        "this chat" would let the release miss the binding the bind wrote.
-
-        Carries the forum Topic so dashboard-mirrored replies for a forum-linked
-        session thread back into the SAME Topic (via
-        ``_deliver_cross_surface_reply``'s ``thread_id=link.thread_id``), not the
-        supergroup General. ``None`` only for a DM — an authorized forum turn
-        always carries a Topic, General being denied at the gate.
-        """
-        topic = self._route_thread(route)
-        return ChannelLink(
-            "telegram",
-            channel_id=str(chat_id),
-            thread_id=(str(topic) if topic is not None else None),
-        )
+        """The one Telegram conversation spelling shared by mirror and resume paths."""
+        return self._session_resume.link_for(chat_id, self._route_thread(route))
 
     def _bind_origin_mirror(self, session_key: str, route: tuple[str, str], chat_id: int) -> None:
         """Mirror this conversation's dashboard tab back to Telegram, unasked.
@@ -2757,7 +2836,13 @@ class TelegramDispatcher:
             location=self._origin_mirror_link(route, chat_id),
         )
 
-    async def _handle_link(self, route: tuple[str, str], chat_id: int) -> None:
+    async def _handle_link(
+        self,
+        route: tuple[str, str],
+        chat_id: int,
+        *,
+        resumed_key: str | None = None,
+    ) -> None:
         """Re-enable mirroring of this conversation's dashboard tab back here.
 
         The rebind sequence, its batching and its reply live in the shared
@@ -2767,21 +2852,51 @@ class TelegramDispatcher:
         of the unlink command.
         """
         assert self.client is not None
+        thread = self._route_thread(route)
+        if resumed_key is not None:
+            await self._reply(
+                chat_id,
+                "⚠️ A resumed session is active here. Send /unlink first.",
+                thread=thread,
+            )
+            return
         # Through the shared helper, which owns the claim-before-withdrawal
         # ordering and the single batched write. The key is ROTATED: a mirror
         # binding is DURABLE and re-read on the next inbound turn, so writing it
         # against a generation the idle window has retired would leave the very
         # next message unlinked again.
-        reply = rebind_conversation_location(
-            self.sessions,
-            key=self._rotated_session_key(route),
-            location=self._origin_mirror_link(route, chat_id),
-            unlink_command="/unlink",
-        )
-        await self._reply(chat_id, reply, thread=self._route_thread(route))
+        try:
+            reply = rebind_conversation_location(
+                self.sessions,
+                key=self._rotated_session_key(route),
+                location=self._origin_mirror_link(route, chat_id),
+                unlink_command="/unlink",
+            )
+        except ConversationOwnershipConflict:
+            logger.info("telegram link refused: conversation already held")
+            await self._reply(
+                chat_id,
+                "⚠️ Another session is already linked here. Send /unlink first.",
+                thread=thread,
+            )
+            return
+        await self._reply(chat_id, reply, thread=thread)
 
     async def _handle_unlink(self, route: tuple[str, str], chat_id: int) -> None:
         assert self.client is not None
+        thread = self._route_thread(route)
+        try:
+            left_resumed = await self._session_resume.leave_resumed_session(chat_id, thread)
+        except ResumeReleaseError:
+            await self._reply(chat_id, _RELEASE_FAILURE, thread=thread)
+            return
+        if left_resumed is not None:
+            await self._reply(
+                chat_id,
+                "✅ Left the resumed session. Back to your Telegram conversation.",
+                thread=thread,
+            )
+            return
         # Rotated, for the same reason as /link: the opt-out is durable and is
         # re-read per turn, so it has to land on the key the next turn will use.
         key = self._rotated_session_key(route)
@@ -2807,37 +2922,48 @@ class TelegramDispatcher:
         reply_text: str,
         is_new: bool,
         agent: str | None = None,
+        mirror_mids: tuple[str, str] | None = None,
     ) -> None:
-        """Record the turn to conversation_log (dashboard visibility + restart)."""
-        if self.conv_log is None:
+        """Persist one atomic turn, deduplicating rows already projected live."""
+        if self.conv_log is None or privacy_mode.is_restricted(session_key):
             return
-        # The privacy modes' central promise: an incognito or temporary
-        # conversation writes no transcript. Checked HERE rather than at each
-        # caller because this is the only writer, so one gate covers the turn, the
-        # drained queue and the steered continuation alike.
-        if privacy_mode.is_restricted(session_key):
-            return
-        self.conv_log.append(session_key, "user", user_text, agent=agent, mid=mint_row_mid())
-        if reply_text:
-            self.conv_log.append(
-                session_key, "assistant", reply_text, agent=agent, mid=mint_row_mid()
-            )
-        if is_new and not auto_title.is_titled(session_key):
-            # Skipped when auto-title has CLAIMED this session, because the two
-            # writers race and the loser is always the generated one: the fallback
-            # runs first (it is synchronous, on the turn), and
-            # ``_record_is_untitled`` then refuses the generated title because the
-            # record already has one. The effect is not a cosmetic downgrade — it
-            # makes auto-titling inert on this channel while still spending a
-            # background turn per conversation to produce a name nobody sees.
-            #
-            # The claim, not the completion, is the right thing to check: a claimed
-            # session is one where a name is on its way, and if that turn fails
-            # ``maybe_auto_title`` releases the claim so the next exchange retries.
-            # A conversation that is briefly untitled is a better outcome than one
-            # permanently named after its first forty characters.
-            title = (user_text or "").strip().replace("\n", " ")[:40] or "Telegram"
-            self.conv_log.set_title(session_key, title)
+        with self.conv_log.atomic_appends(session_key):
+            if mirror_mids is not None:
+                user_mid, assistant_mid = mirror_mids
+                self.conv_log.append_if_absent(
+                    session_key,
+                    "user",
+                    user_text,
+                    agent=agent,
+                    mid=user_mid,
+                )
+                if reply_text:
+                    self.conv_log.append_if_absent(
+                        session_key,
+                        "assistant",
+                        reply_text,
+                        agent=agent,
+                        mid=assistant_mid,
+                    )
+            else:
+                self.conv_log.append(
+                    session_key,
+                    "user",
+                    user_text,
+                    agent=agent,
+                    mid=mint_row_mid(),
+                )
+                if reply_text:
+                    self.conv_log.append(
+                        session_key,
+                        "assistant",
+                        reply_text,
+                        agent=agent,
+                        mid=mint_row_mid(),
+                    )
+            if is_new and not auto_title.is_titled(session_key):
+                title = (user_text or "").strip().replace("\n", " ")[:40] or "Telegram"
+                self.conv_log.set_title(session_key, title)
 
     async def _maybe_notice(
         self, chat_id: int, route: tuple[str, str], session_key: str, provider: Any
@@ -2865,7 +2991,13 @@ class TelegramDispatcher:
                 thread=self._route_thread(route),
             )
 
-    async def _handle_compact(self, route: tuple[str, str], chat_id: int) -> None:
+    async def _handle_compact(
+        self,
+        route: tuple[str, str],
+        chat_id: int,
+        *,
+        session_key: str | None = None,
+    ) -> None:
         """In-place ACP ``/compact`` on the user's session (mirrors Slack).
 
         Holds the per-session semaphore for the WHOLE compaction. Each Telegram
@@ -2877,12 +3009,12 @@ class TelegramDispatcher:
         turn is already in flight); the ``finally`` always releases it.
         """
         assert self.client is not None
-        session_key = self._session_key(route)
+        target_key = session_key or self._session_key(route)
         thread = self._route_thread(route)
         # Atomically take the turn semaphore, or refuse. Distinguish "busy" (a
         # turn is streaming) from "no session yet" for the user-facing note.
-        if not await self.sessions.try_acquire(session_key):
-            if self.sessions.has_session(session_key):
+        if not await self.sessions.try_acquire(target_key):
+            if self.sessions.has_session(target_key):
                 await self._reply(
                     chat_id,
                     "⏳ Still working on your last message — try /compact once it finishes.",
@@ -2892,7 +3024,7 @@ class TelegramDispatcher:
                 await self._reply(chat_id, "No active session to compact.", thread=thread)
             return
         try:
-            provider = self.sessions.get_provider(session_key)
+            provider = self.sessions.get_provider(target_key)
             if provider is None:
                 await self._reply(chat_id, "No active session to compact.", thread=thread)
                 return
@@ -2931,7 +3063,7 @@ class TelegramDispatcher:
                 else:
                     result_text = "⚠️ Compaction timed out."
             except Exception:
-                logger.warning("Telegram /compact failed for %s", session_key, exc_info=True)
+                logger.warning("Telegram /compact failed for %s", target_key, exc_info=True)
                 result_text = "❌ Compaction failed unexpectedly."
                 # Drop the wedged native conversation, NOT the session's channel
                 # identity: the map entry carries the mirror binding, so a full
@@ -2939,7 +3071,7 @@ class TelegramDispatcher:
                 # Housekeeping never unlinks (see ``SessionMap.prune`` and
                 # ``SessionManager._recycle_held``).
                 try:
-                    await self.sessions.discard_conversation(session_key)
+                    await self.sessions.discard_conversation(target_key)
                 except Exception:
                     logger.debug("Telegram: discard after compact failure failed", exc_info=True)
 
@@ -2951,4 +3083,4 @@ class TelegramDispatcher:
         finally:
             # Always release the semaphore we took. No-op if the except path
             # already tore the session down (release() looks up by key).
-            self.sessions.release(session_key)
+            self.sessions.release(target_key)

--- a/src/kiro_crew/webex/transport_dispatch.py
+++ b/src/kiro_crew/webex/transport_dispatch.py
@@ -824,8 +824,9 @@ class WebexDispatcher:
 
         Deliberately not a dashboard-session picker: resuming one of those needs
         the durable resume-expectation store and an inbound path that resolves the
-        mirror binding, which is why ``supports_session_resume`` is Discord-only
-        and the capability ledger pins it that way.
+        mirror binding. Webex implements neither and therefore leaves
+        ``supports_session_resume`` false; Discord and Telegram are the shipped
+        transports that currently declare it.
         """
         if self.conv_log is None:
             await self._reply(inbound, "ℹ️ Conversation history is not available.")

--- a/test/chat_test_helpers.py
+++ b/test/chat_test_helpers.py
@@ -136,24 +136,50 @@ def _make_state(tmp_path, **kwargs):
     # drain's mirror-retarget comparison reads the link's identity fields, so a
     # bare tuple would make every mirror identical).
     _mirror_links: dict[str, ChannelLink] = {}
+    #: Keys whose binding accepts INBOUND messages, so ``find_mirror_sessions``
+    #: can answer the ``inbound_only`` question the resume paths ask.
+    _inbound_keys: set[str] = set()
 
-    def _set_mirror_link(key, channel_id, thread_ts):
+    def _set_mirror_link(key, channel_id=None, thread_ts=None, *, accepts_inbound=False, reason=""):
+        # Two shapes reach this double. Production is
+        # ``(key, ChannelLink, *, accepts_inbound, reason)``; the Slack-era callers
+        # in these tests pass ``(key, channel_id, thread_ts)``. Accepting both is
+        # what lets ONE double serve every mirror path — without the keyword-only
+        # arguments the channel-neutral link endpoint raises TypeError, which
+        # surfaces as a 500 and hides whatever the test was actually asserting.
+        if isinstance(channel_id, ChannelLink):
+            _mirror_links[key] = channel_id
+            if accepts_inbound:
+                _inbound_keys.add(key)
+            else:
+                _inbound_keys.discard(key)
+            return
         if channel_id or thread_ts:
             _mirror_links[key] = ChannelLink(
                 channel_type="slack", channel_id=channel_id, thread_id=thread_ts
             )
         else:
             _mirror_links.pop(key, None)
+            _inbound_keys.discard(key)
 
     def _get_mirror_link(key):
         return _mirror_links.get(key)
 
-    def _clear_mirror_link(key):
+    def _clear_mirror_link(key, *, reason=""):
+        _inbound_keys.discard(key)
         return _mirror_links.pop(key, None) is not None
+
+    def _find_mirror_sessions(link, *, inbound_only=False):
+        return [
+            key
+            for key, candidate in _mirror_links.items()
+            if candidate == link and (not inbound_only or key in _inbound_keys)
+        ]
 
     sessions.set_mirror_link = MagicMock(side_effect=_set_mirror_link)
     sessions.get_mirror_link = MagicMock(side_effect=_get_mirror_link)
     sessions.clear_mirror_link = MagicMock(side_effect=_clear_mirror_link)
+    sessions.find_mirror_sessions = MagicMock(side_effect=_find_mirror_sessions)
     state = DashboardState(
         sessions=sessions,
         crons=MagicMock(list_jobs=MagicMock(return_value=[]), status=MagicMock(return_value={})),

--- a/test/test_capability_ledger.py
+++ b/test/test_capability_ledger.py
@@ -298,10 +298,10 @@ class TestSessionResumeIsDeclaredOnlyWhereItIsHonoured:
     A dashboard connect on a transport declaring it marks the binding
     ``accepts_inbound``, and the slot row then reports ``direction: both`` — the
     dashboard is telling the user that replies come back here. That is only true
-    where the transport's inbound path resolves the mirror binding. Discord's
-    does (``DiscordSessionResume.resumed_session``); every other transport builds
-    a session key from the route alone and never looks the binding up, so a reply
-    there runs in a SEPARATE session with none of this conversation's history.
+    where the transport's inbound path resolves the mirror binding. Discord and
+    Telegram do; every other transport builds a session key from the route alone
+    and never looks the binding up, so a reply there runs in a SEPARATE session
+    with none of this conversation's history.
 
     This pins the current set. A new transport declaring the flag fails here, and
     that is the point: the author has to come and confirm its inbound path really
@@ -316,12 +316,19 @@ class TestSessionResumeIsDeclaredOnlyWhereItIsHonoured:
             "would silently become outbound-only and replies would stop resuming"
         )
 
+    def test_telegram_declares_it(self) -> None:
+        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
+
+        assert TELEGRAM_CAPABILITIES.supports_session_resume is True, (
+            "Telegram stopped declaring session resume even though its dispatcher "
+            "resolves the durable mirror binding before routing inbound messages"
+        )
+
     def test_no_other_transport_declares_it(self) -> None:
         from kiro_crew.feishu.transport import FEISHU_CAPABILITIES
         from kiro_crew.imessage.transport import IMESSAGE_CAPABILITIES
         from kiro_crew.slack.transport import SLACK_CAPABILITIES
         from kiro_crew.teams.transport import TEAMS_CAPABILITIES
-        from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES
         from kiro_crew.webex.transport import WEBEX_CAPABILITIES
         from kiro_crew.wecom.transport import WECOM_CAPABILITIES
         from kiro_crew.weixin.transport import WEIXIN_CAPABILITIES
@@ -330,7 +337,6 @@ class TestSessionResumeIsDeclaredOnlyWhereItIsHonoured:
         others = {
             "slack": SLACK_CAPABILITIES,
             "teams": TEAMS_CAPABILITIES,
-            "telegram": TELEGRAM_CAPABILITIES,
             "webex": WEBEX_CAPABILITIES,
             "wecom": WECOM_CAPABILITIES,
             "weixin": WEIXIN_CAPABILITIES,
@@ -342,9 +348,9 @@ class TestSessionResumeIsDeclaredOnlyWhereItIsHonoured:
         assert claiming == [], (
             f"{claiming} declare session resume, but their inbound paths derive a "
             "session key from the route and never resolve the mirror binding — the "
-            "dashboard would promise a two-way link that drops replies. Slack is "
-            "separate: it routes inbound through its own thread index and never "
-            "sets `accepts_inbound`."
+            "dashboard would promise a two-way link that drops replies. Discord and "
+            "Telegram are tested positively above; Slack is separate because it routes "
+            "inbound through its own thread index and never sets `accepts_inbound`."
         )
 
     def test_the_default_is_off(self) -> None:

--- a/test/test_channel_row_identity.py
+++ b/test/test_channel_row_identity.py
@@ -270,6 +270,131 @@ class TestDiscordMirroredBranchStaysIdempotent:
         assert len(set(mids)) == 2
 
 
+class TestTelegramResumedDurability:
+    @staticmethod
+    def _telegram_cls():
+        module = __import__("kiro_crew.telegram.transport_dispatch", fromlist=["_"])
+        return _dispatcher_class(module)
+
+    @staticmethod
+    def _state_and_slot(tmp_path):
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot(
+            name="chat-1",
+            linked_session_key="dashboard:chat-1",
+        )
+        return state, slot
+
+    @pytest.mark.parametrize("save_first", [True, False], ids=["save-first", "write-first"])
+    def test_projected_pair_is_exactly_once_under_both_writer_orderings(
+        self, tmp_path, save_first
+    ) -> None:
+        from kiro_crew.dashboard.chat_persistence import _save_slot_to_history
+
+        state, slot = self._state_and_slot(tmp_path)
+        key = "dashboard:chat-1"
+        project = getattr(channel_slots, "project_channel_turn_live")
+        mids = project(state, key, "hello", "world", broadcast_user=True)
+        assert mids is not None
+
+        if save_first:
+            assert _save_slot_to_history(state, slot, force=True)
+        self._telegram_cls()._persist_turn(
+            SimpleNamespace(conv_log=state.conversation_log),
+            key,
+            "hello",
+            "world",
+            False,
+            agent="research-agent",
+            mirror_mids=mids,
+        )
+        if not save_first:
+            assert _save_slot_to_history(state, slot, force=True)
+
+        rows = _rows_on_disk(state.conversation_log, key)
+        assert [(row["role"], row["content"]) for row in rows] == [
+            ("user", "hello"),
+            ("assistant", "world"),
+        ]
+        assert [row_mid(row) for row in rows] == list(mids)
+
+    @pytest.mark.parametrize(
+        "mirror_mids, expected_method",
+        [
+            pytest.param(None, "append", id="no-live-slot"),
+            pytest.param(
+                ("m-1111111111111111", "m-2222222222222222"),
+                "append_if_absent",
+                id="projected-slot",
+            ),
+        ],
+    )
+    def test_durable_pair_is_atomic_and_uses_the_right_write_path(
+        self, mirror_mids, expected_method
+    ) -> None:
+        from contextlib import contextmanager
+
+        class _AtomicLog:
+            def __init__(self) -> None:
+                self.depth = 0
+                self.calls: list[tuple[str, str, str]] = []
+
+            @contextmanager
+            def atomic_appends(self, key: str):
+                self.depth += 1
+                try:
+                    yield
+                finally:
+                    self.depth -= 1
+
+            def append(
+                self,
+                key: str,
+                role: str,
+                content: str,
+                *,
+                agent: str | None = None,
+                mid: str | None = None,
+            ) -> None:
+                assert self.depth == 1
+                self.calls.append(("append", role, mid or ""))
+
+            def append_if_absent(
+                self,
+                key: str,
+                role: str,
+                content: str,
+                *,
+                agent: str | None = None,
+                mid: str | None = None,
+            ) -> bool:
+                assert self.depth == 1
+                self.calls.append(("append_if_absent", role, mid or ""))
+                return True
+
+            def set_title(self, key: str, title: str) -> None:
+                assert self.depth == 1
+
+        log = _AtomicLog()
+        self._telegram_cls()._persist_turn(
+            SimpleNamespace(conv_log=log),
+            "dashboard:chat-1",
+            "hello",
+            "world",
+            False,
+            agent="research-agent",
+            mirror_mids=mirror_mids,
+        )
+
+        assert [method for method, _role, _mid in log.calls] == [
+            expected_method,
+            expected_method,
+        ]
+        assert [role for _method, role, _mid in log.calls] == ["user", "assistant"]
+        assert all(mid for _method, _role, mid in log.calls)
+        assert len({mid for _method, _role, mid in log.calls}) == 2
+
+
 class TestIdentitySurvivesMaterialization:
     """The load-bearing half: a persisted id is PRESERVED, not re-minted.
 

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -137,7 +137,12 @@ def _caps_transport(channel_type: str, **overrides):
 def _prep(tmp_path, monkeypatch):
     monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
     state = _make_state(tmp_path)
-    state.sessions.get_mirror_link = MagicMock(return_value=None)
+    # ``get_mirror_link`` is deliberately NOT stubbed to a constant None here. The
+    # shared double is dict-backed and already answers None while nothing is bound,
+    # so a constant made reads disagree with writes — the endpoint's own
+    # claim-then-release logic reads this accessor, and a stub that never sees the
+    # claim turned the release into a silent no-op that tests could not observe.
+    # Individual tests still override it where they need a specific answer.
     state.sessions.get_slack_link = MagicMock(return_value=(None, None))
     state.get_or_create_slot("s1")
     state.push_slots_update = MagicMock()
@@ -257,7 +262,11 @@ class TestMirrorLink:
         # test. Without this, a denial at the very first gate would produce the
         # same 403 and the same unpersisted link.
         assert transport.send_message.await_count >= 1
-        state.sessions.set_mirror_link.assert_not_called()
+        # The claim is taken BEFORE the announcement (an inbound reply arriving in
+        # the delivery window would otherwise run in the channel's native
+        # session), so the invariant is not "never written" but "does not
+        # SURVIVE": the denial releases it.
+        assert state.sessions.get_mirror_link("dashboard:s1") is None
         state = _prep(tmp_path, monkeypatch)
         async with TestClient(TestServer(_make_mirror_app(state))) as client:
             resp = await client.post(
@@ -1109,8 +1118,9 @@ class TestMirrorLinkEdgeCases:
             assert resp.status == 403
             assert (await resp.json())["code"] == "channel_not_permitted"
 
-        # The link must NOT be persisted.
-        state.sessions.set_mirror_link.assert_not_called()
+        # No binding may SURVIVE. The claim is taken before the announcement, so
+        # this denial releases it rather than never writing it.
+        assert state.sessions.get_mirror_link("dashboard:s1") is None
         # The initial announcement must NOT have been sent either.
         transport.send_message.assert_not_awaited()
 
@@ -1367,8 +1377,11 @@ class TestMirrorBackfillFidelity:
     ):
         """The 200 must not be returned before the seeding is delivered.
 
-        This is the property that forbids backgrounding this path: the mirror
-        link is persisted only after every unit has cleared governance.
+        This is the property that forbids backgrounding this path. The observable
+        is the ORDER of the sends against the response, not the position of the
+        persist: the binding is now claimed BEFORE the announcement, because an
+        inbound reply arriving during a multi-second backfill would otherwise run
+        in the channel's native session.
         """
         state, transport = self._linked(tmp_path, monkeypatch)
         slot = state.get_or_create_slot("s1")
@@ -1384,16 +1397,220 @@ class TestMirrorBackfillFidelity:
             return await original_send(*args, **kwargs)
 
         transport.send_message = _tracked_send
-        state.sessions.set_mirror_link = MagicMock(
-            side_effect=lambda *a, **k: order.append("persist")
-        )
+        real_set = state.sessions.set_mirror_link
+
+        def _tracked_set(*a, **k):
+            order.append("persist")
+            return real_set(*a, **k)
+
+        state.sessions.set_mirror_link = MagicMock(side_effect=_tracked_set)
 
         await self._link(state)
         assert "persist" in order, "link was never persisted"
-        assert (
-            order.index("persist") == len(order) - 1
-        ), "the link was persisted before delivery finished"
+        # Claimed first, so every send follows it — and the request did not return
+        # until they had all gone out, which is what "inline" means here.
+        assert order.index("persist") == 0, "the claim must precede the announcement"
         assert order.count("send") >= 3, "announcement + both messages should have been sent"
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_opt_out_is_left_alone_on_rollback(self, tmp_path, monkeypatch):
+        """A failed READ must not mutate state.
+
+        Defaulting the snapshot to False would let the rollback clear a standing
+        refusal to mirror that the user set deliberately — a read failure silently
+        changing a preference.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", session_resume=True)
+        state.register_channel_transport(transport)
+        state.sessions.mirror_opt_out = MagicMock(side_effect=OSError("unreadable"))
+        state.sessions.set_mirror_opt_out = MagicMock()
+        transport.send_message = AsyncMock(side_effect=RuntimeError("transport died"))
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 502
+
+        # The claim withdrew it, but the rollback must not GUESS a value to restore.
+        restored = [
+            call
+            for call in state.sessions.set_mirror_opt_out.call_args_list
+            if call.args[1] is True
+        ]
+        assert not restored, "the rollback invented an opt-out value it never read"
+        assert state.sessions.get_mirror_link("dashboard:s1") is None
+
+    @pytest.mark.asyncio
+    async def test_a_claim_that_cannot_persist_leaves_no_live_binding(self, tmp_path, monkeypatch):
+        """A batch writes on the way OUT, so a failed write leaves live-but-undurable.
+
+        The in-memory map is already mutated when the write fails, so without this
+        the request 500s while inbound routing resolves a binding that no restart
+        can recover.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", session_resume=True)
+        state.register_channel_transport(transport)
+        real_batched_save = state.sessions.batched_save
+        failed: list[bool] = []
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _batch_that_fails_on_exit():
+            with real_batched_save():
+                yield
+            if not failed:
+                failed.append(True)
+                raise OSError("disk full")
+
+        state.sessions.batched_save = _batch_that_fails_on_exit
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 502
+            assert (await resp.json())["code"] == "channel_link_failed"
+
+        assert failed, "the write failure was never simulated"
+        assert state.sessions.get_mirror_link("dashboard:s1") is None
+        assert transport.send_message.await_count == 0, "nothing may be announced"
+
+    @pytest.mark.asyncio
+    async def test_a_refused_claim_does_not_withdraw_the_opt_out(self, tmp_path, monkeypatch):
+        """A conflict must leave no trace, including the standing mirror refusal.
+
+        ``set_mirror_link`` refuses before mutating, so ordering it ahead of the
+        opt-out withdrawal is what keeps a refused link from flipping a preference
+        the user set deliberately.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", session_resume=True)
+        state.register_channel_transport(transport)
+
+        from kiro_crew.session_map import ConversationOwnershipConflict
+
+        state.sessions.set_mirror_link = MagicMock(
+            side_effect=ConversationOwnershipConflict("taken")
+        )
+        state.sessions.set_mirror_opt_out = MagicMock()
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 409
+            assert (await resp.json())["code"] == "conversation_occupied"
+
+        state.sessions.set_mirror_opt_out.assert_not_called()
+        assert transport.send_message.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_rebind_during_delivery_survives_a_failed_link(self, tmp_path, monkeypatch):
+        """The rollback must not restore stale state over a newer binding.
+
+        Claiming first means a failure has something to undo — but between the
+        claim and the failure another writer may have rebound the session, and it
+        takes no lock of ours. The undo is therefore conditional: it fires only
+        while the binding is still this request's own claim.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", session_resume=True)
+        state.register_channel_transport(transport)
+        rival = ChannelLink(channel_type="telegram", channel_id="999", thread_id=None)
+        at_send: list[Any] = []
+
+        async def _rebind_then_fail(*args, **kwargs):
+            # What the claim looks like at the first send — this is the invariant
+            # the whole reorder exists for.
+            at_send.append(state.sessions.get_mirror_link("dashboard:s1"))
+            # A concurrent writer takes the session while the announcement is in
+            # flight, then this delivery fails.
+            state.sessions.set_mirror_link("dashboard:s1", rival, accepts_inbound=True)
+            raise RuntimeError("transport died")
+
+        transport.send_message = _rebind_then_fail
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 502
+
+        assert at_send, "the announcement was never attempted"
+        assert at_send[0] is not None, "the claim was not in place before the first send"
+        observed = state.sessions.get_mirror_link("dashboard:s1")
+        assert observed == rival, f"rollback overwrote a newer binding; observed {observed!r}"
+
+    @pytest.mark.asyncio
+    async def test_a_failed_link_releases_its_own_claim(self, tmp_path, monkeypatch):
+        """Non-vacuity: with no rival, the claim really is released."""
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", session_resume=True)
+        state.register_channel_transport(transport)
+        transport.send_message = AsyncMock(side_effect=RuntimeError("transport died"))
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 502
+
+        assert state.sessions.get_mirror_link("dashboard:s1") is None
+
+    @pytest.mark.asyncio
+    async def test_a_reply_during_the_backfill_resolves_the_dashboard_session(
+        self, tmp_path, monkeypatch
+    ):
+        """The window this ordering exists to close.
+
+        The notice says "continuing here", then the catch-up transcript goes out
+        one message at a time against the transport's rate limit — seconds, not an
+        instant. A reply arriving in that window must already resolve THIS session;
+        with the claim taken last it resolved nothing and ran in the channel's
+        native session, which is the one the notice said the user had left.
+        """
+        state = _prep(tmp_path, monkeypatch)
+        transport = _fake_transport("telegram", session_resume=True)
+        state.register_channel_transport(transport)
+        slot = state.get_or_create_slot("s1")
+        slot.append("user", "one")
+        slot.append("assistant", "two")
+        slot.drain()
+
+        link = ChannelLink(channel_type="telegram", channel_id="123", thread_id=None)
+        resolved_mid_delivery: list[list[str]] = []
+        original_send = transport.send_message
+
+        async def _probe_send(*args, **kwargs):
+            # Asked at every send, INCLUDING the first (the announcement), which is
+            # the earliest moment a user could possibly reply.
+            resolved_mid_delivery.append(
+                state.sessions.find_mirror_sessions(link, inbound_only=True)
+            )
+            return await original_send(*args, **kwargs)
+
+        transport.send_message = _probe_send
+
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+
+        assert resolved_mid_delivery, "nothing was delivered, so the window was never observed"
+        assert all(
+            owners == ["dashboard:s1"] for owners in resolved_mid_delivery
+        ), f"the binding was not resolvable during delivery: {resolved_mid_delivery}"
 
 
 class TestInboundClaimFollowsTheCapability:
@@ -1534,7 +1751,6 @@ class TestInboundClaimFollowsTheCapability:
         monkeypatch.setattr("kiro_crew.platform.governance_profiles.governance_permits", _permits)
         state = _prep(tmp_path, monkeypatch)
         state.register_channel_transport(transport)
-        state.sessions.set_mirror_link = MagicMock()
         slot = state.get_or_create_slot("s1")
         slot.messages.extend(
             [
@@ -1550,7 +1766,11 @@ class TestInboundClaimFollowsTheCapability:
             )
             assert resp.status == 403
 
-        state.sessions.set_mirror_link.assert_not_called()
+        # The claim is taken before delivery, so the guarantee is that no binding —
+        # and in particular no INBOUND one — survives the denial.
+        assert state.sessions.get_mirror_link("dashboard:s1") is None
+        link = ChannelLink(channel_type="discord", channel_id="123", thread_id=None)
+        assert state.sessions.find_mirror_sessions(link, inbound_only=True) == []
 
     @pytest.mark.asyncio
     async def test_the_precheck_asks_the_writers_exact_question(self, tmp_path, monkeypatch):

--- a/test/test_chat_mirror.py
+++ b/test/test_chat_mirror.py
@@ -1418,20 +1418,35 @@ class TestInboundClaimFollowsTheCapability:
         assert state.sessions.set_mirror_link.call_args.kwargs["accepts_inbound"] is True
 
     @pytest.mark.asyncio
-    async def test_a_transport_that_cannot_resume_stays_outbound_only(self, tmp_path, monkeypatch):
-        """Degrade, never over-promise.
-
-        Telegram builds its session key from the route and never consults the
-        binding, so claiming inbound would not make replies come back — it would
-        only make the slot row say they do.
-        """
+    async def test_target_policy_can_keep_capable_transport_outbound_only(
+        self, tmp_path, monkeypatch
+    ):
+        transport = _fake_transport("telegram", session_resume=True)
+        transport.may_resume_from = MagicMock(return_value=False)
         state = _prep(tmp_path, monkeypatch)
-        state.register_channel_transport(_fake_transport("telegram", session_resume=False))
+        state.register_channel_transport(transport)
         state.sessions.set_mirror_link = MagicMock()
+
         async with TestClient(TestServer(_make_mirror_app(state))) as client:
             resp = await client.post(
                 "/api/chat/slots/s1/mirror-link",
                 json={"channel_type": "telegram", "target_id": "user:123"},
+            )
+            assert resp.status == 200
+
+        transport.may_resume_from.assert_called_once_with("123", None)
+        assert state.sessions.set_mirror_link.call_args.kwargs["accepts_inbound"] is False
+
+    @pytest.mark.asyncio
+    async def test_a_transport_that_cannot_resume_stays_outbound_only(self, tmp_path, monkeypatch):
+        """A transport without an inbound resolver must never receive the marker."""
+        state = _prep(tmp_path, monkeypatch)
+        state.register_channel_transport(_fake_transport("synthetic", session_resume=False))
+        state.sessions.set_mirror_link = MagicMock()
+        async with TestClient(TestServer(_make_mirror_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/mirror-link",
+                json={"channel_type": "synthetic", "target_id": "user:123"},
             )
             assert resp.status == 200
         assert state.sessions.set_mirror_link.call_args.kwargs["accepts_inbound"] is False

--- a/test/test_discord_outbound_files.py
+++ b/test/test_discord_outbound_files.py
@@ -290,7 +290,9 @@ class TestRestrictedGate:
     def test_no_live_slot_falls_through_to_the_persisted_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from kiro_crew.messaging import upload_gate as ug
         monkeypatch.setattr(
-            ug, "_persisted_mode_is_restricted", lambda key, probe: key == "dashboard:ghost"
+            ug,
+            "_persisted_mode_is_restricted",
+            lambda key, probe, unknown_denies=True: key == "dashboard:ghost",
         )
         assert _restricted("dashboard:ghost") is True
         assert _restricted("dashboard:kept") is False

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -682,24 +682,35 @@ async def test_binding_claimed_during_header_edit_is_not_overwritten() -> None:
 
 @pytest.mark.asyncio
 async def test_resumed_turn_lands_in_live_dashboard_window() -> None:
-    """A resumed turn must enter the OPEN slot's window, not just disk.
-
-    The dashboard save writes meta + frozen prefix + its own window + foreign
-    tail. A disk-only append made before a later dashboard turn is therefore
-    re-serialized AFTER it and the transcript reads back out of order. Landing
-    the turn in the live window keeps it inside the region the save
-    re-serializes. Mirrors dashboard/cron_inject.py.
-    """
+    """A resumed turn is projected user-first without a new user-row broadcast."""
     log = _log()
     log.messages["dashboard:chat-1"] = [{"role": "assistant", "content": "prior"}]
     dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    durable: list[tuple[str, str, str]] = []
+
+    def _append_if_absent(
+        key: str,
+        role: str,
+        content: str,
+        *,
+        agent: str | None = None,
+        mid: str | None = None,
+    ) -> None:
+        durable.append((role, content, mid or ""))
+
+    log.append_if_absent = _append_if_absent  # type: ignore[attr-defined]
 
     class _Slot:
         def __init__(self) -> None:
-            self.messages: list[tuple[str, str]] = []
+            self.messages: list[dict[str, Any]] = []
+            self.broadcasts: list[tuple[str, bool]] = []
 
-        def append(self, role: str, content: str, cls: str = "", **kw: Any) -> None:
-            self.messages.append((role, content))
+        def append(self, role: str, content: str, cls: str = "", **kw: Any) -> dict[str, Any]:
+            mid = f"m-{len(self.messages) + 1:016x}"
+            row = {"role": role, "content": content, "meta": {"mid": mid}}
+            self.messages.append(row)
+            self.broadcasts.append((role, bool(kw.get("broadcast_user"))))
+            return row
 
     class _State:
         def __init__(self) -> None:
@@ -718,13 +729,20 @@ async def test_resumed_turn_lands_in_live_dashboard_window() -> None:
     await dispatcher.handle_message(_message("!sessions"))
     custom_id, message_id = _picker_button(client)
     await dispatcher.on_interaction(_interaction(custom_id, message_id))
+    pushes_before_turn = state.pushes
     await dispatcher.handle_message(_message("continue here"))
 
     assert sessions.last_key == "dashboard:chat-1"
-    roles = [r for r, _ in state.slot.messages]
-    assert roles == ["user", "assistant"], state.slot.messages
-    assert state.slot.messages[0][1] == "continue here"
-    assert state.pushes >= 1
+    assert [(row["role"], row["content"]) for row in state.slot.messages] == [
+        ("user", "continue here"),
+        ("assistant", "Answer: continue here"),
+    ]
+    assert state.slot.broadcasts == [("user", False), ("assistant", False)]
+    assert durable == [
+        ("user", "continue here", "m-0000000000000001"),
+        ("assistant", "Answer: continue here", "m-0000000000000002"),
+    ]
+    assert state.pushes == pushes_before_turn + 1
 
 
 @pytest.mark.asyncio

--- a/test/test_discord_sessions.py
+++ b/test/test_discord_sessions.py
@@ -704,6 +704,7 @@ async def test_resumed_turn_lands_in_live_dashboard_window() -> None:
         def __init__(self) -> None:
             self.messages: list[dict[str, Any]] = []
             self.broadcasts: list[tuple[str, bool]] = []
+            self.is_restricted = False
 
         def append(self, role: str, content: str, cls: str = "", **kw: Any) -> dict[str, Any]:
             mid = f"m-{len(self.messages) + 1:016x}"
@@ -746,6 +747,79 @@ async def test_resumed_turn_lands_in_live_dashboard_window() -> None:
 
 
 @pytest.mark.asyncio
+async def test_restricted_resumed_turn_is_neither_projected_nor_persisted() -> None:
+    """Discord had the same two-writer leak as Telegram.
+
+    A resumed ``dashboard:`` key gets its privacy mode from the dashboard slot.
+    Without the caller-side gate Discord projected the turn into that slot (making
+    it dirty for a later flush) and also appended it directly to durable history.
+    Neither path may see content for an incognito or temporary session.
+    """
+    log = _log()
+    log.messages["dashboard:chat-1"] = [{"role": "assistant", "content": "prior"}]
+    dispatcher, client, sessions = _dispatcher({"u1"}, log)
+    durable_before = list(log.messages["dashboard:chat-1"])
+    persist_calls: list[str] = []
+    real_persist = dispatcher._persist_turn
+
+    def _persist(*args: Any, **kwargs: Any) -> None:
+        persist_calls.append(str(args[0]))
+        real_persist(*args, **kwargs)
+
+    dispatcher._persist_turn = _persist  # type: ignore[method-assign]
+
+    class _RestrictedSlot:
+        is_restricted = True
+
+        def __init__(self) -> None:
+            self.messages: list[dict[str, Any]] = []
+
+        def append(self, role: str, content: str, cls: str = "", **kw: Any) -> dict[str, Any]:
+            row = {"role": role, "content": content, "meta": {"mid": f"m-{len(self.messages)}"}}
+            self.messages.append(row)
+            return row
+
+    class _State:
+        def __init__(self) -> None:
+            self.slot = _RestrictedSlot()
+
+        def get_slot(self, name: str) -> Any:
+            return self.slot if name == "chat-1" else None
+
+        def push_slots_update(self) -> None:
+            raise AssertionError("a restricted turn must not dirty or push its slot")
+
+    state = _State()
+    dispatcher._session_resume.dashboard_state = state
+
+    await dispatcher.handle_message(_message("!sessions"))
+    custom_id, message_id = _picker_button(client)
+    await dispatcher.on_interaction(_interaction(custom_id, message_id))
+    await dispatcher.handle_message(_message("private continuation"))
+
+    assert sessions.last_key == "dashboard:chat-1"
+    assert state.slot.messages == []
+    assert persist_calls == []
+    assert log.messages["dashboard:chat-1"] == durable_before
+
+
+@pytest.mark.asyncio
+async def test_discord_restricted_decision_allows_unknown_but_denies_live_slot() -> None:
+    """Cold ordinary resumes keep history; an affirmative live restriction wins."""
+    dispatcher, _, _ = _dispatcher({"u1"}, _log())
+
+    dispatcher._session_resume.dashboard_state = SimpleNamespace(
+        sessions=None, get_slot=lambda _name: SimpleNamespace(is_restricted=True)
+    )
+    assert await dispatcher._session_restricted("dashboard:chat-1") is True
+
+    dispatcher._session_resume.dashboard_state = SimpleNamespace(
+        sessions=None, get_slot=lambda _name: None
+    )
+    assert await dispatcher._session_restricted("dashboard:missing") is False
+
+
+@pytest.mark.asyncio
 async def test_mirrored_turn_persists_idempotently() -> None:
     """The slot's own save re-serializes its window, so the disk write must not
     duplicate what the live slot already carries."""
@@ -758,7 +832,11 @@ async def test_mirrored_turn_persists_idempotently() -> None:
 
     class _State:
         def get_slot(self, name: str) -> Any:
-            return type("S", (), {"append": lambda *a, **k: None})()
+            return type(
+                "S",
+                (),
+                {"append": lambda *a, **k: None, "is_restricted": False},
+            )()
 
         def push_slots_update(self) -> None:
             return None

--- a/test/test_session_map_mirror.py
+++ b/test/test_session_map_mirror.py
@@ -172,13 +172,14 @@ class TestMirrorReverseLookup:
             accepts_inbound=True,
         )
 
-        assert session_map.find_mirror_sessions(link, inbound_only=True) == [
-            "dashboard:chat-1"
-        ]
-        assert session_map.find_mirror_sessions(
-            ChannelLink(channel_type="discord", channel_id="dm-2"),
-            inbound_only=True,
-        ) == []
+        assert session_map.find_mirror_sessions(link, inbound_only=True) == ["dashboard:chat-1"]
+        assert (
+            session_map.find_mirror_sessions(
+                ChannelLink(channel_type="discord", channel_id="dm-2"),
+                inbound_only=True,
+            )
+            == []
+        )
 
     def test_duplicate_locations_are_explicit_not_arbitrarily_resolved(self, session_map):
         link = ChannelLink(channel_type="discord", channel_id="dm-1")
@@ -285,9 +286,7 @@ class TestClearMirrorLinksAt:
         assert session_map.get_mirror_link("dashboard:chat-1") is None
 
     def test_slack_bindings_are_out_of_scope(self, session_map):
-        session_map.set(
-            "dashboard:chat-1", "sid-abc"
-        )  # Slack link needs an entry to attach to
+        session_map.set("dashboard:chat-1", "sid-abc")  # Slack link needs an entry to attach to
         session_map.set_mirror_link(
             "dashboard:chat-1",
             ChannelLink(channel_type="slack", channel_id="C1", thread_id="ts-1"),
@@ -468,9 +467,7 @@ class TestPersistence:
             sm.set_mirror_link("dashboard:chat-1", link, accepts_inbound=True)
         with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
             sm2 = SessionMap()
-            assert sm2.find_mirror_sessions(link, inbound_only=True) == [
-                "dashboard:chat-1"
-            ]
+            assert sm2.find_mirror_sessions(link, inbound_only=True) == ["dashboard:chat-1"]
 
     def test_mirror_round_trips_to_disk(self, tmp_path):
         with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
@@ -571,21 +568,20 @@ class TestConversationOwnership:
             "dashboard:chat-2",
         ]
 
-    def test_a_non_resuming_transport_is_never_refused(self, session_map):
-        """Pins the blast radius: a Telegram chat cannot become inbound-committed.
+    def test_telegram_outbound_mirrors_stay_open_until_resume_claim(self, session_map):
+        """Telegram outbound mirrors remain shareable until one accepts inbound.
 
-        ``telegram/transport_dispatch.py`` calls ``set_mirror_link`` without
-        catching this exception, and an uncaught raise inside a channel command
-        handler is a dropped task and a silent no-reply. It stays unreachable
-        because Telegram does not declare ``supports_session_resume``, so the
-        dashboard never marks its bindings inbound and nothing else does either.
+        Two outbound-only dashboard mirrors may target the same chat. Once a
+        selected session claims that chat for inbound resume, every other occupant
+        becomes a blocker so routing can never become ambiguous.
         """
         chat = ChannelLink(channel_type="telegram", channel_id="55", thread_id=None)
         session_map.set_mirror_link("dashboard:chat-1", chat)
-        # Two dashboard sessions mirroring one Telegram chat: allowed before this
-        # rule, allowed after it.
         session_map.set_mirror_link("dashboard:chat-2", chat)
         assert len(session_map.find_mirror_sessions(chat)) == 2
+
+        with pytest.raises(ConversationOwnershipConflict):
+            session_map.set_mirror_link("dashboard:chat-3", chat, accepts_inbound=True)
 
     def test_the_same_session_may_rebind_itself(self, session_map):
         """A reconnect is not a rivalry."""
@@ -711,7 +707,6 @@ class TestBatchedSave:
 
 
 class TestAutomaticMirrorOptOut:
-
     """The persisted refusal of automatic origin mirroring (issue #2959).
 
     A channel that binds its own conversation on every inbound turn re-asserts
@@ -785,9 +780,7 @@ class TestAutomaticMirrorOptOut:
         flagged = [k for k, e in session_map._data.items() if e.get("flags")]
         assert flagged == ["telegram:kirocrew:direct:7"]
 
-    def test_a_refusal_stored_under_the_old_generation_key_is_still_honoured(
-        self, session_map
-    ):
+    def test_a_refusal_stored_under_the_old_generation_key_is_still_honoured(self, session_map):
         """Upgrading must not silently restore mirroring.
 
         An earlier build keyed the refusal by the generation-suffixed session key.
@@ -810,10 +803,7 @@ class TestAutomaticMirrorOptOut:
         assert mgr.mirror_opt_out("telegram:kirocrew:direct:7:gen3") is True
         # Promoted to the bucket, and the generation row retired with it.
         assert session_map.get_flag("telegram:kirocrew:direct:7", MIRROR_OPT_OUT_FLAG) is True
-        assert (
-            session_map.get_flag("telegram:kirocrew:direct:7:gen3", MIRROR_OPT_OUT_FLAG)
-            is False
-        )
+        assert session_map.get_flag("telegram:kirocrew:direct:7:gen3", MIRROR_OPT_OUT_FLAG) is False
         # And it now survives the rotation that would have dropped it.
         assert mgr.mirror_opt_out("telegram:kirocrew:direct:7:gen4") is True
 
@@ -840,9 +830,7 @@ class TestAutomaticMirrorOptOut:
         assert session_map.get_flag("slack:kirocrew:temporary", "temporary") is False
         assert session_map.get_flag("slack:kirocrew:incognito", "incognito") is False
 
-    def test_a_stale_sid_is_still_collected_when_the_flag_is_session_scoped(
-        self, session_map
-    ):
+    def test_a_stale_sid_is_still_collected_when_the_flag_is_session_scoped(self, session_map):
         """The repair branch is for settings only, not for any flag at all."""
         key = "slack:kirocrew:direct:7"
         session_map.set(key, "sid-that-no-longer-exists")
@@ -862,9 +850,7 @@ class TestAutomaticMirrorOptOut:
         assert session_map.prune() == 0
         assert session_map.get_flag(key, MIRROR_OPT_OUT_FLAG) is True
 
-    def test_prune_clears_a_stale_sid_instead_of_dropping_the_opt_out(
-        self, session_map, tmp_path
-    ):
+    def test_prune_clears_a_stale_sid_instead_of_dropping_the_opt_out(self, session_map, tmp_path):
         """The other stale branch: the setting must outlive the native session.
 
         A conversation that HAS run turns carries a ``sid``. When kiro-cli
@@ -929,9 +915,7 @@ class TestInboundUnbindIsLoud:
     future caller inherits the behavior instead of having to remember it.
     """
 
-    def test_clear_mirror_link_audits_and_announces(
-        self, session_map, unbind_calls, sel_events
-    ):
+    def test_clear_mirror_link_audits_and_announces(self, session_map, unbind_calls, sel_events):
         session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
         assert session_map.clear_mirror_link("dashboard:chat-1", reason="dashboard_unlink")
 
@@ -963,18 +947,25 @@ class TestInboundUnbindIsLoud:
         "removal, reason",
         [
             # An explicit clear through set_mirror_link(None).
-            (lambda m, k: m.set_mirror_link(k, None, reason="dashboard_unlink"),
-             "dashboard_unlink"),
+            (
+                lambda m, k: m.set_mirror_link(k, None, reason="dashboard_unlink"),
+                "dashboard_unlink",
+            ),
             # An overwrite onto another location ends the old resume as thoroughly.
-            (lambda m, k: m.set_mirror_link(
-                k,
-                ChannelLink(channel_type="discord", channel_id="chan-2"),
-                accepts_inbound=True,
-                reason="origin_rebind",
-            ), "origin_rebind"),
+            (
+                lambda m, k: m.set_mirror_link(
+                    k,
+                    ChannelLink(channel_type="discord", channel_id="chan-2"),
+                    accepts_inbound=True,
+                    reason="origin_rebind",
+                ),
+                "origin_rebind",
+            ),
             # Same location, inbound flag dropped: no longer resumable.
-            (lambda m, k: m.set_mirror_link(k, INBOUND_LINK, reason="origin_rebind"),
-             "origin_rebind"),
+            (
+                lambda m, k: m.set_mirror_link(k, INBOUND_LINK, reason="origin_rebind"),
+                "origin_rebind",
+            ),
             # A whole-entry delete carrying its caller's reason.
             (lambda m, k: m.delete(k, reason="session_destroyed"), "session_destroyed"),
             # A caller that names none is recorded as unattributed, not skipped.
@@ -989,9 +980,7 @@ class TestInboundUnbindIsLoud:
 
         assert unbind_calls == [("dashboard:chat-1", INBOUND_LINK, reason)]
 
-    def test_rebinding_the_same_inbound_binding_is_not_a_removal(
-        self, session_map, unbind_calls
-    ):
+    def test_rebinding_the_same_inbound_binding_is_not_a_removal(self, session_map, unbind_calls):
         session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
         session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
 
@@ -1056,9 +1045,7 @@ class TestPruneRemovesThroughTheChokePoint:
         assert UNBIND_REASON_PRUNED_STALE in audits[0]["resources"]
         assert unbind_calls == [(key, INBOUND_LINK, UNBIND_REASON_PRUNED_STALE)]
 
-    def test_collecting_an_unbound_row_stays_silent(
-        self, session_map, unbind_calls, sel_events
-    ):
+    def test_collecting_an_unbound_row_stays_silent(self, session_map, unbind_calls, sel_events):
         """The reachable case is unchanged: garbage strands nobody, so no event.
 
         Routing prune through the choke point must not start narrating ordinary
@@ -1113,9 +1100,7 @@ class TestPruneRemovesThroughTheChokePoint:
             assert len(replace_threads) == 1
             assert replace_threads[0] is not loop_thread
 
-    def test_a_collected_thread_binding_leaves_the_index(
-        self, session_map, monkeypatch
-    ):
+    def test_a_collected_thread_binding_leaves_the_index(self, session_map, monkeypatch):
         """The reverse index cannot outlive the entry that owned the thread."""
         key = "dashboard:chat-1"
         session_map.set_slack_link(key, "1700000000.000100", "C123")
@@ -1135,18 +1120,28 @@ class TestOutboundOnlyStaysQuiet:
             # An outbound-only mirror, cleared by key and deleted with its entry;
             # a Slack binding (its own reverse index); and an inbound flag with no
             # mirror, which routes nothing and so is no loss.
-            (lambda m: m.set_mirror_link("dashboard:chat-1", INBOUND_LINK),
-             lambda m: m.clear_mirror_link("dashboard:chat-1")),
-            (lambda m: m.set_mirror_link("dashboard:chat-1", INBOUND_LINK),
-             lambda m: m.delete("dashboard:chat-1")),
-            (lambda m: m.set_mirror_link(
-                "dashboard:chat-1",
-                ChannelLink(channel_type="slack", channel_id="C1", thread_id="ts-1"),
-             ),
-             lambda m: m.clear_mirror_link("dashboard:chat-1")),
-            (lambda m: (m._ensure_entry("dashboard:chat-1").update(
-                {"mirror_accepts_inbound": True}), m._save()),
-             lambda m: m.delete("dashboard:chat-1")),
+            (
+                lambda m: m.set_mirror_link("dashboard:chat-1", INBOUND_LINK),
+                lambda m: m.clear_mirror_link("dashboard:chat-1"),
+            ),
+            (
+                lambda m: m.set_mirror_link("dashboard:chat-1", INBOUND_LINK),
+                lambda m: m.delete("dashboard:chat-1"),
+            ),
+            (
+                lambda m: m.set_mirror_link(
+                    "dashboard:chat-1",
+                    ChannelLink(channel_type="slack", channel_id="C1", thread_id="ts-1"),
+                ),
+                lambda m: m.clear_mirror_link("dashboard:chat-1"),
+            ),
+            (
+                lambda m: (
+                    m._ensure_entry("dashboard:chat-1").update({"mirror_accepts_inbound": True}),
+                    m._save(),
+                ),
+                lambda m: m.delete("dashboard:chat-1"),
+            ),
         ],
     )
     def test_losing_it_announces_nothing(
@@ -1169,9 +1164,7 @@ class TestOutboundOnlyStaysQuiet:
 class TestAnnouncementIsBestEffort:
     """A broken notifier or audit sink cannot fail the removal that provoked it."""
 
-    def test_listener_exception_is_swallowed_and_logged_at_warning(
-        self, session_map, caplog
-    ):
+    def test_listener_exception_is_swallowed_and_logged_at_warning(self, session_map, caplog):
         def _explode(key, link, reason):
             raise RuntimeError("notifier down")
 
@@ -1189,9 +1182,7 @@ class TestAnnouncementIsBestEffort:
     def test_manager_registers_on_the_shared_registry(self, session_map, tmp_path):
         """A removal through a DIFFERENT map instance is announced too."""
         calls: list[str] = []
-        _manager_over(session_map).set_unbind_listener(
-            lambda key, link, reason: calls.append(key)
-        )
+        _manager_over(session_map).set_unbind_listener(lambda key, link, reason: calls.append(key))
         try:
             session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
             with patch("kiro_crew.session_map.config_dir", return_value=tmp_path):
@@ -1212,9 +1203,7 @@ class TestAuditDoesNotBlockTheLoop:
     """
 
     @pytest.mark.asyncio
-    async def test_the_loop_keeps_beating_while_the_audit_runs(
-        self, session_map, unbind_calls
-    ):
+    async def test_the_loop_keeps_beating_while_the_audit_runs(self, session_map, unbind_calls):
         """The clear must RETURN while the sink is still blocked.
 
         Timing the synchronous call is the only assertion that fails when ``sel()``
@@ -1251,9 +1240,7 @@ class TestAuditDoesNotBlockTheLoop:
             release.set()
 
     @pytest.mark.asyncio
-    async def test_an_audit_failure_is_isolated_and_logged_at_warning(
-        self, session_map, caplog
-    ):
+    async def test_an_audit_failure_is_isolated_and_logged_at_warning(self, session_map, caplog):
         session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
         with caplog.at_level(logging.WARNING, logger="kiro_crew.session_map"):
             with patch("kiro_crew.session_map.sel", side_effect=RuntimeError("sel down")):
@@ -1285,16 +1272,12 @@ class TestAuditDoesNotBlockTheLoop:
 class TestReasonIsNormalizedAtTheChokePoint:
     """An unexpected reason must not reach SEL or the notice copy."""
 
-    def test_an_unknown_reason_is_normalized_and_warned(
-        self, session_map, unbind_calls, caplog
-    ):
+    def test_an_unknown_reason_is_normalized_and_warned(self, session_map, unbind_calls, caplog):
         session_map.set_mirror_link("dashboard:chat-1", INBOUND_LINK, accepts_inbound=True)
         with caplog.at_level(logging.WARNING, logger="kiro_crew.session_map"):
             session_map.clear_mirror_link("dashboard:chat-1", reason="totally_made_up")
 
-        assert unbind_calls == [
-            ("dashboard:chat-1", INBOUND_LINK, UNBIND_REASON_UNSPECIFIED)
-        ]
+        assert unbind_calls == [("dashboard:chat-1", INBOUND_LINK, UNBIND_REASON_UNSPECIFIED)]
         assert any("totally_made_up" in r.getMessage() for r in caplog.records)
 
 
@@ -1351,9 +1334,7 @@ class TestGetRepairsRatherThanUnbinds:
         assert reloaded.get_mirror_link(key) == INBOUND_LINK
         assert unbind_calls == []
 
-    def test_a_truly_unbound_stale_entry_is_still_collected(
-        self, session_map, unbind_calls
-    ):
+    def test_a_truly_unbound_stale_entry_is_still_collected(self, session_map, unbind_calls):
         key = "dashboard:chat-1"
         session_map.set(key, "sid-gone")
 

--- a/test/test_telegram.py
+++ b/test/test_telegram.py
@@ -321,6 +321,7 @@ class FakeSessions:
         self.queued: list = []
         self._gp = FakeProvider()
         self.mirror_links: dict[str, Any] = {}
+        self.inbound_keys: set[str] = set()
         self.mirror_opt_outs: set[str] = set()
         self.batch_depth = 0
         self.batched_writes: list[bool] = []
@@ -383,13 +384,32 @@ class FakeSessions:
         return -1
 
     def set_mirror_link(
-        self, key: str, link: Any, *, reason: str = UNBIND_REASON_UNSPECIFIED
+        self,
+        key: str,
+        link: Any,
+        *,
+        accepts_inbound: bool = False,
+        reason: str = UNBIND_REASON_UNSPECIFIED,
     ) -> None:
         self.batched_writes.append(self.batch_depth > 0)
         self.mirror_links[key] = link
+        if accepts_inbound:
+            self.inbound_keys.add(key)
+        else:
+            self.inbound_keys.discard(key)
 
     def get_mirror_link(self, key: str) -> Any:
         return self.mirror_links.get(key)
+
+    def find_mirror_sessions(self, link: Any, *, inbound_only: bool = False) -> list[str]:
+        return [
+            key
+            for key, candidate in self.mirror_links.items()
+            if candidate == link and (not inbound_only or key in self.inbound_keys)
+        ]
+
+    async def aflush(self) -> None:
+        return None
 
     @contextmanager
     def batched_save(self) -> Any:
@@ -411,6 +431,7 @@ class FakeSessions:
 
     def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
         self.batched_writes.append(self.batch_depth > 0)
+        self.inbound_keys.discard(key)
         return self.mirror_links.pop(key, None) is not None
 
     def clear_mirror_links_at(
@@ -418,6 +439,7 @@ class FakeSessions:
     ) -> list[str]:
         cleared = [key for key, candidate in self.mirror_links.items() if candidate == link]
         for key in cleared:
+            self.inbound_keys.discard(key)
             self.mirror_links.pop(key, None)
         return cleared
 

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1039,7 +1040,7 @@ class TestCommandSurface:
 
     def test_the_menu_and_the_help_card_stay_one_source(self) -> None:
         names = {name for name, _ in COMMAND_SPEC}
-        assert {"agent", "status", "sessions", "cron"} <= names
+        assert {"agent", "status", "session", "cron"} <= names
         # Every row must survive the Bot API's own constraints, or Telegram
         # rejects the WHOLE array and the user loses the entire menu.
         payload = bot_command_payload()
@@ -1213,80 +1214,14 @@ class TestAgentSwitchSafety:
 
 
 class TestSessionsCommand:
-    @pytest.mark.asyncio
-    async def test_the_read_is_audited_on_both_outcomes(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # Reaching into the data home and posting what it finds is an access worth
-        # a record — and the FAILURE path is the one that matters most, because an
-        # unaudited I/O error makes the attempt invisible.
-        from kiro_crew.messaging import sessions_view as sv
-
-        seen: list[dict] = []
-        monkeypatch.setattr(
-            sv, "sel", lambda: SimpleNamespace(log_api_access=lambda **kw: seen.append(kw))
-        )
-        dispatcher, client, _ = _dispatcher({1})
-        monkeypatch.setattr(sv, "_collect_recent_sessions_off_loop", AsyncMock(return_value=[]))
-        await dispatcher.handle_message(_msg("/sessions"))
-        assert seen and seen[-1]["outcome"] == "allowed"
-
-        monkeypatch.setattr(
-            sv,
-            "_collect_recent_sessions_off_loop",
-            AsyncMock(side_effect=OSError("sessions dir gone")),
-        )
-        await dispatcher.handle_message(_msg("/sessions"))
-        assert seen[-1]["outcome"] == "error"
-        assert seen[-1]["source"] == "telegram"
-        assert "Sessions unavailable" in client.sent[-1][0]
+    @staticmethod
+    def _install_log(dispatcher: Any, log: Any) -> None:
+        dispatcher.conv_log = log
+        dispatcher._session_resume.conv_log = log
+        dispatcher._session_resume._controller.conv_log = log
 
     @pytest.mark.asyncio
-    async def test_an_empty_history_says_so(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        dispatcher, client, _ = _dispatcher({1})
-        monkeypatch.setattr(
-            "kiro_crew.telegram.transport_dispatch.collect_recent_sessions_audited",
-            AsyncMock(return_value=[]),
-        )
-        await dispatcher.handle_message(_msg("/sessions"))
-        assert client.sent[-1][0] == "No recent conversations."
-
-    @pytest.mark.asyncio
-    async def test_rows_are_listed_with_a_live_marker_and_redacted(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        dispatcher, client, sessions = _dispatcher({1})
-        stem_lookup = MagicMock(return_value="")
-        sessions.channel_key_for_stem = stem_lookup  # type: ignore[method-assign]
-        rows = [
-            {
-                "key": "telegram_kirocrew_direct_1",
-                "title": f"leak {_AWS_KEY}",
-                "agent": "kirocrew",
-                "active": True,
-            },
-            {
-                "key": "other_session",
-                "title": "older thing",
-                "agent": "researcher",
-                "active": False,
-            },
-        ]
-        monkeypatch.setattr(
-            "kiro_crew.telegram.transport_dispatch.collect_recent_sessions_audited",
-            AsyncMock(return_value=rows),
-        )
-        await dispatcher.handle_message(_msg("/sessions"))
-        out = client.sent[-1][0]
-        assert "🟢" in out and "⚫" in out
-        assert "older thing" in out and "researcher" in out
-        assert _AWS_KEY not in out
-        stem_lookup.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_the_singular_alias_searches_titles_and_message_content(
-        self, tmp_path: Any
-    ) -> None:
+    async def test_singular_alias_fuzzy_searches_and_posts_buttons(self, tmp_path: Any) -> None:
         from kiro_crew.history import ConversationLog
 
         dispatcher, client, _ = _dispatcher({1})
@@ -1297,136 +1232,53 @@ class TestSessionsCommand:
             "user",
             "The blue marmot owns the launch checklist",
         )
-        await asyncio.to_thread(log.set_title, "dashboard:matching", "Unrelated title")
+        await asyncio.to_thread(log.set_title, "dashboard:matching", "General Q&A")
         await asyncio.to_thread(log.append, "dashboard:other", "user", "Different topic")
         await asyncio.to_thread(log.set_title, "dashboard:other", "Other session")
-        dispatcher.conv_log = log
+        self._install_log(dispatcher, log)
 
         await dispatcher.handle_message(_msg("/session blue marmot"))
 
-        out = client.sent[-1][0]
-        assert "Conversation search" in out and "Unrelated title" in out
-        assert "Other session" not in out
+        heading, markup = client.sent[-1]
+        labels = [row[0]["text"] for row in markup["inline_keyboard"]]
+        assert "Dashboard session search" in heading
+        assert any("General Q&A" in label for label in labels)
+        assert all("Other session" not in label for label in labels)
 
     @pytest.mark.asyncio
-    async def test_search_excludes_both_private_modes_and_overfetches(self) -> None:
+    async def test_empty_history_says_so(self, tmp_path: Any) -> None:
+        from kiro_crew.history import ConversationLog
+
         dispatcher, client, _ = _dispatcher({1})
-        limits: list[int] = []
+        self._install_log(dispatcher, ConversationLog(base_dir=tmp_path / "sessions"))
 
-        def _search(_query: str, limit: int) -> list[dict]:
-            limits.append(limit)
-            return [
-                {
-                    "key": "dashboard_incognito",
-                    "title": "Incognito secret",
-                    "memory_mode": "incognito",
-                },
-                {
-                    "key": "dashboard_temporary",
-                    "title": "Temporary secret",
-                    "memory_mode": "temporary",
-                },
-                {
-                    "key": "dashboard_public",
-                    "title": "Public launch plan",
-                    "memory_mode": "persistent",
-                },
-            ]
+        await dispatcher.handle_message(_msg("/session"))
 
-        dispatcher.conv_log = SimpleNamespace(search_sessions=_search)
-
-        await dispatcher.handle_message(_msg("/session launch"))
-
-        out = client.sent[-1][0]
-        assert "Public launch plan" in out
-        assert "Incognito secret" not in out and "Temporary secret" not in out
-        assert limits and limits[0] > 10, "filtering after a 10-row fetch can starve public hits"
+        assert client.sent[-1][0] == "No recent dashboard sessions."
 
     @pytest.mark.asyncio
-    async def test_search_restores_dashboard_stems_before_the_live_check(self) -> None:
-        dispatcher, client, sessions = _dispatcher({1})
-        seen: list[str] = []
-
-        def _has_session(key: str) -> bool:
-            seen.append(key)
-            return key == "dashboard:matching"
-
-        sessions.has_session = _has_session  # type: ignore[method-assign]
-        dispatcher.conv_log = SimpleNamespace(
-            search_sessions=lambda *_a, **_kw: [
-                {
-                    "key": "dashboard_matching",
-                    "title": "Matching session",
-                    "memory_mode": "persistent",
-                }
-            ]
-        )
-
-        await dispatcher.handle_message(_msg("/session matching"))
-
-        assert "🟢 Matching session" in client.sent[-1][0]
-        assert seen == ["dashboard:matching"]
-
-    @pytest.mark.asyncio
-    async def test_search_uses_the_session_map_for_channel_stems(self) -> None:
-        dispatcher, client, sessions = _dispatcher({1})
-        seen: list[str] = []
-        channel_key = "telegram:kirocrew:direct:1"
-
-        sessions.channel_key_for_stem = (  # type: ignore[method-assign]
-            lambda stem: channel_key if stem == "telegram_kirocrew_direct_1" else ""
-        )
-
-        def _has_session(key: str) -> bool:
-            seen.append(key)
-            return key == channel_key
-
-        sessions.has_session = _has_session  # type: ignore[method-assign]
-        dispatcher.conv_log = SimpleNamespace(
-            search_sessions=lambda *_a, **_kw: [
-                {
-                    "key": "telegram_kirocrew_direct_1",
-                    "title": "Live Telegram work",
-                    "memory_mode": "persistent",
-                }
-            ]
-        )
-
-        await dispatcher.handle_message(_msg("/session live work"))
-
-        assert "🟢 Live Telegram work" in client.sent[-1][0]
-        assert seen == [channel_key]
-
-    @pytest.mark.asyncio
-    async def test_a_search_with_no_matches_says_what_was_searched(self) -> None:
-        dispatcher, client, _ = _dispatcher({1})
-        dispatcher.conv_log = SimpleNamespace(search_sessions=lambda *_a, **_kw: [])
-
-        await dispatcher.handle_message(_msg("/sessions missing phrase"))
-
-        assert "No conversations matched “missing phrase”" in client.sent[-1][0]
-
-    @pytest.mark.asyncio
-    async def test_a_search_failure_is_audited_and_fails_closed(
-        self, monkeypatch: pytest.MonkeyPatch
+    async def test_search_failure_is_audited_and_fails_closed(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        seen: list[dict] = []
+        from kiro_crew.history import ConversationLog
+        from kiro_crew.messaging import session_resume as resume_core
+
+        dispatcher, client, _ = _dispatcher({1})
+        log = ConversationLog(base_dir=tmp_path / "sessions")
+        self._install_log(dispatcher, log)
+        seen: list[dict[str, Any]] = []
         monkeypatch.setattr(
-            "kiro_crew.telegram.transport_dispatch.sel",
+            resume_core,
+            "sel",
             lambda: SimpleNamespace(log_api_access=lambda **kw: seen.append(kw)),
         )
-        dispatcher, client, _ = _dispatcher({1})
-
-        def _boom(*_a: Any, **_kw: Any) -> list[dict]:
-            raise OSError("search index unavailable")
-
-        dispatcher.conv_log = SimpleNamespace(search_sessions=_boom)
+        monkeypatch.setattr(log, "search_sessions", MagicMock(side_effect=OSError("gone")))
 
         await dispatcher.handle_message(_msg("/session launch"))
 
         assert seen and seen[-1]["outcome"] == "error"
         assert seen[-1]["source"] == "telegram"
-        assert client.sent[-1][0] == "Sessions unavailable."
+        assert client.sent[-1][0] == "⚠️ Recent sessions are unavailable."
 
 
 class TestAgentPicker:
@@ -2416,13 +2268,14 @@ class TestSessionsIsDirectMessageOnly:
     @pytest.mark.asyncio
     async def test_a_forum_topic_is_refused_and_lists_nothing(self) -> None:
         dispatcher, client, _ = _dispatcher({1}, allow_forum=True, allowed_forum_chat_ids=[-100999])
-        with patch(
-            "kiro_crew.telegram.transport_dispatch.collect_recent_sessions_audited"
-        ) as collect:
-            await dispatcher.handle_message(_forum_msg("/sessions"))
-        # The refusal is the point, but so is not having READ the directory: a
-        # listing that was collected and then not sent still touched the data home.
-        collect.assert_not_called()
+        picker = AsyncMock()
+        dispatcher._session_resume.show_picker = picker
+
+        await dispatcher.handle_message(_forum_msg("/sessions"))
+
+        # The refusal is the point, but so is not having READ the directory: the
+        # picker owns the read and must never be called for a shared Topic.
+        picker.assert_not_awaited()
         reply = client.sent[-1][0]
         assert "direct message" in reply
         # No titles leak through the refusal itself.
@@ -2453,15 +2306,13 @@ class TestSessionsIsDirectMessageOnly:
         dispatcher, client, sessions = _dispatcher({7, 8})
         dispatcher.cron_service = MagicMock()
         dispatcher.subagent_manager = MagicMock()
+        picker = AsyncMock()
+        dispatcher._session_resume.show_picker = picker
 
-        with patch(
-            "kiro_crew.telegram.transport_dispatch.collect_recent_sessions_audited"
-        ) as collect:
-            await dispatcher.handle_message(_dm(command))
+        await dispatcher.handle_message(_dm(command))
 
-        # Refused BEFORE the listing was built, for the same reason a Topic is:
-        # a listing collected and then not sent still read the data.
-        collect.assert_not_called()
+        # Refused BEFORE any picker or host listing is built.
+        picker.assert_not_awaited()
         assert not dispatcher.cron_service.method_calls
         assert "single operator" in client.sent[-1][0]
 
@@ -3012,7 +2863,9 @@ class TestPrivacyModes:
         logged: list = []
         d, _, _ = _dispatcher({7})
         d.conv_log = SimpleNamespace(  # type: ignore[assignment]
-            append=lambda *a, **k: logged.append(a), set_title=lambda *a, **k: None
+            append=lambda *a, **k: logged.append(a),
+            set_title=lambda *a, **k: None,
+            atomic_appends=lambda _key: nullcontext(),
         )
         key = "telegram:kirocrew:direct:7"
         d._persist_turn(key, "hello", "hi there", True, "kirocrew")
@@ -3281,7 +3134,9 @@ class TestAMidTurnModifierSurvivesTheQueue:
         key = d._session_key(("direct", "7"))
         logged: list = []
         d.conv_log = SimpleNamespace(  # type: ignore[assignment]
-            append=lambda *a, **k: logged.append(a), set_title=lambda *a, **k: None
+            append=lambda *a, **k: logged.append(a),
+            set_title=lambda *a, **k: None,
+            atomic_appends=lambda _key: nullcontext(),
         )
         sessions.enqueue(key, "1", "summarise this", force=True, privacy_request="temporary")
 
@@ -3775,6 +3630,7 @@ class TestFallbackTitleYieldsToAutoTitle:
         log = SimpleNamespace(
             append=lambda *a, **k: None,
             set_title=lambda key, title: titles.append((key, title)),
+            atomic_appends=lambda _key: nullcontext(),
         )
         return log, titles
 
@@ -3936,7 +3792,9 @@ class TestRotationChokepoint:
         d._conv.maybe_rotate(route, time.time() - 3600, idle_minutes=1, daily_reset_hour=-1)
         logged: list[Any] = []
         d.conv_log = SimpleNamespace(  # type: ignore[assignment]
-            append=lambda *a, **k: logged.append(a), set_title=lambda *a, **k: None
+            append=lambda *a, **k: logged.append(a),
+            set_title=lambda *a, **k: None,
+            atomic_appends=lambda _key: nullcontext(),
         )
         await d.handle_message(_dm("/temporary"))
         assert privacy_mode.is_temporary(d._session_key(route))
@@ -4096,29 +3954,29 @@ async def _false(_channel: str) -> bool:
 
 
 class TestSessionsAuditCaller:
-    """The audit's subject is the participant, not the channel.
-
-    `caller` was the constant `"telegram"`, which is the SOURCE. With more than one
-    entry in `allowed_user_ids` — the forum case this channel now serves — a read of
-    every conversation's titles could not be attributed to anyone.
-    """
-
     @pytest.mark.asyncio
-    async def test_the_requesting_user_id_is_the_audited_caller(self) -> None:
-        from kiro_crew.telegram import transport_dispatch as td
+    async def test_the_requesting_user_id_is_the_audited_caller(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from kiro_crew.history import ConversationLog
+        from kiro_crew.messaging import session_resume as resume_core
 
-        d, _, _ = _dispatcher({7})
-        calls: list[dict] = []
+        dispatcher, _, _ = _dispatcher({7})
+        log = ConversationLog(base_dir=tmp_path / "sessions")
+        dispatcher.conv_log = log
+        dispatcher._session_resume.conv_log = log
+        dispatcher._session_resume._controller.conv_log = log
+        calls: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            resume_core,
+            "sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: calls.append(kw)),
+        )
 
-        async def _collect(sessions: Any, **kw: Any) -> list:
-            calls.append(kw)
-            return []
+        await dispatcher.handle_message(_dm("/session"))
 
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(td, "collect_recent_sessions_audited", _collect)
-            await d.handle_message(_dm("/sessions"))
         assert calls and calls[0]["caller"] == "7"
-        assert calls[0]["source"] == "telegram", "the source stays the channel"
+        assert calls[0]["source"] == "telegram"
 
 
 class TestHiddenLinkUrls:
@@ -4340,7 +4198,7 @@ class TestDurableWritesUseTheRotatedKey:
         "_handle_model": False,
         "_apply_model": False,
         "_apply_agent": False,
-        "on_callback": False,
+        "_callback_session_key": False,
     }
 
     def test_every_classified_method_matches_its_side(self) -> None:
@@ -4379,7 +4237,12 @@ class TestDurableWritesUseTheRotatedKey:
             elif "_session_key(route)" in line and current:
                 consumers.add(current)
         # These resolve a key for reasons the durable/live split does not govern.
-        exempt = {"_rotated_session_key", "handle_message", "_notify_mode"}
+        exempt = {
+            "_rotated_session_key",
+            "handle_message",
+            "_notify_mode",
+            "_callback_session_key",
+        }
         missing = consumers - set(self._CLASSIFIED) - exempt
         assert not missing, f"unclassified session-key consumers: {sorted(missing)}"
 

--- a/test/test_telegram_parity.py
+++ b/test/test_telegram_parity.py
@@ -1497,9 +1497,12 @@ class TestUploadGate:
 
         dispatcher, _, _ = _dispatcher({1})
         dispatcher.dashboard_state = SimpleNamespace(get_slot=lambda _name: None)
-        # Two args now: the gate takes the persisted probe as a PARAMETER rather
-        # than importing it, so `messaging` keeps its one-way dependency.
-        monkeypatch.setattr(ug, "_persisted_mode_is_restricted", lambda key, probe: True)
+        # The persisted probe is a PARAMETER rather than an import, so `messaging`
+        # keeps its one-way dependency; the third argument is the unknown-mode
+        # posture, which the upload ceiling leaves fail-closed.
+        monkeypatch.setattr(
+            ug, "_persisted_mode_is_restricted", lambda key, probe, unknown_denies=True: True
+        )
         assert await dispatcher._uploads_restricted("dashboard:ghost") is True
 
     @pytest.mark.asyncio
@@ -2982,8 +2985,11 @@ class TestARestrictedSessionWritesNothingAtAll:
                 if node.name not in functions:
                     continue
                 # Both shapes count: an early return (``_persist_turn``) and a
-                # guarded branch that answers the user (``_handle_title``).
-                if "is_restricted" not in ast.dump(node):
+                # guarded branch that answers the user (``_handle_title``). The
+                # dashboard-aware helper is named ``_session_restricted`` rather
+                # than ``privacy_mode.is_restricted``; both are explicit gates.
+                dump = ast.dump(node)
+                if "is_restricted" not in dump and "session_restricted" not in dump:
                     ungated.append(f"{channel}.{node.name}")
         assert not ungated, (
             "these write a durable title without checking the privacy mode, so a "

--- a/test/test_telegram_sessions.py
+++ b/test/test_telegram_sessions.py
@@ -16,12 +16,13 @@ from kiro_crew.history import ConversationLog
 from kiro_crew.messaging import auto_title
 from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
 from kiro_crew.messaging.renderer import session_provenance_tag
-from kiro_crew.messaging.session_resume import RoutingDecision
+from kiro_crew.messaging.session_resume import SETTLE_NOTHING, RoutingDecision
 from kiro_crew.messaging.session_trust import clear_trusted_sessions
 from kiro_crew.session import _opt_out_key
 from kiro_crew.session_allocation import SessionClosingError
 from kiro_crew.session_map import ConversationOwnershipConflict
 from kiro_crew.telegram.renderer import TelegramApprovalDecider
+from kiro_crew.telegram.session_resume import _ROUTE_OWNER_REFUSAL
 from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES, TelegramInboundMessage
 from kiro_crew.telegram.transport_dispatch import TelegramDispatcher
 
@@ -542,6 +543,321 @@ class TestTelegramSessionPicker:
         assert expectation is not None and expectation.retired
         assert "Couldn't resume" in client.edits[-1][1]
 
+    @pytest.mark.asyncio
+    async def test_a_detached_expectation_never_reaches_a_non_owner(self, tmp_path: Any) -> None:
+        """The live-binding gate alone is not the whole owner rule.
+
+        The binder also answers from the durable expectation store, so a binding
+        that was detached while its expectation survives resolves NO key and no
+        ambiguity — yet still yields a notice built from the dashboard session's
+        title. With a multi-user allow-list that notice would disclose host-wide
+        history to a non-owner, so any non-empty decision becomes the generic
+        refusal, and its settlement stays owed for the real owner.
+        """
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path, allowed={7, 8})
+        resume = dispatcher._session_resume
+        # No live binding at all: the first gate cannot fire.
+        assert sessions.find_mirror_sessions(resume.link_for(7, None)) == []
+        await resume.expectations.record("chat:7", "dashboard:secret", "Acquisition planning")
+
+        decision = await resume.route(7, 7, "private", None)
+
+        assert decision.refusal == _ROUTE_OWNER_REFUSAL
+        assert "Acquisition planning" not in (decision.refusal or "")
+        assert decision.resumed_key is None
+        assert decision.settle == SETTLE_NOTHING, "the notice stays owed, not acknowledged"
+        # And the record survives, so the owner still gets told.
+        still_there = await resume.expectations.get("chat:7")
+        assert still_there is not None and not still_there.retired
+
+    @pytest.mark.asyncio
+    async def test_the_owner_still_receives_the_detach_notice(self, tmp_path: Any) -> None:
+        """Non-vacuity: the gate refuses the non-owner, not the mechanism."""
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        resume = dispatcher._session_resume
+        await resume.expectations.record("chat:7", "dashboard:secret", "Acquisition planning")
+
+        decision = await resume.route(7, 7, "private", None)
+
+        assert decision.refusal != _ROUTE_OWNER_REFUSAL
+        assert decision.refusal is not None and "Acquisition planning" in decision.refusal
+
+    @pytest.mark.asyncio
+    async def test_a_rebind_landing_before_the_lock_is_not_erased(self, tmp_path: Any) -> None:
+        """The transaction must decide on state it read UNDER the map lock.
+
+        Moving the batch off the loop opened a window: the dashboard and other
+        channels bind without taking ``binder.lock``, so a rebind can land between
+        the loop-side read and the worker acquiring ``_MAP_LOCK``. Acting on the
+        stale view would clear a key whose newer, deliberate mirror this pick never
+        saw. Simulated by rebinding at batch entry — inside the lock, before the
+        transaction body runs.
+        """
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        native_key = dispatcher._session_key(("direct", "7"))
+        sessions.set_mirror_link(native_key, link, accepts_inbound=False)
+        real_batched_save = sessions.batched_save
+        injected: list[bool] = []
+
+        @contextmanager
+        def _rebind_then_batch() -> Any:
+            with real_batched_save():
+                if not injected:
+                    injected.append(True)
+                    # A deliberate dashboard mirror claims this DM first.
+                    sessions.mirror_links["dashboard:other"] = link
+                yield
+
+        sessions.batched_save = _rebind_then_batch  # type: ignore[method-assign]
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert injected, "the rebind was never simulated"
+        assert sessions.mirror_links.get("dashboard:other") == link, "newer mirror was erased"
+        assert sessions.mirror_links.get(native_key) == link, "displaced key was cleared anyway"
+        assert "dashboard:chat-1" not in sessions.inbound_keys, "the pick must not bind"
+        expectation = await dispatcher._session_resume.expectations.get("chat:7")
+        assert expectation is not None and expectation.retired
+
+    @pytest.mark.asyncio
+    async def test_the_binding_transaction_runs_off_the_event_loop(self, tmp_path: Any) -> None:
+        """A whole-map rewrite must not stall the loop every other task shares.
+
+        ``batched_save`` holds the map lock across the block and writes the file on
+        the way out, so the commit and its rollback both belong in a worker thread.
+        The map documents itself as callable from any thread; what this pins is that
+        the batch is not entered from the loop thread.
+        """
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        loop_thread = threading.get_ident()
+        batch_threads: list[int] = []
+        real_batched_save = sessions.batched_save
+
+        @contextmanager
+        def _recording_batch() -> Any:
+            batch_threads.append(threading.get_ident())
+            with real_batched_save():
+                yield
+
+        sessions.batched_save = _recording_batch  # type: ignore[method-assign]
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert sessions.inbound_keys == {"dashboard:chat-1"}, "the bind must still succeed"
+        assert batch_threads, "expected the binding transaction to open a batch"
+        assert all(
+            tid != loop_thread for tid in batch_threads
+        ), "a session-map batch ran on the event loop"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_expectation_store_answers_the_press(self, tmp_path: Any) -> None:
+        """A consumed choice must never end in silence.
+
+        The snapshot read runs AFTER the picker registry hands over the choice, so
+        an escaping store error would discard the press with no reply and leave a
+        dead button. It settles fail-closed instead.
+        """
+        from kiro_crew.messaging.resume_expectation import ExpectationStoreError
+
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        expectations = dispatcher._session_resume.expectations
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+
+        async def _boom(channel_id: str) -> None:
+            raise ExpectationStoreError("holds a malformed row")
+
+        expectations.get = _boom  # type: ignore[method-assign]
+
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert sessions.inbound_keys == set(), "no binding may be claimed"
+        assert "Couldn't save" in client.edits[-1][1]
+
+    @pytest.mark.asyncio
+    async def test_a_press_serializes_against_the_next_message(self, tmp_path: Any) -> None:
+        """A press and the message after it are independent Telegram tasks.
+
+        Without a shared per-route lock the message can resolve its session before
+        the press commits the binding, so its turn — and its transcript — lands in
+        the native session the user just left.
+        """
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+
+        route_id = dispatcher._session_resume.expectation_id(7, None)
+        held: list[str] = []
+        real_choose = dispatcher._session_resume.choose
+
+        async def _slow_choose(*args: Any, **kwargs: Any) -> None:
+            held.append("choose-start")
+            await asyncio.sleep(0.05)
+            await real_choose(*args, **kwargs)
+            held.append("choose-end")
+
+        dispatcher._session_resume.choose = _slow_choose  # type: ignore[method-assign]
+
+        async def _message_after_press() -> None:
+            await asyncio.sleep(0.01)
+            held.append("message")
+            async with dispatcher._routing_turn(route_id):
+                held.append("message-routed")
+
+        await asyncio.gather(
+            dispatcher.on_callback(_callback(data, message_id=message_id)),
+            _message_after_press(),
+        )
+
+        assert held.index("choose-end") < held.index(
+            "message-routed"
+        ), f"the message routed before the press committed: {held}"
+        assert sessions.inbound_keys == {"dashboard:chat-1"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["/spawn list", "/task status"])
+    async def test_host_listings_are_not_routed_through_a_binding(
+        self, tmp_path: Any, command: str
+    ) -> None:
+        """A host-scoped listing reports on the box, not on the resumed session.
+
+        Routing it through a resumed binding lets a stale or refused one withhold
+        output that has nothing to do with that session.
+        """
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(refusal="🔒 refused")
+        )
+
+        await dispatcher.handle_message(_dm(command))
+
+        dispatcher._session_resume.route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_conversation_scoped_spawn_still_routes(self, tmp_path: Any) -> None:
+        """Non-vacuity: the bypass is keyed on the ARGUMENT, not the verb."""
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+
+        await dispatcher.handle_message(_dm("/spawn go research this"))
+
+        dispatcher._session_resume.route.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_resumed_session_does_not_inherit_the_route_model(self, tmp_path: Any) -> None:
+        """A Telegram /model pick must not follow the user into someone else's session.
+
+        ``_model_pref`` is this ROUTE's choice. A resumed dashboard conversation
+        already has a model of its own, so handing the route's preference to a cold
+        start would run it under a model its owner never picked — silently, and for
+        every later turn.
+        """
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        route = dispatcher._route_key(chat_type="private", user_id=7, chat_id=7, thread=None)
+        dispatcher._model_pref[route] = "telegram-picked-model"
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+
+        await dispatcher.handle_message(_dm("continue here"))
+
+        assert sessions.last_key == "dashboard:chat-1"
+        assert sessions.last_model is None, "the resumed session inherited the route's model"
+
+    @pytest.mark.asyncio
+    async def test_a_native_turn_still_uses_the_route_model(self, tmp_path: Any) -> None:
+        """Non-vacuity: the preference still applies to Telegram's own session."""
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        route = dispatcher._route_key(chat_type="private", user_id=7, chat_id=7, thread=None)
+        dispatcher._model_pref[route] = "telegram-picked-model"
+
+        await dispatcher.handle_message(_dm("hello"))
+
+        assert sessions.last_model == "telegram-picked-model"
+
+    @pytest.mark.asyncio
+    async def test_unified_dm_scope_still_gets_one_click_takeover(self, tmp_path: Any) -> None:
+        """A non-default ``dm_scope`` must not cost the headline behaviour.
+
+        With ``dm_scope="unified"`` the native bucket is a ``unified:`` key, so the
+        namespace test that recognises a ``telegram:`` origin mirror sees a stranger
+        and refuses — the user is told to ``/unlink`` first, which is exactly the
+        friction one-click takeover removes. The dispatcher supplies its own key so
+        the classifier does not have to infer the scope.
+        """
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        unified_native = "unified:kirocrew:direct:7"
+        sessions.set_mirror_link(unified_native, link, accepts_inbound=False)
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher._session_resume.choose(
+            client,
+            _callback(data, message_id=message_id),
+            native_key=unified_native,
+        )
+
+        assert sessions.inbound_keys == {"dashboard:chat-1"}, "the takeover must bind"
+        assert unified_native not in sessions.mirror_links, "the native mirror must be replaced"
+        assert "Resumed" in client.edits[-1][1]
+
+    @pytest.mark.asyncio
+    async def test_a_foreign_native_key_grants_nothing(self, tmp_path: Any) -> None:
+        """The supplied key is only honoured while it occupies THIS conversation."""
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        sessions.set_mirror_link("dashboard:other", link, accepts_inbound=False)
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher._session_resume.choose(
+            client,
+            _callback(data, message_id=message_id),
+            native_key="unified:kirocrew:direct:999",
+        )
+
+        assert sessions.inbound_keys == set(), "an unrelated mirror must not be displaced"
+        assert sessions.mirror_links.get("dashboard:other") == link
+        assert "already attached" in client.edits[-1][1]
+
+    @pytest.mark.asyncio
+    async def test_failed_bind_restores_the_expectation_it_displaced(self, tmp_path: Any) -> None:
+        """A failed pick must not turn a live record into a detach marker.
+
+        ``record`` overwrites the channel's expectation, so retiring the
+        replacement on failure leaves DETACHED where ACTIVE used to be — and that
+        active record is the evidence a lost link still owes the user a notice.
+        Retiring it makes the next message route natively, so the notice is never
+        delivered.
+        """
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        expectations = dispatcher._session_resume.expectations
+
+        prior = await expectations.record("chat:7", "dashboard:earlier", "Earlier work")
+        assert not prior.retired
+
+        sessions.batch_failures = 1
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        restored = await expectations.get("chat:7")
+        assert restored is not None
+        assert restored.retired is False, "the displaced ACTIVE record must not detach"
+        assert restored.key == "dashboard:earlier"
+        assert restored.title == "Earlier work"
+        assert restored.version > prior.version, "the undo writes a successor, not a rewrite"
+        assert "Couldn't resume" in client.edits[-1][1]
+
 
 class TestTelegramInboundResumeRouting:
     @pytest.mark.asyncio
@@ -994,3 +1310,302 @@ class TestTelegramResumeIntegration:
         shared = TelegramTransport(_Client(), allowed_user_ids={7, 8})
         assert shared.may_resume_from("7", None) is False
         assert shared.may_resume_from("8", None) is False
+
+
+class TestTelegramRestrictedResumedSession:
+    """An incognito or temporary DASHBOARD session resumed here writes no transcript.
+
+    The exposure this pins is specific to inbound resume: before Telegram could
+    resume, the persist path only ever saw a Telegram-native key, for which
+    ``privacy_mode.is_restricted`` is the right predicate. A resumed turn carries a
+    ``dashboard:`` key instead, and that predicate reads a process-local tracker a
+    dashboard slot never populates — so on its own it answers False for an
+    incognito session and the turn would land in durable history.
+    """
+
+    def _state(self, slot: Any) -> Any:
+        """Minimal dashboard state: only ``get_slot`` and ``sessions`` are read."""
+        return SimpleNamespace(sessions=None, get_slot=lambda name: slot)
+
+    @pytest.mark.asyncio
+    async def test_restricted_live_slot_is_reported_restricted(self, tmp_path: Any) -> None:
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(SimpleNamespace(is_restricted=True))
+
+        assert await dispatcher._session_restricted("dashboard:chat-1") is True
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_live_slot_still_persists(self, tmp_path: Any) -> None:
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(SimpleNamespace(is_restricted=False))
+
+        assert await dispatcher._session_restricted("dashboard:chat-1") is False
+
+    @pytest.mark.asyncio
+    async def test_channel_privacy_mode_alone_would_have_failed_open(self, tmp_path: Any) -> None:
+        """The regression anchor: the native predicate cannot see this restriction."""
+        from kiro_crew.messaging import privacy_mode
+
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(SimpleNamespace(is_restricted=True))
+
+        # What the writer-side gate would have concluded on its own.
+        assert privacy_mode.is_restricted("dashboard:chat-1") is False
+        # What the caller-side ceiling concludes instead.
+        assert await dispatcher._session_restricted("dashboard:chat-1") is True
+
+    @pytest.mark.asyncio
+    async def test_a_closed_tab_keeps_recording_unless_the_mode_says_otherwise(
+        self, tmp_path: Any
+    ) -> None:
+        """No live slot and NO transcript: recording must continue.
+
+        The one unknown history allows, and it is the cold-resume case: nothing on
+        disk claims the session is restricted. An unknown with a transcript present
+        is a different case and denies — see the ambiguous-record test.
+        """
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(None)
+
+        assert await dispatcher._session_restricted("dashboard:never-existed") is False
+
+    @pytest.mark.asyncio
+    async def test_an_affirmative_incognito_marker_still_denies(self, tmp_path: Any) -> None:
+        """The closed-tab rung that DOES restrict: the transcript says incognito."""
+        from kiro_crew.messaging import upload_gate
+
+        assert (
+            upload_gate._persisted_mode_is_restricted(
+                "dashboard:gone", lambda name: (True, "incognito"), False
+            )
+            is True
+        )
+        assert (
+            upload_gate._persisted_mode_is_restricted(
+                "dashboard:gone", lambda name: (True, "persistent"), False
+            )
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_existing_but_unreadable_record_denies_history(self, tmp_path: Any) -> None:
+        """An ambiguous or corrupt transcript is where an incognito session hides.
+
+        ``_probe_persisted_session`` reports ``(True, None)`` when one stem matches
+        several transcripts, so taking the write would risk persisting a session
+        that promised to leave nothing. A legacy header with no ``memory_mode``
+        does NOT land here — it reads ``persistent`` — so denying costs no ordinary
+        history.
+        """
+        from kiro_crew.messaging import upload_gate
+
+        assert (
+            upload_gate._persisted_mode_is_restricted(
+                "dashboard:ambiguous", lambda name: (True, None), False
+            )
+            is True
+        )
+        # Truly absent is the one unknown history still allows.
+        assert (
+            upload_gate._persisted_mode_is_restricted(
+                "dashboard:absent", lambda name: (False, None), False
+            )
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_upload_ceiling_keeps_denying_an_unknown_mode(self, tmp_path: Any) -> None:
+        """The two postures stay independent: uploads deny unknown either way."""
+        from kiro_crew.messaging import upload_gate
+
+        for probe_result in ((False, None), (True, None)):
+            assert (
+                upload_gate._persisted_mode_is_restricted(
+                    "dashboard:gone", lambda name, r=probe_result: r
+                )
+                is True
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_temporary_resumed_session_reads_no_memory(self, tmp_path: Any) -> None:
+        """The write gate does not cover the INBOUND half.
+
+        ``temporary`` blocks memory reads, and for a resumed ``dashboard:`` key that
+        fact lives on the slot. Left to the channel tracker, stored memories and
+        lessons would enter the model prompt for a session that asked for none.
+        """
+        from kiro_crew.messaging import privacy_mode
+
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(
+            SimpleNamespace(is_restricted=True, blocks_reads=True)
+        )
+
+        # What the channel-local predicate would have concluded on its own.
+        assert privacy_mode.is_temporary("dashboard:chat-1") is False
+        assert await dispatcher._blocks_memory_reads("dashboard:chat-1") is True
+
+    @pytest.mark.asyncio
+    async def test_an_incognito_resumed_session_still_reads(self, tmp_path: Any) -> None:
+        """The documented difference between the two modes survives the fix."""
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(
+            SimpleNamespace(is_restricted=True, blocks_reads=False)
+        )
+
+        assert await dispatcher._session_restricted("dashboard:chat-1") is True
+        assert await dispatcher._blocks_memory_reads("dashboard:chat-1") is False
+
+    @pytest.mark.asyncio
+    async def test_the_read_gate_reaches_the_prompt_builder(self, tmp_path: Any) -> None:
+        """End to end: the gate's answer is the value the prompt builder receives."""
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        dispatcher.dashboard_state = self._state(
+            SimpleNamespace(is_restricted=False, blocks_reads=True)
+        )
+
+        await dispatcher.handle_message(_dm("what did we decide?"))
+
+        assert dispatcher.ctx_builder.build_calls[-1]["blocks_reads"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_native_telegram_key_is_unaffected(self, tmp_path: Any) -> None:
+        """A key with no dashboard slot falls back to this channel's own mode."""
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher.dashboard_state = self._state(SimpleNamespace(is_restricted=True))
+
+        assert await dispatcher._session_restricted("telegram:direct:7") is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command",
+        ["/temporary", "/incognito private question"],
+    )
+    async def test_privacy_modifier_is_refused_while_resumed(
+        self, tmp_path: Any, command: str
+    ) -> None:
+        """A channel-local mark cannot promise privacy for a persistent live slot."""
+        from kiro_crew.messaging import privacy_mode
+
+        privacy_mode.reset()
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+
+        await dispatcher.handle_message(_dm(command))
+
+        assert not privacy_mode.is_restricted("dashboard:chat-1")
+        assert sessions.last_key == "", "the command's message body must not reach the model"
+        assert "NOT processed" in client.sent[-1][0]
+        assert "/unlink" in client.sent[-1][0]
+
+    @pytest.mark.asyncio
+    async def test_restricted_turn_is_neither_projected_nor_persisted(self, tmp_path: Any) -> None:
+        """Skipping only the direct append is insufficient: projection dirties the slot."""
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        persist_calls: list[str] = []
+        dispatcher._persist_turn = (  # type: ignore[method-assign]
+            lambda *args, **kwargs: persist_calls.append(str(args[0]))
+        )
+
+        class _RestrictedSlot:
+            is_restricted = True
+
+            def __init__(self) -> None:
+                self.messages: list[dict[str, Any]] = []
+
+            def append(self, role: str, content: str, cls: str = "", **kw: Any) -> dict[str, Any]:
+                row = {"role": role, "content": content, "meta": {"mid": "m1"}}
+                self.messages.append(row)
+                return row
+
+        slot = _RestrictedSlot()
+        dispatcher.dashboard_state = SimpleNamespace(
+            sessions=None,
+            get_slot=lambda name: slot,
+            push_slots_update=lambda: pytest.fail("restricted projection pushed the slot"),
+        )
+
+        await dispatcher.handle_message(_dm("private continuation"))
+
+        assert sessions.last_key == "dashboard:chat-1"
+        assert slot.messages == []
+        assert persist_calls == []
+
+    @pytest.mark.asyncio
+    async def test_restricted_resumed_title_writes_nothing(self, tmp_path: Any) -> None:
+        """The dashboard-aware gate applies to /title, not only ordinary turns."""
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        titled: list[tuple[Any, ...]] = []
+        dispatcher.conv_log = SimpleNamespace(  # type: ignore[assignment]
+            set_title=lambda *args: titled.append(args)
+        )
+        dispatcher.dashboard_state = self._state(SimpleNamespace(is_restricted=True))
+
+        await dispatcher._handle_title(
+            ("direct", "7"),
+            7,
+            "Private project",
+            session_key="dashboard:chat-1",
+        )
+
+        assert titled == []
+        assert "private" in client.sent[-1][0]
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_resumed_title_updates_live_slot_and_disk(
+        self, tmp_path: Any
+    ) -> None:
+        """A metadata-only rename is stale data: the live slot later writes it back."""
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("chat-1")
+        slot.title = "Old title"
+        slot._titled = True
+        pushed: list[tuple[str, str]] = []
+        state.push_slot_title = (  # type: ignore[method-assign]
+            lambda key, title, **kw: pushed.append((key, title))
+        )
+
+        dispatcher, client, _, _ = _dispatcher(
+            tmp_path,
+            log=state.conversation_log,
+        )
+        dispatcher.dashboard_state = state
+
+        await dispatcher._handle_title(
+            ("direct", "7"),
+            7,
+            "New title",
+            session_key="dashboard:chat-1",
+        )
+
+        assert slot.title == "New title"
+        assert slot._titled is True
+        assert slot._title_origin == "user"
+        assert pushed == [("chat-1", "New title")]
+        assert state.conversation_log.get_metadata("dashboard:chat-1")["title"] == "New title"
+        assert "Renamed" in client.sent[-1][0]
+
+    def test_the_persist_call_is_guarded_by_that_decision(self) -> None:
+        """The ceiling is only a ceiling if the turn path consults it.
+
+        Source-level because the alternative is driving a whole turn to observe an
+        absent write; what matters is the ORDER — the decision is made on the loop,
+        before the worker-thread write it guards.
+        """
+        import inspect
+
+        src = inspect.getsource(TelegramDispatcher)
+        decided = src.index("dashboard_restricted = await self._session_restricted(")
+        guarded = src.index("if not dashboard_restricted:")
+        projected = src.index("mirror_mids = project_channel_turn_live(")
+        persisted = src.index("self._persist_turn,")
+
+        assert decided < guarded < projected < persisted

--- a/test/test_telegram_sessions.py
+++ b/test/test_telegram_sessions.py
@@ -1,0 +1,996 @@
+from __future__ import annotations
+
+import asyncio
+import importlib
+import threading
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from chat_test_helpers import _make_state
+from test_telegram import FakeClient, FakeCtx, FakeProvider
+
+from kiro_crew.history import ConversationLog
+from kiro_crew.messaging import auto_title
+from kiro_crew.messaging.link import UNBIND_REASON_UNSPECIFIED, ChannelLink
+from kiro_crew.messaging.renderer import session_provenance_tag
+from kiro_crew.messaging.session_resume import RoutingDecision
+from kiro_crew.messaging.session_trust import clear_trusted_sessions
+from kiro_crew.session import _opt_out_key
+from kiro_crew.session_allocation import SessionClosingError
+from kiro_crew.session_map import ConversationOwnershipConflict
+from kiro_crew.telegram.renderer import TelegramApprovalDecider
+from kiro_crew.telegram.transport import TELEGRAM_CAPABILITIES, TelegramInboundMessage
+from kiro_crew.telegram.transport_dispatch import TelegramDispatcher
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_trust(monkeypatch: Any) -> Any:
+    clear_trusted_sessions()
+    monkeypatch.setattr(auto_title, "try_claim", lambda _key: False)
+    yield
+    clear_trusted_sessions()
+
+
+class _Client(FakeClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.send_fails = False
+        self.edit_fails = False
+
+    async def send_message(self, chat_id: int, text: str, **kwargs: Any) -> int | None:
+        if self.send_fails:
+            return None
+        return await super().send_message(chat_id, text, **kwargs)
+
+    async def edit_message(
+        self,
+        chat_id: int,
+        message_id: int,
+        text: str,
+        *,
+        parse_mode: Any = None,
+        reply_markup: Any = None,
+        retry_plain: bool = True,
+    ) -> bool:
+        self.edits.append((message_id, text, reply_markup))
+        return not self.edit_fails
+
+
+class _Sessions:
+    def __init__(self) -> None:
+        self.provider = FakeProvider()
+        self.provider.cwd = "/workspace"
+        self.last_key = ""
+        self.last_agent: str | None = None
+        self.last_model: str | None = None
+        self.is_new_result = False
+        self.resumed_result = True
+        self.closing = False
+        self.busy = False
+        self.successes: list[str] = []
+        self.failures: list[str] = []
+        self.released: list[str] = []
+        self.set_channel_calls: list[tuple[str, str]] = []
+        self.origin_links: dict[str, ChannelLink] = {}
+        self.mirror_links: dict[str, ChannelLink] = {}
+        self.inbound_keys: set[str] = set()
+        self.mirror_opt_outs: set[str] = set()
+        self.queued: list[tuple[str, str, dict[str, Any]]] = []
+        self.flushed: list[dict[str, ChannelLink]] = []
+        self.flush_error: Exception | None = None
+        self.batch_failures = 0
+        self.approval_policies: list[tuple[str, str]] = []
+
+    async def get_or_create(
+        self,
+        key: str,
+        *,
+        agent: str | None = None,
+        channel_id: str | None = None,
+        model: str | None = None,
+    ) -> tuple[FakeProvider, bool, bool]:
+        self.last_key = key
+        self.last_agent = agent
+        self.last_model = model
+        return self.provider, self.is_new_result, self.resumed_result
+
+    def begin_turn(self, key: str) -> None:
+        if self.closing:
+            raise SessionClosingError("closing")
+
+    async def set_channel(self, key: str, channel: str) -> None:
+        self.set_channel_calls.append((key, channel))
+
+    def set_origin_link(self, key: str, link: ChannelLink) -> None:
+        self.origin_links[key] = link
+
+    def get_origin_link(self, key: str) -> ChannelLink | None:
+        return self.origin_links.get(key)
+
+    def set_mirror_link(
+        self,
+        key: str,
+        link: ChannelLink,
+        *,
+        accepts_inbound: bool = False,
+        reason: str = UNBIND_REASON_UNSPECIFIED,
+    ) -> None:
+        rivals = [
+            other
+            for other, candidate in self.mirror_links.items()
+            if other != key and candidate == link
+        ]
+        if rivals and (accepts_inbound or any(other in self.inbound_keys for other in rivals)):
+            raise ConversationOwnershipConflict("conversation already held")
+        self.mirror_links[key] = link
+        if accepts_inbound:
+            self.inbound_keys.add(key)
+        else:
+            self.inbound_keys.discard(key)
+
+    def get_mirror_link(self, key: str) -> ChannelLink | None:
+        return self.mirror_links.get(key)
+
+    def find_mirror_sessions(self, link: ChannelLink, *, inbound_only: bool = False) -> list[str]:
+        return [
+            key
+            for key, candidate in self.mirror_links.items()
+            if candidate == link and (not inbound_only or key in self.inbound_keys)
+        ]
+
+    def clear_mirror_link(self, key: str, *, reason: str = UNBIND_REASON_UNSPECIFIED) -> bool:
+        self.inbound_keys.discard(key)
+        return self.mirror_links.pop(key, None) is not None
+
+    def clear_mirror_links_at(
+        self, link: ChannelLink, *, reason: str = UNBIND_REASON_UNSPECIFIED
+    ) -> list[str]:
+        cleared = self.find_mirror_sessions(link)
+        for key in cleared:
+            self.inbound_keys.discard(key)
+            self.mirror_links.pop(key, None)
+        return cleared
+
+    async def aflush(self) -> None:
+        if self.flush_error is not None:
+            raise self.flush_error
+        self.flushed.append(dict(self.mirror_links))
+
+    @contextmanager
+    def batched_save(self) -> Any:
+        yield
+        if self.batch_failures:
+            self.batch_failures -= 1
+            raise OSError("simulated batch write failure")
+
+    def set_mirror_opt_out(self, key: str, opted_out: bool) -> None:
+        if opted_out:
+            self.mirror_opt_outs.add(_opt_out_key(key))
+        else:
+            self.mirror_opt_outs.discard(_opt_out_key(key))
+
+    def mirror_opt_out(self, key: str) -> bool:
+        return _opt_out_key(key) in self.mirror_opt_outs
+
+    def max_generation(self, bucket: str) -> int:
+        return -1
+
+    def channel_key_for_stem(self, stem: str) -> str:
+        return ""
+
+    def is_busy(self, key: str) -> bool:
+        return self.busy
+
+    def has_session(self, key: str) -> bool:
+        return True
+
+    def get_provider(self, key: str) -> FakeProvider:
+        return self.provider
+
+    def get_pid(self, key: str) -> None:
+        return None
+
+    def record_success(self, key: str) -> None:
+        self.successes.append(key)
+
+    async def record_failure(self, key: str) -> None:
+        self.failures.append(key)
+
+    def release(self, key: str) -> None:
+        self.released.append(key)
+
+    def check_context_usage(self, key: str, provider: Any) -> float:
+        return 0.0
+
+    def enqueue(self, key: str, ts: str, text: str, *, force: bool = False, **kwargs: Any) -> bool:
+        if force or self.busy:
+            self.queued.append((ts, text, kwargs))
+            return True
+        return False
+
+    def dequeue(self, key: str) -> tuple[str, str, dict[str, Any]] | None:
+        return self.queued.pop(0) if self.queued else None
+
+    def clear_queue(self, key: str) -> None:
+        self.queued.clear()
+
+    async def try_acquire(self, key: str) -> bool:
+        return not self.busy
+
+    async def discard_conversation(self, key: str) -> None:
+        return None
+
+    def set_approval_policy(self, key: str, policy: str) -> None:
+        self.approval_policies.append((key, policy))
+
+
+def _config() -> Any:
+    return SimpleNamespace(
+        telegram=SimpleNamespace(
+            soft_threshold_pct=80,
+            allow_forum=True,
+            allowed_forum_chat_ids=[-100],
+            show_thinking=False,
+            voice_replies=False,
+            forum_activation="always",
+        ),
+        dashboard=SimpleNamespace(restore_window_minutes=30, surface_channel_sessions=True),
+        agent=SimpleNamespace(default_agent="kirocrew"),
+        messaging=SimpleNamespace(
+            dm_scope="per-channel-peer",
+            idle_reset_minutes=0,
+            daily_reset_hour=-1,
+            queue_mode="steer",
+        ),
+        raw={},
+    )
+
+
+def _log(tmp_path: Any, *, agent: str = "") -> ConversationLog:
+    from kiro_crew.history import allow_on_loop_persist
+
+    log = ConversationLog(base_dir=tmp_path / "sessions")
+    with allow_on_loop_persist():
+        log.append("dashboard:chat-1", "assistant", "prior work")
+        log.set_title("dashboard:chat-1", "Launch plan")
+        if agent:
+            log.update_metadata("dashboard:chat-1", {"agent": agent})
+    return log
+
+
+def _dispatcher(
+    tmp_path: Any,
+    *,
+    allowed: set[int] | None = None,
+    log: ConversationLog | None = None,
+) -> tuple[TelegramDispatcher, _Client, _Sessions, ConversationLog]:
+    sessions = _Sessions()
+    conv_log = log or _log(tmp_path)
+    dispatcher = TelegramDispatcher(
+        sessions=sessions,  # type: ignore[arg-type]
+        ctx_builder=FakeCtx(),  # type: ignore[arg-type]
+        cfg=_config(),
+        allowed_user_ids=allowed if allowed is not None else {7},
+        conv_log=conv_log,
+    )
+    client = _Client()
+    dispatcher.client = client  # type: ignore[assignment]
+    return dispatcher, client, sessions, conv_log
+
+
+def _dm(text: str, *, chat_id: int = 7, user_id: int = 7) -> TelegramInboundMessage:
+    return TelegramInboundMessage(
+        channel_type="telegram",
+        user_id=str(user_id),
+        conversation_id=str(chat_id),
+        text=text,
+        chat_type="private",
+    )
+
+
+def _topic(text: str, thread: int) -> TelegramInboundMessage:
+    return TelegramInboundMessage(
+        channel_type="telegram",
+        user_id="7",
+        conversation_id="-100",
+        text=text,
+        chat_type="supergroup",
+        thread_id=str(thread),
+    )
+
+
+def _callback(data: str, *, message_id: int = 101, label: str = "") -> Any:
+    return SimpleNamespace(
+        callback_query_id="q1",
+        user_id=7,
+        chat_id=7,
+        message_id=message_id,
+        data=data,
+        label=label,
+        chat_type="private",
+        message_thread_id=None,
+    )
+
+
+def _picker_button(client: _Client) -> tuple[str, int]:
+    _text, markup = client.sent[-1]
+    button = markup["inline_keyboard"][0][0]
+    return str(button["callback_data"]), client._mid
+
+
+def _resume_module() -> Any:
+    return importlib.import_module("kiro_crew.telegram.session_resume")
+
+
+async def _bind(
+    dispatcher: TelegramDispatcher,
+    client: _Client,
+) -> None:
+    await dispatcher.handle_message(_dm("/sessions"))
+    data, message_id = _picker_button(client)
+    await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+
+class TestTelegramSessionPicker:
+    @pytest.mark.asyncio
+    async def test_keyboard_payload_owner_message_index_and_double_press(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+
+        await dispatcher.handle_message(_dm("/sessions"))
+
+        data, message_id = _picker_button(client)
+        markup = client.sent[-1][1]
+        assert data.startswith("s:")
+        assert data.isascii() and len(data.encode("ascii")) <= 64
+        assert all(len(row) == 1 for row in markup["inline_keyboard"])
+
+        await dispatcher.on_callback(_callback(data, message_id=message_id + 1))
+        assert sessions.mirror_links == {}
+        await dispatcher.on_callback(_callback(data.replace(":0", ":99"), message_id=message_id))
+        assert sessions.mirror_links == {}
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+        assert sessions.find_mirror_sessions(
+            ChannelLink("telegram", channel_id="7"), inbound_only=True
+        ) == ["dashboard:chat-1"]
+        before = dict(sessions.mirror_links)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+        assert sessions.mirror_links == before
+        assert "expired" in client.edits[-1][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_failed_post_registers_no_picker(self, tmp_path: Any) -> None:
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        client.send_fails = True
+
+        await dispatcher.handle_message(_dm("/sessions"))
+
+        assert len(dispatcher._session_resume.pickers) == 0
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            pytest.param(_dm("/sessions", chat_id=8), id="private-chat-not-user"),
+            pytest.param(_topic("/sessions", 11), id="forum-topic"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_owner_gate_runs_before_history_read(
+        self, tmp_path: Any, message: TelegramInboundMessage, monkeypatch: Any
+    ) -> None:
+        log = _log(tmp_path)
+        reads = 0
+
+        def _read() -> list[dict[str, Any]]:
+            nonlocal reads
+            reads += 1
+            return []
+
+        monkeypatch.setattr(log, "list_sessions", _read)
+        dispatcher, _, _, _ = _dispatcher(tmp_path, log=log)
+
+        await dispatcher.handle_message(message)
+
+        assert reads == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_allowed_ids_are_not_an_owner(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        log = _log(tmp_path)
+        read = AsyncMock()
+        monkeypatch.setattr(log, "list_sessions", read)
+        dispatcher, client, _, _ = _dispatcher(tmp_path, allowed={7, 8}, log=log)
+
+        await dispatcher.handle_message(_dm("/sessions"))
+
+        assert read.call_count == 0
+        assert "single" in client.sent[-1][0] or "exactly one" in client.sent[-1][0]
+
+    @pytest.mark.asyncio
+    async def test_expectation_is_durable_before_success_and_no_history_is_replayed(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        await dispatcher.handle_message(_dm("/sessions"))
+        data, message_id = _picker_button(client)
+        sent_before = len(client.sent)
+        seen: list[Any] = []
+        real_edit = client.edit_message
+
+        async def _observe(*args: Any, **kwargs: Any) -> bool:
+            if "Resumed" in str(args[2]):
+                seen.append(await dispatcher._session_resume.expectations.get("chat:7"))
+            return await real_edit(*args, **kwargs)
+
+        client.edit_message = _observe  # type: ignore[method-assign]
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert seen and seen[0].key == "dashboard:chat-1"
+        assert len(client.sent) == sent_before, "Telegram resume must not replay transcript rows"
+        assert client.edits[-1][0] == message_id
+        assert client.edits[-1][2] == {"inline_keyboard": []}
+        assert sessions.last_key == ""
+
+    def test_expectation_and_link_identity_include_the_full_topic(self, tmp_path: Any) -> None:
+        mod = _resume_module()
+        resume = mod.TelegramSessionResume(_Sessions(), _log(tmp_path), {7})
+
+        assert resume.expectation_id(7, None) == "chat:7"
+        assert resume.expectation_id(-100, 11) == "topic:-100:11"
+        assert resume.expectation_id(-100, 12) == "topic:-100:12"
+        assert resume.link_for(-100, 11) == ChannelLink(
+            "telegram", channel_id="-100", thread_id="11"
+        )
+
+    @pytest.mark.asyncio
+    async def test_pick_replaces_outbound_native_mirror_in_one_click(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        native_key = dispatcher._session_key(("direct", "7"))
+        sessions.set_mirror_link(native_key, link, accepts_inbound=False)
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert native_key not in sessions.mirror_links
+        assert sessions.find_mirror_sessions(link, inbound_only=True) == ["dashboard:chat-1"]
+        assert "Resumed" in client.edits[-1][1]
+
+    @pytest.mark.asyncio
+    async def test_pick_never_displaces_deliberate_dashboard_mirror(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        native_key = dispatcher._session_key(("direct", "7"))
+        deliberate_key = "dashboard:deliberate"
+        sessions.set_mirror_link(native_key, link, accepts_inbound=False)
+        sessions.set_mirror_link(deliberate_key, link, accepts_inbound=False)
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert sessions.mirror_links == {
+            native_key: link,
+            deliberate_key: link,
+        }
+        assert sessions.inbound_keys == set()
+        assert "already attached" in client.edits[-1][1]
+
+    @pytest.mark.asyncio
+    async def test_failed_takeover_restores_outbound_native_mirror(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        native_key = dispatcher._session_key(("direct", "7"))
+        sessions.set_mirror_link(native_key, link, accepts_inbound=False)
+        real_set = sessions.set_mirror_link
+
+        def _fail_selected(
+            key: str,
+            candidate: ChannelLink,
+            *,
+            accepts_inbound: bool = False,
+            reason: str = UNBIND_REASON_UNSPECIFIED,
+        ) -> None:
+            if key == "dashboard:chat-1" and accepts_inbound:
+                raise OSError("simulated bind failure")
+            real_set(
+                key,
+                candidate,
+                accepts_inbound=accepts_inbound,
+                reason=reason,
+            )
+
+        sessions.set_mirror_link = _fail_selected  # type: ignore[method-assign]
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert sessions.mirror_links == {native_key: link}
+        assert sessions.inbound_keys == set()
+        assert "Couldn't resume" in client.edits[-1][1]
+        expectation = await dispatcher._session_resume.expectations.get("chat:7")
+        assert expectation is not None and expectation.retired
+
+        sent_before = len(client.sent)
+        await dispatcher.handle_message(_dm("continue natively"))
+        assert sessions.last_key == native_key
+        assert not any("NOT processed" in text for text, _ in client.sent[sent_before:])
+
+    @pytest.mark.asyncio
+    async def test_batch_write_failure_rolls_back_claim_and_expectation(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        native_key = dispatcher._session_key(("direct", "7"))
+        sessions.set_mirror_link(native_key, link, accepts_inbound=False)
+        sessions.batch_failures = 1
+
+        await dispatcher.handle_message(_dm("/session launch"))
+        data, message_id = _picker_button(client)
+        await dispatcher.on_callback(_callback(data, message_id=message_id))
+
+        assert sessions.mirror_links == {native_key: link}
+        assert sessions.inbound_keys == set()
+        expectation = await dispatcher._session_resume.expectations.get("chat:7")
+        assert expectation is not None and expectation.retired
+        assert "Couldn't resume" in client.edits[-1][1]
+
+
+class TestTelegramInboundResumeRouting:
+    @pytest.mark.asyncio
+    async def test_ordinary_message_takes_one_routing_decision(self, tmp_path: Any) -> None:
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+
+        await dispatcher.handle_message(_dm("continue here"))
+
+        dispatcher._session_resume.route.assert_awaited_once_with(7, 7, "private", None)
+        assert sessions.last_key == "dashboard:chat-1"
+
+    @pytest.mark.asyncio
+    async def test_multi_user_binding_is_refused_before_it_can_route(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path, allowed={7, 8})
+        link = dispatcher._session_resume.link_for(7, None)
+        sessions.set_mirror_link("dashboard:chat-1", link, accepts_inbound=True)
+
+        await dispatcher.handle_message(_dm("must stay private"))
+
+        assert sessions.last_key == ""
+        assert any("exactly one" in text for text, _ in client.sent)
+        assert any("NOT processed" in text for text, _ in client.sent)
+
+    @pytest.mark.parametrize(
+        ("command", "handler", "target_kw"),
+        [
+            ("/compact", "_handle_compact", "session_key"),
+            ("/stop", "_handle_stop", "session_key"),
+            ("/model", "_handle_model", "session_key"),
+            ("/title renamed", "_handle_title", "session_key"),
+            ("/spawn do work", "_handle_spawn", "session_key"),
+            ("/task run spec.md", "_handle_task", "session_key"),
+            ("/link", "_handle_link", "resumed_key"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_session_scoped_commands_receive_resumed_key(
+        self, tmp_path: Any, command: str, handler: str, target_kw: str
+    ) -> None:
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        mocked = AsyncMock()
+        setattr(dispatcher, handler, mocked)
+
+        await dispatcher.handle_message(_dm(command))
+
+        mocked.assert_awaited_once()
+        assert mocked.await_args.kwargs[target_kw] == "dashboard:chat-1"
+
+    @pytest.mark.parametrize("command", ["/new", "/unlink"])
+    @pytest.mark.asyncio
+    async def test_recovery_command_releases_binding_and_next_message_runs_once(
+        self, tmp_path: Any, command: str
+    ) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        await _bind(dispatcher, client)
+        link = dispatcher._session_resume.link_for(7, None)
+        assert sessions.find_mirror_sessions(link, inbound_only=True) == ["dashboard:chat-1"]
+
+        await dispatcher.handle_message(_dm(command))
+
+        assert sessions.find_mirror_sessions(link, inbound_only=True) == []
+        assert any("resumed session" in text for text, _ in client.sent)
+        sent_before = len(client.sent)
+        await dispatcher.handle_message(_dm("continue natively"))
+        assert sessions.last_key != "dashboard:chat-1"
+        assert len(client.sent) > sent_before
+        assert not any("NOT processed" in text for text, _ in client.sent[sent_before:])
+
+    @pytest.mark.parametrize("command", ["/help", "/status", "/new", "/unlink"])
+    @pytest.mark.asyncio
+    async def test_commands_remain_native_and_recovery_commands_bypass_refusals(
+        self, tmp_path: Any, command: str
+    ) -> None:
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(refusal="must not run")
+        )
+
+        await dispatcher.handle_message(_dm(command))
+
+        dispatcher._session_resume.route.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_refusal_delivery_leaves_settlement_owed(self, tmp_path: Any) -> None:
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        decision = RoutingDecision(refusal="Detached")
+        dispatcher._session_resume.route = AsyncMock(return_value=decision)
+        dispatcher._session_resume.settle = AsyncMock()
+        client.send_fails = True
+
+        await dispatcher.handle_message(_dm("continue"))
+
+        dispatcher._session_resume.settle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_successful_refusal_delivery_settles(self, tmp_path: Any) -> None:
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        decision = RoutingDecision(refusal="Detached")
+        dispatcher._session_resume.route = AsyncMock(return_value=decision)
+        dispatcher._session_resume.settle = AsyncMock()
+
+        await dispatcher.handle_message(_dm("continue"))
+
+        dispatcher._session_resume.settle.assert_awaited_once_with(7, None, decision)
+
+    @pytest.mark.asyncio
+    async def test_topic_routing_locks_are_isolated(self, tmp_path: Any) -> None:
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        topic_12_routed = asyncio.Event()
+        crossed: list[bool] = []
+
+        async def _route(
+            user_id: int,
+            chat_id: int,
+            chat_type: str,
+            thread: int | None,
+        ) -> RoutingDecision:
+            assert user_id == 7 and chat_type == "supergroup"
+            if thread == 12:
+                topic_12_routed.set()
+            return RoutingDecision(refusal=f"Detached {thread}")
+
+        real_send = client.send_message
+
+        async def _send(chat_id: int, text: str, **kwargs: Any) -> int | None:
+            if text == "Detached 11":
+                try:
+                    await asyncio.wait_for(topic_12_routed.wait(), timeout=1)
+                    crossed.append(True)
+                except asyncio.TimeoutError:
+                    crossed.append(False)
+            return await real_send(chat_id, text, **kwargs)
+
+        dispatcher._session_resume.route = _route  # type: ignore[method-assign]
+        client.send_message = _send  # type: ignore[method-assign]
+
+        await asyncio.gather(
+            dispatcher.handle_message(_topic("one", 11)),
+            dispatcher.handle_message(_topic("two", 12)),
+        )
+
+        assert crossed == [True]
+
+    @pytest.mark.asyncio
+    async def test_same_route_waiters_settle_only_after_the_last_refusal(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        decision = RoutingDecision(refusal="Detached")
+        dispatcher._session_resume.route = AsyncMock(return_value=decision)
+        settlements: list[int] = []
+
+        async def _settle(*args: Any) -> None:
+            settlements.append(1)
+
+        dispatcher._session_resume.settle = _settle  # type: ignore[method-assign]
+        real_send = client.send_message
+        first_started = asyncio.Event()
+        second_started = asyncio.Event()
+
+        async def _send(chat_id: int, text: str, **kwargs: Any) -> int | None:
+            if text == "Detached" and not first_started.is_set():
+                first_started.set()
+                await asyncio.wait_for(second_started.wait(), timeout=1)
+            return await real_send(chat_id, text, **kwargs)
+
+        client.send_message = _send  # type: ignore[method-assign]
+        first = asyncio.create_task(dispatcher.handle_message(_dm("first")))
+        await first_started.wait()
+        second = asyncio.create_task(dispatcher.handle_message(_dm("second")))
+        while len(dispatcher._routing_locks["chat:7"][1]) < 2:
+            await asyncio.sleep(0)
+        second_started.set()
+        await asyncio.gather(first, second)
+
+        assert settlements == [1]
+
+    @pytest.mark.asyncio
+    async def test_busy_resumed_session_refuses_without_queue_or_steer(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        sessions.busy = True
+
+        await dispatcher.handle_message(_dm("continue"))
+
+        assert any("busy" in text.lower() for text, _ in client.sent)
+        assert sessions.queued == []
+        assert sessions.provider.steered == []
+        assert sessions.last_key == ""
+
+    @pytest.mark.asyncio
+    async def test_queue_drain_keeps_native_affinity_after_a_later_bind(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        native_key = dispatcher._session_key(("direct", "7"))
+        sessions.queued.append(("1", "queued text", {}))
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+
+        await dispatcher._drain_queue(native_key, 7, 7)
+
+        dispatcher._session_resume.route.assert_not_awaited()
+        assert sessions.last_key == native_key
+
+    @pytest.mark.asyncio
+    async def test_option_redispatch_routes_once_to_the_retained_resumed_key(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        tag = session_provenance_tag("dashboard:chat-1")
+
+        await dispatcher.on_callback(_callback(f"opt:0:{tag}", label="Ship it"))
+
+        dispatcher._session_resume.route.assert_awaited_once_with(7, 7, "private", None)
+        assert sessions.last_key == "dashboard:chat-1"
+
+
+class TestTelegramModelPickerRouting:
+    @pytest.mark.asyncio
+    async def test_unlink_makes_resumed_model_picker_stale(self, tmp_path: Any) -> None:
+        dispatcher, client, sessions, _ = _dispatcher(tmp_path)
+        sessions.provider.advertised = [{"modelId": "gpt-test", "name": "Test model"}]
+        link = dispatcher._session_resume.link_for(7, None)
+        sessions.set_mirror_link("dashboard:chat-1", link, accepts_inbound=True)
+
+        await dispatcher.handle_message(_dm("/model"))
+        model_message_id = client._mid
+        await dispatcher.handle_message(_dm("/unlink"))
+        await dispatcher.on_callback(_callback("m:1", message_id=model_message_id))
+
+        assert sessions.provider.set_models == []
+        assert "no longer controls" in client.edits[-1][1]
+
+
+class TestTelegramApprovalResumeRouting:
+    async def _arm(self, key: str, request_id: str = "rq1") -> asyncio.Future[bool]:
+        future: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        token = TelegramApprovalDecider.key(key, request_id)
+        TelegramApprovalDecider._REGISTRY[token] = future
+        TelegramApprovalDecider.arm(token, "nonce")
+        return future
+
+    @pytest.mark.asyncio
+    async def test_approval_uses_the_current_resumed_key(self, tmp_path: Any) -> None:
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        sessions.set_mirror_link("dashboard:chat-1", link, accepts_inbound=True)
+        future = await self._arm("dashboard:chat-1")
+        try:
+            await dispatcher.on_callback(_callback("a:rq1:nonce:1"))
+            assert future.done() and future.result() is True
+        finally:
+            TelegramApprovalDecider._REGISTRY.clear()
+
+    @pytest.mark.asyncio
+    async def test_moved_binding_expires_old_trust_nonce_without_mutation(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        sessions.set_mirror_link("dashboard:chat-1", link, accepts_inbound=True)
+        old = await self._arm("dashboard:chat-1")
+        sessions.clear_mirror_link("dashboard:chat-1")
+        sessions.set_mirror_link("dashboard:chat-2", link, accepts_inbound=True)
+        try:
+            await dispatcher.on_callback(_callback("a:rq1:nonce:t"))
+            assert not old.done()
+            assert sessions.approval_policies == []
+        finally:
+            TelegramApprovalDecider._REGISTRY.clear()
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_binding_never_falls_back_to_native_approval(
+        self, tmp_path: Any
+    ) -> None:
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path)
+        link = dispatcher._session_resume.link_for(7, None)
+        for key in ("dashboard:chat-1", "dashboard:chat-2"):
+            sessions.mirror_links[key] = link
+            sessions.inbound_keys.add(key)
+        native = dispatcher._session_key(("direct", "7"))
+        future = await self._arm(native)
+        try:
+            await dispatcher.on_callback(_callback("a:rq1:nonce:1"))
+            assert not future.done()
+        finally:
+            TelegramApprovalDecider._REGISTRY.clear()
+
+
+class TestTelegramColdResume:
+    @pytest.mark.parametrize(
+        "recorded, expected",
+        [
+            pytest.param("research-agent", "research-agent", id="recorded"),
+            pytest.param("default", "kirocrew", id="default-sentinel"),
+            pytest.param("Auto", "kirocrew", id="auto-sentinel"),
+            pytest.param("", "kirocrew", id="absent"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_persisted_agent_policy_is_used_consistently(
+        self, tmp_path: Any, recorded: str, expected: str
+    ) -> None:
+        log = _log(tmp_path, agent=recorded)
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path, log=log)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        captured: list[str | None] = []
+        real_persist = dispatcher._persist_turn
+
+        def _persist(*args: Any, **kwargs: Any) -> None:
+            captured.append(kwargs.get("agent", args[5] if len(args) > 5 else None))
+            real_persist(*args, **kwargs)
+
+        dispatcher._persist_turn = _persist  # type: ignore[method-assign]
+        await dispatcher.handle_message(_dm("continue"))
+
+        assert sessions.last_agent == expected
+        assert dispatcher.ctx_builder.build_calls[-1]["agent"] == expected
+        assert captured == [expected]
+
+    @pytest.mark.asyncio
+    async def test_persisted_agent_metadata_read_runs_off_loop(self, tmp_path: Any) -> None:
+        log = _log(tmp_path, agent="research-agent")
+        dispatcher, _, _, _ = _dispatcher(tmp_path, log=log)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        loop_thread = threading.get_ident()
+        reads: list[int] = []
+        real_get = log.get_metadata
+
+        def _get(key: str) -> dict[str, Any]:
+            reads.append(threading.get_ident())
+            return real_get(key)
+
+        log.get_metadata = _get  # type: ignore[method-assign]
+        await dispatcher.handle_message(_dm("continue"))
+
+        assert reads and all(thread_id != loop_thread for thread_id in reads)
+
+    @pytest.mark.asyncio
+    async def test_unreadable_agent_metadata_falls_back_to_route_agent(self, tmp_path: Any) -> None:
+        log = _log(tmp_path)
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path, log=log)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+
+        def _broken(key: str) -> dict[str, Any]:
+            raise OSError("unreadable")
+
+        log.get_metadata = _broken  # type: ignore[method-assign]
+        await dispatcher.handle_message(_dm("continue"))
+
+        assert sessions.last_agent == "kirocrew"
+
+    @pytest.mark.asyncio
+    async def test_cold_resume_suppresses_every_native_only_side_effect(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        from kiro_crew.dashboard import channel_slots
+
+        log = _log(tmp_path, agent="research-agent")
+        dispatcher, _, sessions, _ = _dispatcher(tmp_path, log=log)
+        sessions.is_new_result = True
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        surface = AsyncMock()
+        monkeypatch.setattr(channel_slots, "surface_dispatcher_session", surface)
+        title_claims: list[str] = []
+        monkeypatch.setattr(auto_title, "try_claim", lambda key: title_claims.append(key) or True)
+        before = log.get_metadata("dashboard:chat-1").get("title")
+
+        await dispatcher.handle_message(_dm("continue"))
+
+        assert sessions.set_channel_calls == []
+        assert sessions.origin_links == {}
+        assert log.get_metadata("dashboard:chat-1").get("title") == before
+        assert title_claims == []
+        surface.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resumed_turn_explicitly_broadcasts_channel_user_row(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        from kiro_crew.dashboard import channel_slots
+
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        dispatcher._session_resume.route = AsyncMock(
+            return_value=RoutingDecision(resumed_key="dashboard:chat-1")
+        )
+        broadcasts: list[bool] = []
+
+        def _project(*_args: Any, **kwargs: Any) -> None:
+            broadcasts.append(bool(kwargs.get("broadcast_user")))
+
+        monkeypatch.setattr(channel_slots, "project_channel_turn_live", _project)
+
+        await dispatcher.handle_message(_dm("continue"))
+
+        assert broadcasts == [True]
+
+
+class TestTelegramResumeIntegration:
+    def test_dashboard_state_injection_reaches_the_resume_controller(self, tmp_path: Any) -> None:
+        dispatcher, client, _, _ = _dispatcher(tmp_path)
+        state = _make_state(tmp_path)
+        transport = SimpleNamespace(channel_type="telegram", dispatcher=dispatcher, client=client)
+
+        state.register_channel_transport(transport)
+
+        assert dispatcher.dashboard_state is state
+        assert dispatcher._session_resume.dashboard_state is state
+
+    def test_link_spelling_matches_the_existing_mirror_path(self, tmp_path: Any) -> None:
+        dispatcher, _, _, _ = _dispatcher(tmp_path)
+        route = ("forum", "-100:11")
+
+        assert dispatcher._session_resume.link_for(-100, 11) == dispatcher._origin_mirror_link(
+            route, -100
+        )
+
+    def test_capability_exposes_inbound_resume(self) -> None:
+        assert TELEGRAM_CAPABILITIES.supports_session_resume is True
+
+    def test_dashboard_resume_target_requires_one_owner_dm(self) -> None:
+        from kiro_crew.telegram.transport import TelegramTransport
+
+        owner = TelegramTransport(_Client(), allowed_user_ids={7})
+        assert owner.may_resume_from("7", None) is True
+        assert owner.may_resume_from("8", None) is False
+        assert owner.may_resume_from("7", "11") is False
+
+        shared = TelegramTransport(_Client(), allowed_user_ids={7, 8})
+        assert shared.may_resume_from("7", None) is False
+        assert shared.may_resume_from("8", None) is False


### PR DESCRIPTION
## What this changes

Telegram's `/session` could only *search*: it printed matching dashboard
conversations as text, with no way to attach to one. This makes the results
actionable — `/session <query>` posts them as inline buttons, and one press binds
the chat to that dashboard session, so ordinary messages continue it until `/new`
or `/unlink`. This brings Telegram to functional parity with Discord for dashboard
session takeover.

- **Picker → bind.** `/session <query>` ranks dashboard conversations over both
  titles and message content and posts them as inline buttons. `/session` is now
  the primary spelling; `/sessions` remains an alias.
- **One-click takeover.** A press binds with no preparatory `/unlink`, replacing
  only Telegram-*native* outbound mirrors of the same DM. A deliberate dashboard
  mirror already attached to that chat is left intact and the press is refused
  instead.
- **Commands follow the resumed session.** Routing resolves *before* command
  dispatch, so `/stop`, `/compact`, `/model` and `/title` act on the resumed
  session rather than the native one. Recovery and host commands stay native.
- **Release.** `/new` and `/unlink` release through `SessionBinder.release`,
  clearing the binding *and* retiring the durable expectation, so the next
  message runs natively with no stale refusal.
- **Ownership.** Inbound binding requires the single configured operator in a
  private DM, via a new `may_resume_from` transport hook that fails closed. It is
  rechecked on every inbound route and every callback press, so a stale or
  dashboard-created binding cannot bypass the rule. Forum Topics and multi-user
  allow-lists are refused.
- **Rollback.** Any failure — a lost claim, a persistence error, or a batch-write
  failure at context exit — restores both the mirror state and the expectation.
- **Model picker.** Pickers bind to an exact session and revalidate on press, so a
  stale picker cannot mutate a detached session; only native pickers persist the
  route preference.
- Discord's existing non-broadcast live projection is preserved behind an explicit
  `broadcast_user` parameter, which Telegram opts into.

Docs updated in the same commit: `docs/system-specs/modules/messaging.md` and
`src/kiro_crew/docs/telegram-integration.md`, plus the transport/mirror/Webex
contract docstrings that named Discord as the only inbound-resolving channel.

## Testing

- **877 passed** — `test_telegram.py`, `test_telegram_sessions.py` (new, covering
  the picker, takeover, rollback, ownership and stale-picker paths),
  `test_telegram_parity.py`, `test_discord_sessions.py`,
  `test_channel_row_identity.py`.
- **292 passed** — `test_capability_ledger.py`, `test_chat_mirror.py`,
  `test_session_map_mirror.py`, `test_teams_sessions.py`, `test_teams_routing.py`.
- flake8 clean; `mypy --platform linux` clean across 1,283 files; black, isort,
  subprocess-encoding, docs-lint, brand and harness-parity gates all pass.
- **Smoke-tested in an isolated `kirocrew pod`** on this branch: the worktree's
  gateway boots healthy, then the real flow was driven against real on-disk state
  (real `ConversationLog`, `SessionManager`/`SessionMap`, `ResumeExpectations`,
  and the real dispatcher command dispatch) with only the Bot API client stubbed —
  28/28 assertions, covering picker → durable bind → routing to the dashboard
  session → non-owner refusal → `/unlink` release → protected dashboard mirror.
  Teardown verified zero residue and an untouched live plane.

## Not covered

- **No live-bot test.** A pod force-disables Telegram and scrubs
  `TELEGRAM_BOT_TOKEN` by design (`SEED_DISABLED_SECTIONS`, `build_pod_env`) so it
  can never answer real people as the operator's bot, and `telegram/client.py`
  hardcodes the Bot API base URL. The physical button tap therefore needs a human
  with a real token and Telegram account.
- No model turn ran in the pod smoke test, so `/stop`, `/compact`, `/model` and
  `/title` against a resumed session are covered by unit tests only.
- The forum-Topic refusal is verified at the policy level (`may_resume_from`),
  not through a real Topic message.
