### PR TITLE
refactor(mcp-gateway): drop the unread settings overlay (#8111)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -842,7 +842,6 @@ test/test_mcp_gateway_image_budget.py
 test/test_mcp_gateway_oversize.py
 test/test_mcp_gateway_pool_integ.py
 test/test_mcp_gateway_recaller.py
-test/test_mcp_gateway_rewriter_fingerprint.py
 test/test_mcp_gateway_session_inject.py
 test/test_mcp_gateway_shutdown_and_env.py
 test/test_mcp_gateway_stub_admission_fallback.py

--- a/docs/architecture/design-notes/mcp-stub-decoupling.md
+++ b/docs/architecture/design-notes/mcp-stub-decoupling.md
@@ -65,12 +65,14 @@ Two paths emit stubs, and both are now unconditional for stdio servers:
 
 - **Agent-declared servers** in `~/.kiro/agents/*.json`, wrapped in that agent's
   overlay.
-- **Global `settings/mcp.json` servers**, relocated into each agent's overlay so
-  the stub carries the right agent identity, and dropped from the settings
-  overlay in the same pass. That relocation is what keeps a server from being
-  wrapped twice under two identities; it previously applied only to poolable
-  servers, leaving everything else to merge raw with no stub and therefore no
-  callback address.
+- **Global `settings/mcp.json` servers**, injected into each agent's overlay so
+  the stub carries the right agent identity. The injected stub takes precedence
+  over the raw same-named global entry at ACP `session/new`
+  (`session_servers.py`), which is what keeps a server from being wrapped twice
+  under two identities; no settings overlay is written and the real settings
+  file is never modified (#8111). The injection previously applied only to
+  poolable servers, leaving everything else to merge raw with no stub and
+  therefore no callback address.
 
 ## The acquisition path
 
@@ -145,7 +147,8 @@ unrelated session.
 - `UNPOOLABLE_SERVERS` — Kiro Crew's own MCP servers, which bind to
   `KIROCREW_SESSION_KEY` and are passed through unwrapped. They are already
   per-session by construction; giving them stubs is a separate change.
-- HTTP/SSE MCP entries. They need no stub and stay raw in the settings overlay.
+- HTTP/SSE MCP entries. They need no stub and merge raw from the real settings
+  file.
 - Per-server MCP Apps control. Orthogonal to stub emission.
 
 ## Superseded: the stub is opt-in per server, not unconditional

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -2534,7 +2534,6 @@ class AcpClient:
         acp_backend: str = "",
         audit_source: str | None = None,
         mcp_gateway_overlay: str | Path | None = None,
-        mcp_gateway_settings_mcp_json: str | Path | None = None,
         mcp_gateway_socket: str | Path | None = None,
         permission_mode: str | None = None,
     ):
@@ -2595,9 +2594,6 @@ class AcpClient:
         # the same-named entries in the agent spec. Nothing is written to the
         # user's project or to ~/.kiro/agents. None = pooling off.
         self._mcp_gateway_overlay = str(mcp_gateway_overlay) if mcp_gateway_overlay else None
-        self._mcp_gateway_settings_mcp_json = (
-            str(mcp_gateway_settings_mcp_json) if mcp_gateway_settings_mcp_json else None
-        )
         self._mcp_gateway_socket = str(mcp_gateway_socket) if mcp_gateway_socket else None
         self._sandbox_cleanup: str | None = None
         self._bound_workspace_fd: int | None = None

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -694,7 +694,6 @@ class AcpRuntime:
         sandbox_mode: str = "auto",
         extra_env: dict[str, str] | None = None,
         mcp_gateway_overlay: str | Path | None = None,
-        mcp_gateway_settings_mcp_json: str | Path | None = None,
         mcp_gateway_socket: str | Path | None = None,
         max_age_secs: float = _DEFAULT_MAX_AGE_SECS,
         max_rss_mb: float = _DEFAULT_MAX_RSS_MB,
@@ -729,9 +728,6 @@ class AcpRuntime:
         self._sandbox_mode = sandbox_mode
         self._extra_env = extra_env or {}
         self._mcp_gateway_overlay = str(mcp_gateway_overlay) if mcp_gateway_overlay else None
-        self._mcp_gateway_settings_mcp_json = (
-            str(mcp_gateway_settings_mcp_json) if mcp_gateway_settings_mcp_json else None
-        )
         self._mcp_gateway_socket = str(mcp_gateway_socket) if mcp_gateway_socket else None
         # Whether sessions on this runtime should hold drain_init() open for
         # slow MCP servers (the no-report ceiling). A runtime whose agent is

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -4022,11 +4022,9 @@ class KiroCrewConfig:
         if _gw.stub_servers:
             _gw_overlay = _gw.overlay_dir or str(default_overlay_dir())
             _gw_socket = _gw.socket_path or str(default_socket_path())
-            _gw_settings = str(Path(_gw_overlay).parent / "settings" / "mcp.json")
         else:
             _gw_overlay = None
             _gw_socket = None
-            _gw_settings = None
 
         # Effort-drop warnings already emitted by this factory, keyed by
         # (resolved model, level) — see the gate below. Benign under threads:
@@ -4153,7 +4151,6 @@ class KiroCrewConfig:
                 tool_search_min_pct=tool_search_min_pct,
                 tool_search_min_tokens=tool_search_min_tokens,
                 mcp_gateway_overlay=_gw_overlay,
-                mcp_gateway_settings_mcp_json=_gw_settings,
                 mcp_gateway_socket=_gw_socket,
             )
 

--- a/src/kiro_crew/mcp_gateway/rewriter.py
+++ b/src/kiro_crew/mcp_gateway/rewriter.py
@@ -61,6 +61,13 @@ _FINGERPRINT_NAME = ".rewrite-fingerprint"
 # of serving overlays produced by older logic. The package version is also in
 # the fingerprint, so a release bump invalidates regardless; this constant is
 # the explicit knob for in-development changes.
+# Deliberately NOT bumped for the #8111 settings-overlay removal: the per-agent
+# overlay bytes are unchanged, the leftover overlay file is retained and
+# ignored (never consumed), and a stored ``settings_overlay`` output signature
+# is not rejected — it keeps vouching for the leftover's ACL relock — so a
+# pre-change fingerprint still validates correctly, and bumping would
+# gratuitously defeat the #5344 transient-keep gate (which compares stored vs
+# current inputs) on the first upgraded boot.
 _FINGERPRINT_SCHEMA = 3
 
 
