### PR TITLE
fix(service): refuse a system unit SELinux proves cannot start

### DIFF
--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -586,6 +586,33 @@ login (or `sudo` with no `$SUDO_USER`), first create or pick a normal account an
 install as it, e.g. `sudo -u <user> KIROCREW_KIRO_BIN=... kirocrew service
 install` (the official Docker image already runs as the `kirocrew` user).
 
+### SELinux-enforcing hosts with kirocrew under `$HOME`
+
+On an SELinux-enforcing host whose kirocrew lives under `$HOME` — the default on
+Bazzite, Fedora Silverblue/Kinoite and other atomic desktops — a **system**
+service cannot start at all. systemd (PID 1) runs in the `init_t` domain, the
+policy does not allow that domain to `execute` a file carrying a home label
+(`user_home_t`), and the unit fails every start with `status=203/EXEC` until it
+exhausts its restart limit.
+
+The binary is fine. `test -x` on it succeeds, the shebang is correct, and the
+permissions are right — the policy's execute check is the only thing that fails,
+which is why `203/EXEC` here looks identical to a genuinely missing or
+non-executable path. `kirocrew service install` therefore asks the loaded policy
+before writing anything, and if the unit provably cannot start it **refuses up
+front** and prints a ready-to-paste per-user unit instead of leaving a
+crash-looping service enabled at every boot.
+
+A per-user unit is not affected, because the per-user systemd manager does not
+run in PID 1's domain. Follow the commands the refusal prints, then manage the
+service with `systemctl --user status|restart kirocrew` and `journalctl --user -u
+kirocrew -f`. Note that `kirocrew service status` / `uninstall` only look at the
+system unit, so they will not see a user unit ([#7165] tracks adding a first-class
+`--user` scope). Installing kirocrew onto a system-labelled path such as
+`/usr/local/bin` also avoids the problem.
+
+[#7165]: https://github.com/kirodotdev/KiroCrew/issues/7165
+
 ### Setting the service port
 
 A system service inherits none of your shell environment, so `export

--- a/src/kiro_crew/service/linux.py
+++ b/src/kiro_crew/service/linux.py
@@ -12,6 +12,18 @@ per-user systemd manager — ``systemctl --user`` fails with
 uniformly across any distro shipping systemd >= 219, which is
 everything since 2015.
 
+One host class this choice does NOT work on, and cannot be made to work by
+anything the installer writes: an SELinux-enforcing host whose kirocrew lives
+under ``$HOME`` (the default on Bazzite, Fedora Silverblue/Kinoite and other
+atomic desktops). PID 1's domain is denied ``execute`` on a home-labelled file,
+so the unit fails every start with ``203/EXEC`` (#7165). :mod:`kiro_crew.service
+.selinux` detects exactly that case by querying the loaded policy, and
+:func:`install` refuses up front with a rendered user-scope unit as the remedy
+rather than writing a unit that provably cannot start. A per-user install mode is
+the real fix and is deliberately NOT implemented here — it is an install-model
+change (scope-aware status/restart/uninstall, where the AppArmor profile and the
+root-owned overrides file live) rather than a mechanical one.
+
 Sudo scope: this file escalates ``systemctl``, ``install``, ``mkdir``,
 ``rm``, ``rmdir`` and ``test`` directly, and lends its privileged helpers
 to ``service/apparmor.py``, which adds ``apparmor_parser``, ``aa-exec``,
@@ -51,6 +63,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -58,7 +71,7 @@ import tempfile
 from pathlib import Path
 
 from kiro_crew.gateway_shutdown_budget import TOTAL_SHUTDOWN_BUDGET_SECS
-from kiro_crew.service import apparmor
+from kiro_crew.service import apparmor, selinux
 from kiro_crew.service.common import (
     SERVICE_NAME,
     kirocrew_bin,
@@ -69,6 +82,14 @@ from kiro_crew.service.common import systemd_quote as _sd_quote
 log = logging.getLogger(__name__)
 
 UNIT_PATH = Path(f"/etc/systemd/system/{SERVICE_NAME}.service")
+
+# Where a user-scope unit belongs, per systemd.unit(5) — RELATIVE to the service
+# account's home, deliberately. Referenced only in the printed remedy; nothing in
+# this module writes here. It is not spelled "~/.config/..." because "~" resolves
+# against whoever pastes the command, and `service install` is documented to run
+# under sudo — so a tilde would silently name root's home in the one shell the
+# operator is most likely to be sitting in.
+USER_UNIT_SUBDIR = Path(".config/systemd/user")
 
 # Operator-editable environment overrides, read by the unit via
 # ``EnvironmentFile=``. Placed AFTER the baked ``Environment=`` lines in the
@@ -168,8 +189,8 @@ def _home_for_user(user: str) -> str:
         return str(Path.home())
 
 
-def render_unit() -> str:
-    """Render the systemd system-unit file contents.
+def render_unit(*, user_scope: bool = False) -> str:
+    """Render the systemd unit file contents.
 
     Runs the gateway as the invoking user (``User=``, ``Group=``) so it
     has access to ``$HOME/.kiro/crew``, the user's config, etc. The PATH
@@ -185,10 +206,23 @@ def render_unit() -> str:
     (:func:`install_apparmor_profile`), and when both mechanisms are present
     systemd's ``change_onexec`` transition silently wins over the kernel's
     automatic path attachment, defeating it.
+
+    ``user_scope`` renders the ``systemctl --user`` variant this module only ever
+    PRINTS (see :func:`selinux_refusal`) — rendered here rather than hand-written
+    so the copy-pasteable remedy cannot drift from the unit we actually install.
+    Two directives differ, and both are hard requirements of the per-user manager
+    rather than style choices: ``User=``/``Group=`` are rejected outright in a
+    user unit (the manager already runs as that account), and the install target
+    is ``default.target`` because ``multi-user.target`` is a system target the
+    user manager does not have.
     """
     bin_path = kirocrew_bin()
     user = _current_user()
-    group = _current_group(user) if user else ""
+    # Only the system unit carries Group=, and resolving it costs an `id -gn`
+    # subprocess — skipped for the user scope both because the value is unused
+    # and because this render happens on the refusal path, which must not shell
+    # out on a host it is declining to touch.
+    group = _current_group(user) if user and not user_scope else ""
     # Tie HOME / WorkingDirectory to the SAME account as User= (see
     # _home_for_user): under `sudo -H` the process HOME is /root while User= is
     # the sudo-selected human, and baking /root in would break service start.
@@ -238,9 +272,10 @@ def render_unit() -> str:
         "\n"
         "[Service]\n"
         "Type=simple\n"
-        f"User={user}\n"
-        f"Group={group}\n"
-        f"WorkingDirectory={home}\n"
+        # Omitted for the user scope: the per-user manager already runs as this
+        # account, and it REJECTS User=/Group= outright ("Unknown key name"),
+        # which would make the whole unit unloadable rather than merely noisy.
+        + ("" if user_scope else f"User={user}\nGroup={group}\n") + f"WorkingDirectory={home}\n"
         f"ExecStart={exec_start}\n"
         # `always`, not `on-failure`: the gateway deliberately exits on its own
         # to be relaunched — the stale-asset watchdog shuts down cleanly when a
@@ -270,7 +305,10 @@ def render_unit() -> str:
         f"{env_lines}"
         "\n"
         "[Install]\n"
-        "WantedBy=multi-user.target\n"
+        # multi-user.target is a SYSTEM target; the per-user manager has no such
+        # unit, so a user-scope install must want default.target instead or
+        # `systemctl --user enable` fails.
+        + ("WantedBy=default.target\n" if user_scope else "WantedBy=multi-user.target\n")
     )
 
 
@@ -488,6 +526,147 @@ def _env_file_is_untouched_seed() -> bool:
         return False
 
 
+def _user_scope_remedy() -> str:
+    """The commands that stand up a working per-user unit on this host.
+
+    Shared by :func:`selinux_refusal` (pre-flight proved the system unit cannot
+    start) and :func:`selinux_start_failure_hint` (it started nothing and SELinux
+    is enforcing), so the operator is handed the same verified sequence either
+    way and the two cannot drift.
+
+    **Every path and account is spelled out, and none is taken from the pasting
+    shell.** A user unit has no ``User=`` — the account it runs as is whichever
+    manager loads it — so ``~`` and ``$USER`` would decide who runs the agent.
+    ``service install`` is documented to run under ``sudo``, so the shell reading
+    this is usually root's: a tilde would name ``/root``, ``$USER`` would expand to
+    ``root``, and the remedy would hand an operator a unit that runs untrusted
+    agent tools as root — defeating the same invariant :func:`install` enforces by
+    refusing a ``User=root`` unit. Hence the absolute home, the explicit account
+    name, and the warning.
+
+    Both generated paths go through :func:`shlex.quote`, like the ``.env`` remedy
+    in :mod:`kiro_crew.service.common`: these lines are copy-pasted verbatim, and
+    an account home containing a space would word-split, so ``mkdir`` would create
+    the wrong directories and the redirect would put the unit somewhere systemd
+    never reads. Ordinary paths come back unquoted, so the common case is
+    unchanged.
+    """
+    unit_body = render_unit(user_scope=True)
+    user = _current_user()
+    home = _home_for_user(user) if user else str(Path.home())
+    account = user or "<the service account>"
+    unit_dir = shlex.quote(str(Path(home) / USER_UNIT_SUBDIR))
+    unit_file = shlex.quote(str(Path(home) / USER_UNIT_SUBDIR / UNIT_PATH.name))
+    return (
+        f"   Run the next four commands AS {account} — a user unit carries no\n"
+        f"   User=, so it runs as whichever account's manager loads it. Loading it\n"
+        f"   from a root shell (the shell you are probably in, since `service\n"
+        f"   install` needs sudo) would run the agent as ROOT, which this installer\n"
+        f"   otherwise refuses outright. `sudo -u {account}` is NOT enough — it\n"
+        f"   creates no session, so `systemctl --user` cannot reach that account's\n"
+        f"   manager. Get a real session first, e.g. `machinectl shell {account}@`,\n"
+        f"   or just log in as {account}.\n"
+        f"\n"
+        f"     mkdir -p {unit_dir}\n"
+        f"     cat > {unit_file} <<'KIROCREW_UNIT'\n"
+        f"{unit_body}"
+        f"KIROCREW_UNIT\n"
+        f"     systemctl --user daemon-reload\n"
+        f"     systemctl --user enable --now {SERVICE_NAME}.service\n"
+        f"\n"
+        f"   Then, back in a root shell — this one step needs privilege, and takes\n"
+        f"   the account name explicitly so it cannot land on the wrong user:\n"
+        f"\n"
+        f"     loginctl enable-linger {shlex.quote(account)}\n"
+        f"\n"
+        f"   Manage it with `systemctl --user status|restart {SERVICE_NAME}` and\n"
+        f"   `journalctl --user -u {SERVICE_NAME} -f`. `kirocrew service "
+        f"status|uninstall`\n"
+        f"   only looks at the system unit, so it will not see this one."
+    )
+
+
+def selinux_refusal(reason: str) -> str:
+    """Operator-facing refusal for a system unit SELinux proves cannot start.
+
+    A refusal rather than a warning because everything after this point is
+    destructive to no purpose: install would write the unit, ``enable`` it, fail
+    at the first ``systemctl restart``, and leave a unit enabled that crash-loops
+    at every boot until it exhausts ``StartLimitBurst``. Stopping before the
+    first write leaves the host exactly as it was found.
+
+    The remedy embeds a ready-to-paste user unit rendered by :func:`render_unit`,
+    not prose describing one: the operator's working unit then carries the same
+    ``ExecStart`` and the same baked environment as the unit we would have
+    installed, and cannot drift from it as this module changes.
+    """
+    return (
+        f"Refusing to install a system service that cannot start on this host.\n"
+        f"   {reason}.\n"
+        f"\n"
+        f"   This is SELinux type enforcement, not a broken file. The binary is\n"
+        f"   perfectly ordinary — it exists, it is executable, and `test -x` on\n"
+        f"   it succeeds; the policy's execute check is the only thing that\n"
+        f"   fails, and nothing short of asking the policy reveals it. A unit at\n"
+        f"   {UNIT_PATH} would fail every start with\n"
+        f"   status=203/EXEC until it hit its restart limit.\n"
+        f"\n"
+        f"   A per-user unit is not subject to this: the per-user systemd manager\n"
+        f"   does not run in PID 1's domain, so it is allowed to execute a binary\n"
+        f"   under $HOME.\n"
+        f"\n"
+        f"{_user_scope_remedy()}\n"
+        f"\n"
+        f"   Installing kirocrew outside $HOME (onto a system-labelled path such\n"
+        f"   as /usr/local/bin) also resolves it. Relocating only the LAUNCHER\n"
+        f"   does not: whatever systemd execs still runs in PID 1's domain, so\n"
+        f"   the next execve of the binary under $HOME is denied identically."
+    )
+
+
+def selinux_start_failure_hint() -> str:
+    """SELinux context to append when the unit was written but would not start.
+
+    Covers the residue the pre-flight cannot prove. That check asks only whether
+    PID 1's domain may execute the file systemd itself ``execve``s; it cannot
+    follow what that file execs at runtime, so a ``KIROCREW_SERVICE_BIN`` override
+    naming a system-labelled wrapper that later runs a binary under ``$HOME``
+    passes the gate and still fails — as the shell's exit 126 rather than
+    ``203/EXEC``, since the wrapper itself execs fine. Rather than guess at a
+    wrapper's contents (see the boundary discussion in
+    :mod:`kiro_crew.service.selinux`), name SELinux here, where the unit has
+    actually failed, so the operator is never left with only "run journalctl".
+
+    Deliberately the HYPOTHESIS and the command that settles it — NOT the
+    user-scope remedy :func:`selinux_refusal` prints. This fires on every failed
+    restart on every enforcing host, which is all of RHEL/Fedora, including the
+    ones the pre-flight positively proved ALLOW for; a port conflict on a stock
+    RHEL box would otherwise be answered with a wall of SELinux text and a
+    pasteable unit for a denial nobody has observed. A remedy belongs behind a
+    proven denial, so this points at the documented one and stops.
+
+    Empty on any host that is not enforcing, so nothing changes on the
+    overwhelming majority of installs.
+    """
+    if not selinux.is_enforcing():
+        return ""
+    return (
+        f"\n\nSELinux is enforcing here, which is one common cause of a unit that\n"
+        f"   installs and then will not start. This is a hypothesis, not a finding:\n"
+        f"   the pre-flight found no proven denial for {kirocrew_bin()}, but it only\n"
+        f"   checks the file systemd execs and the interpreter its shebang names, so\n"
+        f"   if that file is a wrapper, whatever IT runs is not covered. Settle it\n"
+        f"   with:\n"
+        f"\n"
+        f"     sudo ausearch -m avc -ts recent\n"
+        f"\n"
+        f"   An `avc: denied {{ execute }}` naming the gateway binary means no system\n"
+        f"   unit can work on this host. The per-user remedy is in\n"
+        f"   docs/guides/install.md, \"SELinux-enforcing hosts with kirocrew under\n"
+        f"   $HOME\". No such denial means this failure is something else."
+    )
+
+
 def install() -> apparmor.ProfileOutcome:
     """Write the unit file and enable+start the service. Idempotent.
 
@@ -533,6 +712,17 @@ def install() -> apparmor.ProfileOutcome:
             "service install`), or set $USER to a non-root account."
         )
 
+    # Last gate before anything is written: on an SELinux-enforcing host whose
+    # kirocrew lives under $HOME, PID 1's domain is denied execute on the binary
+    # this unit would name, so the unit can never start (#7165). Everything below
+    # would still "succeed" up to the first `systemctl restart`, leaving an
+    # enabled unit crash-looping at 203/EXEC on every boot. Fires only on a
+    # proven policy denial and fails open on every indeterminate answer, so a
+    # host without SELinux, or in permissive mode, is unaffected.
+    blocked, selinux_reason = selinux.blocks_system_unit(kirocrew_bin())
+    if blocked:
+        raise ServiceInstallError(selinux_refusal(selinux_reason))
+
     needs_profile, profile_reason = apparmor.should_install()
     write_res = _write_unit_via_sudo(render_unit())
     if write_res.returncode != 0:
@@ -577,6 +767,11 @@ def install() -> apparmor.ProfileOutcome:
             f"`sudo systemctl restart` failed: "
             f"{(restart_res.stderr or restart_res.stdout).strip()}\n"
             f"Run `sudo journalctl -u {SERVICE_NAME}.service -n 50` for details."
+            # The pre-flight only proves denials for the file systemd itself
+            # execs, so a wrapper's delegated binary can still be denied and land
+            # here. Name SELinux where the unit has actually failed rather than
+            # leave the operator with only a journalctl command.
+            + selinux_start_failure_hint()
         )
 
     return profile_outcome

--- a/src/kiro_crew/service/selinux.py
+++ b/src/kiro_crew/service/selinux.py
@@ -1,0 +1,325 @@
+"""Pre-flight: can systemd's own domain execute the binary we are about to
+name in ``ExecStart``?
+
+On an SELinux-enforcing host where kirocrew is installed under ``$HOME`` — the
+default on Bazzite, Fedora Silverblue/Kinoite and every other atomic desktop —
+a **system**-scope unit at ``/etc/systemd/system`` can never start. PID 1 runs
+in the ``init_t`` domain, the binary carries a home label (``user_home_t``), and
+the loaded policy does not grant ``init_t`` ``execute`` on that label. ``execve``
+returns ``EACCES`` and systemd reports ``status=203/EXEC``, which it then repeats
+until ``StartLimitBurst`` is exhausted (#7165).
+
+**Why this needs a dedicated check instead of an ordinary file test.** ``203/EXEC``
+has several causes that are indistinguishable in the unit's status output: the
+path does not exist, it is not executable, its shebang interpreter is wrong, or
+the file is *perfectly fine* and SELinux refused the execute. Only the last one
+survives every check an installer would normally run — the policy grants
+``getattr`` on a home-labelled file while denying ``execute``, so ``os.access(...,
+X_OK)`` / ``test -x`` return **True** and the file looks correct right up to the
+moment systemd tries to run it. A mode check therefore cannot answer this
+question; the only thing that can is the policy itself.
+
+So we ask the policy directly, through the kernel's ``compute_av`` interface
+(``/sys/fs/selinux/access``). That is a pure query — it decides nothing, relabels
+nothing, needs no root, and writes no state anywhere on the host.
+
+**Mechanism-based, never distro-based** — the same rule :mod:`kiro_crew.service
+.apparmor` states for its own gate, for the same reason: an ID check would miss
+every derivative (Bazzite is a Fedora derivative of a derivative) and would
+wrongly fire on a Fedora host that installed kirocrew system-wide, or one whose
+operator has loaded a policy module granting the access. Nothing here matches a
+distro name, a version, or even a *type* name. Every input is read from the
+running kernel:
+
+* enforcing state from ``/sys/fs/selinux/enforce``,
+* the domain that will do the ``execve`` from ``/proc/1/attr/current`` (whatever
+  PID 1 actually is on this host, not a hardcoded ``init_t``),
+* the file's label from its ``security.selinux`` xattr,
+* the verdict from the loaded policy.
+
+**It fires only on a proven positive, and fails OPEN everywhere else.** SELinux
+absent, permissive, an unreadable label, a kernel that refuses the query, a
+policy whose source domain is *per-domain permissive* — every one of those
+returns "not blocked" and the install proceeds exactly as it did before this
+module existed. A pre-flight that guesses wrong in the refusing direction would
+break installs that work today, which is strictly worse than the bug it prevents.
+
+**No override knob, deliberately.** The check reads the live policy, so an
+operator who loads a policy module granting the access flips it off by itself —
+``compute_av`` starts answering ALLOW and the gate goes quiet with no flag to
+remember. An escape hatch could only ever re-enable an install that provably
+crash-loops.
+
+**Coverage boundary, stated because it is reachable.** This answers exactly one
+question: may PID 1's domain execute the file systemd itself ``execve``s at unit
+start, and the interpreter its shebang names? It does NOT and cannot cover what
+that file goes on to exec at RUNTIME. A ``KIROCREW_SERVICE_BIN`` override naming a
+system-labelled wrapper that later runs a binary under ``$HOME`` therefore passes
+this gate and still fails to serve — with the shell's exit 126, not ``203/EXEC``,
+since the wrapper itself execs fine.
+
+That hole cannot be closed soundly here. Following the delegation would mean
+deciding what an arbitrary shell script executes, and the weaker version —
+scanning a wrapper for path-shaped literals — would refuse installs over a path in
+a comment or an untaken branch, because a literal appearing in a script is not
+proof it is ever executed. Refusing on "cannot inspect" is the same violation from
+the other side. So the boundary is left where soundness puts it, and
+:func:`kiro_crew.service.linux.install` covers the residue at the point of failure
+instead: when the unit is written and the first ``systemctl restart`` fails on an
+enforcing host, its error names SELinux as a candidate and prints the same
+user-scope remedy. Nothing is left silently unexplained, and no install that would
+have worked is refused.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+SELINUX_FS = Path("/sys/fs/selinux")
+_ENFORCE_PATH = SELINUX_FS / "enforce"
+_ACCESS_PATH = SELINUX_FS / "access"
+_CLASS_DIR = SELINUX_FS / "class"
+# The domain that performs the execve for a system-scope unit: whatever PID 1
+# is. Read rather than assumed — "init_t" is the Fedora/refpolicy answer, but
+# the point of this module is to ask the host instead of encoding one policy's
+# type names.
+_SYSTEM_MANAGER_ATTR = Path("/proc/1/attr/current")
+
+# libselinux's SELINUX_AVD_FLAGS_PERMISSIVE. Set in the compute_av reply when
+# the SOURCE DOMAIN is marked permissive in policy, which means the kernel logs
+# the denial and allows the access anyway. A denial from a permissive domain is
+# therefore not a start failure, so it must not refuse an install.
+_AVD_FLAG_PERMISSIVE = 0x0001
+
+# Bytes of a shebang we are willing to read. A Linux kernel truncates the
+# interpreter line at BINPRM_BUF_SIZE (256) anyway, so nothing beyond it can
+# affect which interpreter actually runs.
+_SHEBANG_LIMIT = 256
+
+
+def is_enforcing() -> bool:
+    """True only when the kernel is actively enforcing policy.
+
+    In permissive mode the denial is logged and the ``execve`` succeeds, so the
+    unit starts and there is nothing to warn about. An absent or unreadable
+    ``enforce`` node (no SELinux, selinuxfs not mounted, a container) reads as
+    not enforcing — the fail-open direction.
+    """
+    try:
+        return _ENFORCE_PATH.read_text(encoding="ascii").strip() == "1"
+    except OSError:
+        return False
+
+
+def _system_manager_context() -> str | None:
+    """SELinux context of PID 1, or None when it cannot be read.
+
+    This is the domain that will call ``execve`` on the unit's ``ExecStart`` for
+    a system-scope unit, so it is the only correct source context for the query.
+    """
+    try:
+        raw = _SYSTEM_MANAGER_ATTR.read_text(encoding="ascii")
+    except (OSError, UnicodeDecodeError):
+        return None
+    # The kernel NUL-terminates the attribute; a bare strip leaves it behind and
+    # the policy lookup would then fail to parse the context.
+    context = raw.strip().rstrip("\x00").strip()
+    return context or None
+
+
+def _file_context(path: str) -> str | None:
+    """SELinux label of ``path``, following symlinks. None when unavailable.
+
+    Symlinks are resolved because the kernel checks the label of the file it
+    actually executes, and the shipped install path is a symlink chain
+    (``~/.local/bin/kirocrew`` → ``~/.kiro/crew-venv/bin/kirocrew``). Reading the
+    label of the *link* would answer the wrong question.
+    """
+    getxattr = getattr(os, "getxattr", None)  # Linux-only; absent elsewhere.
+    if getxattr is None:
+        return None
+    try:
+        raw = getxattr(os.path.realpath(path), "security.selinux")
+    except (OSError, ValueError):
+        return None
+    try:
+        context = raw.decode("ascii").strip().rstrip("\x00").strip()
+    except UnicodeDecodeError:
+        return None
+    return context or None
+
+
+def _read_int(path: Path) -> int | None:
+    try:
+        return int(path.read_text(encoding="ascii").strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _class_index(object_class: str) -> int | None:
+    """Numeric class id the ``compute_av`` interface expects."""
+    return _read_int(_CLASS_DIR / object_class / "index")
+
+
+def _perm_bit(object_class: str, permission: str) -> int | None:
+    """Access-vector bit for one permission of one class.
+
+    selinuxfs exposes the 1-based BIT NUMBER, not the mask, so the value is
+    shifted rather than used directly — reading it as a mask would test an
+    unrelated permission (``execute`` is bit 15, i.e. mask ``0x4000``).
+    """
+    bit = _read_int(_CLASS_DIR / object_class / "perms" / permission)
+    if bit is None or bit < 1 or bit > 32:
+        return None
+    return 1 << (bit - 1)
+
+
+def _query_access(query: str) -> str | None:
+    """Put one question to ``/sys/fs/selinux/access`` and return the raw reply.
+
+    The write carries the question and the read returns the answer on the SAME
+    descriptor — that is the interface's contract, not an accident, so the two
+    cannot be split across separate opens. Nothing is relabelled, no policy is
+    modified, and no privilege is required beyond the calling domain's own
+    ``security { compute_av }``. Any failure returns None, which every caller
+    treats as "no verdict".
+
+    Separate from :func:`_compute_av` so the parsing can be exercised without a
+    test having to monkeypatch ``os.open`` / ``os.read`` globally — patching
+    those breaks pytest's own I/O, and a test that reaches for them is one edit
+    away from writing to real selinuxfs.
+    """
+    try:
+        fd = os.open(_ACCESS_PATH, os.O_RDWR)
+    except OSError:
+        return None
+    try:
+        os.write(fd, query.encode("ascii"))
+        os.lseek(fd, 0, os.SEEK_SET)
+        return os.read(fd, 4096).decode("ascii")
+    except (OSError, UnicodeDecodeError, UnicodeEncodeError):
+        return None
+    finally:
+        os.close(fd)
+
+
+def _compute_av(
+    source_context: str, target_context: str, object_class: str
+) -> tuple[int, int] | None:
+    """Ask the loaded policy for ``(allowed_vector, flags)``, or None.
+
+    A read-only decision query: ``ffffffff`` requests the full access vector so
+    one round trip answers every permission of the class.
+    """
+    class_id = _class_index(object_class)
+    if class_id is None:
+        return None
+    reply = _query_access(f"{source_context} {target_context} {class_id} ffffffff")
+    if reply is None:
+        return None
+    # "allowed decided auditallow auditdeny seqno flags", all hex but seqno.
+    fields = reply.split()
+    if len(fields) < 6:
+        return None
+    try:
+        return int(fields[0], 16), int(fields[5], 16)
+    except ValueError:
+        return None
+
+
+def _interpreter_of(path: str) -> str | None:
+    """Interpreter named by ``path``'s shebang, or None if it is not a script.
+
+    The installed entry point is a shebang script naming the venv interpreter,
+    and that interpreter is under ``$HOME`` too. Checking only the script would
+    pass a case that still fails at ``execve`` of the interpreter — a false
+    negative that would let the doomed install proceed and make this gate look
+    broken rather than absent.
+    """
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(_SHEBANG_LIMIT)
+    except OSError:
+        return None
+    if not head.startswith(b"#!"):
+        return None
+    line = head[2:].split(b"\n", 1)[0]
+    try:
+        text = line.decode("utf-8").strip()
+    except UnicodeDecodeError:
+        return None
+    if not text:
+        return None
+    # `#!/usr/bin/env python3` names env as the executed file, which is what the
+    # kernel checks; the first token is the right answer either way.
+    candidate = text.split()[0]
+    return candidate if candidate.startswith("/") else None
+
+
+def _execute_denied(source_context: str, path: str) -> str | None:
+    """Label of ``path`` when ``source_context`` provably may not execute it.
+
+    None means "no proven denial" and covers every indeterminate case: no label,
+    no policy answer, a permissive source domain, or an outright ALLOW.
+    """
+    label = _file_context(path)
+    if label is None:
+        return None
+    execute_bit = _perm_bit("file", "execute")
+    if execute_bit is None:
+        return None
+    verdict = _compute_av(source_context, label, "file")
+    if verdict is None:
+        return None
+    allowed, flags = verdict
+    if flags & _AVD_FLAG_PERMISSIVE:
+        # Denials from a permissive domain are logged, not enforced, so the
+        # execve still succeeds and the unit starts.
+        return None
+    if allowed & execute_bit:
+        return None
+    return label
+
+
+def blocks_system_unit(exec_path: str) -> tuple[bool, str]:
+    """Whether a system unit running ``exec_path`` provably cannot start.
+
+    Returns ``(blocked, reason)``. ``reason`` is always populated so a caller can
+    report why the gate stayed quiet as readily as why it fired.
+
+    The three conditions are independent and all must hold, each read from the
+    running kernel rather than inferred: policy is being enforced, PID 1's domain
+    is known, and that domain is denied ``execute`` on the file systemd would run
+    (the resolved binary, or the interpreter its shebang names).
+    """
+    if not is_enforcing():
+        return False, "SELinux is not enforcing on this host"
+    source_context = _system_manager_context()
+    if source_context is None:
+        return False, f"could not read the system manager's domain from {_SYSTEM_MANAGER_ATTR}"
+
+    # The binary first, then the interpreter its shebang names: either one being
+    # denied is enough to guarantee 203/EXEC, and naming the right file makes the
+    # difference between an actionable message and a puzzle.
+    resolved = os.path.realpath(exec_path)
+    candidates = [resolved]
+    interpreter = _interpreter_of(resolved)
+    if interpreter:
+        candidates.append(os.path.realpath(interpreter))
+
+    for candidate in candidates:
+        label = _execute_denied(source_context, candidate)
+        if label is not None:
+            return True, (
+                f"SELinux is enforcing and its policy does not allow "
+                f"{source_context} (systemd, PID 1) to execute {candidate}, "
+                f"which is labelled {label}"
+            )
+    return (
+        False,
+        f"SELinux policy allows {source_context} to execute " f"{' and '.join(candidates)}",
+    )

--- a/test/test_service_selinux.py
+++ b/test/test_service_selinux.py
@@ -1,0 +1,753 @@
+"""SELinux pre-flight for the Linux system unit (#7165).
+
+Pure-logic tests: every kernel interface the module reads is redirected at a
+tmp_path fake or monkeypatched, so nothing here reads the host's real policy,
+label set, or enforcing state. That matters twice over — the suite must produce
+the same verdicts on an AppArmor-only CI runner as on an SELinux-enforcing
+workstation, and a test must never be in a position to write to selinuxfs.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kiro_crew.service import linux as svc_linux
+from kiro_crew.service import selinux as sel
+from kiro_crew.service.common import SERVICE_NAME
+
+# Contexts as they appear on a Fedora-family targeted policy. Only used as
+# opaque strings — the module never parses or matches on a type name.
+INIT_T = "system_u:system_r:init_t:s0"
+HOME_T = "unconfined_u:object_r:user_home_t:s0"
+BIN_T = "system_u:object_r:bin_t:s0"
+
+EXECUTE_BIT = 15  # 1-based bit number as selinuxfs reports it; mask 0x4000.
+EXECUTE_MASK = 1 << (EXECUTE_BIT - 1)
+GETATTR_MASK = 1 << (4 - 1)
+
+
+def _fake_selinuxfs(tmp_path, *, enforce="1", execute_bit=EXECUTE_BIT, index=6):
+    """Build a selinuxfs-shaped tree and point the module at it."""
+    root = tmp_path / "selinux"
+    (root / "class" / "file" / "perms").mkdir(parents=True)
+    if enforce is not None:
+        (root / "enforce").write_text(enforce)
+    (root / "class" / "file" / "index").write_text(str(index))
+    if execute_bit is not None:
+        (root / "class" / "file" / "perms" / "execute").write_text(str(execute_bit))
+    return root
+
+
+@pytest.fixture
+def selinuxfs(tmp_path, monkeypatch):
+    """An enforcing SELinux host whose policy answers are set per-test."""
+    root = _fake_selinuxfs(tmp_path)
+    monkeypatch.setattr(sel, "SELINUX_FS", root)
+    monkeypatch.setattr(sel, "_ENFORCE_PATH", root / "enforce")
+    monkeypatch.setattr(sel, "_CLASS_DIR", root / "class")
+    monkeypatch.setattr(sel, "_ACCESS_PATH", root / "access")
+    return root
+
+
+@pytest.fixture
+def policy(monkeypatch):
+    """Control ``_compute_av``'s answer without touching a kernel interface."""
+
+    def configure(allowed: int, flags: int = 0):
+        monkeypatch.setattr(sel, "_compute_av", lambda _s, _t, _c: (allowed, flags))
+
+    return configure
+
+
+class TestEnforcingDetection:
+    """Only an actively enforcing kernel can turn a denial into a start failure."""
+
+    def test_enforce_one_is_enforcing(self, selinuxfs):
+        assert sel.is_enforcing() is True
+
+    def test_permissive_is_not_enforcing(self, selinuxfs):
+        """In permissive mode the denial is logged and the execve succeeds."""
+        (selinuxfs / "enforce").write_text("0")
+        assert sel.is_enforcing() is False
+
+    def test_absent_selinuxfs_is_not_enforcing(self, selinuxfs):
+        """No SELinux at all — the overwhelmingly common case — must read False."""
+        (selinuxfs / "enforce").unlink()
+        assert sel.is_enforcing() is False
+
+    def test_unparseable_enforce_is_not_enforcing(self, selinuxfs):
+        (selinuxfs / "enforce").write_text("banana")
+        assert sel.is_enforcing() is False
+
+
+class TestLabelReading:
+    """The label of the file the kernel actually executes, not of the symlink."""
+
+    def test_unreadable_xattr_reads_as_no_label(self, tmp_path, monkeypatch):
+        """A filesystem that cannot answer must not be read as a label.
+
+        Patched rather than relying on an unlabelled temp file: on a real
+        SELinux host every file HAS a label (a tmp file comes back as
+        ``default_t``), so a host-dependent version of this test passes on CI
+        and fails on exactly the machines the feature is for.
+        """
+
+        def refuse(*_a):
+            raise OSError("xattr not supported")
+
+        # raising=False: os.getxattr is Linux-only and absent on Windows, where
+        # this file is still collected. Setting it there is exactly right — the
+        # parse logic under test is platform-independent, and _file_context()
+        # reaches it through getattr(os, "getxattr", None).
+        monkeypatch.setattr(sel.os, "getxattr", refuse, raising=False)
+        target = tmp_path / "kirocrew"
+        target.write_text("#!/bin/sh\n")
+        assert sel._file_context(str(target)) is None
+
+    def test_absent_path_reads_as_no_label(self, tmp_path):
+        assert sel._file_context(str(tmp_path / "nope")) is None
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="symlink creation needs privilege on Windows and realpath anchors "
+        "a POSIX path to a drive letter, so neither the setup nor the asserted "
+        "path is meaningful there; the module only ever runs on Linux",
+    )
+    def test_label_is_read_through_a_symlink_chain(self, tmp_path, monkeypatch):
+        """~/.local/bin/kirocrew is a symlink to the venv entry point.
+
+        SELinux checks the label of the resolved file, so reading the LINK's
+        label would answer a question the kernel never asks.
+        """
+        real = tmp_path / "venv" / "bin" / "kirocrew"
+        real.parent.mkdir(parents=True)
+        real.write_text("#!/usr/bin/python3\n")
+        link = tmp_path / "kirocrew"
+        link.symlink_to(real)
+
+        seen: list[str] = []
+
+        def fake_getxattr(path, name):
+            seen.append(os.fspath(path))
+            assert name == "security.selinux"
+            return HOME_T.encode() + b"\x00"
+
+        monkeypatch.setattr(sel.os, "getxattr", fake_getxattr, raising=False)
+        assert sel._file_context(str(link)) == HOME_T
+        assert seen == [str(real)], "must read the resolved target's label"
+
+    def test_trailing_nul_is_stripped(self, tmp_path, monkeypatch):
+        """The kernel NUL-terminates the value; a bare strip leaves it behind
+        and the policy query would then fail to parse the context."""
+        monkeypatch.setattr(sel.os, "getxattr", lambda *_a: BIN_T.encode() + b"\x00", raising=False)
+        target = tmp_path / "kirocrew"
+        target.write_text("x")
+        assert sel._file_context(str(target)) == BIN_T
+
+
+class TestPermBitDecoding:
+    """selinuxfs exposes a 1-based BIT NUMBER, not a mask."""
+
+    def test_bit_number_becomes_a_mask(self, selinuxfs):
+        assert sel._perm_bit("file", "execute") == EXECUTE_MASK == 0x4000
+
+    def test_out_of_range_bit_is_rejected(self, selinuxfs):
+        (selinuxfs / "class" / "file" / "perms" / "execute").write_text("99")
+        assert sel._perm_bit("file", "execute") is None
+
+    def test_missing_perm_file_is_none(self, selinuxfs):
+        (selinuxfs / "class" / "file" / "perms" / "execute").unlink()
+        assert sel._perm_bit("file", "execute") is None
+
+
+class TestBlocksSystemUnit:
+    """The gate: fires ONLY on a proven denial, fails open on everything else."""
+
+    @staticmethod
+    def _binary(tmp_path, shebang: str | None = None) -> str:
+        path = tmp_path / "kirocrew"
+        path.write_text(f"{shebang}\n" if shebang else "\x7fELF")
+        path.chmod(0o755)
+        return str(path)
+
+    def test_fires_when_policy_denies_execute(self, selinuxfs, policy, monkeypatch, tmp_path):
+        binary = self._binary(tmp_path)
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: HOME_T)
+        # getattr allowed, execute NOT — the exact shape that makes the file look
+        # fine to every ordinary check while systemd still gets 203/EXEC.
+        policy(GETATTR_MASK)
+
+        blocked, reason = sel.blocks_system_unit(binary)
+        assert blocked is True
+        assert INIT_T in reason and HOME_T in reason and binary in reason
+
+    def test_fires_on_any_denied_label_not_just_user_home_t(
+        self, selinuxfs, policy, monkeypatch, tmp_path
+    ):
+        """The gate must key on the POLICY VERDICT, never on a type name.
+
+        A checkout outside /home (``/local/home/...``, a bind-mounted work area,
+        ``/opt``) does not match the home fcontext regex and comes back as
+        ``default_t`` — verified on the development host, where the gate
+        correctly fired on ``default_t`` rather than the ``user_home_t`` the
+        issue reports. Matching on the reported type name would have missed it.
+        """
+        other_label = "unconfined_u:object_r:default_t:s0"
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: other_label)
+        policy(GETATTR_MASK)
+
+        blocked, reason = sel.blocks_system_unit(self._binary(tmp_path))
+        assert blocked is True
+        assert other_label in reason
+
+    def test_quiet_when_policy_allows_execute(self, selinuxfs, policy, monkeypatch, tmp_path):
+        binary = self._binary(tmp_path)
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: BIN_T)
+        policy(GETATTR_MASK | EXECUTE_MASK)
+
+        blocked, reason = sel.blocks_system_unit(binary)
+        assert blocked is False
+        assert "allows" in reason
+
+    def test_quiet_when_not_enforcing(self, selinuxfs, policy, monkeypatch, tmp_path):
+        """Permissive: the denial is logged, the unit starts. Must not refuse."""
+        (selinuxfs / "enforce").write_text("0")
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: HOME_T)
+        policy(GETATTR_MASK)
+
+        blocked, reason = sel.blocks_system_unit(self._binary(tmp_path))
+        assert blocked is False
+        assert "not enforcing" in reason
+
+    def test_quiet_when_source_domain_is_permissive(self, selinuxfs, policy, monkeypatch, tmp_path):
+        """A per-domain permissive source still executes despite the denial.
+
+        Global mode is enforcing here, so only the reply's flags word
+        distinguishes this from a real failure.
+        """
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: HOME_T)
+        policy(GETATTR_MASK, flags=sel._AVD_FLAG_PERMISSIVE)
+
+        blocked, _ = sel.blocks_system_unit(self._binary(tmp_path))
+        assert blocked is False
+
+    def test_quiet_when_pid1_context_is_unreadable(self, selinuxfs, policy, monkeypatch, tmp_path):
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: None)
+        policy(GETATTR_MASK)
+        blocked, reason = sel.blocks_system_unit(self._binary(tmp_path))
+        assert blocked is False
+        assert "system manager" in reason
+
+    def test_quiet_when_the_file_has_no_label(self, selinuxfs, policy, monkeypatch, tmp_path):
+        """An unlabelled or unreadable path yields no verdict, so no refusal."""
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: None)
+        policy(GETATTR_MASK)
+        blocked, _ = sel.blocks_system_unit(self._binary(tmp_path))
+        assert blocked is False
+
+    def test_quiet_when_the_policy_query_fails(self, selinuxfs, monkeypatch, tmp_path):
+        """A kernel that refuses _compute_av must not be read as a denial."""
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        monkeypatch.setattr(sel, "_file_context", lambda _p: HOME_T)
+        monkeypatch.setattr(sel, "_compute_av", lambda *_a: None)
+        blocked, _ = sel.blocks_system_unit(self._binary(tmp_path))
+        assert blocked is False
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="a shebang is a POSIX exec mechanism and the interpreter path it "
+        "names is required to be absolute-POSIX; on Windows tmp_path yields "
+        "C:\\... so _interpreter_of correctly declines it and there is nothing "
+        "to assert",
+    )
+    def test_fires_on_a_denied_shebang_interpreter(self, selinuxfs, policy, monkeypatch, tmp_path):
+        """The entry point is a script naming a venv interpreter under $HOME.
+
+        Checking only the script would pass a case that still fails at the
+        execve of the interpreter — a false negative that lets the doomed
+        install proceed.
+        """
+        interpreter = tmp_path / "venv" / "bin" / "python3"
+        interpreter.parent.mkdir(parents=True)
+        interpreter.write_bytes(b"\x7fELF")
+        script = self._binary(tmp_path, shebang=f"#!{interpreter}")
+
+        monkeypatch.setattr(sel, "_system_manager_context", lambda: INIT_T)
+        # The script itself is fine; only the interpreter is home-labelled.
+        monkeypatch.setattr(
+            sel,
+            "_file_context",
+            lambda p: HOME_T if p == str(interpreter) else BIN_T,
+        )
+        monkeypatch.setattr(
+            sel,
+            "_compute_av",
+            lambda _s, target, _c: (
+                (GETATTR_MASK, 0) if target == HOME_T else (GETATTR_MASK | EXECUTE_MASK, 0)
+            ),
+        )
+
+        blocked, reason = sel.blocks_system_unit(script)
+        assert blocked is True
+        assert str(interpreter) in reason
+
+    def test_non_absolute_shebang_is_ignored(self, selinuxfs, tmp_path):
+        """`#!python3` names nothing the kernel can resolve for us to check."""
+        script = self._binary(tmp_path, shebang="#!python3")
+        assert sel._interpreter_of(script) is None
+
+    def test_env_shebang_reports_env_as_the_executed_file(self, tmp_path):
+        """`#!/usr/bin/env python3` execs env; env is what the kernel checks."""
+        script = self._binary(tmp_path, shebang="#!/usr/bin/env python3")
+        assert sel._interpreter_of(script) == "/usr/bin/env"
+
+    def test_elf_binary_has_no_interpreter(self, tmp_path):
+        assert sel._interpreter_of(self._binary(tmp_path)) is None
+
+
+class TestComputeAvQuery:
+    """Query construction and reply parsing, exercised through the ``_query_access``
+    seam so no test ever monkeypatches ``os.open`` (which breaks pytest's own
+    I/O) or comes within one edit of writing to real selinuxfs."""
+
+    def test_query_is_written_and_reply_parsed(self, selinuxfs, monkeypatch):
+        asked: list[str] = []
+
+        def fake_query(query: str) -> str:
+            asked.append(query)
+            return "220990 ffffffff 0 ffffffff 1 0"
+
+        monkeypatch.setattr(sel, "_query_access", fake_query)
+        assert sel._compute_av(INIT_T, HOME_T, "file") == (0x220990, 0)
+        # class id 6 from the faked index; ffffffff asks for the full vector.
+        assert asked == [f"{INIT_T} {HOME_T} 6 ffffffff"]
+
+    def test_permissive_flag_is_taken_from_the_last_field(self, selinuxfs, monkeypatch):
+        """flags is field 6, not field 5 — an off-by-one here would silently
+        read seqno as the permissive bit and disable the whole gate."""
+        monkeypatch.setattr(sel, "_query_access", lambda _q: "220990 ffffffff 0 ffffffff 7 1")
+        assert sel._compute_av(INIT_T, HOME_T, "file") == (0x220990, 1)
+
+    def test_truncated_reply_is_no_answer(self, selinuxfs, monkeypatch):
+        monkeypatch.setattr(sel, "_query_access", lambda _q: "220990 ffffffff")
+        assert sel._compute_av(INIT_T, HOME_T, "file") is None
+
+    def test_non_hex_reply_is_no_answer(self, selinuxfs, monkeypatch):
+        """A reply shaped right but not parseable must not become a verdict."""
+        monkeypatch.setattr(sel, "_query_access", lambda _q: "zzz ffffffff 0 ffffffff 1 0")
+        assert sel._compute_av(INIT_T, HOME_T, "file") is None
+
+    def test_unavailable_transport_is_no_answer(self, selinuxfs, monkeypatch):
+        """A kernel that refuses _compute_av, or no selinuxfs at all."""
+        monkeypatch.setattr(sel, "_query_access", lambda _q: None)
+        assert sel._compute_av(INIT_T, HOME_T, "file") is None
+
+    def test_unopenable_access_node_yields_no_reply(self, selinuxfs):
+        """The real transport against a path that does not exist."""
+        assert sel._query_access("anything") is None
+
+    def test_missing_class_index_is_no_answer(self, selinuxfs, monkeypatch):
+        monkeypatch.setattr(sel, "_query_access", lambda _q: "0 0 0 0 0 0")
+        (selinuxfs / "class" / "file" / "index").unlink()
+        assert sel._compute_av(INIT_T, HOME_T, "file") is None
+
+
+class TestUserScopeUnitRendering:
+    """The remedy is rendered by the real renderer, so it cannot drift."""
+
+    @staticmethod
+    def _render(monkeypatch, user_scope):
+        monkeypatch.setenv("USER", "tester")
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/home/tester/.local/bin/kirocrew",
+        ):
+            return svc_linux.render_unit(user_scope=user_scope)
+
+    def test_user_unit_omits_user_and_group(self, monkeypatch):
+        """A user manager rejects User=/Group=, making the unit unloadable."""
+        unit = self._render(monkeypatch, True)
+        assert "\nUser=" not in unit
+        assert "\nGroup=" not in unit
+
+    def test_system_unit_still_carries_user_and_group(self, monkeypatch):
+        unit = self._render(monkeypatch, False)
+        assert "\nUser=tester\n" in unit
+        assert "\nGroup=" in unit
+
+    def test_default_scope_is_system(self, monkeypatch):
+        """Callers that pass nothing must get exactly today's unit."""
+        monkeypatch.setenv("USER", "tester")
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/home/tester/.local/bin/kirocrew",
+        ):
+            assert svc_linux.render_unit() == svc_linux.render_unit(user_scope=False)
+
+    def test_user_unit_wants_default_target(self, monkeypatch):
+        """multi-user.target is a system target the user manager does not have."""
+        unit = self._render(monkeypatch, True)
+        assert "WantedBy=default.target" in unit
+        assert "multi-user.target" not in unit
+
+    def test_system_unit_wants_multi_user_target(self, monkeypatch):
+        unit = self._render(monkeypatch, False)
+        assert "WantedBy=multi-user.target" in unit
+
+    def test_both_scopes_share_exec_start_and_environment(self, monkeypatch):
+        """The pasted unit must run the same thing with the same environment."""
+        system = self._render(monkeypatch, False)
+        user = self._render(monkeypatch, True)
+        exec_line = [ln for ln in system.splitlines() if ln.startswith("ExecStart=")]
+        assert exec_line and exec_line[0] in user.splitlines()
+        for line in system.splitlines():
+            if line.startswith("Environment="):
+                assert line in user.splitlines()
+
+
+class TestStartFailureCoversWhatThePreflightCannotProve:
+    """The pre-flight only judges the file systemd itself execs.
+
+    A `KIROCREW_SERVICE_BIN` override naming a system-labelled WRAPPER that later
+    runs a binary under $HOME passes the gate and still cannot serve -- as the
+    shell's exit 126, not 203/EXEC, because the wrapper execs fine. Following the
+    delegation is not decidable and scanning the wrapper for path literals would
+    refuse over a path in a comment, so the residue is caught where the unit
+    actually failed instead.
+    """
+
+    @staticmethod
+    def _restart_fails(monkeypatch, *, enforcing):
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        # The gate finds nothing: this is precisely the wrapper case.
+        monkeypatch.setattr(svc_linux.selinux, "blocks_system_unit", lambda _p: (False, "allowed"))
+        monkeypatch.setattr(svc_linux.selinux, "is_enforcing", lambda: enforcing)
+
+        def run(argv, **_kw):
+            if argv[:3] == ["sudo", "systemctl", "restart"]:
+                return MagicMock(returncode=1, stdout="", stderr="Job failed")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        return run
+
+    def test_enforcing_host_gets_the_selinux_hypothesis_and_remedy(self, monkeypatch):
+        run = self._restart_fails(monkeypatch, enforcing=True)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/usr/local/bin/kirocrew-wrapper",
+            ),
+            patch("kiro_crew.service.linux.subprocess.run", side_effect=run),
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        msg = str(exc.value)
+        # Prose assertions run against whitespace-collapsed text: the message is
+        # hard-wrapped, so a literal substring can straddle a newline and a test
+        # pinned to the exact wrap breaks on any reflow.
+        flat = " ".join(msg.split())
+        # The original failure is still reported first.
+        assert "systemctl restart` failed" in flat
+        # Then SELinux as a CANDIDATE, with the command that settles it.
+        assert "SELinux is enforcing" in flat
+        assert "hypothesis, not a finding" in flat
+        assert "ausearch -m avc" in flat
+        # And it must be honest that the gate looked and found nothing.
+        assert "found no proven denial" in flat
+        assert "/usr/local/bin/kirocrew-wrapper" in flat
+        # It points at the documented remedy; it does NOT paste one. This fires on
+        # every failed restart on every enforcing host -- all of RHEL/Fedora --
+        # including hosts the pre-flight positively proved ALLOW for, so a port
+        # conflict must not be answered with a pasteable unit for a denial nobody
+        # has observed.
+        assert "docs/guides/install.md" in flat
+        assert "KIROCREW_UNIT" not in msg
+        assert "systemctl --user enable --now" not in msg
+        assert "loginctl enable-linger" not in msg
+
+    def test_the_hint_is_much_shorter_than_the_proven_refusal(self, monkeypatch):
+        """A hypothesis must not cost the operator as much text as a finding."""
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(svc_linux.selinux, "is_enforcing", lambda: True)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch.object(svc_linux, "_home_for_user", return_value="/home/tester"),
+        ):
+            hint = svc_linux.selinux_start_failure_hint()
+            refusal = svc_linux.selinux_refusal("a proven denial")
+
+        # Measured on this tree: 15 lines vs 68. The bound is what stops the
+        # remedy (or another wall of prose) drifting back onto the guess path.
+        assert len(hint.splitlines()) <= 20, "the hypothesis path must stay compact"
+        assert len(refusal.splitlines()) > len(hint.splitlines()) * 3
+
+    def test_non_enforcing_host_gets_no_selinux_noise(self, monkeypatch):
+        """A restart failure on a host without SELinux must read exactly as before."""
+        run = self._restart_fails(monkeypatch, enforcing=False)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/usr/local/bin/kirocrew",
+            ),
+            patch("kiro_crew.service.linux.subprocess.run", side_effect=run),
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        msg = str(exc.value)
+        assert "systemctl restart` failed" in msg
+        assert "SELinux" not in msg
+        assert "ausearch" not in msg
+
+    def test_hint_is_empty_off_the_enforcing_path(self, monkeypatch):
+        monkeypatch.setattr(svc_linux.selinux, "is_enforcing", lambda: False)
+        assert svc_linux.selinux_start_failure_hint() == ""
+
+    def test_only_the_proven_refusal_carries_the_remedy(self, monkeypatch):
+        """The remedy belongs behind a proven denial, not ahead of a guess."""
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(svc_linux.selinux, "is_enforcing", lambda: True)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch.object(svc_linux, "_home_for_user", return_value="/home/tester"),
+        ):
+            remedy = svc_linux._user_scope_remedy()
+            assert remedy in svc_linux.selinux_refusal("some proven denial")
+            assert remedy not in svc_linux.selinux_start_failure_hint()
+
+
+class TestInstallRefusesAnUnstartableSystemUnit:
+    """install() must stop BEFORE the first write, not after enabling a
+    crash-looping unit."""
+
+    @staticmethod
+    def _blocked(monkeypatch, blocked=True):
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setattr(
+            svc_linux.selinux,
+            "blocks_system_unit",
+            lambda _p: (blocked, "policy denies init_t execute on user_home_t"),
+        )
+
+    def test_install_raises_before_touching_the_host(self, monkeypatch):
+        self._blocked(monkeypatch)
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch("kiro_crew.service.linux.subprocess.run", return_value=ok) as run,
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        assert run.call_args_list == [], (
+            "a proven-unstartable unit must be refused before any subprocess "
+            f"runs; got {[list(c.args[0]) for c in run.call_args_list]}"
+        )
+        msg = str(exc.value)
+        assert "203/EXEC" in msg
+        assert "policy denies init_t execute on user_home_t" in msg
+
+    def test_refusal_carries_a_pasteable_user_unit(self, monkeypatch):
+        self._blocked(monkeypatch)
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/home/tester/.local/bin/kirocrew",
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        msg = str(exc.value)
+        # The remedy must be the user-scope unit, complete and self-contained.
+        assert "systemctl --user enable --now" in msg
+        assert "loginctl enable-linger" in msg
+        assert str(svc_linux.USER_UNIT_SUBDIR) in msg
+        assert "WantedBy=default.target" in msg
+        assert "ExecStart=" in msg
+        # Every command named must exist. `kirocrew service` has only
+        # install/uninstall/status, so the remedy may not invent a subcommand.
+        assert "kirocrew service print-unit" not in msg
+
+    def test_refusal_names_only_real_service_subcommands(self, monkeypatch):
+        """Guards the class of bug where a remedy prints a command we do not
+        ship, which sends the operator into `invalid choice`."""
+        self._blocked(monkeypatch)
+        with patch(
+            "kiro_crew.service.common.shutil.which",
+            return_value="/home/tester/.local/bin/kirocrew",
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        real = {"install", "uninstall", "status"}
+        for token in str(exc.value).split("kirocrew service ")[1:]:
+            word = token.split()[0].strip("`.,\n")
+            # A pipe-joined hint like `status|uninstall` names several at once.
+            assert set(word.split("|")) <= real, f"unknown subcommand: {word}"
+
+    def test_refusal_never_lets_the_pasting_shell_pick_the_account(self, monkeypatch):
+        """A user unit has no User=, so whoever's manager loads it runs the agent.
+
+        `service install` runs under sudo, so the shell reading this refusal is
+        usually root's. If the remedy said `~` or `$USER` it would name /root and
+        root, and the operator would end up running untrusted agent tools as root
+        -- the exact thing install() refuses outright a few lines earlier. Nothing
+        in the remedy may be resolved by the shell that pastes it.
+        """
+        self._blocked(monkeypatch)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch.object(svc_linux, "_home_for_user", return_value="/home/tester"),
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        msg = str(exc.value)
+        assert "$USER" not in msg, "the pasting shell must not choose the account"
+        assert "~/" not in msg, "the pasting shell must not choose the home"
+        # Joined the same way the code joins it rather than hard-coded with
+        # forward slashes: this file is collected on Windows, where Path renders
+        # separators as backslashes, and a POSIX-spelled literal here fails there
+        # for a reason that has nothing to do with the property being tested.
+        expected_unit = (
+            Path("/home/tester") / svc_linux.USER_UNIT_SUBDIR / (f"{SERVICE_NAME}.service")
+        )
+        assert str(expected_unit) in msg
+        assert "loginctl enable-linger tester" in msg
+
+    def test_refusal_warns_that_a_root_shell_would_run_the_agent_as_root(self, monkeypatch):
+        """The path names alone are not enough -- an operator pasting into the
+        wrong shell must be told what goes wrong, since a user unit gives no
+        error, it just silently runs as the wrong account."""
+        self._blocked(monkeypatch)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch.object(svc_linux, "_home_for_user", return_value="/home/tester"),
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        msg = str(exc.value)
+        assert "AS tester" in msg
+        assert "ROOT" in msg
+        # `sudo -u` looks like the obvious way to run as another account and
+        # cannot work here (no session, so no user manager to talk to).
+        assert "sudo -u tester` is NOT" in msg
+        assert "machinectl shell tester@" in msg
+
+    def test_remedy_quotes_a_home_containing_a_space(self, monkeypatch):
+        """The remedy is copy-pasted verbatim, so an unquoted path word-splits.
+
+        `mkdir -p /home/tester with space/.config/systemd/user` would create two
+        wrong directories and the redirect would land the unit where systemd never
+        looks -- an operator following the instructions exactly would end up with
+        no service and no error explaining why.
+        """
+        self._blocked(monkeypatch)
+        spaced_home = "/home/tester with space"
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch.object(svc_linux, "_home_for_user", return_value=spaced_home),
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        msg = str(exc.value)
+        quoted = shlex.quote(str(Path(spaced_home) / svc_linux.USER_UNIT_SUBDIR))
+        assert f"mkdir -p {quoted}" in msg
+        # The bare, splittable form must be gone entirely.
+        assert f"mkdir -p {spaced_home}" not in msg
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="shlex.quote is POSIX and quotes the backslashes in a Windows path, "
+        "so 'needs no quoting' is only meaningful on POSIX -- and what this renders "
+        "is a Linux shell snippet either way",
+    )
+    def test_ordinary_paths_are_not_needlessly_quoted(self, monkeypatch):
+        """shlex.quote leaves simple paths alone; the common case must stay clean."""
+        self._blocked(monkeypatch)
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch.object(svc_linux, "_home_for_user", return_value="/home/tester"),
+        ):
+            with pytest.raises(svc_linux.ServiceInstallError) as exc:
+                svc_linux.install()
+
+        assert "'" not in str(exc.value).split("mkdir -p ")[1].splitlines()[0]
+
+    def test_install_proceeds_normally_when_not_blocked(self, monkeypatch):
+        """The overwhelmingly common host must be completely unaffected."""
+        self._blocked(monkeypatch, blocked=False)
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/usr/local/bin/kirocrew",
+            ),
+            patch("kiro_crew.service.linux.subprocess.run", return_value=ok) as run,
+        ):
+            svc_linux.install()
+
+        called = [list(c.args[0]) for c in run.call_args_list]
+        assert ["sudo", "systemctl", "enable", f"{SERVICE_NAME}.service"] in called
+        assert ["sudo", "systemctl", "restart", f"{SERVICE_NAME}.service"] in called
+
+    def test_gate_is_asked_about_the_unit_exec_path(self, monkeypatch):
+        """It must judge the SAME binary render_unit puts in ExecStart."""
+        monkeypatch.setenv("USER", "tester")
+        monkeypatch.setattr(svc_linux.os, "geteuid", lambda: 1000, raising=False)
+        asked: list[str] = []
+        monkeypatch.setattr(
+            svc_linux.selinux,
+            "blocks_system_unit",
+            lambda path: (asked.append(path), (False, "allowed"))[1],
+        )
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch(
+                "kiro_crew.service.common.shutil.which",
+                return_value="/home/tester/.local/bin/kirocrew",
+            ),
+            patch("kiro_crew.service.linux.subprocess.run", return_value=ok),
+        ):
+            svc_linux.install()
+
+        assert asked == ["/home/tester/.local/bin/kirocrew"]


