### PR TITLE
fix(ci): re-measure the stale t-chunk bundle ceiling

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -57,11 +57,18 @@ export const CHUNK_BUDGETS = {
   // `t()` no longer pull the other twelve catalogs in behind them. Sized for the
   // English catalog plus headroom; a jump here means a non-English catalog, or a
   // library, reached the runtime module.
-  // Re-measured 2026-08-27 at 702 KB: the previous `measured 641 KB` note was
-  // ~60 KB stale, which left main sitting a few hundred bytes under its own
-  // ceiling, so any PR adding an English string tripped this gate rather than
-  // the new library or surface it exists to catch.
-  t: 740 * KB, // measured 702 KB
+  // Re-measured 2026-09-04 at 740 KB, and the 702 KB note above was ~38 KB
+  // stale, which is the same recurrence it describes: main drifted to EXACTLY
+  // 740.00 KB (757,764 B, 4 B over its own ceiling), so the gate began failing
+  // on the merge ref of every open PR rather than on the new library or surface
+  // it exists to catch. Attribution was measured, not assumed -- the branch that
+  // tripped it first builds a BYTE-IDENTICAL `t` chunk to its own base
+  // (`t-BLZeayKy.js`, 755,868 B on both), and main's tip alone, with none of that
+  // branch's code, reproduces the 4-byte failure with the same content hash. So
+  // the growth is main's accumulated English strings, and headroom is what was
+  // actually missing. 5% headroom, matching the `all` entry's convention above,
+  // so the next English string does not re-trip this for the third time.
+  t: 777 * KB, // measured 740 KB on main @ 1cd64b8c9 (~5% headroom)
 
   // Pierre editor implementation (PR #4072 replaced Monaco, whose
   // 'editor.api2' chunk this entry set used to carry) -- the code-editor


### PR DESCRIPTION
## Problem / Motivation

The bundle-size gate fails on the merge ref of every open PR. main's tip builds the i18n runtime chunk at **exactly 740.00 KB (757,764 B), 4 bytes over its own 740 KB ceiling**:

```
FAIL assets/t-Cr8LfdHT.js: 740.0 KB exceeds its 740.0 KB budget by 4 B (chunk 't')
```

So the gate no longer reports the new library or surface it exists to catch. It reports whichever PR happens to open next.

## Why it matters

Every open PR is charged a failure that belongs to main, and the signal is actively misleading: the failing check names the PR's own chunk, so the natural reading is "my change grew the bundle". The gate's value is that crossing it means something arrived that should not have; at 4 bytes of slack it means nothing.

This is the second occurrence of the same thing, and the entry's own comment describes the first: a `measured 641 KB` note went ~60 KB stale, main drifted to a few hundred bytes under the ceiling, and any PR adding an English string tripped it. The `measured 702 KB` note that replaced it is now ~38 KB stale.

## What changed (motivation -> approach -> change)

Attribution was measured, not assumed, because "the ceiling is stale" and "this PR grew the chunk" predict the same red check:

- The branch that tripped this first builds a **byte-identical** `t` chunk to its own base: `t-BLZeayKy.js`, 755,868 B on both sides, same content hash. That branch does not touch the chunk at all.
- main's tip alone, carrying none of that branch's code, **reproduces the 4-byte failure** with a different content hash, `t-Cr8LfdHT.js` at 757,764 B -- which is also the exact filename CI reported on the merge ref.

So the growth is main's accumulated English strings. The chunk is the i18n runtime (the i18next singleton, `initI18n`, the English catalog); there is no library or surface to split out, and headroom is what was actually missing.

Re-measured at 740 KB with 5% headroom -> **777 KB**, matching the convention the `all` entry above already uses, so the next English string does not re-trip this a third time. The comment records the measurement, the attribution, and the reasoning, so the next person to hit it can tell drift from a real regression.

## Tests

N/A -- this is a CI threshold constant with no runtime behaviour. It is verified by running the gate itself, below.

## Manual verification

Both measured with `npx vite build --mode analyze` then `node scripts/check-bundle-size.mjs`:

| Tree | Ceiling | Result |
|---|---|---|
| main tip `1cd64b8c9` | 740 KB (before) | **FAIL** -- `t` 740.00 KB over by 4 B |
| main tip `1cd64b8c9` | 777 KB (this PR) | PASS -- 805 chunks within budget |

And the number is load-bearing rather than cosmetic: putting the ceiling back to 740 KB on the same built tree fails again, which also confirms no other chunk is riding near its own budget and being masked.

## Related Issues

Found while driving another PR's checks; that PR is blocked by this and carries the same evidence in its own thread. This fix is deliberately separate because the defect is main's, not that branch's, and merging it unblocks every open PR rather than one.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **a ceiling with a stale `measured` note converts into a tripwire that fires on the next unrelated PR.** A budget whose recorded measurement is far below the current true value has no headroom left, so the first PR to add any byte to that chunk inherits a failure it did not cause -- and the check names that PR's chunk, so the misattribution is the default reading.

The generalizable part is the diagnostic, not the bump: when a ceiling fails by a handful of bytes, build the BASE and the branch and compare the chunk's content hash before touching the number. Identical hashes on both sides prove the branch is not the cause, and reproducing the failure on the base tree alone proves where it belongs. This entry has now gone stale twice; the 5% headroom convention is what keeps the third time from happening.
