### PR TITLE
fix(ci): show a fork review body whose verdict stamp is missing

### DIFF
--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -377,6 +377,28 @@ jobs:
           model_provider = "amazon-bedrock"
           model = "openai.gpt-5.6-sol"
           model_reasoning_effort = "medium"
+
+          # Keep the inherited AWS credentials OUT of the environment the model's
+          # own shell tool inherits. `codex exec` gives the model a shell (the
+          # Opus lane instead runs with `--allowedTools "Read,Grep,Glob"`, so it
+          # has no such surface), and this lane runs on a fork's UNTRUSTED diff,
+          # so a prompt-injected reviewer can be asked to dump its environment.
+          # Redaction alone cannot close that: it matches the credential's shapes
+          # and its verbatim VALUE, and a model told to print the value with
+          # delimiters, in chunks, or re-encoded defeats both. Removing the value
+          # from the shell's environment cannot be evaded by how it is printed.
+          #
+          # This does NOT affect Bedrock auth: the provider resolves credentials
+          # in the codex PROCESS environment, which this policy does not touch --
+          # it governs only the env handed to subprocesses the shell tool spawns.
+          #
+          # `ignore_default_excludes` defaults to TRUE, which KEEPS variables
+          # whose names contain KEY, SECRET or TOKEN. Setting it false restores
+          # those built-in exclusions, so GH_TOKEN and any future secret-shaped
+          # variable are dropped too rather than needing to be named here.
+          [shell_environment_policy]
+          ignore_default_excludes = false
+          filters = { "AWS_ACCESS_KEY_ID" = "exclude", "AWS_SECRET_ACCESS_KEY" = "exclude", "AWS_SESSION_TOKEN" = "exclude", "AWS_*" = "exclude" }
           EOF
 
       # Mint short-lived, Bedrock-only creds immediately before the model call,
@@ -385,6 +407,34 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
+
+      # `configure-aws-credentials` exports through `core.exportVariable`, which
+      # WRITES each value into `$RUNNER_TEMP/_runner_file_commands/set_env_*`.
+      # The runner has already consumed those files by the time this step starts,
+      # so truncating them changes no variable -- but it removes the only on-disk
+      # copy of the credential.
+      #
+      # This is the gap the other two fences cannot close, because both of them
+      # guard the ENVIRONMENT: the codex lane drops the AWS variables from the
+      # shell tool's env, and the Opus steps deny `Read(//proc/**)`. A set_env
+      # file is an ordinary FILE under a directory these lanes legitimately read,
+      # so the model could open it directly and emit the value in chunks that no
+      # shape rule matches. Remove the value instead of filtering the output.
+      - name: Scrub persisted credential files before the model runs
+        run: |
+          set -uo pipefail
+          dir="${RUNNER_TEMP:-}/_runner_file_commands"
+          if [ -z "${RUNNER_TEMP:-}" ] || [ ! -d "$dir" ]; then
+            echo "no runner file-command directory; nothing to truncate"
+            exit 0
+          fi
+          n=0
+          for f in "$dir"/set_env_*; do
+            [ -f "$f" ] || continue
+            : > "$f"
+            n=$((n + 1))
+          done
+          echo "truncated $n persisted set_env_* file(s)"
 
       - name: GPT 5.6 review (discovery pass)
         id: review
@@ -630,6 +680,25 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
 
+      # Same scrub as before the discovery pass, for the same reason: the minted
+      # credential is also written to `$RUNNER_TEMP/_runner_file_commands/set_env_*`,
+      # which is a FILE and so is covered by neither of the environment fences.
+      - name: Scrub persisted credential files before the model runs
+        run: |
+          set -uo pipefail
+          dir="${RUNNER_TEMP:-}/_runner_file_commands"
+          if [ -z "${RUNNER_TEMP:-}" ] || [ ! -d "$dir" ]; then
+            echo "no runner file-command directory; nothing to truncate"
+            exit 0
+          fi
+          n=0
+          for f in "$dir"/set_env_*; do
+            [ -f "$f" ] || continue
+            : > "$f"
+            n=$((n + 1))
+          done
+          echo "truncated $n persisted set_env_* file(s)"
+
       - name: GPT 5.6 review (falsification pass)
         id: gpt_pass2
         env:
@@ -716,6 +785,23 @@ jobs:
         run: |
           if [ -f codex-review-output.md ]; then
             perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' codex-review-output.md
+            # Then redact the ACTUAL inherited credential VALUES, not just their
+            # shapes. An AWS secret access key is 40 characters of [A-Za-z0-9/+=]
+            # with no distinctive prefix, so a BARE value (no `name=` beside it)
+            # survives every shape rule above: it is not AKIA/ASIA, it is not a
+            # named key=value, and it is far short of the 200+ char base64 run the
+            # withhold filter looks for. Matching the value itself cannot be
+            # evaded by how the model chooses to print it. This runs before the
+            # comment step, so it protects the blocked, clear and unstamped paths
+            # alike rather than only the branch that surfaces an unstamped body.
+            for cred in AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_ACCESS_KEY_ID; do
+              val="$(printenv "$cred" 2>/dev/null || true)"
+              # Length guard, not just an emptiness guard: `\Q\E` on an empty
+              # string is an empty pattern that matches at EVERY position and
+              # would carpet the file with the marker.
+              [ "${#val}" -ge 16 ] || continue
+              CRED_VALUE="$val" perl -i -pe 's/\Q$ENV{CRED_VALUE}\E/[REDACTED-CREDENTIAL]/g' codex-review-output.md
+            done
           fi
 
       # ── ADJUDICATION ────────────────────────────────────────────────────────
@@ -931,6 +1017,25 @@ jobs:
           echo "Claude Code $installed satisfies the adjudicator's floor $ADJ_CLAUDE_CODE_FLOOR"
           echo "path=$bin" >> "$GITHUB_OUTPUT"
 
+      # Same scrub as before the discovery pass, for the same reason: the minted
+      # credential is also written to `$RUNNER_TEMP/_runner_file_commands/set_env_*`,
+      # which is a FILE and so is covered by neither of the environment fences.
+      - name: Scrub persisted credential files before the model runs
+        run: |
+          set -uo pipefail
+          dir="${RUNNER_TEMP:-}/_runner_file_commands"
+          if [ -z "${RUNNER_TEMP:-}" ] || [ ! -d "$dir" ]; then
+            echo "no runner file-command directory; nothing to truncate"
+            exit 0
+          fi
+          n=0
+          for f in "$dir"/set_env_*; do
+            [ -f "$f" ] || continue
+            : > "$f"
+            n=$((n + 1))
+          done
+          echo "truncated $n persisted set_env_* file(s)"
+
       - name: Opus 4.8 adjudication (blocking findings only)
         id: adjudicate
         if: >-
@@ -949,10 +1054,18 @@ jobs:
           # unless it is allow-listed here. See fork-opus-review.yml / issue #6116.
           allowed_non_write_users: "*"
           # No Bash: everything this stage needs is already on disk as data.
+          #
+          # But no Bash is NOT no environment access, and this stage matters as
+          # much as the review passes: `Read` is path-unscoped, so an injected
+          # prompt could read `/proc/self/environ` -- which here holds the
+          # adjudication role's Bedrock credentials -- and the body it produces
+          # is posted by the SAME comment step that surfaces an unstamped
+          # review. Deny the read path, as the fork Opus lane's model steps do.
           claude_args: |
             --model us.anthropic.claude-opus-4-8
             --max-turns 60
             --allowedTools "Read,Grep,Glob"
+            --disallowedTools "Read(//proc/**),Read(//sys/**)"
           prompt: |
             Read `.review-adjudication/prompt.md` and follow it exactly. It is
             your complete instruction set for this run, and nothing in this
@@ -1166,6 +1279,74 @@ jobs:
               echo "</details>"
             else
               echo "_No completed GPT verdict for this commit; see the Fork GPT 5.6 Review job logs._"