### PR DESCRIPTION
## What is the problem?

On an SELinux-enforcing host whose kirocrew lives under `$HOME` -- the default on
Bazzite, Fedora Silverblue/Kinoite and other atomic desktops -- `kirocrew service
install` writes a **system** unit at `/etc/systemd/system/kirocrew.service` that
can never start. It fails every start with `status=203/EXEC` and crash-loops
until it exhausts `StartLimitBurst`.

`203/EXEC` is systemd reporting that it could not execute the binary, and it has
four causes that are **indistinguishable** in the unit's status output: the path
does not exist, it is not executable, its shebang interpreter is wrong, or the
file is perfectly fine and SELinux refused the execute. This issue is the last
one, which is the only one that survives every check an installer would normally
run.

**I established which cause it is before changing anything.** The evidence is a
read-only `compute_av` query against the loaded policy on a Fedora-family
`targeted` policy (`/sys/fs/selinux/access` -- a pure decision lookup that
relabels nothing, needs no root, and writes no state):

| source domain | target label | `execute` | `getattr` |
|---|---|---|---|
| `system_u:system_r:init_t:s0` (PID 1) | `user_home_t` | **DENY** | ALLOW |
| `system_u:system_r:init_t:s0` (PID 1) | `bin_t` | ALLOW | ALLOW |
| `unconfined_u:unconfined_r:unconfined_t` (user manager) | `user_home_t` | ALLOW | ALLOW |

