### PR TITLE
fix(cron): give a cron's first run a caller identity before it dispatches

### DIFF
--- a/src/kiro_crew/dashboard/cron_inject.py
+++ b/src/kiro_crew/dashboard/cron_inject.py
@@ -358,6 +358,55 @@ def _prompt_already_recorded(slot: Any, prompt_body: str, own_marker: str) -> bo
     return False
 
 
+def _safe_job_name(job: Any) -> str:
+    """*job*'s name with both redactors applied, in the order production applies them.
+
+    One definition because two callers need the identical string: the slot title and
+    the transcript headers. The credential pass deliberately runs over the URL pass's
+    output, so reversing them can yield bytes production never writes.
+    """
+    safe, _ = redact_exfiltration_urls(job.name)
+    safe, _ = redact_credentials(safe)
+    return safe
+
+
+def ensure_cron_slot(state: Any, job: Any) -> Any:
+    """Create (or find) *job*'s dashboard slot and bind it to ``cron:<job_id>``.
+
+    Idempotent, and called from TWO places for one reason. Session-control verbs
+    resolve a caller by walking the live slots for one whose history key matches the
+    caller's session key (``caller_slot_key``), so a cron that has no slot yet has no
+    identity and is refused with ``caller_unidentified``. The result-injection path
+    below runs only AFTER the turn, which used to make that the state of every job's
+    FIRST run — it worked from run 2 onward purely because run 1 left the slot behind.
+    The gateway therefore calls this immediately before it dispatches the prompt, and
+    the injection path calls it again to write the result into the same slot.
+
+    Publishing to the dashboard-surface registry is part of the contract, not a
+    detail: every gate that asks "does this session have a tab?" — ``dashboard_slot_key``
+    for sub-agent event routing and completion injection, widget/question/approval
+    delivery — reads that registry, and a created-but-unpublished slot silently fails
+    those gates until some unrelated slot change happens to republish it. (Same
+    invariant as ``channel_slots.reconcile`` — see the comment there.)
+    """
+    slot = state.get_or_create_slot(
+        name=f"cron-{job.id}",
+        agent=job.agent_id or "",
+        # A cron result is the job's output, not something the person typed.
+        # A USER label would expose it to any app holding `slots:user`.
+        origin=SlotOrigin.CRON,
+    )
+    safe_name = _safe_job_name(job)
+    slot.title = f"Cron: {safe_name}"
+    if not slot.linked_session_key:
+        slot.linked_session_key = f"cron:{job.id}"
+
+    from kiro_crew.dashboard.chat_utils import _sync_dashboard_slots
+
+    _sync_dashboard_slots(state)
+    return slot
+
+
 def inject_cron_result_to_dashboard(
     state: DashboardState,
     job: "CronJob",
@@ -410,30 +459,15 @@ def inject_cron_result_to_dashboard(
     replay path, or a run that measured nothing) records nothing and keeps
     whatever snapshot an earlier run stored.
     """
-    slot_name = f"cron-{job.id}"
-    slot = state.get_or_create_slot(
-        name=slot_name,
-        agent=job.agent_id or "",
-        # A cron result is the job's output, not something the person typed.
-        # A USER label would expose it to any app holding `slots:user`.
-        origin=SlotOrigin.CRON,
-    )
-    safe_name, _ = redact_exfiltration_urls(job.name)
-    safe_name, _ = redact_credentials(safe_name)
-    slot.title = f"Cron: {safe_name}"
-    if not slot.linked_session_key:
-        slot.linked_session_key = f"cron:{job.id}"
+    slot = ensure_cron_slot(state, job)
+    safe_name = _safe_job_name(job)
+    # First run for this slot, so pull the job's durable transcript in. The test is
+    # "the slot has no messages yet", NOT "it has no linked session key": the key is
+    # now set by ``ensure_cron_slot`` before the turn is dispatched (so the running
+    # turn has a caller identity — see that function), which would make a key-based
+    # test read every run as a repeat and silently stop hydrating after a restart.
+    if not slot.messages:
         hydrate_slot_from_history(slot, history or [])
-    # Publish the (possibly just-created) tab to the dashboard-surface registry
-    # BEFORE anything routes against it. Every gate that asks "does this session
-    # have a tab?" — dashboard_slot_key for sub-agent event routing and
-    # completion injection, widget/question/approval delivery — reads that
-    # registry, and a created-but-unpublished slot silently fails those gates
-    # until some unrelated slot change happens to republish. (Same invariant as
-    # channel_slots.reconcile — see the comment there.)
-    from kiro_crew.dashboard.chat_utils import _sync_dashboard_slots
-
-    _sync_dashboard_slots(state)
 
     # Rows this call owes the durable transcript, in the order they happened.
     # Collected rather than written per row: the pair is flushed once, below,

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -113,6 +113,7 @@ from kiro_crew.dashboard.chat_utils import (
 )
 from kiro_crew.dashboard.cron_inject import (
     context_meter_reading,
+    ensure_cron_slot,
     inject_cron_result_to_dashboard,
     prefetch_cron_history,
 )
@@ -4352,6 +4353,17 @@ class GatewayOrchestrator:
                         # Brackets only the model turn — session acquisition and
                         # the episodic-query embed above are setup, not the turn.
                         _turn_t0 = time.monotonic()
+                        # Give the turn a caller IDENTITY before it can call a
+                        # session-control verb. Those verbs resolve the caller by
+                        # matching its session key against a live slot, so without a
+                        # slot the job's first run is refused `caller_unidentified`
+                        # while every later run succeeds on the slot run 1 left
+                        # behind. Idempotent, and gated on the same condition the
+                        # result-injection path uses — including its
+                        # `self.dashboard_state` test, since a gateway running
+                        # without a dashboard has no slots to mint into.
+                        if self.dashboard_state and job.persistent_session and not job.hide_in_chat:
+                            ensure_cron_slot(self.dashboard_state, job)
                         _prompt_dispatched = True
                         result_text, _carried_credits = await _cron_stream_with_posttoken_resume(
                             client,
@@ -4493,6 +4505,11 @@ class GatewayOrchestrator:
                 # above. acp reports no duration, so this is the row's fallback.
                 _turn_t0 = time.monotonic()
                 _gate = _GateTally()
+                # Same caller-identity mint as the sequential path above — see the
+                # comment there for why it has to happen before dispatch, and why
+                # the `self.dashboard_state` test belongs in the gate.
+                if self.dashboard_state and job.persistent_session and not job.hide_in_chat:
+                    ensure_cron_slot(self.dashboard_state, job)
                 _prompt_dispatched = True
                 result_text, _carried_credits = await _cron_stream_with_posttoken_resume(
                     client,

--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -14,6 +14,7 @@ from kiro_crew.dashboard.cron_inject import (
     _UNCHANGED_PROMPT_BODY,
     _parse_prompt_row,
     _prompt_row_body,
+    ensure_cron_slot,
     inject_cron_result_to_dashboard,
     run_marker,
 )
@@ -1257,3 +1258,61 @@ class TestHasSlot:
         state._slots = {}
         state.has_slot = DashboardState.has_slot.__get__(state)
         assert state.has_slot("nonexistent") is False
+
+
+def test_ensure_cron_slot_binds_identity_before_any_result_exists():
+    """A cron's FIRST run had no slot, so it had no caller identity (#8336).
+
+    ``caller_slot_key`` resolves a caller by matching its session key against a live
+    slot's history key, which derives from ``linked_session_key``. The bind therefore
+    has to happen when the slot is created -- before any result exists -- because the
+    gateway calls this before it dispatches the prompt. Previously the only creator
+    was the result-injection path, which runs after the turn, so run 1 was refused
+    ``caller_unidentified`` and run 2 onward succeeded on the slot run 1 left behind.
+    """
+    state = _make_state()
+    job = _make_job(job_id="firstrun1")
+
+    slot = ensure_cron_slot(state, job)
+
+    assert slot.key == "cron-firstrun1"
+    assert slot.linked_session_key == "cron:firstrun1"
+    assert slot.messages == [], "minting a slot must not fabricate transcript rows"
+
+
+def test_ensure_cron_slot_is_idempotent_for_the_injection_path():
+    """Called twice per run -- once before dispatch, once by the injection path --
+    so a second call must return the SAME slot rather than orphan the first."""
+    state = _make_state()
+    job = _make_job(job_id="twice1")
+
+    first = ensure_cron_slot(state, job)
+    second = ensure_cron_slot(state, job)
+
+    assert first is second
+    assert list(state._slots) == ["cron-twice1"]
+
+
+def test_injection_still_hydrates_history_into_a_pre_minted_slot():
+    """The first-run test must be "no messages yet", NOT "no linked session key".
+
+    The gateway now binds ``linked_session_key`` before the turn runs, so a key-based
+    test would read the very first injection as a repeat visit and stop hydrating the
+    job's durable transcript -- after a restart the tab would come back holding only
+    the newest result. This drives the pre-minted ordering the gateway produces.
+    """
+    history = [
+        {"role": "user", "content": "earlier instruction", "cls": "cron-prompt"},
+        {"role": "assistant", "content": "earlier result", "cls": "cron-result"},
+    ]
+    state = _make_state(history_messages=history)
+    job = _make_job(job_id="rehydrate1")
+
+    ensure_cron_slot(state, job)
+    inject_cron_result_to_dashboard(state, job, "fresh result", history=history)
+
+    messages = state._slots["cron-rehydrate1"].messages
+    assert any(
+        "earlier" in (m.get("content") or "") for m in messages
+    ), "history was not hydrated into a slot that already carried its session key"
+    assert any("fresh result" in (m.get("content") or "") for m in messages)


### PR DESCRIPTION
## Problem / Motivation

A cron job's **first** run has no caller identity, so every session-control verb it calls is refused. Later runs of the same job work.

Session-control resolves a caller by walking the live dashboard slots for one whose history key matches the caller's session key:

- `caller_slot_key` iterates `state._slots` and matches `slot_history_key(slot)` / `slot.key`, returning `""` when nothing matches.
- `""` reaches the deny — `raise deny("caller session could not be identified", "caller_unidentified")`.

A cron presents `cron:<job_id>`. That key was written onto the slot in exactly one place: `inject_cron_result_to_dashboard`, via `slot.linked_session_key = f"cron:{job.id}"`. That function is the **result** path — it runs after the turn has finished and a `result_text` exists. So while the first turn is actually executing, the slot does not exist, the caller cannot be identified, and the verb is refused. From run 2 onward it succeeds, because run 1 left the slot behind.

## Why it matters

Every session-control-using cron is broken on its first run and works from then on, which is close to the worst possible shape for a defect: the second attempt at anything always succeeds, so it looks like a transient glitch rather than a reproducible bug and never gets diagnosed.

It also bites hardest exactly where nobody is watching. A cron's first run is typically the unattended one right after the job is authored or after a gateway restart re-creates state — so the failure lands in a run with no human present, and the retry a human triggers to reproduce it passes.

## What changed (motivation → approach → change)

Symptom: `caller_unidentified` on a cron's first run only. Root cause: the slot that carries the identity is created by the result path, which runs after the turn it needs to identify. Change: create it before dispatch instead.

- Extract the slot mint into `ensure_cron_slot(state, job)` — `get_or_create_slot`, title, `linked_session_key`, and the dashboard-surface publish.
- Call it from the gateway immediately before the prompt is dispatched, at both agent-turn dispatch sites, behind the same `job.persistent_session and not job.hide_in_chat` condition the injection path already uses. A hidden cron therefore still gets no tab.
- It sits after the fire-time governance gate, so a **denied** run still creates nothing — no empty tab appears for a job that never ran.
- The helper is idempotent, so the injection path finds the same slot and the result write is unchanged.

The alternative considered was resolving `cron:<id>` to `cron-<id>` by naming convention inside `caller_slot_key`, without creating anything. Rejected: it hands back a key naming a slot that does not exist, so any caller that then looks the slot up gets a `KeyError`, and it duplicates the slot-naming convention in a second place. Making the identity real is the smaller long-term surface.

### The invariant that moves with it

The injection path used *"no linked session key yet"* as its test for *"first run, hydrate from history"*. Binding the key before the turn makes that test read **every** run as a repeat, silently stopping hydration — after a restart the tab would come back holding only the newest result, with the job's history gone from view. The test is now *"the slot has no messages yet"*, which is the condition that was actually meant.

This is the trap in the obvious version of this fix, so it is the behaviour the new tests pin.

`_safe_job_name` shares the two-pass name redaction (URL pass, then credential pass, in that order) between the slot title and the transcript headers, rather than letting the extraction leave two copies that can drift.

## Tests

Three added to `test/test_dashboard_cron_to_chat.py`:

- `test_injection_still_hydrates_history_into_a_pre_minted_slot` — the important one. It is **red against the previous condition**: reverting the hydration test to `if not slot.linked_session_key:` fails it with `AssertionError: history was not hydrated into a slot that already carried its session key`. This locks in the invariant above.
- `test_ensure_cron_slot_binds_identity_before_any_result_exists` — identity is bound at creation, before any result exists, and minting fabricates no transcript rows.
- `test_ensure_cron_slot_is_idempotent_for_the_injection_path` — the second call returns the same slot rather than orphaning the first.

```
python -m pytest test/test_dashboard_cron_to_chat.py test/test_cron_hide_in_chat.py \
  test/test_cron_thread_routing.py test/test_session_control.py \
  test/test_cron_context_meter_seed.py test/test_dashboard_cron_to_chat_handler.py \
  test/test_member_session_control.py test/test_stop_addresses_linked_session.py \
  test/test_active_turn_session_key.py -q
297 passed, 73 warnings in 46.51s
```

```
python scripts/check_black_formatting.py
black gate scope: origin/main...HEAD (3 changed file(s))
black gate passed: nothing in scope is unformatted outside the baseline
```

## Manual verification

N/A — unit coverage sufficient. Driving this end to end needs a real first-run cron dispatch inside a live gateway, which the existing suite already covers at the two seams this touches (`test_cron_thread_routing.py` for the callback's inject decision, `test_cron_hide_in_chat.py` for the hidden-cron suppression that gates the new call). The hidden-cron and dedup paths are asserted unchanged by those files.

## Related Issues

Refs #8336

## Pattern harvest

Rule candidate: review-prompt

Pattern: an identity or registration a turn depends on is created by that turn's own *completion* path, so the first execution runs without it and every subsequent one inherits it from the previous run. The tell is a `get_or_create_*` whose only call site is downstream of the work that needs its result — the defect then presents as "fails once, then works forever", which reads as transient.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the new helper's docstring records why it has two call sites
- [x] No secrets, credentials, or internal references in the diff
