### PR TITLE
fix(dashboard): give remaining srcDoc frames a compositing layer (#8075)

### DIFF
--- a/website/src/apps/pptx-maker/BoardFrame.tsx
+++ b/website/src/apps/pptx-maker/BoardFrame.tsx
@@ -66,7 +66,12 @@ export default function BoardFrame({ html, title }: BoardFrameProps) {
             style={{
               width: `${BOARD_WIDTH}px`,
               height: `${intrinsicHeight}px`,
-              transform: `scale(${scale})`,
+              // `translateZ(0)` composed onto the scale, not instead of it: the
+              // scale is the board's whole geometry. A 2D transform makes a
+              // stacking context but does NOT force this frame onto its own
+              // compositing layer, so an engine can skip its first paint and
+              // leave the preview blank. Same remedy as ArtifactThumbs.
+              transform: `scale(${scale}) translateZ(0)`,
               transformOrigin: 'top left',
             }}
           />
@@ -114,7 +119,9 @@ export function BoardThumb({
         style={{
           width: `${BOARD_WIDTH}px`,
           height: `${BOARD_HEIGHT}px`,
-          transform: `scale(${width / BOARD_WIDTH})`,
+          // Composed onto the scale for the same reason as BoardFrame above:
+          // promotion without losing the thumbnail's geometry.
+          transform: `scale(${width / BOARD_WIDTH}) translateZ(0)`,
           transformOrigin: 'top left',
         }}
       />

--- a/website/src/components/FileRenderers.tsx
+++ b/website/src/components/FileRenderers.tsx
@@ -268,6 +268,9 @@ export const HtmlViewer = memo(function HtmlViewer({ content }: { content: strin
         srcDoc={content}
         sandbox=""
         className="w-full h-full border-none"
+        // Own compositing layer: a sandboxed srcDoc frame with no transform can
+        // skip its first paint and render blank. Same remedy as McpAppFrame.
+        style={{ transform: 'translateZ(0)' }}
         title={i18nT('components.fileRenderers.html_preview')}
       />
     </div>

--- a/website/src/components/McpAppFrame.tsx
+++ b/website/src/components/McpAppFrame.tsx
@@ -1017,7 +1017,14 @@ export default function McpAppFrame({ payload }: { payload: McpAppRenderPayload 
           tabIndex={0}
           allow={allow || undefined}
           className="w-full border-none bg-card block"
-          style={{ height: displayHeight }}
+          // `translateZ(0)` promotes the frame onto its own compositing layer.
+          // Without it an engine can lay the srcDoc document out, run its
+          // scripts and report a correct height while rasterizing nothing —
+          // and this frame is a full-screen overlay, so a skipped first paint
+          // is a blank viewport with no error state. The 3D form adds no
+          // visual offset with no perspective set. Same remedy as
+          // ArtifactBody / WidgetFrame / ArtifactThumbs; keep them in step.
+          style={{ height: displayHeight, transform: 'translateZ(0)' }}
           title={`${payload.server} / ${payload.tool}`}
         />
       </div>

--- a/website/src/test/FileRenderers.test.tsx
+++ b/website/src/test/FileRenderers.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactNode } from 'react'
-import { columnLetter, detectFileType, JsonlViewer, OfficeViewer, SheetViewer } from '../components/FileRenderers'
+import { columnLetter, detectFileType, HtmlViewer, JsonlViewer, OfficeViewer, SheetViewer } from '../components/FileRenderers'
 
 // `useCanOpenFile` reads both of these, and it is the gate deciding whether the
 // Open button exists at all. Drive them explicitly: on the test host they would
@@ -95,6 +95,18 @@ describe('JsonlViewer', () => {
     const content = '{"a":1}\n\n\n{"b":2}\n'
     render(<JsonlViewer content={content} />)
     expect(screen.getByText('2 lines')).toBeInTheDocument()
+  })
+})
+
+describe('HtmlViewer', () => {
+  it('gives the preview frame its own compositing layer so a skipped first paint cannot blank it', () => {
+    const { container } = render(<HtmlViewer content="<p>preview</p>" />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe).not.toBeNull()
+    expect(iframe.style.transform).toBe('translateZ(0)')
+    // The isolation contract must survive the style change: an empty sandbox
+    // is what keeps the srcDoc document inert.
+    expect(iframe.getAttribute('sandbox')).toBe('')
   })
 })
 

--- a/website/src/test/McpAppFrame.test.tsx
+++ b/website/src/test/McpAppFrame.test.tsx
@@ -53,6 +53,17 @@ describe('McpAppFrame', () => {
     expect(iframe.getAttribute('sandbox')).not.toContain('allow-same-origin')
   })
 
+  it('gives the app frame its own compositing layer so a skipped first paint cannot blank it', () => {
+    const { container } = renderWithProviders(<McpAppFrame payload={payload()} />)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement
+    expect(iframe).not.toBeNull()
+    expect(iframe.style.transform).toBe('translateZ(0)')
+    // Additive: the script-reported height sizing must survive the promotion —
+    // losing it would collapse the frame for every app, a bigger regression
+    // than the blank first paint being fixed.
+    expect(iframe.style.height).not.toBe('')
+  })
+
   it('renders the server/tool header', () => {
     const { getByText } = renderWithProviders(<McpAppFrame payload={payload()} />)
     expect(getByText('excalidraw')).toBeTruthy()

--- a/website/src/test/PptxMakerPage.test.tsx
+++ b/website/src/test/PptxMakerPage.test.tsx
@@ -19,6 +19,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
 
 import {
+  BOARD_WIDTH,
   DECK_TABS,
   countBoardSlides,
   filterDecks,
@@ -283,6 +284,37 @@ describe('board helpers', () => {
       expect(frame.getAttribute('sandbox')).toBe('')
     }
     unmount()
+  })
+
+  it('promotes both board frames onto their own compositing layer without losing the scale', () => {
+    // BoardFrame only mounts its iframe once it has measured a container
+    // width, and jsdom reports 0 — pin the measurement so the scaled frame
+    // actually renders and its transform can be asserted.
+    const rect = vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+      width: 960, height: 540, top: 0, left: 0, right: 960, bottom: 540, x: 0, y: 0,
+      toJSON: () => ({}),
+    } as DOMRect)
+    try {
+      const { container, unmount } = render(
+        <>
+          <BoardFrame html="<div class='slide'>a</div>" title="board" />
+          <BoardThumb html="<div class='slide'>a</div>" width={52} title="thumb" />
+        </>,
+      )
+      const frames = Array.from(container.querySelectorAll('iframe'))
+      expect(frames.length).toBe(2)
+      // `translateZ(0)` must be COMPOSED onto the scale, not replace it: the
+      // scale is each frame's whole geometry, and a bare translateZ(0) would
+      // render the 1920px document at full size inside the preview box.
+      expect(frames[0].style.transform).toBe(`scale(${960 / BOARD_WIDTH}) translateZ(0)`)
+      expect(frames[1].style.transform).toBe(`scale(${52 / BOARD_WIDTH}) translateZ(0)`)
+      for (const frame of frames) {
+        expect(frame.style.transformOrigin).toBe('top left')
+      }
+      unmount()
+    } finally {
+      rect.mockRestore()
+    }
   })
 
   it('collects theme accents in order and skips gaps', () => {


### PR DESCRIPTION
## Summary

Follow-up enumeration to the compositing-promotion class: three remaining sandboxed `srcDoc` iframes carried no compositing-layer promotion, so an engine could lay the document out, run its scripts and report a correct height while rasterizing nothing — a skipped first paint renders blank.

- **`McpAppFrame`** — the full-screen MCP app overlay, where a skipped paint is a blank viewport with no error state. `transform: 'translateZ(0)'` joins the script-reported `height` in the iframe's style object.
- **`BoardFrame` + `BoardThumb`** (pptx-maker) — both frames carried a 2D `scale(...)` only, which makes a stacking context but does not force layer promotion. `translateZ(0)` is **composed onto** the scale (`scale(...) translateZ(0)`), never replacing it: the scale is each frame's whole geometry, and `transformOrigin` is unchanged. Same composition as the merged gallery-thumbnail precedent in `ArtifactThumbs`.
- **`HtmlViewer`** (`FileRenderers`) — plain `srcDoc` preview, plain `style={{ transform: 'translateZ(0)' }}`, consistent with sibling renderers.

The sandbox attributes are untouched on all three sites (`allow-scripts allow-forms` on McpAppFrame; empty sandbox on the board frames and HtmlViewer), and the HtmlViewer test now pins the empty sandbox alongside the promotion.

## Evidence

This is a compositing hint with **no visual delta in a healthy renderer**, so a screenshot cannot demonstrate the fix. The per-site style assertions are the evidence instead, mirroring the existing promotion tests:

<!-- no-visual-delta -->
**Why no screenshot:** the change is a compositing hint (`translateZ(0)`) with zero visual delta in a healthy renderer — the defect it prevents (a skipped first paint) is nondeterministic and cannot be staged for a capture, so the pinned style assertions below are the evidence.

- `McpAppFrame.test.tsx` — pins `transform: translateZ(0)` and that the script-reported height sizing survives.
- `PptxMakerPage.test.tsx` — pins `scale(...) translateZ(0)` on both board frames (measurement pinned so the scaled frame mounts in jsdom), that the scale survives the composition, and that `transformOrigin` stays `top left`.
- `FileRenderers.test.tsx` — pins the HtmlViewer promotion and the empty sandbox.

Deliberately no registry or enumerating test for the class — each site pins only its own style.

## Testing

- `npx tsc -b` — clean
- `npx eslint` on all six changed files — clean
- Diff-scoped brand gate — clean
- Vitest runs in CI (per-site assertions above are new)

## Notes

A local review pass flagged one Low advisory: promoting the intrinsic-height `BoardFrame` iframe asks the compositor for a `1920 × (1080+gap)·slides` layer on long decks — a bounded GPU-memory cost traded for a certain blank-frame bug, and Chromium tiles composited layers. If it ever shows up in profiling, the promotion can move to the fixed-size clipping wrapper instead.

## Pattern harvest

Rule candidate: a sandboxed `srcDoc` iframe must carry compositing-layer promotion (`translateZ(0)`, composed onto any existing `scale(...)` rather than replacing it) — a 2D transform alone makes a stacking context but does not force promotion, and an unpromoted frame can skip its first paint and render blank. This PR closes the last three known sites of the class; a new `srcDoc` frame added without promotion re-opens it, so the pattern is a reviewable rule candidate for `website/AUTOSDE.yaml`.

Closes #8075
