### PR TITLE
fix(config): make the startup config notices answerable and one line each

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -219,11 +219,15 @@ stored `0` is not read as `False`.
 
 Registered so far: `mcp_gateway.forward_declared_env` (False -> True, #4566),
 `session.autocompact_pct` (90.0 -> 70.0, #4388), `stt.streaming` (False -> True,
-0.5.0) and `stt.model` ("turbo" -> "base", 0.5.0).
+0.5.0), `stt.model` ("turbo" -> "base", 0.5.0),
+`dashboard.loop_stall_exit_after_secs` (25 -> unset, #6651) and
+`instances.warm_set_cap` (5 -> 0, #7248).
 
-`stt.provider` is deliberately absent even though its default moved to `local`:
-`_validated_stt_provider` coerces a retired value at parse time, so the stored
-value never wins and there is no drift for an operator to adopt.
+`stt.provider` is deliberately absent from `SUPERSEDED_DEFAULTS` even though its
+default moved to `local`: `_validated_stt_provider` coerces a retired value at
+parse time, so the stored value never wins and there is no *default* for an
+operator to adopt. It is instead a **coerced value**, tracked separately in
+`COERCED_VALUES` — see below.
 
 Both sides of an entry are **history**, so both are literals: a later change to
 the same key APPENDS a new entry rather than editing an existing one, which keeps
@@ -236,14 +240,110 @@ value that no longer exists.
 
 Two surfaces render it, and neither writes:
 
-- The load path warns once per key per process, evaluated on the **stored base
-  document before the `config.local.json` merge** -- an overlay value is the
-  operator's live choice and says nothing about what the base materialized, so a
-  base drift is still reported when an overlay masks it, and an overlay-only value
-  is not reported at all.
+- The load path emits **one** warning naming every drifted key plus the command to
+  resolve it, evaluated on the **stored base document before the
+  `config.local.json` merge** -- an overlay value is the operator's live choice and
+  says nothing about what the base materialized, so a base drift is still reported
+  when an overlay masks it, and an overlay-only value is not reported at all. One
+  line rather than one per key: the registry is append-only, so a per-key line
+  grows without bound on exactly the long-lived installs with the most real drift,
+  and it lands on every short-lived `kirocrew` invocation, where the
+  once-per-process guard buys nothing because there the process IS the invocation.
+  The per-key text is still emitted at debug, so `-vv` keeps it in the log.
 - `kirocrew doctor` prints a `Stored Defaults` section reading `config.json`
   directly. Drift is informational and does NOT become an issue; an unreadable or
   malformed config does.
+
+## Acknowledging a superseded default
+
+Value equality alone cannot falsify a report, so before #7559 an operator who
+deliberately chose a value equal to a superseded default was told about it on every
+load forever, with no way to answer -- and that unanswerable line competed for
+attention with the genuine drift on the same install.
+
+`kirocrew config defaults` is the surface that resolves the ambiguity the load path
+must not resolve for anyone:
+
+- no flag lists each drifted key with its stored value, the current default, and
+  the release that changed it, marking anything already affirmed;
+- `--adopt [KEY...]` REMOVES the stored keys, so `data.get(key, DEFAULT)` resolves
+  the current default from the next load and the next full rewrite materializes it.
+  Rewriting is safe here where it is not on the load path because the operator
+  asked by name, and only a key whose stored value IS the superseded default is
+  ever removed. Detection runs again inside the write lock, so a value changed
+  since it was listed is left alone;
+- `--keep [KEY...]` records the stored values as intentional, which suppresses the
+  load-path line for exactly those values.
+
+An acknowledgment records `<dotted key> -> the acked VALUE`, not the key alone, so
+it covers the choice rather than the key: change the value later and the report
+returns. Acks live in `~/.kiro/crew/superseded_acked.json` (`{"acked": {...}}`),
+**not** in `config.json` -- a `to_dict()` rewrite carries only schema fields, so
+the same materialization behaviour this whole mechanism reports on would silently
+drop an ack stored in the config document. Three properties of that file matter:
+
+- **Reads cannot block indefinitely.** The read runs on the config-load path, which
+  is an event-loop path, and the file sits at a path the agent can name -- where
+  `open()` on a FIFO waits for a writer forever and would wedge the gateway rather
+  than merely delay it. `_read_ack_document` therefore `lstat`s and refuses anything
+  that is not a REGULAR file (links included) or is over `ACK_MAX_BYTES` (64 KiB),
+  opens with `O_NONBLOCK | O_NOFOLLOW` where the platform has them so a leaf swapped
+  after the `lstat` fails instead of waiting, re-checks the OPENED object with
+  `fstat`, then finishes with one capped `os.read`.
+- **Every refusal fails soft.** Missing, non-regular, oversized, unreadable,
+  malformed, not an object, a non-string key: an ack suppresses one line and changes
+  no runtime behaviour, so the worst consequence of ignoring a broken file is being
+  told again. That soft read is also why the file carries no schema version -- any
+  shape it cannot understand is already handled, so the field would have no reader.
+- **Writes never RESOLVE the leaf.** The config writers deliberately FOLLOW a link,
+  because symlinking `config.json` into a dotfiles repo is a supported setup; here
+  that would let a link planted at this path redirect the write onto an arbitrary
+  file. `_update_acked` refuses a link it can see AND writes through `atomic_write`,
+  which renames a fresh temp file OVER the leaf -- so a link swapped in after the
+  check is replaced rather than followed. The check reports the condition; the rename
+  is what makes it unexploitable.
+- **Every mutation is a locked read-modify-write.** `_update_acked` holds the ack
+  file's own lock across read, merge and write, so two concurrent `--keep` calls
+  cannot both read the same map and have the second replacement drop the first
+  operator's acknowledgment.
+- **`record_acks` re-reads the config under its lock**, rather than trusting the
+  caller's snapshot, and re-checks that each key is still drifted. A value changed
+  between the listing and the call would otherwise be acknowledged at its superseded
+  snapshot, which then suppresses the report for a value the operator never affirmed.
+  The ack write happens inside that same config lock hold; lock order is
+  config-then-ack at the only site that nests them.
+
+`--adopt` also drops the ack for a key it removed, since the acked value is no
+longer stored and keeping it would silence a genuinely deliberate choice made
+later. When `config.local.json` also carries an adopted key the report says the
+overlay still overrides it, because the EFFECTIVE value did not change. Every
+filesystem refusal on these paths surfaces as a controlled non-zero CLI error,
+never a traceback.
+
+`doctor` LISTS an acknowledged entry rather than hiding it: an ack answers the
+unsolicited load-path line, while `doctor` answers "what does this install still
+hold?", and hiding an affirmed value would make that answer wrong.
+
+## Coerced values (removable, never affirmable)
+
+`COERCED_VALUES` in the same module tracks a second, distinct kind: a stored value
+the loader **replaces** at parse time rather than merely overriding. The difference
+decides what an operator may do about it. A superseded default still wins, so it
+may be a deliberate choice and must not be rewritten. A coerced value cannot win,
+so there is nothing to preserve — which makes removing it unambiguously safe and
+makes affirming it meaningless, and `--keep` refuses it by name rather than
+promising a setting that never takes effect. Left in place it is inert bytes that
+cost a warning on every load, forever, because a load never writes.
+
+One entry today: `stt.provider`, whose retired and unknown values degrade to
+`local`. The `is_coerced` predicate rides on the ENTRY, not in the detector's loop,
+so appending a retirement is genuinely sufficient — a detector switching on
+`dotted_key` would leave an appended entry silently unreported, with no test red and
+an operator stuck with a warning nothing can clear. That predicate delegates to
+`sections.stt_provider_is_coerced()` rather than restating a provider list, so the
+surface offering to remove a value cannot come to disagree with the loader about
+which ones are dispatchable. The retirement notice in `_validated_stt_provider`
+names the command, for the same reason the drift line does.
 
 **Why nothing is corrected automatically.** At least one registered key also has a
 documented escape hatch (`mcp_gateway.forward_declared_env`, whose stored `false`

--- a/src/kiro_crew/cli.py
+++ b/src/kiro_crew/cli.py
@@ -2455,6 +2455,9 @@ Examples:
   kirocrew config get agent.provider    # Get a specific value
   kirocrew config set dashboard.url http://localhost:5476
   kirocrew config edit                  # Open in $EDITOR
+  kirocrew config defaults              # Stored values holding a superseded default
+  kirocrew config defaults --adopt      # Take the current defaults for all of them
+  kirocrew config defaults --keep session.autocompact_pct   # Affirm one as intentional
 
 The dashboard port is set with the KIROCREW_PORT env var, not a config key.
 """,
@@ -2473,6 +2476,26 @@ The dashboard port is set with the KIROCREW_PORT env var, not a config key.
         help="Save to config.local.json (persists across upgrades)",
     )
     cfg_sub.add_parser("edit", help="Open config in $EDITOR")
+    cfg_defaults = cfg_sub.add_parser(
+        "defaults",
+        help="Review stored values that still hold a superseded default",
+    )
+    cfg_defaults.add_argument(
+        "keys",
+        nargs="*",
+        help="Limit to these dotted keys (default: every drifted key)",
+    )
+    _cfg_def_mode = cfg_defaults.add_mutually_exclusive_group()
+    _cfg_def_mode.add_argument(
+        "--adopt",
+        action="store_true",
+        help="Remove the stored keys so the current defaults apply",
+    )
+    _cfg_def_mode.add_argument(
+        "--keep",
+        action="store_true",
+        help="Record the stored values as intentional and stop reporting them",
+    )
 
     # Last registration done: stop argparse from answering an unknown command
     # with the internal mcp-* server names. Must come after every add_parser,

--- a/src/kiro_crew/cli_config.py
+++ b/src/kiro_crew/cli_config.py
@@ -18,6 +18,16 @@ from kiro_crew.config.loader import (
     config_path,
     update_config_locked,
 )
+from kiro_crew.config.superseded_defaults import (
+    acked_superseded,
+    coerced_value_drift,
+    coercion_summary,
+    drift_summary,
+    drop_acks,
+    drop_drifted_keys,
+    record_acks,
+    superseded_default_drift,
+)
 from kiro_crew.hooks import safe_read_file
 from kiro_crew.sel import sel
 
@@ -229,9 +239,231 @@ def _config_cmd(args: argparse.Namespace) -> None:
         )
         editor = os.environ.get("EDITOR", "vi")
         os.execvp(editor, [editor, str(p)])
+    elif action == "defaults":
+        _defaults_cmd(args)
     else:
-        print("Usage: kirocrew config {get,set,edit}", file=sys.stderr)
+        print("Usage: kirocrew config {get,set,edit,defaults}", file=sys.stderr)
         sys.exit(1)
+
+
+def _defaults_cmd(args: argparse.Namespace) -> None:
+    """Review, adopt, or affirm stored values that no longer match the shipped ones.
+
+    Two kinds, and the difference decides what an operator may do:
+
+    - a SUPERSEDED DEFAULT still wins, so it may be a deliberate choice. It can be
+      adopted away or affirmed.
+    - a COERCED value cannot win -- the loader replaces it at parse time -- so there
+      is nothing to affirm and ``--keep`` refuses it by name rather than promising a
+      setting that never takes effect.
+
+    Three modes over one detection pass, so the list an operator reads and the set a
+    flag acts on cannot disagree:
+
+    - no flag: list both kinds, marking anything already affirmed.
+    - ``--adopt``: remove the keys, so the loader resolves the current default.
+      Rewriting is safe here where it is not on the load path because the operator
+      asked by name, and only a key that IS drifted or coerced is ever removed.
+      Detection runs again inside the write lock, so a value changed since it was
+      listed is left alone.
+    - ``--keep``: record the stored values as intentional, silencing the load-path
+      notice for exactly those values. Changing a value later reports it again.
+
+    A bare ``--adopt``/``--keep`` skips keys already affirmed, so it cannot silently
+    undo an earlier decision; naming a key explicitly still acts on it. A key that
+    is neither drifted nor coerced is refused rather than silently ignored, because
+    a typo would otherwise read as success.
+    """
+    path = config_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print("✅ No config.json yet — the current defaults already apply.")
+        return
+    except OSError as e:
+        print(f"❌ Could not read {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    except ValueError as e:
+        # ValueError covers both shapes of unreadable content without restating
+        # them: json.JSONDecodeError and UnicodeDecodeError are both subclasses.
+        print(f"❌ Could not read {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(raw, dict):
+        print(f"❌ {path} is not a JSON object", file=sys.stderr)
+        sys.exit(1)
+
+    # acked={} so the operator sees the whole truth; an ack answers the unsolicited
+    # load-path line, not the question they just typed.
+    drifted = superseded_default_drift(raw, acked={})
+    coerced = coerced_value_drift(raw)
+    acked = acked_superseded()
+    wanted = list(getattr(args, "keys", None) or [])
+    if wanted:
+        known = {e.dotted_key for e in drifted} | {c.dotted_key for c, _ in coerced}
+        unknown = [k for k in wanted if k not in known]
+        if unknown:
+            print(
+                "❌ Not holding a superseded default or a coerced value: " + ", ".join(unknown),
+                file=sys.stderr,
+            )
+            print(
+                "   Run 'kirocrew config defaults' with no arguments to see the list.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        drifted = [e for e in drifted if e.dotted_key in wanted]
+        coerced = [(c, v) for c, v in coerced if c.dotted_key in wanted]
+
+    if not drifted and not coerced:
+        print("✅ No stored value holds a superseded default.")
+        return
+
+    keeping = getattr(args, "keep", False)
+    if keeping and coerced:
+        # There is nothing to affirm: the loader replaces the value whatever the
+        # operator thinks of it, so recording it as intentional would promise a
+        # setting that never takes effect.
+        for centry, stored in coerced:
+            print(
+                f"⚠️  {centry.dotted_key} ({stored!r}) cannot be kept — "
+                f"the loader replaces it. Use --adopt to drop it."
+            )
+        coerced = []
+        if not drifted:
+            return
+
+    if (getattr(args, "adopt", False) or keeping) and not wanted:
+        # A bare --adopt/--keep means "all of them", and an affirmed value is not
+        # one of them: the operator already answered for that key, so sweeping it
+        # up here would silently undo their decision. Naming a key explicitly
+        # still acts on it -- that is the operator saying so again.
+        drifted = [e for e in drifted if e.dotted_key not in acked]
+        if not drifted and not coerced:
+            print("✅ Nothing left to act on — every remaining value is acknowledged.")
+            print("   Name a key explicitly to change one of those.")
+            return
+
+    keys = [e.dotted_key for e in drifted]
+
+    if getattr(args, "adopt", False):
+        removed: list[str] = []
+        coerced_keys = [c.dotted_key for c, _ in coerced]
+
+        def _mutate(existing: dict) -> dict:
+            # Re-detect inside the lock: the document read above is a snapshot, and
+            # removing a key whose value changed since would discard a live choice.
+            fresh = [
+                e.dotted_key
+                for e in superseded_default_drift(existing, acked={})
+                if e.dotted_key in keys
+            ]
+            fresh += [
+                c.dotted_key
+                for c, _ in coerced_value_drift(existing)
+                if c.dotted_key in coerced_keys
+            ]
+            removed.extend(drop_drifted_keys(existing, fresh))
+            return existing
+
+        try:
+            update_config_locked(config_path(), mutate=_mutate)
+        except ConfigReadError as e:
+            print(f"❌ Cannot edit a corrupt config.json: {e}", file=sys.stderr)
+            sys.exit(1)
+        except OSError as e:
+            # A read-only or full data home, or a refused link: report it and stop,
+            # rather than letting the CLI die on a traceback.
+            print(f"❌ Could not write {config_path()}: {e}", file=sys.stderr)
+            sys.exit(1)
+        # An adopted key no longer stores the acked value, so its ack is dead
+        # bookkeeping; dropping it keeps a later deliberate choice reportable.
+        try:
+            if removed:
+                drop_acks(removed)
+        except OSError as e:
+            print(f"⚠️  Adopted, but could not update acknowledgments: {e}", file=sys.stderr)
+        sel().log_api_access(
+            caller="cli",
+            operation="config_adopt_defaults",
+            outcome="allowed",
+            source="cli",
+            resources=",".join(removed) or "none",
+        )
+        # An overlay value outranks the base file, so for a key it also carries the
+        # EFFECTIVE value does not change -- saying the default now applies would be
+        # false. Report what actually happened instead.
+        overridden = _overlay_keys(removed)
+        for key in removed:
+            if key in overridden:
+                print(f"✅ {key} removed from config.json — config.local.json still overrides it")
+            else:
+                print(f"✅ {key} removed — the current default now applies")
+        if not removed:
+            print("Nothing removed — the stored values changed since they were listed.")
+        else:
+            print("\nRestart the gateway for a running instance to pick this up.")
+        return
+
+    if keeping:
+        try:
+            recorded = record_acks(keys)
+        except ConfigReadError as e:
+            print(f"❌ Cannot read a corrupt config.json: {e}", file=sys.stderr)
+            sys.exit(1)
+        except OSError as e:
+            print(f"❌ Could not record acknowledgments: {e}", file=sys.stderr)
+            sys.exit(1)
+        if not recorded:
+            print("Nothing recorded — the stored values changed since they were listed.")
+            return
+        sel().log_api_access(
+            caller="cli",
+            operation="config_keep_defaults",
+            outcome="allowed",
+            source="cli",
+            resources=",".join(recorded),
+        )
+        for key in recorded:
+            print(f"✅ {key} recorded as intentional — no longer reported")
+        print("\nChanging one of these values later reports it again.")
+        return
+
+    for entry in drifted:
+        mark = "✅ acknowledged as intentional" if entry.dotted_key in acked else "ℹ️ "
+        print(f"{mark} {drift_summary(entry)}\n")
+    for centry, stored in coerced:
+        print(f"ℹ️  {coercion_summary(centry, stored)}\n")
+    if coerced or any(e.dotted_key not in acked for e in drifted):
+        print("Take the current defaults:  kirocrew config defaults --adopt")
+        print("Affirm your values:         kirocrew config defaults --keep")
+        print("Either accepts specific keys, e.g. --keep session.autocompact_pct")
+
+
+def _overlay_keys(dotted_keys: list[str]) -> set[str]:
+    """Return the subset of *dotted_keys* that ``config.local.json`` also carries.
+
+    Removing such a key from the base file does not change the value the loader
+    resolves -- the overlay still wins -- so the adopt report must not claim the
+    current default now applies. Reads only, and treats an unreadable overlay as
+    carrying nothing: a wrong claim is worse than a missing note either way, and
+    every other surface already tolerates a broken overlay.
+    """
+    p = config_local_path()
+    if not p.is_file():
+        return set()
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # ValueError covers malformed JSON and invalid UTF-8 alike; either way the
+        # overlay is treated as carrying nothing.
+        return set()
+    if not isinstance(raw, dict):
+        return set()
+    found = set()
+    for dotted in dotted_keys:
+        if _dict_get(raw, dotted) is not _MISSING:
+            found.add(dotted)
+    return found
 
 
 def _dict_get(d: dict, key: str) -> object:

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -1269,7 +1269,7 @@ _REPORTED_SUPERSEDED_KEYS: set[str] = set()
 
 
 def _report_superseded_defaults(base_data: dict) -> None:
-    """Warn once per key when a stored base value still holds a superseded default.
+    """Warn once when stored base values still hold a superseded default.
 
     *base_data* is the ``config.json`` document as read, BEFORE the
     ``config.local.json`` overlay is merged over it. Reporting on the base is the
@@ -1281,15 +1281,37 @@ def _report_superseded_defaults(base_data: dict) -> None:
     are the same bytes on disk, so a rewrite cannot correct one without overriding
     the other. Telling the operator is the part that can be done without guessing.
 
-    Warned at most once per key per process. The gateway loads config repeatedly,
-    and a line the operator has already read is noise that trains them to ignore
-    the next one; the durable, re-readable rendering lives in ``doctor``.
+    ONE line naming every drifted key, not one line per key. The registry is
+    append-only, so a per-key line means the terminal noise on a long-lived install
+    grows with every default the project ever changes -- and it lands on every
+    short-lived ``kirocrew`` invocation, where the once-per-process guard below
+    buys nothing because there the process IS the invocation. The per-key detail
+    belongs on the surface the operator asked for: ``kirocrew config defaults``,
+    and ``doctor``. It is also emitted at debug here, so a gateway run with
+    ``-vv`` still carries the full text in its own log.
+
+    Keys already named in this process are not repeated, so a gateway that loads
+    config many times says it once. An acknowledged key is not reported at all --
+    ``superseded_default_drift`` filters it -- which is what makes this line
+    answerable instead of permanent.
     """
-    for entry in superseded_default_drift(base_data):
-        if entry.dotted_key in _REPORTED_SUPERSEDED_KEYS:
-            continue
+    drifted = [
+        e
+        for e in superseded_default_drift(base_data)
+        if e.dotted_key not in _REPORTED_SUPERSEDED_KEYS
+    ]
+    if not drifted:
+        return
+    for entry in drifted:
         _REPORTED_SUPERSEDED_KEYS.add(entry.dotted_key)
-        logger.warning("Superseded default in stored config: %s", drift_summary(entry))
+        logger.debug("Superseded default in stored config: %s", drift_summary(entry))
+    logger.warning(
+        "%d stored config value(s) still hold a superseded default: %s. "
+        "Run 'kirocrew config defaults' to see each one, '--adopt' to take the "
+        "current defaults, or '--keep' to affirm yours and stop this notice.",
+        len(drifted),
+        ", ".join(e.dotted_key for e in drifted),
+    )
 
 
 def stamp_config_meta(data: dict) -> dict:

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -3484,6 +3484,16 @@ _VALID_CHANNEL_PREFIXES = ("C", "D", "G")
 _WARNED_STT_PROVIDERS: set[str] = set()
 
 
+def stt_provider_is_coerced(value: object) -> bool:
+    """True when a stored ``stt.provider`` cannot take effect and is replaced.
+
+    The single source of truth for "this stored value is inert", so the surface that
+    offers to remove it (``kirocrew config defaults``) cannot come to disagree with
+    the loader about which providers are dispatchable.
+    """
+    return value not in _VALID_STT_PROVIDERS
+
+
 def _validated_stt_provider(value: object) -> str:
     """Return *value* if it is selectable, else degrade to ``local`` with a reason.
 
@@ -3491,6 +3501,11 @@ def _validated_stt_provider(value: object) -> str:
     an unusable one must leave voice input working the way
     :func:`_normalize_acp_backend` degrades an unusable persisted backend, rather
     than failing the load that read it.
+
+    The notice names the command that removes the dead value. A load never writes,
+    so without that pointer the line repeats on every invocation forever -- and
+    unlike a superseded default there is nothing here to preserve, since the stored
+    value cannot take effect either way.
     """
     if value in _VALID_STT_PROVIDERS:
         return str(value)
@@ -3502,13 +3517,15 @@ def _validated_stt_provider(value: object) -> str:
         logger.warning(
             "STT provider %r is retired; using %r instead. It needed a separate "
             "out-of-band install, which the bundled local engine removes while "
-            "recognising the same speech.",
+            "recognising the same speech. Run 'kirocrew config defaults --adopt' "
+            "to drop the stored value and this notice.",
             value,
             STT_PROVIDER_LOCAL,
         )
     else:
         logger.warning(
-            "Unknown STT provider %r; using %r instead. Selectable providers: %s",
+            "Unknown STT provider %r; using %r instead. Selectable providers: %s. "
+            "Run 'kirocrew config defaults --adopt' to drop the stored value.",
             value,
             STT_PROVIDER_LOCAL,
             ", ".join(_VALID_STT_PROVIDERS),

--- a/src/kiro_crew/config/superseded_defaults.py
+++ b/src/kiro_crew/config/superseded_defaults.py
@@ -27,19 +27,54 @@ leave the change to the operator: a warning on the gateway's own log and a
 ``doctor`` section naming the key, the stored value, the current default, and the
 release that changed it.
 
+Why the report is acknowledgeable
+---------------------------------
+Value equality alone cannot falsify a report, so an operator who deliberately
+chose a value that happens to equal a superseded default was told about it on
+every load, forever, with no way to answer (issue #7559). Worse, the registry is
+append-only: each new entry adds another permanent line, and a section that is
+mostly unanswerable noise is a section operators learn to skip -- which costs
+exactly the genuine drift the mechanism exists to surface.
+
+So the report is now falsifiable. :func:`acked_superseded` reads an
+acknowledgment file recording ``<dotted key> -> the value that was acked``, and a
+key whose STORED value still equals its acked value is not reported. The value is
+recorded rather than a bare key name so the acknowledgment covers the choice, not
+the key: change the value later and the report returns.
+
+The acknowledgment lives in its own file, NOT in ``config.json``, because a full
+``to_dict()`` rewrite carries only schema fields -- the same materialization
+behaviour that created this whole problem would silently drop an ack stored
+anywhere in the config document. Losing the file is harmless by construction: it
+changes no runtime behaviour, only whether one line is printed.
+
 Scope discipline
 -----------------
-Nothing here writes to configuration: detection is pure, and the doctor renderer
-below only reads. Reading `config.json` lives HERE rather than in the CLI so the
-config package stays the one place that knows what the stored document means; the
-caller's job is to decide when to show it.
+Nothing here writes to CONFIGURATION. Detection is pure; :func:`drop_drifted_keys`
+mutates a dict handed to it by a caller that already owns the config lock;
+:func:`record_acks` opens ``config.json`` only to READ it, under that same lock,
+because acknowledging a value it did not just read would record a stale one. The
+one file this module writes is the acknowledgment file, which holds no settings.
+
+Rendering splits by who asked. ``doctor``'s section lives HERE, reading
+``config.json`` directly, so the config package stays the one place that knows what
+the stored document means. ``kirocrew config defaults`` lives in ``cli_config``,
+because deciding what to DO about drift -- adopt, affirm, or just look -- is the
+CLI's job, and it calls into the helpers above rather than reimplementing them.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import stat
+from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
+
+from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +195,224 @@ def _split_dotted(dotted_key: str) -> tuple[str, str]:
     return section, field
 
 
-def superseded_default_drift(base_data: dict) -> list[SupersededDefault]:
+#: Name of the acknowledgment file inside the data home. Its own file rather than
+#: a block in ``config.json``: a ``to_dict()`` rewrite carries only schema fields,
+#: so an ack stored in the config document would be dropped by the very
+#: materialization behaviour this module exists to report on.
+ACK_FILE_NAME = "superseded_acked.json"
+
+
+class AckPathRefused(OSError):
+    """The acknowledgment path is not a plain file we may read or replace.
+
+    An ``OSError`` subclass on purpose: every caller already has to handle a failed
+    write on a read-only or full data home, and this is the same class of refusal.
+    """
+
+
+#: Ceiling on the acknowledgment file. The map holds one small entry per registry
+#: row, so anything larger is not this file; capping the read keeps a single
+#: ``os.read`` bounded, which is what lets it run on the config-load path.
+ACK_MAX_BYTES = 64 * 1024
+
+
+def ack_file_path() -> Path:
+    """Return the acknowledgment file's path inside the data home.
+
+    ``config_dir`` is imported lazily for the same reason ``config_path`` is: the
+    loader imports this module, so a module-level import would be a cycle.
+    """
+    from kiro_crew.config.loader import config_dir  # circular import
+
+    return config_dir() / ACK_FILE_NAME
+
+
+def _read_ack_document() -> object:
+    """Read and parse the acknowledgment file, or return ``None``.
+
+    **This runs on the config-load path, which is an event-loop path**, so the read
+    must not be able to block indefinitely. The file lives at a path the agent can
+    name, and ``open()`` on a FIFO waits for a writer forever -- that would wedge
+    the gateway, not merely delay it. Three things keep the read bounded:
+
+    * ``lstat`` refuses anything that is not a REGULAR file, links included;
+    * the open carries ``O_NONBLOCK`` and ``O_NOFOLLOW`` where the platform has
+      them, so a leaf swapped after the ``lstat`` fails or returns immediately
+      instead of waiting;
+    * ``fstat`` re-checks the OPENED object and the size, then a single capped
+      ``os.read`` finishes it.
+
+    Returns ``None`` for every refusal and every read error. An ack suppresses one
+    report line and changes nothing about how config resolves, so the worst
+    consequence of ignoring an unreadable file is that the operator is told again.
+    """
+    path = ack_file_path()
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode) or st.st_size > ACK_MAX_BYTES:
+        logger.debug("Ignoring superseded-default acknowledgments: not a plain small file")
+        return None
+    flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(path, flags)
+    except OSError as e:
+        logger.debug("Ignoring unreadable superseded-default acknowledgments: %s", e)
+        return None
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode) or opened.st_size > ACK_MAX_BYTES:
+            return None
+        raw = os.read(fd, ACK_MAX_BYTES)
+    except OSError as e:
+        logger.debug("Ignoring unreadable superseded-default acknowledgments: %s", e)
+        return None
+    finally:
+        os.close(fd)
+    try:
+        return json.loads(raw.decode("utf-8"))
+    except ValueError as e:
+        # Covers both failure modes without restating them: UnicodeDecodeError and
+        # json.JSONDecodeError are both ValueError subclasses.
+        logger.debug("Ignoring malformed superseded-default acknowledgments: %s", e)
+        return None
+
+
+def _acked_from_document(raw: object) -> dict[str, object]:
+    """Extract the ack map from a parsed document, tolerating any other shape."""
+    if not isinstance(raw, dict):
+        return {}
+    acked = raw.get("acked")
+    if not isinstance(acked, dict):
+        return {}
+    return {k: v for k, v in acked.items() if isinstance(k, str)}
+
+
+def acked_superseded() -> dict[str, object]:
+    """Return ``{dotted key: acked value}`` from the acknowledgment file.
+
+    Fails SOFT on every problem -- see :func:`_read_ack_document`. That soft read is
+    also why the file carries no schema version: any shape it cannot understand is
+    already handled, so a version field would have no reader.
+    """
+    return _acked_from_document(_read_ack_document())
+
+
+def _update_acked(mutate: Callable[[dict[str, object]], dict[str, object]]) -> dict[str, object]:
+    """Read-modify-write the acknowledgment file under its own lock.
+
+    The whole transaction runs inside one lock hold, so two concurrent ``--keep``
+    calls cannot both read the same map and have the second replacement drop the
+    first operator's acknowledgment.
+
+    **The write never RESOLVES the leaf.** ``write_config_atomically`` deliberately
+    follows a link, because symlinking ``config.json`` into a dotfiles repo is a
+    supported setup; here that would let a link planted at this path redirect the
+    write onto an arbitrary file. ``atomic_write`` renames a fresh temp file OVER
+    the leaf instead, so even a link swapped in after the check below is replaced
+    rather than followed -- the check reports the condition, the rename is what
+    makes it unexploitable.
+
+    Raises ``OSError`` (including :class:`AckPathRefused`) on any filesystem
+    refusal; callers turn that into a controlled CLI error rather than a traceback.
+    """
+    path = ack_file_path()
+    if platform_compat.is_link_or_junction(path):
+        raise AckPathRefused(f"refusing to write through a link at {ACK_FILE_NAME}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.parent / (path.name + ".lock")
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        with platform_compat.file_lock(fd, exclusive=True):
+            current = _acked_from_document(_read_ack_document())
+            updated = dict(mutate(current))
+            atomic_write(path, json.dumps({"acked": updated}, indent=2) + "\n", mode=0o600)
+            return updated
+    finally:
+        os.close(fd)
+
+
+def write_acked_superseded(acked: dict[str, object]) -> None:
+    """Replace the acknowledgment file's map with *acked*, under its lock."""
+    _update_acked(lambda _existing: acked)
+
+
+def record_acks(dotted_keys: list[str]) -> list[str]:
+    """Acknowledge the CURRENTLY stored values for *dotted_keys*; return the keys.
+
+    The config document is re-read and re-checked for drift **under its own lock**,
+    not taken from the caller's earlier snapshot: a value changed between the listing
+    and this call would otherwise be acknowledged at its superseded snapshot, which
+    then silently suppresses the report for a value the operator never affirmed. A
+    key that is no longer drifted is skipped rather than acked.
+
+    The ack write happens inside that same config lock hold, so the recorded value
+    cannot be stale by the time it lands. Lock order is config-then-ack at the only
+    site that nests them.
+    """
+    from kiro_crew.config.loader import config_path, update_config_locked  # circular import
+
+    recorded: list[str] = []
+
+    def _under_config_lock(config_doc: dict) -> None:
+        still_drifted = {e.dotted_key for e in superseded_default_drift(config_doc, acked={})}
+        values: dict[str, object] = {}
+        for dotted in dotted_keys:
+            if dotted not in still_drifted:
+                continue
+            stored = _stored_value(config_doc, dotted)
+            if stored is not _ABSENT:
+                values[dotted] = stored
+        if values:
+            _update_acked(lambda existing: {**existing, **values})
+            recorded.extend(values)
+        return None  # read-only: mutate returning None writes no config
+
+    update_config_locked(config_path(), mutate=_under_config_lock, stamp_meta=False)
+    return recorded
+
+
+def drop_acks(dotted_keys: list[str]) -> None:
+    """Forget the acknowledgments for *dotted_keys*, under the file's lock.
+
+    Called after an adopt: the acked value is no longer stored, so keeping the entry
+    would silence a genuinely deliberate choice made later. A no-op when none of the
+    keys is acked, so an adopt on a never-acked key does not touch the file at all.
+    """
+    if not any(k in acked_superseded() for k in dotted_keys):
+        return
+    drop = set(dotted_keys)
+    _update_acked(lambda existing: {k: v for k, v in existing.items() if k not in drop})
+
+
+_ABSENT = object()
+
+
+def _stored_value(base_data: dict, dotted_key: str) -> object:
+    """Return what *base_data* stores at *dotted_key*, or ``_ABSENT``."""
+    section, field = _split_dotted(dotted_key)
+    section_data = base_data.get(section)
+    if not isinstance(section_data, dict) or field not in section_data:
+        return _ABSENT
+    return section_data[field]
+
+
+def _is_acked(entry: SupersededDefault, stored: object, acked: dict[str, object]) -> bool:
+    """True when *stored* is the exact value the operator acknowledged for *entry*.
+
+    Type is compared as well as value, for the same reason detection does: ``bool``
+    is an ``int`` subclass, so an acked ``0`` must not silence a stored ``False``.
+    """
+    if entry.dotted_key not in acked:
+        return False
+    ack = acked[entry.dotted_key]
+    return type(stored) is type(ack) and stored == ack
+
+
+def superseded_default_drift(
+    base_data: dict, acked: dict[str, object] | None = None
+) -> list[SupersededDefault]:
     """Return the registered entries whose STORED value is the superseded default.
 
     *base_data* must be the stored base document (``config.json`` alone), never the
@@ -170,14 +422,21 @@ def superseded_default_drift(base_data: dict) -> list[SupersededDefault]:
     so reporting on the merged view would both miss real drift in the base and
     describe a value the base does not hold.
 
+    *acked* is the acknowledgment map; passing ``None`` reads the acknowledgment
+    file. Pass ``{}`` to get the unacknowledged truth -- what an operator asking
+    "what am I still holding?" wants to see even for values they already affirmed.
+
     An entry is reported only when the stored value equals ``old_default`` with the
     same type -- ``bool`` is an ``int`` subclass, so requiring the type as well
     keeps a stored ``0`` from being read as ``False``. An absent section, an absent
     key, or any other value is not drift: those already resolve to the current
     dataclass default at parse time, which is the desired outcome.
 
-    Pure: reads *base_data* and returns a list. Nothing is mutated or written.
+    Reads *base_data* (and, unless *acked* is supplied, the acknowledgment file)
+    and returns a list. Neither is mutated; no config is written.
     """
+    if acked is None:
+        acked = acked_superseded()
     drifted: list[SupersededDefault] = []
     for entry in SUPERSEDED_DEFAULTS:
         section, field = _split_dotted(entry.dotted_key)
@@ -185,9 +444,108 @@ def superseded_default_drift(base_data: dict) -> list[SupersededDefault]:
         if not isinstance(section_data, dict) or field not in section_data:
             continue
         stored = section_data[field]
-        if type(stored) is type(entry.old_default) and stored == entry.old_default:
-            drifted.append(entry)
+        if type(stored) is not type(entry.old_default) or stored != entry.old_default:
+            continue
+        if _is_acked(entry, stored, acked):
+            continue
+        drifted.append(entry)
     return drifted
+
+
+@dataclass(frozen=True)
+class CoercedValue:
+    """One stored value the loader must REPLACE at parse time, not merely override.
+
+    Distinct from :class:`SupersededDefault`, and the difference decides what an
+    operator can do about it. A superseded default is a value that still works and
+    still wins, so it may be a deliberate choice and must not be rewritten. A
+    coerced value cannot win: the loader replaces it because it names something that
+    no longer exists, so there is no choice to preserve -- which makes removing it
+    unambiguously safe, and makes affirming it meaningless.
+
+    Left in place it is inert bytes that buy nothing and cost a warning on every
+    single load, forever, because a load never writes.
+
+    ``is_coerced`` rides on the ENTRY rather than living in the detector's loop, so
+    appending a retirement is genuinely sufficient. A detector that switched on
+    ``dotted_key`` instead would leave an appended entry silently unreported -- no
+    test goes red, the operator just keeps getting a warning nothing can clear.
+    """
+
+    dotted_key: str
+    resolves_to: str
+    reason: str
+    is_coerced: Callable[[object], bool]
+
+
+def _stt_provider_is_coerced(value: object) -> bool:
+    """Ask the section that owns ``stt.provider`` whether *value* is inert.
+
+    The judgment of what is selectable belongs there, so the surface offering to
+    remove a value cannot come to disagree with the loader about which providers are
+    dispatchable. Imported lazily: the loader pulls this module into its own import
+    chain, so a module-level ``sections`` import would be a cycle.
+    """
+    from kiro_crew.config.sections import stt_provider_is_coerced  # circular import
+
+    return stt_provider_is_coerced(value)
+
+
+#: Stored values the loader coerces. One entry today; append as retirements land.
+COERCED_VALUES: tuple[CoercedValue, ...] = (
+    CoercedValue(
+        dotted_key="stt.provider",
+        resolves_to="local",
+        reason=(
+            "names a retired or unknown speech provider, so voice input already runs " "on 'local'"
+        ),
+        is_coerced=_stt_provider_is_coerced,
+    ),
+)
+
+
+def coerced_value_drift(base_data: dict) -> list[tuple[CoercedValue, object]]:
+    """Return ``(entry, stored value)`` for each registered key the loader coerces."""
+    found: list[tuple[CoercedValue, object]] = []
+    for entry in COERCED_VALUES:
+        section, field = _split_dotted(entry.dotted_key)
+        section_data = base_data.get(section)
+        if not isinstance(section_data, dict) or field not in section_data:
+            continue
+        stored = section_data[field]
+        if entry.is_coerced(stored):
+            found.append((entry, stored))
+    return found
+
+
+def coercion_summary(entry: CoercedValue, stored: object) -> str:
+    """One line describing a coerced stored value and the only useful answer to it."""
+    return (
+        f"{entry.dotted_key} is stored as {stored!r}, which {entry.reason}. "
+        f"The stored value cannot take effect, so removing it changes nothing except "
+        f"that Kiro Crew stops saying so on every load."
+    )
+
+
+def drop_drifted_keys(base_data: dict, dotted_keys: list[str]) -> list[str]:
+    """Remove *dotted_keys* from *base_data* in place; return the ones removed.
+
+    Removal is how a stored value is un-materialized: the loader resolves an absent
+    key as ``data.get(key, DEFAULT)``, so the current default applies from the next
+    load and the next full rewrite materializes it. Mutates the dict the CALLER
+    read under its own lock; this function opens nothing.
+
+    An emptied section is left in place -- an empty object resolves identically to
+    an absent one, and removing it would widen the diff for no gain.
+    """
+    removed: list[str] = []
+    for dotted in dotted_keys:
+        section, field = _split_dotted(dotted)
+        section_data = base_data.get(section)
+        if isinstance(section_data, dict) and field in section_data:
+            del section_data[field]
+            removed.append(dotted)
+    return removed
 
 
 def drift_summary(entry: SupersededDefault) -> str:
@@ -228,10 +586,14 @@ def render_doctor_section(issues: list[str]) -> None:
     release changed it, and leaves the decision with them. An unreadable or
     non-object config IS an issue: that is unambiguously wrong.
 
+    An acknowledged entry is shown here rather than suppressed. An ack answers the
+    UNSOLICITED load-path line; ``doctor`` is the question "what does this install
+    still hold?", and hiding an affirmed value would make the answer wrong.
+
     ``config_path`` is imported lazily because ``config.loader`` imports this
     module for the load-path warning, so a module-level import would be a cycle.
     """
-    from kiro_crew.config.loader import config_path
+    from kiro_crew.config.loader import config_path  # circular import
 
     print("\nStored Defaults")
     path = config_path()
@@ -249,9 +611,25 @@ def render_doctor_section(issues: list[str]) -> None:
         issues.append("stored defaults unreadable")
         return
 
-    drifted = superseded_default_drift(raw)
-    if not drifted:
+    # Acked entries are LISTED, not hidden: an operator reading doctor is asking
+    # what the install still holds, and an affirmed value is part of that answer.
+    # Only the load-path line is silenced by an ack, because that one is unsolicited.
+    acked = acked_superseded()
+    drifted = superseded_default_drift(raw, acked={})
+    coerced = coerced_value_drift(raw)
+    if not drifted and not coerced:
         print("  drift:       ✅ no stored value holds a superseded default")
         return
+    unacked = 0
     for entry in drifted:
-        print(f"  drift:       ℹ️  {drift_summary(entry)}")
+        if entry.dotted_key in acked:
+            print(f"  drift:       ✅ acknowledged as intentional: {drift_summary(entry)}")
+        else:
+            unacked += 1
+            print(f"  drift:       ℹ️  {drift_summary(entry)}")
+    for centry, stored in coerced:
+        unacked += 1
+        print(f"  coerced:     ℹ️  {coercion_summary(centry, stored)}")
+    if unacked:
+        print("  fix:         kirocrew config defaults --adopt      (take the current defaults)")
+        print("  keep:        kirocrew config defaults --keep       (affirm yours, stop reporting)")

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -14,6 +14,7 @@ kirocrew config get agent.model        # print a specific value
 kirocrew config set agent.model auto   # set a value (auto type detection)
 kirocrew config set --local agent.model auto   # write config.local.json instead
 kirocrew config edit                   # open in $EDITOR
+kirocrew config defaults               # stored values holding a superseded default
 ```
 
 Every config change is audit-logged to the security event log.
@@ -22,6 +23,33 @@ Every config change is audit-logged to the security event log.
 `--local` writes to. Its values win over `config.json`.
 
 The dashboard port is **not** a config key: set `KIROCREW_PORT` instead.
+
+## When a Shipped Default Changes
+
+`config.json` is written as a full materialization of the schema, so every key is
+on disk even if you never set it — and a stored value always beats the shipped
+default. Changing a default therefore reaches new installs only: yours keeps
+whatever was written the last time it saved. On startup Kiro Crew prints one line
+naming any key still holding an old default.
+
+`kirocrew config defaults` shows each one with its stored value, the current
+default, and the release that changed it. Two ways to answer it:
+
+```bash
+kirocrew config defaults --adopt       # take the current defaults
+kirocrew config defaults --keep        # affirm your values, stop the notice
+```
+
+Both accept specific keys — `kirocrew config defaults --keep session.autocompact_pct`
+if you chose 90 on purpose and want the rest adopted. `--adopt` removes the keys so
+the current defaults apply from the next start; `--keep` records the exact values
+you affirmed, so changing one later brings the notice back. `kirocrew doctor` lists
+everything, affirmed values included.
+
+The same command also clears a stored value Kiro Crew has to replace — a retired
+`stt.provider` such as `whisper`, which already runs on `local`. That one cannot be
+kept, because the stored name has no engine behind it; `--adopt` drops the dead
+value and the notice with it.
 
 ## Sandbox
 

--- a/test/test_cli_config_defaults.py
+++ b/test/test_cli_config_defaults.py
@@ -1,0 +1,310 @@
+"""``kirocrew config defaults`` -- review, adopt, or affirm superseded defaults.
+
+The load path can only REPORT drift: a stored old default and a deliberate opt-out
+are the same bytes, so it must not rewrite either. This command is the surface
+where the operator resolves that ambiguity themselves, which is what lets the
+report be one answerable line instead of a permanent per-key notice (#7559).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.config import superseded_defaults as SD
+
+DRIFTED = {
+    "session": {"autocompact_pct": 90.0},
+    "mcp_gateway": {"forward_declared_env": False},
+}
+
+
+def _args(*, keys: list[str] | None = None, adopt: bool = False, keep: bool = False):
+    return argparse.Namespace(config_action="defaults", keys=keys or [], adopt=adopt, keep=keep)
+
+
+def _run(args: argparse.Namespace, config_dir: Path) -> None:
+    from kiro_crew.cli_config import _config_cmd
+
+    with (
+        patch("kiro_crew.cli_config.config_path", return_value=config_dir / "config.json"),
+        patch(
+            "kiro_crew.cli_config.config_local_path",
+            return_value=config_dir / "config.local.json",
+        ),
+        patch("kiro_crew.config.loader.config_path", return_value=config_dir / "config.json"),
+        patch("kiro_crew.config.loader.config_dir", return_value=config_dir),
+        patch("kiro_crew.cli_config.sel"),
+    ):
+        _config_cmd(args)
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    d = tmp_path / "crew"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps(DRIFTED), encoding="utf-8")
+    return d
+
+
+def _stored(home: Path) -> dict:
+    return json.loads((home / "config.json").read_text(encoding="utf-8"))
+
+
+def test_listing_names_every_drifted_key_and_both_commands(home, capsys):
+    _run(_args(), home)
+    out = capsys.readouterr().out
+    assert "session.autocompact_pct" in out
+    assert "mcp_gateway.forward_declared_env" in out
+    assert "--adopt" in out and "--keep" in out
+    # Listing changes nothing.
+    assert _stored(home) == DRIFTED
+
+
+def test_adopt_removes_the_keys_so_the_current_default_applies(home, capsys):
+    _run(_args(adopt=True), home)
+    saved = _stored(home)
+    assert "autocompact_pct" not in saved["session"]
+    assert "forward_declared_env" not in saved["mcp_gateway"]
+    out = capsys.readouterr().out
+    assert "current default now applies" in out
+
+
+def test_adopt_touches_only_the_named_key(home):
+    _run(_args(keys=["session.autocompact_pct"], adopt=True), home)
+    saved = _stored(home)
+    assert "autocompact_pct" not in saved["session"]
+    # The escape-hatch key is left exactly as the operator stored it.
+    assert saved["mcp_gateway"]["forward_declared_env"] is False
+
+
+def test_adopt_leaves_a_value_that_changed_since_it_was_listed(home):
+    """Re-detection happens inside the lock, so a concurrent edit is not discarded."""
+    from kiro_crew import cli_config
+    from kiro_crew.cli_config import _config_cmd
+
+    def _steal(existing: dict) -> dict:
+        existing["session"]["autocompact_pct"] = 55.0
+        return existing
+
+    real = SD.superseded_default_drift
+    calls: list[int] = []
+
+    def _drift(base_data, acked=None):
+        # First call is the snapshot read; mutate the file before the locked pass.
+        calls.append(1)
+        if len(calls) == 1:
+            from kiro_crew.config.loader import update_config_locked
+
+            update_config_locked(home / "config.json", mutate=_steal)
+        return real(base_data, acked)
+
+    with (
+        patch("kiro_crew.cli_config.config_path", return_value=home / "config.json"),
+        patch(
+            "kiro_crew.cli_config.config_local_path",
+            return_value=home / "config.local.json",
+        ),
+        patch("kiro_crew.config.loader.config_dir", return_value=home),
+        patch("kiro_crew.cli_config.sel"),
+        patch.object(cli_config, "superseded_default_drift", _drift),
+    ):
+        _config_cmd(_args(keys=["session.autocompact_pct"], adopt=True))
+
+    assert _stored(home)["session"]["autocompact_pct"] == 55.0
+
+
+def test_keep_records_the_stored_values_and_silences_the_report(home, capsys):
+    _run(_args(keep=True), home)
+    with patch("kiro_crew.config.loader.config_dir", return_value=home):
+        assert SD.acked_superseded() == {
+            "session.autocompact_pct": 90.0,
+            "mcp_gateway.forward_declared_env": False,
+        }
+        assert SD.superseded_default_drift(DRIFTED) == []
+    # Nothing in the config document changed -- an ack is bookkeeping, not a setting.
+    assert _stored(home) == DRIFTED
+    assert "recorded as intentional" in capsys.readouterr().out
+
+
+def test_adopting_an_acked_key_drops_its_ack(home):
+    """The ack recorded a value that is no longer stored, so keeping it would
+    silence a genuinely deliberate choice made later."""
+    _run(_args(keys=["session.autocompact_pct"], keep=True), home)
+    _run(_args(keys=["session.autocompact_pct"], adopt=True), home)
+    with patch("kiro_crew.config.loader.config_dir", return_value=home):
+        assert "session.autocompact_pct" not in SD.acked_superseded()
+
+
+def test_a_bare_adopt_leaves_an_acknowledged_value_alone(home, capsys):
+    """The operator already answered for that key; sweeping it up would undo it."""
+    _run(_args(keys=["session.autocompact_pct"], keep=True), home)
+    _run(_args(adopt=True), home)
+    saved = _stored(home)
+    assert saved["session"]["autocompact_pct"] == 90.0
+    assert "forward_declared_env" not in saved["mcp_gateway"]
+
+
+def test_naming_an_acknowledged_key_still_adopts_it(home):
+    """An explicit key is the operator saying so again."""
+    _run(_args(keys=["session.autocompact_pct"], keep=True), home)
+    _run(_args(keys=["session.autocompact_pct"], adopt=True), home)
+    assert "autocompact_pct" not in _stored(home)["session"]
+
+
+def test_a_bare_adopt_with_everything_acknowledged_changes_nothing(home, capsys):
+    _run(_args(keep=True), home)
+    _run(_args(adopt=True), home)
+    assert _stored(home) == DRIFTED
+    assert "Nothing left to act on" in capsys.readouterr().out
+
+
+def test_adopt_says_the_overlay_still_wins_when_it_carries_the_key(home, capsys):
+    """Removing a base key an overlay also carries changes no effective value, so the
+    report must not claim the current default now applies."""
+    (home / "config.local.json").write_text(
+        json.dumps({"session": {"autocompact_pct": 80.0}}), encoding="utf-8"
+    )
+    _run(_args(keys=["session.autocompact_pct"], adopt=True), home)
+    out = capsys.readouterr().out
+    assert "config.local.json still overrides it" in out
+    assert "the current default now applies" not in out
+
+
+def test_an_unknown_key_is_refused_rather_than_silently_ignored(home, capsys):
+    with pytest.raises(SystemExit) as e:
+        _run(_args(keys=["session.timeout_secs"], adopt=True), home)
+    assert e.value.code == 1
+    assert "Not holding a superseded default" in capsys.readouterr().err
+    assert _stored(home) == DRIFTED
+
+
+def test_a_clean_install_says_so(tmp_path, capsys):
+    d = tmp_path / "crew"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"session": {"autocompact_pct": 70.0}}), "utf-8")
+    _run(_args(), d)
+    assert "No stored value holds a superseded default" in capsys.readouterr().out
+
+
+def test_a_missing_config_needs_no_action(tmp_path, capsys):
+    d = tmp_path / "crew"
+    d.mkdir()
+    _run(_args(adopt=True), d)
+    assert "current defaults already apply" in capsys.readouterr().out
+
+
+def test_a_corrupt_config_is_refused_not_overwritten(tmp_path, capsys):
+    d = tmp_path / "crew"
+    d.mkdir()
+    (d / "config.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(SystemExit) as e:
+        _run(_args(adopt=True), d)
+    assert e.value.code == 1
+    assert "Could not read" in capsys.readouterr().err
+    assert (d / "config.json").read_text(encoding="utf-8") == "{not json"
+
+
+def test_invalid_utf8_in_config_gives_an_error_not_a_traceback(tmp_path, capsys):
+    """UnicodeDecodeError is a ValueError but not a JSONDecodeError, so a tuple naming
+    only the latter lets it escape as a traceback."""
+    d = tmp_path / "crew"
+    d.mkdir()
+    (d / "config.json").write_bytes(b'{"session": {"autocompact_pct": 90.0}, "x": "\xff\xfe"}')
+    with pytest.raises(SystemExit) as e:
+        _run(_args(), d)
+    assert e.value.code == 1
+    assert "Could not read" in capsys.readouterr().err
+
+
+def test_invalid_utf8_in_the_overlay_does_not_break_adopt(home, capsys):
+    """An unreadable overlay is treated as carrying nothing, never as a crash."""
+    (home / "config.local.json").write_bytes(b'{"session": "\xff\xfe"}')
+    _run(_args(keys=["session.autocompact_pct"], adopt=True), home)
+    assert "autocompact_pct" not in _stored(home)["session"]
+
+
+# --------------------------------------------------------------------------
+# A coerced value: inert bytes that cost a warning on every load.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def retired(tmp_path: Path) -> Path:
+    d = tmp_path / "crew"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"stt": {"provider": "whisper"}}), "utf-8")
+    return d
+
+
+def test_a_retired_provider_is_listed_as_coerced(retired, capsys):
+    _run(_args(), retired)
+    out = capsys.readouterr().out
+    assert "stt.provider" in out
+    assert "'whisper'" in out
+    assert "cannot take effect" in out
+
+
+def test_adopt_drops_a_retired_provider(retired, capsys):
+    _run(_args(adopt=True), retired)
+    saved = json.loads((retired / "config.json").read_text(encoding="utf-8"))
+    assert "provider" not in saved["stt"]
+    assert "stt.provider removed" in capsys.readouterr().out
+
+
+def test_a_coerced_value_cannot_be_kept(retired, capsys):
+    """Affirming it would promise a setting the loader replaces regardless."""
+    _run(_args(keep=True), retired)
+    out = capsys.readouterr().out
+    assert "cannot be kept" in out
+    saved = json.loads((retired / "config.json").read_text(encoding="utf-8"))
+    assert saved["stt"]["provider"] == "whisper"
+    with patch("kiro_crew.config.loader.config_dir", return_value=retired):
+        assert SD.acked_superseded() == {}
+
+
+def test_a_selectable_provider_is_not_coerced(tmp_path):
+    assert SD.coerced_value_drift({"stt": {"provider": "local"}}) == []
+    assert SD.coerced_value_drift({"stt": {}}) == []
+
+
+def test_an_appended_coerced_entry_is_detected_without_editing_the_detector(monkeypatch):
+    """The predicate rides on the entry, so appending a retirement is sufficient.
+
+    A detector switching on dotted_key would leave this entry silently unreported --
+    no test red, and an operator stuck with a warning nothing can clear.
+    """
+    appended = SD.CoercedValue(
+        dotted_key="agent.provider",
+        resolves_to="acp",
+        reason="names a withdrawn provider",
+        is_coerced=lambda v: v == "gone",
+    )
+    monkeypatch.setattr(SD, "COERCED_VALUES", SD.COERCED_VALUES + (appended,))
+    found = SD.coerced_value_drift({"agent": {"provider": "gone"}})
+    assert [e.dotted_key for e, _ in found] == ["agent.provider"]
+
+
+def test_an_unwritable_data_home_gives_an_error_not_a_traceback(home, capsys):
+    """A read-only or full data home must not surface as an uncaught OSError."""
+    from kiro_crew.config import superseded_defaults as sd
+
+    with patch.object(sd, "_update_acked", side_effect=OSError("read-only file system")):
+        with pytest.raises(SystemExit) as e:
+            _run(_args(keep=True), home)
+    assert e.value.code == 1
+    assert "Could not record acknowledgments" in capsys.readouterr().err
+
+
+def test_an_unwritable_config_on_adopt_gives_an_error_not_a_traceback(home, capsys):
+    from kiro_crew import cli_config
+
+    with patch.object(cli_config, "update_config_locked", side_effect=OSError("disk full")):
+        with pytest.raises(SystemExit) as e:
+            _run(_args(adopt=True), home)
+    assert e.value.code == 1
+    assert "Could not write" in capsys.readouterr().err