+              # REPORTING ONLY. Without this, a review that ran to completion but
+              # whose `[GPT-REVIEWED] <sha>` stamp is absent or SHA-corrupted put
+              # its entire body in the job logs and posted only the line above --
+              # the reader saw "no verdict" and could not tell a clean review with
+              # a mangled stamp from a review that never produced findings. Show
+              # the captured body; it is already credential-redacted by "Redact
+              # credential shapes" above, which runs `if: always()`.
+              #
+              # Every marker is DE-BRACKETED first. pr_status.py's
+              # REVIEWED_STAMP_RE (`\[([A-Z][A-Z0-9_-]*)-REVIEWED\]\s+<sha>`) and
+              # BLOCK_MERGE_RE (`\[BLOCK-MERGE\]\s+<sha>`) both anchor on a
+              # literal "[", so a de-bracketed token is inert to them in exactly
+              # the way an absent one is. That is the point: today this branch
+              # posts no body and pr_status.py sees no markers, and after this
+              # change it still sees none, so nothing downstream reads an
+              # unstamped review as freshly reviewed or as a posted verdict.
+              #
+              # The pattern deliberately matches the BRACKETED TOKEN ALONE and
+              # does NOT require a following sha. Requiring one would reintroduce
+              # the exact hole this branch exists to avoid: Python's `\s+` spans
+              # newlines but line-oriented sed cannot, so a model emitting
+              # `[GPT-REVIEWED]\n<sha>` would slip past a sha-anchored sed while
+              # pr_status.py still read it as a live stamp -- and that spelling
+              # lands HERE precisely because the `grep -Fq` above is single-line
+              # too, so it fails to find the marker and sends us down this branch.
+              # Both parser patterns need `[NAME-REVIEWED]` / `[BLOCK-MERGE]`
+              # contiguous on one line (their character classes exclude newline),
+              # so breaking the bracket alone cannot be bypassed by any
+              # whitespace arrangement.
+              # This branch does not decide the check-run; "Finalize check-run
+              # (fail closed)" below re-derives it from the same missing stamp and
+              # stays `failure`.
+              #
+              # Where this body actually lands: the upsert below (#8292/#8350)
+              # never PATCHes on an incomplete run, so this body is only ever
+              # CREATED, and only when the comment lookup succeeded and found no
+              # existing marker comment. That is also why the de-bracketing above
+              # is load-bearing rather than belt-and-braces -- the comment it
+              # creates is then the ONLY marker comment on the PR, so a live
+              # stamp in it would have nothing to contradict it.
+              if [ -s codex-review-output.md ]; then
+                # WITHHOLD before showing anything. The reviewer runs agentically
+                # with credentials in its environment, and a malicious fork can
+                # inject a prompt that both dumps that environment AND omits the
+                # verdict stamp -- which routes here by construction. The redaction
+                # above catches an AWS key ID and named `key=value` forms but not a
+                # bare secret value, a GitHub token, or a PEM block, and before this
+                # branch existed nothing was posted here at all. So if any
+                # credential shape survives, publish NOTHING and point at the log.
+                # Same pattern as the fork first-principles/UX lanes; a long
+                # unbroken base64 run is included deliberately because an AWS
+                # session token has no distinctive prefix.
+                if grep -Eq '(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|(AKIA|ASIA)[A-Z2-7]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|[A-Za-z0-9/+=]{200,})' codex-review-output.md; then
+                  echo
+                  echo "_The captured output matched a credential shape after redaction, so it is withheld; read it in the Fork GPT 5.6 Review job logs._"
+                else
+                  echo
+                  echo "<details>"
+                  echo "<summary>Captured review output -- no verdict stamp for this commit, so this is NOT a verdict</summary>"
+                  echo
+                  sed -E \
+                    -e 's/\[([A-Z][A-Z0-9_-]*)-REVIEWED\]/(\1-REVIEWED-UNSTAMPED)/g' \
+                    -e 's/\[BLOCK-MERGE\]/(BLOCK-MERGE-UNSTAMPED)/g' \
+                    codex-review-output.md
+                  echo
+                  echo "</details>"
+                fi
+              fi
             fi
             if [ -s codex-adjudication.md ]; then
               echo

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -295,6 +295,25 @@ jobs:
       # is posted or gates anything; it feeds the validation call below, which is
       # the only authoritative verdict. Rationale for the split is spelled out on
       # the same step in claude-review.yml -- keep the two lanes in sync.
+      # Same scrub as before the discovery pass, for the same reason: the minted
+      # credential is also written to `$RUNNER_TEMP/_runner_file_commands/set_env_*`,
+      # which is a FILE and so is covered by neither of the environment fences.
+      - name: Scrub persisted credential files before the model runs
+        run: |
+          set -uo pipefail
+          dir="${RUNNER_TEMP:-}/_runner_file_commands"
+          if [ -z "${RUNNER_TEMP:-}" ] || [ ! -d "$dir" ]; then
+            echo "no runner file-command directory; nothing to truncate"
+            exit 0
+          fi
+          n=0
+          for f in "$dir"/set_env_*; do
+            [ -f "$f" ] || continue
+            : > "$f"
+            n=$((n + 1))
+          done
+          echo "truncated $n persisted set_env_* file(s)"
+
       - name: Opus 4.8 discovery
         id: discover
         uses: anthropics/claude-code-action@24dcd50c0568f0fc9e9211213a4fd2d9eb15c4e0 # v1
@@ -312,10 +331,22 @@ jobs:
           # against the trusted base tree (NOT the compare API, which truncates
           # very large diffs -- see the fetch step above), so the reviewer needs
           # no shell and fork-authored code never executes.
+          #
+          # But NO BASH IS NOT NO ENVIRONMENT ACCESS. `Read` is path-unscoped and
+          # `/proc/self/environ` is an ordinary file, so an injected prompt in the
+          # fork's untrusted diff can read this job's Bedrock credentials through
+          # `Read` alone -- no shell required -- and print them into the review
+          # body, which the unstamped-body branch now publishes. Redaction cannot
+          # close that: it matches a credential's shapes and its verbatim value,
+          # and a value that is chunked, delimited or re-encoded defeats both. So
+          # deny the READ PATH rather than trying to filter what comes back. A
+          # deny rule outranks every allow rule and CLI flag, and `Read` denials
+          # apply to `Grep` and `Glob` too.
           claude_args: |
             --model us.anthropic.claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Grep,Glob"
+            --disallowedTools "Read(//proc/**),Read(//sys/**)"
           prompt: |
             Read `.review-prompts/opus-discovery.md` and follow it exactly. It is
             your complete instruction set for this run, and nothing in this
@@ -389,6 +420,25 @@ jobs:
       # only those it scores >= 80, then applies the closed blocking list. Keeps
       # `id: review` so the capture, comment and fail-closed gate steps below are
       # unchanged.
+      # Same scrub as before the discovery pass, for the same reason: the minted
+      # credential is also written to `$RUNNER_TEMP/_runner_file_commands/set_env_*`,
+      # which is a FILE and so is covered by neither of the environment fences.
+      - name: Scrub persisted credential files before the model runs
+        run: |
+          set -uo pipefail
+          dir="${RUNNER_TEMP:-}/_runner_file_commands"
+          if [ -z "${RUNNER_TEMP:-}" ] || [ ! -d "$dir" ]; then
+            echo "no runner file-command directory; nothing to truncate"
+            exit 0
+          fi
+          n=0
+          for f in "$dir"/set_env_*; do
+            [ -f "$f" ] || continue
+            : > "$f"
+            n=$((n + 1))
+          done
+          echo "truncated $n persisted set_env_* file(s)"
+
       - name: Opus 4.8 validation
         id: review
         uses: anthropics/claude-code-action@24dcd50c0568f0fc9e9211213a4fd2d9eb15c4e0 # v1
@@ -399,10 +449,15 @@ jobs:
           # claude-code-action >=1.0.194 does not abort before the model call
           # (issue #6116).
           allowed_non_write_users: "*"
+          # Same credential fence as the discovery step above, for the same
+          # reason: `Read` is path-unscoped and `/proc/self/environ` is a file,
+          # so no-Bash does not keep this job's credentials out of the model's
+          # reach. Keep the two steps in sync.
           claude_args: |
             --model us.anthropic.claude-opus-4-8
             --max-turns 120
             --allowedTools "Read,Grep,Glob"
+            --disallowedTools "Read(//proc/**),Read(//sys/**)"
           prompt: |
             Read `.review-prompts/opus-validate.md` and follow it exactly. It is
             your complete instruction set for this run, and nothing in this
@@ -436,6 +491,16 @@ jobs:
           # reads the file — the reviewer runs agentically with AWS creds in its
           # environment (mirrors the redaction in claude-review.yml).
           perl -i -pe 's/\b(?:AKIA|ASIA)[A-Z2-7]{16}\b/[REDACTED-AWS-KEY-ID]/g; s{arn:aws\S*}{[REDACTED-ARN]}g; s/\b[0-9]{12}\b/[REDACTED-ACCT]/g; s/(?i)(aws_secret_access_key|aws_session_token|x-amz-security-token)\s*[:=]\s*\S+/$1=[REDACTED]/g' claude-review-output.md
+          # Then the ACTUAL inherited credential VALUES -- see the twin block in
+          # fork-gpt-review.yml. A bare 40-char AWS secret access key has no
+          # distinctive prefix, so it survives every shape rule above and is far
+          # short of the 200+ char base64 run the withhold filter looks for.
+          for cred in AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_ACCESS_KEY_ID; do
+            val="$(printenv "$cred" 2>/dev/null || true)"
+            # Length guard: `\Q\E` on an empty string matches at EVERY position.
+            [ "${#val}" -ge 16 ] || continue
+            CRED_VALUE="$val" perl -i -pe 's/\Q$ENV{CRED_VALUE}\E/[REDACTED-CREDENTIAL]/g' claude-review-output.md
+          done
 
       - name: Post/update summary comment
         if: always()
@@ -473,6 +538,51 @@ jobs:
               echo "</details>"
             else
               echo "_No completed Opus verdict for this commit; see the Fork Opus 4.8 Review job logs._"
