### PR TITLE
feat(goal-conductor): durable inbox and dispatch record

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -5176,9 +5176,10 @@ file-writing tool, and a work item never goes to `spawn_run`,
 dispatch, verify and report on.
 
 **Acceptance is the evaluator's verdict, never your reading of a child's
-transcript.** Shell access exists to run the `goal-conductor` skill's two
+transcript.** Shell access exists to run the `goal-conductor` skill's three
 bundled scripts: `scripts/accept_eval.py` for acceptance verdicts,
-`scripts/ledger_entry.py` for the ledger's item-entry format.
+`scripts/ledger_entry.py` for the ledger's item-entry format, and
+`scripts/dispatch_queue.py` for the durable inbox and dispatch record.
 
 **Patrol with `monitor_start`, never with `wait`.** Arm it with the full cycle
 instructions AND the exit condition, then end the turn; call `autonudge_stop`

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -17,10 +17,16 @@ Your four jobs, none of which can be delegated to a work item:
 Everything else belongs in a work item. This spec has **no `fs_write`** — that
 is deliberate. If a task needs a file written, it is a work item, not something
 you do. `execute_bash` IS granted, for exactly one purpose: running this
-skill's bundled scripts — the acceptance evaluator (`scripts/accept_eval.py`)
-and the ledger entry codec (`scripts/ledger_entry.py`). Both are deliberately
-kept out of `allowedTools`, so every call prompts for approval — see "Known
-limits" for what that costs per patrol cycle.
+skill's bundled scripts — the acceptance evaluator (`scripts/accept_eval.py`),
+the ledger entry codec (`scripts/ledger_entry.py`), and the durable inbox +
+dispatch record (`scripts/dispatch_queue.py`). All three are deliberately kept out of
+`allowedTools`, so every call prompts for approval — see "Known limits" for what
+that costs per patrol cycle.
+
+Between them they hold everything that must survive a lost turn: the evaluator
+holds the VERDICT, the codec holds the ENTRY FORMAT, and the queue holds the two
+things that used to live only in this prose — a mid-flight user message, and
+whether an item was already dispatched.
 
 ## What is a work item
 
@@ -98,7 +104,14 @@ beats more parallelism: every open item is a session the user may have to read.
 
 ### Dispatch a round
 
-For each item in the round:
+For each item in the round, start with `dispatch_queue.py dispatch_begin` and
+`{goal, item}` — before creating anything. It pre-assigns the item's dispatch id
+and returns `replay: true` when a previous attempt already began this item.
+**`replay: true` with `state: "begun"` means a session may already exist for it
+with no seed** — read that session before creating a second one, because an
+unseeded session looks exactly like a quiet one. A second `dispatch_begin`
+deliberately returns the SAME id: a fresh id per attempt is what opens two
+sessions for one item. Then the dispatch itself:
 
 1. `session_create` with a title that says what the item is FOR, `folder` set to
    the goal's folder (missing path segments are created automatically, and the
@@ -114,7 +127,10 @@ For each item in the round:
 2. `session_send` the seed prompt into the new session — the item's goal, its
    acceptance condition, and where to report. The seed is the item's whole
    contract: the child session gets no other context from you.
-3. `session_ledger_record` the item: its goal text, the round number, and — in
+3. `dispatch_queue.py dispatch_sent` with `{goal, item, session}` immediately after the
+   seed lands. This is what closes the replay window: until it is recorded, every
+   later `dispatch_begin` for this item warns that the session may be unseeded.
+4. `session_ledger_record` the item: its goal text, the round number, and — in
    `artifacts`, under an `item-<n>` key — the durable item entry carrying its
    acceptance spec, session key, round, status and read cursor. **Never
    hand-write the entry value: encode it with the bundled codec**
@@ -128,7 +144,12 @@ For each item in the round:
    compaction; `next` carries the resumable intent.
 
 Send the seed BEFORE recording the ledger row as dispatched — a ledger row that
-says "running" for a session that never got its seed is the worse failure.
+says "running" for a session that never got its seed is the worse failure. The
+ordering is still yours to keep, but it is no longer only prose: `dispatch_begin`
+and `dispatch_sent` make a half-finished dispatch VISIBLE to the next turn, so a
+lost turn between create and send is recoverable instead of invisible. What they
+do NOT give you is atomicity — the two session calls are yours to make, so the
+queue can tell you a dispatch was replayed but cannot prevent the replay.
 
 ### Patrol
 
@@ -192,11 +213,11 @@ Each cycle:
    failing it, asking a question, or stalling. Never post "nothing changed".
 
 **Shell exists for the bundled scripts, not for work.** `execute_bash` is
-granted so patrol can run `accept_eval.py` and `ledger_entry.py`. Running a
-work item's build, test, or fix yourself through it is the boundary violation
-this skill exists to prevent — if you need a command run to MAKE something
-true, that is a work item; the bundled scripts only CHECK and ENCODE what is
-already true.
+granted so patrol can run `accept_eval.py`, `ledger_entry.py` and `dispatch_queue.py`.
+Running a work item's build, test, or fix yourself through it is the boundary
+violation this skill exists to prevent — if you need a command run to MAKE
+something true, that is a work item; the bundled scripts only CHECK, ENCODE and
+REMEMBER what is already true.
 
 ### Close the round
 
@@ -212,6 +233,15 @@ original plan did not have. Re-planning mid-round is not: let the round finish.
 The user can message you any time. Apply a changed goal **at the round
 boundary** — that is the re-plan point, and cancelling mid-round throws away
 finished work.
+
+**Park it the moment it arrives: `dispatch_queue.py enqueue` with `{goal, text}`.** Holding
+it "until the boundary" in the conversation alone is how a steering instruction
+disappears — a compaction between arrival and the boundary takes it with no trace.
+At the boundary, `dispatch_queue.py claim` returns every parked message, and `dispatch_queue.py done`
+with their ids drops the ones you applied. A claim does NOT delete: a turn that
+dies after claiming leaves the messages recoverable, and a later claim re-serves
+anything claimed longer ago than `stale_secs`. Use `release` when you claimed a
+message you are not going to apply this round.
 
 One exception: if their message directly invalidates an item that is still
 running, deal with that item now — `session_stop` it, or `session_send` the
@@ -360,9 +390,13 @@ watches, and that cost grows with the loop's own history.
   dispatch (the seed) and one if you ever stop an item — all of which happen
   right after the user approved a plan, not mid-patrol. `execute_bash` also still
   prompts, so **each patrol cycle blocks on one approval for the
-  `accept_eval.py` invocation** plus one per codec call. Size the nudge interval
-  for that, and batch: one evaluator call per cycle carrying every open item, one
-  codec call per map-wide operation. On a host with a governance ceiling even the
+  `accept_eval.py` invocation** plus one per codec call and one per `dispatch_queue.py`
+  call. A dispatch round pays two extra approvals per item for `dispatch_begin` +
+  `dispatch_sent` — that is the price of a recoverable dispatch, and it buys back
+  the case where a lost turn leaves a session nobody can tell is unseeded. Size
+  the nudge interval for that, and batch: one evaluator call per cycle carrying
+  every open item, one codec call per map-wide operation, one `claim` per round
+  boundary rather than a poll per cycle. On a host with a governance ceiling even the
   granted verbs prompt; if you see approvals where this says you should not, that
   is why.
 - **`session_send` reports delivery, not completion.** `started: true` means the
@@ -373,9 +407,10 @@ watches, and that cost grows with the loop's own history.
   and sessions in another workspace are all refused by the shared guard. Plan
   work items onto plain persistent dashboard sessions only.
 - **Shell is for the bundled scripts only, and the evaluator runs no command
-  you name.** `execute_bash` exists so patrol can run `accept_eval.py` and
-  `ledger_entry.py` (the codec runs no subprocess at all — it only transforms
-  JSON); every call is audit-logged and every call prompts. The evaluator
+  you name.** `execute_bash` exists so patrol can run `accept_eval.py`,
+  `ledger_entry.py` and `dispatch_queue.py` (neither the codec nor the queue runs a
+  subprocess at all — one transforms JSON, the other reads and writes one state
+  file); every call is audit-logged and every call prompts. The evaluator
   accepts **no command, argv array, or shell string from a spec** — it builds
   every argv it runs from a fixed template, so `pr_checks` becomes `gh pr
   checks <n>` and nothing else executes. That is deliberate and load-bearing:

--- a/src/kiro_crew/builtin_skills/goal-conductor/scripts/dispatch_queue.py
+++ b/src/kiro_crew/builtin_skills/goal-conductor/scripts/dispatch_queue.py
@@ -1,0 +1,870 @@
+#!/usr/bin/env python3
+"""Durable inbox + dispatch record - the conductor's crash-surviving bookkeeping.
+
+Two things the conductor previously held only in a PROMPT, and therefore only in
+context, which is exactly what compaction and a lost turn take away:
+
+1. **A mid-flight user message.** The user can message the conductor at any time,
+   and the skill's rule is to apply a goal change at the ROUND BOUNDARY. Between
+   arrival and that boundary the message lived nowhere but the conversation, so a
+   compaction in between silently dropped a steering instruction.
+2. **Whether an item was already dispatched.** Dispatch is two calls -
+   ``session_create`` then ``session_send`` - and the skill ordered them with
+   prose ("send the seed BEFORE recording the ledger row"). A turn lost between
+   the two leaves a session with no seed, and the next patrol cycle cannot tell
+   that from a session that is merely quiet.
+
+This script owns both as files on disk, so a fresh turn can read what the last
+one did.
+
+WHAT THIS DOES NOT GIVE YOU, said plainly: dispatch here is
+detectable-and-convergent, NOT atomic. ``dispatch_begin`` hands back the same id
+for an item already begun, so a second attempt is VISIBLE and converges on one
+session instead of opening a second - but ``session_create`` and ``session_send``
+are MCP tool calls the model makes, and this script cannot make them. Only moving
+dispatch into gateway-side code makes a duplicate impossible; that is deliberately
+out of scope here.
+
+No identity, by construction. This is the conductor's own bookkeeping, not an
+authorization boundary: nothing here reads a session key, a gateway credential, or
+the SEL trust root, and nothing here decides what any caller may reach. That is
+what makes it safe as a plain script - a script runs as a child of
+``execute_bash``, where the gateway injects no verifiable identity, so any file
+here that gated access would be gating on an assertion.
+
+Usage:
+    python3 dispatch_queue.py {enqueue|claim|done|release|dispatch_begin|dispatch_sent|status} < in.json
+
+Every mode reads one JSON document on stdin and writes one on stdout. Domain
+problems (an unknown goal id shape, a full inbox, an oversize message) are
+structured ``{"ok": false, "error": {...}}`` results, never crashes - the
+conductor must be able to read WHY and decide. Exit code 0 means the operation
+ran; 2 means stdin was not the JSON the mode needs, or the mode name is unknown.
+
+Every response carries ``state_path``. That is not decoration: the state root is
+resolved from the environment (see :func:`_data_home`), so a conductor that
+records the path in its ledger can tell "the queue is empty" from "the queue is
+somewhere else".
+
+Modes:
+
+``enqueue``  park a mid-flight message until the next round boundary.
+    stdin:  {"goal": "<id>", "text": "..."}
+    stdout: {"ok": true, "id": "...", "pending": 2, "state_path": "..."}
+
+``claim``  take every pending message (call this AT the round boundary).
+    stdin:  {"goal": "<id>", "stale_secs": 900}
+    stdout: {"ok": true, "claimed": [{"id","text","enqueued_at"}], "pending": 0}
+    A claim marks each entry ``claimed`` with a timestamp rather than deleting it,
+    so a turn that dies after claiming does not take the messages with it: a later
+    claim re-serves anything claimed longer ago than ``stale_secs``. Deleting on
+    read would be simpler and would lose exactly the message this script exists to
+    keep.
+
+``done``  drop messages you have applied.
+    stdin:  {"goal": "<id>", "ids": ["..."]}
+    stdout: {"ok": true, "removed": 1, "pending": 0}
+
+``release``  push claimed messages back to pending without applying them.
+    stdin:  {"goal": "<id>", "ids": ["..."]}
+
+``dispatch_begin``  pre-assign (or recover) a work item's dispatch id.
+    stdin:  {"goal": "<id>", "item": "item-1"}
+    stdout: {"ok": true, "dispatch_id": "...", "state": "begun", "attempts": 1,
+             "replay": false}
+    ``replay: true`` with ``state: "begun"`` is the signal that matters: a prior
+    attempt began this item and never recorded a seed, so the session it created
+    (if it created one) has no seed. Read it before creating a second one.
+
+``dispatch_sent``  record that the seed landed.
+    stdin:  {"goal": "<id>", "item": "item-1", "session": "dashboard:slot-3"}
+
+``status``  the whole record, for a patrol cycle.
+    stdin:  {"goal": "<id>"}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+#: A goal id names a DIRECTORY, so it is validated as a single safe segment
+#: rather than sanitized into one. Sanitizing maps two different goals onto one
+#: name (``a/b`` and ``a_b``), which silently merges two goals' queues - the
+#: failure would look like the conductor reading someone else's messages.
+_GOAL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+#: Inbox cap. Full REFUSES rather than dropping the oldest: every entry here is a
+#: message the user typed, and silently discarding one is the failure this script
+#: was built to prevent. The conductor's answer to a full inbox is to run a round
+#: and drain it, which is a real answer.
+MAX_INBOX = 200
+
+#: Per-message cap. Also a refusal rather than a truncation - half a steering
+#: instruction can invert its meaning ("do not ship" -> "do").
+MAX_TEXT = 20_000
+
+#: Dispatch records per goal. A goal with more live items than this is not a
+#: capacity problem to paper over; the skill caps a round at two or three items.
+MAX_ITEMS = 200
+
+#: How long a lock may be held before a holder we can PROVE is gone loses it. A
+#: crashed holder must not wedge a goal forever, and every critical section here
+#: is a read-modify-write of one small file. Age alone is deliberately NOT enough
+#: to steal: a writer merely slower than this is still live, and robbing it is how
+#: two processes end up publishing over each other. See :meth:`_Lock._may_steal`.
+LOCK_STALE_SECS = 60.0
+
+#: The backstop for a lock whose holder cannot be judged dead - an unparseable
+#: pid, or any platform without a non-destructive liveness probe (Windows: see
+#: :func:`_holder_is_alive`). Far longer than ``LOCK_STALE_SECS`` because it is
+#: the window in which a live-but-slow writer would be robbed, and short enough
+#: that a crash on such a platform still frees the goal within one sitting.
+LOCK_ABANDON_SECS = 900.0
+
+LOCK_WAIT_SECS = 5.0
+
+_TERMINAL_DISPATCH = ("sent",)
+
+
+def _error(code: str, message: str, **extra: Any) -> Dict[str, Any]:
+    out: Dict[str, Any] = {"ok": False, "error": {"code": code, "message": message}}
+    out.update(extra)
+    return out
+
+
+def _data_home() -> Path:
+    """Where the state lives.
+
+    Preferred: the package's own resolver, so this agrees with the gateway by
+    construction. It is a function-local import because this script also runs
+    where ``kiro_crew`` is not importable - the skill tree is synced out of the
+    package, and a module-scope import would make the script unusable there.
+
+    Fallback: ``KIROCREW_HOME`` when set, else ``~/.kiro/crew``. That fallback
+    deliberately does NOT re-implement the resolver's override-validity predicate
+    (which rejects an override naming a system directory): a second copy of that
+    rule is a second thing to drift, and the consequence of disagreeing here is
+    not an access decision - it is a queue file under a different root. Which is
+    why every response reports ``state_path``: a conductor that records it can
+    see the disagreement instead of reading an empty queue as "no messages".
+    """
+    try:
+        from kiro_crew.config.paths import data_home  # noqa: PLC0415
+
+        return Path(data_home())
+    except Exception:
+        override = os.environ.get("KIROCREW_HOME", "").strip()
+        if override:
+            return Path(override).expanduser()
+        return Path.home() / ".kiro" / "crew"
+
+
+def _state_path(goal: str) -> Path:
+    return _data_home() / "conductor" / goal / "queue.json"
+
+
+def _now() -> float:
+    return time.time()
+
+
+def _blank(goal: str) -> Dict[str, Any]:
+    return {"version": 1, "goal": goal, "inbox": [], "dispatch": {}}
+
+
+class _Unreadable(Exception):
+    """The record exists but could not be read THIS TIME.
+
+    Distinct from absent on purpose, and the distinction is load-bearing: an
+    earlier revision returned a blank record for any ``OSError``, and every mode
+    then WROTE that blank over the file -- destroying the parked messages this
+    script exists to keep, on a transient read error. Absent may read as blank;
+    unreadable must refuse and leave the bytes alone.
+    """
+
+
+def _quarantine(path: Path) -> None:
+    """Move an unusable record aside, keeping the bytes on disk to look at.
+
+    Best-effort by design: failing to rename must not make the mode fail, because
+    the alternative is a goal whose queue can never be used again. The rename is
+    what makes discarding a record RECOVERABLE, so every discard path goes through
+    here -- an unparseable file and a structurally invalid one are the same class
+    of problem and get the same treatment.
+    """
+    try:
+        path.replace(path.with_suffix(f".corrupt-{int(_now())}"))
+    except OSError:
+        pass
+
+
+def _read(path: Path, goal: str) -> Dict[str, Any]:
+    """Load the record. Absent -> blank; unusable -> quarantine; unreadable -> raise.
+
+    A truncated or hand-edited file must not make every later mode fail -- the
+    conductor would have no way back to a working queue -- so a file whose BYTES
+    read fine but are not a record this script can use is moved aside
+    (``.corrupt-<ts>``, still there to look at) and treated as absent. A file we
+    cannot read at all is a different thing and is not overwritten.
+
+    "Not a record this script can use" covers BOTH unparseable bytes and valid
+    JSON of the wrong shape, and the second is the one worth stating: a file whose
+    ``inbox`` is an object or whose ``dispatch`` is a list still holds the
+    conductor's parked messages and dispatch ids in readable form. Returning a
+    blank for it without the sidecar meant the very next mutation wrote the blank
+    back and those records were gone with no copy anywhere -- the same data loss
+    the unparseable path already quarantined against, reached through a different
+    door.
+
+    The shape check goes one level DEEP, and that is not belt-and-braces. Checking
+    only the containers accepts ``{"inbox": [null]}``: the container is a list, so
+    every mode then reaches for ``entry.get(...)`` on a non-mapping and dies with an
+    uncaught ``AttributeError``. That is the exact failure this function exists to
+    prevent -- a hand-edited or truncated file making every later mode fail with a
+    traceback instead of the structured refusal the conductor can act on -- so a
+    malformed ENTRY is quarantined on the same path as a malformed container.
+    """
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError:
+        return _blank(goal)
+    except OSError as exc:
+        raise _Unreadable(str(exc)) from exc
+    try:
+        data = json.loads(raw)
+    except Exception:
+        _quarantine(path)
+        return _blank(goal)
+    if (
+        not isinstance(data, dict)
+        or not isinstance(data.get("inbox"), list)
+        or not isinstance(data.get("dispatch"), dict)
+        or not all(isinstance(entry, dict) for entry in data["inbox"])
+        or not all(isinstance(rec, dict) for rec in data["dispatch"].values())
+    ):
+        _quarantine(path)
+        return _blank(goal)
+    data["goal"] = goal
+    return data
+
+
+def _write_all(fd: int, payload: bytes, what: str) -> None:
+    """Write every byte, or raise without having written a usable file.
+
+    ``os.write`` is not obliged to consume the whole buffer and does NOT raise when
+    it does not - on a full device it returns a short count. Every caller here
+    needs all-or-nothing, so the loop lives in one place: a partial state record
+    published over a good one destroys the queue, and a partial lock TOKEN is worse
+    than no lock at all, because it can never be matched again and would make every
+    later fenced write refuse.
+    """
+    written = 0
+    while written < len(payload):
+        n = os.write(fd, payload[written:])
+        if n <= 0:
+            # Not an OS exception, just no forward progress - which on a full
+            # device is exactly what a short write looks like.
+            raise OSError(
+                f"short write to {what}: {written} of {len(payload)} bytes (out of space?)"
+            )
+        written += n
+
+
+def _fsync_dir(directory: Path) -> None:
+    """Commit the RENAME, not just the bytes it points at.
+
+    ``os.fsync`` on the temp file makes its CONTENTS durable; the directory entry
+    that ``os.replace`` rewrote is separate metadata and can still be lost. Without
+    this, a power cut just after a successful ``enqueue`` can come back up with the
+    message gone even though the call returned ok -- and a message the user typed
+    that we acknowledged is precisely what this script exists not to lose.
+
+    Best-effort by design. A directory is not openable on Windows, and some
+    filesystems refuse to fsync one; neither is a reason to fail a write whose data
+    is already committed, so the durability is upgraded where it can be and the
+    write stands where it cannot.
+    """
+    if sys.platform == "win32":
+        return
+    try:
+        dir_fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
+def _write(path: Path, data: Dict[str, Any], fence: "_Lock | None" = None) -> None:
+    """Atomic replace + fsync, so a crash mid-write cannot leave half a record.
+
+    Three things have to hold before the ``os.replace`` publishes, and each of them
+    is a way this has already been got wrong:
+
+    - **Every byte is written**, via :func:`_write_all`. Writing once and replacing
+      anyway published truncated JSON over a complete record, and the truncation
+      then read back as corrupt, so the queue was gone.
+    - **The bytes are on the device.** ``os.fsync`` before the rename, so a crash
+      cannot leave the rename durable and the contents not. :func:`_fsync_dir`
+      after it, so the rename itself is durable too.
+    - **We still hold the lock.** ``fence`` is the lock guarding this critical
+      section; if it was stolen while we were slow, we are about to overwrite
+      somebody else's newer state with our stale view. Refusing is the only
+      correct move - see :class:`_Lock`.
+
+    Nothing is published unless all three hold, so a failure here leaves the
+    previous record exactly as it was and drops the temp file.
+
+    The fence is checked TWICE, and the second one is the load-bearing one. An
+    entry check only proves the lock was ours before the slow part; ``os.fsync``
+    waits on the device, which is exactly the window in which a stalled writer gets
+    its lock stolen. Checking only on entry meant a writer could be declared dead,
+    have its lock taken, watch the thief publish, and then ``os.replace`` its own
+    pre-steal view over the newer state -- the lost update the fence exists to stop,
+    reached by being slow in between the check and the publish. The entry check
+    stays because failing before writing anything is cheaper than failing after.
+    """
+    if fence is not None and not fence.still_held():
+        raise _LockLost(f"{fence.path} was taken while this write was in progress")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(f".tmp-{os.getpid()}")
+    payload = json.dumps(data, ensure_ascii=False, indent=1).encode("utf-8")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        _write_all(fd, payload, str(tmp))
+        os.fsync(fd)
+    except BaseException:
+        os.close(fd)
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+    os.close(fd)
+    if fence is not None and not fence.still_held():
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise _LockLost(f"{fence.path} was taken while this write was being flushed")
+    os.replace(str(tmp), str(path))
+    _fsync_dir(path.parent)
+
+
+class _LockLost(Exception):
+    """We held the lock, and by the time we went to publish we no longer did.
+
+    Raised instead of completing the write. The alternative - replacing the file
+    anyway - is a lost update: the process that stole the lock has already written
+    a NEWER record, and our view predates it.
+    """
+
+
+def _holder_is_alive(pid: int) -> bool | None:
+    """Is the recorded lock holder still running? ``None`` means cannot tell.
+
+    Three-valued on purpose, because "cannot tell" must not read as "dead". On
+    POSIX ``os.kill(pid, 0)`` is the standard non-destructive probe. On Windows
+    there is no such probe in the standard library -- ``os.kill`` there ignores the
+    signal and TERMINATES the target -- so this returns ``None`` rather than doing
+    something destructive to answer a bookkeeping question. ``EPERM`` means the pid
+    exists and belongs to somebody else, which is alive for our purposes.
+    """
+    if not hasattr(os, "kill") or sys.platform == "win32":
+        return None
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return None
+    return True
+
+
+class _Lock:
+    """Cross-process lock via ``O_EXCL``, stolen only from a holder that is gone.
+
+    ``fcntl.flock`` would be less code and is not portable to Windows, which this
+    project supports. A lock file is portable; the interesting part is when it may
+    be TAKEN from someone, and that has two halves:
+
+    - **Stealing is liveness-gated, not age-gated.** Age alone says the holder is
+      slow, which is not the same as dead: a writer stalled past
+      ``LOCK_STALE_SECS`` -- a paged-out interpreter, a contended filesystem -- was
+      being robbed while still running, and both processes then published, so the
+      slower one's ``os.replace`` silently dropped the faster one's update. So a
+      steal now needs the holder proved gone (:func:`_holder_is_alive`), with
+      ``LOCK_ABANDON_SECS`` as the backstop for a holder that cannot be judged at
+      all. A crash still frees the goal; a slow writer keeps its lock.
+    - **Ownership is fenced, so a wrong steal cannot corrupt.** The lock file
+      carries a token unique to this acquisition, not just a pid, and
+      :meth:`still_held` re-reads it. ``_write`` checks that immediately before
+      publishing and refuses if the token changed, and ``__exit__`` only unlinks a
+      lock file that is still ours -- deleting the thief's lock would hand the file
+      to a third writer. Gating the steal makes the race rare; fencing is what
+      makes losing it non-destructive, which is why both are here.
+    """
+
+    def __init__(self, target: Path) -> None:
+        self.path = target.with_suffix(".lock")
+        self.held = False
+        # pid for the liveness probe, random half so that a recycled pid - or a
+        # second acquisition by this same process - is still a DIFFERENT owner.
+        self.token = f"{os.getpid()} {os.urandom(8).hex()}"
+
+    def _may_steal(self, age: float) -> bool:
+        """Only take the lock from a holder proved gone, or past the backstop."""
+        if age > LOCK_ABANDON_SECS:
+            return True
+        if age <= LOCK_STALE_SECS:
+            return False
+        try:
+            recorded = self.path.read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            return False
+        try:
+            pid = int(recorded.split()[0])
+        except (ValueError, IndexError):
+            # An unparseable holder cannot be probed, so it waits for the
+            # backstop rather than being treated as dead.
+            return False
+        return _holder_is_alive(pid) is False
+
+    def still_held(self) -> bool:
+        """Is the lock file still the one we created? Cheap enough to call per write."""
+        if not self.held:
+            return False
+        try:
+            return self.path.read_text(encoding="utf-8", errors="replace").strip() == self.token
+        except OSError:
+            # Gone or unreadable: either way it is not demonstrably ours.
+            return False
+
+    def __enter__(self) -> "_Lock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        deadline = _now() + LOCK_WAIT_SECS
+        while True:
+            try:
+                fd = os.open(str(self.path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+                try:
+                    # All-or-nothing like the state write, and for a sharper
+                    # reason: a half-written token can never match again, so the
+                    # lock would be held by nobody and every fenced write under it
+                    # would refuse. Better to fail acquiring.
+                    _write_all(fd, self.token.encode("utf-8"), str(self.path))
+                except BaseException:
+                    os.close(fd)
+                    try:
+                        self.path.unlink()
+                    except OSError:
+                        pass
+                    raise
+                os.close(fd)
+                self.held = True
+                return self
+            except FileExistsError:
+                try:
+                    age = _now() - self.path.stat().st_mtime
+                except FileNotFoundError:
+                    # The holder released it between our open and this stat, so
+                    # the next open is the retry. Still budget-checked below
+                    # rather than `continue`d: an unconditional continue here is
+                    # a hot spin with no exit, which is worse than answering
+                    # `locked`.
+                    age = 0.0
+                except OSError:
+                    # Cannot even judge staleness. Do NOT steal on an unknown
+                    # error -- stealing a lock we cannot reason about is how two
+                    # writers land on one file -- and do not spin: fall through
+                    # to the deadline.
+                    age = 0.0
+                if self._may_steal(age):
+                    try:
+                        self.path.unlink()
+                    except OSError:
+                        # The steal was decided but could not be carried out --
+                        # a lock we may not remove (a goal dir owned by another
+                        # uid, a read-only mount). Fall through to the deadline
+                        # instead of retrying: `continue` here re-decides the
+                        # same steal on the same statable-and-stale file every
+                        # pass, with no sleep and no deadline check, which is
+                        # the hot spin the FileNotFoundError branch above
+                        # already refuses. An un-removable lock must converge
+                        # on `locked`, not pin a core forever.
+                        pass
+                    else:
+                        continue
+                if _now() >= deadline:
+                    raise TimeoutError(
+                        f"{self.path} still held after {LOCK_WAIT_SECS:.0f}s " f"(age {age:.0f}s)"
+                    )
+                time.sleep(0.05)
+
+    def __exit__(self, *exc: Any) -> None:
+        # Only ever unlink a lock that is still ours: if it was stolen, the file
+        # now belongs to another writer and removing it would let a third in.
+        if self.still_held():
+            try:
+                self.path.unlink()
+            except OSError:
+                pass
+        self.held = False
+
+
+def _goal_of(payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any] | None]:
+    goal = payload.get("goal")
+    if not isinstance(goal, str) or not _GOAL_RE.match(goal):
+        return "", _error(
+            "bad_goal",
+            "goal must be 1-64 chars of letters, digits, '.', '_' or '-', starting "
+            "alphanumeric. It names a directory, so it is validated rather than "
+            "sanitized: sanitizing would map two goals onto one queue.",
+        )
+    return goal, None
+
+
+def _ids_of(payload: Dict[str, Any]) -> Tuple[List[str], Dict[str, Any] | None]:
+    ids = payload.get("ids")
+    if not isinstance(ids, list) or not all(isinstance(i, str) and i for i in ids):
+        return [], _error("bad_ids", "ids must be a non-empty list of strings")
+    if not ids:
+        return [], _error("bad_ids", "ids must be a non-empty list of strings")
+    return ids, None
+
+
+def _with_state(goal: str, data: Dict[str, Any], out: Dict[str, Any]) -> Dict[str, Any]:
+    out["state_path"] = str(_state_path(goal))
+    out["pending"] = sum(1 for e in data["inbox"] if e.get("state") == "pending")
+    return out
+
+
+def mode_enqueue(payload: Dict[str, Any]) -> Dict[str, Any]:
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    text = payload.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return _error("bad_text", "text must be a non-empty string")
+    if len(text) > MAX_TEXT:
+        return _error(
+            "text_too_long",
+            f"text is {len(text)} chars; the cap is {MAX_TEXT}. Refused rather than "
+            "truncated: half a steering instruction can invert its meaning.",
+        )
+    path = _state_path(goal)
+    with _Lock(path) as lock:
+        data = _read(path, goal)
+        if len(data["inbox"]) >= MAX_INBOX:
+            return _with_state(
+                goal,
+                data,
+                _error(
+                    "inbox_full",
+                    f"the inbox holds {len(data['inbox'])} entries and caps at "
+                    f"{MAX_INBOX}. Refused rather than dropping the oldest: every "
+                    "entry is a message the user typed. Run a round and drain it.",
+                ),
+            )
+        entry = {
+            "id": uuid.uuid4().hex[:12],
+            "text": text,
+            "enqueued_at": _now(),
+            "state": "pending",
+        }
+        data["inbox"].append(entry)
+        _write(path, data, fence=lock)
+    return _with_state(goal, data, {"ok": True, "id": entry["id"]})
+
+
+def mode_claim(payload: Dict[str, Any]) -> Dict[str, Any]:
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    stale = payload.get("stale_secs", 900)
+    if not isinstance(stale, (int, float)) or isinstance(stale, bool) or stale < 0:
+        return _error("bad_stale_secs", "stale_secs must be a non-negative number")
+    path = _state_path(goal)
+    now = _now()
+    with _Lock(path) as lock:
+        data = _read(path, goal)
+        claimed: List[Dict[str, Any]] = []
+        for e in data["inbox"]:
+            if e.get("state") == "pending":
+                pass
+            elif e.get("state") == "claimed" and now - float(e.get("claimed_at") or 0) > stale:
+                # Re-served, not lost: the turn that claimed it died before
+                # calling done, and the message is still the user's.
+                e["reclaimed"] = int(e.get("reclaimed", 0)) + 1
+            else:
+                continue
+            e["state"] = "claimed"
+            e["claimed_at"] = now
+            claimed.append(
+                {
+                    "id": e["id"],
+                    "text": e["text"],
+                    "enqueued_at": e.get("enqueued_at"),
+                    "reclaimed": int(e.get("reclaimed", 0)),
+                }
+            )
+        _write(path, data, fence=lock)
+    return _with_state(goal, data, {"ok": True, "claimed": claimed})
+
+
+def mode_done(payload: Dict[str, Any]) -> Dict[str, Any]:
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    ids, err = _ids_of(payload)
+    if err:
+        return err
+    path = _state_path(goal)
+    wanted = set(ids)
+    with _Lock(path) as lock:
+        data = _read(path, goal)
+        before = len(data["inbox"])
+        data["inbox"] = [e for e in data["inbox"] if e.get("id") not in wanted]
+        removed = before - len(data["inbox"])
+        _write(path, data, fence=lock)
+    # An id that was not there is NOT an error: a retried done must be safe, or a
+    # conductor that lost the response would have to guess whether to call again.
+    return _with_state(goal, data, {"ok": True, "removed": removed})
+
+
+def mode_release(payload: Dict[str, Any]) -> Dict[str, Any]:
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    ids, err = _ids_of(payload)
+    if err:
+        return err
+    path = _state_path(goal)
+    wanted = set(ids)
+    with _Lock(path) as lock:
+        data = _read(path, goal)
+        released = 0
+        for e in data["inbox"]:
+            if e.get("id") in wanted and e.get("state") == "claimed":
+                e["state"] = "pending"
+                e.pop("claimed_at", None)
+                released += 1
+        _write(path, data, fence=lock)
+    return _with_state(goal, data, {"ok": True, "released": released})
+
+
+def _item_of(payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any] | None]:
+    item = payload.get("item")
+    if not isinstance(item, str) or not item.strip() or len(item) > 128:
+        return "", _error("bad_item", "item must be a non-empty string of at most 128 chars")
+    return item, None
+
+
+def mode_dispatch_begin(payload: Dict[str, Any]) -> Dict[str, Any]:
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    item, err = _item_of(payload)
+    if err:
+        return err
+    path = _state_path(goal)
+    with _Lock(path) as lock:
+        data = _read(path, goal)
+        rec = data["dispatch"].get(item)
+        if rec is None:
+            if len(data["dispatch"]) >= MAX_ITEMS:
+                return _with_state(
+                    goal,
+                    data,
+                    _error(
+                        "too_many_items",
+                        f"{len(data['dispatch'])} dispatch records and the cap is "
+                        f"{MAX_ITEMS}. A round is two or three items; this is a "
+                        "goal that was never closed out, not a cap to raise.",
+                    ),
+                )
+            rec = {
+                "dispatch_id": uuid.uuid4().hex[:12],
+                "state": "begun",
+                "attempts": 1,
+                "begun_at": _now(),
+            }
+            data["dispatch"][item] = rec
+            replay = False
+        else:
+            # The SAME id, deliberately. Handing out a fresh one per attempt is
+            # what opens a second session for one item; returning the first makes
+            # the retry converge and makes the replay visible.
+            rec["attempts"] = int(rec.get("attempts", 1)) + 1
+            rec["last_attempt_at"] = _now()
+            replay = True
+        _write(path, data, fence=lock)
+    out = {
+        "ok": True,
+        "dispatch_id": rec["dispatch_id"],
+        "state": rec["state"],
+        "attempts": rec["attempts"],
+        "replay": replay,
+    }
+    if replay and rec["state"] not in _TERMINAL_DISPATCH:
+        out["warning"] = (
+            "this item was begun and never recorded a seed, so a session may exist "
+            "with no seed. Read it before creating another one."
+        )
+    if rec.get("session"):
+        out["session"] = rec["session"]
+    return _with_state(goal, data, out)
+
+
+def mode_dispatch_sent(payload: Dict[str, Any]) -> Dict[str, Any]:
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    item, err = _item_of(payload)
+    if err:
+        return err
+    session = payload.get("session")
+    if not isinstance(session, str) or not session.strip():
+        return _error("bad_session", "session must be a non-empty string")
+    path = _state_path(goal)
+    with _Lock(path) as lock:
+        data = _read(path, goal)
+        rec = data["dispatch"].get(item)
+        if rec is None:
+            # Recording a send for an item never begun means the caller skipped
+            # dispatch_begin, which is the whole guard. Accepted and FLAGGED
+            # rather than refused: the send already happened, and refusing would
+            # leave the durable record less true than the world.
+            rec = {
+                "dispatch_id": uuid.uuid4().hex[:12],
+                "attempts": 1,
+                "begun_at": _now(),
+                "began_out_of_band": True,
+            }
+            data["dispatch"][item] = rec
+        rec["state"] = "sent"
+        rec["session"] = session
+        rec["sent_at"] = _now()
+        _write(path, data, fence=lock)
+    out: Dict[str, Any] = {"ok": True, "state": "sent", "dispatch_id": rec["dispatch_id"]}
+    if rec.get("began_out_of_band"):
+        out["warning"] = "no dispatch_begin preceded this send; the replay guard was skipped"
+    return _with_state(goal, data, out)
+
+
+def mode_status(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Report the record. Takes the lock even though it writes nothing.
+
+    ``status`` looks like a pure read, but :func:`_read` is not one: on a malformed
+    file it MOVES it aside. Unlocked, that made the read-only mode capable of losing
+    a write -- status reads old corruption, a concurrent ``enqueue`` takes the lock
+    and publishes a valid record over it, and status then renames THAT file to the
+    sidecar, so a message the user typed vanishes from the queue at the hands of a
+    mode that only meant to look. Holding the lock across the read and the existence
+    check is what makes the quarantine decision apply to the file it was made about.
+    """
+    goal, err = _goal_of(payload)
+    if err:
+        return err
+    path = _state_path(goal)
+    with _Lock(path):
+        data = _read(path, goal)
+        exists = path.exists()
+    unsent = sorted(
+        item for item, rec in data["dispatch"].items() if rec.get("state") not in _TERMINAL_DISPATCH
+    )
+    out = {
+        "ok": True,
+        "inbox": data["inbox"],
+        "dispatch": data["dispatch"],
+        "unsent_items": unsent,
+        "exists": exists,
+    }
+    return _with_state(goal, data, out)
+
+
+_MODES = {
+    "enqueue": mode_enqueue,
+    "claim": mode_claim,
+    "done": mode_done,
+    "release": mode_release,
+    "dispatch_begin": mode_dispatch_begin,
+    "dispatch_sent": mode_dispatch_sent,
+    "status": mode_status,
+}
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] not in _MODES:
+        # stdout, matching ledger_entry.py and accept_eval.py: the conductor reads
+        # one stream, and a wrong mode name is the likeliest invocation error.
+        print(
+            json.dumps(
+                {"error": f"usage: dispatch_queue.py {{{'|'.join(sorted(_MODES))}}} < input.json"}
+            )
+        )
+        return 2
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        print(json.dumps({"error": "stdin must be a JSON object"}))
+        return 2
+    if not isinstance(payload, dict):
+        # Explicit, not an assert: asserts vanish under `python -O`, and a JSON
+        # array would then crash inside a mode handler instead of returning the
+        # documented structured exit-2.
+        print(json.dumps({"error": "stdin must be a JSON object"}))
+        return 2
+    try:
+        result = _MODES[sys.argv[1]](payload)
+    except TimeoutError as exc:
+        # A held lock is a real, retryable condition, not a bug: say so in the
+        # same structured shape every other refusal uses.
+        result = _error("locked", f"another writer holds the goal's lock: {exc}")
+    except _Unreadable as exc:
+        # Deliberately NOT recovered into a blank record: the state file is still
+        # on disk with the parked messages in it, and answering "empty" would
+        # invite the caller to write over them.
+        result = _error(
+            "state_unreadable",
+            f"the goal's state file exists but could not be read ({exc}); it was "
+            "left untouched. Fix the read error rather than re-running, or the "
+            "messages parked in it are what gets overwritten.",
+        )
+    except _LockLost as exc:
+        # Nothing was written. Retryable in the same way `locked` is, and named
+        # separately so the conductor can tell "could not start" from "started,
+        # then found the ground had moved".
+        result = _error(
+            "lock_lost",
+            f"the goal's lock was taken while this call was mid-flight ({exc}); "
+            "nothing was written, so the other writer's state stands. Re-run to "
+            "apply this operation on top of it.",
+        )
+    except OSError as exc:
+        # A write that could not complete - a full disk is the case that matters.
+        # The previous record is intact because `_write` refuses to publish a
+        # partial one, and saying so is the whole point of reporting it here.
+        result = _error(
+            "state_write_failed",
+            f"the goal's state could not be written ({exc}); the previous record "
+            "is intact and unmodified.",
+        )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_conductor_queue.py
+++ b/test/test_conductor_queue.py
@@ -1,0 +1,835 @@
+"""The conductor's durable inbox + dispatch record (``scripts/dispatch_queue.py``).
+
+Three properties are load-bearing, and each has a class here:
+
+- **A parked message survives.** A claim does not delete it, a turn that dies
+  after claiming does not take it with it, and a full inbox refuses rather than
+  dropping the oldest — every entry is a message the user typed.
+- **A retried dispatch converges instead of duplicating.** ``dispatch_begin``
+  returns the SAME id for an item already begun, and says so, which is the whole
+  point: a fresh id per attempt is what opens a second session for one item.
+- **It touches no identity.** The script is a plain local state machine; if it
+  ever grew a read of a session key or a gateway credential it would be gating on
+  an assertion, since a script has no verifiable identity. Pinned as a source
+  ratchet rather than trusted to review.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from skill_script_helpers import load_skill_script
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "kiro_crew"
+    / "builtin_skills"
+    / "goal-conductor"
+    / "scripts"
+    / "dispatch_queue.py"
+)
+
+
+#: Mode bits are the skip axis, not the whole module: ``dispatch_queue.py`` is portable by
+#: design (``_Lock`` uses ``O_EXCL`` rather than ``fcntl.flock`` precisely so it
+#: runs on Windows), so the suite has to run there or the portability claim goes
+#: untested. Only the case that needs ``0o000`` to MEAN unreadable is skipped --
+#: on Windows a mode-0 file stays readable by its owner, so the case cannot
+#: express what it asserts.
+_POSIX_MODE_BITS_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="needs 0o000 to make a file unreadable; on Windows the owner still reads it",
+)
+
+#: The same reasoning for the liveness-gated steal: ``os.kill(pid, 0)`` is the
+#: probe, and Windows has no non-destructive equivalent (``os.kill`` there
+#: TERMINATES), so ``_holder_is_alive`` answers "cannot tell" and the only steal
+#: path left is the abandon backstop. The backstop IS covered on every platform;
+#: only the two cases that turn on a real dead-vs-alive answer are skipped.
+_POSIX_LIVENESS_ONLY = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="no non-destructive liveness probe on Windows; the backstop path covers it",
+)
+
+
+def _mod():
+    return load_skill_script("_conductor_queue_under_test", SCRIPT)
+
+
+def _reaped_pid() -> int:
+    """A pid that is definitely gone: spawn something trivial and reap it.
+
+    A hard-coded "surely unused" number is a coin flip, and a zombie still answers
+    ``os.kill(pid, 0)`` — so the child is waited on, which reaps it and makes the
+    probe report it dead.
+    """
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
+def _stalling_write():
+    """An ``os.write`` that stalls on the STATE record and passes everything else.
+
+    The ENOSPC shape: a real short write returns a small count without raising. A
+    mock that keeps returning 1 would let the loop finish a byte at a time and
+    prove nothing, so this one makes one byte of progress and then none.
+
+    Scoped by payload rather than by call count because the lock token goes through
+    ``os.write`` too — stalling that instead would fail acquisition and never reach
+    the write under test.
+    """
+    real_write = os.write
+    stalled = {"yes": False}
+
+    def stalling(fd, data):  # noqa: ANN001, ANN202
+        if b'"inbox"' not in data:
+            return real_write(fd, data)
+        if not stalled["yes"] and len(data) > 1:
+            stalled["yes"] = True
+            return real_write(fd, data[:1])
+        return 0
+
+    return stalling
+
+
+def _run(mode: str, payload: dict, home: Path) -> dict:
+    """Drive the script the way the conductor does: argv mode + JSON on stdin.
+
+    The parent environment is INHERITED and only the home overridden. A stripped
+    env with a hand-written POSIX ``PATH`` would not start an interpreter on
+    Windows, and the isolation that matters here is the state root, which
+    ``KIROCREW_HOME`` already pins (``dispatch_queue.py`` resolves it through the package's
+    own ``data_home``, whose override branch honours it).
+
+    ``cwd`` is not tidiness: a child inheriting pytest's CWD starts in the
+    checkout, so any relative path it ever writes lands in repository state rather
+    than under ``tmp_path``. ``encoding`` pins the decode instead of taking the
+    Windows ANSI code page.
+    """
+    env = dict(os.environ)
+    env.update(
+        {
+            "HOME": str(home),
+            "USERPROFILE": str(home),
+            "KIROCREW_HOME": str(home),
+        }
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), mode],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(home),
+        env=env,
+        check=False,
+    )
+    assert proc.returncode in (0, 2), proc.stderr
+    return json.loads(proc.stdout)
+
+
+class TestInvocationContract:
+    """Same shape as the sibling scripts: one JSON in, one JSON out."""
+
+    def test_an_unknown_mode_is_exit_2_on_stdout(self, tmp_path: Path) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "drain"],
+            input="{}",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(tmp_path),
+            check=False,
+        )
+        assert proc.returncode == 2
+        # stdout, not stderr: the conductor reads one stream.
+        assert "usage: dispatch_queue.py" in json.loads(proc.stdout)["error"]
+
+    def test_a_json_array_on_stdin_is_exit_2_not_a_crash(self, tmp_path: Path) -> None:
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "status"],
+            input="[1, 2]",
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(tmp_path),
+            check=False,
+        )
+        assert proc.returncode == 2
+        assert json.loads(proc.stdout)["error"] == "stdin must be a JSON object"
+
+    def test_every_mode_reports_where_the_state_landed(self, tmp_path: Path) -> None:
+        """``state_path`` is how a conductor tells 'empty' from 'somewhere else'."""
+        out = _run("status", {"goal": "g1"}, tmp_path)
+        assert out["ok"] is True
+        # Compared as path PARTS, not a "/"-separated suffix: the script builds
+        # the path with pathlib, so on Windows the string carries backslashes and
+        # an endswith would never match.
+        assert Path(out["state_path"]).parts[-3:] == ("conductor", "g1", "queue.json")
+        assert out["exists"] is False
+
+
+class TestGoalIdIsValidatedNotSanitized:
+    """A goal id names a directory, and sanitizing merges two goals into one."""
+
+    @pytest.mark.parametrize(
+        "goal",
+        ["../escape", "a/b", "", ".hidden", "x" * 65, "has space", "sym+bol"],
+    )
+    def test_a_goal_that_is_not_one_safe_segment_is_refused(self, goal: str) -> None:
+        mod = _mod()
+        got = mod.mode_status({"goal": goal})
+        assert got["ok"] is False
+        assert got["error"]["code"] == "bad_goal"
+
+    def test_traversal_never_reaches_a_path(self, tmp_path: Path) -> None:
+        out = _run("enqueue", {"goal": "../../etc", "text": "hi"}, tmp_path)
+        assert out["error"]["code"] == "bad_goal"
+        assert not (tmp_path.parent / "etc").exists()
+
+
+class TestAParkedMessageSurvives:
+    def test_enqueue_then_claim_returns_the_text(self, tmp_path: Path) -> None:
+        _run("enqueue", {"goal": "g", "text": "drop item 2"}, tmp_path)
+        out = _run("claim", {"goal": "g"}, tmp_path)
+        assert [c["text"] for c in out["claimed"]] == ["drop item 2"]
+
+    def test_a_claim_does_not_delete_so_a_dead_turn_loses_nothing(self, tmp_path: Path) -> None:
+        """The failure this script exists to prevent, asserted directly."""
+        _run("enqueue", {"goal": "g", "text": "steer left"}, tmp_path)
+        first = _run("claim", {"goal": "g"}, tmp_path)
+        assert len(first["claimed"]) == 1
+        # The turn that claimed it dies here — no `done` call is ever made.
+        # A later claim with the staleness window elapsed re-serves the message.
+        again = _run("claim", {"goal": "g", "stale_secs": 0}, tmp_path)
+        assert [c["text"] for c in again["claimed"]] == ["steer left"]
+        assert again["claimed"][0]["reclaimed"] == 1
+
+    def test_a_fresh_claim_does_not_re_serve_a_live_claim(self, tmp_path: Path) -> None:
+        """Re-serving instantly would double-apply every steering message."""
+        _run("enqueue", {"goal": "g", "text": "x"}, tmp_path)
+        _run("claim", {"goal": "g"}, tmp_path)
+        assert _run("claim", {"goal": "g", "stale_secs": 900}, tmp_path)["claimed"] == []
+
+    def test_done_drops_it_and_a_retried_done_is_safe(self, tmp_path: Path) -> None:
+        got = _run("enqueue", {"goal": "g", "text": "applied"}, tmp_path)
+        _run("claim", {"goal": "g"}, tmp_path)
+        first = _run("done", {"goal": "g", "ids": [got["id"]]}, tmp_path)
+        assert first["removed"] == 1
+        # Idempotent: a conductor that lost the response must be able to repeat it
+        # without having to guess.
+        second = _run("done", {"goal": "g", "ids": [got["id"]]}, tmp_path)
+        assert second["ok"] is True and second["removed"] == 0
+
+    def test_release_puts_it_back_without_applying_it(self, tmp_path: Path) -> None:
+        _run("enqueue", {"goal": "g", "text": "not yet"}, tmp_path)
+        _run("claim", {"goal": "g"}, tmp_path)
+        ids = [e["id"] for e in _run("status", {"goal": "g"}, tmp_path)["inbox"]]
+        rel = _run("release", {"goal": "g", "ids": ids}, tmp_path)
+        assert rel["released"] == 1 and rel["pending"] == 1
+
+    def test_a_full_inbox_refuses_rather_than_dropping_the_oldest(self, tmp_path: Path) -> None:
+        """Silently discarding a user's message is the failure, not the backlog."""
+        mod = _mod()
+        # Seeded as a fixture rather than through MAX_INBOX subprocess calls: the
+        # property under test is the refusal at the cap, not the accumulation.
+        state = tmp_path / "conductor" / "g" / "queue.json"
+        state.parent.mkdir(parents=True)
+        state.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "goal": "g",
+                    "inbox": [
+                        {"id": f"{i:012d}", "text": f"m{i}", "enqueued_at": 0, "state": "pending"}
+                        for i in range(mod.MAX_INBOX)
+                    ],
+                    "dispatch": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+        full = _run("enqueue", {"goal": "g", "text": "one too many"}, tmp_path)
+        assert full["ok"] is False and full["error"]["code"] == "inbox_full"
+        # The oldest is still there — nothing was evicted to make room.
+        inbox = _run("status", {"goal": "g"}, tmp_path)["inbox"]
+        assert len(inbox) == mod.MAX_INBOX and inbox[0]["text"] == "m0"
+
+    def test_an_oversize_message_refuses_rather_than_truncating(self, tmp_path: Path) -> None:
+        """Half a steering instruction can invert its meaning."""
+        mod = _mod()
+        out = _run("enqueue", {"goal": "g", "text": "x" * (mod.MAX_TEXT + 1)}, tmp_path)
+        assert out["error"]["code"] == "text_too_long"
+
+    def test_a_corrupt_record_is_moved_aside_not_fatal(self, tmp_path: Path) -> None:
+        _run("enqueue", {"goal": "g", "text": "before"}, tmp_path)
+        state = tmp_path / "conductor" / "g" / "queue.json"
+        state.write_text("{not json", encoding="utf-8")
+        out = _run("enqueue", {"goal": "g", "text": "after"}, tmp_path)
+        assert out["ok"] is True
+        # Still on disk to look at, rather than deleted.
+        assert list((tmp_path / "conductor" / "g").glob("queue.corrupt-*"))
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            # Parses as JSON, is not a record this script can use, and in each
+            # case still holds the conductor's own bookkeeping in readable form.
+            '{"version": 1, "inbox": {"id": "x"}, "dispatch": {}}',
+            '{"version": 1, "inbox": [], "dispatch": [["item-1", "abc"]]}',
+            '["not", "an", "object"]',
+            # One level DEEPER: the containers are right and the ENTRIES are not.
+            # A container-only check passes these through, and then every mode
+            # reaches for `.get` on a non-mapping.
+            '{"version": 1, "inbox": [null], "dispatch": {}}',
+            '{"version": 1, "inbox": ["just a string"], "dispatch": {}}',
+            '{"version": 1, "inbox": [], "dispatch": {"item-1": "abc"}}',
+        ],
+    )
+    def test_structurally_invalid_state_is_quarantined_not_silently_dropped(
+        self, tmp_path: Path, body: str
+    ) -> None:
+        """Valid JSON of the wrong SHAPE used to be discarded with no sidecar.
+
+        It read as blank and the next mutation wrote the blank back, so the
+        dispatch ids and parked messages in it were gone with no copy anywhere —
+        the same loss the unparseable path already guarded, reached through a
+        different door. The sidecar is what makes it recoverable.
+        """
+        _run("enqueue", {"goal": "g", "text": "before"}, tmp_path)
+        state = tmp_path / "conductor" / "g" / "queue.json"
+        state.write_text(body, encoding="utf-8")
+        out = _run("enqueue", {"goal": "g", "text": "after"}, tmp_path)
+        assert out["ok"] is True
+        sidecars = list((tmp_path / "conductor" / "g").glob("queue.corrupt-*"))
+        assert sidecars, "a discarded record must leave its bytes on disk"
+        assert sidecars[0].read_text(encoding="utf-8") == body
+
+    def test_a_malformed_entry_is_a_structured_refusal_not_a_traceback(
+        self, tmp_path: Path
+    ) -> None:
+        """The point of quarantining is that the CONDUCTOR gets an answer.
+
+        A record whose containers are the right types but whose entries are not
+        (``{"inbox": [null]}``) used to pass the shape check, and the mode then died
+        with an uncaught ``AttributeError`` on ``entry.get`` — a traceback on stderr
+        and no JSON on stdout, which is the one thing the conductor cannot handle.
+        Asserted through the real subprocess, because that is where the difference
+        between an exception and a structured answer actually shows.
+        """
+        _run("enqueue", {"goal": "g", "text": "before"}, tmp_path)
+        state = tmp_path / "conductor" / "g" / "queue.json"
+        state.write_text('{"version": 1, "inbox": [null], "dispatch": {}}', encoding="utf-8")
+        # `_run` itself asserts the exit code is 0 or 2 and that stdout is JSON, so
+        # a traceback fails here rather than being interpreted.
+        out = _run("status", {"goal": "g"}, tmp_path)
+        assert out["ok"] is True
+        assert out["inbox"] == []
+        assert list((tmp_path / "conductor" / "g").glob("queue.corrupt-*"))
+
+
+class TestARetriedDispatchConverges:
+    def test_begin_assigns_an_id_and_reports_no_replay(self, tmp_path: Path) -> None:
+        out = _run("dispatch_begin", {"goal": "g", "item": "item-1"}, tmp_path)
+        assert out["state"] == "begun" and out["replay"] is False and out["attempts"] == 1
+        assert out["dispatch_id"]
+
+    def test_a_second_begin_returns_the_same_id_and_flags_the_replay(self, tmp_path: Path) -> None:
+        """A fresh id per attempt is what opens a second session for one item."""
+        first = _run("dispatch_begin", {"goal": "g", "item": "item-1"}, tmp_path)
+        second = _run("dispatch_begin", {"goal": "g", "item": "item-1"}, tmp_path)
+        assert second["dispatch_id"] == first["dispatch_id"]
+        assert second["replay"] is True and second["attempts"] == 2
+        # And it names the consequence, because a session with no seed looks
+        # exactly like a session that is merely quiet.
+        assert "no seed" in second["warning"]
+
+    def test_a_sent_item_replays_without_the_unseeded_warning(self, tmp_path: Path) -> None:
+        _run("dispatch_begin", {"goal": "g", "item": "item-1"}, tmp_path)
+        _run("dispatch_sent", {"goal": "g", "item": "item-1", "session": "dashboard:s1"}, tmp_path)
+        again = _run("dispatch_begin", {"goal": "g", "item": "item-1"}, tmp_path)
+        assert again["replay"] is True and again["state"] == "sent"
+        assert "warning" not in again
+        # The session it converged on travels with it, so a replay can read it.
+        assert again["session"] == "dashboard:s1"
+
+    def test_status_lists_the_items_that_never_recorded_a_seed(self, tmp_path: Path) -> None:
+        _run("dispatch_begin", {"goal": "g", "item": "item-1"}, tmp_path)
+        _run("dispatch_begin", {"goal": "g", "item": "item-2"}, tmp_path)
+        _run("dispatch_sent", {"goal": "g", "item": "item-2", "session": "dashboard:s2"}, tmp_path)
+        assert _run("status", {"goal": "g"}, tmp_path)["unsent_items"] == ["item-1"]
+
+    def test_a_send_with_no_begin_is_recorded_and_flagged(self, tmp_path: Path) -> None:
+        """The send already happened; refusing would make the record less true."""
+        out = _run(
+            "dispatch_sent", {"goal": "g", "item": "item-9", "session": "dashboard:s9"}, tmp_path
+        )
+        assert out["ok"] is True and "replay guard was skipped" in out["warning"]
+
+
+class TestItTouchesNoIdentity:
+    """The property that makes this safe as a script rather than an MCP tool."""
+
+    def test_the_source_reads_no_identity_or_credential(self) -> None:
+        src = SCRIPT.read_text(encoding="utf-8")
+        code = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+        # A script is a child of execute_bash, where the gateway injects no
+        # verifiable identity — so anything here that read one would be reading an
+        # assertion. Named individually so a new one fails loudly.
+        for forbidden in (
+            "KIROCREW_SESSION_KEY",
+            "KIROCREW_HOST_PID",
+            "_resolve_session_key",
+            "X-Internal-Secret",
+            "read_local_secret",
+            "sel_hmac",
+            "verify_session_pid",
+        ):
+            assert forbidden not in code, f"dispatch_queue.py must not reach for {forbidden}"
+
+    def test_it_makes_no_network_or_subprocess_call(self) -> None:
+        src = SCRIPT.read_text(encoding="utf-8")
+        code = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+        for forbidden in ("subprocess", "urllib", "socket", "http.client", "requests"):
+            assert forbidden not in code, f"dispatch_queue.py must not use {forbidden}"
+
+
+class TestUnreadableIsNotAbsent:
+    """The defect this class exists for destroyed the parked messages.
+
+    An earlier revision returned a BLANK record for any ``OSError``, and every
+    mode then wrote that blank back — so a state file that merely could not be
+    read this time was overwritten, losing exactly what the script is for.
+    """
+
+    @_POSIX_MODE_BITS_ONLY
+    @pytest.mark.skipif(
+        # ``os.geteuid`` does not exist on Windows, and this decorator is
+        # evaluated at COLLECTION time -- reading it directly raises
+        # AttributeError before the skipif above can spare it, which errors every
+        # shard rather than skipping one case.
+        getattr(os, "geteuid", lambda: 1)() == 0,
+        reason="root ignores the mode bits",
+    )
+    def test_an_unreadable_state_file_refuses_and_is_left_untouched(self, tmp_path: Path) -> None:
+        _run("enqueue", {"goal": "g", "text": "must survive"}, tmp_path)
+        state = tmp_path / "conductor" / "g" / "queue.json"
+        before = state.read_bytes()
+        state.chmod(0o000)
+        try:
+            out = _run("enqueue", {"goal": "g", "text": "second"}, tmp_path)
+            assert out["ok"] is False
+            assert out["error"]["code"] == "state_unreadable"
+        finally:
+            state.chmod(0o600)
+        # The bytes are still the ones holding the first message.
+        assert state.read_bytes() == before
+        assert _run("status", {"goal": "g"}, tmp_path)["inbox"][0]["text"] == "must survive"
+
+    def test_absent_still_reads_as_blank(self, tmp_path: Path) -> None:
+        """Only UNREADABLE refuses; a goal with no file yet is normal."""
+        out = _run("status", {"goal": "fresh"}, tmp_path)
+        assert out["ok"] is True and out["inbox"] == [] and out["exists"] is False
+
+
+class TestTheLockAlwaysConvergesOnAnAnswer:
+    """A lock that cannot be judged must answer, not spin.
+
+    The earlier revision's ``except OSError: continue`` around the staleness stat
+    skipped both the deadline check and the sleep, so a stat that keeps failing
+    burns a core forever instead of returning ``locked``.
+    """
+
+    def test_a_live_lock_times_out_instead_of_waiting_forever(self, tmp_path: Path) -> None:
+        mod = _mod()
+        mod.LOCK_WAIT_SECS = 0.2
+        target = tmp_path / "queue.json"
+        (tmp_path / "queue.lock").write_text("999999", encoding="utf-8")
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            with mod._Lock(target):
+                pass
+        assert time.monotonic() - started < 5.0
+
+    def test_a_stat_that_keeps_failing_still_terminates(self, tmp_path: Path) -> None:
+        """The busy-loop regression, forced: staleness can never be judged."""
+        mod = _mod()
+        mod.LOCK_WAIT_SECS = 0.2
+        target = tmp_path / "queue.json"
+        (tmp_path / "queue.lock").write_text("1", encoding="utf-8")
+        real_stat = Path.stat
+
+        def blind_stat(self, *a, **k):  # noqa: ANN001, ANN002, ANN003
+            if self.name == "queue.lock":
+                raise OSError("cannot stat")
+            return real_stat(self, *a, **k)
+
+        started = time.monotonic()
+        with mock.patch.object(Path, "stat", blind_stat):
+            with pytest.raises(TimeoutError):
+                with mod._Lock(target):
+                    pass
+        elapsed = time.monotonic() - started
+        # Converged on the deadline rather than spinning: the old code never
+        # reached the deadline check on this path at all.
+        assert elapsed < 5.0, f"took {elapsed:.1f}s — the deadline was not honoured"
+        # And it did NOT steal a lock whose staleness it could not judge.
+        assert (tmp_path / "queue.lock").exists()
+
+    @_POSIX_LIVENESS_ONLY
+    def test_a_stale_lock_that_cannot_be_unlinked_times_out_instead_of_spinning(
+        self, tmp_path: Path
+    ) -> None:
+        """Deciding to steal is not the same as being able to.
+
+        A stale lock in a directory this process may not write to (a goal dir
+        created under another uid, a read-only mount) still stats fine and still
+        looks steal-worthy, so the steal is re-decided on every pass. With an
+        unconditional ``continue`` that is a tight CPU-pinning loop that never
+        reaches the deadline — the same hot spin the staleness-stat branch
+        already refuses. It has to converge on ``locked``.
+        """
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        lock = tmp_path / "queue.lock"
+        lock.write_text(f"{_reaped_pid()} deadbeef", encoding="utf-8")
+        old = time.time() - (mod.LOCK_STALE_SECS + 30)
+        os.utime(lock, (old, old))
+        real_unlink = Path.unlink
+        attempts = 0
+
+        def refuse_unlink(self, *a, **k):  # noqa: ANN001, ANN002, ANN003
+            nonlocal attempts
+            if self.name == "queue.lock":
+                attempts += 1
+                raise PermissionError("read-only parent")
+            return real_unlink(self, *a, **k)
+
+        started = time.monotonic()
+        with mock.patch.object(Path, "unlink", refuse_unlink):
+            with pytest.raises(TimeoutError):
+                with mod._Lock(target):
+                    pass
+        elapsed = time.monotonic() - started
+        # Converging AT the budget is correct; the bug never converges at all, so
+        # the bound only has to separate "terminated" from "pinned a core".
+        assert (
+            elapsed < 4 * mod.LOCK_WAIT_SECS
+        ), f"took {elapsed:.1f}s — the deadline was not honoured"
+        # The spin's real signature is unbounded retries inside the wait budget:
+        # with the sleep honoured this is ~LOCK_WAIT_SECS/0.05 at the very most.
+        assert attempts < 500, f"{attempts} unlink attempts — this is the hot spin"
+        assert lock.exists(), "a lock it could not remove must be left alone"
+
+    @_POSIX_LIVENESS_ONLY
+    def test_a_stale_lock_from_a_dead_holder_is_stolen(self, tmp_path: Path) -> None:
+        """A crash must not wedge a goal — but the holder has to actually be gone."""
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        lock = tmp_path / "queue.lock"
+        lock.write_text(f"{_reaped_pid()} deadbeef", encoding="utf-8")
+        old = time.time() - (mod.LOCK_STALE_SECS + 30)
+        os.utime(lock, (old, old))
+        with mod._Lock(target):
+            pass  # acquired by stealing; no exception is the assertion
+
+    @_POSIX_LIVENESS_ONLY
+    def test_a_stale_lock_whose_holder_still_runs_is_not_stolen(self, tmp_path: Path) -> None:
+        """The lost-update defect: age alone meant a slow-but-live writer was robbed.
+
+        Both processes then published and the slower ``os.replace`` silently
+        dropped the faster one's update. Being slower than ``LOCK_STALE_SECS`` — a
+        paged-out interpreter, a contended filesystem — is not being dead.
+        """
+        mod = _mod()
+        mod.LOCK_WAIT_SECS = 0.2
+        target = tmp_path / "queue.json"
+        lock = tmp_path / "queue.lock"
+        # This very process is the holder, so liveness is not in question.
+        lock.write_text(f"{os.getpid()} stillhere", encoding="utf-8")
+        old = time.time() - (mod.LOCK_STALE_SECS + 30)
+        os.utime(lock, (old, old))
+        with pytest.raises(TimeoutError):
+            with mod._Lock(target):
+                pass
+        assert lock.exists(), "a live holder's lock must survive"
+
+    def test_a_holder_that_cannot_be_judged_is_stolen_only_past_the_backstop(
+        self, tmp_path: Path
+    ) -> None:
+        """Unparseable holder: not treated as dead, but not wedged forever either.
+
+        Portable on purpose — this is the only steal path Windows has, since it
+        offers no non-destructive liveness probe.
+        """
+        mod = _mod()
+        mod.LOCK_WAIT_SECS = 0.2
+        target = tmp_path / "queue.json"
+        lock = tmp_path / "queue.lock"
+        lock.write_text("not-a-pid", encoding="utf-8")
+
+        stale = time.time() - (mod.LOCK_STALE_SECS + 30)
+        os.utime(lock, (stale, stale))
+        with pytest.raises(TimeoutError):
+            with mod._Lock(target):
+                pass
+
+        abandoned = time.time() - (mod.LOCK_ABANDON_SECS + 30)
+        os.utime(lock, (abandoned, abandoned))
+        with mod._Lock(target):
+            pass  # past the backstop it is stolen; no exception is the assertion
+
+    def test_a_stolen_lock_makes_the_write_refuse_instead_of_clobbering(
+        self, tmp_path: Path
+    ) -> None:
+        """Fencing is what makes losing the race non-destructive rather than silent.
+
+        Gating the steal makes a wrong steal rare; it cannot make it impossible.
+        So the publish itself re-checks ownership: the thief has already written a
+        NEWER record, and replacing it with our pre-steal view is the lost update.
+        """
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        target.write_text('{"version": 1, "inbox": [], "dispatch": {}}', encoding="utf-8")
+        newer = '{"version": 1, "inbox": [], "dispatch": {"item-1": {}}}'
+
+        with mod._Lock(target) as lock:
+            assert lock.still_held()
+            # Another writer takes the lock and publishes while we hold our view.
+            (tmp_path / "queue.lock").write_text("99999 thief", encoding="utf-8")
+            target.write_text(newer, encoding="utf-8")
+            assert lock.still_held() is False
+            with pytest.raises(mod._LockLost):
+                mod._write(target, {"version": 1, "inbox": [], "dispatch": {}}, fence=lock)
+
+        # The thief's record stands, and its lock was not deleted on our way out.
+        assert target.read_text(encoding="utf-8") == newer
+        assert (tmp_path / "queue.lock").read_text(encoding="utf-8") == "99999 thief"
+
+    def test_the_fence_is_rechecked_after_the_flush_not_only_on_entry(self, tmp_path: Path) -> None:
+        """An entry-only check proves the lock was ours before the slow part.
+
+        ``os.fsync`` waits on the device, and that is exactly the window in which a
+        writer looks stalled and gets its lock stolen. Checking only on entry let a
+        writer pass the check, lose the lock during the flush, watch the thief
+        publish, and then ``os.replace`` its own pre-steal view over the newer
+        record — the lost update the fence exists to stop, reached by being slow
+        between the check and the publish. So the steal happens DURING the fsync
+        here, which is the only placement that distinguishes one check from two.
+        """
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        newer = '{"version": 1, "inbox": [{"id": "thiefs"}], "dispatch": {}}'
+        real_fsync = os.fsync
+
+        with mod._Lock(target) as lock:
+            target.write_text(newer, encoding="utf-8")
+
+            def steal_then_fsync(fd):  # noqa: ANN001, ANN202
+                # The lock is taken while we are inside the flush, so the entry
+                # check has already passed.
+                (tmp_path / "queue.lock").write_text("99999 thief", encoding="utf-8")
+                return real_fsync(fd)
+
+            with mock.patch.object(os, "fsync", steal_then_fsync):
+                with pytest.raises(mod._LockLost):
+                    mod._write(target, {"version": 1, "inbox": [], "dispatch": {}}, fence=lock)
+
+        assert target.read_text(encoding="utf-8") == newer, "the newer record was clobbered"
+        # And the fully-written temp file is dropped rather than left to be mistaken
+        # for state or picked up by a later replace.
+        assert not list(tmp_path.glob("queue.tmp-*"))
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="a directory is not openable on Windows; sync is skipped"
+    )
+    def test_the_parent_directory_is_synced_so_the_rename_survives_power_loss(
+        self, tmp_path: Path
+    ) -> None:
+        """Flushing the file commits its CONTENTS; the rename is separate metadata.
+
+        Without a directory sync a power cut just after a successful ``enqueue`` can
+        come back with the message gone even though the call returned ok — and an
+        acknowledged message the user typed is the thing this script exists not to
+        lose. Asserted by watching for an fsync on a DIRECTORY fd, because the file
+        fsync was already there and would make a plain call-count assertion pass
+        against the bug.
+        """
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        real_fsync = os.fsync
+        synced_dirs = []
+
+        def recording_fsync(fd):  # noqa: ANN001, ANN202
+            if os.fstat(fd).st_mode & 0o170000 == 0o040000:  # S_IFDIR
+                synced_dirs.append(fd)
+            return real_fsync(fd)
+
+        with mock.patch.object(os, "fsync", recording_fsync):
+            mod._write(target, {"version": 1, "inbox": [], "dispatch": {}})
+
+        assert synced_dirs, "the rename was never committed — only the bytes it points at"
+
+    @pytest.mark.parametrize("failure", [OSError("cannot open a directory"), None])
+    def test_a_directory_that_cannot_be_synced_does_not_fail_the_write(
+        self, tmp_path: Path, failure: Exception | None
+    ) -> None:
+        """Best-effort is the point: by then the DATA is already committed.
+
+        Some filesystems refuse to fsync a directory, and Windows cannot open one at
+        all — which is why this upgrade is attempted rather than required. Turning
+        either into a failed write would refuse an operation whose bytes are durable,
+        which is worse than the weaker durability it was reaching for. Parametrized
+        over both refusal points: the directory that will not open, and the one that
+        opens and will not sync.
+        """
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        real_open, real_fsync = os.open, os.fsync
+
+        def refusing_open(path, *a, **k):  # noqa: ANN001, ANN002, ANN003, ANN202
+            if Path(path).is_dir():
+                raise OSError("cannot open a directory here")
+            return real_open(path, *a, **k)
+
+        def refusing_fsync(fd):  # noqa: ANN001, ANN202
+            if os.fstat(fd).st_mode & 0o170000 == 0o040000:  # S_IFDIR
+                raise OSError("cannot sync a directory here")
+            return real_fsync(fd)
+
+        patch = (
+            mock.patch.object(os, "open", refusing_open)
+            if failure is not None
+            else mock.patch.object(os, "fsync", refusing_fsync)
+        )
+        with patch:
+            mod._write(target, {"version": 1, "inbox": [{"id": "must-land"}], "dispatch": {}})
+
+        assert json.loads(target.read_text(encoding="utf-8"))["inbox"] == [{"id": "must-land"}]
+
+
+class TestStatusNeverDestroysWhatItOnlyMeantToRead:
+    """``status`` writes nothing, and used to be able to lose a write anyway.
+
+    ``_read`` is not a pure read: on a malformed record it MOVES the file aside. Run
+    without the lock, that made the read-only mode capable of destroying a
+    concurrent writer's valid state — status reads old corruption, ``enqueue`` takes
+    the lock and publishes a good record over it, and status then renames THAT file
+    to the sidecar.
+    """
+
+    def test_status_takes_the_lock_before_it_reads(self, tmp_path: Path) -> None:
+        """Held by somebody else, ``status`` reports `locked` rather than reading.
+
+        That refusal IS the fix: a status that can be made to wait is a status whose
+        quarantine decision applies to the file it was made about. Driven through the
+        subprocess so the structured refusal, not an exception, is what is asserted.
+        """
+        goal_dir = tmp_path / "conductor" / "g"
+        goal_dir.mkdir(parents=True)
+        (goal_dir / "queue.json").write_text(
+            '{"version": 1, "inbox": [], "dispatch": {}}', encoding="utf-8"
+        )
+        # A live holder: this process, so the liveness probe says "still running"
+        # and the lock is not stolen out from under the assertion.
+        (goal_dir / "queue.lock").write_text(f"{os.getpid()} someone-else", encoding="utf-8")
+
+        out = _run("status", {"goal": "g"}, tmp_path)
+        assert out["ok"] is False
+        assert out["error"]["code"] == "locked"
+
+    def test_the_quarantine_decision_is_made_under_the_lock(self, tmp_path: Path) -> None:
+        """The destructive step is the rename, so THAT is what has to be excluded.
+
+        Asserted as the invariant rather than by racing a real writer: at the moment
+        ``_quarantine`` renames the file, the goal's lock must be held by us. That is
+        precisely what makes the interleaving impossible — a lock-respecting
+        ``enqueue`` cannot publish between the read and the rename, so it cannot be
+        the file that gets moved aside. Unlocked, no lock file exists at that point
+        at all, which is the shape of the bug.
+        """
+        mod = _mod()
+        mod._data_home = lambda: tmp_path
+        goal_dir = tmp_path / "conductor" / "g"
+        goal_dir.mkdir(parents=True)
+        state = goal_dir / "queue.json"
+        state.write_text('{"version": 1, "inbox": [null], "dispatch": {}}', encoding="utf-8")
+        lock = goal_dir / "queue.lock"
+        real_quarantine = mod._quarantine
+        held_at_rename = []
+
+        def recording_quarantine(path):  # noqa: ANN001, ANN202
+            held_at_rename.append(
+                lock.exists()
+                and lock.read_text(encoding="utf-8").strip().startswith(str(os.getpid()))
+            )
+            return real_quarantine(path)
+
+        with mock.patch.object(mod, "_quarantine", recording_quarantine):
+            got = mod.mode_status({"goal": "g"})
+
+        assert got["ok"] is True
+        assert held_at_rename == [True], "status quarantined without holding the goal's lock"
+        # And the lock is not left behind for the next caller to time out on.
+        assert not lock.exists()
+
+
+class TestAPartialWriteIsNeverPublished:
+    """A short write used to be accepted and then replaced over a good record.
+
+    ``os.write`` may consume fewer bytes than it is given and does not raise when
+    it does — on a full device that is exactly what happens. Publishing anyway put
+    truncated JSON where the queue was, and the truncation then read back as
+    corrupt, so every parked message was gone.
+    """
+
+    def test_a_short_write_refuses_and_leaves_the_previous_record(self, tmp_path: Path) -> None:
+        mod = _mod()
+        target = tmp_path / "queue.json"
+        good = '{"version": 1, "inbox": [{"id": "keepme"}], "dispatch": {}}'
+        target.write_text(good, encoding="utf-8")
+
+        with mock.patch.object(os, "write", _stalling_write()):
+            with pytest.raises(OSError):
+                mod._write(target, {"version": 1, "inbox": [], "dispatch": {}})
+
+        assert target.read_text(encoding="utf-8") == good
+        # And no half-written temp file left beside it to be mistaken for state.
+        assert not list(tmp_path.glob("queue.tmp-*"))
+
+    def test_a_full_disk_is_reported_as_a_refusal_not_a_crash(self, tmp_path: Path) -> None:
+        """The conductor has to be able to read WHY, and that the record survived.
+
+        Driven through ``main`` rather than the mode function: the structured
+        refusal is what the conductor actually reads on stdout, and a mode raising
+        into a traceback would be indistinguishable from a bug.
+        """
+        _run("enqueue", {"goal": "g", "text": "must survive"}, tmp_path)
+        mod = _mod()
+        mod._data_home = lambda: tmp_path  # the subprocess env does not reach in-process
+
+        out = io.StringIO()
+        with (
+            mock.patch.object(mod.sys, "argv", ["dispatch_queue.py", "enqueue"]),
+            mock.patch.object(
+                mod.sys, "stdin", io.StringIO(json.dumps({"goal": "g", "text": "second"}))
+            ),
+            mock.patch.object(mod.sys, "stdout", out),
+            mock.patch.object(os, "write", _stalling_write()),
+        ):
+            assert mod.main() == 0
+
+        got = json.loads(out.getvalue())
+        assert got["ok"] is False
+        assert got["error"]["code"] == "state_write_failed"
+        assert _run("status", {"goal": "g"}, tmp_path)["inbox"][0]["text"] == "must survive"


