### PR TITLE
fix: publish remaining official app caches atomically

### DIFF
--- a/src/kiro_crew/apps/official_category_order.py
+++ b/src/kiro_crew/apps/official_category_order.py
@@ -50,6 +50,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew.apps.official_catalog import OFFICIAL_CATALOG_BASE, fetch_document
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 
 logger = logging.getLogger(__name__)
@@ -108,8 +109,7 @@ def _read_cache() -> dict[str, Any] | None:
 def _write_cache(doc: dict[str, Any]) -> None:
     path = _cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(doc), encoding="utf-8")
+        atomic_write(path, json.dumps(doc))
     except OSError:
         logger.debug("could not cache the category-order document", exc_info=True)
 

--- a/src/kiro_crew/apps/official_editorial.py
+++ b/src/kiro_crew/apps/official_editorial.py
@@ -40,6 +40,7 @@ from kiro_crew.apps.official_catalog import (
     _resolve_ref,
     fetch_document,
 )
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 
 logger = logging.getLogger(__name__)
@@ -104,8 +105,7 @@ def _read_cache() -> dict[str, Any] | None:
 def _write_cache(doc: dict[str, Any]) -> None:
     path = _cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(doc), encoding="utf-8")
+        atomic_write(path, json.dumps(doc))
     except OSError:
         logger.debug("could not cache the editorial document", exc_info=True)
 

--- a/test/test_official_category_order.py
+++ b/test/test_official_category_order.py
@@ -105,6 +105,31 @@ class TestRefusals:
 
 
 class TestCaching:
+    def test_interrupted_write_keeps_the_previous_cache(self, monkeypatch):
+        path = co._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        previous = _doc(["previous"])
+        replacement = _doc(["replacement"])
+        path.write_text(json.dumps(previous), encoding="utf-8")
+
+        real_write_text = type(path).write_text
+
+        def interrupted_write(self, data, *args, **kwargs):
+            if self == path:
+                real_write_text(self, data[:8], *args, **kwargs)
+                raise OSError("simulated interrupted cache write")
+            return real_write_text(self, data, *args, **kwargs)
+
+        def interrupted_atomic_write(*args, **kwargs):
+            raise OSError("simulated interrupted cache write")
+
+        monkeypatch.setattr(type(path), "write_text", interrupted_write)
+        monkeypatch.setattr(co, "atomic_write", interrupted_atomic_write, raising=False)
+
+        co._write_cache(replacement)
+
+        assert json.loads(path.read_text(encoding="utf-8")) == previous
+
     def test_a_success_is_cached_and_the_fetcher_is_not_called_again(self):
         calls: list[int] = []
 

--- a/test/test_official_editorial.py
+++ b/test/test_official_editorial.py
@@ -52,6 +52,31 @@ class TestRefusals:
 
 
 class TestCaching:
+    def test_interrupted_write_keeps_the_previous_cache(self, monkeypatch):
+        path = oe._cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        previous = _doc([_app("previous")])
+        replacement = _doc([_app("replacement")])
+        path.write_text(json.dumps(previous), encoding="utf-8")
+
+        real_write_text = type(path).write_text
+
+        def interrupted_write(self, data, *args, **kwargs):
+            if self == path:
+                real_write_text(self, data[:8], *args, **kwargs)
+                raise OSError("simulated interrupted cache write")
+            return real_write_text(self, data, *args, **kwargs)
+
+        def interrupted_atomic_write(*args, **kwargs):
+            raise OSError("simulated interrupted cache write")
+
+        monkeypatch.setattr(type(path), "write_text", interrupted_write)
+        monkeypatch.setattr(oe, "atomic_write", interrupted_atomic_write, raising=False)
+
+        oe._write_cache(replacement)
+
+        assert json.loads(path.read_text(encoding="utf-8")) == previous
+
     def test_a_success_is_cached_and_the_fetcher_is_not_called_again(self):
         calls: list[int] = []
 


### PR DESCRIPTION
## Problem / Motivation

The editorial and category-order cache writers publish JSON directly to their live paths. If either write is interrupted after truncation, the last valid cache is destroyed and later readers fall back as though no usable cache existed.

## Why it matters

A transient local I/O failure can turn an otherwise recoverable refresh failure into lost cached Discover content. Readers can also observe partial JSON while a write is in progress.

## What changed (motivation → approach → change)

Both documents already use the same cache contract and the repository already provides a race-safe atomic-write helper. Route both cache writers through that helper so new JSON is staged and atomically replaces the published path only after the write succeeds. Payloads, paths, readers, TTLs, and existing OSError fallback behavior are unchanged.

## Tests

- Added an editorial-cache regression proving an interrupted replacement preserves the previous valid JSON.
- Added the equivalent category-order-cache regression.
- Ran `test/test_official_editorial.py`, `test/test_official_category_order.py`, and `test/test_editorial_sections.py`: 137 passed.
- Black, isort, flake8, isolated mypy, brand gate, and `git diff --check` pass for the touched scope.

## Manual verification

N/A — the deterministic filesystem regressions exercise both changed write paths directly.

## Related Issues

N/A — independently identified correctness defect.

## Pattern harvest

Rule candidate: review-prompt
Pattern: JSON caches read concurrently must be published by atomic replace rather than direct write_text to the published path.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

The contributor license agreement is handled by the repository's existing CLA workflow.