+              # REPORTING ONLY -- see the twin block in fork-gpt-review.yml.
+              # A completed review whose `[OPUS-REVIEWED] <sha>` stamp is absent
+              # or SHA-corrupted used to have its whole body dropped to the job
+              # logs, so a clean review with a mangled stamp was indistinguishable
+              # from one that produced nothing. The body is already
+              # credential-redacted by "Capture and redact review output" above
+              # (`if: always()`).
+              #
+              # Markers are DE-BRACKETED because pr_status.py's REVIEWED_STAMP_RE
+              # and BLOCK_MERGE_RE both anchor on a literal "[": today this branch
+              # posts no body so no markers are visible downstream, and after this
+              # change none are visible either. The check-run is decided
+              # independently by "Finalize check-run (fail closed)" below, which
+              # re-derives the same missing stamp and stays `failure`.
+              #
+              # The pattern matches the BRACKETED TOKEN ALONE, with no following
+              # sha, for the reason spelled out in fork-gpt-review.yml: Python's
+              # `\s+` spans newlines and line-oriented sed cannot, so a
+              # sha-anchored pattern would miss `[OPUS-REVIEWED]\n<sha>` while
+              # pr_status.py still read it as live -- and the single-line
+              # `grep -Fq` above routes exactly that spelling into this branch.
+              if [ -s claude-review-output.md ]; then
+                # WITHHOLD first -- see the twin block in fork-gpt-review.yml. A
+                # malicious fork can inject a prompt that dumps the reviewer's
+                # credential-bearing environment AND omits the verdict stamp, which
+                # routes here; the redaction above misses a bare secret value, a
+                # GitHub token and a PEM block, and nothing was posted here before
+                # this branch existed. Any surviving credential shape means publish
+                # NOTHING. Same pattern as the fork first-principles/UX lanes.
+                if grep -Eq '(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|(AKIA|ASIA)[A-Z2-7]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----|[A-Za-z0-9/+=]{200,})' claude-review-output.md; then
+                  echo
+                  echo "_The captured output matched a credential shape after redaction, so it is withheld; read it in the Fork Opus 4.8 Review job logs._"
+                else
+                  echo
+                  echo "<details>"
+                  echo "<summary>Captured review output -- no verdict stamp for this commit, so this is NOT a verdict</summary>"
+                  echo
+                  sed -E \
+                    -e 's/\[([A-Z][A-Z0-9_-]*)-REVIEWED\]/(\1-REVIEWED-UNSTAMPED)/g' \
+                    -e 's/\[BLOCK-MERGE\]/(BLOCK-MERGE-UNSTAMPED)/g' \
+                    claude-review-output.md
+                  echo
+                  echo "</details>"
+                fi
+              fi
             fi
           } > "${RUNNER_TEMP:-/tmp}/fork-opus-comment.md"
           # Guarded upsert (#8292, #8344): the shared function below is defined

