### PR TITLE
feat(version): honour a BUILD_VERSION package stamp so a distribution names its build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,7 @@ website/.vitest-reports/
 
 # Skill eval A/B outputs (regenerated per run; not review artifacts)
 evals/*/iteration-*/
+
+# A distribution stamps its build number here at packaging time (see
+# kiro_crew/__init__.py); never committed -- a dev checkout runs the bare core.
+src/kiro_crew/BUILD_VERSION

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,7 @@ include setup.py
 
 # --- Top-level package data files (mirror [options.package_data]) ------------
 include src/kiro_crew/py.typed
+include src/kiro_crew/BUILD_VERSION
 include src/kiro_crew/slack-manifest.yaml
 include src/kiro_crew/model_tokens.json
 

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -348,6 +348,60 @@ dependencies = ["kirocrew"]
 The `kirocrew-enterprise` binary sets `KIROCREW_PROFILE=enterprise` and delegates to the
 core `main` — the explicit composition-root path that a security review reads.
 
+### Distribution build version
+
+A distribution that repackages one core release as several builds of its own
+(an enterprise bundle vending `0.6.0.10`, `0.6.0.11`, … of the same `0.6.0`)
+names the build it shipped in a `BUILD_VERSION` file placed **beside
+`kiro_crew/__init__.py`** at packaging time (declared as optional package data;
+absent in this repo and in the wheels it publishes). `kiro_crew/__init__`
+resolves it **at import**, replacing `__version__` for every reader — the About
+page's version chip (`version_display`), `/api/status`, `/api/health`,
+`kirocrew --version`, the diagnostics report, and the governance minimum-version
+floor (`update_required`), which a fleet writes in the distribution's build
+numbers. Two readers deliberately do not change: the anonymous usage beacon
+(`beacon.release` clamps to `major.minor.patch` for cardinality, so a stamped
+build sends the same value as its base), and the About page's changelog, where
+`changelog.running_release` folds the stamp back onto its three-segment release
+so the build marks the `0.6.0` row rather than opening an empty `0.6.0.12` row. Import time is the only point that works:
+`dashboard/handlers/updates.py`, `dashboard/ws.py`, `config/loader.py` and
+`cli_server.py` bind `from kiro_crew import __version__` copies that nothing
+later can reach, so this is deliberately not a `PlatformContext` field — a
+context is composed after those imports.
+
+A file in the package rather than an environment variable, on purpose: the
+version feeds an enterprise ceiling (the minimum-version floor) that the local
+operator must not be able to weaken, and an env var is theirs to set. The file
+sits in the same site-packages tree as the code and carries exactly its trust —
+whoever can write it can write `__init__.py` — so it adds no bypass the bytes did
+not already have, and it is the same model the release lanes use when they
+rewrite the version literal for a nightly or insider build. Being in the bytes,
+it is also what a shadow-venv probe or any fresh interpreter naturally reports.
+
+Fail-closed on shape: only the core base itself, or the base followed by exactly
+one `.N` ASCII-numeric segment over a bare numeric base, is honoured (the read is
+capped, and an oversized, undecodable or unreadable file falls back to the base).
+A different base, a prerelease stamp, a non-numeric or second segment, or a
+suffix over an `rc` / nightly base is a build this core is not; it is ignored
+with one warning and the base stays, so a process can never claim bytes it does
+not run. The contract is the file — its name and that shape — not a Python API;
+the helpers in `kiro_crew/__init__` are private. The accepted shape parses as a
+PEP 440 release wherever the version is compared (`_is_newer` orders `0.6.0.12`
+above `0.6.0` and below `0.6.1`; `release_channel.channel` still reads
+`stable`), and `base_version` — the stable-channel display fold — preserves the
+stamped string, which is what lets the chip show it.
+
+Update lane. A distribution owns its own update path, normally the command
+provider selected by `check_command` / `apply_command` update pins, which never
+consults the public release feed. Should a stamped build reach the feed check,
+`channel_move_pending` compares by **release** (`changelog.release_of_build`
+folds `0.6.0.12` to `0.6.0`), so a stamped build on the lane that shipped its
+release is on that lane, not permanently "ahead" of it; the `update_available`
+verdict needs no fold (`0.6.0` is not newer than `0.6.0.12`). The wheel's
+dist-info metadata is not touched by the stamp — `pip` and `importlib.metadata`
+still report the base — so a downstream that builds its own wheel and needs
+those to differ must bump its own project version as well.
+
 ## Consumption-site wiring
 
 Core consumption sites read the context rather than the module global they

--- a/setup.cfg
+++ b/setup.cfg
@@ -209,6 +209,10 @@ exclude =
 [options.package_data]
 kiro_crew =
     py.typed
+    # Optional distribution build stamp (kiro_crew/__init__.py). Absent in this
+    # repo and in the wheels it publishes; a downstream that writes it before
+    # building its own wheel needs it carried into the package.
+    BUILD_VERSION
     slack-manifest.yaml
     model_tokens.json
     model_registry.json

--- a/src/kiro_crew/__init__.py
+++ b/src/kiro_crew/__init__.py
@@ -3,8 +3,103 @@
 from __future__ import annotations
 
 import asyncio
+import logging
+import os
+import re
 
 __version__ = "0.6.0"
