### PR TITLE
fix(dashboard): name every field GET /api/agents ships, instead of spreading the record

### DIFF
--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -2575,6 +2575,269 @@ async def api_capability_mcp_registry(request: web.Request) -> web.Response:
 # ── KiroCrew Agent CRUD API ──
 
 
+def _roster_mask(value: object) -> str:
+    """Render ONE agent-record value for a roster row, masking what cannot be shown.
+
+    Every record value is agent- or package-writable: an agent can edit
+    ``config.json`` directly, and ``_do_agents_sync`` copies ``description``
+    straight off a discovered agent spec, so a third-party package controls that
+    string. A value the redactors would alter -- credential- or
+    exfiltration-URL-shaped text -- is therefore replaced WHOLESALE by
+    ``_SENSITIVE_MASK``, the sentinel ``_masked_config_dict`` already uses for
+    the same job on ``GET /api/config/kirocrew``. A non-string (the loader lets
+    an object through five declared-``str`` fields) is masked too: it is not
+    renderable, so there is nothing to show. Benign content is byte-identical.
+
+    **A fixed sentinel rather than redacting in place, and that is the whole
+    design.** An in-place scrub makes the browser's view a FUNCTION of the
+    stored value, so the write-side rule that keeps a read-modify-write from
+    persisting that view (``_carries_mask``) has to recognise it by
+    recomputing the transform -- which breaks in two ways a sentinel does not:
+
+    * **Redaction-chain drift.** #8465 wraps this same response in
+      ``redact_record_strings``, whose order differs from ``_redact_external``'s.
+      A recomputed-equality rule would stop matching and silently persist the
+      redacted text; an exact sentinel survives, because scrubbing
+      ``_SENSITIVE_MASK`` leaves it unchanged.
+    * **Stale-view skew.** If the stored value changes between the GET and the
+      PUT (an agent editing ``config.json``, a second dashboard tab), a
+      recomputed rule compares the old view against the NEW value, fails to
+      match, and writes ``[REDACTED ...]`` text into the config as though the
+      operator had typed it. The sentinel does not depend on the stored value at
+      all, so this cannot happen.
+
+    Named cost: a value containing one credential-shaped token is masked
+    entirely, so the owner loses the benign remainder of that string rather than
+    seeing it partially redacted. That is the same trade ``_masked_config_dict``
+    already makes, and it is the price of a view that cannot be mistaken for
+    content.
+    """
+    # Function-local for the reason recorded at the ``_validate_role_model``
+    # import below: ``handlers.core`` resolves ``_get_config_lock`` from THIS
+    # module, so a module-level import here would close the cycle.
+    from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+    if not isinstance(value, str):
+        return _SENSITIVE_MASK
+    return value if _redact_external(value) == value else _SENSITIVE_MASK
+
+
+def _carries_mask(incoming: object) -> bool:
+    """True when *incoming* still CARRIES the mask, so it is not real content.
+
+    The write-side half of ``_roster_mask``. A client that read a roster row and
+    echoed it back sends the mask; persisting it would destroy the operator's
+    stored value. Such a field is treated as UNCHANGED instead.
+
+    **Containment, not equality.** An exact-match rule closes only the
+    echo-it-back case. The editor renders the mask into a text input, so an
+    operator who APPENDS to it submits ``"<mask> and also X"`` -- not equal to the
+    sentinel, so an equality rule would persist the redaction glyphs plus the
+    addition, replacing the stored original. Any string still containing the
+    sentinel is therefore refused as content.
+
+    Consequence, stated because it is a real limitation and not a free win: a
+    genuine replacement must OMIT the sentinel entirely -- clear the field, then
+    type the new value. An edit that keeps the mask and adds to it is dropped
+    rather than half-applied. That is lossy in the operator's INTENT, but it never
+    destroys what is stored, and the alternative writes redaction glyphs into
+    ``config.json`` over the real value.
+
+    This is the remedy ``_masked_config_dict``'s docstring prescribes -- "MUST
+    treat ``_SENSITIVE_MASK`` as 'unchanged' and keep the stored value" -- read
+    the strict way. Because the comparison is against a FIXED sentinel and never
+    against a recomputation of the stored value, it is immune to which redaction
+    chain produced the view and to the stored value having changed since the read.
+
+    Accepted residual, identical in kind to the config endpoint's: an operator
+    cannot store a value containing the mask string. It is eight U+2022 bullets.
+
+    **Recursive, because one shipped field is STRUCTURED.** ``avatar`` is a dict
+    whose ``traits`` values are masked (``_roster_avatar``), so an echoed avatar
+    carries the sentinel one level DOWN. A top-level-only check sees a ``dict``,
+    answers "not a mask", and lets ``_safe_avatar`` persist the sentinel over the
+    stored trait -- the exact corruption this predicate exists to prevent, one
+    level deeper than the flat fields. Any string anywhere inside the value
+    therefore counts.
+
+    Cost of the recursive form, stated because it is sharper than the flat one: if
+    an avatar carries ANY masked trait, the whole avatar field is treated as
+    unchanged, so an edit to a DIFFERENT trait in the same avatar is dropped too.
+    A partial merge would be the alternative, and it is worse: it would have to
+    decide field-by-field which half of a structured value is authoritative, and
+    getting that wrong writes glyphs into stored config. Refusing the whole field
+    never destroys what is stored.
+    """
+    from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+    if isinstance(incoming, str):
+        return _SENSITIVE_MASK in incoming
+    if isinstance(incoming, dict):
+        return any(_carries_mask(val) for val in incoming.values())
+    if isinstance(incoming, (list, tuple)):
+        return any(_carries_mask(val) for val in incoming)
+    return False
+
+
+def _roster_avatar(value: object) -> dict:
+    """The one STRUCTURED field a roster row ships: shape-allowlisted, not masked.
+
+    ``avatar`` is a ``dict``, so ``_roster_mask``'s non-string rule would blank it
+    wholesale -- and the dashboard needs it: ``AgentSelector.tsx`` declares
+    ``avatar?: unknown`` commented "verbatim from the backend", and ``main``'s
+    roster still ships it via the ``asdict`` spread this PR replaces. Withholding
+    it would REGRESS a live feature rather than narrow a disclosure, so it is
+    named in the allowlist like every other shipped field.
+
+    **A shape allowlist, with masking confined to the leaves that can carry user
+    text.** ``_safe_avatar`` is the config's own validator, so only
+    ``{"kind": "ghost", "traits": {...}}`` and ``{"kind": "image", "v": ...,
+    "file": "<digest>.<ext>"}`` survive and junk collapses to ``{}``. Within that,
+    ONLY ``traits`` values are masked:
+
+    - ``kind`` and ``v`` are structural. Mask ``kind`` and the dashboard can no
+      longer tell a ghost from an uploaded picture.
+    - ``file`` is PINNED by ``_AVATAR_FILE_PIN_RE`` to ``<16-hex>.<ext>``, so it is
+      not arbitrary text. A value constrained by a regex is safer than a masked
+      one: the pin REFUSES a bad value where masking would destroy a good one, and
+      a masked ``file`` makes the per-crew avatar endpoint resolve nothing --
+      silently breaking the image.
+    - ``traits`` values are the only user-authored strings here, so they go through
+      ``_roster_mask`` like any other roster string. The renderer resolves an
+      unrecognized trait to absent (``EYES[k] ?? ''``), so a masked trait degrades
+      that axis rather than breaking the face.
+
+    Honest limit on how far the two rules can be told apart: because
+    ``_safe_avatar`` already pins every non-``traits`` leaf to a shape the redactors
+    do not alter (a literal ``kind``, a digest ``file``, a hex ``tile``), a blanket
+    mask over the validated dict would behave the SAME as this targeted one today.
+    The targeted rule is chosen for intent and for the day that pin loosens, not
+    because a live defect separates them -- and no test can pin the difference
+    while the shape validator holds.
+
+    No host path is disclosed by any of this. The picture's bytes live under the
+    data home's agent-fenced ``run/avatars/`` dir and are served by the per-crew
+    avatar endpoint; the config field only marks the choice.
+    """
+    safe = _safe_avatar(value)
+    traits = safe.get("traits")
+    if isinstance(traits, dict):
+        safe = dict(safe)
+        safe["traits"] = {
+            axis: (_roster_mask(val) if isinstance(val, str) else val)
+            for axis, val in traits.items()
+        }
+    return safe
+
+
+def _name_would_be_masked(name: str) -> bool:
+    """True when *name* is credential-shaped, so a roster row would mask it.
+
+    Keyed on ``_roster_mask`` itself rather than on a second detector, so the
+    create-time rule and the read-time rule cannot drift apart: a name that would
+    arrive masked is a name that can never be stored in the first place.
+    """
+    return _roster_mask(name) != name
+
+
+def _agent_roster_row(
+    name: str, scope: str, agent_cfg: KiroCrewAgentConfig, *, redact: bool
+) -> dict[str, object]:
+    """Serialize ONE ``GET /api/agents`` roster row.
+
+    **Key half.** Explicit allowlist -- never a ``dataclasses.asdict`` spread,
+    mirroring the rule ``handlers/members.py`` already documents for
+    ``GET /api/members``. The response is a network-boundary contract, and a
+    spread makes that contract "every field ``KiroCrewAgentConfig`` has now, plus
+    every field anyone adds later", automatically -- so a field added by someone
+    who never looked at this endpoint (internal bookkeeping, a filesystem path, a
+    capability hint, a credential-shaped one) ships to the browser by omission.
+    Naming each field inverts the default: nothing leaves unless it is added here
+    deliberately (#8454). Both row sources go through this one function, so the
+    ``cfg.agents`` rows and the project-scope rows cannot drift into different
+    key sets.
+
+    **Value half.** Every record value goes through ``_roster_mask``, for every
+    caller, uniformly -- see there for why they are all untrusted and why the
+    mask is a fixed sentinel. ``_carries_mask`` is its write-side half in
+    ``api_kirocrew_agent_update``; neither is correct alone, and an end-to-end
+    test does the GET then the PUT to prove the pair.
+
+    Uniform rather than per-field on purpose: an earlier revision exempted the
+    fields the agents page happens to write back today, which encoded a claim
+    about the CLIENT that this side could not enforce -- and it was already
+    wrong, because ``api_kirocrew_agent_update`` accepts ``description`` and
+    ``source`` too.
+
+    ``name`` is the single exception, and only for the owner: it is the row's
+    IDENTITY, addressing ``/api/agents/{name}`` for edit and delete and keying
+    the usage sort, and it travels in the URL rather than the body so the
+    write-side rule cannot protect it. Masking it would make the row
+    unaddressable. An ``app`` token cannot reach those owner-gated routes, so the
+    exemption buys it nothing and ``name`` is masked there. A credential-shaped
+    name is now refused at CREATION (``_name_would_be_masked``), closing the hazard
+    at its source rather than at this one read site -- but only for names arriving
+    through that route, so an already-stored one still reaches here and is still
+    masked for every caller but the owner. Named cost: an app that feeds a roster name to another route sees the
+    mask, which happens only for a name containing credential- or URL-shaped
+    text.
+
+    ``scope`` is never masked: it is a literal written here, not record content.
+    The annotation is ``dict[str, object]`` rather than ``dict[str, str]`` because
+    of ONE field: ``avatar`` is a structured ``dict`` the dashboard needs verbatim
+    (see ``_roster_avatar``). Every other value is a ``str`` -- ``_roster_mask``
+    returns one for every input, including the non-strings the loader lets
+    through.
+
+    Excluded on purpose, each verified to have NO consumer in ``website/src``:
+    ``watchdog_tool_stall_suspect_secs`` and ``watchdog_tool_stall_hard_cap_secs``
+    (per-agent watchdog windows -- backend scheduling knobs the roster does not
+    render) and ``telegram_account`` (deprecated and inert, and the one record
+    field naming an external messaging binding). Adding any of them back is a
+    one-line change plus the pinned key set.
+    """
+    return {
+        # ``name`` is masked for an app token (which can address nothing) and for
+        # every PROJECT row (which nothing can address either: both
+        # ``api_kirocrew_agent_update`` and ``api_kirocrew_agent_delete`` 404 on a
+        # name absent from ``cfg.agents``, and a scanned project agent never is).
+        # A GLOBAL row's name survives for a non-app caller because it is that
+        # row's only handle -- it addresses ``/api/agents/{name}`` for edit and
+        # delete and keys the usage sort -- and masking it there would buy
+        # nothing: the same names are readable unmasked from
+        # ``GET /api/config/kirocrew``, where they are the ``agents`` map's KEYS
+        # and ``_masked_config_dict`` masks only schema-``sensitive`` VALUES.
+        # That last argument does NOT extend to project rows, whose names come
+        # from a filesystem scan and appear in no config, which is why they are
+        # masked here rather than reasoned away.
+        #
+        # Named cost: a project agent whose FILENAME is credential- or
+        # URL-shaped is no longer selectable, because the picker dispatches by
+        # this value (``AgentSelector.tsx:127`` ``onChange(a.name)``). That is
+        # confined to names the redactors would alter; an ordinary project agent
+        # name is byte-identical.
+        "name": _roster_mask(name) if (redact or scope == "project") else name,
+        # The #1684 project-scope tag: "project" rows dispatch only from the
+        # slot whose project they were scanned from. Handler-added, not a
+        # record field.
+        "scope": scope,
+        "kiro_agent": _roster_mask(agent_cfg.kiro_agent),
+        "workspace": _roster_mask(agent_cfg.workspace),
+        "memory_store": _roster_mask(agent_cfg.memory_store),
+        "model": _roster_mask(agent_cfg.model),
+        "reasoning_effort": _roster_mask(agent_cfg.reasoning_effort),
+        "description": _roster_mask(agent_cfg.description),
+        "triggers": _roster_mask(agent_cfg.triggers),
+        "source": _roster_mask(agent_cfg.source),
+        "session_color": _roster_mask(agent_cfg.session_color),
+        # The one STRUCTURED value a row carries -- shape-allowlisted by
+        # ``_safe_avatar`` with masking confined to user-authored ``traits``
+        # values, so ``kind``/``v``/``file`` survive as the pinned shapes the
+        # dashboard and the per-crew avatar endpoint need. See ``_roster_avatar``.
+        "avatar": _roster_avatar(getattr(agent_cfg, "avatar", {})),
+    }
+
+
 async def api_kirocrew_agents(request: web.Request) -> web.Response:
     """GET /api/agents — list all Kiro Crew agent definitions, most-used first.
 
@@ -2586,8 +2849,28 @@ async def api_kirocrew_agents(request: web.Request) -> web.Response:
     dispatch resolves aliases first, so the alias is what would answer.
     """
     cfg = KiroCrewConfig.load()
