### PR TITLE
fix(virtualizer): positional splice anchor on total re-key (#8033)

### DIFF
--- a/website/src/hooks/virtualizer/useVirtualChat.ts
+++ b/website/src/hooks/virtualizer/useVirtualChat.ts
@@ -224,6 +224,50 @@ function captureTopAnchorFrom(
   return bestKey !== null ? { key: bestKey, top: bestTop, index: bestIdx } : null
 }
 
+/** Positional re-identification, shared by TRIGGER 1's and the splice
+ *  triggers' no-surviving-key fallbacks: a row whose key did not survive the
+ *  commit moved by as much as the NEAREST row (by old index) whose key did.
+ *  Returns the displacement resolver — built once per commit, queried per
+ *  mounted node. `survivors` is in ascending old index, so the nearest is one
+ *  of the two neighbours of the change point; ties go to the row ABOVE the
+ *  reader. Survivors before `boundary` (the first old index that changed
+ *  hands) are excluded: they did not move, so their zero displacement says
+ *  nothing about rows at or below the boundary — a splice landing exactly at
+ *  the viewport top would otherwise borrow it and anchor the inserted row
+ *  itself. TRIGGER 1 passes 0 (a prepend renames index 0, so nothing sits
+ *  before its boundary). Only when no survivor remains does `noSurvivorShift`
+ *  stand in (the caller's net count change) — the reader then keeps their
+ *  distance from the END, the one thing a full re-identification of a chat
+ *  transcript preserves, and for a contiguous splice it IS the displacement. */
+function nearestSurvivorShiftFrom<T>(
+  prevItems: readonly T[],
+  prevGetKey: (it: T, i: number) => string,
+  newIndexByKey: ReadonlyMap<string, number>,
+  noSurvivorShift: number,
+  boundary = 0,
+): (idx: number) => number {
+  const survivors: Array<[oldIndex: number, shift: number]> = []
+  for (let i = boundary; i < prevItems.length; i++) {
+    const ni = newIndexByKey.get(prevGetKey(prevItems[i], i))
+    if (ni !== undefined) survivors.push([i, ni - i])
+  }
+  return (idx: number): number => {
+    if (!survivors.length) return noSurvivorShift
+    let lo = 0
+    let hi = survivors.length
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (survivors[mid][0] < idx) lo = mid + 1
+      else hi = mid
+    }
+    const above = survivors[lo - 1]
+    const below = survivors[lo]
+    if (!above) return below[1]
+    if (!below) return above[1]
+    return below[0] - idx < idx - above[0] ? below[1] : above[1]
+  }
+}
+
 /** Screen offset of the mounted row whose key matches, relative to the
  *  scroller's top; null when it is not mounted. Pure over its inputs like the
  *  capture above, so both anchor consumers resolve a row the same way. */