+
+# A distribution that repackages one core release as several builds of its own
+# (an enterprise bundle vending ``0.6.0.10``, ``0.6.0.11``, ... of the same
+# ``0.6.0``) names the build it shipped in a ``BUILD_VERSION`` file placed
+# BESIDE this module at packaging time. The value replaces ``__version__`` for
+# every reader -- the About page's version chip, ``/api/status``,
+# ``/api/health``, ``kirocrew --version``, the diagnostics report, the
+# governance minimum-version floor -- because all of them import this
+# attribute, several as an import-time copy that nothing later can reach.
+# Resolved at import for exactly that reason: it is the only point that
+# precedes every copy. (The anonymous usage beacon is NOT a reader in this
+# sense: ``beacon.release`` deliberately clamps to major.minor.patch, so a
+# stamped build sends the same value as its base. The About page's changelog
+# folds the stamp back onto its release -- ``changelog.running_release``.)
+#
+# A FILE IN THE PACKAGE, not an environment variable, on purpose. The version
+# feeds the governance minimum-version floor (``update_required``), which is an
+# enterprise ceiling the local operator must not be able to weaken; an env var
+# is theirs to set, so ``KIROCREW_BUILD_VERSION=0.6.0.999`` would have waved a
+# forbidden build past the floor. The file sits in the same site-packages tree
+# as this code and carries exactly its trust: whoever can write it can write
+# ``__init__.py`` too, so it adds no bypass the bytes did not already have. It
+# is also the same model the release lanes use when they rewrite the literal
+# above for a nightly or insider build -- the stamp lives in the bytes and is
+# what a shadow-venv probe or a fresh interpreter naturally reports.
+#
+# Fail-closed on shape: only the core base itself, or the base followed by ONE
+# dotted numeric segment, is honoured, and only over a bare numeric base.
+# Anything else (a different base, a prerelease stamp, a non-numeric or second
+# segment, a suffix over an ``rc`` base) is a build this core is not, and
+# stamping it would make the process CLAIM bytes it does not run; it is ignored
+# with one warning and the core base stays. The accepted shape parses as a PEP
+# 440 release everywhere the version is compared (the update check's
+# ``_is_newer``, ``base_version``, ``release_channel.channel``), so a stamped
+# build orders and classifies exactly as its base would.
+_BUILD_VERSION_FILENAME = "BUILD_VERSION"
+_BUILD_VERSION_MAX_CHARS = 64  # a real stamp is ~10 chars; anything larger is not one
+_BARE_RELEASE = re.compile(r"[0-9]+(?:\.[0-9]+)*")
+_BUILD_VERSION_SUFFIX = re.compile(r"\.[0-9]+")
+
+
+def _build_version_override(base: str, candidate: "str | None") -> "str | None":
+    """Return *candidate* when it names a build OF *base*, else ``None``.
+
+    Pure so it can be tested without a file. Accepts ``base`` itself and
+    ``base`` + exactly one ``.N`` ASCII-numeric segment, over a bare numeric
+    ``base`` only (a prerelease or nightly base takes no suffix: the composed
+    string would not parse as a release); surrounding whitespace is stripped.
+    Everything else is refused. Private: the contract is the FILE (its name
+    and this shape), not a Python API -- a distribution writes the file at
+    packaging time and imports nothing.
+    """
+    if not candidate or not base:
+        return None
+    value = candidate.strip()
+    if value == base:
+        return value
+    if not _BARE_RELEASE.fullmatch(base) or not value.startswith(base):
+        return None
+    return value if _BUILD_VERSION_SUFFIX.fullmatch(value[len(base) :]) else None
+
+
+def _apply_build_version_file(base: str, package_dir: "str | None") -> str:
+    if not package_dir:
+        return base
+    path = os.path.join(package_dir, _BUILD_VERSION_FILENAME)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            # One byte past the cap, so an oversized file is detected rather
+            # than silently truncated into a value that happens to parse.
+            raw = handle.read(_BUILD_VERSION_MAX_CHARS + 1)
+    except (OSError, ValueError):
+        # Absent is the normal case: the file exists only in a distribution
+        # that stamps one. Unreadable or undecodable is treated the same --
+        # the base is the honest answer when the stamp cannot be read.
+        return base
+    if not raw.strip():
+        return base
+    override = _build_version_override(base, raw) if len(raw) <= _BUILD_VERSION_MAX_CHARS else None
+    if override is None:
+        logging.getLogger(__name__).warning(
+            "%s %r does not name a build of kiro_crew %s "
+            "(expected the base or base.N); ignoring it",
+            _BUILD_VERSION_FILENAME,
+            raw.strip()[:_BUILD_VERSION_MAX_CHARS],
+            base,
+        )
+        return base
+    return override
+
+
+__version__ = _apply_build_version_file(__version__, os.path.dirname(__file__ or ""))
 
 
 class _LazyShutdownEvent:

--- a/src/kiro_crew/changelog.py
+++ b/src/kiro_crew/changelog.py
@@ -161,17 +161,47 @@ def running_release(version: str) -> tuple[str, bool]:
     ``is_prerelease`` comes from an actual prerelease MARKER rather than from
     ``base != version``: a bare build/local segment (``0.2.0+abc123``) is not a
     prerelease, and testing inequality would badge it "Unreleased".
