### PR TITLE
fix(ops-mission-control): coded 503 on refused ledger writes (#7790)

### DIFF
--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py
@@ -196,34 +196,58 @@ def read_entries() -> list[LedgerEntry]:
     and trust, highest use count), so a read after a merge agrees with what a local
     upsert of the same two entries would have produced. First occurrence keeps its
     position, so ordering stays stable for callers that rank by it.
+
+    Collapsing a FAILED read to ``[]`` is only safe for read-only callers (``match``,
+    ``stats``, the GET routes), where the worst outcome is an empty answer. A
+    read-modify-write that starts from this read must use ``read_entries_for_update``
+    instead: rewriting from the collapsed ``[]`` would truncate the whole ledger on a
+    transient ``EACCES``.
+    """
+    try:
+        return read_entries_for_update()
+    except OSError:
+        logger.exception("ops-mission-control: failed to read ledger")
+        return []
+
+
+def read_entries_for_update() -> list[LedgerEntry]:
+    """The mutation-path read: same parse and reconcile, but ``OSError`` PROPAGATES.
+
+    Every locked read → mutate → ``_write_all`` in this module must start here, not at
+    ``read_entries``. The lenient read answers a failed open with ``[]``, and each of
+    those callers then rewrites the file from what it read — so a transient read fault
+    became a silent full truncation of the team's shared ledger (``hygiene``), a
+    ``404`` claiming an entry never existed while it is still on disk (``remove``), or
+    a "new" entry replacing the merge it should have joined (``upsert``). Refusing is
+    the same posture the incident store's ``_read_index_for_update`` takes, and the
+    route handlers already translate the escape into their coded 503.
+
+    A malformed LINE is still skipped, deliberately: content-level damage is per-line
+    on a JSONL file, the surviving lines are real, and ``hygiene`` rewriting without
+    the broken line is repair. A failed OPEN says nothing about the content at all —
+    there is no partial result to preserve, only a file this process cannot see.
     """
     path = ledger_path()
     if not path.exists():
         return []
     ordered: list[str] = []
     by_id: dict[str, LedgerEntry] = {}
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            for line_no, line in enumerate(handle, start=1):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    entry = LedgerEntry.from_dict(json.loads(line))
-                except (TypeError, ValueError):
-                    logger.warning(
-                        "ops-mission-control: skipping malformed ledger line %d", line_no
-                    )
-                    continue
-                prior = by_id.get(entry.entry_id)
-                if prior is None:
-                    ordered.append(entry.entry_id)
-                    by_id[entry.entry_id] = entry
-                else:
-                    by_id[entry.entry_id] = _reconcile(prior, entry)
-    except OSError:
-        logger.exception("ops-mission-control: failed to read ledger")
-        return []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = LedgerEntry.from_dict(json.loads(line))
+            except (TypeError, ValueError):
+                logger.warning("ops-mission-control: skipping malformed ledger line %d", line_no)
+                continue
+            prior = by_id.get(entry.entry_id)
+            if prior is None:
+                ordered.append(entry.entry_id)
+                by_id[entry.entry_id] = entry
+            else:
+                by_id[entry.entry_id] = _reconcile(prior, entry)
     return [by_id[eid] for eid in ordered]
 
 
@@ -306,7 +330,7 @@ def upsert(entry: LedgerEntry) -> LedgerEntry:
 
 
 def _upsert_locked(entry: LedgerEntry) -> LedgerEntry:
-    existing = {e.entry_id: e for e in read_entries()}
+    existing = {e.entry_id: e for e in read_entries_for_update()}
     prior = existing.get(entry.entry_id)
     if prior is None:
         _append(entry)
@@ -459,7 +483,7 @@ def record_use(entry_id: str, fingerprint: str = "", provider_key: str = "") -> 
 
 
 def _record_use_locked(entry_id: str, fingerprint: str, provider_key: str) -> LedgerEntry | None:
-    entries = read_entries()
+    entries = read_entries_for_update()
     changed = False
     hit: LedgerEntry | None = None
     for entry in entries:
@@ -509,7 +533,7 @@ def record_miss(entry_id: str) -> LedgerEntry | None:
 
 
 def _record_miss_locked(entry_id: str) -> LedgerEntry | None:
-    entries = read_entries()
+    entries = read_entries_for_update()
     hit: LedgerEntry | None = None
     for entry in entries:
         if entry.entry_id != entry_id:
@@ -532,7 +556,7 @@ def _record_miss_locked(entry_id: str) -> LedgerEntry | None:
 def remove(entry_id: str) -> bool:
     # Locked read-modify-write; see ``_LedgerLock``.
     with _LedgerLock():
-        entries = read_entries()
+        entries = read_entries_for_update()
         remaining = [e for e in entries if e.entry_id != entry_id]
         if len(remaining) == len(entries):
             return False
@@ -626,7 +650,7 @@ def hygiene(*, now: datetime | None = None) -> dict[str, int]:
 
 def _hygiene_locked(now: datetime | None) -> dict[str, int]:
     current = now or datetime.now(timezone.utc)
-    entries = read_entries()
+    entries = read_entries_for_update()
     before = len(entries)
 
     # Dedupe by content-addressed id, merging fingerprints and keeping the

--- a/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py
@@ -2337,7 +2337,24 @@ async def _handle_post_ledger(request: web.Request) -> web.StreamResponse:
         trust=str(body.get("trust", "observed")),
         source=str(body.get("source", "human")),
     )
-    stored = await asyncio.to_thread(ledger.upsert, entry)
+    try:
+        stored = await asyncio.to_thread(ledger.upsert, entry)
+    except OSError as exc:
+        # Reported, not raised — the same shape ``_handle_rotation_arm`` uses for a
+        # refusing store, and for the same reason its comment gives: escaping here
+        # becomes aiohttp's default 500, a plain-text body with no ``code`` for the
+        # UI to branch on. ``upsert`` appends or rewrites ``ledger.jsonl`` under the
+        # ledger lock, so a full disk or a permission fault surfaces as ``OSError``
+        # from either the lock acquisition or the write itself. 503 rather than 500
+        # because the condition is transient and retrying is the correct client
+        # behaviour. This was the last trio of mutating routes in this file (POST /
+        # DELETE /ledger and /ledger/hygiene) still answering the bare 500; every
+        # sibling store write already reports a coded refusal.
+        logger.warning("ops-mission-control: ledger write refused, store unwritable")
+        _audit("ledger_post", entry.entry_id, "failure", error="ledger store unwritable")
+        return web.json_response(
+            {"ok": False, "error": str(exc), "code": "ledger_store_unwritable"}, status=503
+        )
     return web.json_response({"entry": stored.to_dict()})
 
 
@@ -2367,7 +2384,11 @@ async def _handle_ledger_hygiene(request: web.Request) -> web.StreamResponse:
     Every stage is independently fault-tolerant. A missing remote, an offline network, a
     conflicted ledger, or an absent embedding model each degrade to a reported
     sub-result; none prevents the local dedupe/decay/prune from running, because local
-    hygiene is the part that always works and always matters.
+    hygiene is the part that always works and always matters. The one exception is the
+    hygiene rewrite itself: a refused read or write there answers a coded 503
+    (``ledger_store_unwritable``) and skips index, prune, and push, because publishing a
+    ledger the dedupe pass never committed to is worse than deferring everything to the
+    next cron run.
 
     **Only the primary instance may run it.** This pass PRUNES a shared ledger, and on a
     team every instance reaching it means N concurrent dedupe/decay/prune passes over one
@@ -2400,7 +2421,30 @@ async def _handle_ledger_hygiene(request: web.Request) -> web.StreamResponse:
         )
 
     pulled = await ledger_sync.sync_safely(direction="pull")
-    summary = await asyncio.to_thread(ledger.hygiene)
+    try:
+        summary = await asyncio.to_thread(ledger.hygiene)
+    except OSError as exc:
+        # ``hygiene`` is a locked read-modify-REWRITE of the whole ledger file, so a
+        # refused write (full disk, permissions, a failed lock) surfaces here as
+        # ``OSError``. Letting it escape gives aiohttp's default 500 — a plain-text
+        # body with no ``code`` — while every other refusal on this route (not
+        # primary, disabled app) answers coded JSON. The pull above already landed
+        # and is harmless to repeat; the push below must NOT run, because it would
+        # publish a ledger the dedupe pass never committed to. 503 rather than 500
+        # because the condition is transient and the cron's next run is the retry.
+        logger.warning("ops-mission-control: ledger hygiene refused, store unwritable")
+        _audit("ledger_hygiene", "rewrite refused", "failure", error="ledger store unwritable")
+        return web.json_response(
+            {
+                "ok": False,
+                "error": str(exc),
+                "code": "ledger_store_unwritable",
+                # The sibling refusal above (409 not_primary) carries this, and the
+                # hygiene SOP branches on ``changed`` to decide whether to speak at all.
+                "changed": False,
+            },
+            status=503,
+        )
     indexed = await asyncio.to_thread(_index_ledger_safely)
     # Retire old CLOSED incidents. Here rather than on the claim path because pruning is
     # maintenance: doing it in `claim` would make an ordinary claim occasionally pay for a
@@ -2481,7 +2525,19 @@ async def _handle_delete_ledger(request: web.Request) -> web.StreamResponse:
         return web.json_response(
             {"error": "id is required", "code": "missing_required_field"}, status=400
         )
-    removed = await asyncio.to_thread(ledger.remove, entry_id)
+    try:
+        removed = await asyncio.to_thread(ledger.remove, entry_id)
+    except OSError as exc:
+        # ``remove`` rewrites the ledger under its lock, so a refused write raises
+        # ``OSError``. The removal route needs the coded refusal for the same reason
+        # the secret-revocation route does: a bare 500 leaves the operator unsure
+        # whether the entry they just deleted is gone, and the honest answer is
+        # "still there, retry". Same shape as ``_handle_rotation_arm``.
+        logger.warning("ops-mission-control: ledger removal refused, store unwritable")
+        _audit("ledger_delete", entry_id, "failure", error="ledger store unwritable")
+        return web.json_response(
+            {"ok": False, "error": str(exc), "code": "ledger_store_unwritable"}, status=503
+        )
     if not removed:
         # Split from the success return rather than computing the status. A 404 IS an error
         # response and needs a `code` the localized UI can switch on; the previous single

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_ledger_index.py
@@ -434,12 +434,13 @@ class TestLedgerMutationsAreLocked(_Env):
 
     def test_hygiene_does_not_erase_an_append_that_races_its_read(self):
         """Drive the exact interleaving deterministically: a new entry is appended DURING