The reply's `flags` word was `0`, so `init_t` is not a per-domain permissive
domain -- this is a real policy denial, not one the kernel would log and allow.

**`getattr` ALLOW with `execute` DENY is the whole diagnostic problem.** It means
a positive on "is this path fine?" is exactly what you get in the broken case:
the file exists, `os.access(..., X_OK)` and `test -x` return **True**, `stat`
works, the shebang is correct. A file that passes `test -x` and still fails
`203/EXEC` is the signature of this cause, and no file-mode check can distinguish
it. Only asking the policy can.

## Why this issue matters to the user

Out-of-the-box `kirocrew service install` is broken on every atomic Fedora
variant, and it fails in the least useful way available: the install writes the
unit, `enable`s it, then fails at the first `systemctl restart` with "run
`journalctl` for details". The host is left with an **enabled unit that
crash-loops at every boot**, and the message names none of the cause. The
reporter had to read the audit log themselves to find it.

## How our fix solves it

Chain from symptom to root cause: the symptom is a crash-looping unit; the
mechanism is `init_t` denied `execute` on the ExecStart binary's label; the root
cause is that the installer commits to system scope without ever asking whether
system scope can work on this host. So it now asks, **before it writes anything**.

New `kiro_crew/service/selinux.py` answers one question -- can the domain that
will perform the `execve` actually execute the file we are about to name in
`ExecStart`? -- and `install()` refuses up front when the answer is provably no.

