### PR TITLE
fix(apps): log why the session agent runner reports itself unavailable

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_runner.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/agent_runner.py
@@ -1180,13 +1180,26 @@ class SessionAgentRunner:
     @staticmethod
     def available() -> bool:
         """True iff a Kiro Crew provider factory can be built (a backend is configured).
-        Lets the backend prefer this runner and fall back to the subprocess ``claude -p``
-        runner only when no provider is available."""
+        Lets the backend prefer this runner; there is no subprocess fallback left, so a
+        False here means the backend stays offline."""
         try:
 
             cfg = KiroCrewConfig.load()
             return cfg.create_provider_factory() is not None
         except Exception:  # noqa: BLE001 — any failure → not available, caller falls back
+            # Do NOT discard this. ``create_provider_factory`` has a single method-level
+            # return and cannot yield None, so False is reachable ONLY from this handler —
+            # i.e. only when something raised. The backend's offline reason already tells
+            # the operator that "the gateway config load or the provider-factory
+            # construction raised", and without this line it can never say WHAT raised.
+            # The realistic cause is the acp → client → session → config.loader circular
+            # import the loader documents, which resolves only when ``acp`` is imported
+            # first, and it was previously invisible in every log.
+            logger.warning(
+                "SessionAgentRunner.available(): provider factory could not be built, "
+                "reporting the agent runner as unavailable",
+                exc_info=True,
+            )
             return False
 
     def ensure_agent_registered(self) -> bool:

--- a/test/test_ai_agent_runner_coverage.py
+++ b/test/test_ai_agent_runner_coverage.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import logging
 import shlex
 import subprocess
 import sys
@@ -1104,6 +1105,25 @@ def test_session_runner_unavailable_when_config_load_raises(monkeypatch):
 
     monkeypatch.setattr(R, "KiroCrewConfig", SimpleNamespace(load=_boom))
     assert R.SessionAgentRunner.available() is False
+
+
+def test_session_runner_logs_the_reason_availability_failed(monkeypatch, caplog):
+    """``create_provider_factory`` cannot return None, so False is reachable ONLY from the
+    ``except`` — the raised exception is therefore the sole record of why the backend went
+    offline, and discarding it left the operator-facing offline reason unable to name a
+    cause (#6566). The boolean contract is unchanged; only the log is added."""
+
+    def _boom():
+        raise RuntimeError("acp -> client -> session -> config.loader circular import")
+
+    monkeypatch.setattr(R, "KiroCrewConfig", SimpleNamespace(load=_boom))
+    with caplog.at_level(logging.WARNING, logger=R.logger.name):
+        assert R.SessionAgentRunner.available() is False
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "the swallowed exception was not logged at all"
+    assert warnings[0].exc_info is not None, "logged without exc_info, so the cause is lost"
+    assert "circular import" in str(warnings[0].exc_info[1])
 
 
 def test_resolve_factory_prefers_the_injected_one():


### PR DESCRIPTION
## Problem / Motivation

`SessionAgentRunner.available()` swallowed every exception and returned `False` with no record of what raised:

```python
try:
    cfg = KiroCrewConfig.load()
    return cfg.create_provider_factory() is not None
except Exception:  # noqa: BLE001
    return False
```

`False` is not a "no backend configured" signal here. `create_provider_factory` has a single method-level return and cannot yield `None`, so the `is not None` test is always true on the non-raising path — which makes `False` reachable **only** from that handler. The raised exception was the sole evidence of why the backend went offline, and it was discarded.

## Why it matters

The auto-improvement loop goes silently offline and the operator-facing reason cannot name a cause. The backend sets `_offline_reason` to text stating that *the gateway config load or the provider-factory construction raised* — true, but the exception had already been dropped two frames earlier, so nothing anywhere could say which.

The realistic failure is concrete, not hypothetical: the `acp -> client -> session -> config.loader` circular import that the loader documents, which resolves only when `acp` is imported before `create_provider_factory()`. An `ImportError` there produces a loop that never runs, a message that says an exception occurred, and no log line to identify it. Anyone debugging that has nothing to work from.

## What changed (motivation → approach → change)

Symptom: the runner reports itself unavailable and no log says why. Root cause: the only path to that return value discards the exception that caused it. Change: log it.

- Log the exception with `exc_info=True` before returning `False`, and record in a comment why the handler is the only path to `False`, so the next reader does not have to re-derive that from `create_provider_factory`.
- Correct the same function's docstring, which still promised a fallback to the subprocess `claude -p` runner. That selection branch no longer exists, so the docstring described behaviour the code cannot perform.

The boolean contract is unchanged: same return values under the same conditions. `WARNING` rather than `ERROR` is deliberate — the loop legitimately continues offline, it just now says why.

Two other docstrings elsewhere still describe the removed `claude -p` fallback. They belong to different functions and are deliberately left for a separate change rather than widening this diff.

## Tests

`test_session_runner_logs_the_reason_availability_failed` (new) drives the handler and asserts it logs at `WARNING` with `exc_info` attached and that the raised cause is recoverable from the record.

`test_session_runner_unavailable_when_config_load_raises` already drove this branch but asserted only the return value, so the discard was invisible to it — which is why the branch had coverage and the defect still shipped.

```
python -m pytest test/test_ai_agent_runner_coverage.py -q
251 passed, 1 skipped, 33 warnings in 30.13s
```

```
python scripts/check_black_formatting.py
black gate scope: origin/main...HEAD (2 changed file(s))
black gate passed: nothing in scope is unformatted outside the baseline
```

## Manual verification

N/A — unit coverage sufficient. The change adds a log record on an existing branch and alters no control flow, so there is no integration path or user-visible surface a manual step could exercise that the test does not.

## Related Issues

Refs #6566 — the third sub-defect only. The parent's primary ask is a status-vocabulary product decision, which this does not touch, so the issue stays open for it.

## Pattern harvest

Rule candidate: review-prompt

Pattern: `except` handler discards the exception on a return path that is *only* reachable from that handler, so the returned value carries no diagnosable cause. The generalizable tell is a boolean/sentinel return in an `except` whose non-raising path cannot produce the same value — grep for `except Exception` bodies containing only `return False` / `return None` / `return []` where the success path provably cannot return that value.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the function's own docstring, corrected in the same diff
- [x] No secrets, credentials, or internal references in the diff