--- a/test/test_config_superseded_defaults.py
+++ b/test/test_config_superseded_defaults.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 
 import pytest
 
+from kiro_crew import platform_compat
 from kiro_crew.config import loader as L
 from kiro_crew.config import superseded_defaults as SD
 from kiro_crew.config.loader import KiroCrewConfig
@@ -57,7 +59,8 @@ def _point_home(tmp_path, monkeypatch) -> None:
     """Redirect every config path at *tmp_path* so nothing touches the real home.
 
     ``render_doctor_section`` resolves ``config_path`` lazily out of the loader
-    module, so patching it there covers the doctor surface too.
+    module, so patching it there covers the doctor surface too. ``config_dir`` is
+    what ``ack_file_path`` resolves, so the acknowledgment file lands here as well.
     """
     cfgp = tmp_path / "config.json"
     monkeypatch.setattr(L, "config_path", lambda: cfgp)
@@ -323,3 +326,300 @@ def test_loop_stall_summary_explains_automatic_default():
     assert "JSON null" in text
     assert "None" not in text
     assert "#6651" in text
+
+
+# --------------------------------------------------------------------------
+# Acknowledgment: the report is falsifiable (#7559).
+# --------------------------------------------------------------------------
+
+
+def test_an_acked_value_is_not_reported(tmp_path, monkeypatch):
+    """A value the operator affirmed is a choice, not drift."""
+    _point_home(tmp_path, monkeypatch)
+    base = {"session": {"autocompact_pct": 90.0}}
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+    assert superseded_default_drift(base) == []
+
+
+def test_changing_an_acked_value_reports_it_again(tmp_path, monkeypatch):
+    """The ack records the VALUE, so it cannot silence a different one later.
+
+    Storing the old default again after acking a different value is exactly the
+    case a key-only ack would hide forever.
+    """
+    _point_home(tmp_path, monkeypatch)
+    SD.write_acked_superseded({"mcp_gateway.forward_declared_env": True})
+    drifted = superseded_default_drift({"mcp_gateway": {"forward_declared_env": False}})
+    assert FDE_ENTRY in drifted
+
+
+def test_an_acked_zero_does_not_silence_a_stored_false(tmp_path, monkeypatch):
+    """bool is an int subclass on the ack side too."""
+    _point_home(tmp_path, monkeypatch)
+    SD.write_acked_superseded({"mcp_gateway.forward_declared_env": 0})
+    assert FDE_ENTRY in superseded_default_drift({"mcp_gateway": {"forward_declared_env": False}})
+
+
+def test_an_explicit_empty_ack_map_shows_the_unacked_truth(tmp_path, monkeypatch):
+    """``acked={}`` answers "what am I holding?" even for affirmed values."""
+    _point_home(tmp_path, monkeypatch)
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+    base = {"session": {"autocompact_pct": 90.0}}
+    assert superseded_default_drift(base, acked={}) == [AUTOCOMPACT_ENTRY]
+
+
+def test_a_corrupt_ack_file_fails_soft(tmp_path, monkeypatch):
+    """An unreadable ack file means the operator is told again, never a crash."""
+    _point_home(tmp_path, monkeypatch)
+    SD.ack_file_path().write_text("{not json", encoding="utf-8")
+    assert SD.acked_superseded() == {}
+    assert FDE_ENTRY in superseded_default_drift({"mcp_gateway": {"forward_declared_env": False}})
+
+
+def test_the_ack_file_lives_outside_config_json(tmp_path, monkeypatch):
+    """A to_dict() rewrite carries only schema fields, so an ack inside the config
+    document would be dropped by the same materialization this module reports on."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 90.0}})
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    KiroCrewConfig().save()
+
+    assert SD.acked_superseded() == {"session.autocompact_pct": 90.0}
+    assert "acked_superseded" not in json.dumps(_on_disk(tmp_path))
+
+
+def test_record_acks_stores_what_is_stored(tmp_path, monkeypatch):
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 90.0}, "stt": {}})
+    # stt.streaming is not stored, so there is no choice to affirm.
+    recorded = SD.record_acks(["session.autocompact_pct", "stt.streaming"])
+    assert recorded == ["session.autocompact_pct"]
+    assert SD.acked_superseded() == {"session.autocompact_pct": 90.0}
+
+
+def test_record_acks_reads_the_config_fresh_not_a_callers_snapshot(tmp_path, monkeypatch):
+    """A value changed since it was listed must not be acked at its old snapshot --
+    that would silence the report for a value the operator never affirmed."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 55.0}})
+    # 55.0 is not the superseded default, so it is not drift and not ackable.
+    assert SD.record_acks(["session.autocompact_pct"]) == []
+    assert SD.acked_superseded() == {}
+
+
+def test_recording_an_ack_merges_with_what_is_already_on_disk(tmp_path, monkeypatch):
+    """The read-modify-write runs inside the file's lock, so a concurrent ack of a
+    different key is not dropped by the second writer's replacement."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 90.0}})
+    SD.write_acked_superseded({"stt.model": "turbo"})
+    SD.record_acks(["session.autocompact_pct"])
+    assert SD.acked_superseded() == {
+        "stt.model": "turbo",
+        "session.autocompact_pct": 90.0,
+    }
+
+
+def test_a_concurrent_ack_written_mid_transaction_survives(tmp_path, monkeypatch):
+    """Proves the merge reads what is on DISK inside the lock, not a stale snapshot."""
+    _point_home(tmp_path, monkeypatch)
+    real = SD._acked_from_document
+    fired: list[int] = []
+
+    def _sneak(raw):
+        # Fires on the locked read; write a rival ack before the merge computes.
+        result = real(raw)
+        if not fired:
+            fired.append(1)
+            SD.ack_file_path().write_text(
+                json.dumps({"acked": {"stt.model": "turbo"}}), encoding="utf-8"
+            )
+        return result
+
+    monkeypatch.setattr(SD, "_acked_from_document", _sneak)
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+    monkeypatch.setattr(SD, "_acked_from_document", real)
+    assert SD.acked_superseded()["session.autocompact_pct"] == 90.0
+
+
+def test_dropping_an_ack_leaves_the_others(tmp_path, monkeypatch):
+    _point_home(tmp_path, monkeypatch)
+    SD.write_acked_superseded({"stt.model": "turbo", "session.autocompact_pct": 90.0})
+    SD.drop_acks(["session.autocompact_pct"])
+    assert SD.acked_superseded() == {"stt.model": "turbo"}
+
+
+def test_dropping_an_unacked_key_never_touches_the_file(tmp_path, monkeypatch):
+    _point_home(tmp_path, monkeypatch)
+    SD.drop_acks(["session.autocompact_pct"])
+    assert not SD.ack_file_path().exists()
+
+
+@pytest.mark.skipif(not platform_compat.IS_POSIX, reason="os.symlink needs elevation on Windows")
+def test_a_link_at_the_ack_path_is_refused_not_written_through(tmp_path, monkeypatch):
+    """The config writers FOLLOW a link on purpose (dotfiles repos). That is wrong for
+    a path the agent can name: following it would overwrite the link's target."""
+    _point_home(tmp_path, monkeypatch)
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"keep": "me"}', encoding="utf-8")
+    SD.ack_file_path().symlink_to(victim)
+
+    with pytest.raises(OSError):
+        SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    assert victim.read_text(encoding="utf-8") == '{"keep": "me"}'
+
+
+@pytest.mark.skipif(not platform_compat.IS_POSIX, reason="os.symlink needs elevation on Windows")
+def test_a_link_swapped_in_after_the_check_is_replaced_not_followed(tmp_path, monkeypatch):
+    """The check reports the condition; the rename-over-leaf is what makes it
+    unexploitable, so a link winning the race still cannot reach its target."""
+    _point_home(tmp_path, monkeypatch)
+    victim = tmp_path / "victim.json"
+    victim.write_text('{"keep": "me"}', encoding="utf-8")
+    ack = SD.ack_file_path()
+
+    def _plant_then_pass(path):
+        ack.symlink_to(victim)
+        return False  # simulate losing the race: the check saw no link
+
+    monkeypatch.setattr(SD.platform_compat, "is_link_or_junction", _plant_then_pass)
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    assert victim.read_text(encoding="utf-8") == '{"keep": "me"}'
+    assert not ack.is_symlink()
+    assert SD.acked_superseded() == {"session.autocompact_pct": 90.0}
+
+
+@pytest.mark.skipif(not platform_compat.IS_POSIX, reason="no os.mkfifo on Windows")
+def test_a_fifo_at_the_ack_path_is_refused_instead_of_blocking(tmp_path, monkeypatch):
+    """The read runs on the config-load path, which is an event-loop path. `open()` on
+    a FIFO waits for a writer forever, which would wedge the gateway."""
+    _point_home(tmp_path, monkeypatch)
+    os.mkfifo(SD.ack_file_path())
+    assert SD.acked_superseded() == {}
+
+
+def test_a_directory_at_the_ack_path_is_refused(tmp_path, monkeypatch):
+    """Only a REGULAR file is read, so no other path shape reaches json.loads."""
+    _point_home(tmp_path, monkeypatch)
+    SD.ack_file_path().mkdir()
+    assert SD.acked_superseded() == {}
+
+
+def test_an_oversized_ack_file_is_refused(tmp_path, monkeypatch):
+    """A capped single read is what keeps the load-path read bounded."""
+    _point_home(tmp_path, monkeypatch)
+    SD.ack_file_path().write_text(" " * (SD.ACK_MAX_BYTES + 1), encoding="utf-8")
+    assert SD.acked_superseded() == {}
+
+
+def test_the_ack_file_carries_no_unread_version_field(tmp_path, monkeypatch):
+    """The soft read already tolerates any shape, so a version nobody checks is a
+    field with no reader."""
+    _point_home(tmp_path, monkeypatch)
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+    raw = json.loads(SD.ack_file_path().read_text(encoding="utf-8"))
+    assert set(raw) == {"acked"}
+
+
+# --------------------------------------------------------------------------
+# Adoption: removing the key is what un-materializes it.
+# --------------------------------------------------------------------------
+
+
+def test_dropping_a_key_makes_the_current_default_apply(tmp_path, monkeypatch):
+    _point_home(tmp_path, monkeypatch)
+    base = {"session": {"autocompact_pct": 90.0}}
+    assert SD.drop_drifted_keys(base, ["session.autocompact_pct"]) == ["session.autocompact_pct"]
+    assert base == {"session": {}}
+    # An emptied section resolves identically to an absent one.
+    assert superseded_default_drift(base) == []
+    _write_config(tmp_path, base)
+    assert KiroCrewConfig.load().session.autocompact_pct == 70.0
+
+
+def test_dropping_an_absent_key_reports_nothing_removed(tmp_path, monkeypatch):
+    _point_home(tmp_path, monkeypatch)
+    base: dict = {"session": {}}
+    assert SD.drop_drifted_keys(base, ["session.autocompact_pct"]) == []
+
+
+# --------------------------------------------------------------------------
+# The load path says it ONCE, in one line, whatever the registry size.
+# --------------------------------------------------------------------------
+
+
+def test_many_drifted_keys_produce_one_warning_line(tmp_path, monkeypatch, caplog):
+    """The registry is append-only, so a per-key line grows without bound on the
+    very installs with the most real drift -- and lands on every CLI invocation."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(
+        tmp_path,
+        {
+            "mcp_gateway": {"forward_declared_env": False},
+            "session": {"autocompact_pct": 90.0},
+            "stt": {"streaming": False, "model": "turbo"},
+            "dashboard": {"loop_stall_exit_after_secs": 25},
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        KiroCrewConfig.load()
+
+    warnings = [r for r in caplog.records if "superseded default" in r.getMessage()]
+    assert len(warnings) == 1
+    text = warnings[0].getMessage()
+    # Every drifted key is named, and the line says what to do about it.
+    for key in (
+        "mcp_gateway.forward_declared_env",
+        "session.autocompact_pct",
+        "stt.streaming",
+        "stt.model",
+        "dashboard.loop_stall_exit_after_secs",
+    ):
+        assert key in text
+    assert "kirocrew config defaults" in text
+
+
+def test_an_acked_key_is_not_named_on_the_load_path(tmp_path, monkeypatch, caplog):
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 90.0}})
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    with caplog.at_level(logging.WARNING, logger=L.__name__):
+        KiroCrewConfig.load()
+
+    assert not [r for r in caplog.records if "superseded default" in r.getMessage()]
+
+
+def test_doctor_lists_an_acked_entry_instead_of_hiding_it(tmp_path, monkeypatch, capsys):
+    """``doctor`` answers "what does this install hold?", so an affirmed value is
+    part of the answer; only the unsolicited load-path line is silenced."""
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 90.0}})
+    SD.write_acked_superseded({"session.autocompact_pct": 90.0})
+
+    issues: list[str] = []
+    SD.render_doctor_section(issues)
+    out = capsys.readouterr().out
+
+    assert "session.autocompact_pct" in out
+    assert "acknowledged as intentional" in out
+    # Nothing is left to act on, so no fix hint is offered.
+    assert "--adopt" not in out
+    assert issues == []
+
+
+def test_doctor_offers_the_commands_when_something_is_unacked(tmp_path, monkeypatch, capsys):
+    _point_home(tmp_path, monkeypatch)
+    _write_config(tmp_path, {"session": {"autocompact_pct": 90.0}})
+
+    issues: list[str] = []
+    SD.render_doctor_section(issues)
+    out = capsys.readouterr().out
+
+    assert "kirocrew config defaults --adopt" in out
+    assert "kirocrew config defaults --keep" in out
+    assert issues == []


### PR DESCRIPTION
## The problem

A long-lived install greets **every single `kirocrew` invocation** — `config get`, `service install`, `service status`, `doctor` — with seven warning lines it can do nothing about:

```
WARNING Superseded default in stored config: mcp_gateway.forward_declared_env ...
WARNING Superseded default in stored config: session.autocompact_pct ...
WARNING Superseded default in stored config: stt.streaming ...
WARNING Superseded default in stored config: stt.model ...
WARNING Superseded default in stored config: dashboard.loop_stall_exit_after_secs ...
WARNING Superseded default in stored config: instances.warm_set_cap ...
WARNING STT provider 'whisper' is retired; using 'local' instead ...
```

Three separate defects:

1. **The report is per KEY and the registry is append-only**, so the noise grows with every default the project ever changes — and lands hardest on the long-lived installs that have the most real drift to report.
2. **The once-per-process guard buys nothing on the CLI.** It was designed for the gateway; on a short-lived command the process *is* the invocation, so every invocation re-warns.
3. **Nothing can answer it.** Drift is decided by value equality, so an operator who deliberately chose a value equal to a superseded default is told about it forever, with no way to say "I meant it" (#7559). `session.autocompact_pct = 90` is the documented maximum of its own validator — precisely the value someone wanting maximum context retention picks.

The module's own comment already named the cost: *"a line the operator has already read is noise that trains them to ignore the next one"*. That is what has happened, and it costs exactly the genuine findings the mechanism exists to surface.

## The change

**One line on the load path**, naming every drifted key plus the command that resolves it. The per-key text stays, at debug, so `-vv` keeps it in the gateway log.

```
WARNING 6 stored config value(s) still hold a superseded default: mcp_gateway.forward_declared_env,
        session.autocompact_pct, stt.streaming, stt.model, dashboard.loop_stall_exit_after_secs,
        instances.warm_set_cap. Run 'kirocrew config defaults' to see each one, '--adopt' to take
        the current defaults, or '--keep' to affirm yours and stop this notice.
```

**`kirocrew config defaults`** — the surface that resolves the ambiguity the load path must not resolve for anyone:

| | |
|---|---|
| no flag | list each key with its stored value, the current default, and the release that changed it |
| `--adopt [KEY...]` | remove the stored keys, so `data.get(key, DEFAULT)` resolves the current default |
| `--keep [KEY...]` | record the stored values as intentional, silencing the notice for exactly those values |

Rewriting is safe under `--adopt` where it is not on the load path, because the operator asked by name and only a key that IS drifted is ever removed. Detection runs **again inside the write lock**, so a value changed since it was listed is left alone.

An acknowledgment records `<key> -> the VALUE`, not the key alone, so it covers the choice rather than the key: change the value later and the report returns. A bare `--adopt`/`--keep` skips keys already affirmed, so it cannot silently undo an earlier decision; naming a key explicitly still acts on it.

Acks live in `~/.kiro/crew/superseded_acked.json`, **not** in `config.json` — a `to_dict()` rewrite carries only schema fields, so the very materialization behaviour this mechanism reports on would silently drop an ack stored in the config document. Every read fails soft: an ack suppresses one line and changes no runtime behaviour, so the worst consequence of a corrupt file is being told again.

**A coerced value is a different kind, and is now tracked as one.** A retired `stt.provider` such as `whisper` cannot win — the loader replaces it at parse time — so there is nothing to affirm, but removing it is unambiguously safe. `COERCED_VALUES` holds it, `--adopt` drops it, and `--keep` refuses it by name rather than promising a setting that never takes effect. `coerced_value_drift()` asks `sections.stt_provider_is_coerced()` rather than restating a provider list that would drift from the one actually dispatched.

**`doctor` lists an acknowledged entry rather than hiding it.** An ack answers the *unsolicited* load-path line; `doctor` answers "what does this install still hold?", and hiding an affirmed value would make that answer wrong.

## Decision this takes

#7559 was routed to `needs-human` to choose between per-key write-path provenance (option 1), a per-key acknowledgment (option 2), report-once (option 3), and status quo (option 4). This implements **option 2**, which the issue itself favours, and does not preclude option 1 later: an ack list is a subset of provenance and provenance could subsume it. It deliberately does not touch every config write path, so it needs no decision about what to assume for keys already on disk with no provenance recorded.

## Verification

End-to-end against a copy of a real long-lived `config.json` (6 drifted keys + a retired `whisper` provider):

- before: 7 warning lines on every invocation → after: 2 (one per kind);
- `config defaults --keep session.autocompact_pct` then `--adopt`: 0 warning lines, and `doctor` still records the affirmed 90.0 as intentional;
- `--adopt` removed `stt.model`, `dashboard.loop_stall_exit_after_secs`, `instances.warm_set_cap`, `stt.provider` and left the affirmed key alone.

52 tests over the two suites, covering: ack suppression, ack invalidation when the value changes, an acked `0` not silencing a stored `False`, a corrupt ack file failing soft, the ack surviving a `KiroCrewConfig().save()` round-trip, adopt-under-lock re-detection, a bare adopt sparing an affirmed value, an unknown key refused rather than ignored, a coerced value listed / adopted / refused by `--keep`, and one warning line for five drifted keys.

Gates: `check_black_formatting`, `check_subprocess_encoding`, `isort`, `flake8`, `mypy --platform linux` (1279 files), `docs-lint`, harness-parity, brand, changelog-history all pass. Full `pytest` run: the failures present are also present on pristine `origin/main` in an equally deep worktree (AF_UNIX path length, missing companion profile), none in config, stt, cli or doctor.

Docs updated in the same commit: `docs/system-specs/modules/config.md` (also corrects its registry list, which still named four entries out of six) and `src/kiro_crew/docs/configuration.md`.

Closes #7559


## Pattern harvest

Rule candidate: A once-per-process warning guard is not a noise control on a short-lived CLI command, because there the process IS the invocation -- a per-key line on an append-only registry re-prints in full on every single run, and the growth is unbounded in the number of defaults the project has ever changed. Emit one line naming all of them plus the command that resolves it, and keep the per-key detail at debug.

Rule candidate: A report decided by value equality alone is unfalsifiable, so it must be acknowledgeable or it becomes permanent noise that crowds out the real findings beside it. Record the acknowledged VALUE, not the key, so the ack covers the operator's choice and expires when the value changes.

Rule candidate: Config writers in this repo deliberately FOLLOW a symlink (a dotfiles-repo `config.json` is supported), so any NEW state file whose path an agent can name must refuse a link at its leaf before writing -- by name, before the open, since Windows has no `O_NOFOLLOW`.

Rule candidate: A file the CLI read-modify-writes needs the whole transaction inside one lock hold, not just an atomic final write; otherwise two concurrent invocations both read the same map and the second replacement silently drops the first one's entry.

Rule candidate: A "registry" whose detector switches on an entry's key buys none of the extensibility its append-only comment claims -- an appended entry is silently never detected and no test goes red. Put the predicate on the entry.
