### PR TITLE
fix(apps): serve a live signal so a stale running record is tellable (#7582)

### DIFF
--- a/docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md
+++ b/docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md
@@ -116,6 +116,21 @@ written from a process that does not own the work reports a run as ended when it
 has not ended. Dev Fleet's registry is the process-memory case (see "Dev Fleet
 runs"). `JobSDK` describes work that the gateway process itself executes.
 
+A durable `running` record and a process actually owning the work are therefore
+two separate facts, and the public view serves both.
+`JobSDK.cancelling_and_live_ids` returns the `cancelling` and `live` run id
+sets under a single lock acquisition, so the two fields describe one instant;
+`live` is live-table membership — claimed at start, dropped after the terminal
+write — the same authority that `cancel` and `reconcile` already consult
+(`src/kiro_crew/apps/job_sdk.py`, `JobSDK.cancelling_and_live_ids`).
+`_public_view` serves that as the boolean `live` field, computed at read time
+from memory — nothing new is persisted, and `origin` and `pid` stay withheld
+(`src/kiro_crew/apps/job_routes.py`, `_public_view`). A record whose terminal
+write failed twice and a record minted by another gateway process both read
+`live: false`, which is what lets an API consumer tell a stale `running`
+record from real work between the reconciliation passes that would eventually
+resolve it.
+
 ## View position is not an App SDK contract
 
 Builtin apps are mounted by the single-segment `/:builtinApp` route, and

--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -1749,8 +1749,8 @@ def _job_view(run: Any) -> dict[str, Any] | None:
     the full ``error``, while this one omits both cancel fields (the backup
     runners declare no cancellability, so they would be permanently false) and
     clamps ``error`` for the caption that renders it. ``_public_view`` also takes
-    a required ``cancelling`` set read from the SDK's live table, which this
-    endpoint has no reason to compute.
+    required ``cancelling`` and ``live`` sets read from the SDK's live table,
+    which this endpoint has no reason to compute.
 
     Sharing one projection between two endpoints with different contracts is how
     a field leaks into one because the other needed it -- and the field at stake

--- a/src/kiro_crew/apps/job_routes.py
+++ b/src/kiro_crew/apps/job_routes.py
@@ -48,8 +48,8 @@ logger = logging.getLogger(__name__)
 
 Handler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
-#: What one store read returns, so ``_read_with_cancelling`` can pair a single
-#: record and a list of them with the same snapshot without losing the type.
+#: What one store read returns, so ``_read_with_snapshots`` can pair a single
+#: record and a list of them with the same snapshots without losing the type.
 _T = TypeVar("_T")
 
 #: Mounted under each app's own namespace.
@@ -92,7 +92,7 @@ def _safe(text: str) -> str:
         return text[:500]
 
 
-def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
+def _public_view(run: JobRun, cancelling: frozenset[str], live: frozenset[str]) -> dict[str, Any]:
     """The record as the browser sees it.
 
     ``origin`` and ``pid`` are host facts with no client meaning, so they are
@@ -100,20 +100,31 @@ def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
     caller- or runner-supplied payload to decide about, which is why there is no
     per-field withholding rule here any more.
 
-    ``cancelling`` is the one field NOT read off the record. It says a cancel has
-    been asked for and the worker has not reached the checkpoint where it records
-    the outcome, and it comes from the SDK's live table via ``cancelling_ids``
-    because ``cancel`` deliberately writes nothing -- see that method for why
-    persisting it would break the single-writer rule. ``cancelling`` is a
-    REQUIRED argument rather than a defaulted one so that a future caller cannot
-    quietly serve ``false`` by forgetting to pass it; a missing argument is a
-    type error at the call site instead of a wrong answer in the response.
+    ``cancelling`` is one of two fields NOT read off the record. It says a cancel
+    has been asked for and the worker has not reached the checkpoint where it
+    records the outcome, and it comes from the SDK's live table via
+    ``cancelling_and_live_ids`` because ``cancel`` deliberately writes nothing -- see that
+    method for why persisting it would break the single-writer rule.
+    ``cancelling`` is a REQUIRED argument rather than a defaulted one so that a
+    future caller cannot quietly serve ``false`` by forgetting to pass it; a
+    missing argument is a type error at the call site instead of a wrong answer
+    in the response.
 
-    A terminal run is never ``cancelling``. The worker writes the record before
-    ``_execute`` drops the live entry, so a read landing between those two would
-    otherwise report ``status: cancelled`` and ``cancelling: true`` together --
-    the cancel both finished and still pending. Once the status carries the
-    answer there is nothing left to be pending.
+    ``live`` is the other, from the same table via ``cancelling_and_live_ids``:
+    whether THIS gateway process holds the run in its live table -- claimed at
+    start, dropped after the terminal write. A durable record can carry
+    ``running`` with nothing owning it -- a terminal write that failed twice,
+    or a record minted by another gateway process -- and ``live`` is the only
+    signal that lets a client tell that stale record from real work; ``origin``
+    and ``pid`` stay withheld. It is REQUIRED for the same reason
+    ``cancelling`` is.
+
+    A terminal run is never ``cancelling`` and never ``live``. The worker
+    writes the record before ``_execute`` drops the live entry, so a read
+    landing between those two would otherwise report ``status: cancelled`` and
+    ``cancelling: true`` together -- the cancel both finished and still
+    pending -- or a finished run as still driven. Once the status carries the
+    answer there is nothing left to be pending or driven.
 
     ``interrupted_from`` and ``interrupt_cause`` are served for the reason they
     exist. They are not host facts -- they are the two facts a client needs to
@@ -128,6 +139,7 @@ def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
         "status": run.status,
         "cancellable": run.cancellable,
         "cancelling": not run.is_terminal and run.run_id in cancelling,
+        "live": not run.is_terminal and run.run_id in live,
         "created_at": run.created_at,
         "updated_at": run.updated_at,
         "finished_at": run.finished_at,
@@ -137,25 +149,36 @@ def _public_view(run: JobRun, cancelling: frozenset[str]) -> dict[str, Any]:
     }
 
 
-def _read_with_cancelling(sdk: JobSDK, read: Callable[[], _T]) -> tuple[_T, frozenset[str]]:
-    """Run one store read and take the cancelling snapshot, in ONE off-loop hop.
+def _read_with_snapshots(
+    sdk: JobSDK, read: Callable[[], _T]
+) -> tuple[_T, frozenset[str], frozenset[str]]:
+    """Run one store read and take the cancelling + live snapshots, in ONE
+    off-loop hop.
 
-    Off the loop because ``cancelling_ids`` takes the SDK's lock and ``_persist``
-    holds that same lock across a disk write, so acquiring it on the loop could
-    park the gateway for the length of that write. The store read is already
-    off-loop work for the same reason, so pairing them adds no hop.
+    Off the loop because ``cancelling_and_live_ids`` takes the SDK's lock and
+    ``_persist`` holds that same lock across a disk write, so acquiring it on
+    the loop could park the gateway for the length of that write. The store
+    read is already off-loop work for the same reason, so pairing them adds no
+    hop.
 
     ONE snapshot per response, not one per row: a list endpoint would otherwise
     render each row against a different instant, so two rows could disagree about
-    a cancel that landed while the page was being built.
+    a cancel that landed while the page was being built. The two sets come from
+    ONE lock acquisition for the same reason: taken separately, a worker
+    finishing between them could serve ``cancelling: true`` and ``live: false``
+    together for a non-terminal record.
 
-    The record is read BEFORE the snapshot, deliberately. A cancel arriving
+    The record is read BEFORE the snapshots, deliberately. A cancel arriving
     between the two is then reported (a ``running`` record against a snapshot
     that has it) rather than missed, which is the direction that serves the user
     who just pressed the button. The reverse order would answer "not cancelling"
-    about a cancel that was already in.
+    about a cancel that was already in. The same order serves ``live``: a
+    worker finishing between the two reads ``live: false``, which is by then
+    the truth.
     """
-    return read(), sdk.cancelling_ids()
+    result = read()
+    cancelling, live = sdk.cancelling_and_live_ids()
+    return result, cancelling, live
 
 
 def _enabled_and_permitted(app_name: str) -> tuple[bool, bool]:
@@ -303,21 +326,23 @@ async def _handle_start(request: web.Request, app_name: str, sdk: JobSDK) -> web
         # aiohttp's default handler as a bare 500 carrying no machine-readable
         # code, which no client can switch on.
         return web.json_response({"error": _safe(str(exc)), "code": "job_start_failed"}, status=503)
-    run, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
+    run, cancelling, live = await asyncio.to_thread(
+        _read_with_snapshots, sdk, lambda: sdk.get(run_id)
+    )
     if run is None:
         return web.json_response(
             {"error": "the run record could not be read back", "code": "run_unreadable"},
             status=500,
         )
-    return web.json_response({"run": _public_view(run, cancelling)})
+    return web.json_response({"run": _public_view(run, cancelling, live)})
 
 
 async def _handle_active(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
     kind = request.query.get("kind", "")
-    runs, cancelling = await asyncio.to_thread(
-        _read_with_cancelling, sdk, lambda: sdk.list_active(kind)
+    runs, cancelling, live = await asyncio.to_thread(
+        _read_with_snapshots, sdk, lambda: sdk.list_active(kind)
     )
-    return web.json_response({"runs": [_public_view(r, cancelling) for r in runs]})
+    return web.json_response({"runs": [_public_view(r, cancelling, live) for r in runs]})
 
 
 async def _handle_recent(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
@@ -330,23 +355,27 @@ async def _handle_recent(request: web.Request, app_name: str, sdk: JobSDK) -> we
             {"error": "limit must be an integer", "code": "invalid_limit"}, status=400
         )
     limit = max(1, min(limit, _RECENT_MAX))
-    runs, cancelling = await asyncio.to_thread(
-        _read_with_cancelling, sdk, lambda: sdk.list_recent(kind, limit)
+    runs, cancelling, live = await asyncio.to_thread(
+        _read_with_snapshots, sdk, lambda: sdk.list_recent(kind, limit)
     )
-    return web.json_response({"runs": [_public_view(r, cancelling) for r in runs]})
+    return web.json_response({"runs": [_public_view(r, cancelling, live) for r in runs]})
 
 
 async def _handle_get(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
     run_id = request.match_info.get("run_id", "")
-    run, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
+    run, cancelling, live = await asyncio.to_thread(
+        _read_with_snapshots, sdk, lambda: sdk.get(run_id)
+    )
     if run is None:
         return web.json_response({"error": "no such run", "code": "job_not_found"}, status=404)
-    return web.json_response({"run": _public_view(run, cancelling)})
+    return web.json_response({"run": _public_view(run, cancelling, live)})
 
 
 async def _handle_cancel(request: web.Request, app_name: str, sdk: JobSDK) -> web.StreamResponse:
     run_id = request.match_info.get("run_id", "")
-    run, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
+    run, cancelling, live = await asyncio.to_thread(
+        _read_with_snapshots, sdk, lambda: sdk.get(run_id)
+    )
     if run is None:
         return web.json_response({"error": "no such run", "code": "job_not_found"}, status=404)
     accepted = await sdk.cancel_async(run_id)
@@ -358,7 +387,7 @@ async def _handle_cancel(request: web.Request, app_name: str, sdk: JobSDK) -> we
             {
                 "error": "this run cannot be cancelled",
                 "code": "job_not_cancellable",
-                "run": _public_view(run, cancelling),
+                "run": _public_view(run, cancelling, live),
             },
             status=409,
         )
@@ -367,8 +396,12 @@ async def _handle_cancel(request: web.Request, app_name: str, sdk: JobSDK) -> we
     # field inside ``run`` is what any later read of the record will now also
     # report, and the two legitimately differ once a fast worker has already
     # reached its checkpoint and recorded ``cancelled``.
-    fresh, cancelling = await asyncio.to_thread(_read_with_cancelling, sdk, lambda: sdk.get(run_id))
-    return web.json_response({"cancelling": True, "run": _public_view(fresh or run, cancelling)})
+    fresh, cancelling, live = await asyncio.to_thread(
+        _read_with_snapshots, sdk, lambda: sdk.get(run_id)
+    )
+    return web.json_response(
+        {"cancelling": True, "run": _public_view(fresh or run, cancelling, live)}
+    )
 
 
 # ── Registration ──

--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -41,7 +41,7 @@ BEFORE handing off, the worker thread is the sole writer from then on, and
 the outcome at its next checkpoint). Reconciliation writes only records from a
 process that is already gone. A requested cancel still has to be visible to a
 reader before that checkpoint arrives, so it is DERIVED on read from the live
-table -- ``cancelling_ids`` -- rather than written down. Reading it costs nothing
+table -- ``cancelling_and_live_ids`` -- rather than written down. Reading it costs nothing
 the rule protects; writing it would cost the rule.
 
 **Claiming a run and LAUNCHING it are separate, and the interval between them is
@@ -1230,6 +1230,57 @@ class JobSDK:
         runs.sort(key=lambda r: (r.updated_at, r.created_at), reverse=True)
         return runs[: max(0, limit)]
 
+    def cancelling_and_live_ids(self) -> tuple[frozenset[str], frozenset[str]]:
+        """One-acquisition snapshot of the ``(cancelling, live)`` run id sets.
+
+        ``live`` is live-table membership: whether THIS process holds the run
+        -- claimed at ``start`` just before the record is persisted and the
+        worker thread launched, dropped only after the terminal write lands.
+        That ownership reading is deliberate: it is the same authority
+        :meth:`cancel` and :meth:`reconcile` already consult (``reconcile``
+        spares exactly the runs reported live here). A durable record can say
+        ``running`` while nothing owns it -- a terminal write that failed
+        twice, or a record minted by another gateway process -- and both are
+        absent from ``live``, which is what distinguishes a stale record from
+        work this process is executing. Derived from memory at read time;
+        nothing new is persisted, so it stays correct under any later
+        heartbeat or lease design layered on top.
+
+        ``cancelling`` is the read side of :meth:`cancel`'s "writes nothing".
+        A requested cancel has to outlive the tab that asked -- that is the
+        whole point of the SDK -- but persisting it from ``cancel`` would make
+        a second writer on that run's file, and one-writer-per-run is what
+        keeps ``atomic_write``'s crash-safety from silently dropping the loser
+        of a concurrent update. So the fact is DERIVED from the live table on
+        read instead. The window it covers is the gap between the request and
+        the worker's next checkpoint, and it closes on its own: the worker
+        records ``cancelled`` and ``_execute`` drops the entry, after which
+        the status carries the answer. Deliberately NOT durable across a
+        restart: a restarted gateway has no live table, and ``reconcile`` has
+        already resolved the run to ``interrupted`` -- there is no pending
+        cancel left to report.
+
+        Both sets come from a SINGLE lock acquisition so a response renders
+        them from one instant. Taken as two separate snapshots, a worker
+        finishing between the acquisitions could serve ``cancelling: true``
+        and ``live: false`` together for a non-terminal record -- a cancel
+        pending on a run nothing owns. Within one snapshot ``cancelling`` is a
+        subset of ``live`` by construction, and one acquisition serves a whole
+        response, so a list endpoint renders every row from ONE snapshot
+        rather than N of them.
+
+        Call OFF the event loop: ``_persist`` holds this same lock across a
+        disk write, so taking it on the loop can park the gateway for the
+        length of that write.
+        """
+        with self._lock:
+            return (
+                frozenset(
+                    run_id for run_id, live in self._live.items() if live.handle.cancelled.is_set()
+                ),
+                frozenset(self._live),
+            )
+
     # ── Cancel ──
 
     def cancel(self, run_id: str) -> bool:
@@ -1255,38 +1306,6 @@ class JobSDK:
         """Loop-native :meth:`cancel`. Present so an on-loop caller does not
         have to know which methods happen to touch the disk."""
         return await asyncio.to_thread(self.cancel, run_id)
-
-    def cancelling_ids(self) -> frozenset[str]:
-        """Run ids whose cancel has been asked for and not yet recorded.
-
-        The read side of :meth:`cancel`'s "writes nothing". A requested cancel
-        has to outlive the tab that asked -- that is the whole point of the SDK --
-        but persisting it from ``cancel`` would make a second writer on that
-        run's file, and one-writer-per-run is what keeps ``atomic_write``'s
-        crash-safety from silently dropping the loser of a concurrent update. So
-        the fact is DERIVED from the live table on read instead, the same way
-        :meth:`reconcile` already derives liveness from it. Nothing new is
-        written and the single-writer rule is untouched.
-
-        The window this covers is the gap between the request and the worker's
-        next checkpoint, which for a runner that checkpoints minutes apart is
-        minutes. It closes on its own: the worker records ``cancelled`` and
-        ``_execute`` drops the entry, after which this returns nothing for that
-        run and the status carries the answer.
-
-        Deliberately NOT durable across a restart. A restarted gateway has no
-        live table, and ``reconcile`` has already resolved the run to
-        ``interrupted`` -- there is no pending cancel left to report.
-
-        Call OFF the event loop. ``_persist`` holds this same lock across a disk
-        write, so taking it on the loop can park the gateway for the length of
-        that write. One acquisition serves a whole response, so a list endpoint
-        renders every row from ONE snapshot rather than from N of them.
-        """
-        with self._lock:
-            return frozenset(
-                run_id for run_id, live in self._live.items() if live.handle.cancelled.is_set()
-            )
 
     # ── Reconciliation ──
 

--- a/test/test_job_routes.py
+++ b/test/test_job_routes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import threading
 import time
 from pathlib import Path
@@ -656,6 +657,104 @@ async def test_a_recorded_cancel_is_no_longer_cancelling(
         assert run["cancelling"] is False
     finally:
         release.set()
+
+
+# ---------------------------------------------------------------------------
+# 9b: the live field — a durable record vs a worker actually driving it
+# ---------------------------------------------------------------------------
+
+
+def _write_raw_running(sdk: JobSDK, run_id: str, kind: str = "slow") -> js.JobRun:
+    """Persist a ``running`` record no thread in this process is driving.
+
+    The shape a record from another gateway process has, and the same shape a
+    twice-failed terminal write leaves behind: durable, non-terminal, absent
+    from the live table. Written raw because going through ``start`` would
+    register exactly the live entry whose absence is the subject.
+    """
+    run = js.JobRun(
+        run_id=run_id,
+        app=APP,
+        kind=kind,
+        status=js.RUNNING,
+        origin="foreign-origin-token",
+    )
+    store = sdk.store
+    store.dir.mkdir(parents=True, exist_ok=True)
+    (store.dir / f"{run.run_id}.json").write_text(json.dumps(run.to_dict()))
+    return run
+
+
+@pytest.mark.asyncio
+async def test_a_driven_run_reads_live_true_then_false_once_finished(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """``live`` follows the worker, not the record.
+
+    While a registered thread drives the run the view says so; once the run is
+    terminal the same read says false — the work is done, nothing is driven.
+    """
+    _setup_guards(tmp_path, monkeypatch)
+    started, release = _parked_cancellable(sdk)
+    rid = sdk.start("slow")
+    try:
+        assert started.wait(timeout=_DEADLINE), "runner never started"
+        await _wait_status(sdk, rid, js.RUNNING)
+        async with TestClient(TestServer(_make_app())) as client:
+            run = (await (await client.get(f"{_base()}/{rid}")).json())["run"]
+            assert run["live"] is True
+            assert run["status"] == js.RUNNING
+            release.set()
+            await _wait_terminal(sdk, rid)
+            done = (await (await client.get(f"{_base()}/{rid}")).json())["run"]
+        assert done["live"] is False
+    finally:
+        release.set()
+
+
+@pytest.mark.asyncio
+async def test_a_stale_running_record_reads_live_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """The issue case: ``running`` on disk, nothing driving it.
+
+    Before ``live`` existed this record was indistinguishable from real work —
+    ``origin`` and ``pid`` are withheld, so status and timestamps were all a
+    client had. The field is the one signal that tells them apart.
+    """
+    _setup_guards(tmp_path, monkeypatch)
+    stale = _write_raw_running(sdk, "e" * 32)
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.get(f"{_base()}/{stale.run_id}")
+        assert resp.status == 200
+        run = (await resp.json())["run"]
+    assert run["status"] == js.RUNNING  # the record still claims work…
+    assert run["live"] is False  # …and the view says nothing drives it
+
+
+@pytest.mark.asyncio
+async def test_active_list_tells_a_live_run_from_a_stale_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk: JobSDK
+) -> None:
+    """``active`` filters on terminal status alone, so a stale-running record
+    lists as active forever — the field must let a consumer tell the two rows
+    apart within one response."""
+    _setup_guards(tmp_path, monkeypatch)
+    stale = _write_raw_running(sdk, "d" * 32)
+    started, release = _parked_cancellable(sdk)
+    rid = sdk.start("slow")
+    try:
+        assert started.wait(timeout=_DEADLINE), "runner never started"
+        await _wait_status(sdk, rid, js.RUNNING)
+        async with TestClient(TestServer(_make_app())) as client:
+            resp = await client.get(f"{_base()}/active")
+            assert resp.status == 200
+            runs = {r["run_id"]: r for r in (await resp.json())["runs"]}
+        assert runs[rid]["live"] is True
+        assert runs[stale.run_id]["live"] is False
+    finally:
+        release.set()
+    await _wait_terminal(sdk, rid)
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -295,7 +295,7 @@ class TestCancellation:
 
 
 # ---------------------------------------------------------------------------
-# 5b. cancelling_ids — the read side of "cancel writes nothing"
+# 5b. the cancelling snapshot — the read side of "cancel writes nothing"
 # ---------------------------------------------------------------------------
 
 
@@ -325,11 +325,11 @@ class TestCancellingIds:
         try:
             assert started.wait(5.0)
             # Nothing has been asked for yet.
-            assert sdk.cancelling_ids() == frozenset()
+            assert sdk.cancelling_and_live_ids()[0] == frozenset()
             assert sdk.cancel(run_id) is True
             # Requested, and readable while the RECORD still says running --
             # which is exactly what a fresh mount has to be able to see.
-            assert run_id in sdk.cancelling_ids()
+            assert run_id in sdk.cancelling_and_live_ids()[0]
             record = sdk.get(run_id)
             assert record is not None and record.status == RUNNING
         finally:
@@ -340,7 +340,7 @@ class TestCancellingIds:
         assert run.status == CANCELLED
         # The worker recorded the outcome and the live entry is gone, so the
         # status now carries the answer and nothing is pending.
-        assert sdk.cancelling_ids() == frozenset()
+        assert sdk.cancelling_and_live_ids()[0] == frozenset()
 
     def test_a_refused_cancel_reports_nothing(self, sdk: JobSDK) -> None:
         """The snapshot follows the ACCEPTED request, not the attempt.
@@ -361,7 +361,7 @@ class TestCancellingIds:
         try:
             assert started.wait(5.0)
             assert sdk.cancel(run_id) is False
-            assert sdk.cancelling_ids() == frozenset()
+            assert sdk.cancelling_and_live_ids()[0] == frozenset()
         finally:
             release.set()
         run = _wait_terminal(sdk, run_id)
@@ -492,6 +492,87 @@ class TestReadViews:
         _wait_terminal(sdk, b_id)
         recent_a = sdk.list_recent(kind="a")
         assert [r.run_id for r in recent_a] == [a_id]
+
+
+class TestLiveness:
+    """A durable ``running`` record and a process owning the work are separate facts.
+
+    The ``live`` set answers from the same live-table membership that ``cancel``
+    and ``reconcile`` already treat as the authority, so a record whose terminal
+    write failed twice and a record minted by another gateway process must both
+    be absent from it — that is the whole signal.
+    """
+
+    def test_live_while_a_registered_thread_runs(self, sdk: JobSDK) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        sdk.register("slow", runner)
+        run_id = sdk.start("slow")
+        try:
+            assert started.wait(5.0)
+            _, live = sdk.cancelling_and_live_ids()
+            assert run_id in live
+        finally:
+            release.set()
+        _wait_terminal(sdk, run_id)
+        # The worker recorded the outcome and the live entry is gone.
+        assert sdk.cancelling_and_live_ids() == (frozenset(), frozenset())
+
+    def test_stale_running_record_is_not_live(self, sdk: JobSDK) -> None:
+        """The issue case: a durable record says ``running``, nothing owns it.
+
+        Written raw with a foreign origin — the shape a record from another
+        gateway process has, and the same shape a twice-failed terminal write
+        leaves behind (a ``running`` record with no live entry). No thread was
+        ever registered for it in this process, so liveness must deny it.
+        """
+        run = JobRun(
+            run_id="e" * 32,
+            app="test-app",
+            kind="work",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        store = sdk.store
+        store.dir.mkdir(parents=True, exist_ok=True)
+        (store.dir / f"{run.run_id}.json").write_text(json.dumps(run.to_dict()))
+        assert sdk.get(run.run_id) is not None  # durably present…
+        _, live = sdk.cancelling_and_live_ids()
+        assert run.run_id not in live  # …but nothing owns it
+
+    def test_one_snapshot_keeps_cancelling_within_live(self, sdk: JobSDK) -> None:
+        """The two sets describe ONE instant, so cancelling ⊆ live holds.
+
+        Both are derived from the live table under a single lock acquisition;
+        taken as two separate snapshots a worker finishing between them could
+        report a cancel pending on a run nothing owns.
+        """
+        started = threading.Event()
+        release = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            release.wait(5.0)
+            return {}
+
+        sdk.register("slow", runner, cancellable=True)
+        run_id = sdk.start("slow")
+        try:
+            assert started.wait(5.0)
+            assert sdk.cancel(run_id) is True
+            cancelling, live = sdk.cancelling_and_live_ids()
+            assert run_id in cancelling
+            assert run_id in live
+            assert cancelling <= live
+        finally:
+            release.set()
+        _wait_terminal(sdk, run_id)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A durable Job SDK record with status `running` carried no signal about whether anything is actually executing it. `list_active` filters on terminal status alone, so a stuck-running record — a twice-failed terminal write (per the `_write_terminal` docstring) or a foreign-origin record from another gateway instance — lists as active forever, and `_public_view` deliberately withholds `origin`/`pid`, leaving API consumers no way to tell a live run from a stale one.

This adds the cheap, self-contained live-membership signal the issue asks for:

- **`JobSDK.cancelling_and_live_ids()`** — a one-lock-acquisition snapshot of both the `cancelling` and `live` run id sets, so a response renders both fields from one instant. `live` is live-table membership (claimed at start, dropped after the terminal write) — the same authority `cancel` and `reconcile` already consult, so no second fact is minted. Taken as two separate snapshots, a worker finishing between the acquisitions could serve `cancelling: true, live: false` together for a non-terminal record; within one snapshot `cancelling ⊆ live` holds by construction (pinned by a test). This method **replaces** `cancelling_ids()`, whose rationale (the read side of `cancel`'s "writes nothing", non-durable across restart) it absorbs — the old method's only production caller moved here, so keeping both would leave a zero-consumer duplicate.
- **`live` boolean in `_public_view`** — served on all six route responses. A terminal run is never `live` (same guard and same rationale as `cancelling`). A twice-failed terminal write and a foreign-origin record both read `live: false`, which is exactly what distinguishes them from real work.

Scope guard honored: no heartbeat cadence, no lease semantics, no eviction/retention (siblings #7588/#7583 own those design questions), no new persisted state — `live` is computed at read time from in-memory membership, and stays correct and composable under any later heartbeat/lease design. `origin` and `pid` stay withheld.

The spec doc (`docs/system-specs/features/app-sdk-durable-jobs-and-view-state.md`) is updated in the same commit.

## Pattern harvest

Not generalizable: no mechanical rule catches this class — the defect is a design gap (a store persisting durable work records while executing them with process-local threads has two truths, and read surfaces built on the record alone conflate them), not a syntactic pattern. The transferable practice is already modeled in this module: derive the process-local truth at read time from the existing authority (`_live` membership) instead of persisting a second fact — the same shape `cancelling` uses. New job-like SDKs should serve both truths from day one.

## Review rounds

Two model-pinned local review lanes ran pre-push on the staged diff (GPT on gpt-5.6-sol mirroring codex-review.yml; Opus on claude-opus-5 mirroring claude-review.yml + base AUTOSDE):

- GPT: 1 Low — `cancelling` and `live` were two separate lock snapshots, allowing a `cancelling: true, live: false` window. Fixed by `cancelling_and_live_ids()` (single acquisition) plus a subset-invariant test.
- Opus: PASS, 2 advisories — docstring overclaimed "a worker thread is driving" during the brief `starting` window; reworded to live-table-ownership terms (also the semantics `reconcile` applies). Flagged `is_live` as zero-consumer surface.
- First Principles (CI lane, round 1): BLOCK on `is_live` riding along with zero production callers, plus a subtraction for the orphaned `cancelling_ids`. **Both applied**: `is_live` deleted (the `live` field and the snapshot form fully close #7582; an app backend that later needs a per-run check has the membership form), `cancelling_ids` deleted with its rationale folded into `cancelling_and_live_ids`, tests repointed.

## Testing

- New route tests: `live: true` while a parked runner is driving; `live: false` after terminal; a raw-written stale `running` record reads `status: running, live: false`; the `active` list distinguishes a live row from a stale row in one response.
- New SDK tests: live membership across the run lifecycle; the stale-record case; `cancelling ⊆ live` within one snapshot.
- Local gates: isort, flake8, mypy (1282 files clean), black gate, subprocess-encoding gate, brand gate, harness-parity gate, docs-lint — all green. Test suites run in CI.

no linked issue: not applicable — this PR closes #7582.

Closes #7582
