### PR TITLE
fix(security): cover HOME env spellings in the rm-rf-home deny rule

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -1279,7 +1279,9 @@ BUILTIN_DENIED_RULES: list[DeniedCommandRule] = [
     ),
     DeniedCommandRule(
         id="local-destructive-rm-rf-home",
-        pattern="rm -rf ~.*",
+        # Also covers $HOME / ${HOME} / ${HOME:?}-family spellings (quoted or not — double
+        # quotes still expand), which the shell resolves to the same path (#8387).
+        pattern="rm -rf \"?(?:~|\\$HOME|\\$\\{HOME(?:\\}|:[^}]*\\})).*",
         category="local-destructive",
         description=(
             "Blocks recursive force-deletion of the user home directory (rm -rf ~...), which "
@@ -1790,6 +1792,8 @@ _LEGACY_RULE_ID_BY_PATTERN: dict[str, str] = {
         "self-protection-cloud"
     ),
     ".*kiro.?crew gateway restart.*": "self-protection-gateway-restart",
+    # Pre-$HOME widening home spelling (#8387): persisted pins keep resolving.
+    "rm -rf ~.*": "local-destructive-rm-rf-home",
 }
 
 
@@ -2378,6 +2382,7 @@ def _exception_eligible(view: str) -> bool:
 _DENY_EXCEPTIONS: dict[str, list[str]] = {
     "rm -rf /.*": list(_INERT_SEARCH_GLOBS),
     "rm -rf ~.*": list(_INERT_SEARCH_GLOBS),
+    "rm -rf \"?(?:~|\\$HOME|\\$\\{HOME(?:\\}|:[^}]*\\})).*": list(_INERT_SEARCH_GLOBS),
 }
 
 # Used to *split* a command into independently-evaluatable segments.

--- a/test/fixtures/denied_commands_golden.json
+++ b/test/fixtures/denied_commands_golden.json
@@ -399,7 +399,7 @@
     "id": "iac-teardown-cdk-destroy",
     "pattern": "cdk destroy.*",
     "category": "iac-teardown",
-    "description": "Blocks `cdk destroy`, which tears down an entire AWS CDK stack and all its provisioned cloud resources \u2014 irreversible infrastructure and data loss."
+    "description": "Blocks `cdk destroy`, which tears down an entire AWS CDK stack and all its provisioned cloud resources — irreversible infrastructure and data loss."
   },
   {
     "id": "local-destructive-chmod-777",
@@ -579,7 +579,7 @@
     "id": "iac-teardown-kubectl-delete-namespace",
     "pattern": "kubectl delete namespace.*",
     "category": "iac-teardown",
-    "description": "Blocks `kubectl delete namespace`, which deletes a Kubernetes namespace and cascades to every workload, service, and volume inside it \u2014 irreversible cluster-wide teardown."
+    "description": "Blocks `kubectl delete namespace`, which deletes a Kubernetes namespace and cascades to every workload, service, and volume inside it — irreversible cluster-wide teardown."
   },
   {
     "id": "local-destructive-mkfs",
@@ -603,7 +603,7 @@
     "id": "iac-teardown-pulumi-destroy",
     "pattern": "pulumi destroy.*",
     "category": "iac-teardown",
-    "description": "Blocks `pulumi destroy`, which deletes all cloud resources managed by a Pulumi stack \u2014 irreversible infrastructure teardown."
+    "description": "Blocks `pulumi destroy`, which deletes all cloud resources managed by a Pulumi stack — irreversible infrastructure teardown."
   },
   {
     "id": "local-destructive-rm-rf-root",
@@ -613,7 +613,7 @@
   },
   {
     "id": "local-destructive-rm-rf-home",
-    "pattern": "rm -rf ~.*",
+    "pattern": "rm -rf \"?(?:~|\\$HOME|\\$\\{HOME(?:\\}|:[^}]*\\})).*",
     "category": "local-destructive",
     "description": "Blocks recursive force-deletion of the user home directory (rm -rf ~...), which would destroy all personal files and config."
   },