--- a/comment-history-baseline.json
+++ b/comment-history-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Comments and docstrings that narrate change history, per file, as a match COUNT. The rule they break is in docs/system-specs/common/code-style.md (\"Comments explain the WHY\"); it predates any enforcement, so the tree is recorded here rather than rewritten in one pass. The gate requires every OTHER file to be clean and none of these counts to grow, so this list can only shrink. Do NOT add or raise an entry to make a red gate green: a new offender means the comment should state CURRENT behavior in present tense. Lower and prune with `python3 scripts/check_comment_history.py --write-baseline`, which never adds or raises one.",
-  "_total": 7606,
+  "_total": 7605,
   "files": {
     "src/kiro_crew/__main__.py": 1,
     "src/kiro_crew/acp/_dispatch.py": 8,
@@ -712,7 +712,7 @@
     "test/test_ai_agent_runner_coverage.py": 1,
     "test/test_ai_backend_routes_coverage.py": 1,
     "test/test_ai_pr_watchers_coverage.py": 1,
-    "test/test_ai_review_workflows.py": 49,
+    "test/test_ai_review_workflows.py": 48,
     "test/test_api_agent_config_put_succeeds.py": 10,
     "test/test_api_agents_create_template.py": 3,
     "test/test_api_agents_order.py": 1,

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -617,10 +617,10 @@ class TestPrReadiness:
         assert 'failed_passes="$(cat codex-failed-passes 2>/dev/null || true)"' in review_step
 
     def test_each_model_call_starts_on_a_fresh_bedrock_session(self) -> None:
-        """One AssumeRole session lasts an hour; the model calls used to share
-        it, so a first call that consumed most of the hour left the next to
-        die on `401 ... security token ... expired` and fail the gate closed
-        with no verdict. Every lane whose job timeout exceeds the session
+        """One AssumeRole session lasts an hour, so model calls that share it let
+        a first call consume most of the hour and leave the next to die on
+        `401 ... security token ... expired`, failing the gate closed with no
+        verdict. Every lane whose job timeout exceeds the session
         lifetime must re-assume before EACH call — the GPT lanes now make three
         (two CLI passes plus the Opus adjudication of the blocking verdict) —
         and each call must be wall-bounded under that lifetime where the lane
@@ -802,9 +802,9 @@ class TestPrReadiness:
         assert "      - CodeQL" in workflow
         for workflow_name in (
             "ci.yml|CI",
-            # Fast Gate carries the eleven cheap blocking gates that used to sit
-            # inside CI. Splitting them out gave the fork reviewers something to
-            # key on in ~1 minute instead of CI's ~54, but a split-out lane that
+            # Fast Gate carries the eleven cheap blocking gates, split out of
+            # CI so the fork reviewers have something to key on in ~1 minute
+            # instead of CI's ~54. But a split-out lane that
             # readiness does not aggregate is a gate that can go red without
             # turning the PR red -- so it is pinned here exactly like CI.
             "fast-gate.yml|Fast Gate",
@@ -1231,8 +1231,8 @@ class TestFirstPrinciplesReview:
         )
 
     def test_one_contract_file_read_from_the_base_ref(self) -> None:
-        # The contract used to be inlined in BOTH lanes and held in sync by a
-        # byte-equality test -- guarding duplication instead of removing it, when
+        # Inlining the contract in BOTH lanes and holding it in sync by a
+        # byte-equality test guards duplication instead of removing it, when
         # `.github/review-prompts/` already existed for exactly this (2 consumers:
         # the Opus lanes). Reading it from the BASE ref is also load-bearing: an
         # inline prompt on the head lets a change edit the reviewer that judges it.
@@ -1563,10 +1563,10 @@ class TestFirstPrinciplesIntentCapSurvivesALongBody:
 class TestIntentReadFailureFailsClosed:
     """Execute the ACTUAL PR-intent read from both lanes with ``gh`` stubbed.
 
-    `2>/dev/null || true` used to collapse a failed API read onto the same
-    empty string as a PR with no description, so the reviewer judged a PR that
-    appeared to state no intent and the author was blamed for a description
-    the workflow never read. These cases pin the three outcomes apart: a read
+    A bare `2>/dev/null || true` collapses a failed API read onto the same
+    empty string as a PR with no description, which would have the reviewer
+    judge a PR that appears to state no intent and blame the author for a
+    description the workflow never read. These cases pin the three outcomes apart: a read
     that succeeds is judged as written, a transient failure is absorbed by the
     bounded retry, and a read that never succeeds fails the step closed while
     naming the read as the cause.
@@ -3787,8 +3787,8 @@ class TestBlockAdjudicationContract:
         assert _step_env("fork-gpt-review.yml", ADJ_GATE)["REASONS"] == "|".join(reasons)
 
     def test_fenced_findings_get_an_annotate_only_pass_that_cannot_unblock(self) -> None:
-        """#8693: the fence's cost used to be a blind block -- no role in the
-        machine channel could say "this combination is too rare". The fenced
+        """A fence on its own costs a blind block: no role in the machine
+        channel can say "this combination is too rare". The fenced
         block gives the arbiter a voice with NO downgrade authority: a FLAG
         only pre-drafts the override rationale a repository writer must
         verify, and the gate never reads it."""
@@ -6656,7 +6656,7 @@ class TestFirstPrinciplesProblemsFirstContract:
 
     def test_undeclared_and_rides_along_are_inventory_tags_not_verdicts(self) -> None:
         # ~50% of PRs drew CONCERNS, so the signal cost nothing to ignore.
-        # These two tags still print, but no longer carry the verdict by
+        # These two tags print as inventory and do not carry the verdict by
         # themselves; CONCERNS is reserved for premise and depth risks.
         contract = _fp_contract()
         assert "`undeclared` and `rides along`\n  are INVENTORY TAGS ONLY" in contract
@@ -6669,7 +6669,7 @@ class TestFirstPrinciplesProblemsFirstContract:
 
     def test_output_leads_with_problems_and_drops_the_praise_punchline(self) -> None:
         contract = _fp_contract()
-        # The PASS punchline no longer argues the author's case.
+        # The PASS punchline does not argue the author's case.
         assert "why every item earns its place" not in contract.split("Output EXACTLY")[0]
         assert "Never\nexplain why every item earns its place" in contract
         assert "the ONE thing a human should still verify before merge" in contract
@@ -6719,3 +6719,686 @@ class TestFirstPrinciplesProblemsFirstContract:
         assert "REPO CONTEXT: Kiro Crew is an open-source AI agent platform" in contract
         assert "DO NOT REASON FROM AN ASSUMED USER COUNT, in either direction" in contract
         assert "the AGENT is untrusted with respect to its own governance" in contract
+
+
+def _review_contract_module():
+    """Import the REAL marker parser so a drift in its regexes fails these tests.
+
+    Re-declaring the patterns here would let the workflow's neutralization and
+    the parser drift apart silently, which is the whole failure mode under test.
+    Loaded via ``load_skill_script`` so the import writes no ``__pycache__``
+    into the checked-in scripts directory.
+    """
+    from skill_script_helpers import load_skill_script
+
+    return load_skill_script(
+        "_review_contract_under_test",
+        ROOT
+        / "src"
+        / "kiro_crew"
+        / "builtin_skills"
+        / "kirocrew-dev"
+        / "prepare-pr"
+        / "scripts"
+        / "_review_contract.py",
+    )
+
+
+class TestForkLaneRedactsCredentialValues:
+    """A BARE credential value must not survive into the posted body.
+
+    Every shape rule in these lanes misses a bare AWS secret access key: it is 40
+    characters of ``[A-Za-z0-9/+=]`` with no distinctive prefix, so it is not
+    ``AKIA``/``ASIA`` (that is the key *ID*), it carries no ``name=`` for the
+    named-pair rule to anchor on, and it is far short of the 200+ char base64 run
+    the withhold filter looks for. The reviewer runs agentically with those values
+    in its environment and a malicious fork can prompt it to print them, so the
+    lanes redact the VALUES too -- which cannot be evaded by how the model chooses
+    to format them.
+    """
+
+    # Shape-accurate stand-in: 40 chars from the AWS secret alphabet, no prefix.
+    FAKE_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+    LANES = (
+        ("fork-gpt-review.yml", "Redact credential shapes", "codex-review-output.md"),
+        ("fork-opus-review.yml", "Capture and redact review output", "claude-review-output.md"),
+    )
+
+    def _run_redaction(
+        self, tmp_path: Path, workflow: str, step: str, out: str, body: str, cred: str
+    ):
+        bash = _bash()
+        if bash is None or shutil.which("perl") is None or shutil.which("jq") is None:
+            pytest.skip("redaction test requires Bash, perl and jq")
+        if os.name == "nt":
+            pytest.skip("the lanes' perl -i redaction is exercised on POSIX runners")
+
+        cwd = tmp_path / "ws"
+        cwd.mkdir()
+        (cwd / out).write_text(body, encoding="utf-8")
+        # The Opus lane folds redaction into its capture step, which reads the
+        # agent transcript; give it one so the real step runs unmodified.
+        exec_file = tmp_path / "exec.json"
+        exec_file.write_text(json.dumps({"result": body}), encoding="utf-8")
+
+        script_file = tmp_path / "step.sh"
+        script_file.write_text(
+            _step_script(_workflow(workflow), step), encoding="utf-8", newline="\n"
+        )
+        env = {**os.environ, "EXEC_FILE": str(exec_file)}
+        # Absent means "not configured", which must be a no-op rather than an
+        # empty pattern -- so the caller can ask for the unset case explicitly.
+        for name in ("AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN", "AWS_ACCESS_KEY_ID"):
+            env.pop(name, None)
+        if cred is not None:
+            env["AWS_SECRET_ACCESS_KEY"] = cred
+        result = subprocess.run(
+            [bash, "-e", str(script_file)], check=False, capture_output=True, cwd=cwd, env=env
+        )
+        return (cwd / out).read_text(encoding="utf-8"), result
+
+    @pytest.mark.parametrize(("workflow", "step", "out"), LANES)
+    def test_a_bare_secret_value_is_redacted(
+        self, tmp_path: Path, workflow: str, step: str, out: str
+    ) -> None:
+        body = f"the agent printed its environment: {self.FAKE_SECRET} and kept going\n"
+        text, result = self._run_redaction(tmp_path, workflow, step, out, body, self.FAKE_SECRET)
+        assert result.returncode == 0, result.stderr.decode()
+        assert self.FAKE_SECRET not in text, f"{workflow}: bare secret survived redaction"
+        assert "[REDACTED-CREDENTIAL]" in text
+        # Surrounding prose is untouched -- this redacts a value, not the body.
+        assert "and kept going" in text
+
+    @pytest.mark.parametrize(("workflow", "step", "out"), LANES)
+    def test_an_unset_credential_does_not_carpet_the_body(
+        self, tmp_path: Path, workflow: str, step: str, out: str
+    ) -> None:
+        """The guard that makes the loop safe.
+
+        ``\\Q\\E`` on an empty string is an empty pattern, which matches at every
+        position -- so an unconfigured credential would otherwise replace the gaps
+        between every character with the marker and destroy the review body.
+        """
+        body = "a perfectly ordinary review body with no secrets in it\n"
+        text, result = self._run_redaction(tmp_path, workflow, step, out, body, None)
+        assert result.returncode == 0, result.stderr.decode()
+        assert "[REDACTED-CREDENTIAL]" not in text
+        assert text.strip() == body.strip()
+
+
+class TestForkLaneSurfacesAnUnstampedReviewBody:
+    """A completed fork review whose verdict stamp is missing must stay readable.
+
+    Both fork lanes decide ``kind`` from the presence of ``[<NAME>-REVIEWED]
+    <head>`` in the captured output. When a review runs to completion but that
+    stamp is absent or SHA-corrupted -- a clean review can carry a truncated
+    sha -- ``kind`` falls to ``incomplete`` and the body goes only to the job
+    logs behind a one-line "no verdict" notice. A reader then cannot tell a
+    clean review with a mangled stamp from a review that produced nothing, and
+    those need opposite responses.
+
+    The branch prints the captured body with every marker DE-BRACKETED, which is
+    what keeps this a reporting change: ``REVIEWED_STAMP_RE`` and
+    ``BLOCK_MERGE_RE`` both anchor on a literal ``[``, so the surfaced body is
+    inert to the parser in exactly the way an absent body is. The check-run
+    conclusion is re-derived independently and still fails closed.
+
+    Deliberately NOT surfaced: the pass-failure stub. If GPT's pass 1 fails,
+    pass 2 still runs but against an empty discovery block, so its output
+    reviewed nothing; publishing it as findings would misrepresent it.
+    """
+
+    HEAD = "07bdb01215b9161c90ae28b11296bfc60ad30646"
+    # (workflow, captured-output filename, comment step, finalize step, stamp name)
+    LANES = (
+        (
+            "fork-gpt-review.yml",
+            "codex-review-output.md",
+            "Post/update summary comment",
+            "GPT",
+        ),
+        (
+            "fork-opus-review.yml",
+            "claude-review-output.md",
+            "Post/update summary comment",
+            "OPUS",
+        ),
+    )
+
+    def _findings_body(self, stamp: str | None) -> str:
+        """A complete review with two findings; ``stamp`` None means unstamped."""
+        body = (
+            "BLOCKING -- src/kiro_crew/apps/builtins/thing/app.json:2 -- new built-in app\n"
+            "Anchor: no-new-builtin-apps\n"
+            "\n"
+            "BLOCKING -- src/kiro_crew/dashboard/chat_folders.py:618 -- blocking call on the loop\n"
+            "Anchor: no-blocking-call-on-event-loop\n"
+            "\n"
+            f"[BLOCK-MERGE] {self.HEAD}\n"
+        )
+        if stamp is not None:
+            body += f"[{stamp}-REVIEWED] {self.HEAD}\n"
+        return body
+
+    def _run_step(
+        self,
+        tmp_path: Path,
+        *,
+        workflow: str,
+        output_file: str,
+        step: str,
+        review_output: str | None,
+        check_id: str = "",
+    ) -> tuple[Path, "subprocess.CompletedProcess[bytes]"]:
+        bash = _bash()
+        if bash is None or shutil.which("jq") is None:
+            pytest.skip("fork-lane comment tests require Bash and jq")
+        if os.name == "nt":
+            pytest.skip("stubbed-PATH gh interception is exercised on POSIX runners")
+
+        stub_dir = tmp_path / "stub"
+        stub_dir.mkdir()
+        calls_dir = tmp_path / "calls"
+        calls_dir.mkdir()
+        cwd = tmp_path / "workspace"
+        cwd.mkdir()
+        runner_temp = tmp_path / "runner-temp"
+        runner_temp.mkdir()
+
+        if review_output is not None:
+            (cwd / output_file).write_text(review_output, encoding="utf-8")
+
+        gh_stub = stub_dir / "gh"
+        gh_stub.write_text(
+            "#!/usr/bin/env bash\n"
+            "# Records the argv of every mutating call and answers the comment\n"
+            "# finder with an empty array, so the step takes its create path.\n"
+            'if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "PATCH" ]; then\n'
+            '  printf \'%s\\n\' "$@" >> "$STUB_CALLS/patch-argv.txt"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "api" ] && [ "$2" = "--method" ] && [ "$3" = "POST" ]; then\n'
+            '  printf \'%s\\n\' "$@" >> "$STUB_CALLS/post-argv.txt"\n'
+            '  echo "1"\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "api" ]; then\n'
+            '  echo -n ""\n'
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "pr" ] && [ "$2" = "comment" ]; then\n'
+            "  shift 3\n"
+            '  if [ "$1" = "--body-file" ]; then cp "$2" "$STUB_CALLS/created-body.md"; fi\n'
+            "  exit 0\n"
+            "fi\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        gh_stub.chmod(0o755)
+
+        script_file = tmp_path / "step.sh"
+        script = _step_script(_workflow(workflow), step)
+        # Each lane assembles its comment under `$RUNNER_TEMP`, which this harness
+        # points at a per-test directory. That is what stops two parametrized cases
+        # from racing on one path and reading each other's body -- which is how a
+        # stamped case's live markers first showed up in the unstamped case's
+        # assertions. Assert the path stays RUNNER_TEMP-scoped, so a regression to a
+        # bare `/tmp` (shared between xdist workers, and the operator's own machine
+        # when the suite runs locally) fails here instead of silently restoring the
+        # race.
+        if step == "Post/update summary comment":
+            assert re.search(
+                r"\$\{RUNNER_TEMP:-[^}]*\}/fork-(?:codex|opus)-comment\.md", script
+            ), f"{workflow}: comment path must be RUNNER_TEMP-scoped, not a bare /tmp path"
+        # `newline="\n"`: text-mode translation writes CRLF on Windows and bash
+        # reads the CR as part of the token (`fi\r` is not the `fi` keyword). These
+        # cases skip on Windows today, so this is belt-and-braces.
+        script_file.write_text(script, encoding="utf-8", newline="\n")
+
+        env = {
+            **os.environ,
+            "PATH": f"{stub_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "REPO": "example/repo",
+            "PR": "1",
+            "HEAD": self.HEAD,
+            "GH_TOKEN": "stub-token",
+            "RUNNER_TEMP": str(runner_temp),
+            "STUB_CALLS": str(calls_dir),
+            "CHECK_ID": check_id,
+            "ADJ_DECISION": "",
+            "ADJ_NOTE": "",
+        }
+        result = subprocess.run(
+            [bash, "-e", str(script_file)],
+            check=False,
+            capture_output=True,
+            cwd=cwd,
+            env=env,
+        )
+        return calls_dir, result
+
+    @pytest.mark.parametrize(("workflow", "output_file", "step", "stamp"), LANES)
+    def test_a_completed_review_with_no_stamp_is_surfaced_not_dropped(
+        self, tmp_path: Path, workflow: str, output_file: str, step: str, stamp: str
+    ) -> None:
+        calls, result = self._run_step(
+            tmp_path,
+            workflow=workflow,
+            output_file=output_file,
+            step=step,
+            review_output=self._findings_body(stamp=None),
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        posted = (calls / "created-body.md").read_text(encoding="utf-8")
+
+        # The lane still reports that it has no verdict -- that is true.
+        assert "No completed" in posted
+        # ...and the findings it DID produce are now readable on the PR rather
+        # than only in the job logs. Both findings, not just the first.
+        assert "no-new-builtin-apps" in posted
+        assert "no-blocking-call-on-event-loop" in posted
+        assert "chat_folders.py:618" in posted
+        # Framed so the body is not mistaken for a verdict.
+        assert "NOT a verdict" in posted
+
+    @pytest.mark.parametrize(("workflow", "output_file", "step", "stamp"), LANES)
+    def test_the_surfaced_body_is_inert_to_the_real_marker_parsers(
+        self, tmp_path: Path, workflow: str, output_file: str, step: str, stamp: str
+    ) -> None:
+        """The invariant that keeps this a reporting change.
+
+        Surfacing a raw body would publish ``[<NAME>-REVIEWED] <head>`` for a
+        review that never completed, and pr_status.py reads that stamp straight
+        out of comment text -- an unstamped review would start reading as freshly
+        reviewed. De-bracketing keeps the downstream view identical to today's.
+        """
+        contract = _review_contract_module()
+        calls, result = self._run_step(
+            tmp_path,
+            workflow=workflow,
+            output_file=output_file,
+            step=step,
+            # Worst case: the body carries BOTH a foreign reviewed-stamp and a
+            # blocking marker, while lacking this lane's own stamp for the head.
+            review_output=self._findings_body(stamp="SOMEOTHER"),
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        posted = (calls / "created-body.md").read_text(encoding="utf-8")
+
+        # The body was surfaced...
+        assert "no-new-builtin-apps" in posted
+        # ...and carries nothing either parser can read.
+        assert contract.REVIEWED_STAMP_RE.findall(posted) == []
+        assert contract.BLOCK_MERGE_RE.findall(posted) == []
+        # The de-bracketed forms are present, so a human can still see what the
+        # model emitted and that it was neutralized rather than deleted.
+        assert "SOMEOTHER-REVIEWED-UNSTAMPED" in posted
+        assert "BLOCK-MERGE-UNSTAMPED" in posted
+
+    @pytest.mark.parametrize(("workflow", "output_file", "step", "stamp"), LANES)
+    def test_the_check_run_still_fails_closed_when_the_stamp_is_missing(
+        self, tmp_path: Path, workflow: str, output_file: str, step: str, stamp: str
+    ) -> None:
+        """Nothing blocks less: the conclusion is re-derived from the same
+        missing stamp and is unchanged by the reporting branch."""
+        calls, result = self._run_step(
+            tmp_path,
+            workflow=workflow,
+            output_file=output_file,
+            step="Finalize check-run (fail closed)",
+            review_output=self._findings_body(stamp=None),
+            check_id="4242",
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        argv = (calls / "patch-argv.txt").read_text(encoding="utf-8")
+        assert "conclusion=failure" in argv
+        assert "conclusion=success" not in argv
+
+    @pytest.mark.parametrize(("workflow", "output_file", "step", "stamp"), LANES)
+    def test_a_marker_split_across_lines_is_still_neutralized(
+        self, tmp_path: Path, workflow: str, output_file: str, step: str, stamp: str
+    ) -> None:
+        """The bypass that a sha-anchored pattern would leave open.
+
+        Python's ``\\s+`` spans newlines; line-oriented ``sed`` cannot. So a body
+        emitting ``[GPT-REVIEWED]\\n<sha>`` would slip past a pattern that required
+        a sha on the same line, while pr_status.py still read it as a live stamp.
+        That spelling lands in THIS branch precisely because the lane's own
+        ``grep -Fq`` is single-line too and so fails to find the marker. The
+        neutralization therefore matches the bracketed token alone.
+        """
+        contract = _review_contract_module()
+        split_body = (
+            "BLOCKING -- src/foo.py:1 -- something\n"
+            f"[BLOCK-MERGE]\n{self.HEAD}\n"
+            f"[{stamp}-REVIEWED]\n{self.HEAD}\n"
+        )
+        # Precondition: the parser really does read the split spelling as live,
+        # otherwise this test would pass for the wrong reason.
+        assert contract.REVIEWED_STAMP_RE.findall(split_body) == [(stamp, self.HEAD)]
+        assert contract.BLOCK_MERGE_RE.findall(split_body) == [self.HEAD]
+
+        calls, result = self._run_step(
+            tmp_path,
+            workflow=workflow,
+            output_file=output_file,
+            step=step,
+            review_output=split_body,
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        posted = (calls / "created-body.md").read_text(encoding="utf-8")
+
+        assert contract.REVIEWED_STAMP_RE.findall(posted) == []
+        assert contract.BLOCK_MERGE_RE.findall(posted) == []
+
+    @pytest.mark.parametrize(("workflow", "output_file", "step", "stamp"), LANES)
+    def test_credential_shaped_unstamped_output_is_withheld_entirely(
+        self, tmp_path: Path, workflow: str, output_file: str, step: str, stamp: str
+    ) -> None:
+        """Surfacing an unstamped body must not become a credential exfil path.
+
+        The reviewer runs agentically with credentials in its environment, and a
+        malicious fork can inject a prompt that BOTH dumps that environment and
+        omits the verdict stamp -- which routes into this branch by construction,
+        because the lane's stamp check is what sends it here. Before this branch
+        existed nothing was posted, so publishing the body is the exposure. The
+        redaction earlier in the lane catches an AWS key ID and named
+        ``key=value`` forms but not a bare secret value, a GitHub token or a PEM
+        block, so any surviving credential shape must withhold the WHOLE body.
+        """
+        secret = "ghp_" + "A1b2C3d4E5f6G7h8I9j0"  # noqa: S105 - shape, not a key
+        calls, result = self._run_step(
+            tmp_path,
+            workflow=workflow,
+            output_file=output_file,
+            step=step,
+            review_output=f"BLOCKING -- src/foo.py:1 -- finding\nenv dump: {secret}\n",
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        posted = (calls / "created-body.md").read_text(encoding="utf-8")
+
+        # The credential shape never reaches the PR...
+        assert secret not in posted
+        # ...and neither does the body that carried it -- withheld wholesale, not
+        # partially scrubbed, because a partial scrub is what missed it already.
+        assert "src/foo.py:1" not in posted
+        assert "withheld" in posted
+        # The lane still reports honestly that it has no verdict.
+        assert "No completed" in posted
+
+    @pytest.mark.parametrize(("workflow", "output_file", "step", "stamp"), LANES)
+    def test_a_stamped_review_keeps_its_markers_intact(
+        self, tmp_path: Path, workflow: str, output_file: str, step: str, stamp: str
+    ) -> None:
+        """The neutralization must not leak out of the unstamped branch.
+
+        A properly stamped blocking review still publishes live markers, because
+        pr_status.py's freshness and blocking reads depend on them.
+        """
+        contract = _review_contract_module()
+        calls, result = self._run_step(
+            tmp_path,
+            workflow=workflow,
+            output_file=output_file,
+            step=step,
+            review_output=self._findings_body(stamp=stamp),
+        )
+        assert result.returncode == 0, result.stderr.decode()
+        posted = (calls / "created-body.md").read_text(encoding="utf-8")
+
+        assert (stamp, self.HEAD) in contract.REVIEWED_STAMP_RE.findall(posted)
+        assert self.HEAD in contract.BLOCK_MERGE_RE.findall(posted)
+        assert "UNSTAMPED" not in posted
+
+
+class TestForkGptLaneKeepsCredentialsOutOfTheModelShell:
+    """`codex exec` hands the model a shell; the Opus lane deliberately does not.
+
+    The Opus fork lane runs with ``--allowedTools "Read,Grep,Glob"``, so its model
+    has no way to read the environment. This lane's model does, and it runs on a
+    fork's UNTRUSTED diff, so a prompt-injected reviewer can be told to print its
+    environment. Redaction cannot close that by itself: it matches the
+    credential's shapes and its verbatim value, and a value printed in chunks,
+    with delimiters, or re-encoded defeats both. The credentials therefore must
+    not be in the shell's environment at all.
+    """
+
+    STEP = "Configure the review CLI for Amazon Bedrock"
+
+    def _config(self, tmp_path: Path) -> dict:
+        import tomllib
+
+        bash = _bash()
+        if bash is None:
+            pytest.skip("writing the review CLI config requires Bash")
+        home = tmp_path / "home"
+        home.mkdir()
+        script_file = tmp_path / "step.sh"
+        script_file.write_text(
+            _step_script(_workflow("fork-gpt-review.yml"), self.STEP),
+            encoding="utf-8",
+            newline="\n",
+        )
+        proc = subprocess.run(
+            [bash, "-e", str(script_file)],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={**os.environ, "HOME": str(home)},
+        )
+        assert proc.returncode == 0, proc.stderr
+        written = home / ".codex" / "config.toml"
+        assert written.is_file(), "the step wrote no config.toml"
+        # PARSE, never grep: a heredoc emitting invalid TOML would still satisfy a
+        # substring assertion while codex discards the policy and the model's
+        # shell keeps the credentials.
+        return tomllib.loads(written.read_text(encoding="utf-8"))
+
+    def test_the_bedrock_provider_still_resolves(self, tmp_path: Path) -> None:
+        # The exclusions must not cost the lane its model: the provider reads its
+        # credentials from the codex PROCESS environment, which the shell policy
+        # does not touch.
+        config = self._config(tmp_path)
+        assert config["model_provider"] == "amazon-bedrock"
+        assert config["model"] == "openai.gpt-5.6-sol"
+
+    def test_every_aws_credential_variable_is_excluded(self, tmp_path: Path) -> None:
+        filters = self._config(tmp_path)["shell_environment_policy"]["filters"]
+        for name in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+            assert filters.get(name) == "exclude", f"{name} still reaches the model's shell"
+        # The wildcard covers an AWS variable a later step introduces without
+        # anyone remembering to name it here.
+        assert filters.get("AWS_*") == "exclude"
+
+    def test_secret_named_variables_are_not_kept(self, tmp_path: Path) -> None:
+        # `ignore_default_excludes` reads backwards: it DEFAULTS TO TRUE, and true
+        # KEEPS variables whose names contain KEY, SECRET or TOKEN. It must be
+        # false so GH_TOKEN and future secret-shaped variables drop out too.
+        policy = self._config(tmp_path)["shell_environment_policy"]
+        assert policy["ignore_default_excludes"] is False
+
+
+class TestForkModelStepsDenyReadingTheEnvironment:
+    """Having no Bash is not the same as having no environment access.
+
+    These lanes run their models with ``--allowedTools "Read,Grep,Glob"`` and no
+    shell, which is why they need no `shell_environment_policy`. But `Read` is
+    path-unscoped and ``/proc/self/environ`` is an ordinary file, so an injected
+    prompt in the fork's untrusted diff could read the job's Bedrock credentials
+    through `Read` alone and print them into a body this PR now publishes.
+    Redaction cannot close that -- an encoded or chunked value evades both the
+    shape rules and the verbatim-value match -- so the read path is denied.
+
+    BOTH workflows this change edits are covered, not just the obvious one. The
+    GPT lane's own Opus ADJUDICATION step is a `claude-code-action` step too, and
+    the body it produces is posted by the SAME comment step that surfaces an
+    unstamped review -- so a fence that skipped it would leave the exposure
+    reachable in a file this diff already touches.
+    """
+
+    WORKFLOWS = ("fork-gpt-review.yml", "fork-opus-review.yml")
+    ACTION = "anthropics/claude-code-action"
+
+    def _model_steps(self) -> list[tuple[str, dict]]:
+        import yaml
+
+        found: list[tuple[str, dict]] = []
+        for workflow in self.WORKFLOWS:
+            doc = yaml.safe_load(_workflow(workflow))
+            steps = [
+                step
+                for job in (doc.get("jobs") or {}).values()
+                for step in (job.get("steps") or [])
+                if self.ACTION in str(step.get("uses") or "")
+            ]
+            # Enumerate rather than grep the file: a NEW model step added without
+            # the fence is exactly the regression this test exists to catch, and a
+            # whole-file substring assertion would still pass with one unfenced
+            # step sitting beside a fenced sibling.
+            assert steps, f"{workflow}: found no {self.ACTION} step to check"
+            found.extend((workflow, step) for step in steps)
+        return found
+
+    @staticmethod
+    def _args(workflow: str, step: dict) -> tuple[str, str]:
+        name = step.get("name") or step.get("id") or "<unnamed>"
+        return f"{workflow}:{name}", step.get("with", {}).get("claude_args", "")
+
+    def test_every_model_step_denies_reading_proc(self) -> None:
+        for workflow, step in self._model_steps():
+            where, args = self._args(workflow, step)
+            assert "--disallowedTools" in args, f"{where}: no --disallowedTools fence"
+            assert "Read(//proc/**)" in args, f"{where}: /proc is still readable"
+
+    def test_the_fence_is_a_deny_not_a_narrowed_allow(self) -> None:
+        # A deny rule outranks every allow rule and CLI flag, so the fence must
+        # not be expressed by narrowing --allowedTools: an allow rule that fails
+        # to match falls back to prompting, which in a non-interactive run is not
+        # a guarantee about what was read.
+        for workflow, step in self._model_steps():
+            where, args = self._args(workflow, step)
+            assert (
+                "Read(//proc" not in args.split("--disallowedTools")[0]
+            ), f"{where}: /proc appears before --disallowedTools, so it may be an allow rule"
+
+    def test_the_lanes_still_have_the_tools_they_review_with(self) -> None:
+        # The fence must not cost a lane its work: each reads the checked-out
+        # tree and its pre-fetched data through exactly these three tools.
+        for workflow, step in self._model_steps():
+            where, args = self._args(workflow, step)
+            assert '--allowedTools "Read,Grep,Glob"' in args, f"{where}: review tools changed"
+            # And Bash stays absent -- the no-shell property these lanes rest on.
+            assert "Bash" not in args, f"{where}: Bash reappeared in a fork model step"
+
+
+class TestModelStepsRunAfterTheCredentialFilesAreScrubbed:
+    """The environment fences do not cover the runner's on-disk copy.
+
+    ``configure-aws-credentials`` exports through ``core.exportVariable``, which
+    writes each value into ``$RUNNER_TEMP/_runner_file_commands/set_env_*``. Both
+    other fences guard the ENVIRONMENT -- the codex lane drops the AWS variables
+    from its shell tool's env, and the Opus steps deny ``Read(//proc/**)`` -- so
+    neither reaches a file sitting under a directory these lanes legitimately
+    read. A model told to open it can emit the value in chunks that match no
+    shape rule, which is why the value is removed rather than filtered.
+    """
+
+    WORKFLOWS = ("fork-gpt-review.yml", "fork-opus-review.yml")
+    SCRUB = "Scrub persisted credential files before the model runs"
+
+    def _jobs(self, workflow: str) -> list[list[dict]]:
+        import yaml
+
+        doc = yaml.safe_load(_workflow(workflow))
+        return [job.get("steps") or [] for job in (doc.get("jobs") or {}).values()]
+
+    @staticmethod
+    def _is_model_step(step: dict) -> bool:
+        if "anthropics/claude-code-action" in str(step.get("uses") or ""):
+            return True
+        # The codex lane invokes the model from a run block, so the `uses` test
+        # alone would miss both of its passes.
+        return "/.bin/codex" in str(step.get("run") or "")
+
+    def _scrub_bodies(self) -> list[str]:
+        bodies = []
+        for workflow in self.WORKFLOWS:
+            for steps in self._jobs(workflow):
+                for step in steps:
+                    if step.get("name") == self.SCRUB:
+                        bodies.append(step.get("run") or "")
+        return bodies
+
+    def test_every_model_step_is_directly_preceded_by_the_scrub(self) -> None:
+        seen = 0
+        for workflow in self.WORKFLOWS:
+            for steps in self._jobs(workflow):
+                for index, step in enumerate(steps):
+                    if not self._is_model_step(step):
+                        continue
+                    seen += 1
+                    where = f"{workflow}:{step.get('name') or step.get('id') or index}"
+                    assert index > 0, f"{where}: model step is first, so nothing scrubbed"
+                    assert steps[index - 1].get("name") == self.SCRUB, (
+                        f"{where}: the step before it is "
+                        f"{steps[index - 1].get('name')!r}, not the scrub"
+                    )
+        # Guard the enumeration itself: a rename that makes `_is_model_step` match
+        # nothing would otherwise turn this into a vacuous pass.
+        assert seen == 5, f"expected 5 model steps across both lanes, found {seen}"
+
+    def test_the_scrub_is_byte_identical_at_every_site(self) -> None:
+        bodies = self._scrub_bodies()
+        assert len(bodies) == 5, f"expected 5 scrub steps, found {len(bodies)}"
+        assert len(set(bodies)) == 1, "the scrub bodies have drifted apart"
+
+    def test_the_scrub_truncates_set_env_files_and_nothing_else(self, tmp_path: Path) -> None:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the scrub step is exercised on POSIX runners")
+        runner_temp = tmp_path / "runner"
+        commands = runner_temp / "_runner_file_commands"
+        commands.mkdir(parents=True)
+        (commands / "set_env_one").write_text(
+            "AWS_SECRET_ACCESS_KEY<<X\nsecret\nX\n", encoding="utf-8"
+        )
+        (commands / "set_env_two").write_text("AWS_SESSION_TOKEN<<Y\ntoken\nY\n", encoding="utf-8")
+        # A sibling command file the runner still needs: truncating it too would
+        # break state passing, so the pattern has to stay scoped to set_env_*.
+        (commands / "save_state_keep").write_text("keep\n", encoding="utf-8")
+
+        script = tmp_path / "scrub.sh"
+        script.write_text(self._scrub_bodies()[0], encoding="utf-8", newline="\n")
+        proc = subprocess.run(
+            [bash, "-e", str(script)],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={**os.environ, "RUNNER_TEMP": str(runner_temp)},
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert (commands / "set_env_one").read_text(encoding="utf-8") == ""
+        assert (commands / "set_env_two").read_text(encoding="utf-8") == ""
+        assert (commands / "save_state_keep").read_text(encoding="utf-8") == "keep\n"
+
+    def test_a_missing_runner_directory_is_not_an_error(self, tmp_path: Path) -> None:
+        # The scrub runs unconditionally before every model step, so a job whose
+        # runner exposes no file-command directory must pass through it rather
+        # than failing the lane before the review starts.
+        bash = _bash()
+        if bash is None:
+            pytest.skip("the scrub step is exercised on POSIX runners")
+        script = tmp_path / "scrub.sh"
+        script.write_text(self._scrub_bodies()[0], encoding="utf-8", newline="\n")
+        proc = subprocess.run(
+            [bash, "-e", str(script)],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={**os.environ, "RUNNER_TEMP": str(tmp_path / "absent")},
+        )
+        assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
**This PR changes the AI review gate that judges pull requests in this repo, including its own.** It does not alter any check-run conclusion, does not touch `/ai-review` override semantics, and nothing that blocked before stops blocking -- the "Tests" section locks that property down explicitly.

It is **not** purely a reporting change, and that exception is the substance of the last review round. Surfacing a body that was previously log-only is itself the new exposure, so the GPT lane now also keeps the AWS credentials out of the environment its model's shell can read. That is a real change to how the reviewer runs, and it is described under "What changed".

Rebased onto `main` (the branch was 407 commits behind and conflicting). The conflict was in `test/test_ai_review_workflows.py`: `8b166f7d5` renamed `TestForkGptVerdictVisibility` to `TestReviewLaneVerdictVisibility` and rewrote it. This PR's test code is module-level and independent of that class, so it re-applies onto the rewrite untouched. One hunk was **dropped** as redundant: the `bash -c` to script-file harness swap is now how `main`'s own helper already runs its step.

## Problem / Motivation

Both fork reviewer lanes decide what to post from one test -- whether the captured output contains `[<NAME>-REVIEWED] <head>`:

```sh
if [ -s claude-review-output.md ] && grep -Fq "[OPUS-REVIEWED] $HEAD" claude-review-output.md; then
```

When a review ran to completion but that stamp was absent or SHA-corrupted, `kind` fell through to `incomplete` and the entire body was dropped. The lane posted one line:

> _No completed Opus verdict for this commit; see the Fork Opus 4.8 Review job logs._

The findings the model did produce survived only in the job log, which a fork contributor cannot open (403). Two very different situations rendered identically: a clean, complete review whose stamp got mangled, and a review that produced nothing at all.

This is not hypothetical. The Opus lane has been observed completing a review cleanly while corrupting the head SHA in its own marker (a hex-prefix duplication, and a 25-character truncation of the 40-character SHA), five consecutive attempts on one PR. In every one of those attempts the review text existed and was unreadable on the PR.

## Why it matters

The reader cannot act, because the two cases need opposite responses. A mangled stamp on a clean review means re-run the lane. No output at all means investigate why the model produced nothing. Told only "no verdict", the contributor cannot tell which, and the person best placed to judge the review is the one denied it.

It also lands hardest on exactly the contributor with the fewest options: these are the fork lanes, so the reader is usually an external contributor who cannot open the job log and cannot re-run the workflow.

## What changed (motivation -> approach -> change)

Symptom: a completed review reports "no verdict" and shows nothing.

Root cause: `kind=incomplete` is a single bucket holding two distinct states -- "no output was captured" and "output was captured but carries no stamp for this head" -- and the branch prints neither.

The change: in that branch, when the captured file is non-empty, print it in a collapsed `<details>` block labelled as not a verdict.

The one thing that makes this safe is the marker handling. `pr_status.py` reads reviewer markers straight out of comment text:

```python
REVIEWED_STAMP_RE = re.compile(r"\[([A-Z][A-Z0-9_-]*)-REVIEWED\]\s+([0-9a-f]{7,40})\b")
BLOCK_MERGE_RE = re.compile(r"\[BLOCK-MERGE\]\s+([0-9a-f]{7,40})\b")
```

Printing a raw body would therefore publish a `[GPT-REVIEWED] <head>` freshness stamp for a review that never completed, and an unstamped review would start reading as freshly reviewed. That would reduce what blocks, so it is not acceptable.

Both patterns anchor on a literal `[`. So every marker is de-bracketed on the way out -- `[GPT-REVIEWED]` becomes `(GPT-REVIEWED-UNSTAMPED)` -- which makes the surfaced body inert to both parsers in exactly the way an absent body is.

The pattern matches the bracketed **token alone** and deliberately does not require a following SHA. Requiring one would leave open the very hole this branch exists to avoid: Python's `\s+` spans newlines, but line-oriented `sed` cannot, so a body emitting `[GPT-REVIEWED]\n<sha>` would slip past a SHA-anchored pattern while `pr_status.py` still read it as a live stamp. That spelling lands in this branch *precisely* because the lane's own `grep -Fq "[GPT-REVIEWED] $HEAD"` is single-line too, so it fails to find the marker and routes there. Both parser patterns need the bracketed token contiguous on one line (their character classes exclude newline), so breaking the bracket cannot be bypassed by any whitespace arrangement. That is the invariant: **before this change the branch posted no body and `pr_status.py` saw no markers; after it, `pr_status.py` still sees none.** The downstream view is unchanged; only a human gains something.

This mirrors an existing precedent in the same file, which already de-fangs `[BLOCK-MERGE]` when adjudication downgrades a verdict.

The check-run is untouched. `Finalize check-run (fail closed)` re-derives its conclusion from the same missing stamp, independently of the comment step, and still resolves `failure`.

### Keeping the credentials out of the model's shell

The GPT lane's reviewer blocked this PR for a residual security finding, and it was correct. Publishing the unstamped body is the new exposure -- nothing was posted in this branch before -- and `codex exec` hands the model a shell, on a fork's untrusted diff. So a prompt-injected reviewer can be told to print its environment, which holds the Bedrock credentials minted immediately before the call.

Redaction cannot close that on its own. This PR already redacts the credentials' shapes and their verbatim values, but a value printed in chunks, with delimiters, or re-encoded defeats both, and no pattern can catch every encoding. The fix therefore removes the value rather than trying to match it: the lane's `config.toml` now excludes the AWS credential variables from the environment the shell tool hands to subprocesses.

```toml
[shell_environment_policy]
ignore_default_excludes = false
filters = { "AWS_ACCESS_KEY_ID" = "exclude", "AWS_SECRET_ACCESS_KEY" = "exclude", "AWS_SESSION_TOKEN" = "exclude", "AWS_*" = "exclude" }
```

Two things about this are worth stating because both read backwards:

- **It does not cost the lane its model.** The Bedrock provider resolves credentials in the codex *process* environment; `shell_environment_policy` governs only the env passed to subprocesses the shell tool spawns. A test asserts the provider config still resolves, so the exclusion cannot pass by simply breaking the reviewer.
- **`ignore_default_excludes` defaults to `true`, and `true` KEEPS** variables whose names contain `KEY`, `SECRET` or `TOKEN`. Setting it `false` restores those built-in exclusions, so `GH_TOKEN` and any future secret-shaped variable drop out without anyone having to name them here.

A second review round showed that reasoning was wrong about the Opus lane, and the correction is worth stating plainly because it is the more interesting half.

I had argued the Opus lane needed no fence because it runs with `--allowedTools "Read,Grep,Glob"` and therefore has no shell. **No shell is not no environment access.** `Read` is path-unscoped and `/proc/self/environ` is an ordinary file, so an injected prompt can read the same Bedrock credentials through `Read` alone. The reviewer caught this; the "it has no Bash" comment in that workflow had been asserting a safety property it did not have.

Both Opus model steps now deny that path:

```
--allowedTools "Read,Grep,Glob"
--disallowedTools "Read(//proc/**),Read(//sys/**)"
```

A **deny** rule is the right shape rather than a narrowed allow list: deny outranks every allow rule and CLI flag and cannot be re-widened, `Read` denials also cover `Grep` and `Glob`, and an allow rule that fails to match falls back to *prompting* -- which guarantees nothing in a non-interactive run. It also costs the lane nothing it legitimately reads: the checkout and the pre-fetched patch are untouched.

Neither lane could solve this the other's way. The GPT lane can drop the credentials from the shell's environment because the codex process keeps its own copy for Bedrock auth. The Opus lane cannot: the environment being read is the action process's own, which must hold the credentials, so the only move is to block the path to it.

Scoped out deliberately: the pass-failure stub is NOT surfaced. If GPT's pass 1 fails, pass 2 still runs but against an empty discovery block, so its output reviewed nothing; publishing that as findings would misrepresent it, and the existing refusal to publish it is correct.

## Findings on issue #8445 that a reviewer should know

I could not reproduce the issue's headline claim, and I am reporting that rather than building on it.

#8445 states that a blocking AUTOSDE rule "masks the entire AI review", so a policy-blocked fork PR "gets no usable code-review signal". On the PR cited as its evidence (#5890, head `07bdb0121`), the GPT lane posted **three** blocking findings, not one:

| # | Anchor rule | Site |
|---|---|---|
| F1 | `no-new-builtin-apps` | `apps/builtins/project_scaffolder/app.json:2` |
| F2 | `no-blocking-call-on-event-loop` | `dashboard/chat_folders.py:618` |
| F3 | `errors-use-error-notice` | `ProjectScaffolderPage.tsx:382` |

F2 and F3 are precisely the code-review signal the issue says is erased, delivered in the same comment as the policy block, each with file:line, mechanism and fix, plus an adjudication block upholding all three individually.

Reading the code agrees: no fork lane truncates or verdict-filters its findings during output assembly. The `blocked` branch prints the whole body. Every finding-count constraint ("at most 1 BLOCK per review", "Blockers only when the verdict is BLOCK") lives in the model prompt, not the shell -- so a single-finding body means the model emitted one finding, which is output never generated, not output truncated. The Opus lane's own job log confirms this directly for #5890: its discovery stage emitted two candidates, the second anchored to no rule and left unelevated by the validator.

So the real defect in this area is not truncation by a blocking rule. It is the unstamped branch fixed here -- output that was generated, then dropped. The two are easy to confuse downstream and need opposite fixes, which is why this PR addresses only the one it can demonstrate.

The issue's remaining asks are left alone on purpose, as maintainer decisions rather than bugs: splitting AUTOSDE enforcement into its own check-run changes review gating topology and what readiness reports for every PR; making fork lanes consume an override marker is a trust-boundary call on untrusted-fork code and is contradicted by a deliberate written position in `pr-readiness.yml`; and the override workflow's concurrency behaviour sits on the override surface.

## Tests

Added `TestForkLaneSurfacesAnUnstampedReviewBody` (10 cases, both lanes), which executes the lanes' real bash step bodies with a stubbed `gh` rather than asserting on YAML text:

- `test_a_completed_review_with_no_stamp_is_surfaced_not_dropped` -- an unstamped two-finding review now has both findings readable on the PR, and the lane still says it has no verdict.
- `test_the_surfaced_body_is_inert_to_the_real_marker_parsers` -- imports the real `_review_contract` module and asserts `REVIEWED_STAMP_RE` and `BLOCK_MERGE_RE` both find **zero** matches in the posted body. Binding to the real regexes means a future drift in the parser fails this test instead of silently re-forging a stamp.
- `test_the_check_run_still_fails_closed_when_the_stamp_is_missing` -- runs the finalize step and asserts `conclusion=failure`, never `success`. This is the "nothing blocks less" assertion.
- `test_a_marker_split_across_lines_is_still_neutralized` -- pins the multiline case above. It first asserts the parser really does read `[<NAME>-REVIEWED]\n<sha>` as live, so the test cannot pass for the wrong reason, then asserts the posted body carries no readable marker.
- `test_a_stamped_review_keeps_its_markers_intact` -- a properly stamped blocking review still publishes live markers, so the neutralization cannot leak out of the unstamped branch.

Result: `483 passed` in `test/test_ai_review_workflows.py`. The parser module is loaded through the repo's `load_skill_script` helper so the import writes no bytecode into the checked-in scripts directory (verified: zero `__pycache__` entries after a run that loads it). `check_black_formatting`, `isort`, `flake8`, `check_changelog_history`, `check_testpaths_coverage` and `check_per_file_coverage` all pass.

Added `TestForkGptLaneKeepsCredentialsOutOfTheModelShell` (3 cases) for the credential exclusion. It runs the real config step with `HOME` redirected and **parses** the `config.toml` it writes with `tomllib`, because a heredoc emitting invalid TOML would satisfy a substring assertion while codex discarded the policy entirely. One case asserts the Bedrock provider still resolves, so the exclusion cannot pass by breaking the lane's model. Mutation-verified: removing the `[shell_environment_policy]` block fails 2 of the 3.

One test-harness detail worth flagging, because it used to be a real trap: each lane assembles its comment under `${RUNNER_TEMP:-/tmp}/fork-*-comment.md`, and the harness points `RUNNER_TEMP` at a per-test directory. That is what stops two parametrized cases from racing on one path -- which is how a stamped case's live markers first appeared in the unstamped case's assertions. The harness asserts the path stays `RUNNER_TEMP`-scoped, so a regression to a bare `/tmp` (shared between xdist workers, and the operator's own machine when the suite runs locally) fails the test instead of silently restoring the race.

## Manual verification

**Not possible before merge, and I want to be exact about why rather than present a green as evidence.** These lanes are `workflow_run`-triggered, and as the file's own header states, `workflow_run` always runs the workflow definition from the default branch. This is also a same-repo PR, so it is reviewed by `codex-review.yml` and `claude-review.yml`; `fork-gpt-review.yml` and `fork-opus-review.yml` will not execute on it at all. No lane on this PR can exercise this change, and any green here says nothing about it. The behavioural tests above run the real step bodies precisely because that is the only pre-merge proof available.

Verified out of band instead: the neutralizing `sed` was run over a synthetic body carrying `[BLOCK-MERGE]`, `[GPT-REVIEWED]`, `[OPUS-REVIEWED]` and `[DESIGN-REVIEWED]` stamps, and the real parser regexes were run over the result -- two stamps and one blocking marker before, zero of each after. Both workflow files parse as YAML.

Also unrun, and stated rather than skipped silently: `run_scoped_tests.py` classifies `.github/workflows/**` as a broad-impact path and would run the full backend suite (62,108 tests). That run measures 21-32 GB on the host this was prepared on, which cannot host it safely alongside other work, so it was deliberately not run locally and is left to CI.

## Pattern harvest

Rule candidate: a neutralizer or guard written as a single-line `sed`/`grep` must not be relied on to sanitize text for a parser whose whitespace class spans newlines. Match the smallest token the parser cannot split (here the bracketed marker) rather than the token plus its argument, and pin it with a test that loads the real parser. This PR contains a live instance in both directions: the lane's `grep -Fq` and the neutralizing `sed` are both single-line while `pr_status.py` uses `\s+`, and that mismatch is what decides whether an unstamped review can forge a freshness stamp.

Secondary observation, not proposed as a rule because it is already covered: `AUTOSDE.yaml`'s `feature-map-correctness` rule expresses the same "the artifact must be true, not merely present" shape that this defect is an instance of -- a marker was present-looking and unusable.

Recording the pattern for the reviewer rather than the rule file, because its scope is one shell idiom: **when a gate keys on a marker it did not itself construct, the failure path must still surface the content the marker was supposed to describe.** Fail-closed on the marker is right; discarding the payload is a separate decision that reads as the same thing. The generalizable half is the neutralization technique -- when reporting content that a downstream parser also reads, break the parser's anchor (here a literal `[`) instead of trusting the content to be marker-free, and pin it with a test that imports the real parser so the two cannot drift.

Refs #8445



