### PR TITLE
fix(identity): one strict session gate for reflexive tools (#5913)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,9 +478,12 @@ Windows specifics: [windows-install](docs/guides/windows-install.md).
   match natural-language variants, the LLM interprets NL.
 - **MCP tools MUST be stateless.** One server process serves many sessions and
   sub-agents, so no module global may hold per-caller data. Resolve identity per
-  call, and use `_resolve_session_key_strict()` for anything that mutates or
-  targets a specific session (the lenient resolver walks process ancestors and a
-  sub-agent would resolve to its parent slot). Durable state lives behind a gateway
+  call, and route anything that mutates or targets a specific session through
+  `mcp_core.require_strict_session_key()` — the shared fail-closed gate — and
+  register the module in `mcp_core.REFLEXIVE_TOOL_MODULES` (the lenient resolver
+  walks process ancestors and a sub-agent would resolve to its parent slot; a
+  ratchet test rejects direct strict-resolver calls outside `mcp_core`). Durable
+  state lives behind a gateway
   endpoint keyed by session. Why, plus the `ask_question` reference
   implementation: [mcp](docs/architecture/mcp.md).
 - **A skill that any shipped feature, tool, or doc references MUST live in

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -625,8 +625,8 @@ answers `tools/list` from):
     over.** The `channels` scope is a per-transport allowlist, so vetting
     `"slack"` for a Telegram send evaluates a Telegram denial against Slack's
     rule — and refuses a permitted Telegram send whenever Slack is denied.
-  - **`channel_type` is the one `send_message` argument that requires
-    `_resolve_session_key_strict()`.** It posts into one specific conversation,
+  - **`channel_type` is the one `send_message` argument that requires strict
+    identity (via `require_strict_session_key`).** It posts into one specific conversation,
     which is the "targets a specific session" case below; the lenient walk
     climbs process ancestors, so a sub-agent would resolve to its parent and
     deliver into the parent's chat window. An unresolvable identity refuses the
@@ -899,8 +899,11 @@ Two failure modes follow.
 backend: the warm pool spawns with an empty key, and a sub-agent inherits its
 parent's tree. `mcp_core.py` offers two resolvers:
 
-- `_resolve_session_key_strict()` for **anything that mutates or targets a
-  specific session** (post to a slot, change its state, deliver a callback). It
+- `_resolve_session_key_strict` for **anything that mutates or targets a
+  specific session** (post to a slot, change its state, deliver a callback) —
+  reached ONLY through `require_strict_session_key()`, the shared fail-closed
+  gate every reflexive tool module routes through (`REFLEXIVE_TOOL_MODULES`
+  enumerates them; a ratchet test rejects direct calls outside `mcp_core`). It
   accepts only the gateway-injected caller context (`mcp_caller.current_caller()`,
   which gatewayd stamps on every forwarded frame after stripping any
   client-forged `kirocrew.caller` block), the injected `KIROCREW_SESSION_KEY`, or
@@ -979,7 +982,7 @@ Structured monitoring deliberately splits mutation from inspection.
 consumer applies them to its authoritative session, so their payloads contain
 neither a session key nor a loop id. `monitor_inspect` needs a result in the same
 turn and therefore calls the session-bound read route only after
-`_resolve_session_key_strict()` succeeds, passing that exact key to `_get`.
+`require_strict_session_key()` resolves, passing that exact key to `_get`.
 It projects that response into bounded agent-oriented state (check counts and
 accepted wake count, plus only a small failed/pending/unknown name sample),
 omitting wake instructions and browser/persistence internals. Inspection reports

--- a/src/kiro_crew/mcp_computer.py
+++ b/src/kiro_crew/mcp_computer.py
@@ -122,8 +122,8 @@ from kiro_crew.mcp_core import (
     _internal_secret,
     _replay_target,
     _resolve_api_target,
-    _resolve_session_key_strict,
     _session_key_header_error,
+    require_strict_session_key,
 )
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
 from kiro_crew.validation import MCP_COMPUTER_SCHEMAS, ValidationError, validate_tool_args
@@ -709,7 +709,9 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
     # ``mcp_core`` itself documents as "agent-writable and therefore forgeable", and
     # an unnamed audit identity is honest where a forged one is a lie. What the audit
     # loses is attribution, which is worth less than the feature working.
-    session_key = _resolve_session_key_strict() or _unresolved_session_key()
+    session_key = require_strict_session_key("computer-use attribution")[0] or (
+        _unresolved_session_key()
+    )
     header_err = _session_key_header_error(session_key)
     if header_err:
         return f"{ERROR_PREFIX}{header_err}"

--- a/src/kiro_crew/mcp_core.py
+++ b/src/kiro_crew/mcp_core.py
@@ -847,6 +847,61 @@ def strict_identity_diagnosis(server: str = "kirocrew-core") -> str:
     )
 
 
