### PR TITLE
fix: reject rooted or dot-only skill names in the name validator (#7842)

### DIFF
--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -19,7 +19,7 @@ from contextlib import suppress
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from itertools import zip_longest
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Callable, Iterator
 
 from kiro_crew import pinned_fs, skill_trust
@@ -2401,8 +2401,29 @@ class SkillsLoader:
 
     @staticmethod
     def _safe_name(name: str) -> bool:
-        """Return True if skill name is safe (no path traversal)."""
-        return bool(name) and ".." not in name and "\\" not in name
+        """Return True if skill name is safe (no traversal, rooted, or dot-only).
+
+        A rooted name must be rejected because ``Path.__truediv__`` discards
+        the base directory when the joined segment is absolute, so
+        ``self._dir / name`` would resolve outside the skills root. Both
+        flavours are checked: POSIX-absolute (``/etc/x``) and Windows
+        rooted/drive-qualified in the forward-slash spelling (``C:/x``,
+        ``C:x``, ``//server/share/x``) — the backslash spelling is already
+        caught by the ``"\\\\"`` rule. Dot-only spellings (``.``, ``./``)
+        must also be rejected: pathlib drops ``.`` components on join, so
+        ``self._dir / "."`` collapses to the skills root itself and a delete
+        would remove every installed skill. ``PurePosixPath(name).parts`` is
+        empty exactly for those spellings.
+        """
+        return (
+            bool(name)
+            and ".." not in name
+            and "\\" not in name
+            and bool(PurePosixPath(name).parts)
+            and not PurePosixPath(name).is_absolute()
+            and not PureWindowsPath(name).is_absolute()
+            and not PureWindowsPath(name).drive
+        )
 
     def load_skill(
         self,

--- a/test/test_skills.py
+++ b/test/test_skills.py
@@ -723,6 +723,49 @@ class TestSkillsCRUD:
         # Nested paths are now allowed
         assert loader.create_skill("foo/bar", "# nested") is True
 
+    def test_rooted_name_load(self, tmp_path):
+        """Rooted names must be rejected: a pathlib join with an absolute
+        segment discards the base directory, escaping the skills root."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        # POSIX-absolute (payload scoped under tmp_path so a guard regression
+        # is contained rather than acted on against the host)
+        assert loader.load_skill(str(tmp_path / "escape")) is None
+        assert loader.load_skill("/foo") is None
+        # Windows drive-qualified, forward-slash spelling
+        assert loader.load_skill("C:/Windows/System32") is None
+        # Windows drive-relative (no root, still re-anchors the join)
+        assert loader.load_skill("C:evil") is None
+        # Forward-slash UNC prefix
+        assert loader.load_skill("//server/share/skill") is None
+        # Backslash spellings stay rejected by the existing backslash rule
+        assert loader.load_skill("C:\\Windows\\evil") is None
+        assert loader.load_skill("\\\\server\\share\\skill") is None
+        # Dot-only spellings collapse the join back onto the skills root
+        assert loader.load_skill(".") is None
+        assert loader.load_skill("./") is None
+        assert loader.load_skill(".//.") is None
+
+    def test_rooted_name_create_update_delete(self, tmp_path):
+        """Skill CRUD must refuse rooted or dot-only names but accept
+        relative ones. Absolute payloads live under tmp_path so a guard
+        regression surfaces as a containment failure, not a host mutation."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        loader = SkillsLoader(skills_path=skills_dir, install_builtins=False)
+        escape = tmp_path / "escape"
+        for rooted in (str(escape), "C:/abs", "C:abs", "//server/share/x", ".", "./"):
+            assert loader.create_skill(rooted, "# bad") is False
+            assert loader.update_skill(rooted, "# bad") is False
+            assert loader.delete_skill(rooted) is False
+        assert not escape.exists()
+        # delete_skill(".") must not have collapsed onto the skills root
+        assert skills_dir.is_dir()
+        # Normal relative names keep working: single-segment and nested
+        assert loader.create_skill("plain", "# ok") is True
+        assert loader.create_skill("nested/child", "# ok") is True
+
     def test_create_then_list(self, tmp_path):
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()


### PR DESCRIPTION
## Summary

The `SkillsLoader` static name validator (`_safe_name` in `src/kiro_crew/skills.py`) rejected parent-directory traversal (`..`) and backslashes, but not **rooted** names. `Path.__truediv__` discards the base directory when the joined segment is absolute, and the dashboard skill routes use a greedy name pattern that preserves slashes, so a rooted name reached the loader verbatim and skill read/write/delete could resolve outside the configured skills root.

This change extends the existing boolean — no restructuring — to also reject:

- POSIX-absolute names (`/etc/x`) via `PurePosixPath(name).is_absolute()`
- Windows rooted names in the forward-slash spelling (`C:/x`, `//server/share/x`) via `PureWindowsPath(name).is_absolute()`
- Windows drive-relative names (`C:x`) via `PureWindowsPath(name).drive`
- Dot-only spellings (`.`, `./`, `.//.`) via `bool(PurePosixPath(name).parts)` — pathlib *drops* `.` components on join, so `self._dir / "."` collapses onto the skills root itself and `delete_skill(".")` would `rmtree` every installed skill (the same defect class reached by collapsing instead of re-anchoring; `_is_pending_slug_safe` already guards its own root the same way)

The backslash spellings (`C:\x`, `\\server\share`) were already rejected by the existing rule and are now locked in with tests.

`_safe_name` is the single chokepoint for `load_skill` / `create_skill` / `update_skill` / `delete_skill` / `is_auto_generated` / `set_inject_on_trigger`, so one extension covers all skill CRUD.

## Tests

- `test_rooted_name_load`: rejection of each rooted spelling (POSIX-absolute, drive-qualified, drive-relative, UNC, both backslash forms) and each dot-only spelling on `load_skill`.
- `test_rooted_name_create_update_delete`: create/update/delete refuse every rooted and dot-only spelling; absolute payloads are scoped under `tmp_path` and containment is asserted afterwards, so a guard regression fails as a containment check instead of mutating the host; the skills root is asserted to survive `delete_skill(".")`; normal single-segment and nested relative names keep working.
- Local gates green: isort, flake8, mypy (1281 files), black diff gate, subprocess-encoding gate, brand gate, harness-parity gate. Full pytest runs in CI.

## Pre-push review

Two model-pinned local review lanes ran (GPT + Opus mirrors of the CI review workflows). Both converged on one High — the dot-only collapse (`delete_skill(".")` reaching the skills root) — plus a Medium on test payload containment. Both are fixed in this commit; no findings remain open.

## Note for the operator (do not action in this PR)

CodeQL alerts **621–629** cover this region and their recorded dismissal rationale names this validator as the barrier. Per the issue, that rationale should be **re-stated after this lands**. This PR deliberately does not touch CodeQL dismissals.

Standalone by request: not folded into #7713 (descriptor-pinning migration), which merged separately and does not close this issue (its `closingIssuesReferences` is empty).

Closes #7842

## Pattern harvest

Rule candidate: semgrep
Pattern: a user-controlled name joined onto a base directory (`base / name` / `os.path.join(base, name)`) guarded only by substring checks (`".." not in name`) — the guard misses rooted segments (pathlib discards the base when the joined segment is absolute or drive-qualified) and dot-only segments (pathlib collapses `.` components, so the join lands on the base itself). Flag joins where the segment validator lacks an `is_absolute()`/`drive`/empty-`parts` rejection. Two instances already exist in this file alone (`_safe_name` fixed here, `_is_pending_slug_safe` fixed earlier), so the class recurs.
