### PR TITLE
fix: dedupe overlapping archive segments in the rotated corpus

### DIFF
--- a/src/kiro_crew/history_projection.py
+++ b/src/kiro_crew/history_projection.py
@@ -432,6 +432,7 @@ class TranscriptReadProjection:
                 # (see the docstring). A healthy read skips these too, so this one
                 # must stay a plain skip.
                 continue
+            seg_rows: list[dict] = []
             for ln in lines[1:]:
                 if not ln.strip():
                     continue
@@ -451,7 +452,23 @@ class TranscriptReadProjection:
                 if "_type" not in row:
                     # `_type` rows are deliberate control records, not messages --
                     # skipping them IS the classification this corpus wants.
-                    rows.append(row)
+                    seg_rows.append(row)
+            # Two SEGMENTS can overlap, not just the archive and the live file.
+            # Archiving is a precondition of the live-file rewrite, so a crash
+            # between those two steps leaves the archived prefix in the live file
+            # as well; the next rotation then computes its own `dropped` from a
+            # live file that still begins with those rows and archives them again
+            # as the following segment. The header check above already names this
+            # ("a retry rotation can archive the same rows successfully") — this
+            # is the guard for it.
+            #
+            # Same identity rule as the archive/live seam, one level down: a
+            # producer only ever persists a PREFIX, so the duplication is always
+            # this segment's head against what the corpus already ends with.
+            # Appending blind instead would not merely show a row twice — this is
+            # the index space `before`/`next_before` and the fork index path
+            # resolve against, so each extra row shifts every index above it.
+            rows.extend(drop_persisted_tail_prefix(rows, seg_rows))
         if complete:
             if not rows:
                 # Segments exist yet no rotate rows parsed — the exact signature