+#: The REFLEXIVE tool surface: every module whose MCP tools embed "my session"
+#: in their semantics (ledger writes, monitor loops, session-scoped control,
+#: attributed channel sends, crew/app state, cron ownership). Each of these
+#: resolves the caller STRICTLY through :func:`require_strict_session_key` —
+#: never the lenient :func:`_resolve_session_key`, whose ``/proc`` ancestor
+#: walk hands a subagent its PARENT slot's identity. This is data, not lore:
+#: ``test/test_identity_topology.py`` scans the source tree and fails when a
+#: module calls the strict resolver directly (bypassing the gate) or calls the
+#: gate without being registered here, so the NEXT reflexive tool cannot skip
+#: the gate silently. Paths are relative to ``src/kiro_crew``.
+REFLEXIVE_TOOL_MODULES: frozenset[str] = frozenset(
+    {
+        "mcp_computer.py",
+        "mcp_cron.py",
+        "mcp_dashboard.py",
+        "mcp_tools/apps.py",
+        "mcp_tools/control.py",
+        "mcp_tools/ledger.py",
+        "mcp_tools/messaging.py",
+        "mcp_tools/workflows.py",
+    }
+)
+
+
+def require_strict_session_key(
+    refusal: str, server: str = "kirocrew-core"
+) -> tuple[str, str]:
+    """The ONE fail-closed identity gate every reflexive tool routes through.
+
+    Returns ``(key, "")`` when the caller is strictly identified, and
+    ``("", error)`` otherwise, where ``error`` is the caller-supplied
+    ``refusal`` text with :func:`strict_identity_diagnosis` appended so the
+    operator learns why THIS install cannot answer "which session is calling".
+
+    Resolution is :func:`_resolve_session_key_strict` — gateway-injected
+    caller context, ``KIROCREW_SESSION_KEY``, or the HMAC-verified host-pid
+    sidecar; never the lenient ``/proc`` ancestor walk, under which a subagent
+    resolves to its PARENT slot and could read or mutate the parent's state.
+
+    The tuple shape is deliberate: each call site keeps its own arm. Most
+    refuse with the ``error`` half; tools that legitimately degrade instead
+    (``autonudge_stop`` short-circuits, ``ask_question`` gates on the
+    dashboard surface, computer-use falls back to an unresolved placeholder)
+    use the resolve half only and ignore ``error``. What no call site may do
+    is resolve identity for a reflexive tool through anything but this gate —
+    the ratchet test over :data:`REFLEXIVE_TOOL_MODULES` enforces exactly
+    that. Callers must send the KEY THIS GATE RETURNED on the wire:
+    re-resolving at the write would check one identity and act as another.
+    """
+    sk = _resolve_session_key_strict()
+    if sk:
+        return sk, ""
+    return "", refusal + strict_identity_diagnosis(server)
+
+
 def _deny_channel_agent_messaging(caller_session: str, tool_name: str) -> str | None:
     """Return an ``Error:`` denial when a channel agent calls a messaging tool.
 

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -41,7 +41,7 @@ from kiro_crew.cron_trigger import _JOB_ID_RE, trigger_cron_job
 from kiro_crew.mcp_caller import current_caller
 from kiro_crew.mcp_core import (
     _resolve_session_key,
-    _resolve_session_key_strict,
+    require_strict_session_key,
     strict_identity_diagnosis,
 )
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
@@ -1519,7 +1519,10 @@ def _authz_session_key() -> str:
     sandbox launcher ran). It is NOT the same as "single user, so anything goes":
     see :func:`_unidentified_caller_refusal`.
     """
-    return _resolve_session_key_strict()
+    # Resolve-half of the shared strict gate only: the refusal text (and its
+    # diagnosis) lives in :func:`_unidentified_caller_refusal`, which each
+    # mutating tool composes itself.
+    return require_strict_session_key("cron ownership authorization")[0]
 
 
 #: A job with no recorded owner. Written by every creation path that has no

--- a/src/kiro_crew/mcp_dashboard.py
+++ b/src/kiro_crew/mcp_dashboard.py
@@ -76,8 +76,7 @@ from kiro_crew.mcp_core import (
     _patch,
     _post,
     _resolve_session_key,
-    _resolve_session_key_strict,
-    strict_identity_diagnosis,
+    require_strict_session_key,
 )
 from kiro_crew.mcp_shared import call_tool_with_logging, run_mcp_stdio_loop
 from kiro_crew.platform import redact_via_context as redact
@@ -789,13 +788,13 @@ def _visible_chat_slots() -> tuple[list[dict], str | None]:
     if err:
         return [], err
     live = [r for r in rows if str(r.get("memory_mode") or "persistent") == "persistent"]
-    caller_key = _resolve_session_key_strict()
+    caller_key, strict_err = require_strict_session_key(
+        "cannot verify which session is calling, so the session list is "
+        "withheld — these tools scope what they show to the caller",
+        server=SERVER_NAME,
+    )
     if not caller_key:
-        return [], (
-            "cannot verify which session is calling, so the session list is "
-            "withheld — these tools scope what they show to the caller"
-            + strict_identity_diagnosis(SERVER_NAME)
-        )
+        return [], strict_err
     scope = _caller_app_scope(caller_key, rows)
     if scope is None:
         return [], (
@@ -833,13 +832,14 @@ def _refuse_tree_shaping_if_unverifiable(verb: str) -> tuple[str, str | None]:
     the endpoint looking like the unconfined person. Every caller of this gate
     must pass what it returns straight to the write.
     """
-    caller_key = _resolve_session_key_strict()
+    caller_key, strict_err = require_strict_session_key(
+        f"Error: cannot verify which session is calling, so {verb} is "
+        "refused — reshaping the shared folder tree requires a caller "
+        "identity the gateway can vouch for.",
+        server=SERVER_NAME,
+    )
     if not caller_key:
-        return "", (
-            f"Error: cannot verify which session is calling, so {verb} is "
-            "refused — reshaping the shared folder tree requires a caller "
-            "identity the gateway can vouch for." + strict_identity_diagnosis(SERVER_NAME)
-        )
+        return "", strict_err
     rows, err = _get_rows("/api/chat/slots")
     if err:
         return "", f"Error: {err}"
@@ -890,14 +890,14 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         # authorize the check and the action as potentially different sessions:
         # the lenient walk reads mutable process state, so what it answers at
         # request time need not be what the gate approved.
-        caller_key = _resolve_session_key_strict()
+        caller_key, strict_err = require_strict_session_key(
+            "Error: this session cannot be identified well enough to control another "
+            "session. Session control authorizes on the calling session's identity, and "
+            "only a gateway-issued key counts — a spawned subagent has none of its own.",
+            server=SERVER_NAME,
+        )
         if not caller_key:
-            return (
-                "Error: this session cannot be identified well enough to control another "
-                "session. Session control authorizes on the calling session's identity, and "
-                "only a gateway-issued key counts — a spawned subagent has none of its own."
-                + strict_identity_diagnosis(SERVER_NAME)
-            )
+            return strict_err
 
     if name == "session_create":
         args = validate_tool_args(args, SESSION_CREATE_SCHEMA)
@@ -1256,13 +1256,14 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
         # an unresolved identity reaches the endpoint as no header at all, where
         # it reads as the unconfined dashboard user. Refuse instead of writing
         # with an authority we cannot name.
-        caller_key = _resolve_session_key_strict()
+        caller_key, strict_err = require_strict_session_key(
+            "Error: cannot verify which session is calling, so this move is "
+            "refused — filing another session requires a caller identity the "
+            "gateway can vouch for.",
+            server=SERVER_NAME,
+        )
         if not caller_key:
-            return (
-                "Error: cannot verify which session is calling, so this move is "
-                "refused — filing another session requires a caller identity the "
-                "gateway can vouch for." + strict_identity_diagnosis(SERVER_NAME)
-            )
+            return strict_err
         # The verified key is passed through unchanged: re-resolving inside the
         # helper would let the write carry a different session's authority than
         # the one checked here.

--- a/src/kiro_crew/mcp_tools/apps.py
+++ b/src/kiro_crew/mcp_tools/apps.py
@@ -337,14 +337,14 @@ def _crew_session_key() -> tuple[str, str]:
     directly attributable. Both crew tools send THIS key rather than resolving
     their own, so the identity that passed the gate is the identity on the wire.
     """
-    _crew_sk = mcp_core._resolve_session_key_strict()
+    _crew_sk, _crew_err = mcp_core.require_strict_session_key(
+        "Error: this tool needs a directly-identified dashboard session. "
+        "A subagent resolves to its parent's session, which would read and "
+        "write the parent crew's ledger. Run this from the crew's own "
+        "session."
+    )
     if not _crew_sk:
-        return "", (
-            "Error: this tool needs a directly-identified dashboard session. "
-            "A subagent resolves to its parent's session, which would read and "
-            "write the parent crew's ledger. Run this from the crew's own "
-            "session." + mcp_core.strict_identity_diagnosis()
-        )
+        return "", _crew_err
     return _crew_sk, ""
 
 

--- a/src/kiro_crew/mcp_tools/control.py
+++ b/src/kiro_crew/mcp_tools/control.py
@@ -733,15 +733,15 @@ def wait(name: str, args: dict[str, Any]) -> str:
     # SUBAGENT's wait. No frontend guard can catch that: with only one wait_id
     # pinging there is no collision to detect.
     #
-    # `_resolve_session_key_strict()` is the existing primitive for exactly
-    # this class of session-mutating tool (monitor_start, autonudge_stop,
-    # set_project) -- it drops the walk and accepts only gateway-injected
-    # caller context, KIROCREW_SESSION_KEY, or a HMAC-verified pid sidecar.
+    # `require_strict_session_key` is the shared gate for exactly this class
+    # of session-mutating tool (monitor_start, autonudge_stop, set_project)
+    # -- it drops the walk and accepts only gateway-injected caller context,
+    # KIROCREW_SESSION_KEY, or a HMAC-verified pid sidecar.
     # When it comes back empty the identity is a guess, so the ping degrades
     # to the original `{}` touch: the session still cannot be reaped
     # mid-sleep, and the countdown simply never appears. Tracked in #2347,
     # which is the work that lets this gate go away.
-    _identified = bool(mcp_core._resolve_session_key_strict())
+    _identified = bool(mcp_core.require_strict_session_key("the wait keepalive ping")[0])
     # The 5s cadence exists ONLY to bound how long the button appears to do
     # nothing. An unidentified sleep publishes nothing and honours no
     # end_wait, so it has no button and would be paying a 12x request
@@ -938,11 +938,13 @@ def autonudge_stop(name: str, args: dict[str, Any]) -> str:
     args = validate_tool_args(args, AUTONUDGE_STOP_SCHEMA)
 
     # Resolve the current session's binding key and stop any loop on it.
-    # STRICT resolution (env-var only, no PID walk): this tool mutates
-    # another process's persistent loop state, and a subagent lives under
-    # the parent slot's process tree — a PID-walk would let it silently
-    # stop the PARENT session's loop (matches set_project's rule).
-    sk = mcp_core._resolve_session_key_strict()
+    # STRICT resolution via the shared gate (env-var only, no PID walk): this
+    # tool mutates another process's persistent loop state, and a subagent
+    # lives under the parent slot's process tree — a PID-walk would let it
+    # silently stop the PARENT session's loop (matches set_project's rule).
+    # Resolve-half only: an empty key deliberately does NOT refuse here — it
+    # falls through to the directive, whose consumer resolves its own session.
+    sk, _ = mcp_core.require_strict_session_key("autonudge_stop")
     # Stateless: emit a directive; the session-aware consumer
     # (chat_runner) resolves the loop by ITS OWN session and stops it. The
     # tool carries no session identity — sk is used only to short-circuit a
@@ -979,7 +981,9 @@ def ask_question(name: str, args: dict[str, Any]) -> str:
     # the session started — a channel-born session with its tab open can
     # render it. Surfaces without a tab still get the [OPTIONS:] hint;
     # an empty (default-install) key falls through to the directive.
-    sk = mcp_core._resolve_session_key_strict()
+    # Resolve-half of the shared strict gate only: ask_question gates on the
+    # dashboard surface, not on identity, so an empty key is not a refusal.
+    sk, _ = mcp_core.require_strict_session_key("ask_question")
     if sk and not has_dashboard_surface(sk):
         return (
             "ask_question only works from a dashboard chat session "
@@ -1003,12 +1007,14 @@ def ask_question(name: str, args: dict[str, Any]) -> str:
 
 def monitor_start(name: str, args: dict[str, Any]) -> str:
     args = validate_tool_args(args, MONITOR_START_SCHEMA)
-    # STRICT resolution (env-var only, no PID walk): monitor_start creates
-    # a persistent unattended loop that repeatedly runs tools in the bound
-    # session. A subagent under the parent's process tree must NOT be able
-    # to PID-walk into the parent's identity and mint a loop the parent
-    # user never asked for (crosses the session authorization boundary).
-    sk = mcp_core._resolve_session_key_strict()
+    # STRICT resolution via the shared gate (env-var only, no PID walk):
+    # monitor_start creates a persistent unattended loop that repeatedly runs
+    # tools in the bound session. A subagent under the parent's process tree
+    # must NOT be able to PID-walk into the parent's identity and mint a loop
+    # the parent user never asked for (crosses the session authorization
+    # boundary). Resolve-half only: the short-circuit below is on context,
+    # not identity, so an empty key falls through to the directive.
+    sk, _ = mcp_core.require_strict_session_key("monitor_start")
     # Stateless: only short-circuit contexts where a directive can
     # never be applied (cron/hook/subagent). The session-aware consumer
     # (chat_runner) supplies the binding key and arms the loop.
@@ -1108,14 +1114,12 @@ def _monitor_context_refusal(tool_name: str, session_key: str, message: str) -> 
 def monitor_watch(name: str, args: dict[str, Any]) -> str:
     """Validate and emit a session-bound structured monitor directive."""
     args = validate_tool_args(args, MONITOR_WATCH_SCHEMA)
-    sk = mcp_core._resolve_session_key_strict()
+    sk, strict_err = mcp_core.require_strict_session_key(
+        "monitor_watch requires an authenticated strict session binding. "
+        "No process-ancestor fallback is used."
+    )
     if not sk:
-        return _monitor_context_refusal(
-            "monitor_watch",
-            sk,
-            "monitor_watch requires an authenticated strict session binding. "
-            "No process-ancestor fallback is used.",
-        )
+        return _monitor_context_refusal("monitor_watch", sk, strict_err)
     if mcp_core._structured_monitor_binding_key(sk) is None:
         return _monitor_context_refusal(
             "monitor_watch",
@@ -1148,14 +1152,12 @@ def monitor_watch(name: str, args: dict[str, Any]) -> str:
 def monitor_inspect(name: str, args: dict[str, Any]) -> str:
     """Read only the monitor bound to a verified strict session identity."""
     validate_tool_args(args, MONITOR_INSPECT_SCHEMA)
-    sk = mcp_core._resolve_session_key_strict()
+    sk, strict_err = mcp_core.require_strict_session_key(
+        "Monitor inspection unavailable without an authenticated strict session binding. "
+        "No process-ancestor fallback is used."
+    )
     if not sk:
-        return _monitor_context_refusal(
-            "monitor_inspect",
-            sk,
-            "Monitor inspection unavailable without an authenticated strict session binding. "
-            "No process-ancestor fallback is used.",
-        )
+        return _monitor_context_refusal("monitor_inspect", sk, strict_err)
     if mcp_core._structured_monitor_binding_key(sk) is None:
         return _monitor_context_refusal(
             "monitor_inspect",
@@ -1241,14 +1243,12 @@ def _compact_monitor_inspection(result: dict[str, Any]) -> dict[str, Any]:
 def monitor_stop(name: str, args: dict[str, Any]) -> str:
     """Emit a durable structured-stop directive without caller identity."""
     args = validate_tool_args(args, MONITOR_STOP_SCHEMA)
-    sk = mcp_core._resolve_session_key_strict()
+    sk, strict_err = mcp_core.require_strict_session_key(
+        "monitor_stop requires an authenticated strict session binding. "
+        "No process-ancestor fallback is used."
+    )
     if not sk:
-        return _monitor_context_refusal(
-            "monitor_stop",
-            sk,
-            "monitor_stop requires an authenticated strict session binding. "
-            "No process-ancestor fallback is used.",
-        )
+        return _monitor_context_refusal("monitor_stop", sk, strict_err)
     if mcp_core._structured_monitor_binding_key(sk) is None:
         return _monitor_context_refusal(
             "monitor_stop",
@@ -1265,20 +1265,18 @@ def monitor_stop(name: str, args: dict[str, Any]) -> str:
 
 def monitor_update(name: str, args: dict[str, Any]) -> str:
     args = validate_tool_args(args, MONITOR_UPDATE_SCHEMA)
-    # STRICT resolution, same rationale as monitor_start/autonudge_stop:
-    # this mutates persistent loop state that drives unattended turns, so a
-    # subagent must not PID-walk into the parent's identity and rewrite the
-    # parent session's instruction.
-    sk = mcp_core._resolve_session_key_strict()
+    # STRICT resolution via the shared gate, same rationale as
+    # monitor_start/autonudge_stop: this mutates persistent loop state that
+    # drives unattended turns, so a subagent must not PID-walk into the
+    # parent's identity and rewrite the parent session's instruction.
+    sk, strict_err = mcp_core.require_strict_session_key(
+        "monitor_update requires an authenticated strict session binding. "
+        "No process-ancestor fallback is used."
+    )
     # Stateless: short-circuit only un-appliable contexts; the
     # consumer resolves the loop by its own session and patches it.
     if not sk:
-        return _monitor_context_refusal(
-            "monitor_update",
-            sk,
-            "monitor_update requires an authenticated strict session binding. "
-            "No process-ancestor fallback is used.",
-        )
+        return _monitor_context_refusal("monitor_update", sk, strict_err)
     if mcp_core._structured_monitor_binding_key(sk) is None:
         return _monitor_context_refusal(
             "monitor_update",

--- a/src/kiro_crew/mcp_tools/ledger.py
+++ b/src/kiro_crew/mcp_tools/ledger.py
@@ -128,20 +128,18 @@ def _strict_session_key() -> tuple[str, str]:
     Returns ``(key, "")`` or ``("", error)``. The lenient default resolver
     includes a ``/proc`` ancestor walk, and a subagent lives under its parent
     slot's process tree — the walk would silently resolve to the PARENT
-    session, disclosing or overwriting the parent's ledger. The strict
-    resolver only accepts gateway-authored identities, and the verified key is
-    passed explicitly to the transport so the value that was checked is the
-    value that is used.
+    session, disclosing or overwriting the parent's ledger. Resolution is
+    delegated to :func:`mcp_core.require_strict_session_key`, the shared
+    fail-closed gate for reflexive tools (this helper is where that gate was
+    promoted from), and the verified key is passed explicitly to the transport
+    so the value that was checked is the value that is used.
     """
-    sk = mcp_core._resolve_session_key_strict()
-    if not sk:
-        return "", (
-            "Error: this session's identity could not be verified strictly, "
-            "so the ledger is not reachable from here. Subagents inherit no "
-            "session identity of their own — record ledger updates from the "
-            "parent session instead." + mcp_core.strict_identity_diagnosis()
-        )
-    return sk, ""
+    return mcp_core.require_strict_session_key(
+        "Error: this session's identity could not be verified strictly, "
+        "so the ledger is not reachable from here. Subagents inherit no "
+        "session identity of their own — record ledger updates from the "
+        "parent session instead."
+    )
 
 
 def session_ledger_read(name: str, args: dict[str, Any]) -> str:

--- a/src/kiro_crew/mcp_tools/messaging.py
+++ b/src/kiro_crew/mcp_tools/messaging.py
@@ -405,14 +405,13 @@ def send_message(name: str, args: dict[str, Any]) -> str:
     # every surface that can legitimately ask for it.
     verified_session = ""
     if channel_type:
-        verified_session = mcp_core._resolve_session_key_strict()
+        verified_session, _strict_err = mcp_core.require_strict_session_key(
+            "Error: cannot verify caller identity for a channel_type send "
+            "(no gateway-injected session key or HMAC-verified pid). "
+            "Refusing to post into a conversation that cannot be attributed."
+        )
         if not verified_session:
-            return (
-                "Error: cannot verify caller identity for a channel_type send "
-                "(no gateway-injected session key or HMAC-verified pid). "
-                "Refusing to post into a conversation that cannot be attributed."
-                + mcp_core.strict_identity_diagnosis()
-            )
+            return _strict_err
     # ``gov_session`` is the identity every gate below is keyed on. It is the
     # STRICT key whenever one was required, so the identity that is checked is
     # the identity the request is later sent under (``_post`` gets the same
@@ -549,14 +548,13 @@ def send_message(name: str, args: dict[str, Any]) -> str:
 
 
 def send_notification(name: str, args: dict[str, Any]) -> str:
-    caller_session = mcp_core._resolve_session_key_strict()
+    caller_session, _strict_err = mcp_core.require_strict_session_key(
+        "Error: cannot verify caller identity for send_notification "
+        "(no gateway-injected session key or HMAC-verified pid). "
+        "Refusing to publish without a trusted governance identity."
+    )
     if not caller_session:
-        return (
-            "Error: cannot verify caller identity for send_notification "
-            "(no gateway-injected session key or HMAC-verified pid). "
-            "Refusing to publish without a trusted governance identity."
-            + mcp_core.strict_identity_diagnosis()
-        )
+        return _strict_err
     # Channel-agent containment: same boundary
     # as send_message — an auto-approved call emits no permission event,
     # so channel.py's guard alone cannot hold it.
@@ -760,7 +758,9 @@ def file_send(name: str, args: dict[str, Any]) -> str:
     # native leg first would reroute the file to the linked chat instead of
     # the named Slack channel.
     channel_warning = ""
-    strict_key = mcp_core._resolve_session_key_strict()
+    # Resolve-half of the shared strict gate only: file_send degrades (skips
+    # the native channel leg) rather than refusing when identity is absent.
+    strict_key, _ = mcp_core.require_strict_session_key("file_send native delivery")
     if strict_key and not args.get("channel"):
         channel_resp = mcp_core._post(
             "/api/channel/upload-file",

--- a/src/kiro_crew/mcp_tools/workflows.py
+++ b/src/kiro_crew/mcp_tools/workflows.py
@@ -246,12 +246,14 @@ def workflow_run(name: str, args: dict[str, Any]) -> str:
     if isinstance(args.get("budget_total"), int):
         wf_body["budget_total"] = args["budget_total"]
     if workflow_ref:
-        session_key = mcp_core._resolve_session_key_strict()
+        session_key, _strict_err = mcp_core.require_strict_session_key(
+            "Error: cannot verify caller identity for workflow_run. Refusing to start a "
+            "session-bound workflow."
+        )
         if not session_key:
             return _wf_return(
                 "workflow_run",
-                "Error: cannot verify caller identity for workflow_run. Refusing to start a "
-                "session-bound workflow." + mcp_core.strict_identity_diagnosis(),
+                _strict_err,
                 outcome="error",
             )
         if args.get("input"):

--- a/test/test_identity_topology.py
+++ b/test/test_identity_topology.py
@@ -537,6 +537,84 @@ def test_session_pid_call_sites_are_registered() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Reflexive-tool strict-gate ratchet (#5913)
+# ---------------------------------------------------------------------------
+# A REFLEXIVE MCP tool is one whose semantics embed "my session": ledger
+# writes, monitor loops, session-scoped control, attributed channel sends. The
+# invariant is that every one of them resolves the caller through the single
+# fail-closed gate ``mcp_core.require_strict_session_key`` — never the lenient
+# resolver (whose /proc ancestor walk hands a subagent its PARENT slot's
+# identity) and never a private copy of the strict check. Before the gate
+# existed the fail-closed handling was re-derived by hand at every call site,
+# and nothing stopped the NEXT reflexive tool from calling the lenient
+# resolver and silently writing the parent slot's state from a subagent.
+# Same shape as the session_pid registry guard above: scan the source, fail on
+# an unregistered file, so the invariant is enforced rather than remembered.
+
+#: Call-form tokens. Prose references (docstrings without parens, ``#``
+#: comments, which are stripped per line below) do not count as calls.
+_STRICT_RESOLVER_CALL = re.compile(r"_resolve_session_key_strict\s*\(")
+_REFLEXIVE_GATE_CALL = re.compile(r"require_strict_session_key\s*\(")
+
+
+def _code_text(path: Path) -> str:
+    """File text with per-line ``#`` comments stripped (heuristic, no parser).
+
+    Good enough for these tokens: neither contains ``#``, and a call is never
+    legitimately split across a comment boundary.
+    """
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(line.split("#", 1)[0] for line in lines)
+
+
+def test_reflexive_tools_route_through_the_strict_gate() -> None:
+    from kiro_crew.mcp_core import REFLEXIVE_TOOL_MODULES
+
+    src = _src_root()
+    direct: set[str] = set()
+    gated: set[str] = set()
+    for p in src.rglob("*.py"):
+        rel = p.relative_to(src).as_posix()
+        text = _code_text(p)
+        if _STRICT_RESOLVER_CALL.search(text):
+            direct.add(rel)
+        if _REFLEXIVE_GATE_CALL.search(text):
+            gated.add(rel)
+
+    # 1. The gate is the ONLY caller of the strict resolver. mcp_core.py hosts
+    #    both, plus the resolver's own internal consumers (diagnosis, the
+    #    Slack identity classifier), so it is the single permitted file.
+    direct -= {"mcp_core.py"}
+    assert not direct, (
+        f"Direct _resolve_session_key_strict() call(s) outside mcp_core: "
+        f"{sorted(direct)}.\n"
+        "Reflexive tools must resolve identity through "
+        "mcp_core.require_strict_session_key so the fail-closed handling "
+        "stays in one place. Route the call through the gate and register "
+        "the module in mcp_core.REFLEXIVE_TOOL_MODULES."
+    )
+
+    # 2. Every module calling the gate is registered as reflexive, and every
+    #    registered module still calls it — the set is data, not lore.
+    gated -= {"mcp_core.py"}
+    registered = set(REFLEXIVE_TOOL_MODULES)
+    unregistered = gated - registered
+    stale = registered - gated
+    assert not unregistered, (
+        f"New reflexive-tool module(s) call require_strict_session_key but are "
+        f"not registered: {sorted(unregistered)}.\n"
+        "Add them to mcp_core.REFLEXIVE_TOOL_MODULES so the reflexive surface "
+        "stays enumerable."
+    )
+    assert not stale, (
+        f"Registered reflexive module(s) no longer call the gate: "
+        f"{sorted(stale)}. Either the tool regressed to a private identity "
+        "check (fix the tool) or it is gone (remove it from "
+        "mcp_core.REFLEXIVE_TOOL_MODULES)."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Class-level publisher guard (#232)
 # ---------------------------------------------------------------------------
 # The "missing X-Session-Key" HTTP 400 was a channel-turn *publisher* gap: a

--- a/test/test_mcp_computer.py
+++ b/test/test_mcp_computer.py
@@ -49,7 +49,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kiro_crew import mcp_computer
+from kiro_crew import mcp_computer, mcp_core
 from kiro_crew.computer_use import backend as cu_backend
 from kiro_crew.computer_use import index as cu_index
 from kiro_crew.computer_use import policy as cu_policy
@@ -409,7 +409,7 @@ def test_oversized_text_is_rejected():
 
 
 def test_shim_uses_the_strict_session_resolver_not_the_lenient_one():
-    """``_resolve_session_key_strict`` only.
+    """Strict identity only, routed through the shared reflexive-tool gate.
 
     The lenient resolver walks ``/proc`` ancestors over ``session_pid_<pid>.txt``,
     which ``mcp_core`` itself documents as "agent-writable and therefore
@@ -417,6 +417,7 @@ def test_shim_uses_the_strict_session_resolver_not_the_lenient_one():
     over the module's source so a future edit cannot quietly swap the resolver.
     """
     src = inspect.getsource(mcp_computer)
+    assert "require_strict_session_key" in src
     assert "_resolve_session_key_strict" in src
     # The lenient name must not appear as a CALL. (It is a prefix of the strict
     # name, so compare call forms rather than substrings.)
@@ -446,7 +447,7 @@ def test_an_unresolved_session_key_PROCEEDS_with_an_empty_identity(
     """
     _enable(keystone)
     posted: list[Any] = []
-    monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: "")
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "")
     monkeypatch.setattr(mcp_computer, "_invoke", lambda *a, **k: posted.append(a) or {"text": "ok"})
     result = mcp_computer._call_tool_inner(TOOL_LIST_APPS, {})
     assert not result.startswith(ERROR_PREFIX), result
@@ -481,7 +482,7 @@ def test_resolved_session_key_is_forwarded_in_body_and_header(
         seen.update({"session_key": session_key, "name": name, "args": args})
         return {"text": "App=…"}
 
-    monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: _SESSION)
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: _SESSION)
     monkeypatch.setattr(mcp_computer, "_invoke", _invoke)
     assert mcp_computer._call_tool_inner(TOOL_LIST_APPS, {}) == "App=…"
     assert seen["session_key"] == _SESSION
@@ -497,7 +498,7 @@ def test_non_latin1_session_key_is_refused_with_an_actionable_message(
     surface as a raw ``UnicodeEncodeError`` instead of "rename the tab".
     """
     _enable(keystone)
-    monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: "dashboard:tab—1")
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:tab—1")
     monkeypatch.setattr(mcp_computer, "_invoke", lambda *a, **k: {"text": "ok"})
     result = mcp_computer._call_tool_inner(TOOL_LIST_APPS, {})
     assert result.startswith(ERROR_PREFIX)
@@ -541,7 +542,7 @@ def test_transport_failure_is_reported_as_an_actionable_error(
 ):
     """An unreachable gateway must be diagnosable, not an opaque internal error."""
     _enable(keystone)
-    monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: _SESSION)
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: _SESSION)
     monkeypatch.setattr(
         mcp_computer,
         "_invoke",
@@ -561,7 +562,7 @@ def test_gateway_refusal_text_is_relayed_verbatim(keystone: Path, monkeypatch: p
     """
     _enable(keystone)
     refusal = f"{ERROR_PREFIX}Blocked by governance policy: capability disabled"
-    monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: _SESSION)
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: _SESSION)
     monkeypatch.setattr(mcp_computer, "_invoke", lambda *a, **k: {"text": refusal})
     assert mcp_computer._call_tool_inner(TOOL_CLICK, {}) == refusal
 
@@ -571,7 +572,7 @@ def test_empty_gateway_body_is_an_error_not_a_silent_success(
 ):
     """A body with neither text nor error must not read as success."""
     _enable(keystone)
-    monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: _SESSION)
+    monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: _SESSION)
     monkeypatch.setattr(mcp_computer, "_invoke", lambda *a, **k: {})
     result = mcp_computer._call_tool_inner(TOOL_LIST_APPS, {})
     assert result.startswith(ERROR_PREFIX)
@@ -2166,7 +2167,7 @@ class TestUnresolvedSessionsAreNamespaced:
         set_current_caller(None)
         set_current_tenant_nonce("cafebabe")
 
-        assert mcp_computer._resolve_session_key_strict() == ""
+        assert mcp_core._resolve_session_key_strict() == ""
         assert mcp_computer._unresolved_session_key().startswith(
             mcp_computer.UNRESOLVED_SESSION_PREFIX
         )
@@ -2181,7 +2182,7 @@ class TestUnresolvedSessionsAreNamespaced:
         set_current_caller(CallerContext(session_key="dashboard:main"))
         set_current_tenant_nonce("cafebabe")
         try:
-            assert mcp_computer._resolve_session_key_strict() == "dashboard:main"
+            assert mcp_core._resolve_session_key_strict() == "dashboard:main"
         finally:
             set_current_caller(None)
 
@@ -2219,7 +2220,7 @@ class TestUnresolvedSessionsAreNamespaced:
         attribution the strict resolver exists to provide."""
         _enable(keystone)
         posted: list[Any] = []
-        monkeypatch.setattr(mcp_computer, "_resolve_session_key_strict", lambda: "dashboard:main")
+        monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "dashboard:main")
         monkeypatch.setattr(
             mcp_computer, "_invoke", lambda *a, **k: posted.append(a) or {"text": "ok"}
         )

--- a/test/test_mcp_dashboard_folders.py
+++ b/test/test_mcp_dashboard_folders.py
@@ -75,7 +75,7 @@ def _verified_caller() -> Any:
     this to empty itself, and the inner patch wins.
     """
     with patch(
-        "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+        "kiro_crew.mcp_core._resolve_session_key_strict",
         return_value="dashboard:chat-1-100",
     ):
         yield
@@ -635,7 +635,7 @@ class TestFolderMoveSession:
         """
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
-            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=""),
             patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
         ):
             out = _call_tool_inner(
@@ -656,7 +656,7 @@ class TestFolderMoveSession:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=_rows),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="dashboard:chat-2-200",
             ),
             patch("kiro_crew.mcp_dashboard._patch", return_value={"ok": True}) as mock_patch,
@@ -978,7 +978,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="subagent:abc123",
             ),
         ):