Three properties matter:

- **Mechanism-based, never distro-based**, the same rule `apparmor.py` already
  states for its own gate. Nothing matches a distro name, a version, or even a
  *type* name. Every input is read from the running kernel: enforcing state from
  `/sys/fs/selinux/enforce`, the executing domain from `/proc/1/attr/current`
  (whatever PID 1 actually is, not a hardcoded `init_t`), the file's label from
  its `security.selinux` xattr, and the verdict from the loaded policy. This is
  not theoretical: on my development host the checkout is outside `/home`, so it
  is labelled `default_t` rather than the `user_home_t` the issue reports -- and
  the gate fired correctly on it. A type-name match would have missed it.
- **Fires only on a proven positive; fails OPEN everywhere else.** SELinux absent,
  permissive mode, an unreadable label, a kernel that refuses the query, a
  truncated reply, a per-domain permissive source -- every one returns "not
  blocked" and the install proceeds byte-identically to today. A pre-flight that
  guesses wrong in the refusing direction would break installs that currently
  work, which is worse than the bug.
- **Refusal, not a warning.** Everything after that point is destructive to no
  purpose. Stopping before the first write leaves the host exactly as found,
  instead of enabled-and-crash-looping.

The refusal embeds a ready-to-paste **user-scope unit rendered by the real
`render_unit()`**, so the operator's working unit carries the same `ExecStart` and
the same baked environment as the unit we would have installed and cannot drift
from it. Two directives differ, and both are hard requirements rather than style:
`User=`/`Group=` are omitted (a user manager rejects them, making the unit
unloadable) and `WantedBy=default.target` replaces `multi-user.target` (a system
target the user manager does not have). `render_unit()`'s default is unchanged,
so every existing caller gets today's unit byte-for-byte.

