### PR TITLE
fix(apps): escape lone surrogate in manifest docstring

### DIFF
--- a/src/kiro_crew/apps/manifest.py
+++ b/src/kiro_crew/apps/manifest.py
@@ -1195,7 +1195,7 @@ def _mirrored_len(text: str) -> int:
     title cap that "a cap that only one side enforces is not a cap"; that holds for the
     UNIT as well as for the number, so the caps are measured the host's way.
     UNPAIRED surrogates are why this passes ``surrogatepass``: JSON can carry a lone
-    ``\ud800`` escape, ``json.loads`` accepts it, and a plain ``utf-16-le`` encode then
+    ``\\ud800`` escape, ``json.loads`` accepts it, and a plain ``utf-16-le`` encode then
     raises ``UnicodeEncodeError`` -- so a manifest would CRASH validation instead of
     being told what is wrong with it. With the flag the count still matches the host
     exactly: a lone surrogate is one unit in both languages, an astral character two.

--- a/test/test_app_manifest.py
+++ b/test/test_app_manifest.py
@@ -1720,3 +1720,19 @@ class TestContributedCommands:
         # Without autoSend the same command is fine.
         cmd.pop("autoSend")
         assert AppManifest.from_dict(self._manifest(cmd)).validate() == []
+
+
+class TestManifestModuleImportable:
+    """The module must import cleanly — no lone surrogates in docstrings (#8391)."""
+
+    def test_mirrored_len_docstring_has_no_surrogates(self):
+        import kiro_crew.apps.manifest as manifest_mod
+
+        doc = manifest_mod._mirrored_len.__doc__ or ""
+        assert chr(0xD800) not in doc
+        doc.encode("utf-8")
+
+    def test_mirrored_len_still_counts_host_units(self):
+        from kiro_crew.apps.manifest import _mirrored_len
+
+        assert _mirrored_len("abc") == 3


### PR DESCRIPTION
## Problem / Motivation

`import kiro_crew.apps.manifest` raises `UnicodeEncodeError` on Python 3.14 because the `_mirrored_len` docstring contains a single-backslash ``\ud800`` escape, which becomes a real lone-surrogate character. That takes down the whole apps chain plus every app test file at collection (all 203 tests dead).

## Why it matters

Anything importing the apps subsystem — CLI commands, bridges, discovery — crashes at import time. Total breakage, one-character-class cause.

## What changed (motivation → approach → change)

Symptom → import-time `UnicodeEncodeError`. Cause → docstring escape interpreted as a real surrogate instead of text. Change → doubled the backslash so the docstring shows the escape as text; no behavior change otherwise.

## Tests

The 203 existing app-manifest tests (previously all dead at collection) pass again, plus a small regression test pinning the import and the surrogate-free docstring (red without the fix, green with it).

## Manual verification

N/A — unit coverage sufficient (import probe plus full test file green).

Fixes #8391


## Pattern harvest
Not generalizable: a one-off docstring escape that only bites on Python 3.14's stricter surrogate handling at import time.