+    # Caller class, resolved once for the whole response. It decides only VALUE
+    # treatment, never the key set -- see ``_roster_mask``.
+    #
+    # The OWNER predicate, not an app-token check. `request.get("app", "")` alone
+    # asks "is this an app?", and a non-owner DASHBOARD session answers no: an
+    # allow-listed messaging user running `!dashboard` holds a dashboard token
+    # with `app == ""` and would have sailed through, which is the same
+    # caller-class hole that keeps reappearing when this question is hand-rolled
+    # per class instead of delegated to the one predicate that already answers
+    # it. `is_owner_dashboard_request` is what `_require_owner` resolves to for
+    # the mutating routes in this module, so the read and write sides now agree
+    # on who the owner is.
+    #
+    # Fails CLOSED -- treated as NOT the owner, so masked -- when the app carries
+    # no state to resolve an owner against. The predicate subscripts
+    # `app["state"]`, and for a disclosure control "unknown caller" must mean
+    # "mask", not "show".
+    from kiro_crew.dashboard.handlers.source_providers import is_owner_dashboard_request
+
+    redact = request.app.get("state") is None or not is_owner_dashboard_request(request)
     agents = [
-        {"name": name, "scope": "global", **dataclasses.asdict(agent_cfg)}
+        _agent_roster_row(name, "global", agent_cfg, redact=redact)
         for name, agent_cfg in cfg.agents.items()
     ]
 
@@ -2611,9 +2894,12 @@ async def api_kirocrew_agents(request: web.Request) -> web.Response:
         except Exception:
             logger.warning("Failed to list project agents for %s", project_dir, exc_info=True)
             project_names = frozenset()
-        base = dataclasses.asdict(KiroCrewAgentConfig())
+        # One shared default record for every project row — they carry no
+        # per-agent config of their own (nothing on disk to read without a
+        # second scan), so the row is the default record under a project tag.
+        project_default = KiroCrewAgentConfig()
         agents.extend(
-            {"name": name, "scope": "project", **base}
+            _agent_roster_row(name, "project", project_default, redact=redact)
             for name in sorted(project_names - set(cfg.agents.keys()))
         )
 
@@ -2629,9 +2915,12 @@ async def api_kirocrew_agents(request: web.Request) -> web.Response:
             # their config-insertion index and form a stable bottom block.
             sorted_agents = sorted(
                 enumerate(agents),
+                # ``str(...)`` because the row's value type widened to ``object``
+                # for ``avatar`` (the one structured field); ``name`` is always a
+                # ``str`` -- masked or verbatim, ``_roster_mask`` returns one.
                 key=lambda item: (
-                    -usage.get(item[1]["name"], (0, 0.0))[0],
-                    -usage.get(item[1]["name"], (0, 0.0))[1],
+                    -usage.get(str(item[1]["name"]), (0, 0.0))[0],
+                    -usage.get(str(item[1]["name"]), (0, 0.0))[1],
                     item[0],
                 ),
             )
@@ -2700,6 +2989,27 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
                 # filesystem, and on a populated agents directory this per-agent
                 # check (in a loop) would stall the gateway loop and heartbeat.
                 _dn = disc.name
+                # The OTHER way a name reaches `cfg.agents`, and the one the
+                # create-route check cannot see. A discovered spec's name is
+                # package-controlled rather than typed by the owner, so "the owner
+                # is reading a string the owner wrote" does not hold for it: a
+                # package could land a credential-shaped name that then reaches
+                # the roster. Refused here, at the second source, for the same
+                # reason it is refused at the first.
+                #
+                # Skipped rather than masked: masking would leave an
+                # unselectable, unrenameable row, and this row has no owner to
+                # rename it -- it comes back on every sync until the PACKAGE is
+                # fixed. The name is deliberately absent from the log line, since
+                # writing it into the log is the disclosure being avoided.
+                if _name_would_be_masked(_dn):
+                    logger.warning(
+                        "refusing to sync a discovered agent whose name is "
+                        "credential- or URL-shaped (source=%s); name withheld "
+                        "from this log deliberately -- fix the providing package",
+                        getattr(disc, "source", "?"),
+                    )
+                    continue
                 _has_on_disk = await asyncio.to_thread(
                     lambda: (kiro_agents_dir_path() / f"{_dn}.json").exists()
                     or _namespaced_agent_file_exists(_dn)
@@ -2974,6 +3284,34 @@ async def api_kirocrew_agents_create(request: web.Request) -> web.Response:
     name = body.get("name", "").strip()
     if not name:
         return web.json_response({"error": "Agent name is required"}, status=400)
+    # Refused at the SOURCE, not masked at one read site. Once such a name is
+    # stored it reaches logs, error messages, telemetry and every other surface
+    # that prints a crew name -- none of which this module controls -- so closing
+    # it here closes it once, where masking a read closes one of N. Keyed on
+    # ``_roster_mask`` via ``_name_would_be_masked``, so this rule and the
+    # roster's cannot drift apart.
+    #
+    # BOUNDARY, stated because it is real and narrower than "the hazard is
+    # closed": this covers only names created THROUGH this route, from now on. A
+    # crew already present in `config.json`, one written there by hand, and one
+    # added by ``_do_agents_sync`` from a discovered spec are NOT retroactively
+    # renamed. That is the reason the owner keeps reading a stored name verbatim:
+    # renaming is the remediation, and a name must be legible to be renamed.
+    #
+    # The name is deliberately NOT echoed back. Reflecting a credential-shaped
+    # string into a response body -- and from there into the request log -- is the
+    # disclosure this rule exists to prevent.
+    if _name_would_be_masked(name):
+        return web.json_response(
+            {
+                "error": (
+                    "Agent name looks like a credential or a URL carrying one. "
+                    "Pick a name that identifies the crew instead."
+                ),
+                "code": "credential_shaped_name",
+            },
+            status=400,
+        )
     # The template pointer must be EXPLICIT. It used to default to "kirocrew",
     # which made every crew created without naming a template an alias for the
     # DEFAULT agent: dispatch flattens an alias to its `kiro_agent`
@@ -3123,6 +3461,26 @@ async def api_kirocrew_agent_update(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "body must be an object", "code": "body_not_object"}, status=400
         )
+    # WRITE-SIDE HALF of the roster mask, and it runs FIRST -- immediately after
+    # the body-object check, before any validation. `GET /api/agents` replaces a
+    # value it cannot show verbatim with `_SENSITIVE_MASK` (`_roster_mask`), and
+    # a client that echoes the record back -- the agents page sends every field
+    # on every save, so that `""` can clear a pin -- would otherwise persist the
+    # mask over the stored original. A field carrying the mask therefore means
+    # "unchanged" and is dropped here, which is the remedy
+    # `_masked_config_dict`'s docstring prescribes verbatim: "MUST treat
+    # `_SENSITIVE_MASK` as 'unchanged' and keep the stored value".
+    #
+    # Ordering is load-bearing, not cosmetic: `model` and `reasoning_effort` are
+    # validated below and would REJECT an echoed mask with a 400, failing an edit
+    # to some unrelated field. Dropping the masked entries before those checks
+    # means a mask can never be validated as if it were content.
+    #
+    # It can run this early only because the predicate matches a FIXED sentinel
+    # and needs no access to the stored record -- a rule that recognised the view
+    # by recomputing the redaction of `agent` would have to wait for the config
+    # load inside the lock, and would therefore sit after these validations.
+    body = {key: val for key, val in body.items() if not _carries_mask(val)}
     if "model" in body:
         pending_model = normalize_agent_model(body["model"])
     # Rejected before the config is even loaded: the check is pure, and every

--- a/test/test_agent_sync_prune.py
+++ b/test/test_agent_sync_prune.py
@@ -156,6 +156,32 @@ class TestAgentSyncPrune:
         cfg.save.assert_not_called()
 
 
