### PR TITLE
test: stop the sensitive-regex linearity ceiling flaking on loaded CI

### DIFF
--- a/test/test_security_regex_linearity.py
+++ b/test/test_security_regex_linearity.py
@@ -292,23 +292,44 @@ def inspect_source(func: object) -> str:
 
 
 def test_long_nonshell_line_does_not_blow_up() -> None:
-    """Complexity guard for Mesh-3693.
+    """Catastrophe ceiling for Mesh-3693.
 
     A ~20 KB newline-free non-shell string is the worst case for the old anchor:
-    eleven branches each retried a greedy ``.*`` from every offset. Measured on
-    the dev box this took ~27 s before the rewrite and ~1.5 s after, so a 6 s
-    ceiling clears the fixed path by ~4x while the quadratic form overshoots by
-    ~4.5x. Deliberately generous -- this test exists to catch a complexity
-    regression, not to benchmark CI.
+    eleven branches each retried a greedy ``.*`` from every offset. On the dev box
+    that form took ~27 s; the rewritten anchor takes ~2.0 s -- a ~14x separation,
+    which is what this test actually keys on.
+
+    Two deliberate choices keep it off the flake list, both learned from a 6.27 s
+    reading on a 16-worker CI shard against the old 6.0 s ceiling:
+
+    * ``min()`` over two repeats, after a warm-up call. The first call pays the
+      one-time ``_build_sensitive_regex`` compile (~0.12 s) and ``min`` discards
+      scheduler interference rather than averaging it in.
+    * a 20 s ceiling, not a ~4x margin over the dev-box reading. The measured
+      contention factor on a loaded shard is ~3.2x (2.0 s -> 6.3 s), so 20 s
+      leaves ~3x headroom above the worst observed fixed-path time while the old
+      form -- ~27 s unloaded, ~86 s at that same contention factor -- still
+      overshoots by >4x.
+
+    This is a catastrophe ceiling, not a benchmark. The DETERMINISTIC net for the
+    specific regression it names is
+    :func:`test_sensitive_anchor_has_no_leading_wildcard`, which reads the anchor
+    out of the source and cannot flake at all; keep that one primary.
     """
     blob = "abcdefgh " * 2500
     assert len(blob) > 20_000
-    started = time.perf_counter()
+    # Warm-up: pays the one-time regex build so it is not billed to a sample.
     verdict = is_sensitive_bash_command(blob)
-    elapsed = time.perf_counter() - started
     assert bool(verdict) is False
-    assert elapsed < 6.0, (
-        f"is_sensitive_bash_command took {elapsed:.2f}s on a 20 KB line -- "
+    samples = []
+    for _ in range(2):
+        started = time.perf_counter()
+        is_sensitive_bash_command(blob)
+        samples.append(time.perf_counter() - started)
+    elapsed = min(samples)
+    assert elapsed < 20.0, (
+        f"is_sensitive_bash_command took {elapsed:.2f}s on a 20 KB line "
+        f"(samples: {[f'{s:.2f}' for s in samples]}) -- "
         "a leading `.*` in the sensitive-path anchor is quadratic"
     )
 


### PR DESCRIPTION
## Problem / Motivation

`test/test_security_regex_linearity.py::test_long_nonshell_line_does_not_blow_up` fails intermittently on the full-suite CI run, two consecutive times:

```
AssertionError: is_sensitive_bash_command took 6.27s on a 20 KB line -- a leading `.*` in the sensitive-path anchor is quadratic
assert 6.272856689000037 < 6.0
```

```
AssertionError: is_sensitive_bash_command took 6.01s on a 20 KB line
assert 6.0072396939999635 < 6.0
```

Nothing in `security.py` regressed. The test asserted a **6.0s absolute wall-clock ceiling on one unwarmed sample**, and the margin it left is smaller than CI's contention factor.

## Why it matters

It is a red on a green suite: a full run costs ~29 minutes, and this failure sends whoever reads it looking for a complexity regression in a DENY-surface regex that does not have one. The second reading landed at 6.007s — 0.1% over the line — so the margin is exhausted, not merely tight, and it will keep firing.

## What changed (motivation → approach → change)

Measured on a dev box, the fixed path is `1.960s` at 20 KB with variance ±0.001s across five warm runs. So the run-to-run spread is negligible and the entire 6.27s reading is load: a 16-worker CI shard runs this ~3.2x slower. The ceiling carried only a ~3x margin, which the contention factor consumes exactly.

What this test *can* discriminate is not a tight absolute time but the **~14x constant-factor gap** between the old anchor (~27s at 20 KB) and the rewritten one (~2.0s). It is now written as a catastrophe ceiling on that gap:

- **warm up once before sampling** — the first call pays the one-time `_build_sensitive_regex` compile (~0.12s, measured), which was previously billed to the single sample;
- **`min()` of two samples** — discards scheduler interference rather than averaging it in;
- **ceiling raised 6.0s → 20.0s** — ~3x headroom above the worst observed fixed-path time (6.27s), while the old form (~27s unloaded, ~86s at that same contention factor) still overshoots by >4x.

The deterministic net for this exact regression is unchanged and stays primary: `test_sensitive_anchor_has_no_leading_wildcard` reads the anchor out of `_build_sensitive_regex`'s source and cannot flake at all. The timing test is the belt to that suspenders, and the docstring now says so.

### Latent finding, deliberately not fixed here

`is_sensitive_bash_command` is **still O(n²)** in line length. Measured:

| input | time |
|---|---|
| 5.6 KB | 0.178s |
| 11 KB | 0.500s |
| 22 KB | 1.901s |
| 45 KB | 7.542s |

Doubling the input quadruples the time. The Mesh-3693 anchor rewrite removed the constant factor, not the order; profiling attributes ~100% of the cost to the verb-anchored branch's greedy `.*` (`(?:cat|head|…)\s.*<sensitive_path>`), with every other top-level branch at ≤0.001s. At 45 KB the 4096-unit traversal budget fails closed first, so this is a latent cost on a gate that runs synchronously on the event loop rather than a live defect. Out of scope for a flake fix on a DENY surface; noted in the commit message so it is not lost.

## Tests

No new tests. The changed test is itself the test: same input, same asserted verdict (`False`), same failure message shape — only the sampling method and the ceiling move. Behaviour of `security.py` is untouched (zero source diff), so the other 56 tests in the file, including all 30 verdict differentials and both source guards, are unchanged and still pass.

`test/test_security_regex_linearity.py`: **57 passed**. `black` clean, `flake8` clean.

## Manual verification

N/A — this is a test-only change and the local run of the affected file is the verification.

## Related Issues

N/A — reported from CI output, no tracking issue filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a performance guard that asserts an absolute wall-clock ceiling with a margin smaller than CI's contention factor. Discriminate on the ratio the regression actually moves, and size any absolute ceiling against a loaded shard rather than a quiet dev box.