@@ -991,7 +991,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="subagent:abc123",
             ),
             patch("kiro_crew.mcp_dashboard._post") as mock_post,
@@ -1005,7 +1005,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="subagent:abc123",
             ),
             patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
@@ -1022,7 +1022,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="cron:job-abc123",
             ),
         ):
@@ -1034,7 +1034,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="cron:job-abc123",
             ),
             patch("kiro_crew.mcp_dashboard._post") as mock_post,
@@ -1067,7 +1067,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="dashboard:chat-gone-999",
             ),
         ):
@@ -1079,7 +1079,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="dashboard:chat-gone-999",
             ),
             patch("kiro_crew.mcp_dashboard._post") as mock_post,
@@ -1108,7 +1108,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="slack:T1:C1:1777",
             ),
         ):
@@ -1130,7 +1130,7 @@ class TestASubagentCannotOutrankItsParent:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=_rows_with_sub),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="subagent:abc123",
             ),
         ):
@@ -1161,7 +1161,7 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
 
     def _as(self, slot: str) -> Any:
         return patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+            "kiro_crew.mcp_core._resolve_session_key_strict",
             return_value=f"dashboard:{slot}",
         )
 
@@ -1240,7 +1240,7 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
     def test_an_unverifiable_caller_cannot_reshape_it_either(self) -> None:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
