### PR TITLE
test: scrub inherited program preloads in rootdir conftest (#8395)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,7 @@ test collected from any testpath, because what they protect is the
 developer's machine rather than the correctness of one suite. Everything that is
 merely suite-specific isolation stays in ``test/conftest.py``.
 
-The floor has seven parts, and each one exists because the "remember to isolate
+The floor has eight parts, and each one exists because the "remember to isolate
 this" contract failed at least once:
 
 * **Services.** ``$XDG_CONFIG_HOME`` is redirected and the stdlib spawn funnels
@@ -29,6 +29,12 @@ this" contract failed at least once:
   ``JIRA_TOKEN_<HEX>`` keys are restored after every test, so a fabricated
   ``.env`` cannot silently override the next test's credentials in the same
   worker.
+* **The inherited environment.** The preloads ``name_grant`` refuses as making a
+  name-based grant unsound -- ``BASH_ENV``/``ENV``/``SHELLOPTS``/``BASHOPTS`` and
+  exported shell functions (``BASH_FUNC_*`` keys, legacy ``() {`` values) -- are
+  scrubbed per test, mirroring the module's own predicate. Without this a
+  RHEL-family host's ``/etc/profile.d/which2.sh`` export of ``BASH_FUNC_which%%``
+  turned 79/163 ``test_name_grant.py`` tests red while Ubuntu CI stayed green.
 * **The agent-spec home.** ``kiro_agents_dir()`` is a LAZY resolver, so neither of
   the two above reaches it, and a test that reaches the spec write path rewrites
   the machine-wide ``<kiro home>/agents/kirocrew.json`` -- the file that decides
@@ -1835,6 +1841,70 @@ def _isolate_kirocrew_home(_isolation_dirs, monkeypatch):
     paths = sys.modules.get("kiro_crew.config.paths")
     if paths is not None:
         monkeypatch.setattr(paths, "_resolved_home", None, raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_inherited_program_preloads(monkeypatch):
+    """Strip the inherited env that makes ``name_grant``'s name-based grant unsound.
+
+    ``name_grant._inherited_preload()`` refuses a command as ``AMBIGUOUS_ENV``
+    (``inherited_env_can_redefine_programs``) whenever the process environment
+    carries a preload that can redefine a program name a child shell will resolve:
+    a ``_ENV_PRELOAD_VARS`` member (``BASH_ENV``/``ENV``/``SHELLOPTS``/``BASHOPTS``),
+    or an EXPORTED SHELL FUNCTION (a key with the ``BASH_FUNC_`` prefix, or the
+    pre-2014 spelling where the bare-named key's VALUE starts with ``() {``). That
+    refusal is checked BEFORE the narrower ones, so it wins whenever it fires.
+
+    This belongs on the floor because the poison is the OPERATOR'S shell, not a
+    test's doing. ``/etc/profile.d/which2.sh`` defines and exports ``which`` as a
+    shell function on every RHEL-family distribution, so ``BASH_FUNC_which%%`` sits
+    in ``os.environ`` for any login shell on Amazon Linux 2023, RHEL, CentOS Stream
+    and Fedora. That single inherited variable made 79 of the 163 tests in
+    ``test/test_name_grant.py`` fail on those hosts -- each asserting on a specific
+    narrower code and receiving ``AMBIGUOUS_ENV`` instead -- while GitHub Actions'
+    Ubuntu runners, which ship no ``which2.sh``, saw an empty ``BASH_FUNC_*`` and
+    stayed green. The production behaviour is correct; what was missing was host
+    isolation of the inherited environment, one scope down from the process-global
+    poisoning the rest of this floor already pins.
+
+    It mirrors ``name_grant``'s own two-sided predicate by IMPORTING the constants
+    rather than re-hardcoding them, so the pin tracks the predicate: if the module
+    grows a new preload var or changes a prefix, the scrub follows without an edit
+    here. It deliberately removes EXACTLY what ``name_grant`` refuses -- no more --
+    rather than asserting a broader "no exported functions of any shape" floor:
+    whether a zsh/ksh or container-runtime encoding deserves the same treatment, and
+    whether the pin should widen to a shell-agnostic rule, is a call left to
+    maintainers.
+
+    Removal rides the shared monkeypatch undo stack (``monkeypatch.delenv``) rather
+    than a manual ``os.environ.pop`` with ``yield``/``finally``. That is required,
+    not stylistic: a test that deliberately sets one of these with
+    ``monkeypatch.setenv`` (see ``TestInheritedHostEnvironment`` in
+    ``test/test_name_grant.py``) runs AFTER this autouse setup, so its value wins for
+    its own duration, and when its patch reverts the key returns to the SCRUBBED
+    (absent) state instead of the operator's original export -- a same-key override
+    inside a test can never leak the removal back out.
+
+    Imports ``kiro_crew.name_grant`` in the body, wrapped in ``try``/``except
+    ImportError`` with an early return, like the other rootdir fixtures: module-level
+    imports here are stdlib + pytest only (see the top docstring), and a partial
+    checkout must not break collection.
+    """
+    try:
+        from kiro_crew.name_grant import (
+            _BASH_FUNC_KEY_PREFIX,
+            _BASH_FUNC_VALUE_PREFIX,
+            _ENV_PRELOAD_VARS,
+        )
+    except ImportError:  # pragma: no cover - a partial checkout must not break collection
+        return
+    for var in _ENV_PRELOAD_VARS:
+        monkeypatch.delenv(var, raising=False)
+    # Snapshot before mutating: monkeypatch.delenv pops from os.environ, so
+    # iterating the live mapping would be a mutate-during-iteration.
+    for key, value in list(os.environ.items()):
+        if key.startswith(_BASH_FUNC_KEY_PREFIX) or value.startswith(_BASH_FUNC_VALUE_PREFIX):
+            monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/docs/system-specs/common/testing-conventions.md
+++ b/docs/system-specs/common/testing-conventions.md
@@ -134,7 +134,17 @@ The **rootdir `conftest.py` is the host-mutation floor**: everything in it prote
 developer's machine rather than the correctness of one suite, so it holds for all
 testpaths. It pins `$XDG_CONFIG_HOME` and the launchd paths, traps the spawn
 funnels against service mutation, pins `KIROCREW_HOME` and the import-time `~/.kiro`
-bindings, redirects `tempfile`'s base, and fails the run on residue in the checkout.
+bindings, redirects `tempfile`'s base, scrubs the inherited environment `name_grant`
+refuses as an unsound name grant, and fails the run on residue in the checkout.
+
+That last pin (`_scrub_inherited_program_preloads`) removes the `BASH_FUNC_*` exported
+shell functions and the `BASH_ENV`/`ENV`/`SHELLOPTS`/`BASHOPTS` preloads that
+`name_grant._inherited_preload()` refuses as `inherited_env_can_redefine_programs`,
+mirroring both halves of that predicate by importing its constants rather than
+re-hardcoding them. RHEL-family hosts export `BASH_FUNC_which%%` from
+`/etc/profile.d/which2.sh` into every login shell, so that refusal fired for reasons the
+test never set: 79 of 163 `test_name_grant.py` tests failed on Amazon Linux 2023 while
+Ubuntu CI, which ships no `which2.sh`, stayed green.
 
 It also pins the other real host paths a test must not reach: the subagent registry (a
 running gateway sweeps stray entries there as orphans), the 610MB embedding-model

--- a/test/test_host_isolation_floor.py
+++ b/test/test_host_isolation_floor.py
@@ -1469,3 +1469,90 @@ class TestTheWorkerBudgetIsMemoryBounded:
         monkeypatch.setattr("builtins.open", _fake_cgroup)
 
         assert budget._cgroup_limit_mib() == 8 * 1024
+
+
+# ── the inherited environment ──────────────────────────────────────────────
+
+
+class TestInheritedProgramPreloadsAreScrubbed:
+    """The inherited environment ``name_grant`` refuses as an unsound name grant.
+
+    ``name_grant._inherited_preload()`` reads the process environment for anything
+    that can redefine a program a child shell will resolve -- a ``_ENV_PRELOAD_VARS``
+    member (``BASH_ENV``/``ENV``/``SHELLOPTS``/``BASHOPTS``), or an EXPORTED SHELL
+    FUNCTION (a ``BASH_FUNC_``-prefixed key, or the pre-2014 spelling whose value
+    starts with ``() {``) -- and that refusal is checked before the narrower ones.
+    On any RHEL-family host ``/etc/profile.d/which2.sh`` exports ``BASH_FUNC_which%%``
+    into every login shell, so the check fired for reasons the test never set: 79 of
+    163 ``test_name_grant.py`` tests failed on Amazon Linux 2023 while Ubuntu CI, which
+    ships no ``which2.sh``, stayed green. The rootdir conftest's
+    ``_scrub_inherited_program_preloads`` removes exactly that set per test.
+
+    The same two jobs the rest of this file uses:
+
+    * **Behaviour** -- the floor is armed (``_inherited_preload()`` is ``None`` inside a
+      normal test even on a host that carries ``BASH_FUNC_which%%`` natively), and it is
+      a net rather than a cage (a test that sets one of these itself still observes the
+      refusal within its own body).
+    * **Ratchet** -- pin the scrubbed set against ``name_grant``'s own predicate
+      constants, the exact symbols the fixture imports, so a rename that would silently
+      un-pin the floor surfaces here instead.
+    """
+
+    def test_the_floor_leaves_no_inherited_preload_for_a_normal_test(self) -> None:
+        """After the autouse floor has run, the predicate finds nothing to refuse.
+
+        This is the whole point of the pin, asserted through ``name_grant``'s own
+        reader rather than a re-implementation of it: none of ``_ENV_PRELOAD_VARS`` is
+        present, no key carries the ``BASH_FUNC_`` prefix, and no value starts with
+        ``() {`` -- so a name-based grant in an unrelated test is decided on its merits,
+        not on whatever the operator's login shell happened to export.
+        """
+        from kiro_crew import name_grant
+
+        assert name_grant._inherited_preload() is None, (
+            "the inherited-environment floor did not fire: os.environ still carries a "
+            "preload name_grant refuses as unsound (e.g. a RHEL-family "
+            "BASH_FUNC_which%% from /etc/profile.d/which2.sh)"
+        )
+
+    def test_a_test_can_still_set_a_preload_and_observe_the_refusal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The floor is a safety net, not a cage: a test that injects one still wins.
+
+        ``monkeypatch.setenv`` runs in the test body, after the autouse scrub, and
+        reverts independently -- so a test that deliberately exercises the
+        inherited-preload path sees the refusal for its own duration without leaking
+        the variable to the next test. This is what lets ``test_name_grant.py``'s
+        deliberate ``BASH_FUNC_which%%`` regression test exist alongside a floor that
+        otherwise removes it.
+        """
+        from kiro_crew import name_grant
+
+        monkeypatch.setenv("BASH_FUNC_x%%", "() { echo hi; }")
+
+        assert name_grant._inherited_preload() is not None, (
+            "a preload set inside the test body was not observed -- the floor is "
+            "removing what the test itself set, i.e. it is a cage not a net"
+        )
+
+    def test_the_scrubbed_set_tracks_name_grants_predicate_constants(self) -> None:
+        """A rename of the predicate must surface here, not silently un-pin the floor.
+
+        The fixture imports these three symbols from ``kiro_crew.name_grant`` rather
+        than re-hardcoding them, precisely so the pin cannot drift from the predicate it
+        exists to mirror. This ratchets their shape: rename or re-spell one and the
+        fixture would go on removing a set that no longer matches what ``name_grant``
+        refuses, with nothing red -- so it is pinned against the same symbols here, the
+        way ``TestTheSharedKiroPathRatchet`` pins the ``~/.kiro`` set against ``src/``.
+        """
+        from kiro_crew.name_grant import (
+            _BASH_FUNC_KEY_PREFIX,
+            _BASH_FUNC_VALUE_PREFIX,
+            _ENV_PRELOAD_VARS,
+        )
+
+        assert _BASH_FUNC_KEY_PREFIX == "BASH_FUNC_"
+        assert _BASH_FUNC_VALUE_PREFIX == "() {"
+        assert set(_ENV_PRELOAD_VARS) >= {"BASH_ENV", "ENV", "SHELLOPTS", "BASHOPTS"}

--- a/test/test_name_grant.py
+++ b/test/test_name_grant.py
@@ -1228,3 +1228,50 @@ class TestHookTierIsUntouched:
             "Running: gh pr view 1", command="gh pr view 1", is_shell=True
         )
         assert result.action == TOOL_AUTO_APPROVE
+
+
+class TestInheritedHostEnvironment:
+    """The AMBIGUOUS_ENV refusal must still be reachable AFTER the host scrub.
+
+    The rootdir ``conftest._scrub_inherited_program_preloads`` removes exactly the
+    entries ``name_grant`` refuses as inherited preloads (both ``_ENV_PRELOAD_VARS``
+    and the exported-shell-function pair) from ``os.environ`` for every test, so the
+    suite is host-independent: ``/etc/profile.d/which2.sh`` exports
+    ``BASH_FUNC_which%%`` on every RHEL-family host, and before the scrub that lone
+    variable turned 79/163 tests in this file red (the early AMBIGUOUS_ENV refusal
+    fired ahead of the narrower code each test asserted on) while Ubuntu CI, which
+    has no ``which2.sh``, stayed green.
+
+    Scrubbing globally means no OTHER test exercises the inherited-preload path as an
+    ambient-environment case any more, so this class owns that coverage deliberately.
+    Each test sets the variable ITSELF, with ``monkeypatch.setenv`` running after the
+    autouse scrub, so the refusal is genuinely exercised rather than depending on
+    whatever the host shell happened to export -- and so the test reads the same on a
+    RHEL host, on Ubuntu, and in CI.
+    """
+
+    def test_the_native_rhel_which_function_export_refuses(self, world, monkeypatch):
+        # The exact spelling `/etc/profile.d/which2.sh` exports on Amazon Linux,
+        # RHEL, CentOS Stream and Fedora. The autouse conftest scrub removed it (if
+        # the host carried it at all), so setting it here is what puts the suite
+        # back into the poisoned state on purpose. `head` still resolves to a
+        # system binary, so the ONLY reason this refuses is the inherited function.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head file") is None
+        monkeypatch.setenv("BASH_FUNC_which%%", "() { echo hi; }")
+        refusal = name_grant.name_grant_refusal("head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.AMBIGUOUS_ENV
+
+    def test_an_inherited_bash_env_preload_refuses(self, world, monkeypatch):
+        # The other half of `name_grant`'s predicate: a `_ENV_PRELOAD_VARS` member
+        # arriving through the environment rather than the command line. Also
+        # scrubbed by the conftest floor, so this test re-injects it deliberately.
+        system_dir, _ = world
+        _program(system_dir, "head")
+        assert name_grant.name_grant_refusal("head file") is None
+        monkeypatch.setenv("BASH_ENV", "/writable/rc")
+        refusal = name_grant.name_grant_refusal("head file")
+        assert refusal is not None
+        assert refusal.code == name_grant.AMBIGUOUS_ENV


### PR DESCRIPTION
## Summary

Fixes #8395. `test/test_name_grant.py` failed 79/163 tests on any RHEL-family host (Amazon Linux 2023, RHEL, CentOS Stream, Fedora) because `/etc/profile.d/which2.sh` exports `BASH_FUNC_which%%` into every login shell. `name_grant._inherited_preload()` correctly refuses such a command as `AMBIGUOUS_ENV` (`inherited_env_can_redefine_programs`), and that broad refusal fires ahead of the narrower ones, so every test asserting a different code got this one instead. Ubuntu CI has no `which2.sh`, so `BASH_FUNC_*` is absent and the suite stayed green there.

This is a **test-isolation gap, not a production defect** — `name_grant` is doing the right thing. The rootdir `conftest.py` already pins `KIROCREW_HOME`, the `~/.kiro` bindings, the SEL dir and `tempfile`'s base, but it did not pin the inherited environment.

## Change

- **`conftest.py`**: new autouse, function-scoped fixture `_scrub_inherited_program_preloads(monkeypatch)`, placed alongside the existing host-mutation-floor pins. It **imports** `_ENV_PRELOAD_VARS`, `_BASH_FUNC_KEY_PREFIX`, `_BASH_FUNC_VALUE_PREFIX` from `kiro_crew.name_grant` and removes matching entries via `monkeypatch.delenv(..., raising=False)` — both halves of name_grant's own two-sided predicate. Removal rides the shared monkeypatch undo stack so a same-key `setenv` inside a test reverts to the scrubbed (absent) state and cannot leak. The scrub mirrors exactly what name_grant refuses (no broader "no exported functions" assertion), leaving the zsh/ksh/container-runtime question (open question 2) to maintainers. The floor docstring was extended with a new "The inherited environment." bullet.
- **`test/test_name_grant.py`**: deliberate regression coverage (`TestInheritedHostEnvironment`) that injects `BASH_FUNC_which%%` and `BASH_ENV` respectively and asserts the exact `AMBIGUOUS_ENV` code, so the inherited-environment path is exercised on purpose (open question 1).
- **`test/test_host_isolation_floor.py`**: floor-guard tests (fixture-armed, floor-not-cage, and a ratchet pinning the predicate constants so a rename surfaces here).
- **`docs/system-specs/common/testing-conventions.md`**: a short consistent note.

Scope: exactly 4 files, ~216 insertions, no unrelated changes.

## Testing

All runs `-q --no-cov -p no:randomly` on an Amazon Linux 2023 host that carries `BASH_FUNC_which%%` natively:

- `test/test_name_grant.py`: 79 failed/84 passed pre-fix → **165 passed**.
- `test_name_grant.py` + `test_host_isolation_floor.py`: **241 passed** (plain and with injected `BASH_FUNC_which%%`).
- Truly-clean baseline (`env -u 'BASH_FUNC_which%%'`): 165 passed.
- Non-vacuity: flipping the regression test's expected code to `SHADOWED` makes it fail as expected.

## Notes for reviewers

- The value-form branch `value.startswith("() {")` scans all env values — faithful to name_grant's predicate but a wider blast radius; flagged for awareness.
- Open question 2 (is `BASH_FUNC_*` the whole set for zsh/ksh/containers) is intentionally left to maintainers; the pin mirrors the module predicate rather than inventing a broader one.
- Supersedes the earlier automated PR #8417, whose branch carried extensive unrelated scope creep (162 files, ~6200 deletions). This PR is scoped to only the isolation fix.