-        hygiene's `read_entries`, in the window `_write_all` would otherwise clobber.
+        hygiene's read, in the window `_write_all` would otherwise clobber.
 
-        A real thread race would be flaky; patching `read_entries` to append-then-return
-        reproduces it every run. The lock does not prevent the interleaving here (same
-        process, re-entrant open) — the assertion is that the appended entry SURVIVES, which
-        it cannot if hygiene rewrites from a snapshot taken before it."""
+        A real thread race would be flaky; patching `read_entries_for_update` (the
+        mutation-path read hygiene starts from) to append-then-return reproduces it every
+        run. The lock does not prevent the interleaving here (same process, re-entrant
+        open) — the assertion is that the appended entry SURVIVES, which it cannot if
+        hygiene rewrites from a snapshot taken before it."""
         from unittest import mock
 
         from kiro_crew.apps.builtins.ops_mission_control.backend import ledger
@@ -447,7 +448,7 @@ class TestLedgerMutationsAreLocked(_Env):
         ledger.upsert(LedgerEntry.create(pattern="original", fix="f"))
         latecomer = LedgerEntry.create(pattern="arrived during hygiene", fix="f2")
 
-        real_read = ledger.read_entries
+        real_read = ledger.read_entries_for_update
         fired = {"done": False}
 
         def read_then_append():
