### PR TITLE
fix(session-pid): bind the signed pid mapping to the process incarnation

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -1023,8 +1023,27 @@ Because the `.txt` lives in the same-uid agent-writable config dir it is NOT
 a trust root on its own; publication therefore also writes a
 `session_pid_<pid>.sig` sidecar:
 
-- **MAC**: HMAC-SHA256 over `"<pid>:<session_key>"` — the pid is bound into
-  the MAC so one pid's pair cannot be replayed under another pid.
+- **MAC**: HMAC-SHA256 over `"<pid>:<body>"`, where *body* is the full
+  published `.txt` content — the session key alone (legacy), or
+  `"<session_key>\n<start_token>"` (recycle-guarded, below). The pid is bound
+  into the MAC so one pid's pair cannot be replayed under another pid, and
+  covering the whole body signs the start token too — flipping only the token
+  invalidates the MAC. A legacy body yields a byte-identical message to the
+  pre-token scheme, so mappings signed before the format change still verify.
+- **PID-recycle guard** (issue #8343): the mapping used to bind only the pid
+  *number*, so a recycled pid kept verifying and answered for the new
+  process with the previous owner's session key until the next restart's
+  orphan sweep. Publication now appends the process start token
+  (`platform_compat.get_process_start_id` — the same incarnation identity
+  `session_pid.py` records in its `<gw>:<pid>:<start_token>` sweep entries)
+  as a second line of the `.txt` (a line, not a colon field, because the
+  session key itself contains colons). Both readers dual-parse legacy
+  vs guarded forms and refuse on a PROVEN mismatch — the lenient reader
+  included, since strict-then-lenient fallbacks (`peer_resolve`) would
+  otherwise silently recover the stale attribution. An absent recorded
+  token (legacy file) or an unreadable live token (Windows, exited process)
+  is unknown, never a mismatch — those resolve as before. Same-uid only:
+  a robustness/misattribution guard, not a privilege boundary.
 - **Key**: a purpose-specific subkey derived from the SEL trust root via a
   domain-separation label (`HMAC(sel_hmac.key, "kirocrew.session_pid.sig.v1")`).
   The raw root never signs a sidecar; the sidecar protocol and the SEL audit

--- a/src/kiro_crew/session_pid_sig.py
+++ b/src/kiro_crew/session_pid_sig.py
@@ -13,7 +13,10 @@ authorization boundary. This module makes the mapping authenticated:
 
 * :func:`publish_session_pid` — the ONLY legitimate write path (gateway-side).
   Writes the ``.txt`` file plus a ``session_pid_<pid>.sig`` sidecar containing
-  an HMAC-SHA256 over ``"<pid>:<session_key>"``, keyed with a subkey **derived
+  an HMAC-SHA256 over ``"<pid>:<body>"`` — *body* being the full published
+  ``.txt`` content: the session key alone (legacy), or the session key plus a
+  second line carrying the process START TOKEN (PID-recycle guard, issue
+  #8343; see below). The MAC is keyed with a subkey **derived
   from** the SEL trust root (``sel_hmac.key`` — the same key that makes the
   security event log tamper-evident, and whose reads are deny-listed for agent
   shells in ``security.py``) via a domain-separation label. The raw root key
@@ -22,6 +25,17 @@ authorization boundary. This module makes the mapping authenticated:
 * :func:`verify_session_pid` — used by STRICT identity resolvers
   (state-mutating MCP tools). Returns the session key only when the sidecar
   verifies; missing/invalid signature fails closed to ``""``.
+
+PID-recycle guard (issue #8343): the mapping and its MAC used to bind only
+the pid NUMBER, so once the OS recycled the pid the mapping still verified
+and answered for the NEW process with the previous owner's session key until
+the next restart's orphan sweep. Publication now records the process
+incarnation (``platform_compat.get_process_start_id`` — the same identity
+``session_pid.py`` writes into its ``<gw>:<pid>:<start_token>`` sweep
+records) and BOTH readers refuse on a proven mismatch, while an absent
+(legacy file) or unreadable (Windows) token stays "unknown", never a
+mismatch. Same-uid only: this is a robustness/misattribution guard, not a
+privilege boundary — the recycled process already runs as the same user.
 
 Why forgery dies: an agent cannot read ``sel_hmac.key`` (deny-listed), so it
 cannot produce a valid sidecar for a forged ``.txt``. Replaying another pid's
@@ -79,6 +93,7 @@ import stat
 import threading
 from pathlib import Path
 
+from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.paths import config_dir
 from kiro_crew.sel import _sel_hmac_key_bytes, sel_hmac_key_path
@@ -276,11 +291,63 @@ def _derive_subkey(root: bytes) -> bytes:
     return hmac.new(root, _SUBKEY_DOMAIN, hashlib.sha256).digest()
 
 
-def _compute_sig(key: bytes, pid: int | str, session_key: str) -> str:
+def _compute_sig(key: bytes, pid: int | str, payload: str) -> str:
+    """MAC over ``"<pid>:<payload>"``, *payload* being the canonical ``.txt``
+    body: the bare session key (legacy) or ``"<session_key>\\n<start_token>"``
+    (recycle-guarded — see :func:`publish_session_pid`). Binding the pid
+    blocks cross-pid replay; covering the whole body means the start token,
+    when present, is signed — flipping only the token invalidates the MAC.
+    A legacy body produces a byte-identical message to the pre-token scheme,
+    so every signed mapping written before the format change still verifies.
+    """
     subkey = _derive_subkey(key)
     return hmac.new(
-        subkey, f"{pid}:{session_key}".encode("utf-8"), hashlib.sha256
+        subkey, f"{pid}:{payload}".encode("utf-8"), hashlib.sha256
     ).hexdigest()
+
+
+def _parse_mapping_body(raw: str) -> tuple[str, str | None] | None:
+    """Split a ``.txt`` body into ``(session_key, start_token)``.
+
+    Dual-parse, following ``session_pid.py``'s legacy-vs-guarded record
+    handling (``<gw>:<pid>`` vs ``<gw>:<pid>:<start_token>``): one line is
+    the legacy pre-token form (token ``None``); two lines are
+    ``<session_key>\\n<start_token>``. The token rides a second LINE rather
+    than a colon field because — unlike that record's integer fields — the
+    session key itself contains colons (``dashboard:chat-7-...``), so a
+    colon split could not tell a legacy key from a key+token pair. Anything
+    else was never written by :func:`publish_session_pid` — refuse
+    (``None``) rather than guess a parse.
+    """
+    lines = raw.strip().split("\n")
+    if len(lines) == 1:
+        session_key = lines[0].strip()
+        return (session_key, None) if session_key else None
+    if len(lines) == 2:
+        session_key, token = lines[0].strip(), lines[1].strip()
+        return (session_key, token) if session_key and token else None
+    return None
+
+
+def _pid_recycled(pid: int | str, recorded_token: str) -> bool:
+    """True iff *pid*'s LIVE start token is readable and differs from
+    *recorded_token* — positive evidence the pid number was recycled to a
+    different process since the mapping was published.
+
+    The asymmetry here is the whole correctness argument (mirroring the
+    sweep guard around ``session_pid.py``'s ``_pid_start_token``): a
+    MISMATCH proves the pid now names a DIFFERENT process, so answering
+    with the mapped key would attribute the new process to the previous
+    owner's session — refuse, on the strict AND the lenient path. An
+    UNREADABLE live token (Windows, exited process, permission) is merely
+    UNKNOWN, never a mismatch — callers keep today's behaviour there, as
+    they do for an ABSENT recorded token (legacy file).
+    """
+    try:
+        live = platform_compat.get_process_start_id(int(pid))
+    except (TypeError, ValueError):
+        return False  # unparseable pid — identity unknown, not a mismatch
+    return live is not None and live != recorded_token
 
 
 def publish_session_pid(pid: int, session_key: str) -> None:
@@ -300,9 +367,27 @@ def publish_session_pid(pid: int, session_key: str) -> None:
     ``session_pid_<pid>.txt``/``.sig`` pointing at an arbitrary writable
     file — an in-place open would follow it and truncate the target.
     ``os.replace`` swaps the symlink itself out instead of following it.
+
+    PID-recycle guard (issue #8343): when the live process's start token is
+    readable (``platform_compat.get_process_start_id`` — the same
+    incarnation identity ``session_pid.py`` records in its
+    ``<gw>:<pid>:<start_token>`` sweep entries), it is appended to the
+    ``.txt`` as a second line and covered by the MAC, so readers can tell
+    "still the process this mapping was published for" from "the OS
+    recycled this pid number". An unreadable token (Windows, probe failure)
+    degrades to the legacy single-line form — readers then treat identity
+    as unknown, exactly as for a pre-change file.
     """
     cfg = config_dir()
-    atomic_write(_txt_path(pid, cfg), session_key)
+    token = platform_compat.get_process_start_id(pid)
+    # The "\n" guard keeps a pathological multi-line session key (never
+    # produced by any surface — keys are single-line ``surface:slot`` shapes)
+    # from aliasing the legacy and token-bearing forms under one MAC.
+    if token and "\n" not in session_key:
+        body = f"{session_key}\n{token}"
+    else:
+        body = session_key
+    atomic_write(_txt_path(pid, cfg), body)
     key = _load_hmac_key()
     if key is None:
         _report_signing_unavailable()
@@ -311,7 +396,7 @@ def publish_session_pid(pid: int, session_key: str) -> None:
         except OSError:
             pass
         return
-    atomic_write(_sig_path(pid, cfg), _compute_sig(key, pid, session_key))
+    atomic_write(_sig_path(pid, cfg), _compute_sig(key, pid, body))
 
 
 # Upper bound for mapping-file reads. Session keys are short strings
@@ -402,9 +487,26 @@ def read_session_pid_txt(pid: int | str, cfg: Path | None = None) -> str:
     *cfg* overrides the mapping directory (callers that already resolved
     ``config_dir()`` pass it through); defaults to :func:`config_dir`.
     Returns ``""`` on any refusal or I/O error. Never raises.
+
+    A PROVEN pid-recycle (recorded start token present and the live token
+    readable but different — see :func:`_pid_recycled`) refuses on this
+    lenient path too, deliberately: several call sites try
+    :func:`verify_session_pid` first and fall back here (``peer_resolve``),
+    so a mismatch surfaced only from the strict path would be silently
+    recovered by the fallback and the stale attribution kept. A mismatch is
+    positive evidence of a wrong owner — unlike an absent or unreadable
+    token, which is merely unknown and resolves as before.
     """
     txt = _read_regular_nofollow(_txt_path(pid, cfg if cfg is not None else config_dir()))
-    return txt.strip() if txt is not None else ""
+    if txt is None:
+        return ""
+    parsed = _parse_mapping_body(txt)
+    if parsed is None:
+        return ""
+    session_key, token = parsed
+    if token is not None and _pid_recycled(pid, token):
+        return ""
+    return session_key
 
 
 def verify_session_pid(pid: int | str, cfg: Path | None = None) -> str:
@@ -423,10 +525,11 @@ def verify_session_pid(pid: int | str, cfg: Path | None = None) -> str:
     sig_raw = _read_regular_nofollow(_sig_path(pid, cfg))
     if txt is None or sig_raw is None:
         return ""
-    session_key = txt.strip()
+    parsed = _parse_mapping_body(txt)
     sig = sig_raw.strip()
-    if not session_key or not sig:
+    if parsed is None or not sig:
         return ""
+    session_key, token = parsed
     key = _load_hmac_key()
     if key is None:
         # Distinguishable from the MAC-mismatch warning below: this branch
@@ -446,11 +549,25 @@ def verify_session_pid(pid: int | str, cfg: Path | None = None) -> str:
             pid,
         )
         return ""
-    expected = _compute_sig(key, pid, session_key)
+    # Recompute over the canonical body: legacy files (no token) produce the
+    # exact pre-change message, so existing signed mappings keep verifying.
+    payload = session_key if token is None else f"{session_key}\n{token}"
+    expected = _compute_sig(key, pid, payload)
     if not hmac.compare_digest(expected, sig):
         logger.warning(
             "session_pid_%s signature mismatch — refusing identity "
             "(possible forgery or stale sidecar)",
+            pid,
+        )
+        return ""
+    # Recycle check AFTER the MAC: the recorded token is only meaningful
+    # once the signature proves it is the one the publisher wrote. Mismatch
+    # = the pid was recycled → refuse; absent/unreadable = unknown → resolve
+    # (see _pid_recycled for why the asymmetry is load-bearing).
+    if token is not None and _pid_recycled(pid, token):
+        logger.warning(
+            "session_pid_%s start-token mismatch — pid was recycled; "
+            "refusing the previous owner's session identity",
             pid,
         )
         return ""

--- a/test/test_session_pid_sig.py
+++ b/test/test_session_pid_sig.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
-from kiro_crew import session_pid_sig
+from kiro_crew import platform_compat, session_pid_sig
 
 SESSION_KEY = "dashboard:chat-7-123456"
 LOGGER_NAME = "kiro_crew.session_pid_sig"
@@ -55,10 +55,19 @@ def cfg(tmp_path):
     ``SecurityEventLog`` singleton, which other tests in the same process may
     or may not have initialized. Its own behavior is covered by
     ``TestTrustRootRecovery``.
+
+    ``platform_compat.get_process_start_id`` is pinned to ``None`` (no start
+    token) so the fixture is deterministic: the fake pids used here (4242,
+    1000, ...) can be LIVE processes on the test host, and a live pid would
+    otherwise make ``publish_session_pid`` capture a real start token and
+    change the exact ``.txt`` bytes these tests assert on. Recycle-guard
+    tests (``TestPidRecycleGuard``) re-patch it per test with controlled
+    values.
     """
     (tmp_path / "sel_hmac.key").write_bytes(b"\x01" * 32)
     with patch.object(session_pid_sig, "config_dir", return_value=tmp_path), \
          patch.object(session_pid_sig, "_sel_hmac_key_bytes", return_value=None), \
+         patch.object(platform_compat, "get_process_start_id", return_value=None), \
          patch.object(
              session_pid_sig,
              "sel_hmac_key_path",
@@ -225,6 +234,129 @@ class TestLenientReader:
             "x" * (session_pid_sig._MAX_MAPPING_FILE_BYTES + 1), encoding="utf-8"
         )
         assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+
+class TestPidRecycleGuard:
+    """Issue #8343: the mapping and its MAC bound only the pid NUMBER, so a
+    recycled pid kept verifying and answered with the previous owner's
+    session key until the next restart's orphan sweep. Publication now also
+    records the process START TOKEN (``platform_compat.get_process_start_id``
+    — the same incarnation identity ``session_pid.py``'s
+    ``<gw>:<pid>:<start_token>`` sweep records use), the signature covers it,
+    and BOTH readers refuse on a proven mismatch.
+
+    The asymmetry under test: a MISMATCH is positive evidence of a recycled
+    pid → refuse; an ABSENT recorded token (legacy file) or an UNREADABLE
+    live token (Windows, exited process) is merely unknown → resolve as
+    before the guard existed.
+    """
+
+    @staticmethod
+    def _live_token(value):
+        return patch.object(
+            platform_compat, "get_process_start_id", return_value=value
+        )
+
+    def test_recycled_pid_refused_by_strict_resolver(self, cfg):
+        """HEADLINE (red against pre-fix main): publish under one process
+        incarnation, present another incarnation of the same pid number —
+        the strict resolver must refuse, not answer with the old key."""
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        with self._live_token("222"):
+            assert session_pid_sig.verify_session_pid(4242) == ""
+
+    def test_recycled_pid_refused_by_lenient_reader(self, cfg):
+        """A proven mismatch refuses on the LENIENT path too: callers like
+        peer_resolve fall back from the strict resolver to this reader, so a
+        refusal surfaced only from the strict path would be silently
+        recovered by the fallback and the stale attribution kept."""
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        with self._live_token("222"):
+            assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+    def test_same_incarnation_still_resolves(self, cfg):
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            assert session_pid_sig.verify_session_pid(4242) == SESSION_KEY
+            assert session_pid_sig.read_session_pid_txt(4242) == SESSION_KEY
+
+    def test_legacy_tokenless_file_still_resolves(self, cfg):
+        """BACKWARD COMPATIBILITY: a signed mapping written before the
+        format change (no token line, MAC over ``"<pid>:<session_key>"``)
+        must not read as tampered or as a mismatch, even when the live
+        token IS readable (absent recorded token = unknown, not mismatch)."""
+        key = b"\x01" * 32
+        (cfg / "session_pid_4242.txt").write_text(SESSION_KEY, encoding="utf-8")
+        (cfg / "session_pid_4242.sig").write_text(
+            session_pid_sig._compute_sig(key, 4242, SESSION_KEY), encoding="utf-8"
+        )
+        with self._live_token("222"):
+            assert session_pid_sig.verify_session_pid(4242) == SESSION_KEY
+            assert session_pid_sig.read_session_pid_txt(4242) == SESSION_KEY
+
+    def test_unreadable_live_token_resolves_as_today(self, cfg):
+        """UNKNOWN ≠ MISMATCH: a recorded token whose live counterpart
+        cannot be read (Windows, process exited, permission) keeps today's
+        behaviour on both paths."""
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        with self._live_token(None):
+            assert session_pid_sig.verify_session_pid(4242) == SESSION_KEY
+            assert session_pid_sig.read_session_pid_txt(4242) == SESSION_KEY
+
+    def test_publish_records_the_token_as_a_second_line(self, cfg):
+        """The on-disk form: ``<session_key>\\n<start_token>``. A second
+        LINE, not a colon field like session_pid.py's integer records,
+        because the session key itself contains colons."""
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        assert (
+            cfg / "session_pid_4242.txt"
+        ).read_text(encoding="utf-8") == f"{SESSION_KEY}\n111"
+
+    def test_signature_covers_the_token(self, cfg):
+        """Flipping ONLY the token line invalidates the MAC — even when the
+        rewritten token matches the live process, so the refusal proven
+        here is the signature's, not the recycle check's."""
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+        (cfg / "session_pid_4242.txt").write_text(
+            f"{SESSION_KEY}\n222", encoding="utf-8"
+        )
+        with self._live_token("222"):
+            assert session_pid_sig.verify_session_pid(4242) == ""
+
+    def test_unsigned_publish_with_token_still_degrades(self, cfg):
+        """The documented unsigned-publish degrade path survives the token:
+        SEL key unavailable → token-bearing ``.txt`` still published (the
+        lenient reader keeps working, recycle guard included), stale sidecar
+        removed, strict resolvers fail closed."""
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)  # signed
+        (cfg / "sel_hmac.key").unlink()
+        with self._live_token("111"):
+            session_pid_sig.publish_session_pid(4242, SESSION_KEY)
+            assert not (cfg / "session_pid_4242.sig").exists()
+            assert session_pid_sig.verify_session_pid(4242) == ""
+            assert session_pid_sig.read_session_pid_txt(4242) == SESSION_KEY
+        with self._live_token("222"):
+            assert session_pid_sig.read_session_pid_txt(4242) == ""
+
+    def test_malformed_multiline_body_refused(self, cfg):
+        """Three-plus lines were never written by publish_session_pid —
+        refuse on both paths rather than guess a parse, even under a valid
+        MAC over the raw body."""
+        key = b"\x01" * 32
+        body = f"{SESSION_KEY}\n111\nextra"
+        (cfg / "session_pid_4242.txt").write_text(body, encoding="utf-8")
+        (cfg / "session_pid_4242.sig").write_text(
+            session_pid_sig._compute_sig(key, 4242, body), encoding="utf-8"
+        )
+        with self._live_token("111"):
+            assert session_pid_sig.verify_session_pid(4242) == ""
+            assert session_pid_sig.read_session_pid_txt(4242) == ""
 
 
 class TestNoNofollowPlatform:


### PR DESCRIPTION
## Symptom

`session_pid_<pid>.txt` maps a pid **number** to a session key, and its HMAC sidecar signs only that number plus the key. Nothing in the file or the signature identifies the process *incarnation* that owned the pid — so once the OS recycles the pid, the mapping still verifies and answers for the **new** process with the **previous owner's** session key. The orphan sweep runs only at gateway start/shutdown, so a mid-run recycle stays misattributed until the next restart.

**Scope, stated honestly:** the mapping directory is same-uid, and the recycled process runs as the same user — this is a **robustness/misattribution defect, not a privilege boundary**. Fixing it prevents wrong-session attribution (state-mutating MCP tools, audit attribution), not an escalation.

## Root cause

`_compute_sig` MAC'd exactly two fields (`"<pid>:<session_key>"`), and the `.txt` carried only the key — the pid *number* was the sole process identity anywhere in the contract (`src/kiro_crew/session_pid_sig.py`).

## Fix

Bind the mapping to the process incarnation, following the in-tree precedent: **`session_pid.py`'s `<gw>:<pid>:<start_token>` dual-parse recycle guard** (its sweep records the start token at spawn, dual-parses legacy vs guarded entries, treats a mismatch as "this PID now belongs to a different process", and treats an unreadable token as unknown — never a mismatch).

- **Publish** (`publish_session_pid`): capture the process start token via `platform_compat.get_process_start_id` and append it as a **second line** of the `.txt`. A second *line* rather than a colon field — unlike the precedent's integer fields, the session key itself contains colons (`dashboard:chat-7-…`), so a colon split could not tell a legacy key from a key+token pair. Token source note: `get_process_start_id` **is** the single shared implementation (already consumed by `apps/backend.py`, `instances/ssh_tunnel_manager.py`, `metrics/local_exporter.py`); `session_pid._pid_start_token` is itself a one-line delegate to it, and importing `session_pid` from `session_pid_sig` would drag `providers.base` into every sandboxed resolver process, so this module calls the shared `platform_compat` implementation directly instead of the private delegate.
- **Sign**: the MAC now covers the **full published body** (`"<pid>:<body>"`). A legacy body produces a byte-identical message to the old scheme, so **every signed mapping written before this change still verifies** — no migration, no tamper false-positive. Flipping only the token invalidates the MAC.
- **Read** (both `verify_session_pid` and `read_session_pid_txt`): dual-parse legacy vs guarded forms. A recorded token that is readable live and **different** is positive evidence of a recycled pid → **refuse**. An **absent** recorded token (legacy file) or an **unreadable** live token (Windows, exited process) is unknown → resolve exactly as today. That asymmetry is the correctness argument and is written as comments at the guard.
- **Lenient reader refuses proven mismatches too, deliberately**: call sites fall back from the strict resolver to the lenient reader (`peer_resolve.py:103-105`), so a mismatch surfaced only from the strict path would be silently recovered by the fallback and the stale attribution kept.
- **Unsigned-publish degrade preserved**: SEL key unavailable → token-bearing `.txt` still published, stale sidecar removed, strict resolvers fail closed (existing + new tests).
- Same-commit spec-doc update: `docs/system-specs/modules/session.md` sidecar-contract section (MAC coverage + recycle-guard bullet).

Out of scope, per the issue triage: making the orphan sweep periodic is a separate change with its own scheduling surface (see "Pattern harvest" below).

## Verification

- **Red before green**: the 5 behavior-changing tests fail against unmodified main (`dabd83e91`) — headline `test_recycled_pid_refused_by_strict_resolver` and `test_recycled_pid_refused_by_lenient_reader` both returned the old owner's key pre-fix. The 4 compatibility guards (legacy file, unknown-token, same-incarnation, sig-coverage) pass on both sides by design. Incarnation is simulated by controlling the token source, never by real pid recycling.
- **Mutation checks** (each mutant applied via cp-aside/cp-back, run, restored, green re-confirmed):
  1. Token dropped from the MAC on both sides → killed by `test_signature_covers_the_token` (1 failed / 46 passed). Verify-side-only variant also run → killed by the round-trip tests.
  2. Absent token treated as mismatch → killed by `test_legacy_tokenless_file_still_resolves` (+2 existing lenient tests).
  3. Mismatch treated as unknown → killed by both recycle headline tests.
  4. Recycle check skipped in the lenient reader only → killed by `test_recycled_pid_refused_by_lenient_reader` while the strict headline stayed green (clean isolation).
- **Existing module**: 38 pre-existing tests unchanged and green (the shared fixture pins the token probe to `None` so live host pids can't perturb exact-content assertions); 47/47 total.
- **Consumer modules** (`test_dashboard_peer_auth`, `test_identity_topology`, `test_mcp_core_audit_e`, `test_mcp_core_set_project`, `test_mcp_cron_caller_identity`, `test_resolve_session_key`, `test_sel`): green except `test_dashboard_peer_auth`'s 4 failures + 2 errors ("AF_UNIX path too long"), reproduced **byte-identically on a pristine `origin/main` worktree** — environmental.
- **Zero-regression proof**: full backend suite on the branch vs a `git worktree` at `origin/main`, sorted failing-id sets diffed both directions — see the checked line below.
- `flake8` and `mypy` clean on touched files; black gate passes (both files baselined).

✅ **Zero-regression:** branch `99 failed, 80092 passed, 2 errors` vs `origin/main` worktree `99 failed, 80083 passed, 2 errors` (pass-count delta = the 9 new tests); the sorted failing-id sets (101 ids each) are **byte-identical both directions** after normalizing one xdist log-interleave artifact (a `Superseded default in stored config:` diagnostic glued onto a summary line — present once in each log, on different tests, both of which failed in both runs). This repo's failing baseline is environmental; set identity is the proof, not "0 failures".

## Pattern harvest

Rule candidate: **a persisted pid-keyed record is only as valid as the pid number is stable — any pid map that outlives its process must record the incarnation (start token) and its signature must cover it, with mismatch=refuse / unknown=proceed asymmetry.** Knowingly out-of-scope sibling: the orphan sweep still runs only at gateway start/shutdown, so a recycled mapping's *files* linger until then (the readers now refuse them, which removes the misattribution); attaching the sweep to a recurring task is a separate scheduling-surface change — sibling issue filed and linked in the comments.

<!-- no-visual-delta -->
Backend-only change (no UI surface); evidence is the red-first test set and mutation kills above — a still frame cannot show a resolver refusal.

Fixes #8343
