### PR TITLE
docs(ops): record why the ledger cursor's lenient read is safe (#7789)

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_index.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger_index.py
@@ -80,6 +80,19 @@ def _read_cursor() -> set[str]:
     A corrupt or missing cursor must degrade to "re-check everything" rather than
     "assume nothing needs importing" — the second would silently leave the index
     permanently stale.
+
+    Deliberately lenient even though this read feeds a write. Elsewhere in the
+    tree a lenient read that becomes the base of a whole-file rewrite is a
+    data-loss bug (see ``aws_control/backend/backup._read_state_for_update`` and
+    its precedents), because the rewrite publishes the empty base over state it
+    never read. Here the write is a UNION — ``_write_cursor(cursor | newly)`` —
+    so an empty base drops previously recorded ids from the cursor while
+    deleting nothing the cursor points at: the next import re-checks the
+    dropped ids and the store's case-insensitive 80-char-prefix dedupe
+    (:meth:`write_episodic`'s text-hash check, strictly broader than exact
+    equality) absorbs the repeats. Self-healing re-check is exactly the fault
+    behaviour the paragraph above asks for, so leniency is correct here and a
+    strict-for-update split would add failure modes without protecting anything.
     """
     try:
         raw = json.loads(_cursor_path().read_text(encoding="utf-8"))
@@ -164,7 +177,7 @@ def import_pending(store: Any, *, limit: int = MAX_PER_IMPORT) -> dict[str, int]
         if wrote:
             result["written"] += 1
         else:
-            # Already present (the store's own exact-text check) — cursor it so the
+            # Already present (the store's own prefix-dedup check) — cursor it so the
             # next import does not pay for the round trip again.
             result["skipped"] += 1
 


### PR DESCRIPTION
## What

Documentation-only: records in `_read_cursor`'s docstring (ops_mission_control
`ledger_index.py`) WHY its lenient read is deliberately safe despite feeding a
write, and corrects a factual misnomer in the neighbouring inline comment.

Refs #7789 (resolves the backup.py site and documents ledger_index.py; the ratchet proposal stays open)

no linked issue closing keyword: #7789 deliberately stays open — its third part
(an AST-based ratchet closing the lenient-read-feeding-rewrite class) is design
discussion that outlives both code sites.

## Why the scope is comment-only

Issue #7789 lists two sites:

1. **`aws_control/backend/backup.py`** — already fixed on main by #7618
   (`f8b3203c0`, merged 2026-09-03): `_read_state_for_update` where only a
   missing file reads as `{}`, `_StateUnreadable` naming which half failed, and
   ~400 lines of tests covering the transient-read-failure / missing-file /
   corruption / lost-write matrix. Nothing left to change there.
2. **`ops_mission_control/backend/ledger_index.py`** — the issue itself says
   the likely resolution is "a comment recording why leniency is correct here,
   not a code change". This PR is that comment.

## What the comment records

`_read_cursor` is lenient (any fault reads as an empty set) and its result
feeds `_write_cursor(cursor | newly)`. Elsewhere that shape is a data-loss bug
(#7618, #7620, #7788) because the downstream write is a whole-file rewrite that
publishes the empty base over state it never read. Here the write is a UNION,
so an empty base drops previously recorded ids from the cursor while deleting
nothing the cursor points at: the next import re-checks the dropped ids and the
store's dedupe absorbs the repeats. A strict-for-update split would add failure
modes (`_read_cursor` is called outside `import_pending`'s only try block, and
that function documents "Never raises") without protecting anything.

Both review lanes flagged the same factual error in my first draft: the store's
guard is a case-insensitive **80-char-prefix** check
(`vector_memory.write_episodic`, `LOWER(SUBSTR(text, 1, 80))`), not the
"exact-text check" the pre-existing inline comment called it. The docstring
names the real mechanism, and the inline comment at the `write_episodic` call
site is corrected to match.

## Testing

Doc-only change (docstring + one comment line, 0 behaviour). Local gates:
`isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1281 files clean),
diff-scoped black gate, brand gate — all green. No UI changes, no screenshots
applicable.

## Pre-push review

Two model-pinned lanes reviewed the staged diff: GPT lane (BLOCK, Medium:
dedupe misnomer + "only shrink" phrasing) and Opus lane (PASS, Low: same
misnomer, verified every other docstring claim against the code). Both findings
fixed before opening this PR.
