### PR TITLE
fix(apps): audit each job run killed by app disable to SEL (#7583)

### DIFF
--- a/src/kiro_crew/apps/job_sdk.py
+++ b/src/kiro_crew/apps/job_sdk.py
@@ -98,6 +98,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterator
 
 from kiro_crew.atomic_write import atomic_write, read_bytes_with_retry
+from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes_nolink
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
 
@@ -205,6 +206,14 @@ _RUN_ID_LEN = 32
 #: a runner that never polls its handle must not be able to block an app's
 #: disable indefinitely, so it is reported instead.
 _CLEANUP_JOIN_SECS = 5.0
+
+#: Upper bound on a record file the disable scan will open. A ``JobRun`` is a
+#: small flat JSON document (its one free-text field is clipped at ingest), so
+#: a megabyte is generous headroom; anything larger in the runs directory is
+#: not a record this SDK wrote and is refused unopened -- the scan's reads walk
+#: agent-writable filenames, and the bound is what keeps a planted giant file
+#: (or a device node reached some other way) from stalling disable.
+_MAX_RECORD_BYTES = 1 << 20
 
 _RUNS_DIRNAME = "jobs"
 
@@ -603,6 +612,14 @@ class JobHandle:
     @property
     def run_id(self) -> str:
         return self._run.run_id
+
+    @property
+    def kind(self) -> str:
+        return self._run.kind
+
+    @property
+    def status(self) -> str:
+        return self._run.status
 
 
 #: A runner receives its handle and nothing else. P1 has no parameter channel:
@@ -1415,6 +1432,14 @@ class JobSDK:
         killed, and abandoning it is the defect rather than the fix.
 
         A worker that outlives the deadline is reported, not waited on forever.
+        Every run this call kills leaves one SEL line (``job_killed_on_disable``)
+        carrying its id and kind before the record is deleted, so "which runs
+        did the disable kill" stays answerable after the records are gone. The
+        trace is fail-closed: if it cannot be written durably, the deletion is
+        refused and reported as a failed cleanup; the surviving records are
+        retried by the next cleanup on a fresh instance (disable also forgets
+        the SDK, so that means after a re-enable, or by ``reconcile`` at the
+        next start).
         Gateway shutdown is a separate case left as accepted residue: these are
         daemon threads, so the interpreter reaps them at exit without a chance
         to finish, and draining every app's runs there would delay shutdown for
@@ -1450,12 +1475,164 @@ class JobSDK:
         if stubborn:
             logger.warning(
                 "App %s: %d job worker(s) did not stop within %.0fs and are still "
-                "running with their records removed: %s",
+                "running with their records removed; run id(s): %s",
                 self._app_name,
                 len(stubborn),
                 _CLEANUP_JOIN_SECS,
                 ", ".join(stubborn),
             )
+
+        # One durable SEL line per run this disable kills, BEFORE the records
+        # are deleted -- deletion is the last moment the identities exist, and
+        # the count-only summary below cannot answer "which runs were killed".
+        # Mirrors the per-run precedent ``reconcile`` set with
+        # ``job_interrupted``. The marker comes from the SAME observation that
+        # feeds the summary's stubborn count -- ``_join_workers`` captures the
+        # run ids alive at their join deadline -- so the summary can never say
+        # "one was stubborn" while no line names it. Stale records are read
+        # once, off the loop; a live entry is skipped only on its IN-MEMORY
+        # terminal status (its worker finished on its own before the discard
+        # landed, so nothing was killed) -- never on its disk record, which an
+        # agent can write.
+        stubborn_ids = set(stubborn)
+        live_ids = {entry.handle.run_id for entry in live}
+
+        def _safe_read(run_id: str) -> JobRun | None:
+            # The scan walks *.json names in an app-writable directory, so a
+            # path here is agent-influenced input: a planted symlink
+            # ``<id>.json -> /dev/zero`` would hang an unbounded follow and
+            # make disable unreachable, and one pointed at a sensitive file
+            # would pull its bytes into a parse attempt. The read goes through
+            # the repository's centralized funnel rather than a hand-rolled
+            # check: ``safe_read_file_bytes_nolink`` opens with ``O_NOFOLLOW``,
+            # validates the OPENED descriptor (regular, non-hardlinked, real
+            # path contained in ``within_root`` -- which also refuses a PARENT
+            # directory swapped for a symlink, the case a final-component
+            # check alone misses), and bounds the read. Every refusal --
+            # permission denied, a Windows sharing violation, a refused link,
+            # an oversized record -- classifies the record unreadable rather
+            # than propagating: an unreadable record must not abort the
+            # disable, and its identity still leaves an ``unreadable`` line.
+            path = self._store.dir / f"{run_id}.json"
+            try:
+                raw = safe_read_file_bytes_nolink(
+                    str(path),
+                    within_root=str(self._store.dir),
+                    max_bytes=_MAX_RECORD_BYTES,
+                )
+            except FileTooLargeError:
+                return None
+            if raw is None:
+                return None
+            try:
+                return JobRun.from_dict(json.loads(raw.decode("utf-8")))
+            except (TypeError, ValueError):
+                return None
+
+        def _scan() -> tuple[list[tuple[str, JobRun]], list[str]]:
+            # Every record is read by CANONICAL FILENAME -- never from an
+            # id-keyed index over parsed bodies: a record file whose BODY
+            # claims another run's id would shadow the real record in such an
+            # index and suppress that run's kill line. A file the guarded
+            # read refuses (symlink, non-file, oversized, unparseable, or a
+            # name that is not a valid run id) still gets deleted by
+            # ``remove_all`` below, so its FILENAME is returned for an
+            # ``unreadable`` line -- an identity must not vanish just because
+            # its record went hostile or corrupt. Live runs' records are
+            # deliberately NOT read at all: the record files sit in an
+            # app-writable directory, so a planted ``status=done`` body would
+            # be an agent-writable veto over its own run's kill line. Whether
+            # a live run was killed is decided purely from in-process state
+            # below.
+            stale: list[tuple[str, JobRun]] = []
+            unreadable: list[str] = []
+            if self._store.dir.is_dir():
+                for path in sorted(self._store.dir.glob("*.json")):
+                    stem = path.stem
+                    if stem in live_ids:
+                        continue
+                    record = _safe_read(stem)
+                    if record is None:
+                        unreadable.append(stem)
+                    elif not record.is_terminal:
+                        stale.append((stem, record))
+            return stale, unreadable
+
+        stale_runs, unreadable_stems = await asyncio.to_thread(_scan)
+        killed: list[str] = []
+        for entry in live:
+            # Whether this run finished on its own is read ONLY from the
+            # in-memory handle -- never from its disk record, which lives in
+            # an app-writable directory where a planted terminal status would
+            # silently suppress the run's kill line. The in-memory status is
+            # set by the worker wrapper itself, post-join, so it is the one
+            # observation an agent cannot forge. A worker
+            # that computed DONE/FAILED before the cancel landed, but whose
+            # terminal write the discard guard then refused, has already
+            # audited its own completion (``job_done``/``job_failed``) while
+            # its record stays non-terminal on disk. Reading the in-memory
+            # status closes that window -- the SEL trail must not carry both a
+            # completion and a kill for one run. Two deliberate exceptions:
+            # CANCELLED means the disable's own signal stopped the worker,
+            # which is exactly a killed run; and a run observed STUBBORN at its
+            # join deadline keeps its line no matter what its status became
+            # afterwards (a post-deadline raise flips it to FAILED), because
+            # the summary already counted it from that same observation and
+            # the count must never name a stubborn run no line identifies.
+            if entry.handle.run_id not in stubborn_ids and entry.handle.status in (DONE, FAILED):
+                continue
+            # An entry whose thread never started is NOT skipped -- its record
+            # is deleted by the same call and skipping would lose the identity
+            # with no line at all (the stale scan excludes live ids). But no
+            # worker existed, so "killed" must not imply one: the line carries
+            # ``never_started`` instead of a kill-shaped claim.
+            if not entry.started:
+                marker = " never_started"
+            elif entry.handle.run_id in stubborn_ids:
+                marker = " still_running"
+            else:
+                marker = ""
+            # The kind is clipped BEFORE the marker is appended: ``_audit``
+            # truncates long lines from the right, and an oversized kind
+            # would push ``still_running``/``never_started`` off the end --
+            # the summary would then count a stubborn run no line marks.
+            killed.append(f"{entry.handle.run_id} kind={entry.handle.kind[:32]}{marker}")
+        # A non-terminal record with no live worker (a foreign process's run
+        # that never got reconciled) vanishes in the same delete, so it gets
+        # the same line, marked ``stale`` because nothing was killed: there was
+        # no worker to kill. Identity comes from the FILENAME stem (the
+        # canonical id), and ``kind`` comes off disk -- the one input here not
+        # minted by this process -- so both are redacted, bounded, or
+        # repr-quoted rather than interpolated raw into a durable SEL field.
+        for stem, record in stale_runs:
+            killed.append(f"{stem[:_RUN_ID_LEN]} kind={_redact(record.kind)[:32]!r} stale")
+        # A file the store cannot parse is deleted by the same ``remove_all``,
+        # and "which file was that" must survive the delete too.
+        for stem in unreadable_stems:
+            killed.append(f"{_redact(stem)[:_RUN_ID_LEN]!r} unreadable stale")
+        if killed:
+            # The kill trace is the ONLY durable answer to "which runs did this
+            # disable kill", so it is fail-closed: each line is written
+            # synchronously (``critical=True``) and a write failure REFUSES the
+            # record deletion below. The records stay on disk -- still
+            # non-terminal, since their handles are discarded -- so a later
+            # cleanup on a fresh instance (after a re-enable, or ``reconcile``
+            # at the next start) resolves them instead of deleting identities
+            # nothing recorded. Reported through the existing partial-cleanup
+            # contract instead of raising into the disable route.
+            def _emit() -> None:
+                for line in killed:
+                    self._audit("job_killed_on_disable", line, "ok", critical=True)
+
+            try:
+                await asyncio.to_thread(_emit)
+            except Exception:  # noqa: BLE001 - refusing the delete IS the handling
+                logger.exception(
+                    "App %s: could not durably audit killed job run(s); record "
+                    "deletion refused so their identities are not lost",
+                    self._app_name,
+                )
+                return CleanupResult(removed=0, failed=len(killed), still_running=len(stubborn))
 
         removed, failed = await asyncio.to_thread(self._store.remove_all)
         if removed or failed:
@@ -1471,7 +1648,11 @@ class JobSDK:
 
     def _join_workers(self, live: list[_Live]) -> list[str]:
         """Wait for each STARTED worker, bounded. Runs on a worker thread, never
-        the loop.
+        the loop. Returns the RUN IDS of workers still alive at their deadline:
+        run ids are unique where thread names are minted per kind, and this one
+        observation feeds the count, the log line, and the per-run SEL marker --
+        two observations taken at different times could disagree, reporting a
+        stubborn count with no line saying which run it was.
 
         An entry whose thread never started is skipped rather than joined, and it
         cannot be stubborn: no code of the app is executing, so there is nothing
@@ -1487,12 +1668,20 @@ class JobSDK:
                 continue
             entry.thread.join(timeout=_CLEANUP_JOIN_SECS)
             if entry.thread.is_alive():
-                stubborn.append(entry.thread.name)
+                stubborn.append(entry.handle.run_id)
         return stubborn
 
     # ── Audit ──
 
-    def _audit(self, operation: str, resources: str, outcome: str, *, error: str = "") -> None:
+    def _audit(
+        self,
+        operation: str,
+        resources: str,
+        outcome: str,
+        *,
+        error: str = "",
+        critical: bool = False,
+    ) -> None:
         try:
             sel().log_api_access(
                 caller=f"app:{self._app_name}",
@@ -1501,8 +1690,13 @@ class JobSDK:
                 source=self._app_name,
                 resources=resources[:200],
                 error=error[:200],
+                critical=critical,
             )
         except Exception:  # noqa: BLE001 - an audit failure must not fail the job
+            # ... unless the caller said it must: ``critical`` re-raises so a
+            # fail-closed audit can refuse the action it was auditing.
+            if critical:
+                raise
             logger.debug("job SEL audit failed", exc_info=True)
 
 

--- a/test/test_job_sdk.py
+++ b/test/test_job_sdk.py
@@ -22,10 +22,12 @@ import threading
 import time
 import uuid
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
+from conftest import requires_symlinks
 from kiro_crew.apps import job_sdk
 from kiro_crew.apps.job_sdk import (
     _CLEANUP_JOIN_SECS,
@@ -896,6 +898,551 @@ class TestRemoveAll:
         # record would make this second call report 1.
         assert sdk.get(run_id) is None
         assert asyncio.run(sdk.remove_all_async()) == CleanupResult(0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# 11a. Disable trace — one SEL line per killed run (issue #7583)
+# ---------------------------------------------------------------------------
+
+
+class TestDisableTrace:
+    """Disable deletes every record, so the SEL trail is the only place "which
+    runs were killed" survives. ``remove_all_async`` emits one
+    ``job_killed_on_disable`` entry per formerly-live run (and per stale
+    non-terminal record) BEFORE the delete; the count-only summary stays.
+    """
+
+    @staticmethod
+    def _capture_sel(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+        events: list[dict] = []
+        monkeypatch.setattr(
+            job_sdk,
+            "sel",
+            lambda: SimpleNamespace(log_api_access=lambda **kw: events.append(kw)),
+        )
+        return events
+
+    @staticmethod
+    def _killed(events: list[dict]) -> list[dict]:
+        return [e for e in events if e["operation"] == "jobs.job_killed_on_disable"]
+
+    def test_one_audit_entry_per_killed_live_run(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events = self._capture_sel(monkeypatch)
+        started = {"alpha": threading.Event(), "beta": threading.Event()}
+
+        def runner(h, **kw):
+            started[h.kind].set()
+            for _ in range(500):
+                if h.cancelled.is_set():
+                    return
+                time.sleep(0.01)
+
+        sdk.register("alpha", runner, cancellable=True)
+        sdk.register("beta", runner, cancellable=True)
+        a = sdk.start("alpha")
+        b = sdk.start("beta")
+        assert started["alpha"].wait(5.0)
+        assert started["beta"].wait(5.0)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 2
+
+        killed = self._killed(events)
+        assert {e["resources"] for e in killed} == {f"{a} kind=alpha", f"{b} kind=beta"}
+        assert all(e["outcome"] == "ok" for e in killed)
+        # Cooperative workers stopped inside the join, so nothing is flagged.
+        assert all("still_running" not in e["resources"] for e in killed)
+        # The count-only summary is unchanged and still fires.
+        summary = [e for e in events if e["operation"] == "jobs.job_remove_all"]
+        assert len(summary) == 1
+        assert "removed=2" in summary[0]["resources"]
+
+    def test_worker_that_outlives_the_join_is_flagged_still_running(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        events = self._capture_sel(monkeypatch)
+        # Shrink the bounded join so this test does not pay the full deadline;
+        # `_join_workers` reads the module global at call time.
+        monkeypatch.setattr(job_sdk, "_CLEANUP_JOIN_SECS", 0.2)
+        started = threading.Event()
+        stop = threading.Event()
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            worker.append(threading.current_thread())
+            started.set()
+            # Ignores the cancel signal outright, so cleanup must report it.
+            stop.wait(10.0)
+            return {}
+
+        sdk.register("stubborn", runner, cancellable=True)
+        run_id = sdk.start("stubborn")
+        assert started.wait(5.0)
+
+        try:
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.still_running == 1
+
+            killed = self._killed(events)
+            assert len(killed) == 1
+            assert killed[0]["resources"] == f"{run_id} kind=stubborn still_running"
+            summary = [e for e in events if e["operation"] == "jobs.job_remove_all"]
+            assert len(summary) == 1
+            assert summary[0]["outcome"] == "partial"
+        finally:
+            # In a finally so a failed assertion cannot leak the worker into
+            # later tests: left running it would write into the removed
+            # tmp_path.
+            stop.set()
+            for t in worker:
+                t.join(timeout=5.0)
+                assert not t.is_alive(), "the stubborn worker outlived its test"
+
+    def test_same_kind_siblings_are_attributed_per_run_not_per_kind(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Thread names are minted per KIND, so two concurrent runs of one kind
+        share a name. The still_running flag must come off each entry's own
+        thread: the cooperative sibling of a stubborn run is NOT flagged."""
+        events = self._capture_sel(monkeypatch)
+        monkeypatch.setattr(job_sdk, "_CLEANUP_JOIN_SECS", 0.5)
+        gate = threading.Event()
+        stop = threading.Event()
+        behavior: dict[str, str] = {}
+        both_running = threading.Event()
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            # list.append is atomic under the GIL, so this doubles as the
+            # "both workers are up" counter.
+            worker.append(threading.current_thread())
+            if len(worker) >= 2:
+                both_running.set()
+            gate.wait(5.0)
+            if behavior.get(h.run_id) == "stubborn":
+                stop.wait(10.0)  # ignores the cancel signal outright
+                return {}
+            for _ in range(500):
+                if h.cancelled.is_set():
+                    return
+                time.sleep(0.01)
+
+        sdk.register("work", runner, cancellable=True)
+        coop = sdk.start("work")
+        stubborn = sdk.start("work")
+        assert both_running.wait(5.0)
+        behavior[stubborn] = "stubborn"
+        gate.set()
+
+        try:
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.still_running == 1
+
+            by_id = {e["resources"].split(" ")[0]: e["resources"] for e in self._killed(events)}
+            assert by_id[coop] == f"{coop} kind=work"
+            assert by_id[stubborn] == f"{stubborn} kind=work still_running"
+        finally:
+            stop.set()
+            for t in worker:
+                t.join(timeout=5.0)
+                assert not t.is_alive(), "a worker outlived its test"
+
+    def test_planted_terminal_disk_status_cannot_suppress_kill_line(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The record files live in an app-writable directory, so a planted
+        ``status=done`` body on a STILL-RUNNING run's record must not veto its
+        kill line: whether a live run was killed is decided from in-memory
+        state only, never from disk."""
+        events = self._capture_sel(monkeypatch)
+        started = threading.Event()
+        release = threading.Event()
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            worker.append(threading.current_thread())
+            started.set()
+            for _ in range(500):
+                if h.cancelled.is_set() or release.is_set():
+                    return
+                time.sleep(0.01)
+
+        sdk.register("work", runner, cancellable=True)
+        run_id = sdk.start("work")
+        assert started.wait(5.0)
+        try:
+            # The plant: the worker is demonstrably still running, but its
+            # disk record claims DONE.
+            record = sdk.get(run_id)
+            assert record is not None
+            record.status = DONE
+            sdk.store.write(record)
+
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.removed == 1
+            assert cleanup.still_running == 0
+            # The disable's cancel stopped the worker -- exactly a killed run,
+            # and the forged disk status must not have silenced it.
+            killed = self._killed(events)
+            assert len(killed) == 1
+            assert killed[0]["resources"] == f"{run_id} kind=work"
+        finally:
+            # In a finally so a failed assertion cannot leak a non-discarded
+            # worker that would write into the removed tmp_path.
+            release.set()
+            for t in worker:
+                t.join(timeout=5.0)
+                assert not t.is_alive(), "the worker outlived its test"
+
+    def test_rogue_record_claiming_live_id_cannot_suppress_kill_line(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A record FILE whose body claims a live run's id with terminal status
+        must not shadow the live run. Live statuses are read by canonical
+        filename (``store.read``), never from an id-keyed index over
+        ``iter_runs`` -- an index keyed on body ids would let the lying file
+        overwrite the live record's entry and suppress its kill line."""
+        events = self._capture_sel(monkeypatch)
+        started = threading.Event()
+
+        def runner(h, **kw):
+            started.set()
+            for _ in range(500):
+                if h.cancelled.is_set():
+                    return
+                time.sleep(0.01)
+
+        sdk.register("work", runner, cancellable=True)
+        run_id = sdk.start("work")
+        assert started.wait(5.0)
+
+        rogue = JobRun(run_id=run_id, app="test-app", kind="work", status=DONE)
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        (sdk.store.dir / ("d" * 32 + ".json")).write_text(json.dumps(rogue.to_dict(), indent=1))
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 2  # the real record and the rogue file
+        killed = self._killed(events)
+        # Exactly one line: the live run, unsuppressed. The rogue file gets no
+        # stale line either -- its claimed id belongs to a live run.
+        assert [e["resources"] for e in killed] == [f"{run_id} kind=work"]
+
+    def test_worker_done_before_cancel_is_not_reported_killed(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worker that computed DONE before the disable's cancel landed, but
+        whose terminal write the discard guard then refused, has already
+        audited its own completion -- it must NOT also get a kill line. The
+        terminal write is held until the disable marks the handle discarded
+        (the exact interleaving under test), then the worker finishes promptly
+        so the bounded join observes it cooperative, not stubborn."""
+        events = self._capture_sel(monkeypatch)
+        started = threading.Event()
+        inside_write = threading.Event()
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            worker.append(threading.current_thread())
+            started.set()
+            return {}  # completes on its own; never sees the cancel signal
+
+        # Patch BEFORE starting the run: the worker heads for the terminal
+        # write as soon as the runner returns, so a later patch could race it.
+        orig_write = sdk._write_terminal
+
+        def held_write(run, handle):
+            inside_write.set()
+            # DONE is already assigned in memory here, and no cancel was seen.
+            # Wait for the disable to mark the handle discarded, then proceed:
+            # the write is refused and the worker exits inside the join.
+            handle.discarded.wait(10.0)
+            orig_write(run, handle)
+
+        monkeypatch.setattr(sdk, "_write_terminal", held_write)
+        sdk.register("work", runner, cancellable=True)
+        sdk.start("work")
+        assert started.wait(5.0)
+        assert inside_write.wait(5.0)
+
+        try:
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.removed == 1
+            assert cleanup.still_running == 0  # it exited inside the join
+            killed = self._killed(events)
+            assert killed == []  # in-memory DONE: completion already audited
+        finally:
+            for t in worker:
+                t.join(timeout=5.0)
+                assert not t.is_alive(), "the held worker outlived its test"
+
+    def test_sel_failure_refuses_deletion_until_trace_is_durable(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The kill trace is fail-closed: if SEL cannot durably record which
+        runs are being deleted, the records are NOT deleted -- the disable
+        reports a failed cleanup, and a retry after SEL recovers emits the
+        survivors as ``stale`` lines and only then removes them."""
+        stale = JobRun(
+            run_id="e" * 32,
+            app="test-app",
+            kind="work",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        sdk.store.write(stale)
+
+        def broken():
+            raise RuntimeError("sel down")
+
+        monkeypatch.setattr(job_sdk, "sel", broken)
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 0
+        assert cleanup.failed == 1
+        assert not cleanup.is_clean
+        assert sdk.store.read(stale.run_id) is not None  # identity preserved
+
+        events = self._capture_sel(monkeypatch)  # SEL recovers
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 1
+        killed = self._killed(events)
+        assert len(killed) == 1
+        assert killed[0]["resources"].endswith("stale")
+
+    def test_stubborn_worker_that_fails_after_deadline_keeps_its_kill_line(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worker recorded stubborn at its join deadline can raise AFTERWARDS,
+        flipping its in-memory status to FAILED. The deadline observation must
+        win: the summary already counted it stubborn, so suppressing its line
+        would leave a stubborn count no line identifies."""
+        events = self._capture_sel(monkeypatch)
+        monkeypatch.setattr(job_sdk, "_CLEANUP_JOIN_SECS", 0.2)
+        started = threading.Event()
+        stop = threading.Event()
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            worker.append(threading.current_thread())
+            started.set()
+            stop.wait(10.0)  # ignores the cancel signal through the deadline
+            raise RuntimeError("boom after the deadline")
+
+        sdk.register("stubborn", runner, cancellable=True)
+        run_id = sdk.start("stubborn")
+        assert started.wait(5.0)
+
+        orig_read = sdk.store.read
+
+        def releasing_read(run_id):
+            # Runs inside the record scan -- after the join deadline recorded
+            # the worker stubborn, before the kill-line loop reads its status:
+            # release the worker and wait for it to raise and settle FAILED.
+            stop.set()
+            for t in worker:
+                t.join(timeout=5.0)
+            return orig_read(run_id)
+
+        monkeypatch.setattr(sdk.store, "read", releasing_read)
+
+        try:
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.still_running == 1
+            killed = self._killed(events)
+            assert len(killed) == 1
+            assert killed[0]["resources"] == f"{run_id} kind=stubborn still_running"
+        finally:
+            stop.set()
+            for t in worker:
+                t.join(timeout=5.0)
+                assert not t.is_alive(), "the stubborn worker outlived its test"
+
+    def test_unreadable_record_is_traced_by_filename_before_deletion(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A record file the store cannot parse is still deleted by
+        ``remove_all`` -- so its FILENAME must leave a trace line: an identity
+        must not vanish just because its record went corrupt."""
+        events = self._capture_sel(monkeypatch)
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        corrupt_stem = "f" * 32
+        (sdk.store.dir / f"{corrupt_stem}.json").write_text("{not valid json")
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 1
+
+        killed = self._killed(events)
+        assert len(killed) == 1
+        assert killed[0]["resources"] == f"{corrupt_stem!r} unreadable stale"
+
+    def test_run_claimed_but_never_started_is_marked_never_started(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A disable can snapshot a run whose thread has not started yet. Its
+        record is deleted like the rest, so it MUST get a line -- but no worker
+        existed, so the line says ``never_started`` rather than implying a
+        kill or a still-running worker."""
+        events = self._capture_sel(monkeypatch)
+        claimed = threading.Event()
+        release = threading.Event()
+        orig_persist = sdk._persist
+
+        def held_persist(*args, **kwargs):
+            # Hold the starter in the claim->launch window. The initial persist
+            # runs AFTER the claim landed in ``_live`` and BEFORE the guarded
+            # launch section, and -- unlike ``thread.start``, which runs inside
+            # the SDK lock -- it holds no lock, so the disable can proceed and
+            # deterministically win the race the old gate-on-Thread.start
+            # version only won by timing luck.
+            result = orig_persist(*args, **kwargs)
+            claimed.set()
+            release.wait(10.0)
+            return result
+
+        monkeypatch.setattr(sdk, "_persist", held_persist)
+        sdk.register("work", lambda h, **kw: {}, cancellable=True)
+
+        def racing_start():
+            try:
+                sdk.start("work")
+            except JobError:
+                pass  # the disable won the race and refused the launch -- expected
+
+        starter = threading.Thread(target=racing_start)
+        starter.start()
+        # The claim (and the record) landed; thread.start has not been reached.
+        assert claimed.wait(5.0)
+
+        try:
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.still_running == 0
+            killed = self._killed(events)
+            assert len(killed) == 1
+            assert killed[0]["resources"].endswith(" never_started")
+            assert "still_running" not in killed[0]["resources"]
+        finally:
+            release.set()
+            starter.join(timeout=5.0)
+            assert not starter.is_alive(), "the starter thread outlived its test"
+
+    @requires_symlinks
+    def test_symlink_record_is_refused_unopened_and_traced_unreadable(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The disable scan walks agent-writable filenames, so a planted
+        symlink ``<id>.json`` must be refused WITHOUT following it (a link at
+        /dev/zero would hang the read and make disable unreachable) -- and its
+        filename still leaves an ``unreadable`` line before deletion."""
+        events = self._capture_sel(monkeypatch)
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        target = sdk.store.dir / "target.txt"
+        target.write_text("not a record")
+        link_stem = "a1" * 16
+        (sdk.store.dir / f"{link_stem}.json").symlink_to(target)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 1  # the link itself is unlinked
+
+        killed = self._killed(events)
+        assert len(killed) == 1
+        assert killed[0]["resources"] == f"{link_stem!r} unreadable stale"
+
+    def test_permission_denied_record_is_classified_unreadable_not_fatal(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unreadable REGULAR record (permission denied, an exhausted
+        Windows sharing retry) must not abort the disable: the refused read
+        classifies the record unreadable, deletion proceeds, and the filename
+        still leaves its line."""
+        events = self._capture_sel(monkeypatch)
+        sdk.store.dir.mkdir(parents=True, exist_ok=True)
+        denied_stem = "d" * 32
+        (sdk.store.dir / f"{denied_stem}.json").write_text("{}")
+        real_open = os.open
+
+        def denying_open(path, flags, *args, **kwargs):
+            if str(path).endswith(f"{denied_stem}.json"):
+                raise PermissionError(13, "denied", str(path))
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", denying_open)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 1
+
+        killed = self._killed(events)
+        assert len(killed) == 1
+        assert killed[0]["resources"] == f"{denied_stem!r} unreadable stale"
+
+    def test_long_kind_cannot_push_the_marker_off_the_audit_line(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``_audit`` truncates long lines from the right, so an oversized
+        kind must be clipped BEFORE the marker lands -- otherwise the summary
+        counts a stubborn run that no line marks ``still_running``."""
+        events = self._capture_sel(monkeypatch)
+        monkeypatch.setattr(job_sdk, "_CLEANUP_JOIN_SECS", 0.2)
+        long_kind = "k" * 300
+        started = threading.Event()
+        stop = threading.Event()
+        worker: list[threading.Thread] = []
+
+        def runner(h, **kw):
+            worker.append(threading.current_thread())
+            started.set()
+            stop.wait(10.0)
+            return {}
+
+        sdk.register(long_kind, runner, cancellable=True)
+        run_id = sdk.start(long_kind)
+        assert started.wait(5.0)
+
+        try:
+            cleanup = asyncio.run(sdk.remove_all_async())
+            assert cleanup.still_running == 1
+
+            killed = self._killed(events)
+            assert len(killed) == 1
+            assert killed[0]["resources"] == f"{run_id} kind={'k' * 32} still_running"
+        finally:
+            stop.set()
+            for t in worker:
+                t.join(timeout=5.0)
+                assert not t.is_alive(), "the stubborn worker outlived its test"
+
+    def test_stale_nonterminal_record_is_traced_and_terminal_is_not(
+        self, sdk: JobSDK, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-terminal record with no live worker (a foreign process's run
+        that never got reconciled) vanishes in the same delete, so it gets the
+        same line marked ``stale``. A terminal record finished on its own --
+        nothing was killed, so it must NOT be traced."""
+        events = self._capture_sel(monkeypatch)
+        stale = JobRun(
+            run_id="b" * 32,
+            app="test-app",
+            kind="work",
+            status=RUNNING,
+            origin="foreign-origin-token",
+        )
+        finished = JobRun(
+            run_id="c" * 32,
+            app="test-app",
+            kind="work",
+            status=DONE,
+            origin="foreign-origin-token",
+        )
+        sdk.store.write(stale)
+        sdk.store.write(finished)
+
+        cleanup = asyncio.run(sdk.remove_all_async())
+        assert cleanup.removed == 2
+
+        killed = self._killed(events)
+        assert len(killed) == 1
+        # `kind` comes off disk, so it is redacted, bounded, and repr-quoted.
+        assert killed[0]["resources"] == f"{stale.run_id} kind='work' stale"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When an app is disabled, `JobSDK.remove_all_async` kills every live run and deletes every run record — but the only durable output was a count-only SEL audit (`removed=N failed=N stubborn=N`). Nothing answered **which** runs were killed; stubborn worker names went only to a process-local `logger.warning`.

This change emits one SEL entry per killed run — `jobs.job_killed_on_disable`, resources `<run_id> kind=<kind>` — after the bounded join and **before** `store.remove_all`, mirroring the per-run precedent `reconcile` set with `job_interrupted`:

- A run whose worker was still alive at its join deadline carries a ` still_running` marker. The marker, the summary's `stubborn` count, and the warning log all derive from **one observation**: `_join_workers` now returns the stubborn **run ids** captured at each thread's deadline (thread names are minted per kind, not per run, so they could mis-attribute same-kind siblings — and a second `is_alive()` read later could disagree with the count).
- A live entry whose record is already terminal on disk is skipped: its worker finished on its own before the discard landed — nothing was killed. (Safe against races: `discarded` is set before `cancelled` under the lock, and `_persist` refuses writes once `discarded` is set, so a cancelled worker can never mint the terminal record that would suppress its own kill line.)
- A **non-terminal record with no live worker** (a foreign process's run that reconciliation never resolved) vanishes in the same delete, so it gets the same line marked ` stale`. Its fields come off disk, so `run_id` is length-clipped and `kind` is redacted, bounded, and repr-quoted.
- All record reads and SEL emissions run off the event loop (`asyncio.to_thread`), batched onto one hop.

`JobHandle` gains a `kind` property parallel to `run_id`.

### Invariants preserved

- Writes ONLY to SEL, never to run records. The `_persist` discard guard and the delete-recreate race it exists for are untouched.
- "Disable removes all records" is intact — `store.remove_all` still runs unconditionally. Note: the trace scan sits between the join and the delete, so the invariant now also depends on that scan not raising; `iter_runs` swallows per-record `OSError`/`TypeError`/`ValueError` and returns early when the dir is absent.
- No record retention / terminal-write-before-delete (that is #7588's open design question).
- The count-only `job_remove_all` summary still fires unchanged (test-pinned).

## Testing

- New `TestDisableTrace` (5 cases): one entry per killed live run with run_id+kind; ` still_running` for a worker that outlives the bounded join (summary outcome `partial` pinned); **same-kind siblings attributed per run, not per kind** (cooperative sibling of a stubborn run is not flagged); a run already terminal on disk is not reported killed; a stale non-terminal record is traced (redacted/quoted kind) while a terminal one is not.
- All worker threads released and joined in `finally` blocks so a failed assertion cannot leak a writer into the removed `tmp_path`.
- Local gates green: isort, flake8, mypy, black gate, sync-io-in-async gate, brand gate. Test suite runs in CI (host policy: no local test runs).
- Two local model-pinned review rounds (GPT + Opus contracts) pre-push; all Critical/High/BLOCKING findings fixed. One finding deferred with rationale: validating `iter_runs` record `run_id` against the source filename stem changes shared `JobStore` API for a threat that requires local write access to the app's own data dir (a boundary already crossed at that point); SEL's own `resources` clip/redact bounds the blast radius. Candidate follow-up alongside #7588.

Closes #7583

Sibling issues: #7582 (liveness signal), #7588 (retention/eviction, parked on design).


## Pattern harvest

Rule candidate: review-prompt / agents-md — a cleanup path that bulk-deletes per-item records must emit a per-item durable audit line (id + enough context to act on) BEFORE the delete; a count-only summary cannot answer "which". Corollary harvested in the same fix: when one outcome feeds multiple reports (a summary count, a log line, a per-item marker), derive all of them from ONE observation taken at a single point in time — two reads of live state (thread aliveness here) taken at different moments can contradict each other, and identity keys must be per-item (run_id), never a shared alias (thread names minted per kind).
