### PR TITLE
fix(ci): guard the review lanes against verdict overwrite (#8344)

### DIFF
--- a/.github/workflows/design-review.yml
+++ b/.github/workflows/design-review.yml
@@ -479,7 +479,7 @@ jobs:
               echo "_Design-level review of \`$HEAD\` — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
               printf '%s\n' "$summary"
-            } > /tmp/design-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/design-comment.md"
           else
             # No parseable verdict → the review errored or emitted no header. Do
             # NOT post the raw model/error text: it can carry internal detail
@@ -502,7 +502,7 @@ jobs:
               echo "## Design Review (Fable 5) — ⚠️ could not complete"
               echo
               echo "_The design review did not produce a verdict for \`$HEAD\` ($why). See the Design Review job logs. Advisory — does not block merge._"
-            } > /tmp/design-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/design-comment.md"
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids / ARNs
           # from whatever we post (a valid-verdict body may quote an ARN from the
@@ -510,22 +510,116 @@ jobs:
           # above, this keeps internal detail out of the public PR comment. The
           # SYSTEM RULES prompt also forbids emitting secrets; this is the
           # mechanical backstop. Mirrors codex-review.yml's redaction step.
-          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' /tmp/design-comment.md
-          # Author filter: only a github-actions[bot] comment may match, so a PR
-          # commenter can't plant the marker and have us PATCH their comment.
-          # Per-page --jq under --paginate emits only matching ids; head -n1 takes
-          # the first across pages (no malformed multi-line id).
-          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null \
-            | head -n1 || true)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat /tmp/design-comment.md)" >/dev/null || true
-            echo "Updated existing design-review comment #$existing"
-          else
-            gh pr comment "$PR" --body-file /tmp/design-comment.md || true
-            echo "Created new design-review comment"
-          fi
+          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' "${RUNNER_TEMP:-/tmp}/design-comment.md"
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
+          guarded_comment_upsert "$MARKER" "[DESIGN-REVIEWED]" "Design Review" "${RUNNER_TEMP:-/tmp}/design-comment.md"
 
       # This step converts the design verdict into the "Design Review" check
       # status. A real BLOCK verdict now FAILS the check (emits ::error:: and

--- a/.github/workflows/first-principles-review.yml
+++ b/.github/workflows/first-principles-review.yml
@@ -444,13 +444,13 @@ jobs:
               echo "## First Principles Review (Fable 5) — ⏭️ no contract on the base commit"
               echo
               echo "_\`.github/review-prompts/first-principles.md\` does not exist on this PR's base commit, so there is no trusted contract to review \`$HEAD\` against. The contract is deliberately read from the base and never from the head, so a change cannot edit the reviewer that judges it — which also means this lane cannot review the pull request that introduces or moves the contract. Advisory — does not block merge._"
-            } > /tmp/fp-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
             existing="$(find_existing)"
             if [ -n "$existing" ] && [ "$existing" != "null" ]; then
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-                --field body="$(cat /tmp/fp-comment.md)" >/dev/null || true
+                --field body="$(cat "${RUNNER_TEMP:-/tmp}/fp-comment.md")" >/dev/null || true
             else
-              gh pr comment "$PR" --body-file /tmp/fp-comment.md || true
+              gh pr comment "$PR" --body-file "${RUNNER_TEMP:-/tmp}/fp-comment.md" || true
             fi
             exit 0
           fi
@@ -464,9 +464,9 @@ jobs:
                 echo "## First Principles Review (Fable 5) — ⏭️ skipped"
                 echo
                 echo "_Revision \`$HEAD\` ships no reviewable capability (docs, tests or generated files only), so there is nothing to inventory. Advisory — does not block merge._"
-              } > /tmp/fp-comment.md
+              } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-                --field body="$(cat /tmp/fp-comment.md)" >/dev/null || true
+                --field body="$(cat "${RUNNER_TEMP:-/tmp}/fp-comment.md")" >/dev/null || true
               echo "Updated existing first-principles-review comment #$existing to skip notice"
             fi
             exit 0
@@ -513,7 +513,7 @@ jobs:
               echo "_Premise-level review of \`$HEAD\` — why this exists and whether the shipped surface is the smallest honest version. Updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
               printf '%s\n' "$summary"
-            } > /tmp/fp-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
           else
             # No parseable verdict → the review errored or emitted no header. Do
             # NOT post the raw model/error text: it can carry internal detail
@@ -536,14 +536,14 @@ jobs:
               echo "## First Principles Review (Fable 5) — ⚠️ could not complete"
               echo
               echo "_The first-principles review did not produce a verdict for \`$HEAD\` ($why). See the First Principles Review job logs. Advisory — does not block merge._"
-            } > /tmp/fp-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids / ARNs
           # from whatever we post. Combined with the "no raw text unless a verdict
           # parsed" gate above, this keeps internal detail out of the public PR
           # comment. Mirrors design-review.yml's redaction step, plus GitHub token
           # shapes, which the sibling lanes do not cover.
-          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g; s/\bgh[pousr]_[A-Za-z0-9]{20,}\b/[REDACTED-GH-TOKEN]/g; s/\bgithub_pat_[A-Za-z0-9_]{20,}\b/[REDACTED-GH-TOKEN]/g' /tmp/fp-comment.md
+          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g; s/\bgh[pousr]_[A-Za-z0-9]{20,}\b/[REDACTED-GH-TOKEN]/g; s/\bgithub_pat_[A-Za-z0-9_]{20,}\b/[REDACTED-GH-TOKEN]/g' "${RUNNER_TEMP:-/tmp}/fp-comment.md"
           # WITHHOLD GATE. The reviewer runs with read-only tools and no shell or
           # network, so the review text is its ONLY channel to a public audience --
           # which means this boundary, not the prompt's "never output secrets"
@@ -553,7 +553,7 @@ jobs:
           # long unbroken base64 run is included deliberately (an AWS session
           # token has no distinctive prefix); a false positive costs one advisory
           # comment, and the check stays green either way.
-          if grep -Eq '(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|(AKIA|ASIA)[A-Z2-7]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|[A-Za-z0-9/+=]{200,})' /tmp/fp-comment.md; then
+          if grep -Eq '(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|(AKIA|ASIA)[A-Z2-7]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|[A-Za-z0-9/+=]{200,})' "${RUNNER_TEMP:-/tmp}/fp-comment.md"; then
             echo "::warning::the first-principles review output matched a credential shape after redaction; the body was withheld and no verdict is reported for $HEAD."
             echo "verdict=UNKNOWN" >> "$GITHUB_OUTPUT"
             {
@@ -561,19 +561,117 @@ jobs:
               echo "## First Principles Review (Fable 5) — ⚠️ output withheld"
               echo
               echo "_The review of \`$HEAD\` produced text that still matched a credential shape after redaction, so the body was withheld and no verdict is reported. See the job logs. Advisory — does not block merge._"
-            } > /tmp/fp-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/fp-comment.md"
           fi
-          # Author filter: only a github-actions[bot] comment may match, so a PR
-          # commenter can't plant the marker and have us PATCH their comment.
-          existing="$(find_existing)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat /tmp/fp-comment.md)" >/dev/null || true
-            echo "Updated existing first-principles-review comment #$existing"
-          else
-            gh pr comment "$PR" --body-file /tmp/fp-comment.md || true
-            echo "Created new first-principles-review comment"
-          fi
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
+          guarded_comment_upsert "$MARKER" "[FIRST-PRINCIPLES-REVIEWED]" "First Principles Review" "${RUNNER_TEMP:-/tmp}/fp-comment.md"
 
       # Converts the verdict into the "First Principles Review" check status. A
       # real BLOCK verdict FAILS the check (emits ::error:: and exits 1) -- the

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -591,19 +591,115 @@ jobs:
               echo "_The design review did not produce a verdict for \`$HEAD\` ($why). See the Fork Design Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/design-comment.md"
           fi
-          # Author-filtered per-page jq lookup so a PR commenter can't plant the
-          # marker and have us PATCH their comment. head -n1 across pages.
-          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null \
-            | head -n1 || true)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat "$RUNNER_TEMP/design-comment.md")" >/dev/null || true
-            echo "Updated existing design-review comment #$existing"
-          else
-            gh pr comment "$PR" --body-file "$RUNNER_TEMP/design-comment.md" || true
-            echo "Created new design-review comment"
-          fi
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
+          guarded_comment_upsert "$MARKER" "[DESIGN-REVIEWED]" "Fork Design Review" "$RUNNER_TEMP/design-comment.md"
 
       # Finalize the "Design Review" check-run, keyed to head_sha. ADVISORY
       # contract: FAILURE only on a real BLOCK verdict; SUCCESS on PASS/CONCERNS;

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -605,6 +605,114 @@ jobs:
               --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null \
               | head -n1 || true
           }
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
           if [ "${WITHHELD:-}" = "true" ]; then
             # The review text matched a credential shape after redaction, so the
             # body was discarded upstream. Say that plainly and report no verdict.
@@ -614,13 +722,7 @@ jobs:
               echo
               echo "_The review of \`$HEAD\` produced text that still matched a credential shape after redaction, so the body was withheld and no verdict is reported. See the Fork First Principles Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/fp-comment.md"
-            existing="$(find_existing)"
-            if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-                --field body="$(cat "$RUNNER_TEMP/fp-comment.md")" >/dev/null || true
-            else
-              gh pr comment "$PR" --body-file "$RUNNER_TEMP/fp-comment.md" || true
-            fi
+            guarded_comment_upsert "$MARKER" "[FIRST-PRINCIPLES-REVIEWED]" "Fork First Principles Review" "$RUNNER_TEMP/fp-comment.md"
             exit 0
           fi
           # SKIPPED and NO_CONTRACT are DIFFERENT facts and no longer share one
@@ -690,17 +792,7 @@ jobs:
               echo "_The first-principles review did not produce a verdict for \`$HEAD\` ($why). See the Fork First Principles Review job logs. Advisory — does not block merge._"
             } > "$RUNNER_TEMP/fp-comment.md"
           fi
-          # Author-filtered per-page jq lookup so a PR commenter can't plant the
-          # marker and have us PATCH their comment. head -n1 across pages.
-          existing="$(find_existing)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat "$RUNNER_TEMP/fp-comment.md")" >/dev/null || true
-            echo "Updated existing first-principles-review comment #$existing"
-          else
-            gh pr comment "$PR" --body-file "$RUNNER_TEMP/fp-comment.md" || true
-            echo "Created new first-principles-review comment"
-          fi
+          guarded_comment_upsert "$MARKER" "[FIRST-PRINCIPLES-REVIEWED]" "Fork First Principles Review" "$RUNNER_TEMP/fp-comment.md"
 
       # Finalize the "First Principles Review" check-run, keyed to head_sha.
       # ADVISORY contract: FAILURE only on a real BLOCK verdict; SUCCESS on

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -1139,65 +1139,116 @@ jobs:
                 echo "- **$rid** \`$rloc\` — $rtxt"
               done < "${RUNNER_TEMP:-/tmp}/codex-adjudication-flags.md"
             fi
-          } > /tmp/fork-codex-comment.md
-          # Find the bot's existing marker comment (first match wins) and
-          # capture its id. Guards:
-          #   - author filter: only a github-actions[bot] comment can match, so a
-          #     PR commenter cannot plant the marker and have this step PATCH
-          #     their comment with the write-scoped token.
-          #   - per-page jq: with --paginate the --jq filter runs PER PAGE.
-          # An incomplete run never modifies an existing comment (see below), so
-          # only the id is needed here: no body capture, no PATCH decision that
-          # depends on the current body.
-          # Capture the paginated query's FULL output first so its own exit
-          # status alone decides lookup_ok. Piping straight into `head -n1`
-          # would let `head` close the pipe after the first of several matches
-          # (a marker duplicated across API pages) and, under `set -o pipefail`,
-          # make the whole pipeline non-zero -- misreading a successful lookup as
-          # a failure. So select the first id in a second step off the captured
-          # value.
-          lookup_ok=1
-          all_matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null)" || lookup_ok=0
-          existing="$(printf '%s\n' "$all_matches" | head -n1)"
-          if [ "$kind" = "incomplete" ]; then
-            # Stale-read race (#8292): an incomplete run NEVER modifies an
-            # existing comment, whether or not it carries [GPT-REVIEWED].
-            # Overlapping runs for different SHAs can read this comment before a
-            # newer run PATCHes its verdict in; an incomplete run that read first
-            # would otherwise clobber the newer run's just-published verdict with
-            # its own "review incomplete" body, and even a PATCH that only
-            # preserved the verdict and prepended a notice would restore the
-            # stale body it read. So when a comment already exists -- OR the
-            # lookup could not confirm one does not (a transient API error must
-            # not be read as "no comment", which would send this incomplete run
-            # to the create path and post a spurious marker over a live verdict)
-            # -- leave it untouched and emit a diagnostic only. Only when the
-            # lookup SUCCEEDED and found nothing does an incomplete run create
-            # the first "review incomplete" placeholder. The fail-closed
-            # "Finalize check-run" step still gates merge, so an incomplete run
-            # is never mistaken for an approval; the fork lane has no override.
-            if [ "$lookup_ok" -eq 0 ]; then
-              echo "Incomplete run for $HEAD; lookup failed, skipping to avoid posting a spurious marker over a possibly-live verdict"
-            elif [ -n "$existing" ] && [ "$existing" != "null" ]; then
-              echo "Incomplete run for $HEAD; left existing comment #$existing untouched to avoid overwriting a newer verdict"
+          } > "${RUNNER_TEMP:-/tmp}/fork-codex-comment.md"
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
             else