@@ -457,7 +458,7 @@ class TestLedgerMutationsAreLocked(_Env):
                 ledger._append(latecomer)  # the concurrent POST
             return rows
 
-        with mock.patch.object(ledger, "read_entries", read_then_append):
+        with mock.patch.object(ledger, "read_entries_for_update", read_then_append):
             ledger.hygiene()
 
         patterns = {e.pattern for e in ledger.read_entries()}

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_routes.py
@@ -3447,6 +3447,120 @@ class TestAStoreThatRefusesToWriteIsReportedNotCrashed(unittest.IsolatedAsyncioT
 
         self.assertEqual(body["code"], "app_config_corrupt")
 
+    async def test_a_refused_ledger_post_is_a_coded_503_not_a_500(self):
+        """POST /ledger appends-or-rewrites under the ledger lock, so it can refuse.
+
+        The ledger trio (POST, DELETE, hygiene) was the last set of mutating routes in
+        this file still answering aiohttp's bare plain-text 500 on a refused write —
+        every sibling store write already reports ``{ok, error, code}``.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import ledger
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(ledger, "upsert", self._refuse):
+                client = await self._client(app)
+                resp = await client.post(
+                    "/api/apps/ops-mission-control/ledger",
+                    json={"pattern": "disk full on host", "fix": "clear the spool"},
+                )
+                self.assertEqual(resp.status, 503)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "ledger_store_unwritable")
+        self.assertIs(body["ok"], False)
+
+    async def test_a_refused_ledger_delete_never_reports_success(self):
+        """Same property as the secret-revocation route: anything 2xx here is the bug.
+
+        A refused rewrite means the entry the operator just deleted is still on disk,
+        and the previous escape (bare 500) left them unable to tell that from a crash
+        after the write. The coded 503 says plainly: still there, retry.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import ledger
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(ledger, "remove", self._refuse):
+                client = await self._client(app)
+                resp = await client.delete(
+                    "/api/apps/ops-mission-control/ledger?id=abc123",
+                )
+                self.assertEqual(resp.status, 503, "a refused removal answered as success")
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "ledger_store_unwritable")
+        self.assertNotIn("removed", body, "the refusal must not claim a removal verdict")
+
+    async def test_a_failed_underlying_read_on_delete_is_a_503_not_a_404(self):
+        """The read half of the same fault, driven from below the handler.
+
+        ``remove`` starts from a read of the file it rewrites. When that READ was the
+        thing that failed, the lenient read collapsed it to ``[]`` and the route
+        answered a coded 404 — "no such entry" — about an entry still on disk, with no
+        failure audit. Found in review (GPT 5.6). With the mutation path on the strict
+        read, the same fault now surfaces as the identical retryable 503 the write
+        half answers, and the entry is not mis-reported as absent.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import ledger
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(ledger, "read_entries_for_update", self._refuse):
+                client = await self._client(app)
+                resp = await client.delete(
+                    "/api/apps/ops-mission-control/ledger?id=abc123",
+                )
+                self.assertNotEqual(resp.status, 404, "a failed read was reported as absence")
+                self.assertEqual(resp.status, 503)
+                body = await resp.json()
+
+        self.assertEqual(body["code"], "ledger_store_unwritable")
+
+    async def test_a_refused_hygiene_rewrite_is_a_coded_503_and_audited(self):
+        """``hygiene`` rewrites the whole ledger; a refused rewrite must not push.
+
+        Also pins that the refusal is AUDITED as a failure: the success path writes a
+        ``ledger_hygiene`` audit line, and a refusal that skipped the audit would make
+        the maintenance pass look like it never ran rather than like it failed.
+        """
+        from kiro_crew.apps.builtins.ops_mission_control.backend import ledger, ledger_sync
+
+        directions: list[str] = []
+
+        async def _sync(*, direction="pull"):
+            directions.append(direction)
+            return ""
+
+        app = web.Application()
+        routes.register_routes(app)
+        with mock.patch.object(routes, "is_app_enabled", return_value=True):
+            with mock.patch.object(routes.rotation, "is_primary", return_value=True):
+                with mock.patch.object(ledger_sync, "sync_safely", _sync):
+                    with mock.patch.object(ledger, "hygiene", self._refuse):
+                        with mock.patch.object(routes, "_audit") as audited:
+                            client = await self._client(app)
+                            resp = await client.post(
+                                "/api/apps/ops-mission-control/ledger/hygiene"
+                            )
+                            self.assertEqual(resp.status, 503)
+                            body = await resp.json()
+
+        self.assertEqual(body["code"], "ledger_store_unwritable")
+        self.assertIs(body["ok"], False)
+        self.assertNotIn(
+            "push", directions, "a ledger the dedupe never committed to must not be pushed"
+        )
+        failures = [
+            c
+            for c in audited.call_args_list
+            if c.args[0] == "ledger_hygiene" and c.args[2] == "failure"
+        ]
+        self.assertEqual(len(failures), 1, "the refusal must be audited as a failure")
+
     async def test_a_claim_survives_a_failed_ledger_annotation(self):
         """The claim is committed before the annotation runs, so it must not be un-reported.
 