@@ -787,11 +794,15 @@ def _rewrite_single_spec(
         if not resolved_cmd:
             # Membership in ``inject`` was vetted by
             # _injectable_settings_servers (same resolver, same pass), so this
-            # only fires on a filesystem race between the two probes. The
-            # entry was already DROPPED from the settings overlay on the
-            # strength of that vetting — injecting it RAW (unwrapped) keeps
-            # the server's tools alive for the session; skipping would make
-            # it vanish entirely.
+            # only fires on a filesystem race between the two probes. What
+            # matters is NOT publishing a wrapped stub whose pooled spawn is a
+            # guaranteed ENOENT. The RAW (unwrapped) copy written instead is
+            # inert at ``session/new`` — only marker-carrying stub entries are
+            # lifted (see ``session_servers.pooled_session_servers``) — so the
+            # session's access to this server comes from kiro-cli's own merge
+            # of the real settings file, exactly as if the server had never
+            # been vetted; the raw copy only keeps the overlay mirroring the
+            # injection set this pass decided on.
             logger.warning(
                 "rewriter: settings server %r became unresolvable between "
                 "vetting and injection; injecting it unwrapped into agent %r",
@@ -834,28 +845,25 @@ def _injectable_settings_servers(
     notes: _RewritePassNotes | None = None,
 ) -> dict[str, Any]:
     """Return ``{raw_name: raw_entry}`` of stdio servers in the global
-    ``settings/mcp.json`` that must be RELOCATED out of the settings overlay
-    into a per-agent one.
+    ``settings/mcp.json`` that must be INJECTED into every per-agent overlay.
 
-    The returned set does double duty: every name in it is injected per-agent
-    AND dropped from the settings overlay. Those two must be the SAME set — a
-    server dropped from settings but not injected anywhere simply disappears,
-    taking its MCP tools with it, which is strictly worse than either stubbing
-    it or leaving it alone. So the stub opt-in is applied HERE, once, rather
-    than at the injection loop, where filtering would silently desync the two.
+    Each returned server is wrapped with the receiving agent's own name, so the
+    stub carries a correct ``--agent`` identity, and injected at ACP
+    ``session/new`` — where a session-injected server takes precedence over the
+    raw same-named entry kiro-cli merges from the real settings file (see
+    ``session_servers.py``). That precedence is what prevents the duplicate /
+    empty-``--agent`` collision; the settings file itself is never modified and
+    no settings overlay is written.
 
-    These are exactly the servers that, if wrapped in BOTH the settings
-    overlay and a per-agent overlay, collide on name inside kiro-cli (two
-    same-named stubs — one with the correct ``--agent``, one with an empty
-    ``--agent`` because settings has no ``name``). By relocating them into
-    each agent's own overlay (with the right identity) and dropping them from
-    the settings overlay, the duplicate disappears. HTTP/SSE settings servers
-    are NOT returned — they need no stub and stay raw in the settings overlay,
-    merging globally.
+    Servers NOT returned are left entirely to kiro-cli's own settings merge:
+    HTTP/SSE servers need no stub, and an unstubbed, unresolvable, or
+    env-withholding server keeps its pre-pooling behaviour (launched
+    per-session with its own environment) rather than being pooled into a
+    stub whose spawn would fail or run credential-less.
 
-    Keys are the RAW settings names, because the caller filters ``src_servers``
-    (raw-keyed) with this set. Stub membership is tested under both the raw name
-    and the slash-free alias, since the config may carry either spelling.
+    Keys are the RAW settings names. Stub membership is tested under both the
+    raw name and the slash-free alias, since the config may carry either
+    spelling.
     """
     servers = settings_spec.get("mcpServers") or {}
     out: dict[str, Any] = {}
@@ -875,24 +883,25 @@ def _injectable_settings_servers(
             # Source settings should be raw; ignore an already-wrapped entry.
             continue
         if "command" not in entry:
-            # HTTP/SSE — shareable, no stub needed; leave in settings overlay.
+            # HTTP/SSE — no stub needed; kiro-cli merges it from the real
+            # settings file.
             continue
         if not (name in stub_servers or mcp_server_alias(name) in stub_servers):
-            # Not stubbed: leave it RAW in the settings overlay so the session
-            # launches it directly. Relocating it here would delete it from the
-            # only overlay that still lists it.
+            # Not stubbed: leave it to kiro-cli's own merge of the real
+            # settings file, so the session launches it directly.
             continue
         entry_env = _normalized_env(entry, context=f"settings server {name!r}")
         if not _resolve_target_command(str(entry.get("command", "")), entry_env, notes):
             # Issue #3495 cause A, settings edition: an unresolvable bare
-            # command must not be relocated into a stub whose pooled spawn is
-            # a guaranteed ENOENT. Leaving it raw in the settings overlay
-            # preserves the pre-pooling behaviour (kiro-cli merges and
-            # launches it with its own environment).
+            # command must not be pooled into a stub whose spawn is a
+            # guaranteed ENOENT. Leaving it out of the injection set
+            # preserves the pre-pooling behaviour (kiro-cli merges the real
+            # settings file and launches it with its own environment).
             logger.warning(
                 "rewriter: cannot resolve MCP command %r for opted-in "
                 "settings server %r on the gateway search path; leaving it "
-                "raw in the settings overlay. Use an absolute path to pool it.",
+                "to kiro-cli's own settings merge. Use an absolute path to "
+                "pool it.",
                 entry.get("command", ""), name,
             )
             continue
@@ -910,7 +919,7 @@ def _injectable_settings_servers(
             logger.warning(
                 "rewriter: opted-in settings server %r declares env "
                 "(%d keys) of which some would be withheld from a shared "
-                "backend (%s); leaving it raw in the settings overlay.",
+                "backend (%s); leaving it to kiro-cli's own settings merge.",
                 name, len(entry_env),
                 "mcp_gateway.forward_declared_env is off — enable it to pool"
                 if not forward_env
@@ -989,7 +998,6 @@ def _overlay_inputs_unchanged(
 def _kept_artifacts_vouched(
     stored: dict[str, Any] | None,
     *,
-    overlay_dir: Path,
     env_dir: Path,
 ) -> bool:
     """Validate and re-protect the SHARED artifacts a keep would serve.
@@ -1044,26 +1052,6 @@ def _kept_artifacts_vouched(
                 os.chmod(env_dir, 0o700)
         for name in sidecar_sigs:
             platform_compat.restrict_to_owner(env_dir / name)
-        # The settings overlay is KEPT on this pass (#5328), and it carries the
-        # passed-through env of every non-poolable / HTTP-SSE global server, so a
-        # loosened ACL on it would otherwise persist for the gateway's lifetime.
-        # Only the protection is re-asserted, not the content: its recorded
-        # signature is deliberately NOT compared, because no available action
-        # would improve on a mismatch -- this pass cannot rewrite it (the source
-        # is unreadable), must not delete it (#5328: that strips every global
-        # server), and refusing the agent keeps would not repair it while making
-        # the injection loss worse. Guarded on existence rather than treated as a
-        # refusal: an absent settings overlay has no ACL to repair and is not
-        # something this pass is serving.
-        settings_overlay_file = overlay_dir.parent / "settings" / "mcp.json"
-        if outputs.get("settings_overlay") is not None and (
-            settings_overlay_file.is_file()
-        ):
-            platform_compat.make_owner_only_dir(settings_overlay_file.parent)
-            if platform_compat.IS_POSIX:
-                # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- 0o700 is OWNER-ONLY, the tightest traversable mode for a directory holding a credential-bearing overlay; the rule's suggested 0o644 would grant world-read and drop the execute bit a directory needs. Raw os.chmod because this path must FAIL LOUD into the full rewrite, matching _cached_rewrite_result.  # noqa: E501
-                os.chmod(settings_overlay_file.parent, 0o700)
-            platform_compat.restrict_to_owner(settings_overlay_file)
     except OSError:
         return False
     # Same comparison the cached path makes, for the same reason.
@@ -1243,9 +1231,6 @@ def _load_fingerprint(path: Path) -> dict[str, Any] | None:
             return None
         if not _valid_sig(sig):
             return None
-    settings_sig = outputs.get("settings_overlay")
-    if settings_sig is not None and not _valid_sig(settings_sig):
-        return None
     if not all(
         isinstance(k, str) and _WHICH_KEY_SEP in k and isinstance(v, str)
         for k, v in which.items()
@@ -1274,33 +1259,18 @@ def _cached_rewrite_result(
     rewrite instead of serving a dead absolute path forever.
 
     On success the prune passes still run (stat-only), so a stray file in the
-    overlay tree is removed exactly as on the full path — including a
-    leftover settings overlay whose source is gone.
+    overlay tree is removed exactly as on the full path.
     """
     outputs = stored["outputs"]
     overlay_sigs: dict[str, Any] = outputs["overlays"]
     sidecar_sigs: dict[str, Any] = outputs["sidecars"]
     env_dir = env_sidecar_dir_for_stubs(stubs_dir)
-    settings_overlay_file = overlay_dir.parent / "settings" / "mcp.json"
     try:
         for name, sig in overlay_sigs.items():
             if _stat_sig(overlay_dir / name) != sig:
                 return None
         for name, sig in sidecar_sigs.items():
             if _stat_sig(env_dir / name) != sig:
-                return None
-        settings_sig = outputs.get("settings_overlay")
-        if settings_sig is not None:
-            if _stat_sig(settings_overlay_file) != settings_sig:
-                return None
-        elif settings_overlay_file.is_file():
-            # The previous run produced no settings overlay, yet one exists —
-            # e.g. its deletion failed transiently on the full path (Windows
-            # sharing violation). Removed global MCP servers must not stay
-            # active: retry the deletion, and refuse the cache if it survives.
-            try:
-                settings_overlay_file.unlink()
-            except OSError:
                 return None
     except OSError:
         return None
@@ -1340,12 +1310,6 @@ def _cached_rewrite_result(
             *(env_dir / n for n in sidecar_sigs),
             overlay_dir / _FINGERPRINT_NAME,
         ]
-        if settings_sig is not None:
-            platform_compat.make_owner_only_dir(settings_overlay_file.parent)
-            if platform_compat.IS_POSIX:
-                # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- same as the env_dir site above: 0o700 is owner-only and fail-loud is required.  # noqa: E501
-                os.chmod(settings_overlay_file.parent, 0o700)
-            protected.append(settings_overlay_file)
         for artifact in protected:
             platform_compat.restrict_to_owner(artifact)
     except OSError:
@@ -1469,6 +1433,51 @@ def _store_fingerprint(
         )
 
 
+def _relock_legacy_settings_overlay(
+    overlay_dir: Path, stored: dict[str, Any] | None
+) -> None:
+    """Re-assert owner-only protection on the leftover pre-#8111 settings
+    overlay — the ONE guard the removal keeps for that file.
+
+    The pass no longer writes, reads, or deletes the leftover, but the old
+    code re-tightened its ACL on every boot (a chmod / DACL edit changes no
+    content signature), and the file carries the passed-through env (tokens /
+    API keys) of non-poolable global servers. Dropping that repair would let
+    a once-loosened ACL stay loosened forever.
+
+    Provenance-gated exactly like the old lockdown: only a file whose live
+    ``_stat_sig`` matches the fingerprint's recorded ``settings_overlay``
+    signature is touched — tightening, never deleting, and never a file the
+    recorded signature cannot vouch for.
+
+    Best-effort rather than fail-loud: the old cache path fell through to the
+    full rewrite on failure because the full rewrite RE-CREATED the file
+    through protect-before-content writers. There is no writer any more, so
+    refusing the cache would force full rewrites forever without repairing
+    anything; log and retry next pass instead.
+    """
+    if stored is None:
+        return
+    outputs = stored.get("outputs")
+    sig = outputs.get("settings_overlay") if isinstance(outputs, dict) else None
+    if sig is None:
+        return
+    legacy = overlay_dir.parent / "settings" / "mcp.json"
+    try:
+        if _stat_sig(legacy) != sig:
+            return
+        platform_compat.make_owner_only_dir(legacy.parent)
+        if platform_compat.IS_POSIX:
+            # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions -- 0o700 is OWNER-ONLY, the tightest traversable mode for a directory holding a credential-bearing file; the rule's suggested 0o644 would grant world-read and drop the execute bit a directory needs.  # noqa: E501
+            os.chmod(legacy.parent, 0o700)
+        platform_compat.restrict_to_owner(legacy)
+    except OSError:
+        logger.debug(
+            "could not re-lock the legacy settings overlay; retrying next pass",
+            exc_info=True,
+        )
+
+
 def rewrite_agents(
     *,
     source_dir: Path,
@@ -1526,6 +1535,24 @@ def rewrite_agents(
           to spawn for a new pool key.
     """
     stub_set = stub_servers or frozenset()
+
+    # A pre-#8111 release wrote a settings overlay to
+    # ``<overlay_dir>/../settings/mcp.json``; this pass no longer writes,
+    # reads, or DELETES it. Deliberately not swept: the leftover was always
+    # written owner-only via ``atomic_write(..., restrict_to_owner=True)``
+    # into a 0o700 directory (issue #5285), its content is a subset copy of
+    # the user's real ``~/.kiro/settings/mcp.json`` (same secrets, same disk,
+    # same protection), and nothing reads it — so it is inert, not exposed.
+    # An automated deleter, by contrast, is an attack surface: it must prove
+    # the path is not the real settings file, not someone else's file under a
+    # custom ``overlay_dir``, and not a symlink-redirected parent, and carry
+    # deletion provenance across fingerprint rewrites. Leaving the file alone
+    # has none of those failure modes; a user who wants it gone deletes it
+    # once by hand. ONE guard is kept — the per-boot owner-only ACL relock
+    # (see ``_relock_legacy_settings_overlay``, called below once the stored
+    # fingerprint is loaded), because a loosened ACL is the one way the
+    # leftover could stop being inert.
+
     if not source_dir.is_dir():
         logger.warning("agent source dir missing: %s", source_dir)
         return {}, {}
@@ -1575,6 +1602,10 @@ def rewrite_agents(
         identity_keys=identity_keys,
     )
     stored = _load_fingerprint(fingerprint_path)
+    # One call covers both paths below (cache hit returns early; the full
+    # rewrite continues): re-tighten the leftover pre-#8111 settings overlay's
+    # ACL when the stored fingerprint vouches for it.
+    _relock_legacy_settings_overlay(overlay_dir, stored)
     if stored is not None and stored.get("inputs") == current_inputs:
         cached = _cached_rewrite_result(
             stored, overlay_dir=overlay_dir, stubs_dir=stubs_dir
@@ -1594,30 +1625,21 @@ def rewrite_agents(
     # bypasses the gateway unless wrapped (the "kirocrew-lite bypass" class of
     # bug: agents with empty mcpServers inherit the global's unwrapped entries).
     #
-    # Wrapping the poolable servers in the settings overlay too does NOT work
-    # — settings/mcp.json has no "name", so those stubs get an
-    # empty ``--agent`` AND collide (same name) with the correctly-wrapped
-    # per-agent copy, double-spawning inside kiro-cli (server_init_failure).
-    #
-    # The fix is two-sided: INJECT each poolable settings server into
-    # every agent's own overlay (wrapped with that agent's name), and DROP it
-    # from the settings overlay. Empty-mcpServers agents then get pooled
-    # coverage with the right identity, and no name ever appears wrapped in
-    # both overlays. Non-poolable / HTTP settings servers stay raw in settings.
-    settings_src_spec: dict[str, Any] | None = None
+    # The fix is per-agent injection: each poolable settings server is added to
+    # every agent's own overlay, wrapped with THAT agent's name, and the stub is
+    # injected at ACP ``session/new``, where it takes precedence over the raw
+    # same-named global entry kiro-cli merges (see ``session_servers.py``).
+    # Empty-``mcpServers`` agents get pooled coverage with the right identity,
+    # and the duplicate / empty-``--agent`` collision never arises. The real
+    # settings file is never modified, and no settings overlay is written:
+    # non-poolable and HTTP/SSE servers keep merging from the real file exactly
+    # as before pooling existed.
     settings_poolable: dict[str, Any] = {}
     settings_read_transient = False
-    # ``True`` only when this pass ESTABLISHED that there is nothing usable to
-    # relocate: confirmed absent, present but not a regular file, or bad content.
-    # Deliberately NOT the same as "we ended up with no spec", which a transient
-    # fault also produces. It is what licenses pruning the previous settings
-    # overlay, and it is read once, below, instead of being re-derived there.
-    settings_prunable = False
     if kiro_settings_json.is_file():
         try:
             loaded = json.loads(kiro_settings_json.read_text())
             if isinstance(loaded, dict):
-                settings_src_spec = loaded
                 settings_poolable = _injectable_settings_servers(
                     loaded, stub_set,
                     pooling_enabled=pooling_enabled,
@@ -1625,20 +1647,17 @@ def rewrite_agents(
                     identity_keys=identity_keys,
                     notes=notes,
                 )
-            else:
-                # Valid JSON, wrong shape: deterministic, and fixing it changes
-                # the stat signature, so this classification is safe to cache.
-                settings_prunable = True
+            # Valid JSON but not a dict: deterministic bad content, cacheable
+            # (fixing it changes the stat signature); nothing to inject.
         except OSError as exc:
             # Transient read failure: same reasoning as the per-agent site —
             # do not cache a pass that treated an existing settings file as
-            # absent, and keep the previous settings overlay (#5328).
+            # absent, and keep the previous per-agent overlays (#5328/#5344).
             notes.source_read_failed = True
             settings_read_transient = True
             logger.warning("failed to read global mcp.json: %s", exc)
         except json.JSONDecodeError as exc:
             # Content problem — cacheable; a fix changes the stat signature.
-            settings_prunable = True
             logger.warning("failed to read global mcp.json: %s", exc)
     else:
         # ``is_file()`` answers False for a missing file AND for a stat fault
@@ -1653,24 +1672,21 @@ def rewrite_agents(
         # empty injection set, which is #5344 through the stat path rather than
         # the read path.
         #
-        # So classify explicitly, and do it HERE rather than beside the prune:
-        # ONE classification then serves both the injection decision below and
-        # the prune, instead of the prune's answer arriving after the agent loop
-        # has already acted on a different one. Only ``FileNotFoundError`` may
-        # mean absent; every other OSError means unknown.
+        # So classify explicitly: only ``FileNotFoundError`` may mean absent
+        # (deterministic, cacheable, nothing to inject); every other OSError
+        # means unknown, which must stay uncacheable and keep the previous
+        # per-agent overlays.
         try:
             kiro_settings_json.stat()
         except FileNotFoundError:
-            settings_prunable = True  # confirmed absent: deleted between runs
+            pass  # confirmed absent: nothing to inject, cacheable
         except OSError as exc:
             notes.source_read_failed = True  # unknown: keep and retry
             settings_read_transient = True
             logger.warning("failed to stat global mcp.json: %s", exc)
-        else:
-            # Stats fine but is not a regular file (e.g. a directory in its
-            # place): a permanent misconfiguration, deterministic like bad
-            # content, not a transient fault to retry forever.
-            settings_prunable = True
+        # A path that stats fine but is not a regular file (e.g. a directory
+        # in its place) is a permanent misconfiguration, deterministic like
+        # bad content: cacheable, nothing to inject.
 
     # Names of agents whose overlay could not be refreshed THIS PASS for a
     # TRANSIENT reason (source read failure, overlay write failure). The prune
@@ -1729,7 +1745,7 @@ def rewrite_agents(
     # keep is allowed at all and every agent goes through the
     # protect-before-content writers instead.
     if injection_unknown and not _kept_artifacts_vouched(
-        stored, overlay_dir=overlay_dir, env_dir=env_sidecar_dir_for_stubs(stubs_dir)
+        stored, env_dir=env_sidecar_dir_for_stubs(stubs_dir)
     ):
         injection_unknown = False
         logger.warning(
@@ -1815,17 +1831,19 @@ def rewrite_agents(
         target = overlay_dir / path.name
         try:
             # Atomic + owner-only: temp-file + os.replace (via atomic_write) so a
-            # live session reading this overlay through the bind-mount never
-            # sees a truncated spec (which would make the agent's MCP servers
-            # vanish mid-run). ``restrict_to_owner=True`` locks the temp file
-            # down BEFORE the passed-through non-poolable / HTTP-SSE env blocks
-            # (tokens / API keys) reach it — POSIX mode bits are a no-op against
-            # NTFS ACLs, and the previous Windows-only post-rename lockdown left
-            # them readable under the inherited DACL for the write window
-            # (issue #5285). It implies 0o600 on POSIX. A lockdown failure now
-            # happens before the rename, so the OSError handler below skips the
-            # overlay without ever publishing an unprotected copy. Matches the
-            # env sidecar and settings overlay.
+            # concurrent reader — the per-session stub injection resolves this
+            # overlay at ACP ``session/new`` (see ``session_servers.py``; there
+            # is no bind mount), and the cache-validation pass digests it —
+            # never sees a truncated spec (which would make the agent's MCP
+            # servers vanish mid-run). ``restrict_to_owner=True`` locks the temp
+            # file down BEFORE the passed-through non-poolable / HTTP-SSE env
+            # blocks (tokens / API keys) reach it — POSIX mode bits are a no-op
+            # against NTFS ACLs, and the previous Windows-only post-rename
+            # lockdown left them readable under the inherited DACL for the write
+            # window (issue #5285). It implies 0o600 on POSIX. A lockdown
+            # failure now happens before the rename, so the OSError handler
+            # below skips the overlay without ever publishing an unprotected
+            # copy. Matches the env sidecar.
             atomic_write(target, json.dumps(new_spec, indent=2) + "\n", restrict_to_owner=True)
         except OSError as exc:
             logger.warning(
@@ -1901,77 +1919,6 @@ def rewrite_agents(
 
     total_wrapped = sum(results.values())
 
-    # Write the settings overlay with the poolable servers REMOVED — they were
-    # injected per-agent above (with correct identities). Non-poolable and
-    # HTTP/SSE servers stay raw here and continue to merge into every agent at
-    # runtime, exactly as before pooling existed. This guarantees no server
-    # name is ever wrapped in both a per-agent overlay and the settings
-    # overlay, eliminating the duplicate-stub / empty-``--agent`` collision.
-    settings_overlay_path = None
-    settings_overlay_dir = overlay_dir.parent / "settings"
-    settings_overlay_file = settings_overlay_dir / "mcp.json"
-    if settings_src_spec is not None:
-        platform_compat.make_owner_only_dir(settings_overlay_dir)
-        settings_overlay_path = settings_overlay_file
-        try:
-            src_servers = settings_src_spec.get("mcpServers")
-            new_settings = dict(settings_src_spec)
-            if isinstance(src_servers, dict):
-                # Drop poolable servers (relocated per-agent) and strip internal
-                # rewriter markers from the passed-through entries so a polluted
-                # or stale source can't leak ``_mc_mcp_gateway_wrapped`` /
-                # ``poolable`` into the overlay (harmless today since kiro-cli
-                # tolerates unknown fields, but a future strict parser would trip).
-                new_settings["mcpServers"] = {
-                    name: (
-                        {k: v for k, v in entry.items()
-                         if k not in (_WRAPPER_MARKER, "poolable")}
-                        if isinstance(entry, dict) else entry
-                    )
-                    for name, entry in src_servers.items()
-                    if name not in settings_poolable
-                }
-            else:
-                # Malformed source (mcpServers not a dict): normalize rather
-                # than propagate the broken shape into a freshly-written overlay.
-                new_settings["mcpServers"] = {}
-            # Atomic + owner-only: temp-file + os.replace (via atomic_write) so a
-            # live session reading this overlay through the bind-mount never
-            # sees a truncated mcp.json (which would make its MCP servers
-            # vanish mid-run). ``restrict_to_owner=True`` locks the temp file
-            # down BEFORE the passed-through non-poolable / HTTP-SSE env blocks
-            # (tokens / API keys) reach it — the previous Windows-only
-            # post-rename lockdown left them readable under the inherited DACL
-            # for the write window (issue #5285). It implies 0o600 on POSIX.
-            # Matches the env sidecar and per-agent overlay.
-            atomic_write(
-                settings_overlay_path,
-                json.dumps(new_settings, indent=2) + "\n",
-                restrict_to_owner=True,
-            )
-            logger.info(
-                "mcp-gateway rewriter: global mcp.json overlay written, "
-                "%d poolable server(s) relocated to per-agent overlays (overlay=%s)",
-                len(settings_poolable), settings_overlay_path,
-            )
-        except OSError as exc:
-            logger.warning("failed to write global mcp.json overlay: %s", exc)
-            settings_overlay_path = None
-            overlay_write_failed = True
-    else:
-        # ``settings_src_spec`` is None: the source is absent, was unreadable or
-        # unstatable this pass, or carried bad content. Only CONFIRMED absence
-        # and deterministic bad content prune the previous overlay (matching the
-        # per-agent rule and the cached path's keying); a transient read or a
-        # swallowed stat fault keeps it (#5328). That classification was made
-        # once at the read site above -- re-deriving it here is what let the
-        # agent loop act on a different answer than the prune (#5344).
-        if settings_prunable and settings_overlay_file.is_file():
-            try:
-                settings_overlay_file.unlink()
-            except OSError:
-                pass
-
     logger.info(
         "mcp-gateway rewriter: %d agent file(s), %d MCP server(s) wrapped total, "
         "%d target env var(s) (overlay=%s)",
@@ -2002,36 +1949,63 @@ def rewrite_agents(
         # (a rotated credential silently kept flowing the old value). Re-resolve
         # on every boot instead; specs with no placeholder still cache normally.
         uncacheable = "declared env contains ${VAR} placeholder(s)"
+    # While the leftover pre-#8111 settings overlay survives, the provenance
+    # that licenses its per-boot ACL relock lives ONLY in the stored
+    # fingerprint's ``settings_overlay`` signature. Both fingerprint-
+    # replacement paths below carry that signature forward while the file
+    # exists — dropping it would silently end the relock guard for the rest of
+    # the install's life. Never re-derived from the live file: a file edited
+    # since the pre-change release recorded it loses its vouching exactly as
+    # it should.
+    legacy_sig = None
+    _stored_outputs = (stored or {}).get("outputs")
+    if isinstance(_stored_outputs, dict):
+        legacy_sig = _stored_outputs.get("settings_overlay")
+    if legacy_sig is not None:
+        try:
+            if not (overlay_dir.parent / "settings" / "mcp.json").is_file():
+                legacy_sig = None  # file gone: nothing left to vouch for
+        except OSError:
+            pass  # unknown: keep the signature, losing it is the worse error
+
     if uncacheable:
         logger.debug("rewriter: %s; not caching this rewrite", uncacheable)
         # Remove any fingerprint from an earlier successful run: it could
         # still match the current inputs (this rewrite may have been forced by
         # a missing output, not an input change) and would freeze the
         # degraded state instead of retrying.
-        with contextlib.suppress(OSError):
-            fingerprint_path.unlink(missing_ok=True)
+        if legacy_sig is not None:
+            # Replace rather than unlink: empty ``inputs`` can never match a
+            # real pass (so no degraded state is served from cache), while the
+            # relock provenance survives for the next pass.
+            _store_fingerprint(
+                fingerprint_path,
+                inputs={},
+                outputs={
+                    "overlays": {},
+                    "sidecars": {},
+                    "settings_overlay": legacy_sig,
+                },
+                which={},
+            )
+        else:
+            with contextlib.suppress(OSError):
+                fingerprint_path.unlink(missing_ok=True)
     else:
         output_sigs: dict[str, Any] = {
             "overlays": {n: _stat_sig(overlay_dir / n) for n in sorted(written)},
             "sidecars": {
                 n: _stat_sig(env_dir / n) for n in sorted(written_sidecars)
             },
-            "settings_overlay": (
-                _stat_sig(settings_overlay_path)
-                if settings_overlay_path is not None
-                else None
-            ),
         }
+        if legacy_sig is not None:
+            output_sigs["settings_overlay"] = legacy_sig
         # A None signature means an output vanished between write and stat —
         # storing it would produce a fingerprint the loader rejects anyway;
         # skip storing so the next boot simply rewrites.
         if (
             all(output_sigs["overlays"].values())
             and all(output_sigs["sidecars"].values())
-            and (
-                settings_overlay_path is None
-                or output_sigs["settings_overlay"] is not None
-            )
         ):
             _store_fingerprint(
                 fingerprint_path,
@@ -2040,11 +2014,6 @@ def rewrite_agents(
                 which=notes.which_results,
             )
 
-    # NOTE: the settings overlay path (when present) is bind-mounted by
-    # ``sandbox.py`` via a fixed location derived from the overlay dir —
-    # callers do not need to thread it back through ``results``. Keeping
-    # ``results`` as a pure ``dict[str, int]`` matches the declared return
-    # type and avoids smuggling heterogeneous values through a sentinel key.
     return results, target_env
 
 

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -304,7 +304,6 @@ class AcpProvider(LLMProvider):
         tool_search_min_pct: object = None,
         tool_search_min_tokens: object = None,
         mcp_gateway_overlay: str | Path | None = None,
-        mcp_gateway_settings_mcp_json: str | Path | None = None,
         mcp_gateway_socket: str | Path | None = None,
         permission_mode: str | None = None,
         crew_agent: str | None = None,
@@ -326,7 +325,6 @@ class AcpProvider(LLMProvider):
             "extra_env": extra_env,
             "acp_backend": acp_backend,
             "mcp_gateway_overlay": mcp_gateway_overlay,
-            "mcp_gateway_settings_mcp_json": mcp_gateway_settings_mcp_json,
             "mcp_gateway_socket": mcp_gateway_socket,
             # Claude permission mode (Auto-mode/permission-UI parity). None on the
             # kiro-cli path — fully inert; a companion-registered backend threads
@@ -792,9 +790,6 @@ class AcpProvider(LLMProvider):
         sandbox_mode = getattr(self._client, "_sandbox_mode", "auto")
         extra_env = getattr(self._client, "_extra_env", None) or {}
         mcp_gateway_overlay = getattr(self._client, "_mcp_gateway_overlay", None)
-        mcp_gateway_settings_mcp_json = getattr(
-            self._client, "_mcp_gateway_settings_mcp_json", None
-        )
         mcp_gateway_socket = getattr(self._client, "_mcp_gateway_socket", None)
 
         # Check for session resume
@@ -812,7 +807,6 @@ class AcpProvider(LLMProvider):
             sandbox_mode=sandbox_mode,
             extra_env=extra_env,
             mcp_gateway_overlay=mcp_gateway_overlay,
-            mcp_gateway_settings_mcp_json=mcp_gateway_settings_mcp_json,
             mcp_gateway_socket=mcp_gateway_socket,
             acp_backend=self._client.backend,
             crew_agent=self._crew_agent,
@@ -913,7 +907,6 @@ class AcpProvider(LLMProvider):
                         sandbox_mode=sandbox_mode,
                         extra_env=extra_env,
                         mcp_gateway_overlay=mcp_gateway_overlay,
-                        mcp_gateway_settings_mcp_json=mcp_gateway_settings_mcp_json,
                         mcp_gateway_socket=mcp_gateway_socket,
                         acp_backend=self._client.backend,
                         crew_agent=self._crew_agent,

--- a/src/kiro_crew/session_allocation.py
+++ b/src/kiro_crew/session_allocation.py
@@ -216,7 +216,6 @@ def _collect_parent_runtime_kwargs(
         ("_sandbox_mode", "sandbox_mode"),
         ("_extra_env", "extra_env"),
         ("_mcp_gateway_overlay", "mcp_gateway_overlay"),
-        ("_mcp_gateway_settings_mcp_json", "mcp_gateway_settings_mcp_json"),
         ("_mcp_gateway_socket", "mcp_gateway_socket"),
         ("backend", "acp_backend"),
     ):

--- a/test/test_acp_backend_kas.py
+++ b/test/test_acp_backend_kas.py
@@ -310,7 +310,6 @@ class TestCompanionRuntimeInheritsBackend:
             "_sandbox_mode",
             "_extra_env",
             "_mcp_gateway_overlay",
-            "_mcp_gateway_settings_mcp_json",
             "_mcp_gateway_socket",
         ):
             setattr(provider.client, attr, None)

--- a/test/test_acp_provider.py
+++ b/test/test_acp_provider.py
@@ -716,7 +716,6 @@ class TestStartKiroRuntimeResume:
         provider._client._sandbox_mode = "auto"
         provider._client._extra_env = {}
         provider._client._mcp_gateway_overlay = None
-        provider._client._mcp_gateway_settings_mcp_json = None
         provider._client._mcp_gateway_socket = None
         # _model is a real string (not a MagicMock) so the DEFAULT_MODEL guard
         # in _start_kiro_runtime compares correctly.
@@ -869,7 +868,6 @@ class TestKiroStartupMetric:
         provider._client._sandbox_mode = "auto"
         provider._client._extra_env = {}
         provider._client._mcp_gateway_overlay = None
-        provider._client._mcp_gateway_settings_mcp_json = None
         provider._client._mcp_gateway_socket = None
         provider._client._resume_session_id = ""
         provider._client._model = model
@@ -955,7 +953,6 @@ class TestFixBDeadRuntimeRespawn:
         provider._client._sandbox_mode = "auto"
         provider._client._extra_env = {}
         provider._client._mcp_gateway_overlay = None
-        provider._client._mcp_gateway_settings_mcp_json = None
         provider._client._mcp_gateway_socket = None
         provider._client._model = "auto"
         return provider
@@ -1112,7 +1109,6 @@ class TestStartKiroRuntimeModelEntitlement:
         provider._client._sandbox_mode = "auto"
         provider._client._extra_env = {}
         provider._client._mcp_gateway_overlay = None
-        provider._client._mcp_gateway_settings_mcp_json = None
         provider._client._mcp_gateway_socket = None
         provider._client._model = model
         provider._client._resume_session_id = ""  # straight to create_session

--- a/test/test_mcp_gateway_rewriter.py
+++ b/test/test_mcp_gateway_rewriter.py
@@ -31,14 +31,17 @@ from kiro_crew.mcp_gateway.rewriter import (
 from kiro_crew.sandbox import scrub_agent_denied_env
 
 
-class TestSettingsRelocationMatchesInjection:
-    """``_injectable_settings_servers`` drives BOTH the per-agent injection and
-    the removal from the global settings overlay, so it must return exactly the
-    servers that get injected.
+class TestSettingsInjection:
+    """``_injectable_settings_servers`` drives the per-agent injection of
+    global settings servers, so it must return exactly the servers that get
+    injected.
 
-    A name returned here but not injected is deleted from the only overlay that
-    still lists it — the server vanishes and its MCP tools disappear, which is
-    strictly worse than either stubbing it or leaving it alone.
+    A server it returns is wrapped with each agent's own name and injected at
+    ACP ``session/new``, where the stub takes precedence over the raw
+    same-named entry kiro-cli merges from the real settings file
+    (``session_servers.py``). A server it does NOT return is left entirely to
+    that merge — the rewriter never writes a settings overlay and never
+    modifies the real settings file (#8111).
     """
 
     def _spec(self) -> dict:
@@ -50,19 +53,20 @@ class TestSettingsRelocationMatchesInjection:
             }
         }
 
-    def test_unstubbed_stdio_server_is_left_in_the_settings_overlay(self) -> None:
+    def test_unstubbed_stdio_server_is_not_injected(self) -> None:
         out = _injectable_settings_servers(self._spec(), frozenset(["beta-mcp"]))
-        # beta is stubbed -> relocated. alpha is NOT -> must stay put, or it is
-        # dropped from settings while nothing injects it.
+        # beta is stubbed -> injected. alpha is NOT -> left to kiro-cli's own
+        # merge of the real settings file.
         assert set(out) == {"beta-mcp"}
 
-    def test_nothing_stubbed_relocates_nothing(self) -> None:
-        """The shipped default. Every server stays raw in the settings overlay."""
+    def test_nothing_stubbed_injects_nothing(self) -> None:
+        """The shipped default. Every server merges raw from the real
+        settings file."""
         assert _injectable_settings_servers(self._spec(), frozenset()) == {}
 
     def test_alias_spelling_is_honoured(self) -> None:
         """The config may carry the slash-free alias while settings keeps the raw
-        key; matching only the raw name would silently fail to relocate a
+        key; matching only the raw name would silently fail to inject a
         stubbed slash-named server."""
         spec = {"mcpServers": {"npm:@playwright/mcp": {"command": sys.executable}}}
         from kiro_crew.mcp_gateway.rewriter import mcp_server_alias
@@ -73,21 +77,21 @@ class TestSettingsRelocationMatchesInjection:
         # Keyed by the RAW name, because the caller filters raw-keyed src_servers.
         assert set(out) == {"npm:@playwright/mcp"}
 
-    def test_http_server_is_never_relocated_even_when_listed(self) -> None:
-        """HTTP/SSE needs no stub and merges globally; relocating it would strip
-        it from settings for no gain."""
+    def test_http_server_is_never_injected_even_when_listed(self) -> None:
+        """HTTP/SSE needs no stub and merges globally; injecting it would gain
+        nothing."""
         out = _injectable_settings_servers(self._spec(), frozenset(["http-mcp"]))
         assert out == {}
 
-    def test_end_to_end_unstubbed_server_survives_in_the_written_overlay(
+    def test_end_to_end_no_settings_overlay_and_real_settings_untouched(
         self, tmp_path: Path
     ) -> None:
-        """Drive the real ``rewrite_agents`` and read the overlay it writes.
+        """Drive the real ``rewrite_agents`` and inspect what it wrote.
 
-        The unit tests above pin the producer; this pins the WIRING. Without it
-        the call site could pass the wrong set (or none) and no test would fail,
-        while every unstubbed global server silently vanished from the only
-        overlay that lists it.
+        The unit tests above pin the producer; this pins the WIRING: the
+        stubbed global lands wrapped in the agent overlay, no settings overlay
+        appears anywhere under the overlay tree (#8111), and the real settings
+        file is byte-identical afterwards.
         """
         from kiro_crew.mcp_gateway.rewriter import rewrite_agents
 
@@ -99,6 +103,7 @@ class TestSettingsRelocationMatchesInjection:
         settings_dir = tmp_path / "settings"
         settings_dir.mkdir()
         (settings_dir / "mcp.json").write_text(json.dumps(self._spec()), encoding="utf-8")
+        settings_before = (settings_dir / "mcp.json").read_bytes()
 
         overlay_dir = tmp_path / "overlay" / "agents"
         rewrite_agents(
@@ -109,16 +114,16 @@ class TestSettingsRelocationMatchesInjection:
             stub_servers=frozenset(["beta-mcp"]),
         )
 
-        written = json.loads(
-            (overlay_dir.parent / "settings" / "mcp.json").read_text(encoding="utf-8")
-        )
-        names = set(written["mcpServers"])
-        # alpha was never stubbed: it must still be here, raw, for the session to
-        # launch itself. beta was stubbed, so it moved to the per-agent overlay.
-        assert "alpha-mcp" in names
-        assert "beta-mcp" not in names
-        # HTTP always stays and merges globally.
-        assert "http-mcp" in names
+        overlay = json.loads((overlay_dir / "kirocrew.json").read_text(encoding="utf-8"))
+        names = set(overlay["mcpServers"])
+        # beta was stubbed: injected per-agent, wrapped. alpha and http were
+        # not: they stay solely in the real settings file for kiro-cli's merge.
+        assert "beta-mcp" in names
+        assert "alpha-mcp" not in names
+        assert "http-mcp" not in names
+        # No settings overlay is written, and the real settings file is intact.
+        assert not (overlay_dir.parent / "settings").exists()
+        assert (settings_dir / "mcp.json").read_bytes() == settings_before
 
 
 def _rewrite(

--- a/test/test_mcp_gateway_rewriter_fingerprint.py
+++ b/test/test_mcp_gateway_rewriter_fingerprint.py
@@ -113,9 +113,7 @@ _AMBIENT_READ_ALLOWLIST = frozenset(
 
 #: Entry points of the rewrite pass; the scan covers their transitive
 #: in-module reference closure (see ``_referenced_defs``).
-_REWRITE_PASS_ROOTS = frozenset(
-    {"rewrite_agents", "_rewrite_single_spec", "_build_stub_entry"}
-)
+_REWRITE_PASS_ROOTS = frozenset({"rewrite_agents", "_rewrite_single_spec", "_build_stub_entry"})
 
 
 def _module_config_names(tree: ast.Module) -> set[str]:
@@ -172,9 +170,7 @@ def _env_key(args: list[ast.expr]) -> str:
     return "<dynamic>"
 
 
-def _ambient_reads(
-    func_name: str, fn: ast.AST, config_names: set[str]
-) -> set[tuple[str, str]]:
+def _ambient_reads(func_name: str, fn: ast.AST, config_names: set[str]) -> set[tuple[str, str]]:
     """Best-effort detectors for the common ambient channels.
 
     Not a sandbox: a determined read can evade an AST scan. The goal is to
@@ -204,9 +200,7 @@ def _ambient_reads(
                     hits.add((func_name, f".{func.attr}()"))
         elif isinstance(node, ast.Subscript) and _is_os_environ(node.value):
             key = "<dynamic>"
-            if isinstance(node.slice, ast.Constant) and isinstance(
-                node.slice.value, str
-            ):
+            if isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
                 key = node.slice.value
             hits.add((func_name, f"os.environ:{key}"))
             consumed.add(id(node.value))
@@ -300,18 +294,10 @@ def _mk_tree(
     settings = root / "settings"
     settings.mkdir(exist_ok=True)
     (settings / "mcp.json").write_text(
-        json.dumps(
-            {
-                "mcpServers": {
-                    "global-x": {"command": _CMD, "args": ["g"], "poolable": True}
-                }
-            }
-        )
+        json.dumps({"mcpServers": {"global-x": {"command": _CMD, "args": ["g"], "poolable": True}}})
     )
     for i in range(n_agents):
-        servers: dict[str, Any] = {
-            "srv": {"command": _CMD, "args": [f"a{i}"], "poolable": True}
-        }
+        servers: dict[str, Any] = {"srv": {"command": _CMD, "args": [f"a{i}"], "poolable": True}}
         if with_env:
             servers["srv"]["env"] = {"K": "v"} if env is None else dict(env)
         (src / f"agent-{i}.json").write_text(
@@ -480,9 +466,7 @@ def test_pool_identity_env_change_invalidates(
     # global-x is wrapped while OAUTH_TOKEN is withheld.
     assert before[0]["agent-0.json"] == 1, "a withheld key must block pooling"
 
-    monkeypatch.setattr(
-        rewriter, "pool_identity_env_keys", lambda: frozenset({"OAUTH_TOKEN"})
-    )
+    monkeypatch.setattr(rewriter, "pool_identity_env_keys", lambda: frozenset({"OAUTH_TOKEN"}))
     after = _rewrite(tmp_path)
     assert rewrite_counter["n"] == 4, "an identity-list edit must not serve the cache"
     # Non-vacuous, and the feature's headline behaviour: naming the key folds it
@@ -541,9 +525,7 @@ def test_a_spec_without_placeholders_still_caches(
     assert rewrite_counter["n"] == before, "an unchanged boot must serve the cache"
 
 
-def test_source_content_change_invalidates(
-    tmp_path: Path, rewrite_counter: dict[str, int]
-) -> None:
+def test_source_content_change_invalidates(tmp_path: Path, rewrite_counter: dict[str, int]) -> None:
     src = _mk_tree(tmp_path)
     _rewrite(tmp_path)
     spec = json.loads((src / "agent-0.json").read_text())
@@ -581,19 +563,20 @@ def test_settings_mcp_json_change_invalidates(
     assert rewrite_counter["n"] == before + 2
 
 
-def test_settings_mcp_json_deletion_invalidates_and_prunes_overlay(
+def test_settings_mcp_json_deletion_invalidates(
     tmp_path: Path, rewrite_counter: dict[str, int]
 ) -> None:
+    """Deleting the global settings file changes the injection set, so the
+    cache must invalidate. No settings overlay is involved: the rewriter never
+    writes one (#8111)."""
     _mk_tree(tmp_path)
     _rewrite(tmp_path)
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
-    assert settings_overlay.is_file()
+    assert not (tmp_path / "mcp-gateway" / "settings" / "mcp.json").exists()
     (tmp_path / "settings" / "mcp.json").unlink()
 
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
     assert rewrite_counter["n"] == before + 2
-    assert not settings_overlay.exists()
 
 
 @pytest.mark.parametrize(
@@ -634,7 +617,9 @@ def test_path_env_change_invalidates(
     """PATH feeds shutil.which bare-name resolution."""
     _mk_tree(tmp_path)
     _rewrite(tmp_path)
-    monkeypatch.setenv("PATH", str(tmp_path / "extra-bin") + os.pathsep + os.environ.get("PATH", ""))
+    monkeypatch.setenv(
+        "PATH", str(tmp_path / "extra-bin") + os.pathsep + os.environ.get("PATH", "")
+    )
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
     assert rewrite_counter["n"] == before + 2
@@ -927,8 +912,7 @@ def test_missing_env_sidecar_forces_full_rewrite(
         json.dumps(
             {
                 "inputs": {},
-                "outputs": {"overlays": ["../escape.json"], "sidecars": [],
-                            "settings_overlay": False},
+                "outputs": {"overlays": ["../escape.json"], "sidecars": []},
                 "results": {},
                 "target_env": {},
             }
@@ -1025,9 +1009,7 @@ def test_unresolved_bare_command_is_reprobed_and_install_invalidates(
 
     _rewrite(tmp_path)
     assert rewrite_counter["n"] == before + 1  # probe disagreed -> full rewrite
-    overlay = json.loads(
-        (tmp_path / "mcp-gateway" / "agents" / "agent-0.json").read_text()
-    )
+    overlay = json.loads((tmp_path / "mcp-gateway" / "agents" / "agent-0.json").read_text())
     args = overlay["mcpServers"]["srv"]["args"]
     i = args.index("--target-command")
     # normcase: which() may report a differently-cased/slashed spelling on
@@ -1045,9 +1027,7 @@ def test_resolved_binary_removal_invalidates(
     bin_dir.mkdir()
     # .bat on Windows: shutil.which resolves bare names only through PATHEXT.
     exe_name = (
-        "kirocrew-test-vanishing-cmd.bat"
-        if os.name == "nt"
-        else "kirocrew-test-vanishing-cmd"
+        "kirocrew-test-vanishing-cmd.bat" if os.name == "nt" else "kirocrew-test-vanishing-cmd"
     )
     exe = bin_dir / exe_name
     exe.write_text("#!/bin/sh\nexit 0\n")
@@ -1119,33 +1099,28 @@ def test_cache_hit_retightens_all_artifact_permissions(
 ) -> None:
     """A chmod changes no content signature, so the cache-hit path must
     re-assert owner-only permissions on EVERY served artifact — overlay
-    files, env sidecars, the settings overlay (file + dir), and the
-    fingerprint — not just the containing directories (on Windows the file
-    DACL is what carries access)."""
+    files, env sidecars, and the fingerprint — not just the containing
+    directories (on Windows the file DACL is what carries access)."""
     import stat as _stat
 
     _mk_tree(tmp_path, n_agents=1)
     _rewrite(tmp_path)
     overlay_dir = tmp_path / "mcp-gateway" / "agents"
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
     env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
     artifacts = [
         overlay_dir / "agent-0.json",
-        settings_overlay,
         overlay_dir / _FINGERPRINT_NAME,
         *env_dir.glob("*.json"),
     ]
-    assert len(artifacts) >= 4  # incl. at least one sidecar
+    assert len(artifacts) >= 3  # incl. at least one sidecar
     for a in artifacts:
         a.chmod(0o644)
-    settings_overlay.parent.chmod(0o755)
 
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
     assert rewrite_counter["n"] == before  # cache hit (chmod is stat-invisible)
     for a in artifacts:
         assert _stat.S_IMODE(a.stat().st_mode) == 0o600, a
-    assert _stat.S_IMODE(settings_overlay.parent.stat().st_mode) == 0o700
 
 
 def test_transient_source_read_failure_is_not_cached(
@@ -1182,15 +1157,11 @@ def test_transient_settings_read_failure_is_not_cached(
     """The settings/mcp.json read site has the same transient-failure rule as
     the agent-spec site: a pass that treated an existing settings file as
     absent must not be cached, and a fingerprint from an earlier healthy run
-    must be removed. Since #5328 the degraded pass also KEEPS the previous
-    settings overlay (the prune is keyed on source existence, not on whether
-    this pass managed to read the source)."""
+    must be removed."""
     src = _mk_tree(tmp_path)
     _rewrite(tmp_path)  # healthy run: fingerprint exists
     fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
     assert fp.is_file()
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
-    assert settings_overlay.is_file()
 
     _bump_mtime(src / "agent-0.json")  # invalidate so the next call rewrites
     real_read = Path.read_text
@@ -1206,17 +1177,11 @@ def test_transient_settings_read_failure_is_not_cached(
     fail["on"] = False
 
     assert not fp.exists()  # degraded pass not cached, stale fingerprint gone
-    # The previous healthy settings overlay survived the degraded pass —
-    # unlinking it here would strip every session's global MCP servers until
-    # a later pass succeeds (#5328).
-    assert settings_overlay.is_file()
 
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
     assert rewrite_counter["n"] == before + 2  # full retry after fault clears
     assert fp.is_file()
-    # The settings overlay is (still) present after the healthy retry.
-    assert (tmp_path / "mcp-gateway" / "settings" / "mcp.json").is_file()
 
 
 def test_transient_settings_read_failure_does_not_rewrite_agent_overlays(
@@ -1226,22 +1191,19 @@ def test_transient_settings_read_failure_does_not_rewrite_agent_overlays(
     nothing: the injection set is unknown, not empty, so no agent overlay may
     be written from it (#5344).
 
-    A healthy pass relocates each poolable settings server OUT of the settings
-    overlay and INTO every agent overlay. #5328 made the degraded pass keep the
-    previous settings overlay -- but the agent loop still ran with an empty
-    injection set, so a rewritten agent overlay dropped those servers while the
-    kept settings overlay no longer listed them either. They existed in NEITHER
-    location for the rest of the gateway's lifetime. The pass must refuse to
-    rewrite instead, exactly as the per-agent transient read failure does."""
+    A healthy pass injects each poolable settings server INTO every agent
+    overlay; the raw entry still merges from the real settings file, but it
+    runs per-session and unpooled, without the identity the stub carries.
+    Rewriting an agent overlay from an empty injection set would silently
+    unpool every globally-declared server for the rest of the gateway's
+    lifetime. The pass must refuse to rewrite instead, exactly as the
+    per-agent transient read failure does."""
     _mk_tree(tmp_path)
-    _rewrite(tmp_path)  # healthy pass: global-x relocated into every agent
+    _rewrite(tmp_path)  # healthy pass: global-x injected into every agent
     overlay_dir = tmp_path / "mcp-gateway" / "agents"
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
     for i in range(2):
         healthy = json.loads((overlay_dir / f"agent-{i}.json").read_text())
         assert "global-x" in healthy["mcpServers"]
-    # The relocation is what makes the loss total: settings no longer lists it.
-    assert "global-x" not in json.loads(settings_overlay.read_text())["mcpServers"]
     before = {p.name: p.read_bytes() for p in overlay_dir.glob("*.json")}
     assert before
 
@@ -1256,9 +1218,9 @@ def test_transient_settings_read_failure_does_not_rewrite_agent_overlays(
     # No agent overlay was rewritten at all: byte-identical to the healthy pass.
     for i in range(2):
         kept = json.loads((overlay_dir / f"agent-{i}.json").read_text())
-        assert "global-x" in kept["mcpServers"], (
-            "the injected global server must survive a settings read failure"
-        )
+        assert (
+            "global-x" in kept["mcpServers"]
+        ), "the injected global server must survive a settings read failure"
     assert {p.name: p.read_bytes() for p in overlay_dir.glob("*.json")} == before
     # A kept overlay's stub still needs its target mapping published, or it
     # resolves through the bare-name fallback.
@@ -1290,30 +1252,31 @@ def test_a_changed_agent_spec_is_not_deferred_by_a_settings_read_failure(
 
     # The operator revokes an approval on the agent's own server.
     (src / "agent-0.json").write_text(
-        json.dumps({
-            "name": "agent-0",
-            "mcpServers": {"srv": {"command": _CMD, "args": ["a0"],
-                                   "env": {"K": "v"}, "disabled": True}},
-        })
+        json.dumps(
+            {
+                "name": "agent-0",
+                "mcpServers": {
+                    "srv": {"command": _CMD, "args": ["a0"], "env": {"K": "v"}, "disabled": True}
+                },
+            }
+        )
     )
     with _settings_unreadable():
         _rewrite(tmp_path)
 
     spec = json.loads(overlay.read_text())
-    assert spec["mcpServers"]["srv"].get("disabled") is True, (
-        "a revoked/disabled server must not be deferred to the next boot"
-    )
+    assert (
+        spec["mcpServers"]["srv"].get("disabled") is True
+    ), "a revoked/disabled server must not be deferred to the next boot"
     # The cost is declared: the injection could not be established this pass.
     assert "global-x" not in spec["mcpServers"]
-    assert not (
-        tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
-    ).exists()
+    assert not (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).exists()
 
 
 def test_a_deleted_overlay_is_rebuilt_even_on_a_settings_read_failure(
     tmp_path: Path,
 ) -> None:
-    """"Inputs unchanged" does not imply "there is an overlay to keep".
+    """ "Inputs unchanged" does not imply "there is an overlay to keep".
 
     A missing output is itself a reason the cached early return did not fire, so
     this pass can reach the loop with every input signature still matching while
@@ -1351,10 +1314,12 @@ def test_settings_read_failure_with_nothing_stubbed_still_rewrites(
 
     # A real source change, so a refusal would be visible as a stale overlay.
     (src / "agent-0.json").write_text(
-        json.dumps({
-            "name": "agent-0",
-            "mcpServers": {"late": {"command": _CMD, "args": ["l"]}},
-        })
+        json.dumps(
+            {
+                "name": "agent-0",
+                "mcpServers": {"late": {"command": _CMD, "args": ["l"]}},
+            }
+        )
     )
     with _settings_unreadable():
         _rewrite(tmp_path, stub_servers=frozenset())
@@ -1449,18 +1414,14 @@ def test_a_known_settings_change_refuses_the_keep(tmp_path: Path) -> None:
 
     # The operator revokes the global server, and the parse (not the stat) faults.
     (src.parent / "settings" / "mcp.json").write_text(
-        json.dumps({
-            "mcpServers": {
-                "global-x": {"command": _CMD, "args": ["g"], "disabled": True}
-            }
-        })
+        json.dumps({"mcpServers": {"global-x": {"command": _CMD, "args": ["g"], "disabled": True}}})
     )
     with _settings_text_unreadable():
         _rewrite(tmp_path)
 
-    assert "global-x" not in json.loads(overlay.read_text())["mcpServers"], (
-        "a signable, changed settings file must refuse the keep"
-    )
+    assert (
+        "global-x" not in json.loads(overlay.read_text())["mcpServers"]
+    ), "a signable, changed settings file must refuse the keep"
 
 
 def test_a_tampered_overlay_is_not_served_by_a_keep(tmp_path: Path) -> None:
@@ -1504,12 +1465,12 @@ def test_an_unvouched_sidecar_blocks_every_keep(tmp_path: Path) -> None:
 
     # No keep happened, so every overlay was rewritten -- without the injection.
     for i in range(2):
-        servers = json.loads(
-            (tmp_path / "mcp-gateway" / "agents" / f"agent-{i}.json").read_text()
-        )["mcpServers"]
-        assert "global-x" not in servers, (
-            "an unvouched sidecar set must withdraw the keep for every agent"
-        )
+        servers = json.loads((tmp_path / "mcp-gateway" / "agents" / f"agent-{i}.json").read_text())[
+            "mcpServers"
+        ]
+        assert (
+            "global-x" not in servers
+        ), "an unvouched sidecar set must withdraw the keep for every agent"
 
 
 def test_a_vanished_target_binary_refuses_the_keep(
@@ -1548,20 +1509,17 @@ def test_a_vanished_target_binary_refuses_the_keep(
     # The keep was refused, so the overlay was rewritten -- and the now-dead
     # bare command is left unwrapped rather than pointed at a stale path.
     servers = json.loads(overlay.read_text())["mcpServers"]
-    assert "global-x" not in servers, (
-        "a vanished target binary must refuse the keep"
-    )
+    assert "global-x" not in servers, "a vanished target binary must refuse the keep"
     assert "--target-command" not in json.dumps(servers.get("srv", {}))
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits")
 def test_a_keep_retightens_every_artifact_it_serves(tmp_path: Path) -> None:
     """A chmod changes no signature, so a keep must re-assert owner-only
-    protection on everything it serves -- the kept overlay, the env sidecars and
-    their directory, and the settings overlay (file and dir) that #5328 keeps on
-    this pass. Mirrors the cache-hit path's guarantee, for the same reason: on
-    Windows the file DACL rather than the directory is what carries access, and
-    these files hold the passed-through env of non-poolable servers.
+    protection on everything it serves -- the kept overlay, and the env sidecars
+    and their directory. Mirrors the cache-hit path's guarantee, for the same
+    reason: on Windows the file DACL rather than the directory is what carries
+    access, and these files hold the passed-through env of non-poolable servers.
 
     The fingerprint file is deliberately NOT in the set: this pass unlinks it
     (uncacheable), so re-protecting a file about to be deleted is a no-op."""
@@ -1570,14 +1528,11 @@ def test_a_keep_retightens_every_artifact_it_serves(tmp_path: Path) -> None:
     _mk_tree(tmp_path, n_agents=1)
     _rewrite(tmp_path)
     overlay_dir = tmp_path / "mcp-gateway" / "agents"
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
     env_dir = tmp_path / "mcp-gateway" / "stubs" / "env"
-    artifacts = [overlay_dir / "agent-0.json", settings_overlay,
-                 *env_dir.glob("*.json")]
-    assert len(artifacts) >= 3  # incl. at least one sidecar
+    artifacts = [overlay_dir / "agent-0.json", *env_dir.glob("*.json")]
+    assert len(artifacts) >= 2  # incl. at least one sidecar
     for a in artifacts:
         a.chmod(0o644)
-    settings_overlay.parent.chmod(0o755)
     env_dir.chmod(0o755)
 
     with _settings_unreadable():
@@ -1585,12 +1540,9 @@ def test_a_keep_retightens_every_artifact_it_serves(tmp_path: Path) -> None:
 
     # The keep happened (the injected global survived) AND everything it serves
     # was retightened.
-    assert "global-x" in json.loads(
-        (overlay_dir / "agent-0.json").read_text()
-    )["mcpServers"]
+    assert "global-x" in json.loads((overlay_dir / "agent-0.json").read_text())["mcpServers"]
     for a in artifacts:
         assert _stat.S_IMODE(a.stat().st_mode) == 0o600, a
-    assert _stat.S_IMODE(settings_overlay.parent.stat().st_mode) == 0o700
     assert _stat.S_IMODE(env_dir.stat().st_mode) == 0o700
 
 
@@ -1611,9 +1563,7 @@ def test_a_swallowed_stat_fault_is_unknown_not_absent(
     src = _mk_tree(tmp_path, n_agents=1)
     _rewrite(tmp_path)
     overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
     assert "global-x" in json.loads(overlay.read_text())["mcpServers"]
-    assert settings_overlay.is_file()
 
     real_stat = Path.stat
     fail = {"on": True}
@@ -1629,14 +1579,11 @@ def test_a_swallowed_stat_fault_is_unknown_not_absent(
     _rewrite(tmp_path)
     fail["on"] = False
 
-    assert "global-x" in json.loads(overlay.read_text())["mcpServers"], (
-        "a swallowed stat fault must read as unknown, not as an absent file"
-    )
-    # The previous settings overlay survives too, and the pass is not cached.
-    assert settings_overlay.is_file()
-    assert not (
-        tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
-    ).exists()
+    assert (
+        "global-x" in json.loads(overlay.read_text())["mcpServers"]
+    ), "a swallowed stat fault must read as unknown, not as an absent file"
+    # The pass is not cached.
+    assert not (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).exists()
 
 
 @pytest.mark.parametrize(
@@ -1647,29 +1594,28 @@ def test_a_swallowed_stat_fault_is_unknown_not_absent(
     ],
     ids=["bad_json", "non_dict"],
 )
-def test_deterministic_settings_content_prunes_its_overlay(
+def test_deterministic_settings_content_is_cacheable_and_injects_nothing(
     tmp_path: Path, payload: str, why: str
 ) -> None:
-    """A settings source that is present but unusable prunes the previous
-    settings overlay, exactly as a deleted source does -- unlike a transient
-    fault, which keeps it (#5328).
-
-    Both branches were reachable and uncovered: a mutation removing either
-    prune reddened nothing until these existed, and an earlier attempt at the
-    #5344 classification silently stopped pruning on both. The distinction that
-    matters is deterministic-vs-transient, not spec-vs-no-spec: fixing bad
-    content changes the file's stat signature, so this pass is safe to cache."""
+    """A settings source that is present but unusable is a deterministic
+    CONTENT problem, unlike a transient fault: the injection set is
+    established as empty (the agent overlays drop the injected globals) and
+    the pass is safe to cache -- fixing the content changes the file's stat
+    signature. No settings overlay exists in either state (#8111)."""
     src = _mk_tree(tmp_path, n_agents=1)
     _rewrite(tmp_path)
-    settings_overlay = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
-    assert settings_overlay.is_file(), "healthy pass writes the settings overlay"
+    overlay = tmp_path / "mcp-gateway" / "agents" / "agent-0.json"
+    assert "global-x" in json.loads(overlay.read_text())["mcpServers"]
 
     (src.parent / "settings" / "mcp.json").write_text(payload)
     _rewrite(tmp_path)
 
-    assert not settings_overlay.exists(), f"{why} must prune the stale overlay"
+    assert (
+        "global-x" not in json.loads(overlay.read_text())["mcpServers"]
+    ), f"{why} is deterministic: the empty injection set must be applied"
     # Deterministic, so the pass is cacheable -- the transient arm is not.
     assert (tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME).is_file()
+    assert not (tmp_path / "mcp-gateway" / "settings" / "mcp.json").exists()
 
 
 def test_malformed_json_source_is_still_cacheable(
@@ -1727,24 +1673,117 @@ def test_sidecar_write_failure_is_not_cached(
     assert fp.is_file()
 
 
-def test_stray_settings_overlay_is_pruned_on_the_skip_path(
+def test_no_settings_overlay_is_ever_written(tmp_path: Path) -> None:
+    """Locks the #8111 removal in: a healthy pass over a settings file holding
+    poolable AND non-poolable servers must not write
+    ``<overlay_dir>/../settings/mcp.json`` — nothing ever read it. The real
+    settings file is not modified either, and the stored fingerprint carries
+    no ``settings_overlay`` output."""
+    src = _mk_tree(tmp_path, n_agents=1)
+    real_settings = src.parent / "settings" / "mcp.json"
+    spec = json.loads(real_settings.read_text())
+    # A non-poolable (HTTP/SSE) entry of the kind the old overlay existed to
+    # pass through.
+    spec["mcpServers"]["http-y"] = {"url": "https://example.invalid/mcp"}
+    real_settings.write_text(json.dumps(spec))
+    before_bytes = real_settings.read_bytes()
+
+    _rewrite(tmp_path)
+
+    assert not (tmp_path / "mcp-gateway" / "settings").exists()
+    assert real_settings.read_bytes() == before_bytes
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    outputs = json.loads(fp.read_text())["outputs"]
+    assert "settings_overlay" not in outputs
+
+
+def test_legacy_settings_overlay_is_left_untouched(
     tmp_path: Path, rewrite_counter: dict[str, int]
 ) -> None:
-    """A settings overlay whose deletion failed on a prior full pass must not
-    survive cache hits — removed global MCP servers must not stay active."""
-    src = _mk_tree(tmp_path, n_agents=1)
-    (tmp_path / "settings" / "mcp.json").unlink()
-    _bump_mtime(src / "agent-0.json")  # ensure fresh inputs
-    _rewrite(tmp_path)  # fingerprint records: no settings overlay
+    """A settings overlay left behind by a pre-#8111 release is deliberately
+    NOT deleted: it was always written owner-only into a 0o700 directory
+    (issue #5285), its content is a subset copy of the user's real settings
+    file, and nothing reads it -- inert, not exposed. An automated deleter
+    would itself be an attack surface (real-settings aliasing, foreign files
+    under a custom overlay_dir, symlink-redirected parents), so the pass must
+    leave the file byte-identical, on the full path and on cache hits alike."""
+    _mk_tree(tmp_path, n_agents=1)
+    leftover = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    leftover.parent.mkdir(parents=True, exist_ok=True)
+    leftover.write_text(json.dumps({"mcpServers": {"old": {"command": "x"}}}))
+    before_bytes = leftover.read_bytes()
 
-    stray = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
-    stray.parent.mkdir(parents=True, exist_ok=True)
-    stray.write_text("{}")
+    _rewrite(tmp_path)  # full pass
+    assert leftover.read_bytes() == before_bytes
+
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)  # cache hit
+    assert rewrite_counter["n"] == before
+    assert leftover.read_bytes() == before_bytes
+
+
+def test_legacy_fingerprint_with_settings_overlay_output_still_cache_hits(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """The upgrade-safety invariant of the #8111 removal: a fingerprint
+    written by a pre-change release carries an ``outputs.settings_overlay``
+    signature. The loader must IGNORE it — not reject it — so the first
+    upgraded boot over unchanged inputs is still served from cache, and the
+    #5344 transient-keep gate keeps comparing inputs meaningfully."""
+    _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    stored = json.loads(fp.read_text())
+    stored["outputs"]["settings_overlay"] = [3, 5, "ab"]  # pre-change shape
+    fp.write_text(json.dumps(stored, sort_keys=True))
 
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
+    assert rewrite_counter["n"] == before  # cache hit; the stale key is inert
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits")
+def test_legacy_overlay_acl_is_retightened_when_vouched(
+    tmp_path: Path, rewrite_counter: dict[str, int]
+) -> None:
+    """The ONE guard kept for the leftover pre-#8111 overlay: a loosened ACL
+    is re-tightened on every pass — cache hits included — when the stored
+    fingerprint's recorded ``settings_overlay`` signature vouches for the
+    file. An unvouched file is never chmodded, the bytes are never touched,
+    and the vouching signature is carried across a fingerprint rewrite while
+    the file survives (dropping it would silently end the guard)."""
+    import stat as _stat
+
+    from kiro_crew.mcp_gateway.rewriter import _stat_sig
+
+    src = _mk_tree(tmp_path, n_agents=1)
+    _rewrite(tmp_path)
+    fp = tmp_path / "mcp-gateway" / "agents" / _FINGERPRINT_NAME
+    legacy = tmp_path / "mcp-gateway" / "settings" / "mcp.json"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_text("{}")
+    legacy.chmod(0o644)
+
+    # Unvouched (fresh fingerprint carries no signature): left alone.
+    before = rewrite_counter["n"]
+    _rewrite(tmp_path)
     assert rewrite_counter["n"] == before  # cache hit
-    assert not stray.exists()  # and the stray overlay was swept
+    assert _stat.S_IMODE(legacy.stat().st_mode) == 0o644
+
+    # Vouched (the pre-change release recorded the signature): re-tightened.
+    sig = _stat_sig(legacy)
+    stored = json.loads(fp.read_text())
+    stored["outputs"]["settings_overlay"] = sig
+    fp.write_text(json.dumps(stored, sort_keys=True))
+    content_before = legacy.read_bytes()
+    _rewrite(tmp_path)
+    assert _stat.S_IMODE(legacy.stat().st_mode) == 0o600
+    assert legacy.read_bytes() == content_before  # tightened, never rewritten
+
+    # The vouching signature survives a full-rewrite fingerprint replacement.
+    _bump_mtime(src / "agent-0.json")
+    _rewrite(tmp_path)  # full rewrite, fingerprint re-stored
+    assert json.loads(fp.read_text())["outputs"]["settings_overlay"] == sig
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX permission bits")
@@ -1780,9 +1819,7 @@ def test_lockdown_failure_falls_through_to_full_rewrite(
             raise OSError("operation not permitted (foreign owner)")
         real(path)
 
-    monkeypatch.setattr(
-        "kiro_crew.mcp_gateway.rewriter.platform_compat.restrict_to_owner", failing
-    )
+    monkeypatch.setattr("kiro_crew.mcp_gateway.rewriter.platform_compat.restrict_to_owner", failing)
     before = rewrite_counter["n"]
     _rewrite(tmp_path)
     fail["on"] = False

--- a/test/test_session_coverage.py
+++ b/test/test_session_coverage.py
@@ -487,7 +487,6 @@ class TestParentRuntimeKwargs:
             _sandbox_mode="strict",
             _extra_env={"A": "1"},
             _mcp_gateway_overlay={"servers": {}},
-            _mcp_gateway_settings_mcp_json="/tmp/mcp.json",
             _mcp_gateway_socket="/tmp/gw.sock",
         )
         _register(mgr, "d1", provider=_stub_provider(client=client))
@@ -496,7 +495,6 @@ class TestParentRuntimeKwargs:
             "sandbox_mode": "strict",
             "extra_env": {"A": "1"},
             "mcp_gateway_overlay": {"servers": {}},
-            "mcp_gateway_settings_mcp_json": "/tmp/mcp.json",
             "mcp_gateway_socket": "/tmp/gw.sock",
         }
 


### PR DESCRIPTION
## Summary

Fixes #8111: `rewrite_agents` wrote a settings overlay to `<overlay_dir>/../settings/mcp.json` that had **zero consumers** — the path was threaded as `mcp_gateway_settings_mcp_json` through 5 files (14 occurrences, all assignment/plumbing), and the closing comments claimed `sandbox.py` bind-mounts it, which it never did. `session_servers.py` documents the superseding design: pooled servers are injected per-agent at ACP `session/new`, with no bind mount.

### What changed

- **`mcp_gateway/rewriter.py`** — deleted the settings-overlay write/prune/lockdown branches and the `settings_overlay` output-signature field. The fingerprint schema is deliberately **not** bumped: the field was output-only, a stored copy is now simply ignored, so pre-change fingerprints still validate and the #5344 transient-keep gate survives upgrade. The three false bind-mount comments now describe the injection design.
- **Leftover file: deliberately left alone.** A pre-change release's overlay file was always written owner-only into a 0o700 directory (issue #5285), its content is a subset copy of the user's real settings file (same secrets, same disk, same protection), and nothing reads it — inert, not exposed. An automated deleter is itself an attack surface (real-settings aliasing, foreign files under a custom `overlay_dir`, symlink-redirected parents, deletion provenance across fingerprint rewrites — each was a real finding against earlier sweep drafts of this PR), so none ships. The decision is documented at the top of the pass and locked by `test_legacy_settings_overlay_is_left_untouched`.
- **Plumbing removal** — `mcp_gateway_settings_mcp_json` dropped end-to-end from `config/loader.py`, `providers/acp.py`, `acp/client.py`, `acp/runtime.py`, `session_allocation.py`.
- **`docs/architecture/design-notes/mcp-stub-decoupling.md`** — relocation/settings-overlay wording updated to the injection design.

### Functional safety

The overlay's stated purpose is already satisfied without it: poolable settings servers reach sessions via per-agent overlay injection at `session/new`, and non-poolable / HTTP-SSE servers merge from the real `~/.kiro/settings/mcp.json`, which the rewriter never modifies. Grep closure re-verified on current main before removal: zero consumers.

### Review history (two blind model-pinned pre-push lanes + CI rounds)

Pre-push round 1 (GPT lane): schema-bump upgrade regression (reverted — stale key ignored instead), sweep ordering, failed-delete relock — all fixed.
Pre-push round 2 (Opus lane): PASS; gateway-off sweep gap, real-settings guard, legacy-fingerprint cache-hit test — addressed.
CI GPT rounds 1-4 then found four further real defects, ALL in the migration sweep that this PR had added (delete-unrelated-file risk, boot-path AUTOSDE rule ×2, provenance loss, symlink-redirected parent). Rather than continue hardening a deleter for an inert file, the sweep was removed entirely — minimal surface area, zero deletion attack surface, and the spec's original scope.

Deferred (pre-existing shipped behavior, needs live-binary harness work): pinning `session/new` precedence against the global-settings tier specifically; today's anti-drift test pins the agent-spec tier only.

### Tested

- `isort --check-only`, `flake8`, `mypy src/kiro_crew/`, diff-scoped black/brand gates — all green locally (black baseline pruned per the gate's own instruction: `test/test_mcp_gateway_rewriter_fingerprint.py` graduated).
- Tests lock the removal in: no settings overlay is ever written; the real settings file stays byte-identical; the leftover overlay is left byte-identical on full passes and cache hits; a pre-change fingerprint carrying the old `settings_overlay` output key still cache-hits.
- Full pytest runs in CI (per repo policy, tests are not run on this host).

No UI changes — no screenshots required.

Closes #8111
