### PR TITLE
test: scrub inherited shell-preload env from every test (#8395)

### DIFF
--- a/AUTOSDE.yaml
+++ b/AUTOSDE.yaml
@@ -266,7 +266,9 @@ custom-rules:
         host service mutation, pins KIROCREW_HOME per test (with
         `config.paths._resolved_home` reset, since resolving the home CREATES it
         and can run the legacy migration), pins the import-time `~/.kiro`
-        bindings via `_isolate_shared_kiro_paths`, pins the SEL default dir
+        bindings via `_isolate_shared_kiro_paths`, scrubs the inherited
+        shell-preload and exported-function variables `name_grant` refuses on
+        (`BASH_ENV`/`ENV`/..., `BASH_FUNC_*`), pins the SEL default dir
         session-wide, redirects `tempfile`'s base with residue reported, and
         fails the run on residue at the repository root.
       - `test/conftest.py` adds ~20 MORE autouse fixtures, and it applies ONLY to

--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ test collected from any testpath, because what they protect is the
 developer's machine rather than the correctness of one suite. Everything that is
 merely suite-specific isolation stays in ``test/conftest.py``.
 
-The floor has seven parts, and each one exists because the "remember to isolate
+The floor has eight parts, and each one exists because the "remember to isolate
 this" contract failed at least once:
 
 * **Services.** ``$XDG_CONFIG_HOME`` is redirected and the stdlib spawn funnels
@@ -29,6 +29,14 @@ this" contract failed at least once:
   ``JIRA_TOKEN_<HEX>`` keys are restored after every test, so a fabricated
   ``.env`` cannot silently override the next test's credentials in the same
   worker.
+* **The inherited shell environment.** The entries ``name_grant`` refuses as
+  inherited preloads are removed for each test's duration and restored
+  afterwards: the ``_ENV_PRELOAD_VARS`` names (``BASH_ENV``, ``ENV``, ...) and
+  exported bash functions (``BASH_FUNC_*`` keys, or the legacy bare-name
+  spelling whose value starts with ``() {``). RHEL-family hosts export ``which``
+  as a function from ``/etc/profile.d/which2.sh``, and that refusal is checked
+  before every narrower code, so 79 of 163 name-grant tests observed the wrong
+  refusal on those hosts while Ubuntu CI stayed green (issue #8395).
 * **The agent-spec home.** ``kiro_agents_dir()`` is a LAZY resolver, so neither of
   the two above reaches it, and a test that reaches the spec write path rewrites
   the machine-wide ``<kiro home>/agents/kirocrew.json`` -- the file that decides
@@ -559,6 +567,82 @@ def _no_credential_env_residue():
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = before[key]
+
+
+@pytest.fixture(autouse=True)
+def _scrub_inherited_preload_env(monkeypatch):
+    """Hide the entries ``name_grant`` refuses as inherited preloads, then restore them.
+
+    RHEL-family distributions (Amazon Linux 2023, RHEL, CentOS Stream, Fedora) ship
+    ``/etc/profile.d/which2.sh``, which exports ``which`` as a shell function -- so
+    ``BASH_FUNC_which%%`` sits in ``os.environ`` of any login shell before pytest even
+    starts. ``name_grant._inherited_preload()`` fires its AMBIGUOUS_ENV refusal on
+    exactly that shape, and that refusal is checked before every narrower code, so on
+    such a host 79 of the 163 tests in ``test/test_name_grant.py`` observed
+    ``inherited_env_can_redefine_programs`` instead of the code they assert, while
+    Ubuntu CI (no ``which2.sh``) stayed green (issue #8395). The detector's OTHER half
+    is host state just as easily: a login profile exporting ``BASH_ENV``, or a
+    container image setting ``ENV``, reproduces the same failure shape with no
+    ``which2.sh`` anywhere. The PRODUCT behaviour is correct -- an inherited preload
+    genuinely can redefine a program the agent runs -- the gap was that this floor
+    pins the data home, the credential env and the temp base, but not the environment
+    the run inherited.
+
+    The predicate is IMPORTED from ``name_grant`` rather than restated, so the scrub
+    and the detector cannot drift apart, and it mirrors BOTH halves the detector
+    checks: the ``_ENV_PRELOAD_VARS`` names (matched truthy, exactly as the detector's
+    ``os.environ.get(var)`` reads them -- an empty value triggers no refusal and is
+    left alone), and the exported-function pair (the ``BASH_FUNC_`` key prefix, plus
+    the legacy bare-name spelling whose value starts with ``() {``). It is also
+    deliberately no WIDER than that predicate: this is not a general "no exported
+    functions" floor -- how wide the detector should be is ``name_grant``'s design
+    question, and the scrub merely mirrors its answer. The import is deliberately
+    UNGUARDED, like ``_no_credential_env_residue``'s: an ImportError escape hatch
+    would disarm the scrub silently on a broken checkout and hand back the exact
+    79-failure pattern this fixture exists to remove, as a wall of wrong refusal
+    codes instead of one clear error.
+
+    The removals are recorded on the test's shared ``monkeypatch`` instance rather
+    than hand-rolled, and that is load-bearing, not convenience. Same-scope autouse
+    fixtures are ordered so that OTHER monkeypatch users run first (alphabetically in
+    practice), so a hand-rolled save/restore here tears down BEFORE monkeypatch's
+    undo -- and for a test that ``monkeypatch.setenv``-overrides the SAME key the
+    host inherited (recorded "was absent", because this scrub had removed it), the
+    undo then deletes the inherited value the hand-rolled restore had just put back,
+    leaking the removal out of the test. On one shared undo stack the nesting is
+    correct BY CONSTRUCTION: the test's later record is undone first (its delete
+    tolerates the key already being gone), then this fixture's ``delenv`` record
+    restores the inherited value. ``test_name_grant.py::TestInheritedHostEnvironment``
+    pins exactly that same-key case, and
+    ``test_host_isolation_floor.py::TestInheritedShellEnvironmentIsScrubbed`` drives
+    one real cycle of this fixture directly.
+
+    The deliberate AMBIGUOUS_ENV tests lose nothing: they construct their entries
+    inside the test body, after the scrub. The teardown sweep below is the
+    ``_no_credential_env_residue`` half of the contract: a matching entry still
+    present at teardown is either a raw ``os.environ`` write (no undo record --
+    swept here, stays gone) or a monkeypatch-managed one (its undo re-deletes
+    tolerantly or restores what it recorded), so nothing this fixture scrubbed and
+    nothing a test leaked survives past the test on this worker.
+    """
+    from kiro_crew.name_grant import (
+        _BASH_FUNC_KEY_PREFIX,
+        _BASH_FUNC_VALUE_PREFIX,
+        _ENV_PRELOAD_VARS,
+    )
+
+    def _is_inherited_preload(key: str, value: str) -> bool:
+        if key in _ENV_PRELOAD_VARS:
+            return bool(value)
+        return key.startswith(_BASH_FUNC_KEY_PREFIX) or value.startswith(_BASH_FUNC_VALUE_PREFIX)
+
+    for key in [k for k, v in os.environ.items() if _is_inherited_preload(k, v)]:
+        monkeypatch.delenv(key)
+    try:
+        yield
+    finally:
+        for key in [k for k, v in os.environ.items() if _is_inherited_preload(k, v)]:
+            os.environ.pop(key, None)
 
 
 @pytest.fixture(autouse=True)

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -134,7 +134,12 @@ The **rootdir `conftest.py` is the host-mutation floor**: everything in it prote
 developer's machine rather than the correctness of one suite, so it holds for all
 testpaths. It pins `$XDG_CONFIG_HOME` and the launchd paths, traps the spawn
 funnels against service mutation, pins `KIROCREW_HOME` and the import-time `~/.kiro`
-bindings, redirects `tempfile`'s base, and fails the run on residue in the checkout.
+bindings, scrubs the inherited shell-preload and exported-function variables
+`name_grant` refuses on (`BASH_ENV`/`ENV`/`SHELLOPTS`/`BASHOPTS`, `BASH_FUNC_*` keys,
+and the legacy `() {` value spelling — a RHEL-family host inherits `BASH_FUNC_which%%`
+from `which2.sh`, and the refusal outranks every narrower code), redirects
+`tempfile`'s base, and fails the run on residue in the
+checkout.
 
 It also pins the other real host paths a test must not reach: the subagent registry (a
 running gateway sweeps stray entries there as orphans), the 610MB embedding-model

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -833,6 +833,72 @@ class TestDynamicCredentialEnvironmentIsRestored:
         assert "JIRA_TOKEN_AABBCC" not in os.environ
 
 
+class TestInheritedShellEnvironmentIsScrubbed:
+    """The entries ``name_grant`` refuses as inherited preloads are hidden per test.
+
+    On a RHEL-family host ``which2.sh`` puts ``BASH_FUNC_which%%`` in every login
+    shell's environment, and ``name_grant``'s AMBIGUOUS_ENV refusal -- checked before
+    every narrower code -- then rewrote what 79 unrelated assertions observed
+    (issue #8395). The scrub under test is ``conftest._scrub_inherited_preload_env``,
+    driven directly (see ``_autouse_floor_generator``); the domain-level regression
+    lives in ``test_name_grant.py::TestInheritedHostEnvironment``, but only this
+    direct drive survives ``autouse=True`` being dropped or the restore half being
+    lost, because it asserts the marker and both halves of one real cycle.
+    """
+
+    def test_this_test_starts_without_the_injected_entries(self) -> None:
+        """True on every host: the live scrub hides even a genuinely inherited entry."""
+        assert "BASH_FUNC_kcfloor%%" not in os.environ
+        assert "BASH_ENV" not in os.environ
+
+    def test_an_inherited_entry_is_scrubbed_then_restored_by_one_cycle(self) -> None:
+        """One full cycle of the real fixture: inject first, so it reads as inherited.
+
+        The fixture records its removals on the monkeypatch instance it is handed,
+        so the restore under test is that instance's ``undo`` -- driven explicitly
+        here, exactly as pytest drives the shared per-test instance after every
+        fixture teardown. A failure part-way cannot leak the entries past this
+        test: the live autouse instance of the same fixture wraps this test too,
+        and its teardown sweep removes matching entries its own snapshot never saw.
+        """
+        mp = pytest.MonkeyPatch()
+        os.environ["BASH_FUNC_kcfloor%%"] = "() { :; }"
+        os.environ["BASH_ENV"] = "/etc/kc-floor-rc"
+        try:
+            cycle = _autouse_floor_generator("_scrub_inherited_preload_env")(mp)
+            next(cycle)  # the floor's setup: the scrub under test
+            assert "BASH_FUNC_kcfloor%%" not in os.environ
+            assert "BASH_ENV" not in os.environ
+            with pytest.raises(StopIteration):
+                next(cycle)  # the floor's teardown sweep: inherited keys stay absent
+            assert "BASH_FUNC_kcfloor%%" not in os.environ
+            mp.undo()  # the restore under test: rides the monkeypatch undo stack
+            assert os.environ.get("BASH_FUNC_kcfloor%%") == "() { :; }"
+            assert os.environ.get("BASH_ENV") == "/etc/kc-floor-rc"
+        finally:
+            mp.undo()
+            os.environ.pop("BASH_FUNC_kcfloor%%", None)
+            os.environ.pop("BASH_ENV", None)
+
+    def test_an_entry_leaked_during_a_test_is_swept_by_the_floors_own_teardown(self) -> None:
+        """The sweep half: a raw write that appeared mid-test does not leak on."""
+        mp = pytest.MonkeyPatch()
+        try:
+            cycle = _autouse_floor_generator("_scrub_inherited_preload_env")(mp)
+            next(cycle)  # the floor's setup: nothing inherited, nothing recorded
+
+            os.environ["BASH_FUNC_kcfloor%%"] = "() { leaked; }"
+
+            with pytest.raises(StopIteration):
+                next(cycle)  # the floor's teardown: the sweep under test
+            assert "BASH_FUNC_kcfloor%%" not in os.environ
+            mp.undo()  # no record for a raw write, so the sweep's removal stands
+            assert "BASH_FUNC_kcfloor%%" not in os.environ
+        finally:
+            mp.undo()
+            os.environ.pop("BASH_FUNC_kcfloor%%", None)
+
+
 # ── the logging record factory ─────────────────────────────────────────────
 
 

--- a/test/test_name_grant.py
+++ b/test/test_name_grant.py
@@ -988,6 +988,98 @@ class TestDispatchers:
         assert name_grant.name_grant_refusal("head file") is None
 
 
+class TestInheritedHostEnvironment:
+    """The rootdir conftest scrubs the inherited entries name_grant refuses on.
+
+    RHEL-family hosts export ``which`` as a shell function from
+    ``/etc/profile.d/which2.sh``, so ``BASH_FUNC_which%%`` is inherited by every
+    login shell -- and the AMBIGUOUS_ENV refusal above is checked before every
+    narrower code, so without the scrub 79 of the 163 tests in this file observed
+    ``inherited_env_can_redefine_programs`` instead of the code they assert
+    (issue #8395). ``_inherited_preload()``'s OTHER half is host state just as
+    easily: a login profile exporting ``BASH_ENV``, or a container image setting
+    ``ENV``, reproduces the same shape with no ``which2.sh`` anywhere. Ubuntu CI
+    carries neither, which is why this class injects both itself: the defect has
+    to be reproducible everywhere, not only on the hosts that revealed it.
+    """
+
+    _RHEL_KEY = "BASH_FUNC_which%%"
+    _RHEL_VALUE = "() {  ( alias; eval ${which_declare} ) | /usr/bin/which $@; }"
+    _PRELOAD_KEY = "BASH_ENV"
+    _PRELOAD_VALUE = "/etc/kc-inherited-rc"
+
+    @pytest.fixture(scope="class")
+    def _inherited_shell_environment(self):
+        """Make the variables INHERITED state, not something the test created.
+
+        Class-scoped on purpose: pytest instantiates higher-scoped fixtures
+        first, so this runs before the function-scoped autouse scrub in the
+        rootdir conftest -- both variables are already in the environment when
+        the scrub looks, exactly as a login shell's exports are. The deliberate
+        AMBIGUOUS_ENV tests above are the opposite shape: they construct their
+        entries inside the test body, AFTER the scrub, which is why a global
+        scrub costs them nothing. Raw ``os.environ`` rather than ``monkeypatch``
+        because the built-in monkeypatch fixture is function-scoped.
+
+        The teardown asserts the variables are BACK before putting the host's own
+        values back: the scrub's contract is save-and-restore, and the restore half
+        is observable only here, after the last test's own fixtures -- monkeypatch's
+        undo included -- have finished. The prior values are snapshotted first, so a
+        worker on a genuinely RHEL-family host keeps its real export: what this
+        fixture injects is removed, what the host actually had is restored.
+        """
+        saved = {key: os.environ.get(key) for key in (self._RHEL_KEY, self._PRELOAD_KEY)}
+        os.environ[self._RHEL_KEY] = self._RHEL_VALUE
+        os.environ[self._PRELOAD_KEY] = self._PRELOAD_VALUE
+        try:
+            yield
+        finally:
+            missing = [key for key in (self._RHEL_KEY, self._PRELOAD_KEY) if key not in os.environ]
+            for key, prior in saved.items():
+                if prior is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = prior
+            assert not missing, (
+                "the conftest scrub removed these inherited entries but did not "
+                f"restore them after the test: {missing}"
+            )
+
+    def test_a_narrower_code_survives_an_inherited_hostile_environment(
+        self, _inherited_shell_environment, world
+    ):
+        # With the rootdir scrub disabled this fails three times over: both
+        # variables are still visible here, and the refusal below comes back
+        # AMBIGUOUS_ENV -- the broadest code, checked first -- instead of the
+        # DISPATCHER code this command actually earns. That inversion is the
+        # whole issue: one host-inherited variable rewrote what 79 unrelated
+        # assertions saw.
+        assert self._RHEL_KEY not in os.environ
+        assert self._PRELOAD_KEY not in os.environ
+        system_dir, _ = world
+        _program(system_dir, "env")
+        _program(system_dir, "head")
+        refusal = name_grant.name_grant_refusal("env head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.DISPATCHER
+
+    def test_a_monkeypatched_same_key_does_not_defeat_the_restore(
+        self, _inherited_shell_environment, monkeypatch
+    ):
+        # The teardown-ordering trap: this test overrides the SAME key the host
+        # inherited. The scrub removed it first, so monkeypatch records "was
+        # absent" and its undo DELETES the key -- the inherited value survives
+        # only because the scrub records its removals on the same shared
+        # monkeypatch instance, whose LIFO undo deletes this override first and
+        # restores the inherited value after. A hand-rolled restore in the
+        # scrub would run BEFORE monkeypatch's undo and be deleted by it. The
+        # class fixture's teardown assertion is the observer that fails when
+        # the inherited entry leaks out of the worker's environment.
+        assert self._RHEL_KEY not in os.environ
+        monkeypatch.setenv(self._RHEL_KEY, "() { overridden; }")
+        assert os.environ[self._RHEL_KEY] == "() { overridden; }"
+
+
 class TestInterpreterChain:
     """A pinned script binds its bytes; its interpreter must face the same rules."""
 


### PR DESCRIPTION
## Problem / Motivation

On any RHEL-family host (Amazon Linux 2023, RHEL, CentOS Stream, Fedora), `/etc/profile.d/which2.sh` exports `which` as a bash function, so `BASH_FUNC_which%%` sits in `os.environ` of every login shell. `name_grant._inherited_preload()` fires its `AMBIGUOUS_ENV` refusal on that inherited variable, and that refusal is checked before every narrower code — so 79 of 163 tests in `test/test_name_grant.py` that assert *other* refusal codes observe `inherited_env_can_redefine_programs` instead and fail. The reporter proved causality: unsetting that one variable takes the suite from 79-failed to 163-passed on the same commit and host. Ubuntu CI carries no `which2.sh`, which is why CI stays green while every RHEL-family contributor sees a red wall.

## Why it matters

Any contributor on a RHEL-family workstation cannot run the name-grant suite (and by extension `python -m pytest`) clean, and the failure shape — 79 wrong refusal *codes*, no traceback pointing at the cause — reads like a broken product, not a test-isolation gap. The detector's other half is host state just as easily: a profile exporting `BASH_ENV` or a container image setting `ENV=…` reproduces the identical shape with no `which2.sh` anywhere. The product behaviour is correct (an exported `which` genuinely can redefine a program the agent runs); only the tests were unprotected.

## What changed (motivation → approach → change)

Symptom → root cause: the rootdir `conftest.py` host floor pins the data home, credential env, and tempfile base, but not the *inherited environment*, so a host-level export outranked every narrower assertion in the suite.

Approach: scrub exactly what the detector refuses — no more, no less. The new autouse fixture `_scrub_inherited_preload_env` (rootdir `conftest.py`, beside the credential-env floor) hides every entry matching `name_grant`'s own predicate for each test's duration, with both halves imported from the module so scrub and detector cannot drift apart: the `_ENV_PRELOAD_VARS` names (`BASH_ENV`/`ENV`/`SHELLOPTS`/`BASHOPTS`, matched truthy exactly as the detector reads them) and the exported-function pair (`BASH_FUNC_` key prefix, legacy `() {` value prefix). Deliberately no wider: how wide the detector should be is `name_grant`'s design question (reporter's open question 2 is left to maintainers).

Mechanism detail that pre-push review forced: the removals are recorded on the test's shared `monkeypatch` instance rather than hand-rolled. Same-scope autouse fixtures order other monkeypatch users first, so a hand-rolled restore tears down *before* monkeypatch's undo — and a test that `monkeypatch.setenv`-overrides the same key the host inherited (recorded "was absent", because the scrub removed it) would have that undo delete the just-restored inherited value, leaking the removal out of the test. One shared LIFO undo stack makes the nesting correct by construction; a teardown sweep keeps raw `os.environ` writes from leaking forward. The deliberate `AMBIGUOUS_ENV` tests (`test_name_grant.py:913-965`) lose nothing — they construct their entries inside the test body, after the scrub, and still pass.

Docs updated in the same commit: the conftest module docstring (floor is now eight parts), `docs/system-specs/common/testing-conventions.md`'s floor enumeration, and the `no-test-side-effects` rule's floor enumeration in `AUTOSDE.yaml`.

## Tests

- `test_name_grant.py::TestInheritedHostEnvironment::test_a_narrower_code_survives_an_inherited_hostile_environment` — injects `BASH_FUNC_which%%` *and* `BASH_ENV` as genuinely inherited state (class-scoped fixture, instantiated before the function-scoped scrub) and asserts a dispatcher scenario keeps its own `DISPATCHER` code. Mutation-verified: with the scrub predicate disabled it fails on the visibility asserts, and the whole file reproduces the reported shape (80 failed / 84 passed).
- `…::test_a_monkeypatched_same_key_does_not_defeat_the_restore` — pins the same-key teardown-ordering trap; the class fixture's teardown assertion observes that the inherited values survived the test. Fails under a hand-rolled-restore implementation (reproduced empirically before switching to the shared-undo-stack design).
- `test_host_isolation_floor.py::TestInheritedShellEnvironmentIsScrubbed` (3 tests) — drives one real cycle of the fixture directly per the floor convention (`_autouse_floor_generator` asserts `autouse` is still armed), covering scrub, restore-via-undo, and the raw-leak sweep.
- Full `test/test_name_grant.py`: 165 passed clean AND under an injected hostile environment (`BASH_FUNC_which%%` + `BASH_ENV` + `ENV` + `SHELLOPTS`), which failed 80 tests before the fix.

## Manual verification

Full local gate run: isort, flake8, mypy (1279 files), black + subprocess-encoding ratchets, docs-lint, brand check, and the complete pytest suite (84,847 passed; the residual fail set is byte-identical to a pre-change stash control on the same host — all pre-existing host quirks: long-TMPDIR `AF_UNIX` limits and `/local/home` symlink resolution, none in the changed files' domains).

## Related Issues

Closes #8395

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a per-test env save/restore fixture that hand-rolls its teardown races `monkeypatch`'s undo — same-scope autouse ordering puts other monkeypatch users first, so a same-key `monkeypatch.setenv` undo deletes the hand-restored value; record removals on the shared monkeypatch instance instead so nesting is LIFO by construction"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