@@ -646,33 +690,11 @@ export function useVirtualChat<T>(
       // the START of the transcript rather than the rows being read. So the
       // topmost visible row is re-identified by POSITION: it moved by as much as
       // the NEAREST row (by old index) whose key did survive, and its new key is
-      // whatever now sits at old index + that displacement. Only when no key
-      // survives anywhere does the net count stand in — the reader then keeps
-      // their distance from the END, the one thing a full re-identification of a
-      // chat transcript preserves.
-      const survivors: Array<[oldIndex: number, shift: number]> = []
-      const prev = prependPrev.items
-      for (let i = 0; i < prev.length; i++) {
-        const ni = newIndexByKey.get(prependPrev.getKey(prev[i], i))
-        if (ni !== undefined) survivors.push([i, ni - i])
-      }
-      // `survivors` is in ascending old index, so the nearest is one of the two
-      // neighbours of the insertion point; ties go to the row ABOVE the reader.
-      const shiftAt = (idx: number): number => {
-        if (!survivors.length) return inserted
-        let lo = 0
-        let hi = survivors.length
-        while (lo < hi) {
-          const mid = (lo + hi) >> 1
-          if (survivors[mid][0] < idx) lo = mid + 1
-          else hi = mid
-        }
-        const above = survivors[lo - 1]
-        const below = survivors[lo]
-        if (!above) return below[1]
-        if (!below) return above[1]
-        return below[0] - idx < idx - above[0] ? below[1] : above[1]
-      }
+      // whatever now sits at old index + that displacement (see
+      // nearestSurvivorShiftFrom).
+      const shiftAt = nearestSurvivorShiftFrom(
+        prependPrev.items, prependPrev.getKey, newIndexByKey, inserted,
+      )
       prependAnchor = captureTopAnchorFrom(prependEl, elIndexRef.current.entries(), (idx) => {
         const j = idx + shiftAt(idx)
         const it = items[j]
@@ -793,7 +815,7 @@ export function useVirtualChat<T>(
     // Retirement has neither dependency, which is why it sits outside.
     if ((midListInserted || rowsRemoved || rowSwapped) && !anchorCapturedThisRender && !stickRef.current) {
       const spliceEl = scrollerRef.current
-      const spliceAnchor = spliceEl
+      let spliceAnchor = spliceEl
         ? captureTopAnchorFrom(spliceEl, elIndexRef.current.entries(), (idx) => {
             // PREVIOUS items at the node's PREVIOUS index, filtered to rows that
             // survive this commit — trigger 1's resolution, for the same reason:
@@ -804,6 +826,34 @@ export function useVirtualChat<T>(
             return survivingKeys.has(k) ? k : null
           })
         : null
+      if (!spliceAnchor && spliceEl) {
+        // No visible row kept its key — the splice landed together with a total
+        // re-identification of the on-screen rows (the wholesale-rebuild shape
+        // TRIGGER 1 already covers; the splice half was deferred there and is
+        // #8033). Standing down leaves scrollTop where it was and displaces the
+        // reader by the spliced rows' height, so the topmost visible row is
+        // re-identified by POSITION, exactly as TRIGGER 1 does: for rows below
+        // the splice point the displacement is the inserted-above count, which
+        // the nearest surviving old-index neighbour carries whenever any row
+        // between the splice and the reader keeps its key. `movedIndex` is the
+        // change boundary: survivors above it did not move, and borrowing their
+        // zero displacement would anchor a splice landing exactly at the
+        // viewport top on the inserted row itself.
+        const newIndexByKey = new Map<string, number>()
+        for (let i = 0; i < items.length; i++) newIndexByKey.set(getKey(items[i], i), i)
+        const shiftAt = nearestSurvivorShiftFrom(
+          prependPrev.items, prependPrev.getKey, newIndexByKey,
+          itemCount - prependPrev.count, Math.max(movedIndex, 0),
+        )
+        // The positional anchor names a row of the NEW list, so it is priced by
+        // the CURRENT render's getKey paired with the current items — the same
+        // pairing contract as TRIGGER 1's fallback.
+        spliceAnchor = captureTopAnchorFrom(spliceEl, elIndexRef.current.entries(), (idx) => {
+          const j = idx + shiftAt(idx)
+          const it = items[j]
+          return it ? getKey(it, j) : null
+        })
+      }
       if (spliceAnchor) {
         shiftAnchorRef.current = spliceAnchor
         shiftStageRef.current = 'ready'

--- a/website/src/test/useVirtualChat.prependAnchor.test.tsx
+++ b/website/src/test/useVirtualChat.prependAnchor.test.tsx
@@ -787,6 +787,136 @@ describe('useVirtualChat: prepend compensation (load older history)', () => {
     expect(Math.abs(after! - before!.top)).toBeLessThanOrEqual(1)
   })
 
+  it('holds the reader by POSITION when a splice retires every visible key', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(base)
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const at = before[0].idx
+    expect(at).toBeGreaterThan(1)
+    const beforeTop = readScrollTop()
+
+    // A "thinking" row mounts above the viewport in the SAME commit that
+    // re-identifies every visible row (each streamed row replaced by its server
+    // copy under a different key). Index 0 keeps its key, so this is the splice
+    // path, not a prepend — and no visible key survives for the anchor to
+    // follow, so the row must be re-found by where it now sits.
+    const rekeyed = base.map((it, i) =>
+      i >= at && i < at + before.length ? { id: `r${i}` } : it,
+    )
+    const spliced = [...rekeyed.slice(0, at - 1), { id: 'ghost' }, ...rekeyed.slice(at - 1)]
+    act(() => { view.rerender(<Harness items={spliced} scrollerRef={scrollerRef} />) })
+
+    // Not vacuous: every previously visible key is genuinely gone, and the
+    // ghost really mounted above the reader.
+    for (const v of before) expect(screenTopOf(el, v.key)).toBeNull()
+    expect(screenTopOf(el, 'ghost')).not.toBeNull()
+
+    // The topmost visible row is the positional successor of the row that was
+    // there, held at the same screen offset by a scrollTop write over the
+    // inserted row — without the positional anchor it moves down by the
+    // inserted row's height.
+    const after = visibleByIndex(el)
+    expect(after.length).toBeGreaterThan(0)
+    expect(after[0].idx).toBe(at + 1)
+    expect(after[0].key).toBe(`r${at}`)
+    expect(Math.abs(after[0].top - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('holds the reader by POSITION across a splice-with-total-retirement when getKey is INDEX-ADDRESSED', () => {
+    // The positional anchor names a row of the NEW list, so it must be priced
+    // by the CURRENT render's getKey paired with the current items — the same
+    // pairing contract PR 8001 pinned for the prepend fallback. An identity
+    // getKey cannot tell the two pairings apart; this one can.
+    const base = mkItems(30)
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(base, PositionalHarness)
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const at = before[0].idx
+    expect(at).toBeGreaterThan(1)
+    const beforeTop = readScrollTop()
+
+    const rekeyed = base.map((it, i) =>
+      i >= at && i < at + before.length ? { id: `r${i}` } : it,
+    )
+    const spliced = [...rekeyed.slice(0, at - 1), { id: 'ghost' }, ...rekeyed.slice(at - 1)]
+    act(() => { view.rerender(<PositionalHarness items={spliced} scrollerRef={scrollerRef} />) })
+
+    for (const v of before) expect(screenTopOf(el, v.key)).toBeNull()
+    expect(screenTopOf(el, 'ghost')).not.toBeNull()
+
+    const after = visibleByIndex(el)
+    expect(after.length).toBeGreaterThan(0)
+    expect(after[0].idx).toBe(at + 1)
+    expect(after[0].key).toBe(`r${at}`)
+    expect(Math.abs(after[0].top - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('does not anchor the inserted row when the splice lands exactly at the viewport top', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(base)
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const at = before[0].idx
+    expect(at).toBeGreaterThan(1)
+    const beforeTop = readScrollTop()
+
+    // The ghost mounts AT the topmost visible row's own index while every
+    // visible key retires. Rows above the viewport keep their keys but did NOT
+    // move (they sit above the splice): borrowing their zero displacement
+    // would resolve the anchor to the ghost itself and hold the wrong row.
+    // The change boundary excludes them, so the displacement comes from the
+    // survivors below (+1).
+    const rekeyed = base.map((it, i) =>
+      i >= at && i < at + before.length ? { id: `r${i}` } : it,
+    )
+    const spliced = [...rekeyed.slice(0, at), { id: 'ghost' }, ...rekeyed.slice(at)]
+    act(() => { view.rerender(<Harness items={spliced} scrollerRef={scrollerRef} />) })
+
+    // Not vacuous: every previously visible key is genuinely gone, and the
+    // ghost really mounted.
+    for (const v of before) expect(screenTopOf(el, v.key)).toBeNull()
+    expect(screenTopOf(el, 'ghost')).not.toBeNull()
+
+    // The reader's row (its re-keyed copy, now one index down) is held at its
+    // screen offset; anchoring the ghost instead would leave it one row lower
+    // with no scrollTop write.
+    const held = screenTopOf(el, `r${at}`)
+    expect(held).not.toBeNull()
+    expect(Math.abs(held! - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
+  it('does not anchor the inserted row at the viewport top when getKey is INDEX-ADDRESSED', () => {
+    const base = mkItems(30)
+    const { el, view, scrollerRef, readScrollTop } = mountScrolledUp(base, PositionalHarness)
+
+    const before = visibleByIndex(el)
+    expect(before.length).toBeGreaterThan(0)
+    const at = before[0].idx
+    expect(at).toBeGreaterThan(1)
+    const beforeTop = readScrollTop()
+
+    const rekeyed = base.map((it, i) =>
+      i >= at && i < at + before.length ? { id: `r${i}` } : it,
+    )
+    const spliced = [...rekeyed.slice(0, at), { id: 'ghost' }, ...rekeyed.slice(at)]
+    act(() => { view.rerender(<PositionalHarness items={spliced} scrollerRef={scrollerRef} />) })
+
+    for (const v of before) expect(screenTopOf(el, v.key)).toBeNull()
+    expect(screenTopOf(el, 'ghost')).not.toBeNull()
+
+    const held = screenTopOf(el, `r${at}`)
+    expect(held).not.toBeNull()
+    expect(Math.abs(held! - before[0].top)).toBeLessThanOrEqual(1)
+    expect(readScrollTop()).toBeGreaterThan(beforeTop)
+  })
+
   it('still follows to the bottom when a row is SPLICED IN while PINNED', () => {
     const base = mkItems(30)
     const { el, view, scrollerRef, readScrollTop } = mountAtBottom(base)


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

The mid-list splice capture (TRIGGERS 4/5/6) anchors the topmost visible mounted row whose key survives the commit, filtered through `survivingKeys`. When every visible row's key retires in one commit — a total re-identification of the on-screen rows, e.g. each streamed row replaced by its server copy under a different key, landing in the same commit as a splice — the capture returns `null` and silently stands down: no anchor, no scroll compensation, and the reader is displaced by the inserted rows' height.

The prepend path (TRIGGER 1) had the identical stand-down; PR #8001 fixed it by re-finding the row by POSITION (nearest-survivor displacement, net count as last resort). The splice half was knowingly deferred there as an accepted-and-deferred First Principles advisory. This PR closes it: the class is the same — a compensation path whose anchor-not-found branch is a silent no-op.

## Why it matters

A reader scrolled up through history loses their place whenever a transcript refresh re-identifies the visible rows together with a mid-list insert/removal/swap: the viewport silently jumps by the spliced rows' height. Bounded harm, but it is the last silent no-op branch of this class in the virtualizer.

## What changed (motivation → approach → change)

Symptom → root cause: the splice capture's `keyAt` filter admits only surviving keys, so a commit that retires every visible key gives `captureTopAnchorFrom` nothing to bind and the branch exits without arming the consumer.

Approach: reuse TRIGGER 1's positional re-identification rather than duplicating it.

- Factored PR #8001's nearest-survivor displacement machinery into a shared module-level helper, `nearestSurvivorShiftFrom(prevItems, prevGetKey, newIndexByKey, noSurvivorShift, boundary)`. TRIGGER 1's fallback now calls it (behavior unchanged, `boundary` defaults to 0 — a prepend renames index 0, so nothing sits before its boundary).
- Extended the splice capture: when the surviving-key capture returns `null`, re-run it with a positional `keyAt` — the row moved by as much as its nearest surviving old-index neighbour, and its new key is whatever now sits at old index + that displacement, priced by the CURRENT render's `getKey` paired with the current items (the pairing contract PR #8001 pinned). The resolved anchor arms the existing splice consumer (`shiftAnchorRef`/`shiftStageRef` stage `'ready'`, plus the `rowSwapped` → `spliceCommit` bump), so part 2 performs the ordinary scrollTop correction.
- The `boundary` parameter is new relative to PR #8001's machinery and carries the splice-specific correctness rule (surfaced by the pre-push review): survivors ABOVE the first changed index (`movedIndex`) did not move, and borrowing their zero displacement would anchor a splice landing exactly at the viewport top on the inserted row itself. Excluding them makes the displacement come from survivors at/after the change; when none remain, `noSurvivorShift` (the net count change) stands in, which for a contiguous splice above the reader IS the exact displacement.

## Tests

Four regressions in `website/src/test/useVirtualChat.prependAnchor.test.tsx`, all on the existing `mountScrolledUp` harness, each proving non-vacuity (every previously visible key genuinely gone, ghost genuinely mounted) and that the hold is a real `scrollTop` write:

- `holds the reader by POSITION when a splice retires every visible key` — one row inserted above the viewport, index 0's key held, every visible row re-keyed; the topmost visible row keeps its screen offset (without the fix it moves down by the inserted row's height).
- `holds the reader by POSITION across a splice-with-total-retirement when getKey is INDEX-ADDRESSED` — pins the current-items/current-getKey pairing contract an identity getKey cannot distinguish.
- `does not anchor the inserted row when the splice lands exactly at the viewport top` — the boundary case: rows above the viewport keep their keys but did not move; without the boundary exclusion the anchor resolves to the ghost itself and no correction runs.
- `does not anchor the inserted row at the viewport top when getKey is INDEX-ADDRESSED` — same boundary case under the ChatPage-shaped getKey.

## Manual verification

N/A — the deterministic fake-layout harness reproduces the displacement pixel-for-pixel (the same engine the existing prepend/splice regressions use), and the change is unreachable except on the total-retirement commit it targets.

## Related Issues

Closes #8033

## Pattern harvest

Not generalizable: this closes the second (and last) known instance of the "compensation path whose anchor-not-found branch is a silent no-op" class that PR #8001 named; both paths now share one positional-fallback helper, so a third instance would reuse it rather than re-derive it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, hook-internal behavior documented in code comments
- [x] No secrets, credentials, or internal references in the diff