--- a/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
+++ b/src/kiro_crew/apps/builtins/ops_mission_control/tests/test_store_and_gate.py
@@ -1420,6 +1420,38 @@ class TestLedger(_HomeIsolated):
         self.assertEqual(len(entries), 1)
         self.assertEqual(set(entries[0].fingerprints), {"a", "b"})
 
+    def test_a_failed_mutation_read_refuses_instead_of_truncating(self):
+        """Every read-modify-rewrite must refuse when it could not read what it rewrites.
+
+        The lenient ``read_entries`` answers a failed open with ``[]``, and each mutation
+        path then calls ``_write_all`` with what it read — so before the strict read, a
+        transient ``EACCES`` at hygiene time silently truncated the team's whole shared
+        ledger, ``remove`` answered "not found" about an entry still on disk, and
+        ``upsert`` re-created an entry instead of merging into it. Found in review
+        (GPT 5.6). The property pinned here is the refusal ORDER: the ``OSError``
+        escapes before any rewrite, so the file survives the fault untouched.
+        """
+        from unittest import mock
+
+        from kiro_crew.apps.builtins.ops_mission_control.backend import ledger, models
+
+        ledger.upsert(models.LedgerEntry.create(pattern="p", fix="f", fingerprints=["a"]))
+        refuse = mock.Mock(side_effect=PermissionError(13, "Permission denied"))
+        with mock.patch.object(ledger, "read_entries_for_update", refuse):
+            with self.assertRaises(OSError):
+                ledger.hygiene()
+            with self.assertRaises(OSError):
+                ledger.remove("any-id")
+            with self.assertRaises(OSError):
+                ledger.upsert(models.LedgerEntry.create(pattern="q", fix="g"))
+            with self.assertRaises(OSError):
+                ledger.record_use("any-id")
+            with self.assertRaises(OSError):
+                ledger.record_miss("any-id")
+        entries = ledger.read_entries()
+        self.assertEqual(len(entries), 1, "the ledger must survive a refused read intact")
+        self.assertEqual(entries[0].pattern, "p")
+
     def test_relearning_does_not_weaken_trust(self):
         from kiro_crew.apps.builtins.ops_mission_control.backend import ledger, models
 