+class TestSyncRefusesCredentialShapedNames:
+    """The SECOND way a name reaches `cfg.agents`, which the create route cannot see.
+
+    A discovered spec's name is package-controlled, not typed by the owner, so
+    "the owner is reading a string the owner wrote" does not hold for it: a package
+    could land a credential-shaped name that then reaches the roster. Refused at
+    this source too (#8454).
+    """
+
+    PROBE = "AKIAIOSFODNN7EXAMPLE"
+
+    @pytest.mark.asyncio
+    async def test_a_credential_shaped_discovered_name_is_not_synced(self):
+        cfg = _make_config({})
+        body = await _run_sync(cfg, [_make_aim_agent(self.PROBE)])
+        assert self.PROBE not in cfg.agents, "a credential-shaped package name was stored"
+        assert self.PROBE not in json.dumps(body), "the name was echoed into the response"
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_discovered_name_still_syncs(self):
+        """The direction that proves the refusal is narrow, not a blanket."""
+        cfg = _make_config({})
+        await _run_sync(cfg, [_make_aim_agent("oncall-triage")])
+        assert "oncall-triage" in cfg.agents
+
+
 class TestAgentSyncFsCheckIsOffloaded:
     """The per-agent on-disk existence check (a stat + a namespaced glob) runs in
     a loop over discovered agents; on a populated agents directory it must be

--- a/test/test_agents_roster_contract.py
+++ b/test/test_agents_roster_contract.py
@@ -1,0 +1,977 @@
+"""``GET /api/agents`` ships an explicit allowlist, never the whole record.
+
+The endpoint used to build each row with ``{**dataclasses.asdict(agent_cfg)}``,
+which made its response contract "every field ``KiroCrewAgentConfig`` has now,
+plus every field anyone adds later", automatically — a field added by someone
+who never looked at this endpoint shipped to the browser by omission. #8454
+converted both row sources to an explicit allowlist, mirroring the rule
+``handlers/members.py`` already documents for ``GET /api/members``.
+
+These tests are the half that keeps it converted. The key set is pinned as a
+literal, and a separate ratchet compares that literal against the live record
+so a field added to ``KiroCrewAgentConfig`` fails here rather than silently
+appearing in the response — which is the whole point of the change: the default
+becomes "nothing unless someone adds it".
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import tempfile
+import types
+import unittest.mock
+from pathlib import Path
+from typing import cast
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.config.sections import KiroCrewAgentConfig, _safe_avatar
+from kiro_crew.dashboard.handlers.agents import (
+    _agent_roster_row,
+    _carries_mask,
+    _name_would_be_masked,
+    _roster_mask,
+)
+
+# The EXACT key set every row carries, from BOTH sources (the ``cfg.agents``
+# rows and the project-scope rows). ``name`` and ``scope`` are handler-added;
+# the rest are allowlisted record fields. Changing this set is a
+# network-boundary contract change: check the frontend consumers first
+# (``website/src/components/AgentSelector.tsx`` declares the ``KiroCrewAgent``
+# interface the dashboard reads).
+ROSTER_ROW_KEYS = frozenset(
+    {
+        "name",
+        "scope",
+        "kiro_agent",
+        "workspace",
+        "memory_store",
+        "model",
+        "reasoning_effort",
+        "description",
+        "triggers",
+        "source",
+        "session_color",
+        "avatar",
+    }
+)
+
+# Record fields deliberately withheld, each verified to have no consumer in
+# ``website/src``: the two watchdog windows are backend scheduling knobs the
+# roster does not render, and ``telegram_account`` is deprecated and inert.
+WITHHELD_RECORD_FIELDS = frozenset(
+    {
+        "watchdog_tool_stall_suspect_secs",
+        "watchdog_tool_stall_hard_cap_secs",
+        "telegram_account",
+    }
+)
+
+
+def _make_app() -> web.Application:
+    """Minimal aiohttp app with just the roster endpoint."""
+    from kiro_crew.dashboard.handlers import api_kirocrew_agents
+
+    app = web.Application()
+    app.router.add_get("/api/agents", api_kirocrew_agents)
+    return app
+
+
+def _seed_config_with_every_field_set() -> dict:
+    """A config whose agent sets EVERY record field, withheld ones included.
+
+    A withheld field left at its default is indistinguishable from a withheld
+    field that is absent, so the fixture gives each one a distinctive value: an
+    assertion on its absence then actually proves the allowlist rather than the
+    default happening to be falsy.
+    """
+    return {
+        "agents": {
+            "roster-probe": {
+                "kiro_agent": "kirocrew",
+                "workspace": "probe-ws",
+                "memory_store": "probe-ms",
+                "model": "claude-opus-5",
+                "reasoning_effort": "high",
+                "description": "probe description",
+                "triggers": "probe triggers",
+                "source": "kirocrew",
+                "session_color": "#abcdef",
+                # Withheld — must NOT appear in the response.
+                "watchdog_tool_stall_suspect_secs": 111.0,
+                "watchdog_tool_stall_hard_cap_secs": 222.0,
+                "telegram_account": "probe-telegram-binding",
+            },
+        },
+        "default_agent": "roster-probe",
+        "workspaces": {"default": {"dir": "workspace"}, "probe-ws": {"dir": "workspace"}},
+    }
+
+
+class TestRosterRowKeySet:
+    """The response's exact key set, measured at the endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_global_row_ships_exactly_the_allowlist(self) -> None:
+        """A ``cfg.agents`` row carries the allowlist and nothing else."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(_seed_config_with_every_field_set(), f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                async with TestClient(TestServer(_make_app())) as client:
+                    resp = await client.get("/api/agents")
+                    assert resp.status == 200
+                    row = {a["name"]: a for a in (await resp.json())["agents"]}["roster-probe"]
+
+            assert set(row) == ROSTER_ROW_KEYS
+            # The allowlisted values still arrive — an allowlist that shipped
+            # the right KEYS with empty values would pass a key-set assertion
+            # while breaking every consumer.
+            assert row["scope"] == "global"
+            assert row["workspace"] == "probe-ws"
+            assert row["memory_store"] == "probe-ms"
+            assert row["model"] == "claude-opus-5"
+            assert row["reasoning_effort"] == "high"
+            assert row["description"] == "probe description"
+            assert row["triggers"] == "probe triggers"
+            assert row["session_color"] == "#abcdef"
+            # And the withheld fields are gone even though the config set them
+            # to distinctive non-default values.
+            assert not (set(row) & WITHHELD_RECORD_FIELDS)
+            assert "probe-telegram-binding" not in json.dumps(row)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_project_row_ships_the_same_key_set(self, monkeypatch) -> None:
+        """A project-scope row carries the SAME keys as a global row.
+
+        The two sources were separate spreads before #8454, so they could drift
+        into different key sets; pinning both is what makes one allowlist the
+        answer for the whole response.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.agents.active_project_dir",
+            lambda state, key: "/probe/project",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.agents.project_agent_names",
+            lambda project_dir, **kw: frozenset({"project-only-agent"}),
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(_seed_config_with_every_field_set(), f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                app = _make_app()
+                # Truthy state with no conversation log: the handler then takes
+                # the project-scan branch and skips the usage re-sort.
+                app["state"] = types.SimpleNamespace(conversation_log=None)
+                async with TestClient(TestServer(app)) as client:
+                    resp = await client.get("/api/agents")
+                    assert resp.status == 200
+                    rows = {a["name"]: a for a in (await resp.json())["agents"]}
+
+            assert "project-only-agent" in rows, "project scan produced no row to check"
+            project_row = rows["project-only-agent"]
+            assert set(project_row) == ROSTER_ROW_KEYS
+            assert set(project_row) == set(rows["roster-probe"])
+            assert project_row["scope"] == "project"
+            assert not (set(project_row) & WITHHELD_RECORD_FIELDS)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_app_token_caller_gets_the_same_keys_with_scrubbed_values(self) -> None:
+        """End to end: the caller class is resolved from the request, not passed in.
+
+        The row-level tests cover ``redact=`` directly; this one covers the
+        WIRING -- that the handler reads the caller class off the request at all.
+        A middleware sets ``request["app"]``, which is what ``token_auth`` does
+        for a verified app token and what ``members.py::_deny_app_caller`` reads.
+        """
+        probe = "AKIAIOSFODNN7EXAMPLE"
+        seed = _seed_config_with_every_field_set()
+        seed["agents"]["roster-probe"]["description"] = f"see {probe}"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+
+            @web.middleware
+            async def _as_app(request: web.Request, handler):  # type: ignore[no-untyped-def]
+                request["app"] = "probe-app"
+                return await handler(request)
+
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                app = web.Application(middlewares=[_as_app])
+                from kiro_crew.dashboard.handlers import api_kirocrew_agents
+
+                app.router.add_get("/api/agents", api_kirocrew_agents)
+                async with TestClient(TestServer(app)) as client:
+                    resp = await client.get("/api/agents")
+                    assert resp.status == 200
+                    body = await resp.json()
+                    row = {a["name"]: a for a in body["agents"]}["roster-probe"]
+
+            assert set(row) == ROSTER_ROW_KEYS, "key set must not depend on caller class"
+            assert probe not in json.dumps(row), "app token received an unscrubbed value"
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+class TestRosterRowIsAnAllowlistNotASpread:
+    """The property that survives the record growing."""
+
+    def test_record_field_added_later_is_not_shipped_by_omission(self) -> None:
+        """Every ``KiroCrewAgentConfig`` field is either allowlisted or withheld.
+
+        This is the ratchet. It fails when a field is ADDED to the record, and
+        that failure is the feature: the author has to decide whether the
+        browser should see it, instead of a spread deciding for them.
+        """
+        record_fields = {f.name for f in dataclasses.fields(KiroCrewAgentConfig)}
+        unclassified = record_fields - ROSTER_ROW_KEYS - WITHHELD_RECORD_FIELDS
+        assert not unclassified, (
+            f"KiroCrewAgentConfig grew {sorted(unclassified)}. GET /api/agents is an "
+            "explicit allowlist (#8454), so decide deliberately: add the field to "
+            "_agent_roster_row AND ROSTER_ROW_KEYS if the dashboard needs it, or to "
+            "WITHHELD_RECORD_FIELDS if it must not leave the process."
+        )
+        # The withheld set must name real fields — a typo there would silently
+        # stop classifying anything and let the next added field through.
+        assert WITHHELD_RECORD_FIELDS <= record_fields
+        # And the allowlist must not claim a record field that no longer exists.
+        assert ROSTER_ROW_KEYS - {"name", "scope"} <= record_fields
+
+    def test_an_attribute_the_allowlist_does_not_name_is_dropped(self) -> None:
+        """Behavioral proof, not just a literal comparison.
+
+        A record carrying an extra attribute — the shape of a field added
+        later — serializes to the same key set. Under the old spread this row
+        would have carried ``secret_future_field``.
+        """
+
+        def _clone(f: dataclasses.Field) -> dataclasses.Field:
+            """Rebuild ONE field, preserving how its default is supplied.
+
+            A probe that REBUILDS the class it inspects can manufacture a failure
+            that does not exist in the class. ``avatar`` uses
+            ``default_factory=dict`` -- a mutable default must -- so its
+            ``f.default`` is ``dataclasses.MISSING``; passing that straight to
+            ``field(default=...)`` produces a field with NO default, and a
+            non-default field after defaulted ones is a hard
+            ``TypeError: non-default argument 'avatar' follows default argument``
+            at class-creation time. That error was this probe's, not the record's:
+            ``KiroCrewAgentConfig()`` instantiates fine on a clean tree.
+            """
+            if f.default_factory is not dataclasses.MISSING:
+                return dataclasses.field(default_factory=f.default_factory)
+            return dataclasses.field(default=f.default)
+
+        grown = dataclasses.make_dataclass(
+            "GrownAgentConfig",
+            [(f.name, f.type, _clone(f)) for f in dataclasses.fields(KiroCrewAgentConfig)]
+            + [("secret_future_field", str, dataclasses.field(default="must-not-ship"))],
+        )
+        row = _agent_roster_row("grown", "global", cast(KiroCrewAgentConfig, grown()), redact=False)
+        assert set(row) == ROSTER_ROW_KEYS
+        assert "secret_future_field" not in row
+        assert "must-not-ship" not in json.dumps(row)
+
+
+class TestUnshowableValuesAreMasked:
+    """The read half: nothing that cannot be shown verbatim leaves as content."""
+
+    PROBE = "AKIAIOSFODNN7EXAMPLE"
+    UNCOERCED_BY_LOADER = ("kiro_agent", "workspace", "memory_store", "description", "source")
+    # ``avatar`` is the ONE structured value a row ships, so the uniform
+    # string sweeps below do not apply to it: it is shape-allowlisted by
+    # ``_safe_avatar`` with masking confined to user-authored ``traits``
+    # values, and is pinned separately -- in BOTH directions -- by
+    # ``TestAvatarIsShapeAllowlistedNotMasked``. Excluded here rather than
+    # softening these assertions, so the rule for every other field stays
+    # "the sentinel, exactly".
+    RECORD_FIELDS_SHIPPED = tuple(sorted(ROSTER_ROW_KEYS - {"name", "scope", "avatar"}))
+
+    def _full(self) -> KiroCrewAgentConfig:
+        return KiroCrewAgentConfig(
+            kiro_agent=self.PROBE,
+            workspace=f"ws-{self.PROBE}",
+            memory_store=f"ms-{self.PROBE}",
+            triggers=f"use when {self.PROBE}",
+            model=self.PROBE,
+            reasoning_effort=self.PROBE,
+            session_color=self.PROBE,
+            description=f"see {self.PROBE}",
+            source=self.PROBE,
+        )
+
+    @pytest.mark.parametrize("redact", [False, True])
+    def test_no_record_field_ships_a_credential_shaped_value(self, redact: bool) -> None:
+        """Uniform across callers: an earlier revision exempted the fields the
+        agents page writes back, which encoded a claim about the CLIENT that this
+        side could not enforce (the PUT accepts `description` and `source` too)."""
+        row = _agent_roster_row("probe", "global", self._full(), redact=redact)
+        for field in self.RECORD_FIELDS_SHIPPED:
+            assert self.PROBE not in row[field], f"{field} shipped unmasked"
+            assert _carries_mask(row[field]), f"{field} should be the sentinel"
+
+    @pytest.mark.parametrize("redact", [False, True])
+    @pytest.mark.parametrize("field", UNCOERCED_BY_LOADER)
+    def test_a_non_string_is_masked_not_emptied(self, field: str, redact: bool) -> None:
+        """The loader lets an object through five declared-`str` fields.
+
+        Masking rather than coercing to `""` is what lets the write-side rule
+        PRESERVE it: an echoed `""` would read as a genuine edit and overwrite the
+        stored value, which was a real defect in an earlier revision.
+        """
+        cfg = KiroCrewAgentConfig()
+        object.__setattr__(cfg, field, {"nested": "object"})
+        row = _agent_roster_row("probe", "global", cfg, redact=redact)
+        assert _carries_mask(row[field])
+        assert "nested" not in json.dumps(row)
+
+    def test_every_value_is_a_string_except_the_one_structured_field(self) -> None:
+        """`dict[str, object]` is honest about exactly one field, not a loophole.
+
+        Every value is a `str` but `avatar`, which is a `dict` the dashboard needs
+        verbatim. Asserting the exception BY NAME means a second structured field
+        cannot appear without this test failing.
+        """
+        cfg = KiroCrewAgentConfig()
+        object.__setattr__(cfg, "description", {"nested": "object"})
+        for redact in (False, True):
+            row = _agent_roster_row("probe", "global", cfg, redact=redact)
+            assert isinstance(row["avatar"], dict)
+            non_str = {k for k, v in row.items() if not isinstance(v, str)}
+            assert non_str == {"avatar"}, f"unexpected structured value(s): {non_str}"
+
+    def test_owner_keeps_name_addressable_but_app_token_does_not_need_it(self) -> None:
+        """``name`` survives only where something can actually address it.
+
+        A GLOBAL row's name is its only handle -- it addresses
+        ``/api/agents/{name}`` for edit and delete and keys the usage sort -- and
+        masking it for a non-app caller would buy nothing, since the same names
+        are readable unmasked from ``GET /api/config/kirocrew`` as the ``agents``
+        map's KEYS (``_masked_config_dict`` masks only schema-``sensitive``
+        VALUES).
+
+        A PROJECT row is masked for every caller. That argument does not transfer
+        to it: project names come from a filesystem scan and appear in no config.
+        Nothing can address one either -- both mutating routes 404 on a name
+        absent from ``cfg.agents``, and a scanned project agent never is -- so no
+        opaque replacement identifier is needed.
+        """
+        # Global + owner: verbatim, because it is addressable.
+        g = _agent_roster_row(f"crew-{self.PROBE}", "global", KiroCrewAgentConfig(), redact=False)
+        assert g["name"] == f"crew-{self.PROBE}"
+        assert g["scope"] == "global"
+        # Global + app token: masked, because an app cannot reach those routes.
+        ga = _agent_roster_row(f"crew-{self.PROBE}", "global", KiroCrewAgentConfig(), redact=True)
+        assert _carries_mask(ga["name"])
+        # Project: masked for BOTH callers, because nothing addresses a project row.
+        for redact in (False, True):
+            p = _agent_roster_row(
+                f"crew-{self.PROBE}", "project", KiroCrewAgentConfig(), redact=redact
+            )
+            assert _carries_mask(p["name"]), f"project name unmasked at redact={redact}"
+            assert p["scope"] == "project"
+        # An ordinary name is byte-identical everywhere, so normal rosters and
+        # normal project agents stay selectable.
+        for scope in ("global", "project"):
+            for redact in (False, True):
+                row = _agent_roster_row("my-agent", scope, KiroCrewAgentConfig(), redact=redact)
+                assert row["name"] == "my-agent"
+
+    @pytest.mark.parametrize("redact", [False, True])
+    def test_benign_content_is_never_altered(self, redact: bool) -> None:
+        """A mask that swallows legitimate text is a rendering bug, not hardening."""
+        cfg = KiroCrewAgentConfig(description="a plain crew", triggers="use for triage")
+        row = _agent_roster_row("kirocrew", "global", cfg, redact=redact)
+        assert row["description"] == "a plain crew"
+        assert row["triggers"] == "use for triage"
+        assert row["name"] == "kirocrew"
+
+    def test_both_caller_classes_ship_the_same_key_set(self) -> None:
+        """Only values differ. A caller-dependent KEY set would be a second contract."""
+        cfg = KiroCrewAgentConfig(description="d", triggers="t")
+        owner = _agent_roster_row("probe", "global", cfg, redact=False)
+        app = _agent_roster_row("probe", "global", cfg, redact=True)
+        assert set(owner) == set(app) == ROSTER_ROW_KEYS
+
+
+class TestAvatarIsShapeAllowlistedNotMasked:
+    """The one structured field: masked where it can carry text, intact elsewhere.
+
+    Both directions are asserted on purpose. A test that only checks masking
+    passes just as well against a blanket mask -- and a blanket here would break
+    the feature: a masked ``file`` makes the per-crew avatar endpoint resolve
+    nothing, and a masked ``kind`` loses ghost-vs-image.
+    """
+
+    PROBE = "AKIAIOSFODNN7EXAMPLE"
+    FILE_PIN = "0123456789abcdef.png"
+
+    def test_a_credential_shaped_trait_value_is_masked(self) -> None:
+        row = _agent_roster_row(
+            "probe",
+            "global",
+            cast(
+                KiroCrewAgentConfig,
+                types.SimpleNamespace(
+                    **{
+                        **{f.name: "" for f in dataclasses.fields(KiroCrewAgentConfig)},
+                        "avatar": {"kind": "ghost", "traits": {"eyes": self.PROBE}},
+                    }
+                ),
+            ),
+            redact=False,
+        )
+        avatar = cast(dict, row["avatar"])
+        assert _carries_mask(avatar["traits"]["eyes"]), "a user-authored trait was not masked"
+        assert self.PROBE not in json.dumps(row)
+
+    def test_the_pinned_file_and_kind_survive_intact(self) -> None:
+        """The direction that rots. `file` is regex-pinned, so it needs no mask.
+
+        A value constrained by ``_AVATAR_FILE_PIN_RE`` is safer than a masked one:
+        the pin refuses a bad value, where masking destroys a good one.
+        """
+        row = _agent_roster_row(
+            "probe",
+            "global",
+            cast(
+                KiroCrewAgentConfig,
+                types.SimpleNamespace(
+                    **{
+                        **{f.name: "" for f in dataclasses.fields(KiroCrewAgentConfig)},
+                        "avatar": {"kind": "image", "v": 17, "file": self.FILE_PIN},
+                    }
+                ),
+            ),
+            redact=False,
+        )
+        avatar = cast(dict, row["avatar"])
+        assert avatar["kind"] == "image", "the dashboard could not tell ghost from image"
+        assert avatar["file"] == self.FILE_PIN, "the avatar endpoint would resolve nothing"
+        assert avatar["v"] == 17
+        assert not _carries_mask(avatar["file"])
+
+    def test_the_pin_that_makes_targeted_masking_safe_still_holds(self) -> None:
+        """The PRECONDITION, not the consequence -- and this one can redden.
+
+        No test can separate "mask only `traits`" from "mask every leaf": while
+        `_safe_avatar` pins each non-`traits` leaf to a shape the redactors do not
+        alter, the two behave identically, so a mutation masking everything leaves
+        the suite green. The targeted rule is therefore documentation.
+
+        What actually protects `file` is the PIN. So assert the pin. This fails the
+        day someone loosens the validator -- which is exactly the day the targeted
+        masking stops being documentation and starts being load-bearing, and the
+        day `_roster_avatar`'s docstring claim ("a blanket would behave the same")
+        stops being true.
+
+        Measured shapes, not assumed: a `file` failing the pin is DROPPED while
+        `kind` is kept; a junk or missing `kind` collapses the whole override; a
+        non-hex `tile` collapses it too, which is what keeps `javascript:` out of
+        the SVG markup `tile` is interpolated into.
+        """
+        good = {"kind": "image", "v": 17, "file": self.FILE_PIN}
+        assert _safe_avatar(good)["file"] == self.FILE_PIN
+
+        for bad_file in ("notadigest.png", "../../etc/passwd", "0123456789abcdef.svg", "0123.png"):
+            got = _safe_avatar({"kind": "image", "file": bad_file})
+            assert "file" not in got, f"the pin let {bad_file!r} through"
+            assert got.get("kind") == "image"
+
+        for bad_kind in (
+            {"kind": "nonsense", "traits": {"eyes": "wide"}},
+            {"traits": {"eyes": "wide"}},
+        ):
+            assert _safe_avatar(bad_kind) == {}, "kind is no longer held to its literal set"
+
+        assert _safe_avatar({"kind": "ghost", "traits": {"tile": "javascript:alert(1)"}}) == {}
+        assert (
+            _safe_avatar({"kind": "ghost", "traits": {"tile": "#a1b2c3"}})["traits"]["tile"]
+            == "#a1b2c3"
+        )
+
+        # And the roster inherits the pin rather than re-implementing it.
+        row = _agent_roster_row(
+            "probe",
+            "global",
+            cast(
+                KiroCrewAgentConfig,
+                types.SimpleNamespace(
+                    **{
+                        **{f.name: "" for f in dataclasses.fields(KiroCrewAgentConfig)},
+                        "avatar": {"kind": "image", "file": "../../etc/passwd"},
+                    }
+                ),
+            ),
+            redact=False,
+        )
+        assert "file" not in cast(dict, row["avatar"])
+
+    def test_junk_collapses_rather_than_shipping_verbatim(self) -> None:
+        row = _agent_roster_row(
+            "probe",
+            "global",
+            cast(
+                KiroCrewAgentConfig,
+                types.SimpleNamespace(
+                    **{
+                        **{f.name: "" for f in dataclasses.fields(KiroCrewAgentConfig)},
+                        "avatar": {"kind": "nonsense", "evil": self.PROBE},
+                    }
+                ),
+            ),
+            redact=False,
+        )
+        assert self.PROBE not in json.dumps(row)
+        assert "evil" not in cast(dict, row["avatar"])
+
+
+class TestCredentialShapedNamesAreRefusedAtCreation:
+    """The hazard is closed where the name comes to exist, not where it is read.
+
+    GPT 5.6 asked for `_roster_mask(name)` on every caller, owner included. That
+    masks the field the owner needs to SELECT, RENAME and tell crews apart, and it
+    closes one read site out of N -- a stored credential-shaped name still reaches
+    logs, error messages and telemetry. Refusing it at creation closes the source.
+    """
+
+    PROBE = "AKIAIOSFODNN7EXAMPLE"
+
+    def test_the_create_rule_is_keyed_to_the_read_rule(self) -> None:
+        """One detector, so the two halves cannot drift apart.
+
+        Anything the roster would mask is refused at creation; anything it ships
+        verbatim is accepted. That equivalence is the invariant, not two lists.
+        """
+        for candidate in (self.PROBE, f"https://x.example/?token={self.PROBE}"):
+            assert _name_would_be_masked(candidate) is True
+            assert _roster_mask(candidate) != candidate
+        for benign in ("oncall", "kirocrew", "crew-7", "release manager"):
+            assert _name_would_be_masked(benign) is False
+            assert _roster_mask(benign) == benign
+
+    @pytest.mark.asyncio
+    async def test_creation_refuses_a_credential_shaped_name(self) -> None:
+        seed = _seed_config_with_every_field_set()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                from kiro_crew.dashboard.handlers import api_kirocrew_agents_create
+
+                # POST is owner-gated (`_require_owner`), so the caller must BE the
+                # owner for the request to reach the name check at all.
+                @web.middleware
+                async def _owner(request: web.Request, handler):  # type: ignore[no-untyped-def]
+                    request["app"] = ""
+                    request["user"] = "owner-1"
+                    return await handler(request)
+
+                app = web.Application(middlewares=[_owner])
+                app["state"] = types.SimpleNamespace(owner_id="owner-1", conversation_log=None)
+                app.router.add_post("/api/agents", api_kirocrew_agents_create)
+                async with TestClient(TestServer(app)) as client:
+                    resp = await client.post(
+                        "/api/agents",
+                        json={"name": self.PROBE, "kiro_agent": "kirocrew"},
+                    )
+                    assert resp.status == 400, await resp.text()
+                    payload = await resp.json()
+                    assert payload["code"] == "credential_shaped_name"
+                    # The refusal must not reflect the value into the response or
+                    # the request log -- that is the disclosure being prevented.
+                    assert self.PROBE not in json.dumps(payload)
+            # And nothing was stored under it.
+            assert self.PROBE not in json.loads(tmp.read_text()).get("agents", {})
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+class TestCallerClassIsTheOwnerPredicate:
+    """Who counts as the owner is delegated, not hand-rolled per caller class."""
+
+    PROBE = "AKIAIOSFODNN7EXAMPLE"
+
+    def _app(self, *, user: str, owner_id: str) -> web.Application:
+        """An app whose requests carry a dashboard identity and an owner_id.
+
+        `is_owner_dashboard_request` requires `app == ""` (a dashboard token, not
+        an app token), a non-empty `user`, and a match against `state.owner_id`.
+        """
+
+        @web.middleware
+        async def _identity(request: web.Request, handler):  # type: ignore[no-untyped-def]
+            request["app"] = ""
+            request["user"] = user
+            return await handler(request)
+
+        from kiro_crew.dashboard.handlers import api_kirocrew_agents
+
+        app = web.Application(middlewares=[_identity])
+        app["state"] = types.SimpleNamespace(owner_id=owner_id, conversation_log=None)
+        app.router.add_get("/api/agents", api_kirocrew_agents)
+        return app
+
+    async def _name_for(self, app: web.Application, tmp: Path) -> str:
+        with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.get("/api/agents")
+                assert resp.status == 200
+                rows = (await resp.json())["agents"]
+        return str(rows[0]["name"])
+
+    def _seed(self) -> Path:
+        seed = _seed_config_with_every_field_set()
+        seed["agents"] = {f"crew-{self.PROBE}": seed["agents"]["roster-probe"]}
+        seed["default_agent"] = f"crew-{self.PROBE}"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            return Path(f.name)
+
+    @pytest.mark.asyncio
+    async def test_a_non_owner_dashboard_session_gets_the_name_masked(self) -> None:
+        """The hole an app-token-only check leaves open.
+
+        `request.get("app", "")` asks "is this an app?", and a non-owner DASHBOARD
+        session answers no -- an allow-listed messaging user running `!dashboard`
+        holds a dashboard token with `app == ""`. That caller is not the trust
+        root, so it must not receive a credential-shaped crew name raw.
+        """
+        tmp = self._seed()
+        try:
+            name = await self._name_for(self._app(user="someone-else", owner_id="owner-1"), tmp)
+            assert _carries_mask(name), "a non-owner dashboard session saw the raw name"
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_the_owner_still_gets_an_addressable_global_name(self) -> None:
+        """The owner keeps the row's only handle, or edit and delete break."""
+        tmp = self._seed()
+        try:
+            name = await self._name_for(self._app(user="owner-1", owner_id="owner-1"), tmp)
+            assert name == f"crew-{self.PROBE}"
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_a_stateless_app_fails_closed(self) -> None:
+        """No state means no owner can be resolved, so mask rather than show.
+
+        `is_owner_dashboard_request` subscripts `app["state"]`. For a disclosure
+        control, "unknown caller" must mean "mask".
+        """
+        tmp = self._seed()
+        try:
+            name = await self._name_for(_make_app(), tmp)
+            assert _carries_mask(name)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def test_a_mask_nested_in_a_structured_field_is_refused(self) -> None:
+        """The corruption a top-level-only check let through.
+
+        `avatar` is a dict whose `traits` values are masked, so an echoed avatar
+        carries the sentinel one level DOWN. A flat check sees a `dict`, answers
+        "not a mask", and lets `_safe_avatar` persist the sentinel over the stored
+        trait. Any string anywhere inside the value must count.
+        """
+        from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+        assert _carries_mask({"kind": "ghost", "traits": {"eyes": _SENSITIVE_MASK}}) is True
+        assert _carries_mask({"kind": "ghost", "traits": {"eyes": f"{_SENSITIVE_MASK} x"}}) is True
+        assert _carries_mask([{"traits": {"eyes": _SENSITIVE_MASK}}]) is True
+        # A clean structured value is still a genuine edit.
+        assert _carries_mask({"kind": "image", "v": 17, "file": "0123456789abcdef.png"}) is False
+        assert _carries_mask({"kind": "ghost", "traits": {"eyes": "wide", "blush": True}}) is False
+
+    @pytest.mark.asyncio
+    async def test_an_echoed_avatar_does_not_overwrite_a_masked_trait(self) -> None:
+        """End to end: the sentinel never reaches config.json through the nest."""
+        from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+        seed = _seed_config_with_every_field_set()
+        stored = f"eyes-{self.PROBE}"
+        seed["agents"]["roster-probe"]["avatar"] = {"kind": "ghost", "traits": {"eyes": stored}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with (
+                unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp),
+                unittest.mock.patch(
+                    "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+                    lambda request: True,
+                ),
+            ):
+                from kiro_crew.dashboard.handlers import api_kirocrew_agent_update
+
+                app = web.Application()
+                app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+                async with TestClient(TestServer(app)) as client:
+                    put = await client.put(
+                        "/api/agents/roster-probe",
+                        json={"avatar": {"kind": "ghost", "traits": {"eyes": _SENSITIVE_MASK}}},
+                    )
+                    assert put.status == 200, await put.text()
+            after = json.loads(tmp.read_text())["agents"]["roster-probe"]["avatar"]
+            assert _SENSITIVE_MASK not in json.dumps(after), "the nested sentinel was persisted"
+            assert after["traits"]["eyes"] == stored
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+class TestMaskIsTreatedAsUnchangedOnWrite:
+    """The write half, without which the read half destroys stored config."""
+
+    PROBE = "AKIAIOSFODNN7EXAMPLE"
+
+    @pytest.fixture(autouse=True)
+    def _as_owner(self, monkeypatch):
+        """Run past the owner gate.
+
+        These tests exercise the write-side rule, not the owner boundary -- that
+        has its own enumerate-the-invariant coverage in
+        `test_agents_endpoints_owner_auth.py`. Same patch `test_config_api.py`
+        uses for the mutating agent endpoints.
+        """
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            lambda request: True,
+        )
+
+    def test_the_sentinel_is_the_one_the_config_endpoint_uses(self) -> None:
+        """Not a private copy: drift would silently break the round-trip rule."""
+        from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+        assert _carries_mask(_SENSITIVE_MASK)
+        row = _agent_roster_row(
+            "probe", "global", KiroCrewAgentConfig(description=f"see {self.PROBE}"), redact=False
+        )
+        assert row["description"] == _SENSITIVE_MASK
+
+    def test_real_content_is_not_treated_as_the_mask(self) -> None:
+        assert _carries_mask("plain text") is False
+        assert _carries_mask("") is False
+        assert _carries_mask({"a": 1}) is False
+
+    def test_a_mask_the_operator_appended_to_is_still_refused(self) -> None:
+        """The editor renders the mask into a text input, so it can be typed past.
+
+        An exact-match rule closes only the echo-it-back case. Appending to the
+        mask produces a string that is not the sentinel, so equality would persist
+        the redaction glyphs plus the addition over the stored original -- the data
+        loss this rule exists to stop.
+        """
+        from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+        assert _carries_mask(_SENSITIVE_MASK) is True
+        assert _carries_mask(f"{_SENSITIVE_MASK} and also X") is True
+        assert _carries_mask(f"prefix {_SENSITIVE_MASK}") is True
+        assert _carries_mask(f"a {_SENSITIVE_MASK} b") is True
+
+    @pytest.mark.asyncio
+    async def test_appending_to_a_masked_field_does_not_overwrite_it(self) -> None:
+        """End to end: glyphs never reach config.json, and the original survives.
+
+        This is GPT 5.6's finding on `a34a51a88`'s successor as an executable test:
+        masked trigger -> editor appends text -> PUT must NOT persist the sentinel
+        plus the text.
+        """
+        from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+        seed = _seed_config_with_every_field_set()
+        stored = f"use when {self.PROBE}"
+        seed["agents"]["roster-probe"]["triggers"] = stored
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                from kiro_crew.dashboard.handlers import api_kirocrew_agent_update
+
+                app = web.Application()
+                app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+                async with TestClient(TestServer(app)) as client:
+                    put = await client.put(
+                        "/api/agents/roster-probe",
+                        json={"triggers": f"{_SENSITIVE_MASK} and also triage"},
+                    )
+                    assert put.status == 200, await put.text()
+            after = json.loads(tmp.read_text())["agents"]["roster-probe"]
+            assert after["triggers"] == stored, "the appended mask was persisted"
+            assert _SENSITIVE_MASK not in after["triggers"]
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_end_to_end_read_then_write_preserves_the_stored_value(self) -> None:
+        """The whole point, over HTTP: GET the roster, PUT the row back.
+
+        This is the round-trip defect as an executable test. The agents page seeds
+        its edit sheet from a roster row and `saveEdit` returns every field
+        unconditionally, so without the write-side rule the mask would be
+        persisted over the operator's stored value on the next save of an
+        unrelated field.
+        """
+        seed = _seed_config_with_every_field_set()
+        stored_triggers = f"use when {self.PROBE}"
+        seed["agents"]["roster-probe"]["triggers"] = stored_triggers
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                from kiro_crew.dashboard.handlers import (
+                    api_kirocrew_agent_update,
+                    api_kirocrew_agents,
+                )
+
+                app = web.Application()
+                app.router.add_get("/api/agents", api_kirocrew_agents)
+                app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+                async with TestClient(TestServer(app)) as client:
+                    resp = await client.get("/api/agents")
+                    rows = {a["name"]: a for a in (await resp.json())["agents"]}
+                    row = rows["roster-probe"]
+                    assert _carries_mask(row["triggers"]), "the value should arrive masked"
+                    # Echo the row back the way `saveEdit` does: every field, always.
+                    put = await client.put(
+                        "/api/agents/roster-probe",
+                        json={
+                            "kiro_agent": row["kiro_agent"],
+                            "workspace": row["workspace"],
+                            "memory_store": row["memory_store"],
+                            "triggers": row["triggers"],
+                            "model": row["model"],
+                            "reasoning_effort": row["reasoning_effort"],
+                            "session_color": row["session_color"],
+                        },
+                    )
+                    assert put.status == 200, await put.text()
+
+                stored = json.loads(tmp.read_text())["agents"]["roster-probe"]
+                assert stored["triggers"] == stored_triggers, "the mask was persisted"
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_a_stale_view_cannot_corrupt_the_config(self) -> None:
+        """The failure mode a recomputed-equality rule had and a sentinel does not.
+
+        If the stored value changes between the GET and the PUT (an agent editing
+        `config.json`, a second dashboard tab), a rule that recognised the view by
+        recomputing the redaction of the CURRENT value would stop matching and
+        write the redacted text in as though the operator had typed it. The
+        sentinel does not depend on the stored value, so the stale echo is still
+        recognised and dropped.
+        """
+        seed = _seed_config_with_every_field_set()
+        seed["agents"]["roster-probe"]["triggers"] = f"first {self.PROBE}"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                from kiro_crew.dashboard.handlers import (
+                    api_kirocrew_agent_update,
+                    api_kirocrew_agents,
+                )
+
+                app = web.Application()
+                app.router.add_get("/api/agents", api_kirocrew_agents)
+                app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+                async with TestClient(TestServer(app)) as client:
+                    rows = {
+                        a["name"]: a
+                        for a in (await (await client.get("/api/agents")).json())["agents"]
+                    }
+                    stale = rows["roster-probe"]["triggers"]
+                    # Someone else rewrites the stored value AFTER the read.
+                    on_disk = json.loads(tmp.read_text())
+                    on_disk["agents"]["roster-probe"]["triggers"] = f"second {self.PROBE} changed"
+                    tmp.write_text(json.dumps(on_disk))
+                    put = await client.put("/api/agents/roster-probe", json={"triggers": stale})
+                    assert put.status == 200, await put.text()
+
+                stored = json.loads(tmp.read_text())["agents"]["roster-probe"]
+                assert stored["triggers"] == f"second {self.PROBE} changed"
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_an_echoed_mask_cannot_reject_an_unrelated_edit(self) -> None:
+        """The mask filter runs BEFORE the validated fields are validated.
+
+        ``model`` and ``reasoning_effort`` are checked before the config load and
+        reject a bad value with 400. If the mask filter ran after them, a client
+        echoing a masked ``reasoning_effort`` back would have its whole save
+        rejected -- failing an edit to some unrelated field. Dropping masked
+        entries first means a mask is never validated as if it were content.
+        """
+        seed = _seed_config_with_every_field_set()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                from kiro_crew.dashboard.handlers import api_kirocrew_agent_update
+                from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK
+
+                app = web.Application()
+                app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+                async with TestClient(TestServer(app)) as client:
+                    put = await client.put(
+                        "/api/agents/roster-probe",
+                        # The mask in a VALIDATED field, alongside a real edit.
+                        json={
+                            "reasoning_effort": _SENSITIVE_MASK,
+                            "model": _SENSITIVE_MASK,
+                            "triggers": "a genuine new value",
+                        },
+                    )
+                    assert put.status == 200, await put.text()
+                stored = json.loads(tmp.read_text())["agents"]["roster-probe"]
+                # The real edit landed...
+                assert stored["triggers"] == "a genuine new value"
+                # ...and the masked fields kept their stored values.
+                assert stored["reasoning_effort"] == "high"
+                assert stored["model"] == "claude-opus-5"
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    @pytest.mark.asyncio
+    async def test_a_real_edit_still_writes_through(self) -> None:
+        """The rule must not swallow an actual change, or editing is broken."""
+        seed = _seed_config_with_every_field_set()
+        seed["agents"]["roster-probe"]["triggers"] = f"use when {self.PROBE}"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(seed, f)
+            tmp = Path(f.name)
+        try:
+            with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=tmp):
+                from kiro_crew.dashboard.handlers import api_kirocrew_agent_update
+
+                app = web.Application()
+                app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+                async with TestClient(TestServer(app)) as client:
+                    put = await client.put(
+                        "/api/agents/roster-probe", json={"triggers": "an actual new value"}
+                    )
+                    assert put.status == 200, await put.text()
+                stored = json.loads(tmp.read_text())["agents"]["roster-probe"]
+                assert stored["triggers"] == "an actual new value"
+        finally:
+            tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Problem / Motivation