-            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=""),
             patch("kiro_crew.mcp_dashboard._post") as mock_post,
         ):
             out = _call_tool_inner("chat_folder_create", {"name": "Q3"})
@@ -1270,7 +1270,7 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=rows),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="channel:C123",
             ),
             patch("kiro_crew.mcp_dashboard._post") as mock_post,
@@ -1293,7 +1293,7 @@ class TestTheFolderPolicyIsTheEndpointsNotThisServers:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=rows),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="slack:T1/C1",
             ),
             patch("kiro_crew.mcp_dashboard._post", return_value=made) as mock_post,
@@ -1322,7 +1322,7 @@ class TestEveryFolderWriteCarriesTheVerifiedKey:
 
     def _as(self, slot: str) -> Any:
         return patch(
-            "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+            "kiro_crew.mcp_core._resolve_session_key_strict",
             return_value=f"dashboard:{slot}",
         )
 
@@ -1383,7 +1383,7 @@ class TestTheSessionListIsScopedToTheCaller:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="dashboard:chat-1-100",
             ),
         ):
@@ -1397,7 +1397,7 @@ class TestTheSessionListIsScopedToTheCaller:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="dashboard:chat-3-300",
             ),
         ):
@@ -1407,7 +1407,7 @@ class TestTheSessionListIsScopedToTheCaller:
     def test_an_unverifiable_caller_is_shown_nothing(self) -> None:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
