### PR TITLE
fix(doctor): pin utf-8 on five text-mode subprocess probes

### DIFF
--- a/.github/subprocess-encoding-baseline.txt
+++ b/.github/subprocess-encoding-baseline.txt
@@ -33,7 +33,6 @@
 1 src/kiro_crew/builtin_skills/browser-recording/scripts/record_browser.py
 2 src/kiro_crew/builtin_skills/ios-simulator-preview/scripts/sim_mirror.py
 1 src/kiro_crew/cli.py
-5 src/kiro_crew/cli_doctor.py
 1 src/kiro_crew/cli_perf.py
 2 src/kiro_crew/cli_setup.py
 1 src/kiro_crew/cloud/aws.py

--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -1423,6 +1423,8 @@ def _linger_enabled(user: str) -> bool | None:
             ["loginctl", "show-user", user, "-p", "Linger", "--value"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=5,
         )
     except (OSError, subprocess.SubprocessError):
@@ -1659,6 +1661,8 @@ def _detect_userspace_oom_killer() -> str | bool | None:
                 [systemctl, "is-active", unit],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
         except (OSError, subprocess.SubprocessError):
@@ -2739,6 +2743,8 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
                 [KIRO_CLI_BIN, "whoami"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
             )
             if r.returncode == 0:
@@ -2768,6 +2774,8 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
                 ["node", "-v"],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
             )
             major = int(node_ver_result.stdout.strip().lstrip("v").split(".")[0])