+
+    A distribution build stamp (``0.6.0.12`` -- a ``BUILD_VERSION`` file beside
+    ``kiro_crew/__init__.py``, see there) is a build OF the ``0.6.0`` release,
+    and the release's notes are its notes: the segments past the third are
+    folded off here so the running build marks the ``0.6.0`` row instead of
+    opening an empty ``0.6.0.12`` row above it. Headings never carry a fourth
+    segment, so nothing a heading names can be shadowed by the fold.
     """
     v = version.strip()
     if not v:
         return "", False
     m = _BASE_RE.fullmatch(v)
     if m:
-        return m.group("base"), bool(m.group("pre"))
+        return release_of_build(m.group("base")), bool(m.group("pre"))
     loose = _RUNNING_RE.fullmatch(v)
     if loose:
-        return loose.group("base"), bool(loose.group("pre"))
+        return release_of_build(loose.group("base")), bool(loose.group("pre"))
     return v, False
+
+
+def release_of_build(version: str) -> str:
+    """``0.6.0.12`` -> ``0.6.0``; anything that is not a build stamp is itself.
+
+    The one fold that treats a distribution build stamp as a build OF its
+    release. Shared with the update check's channel-move compare, which asks
+    whether the running RELEASE is ahead of the lane -- a stamped build is not.
+
+    Folds ONLY the stamp shape the stamp rule admits: exactly one ASCII-numeric
+    fourth segment over a three-segment numeric release. The release lanes' own
+    dotted spellings -- the nightly wheel ``X.Y.Z.devN`` and a ``X.Y.Z.postN``
+    -- also carry a fourth dot-segment and MUST NOT fold: a nightly
+    ``0.6.0.dev0906`` compared as ``0.6.0`` against its own lane's
+    ``0.6.0.dev0907`` would read as permanently ahead, the exact false
+    channel-move this fold exists to prevent for stamps.
+    """
+    segments = version.split(".")
+    if len(segments) != 4:
+        return version
+    if not all(seg.isascii() and seg.isdigit() for seg in segments):
+        return version
+    return ".".join(segments[:3])
 
 
 def _sort_key(version: str) -> tuple[int, ...]:

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -19,7 +19,7 @@ from aiohttp.client_exceptions import ClientConnectionResetError
 
 from kiro_crew import __version__ as _local_version
 from kiro_crew import dep_sync, shutdown_event
-from kiro_crew.changelog import Release, base_version, build_release_list
+from kiro_crew.changelog import Release, base_version, build_release_list, release_of_build
 from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
@@ -1167,7 +1167,15 @@ async def _check_release_feed(capability: UpdateCapability) -> None:
         # lane publishes, so the lane never shipped it. Written from the same
         # response as the verdict so a consumer can never pair one channel's
         # move state with another channel's version.
-        channel_move_pending=_is_newer(_local_version, remote_version) is True,
+        #
+        # Compared by RELEASE: a distribution build stamp (``0.6.0.12``, see
+        # ``kiro_crew/__init__``) is a build OF ``0.6.0``, which the lane did
+        # ship. Comparing the raw stamp would read every stamped build as
+        # permanently ahead of its own lane and pin a standing "re-run the
+        # installer" affordance on the About panel, pointing at the bare wheel
+        # that would un-stamp it. The ``available`` verdict above needs no fold:
+        # ``0.6.0`` is not newer than ``0.6.0.12`` either way.
+        channel_move_pending=_is_newer(release_of_build(_local_version), remote_version) is True,
         check_status=CHECK_SUCCEEDED,
         **extra,
     )

--- a/test/test_build_version_override.py
+++ b/test/test_build_version_override.py
@@ -1,0 +1,409 @@
+"""``kiro_crew/BUILD_VERSION`` -- a distribution's build stamp over ``__version__``.
+
+The contract is the FILE (its name and the ``<base>.N`` shape), not a Python
+API, so the helpers are private and imported here under test-local names.
+
+A distribution that repackages one core release as several builds of its own
+(``0.6.0.10``, ``0.6.0.11``, ... of the same ``0.6.0``) had no way to make the
+running process say which one it was: the About page's version chip,
+``/api/status``, ``/api/health``, ``kirocrew --version`` and the diagnostics
+report all read ``kiro_crew.__version__``, several through an import-time copy
+(``dashboard/handlers/updates.py::_local_version``, ``ws.py``) that nothing
+after import can reach. The stamp is a file BESIDE ``kiro_crew/__init__.py``,
+written at packaging time and resolved at import -- the one point that
+precedes every copy -- and deliberately not an environment variable, which the
+local operator could set to wave a forbidden build past the governance
+minimum-version floor.
+
+Pinned here: the shape rule (only the base, or the base plus ``.N`` numeric
+segments over a bare numeric base, is honoured; anything else is refused with
+a warning and the base stays); the file resolution (absent, blank, unreadable,
+foreign, valid); and the reach -- in a fresh interpreter importing a package
+that carries the file, the dashboard's import-time copies, ``version_display``
+and ``--version`` all report the stamp, and the governance floor sees it too.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import kiro_crew
+from kiro_crew import _BUILD_VERSION_FILENAME as BUILD_VERSION_FILENAME
+from kiro_crew import _build_version_override as build_version_override
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC = REPO_ROOT / "src"
+PKG_DIR = SRC / "kiro_crew"
+
+
+# ── build_version_override: the shape rule ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "candidate, expected",
+    [
+        ("0.6.0.12", "0.6.0.12"),
+        ("0.6.0", "0.6.0"),  # the first build on a new core IS the base
+        ("0.6.0.0", "0.6.0.0"),
+        ("0.6.0.1.2", None),  # exactly one segment: every named build uses one
+        ("  0.6.0.12\n", "0.6.0.12"),  # a trailing newline from `echo >`
+        ("0.5.0.16", None),  # a different base
+        ("0.6.1", None),
+        ("0.6.0-rc.1", None),  # a prerelease stamp is not a build of the base
+        ("0.6.0rc1", None),
+        ("0.6.0.", None),
+        ("0.6.0.x", None),
+        ("0.6.0.12a", None),
+        ("0.6.01", None),  # prefix without the dot boundary
+        ("0.6.0+toolbox.12", None),  # local segments do not parse downstream
+        ("", None),
+        (None, None),
+    ],
+)
+def test_shape_rule(candidate, expected) -> None:
+    assert build_version_override("0.6.0", candidate) == expected
+
+
+@pytest.mark.parametrize(
+    "base, candidate",
+    [
+        ("0.6.0rc4", "0.6.0rc4.10"),  # composes to something _is_newer cannot parse
+        ("0.6.0-nightly.20260904t000000", "0.6.0-nightly.20260904t000000.1"),
+        ("0.6.0.dev20260904", "0.6.0.dev20260904.1"),
+    ],
+)
+def test_a_prerelease_base_takes_no_suffix(base, candidate) -> None:
+    """Only a bare numeric release can be extended; the release lanes' own
+    stamps (rc, nightly, dev) are already the whole build identity."""
+    assert build_version_override(base, candidate) is None
+    assert build_version_override(base, base) == base  # the base itself still passes
+
+
+def test_every_non_digit_in_a_segment_is_refused() -> None:
+    """The rule, not a sample of it: segments are ASCII decimal only."""
+    import string
+
+    for ch in string.printable:
+        # "." is the segment separator and surrounding whitespace is stripped
+        # (both pinned in test_shape_rule); everything else must be refused.
+        if ch.isdigit() or ch == "." or ch.isspace():
+            continue
+        for bad in (f"0.6.0.{ch}", f"0.6.0.{ch}12", f"0.6.0.1{ch}2", f"0.6.0.12{ch}"):
+            assert build_version_override("0.6.0", bad) is None, repr(bad)
+    # Unicode digit classes are not ASCII decimal; a build script never writes
+    # them, and a comparator downstream would choke.
+    assert build_version_override("0.6.0", "0.6.0.\u0663") is None
+    assert build_version_override("0.6.0", "0.6.0.\u00b2") is None
+    for n in range(0, 200):
+        assert build_version_override("0.6.0", f"0.6.0.{n}") == f"0.6.0.{n}"
+
+
+def test_empty_base_never_matches() -> None:
+    assert build_version_override("", "0.6.0.12") is None
+
+
+# ── _apply_build_version_file: what the import does with the file ───────────
+
+
+def test_no_file_keeps_the_base(tmp_path) -> None:
+    assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0"
+
+
+def test_no_package_dir_keeps_the_base() -> None:
+    assert kiro_crew._apply_build_version_file("0.6.0", "") == "0.6.0"
+    assert kiro_crew._apply_build_version_file("0.6.0", None) == "0.6.0"
+
+
+def test_a_blank_file_keeps_the_base(tmp_path) -> None:
+    (tmp_path / BUILD_VERSION_FILENAME).write_text("  \n", encoding="utf-8")
+    assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0"
+
+
+def test_a_build_of_the_base_is_applied(tmp_path) -> None:
+    (tmp_path / BUILD_VERSION_FILENAME).write_text("0.6.0.12\n", encoding="utf-8")
+    assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0.12"
+
+
+def test_an_unreadable_file_keeps_the_base(tmp_path) -> None:
+    """A directory where the file should be: open() raises, the base stays."""
+    (tmp_path / BUILD_VERSION_FILENAME).mkdir()
+    assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0"
+
+
+def test_a_foreign_value_is_refused_with_one_warning(tmp_path, caplog) -> None:
+    (tmp_path / BUILD_VERSION_FILENAME).write_text("0.5.0.16\n", encoding="utf-8")
+    with caplog.at_level("WARNING", logger="kiro_crew"):
+        assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0"
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert BUILD_VERSION_FILENAME in warnings[0].getMessage()
+    assert "0.5.0.16" in warnings[0].getMessage()
+
+
+def test_an_oversized_file_is_refused_not_truncated(tmp_path, caplog) -> None:
+    """The read is capped, and a file past the cap is a foreign value: it must
+    not be truncated into a prefix that happens to parse as ``<base>.N``."""
+    (tmp_path / BUILD_VERSION_FILENAME).write_bytes(b"0.6.0." + b"9" * 4096)
+    with caplog.at_level("WARNING", logger="kiro_crew"):
+        assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0"
+    assert BUILD_VERSION_FILENAME in caplog.text
+    # ...while a stamp comfortably under the cap is still honoured.
+    (tmp_path / BUILD_VERSION_FILENAME).write_text("0.6.0.1234567890\n", encoding="utf-8")
+    assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0.1234567890"
+
+
+def test_an_undecodable_file_keeps_the_base(tmp_path) -> None:
+    (tmp_path / BUILD_VERSION_FILENAME).write_bytes(b"\xff\xfe0.6.0.1")
+    assert kiro_crew._apply_build_version_file("0.6.0", str(tmp_path)) == "0.6.0"
+
+
+# ── reach: a fresh interpreter importing a package that carries the file ────
+
+
+def _stamped_package_root(tmp_path: Path, stamp: str | None) -> Path:
+    """A ``kiro_crew`` package that IS the source tree's, with the file beside it.
+
+    ``__init__.py`` is a byte copy of the real one (the code under test) plus a
+    ``__path__`` line that points submodule resolution back at ``src/kiro_crew``,
+    so ``kiro_crew.dashboard...`` imports the real modules while
+    ``kiro_crew.__file__`` -- the anchor the stamp is read beside -- is the
+    copy. Nothing is written into the source tree, and no symlink is needed.
+    """
+    root = tmp_path / "pkgroot"
+    pkg = root / "kiro_crew"
+    pkg.mkdir(parents=True)
+    init_src = (PKG_DIR / "__init__.py").read_text(encoding="utf-8")
+    (pkg / "__init__.py").write_text(
+        init_src + f"\n__path__.append({str(PKG_DIR)!r})\n", encoding="utf-8"
+    )
+    if stamp is not None:
+        (pkg / BUILD_VERSION_FILENAME).write_text(stamp, encoding="utf-8")
+    return root
+
+
+def _fresh_interpreter(tmp_path: Path, stamp: str | None, code: str) -> subprocess.CompletedProcess:
+    root = _stamped_package_root(tmp_path, stamp)
+    env = dict(os.environ)
+    # The stamped package root first; the parent's sys.path follows only for
+    # third-party deps. No bytecode: the child must leave nothing behind, in
+    # the source tree or in tmp_path.
+    env["PYTHONPATH"] = os.pathsep.join([str(root)] + [p for p in sys.path if p])
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return subprocess.run(
+        [sys.executable, "-c", f"PKG = {str(root / 'kiro_crew')!r}\n" + code],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env=env,
+        cwd=str(tmp_path),
+        timeout=120,
+    )
+
+
+_REACH_PROBE = """
+import os
+import kiro_crew
+from kiro_crew.dashboard.handlers import updates
+from kiro_crew.dashboard import ws
+from kiro_crew.dashboard import handlers_system
+from kiro_crew import release_channel
+from kiro_crew.platform import update_governance
+assert os.path.dirname(kiro_crew.__file__) == PKG, kiro_crew.__file__
+assert os.path.dirname(updates.__file__) != PKG  # the REAL dashboard module
+print("version", kiro_crew.__version__)
+print("updates", updates._local_version)
+print("ws", ws._local_version)
+print("display", updates.status_update_fields()["version_display"])
+print("health", handlers_system.kiro_crew.__version__)
+print("channel", release_channel.channel())
+"""
+
+
+def _parse(out: str) -> dict[str, str]:
+    return dict(line.split(" ", 1) for line in out.strip().splitlines())
+
+
+def test_the_stamp_reaches_every_import_time_copy(tmp_path) -> None:
+    """The property the file exists for: a package carrying it names the build
+    everywhere a user can read a version."""
+    base = _fresh_interpreter(tmp_path / "a", None, _REACH_PROBE)
+    assert base.returncode == 0, base.stderr
+    got_base = _parse(base.stdout)
+    stamped = f"{got_base['version']}.12"
+
+    proc = _fresh_interpreter(tmp_path / "b", stamped + "\n", _REACH_PROBE)
+    assert proc.returncode == 0, proc.stderr
+    got = _parse(proc.stdout)
+    assert got["version"] == stamped
+    assert got["updates"] == stamped  # -> the About chip's version_display
+    assert got["ws"] == stamped  # -> the reload-on-upgrade compare
+    assert got["display"] == stamped  # base_version is the identity on <base>.N
+    assert got["health"] == stamped  # -> /api/health identity for the desktop guard
+    assert got["channel"] == "stable"  # no prerelease marker: still a stable build
+    assert BUILD_VERSION_FILENAME not in proc.stderr
+
+
+def test_a_refused_file_leaves_every_copy_on_the_base(tmp_path) -> None:
+    base = _fresh_interpreter(tmp_path / "a", None, _REACH_PROBE)
+    got_base = _parse(base.stdout)
+    proc = _fresh_interpreter(tmp_path / "b", "9.9.9.1\n", _REACH_PROBE)
+    assert proc.returncode == 0, proc.stderr
+    assert _parse(proc.stdout) == got_base
+    assert BUILD_VERSION_FILENAME in proc.stderr  # the one warning, on stderr
+
+
+def test_the_cli_version_flag_reports_the_build(tmp_path) -> None:
+    """``kirocrew --version`` is an argparse ``action="version"`` that reads
+    ``__version__`` at parser build; it inherits the stamp with no CLI change."""
+    base = _fresh_interpreter(
+        tmp_path / "a", None, "import kiro_crew; print(kiro_crew.__version__)"
+    )
+    stamped = f"{base.stdout.strip()}.12"
+    proc = _fresh_interpreter(
+        tmp_path / "b",
+        stamped,
+        "import sys\nsys.argv = ['kirocrew', '--version']\n"
+        "from kiro_crew.cli import main\n"
+        "try:\n    main()\nexcept SystemExit as exc:\n    raise SystemExit(exc.code or 0)\n",
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == f"kirocrew {stamped}"
+
+
+def test_the_governance_floor_sees_the_stamp(tmp_path) -> None:
+    """A fleet floor is written in the distribution's build numbers. Before
+    the stamp the core base could never satisfy ``0.6.0.10`` and every host
+    read as permanently below the floor; with it the floor works as written."""
+    code = (
+        "import kiro_crew\n"
+        "from kiro_crew.dashboard.handlers import updates\n"
+        "from kiro_crew.platform import update_governance as ug\n"
+        "print('version', kiro_crew.__version__)\n"
+        "print('required', ug.update_required(updates._local_version))\n"
+    )
+    base = _fresh_interpreter(
+        tmp_path / "a", None, "import kiro_crew; print(kiro_crew.__version__)"
+    )
+    core = base.stdout.strip()
+    proc = _fresh_interpreter(tmp_path / "b", f"{core}.12\n", code)
+    assert proc.returncode == 0, proc.stderr
+    got = _parse(proc.stdout)
+    assert got["version"] == f"{core}.12"
+    # Unpinned in this environment: no floor, so not required. The point is
+    # that the floor is evaluated over the STAMPED copy, the same value the
+    # gateway's `_running_version` and the status payload carry.
+    assert got["required"] == "False"
+
+
+def test_a_child_leaves_no_bytecode_behind(tmp_path) -> None:
+    proc = _fresh_interpreter(tmp_path, "0.0.0", "import kiro_crew")
+    assert proc.returncode == 0, proc.stderr
+    assert not list(tmp_path.rglob("__pycache__"))
+
+
+def test_update_compare_orders_stamped_builds() -> None:
+    """The stamp now feeds the update check's comparator: ``<base>.<n>`` must
+    order by ``n`` (incl. the 9->10 / 99->100 boundaries), sit above the bare
+    base, and below the next patch line."""
+    from kiro_crew.dashboard.handlers.updates import _is_newer
+
+    numbers = list(range(0, 25)) + [98, 99, 100, 101, 999, 1000]
+    for n in numbers:
+        for m in numbers:
+            assert _is_newer(f"0.6.0.{n}", f"0.6.0.{m}") is (n > m), (n, m)
+        assert _is_newer("0.6.1", f"0.6.0.{n}") is True
+        assert _is_newer(f"0.6.0.{n}", "0.6.0") is (n > 0)
+
+
+# ── the About page's changelog marks the RELEASE the build belongs to ────────
+
+
+def test_changelog_marks_the_release_row_for_a_stamped_build() -> None:
+    """``0.6.0.12`` is a build OF 0.6.0: its notes are 0.6.0's, so the running
+    build must mark that row -- not open an empty ``0.6.0.12`` row above it."""
+    from kiro_crew.changelog import build_release_list, running_release
+
+    assert running_release("0.6.0.12") == ("0.6.0", False)
+    assert running_release("0.6.0") == ("0.6.0", False)  # three segments untouched
+    assert running_release("0.6.0rc3") == ("0.6.0", True)  # the lanes' own stamps still fold
+    md = "# Changelog\n\n## [0.6.0] — 2026-09-01\n\nnotes\n\n## [0.5.0] — 2026-08-29\n\nolder\n"
+    rows = build_release_list(md, "0.6.0.12")
+    assert [r.version for r in rows] == ["0.6.0", "0.5.0"]  # no phantom 0.6.0.12 row
+    current = [r for r in rows if r.is_current]
+    assert [r.version for r in current] == ["0.6.0"]
+    assert current[0].body.strip() == "notes"
+    assert current[0].in_progress is False
+
+
+def test_channel_move_compares_by_release_not_by_stamp() -> None:
+    """A stamped ``0.6.0.12`` on the stable lane whose current release is
+    ``0.6.0`` is ON that lane, not ahead of it: the feed check must not flag a
+    permanent channel move (which the About panel renders as a standing
+    "re-run the installer" affordance pointing at the bare wheel)."""
+    from kiro_crew.changelog import release_of_build
+    from kiro_crew.dashboard.handlers.updates import _is_newer
+
+    assert release_of_build("0.6.0.12") == "0.6.0"
+    assert release_of_build("0.6.0") == "0.6.0"
+    # The lanes' own spellings are untouched -- including the two that ALSO
+    # carry a fourth dot-segment. A nightly venv install compared as its bare
+    # release against its own lane's newer nightly would read as permanently
+    # ahead, which is the very false move this fold exists to prevent.
+    for lane in ("0.6.0rc4", "0.6.0.dev0906", "0.6.0.post1", "0.6.0-nightly.20260904t000000"):
+        assert release_of_build(lane) == lane, lane
+    assert _is_newer(release_of_build("0.6.0.dev0906"), "0.6.0.dev0907") is False
+    assert release_of_build("0.6.0.\u0663") == "0.6.0.\u0663"  # not an ASCII stamp
+    assert release_of_build("0.6.0.1.2") == "0.6.0.1.2"  # the stamp rule admits one segment
+    # The exact expression _check_release_feed stores as channel_move_pending:
+    assert _is_newer(release_of_build("0.6.0.12"), "0.6.0") is not True
+    # ...while the verdict direction still says "0.6.0 is not an update":
+    assert _is_newer("0.6.0", "0.6.0.12") is False
+    # ...and a genuinely ahead build still reads as a move:
+    assert _is_newer(release_of_build("0.7.0.3"), "0.6.0") is True
+
+
+def test_the_feed_check_source_folds_the_stamp() -> None:
+    """Pins the call site itself: the compare in ``_check_release_feed`` goes
+    through ``release_of_build``, so a refactor cannot quietly revert it."""
+    src = (PKG_DIR / "dashboard" / "handlers" / "updates.py").read_text(encoding="utf-8")
+    assert "channel_move_pending=_is_newer(release_of_build(_local_version), remote_version)" in src
+
+
+def test_telemetry_release_is_unchanged_by_the_stamp() -> None:
+    """The anonymous usage beacon deliberately reports ``major.minor.patch``
+    only (cardinality); a stamped build sends the same value as its base."""
+    from kiro_crew import beacon
+
+    assert beacon.release("0.6.0.12") == beacon.release("0.6.0") == "0.6.0"
+
+
+# ── the version-line regexes the release lanes rely on still see ONE line ───
+
+
+def test_the_assignment_line_is_still_the_first_version_match() -> None:
+    """``build-wheel.yml`` / ``build-desktop.yml`` / ``build-windows.yml`` sed the
+    FIRST ``__version__ = "..."`` line, ``nightly.yml`` greps the first line
+    naming ``__version__``, and the git-checkout update path regexes the same.
+    The stamp code must not put another candidate ahead of the assignment."""
+    import re
+
+    src = (PKG_DIR / "__init__.py").read_text(encoding="utf-8")
+    first_mention = next(line for line in src.splitlines() if "__version__" in line)
+    assert re.fullmatch(r'__version__ = "[^"]+"', first_mention), first_mention
+    quoted = re.findall(r'^__version__\s*=\s*"[^"]*"', src, re.MULTILINE)
+    assert len(quoted) == 1, quoted
+
+
+def test_the_file_is_not_shipped_by_this_repo() -> None:
+    """The stamp belongs to a distribution's packaging step; the repo and the
+    wheels it publishes carry none, and the gitignore keeps a dev experiment
+    from being committed."""
+    assert not (PKG_DIR / BUILD_VERSION_FILENAME).exists()
+    assert f"src/kiro_crew/{BUILD_VERSION_FILENAME}" in (REPO_ROOT / ".gitignore").read_text(
+        encoding="utf-8"
+    )


### PR DESCRIPTION
## Problem / Motivation

A distribution that repackages one core release as several builds of its own — an enterprise bundle vending `0.6.0.10`, `0.6.0.11`, `0.6.0.12` of the same `0.6.0` core — has no way to make the running process say which build it is. `kiro_crew.__version__` is the core base, and every version a user can read comes from it: the About page's version chip (`version_display`), `/api/status`, `/api/health`, `kirocrew --version`, the diagnostics report, the governance min-version floor. On such a distribution the dashboard shows **`v0.6.0` · up to date** on every one of its releases, so a user reporting a bug or confirming a fix landed cannot tell which build they are running.

Several of those readers bind `from kiro_crew import __version__` **at import time** (`dashboard/handlers/updates.py::_local_version`, `dashboard/ws.py`, `config/loader.py`, `cli_server.py`). Nothing composed later — a `PlatformContext` field, a plugin, a route — can reach those copies, so a downstream cannot fix this from outside the core without patching module state before the first core import.

## Why it matters

Any downstream that ships more than one build per core release hits this: the enterprise/internal editions composed through the `kirocrew.plugins` seam today, and any distro or corporate repackager tomorrow. Without it they either show the wrong version or reach into core module state from their launcher — the second is exactly what the CPP seam exists to make unnecessary.

## What changed (motivation → approach → change)

**Goal:** let a distribution name its build once, and have every reader in the process report it — without the core learning anything about bundle layouts, and without handing the local operator a new lever over an enterprise ceiling.

**Approach:** a `BUILD_VERSION` file placed **beside `kiro_crew/__init__.py`** at packaging time, resolved in `kiro_crew/__init__` at import. Import time is the only point that precedes every import-time copy, which is why this is deliberately *not* a `PlatformContext` field (a context is composed after those imports).

A **file in the package, not an environment variable**, on purpose — this PR's first revision used `KIROCREW_BUILD_VERSION`, and GPT 5.6 correctly flagged that the version feeds the governance minimum-version floor (`update_required`), an enterprise ceiling the local operator must not be able to weaken; an env var is theirs to set, so `=0.6.0.999` would have waved a forbidden build past the floor. The file sits in the same site-packages tree as the code and carries exactly its trust: whoever can write it can write `__init__.py`, so it adds no bypass the bytes did not already have. It is also the same model the release lanes already use when they `sed` the version literal for a nightly/insider build — the stamp lives in the bytes and is what a shadow-venv probe or any fresh interpreter naturally reports (so `verify_shadow_venv` needs no change: an installed wheel's answer is its own file or none).