### PR DESCRIPTION
## Summary

Closes #7790.

The issue lists seven mutating `ops-mission-control` handlers whose store-write failures escaped as aiohttp's bare plain-text 500. Six of them (put/delete secret, settings, provider config, transition, decide_proposal) were already covered on main by #7788/#7794 with per-store coded refusals and tests. This PR closes the remaining class: the three ledger mutating routes.

**Write half (the issue as filed).** `POST /ledger`, `DELETE /ledger`, and `POST /ledger/hygiene` all rewrite `ledger.jsonl` through `atomic_write` under the ledger lock, which raises `OSError` on a refused write. Each now answers the shape `_handle_rotation_arm` established: `{ok: false, error, code: "ledger_store_unwritable"}`, status 503 (transient, retry is correct). The hygiene route additionally skips index/prune/push when the rewrite was refused — publishing a ledger the dedupe pass never committed to is worse than deferring to the next cron run — and audits the refusal as a failure.

**Read half (found in pre-push review, GPT 5.6 — the worse one).** `ledger.read_entries` collapses a failed *open* to `[]`, and every locked read-modify-rewrite in `ledger.py` started from it. So a transient `EACCES` at hygiene time silently truncated the whole shared ledger, `DELETE` answered a coded 404 about an entry still on disk, and `upsert` re-created instead of merging. The five mutation paths (`upsert`, `record_use`, `record_miss`, `remove`, `hygiene`) now start from a new `read_entries_for_update()` that propagates `OSError`; the lenient `read_entries` remains for read-only callers (`match`, `stats`, GET routes) and delegates to it. Both `record_*` callers in `dispatch.py` already tolerate `OSError` (`record_miss` is wrapped; `record_use` propagates into the claim path's existing degrade-to-claim-without-matches arm).

Slug note: the issue text suggested `incident_store_unwritable` for the hygiene route, but the store that fails there is the ledger, not the incident index — the per-store naming rule the same suggestion establishes gives `ledger_store_unwritable`. The incident-index writes on transition/decide already answer `dispatch_index_*` codes via `_store_read_refusal` since #7794.

## Changes

- `src/kiro_crew/apps/builtins/ops_mission_control/backend/routes.py`: coded 503 arms on the three ledger routes; hygiene 503 carries `changed: false` (the SOP branches on it) and the docstring's fault-tolerance paragraph now states the deliberate exception.
- `src/kiro_crew/apps/builtins/ops_mission_control/backend/ledger.py`: `read_entries_for_update()` (strict) extracted from `read_entries()` (lenient, now delegating); five mutation call sites switched.
- Tests: refused write → coded 503 for all three routes (hygiene one also pins push-is-skipped and the failure audit); failed underlying read on DELETE → 503, not 404; ledger-level pin that a failed mutation read refuses before any rewrite and the file survives intact.

## Testing

- Local gates: isort, flake8, mypy (clean), diff-scoped black/brand/scrub gates. Test suites run in CI per operator instruction (no local test runs on this host).
- Pre-push review: GPT 5.6 lane ×2 (one PASS; one HIGH — the lenient mutation read — fixed above) and Opus lane (PASS; two advisories applied: docstring drift, `changed: false`).

No UI changes, no screenshots required.

## Pattern harvest

Rule candidate: review checklist / semgrep
Pattern: a lenient reader that collapses a failed read to an empty default (`[]`/`{}`) feeding a locked read-modify-REWRITE — the rewrite publishes the collapsed default and silently truncates the store. Third recurrence in this app alone (app-config `set_top_level`, the incident index, now the ledger). Detectable shape: `except OSError: return []` (or `.get(..., {})` on a read) whose callers pass the result to a whole-file write (`_write_all`, `atomic_write`). Mutation paths must use a strict read that refuses; lenient defaults are for read-only callers.