`GET /api/agents` built every roster row with a dataclass spread:

```python
{"name": name, "scope": "global", **dataclasses.asdict(agent_cfg)}
```

So the endpoint's response contract was not a list of fields anyone chose -- it was "every field `KiroCrewAgentConfig` has today, plus every field anyone adds tomorrow", automatically. The project-scope rows had a second copy of the same spread (`base = dataclasses.asdict(KiroCrewAgentConfig())`), so the two sources could also drift into different key sets.

`handlers/members.py` made the opposite call for `GET /api/members` and wrote down why:

> Explicit allowlist -- never a dataclass spread. The response is a network-boundary contract: spreading `AgentConfig` would ship every future field (including a credential-shaped one) to the roster endpoint automatically.

**The defect is the pattern, not any single field.** Measured, not inferred -- the response shipped 14 keys (12 record fields + handler-added `name` and `scope`), and none of the 12 is a credential. The bug is that nothing stood between a field being added to the record and that field reaching the browser.

## Why it matters

Two things make the direction matter more than the field list of the day:

1. **The next field decides itself.** Whoever adds a field to `KiroCrewAgentConfig` -- for a scheduler knob, a resolved path, a capability hint -- ships it to every caller of this endpoint without ever opening `agents.py`. Nobody reviews a decision that was never made.
2. **The caller set is wider than the dashboard.** This handler carries neither `_require_owner` nor `_deny_app_caller`, unlike `/api/members` (which 404s app-token callers) and unlike `POST /api/agents/sync` (owner-gated). Two shipped app manifests declare `/api/agents` in their `api` allowlist (`static/dist/apps/agent-worlds/app.json`, `static/dist/apps/demo-app/app.json`), and the app-kit docs and federated-app RFC use it as their worked example. So installed third-party apps are real, present callers.