-              gh pr comment "$PR" --body-file /tmp/fork-codex-comment.md || true
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
             fi
-          else
-            # A completed verdict (blocked/clear) must become visible. If the
-            # lookup succeeded and found the marker, PATCH it in place; otherwise
-            # -- no existing comment, OR the lookup failed so we cannot confirm
-            # one -- create. A duplicate comment on a transient error is far more
-            # recoverable than a real verdict that never posts, so a completed
-            # run always publishes rather than staying silent.
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
             if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-                --field body="$(cat /tmp/fork-codex-comment.md)" >/dev/null || true
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
             else
-              gh pr comment "$PR" --body-file /tmp/fork-codex-comment.md || true
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
             fi
-          fi
+          }
+          guarded_comment_upsert "$MARKER" "[GPT-REVIEWED]" "Fork GPT 5.6 Review" "${RUNNER_TEMP:-/tmp}/fork-codex-comment.md"
 
       # Fail-CLOSED finalize of the required "GPT 5.6 Review" check-run, keyed to
       # head_sha; posts a failing check-run if the job died before opening one.

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -474,14 +474,116 @@ jobs:
             else
               echo "_No completed Opus verdict for this commit; see the Fork Opus 4.8 Review job logs._"
             fi
-          } > /tmp/fork-opus-comment.md
-          existing="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
-            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$MARKER\"))) | .id" 2>/dev/null | head -n1 || true)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" --field body="$(cat /tmp/fork-opus-comment.md)" >/dev/null || true
-          else
-            gh pr comment "$PR" --body-file /tmp/fork-opus-comment.md || true
-          fi
+          } > "${RUNNER_TEMP:-/tmp}/fork-opus-comment.md"
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
+          guarded_comment_upsert "$MARKER" "[OPUS-REVIEWED]" "Fork Opus 4.8 Review" "${RUNNER_TEMP:-/tmp}/fork-opus-comment.md"
 
       # Fail-CLOSED finalize of the required "Opus 4.8 Review" check-run, keyed to
       # head_sha; posts a failing check-run if the job died before opening one.

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -721,9 +721,9 @@ jobs:
                 echo "## UX Review (Fable 5, fork) — ⏭️ skipped"
                 echo
                 echo "_Revision \`$HEAD\` touches no user-facing surface (no changes under \`website/\` or committed screenshots), so the UX review was skipped. Advisory — does not block merge._"
-              } > /tmp/ux-comment.md
+              } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-                --field body="$(cat /tmp/ux-comment.md)" >/dev/null || true
+                --field body="$(cat "${RUNNER_TEMP:-/tmp}/ux-comment.md")" >/dev/null || true
               echo "Updated existing ux-review comment #$existing to skip notice"
             fi
             exit 0
@@ -777,7 +777,7 @@ jobs:
               echo "_UX-level review of \`$HEAD\` via the fork AI-review pipeline — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
               printf '%s\n' "$summary"
-            } > /tmp/ux-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
           else
             # No parseable verdict → the review errored or emitted no header.
             # Do NOT post the raw model/error text: it can carry internal
@@ -801,24 +801,122 @@ jobs:
               echo "## UX Review (Fable 5, fork) — ⚠️ could not complete"
               echo
               echo "_The UX review did not produce a verdict for \`$HEAD\` ($why). See the Fork UX Review job logs. Advisory — does not block merge._"
-            } > /tmp/ux-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids / ARNs
           # from whatever we post. Combined with the "no raw text unless a
           # verdict parsed" gate above, this keeps internal detail out of the
           # public PR comment. Mirrors ux-review.yml's redaction step.
-          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' /tmp/ux-comment.md
-          # Author filter: only a github-actions[bot] comment may match, so a PR
-          # commenter can't plant the marker and have us PATCH their comment.
-          existing="$(find_existing)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat /tmp/ux-comment.md)" >/dev/null || true
-            echo "Updated existing ux-review comment #$existing"
-          else
-            gh pr comment "$PR" --body-file /tmp/ux-comment.md || true
-            echo "Created new ux-review comment"
-          fi
+          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' "${RUNNER_TEMP:-/tmp}/ux-comment.md"
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
+          guarded_comment_upsert "$MARKER" "[UX-REVIEWED]" "Fork UX Review" "${RUNNER_TEMP:-/tmp}/ux-comment.md"
 
       # Finalize the "UX Review" check-run (ADVISORY), keyed to head_sha. A real
       # BLOCK verdict → failure (the one case the shipped experience is judged

--- a/.github/workflows/ux-review.yml
+++ b/.github/workflows/ux-review.yml
@@ -611,9 +611,9 @@ jobs:
                 echo "## UX Review (Fable 5) — ⏭️ skipped"
                 echo
                 echo "_Revision \`$HEAD\` touches no user-facing surface (no changes under \`website/\` or committed screenshots), so the UX review was skipped. Advisory — does not block merge._"
-              } > /tmp/ux-comment.md
+              } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-                --field body="$(cat /tmp/ux-comment.md)" >/dev/null || true
+                --field body="$(cat "${RUNNER_TEMP:-/tmp}/ux-comment.md")" >/dev/null || true
               echo "Updated existing ux-review comment #$existing to skip notice"
             fi
             exit 0
@@ -667,7 +667,7 @@ jobs:
               echo "_UX-level review of \`$HEAD\` — updated in place on each push. **A BLOCK verdict blocks PR readiness**; PASS/CONCERNS are advisory._"
               echo
               printf '%s\n' "$summary"
-            } > /tmp/ux-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
           else
             # No parseable verdict → the review errored or emitted no header.
             # Do NOT post the raw model/error text: it can carry internal
@@ -691,25 +691,122 @@ jobs:
               echo "## UX Review (Fable 5) — ⚠️ could not complete"
               echo
               echo "_The UX review did not produce a verdict for \`$HEAD\` ($why). See the UX Review job logs. Advisory — does not block merge._"
-            } > /tmp/ux-comment.md
+            } > "${RUNNER_TEMP:-/tmp}/ux-comment.md"
           fi
           # Defense-in-depth: scrub credential shapes AND AWS account ids /
           # ARNs from whatever we post. Combined with the "no raw text unless
           # a verdict parsed" gate above, this keeps internal detail out of
           # the public PR comment. Mirrors design-review.yml's redaction step.
-          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' /tmp/ux-comment.md
-          # Author filter: only a github-actions[bot] comment may match, so a
-          # PR commenter can't plant the marker and have us PATCH their
-          # comment.
-          existing="$(find_existing)"
-          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
-              --field body="$(cat /tmp/ux-comment.md)" >/dev/null || true
-            echo "Updated existing ux-review comment #$existing"
-          else
-            gh pr comment "$PR" --body-file /tmp/ux-comment.md || true
-            echo "Created new ux-review comment"
-          fi
+          perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' "${RUNNER_TEMP:-/tmp}/ux-comment.md"
+          # Guarded upsert (#8292, #8344): the shared function below is defined
+          # byte-identically in every review lane; test_ai_review_workflows.py
+          # pins all copies to one canonical body so the invariant cannot
+          # drift lane by lane.
+          guarded_comment_upsert() {
+            local marker="$1" stamp="$2" lane="$3" out_file="$4"
+            local matches existing lookup_ok pr_head="" attempt withhold=""
+            # Find the bot's existing marker comment (first match wins) and
+            # capture its id. Author filter: only a github-actions[bot]
+            # comment can match, so a PR commenter cannot plant the marker and
+            # have this step PATCH their comment with the write-scoped token.
+            # Only the id is read: no decision below inspects the current
+            # body, so this function has no read-modify-write window on it.
+            # Capture the paginated query's FULL output first and select the
+            # first id off the captured value -- a `... | head -n1` inside the
+            # pipeline lets head's early exit SIGPIPE the api call and misread
+            # a successful lookup as a failure under pipefail (#8350).
+            # Retry a transient failure: whether a comment exists is a gating
+            # input here, and one blip is not evidence that none does.
+            lookup_ok=0
+            for attempt in 1 2 3; do
+              if matches="$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
+                --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body | startswith(\"$marker\"))) | .id" 2>/dev/null)"; then
+                lookup_ok=1
+                break
+              fi
+              matches=""
+              echo "Reading this PR's comments failed on attempt $attempt."
+              if [ "$attempt" -lt 3 ]; then
+                sleep "$attempt"
+              fi
+            done
+            existing="$(printf '%s\n' "$matches" | awk 'NR == 1')"
+            # This lane's marker comment is ONE slot shared by every run on the
+            # PR, and the REST comments API has no If-Match, so a write to it
+            # is last-writer-wins with no way to detect the loss afterwards --
+            # it exposes no edit history either (#8292). Exactly one kind of
+            # run may therefore claim the slot: a COMPLETED verdict for the
+            # PR's CURRENT head. Every other case leaves an existing comment
+            # untouched, because each of them can lose a live verdict.
+            if ! grep -Fq "$stamp $HEAD" "$out_file"; then
+              # No "<stamp> $HEAD" proof marker: this is a review FAILURE
+              # notice, and PATCHing one over a completed verdict buries that
+              # verdict -- blocking findings included -- where no reader or
+              # tool looks. Note that PRESERVING the verdict and prepending a
+              # staleness notice is not a safe alternative: it reads the body
+              # and writes a merge of it back, so a verdict published between
+              # the read and the write is restored away.
+              withhold="run for $HEAD produced no completed verdict"
+            else
+              # A completed verdict for a SUPERSEDED head is the same loss
+              # arriving late: an older run can finish after a newer one has
+              # already published, and the fork lanes' concurrency group is
+              # keyed per head so they are not cancelled -- while a cancelled
+              # same-repo run still executes this if:always() step. So confirm
+              # this run is still the PR's head before claiming the slot.
+              # Retry a transient read the way this lane's other gating reads
+              # do, then treat an unreadable head as NOT confirmed: writing is
+              # the destructive half, so it must not proceed on an unknown.
+              for attempt in 1 2 3; do
+                if pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha')" \
+                  && [ -n "$pr_head" ]; then
+                  break
+                fi
+                pr_head=""
+                echo "Reading this PR's head sha failed on attempt $attempt."
+                if [ "$attempt" -lt 3 ]; then
+                  sleep "$attempt"
+                fi
+              done
+              if [ -z "$pr_head" ]; then
+                withhold="this PR's head was unreadable after 3 attempts, so $HEAD cannot be confirmed current"
+              elif [ "$pr_head" != "$HEAD" ]; then
+                withhold="$HEAD is no longer this PR's head ($pr_head)"
+              fi
+            fi
+            if [ -n "$withhold" ]; then
+              # A lookup that ERRORED is not "no comment exists": taking the
+              # create path there plants a second marker comment over a
+              # possibly-live verdict, which no later run undoes.
+              if [ "$lookup_ok" -eq 0 ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); the comment lookup also failed, so nothing was posted"
+                return 0
+              fi
+              if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+                echo "Withholding $lane comment for $HEAD ($withhold); left existing comment #$existing untouched"
+                return 0
+              fi
+              # The lookup SUCCEEDED and found nothing, so there is no verdict
+              # to lose: posting the body as a NEW comment buries nothing.
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+              return 0
+            fi
+            if [ "$lookup_ok" -eq 1 ] && [ -n "$existing" ] && [ "$existing" != "null" ]; then
+              gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
+                --field body="$(cat "$out_file")" >/dev/null || true
+              echo "Updated existing $lane comment #$existing"
+            else
+              # No existing comment -- or a lookup that could not confirm one
+              # -- falls through to CREATE either way: a completed verdict for
+              # the confirmed current head must never be dropped because the
+              # comment lookup failed, since a duplicate comment is
+              # recoverable and an unposted verdict is not (#8350).
+              gh pr comment "$PR" --body-file "$out_file" || true
+              echo "Created new $lane comment"
+            fi
+          }
+          guarded_comment_upsert "$MARKER" "[UX-REVIEWED]" "UX Review" "${RUNNER_TEMP:-/tmp}/ux-comment.md"
 
       # Converts the UX verdict into the "UX Review" check status. A real
       # BLOCK verdict FAILS the check (emits ::error:: and exits 1) — the one

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -592,16 +592,66 @@ no-output review must not look clean. A BLOCKING-labelled finding without the
 `[BLOCK-MERGE]` marker is only a non-gating **advisory warning**, since a coherence
 check on that pairing mis-fires whenever the model quotes prior text.
 
