### PR TITLE
fix(ci): enable no-eval for the website application tree (#7699)

### DIFF
--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -57,6 +57,13 @@ export default [
         }],
       }],
       'no-console': 'warn',
+      // `no-eval` is not part of eslint:recommended, so without this line eval
+      // is unlinted across the application tree. The tree is at zero eval sites
+      // in .ts/.tsx (every `eval` match under src/ is prose in comments), so
+      // like the native-<select> gate below this is a hard-zero 'error', not a
+      // 'warn' riding the ratchet. The one deliberate eval lives in the .mjs
+      // generator block below, guarded by its own reviewed directive.
+      'no-eval': 'error',
       // A native <select> renders an OS-drawn popup: it ignores every theme
       // token, cannot be styled per row, and looks nothing like the rest of the
       // dashboard. Every dropdown goes through the shared Radix components —


### PR DESCRIPTION
## Summary

`no-eval` is not part of `eslint:recommended`, and the base `files: ['src/**/*.{ts,tsx}']` block in `website/eslint.config.js` never enabled it — so `eval` was unlinted across the entire application tree. This adds `'no-eval': 'error'` to that base block.

The tree is at **zero** eval sites in `.ts`/`.tsx` (every `eval` match under `src/` is prose in comments, per the issue's scope check and re-verified here), so this is a hard-zero `error` like the native-`<select>` gate, not a `warn` riding the `--max-warnings` budget.

Closes #7699

## What #7569 already covered (and why this PR is one line of config)

Issue #7699 proposed three hunks. Two of them landed on main via #7569 before this PR:

- the `src/**/*.mjs` block enabling `no-eval` (making the generator's line-173 disable directive **used** and killing the permanent unused-directive warning), and
- the ratchet: `ci.yml` now runs `npx eslint src/ --max-warnings 0`, so the "lower the ceiling" hunk is obsolete — the ceiling is already at the floor.

The remaining gap was the base application block, which is this PR. Per the issue, the `.mjs` generator file itself is untouched (its directive stays as-is, now live via the existing `.mjs` block).

## Deliberately out of scope

- `no-new-func` (the `new Function` in `serviceWorkerSkipRules.test.ts`) — the reporter explicitly excluded it as a separate decision. Note: `no-eval` also does not cover `no-implied-eval` (string-arg `setTimeout`/`setInterval`), so this PR narrows the eval-family gap rather than closing it entirely; those two rules remain a possible follow-up.
- The #7695 exhaustive-deps fix — explicitly not folded in.

## Pattern harvest

Rule candidate: eslint config self-check — a `// eslint-disable-next-line <rule>` directive is only meaningful when some config block matching that file enables `<rule>`; a directive naming a never-enabled rule is a permanent unused-directive warning. ESLint's own `linterOptions.reportUnusedDisableDirectives: 'error'` (flat config) is the built-in detector for this class and would turn the silent decay into a hard failure; the tree is already at zero unused directives, so it could land as a hard-zero gate. Beyond that, the specific defect class (security-relevant rules like `no-eval`/`no-new-func`/`no-implied-eval` absent from the base block) is closed for `no-eval` by this PR and enumerated as follow-up above.

## Verification

- `cd website && npx eslint src/` → exit 0, **0 errors, 0 warnings** (measured count 0 under the `--max-warnings 0` ceiling; the one deliberate `eval` in `crew-ghost-sprite.gen.mjs` stays suppressed by its now-live directive)
- `npx tsc -b` → pass
- Pre-push review: GPT lane (gpt-5.6-sol) PASS; Opus lane (claude-opus-5) PASS with two Low advisories — the comment-direction fix is folded into this commit, the scope note is the paragraph above

no linked issue: linked — Closes #7699.

No UI change — lint config only, no screenshots warranted.
