### PR TITLE
fix(sandbox): hoist launcher imports before isolation (#8151)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
@@ -107,7 +107,95 @@ def _git_env(*, network_protocol: str = "") -> dict[str, str]:
     return env
 
 
+class IsolationProbeError(RuntimeError):
+    """The push-isolation probe COULD NOT RUN — its sandbox launcher failed.
+
+    Raised instead of the fail-closed ``False`` because the two nonzero exits
+    mean opposite things: a probe that RAN and found a live url is a repository
+    problem ("re-run repository setup" fixes it), while a probe whose launcher
+    died before ``git`` executed says nothing about the remotes and setup
+    cannot fix it. Subclasses ``RuntimeError`` so the run-start route's
+    existing handler surfaces the message verbatim instead of a 500.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(
+            "the push-isolation probe could not run: the sandbox launcher "
+            "failed before git executed"
+            + (f" ({detail})" if detail else "")
+            + " — the clone's remote urls were never read, so this is a "
+            "sandbox failure, not a live push url; fix the sandbox (see the "
+            "gateway log) rather than re-running repository setup"
+        )
+        self.detail = detail
+
+
+#: Signatures only the namespace-sandbox launcher emits on stderr, matched
+#: STRUCTURALLY so repository-influenced text cannot satisfy them (raised by
+#: the Opus review of this branch): a repo may legally be NAMED
+#: ``kirocrew_sandbox_x`` (``_GITHUB_RE`` admits ``_``), which puts that
+#: substring into the clone PATH that git echoes on path-printing fatals — so
+#: the script-filename marker only counts inside a real Python traceback frame
+#: (``File "…kirocrew_sandbox_….py"`` plus the ``Traceback`` banner, a shape
+#: git never prints), and the launcher's deliberate refusal prefixes must
+#: START a stderr line (owner/repo names cannot contain a space or colon, so
+#: no echoed path can begin a line with ``sandbox: ``). ``sandbox: WARNING``
+#: is deliberately NOT classified: the launcher warns and then still runs the
+#: command, so a warning can coexist with git's own exit code and must not
+#: reclassify it. The prefixes are pinned against the generated launcher by a
+#: round-trip test so this list cannot drift silently.
+_LAUNCHER_EXIT_PREFIXES = (
+    "sandbox: BLOCKED",
+    "sandbox: FATAL",
+    "sandbox: unshare(",
+    "sandbox_launcher:",
+)
+_LAUNCHER_TRACEBACK_RE = re.compile(r'^\s*File "[^"\n]*kirocrew_sandbox_[^"\n]*\.py"', re.MULTILINE)
+
+
+def _launcher_failure_detail(stderr: str) -> str | None:
+    """The bounded, redacted detail line when *stderr* shows the sandbox
+    launcher itself failed, else ``None`` (the exit code is git's own)."""
+    lines = [line.strip() for line in stderr.strip().splitlines() if line.strip()]
+    launcher_failed = any(line.startswith(_LAUNCHER_EXIT_PREFIXES) for line in lines) or (
+        "Traceback (most recent call last)" in stderr
+        and _LAUNCHER_TRACEBACK_RE.search(stderr) is not None
+    )
+    if not launcher_failed:
+        return None
+    # The surfaced message carries only a bounded tail; the full (redacted,
+    # bounded) stderr goes to the log here, at the one classification site, so
+    # "see the gateway log" in the raised message is a promise that is kept.
+    logger.error(
+        "push-isolation probe could not run — sandbox launcher stderr (redacted): %s",
+        redact_via_context(stderr.strip())[:2000],
+    )
+    # The last line is the significant one for both failure shapes: a Python
+    # traceback ends with the exception ("ModuleNotFoundError: ..."), and the
+    # launcher's own sys.exit messages lead with their prefix.
+    tail = lines[-1] if lines else ""
+    # Redact BEFORE the bound, same as every stderr surface in this module.
+    return redact_via_context(tail)[:200]
+
+
 def _origin_urls(repo: Path, *, push: bool) -> list[str] | None:
+    """Read origin's fetch/push urls from the clone's local config, as data.
+
+    Returns the url list, ``[]`` when the key is absent, or ``None`` for an
+    ambiguous git failure (callers fail closed on ``None``). Raises
+    :class:`IsolationProbeError` for the one nonzero exit that is NOT evidence
+    about the remotes at all: a namespace-sandbox launcher dying before git
+    executed, identified by the launcher's own stderr signature. This module
+    spawns git directly, so no launcher exists in this probe's chain on a
+    stock install — the signature appears only on deployments that route the
+    gateway's subprocesses through the sandbox (the issue #8151 host, where
+    every ``git remote get-url`` probe carried the launcher's traceback), and
+    the classification is inert everywhere else because the structural
+    matching in :func:`_launcher_failure_detail` cannot be satisfied by git's
+    own output. Collapsing that crash into the fail-closed path reported
+    "push is not disabled" for a clone whose remotes were never read — the
+    misleading 409 in issue #8151.
+    """
     key = "remote.origin.pushurl" if push else "remote.origin.url"
     try:
         proc = subprocess.run(
@@ -130,6 +218,10 @@ def _origin_urls(repo: Path, *, push: bool) -> list[str] | None:
         )
     except (OSError, subprocess.SubprocessError):
         return None
+    if proc.returncode != 0:
+        detail = _launcher_failure_detail(proc.stderr or "")
+        if detail is not None:
+            raise IsolationProbeError(detail)
     if proc.returncode == 1:
         return []
     if proc.returncode != 0:
@@ -308,7 +400,14 @@ def _push_disabled(repo: Path) -> bool:
 
 
 def _repository_is_isolated(repo: Path) -> bool:
-    """True only when metadata/config is safe and every origin URL is disabled."""
+    """True only when metadata/config is safe and every origin URL is disabled.
+
+    Fails CLOSED (``False``) for ambiguous git errors, but raises
+    :class:`IsolationProbeError` when the probe's sandbox launcher crashed
+    before git executed — that exit is not evidence about the remotes, and
+    reporting it as "push is not disabled" hid the real failure (#8151). Both
+    outcomes refuse to start; only the surfaced reason differs.
+    """
     return _repository_is_safe(repo) and _push_disabled(repo)
 
 
@@ -416,6 +515,23 @@ def validate_target_url(url: str) -> tuple[CloneSpec | None, str]:
 
 
 def setup_safe_clone(url: str, scratch_root: Path, *, timeout_s: int = 300) -> tuple[dict, str]:
+    """Public entry: clone (or reuse) with push disabled. Returns ``(result, err)``.
+
+    A probe whose sandbox launcher crashed surfaces as the error string, not as
+    an exception: this function's callers consume ``(result, err)`` tuples off
+    a worker thread, and a raise here would turn a diagnosable sandbox failure
+    into a 500. The clone (when one exists) is deliberately left in place —
+    its remotes were never read, so there is no isolation verdict to act on,
+    and deleting a good clone over an unrelated sandbox failure only forces a
+    re-download after the sandbox is fixed.
+    """
+    try:
+        return _setup_safe_clone(url, scratch_root, timeout_s=timeout_s)
+    except IsolationProbeError as exc:
+        return {}, str(exc)
+
+
+def _setup_safe_clone(url: str, scratch_root: Path, *, timeout_s: int = 300) -> tuple[dict, str]:
     """Validate and install/reuse the canonical push-disabled clone.
 
     Reuse attests only enforceable properties: canonical location, safe Git
@@ -536,7 +652,11 @@ def list_clone_branches(clone: Path, *, timeout_s: int = 30) -> tuple[list[str],
         return [], f"Not a git clone: {clone}"
     if not _repository_is_safe(clone):
         return [], "clone Git metadata failed safety verification"
-    if not _push_disabled(clone):
+    try:
+        disabled = _push_disabled(clone)
+    except IsolationProbeError as exc:
+        return [], str(exc)
+    if not disabled:
         return [], "clone is not push-disabled"
     proc = subprocess.run(
         [
@@ -807,7 +927,11 @@ def checkout_branch(clone: Path, branch: str, *, timeout_s: int = 120) -> tuple[
         return False, f"invalid branch name: {branch!r}"
     if not _repository_is_safe(clone):
         return False, "clone Git metadata failed safety verification"
-    if not _push_disabled(clone):
+    try:
+        disabled = _push_disabled(clone)
+    except IsolationProbeError as exc:
+        return False, str(exc)
+    if not disabled:
         return False, "clone is not push-disabled"
 
     def _run(*args: str, tmo: int = timeout_s) -> subprocess.CompletedProcess:

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/commit.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/commit.py
@@ -32,7 +32,7 @@ from ..spine.push_policy import (
     scan_content_for_secrets,
 )
 from . import store
-from .clone_setup import _repository_is_isolated, resolve_origin_url
+from .clone_setup import IsolationProbeError, _repository_is_isolated, resolve_origin_url
 
 logger = logging.getLogger(__name__)
 
@@ -261,8 +261,13 @@ def _commit_finding_locked(fp: str) -> dict[str, object]:
     # push. Rechecking only after creating the provisional commit is unsound: once that
     # check fails, rollback Git would itself trust the repository just declared unsafe,
     # while returning without rollback leaves a rejected commit as a future baseline.
-    if not _repository_is_isolated(clone):
-        return {"ok": False, "error": "repository isolation check failed — re-run setup"}
+    try:
+        if not _repository_is_isolated(clone):
+            return {"ok": False, "error": "repository isolation check failed — re-run setup"}
+    except IsolationProbeError as exc:
+        # A crashed probe is a sandbox failure, not an isolation verdict — re-running
+        # setup cannot fix it, so surface the real reason instead (#8151).
+        return {"ok": False, "error": str(exc)}
 
     diff_text = diff_path.read_text(encoding="utf-8")
     if not diff_text.strip():

--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/routes.py
@@ -798,7 +798,12 @@ async def _handle_draft_pr(request: web.Request) -> web.StreamResponse:
         clone = str(config.get("clone") or "").strip()
         if not clone:
             return {"ok": False, "error": "no repository configured"}
-        if not clone_setup._repository_is_isolated(Path(clone)):
+        try:
+            isolated = clone_setup._repository_is_isolated(Path(clone))
+        except clone_setup.IsolationProbeError as exc:
+            # Sandbox failure, not an isolation verdict — name it (#8151).
+            return {"ok": False, "error": str(exc)}
+        if not isolated:
             return {"ok": False, "error": "repository isolation check failed — re-run setup"}
 
         body = body_path.read_text(encoding="utf-8")
@@ -956,7 +961,14 @@ async def _handle_draft_pr(request: web.Request) -> web.StreamResponse:
     if result.get("ok"):
         return web.json_response(result, status=200)
     return web.json_response(
-        {"code": "draft_pr_failed", "error": str(result.get("detail") or "")},
+        {
+            "code": "draft_pr_failed",
+            # `_draft()`'s failure dicts carry `error`; `detail` is kept as the
+            # legacy fallback. Reading only `detail` serialized every failure —
+            # including the sandbox-launcher diagnosis this route now surfaces —
+            # as an empty string. Raised by the GPT review of this branch.
+            "error": _redact_for_display(str(result.get("error") or result.get("detail") or "")),
+        },
         status=400,
     )
 
@@ -1374,6 +1386,14 @@ async def _handle_run_start(_request: web.Request) -> web.StreamResponse:
 
     try:
         result = await asyncio.to_thread(_start)
+    except clone_setup.IsolationProbeError as exc:
+        # Before the generic clause: this subclasses RuntimeError, but it is a
+        # sandbox-launcher failure, not a config/state conflict — a distinct
+        # `code` so a UI branching on it does not render the misleading
+        # push-isolation guidance (#8151). The message is the actionable part.
+        return web.json_response(
+            {"code": "sandbox_launcher_failed", "error": str(exc)}, status=409
+        )
     except (RuntimeError, ValueError, PermissionError) as exc:
         # Already running / no repository configured / push not disabled — all three are
         # "the request conflicts with current state", all three are user-fixable, and the

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/pr_recipe.py
@@ -386,9 +386,15 @@ class GitHubPRRecipe:
 
     def _push_fix_branch(self, *, branch: str) -> tuple[bool, str]:
         """Push HEAD to ``branch`` on the fetch url. Returns (ok, note)."""
-        from ...backend.clone_setup import _repository_is_isolated
+        from ...backend.clone_setup import IsolationProbeError, _repository_is_isolated
 
-        if not _repository_is_isolated(self.clone_path):
+        try:
+            isolated = _repository_is_isolated(self.clone_path)
+        except IsolationProbeError as exc:
+            # Sandbox failure, not an isolation verdict — the note must not
+            # read as if the repository changed under review (#8151).
+            return False, str(exc)
+        if not isolated:
             return False, "repository isolation changed after review"
         url = self._resolve_fetch_url()
         if not url:

--- a/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/profiles/github_repo/profile.py
@@ -1379,13 +1379,21 @@ class RepoIsolation:
         gated recording the clone in the first place, so the setup-time check and this
         run-time check cannot drift apart and disagree. Fails CLOSED: any git error,
         timeout, or unreadable url reads as "push is NOT disabled" and the driver
-        refuses to start.
+        refuses to start — except the launcher-crash class below, which raises instead
+        of returning ``False`` (the run still refuses to start).
 
         BOTH urls, not just the push url: a live FETCH url is a live push target
         (``git push "$(git remote get-url origin)" HEAD`` ignores the push url entirely
         and writes to the fetch url — see ``clone_setup._disable_push``). Checking only
         the push url reported "disabled" for a clone that could still write to the remote;
         `_ok` checks both, and this drifted from it. Raised by the GPT review of this branch.
+
+        One nonzero probe exit is NOT read as a live remote: when the probe's own
+        sandbox launcher crashed before git executed, this propagates
+        ``clone_setup.IsolationProbeError`` instead of returning ``False``. The run
+        still refuses to start either way — the exception exists so the surfaced
+        reason names the sandbox failure rather than the misleading
+        "push is not disabled" (#8151).
         """
 
         from ...backend.clone_setup import _repository_is_isolated

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
@@ -283,12 +283,43 @@ class Driver:
         )
         self._stop = False
         self._repository_retired = False
+        # Terminal latch for a probe whose sandbox launcher crashed: set (then
+        # re-raised) by `_retire_if_unsafe`. Some intermediate layers catch
+        # broadly to keep a run alive (per-candidate error containment), so
+        # `run()` re-raises this before returning stats — otherwise a run
+        # aborted by a safety-probe failure would be recorded as STATUS_DONE.
+        # Raised by the GPT review of this branch.
+        self._probe_failure: Exception | None = None
 
     def _retire_if_unsafe(self, stage: str) -> bool:
         """Stop and atomically retire the clone if post-agent validation fails."""
-        from ..backend.clone_setup import _repository_is_isolated, _retire_unsafe_clone
+        from ..backend.clone_setup import (
+            IsolationProbeError,
+            _repository_is_isolated,
+            _retire_unsafe_clone,
+        )
 
-        if _repository_is_isolated(self.clone):
+        try:
+            isolated = _repository_is_isolated(self.clone)
+        except IsolationProbeError as exc:
+            # The probe could not RUN — its sandbox launcher died before git
+            # executed, which says nothing about the clone. Do NOT retire:
+            # retiring renames away a clone whose remotes were never read,
+            # destroying good state over an unrelated sandbox failure (#8151).
+            # The tightened signature match in `_launcher_failure_detail` is
+            # what keeps this branch unreachable for ambiguous or
+            # repository-influenced errors — those still return False below
+            # and retire as before. Re-raise after recording: swallowing here
+            # let `driver.run()` return normally, so the supervisor recorded
+            # STATUS_DONE for a run aborted by a safety-probe failure (raised
+            # by the GPT review of this branch); the run-loop's catch-all
+            # records STATUS_ERROR with this message instead.
+            self._stop = True
+            self._probe_failure = exc
+            self.log.error("isolation probe could not run after %s: %s", stage, exc)
+            self._progress(stage="isolation_probe_failed", error=str(exc))
+            raise
+        if isolated:
             return False
         retained = _retire_unsafe_clone(self.clone)
         self._repository_retired = True
@@ -2077,6 +2108,12 @@ class Driver:
                 self.stats.filed,
                 self.stats.errors,
             )
