### PR TITLE
fix(chat): record the invisible-only verdict when a turn is persisted

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -225,6 +225,7 @@ from kiro_crew.name_grant import (
     shell_command_for_event,
 )
 from kiro_crew.platform import redact_via_context
+from kiro_crew.preview_text import drop_format_chars
 from kiro_crew.providers.acp import is_claude_backend
 from kiro_crew.providers.base import (
     EVENT_COMPLETE,
@@ -1542,6 +1543,52 @@ def _attach_turn_stats(
         if m.get("role") == "assistant":
             m.setdefault("meta", {})["turn_stats"] = stats
             break
+
+
+def _mark_invisible_only(slot: "_ChatSlot", turn_boundary: int = 0) -> None:
+    """Stamp ``meta.invisible_only`` on a finalized assistant row that renders as nothing.
+
+    A quiet monitor-loop cycle posts a bare U+200B as its say-nothing reply, so
+    a long-running session accretes assistant rows whose content is only Unicode
+    format characters (category Cf) and whitespace. Every consumer currently
+    re-derives that from the content — the sidebar preview via
+    :func:`kiro_crew.preview_text.drop_format_chars`, the transcript via the
+    frontend's ``isInvisibleOnly`` — which makes the convention an unwritten
+    invariant each new reader has to rediscover. Recording the verdict once, at
+    the point the turn is persisted, gives them one field to read instead.
+
+    Delegates to ``drop_format_chars`` rather than restating the Cf test: that
+    function is the single implementation of the drop (the frontend predicate
+    mirrors it), so a third copy here would be the very duplication this
+    removes.
+
+    The marker states a fact about the CONTENT — "this text renders as nothing" —
+    and deliberately not the render decision "hide this row". The retention
+    exceptions stay with the reader because they are not stable at write time: a
+    regenerate can add a visible variant to an already-stamped row, so a
+    "hidden" verdict frozen here would go stale, while an invisible-content
+    verdict never does.
+
+    Written only when true, matching :func:`_attach_turn_stats`'s omit-empty
+    contract: absence means "nobody recorded a verdict", which is exactly the
+    state of every row persisted before this existed, so a reader can treat
+    absence as "derive it yourself" instead of as ``False``.
+
+    ``turn_boundary`` is ``len(slot.messages)`` captured at turn start, so a turn
+    that appended no assistant message cannot walk back and stamp the previous
+    turn's row. No-op when this turn produced no assistant message.
+    """
+    boundary = max(0, turn_boundary)
+    for m in reversed(slot.messages[boundary:]):
+        if m.get("role") != "assistant":
+            continue
+        content = m.get("content")
+        if isinstance(content, str) and drop_format_chars(content).strip() == "":
+            m.setdefault("meta", {})["invisible_only"] = True
+            # Mirror _flush_file_changes: this mutates meta in place without
+            # appending, so nothing else flags the slot for the periodic flush.
+            slot._dirty = True
+        break
 
 
 def _mcp_server_name_is_ambiguous(server_name: str, safe_name: str) -> bool:
@@ -5989,6 +6036,11 @@ async def _run_chat(
     _mirror_active_task_title = ""
     _mirror_thread: str | None = ""
     _mirror_task_counter = 0
+    # Bound BEFORE the try because the finally block reads it: everything this
+    # turn appends lands at or after this index, so an exception raised before
+    # the authoritative re-capture below still leaves a boundary that cannot
+    # walk back into a previous turn's rows.
+    _turn_msg_boundary = len(slot.messages)
     try:
         # Resolve agent bindings early so we pass the correct kiro-cli
         # agent name (e.g. "kirocrew") instead of the KiroCrew slot name
@@ -10124,6 +10176,11 @@ async def _run_chat(
             )
             # Attach accumulated file changes to last assistant message before persist
             _flush_file_changes(slot)
+            # Record whether this turn's reply renders as nothing, so consumers
+            # read one field instead of each re-deriving the Cf rule. AFTER
+            # _flush_file_changes: a row that just gained diff chips is still
+            # invisible-only as TEXT, and the reader needs both facts to decide.
+            _mark_invisible_only(slot, turn_boundary=_turn_msg_boundary)
             # Save to history and trigger memory consolidation
             await save_slot_off_loop(state, slot)
         # Reset ALL retry budgets once the cycle completes (success OR the
@@ -11254,6 +11311,13 @@ async def _run_chat(
         # bug this fix prevents.
         try:
             _flush_file_changes(slot)
+            # Same reason, same wrapping: a cancelled or errored turn can still
+            # have appended a finalized invisible-only reply, and a row that is
+            # persisted without the marker leaves absence permanently ambiguous.
+            # Stamping at BOTH flush sites is what makes absence mean "predates
+            # the marker" rather than "the turn ended the other way".
+            # Idempotent on the success path, which already stamped it.
+            _mark_invisible_only(slot, turn_boundary=_turn_msg_boundary)
         except Exception:
             logger.debug("_flush_file_changes failed", exc_info=True)
         # This turn consumed the one-shot post-compaction re-injection flag but

--- a/test/test_invisible_only_marker.py
+++ b/test/test_invisible_only_marker.py
@@ -1,0 +1,164 @@
+"""Tests for the record-time ``invisible_only`` marker on assistant messages.
+
+Covers ``chat_runner._mark_invisible_only``: the helper that records, once at
+the point a turn is persisted, whether the finalized assistant reply renders as
+nothing. Without it every transcript consumer re-derives the Cf rule from the
+content, and the rows accrete in stores with nothing on them to key off (#7599).
+
+Two properties matter beyond the stamping itself and are asserted here:
+
+* the verdict is computed by the ONE existing implementation of the Cf drop,
+  not a fresh copy of the rule;
+* the stored content is never rewritten — the marker is additive, so a
+  transcript cannot be damaged by it and dropping such rows stays a later,
+  separate decision.
+"""
+
+import inspect
+
+from kiro_crew import preview_text
+from kiro_crew.dashboard import chat_runner
+from kiro_crew.dashboard.chat_runner import _mark_invisible_only
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+def _slot_with_reply(content: str, **append_kwargs) -> _ChatSlot:
+    slot = _ChatSlot("test-invisible-only")
+    slot.append("assistant", content, "msg msg-a", broadcast=False, **append_kwargs)
+    # append flags the slot dirty; clear it so the marker's own flag is visible.
+    slot._dirty = False
+    return slot
+
+
+def test_verdict_comes_from_the_one_cf_implementation():
+    """The helper must delegate, not restate the rule.
+
+    ``drop_format_chars`` documents itself as the single implementation of the
+    Cf drop, and the frontend predicate mirrors it. A private copy inside
+    chat_runner would drift from both — and drift is the defect this marker
+    exists to remove, not a cosmetic concern.
+    """
+    assert chat_runner.drop_format_chars is preview_text.drop_format_chars
+
+
+class TestMarkInvisibleOnly:
+    def test_stamps_a_zwsp_only_reply(self):
+        # The quiet monitor-cycle say-nothing reply.
+        slot = _slot_with_reply("\u200b")
+        _mark_invisible_only(slot)
+        assert slot.messages[-1]["meta"]["invisible_only"] is True
+
+    def test_covers_the_whole_cf_class_plus_padding(self):
+        slot = _slot_with_reply("\u200b\u200c \u200d\u2060\ufeff\u00ad\n")
+        _mark_invisible_only(slot)
+        assert slot.messages[-1]["meta"]["invisible_only"] is True
+
+    def test_ordinary_reply_is_not_stamped_at_all(self):
+        # Absent, not False: absence is what every pre-marker row on disk looks
+        # like, so a reader can treat it as "derive it yourself".
+        slot = _slot_with_reply("done café")
+        _mark_invisible_only(slot)
+        assert "invisible_only" not in slot.messages[-1].get("meta", {})
+
+    def test_embedded_format_chars_are_not_invisible_only(self):
+        slot = _slot_with_reply("a\u200bb")
+        _mark_invisible_only(slot)
+        assert "invisible_only" not in slot.messages[-1].get("meta", {})
+
+    def test_content_is_left_intact(self):
+        # The marker is additive by design. Normalizing the content to empty
+        # would be a lossy one-way write over persisted transcript text.
+        slot = _slot_with_reply("\u200b")
+        _mark_invisible_only(slot)
+        assert slot.messages[-1]["content"] == "\u200b"
+
+    def test_stamps_a_row_that_carries_file_change_chips(self):
+        # The marker states a fact about the TEXT. The chips exception is the
+        # reader's, because it composes with facts the write side cannot know
+        # (a regenerate can add a visible variant turns later).
+        slot = _slot_with_reply("\u200b", meta={"file_changes": [{"path": "a.ts"}]})
+        _mark_invisible_only(slot)
+        meta = slot.messages[-1]["meta"]
+        assert meta["invisible_only"] is True
+        assert meta["file_changes"] == [{"path": "a.ts"}]
+
+    def test_flags_the_slot_dirty(self):
+        # Mirrors _flush_file_changes: meta is mutated in place without an
+        # append, so nothing else marks the slot for the periodic flush.
+        slot = _slot_with_reply("\u200b")
+        _mark_invisible_only(slot)
+        assert slot._dirty is True
+
+    def test_only_the_last_assistant_row_is_considered(self):
+        slot = _ChatSlot("test-invisible-only-multi")
+        slot.append("assistant", "\u200b", "msg msg-a", broadcast=False)
+        slot.append("assistant", "the visible answer", "msg msg-a", broadcast=False)
+        _mark_invisible_only(slot)
+        assert "invisible_only" not in slot.messages[0].get("meta", {})
+        assert "invisible_only" not in slot.messages[1].get("meta", {})
+
+    def test_turn_boundary_protects_the_previous_turn(self):
+        # An error-only turn appends no assistant message; without the boundary
+        # the walk-back would reach into the turn before it.
+        slot = _ChatSlot("test-invisible-only-boundary")
+        slot.append("assistant", "\u200b", "msg msg-a", broadcast=False)
+        boundary = len(slot.messages)
+        slot.append("error", "boom", "msg msg-err", broadcast=False)
+        _mark_invisible_only(slot, turn_boundary=boundary)
+        assert "invisible_only" not in slot.messages[0].get("meta", {})
+
+    def test_no_assistant_message_is_noop(self):
+        slot = _ChatSlot("test-invisible-only-none")
+        slot.append("error", "boom", "msg msg-err", broadcast=False)
+        _mark_invisible_only(slot)
+        assert len(slot.messages) == 1
+        assert "invisible_only" not in slot.messages[0].get("meta", {})
+
+    def test_stamping_twice_is_idempotent(self):
+        # The success path stamps, then the finally block stamps again on the
+        # same row. The second pass must be a no-op, not a second write.
+        slot = _slot_with_reply("\u200b")
+        _mark_invisible_only(slot)
+        first = dict(slot.messages[-1]["meta"])
+        _mark_invisible_only(slot)
+        assert slot.messages[-1]["meta"] == first
+        assert first["invisible_only"] is True
+
+
+class TestPersistCallSite:
+    """The stamp is worthless unless the persist paths actually run it.
+
+    ``run_chat_turn`` has no mountable unit seam, so the wiring is pinned by
+    source the way the frontend pins ChatPage's render chain.
+    """
+
+    src = inspect.getsource(chat_runner)
+    CALL = "_mark_invisible_only(slot, turn_boundary=_turn_msg_boundary)"
+
+    def test_marker_runs_before_the_history_save(self):
+        mark = self.src.index(self.CALL)
+        save = self.src.index("await save_slot_off_loop(state, slot)")
+        assert mark < save
+
+    def test_marker_runs_after_the_file_changes_flush(self):
+        # A row that just gained diff chips must already carry them, so the
+        # reader sees the text verdict and the chips together.
+        flush = self.src.index("_flush_file_changes(slot)")
+        mark = self.src.index(self.CALL)
+        assert flush < mark
+
+    def test_both_flush_sites_stamp(self):
+        # A cancelled or errored turn can still have appended a finalized
+        # invisible-only reply. Stamping at only one site would leave rows
+        # persisted forever without a marker, so absence could never mean
+        # "predates the marker" — which is the contract the reader relies on.
+        assert self.src.count(self.CALL) == 2
+
+    def test_turn_boundary_is_bound_before_the_enclosing_try(self):
+        # The finally block reads _turn_msg_boundary, so it must be bound even
+        # when the turn raises before the authoritative capture.
+        lines = self.src.splitlines()
+        first_bind = next(i for i, ln in enumerate(lines) if "_turn_msg_boundary = " in ln)
+        first_use = next(i for i, ln in enumerate(lines) if self.CALL in ln)
+        assert first_bind < first_use
+        assert lines[first_bind].startswith("    _turn_msg_boundary = len(slot.messages)")

--- a/website/src/test/invisibleText.test.ts
+++ b/website/src/test/invisibleText.test.ts
@@ -77,6 +77,60 @@ describe('isHiddenInvisibleAssistantRow', () => {
   })
 })
 
+describe('isHiddenInvisibleAssistantRow reads the record-time marker', () => {
+  // The backend stamps meta.invisible_only when it persists a turn whose reply
+  // renders as nothing (chat_runner._mark_invisible_only), so this reader keys
+  // off the recorded verdict instead of every consumer re-deriving the Cf rule.
+  it('honours the marker without re-deriving from the content', () => {
+    expect(
+      isHiddenInvisibleAssistantRow({
+        role: 'assistant',
+        content: 'text the Cf test alone would call visible',
+        meta: { invisible_only: true },
+      }),
+    ).toBe(true)
+  })
+
+  it('treats an absent marker as "derive it", not as false', () => {
+    // Every row persisted before the marker existed lacks it; those must keep
+    // being hidden by the derivation, which is what heals existing history.
+    expect(isHiddenInvisibleAssistantRow({ role: 'assistant', content: '\u200b', meta: {} })).toBe(
+      true,
+    )
+  })
+
+  it('never hides a non-assistant row on the strength of a marker', () => {
+    expect(
+      isHiddenInvisibleAssistantRow({
+        role: 'user',
+        content: '\u200b',
+        meta: { invisible_only: true },
+      }),
+    ).toBe(false)
+  })
+
+  it('lets the retention exceptions outrank the marker', () => {
+    // The marker is a fact about the text. Chips are real content, and a
+    // visible variant can be added by a regenerate long after the stamp — so
+    // both still win, or a stale write-time verdict would hide real content.
+    expect(
+      isHiddenInvisibleAssistantRow({
+        role: 'assistant',
+        content: '\u200b',
+        meta: { invisible_only: true, file_changes: [{ path: 'a.ts' }] },
+      }),
+    ).toBe(false)
+    expect(
+      isHiddenInvisibleAssistantRow({
+        role: 'assistant',
+        content: '\u200b',
+        meta: { invisible_only: true },
+        variants: [{ content: 'the earlier visible reply' }, { content: '\u200b' }],
+      }),
+    ).toBe(false)
+  })
+})
+
 describe('ChatPage inline chain consults the skip (source contract)', () => {
   const src = readFileSync(resolve(__dirname, '../pages/ChatPage.tsx'), 'utf8')
 

--- a/website/src/utils/invisibleText.ts
+++ b/website/src/utils/invisibleText.ts
@@ -29,6 +29,15 @@ export function isInvisibleOnly(text: string): boolean {
  * and the row hosts the typing indicator. A hidden row's `turn_stats` are
  * deliberately dropped with it: a say-nothing cycle's footer stats are noise,
  * and cost accounting lives in the usage panels, not the transcript.
+ *
+ * The invisible-only verdict is READ from `meta.invisible_only` when the
+ * backend recorded one at persist time (`chat_runner._mark_invisible_only`),
+ * and only derived from the content otherwise. Absence is not `false`: every
+ * row persisted before the marker existed lacks it, so the derivation stays as
+ * the fallback that keeps that history healing. The marker states a fact about
+ * the content, not the render decision — the exceptions above are still applied
+ * on top of it, because a regenerate can add a visible variant to a row that
+ * was stamped turns ago.
  */
 export function isHiddenInvisibleAssistantRow(
   m: Pick<ChatMessage, 'role' | 'content' | 'meta' | 'variants'>,
@@ -37,5 +46,5 @@ export function isHiddenInvisibleAssistantRow(
   const changes = m.meta?.file_changes
   if (Array.isArray(changes) && changes.length > 0) return false
   if (m.variants?.some(v => !isInvisibleOnly(v.content))) return false
-  return isInvisibleOnly(m.content)
+  return m.meta?.invisible_only === true || isInvisibleOnly(m.content)
 }


### PR DESCRIPTION
## Problem / Motivation

A quiet monitor-loop cycle posts a bare U+200B as its say-nothing assistant reply, so a long-running session's transcript holds runs of assistant rows whose content is only Unicode format characters (category Cf) plus whitespace. Nothing records that at write time. The rows are persisted verbatim and keep accreting, and every consumer that must not draw them re-derives the rule from the content for itself:

- `src/kiro_crew/preview_text.py` `drop_format_chars` — the sidebar/preview side.
- `website/src/utils/invisibleText.ts` `isInvisibleOnly` — the transcript side.

`grep -r invisible_only src/ website/src/` returned nothing before this change, so a new reader (a channel relay, an export, summary extraction) has no field to key off and has to rediscover the convention.

One correction to the issue body, since it matters to anyone reading along: it cites `website/src/pages/chat/groupDisplayItems.ts`. That path is stale — the helper was extracted to `website/src/utils/invisibleText.ts`, which is what this PR touches.

## Why it matters

Render-time filtering hides these rows; it does not stop them being written. So the store keeps growing, and the invisible-row convention stays an unwritten invariant that each future consumer must independently know or silently get wrong — drawing empty bubbles, emitting empty preview lines, or feeding blank rows into an export. Recording the verdict once, where the row is written, is what turns that invariant into a field.

## What changed (motivation -> approach -> change)

Symptom: invisible-only assistant rows accumulate in persisted history with no annotation, and the rule that identifies them exists independently in two places.

Root cause: there is no write-side step. The rule is only ever applied by readers, so it must be re-implemented per reader and can never be recorded.

Change, in three parts:

1. `chat_runner._mark_invisible_only(slot, turn_boundary=...)` — a new helper beside its siblings `_attach_turn_stats` and `_flush_file_changes`. It stamps `meta.invisible_only = True` on the finalized assistant row when the row's content renders as nothing.
2. It is called at **both** persist sites, mirroring `_flush_file_changes`: on the success path after the chip flush and before `save_slot_off_loop`, and in the `finally` block that covers cancel/error. Stamping only the success path would leave rows persisted forever without a marker, which would make absence permanently ambiguous — the reader's contract is that absence means "predates the marker", not "the turn ended the other way". The second pass is idempotent on a row the first already stamped, and `_turn_msg_boundary` is now bound before the enclosing `try` so the `finally` can read it even when the turn raises early.
3. `isHiddenInvisibleAssistantRow` reads `meta.invisible_only` and derives from the content only when the marker is absent.

Three decisions worth disagreeing with cheaply:

**Marker, not normalize-to-empty.** The issue offered both. This takes the marker. It is additive and reversible, it destroys no stored content, it cannot corrupt an existing transcript, and dropping such rows entirely can be built on top of it later. Normalizing the content to empty is a lossy one-way write over durable user history — if the rule is ever wrong, or a row was misjudged, there is nothing left to recover from. If you would rather have the destructive-but-tidier version, this is the place to say so.

**The verdict is computed by delegating to `drop_format_chars`, not by a new test.** That function documents itself as the single implementation of the Cf drop and the frontend predicate mirrors it, so a private copy in `chat_runner` would be exactly the duplication this change exists to remove. A test pins the delegation by identity (`chat_runner.drop_format_chars is preview_text.drop_format_chars`) so a later refactor cannot quietly fork it. Note this is deliberately *not* `validation.strip_hidden_unicode`: that one also drops category Cc and conditionally keeps shaping marks, so using it would have introduced a third, subtly different semantic rather than reusing the matching one.

**The marker states a fact about the content, not the render decision.** It means "this text renders as nothing", not "hide this row". The `file_changes` and visible-variant retention exceptions stay with the reader, because they are not stable at write time — a regenerate can add a visible variant to a row that was stamped turns ago, so a frozen "hidden" verdict would go stale while an invisible-content verdict never does. A row with diff chips is therefore still stamped, and the reader still keeps it visible.

**Neither existing implementation is removed, on purpose.** Render-time filtering is what heals the rows already on disk, and gutting the frontend derivation is only safe once the marker is actually present on stored rows — which it is not for any history that predates this change. So the marker is written only when true, and its absence means "nobody recorded a verdict, derive it yourself" rather than `false`. Migrating the other frontend call sites and the preview/export paths onto the marker is follow-up work, deliberately not in this diff.

## Tests

Both suites were confirmed to fail on unfixed code before being made to pass (source change stashed, tests re-run, change restored).

`test/test_invisible_only_marker.py` (new, 15 tests):

- a ZWSP-only reply is stamped; the whole Cf class plus trailing whitespace is stamped.
- an ordinary reply, and one with embedded format characters, get no key at all — absence, not `False`.
- the stored content is byte-for-byte unchanged after stamping (this is what pins the additive-not-lossy choice).
- a row carrying `file_changes` is still stamped, and its chips are untouched.
- the slot is flagged dirty, so an in-place meta mutation is not dropped by the periodic flush.
- only the last assistant row of the turn is considered; `turn_boundary` stops an assistant-less turn walking back into the previous one; a turn with no assistant row is a no-op.
- stamping twice leaves the meta unchanged, which is what the two call sites do on the success path.
- the delegation identity above.
- four source-contract tests pin the wiring — the call sits after `_flush_file_changes` and before `save_slot_off_loop`, it appears at both flush sites, and `_turn_msg_boundary` is bound before the enclosing `try`. `run_chat_turn` has no mountable unit seam, so this mirrors how the frontend pins ChatPage's render chain by source.

`website/src/test/invisibleText.test.ts` (5 tests added, 16 total):

- the marker is honoured on content the Cf derivation alone would call visible (this is the assertion that fails without the change).
- an absent marker still derives, so pre-marker history keeps healing.
- a non-assistant row is never hidden on the strength of a marker.
- `file_changes` and a visible variant both outrank the marker.

## Manual verification

N/A — unit coverage sufficient. There is no user-visible change: the marker is metadata, and the rows in question were already hidden by the render-time filters this PR leaves in place. The only behavioural difference a user could observe is a row that the backend marked and the frontend would not have derived, and both directions of that are covered by the tests above.

## Related Issues

Refs #7599

## Pattern harvest

Rule candidate: review-prompt
Pattern: a convention applied only by readers is re-implemented once per reader; record the verdict at the write point instead.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the changed behaviour is documented in the two touched docstrings; no user-facing docs describe this convention.
- [x] No secrets, credentials, or internal references in the diff
