### PR TITLE
fix(ci): exclude temp-screenshots evidence from the backend change bucket (#8027)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
   # only_backend / only_frontend are computed here ONCE. `backend` is a
   # catch-all, so every changed file is exactly one of frontend / meta /
   # backend: a diff that touches two buckets (or meta) leaves BOTH flags false
-  # and the full matrix runs.
+  # and the full matrix runs. One exception: temp-screenshots/** evidence
+  # media counts toward NO bucket, so a screenshots-only diff also leaves both
+  # flags false and runs the full matrix (fails safe).
   changes:
     name: Detect changed surface
     runs-on: ubuntu-latest
@@ -79,12 +81,14 @@ jobs:
         with:
           # 'some-with-excludes': a file matches a filter when it matches at
           # least one pattern AND none of the negated ones. That lets `backend`
-          # be a true CATCH-ALL ("every changed file that is not frontend and not
-          # meta") instead of an allowlist that would have to be complete to be
-          # safe. Every changed file therefore lands in exactly one bucket, which
-          # is what makes "only_X means only X changed" literally true -- an
-          # unrecognised path (docs/**, *.md, a new root file) counts as backend
-          # rather than silently riding along under a narrowed suite.
+          # be a true CATCH-ALL ("every changed file that is not frontend, not
+          # meta, and not ignored evidence media") instead of an allowlist that
+          # would have to be complete to be safe. Every changed file therefore
+          # lands in exactly one bucket -- or none, for temp-screenshots/**
+          # evidence -- which is what keeps "only_X means only X changed" true
+          # for real files: an unrecognised path (docs/**, *.md, a new root
+          # file) counts as backend rather than silently riding along under a
+          # narrowed suite.
           # NOTE: this quantifier requires >= v4.0.3 (added upstream in PR #322);
           # v4.0.2 rejects the input and throws, so do not lower the pin.
           predicate-quantifier: 'some-with-excludes'
@@ -99,6 +103,15 @@ jobs:
               - '!website/**'
               - '!.github/**'
               - '!scripts/**'
+              # temp-screenshots/** is never-packaged, never-imported evidence
+              # media (cleanup-temp-screenshots.yml already treats it as
+              # ephemeral), so it must not drag a frontend-only PR into the
+              # full backend matrix (#8027). Excluding it keeps the catch-all
+              # safety property: any unrecognised REAL file still lands in
+              # backend, a screenshots+frontend diff stays only_frontend=true,
+              # and a screenshots-ONLY diff matches no bucket so both flags
+              # stay false and the FULL matrix runs (fails safe).
+              - '!temp-screenshots/**'
             # Independent of the three buckets above: it answers a different
             # question ("could this diff change what a Linux package installs?")
             # and so may overlap them freely.

--- a/scripts/local-gate.py
+++ b/scripts/local-gate.py
@@ -12,13 +12,16 @@ the diff costs, not what the repo costs.
 
 Contract (identical to CI's, fail-open everywhere)
 --------------------------------------------------
-Every changed file lands in exactly ONE bucket, mirroring ci.yml's
-``changes`` job:
+Every changed file lands in exactly ONE bucket -- or, for ignored evidence
+media, none -- mirroring ci.yml's ``changes`` job:
 
 - ``frontend``: ``website/**``
 - ``meta``:     ``.github/**``, ``scripts/**``
-- ``backend``:  everything else (a CATCH-ALL -- an unrecognised path counts as
-  backend, so a new file can never silently ride along under a narrowed run)
+- ``backend``:  everything else except the ignored prefixes (a CATCH-ALL -- an
+  unrecognised path counts as backend, so a new file can never silently ride
+  along under a narrowed run)
+- ignored:      ``temp-screenshots/**`` (evidence media; NO bucket, so an
+  ignored-only diff runs the full gate)
 
 Narrowing happens only when exactly one of frontend/backend changed and meta
 did not:
@@ -71,6 +74,12 @@ from run_scoped_tests import (  # noqa: E402  (path set immediately above)
 # pins this against the workflow file so drift fails a test instead of shipping.
 _FRONTEND_PREFIXES = ("website/",)
 _META_PREFIXES = (".github/", "scripts/")
+# Evidence media ci.yml excludes from EVERY bucket (#8027): temp-screenshots/**
+# is never packaged or imported, so it must not drag a frontend-only diff into
+# the backend matrix. A path here sets NO flag; a diff that is ONLY ignored
+# paths classifies all-False and build_plan() runs the full gate (fail-open),
+# matching CI's full matrix for a screenshots-only PR.
+_IGNORED_PREFIXES = ("temp-screenshots/",)
 _NODE_LAUNCHERS = frozenset({"npm", "npx"})
 
 
@@ -79,12 +88,16 @@ def classify(paths: list[str]) -> tuple[bool, bool, bool]:
 
     Backend is the catch-all: any path that is neither frontend nor meta counts
     as backend, including paths that do not exist yet (adds) or any unexpected
-    shape. There is deliberately NO "unknown" outcome.
+    shape. There is deliberately NO "unknown" outcome. The one carve-out is
+    ``_IGNORED_PREFIXES`` (screenshot evidence), which sets no flag at all --
+    mirroring ci.yml, where those paths match no bucket.
     """
     frontend = meta = backend = False
     for raw in paths:
         p = raw.strip().replace("\\", "/")
         if not p:
+            continue
+        if p.startswith(_IGNORED_PREFIXES):
             continue
         if p.startswith(_FRONTEND_PREFIXES):
             frontend = True
@@ -101,6 +114,12 @@ def changed_files(base: str) -> list[str] | None:
     Includes uncommitted work (staged + unstaged + untracked) -- the local gate
     verifies the working tree, not just commits. Any git failure returns None,
     which the caller maps to the full gate (fail-open).
+
+    BOTH endpoints of a rename are collected: ``--no-renames`` makes git report
+    a rename as a delete plus an add (the same contract run_scoped_tests.py
+    documents, and the same one dorny/paths-filter applies in CI), so renaming
+    a real file INTO an ignored evidence path cannot hide the old path's
+    bucket from classification.
     """
     try:
         merge_base = subprocess.run(
@@ -111,12 +130,13 @@ def changed_files(base: str) -> list[str] | None:
         if merge_base.returncode != 0:
             return None
         committed = subprocess.run(
-            ["git", "diff", "--name-only", merge_base.stdout.strip(), "HEAD"],
+            ["git", "diff", "--name-only", "--no-renames",
+             merge_base.stdout.strip(), "HEAD"],
             cwd=_REPO_ROOT, capture_output=True, text=True,
             encoding="utf-8", errors="replace", timeout=30,
         )
         working = subprocess.run(
-            ["git", "status", "--porcelain"],
+            ["git", "status", "--porcelain", "--no-renames"],
             cwd=_REPO_ROOT, capture_output=True, text=True,
             encoding="utf-8", errors="replace", timeout=30,
         )
@@ -126,10 +146,13 @@ def changed_files(base: str) -> list[str] | None:
         return None
     paths = [line for line in committed.stdout.splitlines() if line.strip()]
     for line in working.stdout.splitlines():
-        # porcelain: "XY path" or "XY old -> new" for renames; take the new name.
-        entry = line[3:].split(" -> ")[-1].strip().strip('"')
-        if entry:
-            paths.append(entry)
+        # porcelain: "XY path". Renames cannot appear (--no-renames above), but
+        # parse the "old -> new" arrow defensively and keep BOTH sides -- the
+        # old path's bucket must not vanish just because the file moved.
+        for part in line[3:].split(" -> "):
+            entry = part.strip().strip('"')
+            if entry:
+                paths.append(entry)
     return paths
 
 
@@ -208,6 +231,12 @@ def build_plan(args: argparse.Namespace) -> Plan:
         return plan
 
     frontend, meta, backend = classify(paths)
+
+    if not (frontend or meta or backend):
+        plan = Plan("only ignored evidence paths changed -- full gate (fail-open)")
+        _backend_full(plan)
+        _frontend_full(plan)
+        return plan
 
     if meta or (frontend and backend):
         plan = Plan(

--- a/scripts/run_scoped_tests.py
+++ b/scripts/run_scoped_tests.py
@@ -201,25 +201,37 @@ def has_broad_impact(paths: list[str]) -> str | None:
 
 
 def surface_bucket(path: str) -> str:
-    """Which of CI's three buckets a changed path falls in.
+    """Which of CI's buckets a changed path falls in (or ``ignored``).
 
     Transcribed from `ci.yml`'s `changes` job, which is the authority for this
     question and computes it once for the whole workflow:
 
         frontend: website/**
         meta:     .github/**  scripts/**
-        backend:  **  minus the two above
+        ignored:  temp-screenshots/**  (evidence media; matches NO bucket)
+        backend:  **  minus the three above
 
     An earlier revision folded `meta` into `backend`, which is wrong in a way that
     is invisible until it bites: `.github/scripts/frontend-blob-reconcile.mjs` is
     asserted on by `website/src/test/frontendBlobReconcile.wireFormat.test.ts`, and
     `scripts/` and `docs/` are read by several i18n and settings specs too. Meta
     paths belong to neither surface and can be read by both.
+
+    ``ignored`` is safe in `plan()` by construction: it is never `meta`, never
+    the surface under test, and never the *other* surface, so an ignored path
+    can only ever leave the decision to the real files in the diff -- and an
+    ignored-ONLY diff has no `other` in its buckets, which returns the full
+    suite (fail-open), matching ci.yml where such a diff sets no flag.
     """
     if path.startswith("website/"):
         return "frontend"
     if path.startswith((".github/", "scripts/")):
         return "meta"
+    if path.startswith("temp-screenshots/"):
+        # Mirrors ci.yml's '!temp-screenshots/**' backend negation (#8027):
+        # committed screenshot evidence must not drag a frontend-only diff
+        # into the full backend matrix.
+        return "ignored"
     # Catch-all, exactly as ci.yml comments it: "an unrecognised path counts as
     # backend and cannot ride along under a narrowed suite".
     return "backend"
@@ -505,6 +517,8 @@ def _self_test() -> int:
     check("bucket: workflows are meta", surface_bucket(".github/workflows/ci.yml") == "meta")
     check("bucket: scripts are meta, NOT backend", surface_bucket("scripts/ci-surface-tests.py") == "meta")
     check("bucket: the runner itself is meta", surface_bucket("scripts/run_scoped_tests.py") == "meta")
+    check("bucket: temp-screenshots is ignored, NOT backend (#8027)", surface_bucket("temp-screenshots/feature/shot.png") == "ignored")
+    check("bucket: ignored is a prefix, not a substring", surface_bucket("temp-screenshotsx/evil.py") == "backend")
 
     # The cross-surface list feeds a runner directly, so it must arrive in that
     # runner's path space. Regression trap: unprocessed, it handed vitest

--- a/test/test_local_gate.py
+++ b/test/test_local_gate.py
@@ -64,10 +64,51 @@ def test_script_exists(gate) -> None:
         ("docs/README.md", (False, False, True)),  # catch-all: unrecognised = backend
         ("newtoplevel.cfg", (False, False, True)),
         ("websites/evil.py", (False, False, True)),  # prefix, not substring
+        # Evidence media matches NO bucket (#8027) -- mirrors ci.yml's
+        # '!temp-screenshots/**' backend negation.
+        ("temp-screenshots/feature/shot.png", (False, False, False)),
+        ("temp-screenshotsx/evil.py", (False, False, True)),  # prefix, not substring
     ],
 )
 def test_classify_buckets(gate, path: str, expected) -> None:
     assert gate.classify([path]) == expected
+
+
+def test_classify_evidence_does_not_flip_frontend_only(gate) -> None:
+    """A screenshots+frontend diff stays frontend-only -- the #8027 fix."""
+    frontend, meta, backend = gate.classify(
+        ["website/src/App.tsx", "temp-screenshots/feature/shot.png"]
+    )
+    assert frontend and not meta and not backend
+
+
+def test_changed_files_keeps_both_rename_endpoints(gate, monkeypatch) -> None:
+    """Renaming a real file INTO temp-screenshots/ must not hide the old
+    path's bucket: ``--no-renames`` splits a rename into delete + add (the
+    same contract run_scoped_tests.py and CI's dorny/paths-filter apply), and
+    the porcelain parser keeps BOTH sides of a defensive ``old -> new`` arrow.
+    """
+    class _Proc:
+        def __init__(self, stdout: str = "") -> None:
+            self.returncode = 0
+            self.stdout = stdout
+
+    def fake_run(argv, **_kwargs):
+        if argv[:2] == ["git", "merge-base"]:
+            return _Proc("abc123\n")
+        if argv[:2] == ["git", "diff"]:
+            assert "--no-renames" in argv, "committed diff must not fold renames"
+            return _Proc("src/kiro_crew/gateway.py\n")
+        assert "--no-renames" in argv, "porcelain status must not fold renames"
+        return _Proc('R  src/kiro_crew/moved.py -> temp-screenshots/f/moved.png\n')
+
+    monkeypatch.setattr(gate.subprocess, "run", fake_run)
+    paths = gate.changed_files("main")
+    assert paths is not None
+    assert "src/kiro_crew/moved.py" in paths
+    assert "temp-screenshots/f/moved.png" in paths
+    # And the classification consequence: the old backend path still counts.
+    assert gate.classify(paths) == (False, False, True)
 
 
 def test_classify_mixed_diff_sets_both_flags(gate) -> None:
@@ -139,10 +180,20 @@ def test_bucket_prefixes_match_ci_changes_job(gate) -> None:
         "ci.yml's backend bucket is no longer a pure '**' catch-all -- "
         "scripts/local-gate.py classify() must be reworked to match"
     )
-    assert negations == set(filters["frontend"]) | set(filters["meta"]), (
-        "ci.yml's backend negations no longer mirror frontend+meta exactly -- "
-        "re-derive the bucket rules in scripts/local-gate.py"
+    ignored = {f"{prefix}**" for prefix in gate._IGNORED_PREFIXES}
+    assert negations == set(filters["frontend"]) | set(filters["meta"]) | ignored, (
+        "ci.yml's backend negations no longer mirror frontend+meta plus the "
+        "ignored evidence prefixes -- re-derive the bucket rules in "
+        "scripts/local-gate.py (_FRONTEND_PREFIXES / _META_PREFIXES / "
+        "_IGNORED_PREFIXES)"
     )
+    # classify() tests the ignored prefixes FIRST, so an entry overlapping a
+    # real bucket would silently shadow it while the set-union above still
+    # passed. Keep the carve-out disjoint from the buckets it is carved from.
+    assert not (
+        set(gate._IGNORED_PREFIXES)
+        & (set(gate._FRONTEND_PREFIXES) | set(gate._META_PREFIXES))
+    ), "_IGNORED_PREFIXES must not overlap the frontend/meta bucket prefixes"
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +249,18 @@ def test_empty_diff_falls_open(gate, monkeypatch) -> None:
 def test_meta_diff_runs_full(gate, monkeypatch) -> None:
     monkeypatch.setattr(gate, "changed_files", lambda base: ["scripts/clean.sh"])
     assert _is_full(gate.build_plan(_args()))
+
+
+def test_evidence_only_diff_falls_open(gate, monkeypatch) -> None:
+    """A screenshots-only diff matches no bucket in CI (full matrix runs);
+    the local gate mirrors that with the full plan (fail-open)."""
+    monkeypatch.setattr(
+        gate, "changed_files",
+        lambda base: ["temp-screenshots/feature/shot.png"],
+    )
+    plan = gate.build_plan(_args())
+    assert _is_full(plan)
+    assert "fail-open" in plan.reason
 
 
 def test_both_surfaces_runs_full(gate, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

The `changes` job's `backend` filter is a catch-all (`**` minus `!website/**`, `!.github/**`, `!scripts/**`), so committed screenshot evidence under `temp-screenshots/**` — which the PR template *mandates* for UI changes — flipped a frontend-only PR's `only_frontend` to false and ran the full ~20k backend matrix instead of the reduced cross-surface set, maximizing exposure to the backend shard isolation-flake class (five consecutive rounds observed on PR #7752).

Fix: add `- '!temp-screenshots/**'` to the `backend` filter, and keep every mirror of the bucket rules in lockstep:

- **`.github/workflows/ci.yml`** — the new negation, plus both comment copies (job-level and filter-step) amended so neither claims the now-false "every file lands in exactly one bucket" invariant.
- **`scripts/local-gate.py`** — `_IGNORED_PREFIXES` carve-out in `classify()`; a diff that classifies all-False takes a new explicit fail-open branch in `build_plan()` (full gate). Also collects BOTH endpoints of a rename in `changed_files()` (`--no-renames`, both sides of the porcelain arrow) so renaming a real file into `temp-screenshots/` cannot hide the old path's bucket — the same contract `run_scoped_tests.py` and dorny/paths-filter already apply.
- **`scripts/run_scoped_tests.py`** — third mirror: `surface_bucket()` gains an `ignored` bucket (safe in `plan()` by construction: never meta, never a surface, so it can only leave the decision to the real files; an ignored-ONLY diff returns the full suite), plus `--test` self-checks.
- **`test/test_local_gate.py`** — the two-directional parity pin now asserts backend negations == frontend ∪ meta ∪ ignored, plus a disjointness pin (an ignored prefix overlapping a real bucket would silently shadow it), classify cases (ignored path sets no flag; prefix-not-substring), the screenshots+frontend stays-frontend-only case, the screenshots-only fail-open `build_plan()` case, and a rename-endpoints pin on `changed_files()`.

### Semantics (verified against dorny/paths-filter v4.0.3 at the pinned SHA)

- A screenshots+frontend diff → `only_frontend=true` (the fix).
- A screenshots-ONLY diff matches **no** bucket → both flags false → **full** matrix. All 14 downstream gates on the `changes` outputs are negative-polarity (`!= 'true'`), and both-false is not a new CI state — every meta-touched diff already produces it — so this routes into an existing, well-exercised path. **Deliberate trade-off:** a screenshots-only PR previously ran the narrowed backend suite (`only_backend=true`) and now runs the full matrix; chosen because failing safe on an unclassifiable diff outranks optimizing a rare shape.
- A rename INTO `temp-screenshots/**` still runs the backend matrix: the action splits a rename into delete(old)+add(new) (`src/main.ts`: "Rename is replaced by delete of original filename and add of new filename"), so the old path still hits the catch-all. `local-gate.py` now matches that contract too.

### Why `linux_packaging` is untouched

The reporter suggested possibly excluding the directory from `linux_packaging` triggers too. That filter is an explicit allowlist of six specific files; `temp-screenshots/**` cannot match it, so the exclusion would be a no-op. Stated here instead of adding dead config.

### Out of scope (pre-existing, noted by review)

`.github/screenshots/**` (the legacy evidence convention) lands in `meta` and forces the full matrix — a worse outcome than #8027 describes, but pre-existing and orthogonal; `scripts/leaf_test_scope.py` has no ignore set either. Both are candidates for a follow-up issue.

## Review

Two pre-push model-pinned reviews (GPT + Opus lanes mirrored locally):
- GPT: 1 Medium (rename-into-evidence bypass). CI half rebutted with the action's source (renames are split delete+add); local-gate half was real and is fixed here with a pinning test.
- Opus: PASS; 3 Medium advisory (two stale comment copies, un-mirrored `surface_bucket()`) and 2 Low (disjointness pin, screenshots-only cost trade) — all addressed in this diff or documented above. AUTOSDE blocking-rule check: no hits (`no-test-side-effects` verified clean on the new tests).

## Testing

- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` (1281 files clean), YAML parse of `ci.yml`, `py_compile` on changed scripts/tests
- Diff-scoped gates: black gate, brand gate, scrub-lint — all green
- `run_scoped_tests.py --test` self-checks pass (including the new `ignored` bucket cases)
- Parity spot-check: negation set == frontend ∪ meta ∪ ignored asserted against the workflow text
- Full pytest runs in CI (no backend runtime code changed; `src/kiro_crew/` untouched)

## Pattern harvest

Rule candidate: parity test
Pattern: a classification rule transcribed into multiple mirrors (ci.yml `changes` filters → `scripts/local-gate.py` → `scripts/run_scoped_tests.py::surface_bucket`) where only SOME mirrors carry a workflow-text parity pin — the unpinned mirror drifts silently when the rule changes (exactly what pre-push review caught here). Candidate: extend the `test_local_gate.py`-style parity assertion to every transcription of the `changes`-job filters, so editing the filter list fails a test in each un-updated mirror rather than relying on review to remember the third copy.

No UI change — no screenshots required.

Closes #8027