The message also records a fix that **looks** right and provably is not:
relocating only the launcher to a system-labelled path does not help, because
whatever systemd execs still runs in PID 1's domain, so the next `execve` of the
binary under `$HOME` is denied identically. `init_t -> user_home_t` is denied
regardless of who initiates the chain.

**No override knob, deliberately.** The check reads the live policy, so an
operator who loads a policy module granting the access turns it off by itself --
`compute_av` starts answering ALLOW and the gate goes quiet with no flag to
remember. An escape hatch could only ever re-enable an install that provably
crash-loops.

### What this PR deliberately does NOT do

It does not add a `--user` install scope (option 1 in the issue). That is an
install-model change, not a mechanical one: it has to decide where the AppArmor
profile lives when the install needs no root, what replaces the root-owned
`/etc/kirocrew/kirocrew.env`, how `status`/`restart`/`uninstall`/`logs` become
scope-aware, and how Make Live's drop-in indirection (#1598) follows. Shipping
half of that would add a second broken path. The predicate this PR lands is the
groundwork an auto-select would call, and the issue stays open for that decision.

## What tests we did

**50 new tests** in `test/test_service_selinux.py`, all pure-logic: every kernel
interface is redirected at a `tmp_path` fake or monkeypatched, so the suite gives
identical verdicts on an AppArmor-only CI runner and on an SELinux-enforcing
workstation, and no test is ever in a position to write to real selinuxfs. That
constraint drove one design change -- the selinuxfs transport was split into
`_query_access()` so tests patch a module seam instead of `os.open`/`os.read`
globally, which breaks pytest's own I/O and leaves a test one edit away from
writing to `/sys`.