**Per the issue's framing: this changes the severity, not the fix.** The endpoint is not anonymous, and a narrower reading -- "only the owner's browser ever sees this" -- would still not justify keeping the spread, because the spread is what makes the *next* field's exposure unreviewed.

### What is sensitive here (naming fields, never values)

- **No credential field exists on this record.** All 12 fields are `str`/`float`; there is no token, secret, or key field. Nothing in this PR, its tests, or this description contains a real secret value.
- **No host filesystem path leaves through this row.** `workspace` and `memory_store` are *names* of `workspaces` / `memory_stores` config entries. The actual directory lives in `WorkspaceConfig.dir`, which this endpoint does not ship, and still does not.
- **`telegram_account`** is the one field naming an external messaging-account binding. It is deprecated and inert (nothing reads it; it is preserved only so an existing config is not rewritten). **Withheld.**
- **`description` and `triggers` are free text an agent can write** through `config.json`, and `description` is additionally **package-controlled** (agent sync copies it off a discovered spec). Both fields are **kept** -- the picker renders `description` and `select_crew` routing depends on `triggers` -- and both are scrubbed on the way out, with the write-side rule below keeping that scrub from destroying the stored value.

## What changed (motivation -> approach -> change)

**Symptom** -- the response ships whatever the record holds, in whatever shape it holds it. **Cause** -- the row was built by spreading the record, so both *which* fields ship and *what* their values are went unexamined. **Change** -- two independent halves at one seam:

**Key half.** One `_agent_roster_row()` allowlist that *names* each shipped field, used by **both** row sources, so the whole response has exactly one key set and adding a field is opt-in:

```
name  scope  kiro_agent  workspace  memory_store  model
reasoning_effort  description  triggers  source  session_color
```

That converts "everything unless someone remembers to exclude it" into "nothing unless someone adds it" -- the direction that stays correct as the record grows.

**Value half: mask, plus a write rule that recognises the mask.** Neither half is correct alone.

**Read half** -- every record value goes through `_roster_mask`. A value the redactors would alter (credential- or exfiltration-URL-shaped text), or a non-string the loader let through, is replaced **wholesale** by `_SENSITIVE_MASK` -- the sentinel `_masked_config_dict` already uses for the same job on `GET /api/config/kirocrew`. Benign content is byte-identical. They are all untrusted: an agent can edit `config.json` directly, and `_do_agents_sync` copies `description` straight off a discovered agent spec (`cfg.agents[disc.name] = KiroCrewAgentConfig(..., description=disc.description, ...)`), so a third-party **package** controls that string.

**Write half** -- `api_kirocrew_agent_update` drops any body field carrying the mask, treating it as unchanged:

```python
body = {key: val for key, val in body.items() if not _carries_mask(val)}
```