### PR DESCRIPTION
## Problem

The `goal-conductor` skill holds two facts nowhere but in the conductor's own
prompt and context:

1. **A user message that arrives mid-round.** The skill's "Goal changes
   mid-flight" section told the conductor to remember the message and apply it at
   the next round boundary. Remembering is context, and context is what
   compaction drops. The user typed a steering instruction and gets no
   acknowledgement that it was lost.
2. **Whether an item was already dispatched.** Dispatch is two MCP calls —
   `session_create` then `session_send` — ordered only by prose ("send the seed
   BEFORE recording the ledger row"). A turn lost between them leaves a session
   with no seed, and the next patrol cycle cannot tell that from a session that
   is merely quiet. The recovery a conductor actually reaches for is a second
   `session_create`, which is how one item becomes two sessions.

## Why it matters

Both failures are silent and both are user-visible. The first discards
something a human typed. The second doubles work under a lost turn — the exact
condition a long-running conductor hits most, since it deliberately ends its turn
and comes back through `monitor_start`.

## Fix

**Symptom:** a mid-flight message and a half-finished dispatch both live only in
context.

**Root cause:** the skill has no durable store. `accept_eval.py` holds the
acceptance verdict and `ledger_entry.py` holds the entry format, but nothing
holds the queue, so the prose had to carry it.

**Change:** a third bundled script, `scripts/dispatch_queue.py`, owning one state
file per goal at `<data_home>/conductor/<goal>/queue.json`. Seven modes:
`enqueue`, `claim`, `done`, `release`, `dispatch_begin`, `dispatch_sent`,
`status`. Same invocation contract as its siblings — argv mode, one JSON on stdin,
one JSON on stdout, exit 0 for "ran" and 2 for a malformed call.

The design choices that carry the properties:

- **A claim does not delete.** It marks and timestamps. A turn that dies after
  claiming leaves the message on disk, and a later `claim` past the staleness
  window re-serves it with a `reclaimed` count. Only an explicit `done` removes
  it.
- **A full inbox refuses.** At `MAX_INBOX` the call returns `inbox_full` rather
  than evicting the oldest — every entry is a message a human typed, so a
  backlog is the better failure. `MAX_TEXT` refuses rather than truncating, for
  the same reason: half a steering instruction can invert its meaning.
- **`dispatch_begin` is idempotent by id.** A second call for the same item
  returns the SAME dispatch id and `replay: true`, plus a warning naming the
  consequence when no seed was recorded yet. A fresh id per attempt is precisely
  what opens a second session.
- **An unreadable state file refuses.** It does not read as blank. A blank read
  would be written back by the next mode, destroying the parked messages the
  script exists to keep.
- **A corrupt or structurally invalid state file is moved aside, not deleted**,
  to `queue.corrupt-<ts>.json`, so the run continues and the bytes stay
  inspectable. Valid JSON with the wrong shape is quarantined on the same path
  rather than being substituted with a blank record. **The shape check goes one
  level deep, not just the containers**: `{"inbox": [null]}` has a list where a
  list belongs, so a container-only check accepts it and every mode then calls
  `entry.get(...)` on a non-mapping and dies with an uncaught `AttributeError` —
  the exact crash the quarantine exists to prevent.
- **Writes are all-or-nothing, and a successful one is durable.** `os.write` is
  looped until every byte lands and `os.replace` is skipped entirely after a
  short write, so a full disk produces a structured refusal and leaves the
  previous record byte-identical rather than publishing truncated JSON. After the
  replace, the **parent directory is fsynced** — `fsync` on the file commits the
  bytes, not the rename that points at them, so power loss between the two loses
  an enqueue the script already reported as succeeded. Best-effort by design: a
  directory is not openable on Windows and some filesystems refuse to sync one,
  neither of which is a reason to fail a write whose data is already committed.
- **`O_EXCL` lockfile with a liveness-gated, fenced steal**, not `fcntl.flock` —
  the backend test suite runs on Windows, and `flock` is not there. A stale lock
  is stolen only once its holder is *proven* dead; a holder that is still running
  is never stolen from, and one that cannot be judged waits for a 900s backstop.
  Ownership is fenced by a token, so a writer whose lock was stolen refuses at
  publish time instead of clobbering the newer state. **The fence is checked
  twice**, and the second check is the load-bearing one: checking only on entry
  leaves the whole `write` + `fsync` window — the slowest part, and exactly where
  a writer stalls long enough to look dead — unguarded, so a writer that passed
  the entry check could still resume after the steal and `os.replace` its stale
  record over the newer one. The re-check sits immediately before the rename,
  unlinks the temp file, and refuses with `lock_lost`.
- **Nothing reads the record outside the lock, including `status`.** `status`
  writes nothing, but `_read` can *quarantine* — so an unlocked read of old
  corruption, racing an `enqueue` that publishes valid state, renames that new
  state aside. A mode that only means to look still needs the lock, because its
  read is not side-effect-free.
- **Every path through the acquire loop converges.** A lock whose staleness
  cannot be judged times out with `locked` rather than spinning, and so does one
  the steal *decides* on but cannot carry out — a lock in a directory this
  process may not write to (a goal dir owned by another uid, a read-only mount)
  still stats fine and still looks steal-worthy, so retrying on a failed
  `unlink` re-decides the same steal every pass with no sleep and no deadline
  check. Only a *successful* unlink retries; a failure falls through to the
  deadline.
- **No identity, no network, no subprocess.** A script under `execute_bash` gets
  no verifiable identity from the gateway, so anything it read would be an
  assertion. Keeping it a plain local state machine is what makes it safe as a
  script rather than an MCP tool, and a source ratchet in the tests pins that.

Goal ids are validated against `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`, not
sanitized: a goal id names a directory, and sanitizing two different ids into one
merges two goals' queues.

Supporting edits, all queue-only:

- `SKILL.md` — `dispatch_begin` before the dispatch steps and `dispatch_sent`
  right after the seed; the `enqueue`/`claim`/`done`/`release` cycle in "Goal
  changes mid-flight"; the added approval cost stated in "Known limits". The
  dispatch list still OPENS with `session_create`, so the atomic-filing property
  #6118 established is untouched.
- `agent.py` — the conductor prompt names three bundled scripts instead of two.

## Tests

`test/test_conductor_queue.py`, 50 cases, one class per load-bearing property:

- `TestInvocationContract` — unknown mode and a JSON array on stdin are exit 2 on
  stdout, not a traceback; every mode reports `state_path`.
- `TestGoalIdIsValidatedNotSanitized` — seven rejected shapes, and `../../etc`
  never reaches a path.
- `TestAParkedMessageSurvives` — the dead-turn case asserted directly: claim,
  die, re-claim, get the text back. Plus idempotent `done`, `release`, the
  refusal at the cap with the oldest still present, oversize refusal, and the
  corrupt-file sidecar.
- `TestARetriedDispatchConverges` — same id and `replay: true` on the second
  begin, the warning naming "no seed", no warning once sent, `unsent_items` in
  status, and a `dispatch_sent` with no begin recorded-and-flagged rather than
  refused (the send already happened; refusing would make the record less true).
- `TestItTouchesNoIdentity` — source ratchet on named session-key and credential
  symbols, and on `subprocess`/`urllib`/`socket`.
- `TestUnreadableIsNotAbsent` — the unreadable file refuses and the bytes are
  byte-identical afterwards; absent still reads as blank.
- `TestTheLockAlwaysConvergesOnAnAnswer` — a live lock times out, a stat that
  always fails still honours the deadline without stealing, a stale lock whose
  `unlink` keeps failing times out instead of spinning, a stale lock from a
  *proven-dead* holder is stolen, one whose holder still runs is not, and a
  holder that cannot be judged is stolen only past the 900s backstop. The
  liveness cases are POSIX-gated and use a genuinely reaped pid, because
  `os.kill(pid, 0)` is only a non-destructive probe on POSIX. The un-removable
  case asserts both halves of the bug it pins: the wall-clock stays inside the
  wait budget *and* the retry count stays bounded, since the failure mode is an
  unbounded retry loop rather than a slow one.
- `TestAPartialWriteIsNeverPublished` — a short write refuses and leaves the
  previous record byte-identical; a simulated full disk is reported as a
  structured refusal rather than a crash. A stolen lock makes the in-flight write
  refuse instead of clobbering the newer state. The fence re-check is driven by
  stealing the lock from *inside* a patched `os.fsync`, so the entry check has
  already passed when the theft lands — the only arrangement that can distinguish
  one fence check from two; it asserts `lock_lost`, that the newer record
  survives, and that no `queue.tmp-*` is left behind. Directory durability is
  asserted by recording fsyncs whose fd `fstat`s as `S_IFDIR`, because a plain
  call-count assertion passes against the bug, and a companion case parametrized
  over "the directory will not open" and "it opens but will not sync" pins the
  best-effort half.
- `TestStatusNeverDestroysWhatItOnlyMeantToRead` — a live foreign lock makes
  `status` return the structured `locked` refusal, and the quarantine case
  asserts the invariant rather than a timing coincidence: `_quarantine` records
  whether `queue.lock` exists *and* carries this pid at the moment of the rename.
- `test_structurally_invalid_state_is_quarantined_not_silently_dropped` —
  parametrized over six malformed bodies, three of them nested (`inbox: [null]`,
  `inbox: ["a string"]`, `dispatch: {"item-1": "abc"}`); asserts the
  `.corrupt-<epoch>` sidecar's bytes equal the original. A sibling case drives
  `status` over a malformed record through the real subprocess, so a traceback
  fails the test rather than being interpreted as output.

The module runs on Windows rather than being collect-ignored, because
portability is the reason `_Lock` uses `O_EXCL` at all — excluding it would leave
that claim untested. Only the cases that need a POSIX-only primitive to mean what
they test are skipped there: `0o000` to MEAN unreadable (a mode-0 file stays
readable by its owner on Windows), and the non-destructive liveness probe (on
Windows `os.kill` *terminates* the target, so the probe returns "cannot be
judged" and the backstop path covers it instead).

## Manual verification

```
$ pytest test/test_conductor_queue.py -q
50 passed

$ pytest test/test_builtin_skill_packaging.py test/test_builtin_skill_scope.py \
    test/test_builtin_skill_sync_safety.py test/test_conductor_agent.py \
    test/test_conductor_ledger_entry.py test/test_conductor_queue.py \
    test/test_conductor_skill.py test/test_conductor_skill_cov80.py \
    test/test_goal_command.py test/test_prepare_pr_profiles.py -q
291 passed

$ isort --check-only  # clean
$ python scripts/check_black_formatting.py
black gate passed: nothing in scope is unformatted outside the baseline
$ flake8              # clean
$ mypy src/kiro_crew/
Success: no issues found in 1289 source files
$ python scripts/check_subprocess_encoding.py       # clean
$ python scripts/check_builtin_skill_scope.py       # clean
$ python scripts/check_testpaths_coverage.py        # clean
$ python scripts/docs_lint.py                       # clean
```

## Why the script is named `dispatch_queue.py`, not `queue.py`

The obvious name shadows the stdlib `queue` module. Because the script lives
inside the package tree, `mypy` resolved `import queue` in six unrelated files
(`embeddings.py`, `cli.py` and others) to this file instead of the stdlib,
producing 21 errors across the repo. The rename is what makes `mypy src/kiro_crew/`
green; nothing else about the script changed with it.

## Relation to #6237

This is the queue half of #6237, rebased onto current `main` and split out on its
own. #6237 also collapsed the eight session-control verb tools into two
op-shaped tools, which #6109 has since made expensive: per-verb auto-approval now
matches on tool NAME, so collapsing the names re-opens a security decision that
is out of scope for a durable queue. That half is being abandoned; this half is
independent of it and does not touch `mcp_dashboard.py`, `channel.py` or
`validation.py`.

no linked issue: this is a split-out half of #6237 (a PR, not a tracked issue), and the durable-queue gap it closes was found while reviewing that PR rather than filed separately.