@@ -3337,7 +3345,12 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
     print("\nConnectivity")
     if kiro:
         kiro_result = subprocess.run(
-            [KIRO_CLI_BIN, "--version"], capture_output=True, text=True, timeout=5
+            [KIRO_CLI_BIN, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
         )
         if kiro_result.returncode == 0:
             ver = kiro_result.stdout.strip() or kiro_result.stderr.strip()


### PR DESCRIPTION
## Problem / Motivation

`kirocrew doctor` runs five subprocess probes in text mode without pinning an encoding: the systemd linger probe (`_linger_enabled`), the userspace OOM killer check (`_detect_userspace_oom_killer`), and three connectivity probes inside `_doctor` (`kiro-cli whoami`, `node -v`, `kiro-cli --version`). A `subprocess.run(..., text=True)` call with no `encoding=` decodes the child's output with `locale.getpreferredencoding(False)`: always UTF-8 on POSIX in practice, but the legacy ANSI code page on Windows (cp1252, cp936, cp949, depending on the system locale). Any non-ASCII byte the child prints comes back as mojibake, or raises `UnicodeDecodeError` and throws away the probe's output entirely.

The mojibake case is not hypothetical for these probes. `kiro-cli whoami` prints the account's display identity, which on a cp936 host is realistically non-ASCII, and version output embeds paths. The doctor is also the surface a fresh install runs first, so this lands on the exact screen a user is staring at when something else has already gone wrong.

## Why it matters

This failure class has hit the project before: #3219 was the dashboard rendering file diffs as mojibake on Windows, and the response was the lint gate plus the shared helper added in #5249. The gate keeps a shrink-only baseline (`.github/subprocess-encoding-baseline.txt`) of the confirmed sites it did not convert, and that baseline's header invites exactly this kind of PR: every count may only go down. `cli_doctor.py` carried 5 calls, the largest single-file count outside the test suite. Leaving it means the one tool whose job is to tell you your install is healthy is the one rendering garbage on precisely the locales where setup is most likely to need diagnosing.

There is a quieter maintainability cost too. The gate judges files a PR touches against their recorded counts, so a file only leaves the ratchet's books when its count reaches zero. Pruning `cli_doctor.py` entirely means future doctor work cannot quietly re-add an unpinned call there without the gate catching it as a fresh offender.

## What changed (motivation → approach → change)

Symptom: five probes decode child output with the host locale. Root cause: `text=True` with no `encoding=`. Change: pin `encoding="utf-8"` with `errors="replace"` on all five, matching how the git probe in this same file was already pinned.

Why UTF-8 is the right pin, and not a new way to be wrong: the contract in `subprocess_utf8.py` says to pin UTF-8 only on children whose output encoding is knowable. All five qualify. `kiro-cli` and `node` always write UTF-8. `loginctl` and `systemctl` are systemd tools that only run on Linux, where the preferred encoding is already UTF-8, so the pin is a no-op there and correct everywhere else. The children that genuinely write in the console encoding (`systeminfo`, `wmic`, arbitrary user shells) are the ones that keep locale decoding on purpose and carry the gate's `# subprocess-encoding: locale` marker instead; none of these five is that kind of child.

Why `errors="replace"` and not strict decoding: a probe whose job is answering "is X installed and working" should degrade one odd byte to a U+FFFD character in place rather than discard its whole output on a decode error. That is the same shape the file-diff fix (#3669) established, and it is what the existing inline pins in this file already do.

Two alternatives I considered and did not take. Using the shared `**UTF8_TEXT` kwargs mapping from `subprocess_utf8.py` would be functionally identical, but every other pin in this file is written inline next to its call, so inline keeps one house style. Converting more baseline files in the same PR would burn down more debt, but the baseline asks for one PR per file or per directory, and keeping this to `cli_doctor.py` holds the review to five call sites plus one baseline line.

The baseline edit is the ratchet doing its job: the file goes from 239 known calls across 116 files to 234 across 115, with the `5 src/kiro_crew/cli_doctor.py` entry deleted through the documented `--update-baseline` refresh, which by construction can only lower counts and prune entries.

For POSIX users the probe output is byte-identical to before, since the pin resolves to the same UTF-8 the locale already produced. Only Windows code-page decoding changes.

One coordination note: open PR #7363 also edits `cli_doctor.py`, but in `_doctor_pod_session_bus`. The five probes here live in `_linger_enabled`, `_detect_userspace_oom_killer`, and `_doctor`, so the diffs do not share hunks. If #7363 lands first, the only interaction is baseline arithmetic, and I will rebase.

## Tests

- Red-green at the gate. Before the change, a direct scan of the file reports the five unpinned calls (lines 1422, 1658, 2738, 2767, 3339 at this base); after the change, it reports none. The gate is the regression lock for this class, so I proved it catches the defect before paying it.
- `python scripts/check_subprocess_encoding.py` passes (234 calls in 115 files remaining), and the `--test` rule-family self-test passes (9 flagged / 9 clean probes).
- `pytest test/test_cli_doctor.py`: 145 passed, 1 skipped, identical before and after the change, so the probes' logic is untouched by the pins.
- flake8 and isort clean on the file; `mypy src/kiro_crew/cli_doctor.py --platform linux` clean; the repo's black and brand gates pass.

## Manual verification

The gates prove the encoding is pinned; they cannot prove what a CJK-locale Windows console renders. My Windows 10 host runs a cp1252 locale, where the doctor's probe output is ASCII-symmetric, so the bug does not visibly reproduce here and I have not captured a before/after. A reviewer on a cp936 box can see the difference by running `kirocrew doctor` on both sides of the patch while `kiro-cli whoami` returns a non-ASCII display name. The knowable-writer argument above plus the gate are what I am standing on.

## Screenshots / video

N/A: terminal output only, no dashboard or UI surface, and the diff touches no frontend files.

## Related Issues

No dedicated issue tracks these five sites; I searched open and closed PRs and issues before starting. Class context: #3219 is the original mojibake report and #5249 added the gate and helper this PR pays a baseline down for.

## Pattern harvest

Rule candidate: lint. The rule already exists: `scripts/check_subprocess_encoding.py` is this exact defect class's gate (#5249), so this PR adds no new rule; it pays the recorded baseline to zero for one file, which is the worklist flow the gate was built for.

## Checklist

- [x] At most two commits (one), with a Conventional Commits title (`fix(doctor): pin utf-8 on five text-mode subprocess probes`)
- [x] Existing tests pass (145 passed / 1 skipped in `test_cli_doctor.py`, unchanged); no new functionality was added, so no new feature tests; the encoding gate is the regression lock for this class
- [x] Self-review completed; the pins follow the file's existing inline style and the `subprocess_utf8.py` knowable-writer contract
- [x] Documentation N/A: no doc describes these call sites, the gate's own header remains the class documentation, and no documented behavior changes
- [x] No secrets, credentials, or internal references in the diff