### PR TITLE
docs(hooks): document fail-closed PreToolUse exit contract (#7744)

### DIFF
--- a/docs/reference/kiro-cli/hooks.md
+++ b/docs/reference/kiro-cli/hooks.md
@@ -19,9 +19,22 @@ Hooks receive JSON via STDIN:
 
 ## Hook output
 
-- **Exit 0**: succeeded, STDOUT captured
-- **Exit 2**: (PreToolUse only) block tool execution, STDERR returned to LLM
-- **Other**: failed, STDERR shown as warning
+- **Exit 0**: succeeded, STDOUT captured. For AgentSpawn/UserPromptSubmit the
+  STDOUT is injected into context; for PreToolUse this is a delivered "allow".
+- **Exit 2**: (PreToolUse only) deny tool execution, STDERR returned to LLM.
+  On non-gating events an exit 2 is not a gate — its block marker is surfaced
+  as injected context text rather than denying anything.
+- **Any other exit** — including a timeout, a crash, or an unexecutable
+  command:
+  - **PreToolUse**: the tool call is **blocked** (fail closed). A gating hook
+    that cannot deliver a verdict resolves to deny, so breaking, slowing, or
+    deleting a deny hook cannot silently disable the policy it enforces. The
+    block detail prefers `result.error`, then STDERR, then `exited with code N`.
+  - **All other events**: warn-only — STDERR is shown as a warning and
+    execution continues.
+
+There is currently no per-hook advisory/fail-open opt-out for PreToolUse; that
+is tracked in [#7547](https://github.com/kirodotdev/KiroCrew/issues/7547).
 
 ## Tool matching
 
@@ -43,7 +56,10 @@ Runs when agent is activated. Exit 0 → STDOUT added to context.
 Runs when user submits prompt. Receives `prompt` field. Exit 0 → STDOUT added to context.
 
 ### PreToolUse
-Runs before tool execution. Can block (exit 2). Receives `tool_name`, `tool_input`.
+Runs before tool execution and gates the tool call: exit 0 allows, exit 2
+denies, and **any other exit** (timeout, crash, unexecutable command) also
+blocks the tool — a hook that cannot deliver a verdict fails closed. Receives
+`tool_name`, `tool_input`.
 
 ### PostToolUse
 Runs after tool execution. Receives `tool_name`, `tool_input`, `tool_response`.

--- a/src/kiro_crew/hooks.py
+++ b/src/kiro_crew/hooks.py
@@ -3463,10 +3463,15 @@ def _hook_subprocess_env(hook: "ScriptHook", context: str) -> dict[str, str]:
 class ScriptHook:
     """Executable hook that runs a shell command on a trigger event.
 
-    Aligned with Kiro CLI hook semantics:
-    - Exit 0: success (stdout → context for AgentSpawn/UserPromptSubmit)
-    - Exit 2: block tool (PreToolUse only, stderr → LLM)
-    - Other: warning (stderr shown to user)
+    Exit-code contract:
+    - Exit 0: success (stdout → context for AgentSpawn/UserPromptSubmit;
+      a delivered "allow" for PreToolUse)
+    - Exit 2: deny tool (PreToolUse only, stderr → LLM)
+    - Any other exit — including timeout, crash, or an unexecutable command:
+      PreToolUse BLOCKS the tool (fail closed; the block detail prefers
+      ``ScriptHookResult.error``, then stderr, then "exited with code N").
+      Every other event stays warn-only (stderr shown to user). There is no
+      per-hook advisory/fail-open opt-out yet (#7547).
     """
 
     id: str = ""

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -22,7 +22,7 @@ from kiro_crew.dashboard.state import (
     parse_cls_meta,
 )
 from kiro_crew.history import ConversationLog
-from kiro_crew.hooks import HOOK_EVENT_PRE_TOOL_USE, ToolHookResult
+from kiro_crew.hooks import HOOK_EVENT_PRE_TOOL_USE, ScriptHookResult, ToolHookResult
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
     EVENT_PERMISSION_REQUEST,
@@ -73,7 +73,17 @@ def _blocking_hook_store(reason: str, hook_name: str = "policy-hook") -> MagicMo
     hs = _make_hook_store()
     hs.fire = AsyncMock(
         return_value=[
-            MagicMock(exit_code=2, stderr=reason, stdout="", hook_name=hook_name)
+            # Real dataclass instance so a renamed production field fails
+            # loudly as a TypeError instead of silently configuring a stale
+            # attribute on a bare MagicMock.
+            ScriptHookResult(
+                hook_id="h-" + hook_name,
+                hook_name=hook_name,
+                event=HOOK_EVENT_PRE_TOOL_USE,
+                exit_code=2,
+                stderr=reason,
+                stdout="",
+            )
         ]
     )
     return hs
@@ -566,7 +576,17 @@ class TestApprovalModes:
         cb = _context_builder(ToolHookResult.auto_approve())
         hook_store = _make_hook_store()
         hook_store.fire = AsyncMock(
-            return_value=[MagicMock(hook_name="policy-gate", **result_kwargs)]
+            # A real ScriptHookResult (not a bare MagicMock) pins the test to
+            # the production dataclass: a renamed field fails loudly here as a
+            # TypeError instead of silently configuring a stale attribute.
+            return_value=[
+                ScriptHookResult(
+                    hook_id="h-policy-gate",
+                    hook_name="policy-gate",
+                    event=HOOK_EVENT_PRE_TOOL_USE,
+                    **result_kwargs,
+                )
+            ]
         )
         state, client = _make_state(tmp_path, context_builder=cb, hook_store=hook_store)
         slot = _make_slot()
@@ -593,7 +613,16 @@ class TestApprovalModes:
         hook_store = _make_hook_store()
         hook_store.fire = AsyncMock(
             return_value=[
-                MagicMock(exit_code=0, stdout="", stderr="", error="", hook_name="policy-gate")
+                # Real dataclass instance (see the no-verdict test above for why).
+                ScriptHookResult(
+                    hook_id="h-policy-gate",
+                    hook_name="policy-gate",
+                    event=HOOK_EVENT_PRE_TOOL_USE,
+                    exit_code=0,
+                    stdout="",
+                    stderr="",
+                    error="",
+                )
             ]
         )
         state, client = _make_state(tmp_path, context_builder=cb, hook_store=hook_store)


### PR DESCRIPTION
## Summary

PR #7422 changed the PreToolUse script-hook exit-code contract: any exit that is neither 0 nor 2 now BLOCKS the tool (fail closed), where it previously only warned. The user-facing hooks reference and the `ScriptHook` docstring still described the old warn-only rule — the opposite of shipped behaviour. This PR is documentation + test hardening only; no runtime behaviour changes.

- `docs/reference/kiro-cli/hooks.md` — the **Hook output** bullets and the **PreToolUse** section now state the shipped contract: exit 0 = allow (stdout injected), exit 2 = deny (stderr returned to the LLM), and **any other exit** (timeout, crash, unexecutable command) blocks the tool, with the block detail preferring `result.error`, then stderr, then `exited with code N`. Non-gating events (postToolUse, userPromptSubmit, stop) keep warn-only semantics. Added a plain note that there is no per-hook advisory/fail-open opt-out yet (tracked in #7547), and a clause that on non-gating events an exit 2 is not a gate (its marker is surfaced as injected text — matches the exit-2 branch in `chat_runner.py`, which has no event check).
- `src/kiro_crew/hooks.py` — the `ScriptHook` dataclass docstring now states the same contract instead of the pre-#7422 "Other: warning" rule.
- `test/test_dashboard_approval.py` — the two tests added by #7422 built their hook results with bare `MagicMock`, so a renamed production field would silently keep passing. They now construct real `ScriptHookResult` instances, so a field rename fails loudly as a `TypeError`. The `_blocking_hook_store` helper (same bare-mock pattern, same file) was hardened the same way. Note: `MagicMock(spec=...)` / `spec_set=...` was evaluated first and rejected — dataclass fields without defaults (`hook_id`, `hook_name`, `event`) are not class attributes, so mock's spec machinery rejects setting them; real dataclass instances are strictly stronger.

Every doc claim was verified against the runtime implementation (`_fire()` in `src/kiro_crew/dashboard/chat_runner.py`, the `elif r.exit_code not in (0, 2)` fail-closed branch).

## Testing

- `isort --check-only src/kiro_crew test` — pass
- `flake8 src/kiro_crew test` — pass
- `mypy src/kiro_crew/` — pass (no issues in 1279 files)
- `scripts/check_black_formatting.py` — pass (post-commit, diff-scoped)
- `scripts/check_brand_name.py` — pass (exit 0, no added-line hits)
- All four `ScriptHookResult` constructions used by the hardened tests verified by direct instantiation (timeout/crash/exit-127/exit-0 kwarg sets), plus a negative check that an unknown field raises `TypeError`
- `pytest` runs in CI (tests are not run locally on this host by policy)

## Pre-push review

Two model-pinned read-only review lanes on the staged diff: GPT lane PASS (no findings); Opus lane PASS (0 blocking, 2 Low advisories — both applied in this commit).

Closes #7744