**Mutation-verified: 17/17 mutants caught.** Each guard was broken in turn and a
named test had to fail:

| mutant | caught by |
|---|---|
| enforcing check removed | `test_quiet_when_not_enforcing` |
| per-domain permissive flag ignored | `test_quiet_when_source_domain_is_permissive` |
| perm bit used as a mask without shifting | `test_bit_number_becomes_a_mask` |
| flags read from the seqno field | `test_permissive_flag_is_taken_from_the_last_field` |
| symlink not resolved before reading the label | `test_label_is_read_through_a_symlink_chain` |
| shebang interpreter never checked | `test_fires_on_a_denied_shebang_interpreter` |
| gate warns instead of refusing | `test_install_raises_before_touching_the_host` |
| user unit keeps `User=`/`Group=` | `test_user_unit_omits_user_and_group` |
| user unit keeps `multi-user.target` | `test_user_unit_wants_default_target` |
| gate asked about the wrong path | `test_gate_is_asked_about_the_unit_exec_path` |
| remedy reverts to a tilde home | `test_refusal_never_lets_the_pasting_shell_pick_the_account` |
| remedy reverts to `$USER` for linger | `test_refusal_never_lets_the_pasting_shell_pick_the_account` |
| remedy drops the run-as-root warning | `test_refusal_warns_that_a_root_shell_would_run_the_agent_as_root` |
| remedy paths unquoted (space-bearing home) | `test_remedy_quotes_a_home_containing_a_space` |
| start-failure hint never fires | `test_enforcing_host_gets_the_selinux_hypothesis_and_remedy` |
| start-failure hint fires on every host | `test_non_enforcing_host_gets_no_selinux_noise` |
| restart failure drops the hint | `test_enforcing_host_gets_the_selinux_hypothesis_and_remedy` |

