### PR TITLE
fix(aws-control): gate drive bootstrap on app-enabled inside the lock

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -388,6 +388,22 @@ def _aws_failed(exc: AWSError) -> web.Response:
     return web.json_response({"error": _safe_error(exc), "code": "aws_call_failed"}, status=502)
 
 
+def _response_code(response: web.Response) -> str:
+    """The machine-readable ``code`` a denial response carries, for the audit trail.
+
+    Never hard-code the reason next to a helper that can answer with more than one.
+    ``_resolve_target`` returns THREE - ``invalid_account``, ``account_unavailable``
+    and ``account_mismatch`` - so auditing a fixed string makes an incident review
+    read "no working connection" for what was in fact a live-identity mismatch, which
+    is the case an operator most needs to see. Falls back to ``unknown`` rather than
+    raising: an audit line is best-effort and must not be able to fail a response.
+    """
+    try:
+        return str(json.loads(response.text or "{}").get("code", "")) or "unknown"
+    except Exception:
+        return "unknown"
+
+
 def _audit_sync(operation: str, resources: str, outcome: str, *, error: str = "") -> None:
     """Best-effort SEL audit for mutations; never blocks the response.
 
@@ -794,10 +810,17 @@ async def _handle_drive_bootstrap(request: web.Request) -> web.Response:
         # owner never confirmed. `_account_target` re-probes the live identity,
         # so requiring it to still resolve the SAME triple is what closes it;
         # consent is re-read for the same reason it is re-read before an upload.
+        #
+        # Each denial audits at the POINT OF DECISION, like the helper's arms
+        # do: `_mutating` records the outcome of whatever response leaves here,
+        # but only a `denied` record naming the reason tells an incident review
+        # why a bucket the owner confirmed was never created.
         recheck = await _account_target(request)
         if isinstance(recheck, web.Response):
+            await _audit("drive_bootstrap", request.path, "denied", error=_response_code(recheck))
             return recheck
         if recheck != (account, profile, region):
+            await _audit("drive_bootstrap", request.path, "denied", error="account_mismatch")
             return _conflict(
                 "this connection changed while the drive was being created; " "nothing was created",
                 "account_mismatch",
@@ -805,10 +828,42 @@ async def _handle_drive_bootstrap(request: web.Request) -> web.Response:
         denied = await _consent(aws_consent.SERVICE_S3, profile, region)
         if denied:
             return denied
+
+        # The app gate is the LAST thing before the billable call, deliberately.
+        # `_guarded` already refused a disabled app before the lock, so this one
+        # exists only for the app being switched off DURING the critical section --
+        # and every await above it (the unbounded lock wait, the tag-discovery
+        # round trip, the live identity re-probe, the consent read) is a point at
+        # which that can happen. A gate placed at the top of the lock is stale by
+        # the time `create_drive` runs, which is the whole failure it was added to
+        # prevent: a bucket billed for a surface the owner has already switched off.
+        #
+        # Read and create share ONE thread hop, so there is no await BETWEEN them
+        # at which the loop could run anything. `create_drive` returns the bucket
+        # name, so `None` is an unambiguous "refused, nothing created".
+        #
+        # A re-check, NOT a lock. `app_lifecycle_lock` is an in-process asyncio
+        # lock covering only the HTTP disable path, while `kirocrew app disable`
+        # runs in a SEPARATE process calling `disable_app` directly
+        # (`cli_commands.py` imports it), so no in-process lock serializes the
+        # writer this would have to wait on. Closing the cross-process window
+        # needs a cross-process lock this repo does not have; a re-check is the
+        # form the repo already accepts here (see
+        # `pptx_maker/backend/provision.py`, and the 9 `_reauthorize_in_lock` call
+        # sites, which all keep the same window).
+        #
         # `create_drive` re-checks the bucket's owner against this account once
         # it exists: its own CLI child resolves the profile independently, so
         # matching triples here cannot promise where the bucket lands.
-        bucket = await asyncio.to_thread(storage_mod.create_drive, profile, region, account)
+        def _create_drive_if_still_enabled() -> str | None:
+            if not is_app_enabled(APP_NAME):
+                return None
+            return storage_mod.create_drive(profile, region, account)
+
+        bucket = await asyncio.to_thread(_create_drive_if_still_enabled)
+        if bucket is None:
+            await _audit("drive_bootstrap", request.path, "denied", error="app_disabled")
+            return _forbidden("aws-control is disabled", "app_disabled")
     return web.json_response({"created": True, "bucket": bucket})
 
 

--- a/test/test_aws_control_app.py
+++ b/test/test_aws_control_app.py
@@ -123,6 +123,22 @@ def _payload(response: web.StreamResponse) -> dict:
     return json.loads(raw.decode("utf-8"))
 
 
+def _denial(audit: mock.Mock, error: str) -> str:
+    """The operation a patched ``_audit`` recorded ``denied`` with ``error``.
+
+    Asserted BEFORE any field is read: a regression that stops auditing leaves
+    nothing to match, and returning early with an assertion reports the event
+    that went missing instead of an IndexError on an empty list.
+    """
+    calls = [
+        call
+        for call in audit.call_args_list
+        if call.args[2:3] == ("denied",) and call.kwargs.get("error") == error
+    ]
+    assert calls, f"no denial audited with error={error!r}"
+    return calls[0].args[0]
+
+
 def _identity(ok: bool, account: str = "", arn: str = "", detail: str = "") -> aws_consent.Identity:
     return aws_consent.Identity(ok=ok, account=account, arn=arn, detail=detail)
 
@@ -2435,6 +2451,7 @@ class TestBootstrapReauthorizes:
             mock.patch.object(routes_mod, "_consent", AsyncMock(return_value=None)),
             mock.patch.object(routes_mod, "_drive_bucket", AsyncMock(return_value="")),
             mock.patch.object(routes_mod.storage_mod, "create_drive") as create,
+            mock.patch.object(routes_mod, "_audit") as audit,
         ):
             resp = asyncio.run(
                 handlers[("POST", "/drive/{account}/bootstrap")](  # type: ignore[operator]
@@ -2444,6 +2461,117 @@ class TestBootstrapReauthorizes:
         assert resp.status == 409
         assert _payload(resp)["code"] == "account_mismatch"
         create.assert_not_called()
+        # The refusal is also a permission DECISION, so it reaches SEL from the
+        # point of decision: `_mutating` records that a response left with a 4xx,
+        # which does not say WHY the confirmed bucket was never created.
+        assert _denial(audit, "account_mismatch") == "drive_bootstrap"
+
+    def test_the_app_disabled_mid_create_refuses_and_creates_nothing(self):
+        # `_guarded` checks the app BEFORE the lock, and the wait for the lock is
+        # unbounded -- so a queued confirm can outlive the app being switched off
+        # and still reach the BILLABLE `create_drive`. Guard 1 of the module
+        # promises a disabled app answers 403 `app_disabled` to everyone; the
+        # recheck inside the lock is what makes the billable path keep it.
+        handlers = _registered()
+        target = (ACCOUNT, "prof-a", "us-west-2")
+        # Enabled at the door, switched off by the time the lock is held.
+        enabled_results = [True, False]
+
+        def _enabled(_name):
+            return enabled_results.pop(0) if enabled_results else False
+
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", side_effect=_enabled),
+            mock.patch.object(routes_mod, "is_owner_dashboard_request", return_value=True),
+            mock.patch.object(routes_mod, "_account_target", AsyncMock(return_value=target)),
+            mock.patch.object(routes_mod, "_consent", AsyncMock(return_value=None)),
+            mock.patch.object(routes_mod, "_drive_bucket", AsyncMock(return_value="")),
+            # A real bucket name, so a missing gate fails on the 403 contract
+            # below rather than on an unserializable mock in the 200 body.
+            mock.patch.object(
+                routes_mod.storage_mod, "create_drive", return_value="kirocrew-drive-abc123def456"
+            ) as create,
+            mock.patch.object(routes_mod, "_audit") as audit,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/bootstrap")](  # type: ignore[operator]
+                    self._confirm_request()
+                )
+            )
+        assert resp.status == 403
+        assert _payload(resp)["code"] == "app_disabled"
+        # The decisive assertion: no bucket was made, so nothing was billed.
+        create.assert_not_called()
+        assert _denial(audit, "app_disabled") == "drive_bootstrap"
+
+    def test_an_account_that_stops_resolving_mid_create_is_audited(self):
+        # The other shape the in-lock re-probe returns: not a different triple
+        # but a refusal response, because the profile no longer resolves to the
+        # requested account at all.
+        handlers = _registered()
+        # The code here is deliberately NOT `account_unavailable`: `_resolve_target`
+        # answers with three different codes, so a test whose fixture happens to use
+        # the one the audit hard-coded would pass against the bug. `account_mismatch`
+        # is the case an incident review most needs to see correctly.
+        unavailable = routes_mod._conflict("profile no longer resolves", "account_mismatch")
+        targets = [(ACCOUNT, "prof-a", "us-west-2"), unavailable]
+
+        async def _target(_request_obj):
+            return targets.pop(0)
+
+        with (
+            mock.patch.object(routes_mod, "is_app_enabled", return_value=True),
+            mock.patch.object(routes_mod, "is_owner_dashboard_request", return_value=True),
+            mock.patch.object(routes_mod, "_account_target", side_effect=_target),
+            mock.patch.object(routes_mod, "_consent", AsyncMock(return_value=None)),
+            mock.patch.object(routes_mod, "_drive_bucket", AsyncMock(return_value="")),
+            mock.patch.object(routes_mod.storage_mod, "create_drive") as create,
+            mock.patch.object(routes_mod, "_audit") as audit,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/bootstrap")](  # type: ignore[operator]
+                    self._confirm_request()
+                )
+            )
+        assert resp is unavailable
+        create.assert_not_called()
+        assert _denial(audit, "account_mismatch") == "drive_bootstrap"
+
+    def test_the_app_disabled_during_the_consent_read_still_creates_nothing(self):
+        # A gate at the TOP of the lock is already stale by the time `create_drive`
+        # runs: the identity re-probe and the consent read are both awaits after it.
+        # Switching the app off DURING the last of those awaits is the case only a
+        # gate placed immediately before the billable call can catch.
+        handlers = _registered()
+        enabled = {"value": True}
+
+        async def _consent_and_disable(*_a, **_k):
+            enabled["value"] = False  # owner switches the app off mid-read
+            return None
+
+        with (
+            mock.patch.object(
+                routes_mod, "is_app_enabled", side_effect=lambda *_a, **_k: enabled["value"]
+            ),
+            mock.patch.object(routes_mod, "is_owner_dashboard_request", return_value=True),
+            mock.patch.object(
+                routes_mod,
+                "_account_target",
+                AsyncMock(return_value=(ACCOUNT, "prof-a", "us-west-2")),
+            ),
+            mock.patch.object(routes_mod, "_consent", side_effect=_consent_and_disable),
+            mock.patch.object(routes_mod, "_drive_bucket", AsyncMock(return_value="")),
+            mock.patch.object(routes_mod.storage_mod, "create_drive") as create,
+            mock.patch.object(routes_mod, "_audit") as audit,
+        ):
+            resp = asyncio.run(
+                handlers[("POST", "/drive/{account}/bootstrap")](  # type: ignore[operator]
+                    self._confirm_request()
+                )
+            )
+        assert resp.status == 403
+        create.assert_not_called()
+        assert _denial(audit, "app_disabled") == "drive_bootstrap"
 
     def test_consent_withdrawn_mid_create_refuses_and_creates_nothing(self):
         handlers = _registered()


### PR DESCRIPTION
## Problem / Motivation

Refs #7174. `aws-control`'s drive bootstrap could bill an S3 bucket for an app the owner had
already switched off, and its two identity denials left no audit record.

`_guarded` checks `is_app_enabled` at the door, but what sits between that check and the billable
`storage_mod.create_drive` is an **unbounded** `_bootstrap_lock` wait plus a tag-discovery round trip
to AWS, a live identity re-probe and a consent read. A confirm queued behind the lock can therefore
outlive the app being disabled and still reach the billable call. The module's own Guard 1 promises a
disabled app answers `403 app_disabled` to everyone; the billable path did not keep that promise.

## What changed

1. **The app-enabled re-check runs LAST inside `_bootstrap_lock`, immediately before the billable
   call** — not at the top. This placement is the point of the fix: a gate at the top of the lock is
   already stale by the time `create_drive` runs, because all four suspension points listed above sit
   after it.
2. **The check and `create_drive` share ONE `asyncio.to_thread` hop**
   (`_create_drive_if_still_enabled`), so no await sits between them for the loop to interleave at.
   `create_drive` is typed `-> str`, so `None` is an unambiguous "refused, nothing created".
3. **The two identity denials now audit at the point of decision**, matching what
   `_reauthorize_in_lock`'s arms already do.
4. **New `_response_code` helper** reads the refusal code out of the response body, because
   `_resolve_target` answers with three different codes (`invalid_account`, `account_unavailable`,
   `account_mismatch`) and hard-coding one records false audit data — SEL would report "no working
   connection" for a live-identity mismatch.

## Why it matters

A disabled app that still creates billable cloud resources is a spend and governance problem, not a
cosmetic one, and an unaudited denial is invisible to an incident review. Both halves of the fix are
things Guard 1 already promised.

## Deliberately NOT done, and the residual window

**An earlier revision of this PR held `app_lifecycle_lock(APP_NAME)` across the check and the create.
It has been withdrawn, and the description above is the shipped design.** Two reasons:

- It cannot close the race it was added for. `app_lifecycle_lock` is an in-process `asyncio` lock,
  but `kirocrew app disable` runs in a **separate process** and calls `disable_app` directly
  (`cli_commands.py` imports it; the lock only covers the HTTP disable path). Serializing against
  that writer needs a **cross-process** lock, which this repository does not have.
- It made things worse elsewhere: it held the app's lifecycle lock across four serial AWS CLI
  children, so the owner's own disable/uninstall would wait behind a billable call for as long as
  those take.

So a residual window remains: a disable landing between the in-thread `is_app_enabled` read and
`create_drive`'s completion. It is narrowed to its practical floor here, its outcome is one empty
bucket reported visibly in the `200` body, and a re-check is the form this repository already accepts
for it — see `pptx_maker/backend/provision.py`, which records "a re-check rather than holding
`app_lifecycle_lock`" as an accepted form, and the 9 `_reauthorize_in_lock` call sites, which all
keep the same window. Closing it properly is cross-process locking infrastructure and belongs in its
own change, not smuggled into a bug fix.

**Known divergence:** `_response_code` makes bootstrap audit a mismatch accurately while
`_reauthorize_in_lock` still hard-codes `account_unavailable` for the same condition, so one
condition audits under two vocabularies by route. Fixing the shared helper touches 9 call sites and
is left as a follow-up rather than widened into this PR.

## Tests

`test/test_aws_control_app.py` — `116 passed, 9 skipped`.

Both new refusal tests are proven non-vacuous by mutation rather than merely passing: deleting the
two gate lines makes `test_the_app_disabled_mid_create_refuses_and_creates_nothing` and
`test_the_app_disabled_during_the_consent_read_still_creates_nothing` FAIL, and the audit test fails
against the hard-coded reason with `AssertionError: no denial audited with error='account_mismatch'`.
The decisive assertion in each is `create.assert_not_called()` — nothing was billed.

Gates: `isort` clean, `flake8` clean, `mypy` clean (1288 files), black gate passed.

## Pattern harvest

Rule candidate: a gate placed at the TOP of a handler is already stale by the time the billable call runs -- re-check the enabling condition inside the same lock that guards the call, as the last thing before it.


- A guard's **position** is part of the guard. Placing this one at the top of the critical section
  compiles, reads correctly, and does nothing — the failure it prevents happens in the awaits below
  it. When a re-check exists because state can change mid-section, it belongs immediately before the
  irreversible call, and a test that only checks "disabled ⇒ 403" cannot tell the two placements
  apart. Mutating the guard away is what proves the test discriminates.
- An in-process lock is not a defence against an out-of-process writer. Before reaching for an
  existing lock, check who else writes the state — here the CLI path bypasses it entirely, so the
  lock would have bought latency and no safety.