Without it the read half destroys stored config: this response feeds a read-modify-write (`openEdit` seeds the agents-page edit sheet from a roster row, `saveEdit` sends every field on every save so `''` can clear a pin), so the mask would be persisted over the operator's original. This is the remedy `_masked_config_dict`'s docstring prescribes **verbatim**: "if one is ever added it MUST treat `_SENSITIVE_MASK` as 'unchanged' and keep the stored value".

**A fixed sentinel rather than redacting in place is the load-bearing choice**, and it is the one thing in this PR that took the longest to get right. An in-place scrub makes the browser's view a *function of the stored value*, so the write rule has to recognise it by recomputing that transform -- which breaks two ways a sentinel does not:

- **Redaction-chain drift.** #8465 wraps this same response in `redact_record_strings`, whose order differs from `_redact_external`'s. A recomputed-equality rule stops matching and silently persists the redacted text. An exact sentinel survives, because scrubbing `********` leaves it unchanged. **This dissolves the #8465 collision earlier revisions of this description escalated as needing a human.**
- **Stale-view skew.** If the stored value changes between the GET and the PUT (an agent editing `config.json`, a second dashboard tab), a recomputed rule compares the old view against the NEW value, fails to match, and writes `[REDACTED ...]` into the config as though the operator had typed it. The sentinel does not depend on the stored value at all. `test_a_stale_view_cannot_corrupt_the_config` pins this.

Two consequences, named rather than buried:

- **A value containing one credential-shaped token is masked entirely**, so the owner loses the benign remainder rather than seeing it partially redacted. Same trade `_masked_config_dict` already makes; the price of a view that cannot be mistaken for content.
- **Accepted residual:** an operator cannot store the mask string itself (eight U+2022 bullets). Identical to the config endpoint's residual.

Masking a non-string rather than coercing it to `""` is what lets the write rule *preserve* it -- an echoed `""` would read as a genuine edit and overwrite the stored value, which was a real defect in an earlier revision of this PR.

**Why the rule is keyed on the backend, not the client.** An earlier revision exempted the seven fields the agents page happens to send today. That encoded a claim about the CLIENT which this side could not enforce -- and it was already wrong: `api_kirocrew_agent_update` accepts **nine** record fields including `description` and `source`, the two exempted on the grounds that no write path accepted them.

**`name` is the single exemption, and only for the owner.** It travels in the URL rather than the body, so the write rule structurally cannot protect it, and masking it would make `/api/agents/{name}` unaddressable for edit and delete (it also keys the usage sort). More than addressable: **renaming is the remediation for a credential-shaped name, so masking it from the owner would remove the only route out of the bad state.** A non-owner, an app token, and every project row get it masked. `scope` is a handler literal and is never touched. `dict[str, str]` is now true rather than aspirational.

**The caller class is the OWNER predicate, not an app-token check.** `bool(request.get("app", ""))` asks "is this an app?", and a non-owner DASHBOARD session answers no -- an allow-listed messaging user running `!dashboard` holds a dashboard token with `app == ""`. `redact` is therefore `not is_owner_dashboard_request(request)`, the same predicate `_require_owner` resolves to for this module's mutating routes, and it fails CLOSED when there is no state to resolve an owner against.

### The hazard is closed at creation, not at one read site