**End-to-end against this host's real kernel, in two arms.** Arm A: untouched.
The host is SELinux-enabled but permissive, so the gate must stay silent -- it
did, via the real `/sys`, exercising the fail-open path. Arm B: only
`selinux_is_enforcing` forced True, every other input real -- the real
`/proc/1/attr/current` (`system_u:system_r:init_t:s0`), the real
`security.selinux` xattr of the real installed binary, and a real `compute_av`
query against the real loaded policy. It fired and named the real label. That is
the reporter's host in every respect except the one bit this machine has set
differently.

`test/test_service.py` (301 tests) passes unchanged. Four failures in it are
pre-existing and unrelated -- `TestExpectedUidOverride` / `TestATakeoverOf...`
fail with "the directory /local/home is owned by uid 65534", the single-uid
user-namespace mapping in my tool sandbox; **verified failing identically on the
base commit** before my changes. `flake8`, `isort` and `mypy` are clean on all
changed files.

### Review round 1

GPT 5.6 raised one blocking, security-class finding and it was correct, so it is
fixed rather than overridden. A user unit carries no `User=` -- the account it runs
as is whichever manager loads it -- and `service install` is documented to run
under `sudo`, so the shell reading this refusal is usually root's. My first
remedy said `mkdir -p ~/.config/systemd/user` and `loginctl enable-linger
"$USER"`, both resolved by the pasting shell: from root they name `/root` and
`root`, and the operator ends up running untrusted agent tools **as root** --
precisely the invariant `install()` enforces by refusing a `User=root` unit a few
lines earlier. The remedy now spells out the resolved account and its absolute
home, passes the account name to `loginctl` explicitly, says what a root shell
would do, and notes that `sudo -u <user>` cannot substitute (it creates no
session, so `systemctl --user` has no manager to reach). Three mutants pin it.

The first-principles review was advisory (CONCERNS) and both of its subtractions
were taken: `render_unit`'s two-value `scope` string became `user_scope: bool`
(exactly one non-default variant is ever constructed) and the four `selinux.py`
helpers are underscore-prefixed, leaving `blocks_system_unit` the module's only
public surface. Design Review PASS and Opus (no findings) needed no changes.

### Review round 2

GPT raised a second blocking finding and it is also real, though its stated
symptom is not: a `KIROCREW_SERVICE_BIN` override can name a **system-labelled
wrapper** that goes on to run a binary under `$HOME`. The pre-flight sees only the
wrapper and its shebang interpreter, both allowed, so it reports "not blocked" and
the unit still cannot serve. It does not, however, fail with `203/EXEC` -- the
wrapper execs fine, so the inner denial surfaces as the shell's exit 126. The
defect is real even though the mechanism was described wrong, so it is fixed
rather than overridden.