-            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=""),
         ):
             out = _call_tool_inner("chat_folder_tree", {})
         assert out.startswith("Error:")
@@ -1419,7 +1419,7 @@ class TestTheSessionListIsScopedToTheCaller:
         with (
             patch("kiro_crew.mcp_dashboard._get", side_effect=self._mixed),
             patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict",
+                "kiro_crew.mcp_core._resolve_session_key_strict",
                 return_value="dashboard:chat-1-100",
             ),
             patch("kiro_crew.mcp_dashboard._patch") as mock_patch,
@@ -1529,9 +1529,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
 
     def test_create_carries_the_verified_key(self):
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch(
                 "kiro_crew.mcp_dashboard._post", return_value={"target": "chat-2", "title": "w"}
             ) as post,
@@ -1541,9 +1539,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
 
     def test_stop_carries_the_verified_key(self):
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch("kiro_crew.mcp_dashboard._post", return_value={"ok": True}) as post,
         ):
             _call_tool_inner("session_stop", {"target": "peer"})
@@ -1551,9 +1547,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
 
     def test_read_carries_the_verified_key(self):
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch("kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 0}) as get,
         ):
             _call_tool_inner("session_read_message", {"target": "peer"})
@@ -1570,9 +1564,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
         Mutation guard: ignoring `already_stopping` restores "nothing to stop".
         """
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch(
                 "kiro_crew.mcp_dashboard._post",
                 return_value={
@@ -1590,9 +1582,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
 
     def test_a_target_that_was_never_running_still_says_nothing_to_stop(self):
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch(
                 "kiro_crew.mcp_dashboard._post",
                 return_value={
@@ -1617,9 +1607,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
         Mutation guard: returning only the head line and "No messages" fails here.
         """
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch(
                 "kiro_crew.mcp_dashboard._get",
                 return_value={"messages": [], "total": 7, "next_since": 7},
@@ -1636,9 +1624,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
         response shape, whatever produces one.
         """
         with (
-            patch(
-                "kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=self.VERIFIED
-            ),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=self.VERIFIED),
             patch("kiro_crew.mcp_dashboard._get", return_value={"messages": [], "total": 7}),
         ):
             out = _call_tool_inner("session_read_message", {"target": "peer"})
@@ -1647,7 +1633,7 @@ class TestTheVerifiedCallerKeyReachesTheRequest:
     def test_an_unverifiable_caller_never_reaches_the_request(self):
         """The refusal must precede the call, not merely alter its key."""
         with (
-            patch("kiro_crew.mcp_dashboard._resolve_session_key_strict", return_value=""),
+            patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value=""),
             patch("kiro_crew.mcp_dashboard._post") as post,
             patch("kiro_crew.mcp_dashboard._get") as get,
         ):

--- a/test/test_strict_identity_diagnostics.py
+++ b/test/test_strict_identity_diagnostics.py
@@ -94,11 +94,15 @@ class TestRefusalsCarryTheDiagnosis:
         """
         import re
 
+        # For modules migrated to the shared reflexive-tool gate (#5913) the
+        # diagnosis is appended INSIDE mcp_core.require_strict_session_key, so
+        # the marker to count is the gate call itself; mcp_cron composes its
+        # refusal (and diagnosis) separately and keeps the direct token.
         roots = {
-            "mcp_tools/ledger.py": "mcp_core.strict_identity_diagnosis",
-            "mcp_tools/apps.py": "mcp_core.strict_identity_diagnosis",
-            "mcp_tools/messaging.py": "mcp_core.strict_identity_diagnosis",
-            "mcp_dashboard.py": "strict_identity_diagnosis(",
+            "mcp_tools/ledger.py": "require_strict_session_key(",
+            "mcp_tools/apps.py": "require_strict_session_key(",
+            "mcp_tools/messaging.py": "require_strict_session_key(",
+            "mcp_dashboard.py": "require_strict_session_key(",
             "mcp_cron.py": "strict_identity_diagnosis(",
         }
         src_root = Path(mcp_core.__file__).parent


### PR DESCRIPTION
## Problem / Motivation

The invariant "every reflexive MCP tool — one whose semantics embed *my session* (ledger writes, monitor loops, session-scoped control, attributed channel sends) — resolves the session key STRICTLY and fails closed" was re-derived by hand at every call site. There was no enumerable set of reflexive tools, the lenient resolver (`_resolve_session_key`, with its `/proc` ancestor walk) is a live adjacent sibling with 12+ legitimate call sites, and the fail-closed handling was duplicated inconsistently across `mcp_dashboard.py` (4 inline blocks), `mcp_tools/control.py`, `messaging.py`, `apps.py`, and `mcp_computer.py`. Nothing stopped the NEXT reflexive tool from calling the lenient resolver and silently writing the parent slot's state from a sub-agent.

## Why it matters

A subagent lives under its parent slot's process tree, so the lenient resolver's ancestor walk hands it the PARENT's identity. One future reflexive tool wired to the wrong resolver quietly crosses the session authorization boundary — a security-class regression that no existing test would catch, because the strict-resolution discipline lived in code review memory, not in an enforced gate.

## What changed (motivation → approach → change)

Follows the issue's own 4-step recipe:

1. **Shared gate** — promoted `mcp_tools/ledger.py::_strict_session_key` to `mcp_core.require_strict_session_key(refusal, server) -> tuple[str, str]`: resolves via `_resolve_session_key_strict`, and on failure returns the caller-supplied refusal text with `strict_identity_diagnosis()` appended. The `(sk, err)` tuple shape is kept so each call site keeps its own arm — tools that legitimately degrade instead of refusing (`autonudge_stop` short-circuits, `ask_question` gates on the dashboard surface, `file_send`/computer-use/cron fall back) use the resolve half only.
2. **Enumerable reflexive set** — `mcp_core.REFLEXIVE_TOOL_MODULES` declares the reflexive surface as data (8 modules), next to the gate.
3. **Migration** — every direct `_resolve_session_key_strict()` call site outside `mcp_core` now routes through the gate, preserving each site's refusal text and degrade semantics: `mcp_dashboard.py` (4 sites), `mcp_tools/control.py` (8 sites incl. the four structured-monitor tools and the wait keepalive), `mcp_tools/messaging.py` (3 sites), `mcp_tools/apps.py`, `mcp_tools/ledger.py` (delegates), `mcp_tools/workflows.py`, `mcp_computer.py`, `mcp_cron.py`. The four structured-monitor refusals now also carry the identity diagnosis (previously they were the only strict refusals without it).
4. **Ratchet test** — `test/test_identity_topology.py::test_reflexive_tools_route_through_the_strict_gate` scans the source tree (same shape as the sibling `session_pid` registry guard): a direct strict-resolver call outside `mcp_core`, a gate caller not registered in `REFLEXIVE_TOOL_MODULES`, or a registered module that stopped calling the gate each fail the test with a targeted message.

The sibling ratchet in `test/test_strict_identity_diagnostics.py` counted the per-site `strict_identity_diagnosis` token; for migrated modules the diagnosis is now appended inside the gate, so its `roots` markers point at the gate call form (found by both pre-push review lanes).

## Tests

- `test_reflexive_tools_route_through_the_strict_gate` (new): pins all three directions of the invariant — no gate bypass, no unregistered gate caller, no stale registry entry.
- `test_strict_identity_diagnostics.py`: `roots` markers updated to the gate call form for migrated modules; the behavioral tests (`test_ledger_refusal_carries_it`, `test_crew_ledger_refusal_carries_it`) still prove the diagnosis is appended, now via the gate.
- `test_mcp_computer.py` / `test_mcp_dashboard_folders.py`: identity patch targets moved from module-local names to `mcp_core._resolve_session_key_strict`, which the gate reads live; the shim source-scan test additionally asserts the gate is present.

## Manual verification

N/A — the change is a pure identity-resolution refactor with source-scan ratchets; unit coverage (existing per-site refusal tests + the new ratchet) is sufficient. Local gates run: isort, flake8, mypy (1282 files clean), diff-scoped black gate.

## Related Issues

Closes #5913

## Pattern harvest

Rule candidate: review-prompt
Pattern: "an invariant enforced by convention at N call sites gets one shared gate plus a source-scanning registry test, so the N+1th site cannot skip it silently" — same shape as the session_pid call-site registry; consider it whenever a security-relevant discipline is duplicated per call site.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