Alternatives considered: a `PlatformContext.edition_version` field (cannot reach the copies; every reader would need rewriting to a lazy call); a build-time rewrite of `__init__.py` (what our lanes do — right for *our* stamps, but a downstream cannot rewrite a wheel it installs); an env var (the ceiling bypass above).

**Fail-closed on shape.** Only the core base itself, or the base followed by **exactly one** `.N` ASCII-numeric segment **over a bare numeric base**, is honoured (every named build uses one; the helpers in `__init__` are private — the contract is the file's name and shape, not a Python API). A different base, a prerelease stamp, a non-numeric or `+local` segment, or a suffix over an `rc`/nightly base (which would compose to something `_is_newer` cannot parse) is a build this core is not; it is ignored with one warning and the base stays. The read is capped (64 chars, one past to detect overflow) and an oversized, undecodable or unreadable file falls back to the base. The accepted shape parses as a PEP 440 release everywhere the version is compared — `_is_newer`, `base_version` (an identity on `<base>.N`), `release_channel.channel` (still `stable`) — so a stamped build orders and classifies exactly as its base would.

**Change:**
- `src/kiro_crew/__init__.py` — `_BUILD_VERSION_FILENAME`, `_build_version_override()` (pure), `_apply_build_version_file()` (all private); `__version__` is reassigned through it right after the literal. The literal assignment stays the FIRST `__version__ = "..."` line: `build-wheel.yml`, `build-desktop.yml`, `build-windows.yml` `sed` that line, `nightly.yml` greps the first mention, and the git-checkout update path regexes it — all still see exactly one candidate (pinned by a test). `logging` joins the module import block (no inline import).
- `setup.cfg` / `MANIFEST.in` — `BUILD_VERSION` declared as optional package data so a downstream that writes it before building its own wheel gets it carried; absent here and in the wheels this repo publishes.
- `.gitignore` — `src/kiro_crew/BUILD_VERSION`, so a dev experiment is never committed.
- `src/kiro_crew/dashboard/handlers/updates.py::_check_release_feed` — `channel_move_pending` compares by **release** (`release_of_build(_local_version)`), so a stamped `0.6.0.12` on a lane whose current release is `0.6.0` is on that lane, not permanently "ahead" of it (which the About panel would render as a standing re-run-the-installer affordance pointing at the bare wheel). The `update_available` verdict needs no fold. A distribution's normal update path is the command provider (pins), which never consults the feed; this covers the case where one does.
- `src/kiro_crew/changelog.py::running_release` / new `release_of_build` — folds ONLY the stamp shape (exactly one ASCII-numeric fourth segment over a numeric release); the lanes' own dotted spellings `X.Y.Z.devN` / `X.Y.Z.postN` are left untouched, so a nightly venv install never reads as ahead of its own lane. It folds a stamp's segments past the third onto its release (`0.6.0.12` → `0.6.0`) so the About page's changelog marks the `0.6.0` row instead of opening an empty `0.6.0.12` row above it; headings never carry a fourth segment, so nothing a heading names can be shadowed. `base_version` (the display fold) is untouched and preserves the stamp.
- Two readers deliberately unchanged, and documented as such: the anonymous usage beacon (`beacon.release` clamps to `major.minor.patch`) and the changelog above.
- `docs/system-specs/modules/platform-context.md` — a "Distribution build version" subsection under Companion packaging.

No behaviour changes without the file: `__version__` is the literal, byte-for-byte.

## Tests

`test/test_build_version_override.py` (41 tests):
- **Shape rule** — parametrized accept/refuse table (base, `.N`, trailing newline; `.N.M`, different base, `rc`, `-rc.1`, trailing dot, alpha, `+local`, no dot boundary, empty/None); a prerelease/nightly/dev base takes no suffix; the property that every non-digit printable injected into a segment is refused, Unicode digit classes refused, `0..199` accepted.
- **File resolution** — no file / no package dir / blank / a directory in its place / undecodable / oversized (refused, not truncated) all keep the base; a build of the base applies; a foreign value is refused with exactly one WARNING naming the file and the value.
- **Reach, in a fresh interpreter** — the child imports a `kiro_crew` package built under `tmp_path` whose `__init__.py` is a byte copy of the real one (plus a `__path__` line pointing submodules at `src/kiro_crew`) with the file beside it; `PYTHONDONTWRITEBYTECODE=1`, `cwd=tmp_path`, nothing written into the source tree (a test asserts no `__pycache__` is left anywhere under `tmp_path`). With the file: `kiro_crew.__version__`, `updates._local_version`, `ws._local_version`, `status_update_fields()["version_display"]`, the `/api/health` reader and `release_channel.channel()` all carry the stamp (and `stable`); a refused file leaves every one of them on the base and emits the warning on stderr; `kirocrew --version` prints the stamped build with no CLI change; `update_required()` is evaluated over the stamped copy.
- **Channel move** — `release_of_build` folds `0.6.0.12`→`0.6.0` and leaves `0.6.0rc4`, `0.6.0.dev0906`, `0.6.0.post1` and a `-nightly.` stamp alone (`_is_newer(release_of_build("0.6.0.dev0906"), "0.6.0.dev0907")` is False); the exact `channel_move_pending` expression is not-True for a stamped build on its own lane and True for a genuinely ahead release; a source pin asserts the call site goes through the fold.
- **Changelog / beacon** — `running_release("0.6.0.12")` is `("0.6.0", False)`; `build_release_list` marks the `0.6.0` row current with its notes and adds no phantom row; `beacon.release("0.6.0.12") == "0.6.0"`.
- **Comparator** — `_is_newer` orders `<base>.<n>` by `n` across 0–25 and the 9→10 / 99→100 / 999→1000 boundaries, above the bare base, below the next patch line.
- **Release-lane regexes** — the literal assignment is the first `__version__` mention and the only quoted assignment in `__init__.py`.
- **Repo hygiene** — the file does not exist in the repo and is gitignored.

Local gates: black, isort, flake8, mypy, subprocess-encoding, sync-io, brand, harness-parity, changelog-history, docs-lint, scrub-lint, per-file coverage, vendor manifest all green. `run_scoped_tests.py --surface backend` on the first revision escalated to the full suite (the diff touches `kiro_crew/__init__.py`): 84688 passed; the 216 failures are environment-specific and reproduce identically on a pristine `origin/main` worktree on this host (193 of them in the same files re-run there) — none touch versioning.

## Manual verification

In a scratch venv with the wheel installed: `echo 0.6.0.12 > site-packages/kiro_crew/BUILD_VERSION`, then `python -c 'import kiro_crew; from kiro_crew.dashboard.handlers import updates; print(kiro_crew.__version__, updates.status_update_fields()["version_display"])'` → `0.6.0.12 0.6.0.12`; remove the file → `0.6.0 0.6.0`; write `0.5.0.16` → one warning on stderr, `0.6.0 0.6.0`. The fresh-interpreter tests run these same probes against a copy of the package.

## Related Issues

N/A — surfaced by the internal edition, which currently works around it by stamping `kiro_crew.__version__` from its CLI entry before the first core import; this seam retires that workaround (its packaging step writes the file instead).

## Pattern harvest

N/A — feature PR (a new seam), not a fix/revert.