It is fixed at the point of failure rather than by closing the static hole,
because the hole cannot be closed soundly. Following the delegation means deciding
what an arbitrary shell script executes. The weaker version -- scanning the wrapper
for path-shaped literals -- would refuse an install over a path in a comment or an
untaken branch, since a literal appearing in a script is not proof it is ever
executed; and refusing on "cannot inspect" is the same violation from the other
side. Either would manufacture false refusals and break the fail-open rule the
whole module rests on.

So: the pre-flight's coverage boundary is now stated explicitly in the module
docstring, and `install()` covers the residue where the unit has actually failed.
When the first `systemctl restart` fails on an enforcing host, the error now names
SELinux as a candidate cause, says plainly that the pre-flight found no proven
denial and why its reach is limited, gives `ausearch -m avc -ts recent` to confirm
it, and prints the same user-scope remedy. On a non-enforcing host the message is
unchanged. That covers wrappers, computed paths, and anything else static analysis
cannot prove, and it adds no false refusals -- five mutants pin it.

The non-blocking finding was also correct and is fixed: both generated paths in the
remedy now go through `shlex.quote`, matching what `common.py` already does for the
`.env` remedy, so an account home containing a space no longer word-splits `mkdir`
and land the unit where systemd never reads it.

### Review round 3 (CI only, no new review findings)

Three CI reds, all mine, all fixed: the De-Amazon scrub lint reads `/home/two
words` (my space-bearing test fixture) as a personal home path, so the fixture is
now `/home/tester with space`, whose first segment matches the placeholder the rest
of the file already uses -- the lint passes locally. The Windows shard failed
`test_ordinary_paths_are_not_needlessly_quoted`, because `shlex.quote` is POSIX and
quotes the backslashes in a Windows path, so "needs no quoting" is only meaningful
on POSIX; that one test is now POSIX-scoped with the reason stated. The branch is
also rebased onto current `main` and squashed to one commit, which the Hygiene gate
requires (it caps a PR at two).

**One remaining red is not mine, and I proved it rather than asserting it.**
`Backend Tests (Windows) (2)` fails
`test_dashboard_cron_to_chat.py::...::test_a_repeat_is_suppressed_even_though_history_is_none`
with `assert 1 == 2`. Nothing in this diff reaches the cron-to-chat path, so I
traced the mechanism instead of waving at it. `CronJob.set_run_result()` stamps
`last_result_ts = time.time()`; `cron_inject` renders the run-boundary marker as
`<!-- ...<job.id>:<ts:.6f} -->` and the dedupe compares the whole row, so that
stamp is what makes two runs distinguishable. The test does two runs back to back
with no sleep. On Linux `time.time()` advances at microsecond scale and the markers
differ; on Windows under CPython 3.12 it comes from `GetSystemTimeAsFileTime` at
the ~15.625 ms system tick, both calls return the same float, the second row is
byte-identical, and it is dropped as a repeat. The CI Windows shard pins 3.12 on
purpose, and `time.time()`'s Windows resolution only improved in 3.13.

Confirmed by reproducing it on Linux: quantizing `time.time()` to a 15.625 ms tick
makes the identical assertion fail deterministically, with none of this change
involved; the same test passes on the same tree with the real clock. It presents as
intermittent because whether the two calls straddle a tick depends on load and on
what ran before them, which is why merely adding tests to the suite can flip it.
Filed separately as #8502 with the mechanism and the repro rather than folded in
here, and the lane is being re-run.

### Review round 4

Board on the current head: Design Review PASS, Opus 4.8 no findings, GPT 5.6 no
findings and no `[BLOCK-MERGE]`. First Principles is CONCERNS (advisory), and one of
its two subtractions was a real defect I had shipped, so it is taken.

**Taken.** The start-failure hint pasted the full 25-line user-scope remedy onto
*every* failed `systemctl restart` on *any* enforcing host -- which is all of
RHEL/Fedora -- including hosts the pre-flight had positively proved ALLOW for. A
plain port conflict on a stock RHEL box would have been answered with a wall of
SELinux text and a pasteable unit for a denial nobody had observed, and the
function's own docstring conceded the denial is a hypothesis there. The hint is now
the hypothesis, the `ausearch` command that settles it, and a pointer to the
documented remedy: 15 lines instead of 68, with the full remedy reachable only
behind a proven denial. Two tests pin it -- one asserts the remedy is absent from
the hint path, one bounds the hint's size and its ratio to the refusal.

**Declined, with reasoning.** The second subtraction asks to drop
`blocks_system_unit`'s not-blocked reason string as having zero consumers. It is
true that `install()` reads the reason only inside `if blocked:`. But that string is
what lets a test say WHICH fail-open branch fired -- `test_quiet_when_not_enforcing`
asserts `"not enforcing"` appears, rather than merely that the call returned False.
In a gate whose correctness is mostly its five distinct fail-open branches (not
enforcing, unreadable PID 1 context, no label, no policy answer, permissive domain),
collapsing them to a bare `False` removes the only evidence that the intended branch
is the one being exercised, and a test that cannot tell them apart would pass with
four of them wired to the wrong condition. Keeping ~40 bytes of reason string is
cheaper than losing that discrimination.

### What I could NOT verify, stated plainly

I did **not** install, enable, start, or modify any systemd unit, and did not run
`restorecon`, `chcon`, `semanage` or `setenforce`. This is a shared development
host with other work running on it, and changing its SELinux state or its units
would affect all of it. Concretely unverified:

1. **A real `203/EXEC` reproduction.** I did not install a system unit and watch
   it fail. The causal claim rests on the policy verdict plus systemd's
   documented behaviour when `execve` returns `EACCES`, not on an observed crash
   loop.
2. **Enforcing mode.** My host is `permissive`, so I forced the enforcing bit in
   Arm B rather than observing it. `compute_av` returns the policy decision
   independent of global mode, and `flags=0` rules out per-domain permissive, so
   the *verdict* is real -- but the *consequence* of that verdict is inferred.
3. **Bazzite's exact policy.** My host runs Amazon Linux 2023's `targeted`
   policy, Fedora-derived and the same policy name, not Bazzite's Fedora 44
   policy. `init_t`-denied-execute-on-home-labels is core refpolicy and the
   reporter's own AVC matches it, but I confirmed it on a sibling policy, not
   theirs.
4. **The wrapper case end to end.** The start-failure hint is unit-tested, but I
   did not install a wrapper unit and watch it fail with exit 126, for the same
   host-safety reason as (1).
5. **That the printed user unit starts.** I did not load it. Its scope-correctness
   is reasoned from `systemd.unit(5)` plus the reporter's own verified workaround,
   and I did confirm locally that `systemd --user` runs in `unconfined_t` (read
   from `/proc/<pid>/attr/current` on two live user managers) and that
   `unconfined_t` is allowed `execute` on `user_home_t` -- which is the structural
   reason a user unit is not affected.

The honest summary: the **cause** is directly measured, the **remedy's mechanism**
is directly measured, and the **end-to-end behaviour on an enforcing atomic
desktop** is reasoned, not observed. A maintainer with a Bazzite or Silverblue
host can close gaps 1-4 in about five minutes.

## Any other suggestions on the work

- `kirocrew doctor` should report this too, so an operator who already has a
  broken unit installed learns why without re-running `install`. Left out to keep
  this diff to one concern.
- The same question exists for pods (`kirocrew-pod@.service` is a user unit, so it
  is unaffected) and for the AppImage launcher path; neither is touched here.
- If a `--user` scope does land, the auto-select heuristic the issue asks for is
  exactly `selinux.blocks_system_unit(kirocrew_bin())` -- the predicate is already
  in the shape a caller would want.

## Pattern harvest

Rule candidate: review-checklist
Pattern: an execute-permission conclusion drawn from `os.access(path, os.X_OK)` or `test -x`. Under an LSM execute denial both return True while `execve` fails, so the check cannot fail in the failing case. Any code that gates an exec decision on a mode test needs a second question: is the *caller's domain* permitted to execute it?

Rule candidate: semgrep
Pattern: a test that monkeypatches `os.open` / `os.read` / `os.write` to fake a `/sys` or `/proc` interface. It breaks pytest's own I/O and leaves the test one edit away from performing the real write; the fix is to extract a module-level transport seam and patch that.

### Supporting notes

- **`203/EXEC` is four different bugs wearing one error code.** Before fixing an
  exec failure, name which of "absent / not executable / bad interpreter / policy
  denied" it is. They are indistinguishable in `systemctl status` and have
  disjoint fixes.
- **State what a positive would have looked like before trusting one.** Here
  `getattr` is ALLOW while `execute` is DENY, so "the path exists and is
  executable" returns True in precisely the broken case. This generalises past
  SELinux: whenever a denial and a success share an observable, find the
  observable that separates them.
- **A policy question has a read-only oracle; use it instead of an experiment.**
  `/sys/fs/selinux/access` answers "would this be allowed?" without performing
  the action, needing root, or changing any state. Reaching for `ausearch` after
  a crash-loop is the same answer obtained destructively and later.
- **Gate on the mechanism, never the distro** (inherited from `apparmor.py`, and
  it paid off again). The gate fired on `default_t` on my host and `user_home_t`
  on the reporter's; any type-name or distro match would have missed one of them.
- **A diagnostic that can refuse must fail open on every indeterminate answer.**
  Enumerate the "cannot tell" branches explicitly -- absent interface, unreadable
  label, refused query, truncated reply, permissive domain -- and route them all
  to "proceed".
- **Prove a pre-existing failure on the base commit before attributing it to the
  environment.** The four `uid 65534` failures were confirmed identical on base;
  saying "sandbox artifact" without that check is a guess.
- **Never print a command you have not confirmed ships.** My first draft of the
  refusal told operators to run `kirocrew service print-unit`, which does not
  exist -- the subcommand list is `install`/`uninstall`/`status`. There is now a
  test asserting the message names only real subcommands, because a remedy that
  sends the user to `invalid choice` is worse than no remedy.

Fixes #7165