-The GPT summary comment is upserted in place, which once let a failed run's
-"review incomplete" body replace a posted verdict — the REST comments API
-exposes no edit history, so a `[BLOCK-MERGE]` finding vanished from every
-surface a reader or tool checks (#8292). The same-repo GPT lane's post step
-now refuses exactly that transition: an incomplete body never overwrites a
-marker-present verdict; it keeps the existing verdict and prepends one dated
-stale-verdict notice instead. Completed verdicts and human overrides still
-replace the comment, and the fail-closed gate above is unchanged. The fork
-GPT lane (`fork-gpt-review.yml`) still PATCHes unconditionally and is tracked
-separately.
+A lane's summary comment is **one slot shared by every run on the PR**, and it
+is upserted in place. The comments API has no `If-Match`, so a write to that
+slot is last-writer-wins, and it exposes no edit history, so the loss is
+undetectable afterwards: a failed run's "review incomplete" body once replaced
+a posted verdict and a `[BLOCK-MERGE]` finding vanished from every surface a
+reader or tool checks (#8292).
+
+Eight of the ten lanes that upsert a verdict comment now let exactly one kind of
+run claim that slot — a **completed verdict for the PR's current head**. The two
+other kinds each lose a live verdict, so each leaves an existing comment
+untouched (#8344):
+
+- **No `"<stamp> <head>"` proof marker** — a review failure. Preserving the
+  verdict and prepending a staleness notice is *not* a safe alternative: it
+  reads the body and writes a merge of it back, so a verdict published between
+  the read and the write is restored away.
+- **A completed verdict for a superseded head** — the same loss arriving late.
+  An older run can finish after a newer one published, because the fork lanes'
+  `concurrency` group is keyed per head so they are not cancelled, and a
+  cancelled same-repo run still executes its `if: always()` posting step. The
+  step reads the PR's head and stands down when it is not the head it
+  reviewed.
+- **A head that cannot be read.** Writing is the destructive half of the
+  guard, so it does not proceed on an unknown: a head unreadable after three
+  attempts is *not confirmed current* and the slot is left alone. The read
+  retries first — with the same bounded backoff this lane's other gating reads
+  use — because one blip is not evidence about the PR, and an API broken
+  enough to fail all three would fail the write too.
+
+Whether a comment exists is the other gating input, so that read retries on the
+same bounded backoff. A lookup still erroring afterwards counts as "a comment
+may exist", not as "none does", so a withheld run posts nothing rather than
+plant a second marker comment over a possibly-live verdict. When the lookup
+succeeded and found nothing there is no verdict to lose, so the body is posted
+as a new comment. Nothing is lost by standing down: the comment names the head
+it reviewed, each head's own check-run is finalized fail-closed, and
+`pr_status.py` matches reviewer stamps against the current head, so a comment
+left in place for an older head reads as *stale* and never as an approval of
+this one.
+
+Human overrides and skip notices are current-head determinations rather than
+review failures, so their upsert sites keep replacing the comment
+unconditionally, and a completed verdict for a **confirmed** current head whose
+*comment* lookup failed still CREATEs rather than stay silent (a duplicate
+comment is recoverable, an unposted verdict is not). The eight guarded lanes
+define the guard as a `guarded_comment_upsert` bash function that
+`test_ai_review_workflows.py` pins byte-identical across every lane, so the
+invariant cannot drift lane by lane.
+
+Two lanes stay outside that function, and both exclusions are deliberate:
+
+- **`codex-review.yml`** carries #8342's own inline preserve-and-prepend shape,
+  pinned byte-for-byte by its own tests — it is the one site left with a
+  read-modify-write window on the slot.
+- **`claude-review.yml`** keeps a plain lookup-then-PATCH. Its incomplete path
+  posts **nothing at all**, so the #8292 class — a failure notice burying a
+  verdict — cannot reach it. What remains is only the superseded-completed
+  window: its `concurrency` group cancels an older run per PR, but the posting
+  step is `if: always()`, which a cancelled run still executes, so an older run
+  holding a completed verdict can still claim the slot.
 
 ### Security posture of the reviewer jobs
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -3483,7 +3483,7 @@ class TestBlockAdjudicationContract:
             if lane == "codex-review.yml":
                 # Only the same-repo lane advertises the ready-to-paste command;
                 # the fork lane's comment carries no override command by
-                # standing design (see TestForkGptVerdictVisibility).
+                # standing design, and the `else` arm below is what pins that.
                 assert "/ai-review override gpt $HEAD: $rtxt" in comment, lane
             else:
                 assert "/ai-review override" not in comment, lane
@@ -4651,358 +4651,587 @@ class TestGptVerdictVisibility:
         assert "stale-notice" not in gate
 
 
-# The fork step writes its comment body to the workflow's hardcoded
-# `/tmp/fork-codex-comment.md` (a fork-lane idiom that is safe on an isolated CI
-# runner). These host-side cases exercise the REAL step, so `_run` rewrites that
-# absolute path under each test's own `tmp_path` before executing it: the writes
-# stay off the operator's machine and never race each other across xdist workers.
-class TestForkGptVerdictVisibility:
-    """The fork GPT lane must never bury a posted verdict under an incomplete body.
+def _exec_transcript(runner_temp: Path, review_text: str) -> dict[str, str]:
+    """Write a claude-code execution_file fixture and return its env binding.
 
-    ``fork-gpt-review.yml``'s ``Post/update summary comment`` step publishes its
-    verdict by editing ONE marker comment in place. A later incomplete run used
-    to PATCH that slot unconditionally, so a real ``[BLOCK-MERGE]`` verdict got
-    overwritten by a short "review incomplete" body -- recoverable only through
-    GraphQL ``userContentEdits``, which no REST reader or tool consults (#8292).
-    An incomplete run therefore NEVER modifies an existing comment: not even to
-    preserve the verdict and prepend a stale notice, because the preserving
-    PATCH is itself a stale-read overwrite (#8350) -- an incomplete run that
-    read verdict V1 would PATCH V1 back over a newer run's V2 that landed in
-    between. So when an existing bot comment is present, an incomplete run
-    leaves it entirely untouched (a diagnostic echo only); only blocked/clear
-    runs PATCH it. Each contract case runs the REAL fork step bash with a
-    stubbed ``gh``.
+    The design-family lanes read the model's review text from the action's
+    transcript (a single result object is one of the three shapes the step's
+    slurp+flatten parse accepts).
+    """
+    exec_file = runner_temp / "execution.json"
+    exec_file.write_text(json.dumps({"result": review_text}), encoding="utf-8")
+    return {"EXEC_FILE": str(exec_file), "REVIEW_OUTCOME": "success"}
 
-    The fork lane differs from the same-repo lane: the step runs under
-    ``set -uo pipefail`` with ``if: always()``, reads a cwd-relative
-    ``codex-review-output.md`` to decide ``kind`` (incomplete/blocked/clear --
-    there is NO human-override kind and NO override footer), and swallows gh
-    errors with ``|| true``.
+
+# One entry per review lane that carries the guarded comment upsert. Each
+# describes how to drive that lane's REAL posting step into a completed run
+# (body carries "<stamp> <head>") and an incomplete one (no verdict for the
+# current head), plus the phrase its incomplete body is known by.
+_GUARDED_LANES = [
+    {
+        "id": "fork-gpt",
+        "workflow": "fork-gpt-review.yml",
+        "step": "Post/update summary comment",
+        "marker": "<!-- codex-ai-review -->",
+        "stamp": "[GPT-REVIEWED]",
+        "incomplete_text": "review incomplete",
+        "needs_perl": False,
+        "env": {"ADJ_DECISION": "", "ADJ_NOTE": ""},
+        "completed": lambda cwd, rt, head: (
+            (cwd / "codex-review-output.md").write_text(
+                f"FINDINGS\n[GPT-REVIEWED] {head}\n", encoding="utf-8"
+            ),
+            {},
+        )[1],
+        "incomplete": lambda cwd, rt, head: {},
+    },
+    {
+        "id": "fork-opus",
+        "workflow": "fork-opus-review.yml",
+        "step": "Post/update summary comment",
+        "marker": "<!-- claude-ai-review -->",
+        "stamp": "[OPUS-REVIEWED]",
+        "incomplete_text": "review incomplete",
+        "needs_perl": False,
+        "env": {},
+        "completed": lambda cwd, rt, head: (
+            (cwd / "claude-review-output.md").write_text(
+                f"FINDINGS\n[OPUS-REVIEWED] {head}\n", encoding="utf-8"
+            ),
+            {},
+        )[1],
+        "incomplete": lambda cwd, rt, head: {},
+    },
+    {
+        "id": "design",
+        "workflow": "design-review.yml",
+        "step": "Post design review summary",
+        "marker": "<!-- design-review -->",
+        "stamp": "[DESIGN-REVIEWED]",
+        "incomplete_text": "could not complete",
+        "needs_perl": True,
+        "env": {"HUMAN_OVERRIDE": "false", "OVERRIDE_ACTOR": "", "ACTOR": "someone"},
+        "completed": lambda cwd, rt, head: _exec_transcript(
+            rt, f"Design-Verdict: PASS\n\nsolid reasoning\n\n[DESIGN-REVIEWED] {head}\n"
+        ),
+        "incomplete": lambda cwd, rt, head: _exec_transcript(
+            rt, "Design-Verdict: PASS\n\nstale reasoning\n\n[DESIGN-REVIEWED] feedbead\n"
+        ),
+    },
+    {
+        "id": "ux",
+        "workflow": "ux-review.yml",
+        "step": "Post UX review summary",
+        "marker": "<!-- ux-review -->",
+        "stamp": "[UX-REVIEWED]",
+        "incomplete_text": "could not complete",
+        "needs_perl": True,
+        "env": {
+            "HUMAN_OVERRIDE": "false",
+            "OVERRIDE_ACTOR": "",
+            "ACTOR": "someone",
+            "UI_SCOPE": "true",
+        },
+        "completed": lambda cwd, rt, head: _exec_transcript(
+            rt, f"UX-Verdict: PASS\n\nsolid reasoning\n\n[UX-REVIEWED] {head}\n"
+        ),
+        "incomplete": lambda cwd, rt, head: _exec_transcript(
+            rt, "UX-Verdict: PASS\n\nstale reasoning\n\n[UX-REVIEWED] feedbead\n"
+        ),
+    },
+    {
+        "id": "first-principles",
+        "workflow": "first-principles-review.yml",
+        "step": "Post first-principles review summary",
+        "marker": "<!-- first-principles-review -->",
+        "stamp": "[FIRST-PRINCIPLES-REVIEWED]",
+        "incomplete_text": "could not complete",
+        "needs_perl": True,
+        "env": {
+            "HUMAN_OVERRIDE": "false",
+            "OVERRIDE_ACTOR": "",
+            "ACTOR": "someone",
+            "SURFACE": "true",
+            "CONTRACT": "true",
+        },
+        "completed": lambda cwd, rt, head: _exec_transcript(
+            rt,
+            "First-Principles-Verdict: PASS\n\nsolid reasoning\n\n"
+            f"[FIRST-PRINCIPLES-REVIEWED] {head}\n",
+        ),
+        "incomplete": lambda cwd, rt, head: _exec_transcript(
+            rt,
+            "First-Principles-Verdict: PASS\n\nstale reasoning\n\n"
+            "[FIRST-PRINCIPLES-REVIEWED] feedbead\n",
+        ),
+    },
+    {
+        "id": "fork-design",
+        "workflow": "fork-design-review.yml",
+        "step": "Post/update design review comment",
+        "marker": "<!-- design-review -->",
+        "stamp": "[DESIGN-REVIEWED]",
+        "incomplete_text": "could not complete",
+        "needs_perl": False,
+        "env": {},
+        "completed": lambda cwd, rt, head: (
+            (rt / "design-review-output.md").write_text(
+                f"solid reasoning\n\n[DESIGN-REVIEWED] {head}\n", encoding="utf-8"
+            ),
+            {"VERDICT": "PASS", "REVIEW_OUTCOME": "success"},
+        )[1],
+        "incomplete": lambda cwd, rt, head: {"VERDICT": "UNKNOWN", "REVIEW_OUTCOME": "failure"},
+    },
+    {
+        "id": "fork-ux",
+        "workflow": "fork-ux-review.yml",
+        "step": "Post UX review summary",
+        "marker": "<!-- ux-review -->",
+        "stamp": "[UX-REVIEWED]",
+        "incomplete_text": "could not complete",
+        "needs_perl": True,
+        "env": {"UI_SCOPE": "true"},
+        "completed": lambda cwd, rt, head: _exec_transcript(
+            rt, f"UX-Verdict: PASS\n\nsolid reasoning\n\n[UX-REVIEWED] {head}\n"
+        ),
+        "incomplete": lambda cwd, rt, head: _exec_transcript(
+            rt, "UX-Verdict: PASS\n\nstale reasoning\n\n[UX-REVIEWED] feedbead\n"
+        ),
+    },
+    {
+        "id": "fork-first-principles",
+        "workflow": "fork-first-principles-review.yml",
+        "step": "Post/update first-principles review comment",
+        "marker": "<!-- first-principles-review -->",
+        "stamp": "[FIRST-PRINCIPLES-REVIEWED]",
+        "incomplete_text": "could not complete",
+        "needs_perl": False,
+        "env": {"WITHHELD": ""},
+        "completed": lambda cwd, rt, head: (
+            (rt / "first-principles-output.md").write_text(
+                f"solid reasoning\n\n[FIRST-PRINCIPLES-REVIEWED] {head}\n", encoding="utf-8"
+            ),
+            {"VERDICT": "PASS", "REVIEW_OUTCOME": "success"},
+        )[1],
+        "incomplete": lambda cwd, rt, head: {"VERDICT": "UNKNOWN", "REVIEW_OUTCOME": "failure"},
+    },
+]
+
+_GUARDED_LANE_PARAMS = [pytest.param(lane, id=lane["id"]) for lane in _GUARDED_LANES]
+
+
+class TestReviewLaneVerdictVisibility:
+    """No review lane may bury a posted verdict under an incomplete body (#8344).
+
+    Covers the eight lanes that upsert a marker-keyed summary comment outside
+    codex-review.yml. Each lane defines the guarded upsert as a byte-identical
+    ``guarded_comment_upsert`` bash function; the identity test pins every
+    copy to one canonical body so the invariant cannot drift lane by lane, and
+    the behavioral tests run each lane's REAL step bash with a stubbed ``gh``
+    for the contract cases.
+
+    The guarded transition is a NO-TOUCH, not a merge: a run whose body
+    carries no ``"<stamp> <head>"`` proof marker leaves an existing comment
+    entirely alone. Reading the body and PATCHing a merge of it back would
+    reopen the same class of loss from the other side, because runs for
+    different heads are not cancelled — a verdict published between the read
+    and the write is restored away.
     """
 
-    MARKER = "<!-- codex-ai-review -->"
-    HEAD = "f" * 40
-    OLD_HEAD = "a" * 40
-    BOT_COMMENT_ID = "555"
-    IMPOSTOR_COMMENT_ID = "666"
+    HEAD = "1234567890abcdef1234567890abcdef12345678"
+    OLD = "aaaa567890abcdef1234567890abcdef1234aaaa"
 
-    def _step(self) -> str:
-        return _step_script(_workflow("fork-gpt-review.yml"), "Post/update summary comment")
-
-    def _gh_stub(
-        self, comments_json: Path, patch_log: Path, created_log: Path, *, lookup_fails: bool = False
-    ) -> str:
-        """A gh stub that answers the three calls this step makes.
-
-        ``gh api .../comments --paginate --jq <f>``: runs the step's own jq
-        filter over an array fixture that holds both an impostor ``mallory``
-        comment and the ``github-actions[bot]`` comment, so the author guard is
-        exercised for real. ``gh api --method PATCH ...``: records the target id
-        and stdin body. ``gh pr comment ...``: records the created body.
-        """
+    def _verdict_body(self, lane: dict, sha: str) -> str:
         return (
-            "#!/usr/bin/env bash\n"
-            'if [ "${1:-}" = "api" ] && [ "${2:-}" = "--method" ] && [ "${3:-}" = "PATCH" ]; then\n'
-            f'  printf \'%s\\n\' "$4" >> "{patch_log}"\n'
-            "  # --field body=<value> follows; find it and record the value.\n"
-            "  shift 4\n"
-            '  while [ "$#" -gt 0 ]; do\n'
-            '    case "$1" in\n'
-            f'      body=*) printf \'%s\' "${{1#body=}}" >> "{patch_log}" ;;\n'
-            '      --field) shift; printf \'%s\' "${1#body=}" >> "' + str(patch_log) + '" ;;\n'
-            "    esac\n"
-            "    shift\n"
-            "  done\n"
-            "  exit 0\n"
-            "fi\n"
-            'if [ "${1:-}" = "api" ]; then\n'
-            # A lookup FAILURE: the comments-list API errors (network/5xx).
-            # The step must not treat the empty output as "no comment".
-            + ("  echo 'gh: API error' >&2\n  exit 1\n" if lookup_fails else "")
-            + "  # Locate the --jq filter and apply it to the array fixture.\n"
-            "  # `gh api --jq` emits RAW output (like `jq -r`), so an @json\n"
-            "  # record prints as compact JSON with no surrounding quotes --\n"
-            "  # the step's `jq -r '.id'` then reparses that line as an object.\n"
-            '  filter=""\n'
-            '  while [ "$#" -gt 0 ]; do\n'
-            '    if [ "$1" = "--jq" ]; then shift; filter="$1"; fi\n'
-            "    shift\n"
-            "  done\n"
-            f'  jq -r "$filter" "{comments_json}"\n'
-            "  exit 0\n"
-            "fi\n"
-            'if [ "${1:-}" = "pr" ] && [ "${2:-}" = "comment" ]; then\n'
-            "  # --body-file <path> is the last pair.\n"
-            '  file=""\n'
-            '  while [ "$#" -gt 0 ]; do\n'
-            '    if [ "$1" = "--body-file" ]; then shift; file="$1"; fi\n'
-            "    shift\n"
-            "  done\n"
-            f'  cat "$file" >> "{created_log}"\n'
-            "  exit 0\n"
-            "fi\n"
-            'echo "unexpected gh call: $*" >&2\n'
-            "exit 9\n"
+            f"{lane['marker']}\n"
+            "## Review — 🔴 changes requested (blocking)\n"
+            "\n"
+            f"a completed review of `{sha}`.\n"
+            "\n"
+            f"{lane['stamp']} {sha}\n"
         )
 
-    def _run(
+    def _run_step(
         self,
+        lane: dict,
         tmp_path: Path,
         *,
-        comments: list[dict],
-        review_output: str | None,
-        lookup_fails: bool = False,
-    ) -> tuple[subprocess.CompletedProcess, Path, Path]:
+        existing_body: str | None,
+        kind: str,
+        extra_env: dict[str, str] | None = None,
+    ) -> tuple[Path, "subprocess.CompletedProcess[bytes]"]:
         bash = _bash()
-        if bash is None:
-            pytest.skip("the step is Bash; skip where Bash is absent")
-        if shutil.which("jq") is None:
-            pytest.skip("the step shells out to jq")
+        if bash is None or shutil.which("jq") is None:
+            pytest.skip("lane upsert tests require Bash and jq")
+        if lane["needs_perl"] and shutil.which("perl") is None:
+            pytest.skip("this lane's posting step redacts with perl")
+        if os.name == "nt":
+            pytest.skip("stubbed-PATH gh interception is exercised on POSIX runners")
 
-        bin_dir = tmp_path / "bin"
-        bin_dir.mkdir()
-        comments_json = tmp_path / "comments.json"
-        comments_json.write_text(json.dumps(comments), encoding="utf-8")
-        patch_log = tmp_path / "patch.log"
-        patch_log.touch()
-        created_log = tmp_path / "created.log"
-        created_log.touch()
-
-        (bin_dir / "gh").write_text(
-            self._gh_stub(comments_json, patch_log, created_log, lookup_fails=lookup_fails),
-            encoding="utf-8",
-        )
-        (bin_dir / "gh").chmod(0o755)
-
-        # The step reads a cwd-relative codex-review-output.md to decide `kind`.
-        # Absent/empty output => incomplete; markers present => blocked/clear.
-        if review_output is not None:
-            (tmp_path / "codex-review-output.md").write_text(review_output, encoding="utf-8")
-
+        stub_dir = tmp_path / "stub"
+        stub_dir.mkdir()
+        calls_dir = tmp_path / "calls"
+        calls_dir.mkdir()
         runner_temp = tmp_path / "runner-temp"
         runner_temp.mkdir()
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
 
-        # The step writes its new comment body to the workflow's HARDCODED
-        # `/tmp/fork-codex-comment.md` (a fork-lane idiom that is safe on an
-        # isolated CI runner). A test must not touch the operator's machine, so
-        # redirect that absolute path under `tmp_path` before running the real
-        # step (AGENTS.md: no test side effects, a spawn's writes stay under
-        # `tmp_path`). The step's other temp files already honour RUNNER_TEMP.
-        comment_file = tmp_path / "fork-codex-comment.md"
-        step = self._step().replace("/tmp/fork-codex-comment.md", str(comment_file))
-        assert "/tmp/fork-codex-comment.md" not in step
+        finder_file = tmp_path / "finder-comments.json"
+        if existing_body is None:
+            finder_file.write_text("[]", encoding="utf-8")
+        else:
+            finder_file.write_text(
+                json.dumps(
+                    [
+                        {"id": 999, "user": {"login": "mallory"}, "body": existing_body},
+                        {
+                            "id": 123,
+                            "user": {"login": "github-actions[bot]"},
+                            "body": existing_body,
+                        },
+                    ]
+                ),
+                encoding="utf-8",
+            )
 
-        proc = subprocess.run(
-            # GitHub executes run-blocks as `bash -e {0}`.
-            [bash, "-e", "-c", step],
+        if kind == "completed":
+            case_env = lane["completed"](cwd, runner_temp, self.HEAD)
+        elif kind == "incomplete":
+            case_env = lane["incomplete"](cwd, runner_temp, self.HEAD)
+        else:
+            case_env = {}
+
+        gh_stub = stub_dir / "gh"
+        gh_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            "# Emulates the two gh surfaces the step uses; records mutations.\n"
+            "# The finder branch runs the step's REAL --jq filter with real jq\n"
+            "# over an array fixture, so a drift in the filter (dropped .id,\n"
+            "# changed author guard) fails these tests instead of hiding.\n"
+            'if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "PATCH" ]; then\n'
+            '  printf \'%s\\n\' "$4" >> "$STUB_CALLS/patch-calls.txt"\n'
+            '  for a in "$@"; do\n'
+            '    case "$a" in body=*) printf \'%s\' "${a#body=}" > "$STUB_CALLS/patched-body.md";; esac\n'
+            "  done\n"
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "api" ] && [ -n "${FINDER_FAIL:-}" ]; then\n'
+            "  # Every attempt at the COMMENT lookup fails, so the retry is\n"
+            "  # visible in the recorded call count; the step must not read a\n"
+            '  # lookup error as "no comment exists".\n'
+            '  case "$2" in\n'
+            "    */comments)\n"
+            '      printf \'%s\\n\' "$2" >> "$STUB_CALLS/comment-reads.txt"\n'
+            "      exit 4\n"
+            "      ;;\n"
+            "  esac\n"
+            "fi\n"
+            'if [ "$1" = "api" ]; then\n'
+            "  # The PR object, from which the step reads the CURRENT head sha.\n"
+            "  # STUB_PR_HEAD unset means the PR still points at this run;\n"
+            "  # set-but-empty means every read fails, so the retry is visible\n"
+            "  # in the recorded call count.\n"
+            '  case "$2" in\n'
+            "    */pulls/*)\n"
+            '      printf \'%s\\n\' "$2" >> "$STUB_CALLS/pr-head-reads.txt"\n'
+            '      if [ -z "${STUB_PR_HEAD-unset}" ]; then exit 5; fi\n'
+            "      printf '%s\\n' \"${STUB_PR_HEAD:-$HEAD}\"\n"
+            "      exit 0\n"
+            "      ;;\n"
+            "  esac\n"
+            "fi\n"
+            'if [ "$1" = "api" ]; then\n'
+            '  filter=""\n'
+            "  grab=0\n"
+            '  for a in "$@"; do\n'
+            '    if [ "$grab" = 1 ]; then filter="$a"; grab=0; fi\n'
+            '    [ "$a" = "--jq" ] && grab=1\n'
+            "  done\n"
+            '  jq -r "$filter" < "$FINDER_COMMENTS_FILE"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then\n'
+            "  shift 3\n"
+            '  if [ "$1" = "--body-file" ]; then cp "$2" "$STUB_CALLS/created-body.md"; fi\n'
+            "  exit 0\n"
+            "fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        gh_stub.chmod(0o755)
+
+        script = _step_script(_workflow(lane["workflow"]), lane["step"])
+        script_file = tmp_path / "step.sh"
+        script_file.write_text(script, encoding="utf-8")
+
+        env = {
+            **os.environ,
+            "PATH": f"{stub_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "REPO": "example/repo",
+            "PR": "1",
+            "HEAD": self.HEAD,
+            "GH_TOKEN": "stub-token",
+            "RUNNER_TEMP": str(runner_temp),
+            "STUB_CALLS": str(calls_dir),
+            "FINDER_COMMENTS_FILE": str(finder_file),
+            "GITHUB_OUTPUT": str(tmp_path / "github-output.txt"),
+            **lane["env"],
+            **case_env,
+            **(extra_env or {}),
+        }
+        # GitHub runs `run:` blocks with `bash -e {0}` when no shell is set.
+        result = subprocess.run(
+            [bash, "-e", str(script_file)],
             check=False,
             capture_output=True,
-            text=True,
-            encoding="utf-8",
-            env={
-                **os.environ,
-                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
-                "GH_TOKEN": "stub",
-                "REPO": "o/r",
-                "PR": "1",
-                "HEAD": self.HEAD,
-                "RUNNER_TEMP": str(runner_temp),
-            },
-            cwd=tmp_path,
+            cwd=cwd,
+            env=env,
         )
-        assert proc.returncode == 0, f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
-        return proc, patch_log, created_log
+        return calls_dir, result
 
-    def _fixture_comments(self, bot_body: str) -> list[dict]:
-        """An array with an impostor first, then the bot's marker comment.
-
-        The impostor plants the marker under a non-bot login: the author guard
-        (`.user.login == "github-actions[bot]"`) must reject it, so a match on
-        it would prove the guard is not exercised.
-        """
-        return [
-            {
-                "id": int(self.IMPOSTOR_COMMENT_ID),
-                "user": {"login": "mallory"},
-                "body": f"{self.MARKER}\nnice try",
-            },
-            {
-                "id": int(self.BOT_COMMENT_ID),
-                "user": {"login": "github-actions[bot]"},
-                "body": bot_body,
-            },
-        ]
-
-    def _blocking_verdict_body(self, head: str, *, extra: str = "") -> str:
-        """A prior completed BLOCK-MERGE verdict comment body, CRLF like GitHub."""
-        lines = [
-            self.MARKER,
-            "## GPT 5.6 Review (fork) — 🔴 changes requested (blocking)",
-            "",
-            f"_Reviewed `{head}` via the fork AI-review pipeline; updated in place on each push._",
-            "",
-            f"[GPT-REVIEWED] {head}",
-            f"[BLOCK-MERGE] {head}",
-            "",
-            "A real blocking finding lives here.",
-        ]
-        if extra:
-            lines.append(extra)
-        # GitHub returns bodies with CRLF; the step must normalize before grep.
-        return "\r\n".join(lines)
-
-    def test_incomplete_run_never_overwrites_a_posted_verdict(self, tmp_path: Path) -> None:
-        # A completed BLOCK-MERGE verdict already sits in the bot comment. An
-        # incomplete run must leave that comment ENTIRELY untouched: no PATCH,
-        # no create. Even a PATCH that "only" preserved the verdict and
-        # prepended a notice is itself the stale-read overwrite (#8350): the
-        # incomplete run read verdict V1, and PATCHing V1 (with a notice) back
-        # would clobber a newer run's V2 that landed in between. So no edit of
-        # any kind may target this comment.
-        verdict_body = self._blocking_verdict_body(self.OLD_HEAD)
-        comments = self._fixture_comments(verdict_body)
-        # review_output=None => the step's `kind` stays "incomplete".
-        _proc, patch_log, created_log = self._run(tmp_path, comments=comments, review_output=None)
-
-        # No PATCH targeted the bot comment (nor the impostor's), and no new
-        # comment was created. A revert to the old preserve-and-prepend PATCH
-        # would record a PATCH here and fail this assertion.
-        assert patch_log.read_text(encoding="utf-8") == ""
-        assert created_log.read_text(encoding="utf-8") == ""
-
-    def test_completed_verdict_still_replaces_the_comment_wholesale(self, tmp_path: Path) -> None:
-        # A completed run for the new HEAD must replace the old body outright:
-        # no stale-notice, old markers gone, new HEAD markers present.
-        old_body = self._blocking_verdict_body(self.OLD_HEAD)
-        comments = self._fixture_comments(old_body)
-        review_output = (
-            f"[GPT-REVIEWED] {self.HEAD}\n"
-            f"[BLOCK-MERGE] {self.HEAD}\n"
-            "Fresh blocking finding.\n"
-        )
-        _proc, patch_log, created_log = self._run(
-            tmp_path, comments=comments, review_output=review_output
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_incomplete_run_never_overwrites_a_posted_verdict(
+        self, lane: dict, tmp_path: Path
+    ) -> None:
+        calls, result = self._run_step(
+            lane, tmp_path, existing_body=self._verdict_body(lane, self.OLD), kind="incomplete"
         )
 
-        patched = patch_log.read_text(encoding="utf-8")
-        # PATCH still targets the bot comment.
-        assert self.BOT_COMMENT_ID in patched
-        # New HEAD markers present; old HEAD markers gone.
-        assert f"[BLOCK-MERGE] {self.HEAD}" in patched
-        assert self.OLD_HEAD not in patched
-        # No stale-notice on a wholesale replace.
-        assert "codex-stale-notice-begin" not in patched
-        assert "did not produce a completed verdict" not in patched
-        assert created_log.read_text(encoding="utf-8") == ""
+        assert result.returncode == 0, result.stderr.decode()
+        # NOTHING was written: no PATCH of any comment, no new comment. The
+        # posted verdict is therefore still exactly what the completed run
+        # published, and no read-modify-write can restore a stale body over a
+        # verdict a concurrent run publishes in the meantime.
+        assert not (calls / "patch-calls.txt").exists()
+        assert not (calls / "patched-body.md").exists()
+        assert not (calls / "created-body.md").exists()
+        # The step says so, naming the comment it deliberately left alone --
+        # and it found that id through the real author-guarded --jq filter, so
+        # it is the bot's comment (123), never the impostor's (999).
+        stdout = result.stdout.decode()
+        assert "left existing comment #123 untouched" in stdout
+        assert "#999" not in stdout
 
-    def test_incomplete_run_never_overwrites_a_marker_absent_comment(self, tmp_path: Path) -> None:
-        # Stale-read race (#8292): overlapping runs for different SHAs. An older
-        # incomplete run reads the bot comment BEFORE a newer run PATCHes its
-        # verdict in, so at read time the body carries no `[GPT-REVIEWED]`
-        # marker yet. The older incomplete run must NOT PATCH -- doing so would
-        # clobber the newer run's just-published verdict with a "review
-        # incomplete" body, re-hiding the finding. An incomplete body never
-        # overwrites an existing comment, marker-present or not.
-        marker_absent_body = "\r\n".join(
-            [
-                self.MARKER,
-                "## GPT 5.6 Review (fork) — ⏳ review incomplete",
-                "",
-                "_No completed GPT verdict for this commit; see the Fork GPT 5.6 Review job logs._",
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_incomplete_run_with_a_failed_lookup_posts_nothing(
+        self, lane: dict, tmp_path: Path
+    ) -> None:
+        # A lookup that errored cannot be read as "no comment exists": taking
+        # the create path there plants a second marker comment over a possibly
+        # live verdict, and a marker planted is not undone by a later run.
+        calls, result = self._run_step(
+            lane,
+            tmp_path,
+            existing_body=self._verdict_body(lane, self.OLD),
+            kind="incomplete",
+            extra_env={"FINDER_FAIL": "1"},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        assert not (calls / "patched-body.md").exists()
+        assert not (calls / "created-body.md").exists()
+        # Whether a comment exists is a gating input, so the read retries
+        # before the step concludes it could not be determined.
+        reads = (calls / "comment-reads.txt").read_text(encoding="utf-8").splitlines()
+        assert len(reads) == 3, reads
+        assert "comment lookup also failed" in result.stdout.decode()
+
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_a_superseded_completed_verdict_leaves_the_comment_alone(
+        self, lane: dict, tmp_path: Path
+    ) -> None:
+        # The same loss arriving late: a run for an older head can COMPLETE
+        # after a newer run published its verdict into the shared slot -- the
+        # fork lanes' concurrency group is keyed per head so they are not
+        # cancelled, and a cancelled same-repo run still executes this
+        # if:always() step. Its verdict is real, but it is not this PR's
+        # verdict any more, so it must not replace the current one.
+        newer = "bbbb567890abcdef1234567890abcdef1234bbbb"
+        calls, result = self._run_step(
+            lane,
+            tmp_path,
+            existing_body=self._verdict_body(lane, newer),
+            kind="completed",
+            extra_env={"STUB_PR_HEAD": newer},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        assert not (calls / "patched-body.md").exists()
+        assert not (calls / "created-body.md").exists()
+        stdout = result.stdout.decode()
+        assert "is no longer this PR's head" in stdout
+        assert "left existing comment #123 untouched" in stdout
+
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_an_unreadable_pr_head_retries_then_withholds(self, lane: dict, tmp_path: Path) -> None:
+        # Writing is the destructive half of the guard, so it must not proceed
+        # on an unknown: a head that stays unreadable is NOT confirmed current
+        # and the shared slot is left alone. A single blip is not evidence
+        # about the PR, so the read retries first, as this lane's other gating
+        # reads do.
+        calls, result = self._run_step(
+            lane,
+            tmp_path,
+            existing_body=self._verdict_body(lane, self.OLD),
+            kind="completed",
+            extra_env={"STUB_PR_HEAD": ""},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        reads = (calls / "pr-head-reads.txt").read_text(encoding="utf-8").splitlines()
+        assert len(reads) == 3, reads
+        assert not (calls / "patched-body.md").exists()
+        assert not (calls / "created-body.md").exists()
+        assert "unreadable after 3 attempts" in result.stdout.decode()
+
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_completed_verdict_still_replaces_the_comment(self, lane: dict, tmp_path: Path) -> None:
+        calls, result = self._run_step(
+            lane, tmp_path, existing_body=self._verdict_body(lane, self.OLD), kind="completed"
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        patched = (calls / "patched-body.md").read_text(encoding="utf-8")
+        # A completed verdict replaces the comment wholesale, exactly as before.
+        assert patched.startswith(f"{lane['marker']}\n")
+        assert f"{lane['stamp']} {self.HEAD}" in patched
+        assert f"{lane['stamp']} {self.OLD}" not in patched
+        assert not (calls / "created-body.md").exists()
+        # The author guard ran inside the real filter: the PATCH must target
+        # the bot's comment (123), not the marker-planting impostor's (999).
+        patch_calls = (calls / "patch-calls.txt").read_text(encoding="utf-8")
+        assert "/comments/123" in patch_calls
+        assert "/comments/999" not in patch_calls
+
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_completed_verdict_creates_when_the_lookup_fails(
+        self, lane: dict, tmp_path: Path
+    ) -> None:
+        # The asymmetry that makes the guard safe in both directions: a
+        # duplicate comment is recoverable, an unposted verdict is not, so a
+        # completed verdict publishes even when the lookup could not confirm
+        # whether a comment already exists (#8350).
+        calls, result = self._run_step(
+            lane,
+            tmp_path,
+            existing_body=self._verdict_body(lane, self.OLD),
+            kind="completed",
+            extra_env={"FINDER_FAIL": "1"},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        created = (calls / "created-body.md").read_text(encoding="utf-8")
+        assert f"{lane['stamp']} {self.HEAD}" in created
+        assert not (calls / "patched-body.md").exists()
+
+    @pytest.mark.parametrize("lane", _GUARDED_LANE_PARAMS)
+    def test_incomplete_with_no_existing_comment_creates_as_before(
+        self, lane: dict, tmp_path: Path
+    ) -> None:
+        calls, result = self._run_step(lane, tmp_path, existing_body=None, kind="incomplete")
+
+        assert result.returncode == 0, result.stderr.decode()
+        created = (calls / "created-body.md").read_text(encoding="utf-8")
+        assert created.startswith(f"{lane['marker']}\n")
+        assert lane["incomplete_text"] in created
+        assert not (calls / "patched-body.md").exists()
+
+    def test_withheld_fork_fp_body_leaves_a_posted_verdict_alone(self, tmp_path: Path) -> None:
+        # The fork first-principles lane posts its withheld notice from a
+        # separate early site; it routes through the same guarded upsert, so a
+        # credential-shaped output discards the body without touching the
+        # previously posted verdict.
+        lane = next(entry for entry in _GUARDED_LANES if entry["id"] == "fork-first-principles")
+        calls, result = self._run_step(
+            lane,
+            tmp_path,
+            existing_body=self._verdict_body(lane, self.OLD),
+            kind="none",
+            extra_env={"WITHHELD": "true", "VERDICT": "UNKNOWN", "REVIEW_OUTCOME": "success"},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        assert not (calls / "patched-body.md").exists()
+        assert not (calls / "created-body.md").exists()
+        assert "left existing comment #123 untouched" in result.stdout.decode()
+
+    def test_skip_notice_still_replaces_the_comment_wholesale(self, tmp_path: Path) -> None:
+        # A skip notice is a COMPLETED determination about the current head
+        # (the revision ships no reviewable surface), not a review failure, so
+        # it deliberately keeps the unguarded replace: guarding it would pin a
+        # stale verdict onto a revision the lane has ruled out of scope.
+        lane = next(entry for entry in _GUARDED_LANES if entry["id"] == "ux")
+        calls, result = self._run_step(
+            lane,
+            tmp_path,
+            existing_body=self._verdict_body(lane, self.OLD),
+            kind="none",
+            extra_env={"UI_SCOPE": "false", "EXEC_FILE": "", "REVIEW_OUTCOME": "success"},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        patched = (calls / "patched-body.md").read_text(encoding="utf-8")
+        assert "⏭️ skipped" in patched
+        assert f"{lane['stamp']} {self.OLD}" not in patched
+
+    def test_guard_function_is_byte_identical_across_all_lanes(self) -> None:
+        bodies = set()
+        for lane in _GUARDED_LANES:
+            script = _step_script(_workflow(lane["workflow"]), lane["step"])
+            bodies.add(_shell_function(script, "guarded_comment_upsert"))
+        assert len(bodies) == 1, (
+            "guarded_comment_upsert must stay byte-identical across every "
+            "review lane; edit all copies together"
+        )
+        canonical = bodies.pop()
+        code_lines = [line for line in canonical.splitlines() if not line.lstrip().startswith("#")]
+        # The lookup reads the id and nothing else. Capturing the current body
+        # is what a merge-and-PATCH shape needs, and the presence of a body in
+        # this function is the signature of that shape coming back.
+        assert "| .id" in canonical
+        assert not any("| {id, body}" in line for line in code_lines)
+        # The first id is selected off the CAPTURED output, never via a
+        # `| head -n1` inside the pipeline (SIGPIPE under pipefail).
+        assert not any("head -n1" in line for line in code_lines)
+        assert any("| awk 'NR == 1'" in line for line in code_lines)
+        # Exactly two conditions withhold the write, and each names itself.
+        assert 'if ! grep -Fq "$stamp $HEAD" "$out_file"; then' in canonical
+        assert 'withhold="run for $HEAD produced no completed verdict"' in canonical
+        # BOTH gating reads retry a transient failure before deciding.
+        assert canonical.count("for attempt in 1 2 3; do") == 2
+        assert canonical.count('if [ "$attempt" -lt 3 ]; then') == 2
+        assert 'pr_head="$(gh api "repos/$REPO/pulls/$PR" --jq \'.head.sha\')"' in canonical
+        # An unreadable head is NOT confirmed current: the destructive write
+        # must not proceed on an unknown, so this arm withholds like the others.
+        assert 'if [ -z "$pr_head" ]; then' in canonical
+        assert "unreadable after 3 attempts" in canonical
+        assert 'elif [ "$pr_head" != "$HEAD" ]; then' in canonical
+        assert 'withhold="$HEAD is no longer this PR\'s head ($pr_head)"' in canonical
+        # A withheld write returns before reaching any PATCH: both no-touch
+        # arms (lookup failed, comment exists) `return 0`, so the only write
+        # left on that path is creating a comment where none exists.
+        withheld = canonical.split('if [ -n "$withhold" ]; then', 1)
+        assert len(withheld) == 2, "the two withhold reasons must share one no-touch block"
+        block = withheld[1].split("\n  fi\n", 1)[0]
+        assert "--method PATCH" not in block
+        assert block.count("return 0") == 3
+        # A failed lookup on a COMPLETED verdict for the current head still
+        # falls through to CREATE, never to silence.
+        assert 'gh pr comment "$PR" --body-file "$out_file"' in canonical
+
+    def test_every_lane_calls_the_guard_and_fork_fp_covers_both_sites(self) -> None:
+        for lane in _GUARDED_LANES:
+            script = _step_script(_workflow(lane["workflow"]), lane["step"])
+            calls = [
+                line.strip()
+                for line in script.splitlines()
+                if line.strip().startswith("guarded_comment_upsert ")
             ]
-        )
-        comments = self._fixture_comments(marker_absent_body)
-        # review_output=None => the step's `kind` stays "incomplete".
-        _proc, patch_log, created_log = self._run(tmp_path, comments=comments, review_output=None)
-
-        # The incomplete run left the existing comment untouched: no PATCH, no
-        # new comment. A revert of the workflow fix (unconditional PATCH in the
-        # else branch) would record a PATCH here and fail this assertion.
-        assert patch_log.read_text(encoding="utf-8") == ""
-        assert created_log.read_text(encoding="utf-8") == ""
-
-    def test_incomplete_run_with_no_existing_comment_creates_as_before(
-        self, tmp_path: Path
-    ) -> None:
-        # No bot comment exists (only the impostor). An incomplete run creates a
-        # fresh comment carrying the marker and the incomplete verdict, with no
-        # stale-notice and no PATCH.
-        comments = [
-            {
-                "id": int(self.IMPOSTOR_COMMENT_ID),
-                "user": {"login": "mallory"},
-                "body": f"{self.MARKER}\nnice try",
-            },
-        ]
-        _proc, patch_log, created_log = self._run(tmp_path, comments=comments, review_output=None)
-
-        created = created_log.read_text(encoding="utf-8")
-        assert created.startswith(self.MARKER)
-        assert "⚠️ review incomplete" in created
-        assert "codex-stale-notice-begin" not in created
-        # No PATCH happened -- nothing to edit.
-        assert patch_log.read_text(encoding="utf-8") == ""
-
-    def test_step_source_carries_the_fix_and_leaves_finalize_untouched(self) -> None:
-        # Static guards: an incomplete run over an existing comment does NOTHING
-        # to it, and the fail-closed finalize step (the fork analogue of
-        # codex-review.yml's "Gate on findings") is untouched by the fix.
-        workflow = _workflow("fork-gpt-review.yml")
-        comment_step = _step_script(workflow, "Post/update summary comment")
-        # The incomplete branch leaves the comment untouched (diagnostic only),
-        # so only the else branch (blocked/clear) PATCHes the existing comment.
-        assert 'if [ "$kind" = "incomplete" ]; then' in comment_step
-        assert "left existing comment #$existing untouched" in comment_step
-        # No stale-notice construction survives anywhere in the step: nothing
-        # writes a notice, builds a merged body, or strips one with sed.
-        assert "codex-stale-notice" not in comment_step
-        assert "fork-codex-merged-comment" not in comment_step
-        assert "fork-codex-existing-comment" not in comment_step
-        # The fork lane has NO human-override footer.
-        assert "/ai-review override" not in comment_step
-
-        finalize_step = _step_script(workflow, "Finalize check-run (fail closed)")
-        assert "stale-notice" not in finalize_step
-
-    def test_incomplete_run_on_lookup_failure_neither_patches_nor_creates(
-        self, tmp_path: Path
-    ) -> None:
-        # An INCOMPLETE run: a transient comments-list API failure must NOT be
-        # read as "no existing comment", which would send it down the create
-        # path and post a fresh "review incomplete" marker over a verdict that
-        # is really still there. So an incomplete run whose lookup failed makes
-        # no edit of any kind (diagnostic only); the fail-closed finalize step
-        # still gates merge.
-        verdict_body = self._blocking_verdict_body(self.OLD_HEAD)
-        comments = self._fixture_comments(verdict_body)
-        proc, patch_log, created_log = self._run(
-            tmp_path, comments=comments, review_output=None, lookup_fails=True
-        )
-
-        assert patch_log.read_text(encoding="utf-8") == ""
-        assert created_log.read_text(encoding="utf-8") == ""
-        assert "lookup failed" in proc.stdout.lower() or "skipping" in proc.stdout.lower()
-
-    def test_completed_run_on_lookup_failure_still_publishes_the_verdict(
-        self, tmp_path: Path
-    ) -> None:
-        # A COMPLETED verdict (blocked/clear) must become visible. The lookup
-        # failure guard is scoped to the incomplete case ONLY: suppressing a
-        # completed verdict on a transient lookup error would trade away the
-        # very visibility this fix restores. A duplicate comment is far more
-        # recoverable than a real verdict that never posts, so a completed run
-        # whose lookup failed falls through to CREATE rather than staying
-        # silent.
-        review_output = f"[GPT-REVIEWED] {self.HEAD}\n[BLOCK-MERGE] {self.HEAD}\nblocking finding"
-        comments = self._fixture_comments(self._blocking_verdict_body(self.OLD_HEAD))
-        _proc, patch_log, created_log = self._run(
-            tmp_path, comments=comments, review_output=review_output, lookup_fails=True
-        )
-
-        # No PATCH (the lookup could not confirm a target), but the verdict WAS
-        # published via create -- not silently dropped.
-        assert patch_log.read_text(encoding="utf-8") == ""
-        assert created_log.read_text(encoding="utf-8") != ""
+            expected = 2 if lane["id"] == "fork-first-principles" else 1
+            assert len(calls) == expected, (lane["id"], calls)
+            for call in calls:
+                assert f'"{lane["stamp"]}"' in call
 
 
 class TestGptRefusalTerminalState:
@@ -5246,9 +5475,7 @@ class TestGptRefusalTerminalState:
         # to remove.
         assert "re-run the workflow or inspect" not in proc.stdout
 
-    def test_completed_verdict_quoting_the_marker_is_not_reclassified(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_verdict_quoting_the_marker_is_not_reclassified(self, tmp_path: Path) -> None:
         # On the clean path codex-review-output.md is verbatim model prose. A
         # review that QUOTES the refusal marker — say, while reviewing this
         # workflow — must not flip a completed verdict into a refusal: the


### PR DESCRIPTION
## Summary

A lane's summary comment is **one slot shared by every run on the PR**, and it is upserted in place. The REST comments API has no `If-Match`, so a write to that slot is last-writer-wins, and it exposes no edit history, so the loss is undetectable afterwards. A failed review run replaced a posted `[GPT-REVIEWED]` pass verdict on PR #7845 a day later, recoverable only from GraphQL edit history (#8292). First-principles is the highest-priority lane: its BLOCK verdict gates PR readiness, so a buried BLOCK is exactly that harm. Merged #8342 addressed this in `codex-review.yml` only.

This PR makes **exactly one kind of run allowed to claim that slot** — a *completed verdict for the PR's current head* — on **eight of the ten lanes that upsert a verdict comment** (nine call sites, because fork first-principles upserts from two places). The other two lanes stay as they are and are now **both declared in the doc**: `codex-review.yml` (#8342's merged preserve-and-prepend shape) and `claude-review.yml` (a plain lookup-then-PATCH whose incomplete path posts nothing at all). Before this PR the doc's census named only the first, which is what First Principles' Watch item caught; see "The tenth site" below.

Closes #8344

Two starting states, and the distinction matters because a reviewer asked for it:

- **Seven lanes were genuinely unguarded** (fork Opus, design, UX, first-principles, and the fork design / fork UX / fork first-principles twins): they PATCHed unconditionally, and they are what #8344 is about.
- **`fork-gpt-review.yml` was already guarded**, with the strongest posture in the repo — an incomplete run never modified an existing comment at all. That arm is what the other seven now adopt, so it is not a newly-guarded site for the #8344 defect and this PR claims no fix there. **It is not left untouched, though, and the earlier wording overstated that** (Design Review and First Principles both flagged it): refactoring it onto the shared function also gives it the superseded-head and unreadable-head arms below, neither of which it had. Strengthening, not a no-op.

## The guard: two ways to lose a verdict, one no-touch answer

A run stands down — leaves an existing comment **untouched**, no PATCH at all — in both of the cases that can lose a live verdict:

**1. The body carries no `"<stamp> <head>"` proof marker.** A review failure. PATCHing a "review incomplete" / "could not complete" body over a completed verdict buries that verdict, blocking findings included.

Preserving the verdict and prepending a dated staleness notice — #8342's shape — is **not** a safe alternative, and this is the substantive correction this PR took from review: it reads the body and writes a *merge* of it back, so a verdict published between the read and the write is restored away. `concurrency` does not cancel a run for a different head, so that window is real, and on the first-principles lane the thing restored away can be a BLOCK.

**2. The body is a completed verdict, but for a superseded head.** The same loss arriving late. An older run can finish *after* a newer one published, because the fork lanes' `concurrency` group is keyed per head so they are not cancelled — and a cancelled same-repo run still executes its `if: always()` posting step. So the step confirms this run is still the PR's head before claiming the slot.

**3. The PR's head cannot be read.** Writing is the destructive half of the guard, so it does not proceed on an unknown: a head unreadable after three attempts is *not confirmed current* and the slot is left alone. The read retries first — `for attempt in 1 2 3` with `sleep "$attempt"`, the same bounded shape this lane's own intent fetch and finalize PATCH already use — because one blip is not evidence about the PR, and an API broken enough to fail all three would fail the write too.

Around all three arms:

- Whether a comment exists is the other gating input, so **that read retries too**, on the same bounded backoff. A lookup still erroring afterwards counts as "a comment may exist", never as "none does" — a withheld run posts nothing rather than plant a second marker comment over a possibly-live verdict, which no later run undoes.
- When the lookup **succeeded and found nothing**, there is no verdict to lose, so the body is posted as a new comment.
- A completed verdict for a **confirmed** current head whose *comment* lookup failed still CREATEs rather than stay silent: a duplicate comment is recoverable, an unposted verdict is not (#8350).
- Human overrides and skip notices are current-head **determinations**, not review failures, so their upsert sites keep their own unconditional PATCH and never route through this function — guarding them would pin a stale verdict onto a revision the lane has ruled out of scope.

Nothing is lost by standing down. The comment names the head it reviewed; each head's own check-run is finalized **fail-CLOSED** by the step below the upsert; and `pr_status.py`'s `evaluate_reviewer_markers` matches reviewer stamps against the **current** head, so a comment left in place for an older head reads as *stale*, never as an approval of this one.

Because nothing is merged, the function reads only the comment **id**. No body capture, no notice markers persisted into comment bodies, no notice-stripping pass. Lookup captures the full paginated output first and selects off the captured value (`awk 'NR == 1'`), never `... | head -n1` inside the pipeline, which lets head's early exit SIGPIPE the api call and misread a successful lookup as failure under pipefail (#8350).

## What changed after review (seven rounds; four produced a fix, and the rest are answered)

**Round 1 — the merge is the bug.** GPT 5.6 (`fork-gpt-review.yml:1067`, "incomplete runs can overwrite newer verdicts") and First Principles ("this port silently deletes the fork GPT lane's stronger guard and reinstalls the exact PATCH-back its own comments call the bug") converged on the same defect from two directions, and the second named the right resolution: base fork-gpt's no-touch posture was the stronger of the two, so it is now canonical for all eight lanes rather than the one that got overwritten. The notice machinery, its persisted `stale-notice-begin/end` markers, and the position-anchored strip an earlier pre-push round had to harden are all deleted — a net subtraction from the function.

**Round 2 — the same loss arriving late.** GPT 5.6 (`fork-opus-review.yml:534`, "older completed runs can erase newer-head verdicts across all fork lanes"): head B completes, then an already-running head A completes and PATCHes the shared slot, and B's current verdict disappears. Correct, and it is the *completed* path, which round 1 left as-is. Fixed as the second withhold arm above rather than by the suggested remedies: per-branch serialization would break the fork lanes' deliberate per-head keying (two PRs can share a commit, which is why those groups key on head repository + head branch), and head-specific comments would replace the one-slot upsert with one comment per push.

**Round 3 — the guard must not resolve its own unknown in favour of writing.** GPT 5.6 (`design-review.yml:560`): round 2's head check failed *open*, so an older completed run plus a transient PR-head read failure still PATCHed the slot. Correct, and the general principle is the one this whole PR is built on — the destructive action needs a positive answer, not the absence of a negative one. Fixed by retrying the read on the repo's established bounded-backoff shape and then treating an unreadable head as a third withhold reason. Not fixed by the suggested "create a separate completed comment", which plants a duplicate marker comment on every transient blip and hands the next run's `startswith(marker)` finder two slots to choose between.

The result is *simpler* than round 2's version: one comparison decides, and every arm of the guard is now the same sentence — *am I the current head, and do I have a completed verdict?*

**Round 4 — partially accepted, and the second half declined on merit.** GPT 5.6 (`design-review.yml:596`): a same-head BLOCK already posted, a cleared re-run, and a *comment*-lookup failure produce a duplicate comment, and `evaluate_reviewer_markers` then still sees the old `[BLOCK-MERGE]` and keeps the PR blocked. Its requested fix has two halves.

*Accepted:* "retry until the existing-comment state is known" — the comment lookup now retries on the same bounded backoff as the head read, so both gating inputs are treated the same way and the duplicate becomes correspondingly rarer. The identity test pins that both reads retry.

*Declined, with the reasoning:* "never CREATE when lookup failed" reverses #8350 and trades a recoverable failure for an unrecoverable one.

- **The consequence is narrower than the finding states, and round 7's adjudication pass is what established it: the comment slot is not the merge gate.** `PR Readiness` resolves each reviewer lane from the lane's **check-run / workflow run**, never from the comment — `pr-readiness.yml` lists `codex-review.yml|GPT 5.6 Review` for a same-repo PR and `checkrun:GPT 5.6 Review` for a fork one, and the fork lane's fail-closed `Finalize check-run` step sets that check-run from the on-disk `codex-review-output.md`, independent of the slot. The comment reader, `evaluate_reviewer_markers`, lives in `pr_status.py` — the **`prepare-pr` skill's status readout**, an agent-side helper, not a gate. So a stale same-head `[BLOCK-MERGE]` comment misleads that readout and nothing else, and it self-corrects on the next run that patches the slot. Earlier rounds of this PR conceded the finding's "the PR stays blocked" premise; that concession was wrong and is withdrawn.
- **The direction of the described failure is fail-CLOSED even in that readout.** The outcome is a PR that stays *blocked* while a clear verdict exists, not one that merges while a BLOCK exists. `pr_status.py` documents that asymmetry as deliberate at the site GPT's scenario runs through: "a `[BLOCK-MERGE]` for the current head gates from ANY trusted comment, bound or not — injection can deny a review, never forge one." Over-blocking is the designed behaviour of that reader, and it clears on the next run.
- **Never CREATE means the clear verdict is never published at all** — not to the comment, and the reader sees the stale BLOCK anyway. The PR is blocked in *both* variants; only one of them also loses the new verdict. #8350 weighed exactly this and chose CREATE, because a duplicate comment is recoverable and an unposted verdict is not.
- **The behaviour is unchanged from `main`.** Every base lane already created when the lookup returned no id, and `codex-review.yml` still does. This finding describes a standing property of the upsert model, not something this diff introduces — so accepting it here would leave the same path live on the ninth site and on `main`.

**Round 5 — declined: the ask is a redesign of the comment model, and the residual window is the floor.** GPT 5.6 (`design-review.yml:609`): run A confirms it is the head, pauses, B publishes, A resumes and PATCHes. True, and irreducible with the tools available. Its own suggested remedies name why it is out of scope: *"use head-specific comment slots or serialize each lane's writes per PR."*

- **The window is already the theoretical minimum for a read-then-write.** The confirmation is the statement immediately before the write, separated by one `if` test. Closing it needs compare-and-swap, and the REST comments API has none — no `If-Match`, no ETag precondition. Every round above narrowed the window; this round asks to eliminate it, which no amount of ordering achieves.
- **Head-specific comment slots means one comment per push.** That is the model #8342 and #8350 chose against, and it would land on all nine sites plus every other marker comment in the repo.
- **Per-PR serialization is not available to the lanes that matter.** The fork lanes key `concurrency` on head repository + head branch precisely because two PRs can share a commit; collapsing them to one group per PR reintroduces the cross-PR mix-up those groups exist to prevent, and `workflow_run`-triggered runs cannot be ordered against each other anyway.
- **The residual harm is bounded, fail-CLOSED, and confined to the human surface.** Both racers hold *completed* verdicts. If the older one wins, the slot holds a verdict stamped for an older head, which `pr_status.py` reads as **stale** — readiness stays blocked, never passes — while the newer head's own check-run, the actual merge gate, is untouched and correct. The cost is a comment that needs a re-run to refresh, not an un-gated merge and not a lost gate signal. The docs state this floor plainly: *"the comments API has no `If-Match`, so a write to that slot is last-writer-wins, and it exposes no edit history, so the loss is undetectable afterwards."*

Redesigning the reviewer comment model is a maintainer's call, not a rider on this port. The lane's `/ai-review override gpt <sha>: <reason>` is the right instrument if a maintainer agrees.

**Not fixed here, and now declared rather than implied:** `codex-review.yml` keeps #8342's merged preserve-and-prepend shape and is the **one remaining** upsert site with a read-modify-write window on its slot. `docs/ci/ci-and-reviews.md` says so explicitly. Reversing a merged, human-reviewed decision on that lane is a separate call and does not belong as a rider on this port.

**Round 6 — declined: this is round 4's declined half restated.** GPT 5.6 (`design-review.yml:618`, "failed lookup preserves stale same-head BLOCK"): an existing same-head BLOCK, a clearing re-run whose *comment* lookup fails, CREATE succeeds, both comments remain, and `evaluate_reviewer_markers` keeps the PR blocked. Its requested fix — *"publish only after successfully locating and replacing or retiring every same-head marker comment"* — is "never publish when the lookup failed" with a stronger precondition, and the round-4 answer applies unchanged: the outcome is **fail-CLOSED** (blocked while a clear verdict exists, never merged while a BLOCK exists); making publication conditional on the lookup **does not unblock that PR**, because the stale `[BLOCK-MERGE]` is still there and the reader still blocks — the only difference is that the clearing verdict is then published nowhere; and reaching that branch already means three retried reads failed, a state in which the proposed "retire" writes would very likely fail too. The path is also unchanged from `main` and identical on `codex-review.yml`.

**Round 7 (post-rebase, `894f5fd`) — the same two asks, now raised together, and the lane's own adjudicator agrees on one of them.** Two fenced findings:

- **F1 `design-review.yml:574`** is round 5 restated: head-confirm races the PATCH. The **annotate-only adjudication pass added upstream in #8693 independently reached the same conclusion this PR argued in round 5** and machine-**FLAGGED** it as a likely edge case: *"The newer verdict can only be overwritten if a full review run publishes within the sub-second gap between the head read and the PATCH, which a minutes-long run cannot do, so the reaching timing is self-contradicting."* It also pre-drafted the override rationale. The fence still blocks regardless of that flag, by design.
- **F2 `fork-gpt-review.yml:1247`** is round 4/6 restated, with a *new* suggested remedy: not "never CREATE", but *"reconcile every matching marker comment after CREATE, neutralizing superseded duplicates before returning."* The adjudicator **UPHELD** this one as a genuine transient scenario, and it is right that the scenario is reachable. A **third run on the identical head then FLAGGED the same finding** and named the reason: *"Readiness is check-run-driven (`pr-readiness.yml:556`; finalize sets it from on-disk output at `fork-gpt-review.yml:1268-1284`), so a stale/duplicate lane comment cannot block readiness."* That is verifiable and correct — see the corrected bullet in round 4 above — so the finding's stated consequence ("keeps readiness blocked", "falsely reports the head blocked") is about the wrong surface. The remedy is also not available, for a reason specific to the branch it lands on: reaching it means the paginated comment lookup failed **three consecutive times**, so there is no id to reconcile — the reconcile pass needs the very lookup that just failed. Doing it anyway (retry the lookup after the CREATE, then rewrite the older comment's `[BLOCK-MERGE]` to a defused marker, mirroring the existing `[BLOCK-MERGE-DOWNGRADED]` sed) is worse on the axis that matters: it is a read-modify-write on a slot we have just established we cannot read reliably, so a verdict published between the failed lookup and the reconcile would be **defused** — converting an over-block into an under-block. That is the direction `pr_status.py` documents as the one it will not trade: *"a `[BLOCK-MERGE]` for the current head gates from ANY trusted comment, bound or not — injection can deny a review, never forge one."* Over-blocking is designed behaviour of that reader and clears on the next run; under-blocking is the class the fence exists to stop.

**The lane is not converging, and that is worth recording as data for whoever adjudicates.** On the *identical* head `3fe6c067`, two runs produced two *different* blocking findings (`design-review.yml:609`, then `:618`) with no diff change between them. On `894f5fd` it raised both of those asks at once, and a third run on that same head raised only one of them — the **same** finding the previous run's adjudicator had UPHELD, this time FLAGGED. So neither the reviewer nor its adjudicator is deterministic on this diff. Rounds 1–3 and round 4's retry half each produced a real fix and are shipped. Rounds 4-declined, 5, 6 and 7 all reduce to the same two asks — stop publishing when a read fails, or replace the one-slot upsert model — and both reverse a merged, human-reviewed decision (#8342, #8350) or the documented fail-closed asymmetry in `pr_status.py`. Neither is a call this port should make, and neither is made here.

## The tenth site (`claude-review.yml`), and the census the doc was carrying

First Principles' Watch item was right: the title said "every review lane" while `claude-review.yml` kept an unguarded unconditional PATCH, **undeclared** — unlike `codex-review.yml`, whose exclusion the doc already named. The doc's census said "nine upsert sites"; there are ten. Fixed here as a documentation and framing correction, not a tenth port:

- `docs/ci/ci-and-reviews.md` now counts **ten** lanes that upsert a verdict comment and declares **both** exclusions in one list, with each one's residual named.
- The commit subject drops the "every review lane" overclaim.
- `claude-review.yml`'s residual is genuinely narrower than the others': **its incomplete path posts nothing at all** (`if [ "$kind" = "incomplete" ]; then ... exit 0`), so the #8292 class — a failure notice burying a verdict — cannot reach it. What remains is only the superseded-completed window: its `concurrency` group is per-PR with `cancel-in-progress: true`, but the posting step is `if: always()`, which a cancelled run still executes, so an older run holding a completed verdict can still claim the slot.
- Porting the guard onto it is **not** in this PR, because that lane's single upsert serves *both* the verdict and the human-override body. Routing it through `guarded_comment_upsert` would first require splitting those two paths — overrides are current-head determinations that keep their unconditional PATCH by declared design — which is a design change on a lane outside the #8344 census, on top of an eight-workflow diff. Same reasoning the maintainer already recorded for `codex-review.yml` in #8462.

## Rebase onto current `main`

The branch went `dirty` and is rebased twice, now onto `9b46746e3`. Two upstream commits touched these files:

**#8693/#8707 `7ef2209cb`** (annotate-only adjudication voice on security-class findings):

- `fork-gpt-review.yml` — resolved by **keeping both sides**: upstream's new "Fenced finding(s) machine-flagged as likely edge case" render block stays inside the comment body, and the tail of the step is this PR's `guarded_comment_upsert`. Upstream's block already writes to `$RUNNER_TEMP`, so it needed no adaptation.
- `test_ai_review_workflows.py` — upstream's only change inside `TestForkGptVerdictVisibility` was **black reflow**, and this PR deletes that class in favour of the per-lane parameterized `TestReviewLaneVerdictVisibility`, so the deletion is the correct resolution. Upstream also left a cross-reference to the deleted class in a comment, which now points at the assertion that actually pins the behaviour.

**#8738 `8c7ad0441`** (a GPT reviewer refusal is its own terminal state):

- `test_ai_review_workflows.py` — its new `TestGptRefusalTerminalState` class is kept in full and lands after this PR's class; the conflict was only that git anchored it against the tail of the class this PR removes.
- `docs/ci/ci-and-reviews.md` — auto-merged; its addition is in the marker-contract list, a different section from the upsert paragraph this PR rewrites.

Both upstream surfaces are green in the post-rebase run (541 tests, 0 failures), and the new adjudication surface is what produced the round-7 flag above.

**One incidental fix, worth flagging to a maintainer:** at `9b46746e3`, `test/test_ai_review_workflows.py` is **not black-clean** and is **not** in `.github/black-baseline.txt` (`8c7ad0441` added a signature black collapses back to one line). Verify with `git show 9b46746e3:test/test_ai_review_workflows.py > /tmp/f.py && black --target-version py310 --check /tmp/f.py`. Since the black gate is diff-scoped, that drift lands on any PR touching the file; this PR formats it, which is the three-line hunk at `test_completed_verdict_quoting_the_marker_is_not_reclassified`. `main-ratchet-audit.yml` runs whole-tree and should be red on `main` until something formats it.

## Why a byte-identical inline function, not a shared script

The issue thread suggested extracting one shared script under `.github/scripts/`. Deliberately not done, for an availability reason specific to these lanes:

- **Fork lanes read their workflow definition from the default branch, but execute scripts from the `base_sha` checkout.** A guard shipped as a checkout script would leave every currently-open fork PR (whose `base_sha` predates this merge) unguarded until rebase — and the five fork lanes are the majority of the sites. Inline in the workflow definition, the guard covers ALL fork PRs the moment this merges.
- The posting steps run `if: always()`, so they must work when checkout failed; a missing script would force either a create-only fallback (comment spam per run) or an unguarded-PATCH fallback (the bug, back).

Single-source-of-truth is enforced mechanically instead: all 8 lanes define the SAME `guarded_comment_upsert()` bash function and `test_guard_function_is_byte_identical_across_all_lanes` pins every copy to one canonical body, so per-lane drift is a test failure.

Also folded in: the six lanes that wrote their comment body to a fixed `/tmp/<lane>-comment.md` now write under `${RUNNER_TEMP:-/tmp}` like the merged codex template — on a runner these are equivalent (RUNNER_TEMP is always set), and it makes the steps' bash parallel-safe for the bash-level tests.

## Tests (bash-level, per lane, against each lane's real posting step)

`TestReviewLaneVerdictVisibility` runs each lane's REAL posting-step bash with a stubbed `gh`. The finder branch executes the step's actual `--jq` filter through real `jq`, so filter drift fails the tests instead of hiding; the stub also answers the PR-object read, with knobs for "the PR has moved on" and "the read failed".

- `test_incomplete_run_never_overwrites_a_posted_verdict` ×8 — **no PATCH call and no created comment at all**, and the step names the comment id it left alone; that id came through the real author-guarded filter, so it is the bot's comment (123) and never the marker-planting impostor's (999)
- `test_a_superseded_completed_verdict_leaves_the_comment_alone` ×8 — round 2's finding, pinned
- `test_an_unreadable_pr_head_retries_then_withholds` ×8 — round 3's finding: exactly three reads are recorded, and nothing is written
- `test_incomplete_run_with_a_failed_lookup_posts_nothing` ×8 — exactly three comment reads are recorded, and a lookup error is still not read as "no comment exists"
- `test_completed_verdict_still_replaces_the_comment` ×8 and `test_completed_verdict_creates_when_the_lookup_fails` ×8 — the asymmetry that keeps a real verdict from being dropped
- `test_incomplete_with_no_existing_comment_creates_as_before` ×8
- fork-FP withheld-site leaves a posted verdict alone (that lane's second call site); UX skip-notice still replaces wholesale (pins the deliberate non-guard)
- identity test (byte-identical function across all 8; it asserts the body is *not* captured and that the withhold block reaches no PATCH, so neither a merge-and-PATCH shape nor a dropped arm can come back unnoticed) + wiring test (every lane calls it; fork-FP covers both its sites)

The notice-strip regression tests from the first draft are removed along with the notice machinery they pinned; the invariant they protected (never delete verdict content) is now structural — nothing is rewritten, so nothing can be truncated.

**Mutation-verified four times** on the shipped shape, each reverting exactly the intended tests to red and green again on restore:

1. turning the ux lane's no-touch arm back into a PATCH → `test_incomplete_run_never_overwrites_a_posted_verdict[ux]` + the identity test
2. deleting the design lane's `lookup_ok` fail-closed arm → `test_incomplete_run_with_a_failed_lookup_posts_nothing[design]` + the identity test
3. inverting the fork-opus lane's superseded-head comparison → `test_a_superseded_completed_verdict_leaves_the_comment_alone[fork-opus]` + the identity test
4. restoring the fail-open behaviour on an unreadable head in the ux lane → `test_an_unreadable_pr_head_retries_then_withholds[ux]` + the identity test

The incomplete-case fixtures use a verdict header with a stale proof marker (the live #7845 shape). A header-LESS summary crashes the design-family posting steps earlier, at the `grep -iE '^...-Verdict:'` pipeline under `set -o pipefail` — a pre-existing lane defect outside this PR's scope (in production those runs post nothing at all, which cannot bury a verdict).

## Verification

- Post-rebase: `test_ai_review_workflows.py`, plus `test_prepare_pr_findings.py` and `test_pr_quality_gates.py` — **541 passed, 0 failed**. That run covers this PR's per-lane guard tests, the adjudication/fenced-flag tests `7ef2209cb` added upstream, and the refusal-state tests `8c7ad0441` added.
- `black --check` clean on `test_ai_review_workflows.py` (upstream dropped it from `.github/black-baseline.txt`, so it is now gated) / flake8 `src/kiro_crew test` / `mypy --platform linux src/kiro_crew` (1294 files, no issues) / black + subprocess-encoding ratchets / docs-lint / brand / harness-parity / changelog-history all pass
- YAML parses for all ten review-lane workflows and `bash -n` is clean on the merged fork-gpt post step; the 8 function bodies verified byte-identical by the identity test after YAML dedent
- `scrub-lint --no-history` reports one pre-existing hit in `test/test_atomic_write_named_duplicates.py`, a file this PR does not touch and whose content is byte-identical to `main` — the `De-Amazon Scrub Lint` check was green on the previous head with the same file in the tree
- `docs/ci/ci-and-reviews.md` updated in the same commit

## Screenshots

No visual change — this PR touches only GitHub Actions workflow definitions, one CI doc, and a backend test module. No user-facing surface, no `website/` file, and no rendered output is affected.

## Pattern harvest

**The bug and all three near-misses are one shape: a mutable shared slot with no compare-and-swap.** #8292 was "a failed run's body replaces a verdict". Draft 1 of this fix was "a failed run's *merge* of a verdict replaces a newer verdict". Draft 2 was "an older *completed* run replaces a newer verdict". Draft 3 was "a run that could not tell whether it was current replaces it anyway". Each round the reviewers moved the same question one step earlier, and the terminal answer is the same one: on an API with no `If-Match`, the only race-free write a run that is not *provably* authoritative can make is **no write at all**. So the guard is a `return`, and every arm of it is one sentence: *am I confirmed to be the current head, and do I have a completed verdict?*

The corollary is the part worth keeping: **a guard whose own input is unknown must not resolve the unknown in favour of the destructive action.** Draft 2 failed open on an unreadable head out of a real fear — dropping a verdict is unrecoverable — but the fix for that fear is to make the unknown *rare* (retry) rather than to make it *permissive*.

The informational bit given up (this verdict is stale) is recovered from an immutable per-head record that already existed — the fail-closed check-run — rather than by writing harder into the mutable one.

Rule candidate: when N workflows must enforce one invariant inside steps that run `if: always()`, define it as a byte-identical bash function in each workflow and pin every copy to one canonical body with a test — never a checkout-loaded shared script, whose availability dies with a failed checkout and whose `base_sha` pin leaves already-open fork PRs unguarded until they rebase.

Third rule candidate, from the tenth-site miss: **a census stated as a number in prose is a claim no test reads, so it goes stale in exactly the direction that flatters the change.** The doc said "nine upsert sites" and the subject said "every review lane" while ten lanes upsert and only eight were guarded — and the one left out was the one whose *narrower* residual made it easy to overlook. The durable form is to declare each exclusion **by name with its own residual**, which is what the doc now does; a bare count invites the reader to assume the remainder is empty.

Second rule candidate: **porting a guard onto a lane that already has one must compare postures first.** Draft 1 *downgraded* fork-gpt because the merged lane was treated as the reference implementation by default; the deleted hunk's own comment said why it was stronger. When a "port" produces a deletion in the target, that deletion is the thing to justify.
