### PR TITLE
fix(ci): stop the readiness sweep cancelling its own queued successor (#8026)

### DIFF
--- a/.github/workflows/pr-readiness-sweep.yml
+++ b/.github/workflows/pr-readiness-sweep.yml
@@ -93,10 +93,23 @@ permissions:
   statuses: read        # read the "PR Readiness" commit status
 
 concurrency:
-  # Collapse an overlapping sweep into one. The sweep is idempotent, so
-  # cancelling an in-flight run is safe.
+  # Collapse overlap WITHOUT cancelling the incumbent. The group alone already
+  # dedupes: GitHub keeps at most one PENDING run per group, and a newer pending
+  # run supersedes the older pending one. `cancel-in-progress: true` would also
+  # cancel the run currently HOLDING the slot -- and a run that is queued
+  # waiting for a runner already holds it, so once repo-wide queue latency
+  # exceeds the 15-minute cron interval every run is killed by its own
+  # successor before executing a single step and the sweep never runs again,
+  # exactly when Actions saturation makes the backstop most needed (#8026).
+  # With `false` the incumbent -- queued or executing -- is never cancelled by
+  # a successor; a queued run that never gets a runner still expires on
+  # GitHub's own queued-run TTL, after which the next tick takes the slot. So
+  # under saturation the sweep degrades to running less often instead of never.
+  # (The old "the sweep is idempotent, so cancelling an in-flight run is safe"
+  # reasoning considered only an executing run and missed that queued runs are
+  # cancellation targets too.)
   group: pr-readiness-sweep
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   sweep:

--- a/test/test_pr_readiness_sweep_policy.py
+++ b/test/test_pr_readiness_sweep_policy.py
@@ -1,0 +1,34 @@
+"""Policy pin for .github/workflows/pr-readiness-sweep.yml's concurrency block.
+
+Lives in its own module so it runs on EVERY matrix leg: the behavioural tests in
+test_pr_readiness_sweep.py carry a module-level skipif for the POSIX toolchain
+(bash, jq, GNU date) they execute the sweep script with, and a pure YAML
+assertion parked there would be silently skipped -- not failed -- on Windows or
+on any runner image missing jq, letting the ratchet protecting #8026 vanish for
+reasons unrelated to the invariant it guards.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "pr-readiness-sweep.yml"
+
+pytestmark = pytest.mark.skipif(not WORKFLOW.exists(), reason="requires the workflow file")
+
+
+def test_concurrency_never_cancels_the_incumbent_run() -> None:
+    """The sweep is the backstop that unfreezes a stale required readiness
+    status, so it must survive runner saturation. A queued run already holds
+    the concurrency slot; with ``cancel-in-progress: true`` the next scheduled
+    tick cancels it, and once queue latency exceeds the cron interval every run
+    is killed by its own successor before executing a step -- the workflow can
+    never run again exactly when it is most needed (#8026). The fixed group
+    alone collapses overlap (GitHub keeps at most one pending run per group);
+    the incumbent must never be a cancellation target."""
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert doc["concurrency"]["group"] == "pr-readiness-sweep"
+    assert doc["concurrency"]["cancel-in-progress"] is False


### PR DESCRIPTION
## Summary

`pr-readiness-sweep.yml` is the backstop that unfreezes a stale required "PR Readiness" commit status. Its concurrency group used `cancel-in-progress: true` — but a run that is *queued* waiting for a runner already holds the concurrency slot, so each scheduled tick cancelled the queued incumbent. Once repo-wide Actions queue latency exceeded the 15-minute cron interval, every run was killed by its own successor before executing a single step and the sweep could never run again — exactly when Actions saturation made the backstop most needed (the issue documents 12+ consecutive cancelled runs with each run's end timestamp equal to its successor's creation timestamp).

## Change

- `.github/workflows/pr-readiness-sweep.yml`: `cancel-in-progress: true` → `false`, with the adjacent comment rewritten. The fixed group alone still collapses overlap — GitHub keeps at most one **pending** run per group and a newer pending run supersedes the older pending one — but the incumbent holding the slot (queued or executing) is never cancelled. Under saturation the sweep degrades to running less often instead of never. The old comment's "the sweep is idempotent, so cancelling an in-flight run is safe" reasoning considered only an *executing* run and missed that queued runs are cancellation targets too. A queued run that never gets a runner still expires on GitHub's own queued-run TTL, after which the next tick takes the slot.
- `test/test_pr_readiness_sweep_policy.py` (new): pins `concurrency.group == "pr-readiness-sweep"` and `cancel-in-progress is False`. Lives in its own module so it runs on every matrix leg — the behavioural tests in `test_pr_readiness_sweep.py` carry a module-level POSIX-toolchain skipif (bash/jq/GNU date) that would silently skip a policy assertion parked there on Windows.

## Sibling scheduled workflows audited (follow-ups, not changed here)

All workflows combining `schedule:` with `cancel-in-progress: true` were checked. Only `pr-readiness-sweep.yml` is a **pure schedule-driven backstop** with a fixed group at a sub-hour interval (the mechanical class of this bug). Noted as potential follow-ups, out of scope per the same-class rule:

- `pr-merge-conflict-label.yml` — fixed group `pr-merge-conflict-label`, `*/30` cron, but **mixed-trigger** (also `push: branches: [main]` + `workflow_dispatch`). Its scheduled lane has the same self-cancellation exposure when queue latency exceeds 30 min, though push-triggered runs break the pure cancel chain.
- `fork-pr-label.yml` — mixed-trigger (`pull_request_target` + hourly cron); the schedule lane shares fixed group `fork-pr-label-sweep`. Same exposure shape at a 60-min threshold.

Remaining schedule+cancel workflows (`nightly.yml`, `memory-benchmark.yml`, `ota-test.yml`, `cleanup-temp-screenshots.yml`, `test-durations.yml`) run daily/weekly — queue latency cannot plausibly exceed their interval, and for the benchmark/build cases cancellation of a superseded run is the intended behaviour.

## Testing

- `yaml.safe_load` round-trip of the edited workflow verifies `concurrency.cancel-in-progress is False`
- `isort --check-only` / `flake8` on the changed test files pass; diff-scoped black gate passes
- New policy test asserts the pinned block (runs in CI on all legs)
- Pre-push adversarial review: GPT lane PASS, Opus lane PASS (2 advisories, both applied: policy test isolated from the toolchain skipif; queue-TTL wording in the comment)

## Pattern harvest

Rule candidate: workflow-policy test (yamllint/pytest class, same shape as `test_pr_readiness_sweep_policy.py`)
Pattern: a workflow combining `schedule:` with a **fixed** `concurrency.group` and `cancel-in-progress: true`, where the cron interval is shorter than plausible Actions queue latency — each tick cancels its own queued predecessor, so under saturation the workflow self-starves to zero executions. A repo-wide policy test could enumerate `.github/workflows/*.yml` and flag any schedule-triggered workflow whose effective group is constant across scheduled runs and whose `cancel-in-progress` is `true` with a sub-hour cron. The two mixed-trigger sweeps listed above would be caught by the same rule.

Closes #8026
