### PR TITLE
ci: re-measure the i18n runtime chunk budget at 740 KB

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -61,7 +61,11 @@ export const CHUNK_BUDGETS = {
   // ~60 KB stale, which left main sitting a few hundred bytes under its own
   // ceiling, so any PR adding an English string tripped this gate rather than
   // the new library or surface it exists to catch.
-  t: 740 * KB, // measured 702 KB
+  // Re-measured 2026-09-04 at 740 KB (4 B over the 740 KB ceiling) after the
+  // inline crew schedule, agent-picker roster failure, and aws-control notice
+  // strings landed on main together; same stale-headroom shape as 08-27, so
+  // the ceiling moves with the measurement again.
+  t: 780 * KB, // measured 740 KB
 
   // Pierre editor implementation (PR #4072 replaced Monaco, whose
   // 'editor.api2' chunk this entry set used to carry) -- the code-editor


### PR DESCRIPTION
## Problem / Motivation

Every PR rebased onto current main fails **Bundle Size Gate** with:

```
FAIL assets/t-Cr8LfdHT.js: 740.0 KB exceeds its 740.0 KB budget by 4 B (chunk 't')
```

The PRs' own diffs do not touch the chunk. #8286 (two workflow prompt bullets and one docs paragraph), #8292's fork-review fix and the nested-submenus fix all show the same red on the same head window (08:40–08:43 UTC), while PRs whose merge ref predates 01:24 UTC pass.

## Why it matters

The gate is red on main's own content, so it blocks unrelated PRs and trains people to rerun or override it — the same shape as the 2026-08-27 stale-headroom incident recorded in the file's own comment. Until the ceiling moves, nothing that touches main can go green.

## What changed (motivation → approach → change)

Three commits landed on main in a seven-minute window (`4e5398dd2` agent-picker roster failure, `de19df867` inline crew schedule, `390ac8d2f` aws-control shared notice), each adding English strings to the `t` runtime catalog. Individually each fit under the 740 KB ceiling; together they put the chunk 4 B over. The `t` budget is documented as "grows a little with every translated string, which is expected and fine; what this ceiling catches is a NEW library or surface" — so the right move is to re-measure and move the ceiling, not to shrink strings.

One-line change in `website/scripts/check-bundle-size.mjs`: `t: 740 * KB` → `t: 780 * KB`, with the measurement note updated to 740 KB on 2026-09-04 and the three contributing merges named in the comment. ~5% headroom, matching the `all` entry's convention.

## Tests

N/A — a budget constant; the gate itself is the test. CI's Bundle Size Gate on this PR verifies the new ceiling holds for the current chunk.

## Manual verification

Read the failing job log on #8286 (job 100965157938) for the exact overage; confirmed via `gh run view` that sibling PRs on the same main window fail the same job and that main's own `ci.yml` skips the gate (PR-only), so main cannot show the red itself.

## Related Issues

no linked issue: main-inherited CI unblocker, no tracked issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