GPT 5.6 asked for `_roster_mask(name)` on every caller including the owner. Declined, with reasons in a [PR comment](https://github.com/kirodotdev/KiroCrew/pull/8472#issuecomment-5549853319); what ships instead refuses a credential-shaped name where it comes to exist:

- `_name_would_be_masked` (`agents.py:2648`) is keyed on `_roster_mask` itself, not a second detector, so the create rule and the read rule cannot drift: what the roster would mask is exactly what creation refuses.
- `api_kirocrew_agents_create` (`agents.py:3187`) returns `400 credential_shaped_name`, and does NOT echo the rejected name -- reflecting it into a body and thence the request log is the disclosure being prevented.
- `PUT` cannot rename (the name comes from `match_info`; there is no `new_name`), so creation is the only user-facing way in.

Masking a read closes one of N surfaces, measurably: `_do_agents_sync` prints a crew name into a log line at `agents.py:2902`, which no response mask touches.

**What this does NOT cover, stated because the boundary is real.** A crew already in `config.json` is not retroactively renamed or refused; a name hand-written into `config.json` bypasses the check (there is no load-time rejection, and refusing to load a config would take the dashboard down over a naming problem); and `_do_agents_sync` writes `cfg.agents[disc.name]` at `agents.py:2910` from a discovered spec without this check, those names being package-controlled rather than user-pasted. Closed for new crews created through the API; open for those three.

**The alternative First Principles asked to see weighed** -- `scrub=redact` for every field, deleting the write rule entirely, since app tokens cannot reach the owner-gated PUT -- is genuinely simpler and was the r4 design. It is rejected because it leaves package-controlled `description` reaching the owner unmasked, contradicting the control `discover.py:53` records for exactly that class of string, and GPT 5.6 blocked it on `5aa800a0d` for that reason. The trade is: one silent-no-op semantic on PUT (a field echoed back unchanged) against owner-visible unredacted third-party text. This PR takes the first; a maintainer who prefers the second can have it by deleting `_carries_mask` and passing `redact` through, and the tests name which ones would need to go.

### Review history, since the value half changed five times

Every revision was driven by a finding, and three corrected errors of mine:

1. **r1** -- allowlist only, values untouched. GPT blocked: agent-writable free text reaches the browser unredacted.
2. **r2** -- unconditional in-place scrub, no write rule. Design **and** GPT convicted it on the same mechanism (the scrubbed value round-trips through `saveEdit` and overwrites stored config); First Principles noted a value-half asymmetry with `/api/members`.
3. **r3** -- scrub removed, arguing it closed nothing because `/api/config/kirocrew` serves the same records unmasked. **Wrong for app tokens**, the caller GPT had named: app-token scope cannot reach that endpoint.
4. **r4** -- split per caller class. Design found the field the split still exempted (`name` for apps); GPT found `description` is package-controlled.
5. **r5** -- per-field rule keyed on the frontend's payload. Design showed the guard was backend-side convention for a client-side invariant; checking the PUT handler showed the exemption was already wrong.
6. **r6** -- uniform in-place scrub plus a write rule keyed on the backend's accepted fields. **I had declined that rule twice claiming it belonged to #8447's chokepoint; wrong, since `/api/members` has no write path.** GPT went green here.
7. **r7 (current)** -- Design's suggested sentinel replaces the recomputed predicate, killing both its stale-view and chain-drift failure modes.

### The ratchet caught a live base change, which is what it is for

`avatar` landed on `main` hours after this branch's base was cut, and the omission ratchet
went red naming the decision instead of just failing:

```
KiroCrewAgentConfig grew ['avatar']. GET /api/agents is an explicit allowlist (#8454),
so decide deliberately: add the field to _agent_roster_row AND ROSTER_ROW_KEYS if the
dashboard needs it, or to WITHHELD_RECORD_FIELDS if it must not leave the process.
```

**Decision: `avatar` SHIPS.** `AgentSelector.tsx` declares `avatar?: unknown` commented
"verbatim from the backend", and `main`'s roster still ships it through the `asdict` spread
this PR replaces -- so the field reaches the dashboard today and withholding it would
regress a live feature rather than narrow a disclosure. What it holds was read before
choosing: a dict, never bytes and never a data URI (so no payload-size change), either
`{"kind":"ghost","traits":{...}}` or `{"kind":"image","v":<int>,"file":"<16-hex>.<ext>"}`,
and **no host path** -- the picture's bytes live under the data home's agent-fenced
`run/avatars/` dir and `file` is a digest-named basename.

**Shape allowlist, with masking confined to `traits` values.** `_roster_avatar` runs
`_safe_avatar` (the config's own validator, so junk collapses to `{}`) and then masks only
the `traits` values. `kind`, `v` and `file` pass through as the pinned shapes they are:

- Mask `kind` and the dashboard can no longer tell a ghost from an uploaded picture.
- Mask `file` and the per-crew avatar endpoint resolves nothing -- the image silently
  breaks. `file` is pinned by `_AVATAR_FILE_PIN_RE` to `<16-hex>.<ext>`, and **a value
  constrained by a regex is safer than a masked one: the pin refuses a bad value, where
  masking destroys a good one.**
- `traits` values are the only user-authored strings, so they take the same `_roster_mask`
  as every other roster string. The renderer resolves an unrecognized trait to absent, so a
  masked trait degrades that axis instead of breaking the face.

A blanket mask would have shipped, through the mask, the exact regression that withholding
the field would have shipped through the allowlist.

**Verified in both directions, because a masking-only test passes just as well against a
blanket.** Over the wire from the registered handler: `{"kind":"image","v":17,"file":
"0123456789abcdef.png"}` intact, while a `traits.eyes` carrying `AKIA...` comes back as the
sentinel and a bool trait is untouched.

**Honest limit:** because `_safe_avatar` already pins every non-`traits` leaf to a shape the
redactors do not alter, a blanket mask behaves the SAME as the targeted one today -- a
mutation that masks every leaf does not redden the suite. The targeted rule is chosen for
intent and for the day that pin loosens, not because a live defect separates them.

### A ratchet whose probe rebuilds the class can manufacture failures

The same push produced a second red -- `TypeError: non-default argument 'avatar' follows
default argument` -- and it was **the probe's, not the record's**. `avatar` uses
`default_factory=dict` (a mutable default must), so `f.default is dataclasses.MISSING`, and
the probe rebuilt every field as `field(default=f.default)`, turning MISSING into *no
default*. A non-default field after defaulted ones is a hard error at class-creation time.

Determined by construction rather than by reading: on clean `origin/main` with no
scaffolding, `KiroCrewAgentConfig()` imports and instantiates fine (13 fields, `avatar ==
{}`); the same probe reproduces the TypeError against that class; preserving
`default_factory` builds it. **Nothing to file against `main`.** The general lesson, now
recorded in the probe itself: a ratchet that REBUILDS the class it inspects can report a
defect it created.

### Consumer inventory (what I checked, and what a positive would have looked like)

Every field I dropped, I looked for as a bare identifier across **all** of `website/src` (`.ts` + `.tsx`, production and test). A positive would have been any occurrence at all: a property read (`a.telegram_account`), a destructure, an index (`row['telegram_account']`), a test fixture, or a declaration in the row's TS interface. Result -- **0 occurrences each**:

| Field | Occurrences in `website/src` | Verdict |
|---|---|---|
| `watchdog_tool_stall_suspect_secs` | 0 | dropped |
| `watchdog_tool_stall_hard_cap_secs` | 0 | dropped |
| `telegram_account` | 0 | dropped |

Corroborated structurally rather than by grep alone: the row's own TS interface `KiroCrewAgent` (`website/src/components/AgentSelector.tsx:12`) declares exactly 10 fields and **does not declare any of the three**, so a consumer reading one would already be a type error. I also checked the paths a grep on field names cannot see:

- **Every `kirocrewAgents()` call site** -- `KiroCrewAgentsPage.tsx:698`, `AgentsPage.tsx:469`, `MembersPage.tsx:221`, and the shared `useAgents` hook. None casts the row to `any` or a widened type.
- **The edit-sheet round-trip, the real regression risk.** `KiroCrewAgentsPage.tsx` populates its editor from a *roster row* (`editingAgent = agents.find(...)`), so a dropped field could in principle be written back as empty. It reads exactly these off it -- `kiro_agent, workspace, memory_store, model, reasoning_effort, description, triggers, source, session_color` -- all allowlisted, and its `AgentUpdatePayload` names 7 explicit fields with no spread. Nothing I dropped can reach a write.
- **The whole row handed to a provider function** -- `AgentSelector.tsx:308` passes the row into `provider.resolveAgentTemplate(a)`. Its parameter type `AgentBinding` declares only `name / kiro_agent? / workspace? / memory_store?` and the implementation returns `agent.kiro_agent || agent.name`. All allowlisted.
- **`scope` is KEPT despite having no production consumer** -- the only reference is a test fixture (`useAgents.projectScope.test.ts:49`) and it is not in the TS interface. It is not unexplained, though: the handler adds it deliberately as #1684's project-scope tag and documents it. A handler-authored, documented field is not the same as a record field arriving by accident, so it stays.
- **The two shipped apps that declare `/api/agents` ARE in the repo, and I had been searching the wrong tree.** My grep scope above was `website/src`; their sources live under `website/public/apps/*/ui/index.mjs`, which that scope never covered -- so "zero consumers" was, for them, an unmeasured claim dressed as a measured one. Corrected: across `website/public/apps/` and `docs/app-kit/`, the three dropped fields have **0 hits**, `demo-app/ui/index.mjs:19` calls `api.get('/api/agents')`, and the only roster field either app reads is **`name`** (3 occurrences, no other field). `agent-worlds` declares the route in its manifest without calling it. So the conclusion is unchanged and now actually measured. The remaining honest limit is narrower than before: an app installed from outside this repo cannot be inspected from here, which is why the allowlist is 11 fields and not 4 -- I removed only fields with a zero-consumer result *and* no interface declaration *and* no plausible render (two backend scheduling knobs and one inert deprecated binding), and kept anything ambiguous.

**No frontend change is needed** and none is included: this only removes keys nothing reads, and no fixture sets them. Every retained value ships byte-identical to what is stored.

### Interaction with #8447 / PR #8465

#8454's acceptance sketch asks to keep the `redact_record_strings` pass. **That chokepoint does not exist on `main`** -- it arrives with #8447's fix, open as PR #8465 -- so this PR cannot keep it, and does not remove or bypass it.

The two are **textually disjoint** -- #8465 wraps the finished list at the `return` plus one import, this PR changes only row construction ~25 lines above -- so whichever lands second needs no reconciliation, and #8465's pass will scrub the allowlisted values this PR narrowed the row to.

**One thing #8465 should know, surfaced by this PR's round 2:** wrapping this response in a redaction pass inherits the read-modify-write hazard described above. `saveEdit` returns seven of these fields unconditionally, so a scrubbed `triggers` will be persisted over the operator's original on the next save. That is not an argument against the chokepoint -- it is the right place for it -- but the chokepoint needs the write-path "unchanged" rule that `_masked_config_dict`'s docstring prescribes. Raised here rather than on #8465 so I am not editing another author's PR; Design Review made the same point ("whichever lands first should own the answer").

## Tests

`test/test_agents_roster_contract.py`, 27 tests.

**Key half**

1. **`test_global_row_ships_exactly_the_allowlist`** / **`test_project_row_ships_the_same_key_set`** -- endpoint-level, both row sources. The fixture sets every record field, giving each withheld one a distinctive non-default value so asserting its absence proves the allowlist rather than a falsy default, and pins that the two sources share one key set.
2. **`test_record_field_added_later_is_not_shipped_by_omission`** -- the ratchet the issue asks for. Every `dataclasses.fields(KiroCrewAgentConfig)` name must be allowlisted or explicitly withheld, so **adding a field to the record fails this test** with a message telling the author to decide. It guards its own guard: the withheld names must be real fields and the allowlist must not claim a field that no longer exists.
3. **`test_an_attribute_the_allowlist_does_not_name_is_dropped`** -- behavioral, not a literal comparison: a synthetic record carrying an extra attribute serializes to the same key set.
4. **`test_app_token_caller_gets_the_same_keys_with_scrubbed_values`** -- endpoint-level through a middleware setting `request["app"]`, so the caller **wiring** is covered, not just the row function's keyword.

**Value half, read side**

5. **`test_no_record_field_ships_a_credential_shaped_value`** (both callers) and **`test_a_non_string_is_masked_not_emptied`** (parametrized over the five fields the loader does not coerce) -- nothing unshowable leaves as content, and a malformed value is masked rather than emptied so the write rule can preserve it.
6. **`test_every_value_is_a_string`**, **`test_benign_content_is_never_altered`** (both callers), **`test_owner_keeps_name_addressable_but_app_token_does_not_need_it`**, **`test_both_caller_classes_ship_the_same_key_set`**.

**Value half, write side**

7. **`test_end_to_end_read_then_write_preserves_the_stored_value`** -- over HTTP: GET the roster, assert the value arrived masked, echo the row back the way `saveEdit` does (every field, always), assert the **stored** value is byte-identical afterwards. The round-trip defect as an executable test rather than an argument.
8. **`test_a_stale_view_cannot_corrupt_the_config`** -- rewrites the stored value between the GET and the PUT, then echoes the stale masked row. Pins the failure mode a recomputed-equality predicate had.
9. **`test_a_real_edit_still_writes_through`** -- the counterweight: the rule must not swallow an actual change.
10. **`test_the_sentinel_is_the_one_the_config_endpoint_uses`** -- the mask is `core._SENSITIVE_MASK`, not a private copy, so drift cannot silently break the round-trip rule. **`test_real_content_is_not_treated_as_the_mask`** -- `""`, plain text and a dict are not the mask.

**Mutation-verified eleven ways, one per distinct defect:** dropping the write-side filter reddens 2 (the round-trip and stale-view tests); dropping the read-side mask reddens 17; replacing the sentinel predicate with a recomputed/substring one reddens 16; coercing a non-string to `""` instead of masking reddens 10; leaving `name` unmasked for app tokens reddens 1; reinstating the `dataclasses.asdict` spread reddens 6; narrowing the write rule from containment to exact equality reddens 2 (an operator appending to a rendered mask); swapping the owner predicate back for the app-token check reddens 2; removing the creation-time name check reddens 1; shipping the avatar dict without `_safe_avatar` reddens 1; dropping `avatar` from the row reddens 9.

## Manual verification

N/A -- unit coverage sufficient, and deliberately so: the assertion is about the exact JSON key set and value shape at the HTTP boundary, which the endpoint-level tests measure directly through `TestClient` rather than approximate. There is no UI change to look at (three keys nothing renders were removed; every retained value is byte-identical), so a screenshot would show an unchanged page.

Gates run: repo black gate **passed**, `flake8` **clean**, `isort --check-only` **clean**, `mypy` on `agents.py` **clean** (the 2 reported errors are pre-existing in `src/kiro_crew/transcribe.py`, untouched here). Tests: 121 passing across `test_agents_roster_contract.py`, `test_api_agents_order.py`, `test_config_api.py` and `test_security_posture.py` -- scoped to the touched files rather than the full suite. `test_config_api.py`'s existing CRUD round-trips assert on `name / kiro_agent / workspace / memory_store` and still pass unchanged.

## Related Issues

Fixes #8454
Refs #8447 (the field-generic redaction chokepoint; PR #8465)

## Pattern harvest

Rule candidate: semgrep
Pattern: whole-record spread (`**dataclasses.asdict(...)`) inside a value returned to an HTTP response boundary -- makes the response contract "every field the record grows", so field exposure is opt-out and silent.

This one generalizes, and the census is small enough to state exactly. After this PR **no `**dataclasses.asdict` spread remains in `dashboard/handlers/`**. Two same-class sites remain, neither touched here:

- `dashboard/handlers/autonudge.py:105` -- `_serialize()` does `payload = asdict(loop)` and then **pops** a field (`payload.pop("monitor", None)`). Same defect class in its purest form: exclusion-based serialization at a response boundary, where a field added to the record ships unless someone remembers to pop it. The strongest candidate for the same conversion. Evidence that it is a growing service record rather than a response DTO: `NudgeLoop` is declared in the service module (`src/kiro_crew/autonudge.py:433`) with **16 fields** -- `id, slot_key, message, idle_secs, max_cycles, cycle_count, active, last_fire_ts, created_ts, stop_sentinel_path, max_runtime_secs, gate, stopped_reason, approval_stalled, next_due_ts, monitor` -- and `stop_sentinel_path` is a **filesystem path reaching the browser**, concretely the field class this PR's own rationale warns about. Reached through `/api/autonudge` listing plus three write responses, so four call sites inherit it.
- `apps/builtins/meetings/backend/providers/tasks.py:197` -- `**asdict(draft)` into a ledger entry. Same *shape*, but a persistence boundary rather than a network one, so the consequence differs; a rule should classify it separately rather than lump it in.

A semgrep rule keyed on a dataclass spread reaching a `web.json_response(...)` value would have caught this endpoint and would catch `autonudge.py`. Left as a candidate rather than done here: writing the rule and converting a second endpoint are each their own change with their own consumer inventory, and this PR's whole point is that a response-contract change needs one.

**Second candidate, from GPT 5.6 round 1:** a dataclass field annotated `str` is not a guarantee at a serialization boundary, because the config loader enforces the annotation for only some fields. Any handler that types its output `dict[str, str]` from record attributes is asserting something the loader does not check. Lint/review-prompt rather than semgrep -- it needs the loader's per-field behavior, which is not local to the call site.

**Third candidate, from Design Review round 2, and the most generalizable of the three:** *a read-side transform is unsafe on any response that feeds a read-modify-write.* Redaction, masking and normalization are all read-side transforms, and this codebase has both shapes -- `_masked_config_dict` is safe only because no write endpoint accepts its output, and its docstring says so; round 1 of this PR added a transform to a response whose values the agents page writes straight back. The rule generalizes as: if a GET's values are ever POSTed/PUT back, either the transform must be absent or the write path must treat the transformed value as "unchanged". Review-prompt candidate, because deciding it needs the *client's* write behavior, which no backend-local rule can see -- and it is the class that would have caught this PR's own round-1 regression, #8465's coming one, and any future masked field on a settings surface.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A: the behavior is documented in the handler docstrings and the pinning tests, and no spec describes this response's key set
- [x] No secrets, credentials, or internal references in the diff
