### PR TITLE
test(metrics): guard the inventory lifetime-total roster (#8048)

### DIFF
--- a/test/metrics/test_inventory_gauges.py
+++ b/test/metrics/test_inventory_gauges.py
@@ -531,6 +531,23 @@ def test_all_names_pass_core_namespace_validation():
         assert validate_name(name) == name
 
 
+def test_lifetime_totals_are_declared_for_the_consumer_that_must_know():
+    """A lifetime-total gauge is not interchangeable with a state gauge.
+
+    Its newest sample is "since this process started", so a consumer that reports
+    the newest sample as a reading shows a number that only grows. The dashboard
+    aggregator differences them instead, and it finds them through this tuple —
+    which must therefore name exactly the one whose reading accumulates, and
+    must stay a subset of the roster. Adding a lifetime-total gauge without
+    listing it here — or leaving a stale name in the tuple after a roster
+    change — would silently demote the series to newest-sample, with nothing
+    failing; this is the inventory half of the guard the process family already
+    has in ``test_process_gauges``.
+    """
+    assert set(ig.LIFETIME_TOTAL_METRICS) == {ig.GAUGE_PROBE_FAILURES}
+    assert set(ig.LIFETIME_TOTAL_METRICS) <= set(ig.ALL_METRIC_NAMES)
+
+
 def test_collection_yields_every_instrument_with_the_expected_shape():
     with (
         patch.object(ig, "read_active_crons", return_value=3),


### PR DESCRIPTION
# Summary

Refs #8048 — implements items 1 and 3 of the issue. **Item 2 (collapsing the two
rosters into a frozenset literal in the telemetry handler) deliberately remains
open for a human design decision**, per the issue's own text: the boot-path
deferred-import tension must be settled first. This PR does not close #8048.

## Item 1 — roster-drift guard (the code change)

Adds `test_lifetime_totals_are_declared_for_the_consumer_that_must_know` to
`test/metrics/test_inventory_gauges.py`, mirroring the process-family guard of
the same name in `test/metrics/test_process_gauges.py` shape-for-shape:

- asserts `inventory_gauges.LIFETIME_TOTAL_METRICS == {GAUGE_PROBE_FAILURES}`
- asserts the tuple stays a subset of `ALL_METRIC_NAMES`

The lifetime-total contract lives in metric names: the dashboard aggregator
(`_lifetime_total_gauge_names()` in
`src/kiro_crew/dashboard/handlers/telemetry.py`) reduces exactly the declared
names window-relative. The process family already had this guard; the inventory
family did not, leaving `kirocrew.inventory.probe.failures` unguarded. An
accumulating gauge added without being declared here — or a stale name left in
the tuple — now fails this test instead of silently demoting the series to
newest-sample.

## Item 3 — release note (disposition, no file change)

The issue asks for a release-note entry covering the counter-to-gauge change.
This repository's release process forbids the direct edit: `CHANGELOG.md` is
written **only at a version bump** (AGENTS.md → "Release Changelog", the
blocking `changelog-is-written-at-version-bump-only` rule, and
`scripts/check_changelog_history.py`, which deterministically refuses an
`[Unreleased]` or draft section). The commit range is the record until the
0.6.0 release PR composes the section.

So item 3 is delivered as ready-to-fold material for the 0.6.0 release author
(also posted on #8048, which stays open via item 2). Suggested
`### Before you upgrade` entry:

> - **Five OTLP metrics change wire type from cumulative sum to gauge** —
>   `kirocrew.process.cpu.seconds`, `kirocrew.process.gc.collections`,
>   `.collected`, `.uncollectable`, and `kirocrew.inventory.probe.failures`
>   keep their names and meaning (totals since the exporting process started)
>   but now arrive as gauges, so a backend applying a counter function
>   (`rate()`, `increase()`, delta-from-cumulative) to them needs re-pointing
>   to consecutive-sample differences. The OTLP encoding also defaults to
>   DELTA temporality when `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`
>   is unset; setting it to `CUMULATIVE` restores the previous encoding. Full
>   migration guidance: docs/guides/telemetry-otlp-export.md ("If you already
>   export these metrics").

The guide already covers all three required points (type change, DELTA default
when the variable is unset, and that setting it restores the old encoding), so
no guide change was needed.

## What was tested

- Local gates: `isort --check-only`, `flake8`, `mypy` (1281 files clean), the
  diff-scoped black gate (run post-commit against `main`), and the brand gate —
  all green. `pytest` runs in CI per this host's policy; the new test is two
  pure set assertions over module constants (no I/O, no platform dependence).
- Two pre-push model-pinned review lanes on the staged diff: GPT lane
  (gpt-5.6-sol) PASS with no findings; Opus lane (claude-opus-5) PASS with 0
  blocking findings and 2 Low advisories — the docstring-overclaim advisory is
  applied in this commit; the tuple-vs-set advisory is declined to keep the
  guard shape-identical to the process-family mirror it exists to pair with.

no linked issue closed on purpose: item 2 of #8048 is an explicitly deferred
design tension that must stay open, so this PR uses Refs, not Closes.