+        if self._probe_failure is not None:
+            # A safety probe that could not run aborted this run; per-candidate
+            # error containment may have swallowed the in-flight raise, so
+            # re-raise here where the supervisor's catch-all records
+            # STATUS_ERROR instead of reading the early stop as DONE.
+            raise self._probe_failure
         return self.stats
 
     def request_stop(self) -> None:

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py
@@ -1,0 +1,183 @@
+"""A crashed isolation probe must surface as a sandbox failure, never as
+"push is not disabled".
+
+Issue #8151: on a host whose LSM kills the namespace-sandbox launcher (AppArmor
+unprivileged-userns restriction), the ``git remote``/``config`` probe exits
+nonzero with the launcher's traceback on stderr. ``_push_disabled`` fail-closed
+that exit into ``False`` and the run-start route reported the 409
+"the clone's push is not disabled — re-run repository setup" for a clone whose
+remotes were never read. These tests pin the distinction:
+
+* an unambiguous launcher signature on stderr + nonzero exit →
+  :class:`IsolationProbeError` naming the sandbox failure (still refuses to
+  start — the surfaced REASON is what changes);
+* every other nonzero exit keeps its existing fail-closed meaning — git's own
+  exit 1 for an absent config key, a launcher WARNING that coexists with a
+  genuine git exit code, an ambiguous fatal, and (the Opus finding on this
+  branch) a git fatal that merely ECHOES a clone path containing the launcher
+  filename substring, which a repository named ``kirocrew_sandbox_x`` can put
+  there legally;
+* tuple-returning entry points (``setup_safe_clone``, ``list_clone_branches``,
+  ``checkout_branch``) convert the raise into their error string instead of
+  letting it escape a worker thread as a 500.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.apps.builtins.auto_improvement.backend import clone_setup
+from kiro_crew.apps.builtins.auto_improvement.profiles.github_repo.profile import (
+    RepoIsolation,
+)
+
+#: The reported crash verbatim (issue #8151): a real Python traceback naming the
+#: launcher's own script file — the frame line plus the banner are what the
+#: structural matcher requires.
+_LAUNCHER_TRACEBACK = (
+    "Traceback (most recent call last):\n"
+    '  File "/home/user/.config/kirocrew/run/kirocrew_sandbox_ab12cd.py", '
+    "line 293, in main\n"
+    "    import platform as _plat\n"
+    "ModuleNotFoundError: No module named 'platform'\n"
+)
+
+_PUSH_ISOLATION_MESSAGE = "push is not disabled"
+
+
+def _proc(returncode: int, stderr: str = "", stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["git"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+@pytest.fixture
+def probe_result(monkeypatch: pytest.MonkeyPatch):
+    """Route ``clone_setup``'s git probe to a canned result."""
+
+    holder: dict = {"proc": _proc(0, stdout="DISABLED_NO_PUSH\n")}
+
+    def _fake_run(*_args, **_kwargs):
+        return holder["proc"]
+
+    monkeypatch.setattr(clone_setup.subprocess, "run", _fake_run)
+    return holder
+
+
+class TestProbeCrashShape:
+    def test_launcher_traceback_raises_probe_error(self, probe_result: dict) -> None:
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        with pytest.raises(clone_setup.IsolationProbeError) as excinfo:
+            clone_setup._push_disabled(Path("/nonexistent/clone"))
+        message = str(excinfo.value)
+        assert "sandbox launcher" in message
+        assert "ModuleNotFoundError: No module named 'platform'" in message
+        # The whole point: the surfaced error must NOT be the push-isolation shape.
+        assert _PUSH_ISOLATION_MESSAGE not in message
+
+    def test_launcher_blocked_message_raises_probe_error(self, probe_result: dict) -> None:
+        probe_result["proc"] = _proc(
+            1, stderr="sandbox: BLOCKED — failed to install seccomp-BPF filter (prctl returned -1)"
+        )
+        with pytest.raises(clone_setup.IsolationProbeError):
+            clone_setup._push_disabled(Path("/nonexistent/clone"))
+
+    def test_absent_key_is_still_not_a_crash(self, probe_result: dict) -> None:
+        """git's own exit 1 (config key absent, empty stderr) keeps meaning []."""
+        probe_result["proc"] = _proc(1)
+        assert clone_setup._origin_urls(Path("/nonexistent/clone"), push=True) == []
+        assert clone_setup._push_disabled(Path("/nonexistent/clone")) is False
+
+    def test_launcher_warning_does_not_reclassify_git_exit(self, probe_result: dict) -> None:
+        """The launcher warns and still runs the command, so a WARNING line can
+        coexist with git's own exit code and must keep git's meaning."""
+        probe_result["proc"] = _proc(
+            1, stderr="sandbox: WARNING — cannot read /home/user/.aws/config (denied)"
+        )
+        assert clone_setup._origin_urls(Path("/nonexistent/clone"), push=True) == []
+
+    def test_ambiguous_git_error_stays_fail_closed(self, probe_result: dict) -> None:
+        probe_result["proc"] = _proc(128, stderr="fatal: not a git repository")
+        assert clone_setup._origin_urls(Path("/nonexistent/clone"), push=True) is None
+        assert clone_setup._push_disabled(Path("/nonexistent/clone")) is False
+
+    def test_a_repo_named_like_the_launcher_cannot_spoof_the_signature(
+        self, probe_result: dict
+    ) -> None:
+        """Repository-influenced text must not satisfy the launcher markers.
+
+        A repo may legally be NAMED ``kirocrew_sandbox_x`` (the owner/repo
+        charset admits ``_``), which puts the launcher-filename substring into
+        the clone PATH that git echoes on path-printing fatals. That must stay
+        an AMBIGUOUS error (fail closed, ``None``), never a launcher crash —
+        otherwise a repository name could suppress clone retirement on the
+        driver path. Raised by the Opus review of this branch.
+        """
+        probe_result["proc"] = _proc(
+            128,
+            stderr=(
+                "fatal: bad config line 1 in file " "/scratch/owner--kirocrew_sandbox_x/.git/config"
+            ),
+        )
+        assert clone_setup._origin_urls(Path("/nonexistent/clone"), push=True) is None
+        assert clone_setup._push_disabled(Path("/nonexistent/clone")) is False
+
+    def test_a_mid_line_prefix_does_not_reclassify(self, probe_result: dict) -> None:
+        """The refusal prefixes only count at line START — text merely
+        containing them (an echoed value, a wrapped message) stays git's own."""
+        probe_result["proc"] = _proc(
+            128, stderr="fatal: unexpected value 'sandbox: BLOCKED' in config"
+        )
+        assert clone_setup._origin_urls(Path("/nonexistent/clone"), push=True) is None
+
+    def test_repo_isolation_propagates_probe_error(
+        self, probe_result: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``RepoIsolation.push_disabled`` (the run-start gate) lets the typed
+        error reach the route handler, which maps it to the distinct
+        ``sandbox_launcher_failed`` code — that is what replaces the misleading
+        409 text."""
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _repo: True)
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        isolation = RepoIsolation(clone_path=Path("/nonexistent/clone"))
+        with pytest.raises(clone_setup.IsolationProbeError):
+            isolation.push_disabled()
+        assert issubclass(clone_setup.IsolationProbeError, RuntimeError)
+
+
+class TestTupleEntryPointsStaySoft:
+    """(result, err) / (ok, note) surfaces must not leak the raise."""
+
+    def test_setup_safe_clone_returns_error_string(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(*_args, **_kwargs):
+            raise clone_setup.IsolationProbeError("ModuleNotFoundError: No module named 'platform'")
+
+        monkeypatch.setattr(clone_setup, "_setup_safe_clone", _boom)
+        result, err = clone_setup.setup_safe_clone(
+            "https://github.com/o/r", Path("/nonexistent/scratch")
+        )
+        assert result == {}
+        assert "sandbox launcher" in err
+        assert _PUSH_ISOLATION_MESSAGE not in err
+
+    def test_list_clone_branches_returns_error_string(
+        self, probe_result: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _repo: True)
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        branches, err = clone_setup.list_clone_branches(tmp_path)
+        assert branches == []
+        assert "sandbox launcher" in err
+
+    def test_checkout_branch_returns_error_string(
+        self, probe_result: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(clone_setup, "_repository_is_safe", lambda _repo: True)
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        ok, note = clone_setup.checkout_branch(tmp_path, "main")
+        assert ok is False
+        assert "sandbox launcher" in note

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2840,6 +2840,18 @@ import os
 import stat
 import tempfile
 
+# Hoisted from Steps 5/6 (used only AFTER unshare()+mount isolation): a
+# FIRST-TIME stdlib import reads module files off disk, and once the child has
+# entered its user+mount namespaces that read can be denied by the host's LSM
+# (seen in the wild: Ubuntu 24.04 with apparmor_restrict_unprivileged_userns=1
+# denies the post-unshare read, so ``import platform`` at seccomp-install time
+# died with ModuleNotFoundError and every sandboxed spawn failed -- #8151).
+# Import EVERYTHING this launcher needs while it is still pre-isolation, so no
+# post-isolation code ever touches the filesystem for stdlib. The static-scan
+# test pins this: every import in this generated script must be module-level.
+import platform as _plat
+import struct as _struct
+
 _CLONE_NEWUSER = 0x10000000
 _CLONE_NEWNS   = 0x00020000
 _MS_RDONLY     = 1
@@ -3103,7 +3115,8 @@ def main():
                     fh.write(expose_data[src_path])
                 # NOTE: this runs inside the embedded Linux-only namespace
                 # launcher script (a standalone /tmp file that imports only
-                # stdlib — sys/ctypes/os/tempfile — and never kiro_crew), so it
+                # stdlib — sys/ctypes/os/stat/tempfile/platform/struct — and
+                # never kiro_crew), so it
                 # must stay a raw os.chmod, NOT platform_compat.chmod_safe
                 # (which is undefined in that process). The launcher never runs
                 # on Windows, so there is no portability loss.
@@ -3216,7 +3229,9 @@ def main():
         # Inside the user namespace, the child has CAP_SYS_ADMIN (owner of the
         # NS) which lets it umount the credential bind-mounts. Drop ALL
         # capabilities from the bounding set and set NO_NEW_PRIVS before exec.
-        import struct as _struct
+        # (_struct is imported in the preamble, pre-isolation -- see the hoist
+        # note there; importing it HERE crashed under AppArmor userns
+        # restriction, #8151.)
 
         _PR_SET_NO_NEW_PRIVS = 38
         _PR_CAPBSET_DROP = 24
@@ -3305,7 +3320,9 @@ def main():
             # setns=308, pivot_root=155, kill=62
             # aarch64: mount=40, umount2=39, unshare=97, setns=268,
             # pivot_root=41, kill=129
-            import platform as _plat
+            # (_plat is imported in the preamble, pre-isolation -- importing it
+            # HERE was the reported #8151 crash: the post-unshare first-time
+            # stdlib read was denied and the whole launcher died.)
             _machine = _plat.machine()
             if _machine == "x86_64":
                 _DENY_SYSCALLS = (165, 166, 272, 308, 155)

--- a/test/test_ai_backend_routes_coverage.py
+++ b/test/test_ai_backend_routes_coverage.py
@@ -1677,6 +1677,23 @@ class TestRunEngine:
         assert payload["code"] == "session_conflict"
         assert payload["error"] == str(exc)
 
+    async def test_a_probe_launcher_crash_gets_its_own_code(
+        self, supervisor: FakeSupervisor
+    ) -> None:
+        """A crashed isolation probe is a sandbox failure, not a state conflict:
+        a UI branching on `code` must not render the push-isolation guidance
+        for it (#8151). It subclasses RuntimeError, so without the dedicated
+        clause it would fall into `session_conflict`."""
+        supervisor.start_raises = clone_setup.IsolationProbeError(
+            "ModuleNotFoundError: No module named 'platform'"
+        )
+        response = await routes._handle_run_start(_request("POST"))
+        assert response.status == 409
+        payload = _json_of(response)
+        assert payload["code"] == "sandbox_launcher_failed"
+        assert "sandbox launcher" in payload["error"]
+        assert "push is not disabled" not in payload["error"]
+
     async def test_status_reads_in_memory_state_only(self, supervisor: FakeSupervisor) -> None:
         supervisor._status = runner.STATUS_RUNNING
         payload = _json_of(await routes._handle_run_status(_request()))

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -946,19 +946,21 @@ class TestBuildLauncherScript:
         assert "unknown arch" not in script
 
         # Execute the arch-dispatch block itself, so this proves the refusal
-        # FIRES rather than that its message is present as text.
+        # FIRES rather than that its message is present as text. The block
+        # starts at the machine read: ``import platform`` no longer sits here —
+        # it is hoisted to the preamble so no first-time stdlib import runs
+        # after namespace/mount isolation (#8151).
         lines = script.splitlines()
         start = -1
         end = -1
         for index, line in enumerate(lines):
-            if start < 0 and line.strip() == "import platform as _plat":
+            if start < 0 and line.strip() == "_machine = _plat.machine()":
                 start = index
             elif start >= 0 and "if _DENY_SYSCALLS:" in line:
                 end = index
                 break
         assert start >= 0 and end > start, "arch-dispatch block not found"
         block = textwrap.dedent("\n".join(lines[start:end]))
-        block = block.replace("import platform as _plat", "")
 
         class _FakePlat:
             def __init__(self, machine):

--- a/test/test_sandbox_launcher_import_hoist.py
+++ b/test/test_sandbox_launcher_import_hoist.py
@@ -1,0 +1,158 @@
+"""The namespace launcher must import everything BEFORE entering isolation.
+
+A first-time stdlib import reads module files off disk. The launcher's Steps
+5/6 (capability drop, seccomp install) run in the child AFTER
+``unshare(NEWUSER)`` + ``unshare(NEWNS)`` + the mount masking, and on a host
+whose LSM restricts unprivileged user namespaces that post-unshare read is
+denied: Ubuntu 24.04 with ``apparmor_restrict_unprivileged_userns=1`` killed
+``import platform`` at seccomp-install time with ``ModuleNotFoundError``, so
+every sandboxed spawn died inside the launcher (#8151). The isolation probe in
+Auto-Improvement then read that crash as "push is not disabled".
+
+The structural rule these tests pin: every ``import`` in the generated launcher
+is MODULE-LEVEL. Module scope runs pre-fork, pre-unshare, so a module-level
+import can never hit the post-isolation filesystem denial; an import nested in
+any function/branch executes wherever its enclosing code does, which for this
+script means potentially after isolation. Asserting "module-level only" is
+stricter than "not after unshare" but needs no control-flow analysis and leaves
+no room for a future lazy import to creep back in past the exact line the bug
+sat on.
+
+Assertions run over the parsed AST, not the source text: the launcher's
+comments narrate the hoist (naming ``import platform``), so a substring match
+would pass on prose alone. Built inside a fixture and Linux-marked for the same
+reasons as ``test_sandbox_launcher_libc_load.py``: ``_build_launcher_script``
+calls ``os.getuid()``, absent on Windows.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+
+import pytest
+
+from kiro_crew.sandbox import _build_launcher_script
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="the namespace launcher is Linux-only: _build_launcher_script uses "
+    "os.getuid() (absent on Windows)",
+)
+
+#: Every launcher variant: the template branches on level (dir lists, expose
+#: files), so asserting one level could miss an import reintroduced in a branch
+#: another level renders.
+_LEVELS = ("standard", "cc", "strict")
+
+
+@pytest.fixture(params=_LEVELS, ids=_LEVELS)
+def launcher_tree(request: pytest.FixtureRequest) -> ast.Module:
+    """Parsed launcher for one sandbox level.
+
+    Parsing doubles as a syntax regression on the generated f-string template.
+    """
+    return ast.parse(_build_launcher_script(request.param))
+
+
+def test_every_launcher_import_is_module_level(launcher_tree: ast.Module) -> None:
+    """No import may execute after namespace/mount isolation.
+
+    The only sanctioned position is a direct child of the module body, which
+    runs before ``fork()`` and therefore before either ``unshare()``. Imports
+    nested in module-level ``if``/``try`` blocks are refused too: they would
+    pass a naive indentation check while still being conditional.
+    """
+    module_level = {id(node) for node in launcher_tree.body}
+    offenders = [
+        f"line {node.lineno}: {ast.dump(node)[:120]}"
+        for node in ast.walk(launcher_tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom)) and id(node) not in module_level
+    ]
+    assert not offenders, (
+        "the generated launcher contains non-module-level import(s); a first-time "
+        "import after unshare()+mount isolation is denied on LSM-restricted hosts "
+        "(#8151) — hoist them into the preamble:\n" + "\n".join(offenders)
+    )
+
+
+def test_post_isolation_modules_are_imported_in_preamble(launcher_tree: ast.Module) -> None:
+    """The two modules Steps 5/6 use must be present at module level.
+
+    Guards the other direction: deleting the hoisted imports would satisfy the
+    module-level-only test while breaking the launcher at runtime.
+    """
+    imported = {
+        alias.name
+        for node in launcher_tree.body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    assert {"platform", "struct"} <= imported, (
+        f"launcher preamble imports {sorted(imported)} — 'platform' (seccomp arch "
+        "table) and 'struct' (BPF packing) are used after isolation and must be "
+        "imported before it"
+    )
+
+
+def test_syspath_purge_precedes_every_filesystem_import(launcher_tree: ast.Module) -> None:
+    """The stdlib-shadowing hardening must stay ahead of the hoisted imports.
+
+    The launcher strips its own script directory from ``sys.path`` before any
+    import that resolves from the filesystem — a sibling ``struct.py`` left in
+    the run/ directory would otherwise shadow the real stdlib. Module-level
+    placement alone (the tests above) stays green if a future edit moves an
+    import ABOVE that purge, silently reinstating the shadowing bug. Only
+    ``import sys`` may precede it: ``sys`` is a builtin and cannot be shadowed,
+    and the purge itself needs it. Raised by the Opus review of this branch.
+    """
+    purge_index = next(
+        (
+            i
+            for i, node in enumerate(launcher_tree.body)
+            if isinstance(node, ast.Assign) and ast.unparse(node).startswith("sys.path[:] =")
+        ),
+        None,
+    )
+    assert purge_index is not None, "the sys.path shadowing purge is gone from the launcher"
+    for i, node in enumerate(launcher_tree.body):
+        if not isinstance(node, (ast.Import, ast.ImportFrom)):
+            continue
+        names = [alias.name for alias in node.names] if isinstance(node, ast.Import) else []
+        if names == ["sys"]:
+            continue
+        assert i > purge_index, (
+            f"launcher line {node.lineno} imports {names or ast.dump(node)[:60]} BEFORE the "
+            "sys.path purge — a sibling module in the launcher's own directory would "
+            "shadow the real stdlib there"
+        )
+
+
+@pytest.mark.parametrize("level", _LEVELS)
+def test_probe_failure_markers_round_trip_against_the_launcher(level: str) -> None:
+    """The probe's launcher-failure signature must track what the launcher emits.
+
+    ``clone_setup._LAUNCHER_EXIT_PREFIXES`` classifies a nonzero probe exit as
+    a launcher failure; each prefix must exist in the generated launcher (and
+    the traceback marker must match the launcher's real filename prefix), or
+    the list has drifted and real launcher deaths fall back to the misleading
+    push-isolation refusal this pairing exists to prevent (#8151).
+    """
+    import inspect
+
+    import kiro_crew.sandbox as sandbox_mod
+    from kiro_crew.apps.builtins.auto_improvement.backend.clone_setup import (
+        _LAUNCHER_EXIT_PREFIXES,
+    )
+
+    script = _build_launcher_script(level)
+    for prefix in _LAUNCHER_EXIT_PREFIXES:
+        assert prefix in script, (
+            f"probe marker {prefix!r} no longer appears in the generated launcher — "
+            "update clone_setup._LAUNCHER_EXIT_PREFIXES together with the launcher"
+        )
+    # The traceback-frame marker keys on the launcher's on-disk filename prefix.
+    assert 'prefix=f"kirocrew_sandbox_' in inspect.getsource(sandbox_mod), (
+        "the launcher's tempfile prefix changed — update the traceback regex in "
+        "clone_setup (_LAUNCHER_TRACEBACK_RE) to match"
+    )

--- a/test/test_spawn_audit.py
+++ b/test/test_spawn_audit.py
@@ -351,7 +351,11 @@ BENIGN_SPAWNS: frozenset[str] = frozenset(
         "apps/builtins/auto_improvement/backend/clone_setup.py::_gh_prefers_ssh",
         "apps/builtins/auto_improvement/backend/clone_setup.py::_run",
         "apps/builtins/auto_improvement/backend/clone_setup.py::list_clone_branches",
-        "apps/builtins/auto_improvement/backend/clone_setup.py::setup_safe_clone",
+        # Renamed from ``setup_safe_clone`` when a thin public wrapper was added
+        # to convert IsolationProbeError into the (result, err) shape (#8151);
+        # the git-clone spawn itself is unchanged and its argv is built from
+        # validated owner/repo components, never raw user text.
+        "apps/builtins/auto_improvement/backend/clone_setup.py::_setup_safe_clone",
         # NOT subprocess spawns: the AST heuristic matches ``asyncio.run`` (attr
         # ``run`` on base ``asyncio``), used here only to drive the async
         # ``SessionAgentRunner._approve`` coroutine from a synchronous test. No child


### PR DESCRIPTION
## Summary

On Ubuntu 24.04 with `apparmor_restrict_unprivileged_userns=1`, the generated namespace-sandbox launcher crashed with `ModuleNotFoundError: No module named 'platform'` — it lazily imported `platform` (Step 6, seccomp arch table) and `struct` (Step 5, capability drop) **after** `unshare()` + mount isolation, and on that host the post-unshare first-time stdlib file read is denied. Auto-Improvement then reported the crash as the misleading 409 *"the clone's push is not disabled — re-run repository setup"*: the probe's git subprocess exited 1 (the same code git uses for an absent config key), and `_push_disabled()` fail-closed it.

Closes #8151

## Changes

**Root cause — `sandbox.py`:** both imports are hoisted into the launcher preamble (module scope runs pre-fork, pre-unshare, and after the `sys.path` stdlib-shadowing purge), so post-isolation code never touches the filesystem for stdlib.

**Legibility — `clone_setup.py`:** `_origin_urls` distinguishes a probe that *could not run* from one that ran and reported. A nonzero exit whose stderr carries an unambiguous launcher signature raises `IsolationProbeError` (redacted bounded stderr tail in the message, full redacted stderr in the log). The signature is matched **structurally** so repository-influenced text cannot satisfy it: the script-filename marker only counts inside a real Python traceback frame, and the refusal prefixes must start a stderr line — a repo legally named `kirocrew_sandbox_x` echoed in a git fatal path stays an ambiguous, fail-closed error. `sandbox: WARNING` never reclassifies (the launcher warns and still runs the command).

**Fail-closed preserved everywhere.** Every path still refuses to proceed; only the surfaced *reason* changes:
- run-start route: distinct `sandbox_launcher_failed` code (was `session_conflict` with the push-isolation text)
- `setup_safe_clone` / `list_clone_branches` / `checkout_branch` / `commit_finding` / draft-PR route / `_push_fix_branch`: the raise becomes their error string
- `driver._retire_if_unsafe`: a probe crash stops the run **without retiring** a clone whose remotes were never read, and re-raises (with a run-end latch) so the supervisor records `STATUS_ERROR` instead of reading the aborted run as done; ambiguous errors keep retiring as before
- draft-PR route serializer now reads the `error` key its failure dicts actually carry (it read only `detail`, serializing every failure as an empty string)

## Tests

- `test/test_sandbox_launcher_import_hoist.py` (new): AST scan pins every launcher import as module-level, after the `sys.path` purge, across all three sandbox levels; round-trip test pins the probe's marker list against the generated launcher text.
- `src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py` (new, co-located with the app's clone_setup tests): launcher traceback / `sandbox: BLOCKED` → typed error with the sandbox message and NOT the push-isolation text; absent-key exit 1, launcher WARNING, ambiguous fatal, spoofed path (`owner--kirocrew_sandbox_x`), and mid-line prefix all keep their existing fail-closed meaning; tuple entry points return the message instead of raising.
- `test/test_ai_backend_routes_coverage.py`: run-start maps the typed error to `sandbox_launcher_failed`.
- `test/test_sandbox_argv.py`: arch-dispatch block locator re-anchored on `_machine = _plat.machine()` (the import is no longer inside the block).

## Review

Two model-pinned pre-push reviews ran (GPT `gpt-5.6-sol` mirroring codex-review, Opus `claude-opus-5` mirroring claude-review + AUTOSDE): 1 blocking finding (spoofable substring markers / lost retirement — fixed with structural matching + retire-by-default) and 8 advisory/medium findings, all addressed (STATUS_ERROR latch, draft-route error key, distinct 409 code, sys.path ordering pin, marker round-trip test, gateway-log promise kept via `logger.error`, docstring repairs, test co-location).

No UI changes; backend only. Local gates: isort, flake8, mypy (1282 files), diff-scoped black, brand — all green. Test suites run in CI.

no linked issue: linked — Closes #8151.


## Pattern harvest

Rule candidate: static scan (now a test) — no import statements below module level in generated pre-isolation launcher scripts. `test/test_sandbox_launcher_import_hoist.py` pins it AST-wide for every sandbox level, so the class (a lazy stdlib import executing after namespace/mount isolation, denied by LSM policy) cannot recur in this template. The companion defect is generalizable too: a probe collapsing "could not run" into its fail-closed verdict — harvested here as the structural stderr-signature classifier plus the round-trip marker test; sibling probes that consume subprocess exit codes as safety verdicts should distinguish crash-of-the-harness from a genuine negative the same way.