--- a/test/test_archive_segment_overlap.py
+++ b/test/test_archive_segment_overlap.py
@@ -1,0 +1,116 @@
+"""Two rotation segments can overlap, and the corpus must serve each row once.
+
+`_maybe_rotate` writes the archive segment BEFORE rewriting the live file, and
+that order is deliberate: until the archive lands, the live file is the only copy
+of those rows. A crash between the two steps therefore leaves the archived prefix
+in the live file as well, and the next rotation computes its own `dropped` from a
+live file that still begins with those rows -- archiving them a second time as the
+following segment.
+
+`read_rotated_messages` concatenates segments, so without a cross-segment guard
+those rows are served twice. That is not cosmetic: this corpus is the index space
+`before`/`next_before` cursors and the fork index path resolve a rendered row's
+position against, so one duplicated row shifts every index above it, silently. A
+reader pages positions that no longer mean what they meant, and an
+index-addressed fork copies a different cutoff than the one on screen.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from kiro_crew import history as history_mod
+from kiro_crew.history_projection import TranscriptReadProjection
+
+
+class _Log:
+    def __init__(self, d: Path) -> None:
+        self._dir = Path(d)
+
+
+def _row(n: str, mid: str | None = None) -> dict:
+    r: dict = {"role": "user", "content": n, "ts": f"2026-01-01T00:00:{n.zfill(2)}Z"}
+    if mid:
+        r["meta"] = {"mid": mid}
+    return r
+
+
+def _segment(adir: Path, stem: str, stamp: str, rows: list[dict]) -> Path:
+    p = adir / f"{stem}{stamp}.jsonl"
+    lines = [json.dumps({"reason": "rotate"})]
+    lines += [json.dumps(r) for r in rows]
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def _proj(tmp_path: Path, segments: list[list[dict]], key: str = "slot-a") -> Any:
+    adir = Path(history_mod._archive_dir(Path(tmp_path)))
+    adir.mkdir(parents=True, exist_ok=True)
+    stem = history_mod._safe_key(key) + history_mod.ARCHIVE_SEGMENT_DELIMITER
+    for i, rows in enumerate(segments):
+        _segment(adir, stem, f"20260101-0000{i:02d}", rows)
+    proj = TranscriptReadProjection.__new__(TranscriptReadProjection)
+    proj._log = _Log(tmp_path)  # type: ignore[attr-defined]
+    return proj
+
+
+def _read(proj: Any, key: str = "slot-a") -> list[str]:
+    rows = TranscriptReadProjection.read_rotated_messages(proj, key)
+    return [r["content"] for r in rows]
+
+
+def test_non_overlapping_segments_are_all_served(tmp_path: Path) -> None:
+    """The guard must not eat rows from a healthy archive."""
+    proj = _proj(tmp_path, [[_row("1"), _row("2")], [_row("3"), _row("4")]])
+    assert _read(proj) == ["1", "2", "3", "4"]
+
+
+def test_a_wholly_duplicated_segment_is_served_once(tmp_path: Path) -> None:
+    """The crash re-archived the entire prefix: segment 2 repeats segment 1."""
+    seg = [_row("1"), _row("2")]
+    proj = _proj(tmp_path, [list(seg), list(seg) + [_row("3")]])
+    assert _read(proj) == ["1", "2", "3"]
+
+
+def test_a_partially_duplicated_segment_is_served_once(tmp_path: Path) -> None:
+    """Only the tail of segment 1 was re-archived at the head of segment 2."""
+    proj = _proj(tmp_path, [[_row("1"), _row("2")], [_row("2"), _row("3")]])
+    assert _read(proj) == ["1", "2", "3"]
+
+
+def test_overlap_is_matched_by_stable_id_when_present(tmp_path: Path) -> None:
+    """`meta.mid` is the identity that cannot collide, so it decides."""
+    proj = _proj(
+        tmp_path,
+        [
+            [_row("1", mid="m1"), _row("2", mid="m2")],
+            [_row("2", mid="m2"), _row("3", mid="m3")],
+        ],
+    )
+    assert _read(proj) == ["1", "2", "3"]
+
+
+def test_distinct_rows_sharing_ts_and_role_are_both_kept(tmp_path: Path) -> None:
+    """A match DELETES a row, so `(ts, role)` alone must never be enough.
+
+    Two different messages can share a second and a speaker. If the identity rule
+    dropped on that pair alone, this second row -- genuinely its own message --
+    would vanish from the corpus and shift every index above it.
+    """
+    a = {"role": "user", "content": "first", "ts": "2026-01-01T00:00:01Z"}
+    b = {"role": "user", "content": "second", "ts": "2026-01-01T00:00:01Z"}
+    proj = _proj(tmp_path, [[a], [b]])
+    assert _read(proj) == ["first", "second"]
+
+
+def test_an_interior_repeat_is_not_treated_as_overlap(tmp_path: Path) -> None:
+    """Both producers persist a PREFIX, never an interior slice.
+
+    A row that reappears in the middle of the next segment is not a re-archived
+    prefix -- it is the reader's own repeated message, and dropping it would
+    delete history the session really contains.
+    """
+    proj = _proj(tmp_path, [[_row("1"), _row("2")], [_row("9"), _row("2")]])
+    assert _read(proj) == ["1", "2", "9", "2"]


### PR DESCRIPTION
Closes #8484. Split out of #7916 under a human override: the finding was real, but low-probability, so it did not hold that PR.

## The seam

`read_rotated_messages` concatenated archive segments with a bare `rows.append(row)` and no cross-segment identity check. `drop_persisted_tail_prefix` guards the **archive↔live** seam — it cannot reach this one, because the duplicate is already inside `rotated` before that comparison runs.

## How two archive segments come to overlap

`HistoryRewriter._maybe_rotate` writes the archive **before** rewriting the live file, deliberately: until the archive lands, the live file is the only copy of those rows, so archiving is a precondition of the rewrite rather than a best-effort side effect.

A hard crash between those two steps leaves `dropped` in **both** places:

1. archive segment N is written;
2. the process dies before the live-file rewrite;
3. the live file still begins with those same rows;
4. the next rotation computes `dropped' = message_lines[:-keep_count]`, which starts with that same prefix, and archives it again as segment N+1;
5. segments N and N+1 overlap, and the reader concatenates both.

The header-damage branch a few lines above already named this hazard — *"a retry rotation can archive the same rows successfully, and then a partial read of this segment duplicates them"* — but nothing guarded it.

## Why a duplicate is worse than showing a row twice

`read_rotated_messages` **is** the pagination index space: `before` / `next_before` cursors and the fork index path both resolve a rendered row's position against it. A duplicated row shifts every index above it, silently. A reader pages positions that no longer mean what they meant, and an index-addressed fork copies a different cutoff than the one on screen. Nothing raises.

## The fix

Accumulate each segment's rows, then apply `drop_persisted_tail_prefix` against the corpus so far before extending. Same rule, same helper, one level down — no new identity logic. Both producers persist a **prefix**, never an interior slice, so the duplication is always a segment's head against what the corpus already ends with, which is exactly the shape that helper was written for.

## Test power — verified in both directions

`test/test_archive_segment_overlap.py`, 6 cases. Three pin the fix and three pin its **limits**, so the suite fails if the guard is missing *or* too greedy:

| mutation | reddens |
|---|---|
| drop the dedup (`rows.extend(seg_rows)`) | `wholly_duplicated` → `['1','2','1','2','3']`, `partially_duplicated` → `['1','2','2','3']`, `overlap_matched_by_stable_id` |
| widen the identity rule to `(ts, role)` only | `distinct_rows_sharing_ts_and_role_are_both_kept` |

The three upper-bound cases stay green under the first mutation **by design** — they assert the guard does not eat rows — which is why the second mutation is what proves they are not vacuous.

`non_overlapping_segments_are_all_served` keeps a healthy archive intact; `an_interior_repeat_is_not_treated_as_overlap` pins that a row reappearing mid-segment is the reader's own repeated message, not a re-archived prefix.

## Cost

The helper's `all(...)` short-circuits on the first mismatch, so the healthy no-overlap path costs one comparison per candidate offset, and the whole read is cached on the segment files' stat signature — it runs once per archive change, not once per page.

## Checks run locally

`pytest` on the new file plus the five adjacent archive/fork/pagination suites (51 passed), `isort`, `flake8`, `mypy --platform linux`, and the black gate. The full suite is left to CI.

**Why no screenshot:** backend-only change to a transcript read projection. There is no user-visible surface in this diff — the observable effect is the absence of duplicated rows in a corpus that only appears after a crash-interrupted rotation, which is not reproducible in a screenshot.