@@ -621,7 +621,7 @@
     "id": "iac-teardown-terraform-destroy",
     "pattern": "terraform destroy.*",
     "category": "iac-teardown",
-    "description": "Blocks `terraform destroy`, which destroys every resource tracked in the Terraform state \u2014 irreversible infrastructure and data loss."
+    "description": "Blocks `terraform destroy`, which destroys every resource tracked in the Terraform state — irreversible infrastructure and data loss."
   },
   {
     "id": "sql-truncate-table",

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -6364,3 +6364,40 @@ class TestPolynomialBacktrackingStaysBounded:
         matcher.match(subject)
         elapsed = time.perf_counter() - start
         assert elapsed < 1.0, f"deny evaluation took {elapsed:.1f}s — gate would stall"
+
+
+class TestRmHomeEnvSpellingsStayDenied:
+    """$HOME / ${HOME} expand to ~, so the home rule must cover them (#8387)."""
+
+    def test_home_env_spellings_denied(self):
+        from kiro_crew import security
+
+        for cmd in [
+            "rm -rf $HOME",
+            "rm -rf $HOME/docs",
+            "rm -rf ${HOME}",
+            "rm -rf ${HOME}/docs",
+            # Braced parameter expansions resolve to home too (#8388).
+            "rm -rf ${HOME:?}",
+            "rm -rf ${HOME:-/tmp/fallback}",
+            "rm -rf ${HOME:=/tmp/fallback}",
+            "rm -rf ${HOME:+/tmp/other}",
+            'rm -rf "$HOME"',
+            'rm -rf "$HOME"/docs',
+            "rm -rf ~",
+            "rm -rf ~/docs",
+        ]:
+            assert security.is_denied(cmd), f"should deny {cmd!r}"
+        # A different variable name must not match.
+        assert not security.is_denied("rm -rf ${HOMEx}"), "should allow ${HOMEx}"
+
+    def test_lookalikes_stay_allowed(self):
+        from kiro_crew import security
+
+        for cmd in ["rm -f ~", "rm ~", "rm -rf", "rm -rf ./rel"]:
+            assert not security.is_denied(cmd), f"should allow {cmd!r}"
+
+    def test_legacy_home_pin_still_resolves(self):
+        from kiro_crew import security
+
+        assert security._rule_id_for_pattern("rm -rf ~.*") == "local-destructive-rm-rf-home"


### PR DESCRIPTION
## Problem / Motivation

The `rm -rf ~` deny rule only recognized the tilde spelling, so the equivalent `$HOME` / `${HOME}` spellings (quoted or not — double quotes still expand) sailed through the deny gate (the sensitive tier never anchored bare home for `~` either, so only the deny gate changes here). Verified: `rm -rf $HOME`, `rm -rf ${HOME}`, and `rm -rf "$HOME"` all return "allow" while `rm -rf ~` is denied.

## Why it matters

The shell expands these spellings to the exact path the rule exists to protect, so a destructive home deletion runs with no policy trip. Same severity class as the `~` case already blocked.

## What changed (motivation → approach → change)

Symptom → shell-equivalent spellings bypass the home rule. Cause → the operand tail anchors at `~.*` only. Change → the tail now accepts `~`, `$HOME`, and `${HOME}` with an optional double quote (single-quoted forms stay allowed since no expansion happens there). Also added a legacy pin alias so persisted `rm -rf ~.*` pins keep resolving. Kept to the operand tail only so this rebases cleanly with #8240.

## Tests

New `TestRmHomeEnvSpellingsStayDenied` (red without the fix, green with it), golden/catalog parity green, neighbor rm/catalog/ReDoS suites green (393 passed).

## Manual verification

N/A — unit coverage sufficient (gate-level probes for all spellings plus lookalikes).

Fixes #8387


## Pattern harvest
Rule candidate: home-directory operands need shell-equivalent-spelling coverage (`~`, `$HOME`, `${HOME}`) — blocking one spelling while the shell expands the others leaves the same hole, as with flag respellings in #8240.

