### PR TITLE
fix(oauth): key banner liveness on the minting child process (#8149)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -28,6 +28,7 @@ import stat
 import subprocess as subprocess_mod
 import sys
 import time
+import uuid
 from collections import deque
 from contextlib import aclosing
 from pathlib import Path
@@ -2605,6 +2606,12 @@ class AcpClient:
         self._process: asyncio.subprocess.Process | None = None
         self._pid: int | None = None
         self._start_time: int | None = None  # process start time for PID recycling detection
+        # Names THIS spawn of the child, not the session it serves: a resume
+        # re-uses the session id on a brand-new process (see ensure_ready's
+        # session/load path), so the session id cannot distinguish the process
+        # that minted a resource from a successor that cannot honor it. Fresh
+        # per spawn, cleared with the process. See ``process_instance``.
+        self._process_instance: str = ""
         self._session_id: str | None = None
         self._next_id = 1
         self._buffer: deque[JsonRpcMessage] = deque(maxlen=100)
@@ -3246,6 +3253,20 @@ class AcpClient:
     def is_process_alive(self) -> bool:
         """True if the underlying process exists and has not exited."""
         return self._is_process_alive()
+
+    @property
+    def process_instance(self) -> str:
+        """Identity of the CURRENT child process instance (``""`` when none).
+
+        A fresh random id per spawn. This — not the ACP session id — is what a
+        resource minted by the child must be compared against later: a resume
+        carries the SAME session id onto a NEW process (``ensure_ready``'s
+        session/load path re-sets ``_session_id`` from ``resume_sid``), so a
+        session-id comparison fails open exactly when the minting process is
+        gone. Liveness is a separate question: this names which spawn, while
+        :meth:`is_process_alive` answers whether it still runs.
+        """
+        return self._process_instance if self._process is not None else ""
 
     @property
     def exit_code(self) -> int | None:
@@ -3995,6 +4016,11 @@ class AcpClient:
             self._discard_sandbox_cleanup()
             raise
         self._pid = self._process.pid
+        # Minted with the process it names, random rather than pid-derived: a
+        # pid can be reused by the OS, and the start-time disambiguator is not
+        # readable on every platform, so equality on a fresh random id is the
+        # comparison that cannot false-match across spawns.
+        self._process_instance = uuid.uuid4().hex[:16]
         _spawn_label = (
             CLAUDE_ACP_BIN
             if self._is_claude
@@ -4316,6 +4342,9 @@ class AcpClient:
         saved_child_pids = self._child_pids
         self._process = None
         self._pid = None
+        # The instance id names the process that just ended; a replacement spawn
+        # mints its own, so nothing may keep answering with this one in between.
+        self._process_instance = ""
         # A walk wedged on the dead PID's /proc entry can never speak for the
         # replacement process, so release it with the oracle it sampled into.
         self._retire_liveness_state()

--- a/src/kiro_crew/acp/runtime.py
+++ b/src/kiro_crew/acp/runtime.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 import weakref
 from collections import deque
 from pathlib import Path
@@ -764,6 +765,11 @@ class AcpRuntime:
         self._start_time: int | None = None
         self._spawn_monotonic: float | None = None
         self._child_pids: dict[int, int | None] = {}
+        # Names THIS spawn of the shared child process (fresh per spawn, cleared
+        # with the process) — the identity a resource minted by the child is
+        # compared against later. See AcpClient.process_instance for why the
+        # session id cannot serve: a resume reuses it on a new process.
+        self._process_instance: str = ""
 
         # Single reader task — the ONLY coroutine that reads stdout
         self._reader_task: asyncio.Task | None = None  # type: ignore[type-arg]
@@ -870,6 +876,16 @@ class AcpRuntime:
     @property
     def pid(self) -> int | None:
         return self._pid
+
+    @property
+    def process_instance(self) -> str:
+        """Identity of the CURRENT child process instance (``""`` when none).
+
+        Fresh per spawn, so equality distinguishes the process that minted a
+        resource from any successor — including one that resumed the same ACP
+        session id. Liveness is asked separately (:meth:`is_alive`).
+        """
+        return self._process_instance if self._process is not None else ""
 
     @property
     def acp_backend(self) -> str:
@@ -1354,6 +1370,9 @@ class AcpRuntime:
             self._discard_sandbox_cleanup()
             raise
         self._pid = self._process.pid
+        # Minted with the process it names — random, not pid-derived, so it
+        # cannot false-match a later spawn that the OS handed a recycled pid.
+        self._process_instance = uuid.uuid4().hex[:16]
         # The subprocess is LIVE from here on but nothing has recorded it yet, so
         # this window needs the same guard AcpClient._spawn has. finish_suspended_spawn
         # documents its own resume failure as FATAL, and _get_start_time can raise;
@@ -1598,6 +1617,9 @@ class AcpRuntime:
                 except asyncio.TimeoutError:
                     pass
             self._process = None
+            # The id names the process that just ended; the next spawn mints its
+            # own, and nothing may answer with this one in between.
+            self._process_instance = ""
             if platform_compat.pid_exists(pid):
                 # Both kill_process_tree calls above swallow OSError by design
                 # (racing a normal exit), which makes a signal-delivery failure

--- a/src/kiro_crew/acp/session_provider.py
+++ b/src/kiro_crew/acp/session_provider.py
@@ -400,6 +400,16 @@ class AcpSessionProvider(LLMProvider):
         return self._runtime.is_alive()
 
     @property
+    def process_instance(self) -> str:
+        """Per-spawn identity of the shared runtime's current process (see base).
+
+        A direct read on purpose: a `getattr` hedge would convert a future
+        wiring break into "no banner is ever live", indistinguishable from
+        correct expiry.
+        """
+        return self._runtime.process_instance
+
+    @property
     def exit_code(self) -> int | None:
         """Runtime process exit code (None if still running)."""
         proc = getattr(self._runtime, "_process", None)

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -62,8 +62,6 @@ from kiro_crew.dashboard.chat_persistence import (
 )
 from kiro_crew.dashboard.chat_runner import (
     _context_usage_payload,
-    _expire_mcp_oauth_banners,
-    _open_mcp_oauth_banner_mids,
     _run_chat,
     _start_next_queued_turn,
     context_entry_expired,
@@ -76,11 +74,13 @@ from kiro_crew.dashboard.chat_utils import (
     _MANUAL_CONTINUE_MSG,
     _MANUAL_RESUME_MSG,
     SYNTHETIC_RECOVERY_KIND,
+    _broadcast_expired_oauth_banners,
     _build_stream_chunk,
     _collapse_wire_rows,
     _edit_queued_by_id,
     _emit_agent_assignment,
     _history_key_for,
+    _live_child_instance,
     _normalize_model,
     _prepare_messages,
     _redact_for_display,
@@ -1951,13 +1951,13 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     queue_snapshot = [{"id": q["id"], "content": q["content"]} for q in slot._queue]
     context_fields = await _context_snapshot_fields(state, slot)
 
-    def _render() -> str:
+    def _render(live_child: str) -> str:
         # Off-loop on purpose. _prepare_messages applies a regex-heavy
         # redaction battery to the ENTIRE history; on a multi-MB session that
         # blocked the event loop past the loop-stall watchdog's exit budget
         # and hard-exited the gateway. json.dumps of the same payload is a
         # second loop-blocking cost, so it lives in the thread too.
-        prepared = _prepare_messages(messages, running)
+        prepared = _prepare_messages(messages, running, live_child=live_child)
         return json.dumps(
             {
                 "key": key,
@@ -1988,7 +1988,13 @@ async def api_chat_slot_detail(request: web.Request) -> web.Response:
     # reconnect + switchSlot + chat_done all refetch) queue here instead of
     # each burning a worker thread on the same multi-MB redaction pass.
     async with slot._detail_render_lock:
-        body = await asyncio.to_thread(_render)
+        # Resolved INSIDE the lock, immediately before the render: the wait
+        # behind another render can outlive a child, and a verdict sampled
+        # before it would serve the dead child's link one more time. On the
+        # event loop on purpose — the session pool is loop-owned and the probe
+        # is two dict lookups plus a returncode read.
+        live_child = _live_child_instance(state, slot)
+        body = await asyncio.to_thread(_render, live_child)
     return web.Response(text=body, content_type="application/json")
 
 
@@ -2443,10 +2449,6 @@ async def _reset_slot_session(
     stale-evidence failure that report exists to remove.
     """
     _unblock_pending_waits(state, slot)
-    # Snapshot the open OAuth banners BEFORE the teardown: a successor session can
-    # start and emit its own request while this one is shutting down, and a sweep
-    # taken afterwards would withdraw that live URL too.
-    doomed_oauth_banners = _open_mcp_oauth_banner_mids(slot)
     try:
         reloaded = await state.sessions.reset(session_key, skip_if_busy=skip_if_busy)
     except BaseException:
@@ -2479,19 +2481,12 @@ async def _reset_slot_session(
         # serialize_slots -- so it only fires when something was recorded.
         if slot.clear_mcp_report():
             state.broadcast_ws("mcp_report_update", {"slot": slot.key, "mcp_report": None})
-        # An open MCP OAuth banner rides the same gate for the same reason, and it
-        # is the widest of the three: every caller of this funnel destroys the child
-        # that owns the loopback listener and the PKCE verifier an open banner's
-        # Authorize link is redeemable against, so the link is dead the moment the
-        # teardown completes. The gateway generation does NOT change here, so the
-        # read-time gate in `_prepare_messages` cannot infer it (issue #7654).
-        #
-        # Gating on `reloaded` is load-bearing in the OTHER direction from the two
-        # above: a `skip_if_busy` decline leaves the session, its child, and its
-        # listener alive, so retiring here would take away a button that still
-        # works -- the one outcome worse than the dead link this fixes. Limited to
-        # the pre-teardown snapshot so a successor's banner is never swept.
-        _expire_mcp_oauth_banners(state, slot, doomed_oauth_banners)
+    # Freshness push for open tabs, OUTSIDE the `reloaded` gate on purpose: the
+    # helper is verdict-driven (it re-resolves the live child and applies the
+    # read gate's own predicate), so after a declined or failed teardown the
+    # still-live child's banners match and nothing is broadcast. See
+    # `_broadcast_expired_oauth_banners` for why no snapshot is needed.
+    _broadcast_expired_oauth_banners(state, slot)
     return reloaded
 
 
@@ -5931,7 +5926,9 @@ async def _live_slot_resume_response(
         window = _collapse_wire_rows(existing.messages)
         total = len(window)
         recent = window[-200:] if total > 200 else window
-        prepared = _prepare_messages(recent, existing.running)
+        prepared = _prepare_messages(
+            recent, existing.running, live_child=_live_child_instance(state, existing)
+        )
         # Raw index this window starts at: the frozen on-disk prefix plus the
         # in-memory rows it skipped. has_more is derived from the same number so
         # the flag cannot contradict the cursor -- counting only the in-memory
@@ -6533,7 +6530,9 @@ async def api_chat_slot_resume(request: web.Request) -> web.Response:
             # `total` is the full on-disk length here, so this already is the
             # raw index the next older page starts from.
             "next_before": total - len(recent),
-            "messages": _prepare_messages(recent, slot.running),
+            "messages": _prepare_messages(
+                recent, slot.running, live_child=_live_child_instance(state, slot)
+            ),
             "queue": [
                 {"id": q["id"], "content": _redact_for_display(q["content"])} for q in slot._queue
             ],

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -81,6 +81,7 @@ from kiro_crew.dashboard.chat_utils import (
     _apply_incognito_prefix,
     _broadcast_auto_tool,
     _broadcast_compaction_result,
+    _broadcast_expired_oauth_banners,
     _dequeue_next_message,
     _dequeue_next_system_message,
     _maybe_consolidate,
@@ -94,7 +95,6 @@ from kiro_crew.dashboard.chat_utils import (
     build_recovery_requeue,
     effective_session_key,
     expire_slack_options,
-    gateway_generation,
     is_harness_slash_command,
     is_system_injection_item,
     mirror_is_paused,
@@ -1628,6 +1628,7 @@ def _emit_mcp_oauth_request(
     server_name: str,
     oauth_url: str,
     card_owned: bool = False,
+    minted_by: str = "",
 ) -> None:
     """Append an mcp_oauth banner so the user can authorize an MCP server.
 
@@ -1635,6 +1636,16 @@ def _emit_mcp_oauth_request(
     pattern, surface a *rejected* banner explaining why instead of silently
     dropping.  Otherwise the user has no idea their MCP server failed to
     authenticate, and they can't escalate to whoever owns that server.
+
+    ``minted_by`` is the process-instance identity of the ACP child asking for
+    authorization — the process whose loopback listener and PKCE verifier the
+    URL is redeemable against. It is stamped into the banner meta so the
+    read-time gate (`_expire_dead_child_oauth_meta`) can withdraw the link the
+    moment that child is no longer the live one serving the slot, HOWEVER it
+    ended: gateway restart, session reset, idle sweep, RSS recycle, or the
+    child exiting on its own. An empty value stamps nothing, and an unstamped
+    banner is judged dead on first read — the fail direction that removes a
+    dead button rather than preserving it.
 
     ``card_owned`` records that some other surface owns this request's consent
     flow end to end — see :func:`_connections_managed_mcp_names`. It is an
@@ -1715,14 +1726,15 @@ def _emit_mcp_oauth_request(
     meta: dict[str, Any] = {
         "server_name": safe_name,
         "oauth_url": oauth_url,
-        # The generation that owns the listener and the PKCE verifier this URL is
-        # redeemable against. Read back by `_expire_stale_generation_oauth_meta`,
-        # which withdraws the link once this is no longer the running generation --
-        # the only way to cover a hard restart, where no code of ours runs to
-        # observe the flow dying. Stamped ONLY on this branch: the rejected-URL
-        # branches carry no `oauth_url`, so they have no link whose liveness this
-        # could describe.
-        "gen": gateway_generation(),
+        # The process instance that owns the listener and the PKCE verifier this
+        # URL is redeemable against. Read back by `_expire_dead_child_oauth_meta`,
+        # which withdraws the link once this is no longer the live child serving
+        # the slot — covering every way the flow can die (hard restart, session
+        # reset, idle sweep, RSS recycle, self-exit) with one comparison, because
+        # no code of ours has to run at the moment of death. Stamped ONLY on this
+        # branch: the rejected-URL branches carry no `oauth_url`, so they have no
+        # link whose liveness this could describe.
+        "child": minted_by,
     }
     if card_owned:
         meta["card_owned"] = True
@@ -1836,126 +1848,6 @@ def _supersede_open_mcp_oauth_banners(
         )
 
 
-def _open_mcp_oauth_banner_mids(slot: "_ChatSlot") -> frozenset[str]:
-    """Row identities of the `mcp_oauth` banners that are open RIGHT NOW.
-
-    Taken BEFORE a teardown so the retirement afterwards can name exactly the flows
-    that teardown ends. Without it, a sweep over `slot.messages` after the await also
-    catches a banner the SUCCESSOR session emitted while the old one was shutting
-    down -- an agent switch racing a concurrent send is enough -- and would withdraw
-    a URL that is perfectly live.
-
-    A row with no `mid` cannot be named and so is never retired. That fails in the
-    safe direction: it leaves a possibly-dead link for the read-time gate to catch
-    after the next restart, rather than removing a working button.
-    """
-    return frozenset(
-        mid
-        for message in slot.messages
-        if message.get("role") == "mcp_oauth"
-        for meta in (message.get("meta") or {},)
-        if meta.get("oauth_url")
-        and not (meta.get("completed") or meta.get("failed") or meta.get("superseded"))
-        for mid in (meta.get("mid"),)
-        if isinstance(mid, str) and mid
-    )
-
-
-def _expire_mcp_oauth_banners(
-    state: "DashboardState", slot: "_ChatSlot", doomed: frozenset[str]
-) -> None:
-    """Retire the `mcp_oauth` banners named by ``doomed`` because their child is gone.
-
-    The companion to `_expire_stale_generation_oauth_meta`, for the one case that gate
-    cannot see. A session reset kills the ACP child and cold-starts a replacement, but
-    it does NOT change the gateway generation, so a read-time comparison against `gen`
-    would keep calling these banners live. Here the teardown is a code path we execute,
-    so the terminal state can be written at the moment it becomes true.
-
-    ``doomed`` is REQUIRED rather than optional, and comes from
-    `_open_mcp_oauth_banner_mids` called before the teardown. Making it a parameter
-    instead of re-deriving the set here is the whole safety property: a caller cannot
-    accidentally sweep a successor session's live banner, because a row minted after
-    the snapshot is not in it.
-
-    Not keyed on a server name, unlike `_supersede_open_mcp_oauth_banners`. The reset
-    destroys the whole child, so every flow it was hosting dies at once regardless of
-    which server asked -- and that also means this is not subject to that function's
-    credential-shaped-name limitation, since it never has to match a redacted name
-    against anything.
-
-    Sync, and every caller invokes it only AFTER its teardown is confirmed. That
-    direction matters: an exception or a cancellation during teardown can leave the
-    child, and the loopback listener its authorize link is redeemable against, alive.
-    Retiring then would remove a button that still works, and the user would have no
-    way back -- `pop_pending_oauth_requests` has already drained the request, so a
-    live child does not re-announce it. A dead link that survives one more turn is
-    the cheaper error, and the read-time generation gate catches it after a restart.
-    """
-    if not doomed:
-        return
-    for message in slot.messages:
-        if message.get("role") != "mcp_oauth":
-            continue
-        meta = message.get("meta") or {}
-        row_mid_pre = meta.get("mid")
-        if not isinstance(row_mid_pre, str) or row_mid_pre not in doomed:
-            # Either unnamed, or minted after the snapshot -- i.e. possibly the
-            # successor session's own live banner. Not ours to withdraw.
-            continue
-        if not meta.get("oauth_url"):
-            # No link to withdraw: the rejected-URL banners, and any row already
-            # retired by this function or by the supersede path -- both of those
-            # drop `oauth_url`, so this guard is also what makes a second call a
-            # no-op. Leaving them alone keeps this from overwriting a recorded
-            # outcome.
-            continue
-        if meta.get("completed") or meta.get("failed"):
-            # A recorded outcome. Unlike `superseded`/`expired` these can still
-            # carry an `oauth_url` -- `_mark_mcp_oauth_completed` sets the flag
-            # without popping the url, since the render layer stops at those
-            # branches -- so they have to be named here rather than relying on
-            # the guard above.
-            continue
-        # Same reason as the supersede path: this copies a stored dict into both
-        # slot.messages and a broadcast that bypasses _prepare_messages. Safe despite
-        # that gate being stricter than the emit-path one because `oauth_url` is dead
-        # data here -- dropped below, and the expired branch renders no link.
-        new_meta = _redact_meta_for_role("mcp_oauth", dict(meta))
-        new_meta.pop("oauth_url", None)
-        new_meta["expired"] = True
-        label = new_meta.get("server_name") or "MCP server"
-        new_content = f"↻ {label} sign-in is no longer active — the session that started it ended."
-        row_mid = new_meta.get("mid")
-        # Resolve by `mid`, not `ts`, for the reason spelled out in
-        # _supersede_open_mcp_oauth_banners: `ts` is not a row identity.
-        if (
-            slot.update_message(
-                message.get("ts", ""),
-                content=new_content,
-                meta=new_meta,
-                mid=row_mid if isinstance(row_mid, str) else None,
-            )
-            is None
-        ):
-            continue
-        # `oauth_url` goes on the wire as an empty string though it is ABSENT from the
-        # persisted meta, because the client merges an incoming meta over the row it
-        # already has. Omitting the key would leave the dead URL on a tab running
-        # pre-upgrade JS, which would keep rendering the link; an empty string fails
-        # that client's own isSafeOAuthUrl check so the banner withdraws instead.
-        state.broadcast_ws(
-            "chat_message_update",
-            {
-                "slot": slot.key,
-                "ts": message.get("ts", ""),
-                "mid": row_mid or "",
-                "meta": {**new_meta, "oauth_url": ""},
-                "content": new_content,
-            },
-        )
-
-
 def _connections_managed_mcp_names() -> frozenset[str]:
     """Servers whose OAuth consent a rendered Connections card owns end to end.
 
@@ -2031,6 +1923,10 @@ async def _drain_session_init_oauth_requests(
         # every session init and the common case is zero requests.
         return
     managed = await asyncio.to_thread(_connections_managed_mcp_names)
+    # The requests were buffered by the child `client` fronts, so that child's
+    # process instance is the identity every one of these banners is stamped
+    # with — the flow's loopback listener and verifier live in it.
+    minted_by = str(getattr(client, "process_instance", "") or "")
     for req in pending:
         if not isinstance(req, dict):
             continue
@@ -2044,6 +1940,7 @@ async def _drain_session_init_oauth_requests(
             server_name,
             req.get("oauthUrl") or "",
             card_owned=bool(server_name) and server_name in managed,
+            minted_by=minted_by,
         )
 
 
@@ -3611,25 +3508,15 @@ async def _consume_pending_reset(
         # failed leaves the session in a state this slot cannot vouch for, and
         # "unknown" is the direction that fails open.
         slot.record_model_withheld(None)
-        # Snapshot before the await, so a banner the successor session emits during
-        # the teardown is not swept along with the ones this reset actually ends.
-        doomed_banners = _open_mcp_oauth_banner_mids(slot)
         try:
             await state.sessions.reset(pending_key)
             torn_down = True
-            # Retire open MCP OAuth banners only AFTER the reset returns, so a
-            # raise skips it. Unlike the withhold verdict above, "unknown" does
-            # NOT fail open here: this reset destroys the child that owns an open
-            # banner's loopback listener, but if it raised instead, that child --
-            # and its still-redeemable link -- may be alive, and retiring the
-            # banner would remove a working button with no way back (the pending
-            # request was already drained, so a live child does not re-announce).
-            # Reaching here without raising is sufficient: a False return means
-            # there was no live session to tear down, in which case the flow is
-            # already dead and the banner is stale either way.
-            _expire_mcp_oauth_banners(state, slot, doomed_banners)
             if slot._pending_reset_history_key == pending_key:
                 slot._pending_reset_history_key = None
+            # Freshness push for open tabs; verdict-driven, so a teardown that
+            # raised above never reaches it and a declined one broadcasts
+            # nothing (see _broadcast_expired_oauth_banners).
+            _broadcast_expired_oauth_banners(state, slot)
         except Exception:
             logger.warning(
                 "Failed to consume pending project-change reset for slot %s",
@@ -3658,10 +3545,6 @@ async def _consume_pending_reset(
             # the transcript into the fresh conversation returns most of what the
             # reset reclaimed. The flag exists on the manager for the HTTP route,
             # which does let a caller choose.
-            # Snapshot before the await, for the same reason as the reset branch:
-            # a banner the successor session emits during this teardown must not be
-            # swept along with the ones the discard actually ends.
-            doomed_discard_banners = _open_mcp_oauth_banner_mids(slot)
             discarded = await state.sessions.discard_conversation(
                 discard_key, replay=False, skip_if_busy=True
             )
@@ -3684,15 +3567,9 @@ async def _consume_pending_reset(
             # longer exists; the fresh one will report for itself.
             if slot.clear_mcp_report():
                 state.broadcast_ws("mcp_report_update", {"slot": slot.key, "mcp_report": None})
-            # An open MCP OAuth banner describes that session too, and more
-            # sharply: `discard_conversation` shuts the child down
-            # (session_lifecycle `await session.provider.shutdown()`), so the
-            # loopback listener and PKCE verifier its Authorize link is
-            # redeemable against are gone. Gated on `discarded` for the same
-            # reason as everything else in this block -- a refusal leaves the
-            # session, and its still-working button, alive -- and limited to the
-            # pre-teardown snapshot so a successor's banner is not swept.
-            _expire_mcp_oauth_banners(state, slot, doomed_discard_banners)
+            # Freshness push for open tabs (verdict-driven — see
+            # _broadcast_expired_oauth_banners).
+            _broadcast_expired_oauth_banners(state, slot)
         except Exception:
             logger.warning(
                 "Failed to consume pending conversation discard for slot %s",
@@ -8908,7 +8785,13 @@ async def _run_chat(
                 # kiro-cli emits this notification when an MCP server's token
                 # has expired or never existed. Surface as an inline banner —
                 # kiro-cli's local callback handles the rest of the OAuth flow.
-                _emit_mcp_oauth_request(state, slot, event.server_name, event.oauth_url)
+                _emit_mcp_oauth_request(
+                    state,
+                    slot,
+                    event.server_name,
+                    event.oauth_url,
+                    minted_by=str(getattr(client, "process_instance", "") or ""),
+                )
                 _record_session_mcp_event(
                     state,
                     slot,
@@ -11314,14 +11197,6 @@ async def _run_chat(
                 except Exception:
                     logger.debug("Stream cleanup failed", exc_info=True)
             if _acquired and (needs_session_reset or needs_conversation_discard):
-                # Snapshot the open OAuth banners BEFORE the await. A successor
-                # session can start and emit its own request while this one is
-                # shutting down (an agent switch racing a concurrent send), and a
-                # sweep taken afterwards would withdraw that live URL too. Placed
-                # above the withhold drop so that drop stays adjacent to the teardown
-                # it describes -- test_every_session_teardown_drops_the_verdict pins
-                # their distance.
-                doomed_banners = _open_mcp_oauth_banner_mids(slot)
                 # Neither branch below goes through `_reset_slot_session`, so the
                 # withhold verdict is dropped here: both replace the session that
                 # advertised the model list (an agent switch can even change the
@@ -11330,7 +11205,6 @@ async def _run_chat(
                 # the slot at "unknown" rather than carrying a verdict it can no
                 # longer vouch for.
                 slot.record_model_withheld(None)
-                oauth_flow_ended = False
                 try:
                     if needs_conversation_discard:
                         # Poisoned-conversation escalation: clear ONLY the
@@ -11339,23 +11213,18 @@ async def _run_chat(
                         # recovery turn cold-starts a fresh native
                         # conversation instead of session/load-ing the same
                         # rejected one (which reset() would do).
-                        oauth_flow_ended = await state.sessions.discard_conversation(session_key)
+                        await state.sessions.discard_conversation(session_key)
                     else:
-                        oauth_flow_ended = await state.sessions.reset(session_key)
+                        await state.sessions.reset(session_key)
                 except Exception:
                     logger.warning("Failed to reset session %s after agent switch", session_key)
-                if oauth_flow_ended:
-                    # Retire open MCP OAuth banners only once the teardown is
-                    # CONFIRMED, and only the ones open BEFORE it. Both calls return
-                    # whether a session was actually torn down, and the unhappy paths
-                    # matter: an exception or a cancellation here can leave the child
-                    # -- and the loopback listener its authorize link is redeemable
-                    # against -- alive. Retiring then would take away a button that
-                    # still works, and the user could not recover, because the pending
-                    # request was already drained by `pop_pending_oauth_requests` and a
-                    # live child does not re-announce it. Same gate, and the same
-                    # reason, as `_reset_slot_session`.
-                    _expire_mcp_oauth_banners(state, slot, doomed_banners)
+                # Freshness push for open tabs. Unconditional where the old
+                # write-time retirement needed an outcome gate: the helper
+                # re-resolves the live child at call time, so a swallowed
+                # teardown failure leaves the child alive, the stamps still
+                # match, and nothing is broadcast (see
+                # _broadcast_expired_oauth_banners).
+                _broadcast_expired_oauth_banners(state, slot)
         finally:
             if _acquired:
                 # A successful reset() above already popped the key under its

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -2488,48 +2488,148 @@ def _collapse_wire_rows(messages: list[dict]) -> list[dict]:
 # provably gone. Every ACP child is a subprocess of the gateway, so the loopback
 # listener and the PKCE verifier that made the banner's URL redeemable died with it.
 #
-# In-memory ON PURPOSE, and random rather than sequential. `connections.warm`
-# documents where a counter leads: its generation restarts at 0 every boot, so a
-# stored `generation=1` compares equal to a different boot's `generation=1` and the
-# row is judged live when it is dead -- that bug already withdrew a URL whose
-# process and session were both alive. A fresh random id cannot collide with a
-# previous boot's, so the comparison stays correct with no bookkeeping and no
-# persisted state to migrate.
-_GATEWAY_GENERATION = uuid.uuid4().hex[:16]
+def _live_child_instance(state: "DashboardState", slot: "_ChatSlot") -> str:
+    """Process-instance identity of the live ACP child serving *slot*, or ``""``.
+
+    The verdict `_prepare_messages` needs to judge an open MCP OAuth banner: a
+    banner's Authorize link is redeemable only while the child process that
+    minted it is alive, because that process holds the loopback callback
+    listener and the PKCE verifier (see `_expire_dead_child_oauth_meta`).
+    Resolved here — on the event loop, where the session pool is in scope —
+    because `_prepare_messages` itself is synchronous, may run in a worker
+    thread, and has no ACP access.
+
+    Resolves the ACTIVE TURN's session key first and the slot's routing only
+    as a fallback, for the reason `_cancel_target` documents: a running turn
+    owns a stable identity, while ``linked_session_key`` is mutable underneath
+    it (a cron injection can rebind a live slot mid-turn). A banner minted
+    during that turn belongs to the turn's own child; re-deriving the key from
+    the routing would compare it against a different or absent provider and
+    withdraw a link that still works.
+
+    ``""`` covers every no-live-child case in one answer: no session in the
+    pool (idle sweep, RSS recycle, reset, gateway restart), a session whose
+    process has exited on its own, and a provider not backed by a process at
+    all. Never raises: a probe failure answers ``""``, which withdraws a
+    possibly-dead button rather than failing the read it rides on.
+    """
+    try:
+        key = getattr(slot, "_active_turn_session_key", "") or effective_session_key(slot)
+        provider = state.sessions.get_provider(key)
+        if provider is None or not provider.is_process_alive():
+            return ""
+        return str(getattr(provider, "process_instance", "") or "")
+    except Exception:
+        logger.debug("live-child probe failed for slot %s", slot.key, exc_info=True)
+        return ""
 
 
-def gateway_generation() -> str:
-    """The generation id of the running gateway process."""
-    return _GATEWAY_GENERATION
+def _broadcast_expired_oauth_banners(state: "DashboardState", slot: "_ChatSlot") -> None:
+    """Push the read-time gate's current verdict on *slot*'s OAuth banners to open tabs.
+
+    The gate in `_prepare_messages` runs only when a client FETCHES, so an
+    already-open tab keeps rendering a dead Authorize link until its next
+    refetch. This closes that window for the teardowns the dashboard can see:
+    call it after any step that may have ended the slot's child (a session
+    reset, an agent switch, a conversation discard, a watchdog recycle) and it
+    re-broadcasts the withdrawal frame for every open banner the gate now
+    judges dead.
+
+    Verdict-driven, not ordering-driven: it resolves the live child at call
+    time and applies the SAME predicate as the read gate, so it needs no
+    pre-teardown snapshot and no outcome gating. Called after a teardown that
+    failed or was declined, the child is still alive, the stamps still match,
+    and nothing is broadcast; a successor session's banner names the successor
+    child and is never swept. That is what lets a caller invoke it
+    unconditionally where the old write-time retirement needed a doomed-set
+    snapshot and a confirmed-teardown gate.
+
+    Deliberately does NOT rewrite the stored rows — the read gate remains the
+    one liveness mechanism and this is presentation freshness only. The frame
+    carries ``oauth_url: ""`` (not an absent key) because the client merges
+    incoming meta over the row it already has, and pre-upgrade JS keeps
+    rendering a link whose key was merely omitted. Best-effort: teardowns the
+    dashboard never observes (the idle sweep, a child exiting on its own) are
+    still caught by the read gate on the tab's next refetch.
+    """
+    # Candidates first, pool second: almost every slot holds no open banner,
+    # and the live-child probe reads the session pool — a side effect the
+    # common case must not pay (and one that would burn a pool read at every
+    # teardown site this helper rides).
+    candidates = [
+        message
+        for message in slot.messages
+        if message.get("role") == "mcp_oauth"
+        for meta in (message.get("meta") or {},)
+        if meta.get("oauth_url")
+        and not (meta.get("completed") or meta.get("failed") or meta.get("superseded"))
+    ]
+    if not candidates:
+        return
+    live_child = _live_child_instance(state, slot)
+    for message in candidates:
+        meta = message.get("meta") or {}
+        verdict = _expire_dead_child_oauth_meta("mcp_oauth", meta, live_child)
+        if verdict is meta:
+            # The gate returns the input unchanged when nothing applies — the
+            # banner is live, already terminal, or has no link to withdraw.
+            continue
+        new_meta = _redact_meta_for_role("mcp_oauth", verdict)
+        new_meta.pop("oauth_url", None)
+        # Meta only, no content override: the read gate rewrites nothing but
+        # meta, so a refetch serves the stored content with `expired` set and
+        # the client renders the expired branch from the meta alone. A content
+        # override here would diverge from what the next fetch says.
+        state.broadcast_ws(
+            "chat_message_update",
+            {
+                "slot": slot.key,
+                "ts": message.get("ts", ""),
+                "mid": str(meta.get("mid") or ""),
+                "meta": {**new_meta, "oauth_url": ""},
+            },
+        )
 
 
-def _expire_stale_generation_oauth_meta(role: str, meta: dict) -> dict:
-    """Present an `mcp_oauth` banner minted by a dead generation as terminal.
+def _expire_dead_child_oauth_meta(role: str, meta: dict, live_child: str) -> dict:
+    """Present an ``mcp_oauth`` banner whose minting child is gone as terminal.
 
-    A read-time gate, and it has to be read-time. The case it exists for is a hard
-    gateway restart: no code of ours runs at the moment the flow dies, so nothing
-    can write the terminal state when it becomes true. Revalidating on every read
-    is the same discipline `connections.mint.expire_dead_holder` already applies to
-    the mint feed, instead of trying to catch every way a flow can end.
+    A read-time gate, and it has to be read-time. The entity whose death
+    invalidates an Authorize link is the ACP child process that minted it — that
+    process holds the loopback callback listener and the PKCE verifier the code
+    is exchanged with. A child can die without any code of ours running at a
+    site that knows about banners: a hard gateway restart, the idle sweep, the
+    RSS recycle, or the child simply exiting. Revalidating on every read is the
+    same discipline ``connections.mint.expire_dead_holder`` already applies to
+    the mint feed, instead of trying to enumerate every way a flow can end.
+
+    ``live_child`` is the process-instance identity of the child CURRENTLY
+    serving the slot, resolved by the caller (empty when there is no live
+    child). It is a per-spawn token, never the ACP session id: a resume carries
+    the same session id onto a NEW process, so a session-id comparison would
+    fail open exactly when the minting process is gone.
 
     Withdraws the link only when ALL of these hold:
 
-    * the row still carries an `oauth_url` -- there is a live-looking button to take
-      away. A row without one has nothing to withdraw and is left untouched, which
-      is what keeps the two rejected-URL banners and an already-retired row alone.
-    * the row is not already terminal. `completed` / `failed` / `superseded` are
-      authoritative outcomes recorded by the process that observed them, and a
-      later read must not reinterpret them.
-    * the row's `gen` is not this process's.
+    * the row still carries an ``oauth_url`` — there is a live-looking button to
+      take away. A row without one has nothing to withdraw and is left
+      untouched, which is what keeps the two rejected-URL banners and an
+      already-retired row alone.
+    * the row is not already terminal. ``completed`` / ``failed`` /
+      ``superseded`` are authoritative outcomes recorded by the process that
+      observed them, and a later read must not reinterpret them.
+    * the row's ``child`` stamp does not name the live child.
 
-    A row carrying NO `gen` is treated as stale, and that is a deduction rather than
-    a guess: the stamp is written by the same build that reads it, so an unstamped
-    row was persisted by an older build -- and running this build means this process
-    replaced the one that wrote that row. Its child cannot still be alive. The
-    effect is that the fix also retires banners that went stale before it shipped.
+    A row carrying NO ``child`` stamp is treated as stale, and that is a
+    deduction rather than a guess: the stamp is written by the same build that
+    reads it, so an unstamped row was persisted by an older build — and running
+    this build means this process replaced the one that hosted that row's
+    child. The effect is that the fix also retires banners that went stale
+    before it shipped, including rows carrying only the older gateway-``gen``
+    stamp.
 
-    Returns the input dict unchanged when nothing applies, so the caller can use the
-    result unconditionally; only the withdrawing path copies.
+    Returns the input dict unchanged when nothing applies, so the caller can use
+    the result unconditionally; only the withdrawing path copies.
     """
     if role != "mcp_oauth":
         return meta
@@ -2537,7 +2637,8 @@ def _expire_stale_generation_oauth_meta(role: str, meta: dict) -> dict:
         return meta
     if meta.get("completed") or meta.get("failed") or meta.get("superseded"):
         return meta
-    if meta.get("gen") == gateway_generation():
+    child = meta.get("child")
+    if child and live_child and child == live_child:
         return meta
     out = dict(meta)
     out.pop("oauth_url", None)
@@ -2545,8 +2646,18 @@ def _expire_stale_generation_oauth_meta(role: str, meta: dict) -> dict:
     return out
 
 
-def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
-    """Prepare messages for API response."""
+def _prepare_messages(messages: list[dict], running: bool, *, live_child: str) -> list[dict]:
+    """Prepare messages for API response.
+
+    ``live_child`` is the process-instance identity of the ACP child currently
+    serving the slot ("" when none is alive) — see
+    :func:`_expire_dead_child_oauth_meta`. REQUIRED and keyword-only on
+    purpose: a caller that forgot it would silently withdraw every live OAuth
+    banner it renders, and no test would see the omission. Resolve it with
+    :func:`_live_child_instance` on the event loop, as close to the render as
+    possible (a verdict sampled long before use can name a child that has
+    since died, serving one stale read).
+    """
     out: list[dict] = []
     for m in _collapse_wire_rows(messages):
         role = m.get("role", "")
@@ -2588,8 +2699,8 @@ def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
             ]
         meta = parse_cls_meta(m.get("cls", ""))
         if meta is not None:
-            msg_out["meta"] = _expire_stale_generation_oauth_meta(
-                role, _redact_meta_for_role(role, meta)
+            msg_out["meta"] = _expire_dead_child_oauth_meta(
+                role, _redact_meta_for_role(role, meta), live_child
             )
         elif isinstance(msg_out.get("meta"), dict):
             # Redact the STORED meta too. Without this branch the stored dict
@@ -2597,8 +2708,8 @@ def _prepare_messages(messages: list[dict], running: bool) -> list[dict]:
             # reach the client exactly as loaded. This is the only guard on
             # meta for the slot-detail response (the load path does not
             # redact meta).
-            msg_out["meta"] = _expire_stale_generation_oauth_meta(
-                role, _redact_meta_for_role(role, msg_out["meta"])
+            msg_out["meta"] = _expire_dead_child_oauth_meta(
+                role, _redact_meta_for_role(role, msg_out["meta"]), live_child
             )
         out.append(msg_out)
     return out

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5356,7 +5356,10 @@ class DashboardState:
         """
 
         async def _on_recycled(key: str, *, reason: str) -> None:
-            from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+            from kiro_crew.dashboard.chat_utils import (
+                _broadcast_expired_oauth_banners,
+                dashboard_slot_key,
+            )
 
             # A channel-born session's key is the channel's own even while its
             # tab is open, so ask which tab displays it rather than reading the
@@ -5376,6 +5379,16 @@ class DashboardState:
             except Exception:
                 logging.getLogger(__name__).exception(
                     "Failed to append recycle notice to slot %s", slot_key
+                )
+            # The recycle ended the child that owned any open MCP OAuth
+            # banner's loopback listener; push the read gate's verdict so an
+            # open tab withdraws the dead Authorize link without waiting for
+            # its next refetch (issue #8149's RSS-recycle path).
+            try:
+                _broadcast_expired_oauth_banners(self, slot)
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "Failed to broadcast OAuth banner expiry for slot %s", slot_key
                 )
 
         self.sessions.set_recycle_callback(_on_recycled)

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -1581,6 +1581,16 @@ class AcpProvider(LLMProvider):
         """True if the underlying OS process has not exited (ignores I/O staleness)."""
         return self._client.is_process_alive()
 
+    @property
+    def process_instance(self) -> str:
+        """Per-spawn identity of the client's current child process (see base).
+
+        A direct read on purpose: a `getattr` hedge would convert a future
+        wiring break into "no banner is ever live", indistinguishable from
+        correct expiry.
+        """
+        return self._client.process_instance
+
     def has_active_turn(self) -> bool:
         """True if a prompt is in flight (and not yet cancelled) on the client."""
         return bool(self._client) and self._client.has_active_turn()

--- a/src/kiro_crew/providers/base.py
+++ b/src/kiro_crew/providers/base.py
@@ -226,6 +226,20 @@ class LLMProvider(ABC):
         return self.is_alive()
 
     @property
+    def process_instance(self) -> str:
+        """Identity of the provider's CURRENT child process instance.
+
+        ``""`` for providers not backed by a child process, and for a
+        process-backed provider whose child is gone. Process-backed providers
+        override this with a per-spawn token so a resource minted by one child
+        (an MCP OAuth authorize link, whose loopback listener and PKCE verifier
+        live in that process) can be recognized as dead once the child is —
+        equality across spawns must be impossible, which is why the ACP session
+        id (reused by resume on a new process) can never serve here.
+        """
+        return ""
+
+    @property
     def exit_code(self) -> int | None:
         """Last child-process exit code, or None if no process or still running."""
         return None

--- a/test/test_chat_utils.py
+++ b/test/test_chat_utils.py
@@ -142,14 +142,14 @@ class TestPrepareMessages:
 
         monkeypatch.setattr(chat_utils, "_collapse_wire_rows", record_collapse)
 
-        result = _prepare_messages(messages, running=True)
+        result = _prepare_messages(messages, running=True, live_child="")
 
         assert calls == [messages]
         assert result == [{"role": "streaming", "content": "hello", "cls": "msg msg-a"}]
 
     def test_strips_done(self):
         msgs = [{"role": "user", "content": "hi"}, {"role": "done", "content": ""}]
-        result = _prepare_messages(msgs, running=False)
+        result = _prepare_messages(msgs, running=False, live_child="")
         assert len(result) == 1
         assert result[0]["role"] == "user"
 
@@ -159,14 +159,14 @@ class TestPrepareMessages:
             {"role": "chunk", "content": "lo"},
             {"role": "user", "content": "next"},
         ]
-        result = _prepare_messages(msgs, running=False)
+        result = _prepare_messages(msgs, running=False, live_child="")
         assert result[0]["role"] == "streaming"
         assert "hel" in result[0]["content"]
         assert result[1]["role"] == "user"
 
     def test_trailing_chunks(self):
         msgs = [{"role": "chunk", "content": "partial"}]
-        result = _prepare_messages(msgs, running=True)
+        result = _prepare_messages(msgs, running=True, live_child="")
         assert len(result) == 1
         assert result[0]["role"] == "streaming"
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -3559,7 +3559,7 @@ class TestPrepareMessages:
             {"role": "done", "content": ""},
             {"role": "assistant", "content": "hi"},
         ]
-        out = _prepare_messages(msgs, running=False)
+        out = _prepare_messages(msgs, running=False, live_child="")
         roles = [m["role"] for m in out]
         assert "queued" in roles, "queued must be preserved for tab-switch indicator"
         assert "done" not in roles, "done must be stripped"
@@ -3573,7 +3573,7 @@ class TestPrepareMessages:
             {"role": "chunk", "content": "Hel"},
             {"role": "chunk", "content": "lo"},
         ]
-        out = _prepare_messages(msgs, running=True)
+        out = _prepare_messages(msgs, running=True, live_child="")
         assert out[-1]["role"] == "streaming"
         assert "Hel" in out[-1]["content"]
 
@@ -7376,7 +7376,7 @@ class TestPrepareMessagesInterleaved:
             {"role": "chunk", "content": "streaming"},
         ]
 
-        result = _prepare_messages(messages, running=True)
+        result = _prepare_messages(messages, running=True, live_child="")
 
         # user, assistant, tool, assistant, streaming (collapsed chunks)
         assert len(result) == 5
@@ -7400,7 +7400,7 @@ class TestPrepareMessagesInterleaved:
             {"role": "assistant", "content": "Segment 2", "cls": "msg msg-a"},
         ]
 
-        result = _prepare_messages(messages, running=False)
+        result = _prepare_messages(messages, running=False, live_child="")
 
         assert len(result) == 4
         roles = [m["role"] for m in result]
@@ -13382,7 +13382,7 @@ class TestRegenerateAndVariants:
         ]
         from kiro_crew.dashboard.chat import _prepare_messages
 
-        prepared = _prepare_messages(slot.messages, False)
+        prepared = _prepare_messages(slot.messages, False, live_child="")
         ai = [m for m in prepared if m.get("role") == "assistant"][0]
         for v in ai["variants"]:
             assert "AKIAIOSFODNN7EXAMPLE" not in v.get("content", "")

--- a/test/test_display_time_redaction.py
+++ b/test/test_display_time_redaction.py
@@ -69,14 +69,14 @@ def _rewrite_last_meta(log, key: str, meta: dict) -> None:
 @pytest.mark.parametrize("role", ["assistant", "system", "tool"])
 def test_prepare_messages_redacts_every_non_user_role(role: str) -> None:
     """`system` was excluded by the old gate, so stored secrets were emitted raw."""
-    out = _prepare_messages([{"role": role, "content": f"key {SECRET}", "cls": "msg"}], False)
+    out = _prepare_messages([{"role": role, "content": f"key {SECRET}", "cls": "msg"}], False, live_child="")
     assert SECRET not in json.dumps(out), f"{role} content emitted unredacted"
 
 
 def test_prepare_messages_leaves_user_content_alone() -> None:
     """User content is deliberately NOT redacted — the author is the only reader."""
     out = _prepare_messages(
-        [{"role": "user", "content": f"key {SECRET}", "cls": "msg msg-u"}], False
+        [{"role": "user", "content": f"key {SECRET}", "cls": "msg msg-u"}], False, live_child=""
     )
     assert SECRET in out[0]["content"]
 
@@ -89,7 +89,9 @@ def test_prepare_messages_redacts_stored_meta_not_just_cls_meta() -> None:
     redaction was the only guard.
     """
     out = _prepare_messages(
-        [{"role": "tool", "content": "ok", "cls": "msg", "meta": {"tool_input": SECRET}}], False
+        [{"role": "tool", "content": "ok", "cls": "msg", "meta": {"tool_input": SECRET}}],
+        False,
+        live_child="",
     )
     assert SECRET not in json.dumps(out), "stored meta emitted unredacted"
 
@@ -293,7 +295,7 @@ def test_load_redacts_content_restoring_the_chokepoint(tmp_path, monkeypatch) ->
     loaded = " ".join(m.get("content", "") for m in slot.messages)
     assert SECRET not in loaded, "content must be clean in memory (the chokepoint)"
     # …and still clean on the way out.
-    assert SECRET not in json.dumps(_prepare_messages(slot.messages, False))
+    assert SECRET not in json.dumps(_prepare_messages(slot.messages, False, live_child=""))
 
 
 def test_load_leaves_user_content_raw(tmp_path, monkeypatch) -> None:
@@ -363,7 +365,7 @@ def test_load_does_not_redact_meta_keeping_boot_fast(tmp_path, monkeypatch) -> N
     loaded_meta = json.dumps([m.get("meta") for m in slot.messages])
     assert SECRET in loaded_meta, "meta was scanned on load — the ~5.5s cost is back"
     # …and the emit path still cleans it on the way out.
-    assert SECRET not in json.dumps(_prepare_messages(slot.messages, False))
+    assert SECRET not in json.dumps(_prepare_messages(slot.messages, False, live_child=""))
 
 
 # ── 6. the META side: a non-emit reader that RE-EMITS the dict ────────────────
@@ -435,8 +437,6 @@ def test_oauth_url_corpus_survives_the_emit_path(monkeypatch) -> None:
     """
     from oauth_url_corpus import LEGIT_OAUTH_URLS
 
-    from kiro_crew.dashboard.chat_utils import gateway_generation
-
     assert LEGIT_OAUTH_URLS, "precondition: the corpus is non-empty"
     blanked = []
     for provider, url in LEGIT_OAUTH_URLS:
@@ -446,20 +446,22 @@ def test_oauth_url_corpus_survives_the_emit_path(monkeypatch) -> None:
                     "role": "mcp_oauth",
                     "content": "authorize",
                     "cls": "msg msg-info",
-                    # Stamped with the LIVE generation, which is what a banner the
-                    # user can still act on always carries: `_emit_mcp_oauth_request`
-                    # is the only producer of these rows and it always stamps. An
-                    # unstamped row means a dead flow and is withdrawn on purpose
-                    # (issue #7654) -- pinned by the next test, so this one keeps
-                    # measuring what it was written to measure: the redaction gate.
+                    # Stamped with the child the caller resolves as LIVE, which is
+                    # what a banner the user can still act on always carries:
+                    # `_emit_mcp_oauth_request` is the only producer of these rows
+                    # and it always stamps. An unstamped row means a dead flow and
+                    # is withdrawn on purpose (issues #7654, #8149) -- pinned by
+                    # the next test, so this one keeps measuring what it was
+                    # written to measure: the redaction gate.
                     "meta": {
                         "server_name": "acme",
                         "oauth_url": url,
-                        "gen": gateway_generation(),
+                        "child": "live-child",
                     },
                 }
             ],
             False,
+            live_child="live-child",
         )
         if out[0]["meta"].get("oauth_url") != url:
             blanked.append(provider)
@@ -469,13 +471,14 @@ def test_oauth_url_corpus_survives_the_emit_path(monkeypatch) -> None:
     )
 
 
-def test_a_legitimate_url_from_a_dead_generation_is_withdrawn() -> None:
+def test_a_legitimate_url_from_a_dead_child_is_withdrawn() -> None:
     """The other side of the corpus test: a real URL is no longer a live one.
 
-    A banner carrying no generation stamp was persisted by an earlier build, so the
+    A banner carrying no child stamp was persisted by an earlier build, so the
     process that owned its loopback listener and PKCE verifier is gone. The URL is
     still a perfectly well-formed provider URL — that is exactly why the scheme and
-    credential gates cannot catch it, and why the liveness gate has to (issue #7654).
+    credential gates cannot catch it, and why the liveness gate has to (issues
+    #7654, #8149).
     """
     from oauth_url_corpus import LEGIT_OAUTH_URLS
 
@@ -490,6 +493,7 @@ def test_a_legitimate_url_from_a_dead_generation_is_withdrawn() -> None:
             }
         ],
         False,
+        live_child="live-child",
     )
     assert out[0]["meta"]["expired"] is True
     assert not out[0]["meta"].get("oauth_url"), "a dead flow still offered its link"

--- a/test/test_inline_tool_cards_props.py
+++ b/test/test_inline_tool_cards_props.py
@@ -373,7 +373,7 @@ class TestProperty7PrepareMessagesChunkCollapse:
         for chunk in trailing_chunks:
             messages.append({"role": "chunk", "content": chunk, "cls": "chunk"})
 
-        result = _prepare_messages(messages, running=True)
+        result = _prepare_messages(messages, running=True, live_child="")
 
         # Count roles in output
         result_roles = [m.get("role") for m in result]

--- a/test/test_mcp_oauth_banner.py
+++ b/test/test_mcp_oauth_banner.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import threading
 from unittest.mock import MagicMock, patch
@@ -32,16 +31,15 @@ from kiro_crew.dashboard.chat_runner import (
     _connections_managed_mcp_names,
     _drain_session_init_oauth_requests,
     _emit_mcp_oauth_request,
-    _expire_mcp_oauth_banners,
     _is_safe_oauth_url,
     _mark_mcp_oauth_completed,
-    _open_mcp_oauth_banner_mids,
     _supersede_open_mcp_oauth_banners,
 )
 from kiro_crew.dashboard.chat_utils import (
+    _broadcast_expired_oauth_banners,
+    _live_child_instance,
     _prepare_messages,
     _redact_meta_for_role,
-    gateway_generation,
 )
 from kiro_crew.dashboard.state import _ChatSlot
 from kiro_crew.mcp_utils import mcp_server_alias
@@ -703,70 +701,81 @@ class TestSupersededOAuthBanners:
         _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
         _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/b")
 
-        prepared = _prepare_messages(list(slot.messages), running=False)
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
         stale = prepared[0]
         assert stale["meta"]["superseded"] is True
         assert not stale["meta"].get("oauth_url")
 
 
-# ── read-time generation gate (issue #7654) ──
+# ── read-time minting-child liveness gate (issues #7654, #8149) ──
 
 
-class TestExpiredByDeadGeneration:
+class TestExpiredByDeadChild:
     """A banner outlives the process whose listener made its URL redeemable.
 
-    The two reachable ways for that to happen announce nothing, so #7639's
-    supersede-on-a-newer-request path never fires: a gateway restart (every ACP
-    child is its subprocess and dies with it) and a session reset (the child is
-    killed and replaced). The banner is on disk with its `oauth_url` intact and
-    the render layer's only gate is a scheme check, so it keeps offering a live
-    "Authorize" button onto a dead loopback port, indefinitely (issue #7654).
+    The entity whose death invalidates the Authorize link is the ACP child that
+    minted it: that process holds the loopback callback listener and the PKCE
+    verifier. Every way it can die is silent to the banner — a gateway restart,
+    a session reset, the idle sweep, the RSS recycle, or the child exiting on
+    its own — so no write-time site can enumerate them. The read-time gate
+    compares the process-instance identity stamped at mint against the child
+    CURRENTLY serving the slot, resolved by the caller of `_prepare_messages`.
     """
 
-    def _stale_slot(self, gen="a-previous-generation"):
-        """A slot holding one open banner stamped with some OTHER generation."""
+    def _slot_with_banner(self, minted_by="child-a"):
+        """A slot holding one open banner stamped with *minted_by*."""
         slot = _ChatSlot("s1")
-        slot.append(
-            "mcp_oauth",
-            "🔐 miro requires authentication.",
-            "msg msg-info",
-            ts="t1",
-            meta={
-                "server_name": "miro",
-                "oauth_url": "https://mcp.miro.com/a?port=55089",
-                "gen": gen,
-            },
+        _emit_mcp_oauth_request(
+            MagicMock(),
+            slot,
+            "miro",
+            "https://mcp.miro.com/a?port=55089",
+            minted_by=minted_by,
         )
         return slot
 
-    def test_banner_from_a_dead_generation_is_presented_as_expired(self):
-        prepared = _prepare_messages(list(self._stale_slot().messages), running=False)
+    def test_banner_is_expired_once_its_child_is_gone(self):
+        """live_child='' is what every teardown looks like from here: the idle
+        sweep, the RSS recycle, a session reset, a gateway restart, and a child
+        that exited on its own all leave no live provider for the slot."""
+        slot = self._slot_with_banner()
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
         assert prepared[0]["meta"]["expired"] is True
 
     def test_the_dead_link_is_withdrawn_not_merely_flagged(self):
         """A client that has never heard of `expired` must still not render it."""
-        prepared = _prepare_messages(list(self._stale_slot().messages), running=False)
+        slot = self._slot_with_banner()
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
         assert not prepared[0]["meta"].get("oauth_url")
 
-    def test_a_banner_from_this_generation_keeps_its_live_link(self):
+    def test_a_banner_from_the_live_child_keeps_its_link(self):
         """The false-positive direction: never take away a working button."""
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
-        prepared = _prepare_messages(list(slot.messages), running=False)
-        assert prepared[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a"
+        slot = self._slot_with_banner(minted_by="child-a")
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="child-a")
+        assert prepared[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a?port=55089"
         assert "expired" not in prepared[0]["meta"]
 
-    def test_emit_stamps_the_minting_generation(self):
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
-        assert slot.messages[0]["meta"]["gen"] == gateway_generation()
+    def test_a_replacement_child_does_not_keep_the_banner_alive(self):
+        """The resume trap. A resumed session carries the SAME ACP session id on
+        a NEW process (client.py re-sets `_session_id` from `resume_sid`), which
+        is why the stamp is a per-spawn process-instance identity and never the
+        session id: the new child holds neither the loopback listener nor the
+        PKCE verifier of the flow the old one started."""
+        slot = self._slot_with_banner(minted_by="child-a")
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="child-b")
+        assert prepared[0]["meta"]["expired"] is True
+        assert not prepared[0]["meta"].get("oauth_url")
+
+    def test_emit_stamps_the_minting_child(self):
+        slot = self._slot_with_banner(minted_by="child-a")
+        assert slot.messages[0]["meta"]["child"] == "child-a"
 
     def test_an_unstamped_legacy_banner_is_expired(self):
-        """A row with no `gen` was written by an older build.
+        """A row with no `child` stamp was written by an older build.
 
-        Running this build means this process replaced the one that wrote it, so
-        its child is provably gone. That deduction is what lets the fix also
-        retire banners that went stale before it shipped.
+        Running this build means this process replaced the one that hosted that
+        row's child, so the child is provably gone. That deduction is what lets
+        the fix also retire banners that went stale before it shipped.
         """
         slot = _ChatSlot("s1")
         slot.append(
@@ -776,13 +785,40 @@ class TestExpiredByDeadGeneration:
             ts="t1",
             meta={"server_name": "miro", "oauth_url": "https://mcp.miro.com/a"},
         )
-        prepared = _prepare_messages(list(slot.messages), running=False)
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="child-a")
         assert prepared[0]["meta"]["expired"] is True
         assert not prepared[0]["meta"].get("oauth_url")
 
+    def test_a_gen_only_legacy_banner_is_expired(self):
+        """A row stamped only with the older gateway-generation key is a
+        pre-upgrade row; its child cannot be the live one."""
+        slot = _ChatSlot("s1")
+        slot.append(
+            "mcp_oauth",
+            "🔐 miro requires authentication.",
+            "msg msg-info",
+            ts="t1",
+            meta={
+                "server_name": "miro",
+                "oauth_url": "https://mcp.miro.com/a",
+                "gen": "some-generation",
+            },
+        )
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="child-a")
+        assert prepared[0]["meta"]["expired"] is True
+
+    def test_an_empty_stamp_never_matches_an_empty_live_child(self):
+        """Both sides empty is two unknowns, not a match: a banner whose minting
+        child could not be identified must not be kept alive by a slot that has
+        no live child either. Pins the non-empty requirement on BOTH sides of
+        the comparison (flipping either `and` to accept empties fails here)."""
+        slot = self._slot_with_banner(minted_by="")
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
+        assert prepared[0]["meta"]["expired"] is True
+
     def test_a_recorded_outcome_is_never_reinterpreted_by_a_later_read(self):
         """`completed`/`failed`/`superseded` were written by the process that
-        observed them; a stale generation does not overrule them."""
+        observed them; a dead minting child does not overrule them."""
         for flag in ("completed", "failed", "superseded"):
             slot = _ChatSlot("s1")
             slot.append(
@@ -793,11 +829,11 @@ class TestExpiredByDeadGeneration:
                 meta={
                     "server_name": "miro",
                     "oauth_url": "https://mcp.miro.com/a",
-                    "gen": "dead",
+                    "child": "dead-child",
                     flag: True,
                 },
             )
-            prepared = _prepare_messages(list(slot.messages), running=False)
+            prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
             assert "expired" not in prepared[0]["meta"], flag
             assert prepared[0]["meta"][flag] is True
 
@@ -806,21 +842,21 @@ class TestExpiredByDeadGeneration:
         their own `failed` reason must survive."""
         slot = _ChatSlot("s1")
         _emit_mcp_oauth_request(MagicMock(), slot, "miro", "javascript:alert(1)")
-        prepared = _prepare_messages(list(slot.messages), running=False)
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
         assert "expired" not in prepared[0]["meta"]
         assert prepared[0]["meta"]["failed"] is True
 
     def test_a_non_oauth_row_is_untouched(self):
         slot = _ChatSlot("s1")
         slot.append("assistant", "hello", "msg msg-a", ts="t1", meta={"oauth_url": "x"})
-        prepared = _prepare_messages(list(slot.messages), running=False)
+        prepared = _prepare_messages(list(slot.messages), running=False, live_child="")
         assert "expired" not in (prepared[0].get("meta") or {})
 
     def test_the_gate_does_not_rewrite_the_stored_row(self):
         """It is a presentation verdict. The transcript keeps saying what happened,
         and re-reading the same slot must not accumulate edits."""
-        slot = self._stale_slot()
-        _prepare_messages(list(slot.messages), running=False)
+        slot = self._slot_with_banner()
+        _prepare_messages(list(slot.messages), running=False, live_child="")
         assert slot.messages[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a?port=55089"
         assert "expired" not in slot.messages[0]["meta"]
 
@@ -838,54 +874,166 @@ class TestExpiredByDeadGeneration:
         assert "completed" not in slot.messages[0]["meta"]
 
 
-class TestExpireOpenBannersOnReset:
-    """The session-reset half of #7654.
+class TestLiveChildInstance:
+    """`_live_child_instance` is the caller-side half of the read-time gate.
 
-    A reset kills the ACP child and cold-starts a replacement, but it does NOT
-    change the gateway generation, so the read-time gate cannot infer it. The
-    teardown is a code path we execute, so the terminal state is written there.
+    `_prepare_messages` is synchronous, may run in a worker thread, and has no
+    ACP access, so its three async callers resolve the live child's identity on
+    the event loop — where the session pool is in scope — and pass the verdict
+    in. `""` is the one answer for every no-live-child case, which is exactly
+    what makes the idle sweep and the RSS recycle covered without either path
+    knowing banners exist: both end in the session being popped from the pool.
     """
 
-    def _slot_with_live_banner(self):
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089")
-        return slot
+    def _state_with_provider(self, provider):
+        state = MagicMock()
+        state.sessions.get_provider.return_value = provider
+        return state
 
-    def test_reset_retires_the_open_banner(self):
-        slot = self._slot_with_live_banner()
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert slot.messages[0]["meta"]["expired"] is True
-        assert "oauth_url" not in slot.messages[0]["meta"]
+    def test_no_session_in_the_pool_answers_empty(self):
+        """The idle-sweep / RSS-recycle / reset / restart shape: the session is
+        gone from the pool, so there is nothing whose identity could match."""
+        state = self._state_with_provider(None)
+        assert _live_child_instance(state, _ChatSlot("s1")) == ""
 
-    def test_the_dead_port_is_not_left_in_the_content(self):
-        slot = self._slot_with_live_banner()
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert "55089" not in slot.messages[0]["content"]
+    def test_a_live_provider_answers_its_process_instance(self):
+        provider = MagicMock()
+        provider.is_process_alive.return_value = True
+        provider.process_instance = "child-a"
+        state = self._state_with_provider(provider)
+        assert _live_child_instance(state, _ChatSlot("s1")) == "child-a"
 
-    def test_it_retires_every_server_not_just_one(self):
-        """The reset destroys the whole child, so every flow it hosted dies."""
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
-        _emit_mcp_oauth_request(MagicMock(), slot, "linear", "https://mcp.linear.app/b")
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert all(m["meta"]["expired"] is True for m in slot.messages)
+    def test_a_dead_process_answers_empty_even_while_registered(self):
+        """The self-exit case: the session is still in the pool but its child
+        exited on its own. The identity of a dead process must not keep its
+        banner's button clickable."""
+        provider = MagicMock()
+        provider.is_process_alive.return_value = False
+        provider.process_instance = "child-a"
+        state = self._state_with_provider(provider)
+        assert _live_child_instance(state, _ChatSlot("s1")) == ""
 
-    def test_a_credential_shaped_server_name_is_still_retired(self):
-        """Unlike the supersede path, this never has to match a redacted name, so
-        #7639's known limitation does not apply here."""
+    def test_a_probe_failure_answers_empty_not_raises(self):
+        """The verdict rides slot-detail reads; a probe failure must degrade to
+        withdrawing a possibly-dead button, never fail the read."""
+        state = MagicMock()
+        state.sessions.get_provider.side_effect = RuntimeError("pool exploded")
+        assert _live_child_instance(state, _ChatSlot("s1")) == ""
+
+    def test_a_provider_without_the_property_answers_empty(self):
+        """A provider not backed by a child process mints no OAuth flows, so an
+        empty identity (expiring any stamped banner) is the correct verdict."""
+        provider = MagicMock(spec=["is_process_alive"])
+        provider.is_process_alive.return_value = True
+        state = self._state_with_provider(provider)
+        assert _live_child_instance(state, _ChatSlot("s1")) == ""
+
+    def test_end_to_end_a_swept_sessions_banner_is_withdrawn_on_read(self):
+        """The whole #8149 defect in one path: mint under child A, sweep the
+        session (pool answers None), and the next read withdraws the link."""
         slot = _ChatSlot("s1")
         _emit_mcp_oauth_request(
-            MagicMock(), slot, "ghp_" + "a" * 36, "https://mcp.example.com/a"
+            MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089", minted_by="child-a"
         )
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert slot.messages[0]["meta"]["expired"] is True
-        assert "oauth_url" not in slot.messages[0]["meta"]
+        state = self._state_with_provider(None)
+        prepared = _prepare_messages(
+            list(slot.messages), running=False, live_child=_live_child_instance(state, slot)
+        )
+        assert prepared[0]["meta"]["expired"] is True
+        assert not prepared[0]["meta"].get("oauth_url")
 
-    def test_a_recorded_outcome_is_left_alone(self):
-        """`completed`/`failed` can still carry an `oauth_url` -- the completion
-        matcher sets the flag without popping it -- so they must be named in the
-        predicate rather than inferred from the url being gone."""
-        for flag in ("completed", "failed"):
+
+class TestBroadcastExpiredOauthBanners:
+    """The freshness push for already-open tabs.
+
+    The read-time gate runs only when a client fetches, so a tab left open
+    across a teardown keeps rendering the dead Authorize link it already has.
+    `_broadcast_expired_oauth_banners` closes that window at the teardowns the
+    dashboard can see. It is verdict-driven — it re-resolves the live child and
+    applies the read gate's own predicate — so callers invoke it
+    unconditionally: no pre-teardown snapshot, no outcome gating.
+    """
+
+    def _state(self, provider):
+        state = MagicMock()
+        state.sessions.get_provider.return_value = provider
+        return state
+
+    def _live_provider(self, token="child-a"):
+        provider = MagicMock()
+        provider.is_process_alive.return_value = True
+        provider.process_instance = token
+        return provider
+
+    def test_a_dead_childs_banner_is_broadcast_as_expired(self):
+        slot = _ChatSlot("s1")
+        _emit_mcp_oauth_request(
+            MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089", minted_by="child-a"
+        )
+        state = self._state(None)  # session swept from the pool
+        _broadcast_expired_oauth_banners(state, slot)
+        state.broadcast_ws.assert_called_once()
+        kind, payload = state.broadcast_ws.call_args[0]
+        assert kind == "chat_message_update"
+        assert payload["meta"]["expired"] is True
+        assert payload["mid"] == slot.messages[0]["meta"]["mid"]
+
+    def test_the_frame_blanks_the_url_for_a_pre_upgrade_client(self):
+        """The client MERGES incoming meta, so omitting the key would leave the
+        dead URL on a tab whose JS does not know `expired`."""
+        slot = _ChatSlot("s1")
+        _emit_mcp_oauth_request(
+            MagicMock(), slot, "miro", "https://mcp.miro.com/a", minted_by="child-a"
+        )
+        state = self._state(None)
+        _broadcast_expired_oauth_banners(state, slot)
+        payload = state.broadcast_ws.call_args[0][1]
+        assert payload["meta"]["oauth_url"] == ""
+
+    def test_the_stored_row_is_not_rewritten(self):
+        """Presentation only: the read gate stays the one liveness mechanism,
+        and the transcript keeps saying what happened."""
+        slot = _ChatSlot("s1")
+        _emit_mcp_oauth_request(
+            MagicMock(), slot, "miro", "https://mcp.miro.com/a", minted_by="child-a"
+        )
+        _broadcast_expired_oauth_banners(self._state(None), slot)
+        assert slot.messages[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a"
+        assert "expired" not in slot.messages[0]["meta"]
+
+    def test_a_live_childs_banner_is_not_broadcast(self):
+        """The declined/failed-teardown shape: the child is still alive, so the
+        stamps match and the button keeps working. This is what lets callers
+        skip the old outcome gate."""
+        slot = _ChatSlot("s1")
+        _emit_mcp_oauth_request(
+            MagicMock(), slot, "miro", "https://mcp.miro.com/a", minted_by="child-a"
+        )
+        state = self._state(self._live_provider("child-a"))
+        _broadcast_expired_oauth_banners(state, slot)
+        state.broadcast_ws.assert_not_called()
+
+    def test_a_successors_banner_is_not_swept_with_the_dead_ones(self):
+        """The race the old snapshot protected against, now answered by
+        identity: the successor's banner names the live child and survives,
+        while the dead child's banner is withdrawn."""
+        slot = _ChatSlot("s1")
+        _emit_mcp_oauth_request(
+            MagicMock(), slot, "miro", "https://mcp.miro.com/old?port=1", minted_by="child-a"
+        )
+        _emit_mcp_oauth_request(
+            MagicMock(), slot, "linear", "https://mcp.linear.app/new?port=2", minted_by="child-b"
+        )
+        state = self._state(self._live_provider("child-b"))
+        _broadcast_expired_oauth_banners(state, slot)
+        state.broadcast_ws.assert_called_once()
+        payload = state.broadcast_ws.call_args[0][1]
+        assert payload["mid"] == slot.messages[0]["meta"]["mid"]
+
+    def test_a_recorded_outcome_is_not_broadcast(self):
+        """`completed`/`failed`/`superseded` rows and the rejected-URL banners
+        are the gate's own exclusions, and the helper inherits them."""
+        for flag in ("completed", "failed", "superseded"):
             slot = _ChatSlot("s1")
             slot.append(
                 "mcp_oauth",
@@ -895,324 +1043,70 @@ class TestExpireOpenBannersOnReset:
                 meta={
                     "server_name": "miro",
                     "oauth_url": "https://mcp.miro.com/a",
+                    "child": "dead-child",
                     flag: True,
                 },
             )
-            _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-            assert "expired" not in slot.messages[0]["meta"], flag
+            state = self._state(None)
+            _broadcast_expired_oauth_banners(state, slot)
+            state.broadcast_ws.assert_not_called()
 
-    def test_an_already_superseded_banner_is_left_alone(self):
-        """The supersede path pops `oauth_url`, which is the state this sees."""
+    def test_no_banner_is_a_noop(self):
         slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/b")
-        assert slot.messages[0]["meta"]["superseded"] is True
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert "expired" not in slot.messages[0]["meta"]
-        # The newest banner was live, so it IS retired.
-        assert slot.messages[1]["meta"]["expired"] is True
-
-    def test_a_rejected_url_banner_is_left_alone(self):
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "javascript:alert(1)")
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert "expired" not in slot.messages[0]["meta"]
-
-    def test_retirement_is_broadcast_so_an_open_tab_repaints(self):
-        slot = self._slot_with_live_banner()
-        state = MagicMock()
-        _expire_mcp_oauth_banners(state, slot, _open_mcp_oauth_banner_mids(slot))
-        state.broadcast_ws.assert_called_once()
-        kind, payload = state.broadcast_ws.call_args[0]
-        assert kind == "chat_message_update"
-        assert payload["meta"]["expired"] is True
-
-    def test_the_broadcast_blanks_the_url_for_a_pre_upgrade_client(self):
-        """The client MERGES incoming meta, so omitting the key would leave the
-        dead URL on a tab whose JS does not know `expired`."""
-        slot = self._slot_with_live_banner()
-        state = MagicMock()
-        _expire_mcp_oauth_banners(state, slot, _open_mcp_oauth_banner_mids(slot))
-        payload = state.broadcast_ws.call_args[0][1]
-        assert payload["meta"]["oauth_url"] == ""
-        assert "oauth_url" not in slot.messages[0]["meta"]
-
-    def test_the_broadcast_names_the_row_by_mid(self):
-        slot = self._slot_with_live_banner()
-        state = MagicMock()
-        _expire_mcp_oauth_banners(state, slot, _open_mcp_oauth_banner_mids(slot))
-        payload = state.broadcast_ws.call_args[0][1]
-        assert payload["mid"] == slot.messages[0]["meta"]["mid"]
-
-    def test_retirement_marks_the_slot_dirty_so_it_reaches_disk(self):
-        slot = self._slot_with_live_banner()
-        slot._dirty = False
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        assert slot._dirty is True
-
-    def test_no_open_banner_is_a_noop(self):
-        slot = _ChatSlot("s1")
-        state = MagicMock()
-        _expire_mcp_oauth_banners(state, slot, _open_mcp_oauth_banner_mids(slot))
+        slot.append("assistant", "hello", "msg msg-a", ts="t1")
+        state = self._state(None)
+        _broadcast_expired_oauth_banners(state, slot)
         state.broadcast_ws.assert_not_called()
 
-    def test_retiring_twice_broadcasts_once(self):
-        slot = self._slot_with_live_banner()
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        state = MagicMock()
-        _expire_mcp_oauth_banners(state, slot, _open_mcp_oauth_banner_mids(slot))
-        state.broadcast_ws.assert_not_called()
 
-    def test_retirement_survives_the_display_time_meta_gate(self):
-        slot = self._slot_with_live_banner()
-        _expire_mcp_oauth_banners(MagicMock(), slot, _open_mcp_oauth_banner_mids(slot))
-        prepared = _prepare_messages(list(slot.messages), running=False)
-        assert prepared[0]["meta"]["expired"] is True
-        assert not prepared[0]["meta"].get("oauth_url")
+# ── per-spawn process-instance identity (the stamp's provider side) ──
 
 
-class TestResetFunnelRetiresBanners:
-    """The switch/reload funnel is the widest reachable reset path.
+class TestProcessInstanceContract:
+    """The identity the banner stamp and the read gate both stand on.
 
-    `_reset_slot_session` is what the agent, model, bulk-model, reasoning-effort
-    and workspace switches plus the reload endpoint all route through, and every
-    one of them destroys the child that owns an open banner's loopback listener.
-    The gateway generation does not change, so the read-time gate cannot see it.
+    A token names ONE spawn of a child process: minted with the process,
+    masked the moment the process object is gone. The property must never
+    answer with a previous spawn's token — that equality is exactly the
+    fail-open the design removes (a resumed session id surviving onto a new
+    process).
     """
 
-    @pytest.mark.asyncio
-    async def test_a_completed_reset_retires_the_open_banner(self):
-        from kiro_crew.dashboard.chat_handlers import _reset_slot_session
+    def _bare_client(self):
+        from kiro_crew.acp.client import AcpClient
 
-        state = MagicMock()
+        client = object.__new__(AcpClient)
+        return client
 
-        async def _reset(_key, *, skip_if_busy=False):
-            return True
+    def _bare_runtime(self):
+        from kiro_crew.acp.runtime import AcpRuntime
 
-        state.sessions.reset = _reset
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089")
+        runtime = object.__new__(AcpRuntime)
+        return runtime
 
-        with patch("kiro_crew.dashboard.chat_handlers._unblock_pending_waits"):
-            assert await _reset_slot_session(state, slot, "dashboard:s1") is True
+    def test_client_answers_empty_without_a_process(self):
+        client = self._bare_client()
+        client._process = None
+        client._process_instance = "left-over-token"
+        assert client.process_instance == ""
 
-        assert slot.messages[0]["meta"]["expired"] is True
-        assert "oauth_url" not in slot.messages[0]["meta"]
+    def test_client_answers_the_current_processes_token(self):
+        client = self._bare_client()
+        client._process = object()
+        client._process_instance = "tok-a"
+        assert client.process_instance == "tok-a"
 
-    @pytest.mark.asyncio
-    async def test_a_declined_reset_keeps_the_live_link(self):
-        """`skip_if_busy` declining leaves the session, its child and its listener
-        alive, so the button still works -- taking it away would be worse than the
-        dead link this fix exists to remove."""
-        from kiro_crew.dashboard.chat_handlers import _reset_slot_session
+    def test_runtime_answers_empty_without_a_process(self):
+        runtime = self._bare_runtime()
+        runtime._process = None
+        runtime._process_instance = "left-over-token"
+        assert runtime.process_instance == ""
 
-        state = MagicMock()
-
-        async def _reset(_key, *, skip_if_busy=False):
-            return False
-
-        state.sessions.reset = _reset
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089")
-
-        with patch("kiro_crew.dashboard.chat_handlers._unblock_pending_waits"):
-            assert await _reset_slot_session(state, slot, "dashboard:s1", skip_if_busy=True) is False
-
-        assert "expired" not in slot.messages[0]["meta"]
-        assert slot.messages[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a?port=55089"
-
-
-class TestPendingResetRetirementIsGatedOnTeardown:
-    """A teardown that RAISED may have left the child alive.
-
-    Retiring then would remove a button that still works, and the user could not
-    recover: `pop_pending_oauth_requests` already drained the request, so a live
-    child never re-announces it. A dead link surviving one more turn is the cheaper
-    error, and the read-time generation gate catches it after a restart.
-    """
-
-    def _slot_with_pending_reset(self):
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089")
-        slot._pending_reset_history_key = "dashboard:s1"
-        return slot
-
-    @pytest.mark.asyncio
-    async def test_a_completed_reset_retires_the_banner(self):
-        state = MagicMock()
-
-        async def _reset(_key, **_kw):
-            return True
-
-        state.sessions.reset = _reset
-        slot = self._slot_with_pending_reset()
-        await chat_runner._consume_pending_reset(state, slot, allow_discard=False)
-        assert slot.messages[0]["meta"]["expired"] is True
-
-    @pytest.mark.asyncio
-    async def test_a_raising_reset_leaves_the_link_alone(self):
-        state = MagicMock()
-
-        async def _reset(_key, **_kw):
-            raise RuntimeError("teardown blew up")
-
-        state.sessions.reset = _reset
-        slot = self._slot_with_pending_reset()
-        await chat_runner._consume_pending_reset(state, slot, allow_discard=False)
-        assert "expired" not in slot.messages[0]["meta"]
-        assert slot.messages[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a?port=55089"
-
-    @pytest.mark.asyncio
-    async def test_a_cancelled_reset_leaves_the_link_alone(self):
-        """CancelledError is a BaseException, so it is not swallowed -- but it must
-        not have retired the banner on its way out either."""
-        state = MagicMock()
-
-        async def _reset(_key, **_kw):
-            raise asyncio.CancelledError()
-
-        state.sessions.reset = _reset
-        slot = self._slot_with_pending_reset()
-        with pytest.raises(asyncio.CancelledError):
-            await chat_runner._consume_pending_reset(state, slot, allow_discard=False)
-        assert "expired" not in slot.messages[0]["meta"]
-        assert slot.messages[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a?port=55089"
-
-    @pytest.mark.asyncio
-    async def test_a_confirmed_discard_also_retires_the_banner(self):
-        """The discard branch of the same function kills the child too.
-
-        `discard_conversation` shuts the provider down, so the listener behind an
-        open banner's link is gone. Covering the reset branch and not its sibling
-        would leave the function asymmetric for no reason a reader could infer.
-        """
-        state = MagicMock()
-
-        async def _discard(_key, **_kw):
-            return True
-
-        state.sessions.discard_conversation = _discard
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089")
-        slot._pending_discard_conversation_key = "dashboard:s1"
-
-        with patch("kiro_crew.dashboard.chat_runner.subagents_attached", return_value=False):
-            await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
-
-        assert slot.messages[0]["meta"]["expired"] is True
-        assert "oauth_url" not in slot.messages[0]["meta"]
-
-    @pytest.mark.asyncio
-    async def test_a_refused_discard_keeps_the_live_link(self):
-        """`skip_if_busy` refusing leaves the session and its listener alive."""
-        state = MagicMock()
-
-        async def _discard(_key, **_kw):
-            return False
-
-        state.sessions.discard_conversation = _discard
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a?port=55089")
-        slot._pending_discard_conversation_key = "dashboard:s1"
-
-        with patch("kiro_crew.dashboard.chat_runner.subagents_attached", return_value=False):
-            await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
-
-        assert "expired" not in slot.messages[0]["meta"]
-        assert slot.messages[0]["meta"]["oauth_url"] == "https://mcp.miro.com/a?port=55089"
-
-    def test_no_call_site_retires_before_its_teardown(self):
-        """Pinned structurally, because the agent-switch site lives inside the turn
-        coroutine and cannot be reached from a unit test.
-
-        The invariant: a retirement must never PRECEDE the teardown it describes. A
-        teardown can raise or be cancelled, leaving the child and its loopback
-        listener alive, and a banner retired first would then have removed a working
-        button for good. Same shape as
-        test_every_session_teardown_drops_the_verdict: the rule is pinned here rather
-        than trusting each future author to remember which side of the await to be on.
-        """
-        from pathlib import Path
-
-        from kiro_crew.dashboard import chat_handlers, chat_runner
-
-        teardowns = ("sessions.reset(", "sessions.discard_conversation(")
-        for module in (chat_runner, chat_handlers):
-            lines = Path(module.__file__).read_text(encoding="utf-8").splitlines()
-            for i, line in enumerate(lines):
-                if "_expire_mcp_oauth_banners(" not in line or "def " in line:
-                    continue
-                # Nothing in the following window may be a teardown call: that would
-                # mean this retirement runs before it.
-                window = lines[i + 1 : i + 20]
-                offenders = [w.strip() for w in window if any(t in w for t in teardowns)]
-                assert not offenders, (
-                    f"{module.__name__}:{i + 1} retires OAuth banners before a teardown "
-                    f"that may fail or be cancelled -> {offenders}"
-                )
-
-    def test_the_agent_switch_site_is_gated_on_its_teardown_outcome(self):
-        """The one site no unit test can reach, pinned by name.
-
-        It sits in the turn coroutine's cleanup tail, so it is only reachable through
-        a full turn. Being AFTER the await is not sufficient there: the surrounding
-        `except Exception` swallows a failed teardown and execution continues, so
-        without a gate on the outcome the retirement would still run on the path
-        where the child may be alive. Asserted on the source because the alternative
-        is no coverage at all.
-        """
-        from pathlib import Path
-
-        from kiro_crew.dashboard import chat_runner
-
-        src = Path(chat_runner.__file__).read_text(encoding="utf-8")
-        assert "if oauth_flow_ended:\n" in src, (
-            "the agent-switch retirement lost its teardown-outcome gate; a swallowed "
-            "teardown failure would now retire a banner whose child may still be live"
-        )
-        gated = src.split("if oauth_flow_ended:\n", 1)[1][:1200]
-        guarded = "_expire_mcp_oauth_banners(state, slot, doomed_banners)" in gated
-        assert guarded, "`if oauth_flow_ended:` no longer guards the retirement call"
-
-    def test_a_successor_banner_minted_during_teardown_is_not_swept(self):
-        """The race GPT caught. The retirement runs AFTER the await, so a failed
-        teardown cannot strand the user -- but that means a successor session can
-        emit its own OAuth request in between, and sweeping the whole slot then
-        would withdraw a URL that is perfectly live.
-        """
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/old?port=1")
-        # Snapshot as a caller does, BEFORE the teardown.
-        doomed = _open_mcp_oauth_banner_mids(slot)
-        # Successor session starts mid-teardown and announces its own flow.
-        _emit_mcp_oauth_request(MagicMock(), slot, "linear", "https://mcp.linear.app/new?port=2")
-
-        _expire_mcp_oauth_banners(MagicMock(), slot, doomed)
-
-        old, new = slot.messages
-        assert old["meta"]["expired"] is True, "the pre-teardown banner should be retired"
-        assert "expired" not in new["meta"], "the successor's live banner was swept"
-        assert new["meta"]["oauth_url"] == "https://mcp.linear.app/new?port=2"
-
-    def test_an_empty_snapshot_retires_nothing(self):
-        """A teardown with nothing open beforehand must not touch a later banner."""
-        slot = _ChatSlot("s1")
-        doomed = _open_mcp_oauth_banner_mids(slot)
-        assert doomed == frozenset()
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
-        state = MagicMock()
-        _expire_mcp_oauth_banners(state, slot, doomed)
-        assert "expired" not in slot.messages[0]["meta"]
-        state.broadcast_ws.assert_not_called()
-
-    def test_the_snapshot_names_only_open_banners(self):
-        """A superseded row carries no url, so it is not in the snapshot."""
-        slot = _ChatSlot("s1")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/a")
-        _emit_mcp_oauth_request(MagicMock(), slot, "miro", "https://mcp.miro.com/b")
-        assert slot.messages[0]["meta"]["superseded"] is True
-        doomed = _open_mcp_oauth_banner_mids(slot)
-        assert doomed == {slot.messages[1]["meta"]["mid"]}
+    def test_runtime_answers_the_current_processes_token(self):
+        runtime = self._bare_runtime()
+        runtime._process = object()
+        runtime._process_instance = "tok-b"
+        assert runtime.process_instance == "tok-b"
 
 
 # ── _ChatSlot.update_message ──

--- a/test/test_session_restore.py
+++ b/test/test_session_restore.py
@@ -387,7 +387,7 @@ class TestRestoreRecentSessions:
         # The credential is gone from what the slot-detail endpoint returns...
         from kiro_crew.dashboard.chat_utils import _prepare_messages
 
-        emitted = _prepare_messages(slot.messages, False)
+        emitted = _prepare_messages(slot.messages, False, live_child="")
         rendered = " ".join(m.get("content", "") for m in emitted)
         assert "AKIAIOSFODNN7EXAMPLE" not in rendered
         assert "[REDACTED" in rendered

--- a/test/test_slot_detail_offload.py
+++ b/test/test_slot_detail_offload.py
@@ -53,9 +53,9 @@ class TestRenderRunsOffTheEventLoop:
         seen: list[int] = []
         real = chat_handlers._prepare_messages
 
-        def _spy(messages: list[dict], running: bool) -> list[dict]:
+        def _spy(messages: list[dict], running: bool, *, live_child: str) -> list[dict]:
             seen.append(threading.get_ident())
-            return real(messages, running)
+            return real(messages, running, live_child=live_child)
 
         monkeypatch.setattr(chat_handlers, "_prepare_messages", _spy)
         async with TestClient(TestServer(_make_app(state))) as client:
@@ -78,7 +78,7 @@ class TestRenderRunsOffTheEventLoop:
         active = 0
         max_active = 0
 
-        def _slow(messages: list[dict], running: bool) -> list[dict]:
+        def _slow(messages: list[dict], running: bool, *, live_child: str) -> list[dict]:
             nonlocal active, max_active
             with gauge_lock:
                 active += 1
@@ -88,7 +88,7 @@ class TestRenderRunsOffTheEventLoop:
             time.sleep(0.05)
             with gauge_lock:
                 active -= 1
-            return real(messages, running)
+            return real(messages, running, live_child=live_child)
 
         monkeypatch.setattr(chat_handlers, "_prepare_messages", _slow)
         async with TestClient(TestServer(_make_app(state))) as client:


### PR DESCRIPTION
## Summary

An `mcp_oauth` banner's Authorize link is redeemable only while the ACP child process that minted it is alive: that process holds the loopback callback listener and the PKCE verifier. Liveness was decided two ways — a read-time gate comparing a gateway-generation stamp, and a write-time retirement called at enumerated teardown sites — and both miss teardowns that end the child WITHIN one gateway generation without routing through a covered site: the idle sweep (`session_cleanup.py`, default 60-min window), the RSS recycle, and a child exiting on its own. The banner then keeps rendering a live Authorize button whose click completes a full provider login onto a dead loopback port (same symptom as #7654 and #7580).

This replaces both mechanisms with one read-time check keyed on the minting child's **process-instance identity**:

- **Identity.** `AcpClient` and `AcpRuntime` mint a fresh random token per spawn (`process_instance`), cleared with the process; the provider surface exposes it (`LLMProvider` default `""`, `AcpProvider`, `AcpSessionProvider`). Deliberately NOT the ACP session id: a resume re-sets `_session_id` from `resume_sid` on a NEW process (`acp/client.py` session/load path), so a session-id comparison fails open exactly when the minting process is gone.
- **Stamp.** `_emit_mcp_oauth_request` stamps the minting child's identity into the banner meta as `child` (replacing the gateway `gen` stamp).
- **Read-time gate.** `_expire_dead_child_oauth_meta` (was `_expire_stale_generation_oauth_meta`) withdraws the link unless the stamp names the child currently serving the slot AND both sides are non-empty (fail-closed). The three `_prepare_messages` callers resolve the verdict on the event loop via `_live_child_instance` — active-turn session key first, slot routing as fallback (a cron injection can rebind a live slot mid-turn, per `_cancel_target`'s rationale) — and pass it as a **required keyword**; the slot-detail path samples it inside the render lock so a queued render cannot serve a verdict that predates the child's death. Rows with no `child` stamp (older builds, `gen`-only rows) expire on first read.
- **Open-tab freshness.** The read gate only runs on fetches, so `_broadcast_expired_oauth_banners` pushes its verdict to already-open tabs after the teardowns the dashboard can see (reset funnel, agent switch, deferred reset/discard consume, watchdog recycle callback). It is verdict-driven rather than ordering-driven — it re-resolves the live child and applies the gate's own predicate — so it needs no pre-teardown doomed-set snapshot and no outcome gate, and it never rewrites stored rows. Teardowns the dashboard never observes (idle sweep, child self-exit) are caught by the read gate on the tab's next refetch (`chat_done`, WS reconnect, switchSlot).
- **Net deletion.** `_expire_mcp_oauth_banners` and `_open_mcp_oauth_banner_mids` (the write-time retirement), their four call sites, the `oauth_flow_ended` outcome gate, and the two source-scanning guard tests that pinned the write-time ordering. One mechanism remains instead of two.

Closes #8149

## Testing

- New `TestExpiredByDeadChild`: a banner is expired once its child is gone (the shape every teardown presents at read time); a replacement child with the same session id does not keep it alive (the resume trap); a banner from the live child is preserved; both-empty identities never match (pins the fail-closed comparison — flipping either `and` fails it); unstamped and `gen`-only legacy rows expire; recorded outcomes are never reinterpreted; the gate never rewrites the stored row.
- New `TestLiveChildInstance`: pool-miss / dead-process / probe-raise / missing-property all answer `""`; end-to-end mint-under-child-A → sweep → read withdraws the link.
- New `TestBroadcastExpiredOauthBanners`: dead child's banner broadcast with `expired` + blanked `oauth_url` (pre-upgrade-client merge safety); live child's banner not broadcast (the declined-teardown shape); a successor's banner never swept; recorded outcomes excluded; stored rows untouched.
- New `TestProcessInstanceContract`: the property answers `""` without a process and the current process's token with one, for both `AcpClient` and `AcpRuntime`.
- Updated the display-time redaction corpus tests to the `child` stamp; updated all `_prepare_messages` call sites to the required keyword.
- Local gates: isort, flake8, mypy (1281 files clean), diff-scoped black gate, subprocess-encoding gate, brand gate, harness-parity gate — all green. Backend test suites run in CI per this host's policy.
- Pre-push review: two model-pinned subagent lanes (GPT, Opus). Both initially returned BLOCK on the open-tab stale-render regression; fixed via the broadcast helper above, plus their non-blocking findings (active-turn key resolution, render-lock verdict sampling, required `live_child` keyword, direct provider attribute reads, identity contract tests).

## Notes

- `minted_by` on `_emit_mcp_oauth_request` keeps a `""` default deliberately: an empty stamp is fail-closed (the banner expires on first read — immediately visible in development), and `test_an_unstamped_legacy_banner_is_expired` pins that consequence. `live_child` on `_prepare_messages` is required because its omission would be invisible.
- No frontend changes: `McpOAuthBanner.tsx` already renders the expired branch from `meta.expired` alone, and meta-only `chat_message_update` frames are an existing client contract.


## Pattern harvest

Rule candidate: AUTOSDE (judgment rule, not mechanizable as semgrep)
Pattern: a resource whose validity is bound to a child process's LIFE (a loopback listener, a PKCE verifier, a lock, a pipe) must be validated at READ time against a per-spawn process-instance identity — never invalidated by enumerating write-time teardown call sites (a new teardown path silently misses the list: this is the third incident in this family after #7654 and #7580), and never keyed on an identifier that survives the process (the ACP session id is re-set from `resume_sid` onto a NEW process, so a session-id comparison fails open exactly when the minting process is gone; a boot-relative counter collides across boots — `connections.warm` documents that incident).
