### PR TITLE
fix(aws-control): offload SEL audit writes to a worker thread (#8139)

### DIFF
--- a/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/aws_control/backend/routes.py
@@ -320,7 +320,7 @@ async def _publish_gate(request: web.Request, operation: str) -> web.Response | 
     policy, every governance profile, and config.json from disk."""
     reason = await asyncio.to_thread(publish_denied_reason, request, _PUBLISH_PROVIDER_ID)
     if reason:
-        _audit(operation, request.path, "denied", error=reason)
+        await _audit(operation, request.path, "denied", error=reason)
         return _forbidden(f"publishing is disabled by policy: {reason}", "publish_denied")
     return None
 
@@ -365,8 +365,15 @@ def _aws_failed(exc: AWSError) -> web.Response:
     return web.json_response({"error": _safe_error(exc), "code": "aws_call_failed"}, status=502)
 
 
-def _audit(operation: str, resources: str, outcome: str, *, error: str = "") -> None:
-    """Best-effort SEL audit for mutations; never blocks the response."""
+def _audit_sync(operation: str, resources: str, outcome: str, *, error: str = "") -> None:
+    """Best-effort SEL audit for mutations; never blocks the response.
+
+    Blocking body of :func:`_audit` — ``log_api_access`` only enqueues onto the
+    writer thread, but the first ``sel()`` of a process CONSTRUCTS the log
+    (trust-dir creation, key load/validation, on Windows the owner-only DACL),
+    so handlers must reach it through the async wrapper, which routes it off
+    the event loop. Only tests and the wrapper call this directly.
+    """
     try:
         sel().log_api_access(
             caller="dashboard-owner",
@@ -380,6 +387,27 @@ def _audit(operation: str, resources: str, outcome: str, *, error: str = "") -> 
         logger.debug("aws-control SEL audit failed", exc_info=True)
 
 
+async def _audit(operation: str, resources: str, outcome: str, *, error: str = "") -> None:
+    """Record a SEL audit event without stalling the event loop.
+
+    ``log_api_access`` itself only enqueues, but first touch pays SEL
+    construction (see :func:`_audit_sync`), so the call is offloaded with
+    ``asyncio.to_thread`` — the same pattern this module already uses for its
+    other blocking calls and the shape ``dashboard.server._audit_denied``
+    settled for SEL specifically. Awaiting keeps the audit-before-response
+    ordering every call site relies on, and the wrapper preserves the
+    never-raises contract of the sync body even if thread dispatch itself
+    fails. Call sites that audit AFTER an external side effect (a mutation
+    outcome, a minted presign URL) wrap this in ``asyncio.shield`` so a client
+    disconnect cannot cancel the record between the side effect and its audit;
+    denial paths have no side effect to orphan and stay unshielded.
+    """
+    try:
+        await asyncio.to_thread(_audit_sync, operation, resources, outcome, error=error)
+    except Exception:
+        logger.debug("aws-control SEL audit dispatch failed", exc_info=True)
+
+
 def _guarded(handler: Handler) -> Handler:
     """Enabled check + owner check — the wrapper every route goes through."""
 
@@ -389,7 +417,7 @@ def _guarded(handler: Handler) -> Handler:
             # Same rule as the owner denial below: a permission DECISION must
             # reach SEL — a request arriving while the app is disabled is a
             # denial an incident review asks about.
-            _audit("access", request.path, "denied", error="app_disabled")
+            await _audit("access", request.path, "denied", error="app_disabled")
             return _forbidden("aws-control is disabled", "app_disabled")
         if not is_owner_dashboard_request(request):
             logger.warning(
@@ -400,7 +428,7 @@ def _guarded(handler: Handler) -> Handler:
             # The permission DECISION must reach SEL, not just the logger —
             # an app token probing the account portal is exactly the event
             # an incident review asks about. Before either response shape.
-            _audit(
+            await _audit(
                 "access",
                 request.path,
                 "denied",
@@ -425,7 +453,7 @@ def _mutating(operation: str) -> Callable[[Handler], Handler]:
 
             state = request.app.get("state")
             if state is not None and _is_restricted_session(state, request):
-                _audit(operation, request.path, "denied", error="restricted session")
+                await _audit(operation, request.path, "denied", error="restricted session")
                 return _forbidden(
                     "this session is restricted from AWS mutations",
                     "restricted_session",
@@ -433,12 +461,19 @@ def _mutating(operation: str) -> Callable[[Handler], Handler]:
             try:
                 response = await handler(request)
             except AWSError as exc:
-                _audit(operation, request.path, "error", error=str(exc))
+                # The handler already ran against AWS, so this audit and the
+                # success/refused one below must survive a client disconnect:
+                # shield keeps the record being written even when the await
+                # itself is cancelled. Before the await this point had no
+                # suspension, so cancellation could never orphan the outcome.
+                await asyncio.shield(_audit(operation, request.path, "error", error=str(exc)))
                 return _aws_failed(exc)
-            _audit(
-                operation,
-                request.path,
-                "success" if response.status < 400 else "refused",
+            await asyncio.shield(
+                _audit(
+                    operation,
+                    request.path,
+                    "success" if response.status < 400 else "refused",
+                )
             )
             return response
 
@@ -856,7 +891,10 @@ async def _handle_drive_download(request: web.Request) -> web.Response:
     # A presign is an ACCESS GRANT (a bearer URL now exists), not a plain
     # read — record it like every other grant so the audit trail can answer
     # "what URLs were minted". The key is metadata, never the URL itself.
-    _audit("drive_download", f"{section}/{key}", "granted")
+    # A bearer URL now exists, so the grant record must survive a client
+    # disconnect: shield keeps the audit being written even when the await
+    # itself is cancelled.
+    await asyncio.shield(_audit("drive_download", f"{section}/{key}", "granted"))
     return web.json_response({"url": url, "expiresSecs": _DOWNLOAD_URL_SECS})
 
 
@@ -1283,16 +1321,8 @@ async def _drive_object_keys(request: web.Request, account: str) -> tuple[set[st
         # failing: the profile became unavailable or now names another account.
         # `_guarded`'s rule is that such a decision reaches SEL, and degrading
         # quietly would drop the one event an incident review asks about.
-        #
-        # OFF-LOOP. `_audit` is synchronous, and on a gateway whose SEL has not
-        # been touched yet the first call constructs the log and writes to disk
-        # -- initialization plus a write, on the event loop, from a route the
-        # console renders on every page load. The eleven older `_audit` calls in
-        # this module are on-loop; this is the one this change adds, and issue
-        # #8139 owns the rest.
-        await asyncio.to_thread(
-            _audit, "shares_list", request.path, "denied", error="account_unavailable"
-        )
+        # `_audit` routes the SEL write off the loop itself (issue #8139).
+        await _audit("shares_list", request.path, "denied", error="account_unavailable")
         return None, "no working connection for this account"
     _account, profile, region = target
     if await _consent(aws_consent.SERVICE_S3, profile, region) is not None:
@@ -1437,7 +1467,7 @@ async def _reauthorize_in_lock(
     on the way in.
     """
     if not await asyncio.to_thread(is_app_enabled, APP_NAME):
-        _audit(operation, request.path, "denied", error="app_disabled")
+        await _audit(operation, request.path, "denied", error="app_disabled")
         return _forbidden("aws-control is disabled", "app_disabled")
     recheck = await _account_target(request)
     if isinstance(recheck, web.Response):
@@ -1446,10 +1476,10 @@ async def _reauthorize_in_lock(
         # `_mutating` records their outcome, but the reconcile READ converts it
         # into a degraded 200 -- so without an audit at the point of decision the
         # denial disappears entirely on that path.
-        _audit(operation, request.path, "denied", error="account_unavailable")
+        await _audit(operation, request.path, "denied", error="account_unavailable")
         return recheck
     if recheck != (account, profile, region):
-        _audit(operation, request.path, "denied", error="account_mismatch")
+        await _audit(operation, request.path, "denied", error="account_mismatch")
         return _conflict(
             "this connection changed while the request was queued; nothing was written",
             "account_mismatch",
@@ -1462,7 +1492,7 @@ async def _reauthorize_in_lock(
     except AWSError as exc:
         return _aws_failed(exc)
     if current != bucket:
-        _audit(operation, request.path, "denied", error="drive_changed")
+        await _audit(operation, request.path, "denied", error="drive_changed")
         return _conflict(
             "this account's drive changed while the request was queued; nothing was written",
             "drive_changed",
@@ -1497,7 +1527,7 @@ async def _reconciled_remote_slugs(request: web.Request) -> tuple[set[str] | Non
         # failing: the profile became unavailable or now names another account,
         # and _guarded's own rule is that such a decision reaches SEL. Degrading
         # quietly would drop the one event an incident review asks about.
-        _audit("library_list", request.path, "denied", error="account_unavailable")
+        await _audit("library_list", request.path, "denied", error="account_unavailable")
         return None, "no working connection for this account"
     account, profile, region = target
     if await _consent(aws_consent.SERVICE_S3, profile, region) is not None:

--- a/test/test_aws_control_routes.py
+++ b/test/test_aws_control_routes.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 
 import asyncio
 import datetime as dt
+import inspect
 import json
 import logging
+import re
+import threading
 from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock
@@ -145,7 +148,60 @@ class TestHelpers:
         # The audit is best-effort: a broken SEL sink must never propagate into
         # the response path, so a raising backend is logged and swallowed.
         with mock.patch.object(routes_mod, "sel", side_effect=RuntimeError("no sel")):
-            routes_mod._audit("op", "res", "denied")  # must not raise
+            routes_mod._audit_sync("op", "res", "denied")  # must not raise
+
+    def test_audit_routes_the_sel_write_off_the_event_loop(self):
+        # The SEL write's first touch pays log construction, so the async
+        # _audit wrapper must hand the sync writer to a worker thread instead
+        # of running it inline on the loop — the regression issue #8139 locks
+        # out. Observed from inside the writer itself (which thread ran it)
+        # rather than by patching the stdlib asyncio module object, which
+        # would leak the mock to unrelated code on other threads.
+        assert asyncio.iscoroutinefunction(routes_mod._audit)
+        seen: dict[str, object] = {}
+
+        def _record(*args: object, **kwargs: object) -> None:
+            seen["thread"] = threading.current_thread()
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+
+        with mock.patch.object(routes_mod, "_audit_sync", side_effect=_record):
+            asyncio.run(routes_mod._audit("op", "res", "denied", error="why"))
+        assert seen["args"] == ("op", "res", "denied")
+        assert seen["kwargs"] == {"error": "why"}
+        # asyncio.run drives the loop on the calling thread, so a writer that
+        # ran on the loop would report this thread.
+        assert seen["thread"] is not threading.current_thread()
+
+    def test_audit_swallows_a_failing_thread_dispatch(self):
+        # The wrapper keeps the sync body's never-raises contract even when
+        # the dispatched call raises out of the worker (the real _audit_sync
+        # swallows its own errors; this pins the wrapper's guard for anything
+        # that escapes thread dispatch itself).
+        with mock.patch.object(
+            routes_mod, "_audit_sync", side_effect=RuntimeError("executor down")
+        ):
+            asyncio.run(routes_mod._audit("op", "res", "denied"))  # must not raise
+
+    def test_every_audit_call_site_awaits_the_wrapper(self):
+        # Wiring pin: with _audit patched as an AsyncMock, an UNAWAITED
+        # `_audit(...)` still lands in call_args_list, so the behavioural
+        # tests cannot detect a dropped `await` — the audit would silently
+        # stop being recorded (only a RuntimeWarning). Pin the source instead:
+        # every call site must `await` the wrapper, directly or through
+        # `asyncio.shield` (the post-side-effect sites). Same style as
+        # test_api_health.py::test_every_middleware_denial_is_audited_off_the_loop.
+        src = inspect.getsource(routes_mod)
+        sites = [m for m in re.finditer(r"_audit\(", src) if not src[: m.start()].endswith("def ")]
+        assert len(sites) >= 13, "expected the module's audit call sites to be present"
+        for m in sites:
+            before = src[: m.start()]
+            line = src[src.rfind("\n", 0, m.start()) + 1 : src.find("\n", m.end())]
+            # `await _audit(` or `await asyncio.shield(  _audit(` — black may
+            # break the shield form across lines, so allow whitespace between.
+            assert re.search(
+                r"await\s+(asyncio\.shield\(\s*)?$", before
+            ), f"_audit call site is not awaited: {line.strip()!r}"
 
     def test_body_returns_empty_dict_for_a_non_dict_json(self):
         # A JSON list is valid JSON but not a body shape the handlers accept;


### PR DESCRIPTION
## Summary

Closes #8139.

The synchronous `_audit` helper in `src/kiro_crew/apps/builtins/aws_control/backend/routes.py` (`sel().log_api_access` — first touch pays SEL construction: trust-dir creation, key load/validation, Windows DACL) was called directly from `async def` handlers at 13 sites, two of them on GET routes the console hits on every page load. Each call stalled the event loop, delaying every other session on the same gateway, including streaming chat turns.

## Change

- Renamed the sync body to `_audit_sync` (unchanged semantics, still swallows its own errors).
- Added an async `_audit` wrapper that does `await asyncio.to_thread(_audit_sync, ...)` once, inside a `try/except` that preserves the never-raises contract even when thread dispatch itself fails — the same shape `dashboard.server._audit_denied` settled for SEL. Future call sites are safe by default.
- Awaited all 13 call sites, preserving audit-before-response ordering within each denial/outcome branch. One pre-existing site that hand-rolled `asyncio.to_thread(_audit, ...)` now uses the wrapper.
- The three audits that record an event AFTER an external side effect (the `_mutating` error and success/refused outcomes, the drive-download presign grant) are wrapped in `asyncio.shield`, so a client disconnect cannot cancel the record between the side effect and its audit — previously impossible because the sync audit had no suspension point. Denial paths have no side effect to orphan and stay unshielded.

## Tests

- `test_audit_routes_the_sel_write_off_the_event_loop` — asserts the writer runs on a worker thread, observed from inside the (patched) writer rather than by patching the stdlib `asyncio` module object.
- `test_audit_swallows_a_failing_thread_dispatch` — pins the wrapper's never-raises guard.
- `test_every_audit_call_site_awaits_the_wrapper` — source-level wiring pin: every `_audit(` occurrence outside its own `def` must be `await`ed (directly or via `asyncio.shield`), because an AsyncMock-patched, unawaited call still lands in `call_args_list` and behavioural tests cannot catch a dropped `await`. Same style as `test_api_health.py::test_every_middleware_denial_is_audited_off_the_loop`.
- `test_audit_swallows_a_failing_sel_backend` updated to target `_audit_sync`.
- Existing `mock.patch.object(routes_mod, "_audit")` seams keep working: `unittest.mock` auto-selects `AsyncMock` for async targets.

## Verification

- Local gates green: isort, flake8, mypy (1281 files), diff-scoped black gate, brand gate. Test suites run in CI per operator policy for this host.
- Pre-push review: GPT lane (gpt-5.6-sol) PASS with no findings; Opus lane (claude-opus-5) PASS with 2 Medium + 2 Low advisory findings, all addressed in this commit (the `asyncio.shield` on post-side-effect audits, the wiring-pin test, removal of a global `asyncio.to_thread` patch in tests, corrected docstring claims about where the blocking cost lives).

## Pattern harvest

Rule candidate: lint/semgrep — a known-blocking audit/SEL helper (sync `sel().log_api_access` wrapper) called directly inside an `async def` without `asyncio.to_thread`. The same class was already fixed piecemeal in md_notebook `server.py`, spec_builder `repository.py`, `cli_chat.py`, and several dashboard handlers; this PR adds a module-local source wiring pin (`test_every_audit_call_site_awaits_the_wrapper`), and the repo-wide version of that pin is what a rule would generalize.

no linked issue: n/a — linked above (Closes #8139).

🤖 Kiro Crew Auto-Pipeline

