### PR TITLE
fix(messaging): derive send_message's channel-session roster from the channel registry

### DIFF
--- a/docs/system-specs/modules/messaging.md
+++ b/docs/system-specs/modules/messaging.md
@@ -600,6 +600,105 @@ named, and the caller cannot tell which one it lost:
 |---|---|---|
 | Slack | `session="slack"`, `channel`, `user`, `thread_ts`, `reply_broadcast` | the Slack client's own path |
 | every other channel | `channel_type` | the conversation the calling session already belongs to |
+| every other channel | `session="<channel>"` | that channel's own configured owner, wherever the call came from |
+
+The two non-Slack rows answer different questions and neither substitutes for the
+other. `channel_type` rides the calling session's `ChannelLink` and **fails closed
+when there is none**, so it serves a session that is already talking on the
+channel; a cron whose origin is the dashboard, or which has no origin at all, has
+no link for it to ride. `session="<channel>"` needs no link — it resolves the
+destination from the transport's own `configured_targets()` through
+`_deliver_channel_dm` — which is what makes it the route for a proactive notice
+raised somewhere other than the channel itself.
+
+**One roster, three views.** The channels a proactive send may name are derived
+ONCE, as `constants.CHANNEL_SEND_NAMESPACES` — `CHANNEL_SESSION_NAMESPACES` minus
+`slack` (its own client, spelled `session="slack"`) and `unified` (a session-key
+bucket, not a transport). The MCP tool's advertised enum
+(`mcp_tools.messaging._CHANNEL_SESSIONS`), the pre-handler validator's pattern
+(`validation._SEND_MESSAGE_SESSION_RE`) and the gateway's accepted `channel_type`
+set (`_SEND_MESSAGE_CHANNEL_TYPES`) all read that one constant, because each is a
+gate the value passes in turn and a narrower one in front silently withholds a
+destination the wider ones behind it would serve. That is not hypothetical: the
+first two were hand-kept and stood at `discord` alone for months after eight more
+transports were registered, so `session="webex"` was refused as malformed by a
+validator while the gateway leg behind it could already resolve and deliver a
+Webex owner DM (#6514). The subtraction itself was then respelled at each of the
+three readers, which is the same shape one level up, so it is derived at the
+definition and the readers name it rather than recompute it.
+
+The roster lives in `constants` (`os` + `re` only) rather than `messaging.link`
+because it has readers on both sides of an import cycle: `messaging.link` is
+itself stdlib-only, but importing a name FROM it executes `messaging/__init__.py`,
+which pulls in `driver` → `acp` → `hooks`, and `hooks` → `webhooks` →
+`validation` is already an edge. `messaging.link` re-exports both names, so its
+own readers are unchanged. One sibling hand-kept copy remains and is NOT derived:
+`autonudge._CHANNEL_KEY_PREFIXES`, which answers a key-SHAPE question rather than
+a send-capability one. Its membership is currently identical to the roster's, so
+the older claim that it is deliberately narrower does not hold; deriving it is
+sound and deliberately out of scope here.
+
+**A channel `session` needs an owner; `channel_type` does not, so the rosters
+differ by one.** `channel_type` names a conversation -- the calling session's, or an
+explicit `target_id` -- and infers no recipient. A channel `session` infers one via
+`_owner_dm_target`, whose safety claim is that the agent can only reach somebody the
+USER configured. `constants.CHANNEL_OWNER_DM_NAMESPACES` is therefore
+`CHANNEL_SEND_NAMESPACES` minus the channels that cannot answer that question, and
+today that is `weixin` and `wecom`. Each folds identities LEARNED from inbound
+traffic into `configured_targets()` — Weixin's `_known_users` (`_allowed |
+_known_users`), WeCom's `_warm_chats`, which under `allow_all_users` become the list
+outright ("there is no configured list to draw on, so the warm peers ARE the list").
+So a peer who messaged the bot once can be the single available direct target, which
+is exactly what `_owner_dm_target` reads as the owner. Nothing downstream catches
+it: both `may_send_to` implementations return True unconditionally under their open
+policy (Weixin's promise to consult `_allowed` alone holds only on its `allowlist`
+branch), and `resolve_configured_target` accepts the learned set too.
+`channel_type` is unaffected for both and stays available.
+
+The exclusion is not hand-kept:
+`test_no_owner_dm_channel_advertises_learned_identities` derives the check from the
+transports, so a channel that starts mixing learned identities into
+`configured_targets()` fails that gate instead of silently becoming an owner-DM
+target. A channel graduates by separating configured recipients from learned peers,
+at which point deleting it from the subtraction is the whole change.
+
+**Widening the roster does not widen the audience.** Whether a channel can take a
+proactive DM is answered per send by `_owner_dm_target`, at the side-effect
+boundary against live config, which is where a runtime question has to be answered
+— a static roster cannot. A transport needing prior inbound state (Teams, WeCom)
+or unable to DM proactively at all (Feishu) marks its targets unavailable; an
+allow-list with several people is refused rather than guessed at. Both degrade to
+the dashboard notification, and the tool says which channel missed rather than
+reporting success.
+
+**Both channel legs require a strictly-resolved caller.** `channel_type` and a
+channel `session` each resolve identity through `mcp_core.require_strict_session_key`
+and refuse when it is absent. The refusal is the control, not a formality:
+`gov_session` otherwise falls back to the lenient resolver, which walks process
+ancestors, so an unidentified sub-agent resolves to its PARENT — and the
+channel-agent containment check (`_deny_channel_agent_messaging`, which fires only
+on an identity starting `channel:`) then does not fire for a contained agent,
+putting the owner-DM egress surface inside its confinement boundary. The gateway's
+fail-closed `channels` re-vet does not backstop that: it covers the transport
+scope, not channel-agent containment. Refusing costs no legitimate caller, because
+the gateway injects `KIROCREW_SESSION_KEY` into every agent/ACP subprocess and a
+cron run carries `cron:<job_id>` in it, with the HMAC-verified host-pid sidecar
+covering PID-namespace-sandboxed sessions; it is absent only where there is no
+session key to inject.
+
+**And the gateway vets that identity rather than the host sentinel.**
+`_deliver_channel_dm` resolves `caller_session or HOST_SESSION_KEY`, and the host
+sentinel is the PERMISSIVE default, so dropping a caller's identity there lets a
+session whose own profile denies the transport reach a host-permitted owner DM —
+the MCP-side channel vet degrades open on an evaluation error, so it is not a
+second guard. Each arm takes its identity from where that arm is trustworthy,
+matching `_channel_delivery_key` on the same path: a cron's body key is
+format-validated before it may escalate routing, and a non-cron caller is
+identified by the `X-Session-Key` header, which `token_auth._verify_unix_peer`
+kernel-attests against the peer's own process ancestry — never the body, which a
+tool argument could name. The governance vet and the delivery key therefore
+resolve the same principal. The `channel_type`/`target_id` leg already worked this
+way; the channel-`session` leg was not migrated with it.
 
 `"slack"` is deliberately **not** a legal `channel_type`: Slack is absent from
 `state.channel_transports` on purpose, so the shared ladder skips it and accepting
@@ -1529,7 +1628,7 @@ answer is not permission: a raised evaluation and a `Decision` without
 - **Runtime identity follows the current turn**: every channel dispatcher passes its trusted transport name as `runtime_source` to `ContextBuilder.build_message`; the shared `drive_turn` pipeline uses `ChannelTurn.channel_type`. A cross-surface resume keeps its original stable session key for conversation continuity, but `[RUNTIME]` names the interface carrying the current message. Follow-up turns refresh the marker because the one-time session context may describe an earlier surface.
 - **Channel dashboard visibility is immediate**: after the first successful turn of a Discord, Telegram, Webex, Teams, WeCom, Weixin, or Feishu-owned session is persisted, the dispatcher triggers the channel-slot reconciler immediately when `dashboard.surface_channel_sessions` is enabled. `DashboardState.register_channel_transport` injects the dashboard state into the bound dispatcher; the lifetime 30-second reconciler remains the recovery path, but the normal first-turn path does not wait for it. Turns that resume an existing `dashboard:` session skip this step because that session already owns a slot.
 - **An owner notification is not Slack-only**: `dashboard/server.py::_dm_owner` prefers the owner's Slack DM and falls back to registered channel transports (`_notify_owner_channels`). It used to no-op entirely without Slack, so an expiring unattended grant was invisible on a Teams-only, Discord-only or Telegram-only install — silence about a security grant lapsing is exactly what the notice exists to prevent. Fallback, not addition: an operator with Slack gets one notice, not one per channel. Reachability is the transport's OWN answer, so this can only reach a destination that channel already authorized. **And a channel must be able to NAME the owner: exactly one configured target, or nothing.** The notice carries the operator's own security state, while an allow-list is a list of people permitted to talk to the agent — not a claim that any one of them is the operator. With several configured targets there is no unambiguous owner, and sending to the first reachable one hands one allow-listed human another's auto-approve state; the count is over ALL configured targets, because a three-person allow-list with one learned route is still a guess. Same premise as `/sessions`' owner-only rule. Per-identity authority within an allow-list would let this deliver on a multi-person install; it does not exist yet on any channel.
-- **The proactive PRODUCERS are still Slack-shaped, and the parity claim says so**: `api_send_message` (the LLM-facing `send_message` tool) has exactly two legs — the origin dashboard slot and `state.slack_client` — and `file_send` posts to the Slack upload route. Neither consults `state.channel_transports`. A cron result still reaches a non-Slack channel when its origin slot is MIRRORED there (`/link`), which is the normal path; what is missing is the tool's own explicit channel/user addressing, whose allow-list, threading and unfurl semantics are Slack concepts. This is the largest remaining outbound gap and it hurts Discord and Telegram identically — routing it through the transport ladder is a change to that handler's contract, not to a channel.
+- **The proactive PRODUCERS started Slack-shaped, and the parity claim tracks how far that has moved**: `api_send_message` (the LLM-facing `send_message` tool) began with exactly two legs — the origin dashboard slot and `state.slack_client` — and `file_send` still posts to the Slack upload route. The tool's own explicit addressing now exists for every registered channel and does consult `state.channel_transports`: `channel_type` (+ optional `target_id`) for the conversation the session belongs to, and `session="<channel>"` for that channel's configured owner. See § Proactive sends. What remains Slack-only is the shape of `channel`/`user`/`thread_ts`/`unfurl_*`, whose allow-list, threading and unfurl semantics are Slack concepts, and `file_send`'s upload route. A cron result also still reaches a non-Slack channel when its origin slot is MIRRORED there (`/link`).
 - **Configured outbound targets are transport-owned**: `MessagingTransport.configured_targets()` returns opaque `ConfiguredChannelTarget` records for the user-configured destinations a dashboard session may link to, including an explicit unavailable reason when a protocol needs prior inbound state or cannot send proactively. `resolve_configured_target()` revalidates the selected opaque id at the side-effect boundary and resolves it to `(conversation_id, thread_id)`; the browser never supplies an unchecked platform conversation id. Discord exposes configured users and threads, and fail-closes thread resolution unless Discord still reports the allow-listed id as an actual thread rather than a normal shared guild channel; Telegram exposes configured DMs; Webex exposes configured DMs plus, when `webex.allow_group_rooms` is on, each space in `webex.allowed_room_ids` as a `room:` target — and `resolve_configured_target` re-validates a `room:` id against BOTH the switch and the list, because an advertised target id travels through the browser and the LLM (it is the `target_id` an MCP send may name) and the config can narrow after one was minted; Weixin exposes allow-listed DMs plus authorized peers learned under its open policy; Teams destinations become available after an authorized inbound activity supplies a conversation/service URL; and WeCom advertises its allow-listed userids plus, under its allow-all policy, the peers it has learned — each either offered or listed with a reason, because `aibot_send_msg` needs no token but the platform only delivers into a conversation the user has already written to. Feishu destinations are visible but unavailable because replies are anchored to an inbound message (no proactive DM in v1).
 - **Configured-target egress is governed at every yield boundary**: the dashboard mirror-link endpoint enters the shared fail-closed `channels` governance ladder before resolving an opaque target (resolution may itself open a remote DM), rechecks before the initial link message, and rechecks before each historical-context message. A profile that narrows after transport startup therefore stops both target resolution and all subsequent sends.
 - **`/link` and `/unlink` are one pair with one location**: `rebind_conversation_location` claims what `release_conversation_location` frees, and both take the channel's single `_origin_mirror_link()` value — the release matches an occupied location by VALUE, so a second spelling of "this conversation" lets it miss the binding the bind wrote. Inside the rebind the **claim goes first**: `batched_save` writes on the way out even when the block raises, so an opt-out withdrawal ordered ahead of a refused claim would persist for a link that never happened and silently turn mirroring back on.

--- a/src/kiro_crew/constants.py
+++ b/src/kiro_crew/constants.py
@@ -380,6 +380,103 @@ AWS_PROFILE_CHARS = "A-Za-z0-9_.+-"
 AWS_PROFILE_NAME_PATTERN = f"^[{AWS_PROFILE_FIRST_CHARS}][{AWS_PROFILE_CHARS}]{{0,127}}\\Z"
 AWS_PROFILE_NAME_RE = re.compile(AWS_PROFILE_NAME_PATTERN)
 
+SLACK_NAMESPACE = "slack"
+
+#: Session-key namespaces owned by a messaging channel, i.e. every prefix a
+#: conversation started OUTSIDE the dashboard can carry. Slack keys are
+#: ``slack:<thread_ts>``; every other transport uses
+#: ``{channel}:{agent}:{chatType}:{user}[:genN]`` (see
+#: ``messaging.link.build_dm_session_key``), plus the ``unified:`` bucket that
+#: ``dm_scope="unified"`` collapses direct DMs into.
+#:
+#: Deliberately excludes the non-channel namespaces that also contain a colon
+#: (``dashboard:``, ``cron:``, ``hook:``, ``subagent:``, ``channel:``) — those
+#: are surfaced by their own owners, not by the channel-session reconciler.
+#:
+#: NOTE: ``autonudge._CHANNEL_KEY_PREFIXES`` is a SEPARATE hand-kept copy. It is
+#: often described as narrower; as of this writing it is not -- both hold the same
+#: 11 namespaces. It answers a different question (does this key SHAPE belong to a
+#: channel rather than a dashboard slot), which is why it lists namespaces nothing
+#: can currently be delivered to. Deriving it from here would be sound and is
+#: deliberately left out of the change that homed this roster; until then, do not
+#: assume the two have diverged, and do not assume they are kept in step either.
+#:
+#: HOMED HERE, not in ``messaging.link``, because the roster has readers on both
+#: sides of an import cycle. ``messaging.link`` is itself stdlib-only, but
+#: importing anything from it executes ``messaging/__init__.py`` first, which
+#: pulls in ``driver`` -> ``acp`` -> ``hooks``; a reader that ``hooks`` is already
+#: mid-import for (``hooks`` -> ``webhooks`` -> ``validation``) then fails with a
+#: partially-initialized ``hooks``. This module imports only ``os`` and ``re``, so
+#: it can be read from anywhere. ``messaging.link`` re-exports both names, which
+#: is where the rest of the codebase still reads them from.
+CHANNEL_SESSION_NAMESPACES: tuple[str, ...] = (
+    SLACK_NAMESPACE,
+    "discord",
+    "telegram",
+    "whatsapp",
+    "webex",
+    "wecom",
+    "teams",
+    "weixin",
+    "imessage",
+    "feishu",
+    "unified",
+)
+
+#: The channels a PROACTIVE send may name -- ``send_message``'s ``channel_type``
+#: and its channel ``session`` values. Derived ONCE here rather than subtracted at
+#: each reader: the same subtraction was spelled in three places, which is the
+#: drift shape that made a Webex owner DM unreachable while the gateway leg behind
+#: it already worked (#6514), one level up.
+#:
+#: Two members of the roster cannot be a send target:
+#:
+#: * ``slack`` has its own client and streaming path and is deliberately absent
+#:   from ``state.channel_transports``, so the shared ladder skips it. It is
+#:   spelled ``session="slack"``.
+#: * ``unified`` is the session-key bucket ``dm_scope="unified"`` collapses DMs
+#:   into, not a transport; no ``ChannelLink`` ever carries it as a channel type.
+CHANNEL_SEND_NAMESPACES: tuple[str, ...] = tuple(
+    sorted(set(CHANNEL_SESSION_NAMESPACES) - {SLACK_NAMESPACE, "unified"})
+)
+
+#: The channels an OWNER-DM may be inferred for -- ``send_message``'s channel
+#: ``session`` values. A strict subset of :data:`CHANNEL_SEND_NAMESPACES`, because
+#: the two ask different questions and only one of them needs an owner.
+#:
+#: ``channel_type`` names a conversation: the one the calling session already
+#: belongs to, or an explicit ``target_id`` the agent supplies. Neither infers a
+#: recipient. A channel ``session`` DOES infer one, from
+#: ``configured_targets()`` via ``_owner_dm_target``, whose safety claim is that
+#: the agent can only reach somebody the USER configured.
+#:
+#: ``weixin`` and ``wecom`` are excluded because that claim is false on both. Each
+#: folds identities LEARNED from inbound traffic into ``configured_targets()`` --
+#: Weixin's ``_known_users`` (``_allowed | _known_users``) and WeCom's
+#: ``_warm_chats``, which under ``wecom.allow_all_users`` become the list outright
+#: ("there is no configured list to draw on, so the warm peers ARE the list"). So a
+#: peer who messaged the bot once can be the single available direct target, which
+#: is exactly what ``_owner_dm_target`` reads as "the owner". Nothing downstream
+#: catches it: both transports' ``may_send_to`` returns True unconditionally under
+#: their open policy (Weixin's promise to consult ``_allowed`` alone holds only on
+#: its ``allowlist`` branch), and ``resolve_configured_target`` accepts the learned
+#: set too. So private agent output would reach an arbitrary peer, not the operator.
+#:
+#: The other seven transports draw ``configured_targets()`` from configured state
+#: alone; ``test_no_owner_dm_channel_advertises_learned_identities`` is the ratchet
+#: that keeps this subtraction honest rather than hand-kept, so a transport that
+#: starts mixing learned identities in fails the gate instead of silently becoming
+#: an owner-DM target.
+#:
+#: This is a per-channel CAPABILITY gap, not drift: the exclusion is derived from
+#: the send roster and carries its reason, the way ``slack`` and ``unified`` do. A
+#: channel graduates by distinguishing configured recipients from learned peers in
+#: ``configured_targets()`` -- at which point deleting it from this subtraction is
+#: the whole change.
+CHANNEL_OWNER_DM_NAMESPACES: tuple[str, ...] = tuple(
+    sorted(set(CHANNEL_SEND_NAMESPACES) - {"weixin", "wecom"})
+)
+
 # The product wordmark, figlet `small`. ONE definition on purpose: copy-pasting
 # it into cli.py and cli_chat.py risks a rename leaving a stale product name in
 # the two most-seen surfaces (bare `kirocrew`, the chat REPL). Import it; never

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -34,6 +34,7 @@ from kiro_crew.config.loader import (
     KiroCrewConfig,
     config_path,
 )
+from kiro_crew.constants import CHANNEL_SEND_NAMESPACES
 from kiro_crew.cron import CronStoreBusy, CronStoreUnreadable
 from kiro_crew.dashboard.channel_folders import (
     LIVE_RELOAD_FIELDS,
@@ -63,7 +64,7 @@ from kiro_crew.dashboard.state import (
 )
 from kiro_crew.dashboard.token_auth import caller_names_a_missing_slot
 from kiro_crew.messaging.display_safety import redact_for_display
-from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES, SLACK_NAMESPACE, ChannelLink
+from kiro_crew.messaging.link import SLACK_NAMESPACE, ChannelLink
 from kiro_crew.messaging.renderer import (
     chunk_for_transport,
     chunk_text,
@@ -125,20 +126,16 @@ _SLACK_SECRET_FIELDS = {
     "app_token": "SLACK_APP_TOKEN",
 }
 
-#: Transports ``send_message``'s ``channel_type`` may name. Derived from the
-#: channel namespaces rather than hand-listed so a new transport is covered by
-#: adding it in one place, minus two members that cannot be a send target:
-#:
-#: * ``slack`` has its own client and streaming path and is deliberately absent
-#:   from ``state.channel_transports``, so ``_resolve_channel_target`` skips it —
-#:   accepting it here would fail every such send closed with no useful reason.
-#:   ``session="slack"`` is the Slack spelling.
-#: * ``unified`` is the session-key bucket ``dm_scope="unified"`` collapses DMs
-#:   into, not a transport; no ``ChannelLink`` ever carries it as a channel type.
-_SEND_MESSAGE_CHANNEL_TYPES: frozenset[str] = frozenset(CHANNEL_SESSION_NAMESPACES) - {
-    SLACK_NAMESPACE,
-    "unified",
-}
+#: Transports ``send_message``'s ``channel_type`` may name, which is also the set
+#: its channel ``session`` values may name. Reads the shared
+#: ``CHANNEL_SEND_NAMESPACES`` rather than subtracting the two non-targets here:
+#: that subtraction was spelled at three separate readers, which is the same drift
+#: shape that left a Webex owner DM unreachable while this module's own leg already
+#: served it (#6514). The exclusions and their reasons are documented at the
+#: definition — ``slack`` has its own client and streaming path and is deliberately
+#: absent from ``state.channel_transports`` (``session="slack"`` is its spelling),
+#: and ``unified`` is a session-key bucket rather than a transport.
+_SEND_MESSAGE_CHANNEL_TYPES: frozenset[str] = frozenset(CHANNEL_SEND_NAMESPACES)
 logger = logging.getLogger(__name__)
 
 
@@ -2297,9 +2294,27 @@ async def api_send_message(request: web.Request) -> web.Response:
                     state,
                     channel_target,
                     channel_text,
-                    # Only a well-formed cron key is trusted as a governance
-                    # identity; anything else is an out-of-band host action.
-                    caller_session=caller_session if is_cron_caller else "",
+                    # Vet on the CALLER's real identity so the fail-closed
+                    # ``channels`` re-vet inside the leg resolves that caller's own
+                    # profile rather than the permissive ``HOST_SESSION_KEY``
+                    # default. Filtering to ``cron:`` here discarded every non-cron
+                    # caller's identity, and the MCP-side channel vet fails OPEN on
+                    # an evaluation error, so a non-cron session whose own profile
+                    # denies the transport could reach a host-permitted target --
+                    # the same hole the ``channel_type``/``target_id`` leg above
+                    # already closed, on the leg that was not migrated with it.
+                    #
+                    # The two arms take their identity from where each is trustworthy,
+                    # matching ``_channel_delivery_key`` on this same path: a cron's
+                    # body key is format-validated above before it may escalate
+                    # routing, and a non-cron caller is identified by the
+                    # ``X-Session-Key`` header, which ``token_auth._verify_unix_peer``
+                    # kernel-attests against the peer's own process ancestry -- never
+                    # the body, which a tool arg could name. So the governance vet and
+                    # the delivery key resolve the SAME principal. Absent (a direct
+                    # operator send naming no session) still degrades to the host
+                    # sentinel inside the leg, unchanged.
+                    caller_session=caller_session if is_cron_caller else declared_session,
                 )
             if channel_type:
                 sent_channel = await _deliver_to_channel(

--- a/src/kiro_crew/mcp_tools/messaging.py
+++ b/src/kiro_crew/mcp_tools/messaging.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from kiro_crew import mcp_core
+from kiro_crew.constants import CHANNEL_OWNER_DM_NAMESPACES
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
 from kiro_crew.platform import redact_via_context as redact
 from kiro_crew.security import BINARY_MIME_ALLOWLIST, redact_credentials, redact_exfiltration_urls
@@ -33,7 +34,34 @@ from kiro_crew.validation import _SLACK_TS_RE, CHANNEL_ID_RE
 #: one delivers a DM to that channel's own configured owner: the gateway resolves
 #: the destination from the transport's configured-target allowlist, so the
 #: agent cannot address anyone the user has not configured for that channel.
-_CHANNEL_SESSIONS: tuple[str, ...] = ("discord",)
+#:
+#: DERIVED from the channel roster, not hand-listed, for the reason
+#: ``SEND_MESSAGE_SCHEMA`` already gives about ``channel_type``: a second copy of
+#: the roster goes stale when a transport is added. This one had. It read
+#: ``("discord",)`` while the gateway leg it feeds
+#: (``dashboard/handlers/messaging.py::_deliver_channel_dm``) was already
+#: channel-neutral — it looks the transport up by name and takes the destination
+#: from that transport's own ``configured_targets()`` — so the eight other
+#: registered channels were refused HERE, by a validator, on their way to a leg
+#: that could serve them.
+#:
+#: Widening the accepted set does not widen the reachable AUDIENCE. Whether a
+#: given channel can actually take a proactive DM is answered per send by
+#: ``_owner_dm_target``, which returns a target only when the transport
+#: advertises exactly ONE available direct target: a channel that needs prior
+#: inbound state (Teams, WeCom) or cannot DM proactively at all (Feishu) marks
+#: its targets unavailable and still degrades to the dashboard notification, and
+#: an ambiguous allow-list is refused rather than guessed at. That gate is at the
+#: side-effect boundary and reads live config, which is where it has to be — a
+#: static tuple here cannot answer a runtime question.
+#:
+#: The two exclusions live with the roster in ``constants.CHANNEL_SEND_NAMESPACES``,
+#: which the gateway's accepted ``channel_type`` set and the validator's pattern
+#: also read, so the subtraction is not respelled per reader. This leg reads the
+#: narrower ``CHANNEL_OWNER_DM_NAMESPACES``, because inferring an OWNER needs the
+#: transport to tell configured recipients from peers learned off inbound traffic
+#: and not every one does -- the reason is recorded at that definition.
+_CHANNEL_SESSIONS: tuple[str, ...] = CHANNEL_OWNER_DM_NAMESPACES
 
 #: Every accepted ``session`` value. The advertised enum is built from this, so
 #: the contract the model is shown and the validation a call is held to cannot
@@ -70,8 +98,18 @@ def schemas() -> list[dict[str, Any]]:
                 "\n\nsession param (optional):"
                 "\n  omitted   — dashboard notification only (default)."
                 '\n  "slack"   — Slack DM + dashboard notification.'
-                '\n  "discord" — Discord DM to the configured owner + dashboard'
-                " notification."
+                '\n  a channel name ("discord", "telegram", "webex", "teams",'
+                ' "whatsapp", "imessage", "feishu") — a DM to'
+                " that channel's own configured owner + dashboard notification."
+                " Only a destination the user already allow-listed for that channel"
+                " is reachable, and only when exactly one is configured: an"
+                " ambiguous allow-list, a channel that is not connected, and a"
+                " channel that cannot DM proactively all fall back to the"
+                " dashboard notification and say so rather than reporting success."
+                ' Not "wecom" or "weixin": each advertises peers learned from'
+                " inbound traffic beside configured ones, so an owner cannot be told"
+                " apart from whoever messaged the bot. Reach those with channel_type,"
+                " which addresses a conversation instead of inferring a recipient."
                 '\n  "origin"  — inject into the dashboard session that spawned'
                 " this cron. Falls through to notification-only if origin is"
                 " unreachable (tab closed, history deleted, or cron has no origin)."
@@ -79,13 +117,16 @@ def schemas() -> list[dict[str, Any]]:
                 "'user' to DM an allowed user, at most one, not both, and either "
                 "one always sends to Slack. channel, user, blocks, thread_ts, "
                 "reply_broadcast and unfurl_links/unfurl_media are Slack protocol "
-                'options: combining any of them with session="discord" is REFUSED, '
+                "options: combining any of them with a channel session is REFUSED, "
                 "not silently ignored."
                 "\n\nOn a non-Slack messaging channel (Telegram, Discord, Teams, "
                 "Webex, WeCom, Weixin, WhatsApp, iMessage) set 'channel_type' to "
                 "that channel's name to post into the conversation you are already "
-                "talking in. That is the only way a message reaches the user there, "
-                "and the Slack-only options above are rejected alongside it."
+                "talking in. Use it in preference to a channel session whenever you "
+                "are talking on that channel — it reaches the conversation at hand, "
+                "where a channel session reaches the channel's configured owner "
+                "wherever the call came from. The Slack-only options above are "
+                "rejected alongside it."
                 "\n\nTo reach a NON-Slack channel (Webex, Telegram, Discord, …) at"
                 " a specific destination, pass channel_type plus target_id, where"
                 " target_id is one of the opaque ids that channel exposes as a"
@@ -181,11 +222,15 @@ def schemas() -> list[dict[str, Any]]:
                         "enum": list(_SESSION_TARGETS),
                         "description": (
                             "Delivery routing. Omit for notification bell only (default). "
-                            '"slack" adds Slack DM delivery. "discord" sends a Discord DM '
-                            "to the configured owner instead; it takes none of the "
-                            "Slack-only options above. "
-                            '"origin" injects into the dashboard session that spawned '
-                            "this cron (falls back to notification if unreachable)."
+                            '"slack" adds Slack DM delivery. A channel name (e.g. '
+                            '"discord", "webex", "telegram") sends a DM on that channel '
+                            "to its configured owner instead; it takes none of the "
+                            "Slack-only options above, and falls back to the "
+                            "notification (saying so) when that channel is not "
+                            "connected or no single configured recipient can be "
+                            'resolved. "origin" injects into the dashboard session '
+                            "that spawned this cron (falls back to notification if "
+                            "unreachable)."
                         ),
                     },
                 },
@@ -412,6 +457,32 @@ def send_message(name: str, args: dict[str, Any]) -> str:
         )
         if not verified_session:
             return _strict_err
+    elif session in _CHANNEL_SESSIONS:
+        # A channel SESSION leaves over the same transports as ``channel_type``, so
+        # it is held to the same identity bar and refused the same way.
+        #
+        # The refusal is the POINT, not a side effect. ``gov_session`` below falls
+        # back to the LENIENT resolver, which walks process ancestors -- so an
+        # unidentified sub-agent resolves to its parent, and the channel-agent
+        # containment check (``_deny_channel_agent_messaging``, keyed on an
+        # identity starting ``channel:``) then does not fire for a contained agent.
+        # That is a confinement bypass onto the owner-DM egress surface, and the
+        # gateway's fail-closed ``channels`` re-vet does NOT backstop it: that gate
+        # covers the transport scope, not channel-agent containment.
+        #
+        # Refusing costs no legitimate caller. The gateway injects
+        # ``KIROCREW_SESSION_KEY`` into every agent/ACP subprocess
+        # (``acp/client.py``) and cron runs carry ``cron:<job_id>`` in it
+        # (``cron_script.py``), with the HMAC-verified host-pid sidecar covering
+        # PID-namespace-sandboxed sessions. It is dropped only when there is no
+        # session key to inject -- exactly the caller that cannot be attributed.
+        verified_session, _strict_err = mcp_core.require_strict_session_key(
+            f"Error: cannot verify caller identity for a session={session!r} send "
+            "(no gateway-injected session key or HMAC-verified pid). "
+            "Refusing to send a DM that cannot be attributed to a caller."
+        )
+        if not verified_session:
+            return _strict_err
     # ``gov_session`` is the identity every gate below is keyed on. It is the
     # STRICT key whenever one was required, so the identity that is checked is
     # the identity the request is later sent under (``_post`` gets the same
@@ -431,11 +502,9 @@ def send_message(name: str, args: dict[str, Any]) -> str:
     # Forward the identity the gateway will re-vet under. The STRICT key whenever
     # one was established above -- never the lenient one, which walks process
     # ancestors and would hand a sub-agent its PARENT's channel permissions at the
-    # egress chokepoint. Every channel egress has a ``channel_type`` and therefore a
-    # strict key, so this covers both channel legs; a cron keeps forwarding its own
-    # key for the Slack/dashboard routing it drives. Without either, nothing is
-    # forwarded and the gateway falls back to the host sentinel, which is correct
-    # only because no channel send can reach that state.
+    # egress chokepoint. BOTH channel legs require one, so every channel egress
+    # forwards a strictly-resolved identity or was already refused above; a cron
+    # keeps forwarding its own key for the Slack/dashboard routing it drives.
     if verified_session:
         payload["caller_session"] = verified_session
     elif is_cron:
@@ -527,9 +596,9 @@ def send_message(name: str, args: dict[str, Any]) -> str:
     if delivered_to and delivered_to != "notification":
         return f"Message sent to the {delivered_to} conversation + notification."
     # Reached the dashboard notification only. Warn loudly when a chat surface
-    # was intended (explicit session=slack/discord, or a cron — which defaults
-    # to Slack) so the caller can detect the miss and retry instead of
-    # reading a success string for a notification-only send.
+    # was intended (explicit session=slack or a channel session, or a cron —
+    # which defaults to Slack) so the caller can detect the miss and retry
+    # instead of reading a success string for a notification-only send.
     if session == "slack":
         return "⚠️ Slack unavailable — delivered as dashboard notification only (NOT in Slack)."
     if session in _CHANNEL_SESSIONS:

--- a/src/kiro_crew/messaging/link.py
+++ b/src/kiro_crew/messaging/link.py
@@ -16,6 +16,24 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+# ``SLACK_NAMESPACE`` and ``CHANNEL_SESSION_NAMESPACES`` are RE-EXPORTED from
+# ``kiro_crew.constants``, which is their canonical home, because the roster has
+# readers on both sides of an import cycle. This module is itself stdlib-only, but
+# importing a name FROM it executes ``messaging/__init__.py`` first, which pulls in
+# ``driver`` -> ``acp`` -> ``hooks``; since ``hooks`` -> ``webhooks`` ->
+# ``validation`` is already an edge, a reader like ``validation`` would get a
+# partially-initialized ``hooks``. Readers inside ``messaging`` and its dependents
+# keep importing from here; readers outside it read ``constants`` directly.
+#
+# The semantics are documented at the definition. Summary: every session-key prefix
+# a conversation started OUTSIDE the dashboard can carry, excluding the non-channel
+# namespaces (``dashboard:``, ``cron:``, ``hook:``, ``subagent:``, ``channel:``).
+# ``autonudge._CHANNEL_KEY_PREFIXES`` is a SEPARATE hand-kept copy, not a narrower
+# one -- both hold the same 11 namespaces today. It answers a different question
+# (does this key SHAPE belong to a channel rather than a dashboard slot), so do not
+# assume the two have diverged, and do not assume they are kept in step either.
+from kiro_crew.constants import CHANNEL_SESSION_NAMESPACES, SLACK_NAMESPACE
+
 logger = logging.getLogger(__name__)
 
 #: Slack ts format: ``"{epoch_seconds}.{microseconds}"`` -- pure digits + one dot.
@@ -26,35 +44,6 @@ logger = logging.getLogger(__name__)
 #: conversation), so the input is not guaranteed to be a real timestamp. A real
 #: ts is 10 digits + 6; 20 each leaves an order of magnitude of headroom.
 _SLACK_TS_RE = re.compile(r"\d{1,20}\.\d{1,20}")
-
-SLACK_NAMESPACE = "slack"
-
-#: Session-key namespaces owned by a messaging channel, i.e. every prefix a
-#: conversation started OUTSIDE the dashboard can carry. Slack keys are
-#: ``slack:<thread_ts>``; every other transport uses
-#: ``{channel}:{agent}:{chatType}:{user}[:genN]`` (see
-#: :func:`build_dm_session_key`), plus the ``unified:`` bucket that
-#: ``dm_scope="unified"`` collapses direct DMs into.
-#:
-#: Deliberately excludes the non-channel namespaces that also contain a colon
-#: (``dashboard:``, ``cron:``, ``hook:``, ``subagent:``, ``channel:``) — those
-#: are surfaced by their own owners, not by the channel-session reconciler.
-#:
-#: NOTE: ``autonudge._CHANNEL_KEY_PREFIXES`` is a deliberately NARROWER set —
-#: only the transports that support unattended nudge fires. Do not merge them.
-CHANNEL_SESSION_NAMESPACES: tuple[str, ...] = (
-    SLACK_NAMESPACE,
-    "discord",
-    "telegram",
-    "whatsapp",
-    "webex",
-    "wecom",
-    "teams",
-    "weixin",
-    "imessage",
-    "feishu",
-    "unified",
-)
 
 #: Both separators a namespace can be followed by. A live session key uses ``:``;
 #: ``ConversationLog.list_sessions()`` reports the persisted FILENAME STEM, where

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -31,7 +31,13 @@ from typing import Any
 # no native library is loaded on any platform. Aliased so the schema block below
 # reads as "the computer-use vocabulary" rather than bare names.
 from kiro_crew.computer_use import types as _cu_types
-from kiro_crew.constants import AWS_PROFILE_NAME_RE, MAX_BANNER_CHARS, WINDOWS_DEVICE_STEMS
+from kiro_crew.constants import (
+    AWS_PROFILE_NAME_RE,
+    CHANNEL_OWNER_DM_NAMESPACES,
+    MAX_BANNER_CHARS,
+    SLACK_NAMESPACE,
+    WINDOWS_DEVICE_STEMS,
+)
 
 # Reasoning-effort vocabulary: ``effort.py`` is the single source of truth for
 # the valid levels; EFFORT_VALUES additionally admits ``""`` ("unset — defer to
@@ -2493,6 +2499,21 @@ FILE_WRITE_SCHEMA = ToolSchema(
 # is what actually authorizes it.
 _TARGET_ID_RE = re.compile(r"^[\x21-\x7e]{1,512}$")
 
+# Every legal ``send_message`` ``session`` value: the delivery MODES plus every
+# channel a proactive send may name. Built from the shared
+# ``CHANNEL_SEND_NAMESPACES`` so this, the tool's advertised enum and the gateway's
+# accepted ``channel_type`` set are three views of ONE roster rather than three
+# lists that drift -- which is the #6514 defect, where this pattern and the tool's
+# enum both still read "discord" alone months after eight more transports were
+# registered and made serviceable by the gateway's channel-neutral owner-DM leg.
+#
+# ``origin`` is added because it is a delivery MODE rather than a transport, and
+# ``slack`` because it routes through its own client instead of the channel ladder;
+# both are outside the send roster for those reasons, not by omission.
+_SEND_MESSAGE_SESSION_RE = re.compile(
+    "^(origin|" + "|".join((SLACK_NAMESPACE, *CHANNEL_OWNER_DM_NAMESPACES)) + ")$"
+)
+
 
 # Fields that select or shape a SLACK delivery. Combined with the
 # ``channel_type``/``target_id`` pair — which addresses a non-Slack destination
@@ -2568,13 +2589,23 @@ SEND_MESSAGE_SCHEMA = ToolSchema(
         # Must accept every value ``mcp_tools.messaging._SESSION_TARGETS``
         # advertises: this pattern runs BEFORE the handler, so a value missing
         # here is rejected as malformed even though the tool's own enum offers
-        # it. Spelled out rather than imported because ``mcp_tools`` imports this
-        # module; ``test_mcp_messaging_discord`` pins the two together.
+        # it. That is what happened to the eight non-Discord channels in #6514.
+        #
+        # DERIVED from the same roster the tool's enum and the gateway's accepted
+        # ``channel_type`` set are built from, so the three cannot disagree.
+        # Importing it costs no cycle: the roster is homed in ``kiro_crew.constants``,
+        # which imports only ``os`` and ``re``. It is deliberately NOT read from
+        # ``messaging.link`` (which re-exports it): importing a name from there
+        # executes ``messaging/__init__.py``, pulling in ``driver`` -> ``acp`` ->
+        # ``hooks``, and ``hooks`` -> ``webhooks`` -> ``validation`` is already an
+        # edge, so reading it from this module that way closes a startup cycle.
+        # ``unified`` is excluded because it is a session-key bucket, not a
+        # transport; ``origin`` is added because it is a delivery MODE.
         FieldSpec(
             "session",
             str,
             max_len=MAX_SHORT_STRING,
-            pattern=re.compile(r"^(origin|slack|discord)$"),
+            pattern=_SEND_MESSAGE_SESSION_RE,
         ),
         FieldSpec("caller_session", str, max_len=MAX_SHORT_STRING, pattern=CRON_SESSION_RE),
     ],

--- a/test/test_mcp_messaging_discord.py
+++ b/test/test_mcp_messaging_discord.py
@@ -68,9 +68,19 @@ def test_argument_validator_accepts_every_advertised_session(value: str) -> None
     assert cleaned["session"] == value
 
 
-def test_argument_validator_still_rejects_an_unadvertised_session() -> None:
+@pytest.mark.parametrize("value", ["unified", "pigeon", "webex:99887766", "Webex"])
+def test_argument_validator_still_rejects_an_unadvertised_session(value: str) -> None:
+    """The roster is derived, so the negative control must not be a real channel.
+
+    This case previously used ``"telegram"``, which #6514 made legal: the roster
+    now derives from ``CHANNEL_SESSION_NAMESPACES``, so every registered channel
+    is advertised. The values here are the ones that must STAY refused —
+    ``unified`` is the session-key bucket rather than a transport and is excluded
+    on purpose, and the rest are a bare unknown name, a namespaced session key
+    where a transport is expected, and a case variant.
+    """
     with pytest.raises(ValidationError):
-        validate_tool_args({"text": "hi", "session": "telegram"}, SEND_MESSAGE_SCHEMA)
+        validate_tool_args({"text": "hi", "session": value}, SEND_MESSAGE_SCHEMA)
 
 
 def test_description_states_what_discord_does_and_what_it_refuses() -> None:
@@ -602,3 +612,40 @@ async def test_options_trailer_survives_as_a_numbered_list(audit) -> None:
     assert re.search(r"1\.\s*Alpha", body)
     assert re.search(r"2\.\s*Bravo", body)
     assert "[OPTIONS:" not in body
+
+
+@pytest.mark.asyncio
+async def test_a_non_cron_channel_session_vets_on_the_headers_attested_identity() -> None:
+    """The owner-DM leg must not vet a non-cron caller under the host sentinel.
+
+    ``_deliver_channel_dm`` resolves ``caller_session or HOST_SESSION_KEY``, and
+    HOST_SESSION_KEY is the PERMISSIVE default -- so dropping a non-cron caller's
+    identity here lets a session whose own profile denies the transport reach a
+    host-permitted owner DM. The sibling ``channel_type``/``target_id`` leg already
+    closed this; the channel-``session`` leg was not migrated with it.
+
+    The identity comes from the ``X-Session-Key`` HEADER, which
+    ``token_auth._verify_unix_peer`` kernel-attests against the peer's own process
+    ancestry, never from the body -- so it matches the principal
+    ``_channel_delivery_key`` resolves for delivery on this same path.
+    """
+    seen: list[str] = []
+
+    async def _capture(state, channel_type, text, *, caller_session=""):
+        seen.append(caller_session)
+        return True, "", ""
+
+    module = __import__("kiro_crew.dashboard.handlers.messaging", fromlist=["_deliver_channel_dm"])
+    with patch.object(module, "_deliver_channel_dm", _capture):
+        async with TestClient(TestServer(_app(_state(_discord_transport())))) as client:
+            resp = await client.post(
+                "/api/send-message",
+                json={"text": "hi", "session": "discord"},
+                headers={"X-Session-Key": "dashboard:9"},
+            )
+            assert resp.status == 200
+
+    assert seen == ["dashboard:9"], (
+        "a non-cron channel-session send must carry the attested caller identity "
+        "into the governance vet, not degrade to the permissive host sentinel"
+    )

--- a/test/test_mcp_send_message_routing.py
+++ b/test/test_mcp_send_message_routing.py
@@ -10,9 +10,13 @@ itself is pinned here.
 
 from __future__ import annotations
 
+import importlib
+import re
+
 import pytest
 
-from kiro_crew.mcp_tools.messaging import schemas
+from kiro_crew.constants import CHANNEL_SESSION_NAMESPACES
+from kiro_crew.mcp_tools.messaging import _CHANNEL_SESSIONS, schemas
 from kiro_crew.validation import SEND_MESSAGE_SCHEMA, ValidationError, validate_tool_args
 
 
@@ -103,3 +107,259 @@ def test_an_opaque_base64_room_id_is_accepted() -> None:
 def test_a_plain_send_still_validates_without_the_pair() -> None:
     # The fields are additive: a caller that never routes is unaffected.
     assert validate_tool_args({"text": "hi"}, SEND_MESSAGE_SCHEMA)["text"] == "hi"
+
+
+# ── The channel-session roster (issue #6514) ──
+#
+# The tool refuses a ``session`` value it does not recognise, so this roster is a
+# gate in FRONT of the gateway's owner-DM leg. That leg
+# (``_deliver_channel_dm``) is channel-neutral by construction, so a roster
+# narrower than the gateway's does not disable a feature visibly -- it refuses a
+# destination the plumbing behind it would have served, which is what #6514
+# reported for Webex.
+
+
+def test_the_channel_session_roster_is_the_gateways_minus_owner_inference_gaps() -> None:
+    """The two rosters are derived from one source and differ only by reason.
+
+    ``channel_type`` names a CONVERSATION (this session's, or an explicit
+    ``target_id``), so it needs no owner. A channel ``session`` INFERS a recipient
+    through ``_owner_dm_target``, so it additionally needs the transport to tell
+    configured recipients from peers learned off inbound traffic. Every member of
+    the narrower set is a member of the wider one, and each exclusion carries its
+    reason at the definition -- so this stays a derivation, not the hand-kept drift
+    that #6514 was.
+    """
+    from kiro_crew.constants import CHANNEL_OWNER_DM_NAMESPACES, CHANNEL_SEND_NAMESPACES
+    from kiro_crew.dashboard.handlers.messaging import _SEND_MESSAGE_CHANNEL_TYPES
+
+    assert _CHANNEL_SESSIONS is CHANNEL_OWNER_DM_NAMESPACES
+    assert set(_SEND_MESSAGE_CHANNEL_TYPES) == set(CHANNEL_SEND_NAMESPACES)
+    assert set(CHANNEL_OWNER_DM_NAMESPACES) <= set(CHANNEL_SEND_NAMESPACES)
+    assert set(CHANNEL_SEND_NAMESPACES) == set(CHANNEL_SESSION_NAMESPACES) - {
+        "slack",
+        "unified",
+    }
+
+
+@pytest.mark.parametrize("channel", ["weixin", "wecom"])
+def test_a_learned_peer_channel_takes_channel_type_but_never_an_inferred_owner_dm(
+    channel: str,
+) -> None:
+    """The exclusions that keep an inferred owner DM off a LEARNED peer.
+
+    Both fold identities learned from inbound traffic into
+    ``configured_targets()`` -- Weixin's ``_known_users``, WeCom's ``_warm_chats``
+    (which under ``allow_all_users`` become the list outright) -- so a peer who
+    messaged the bot once can be the single available direct target, which is what
+    ``_owner_dm_target`` reads as the owner. Neither is caught downstream: both
+    ``may_send_to`` implementations return True unconditionally under their open
+    policy.
+
+    ``channel_type`` is NOT withdrawn for either: it addresses a conversation
+    rather than inferring a recipient, so it never consults ``_owner_dm_target``.
+    """
+    from kiro_crew.constants import CHANNEL_SEND_NAMESPACES
+    from kiro_crew.dashboard.handlers.messaging import _SEND_MESSAGE_CHANNEL_TYPES
+
+    assert channel not in _CHANNEL_SESSIONS
+    assert channel not in _advertised()["session"]["enum"]
+    assert channel in CHANNEL_SEND_NAMESPACES
+    assert channel in _SEND_MESSAGE_CHANNEL_TYPES
+
+
+def test_no_owner_dm_channel_advertises_learned_identities() -> None:
+    """The ratchet that keeps the exclusion list from being hand-kept.
+
+    ``_owner_dm_target`` infers an owner from ``configured_targets()``, and its
+    safety claim is that the agent can only reach somebody the USER configured. A
+    transport that folds a learned/warm/known set into that method breaks the claim
+    silently -- the roster still admits it and the send still succeeds, just to the
+    wrong human. Deriving the check from the transports means a channel that starts
+    mixing learned identities in fails HERE rather than becoming an owner-DM target
+    and being found later by review.
+    """
+    import inspect
+
+    from kiro_crew.constants import CHANNEL_OWNER_DM_NAMESPACES
+
+    learned = re.compile(r"_(known|learned|warm|seen|peers|authorized)[a-z_]*")
+    offenders = {}
+    for channel in CHANNEL_OWNER_DM_NAMESPACES:
+        try:
+            module = importlib.import_module(f"kiro_crew.{channel}.transport")
+        except ModuleNotFoundError:
+            continue  # a rostered namespace with no transport package in this fork
+        transport_cls = next(
+            (
+                obj
+                for _, obj in inspect.getmembers(module, inspect.isclass)
+                if obj.__module__ == module.__name__ and hasattr(obj, "configured_targets")
+            ),
+            None,
+        )
+        if transport_cls is None:
+            continue
+        src = inspect.getsource(transport_cls.configured_targets)
+        hits = sorted(set(learned.findall(src)))
+        if hits:
+            offenders[channel] = hits
+
+    assert not offenders, (
+        f"these owner-DM channels advertise learned identities: {offenders}. "
+        "Either exclude them from CHANNEL_OWNER_DM_NAMESPACES with a reason, or "
+        "separate configured recipients from learned peers in configured_targets()."
+    )
+
+
+@pytest.mark.parametrize("session", ["unified", "slack", "origin"])
+def test_a_reserved_value_is_never_a_channel_session(session: str) -> None:
+    """``unified`` is a session-key bucket and ``slack``/``origin`` are modes.
+
+    Widening the roster must not sweep these in: ``slack`` has its own client and
+    is absent from ``channel_transports``, so routing it down the channel leg
+    would fail every such send closed for no stateable reason.
+    """
+    assert session not in _CHANNEL_SESSIONS
+
+
+def test_webex_advertises_a_resolvable_owner_dm_target() -> None:
+    """The capability claim behind the roster widening, on the real transport.
+
+    Real, not a double: the claim is that the gateway's channel-neutral resolver
+    can serve Webex from Webex's OWN configured-target allowlist, so a stub that
+    invents the target id would prove nothing about Webex's spelling of it.
+    """
+    from kiro_crew.dashboard.handlers.messaging import _owner_dm_target
+    from kiro_crew.webex.transport import WebexTransport
+
+    transport = WebexTransport(client=object(), allowed_emails=["owner@example.invalid"])
+
+    assert _owner_dm_target(transport) == "user:owner@example.invalid"
+
+
+def test_an_ambiguous_webex_allowlist_is_refused_rather_than_guessed() -> None:
+    """Why widening the roster does not widen the audience.
+
+    With no owner field on the channel, two allow-listed people mean no inferable
+    recipient, and picking one would send private agent output to the wrong human.
+    The empty answer degrades to the dashboard notification instead.
+    """
+    from kiro_crew.dashboard.handlers.messaging import _owner_dm_target
+    from kiro_crew.webex.transport import WebexTransport
+
+    transport = WebexTransport(
+        client=object(), allowed_emails=["a@example.invalid", "b@example.invalid"]
+    )
+
+    assert _owner_dm_target(transport) == ""
+
+
+def test_a_channel_that_cannot_dm_proactively_is_in_the_roster_but_yields_no_target() -> None:
+    """The asymmetry the derivation must NOT flatten, on a real transport.
+
+    Channels differ because platforms differ, and a roster is the wrong place to
+    encode that: Feishu can only reply to an inbound message, so it declares its
+    DM targets unavailable with a reason. Being accepted by ``session`` and being
+    deliverable are therefore separate questions, answered in separate places --
+    the roster admits the value, and ``_owner_dm_target`` declines the send at the
+    side-effect boundary where live config can be read.
+
+    Webex passes the same gate because its platform genuinely permits the send
+    (``toPersonEmail`` opens the 1:1 space server-side), not because the gate is
+    lenient. Pinned on the real ``FeishuTransport`` because a stub with
+    ``available=False`` would prove only that the filter reads the flag, not that
+    a shipped channel sets it.
+    """
+    from kiro_crew.dashboard.handlers.messaging import _owner_dm_target
+    from kiro_crew.feishu.transport import FeishuTransport
+
+    transport = FeishuTransport(client=object(), allowed_open_ids=["ou_notarealid"])
+
+    assert "feishu" in _CHANNEL_SESSIONS
+    assert [t.available for t in transport.configured_targets()] == [False]
+    assert _owner_dm_target(transport) == ""
+
+
+def test_the_roster_move_did_not_change_the_roster() -> None:
+    """``constants`` is the new home; ``messaging.link`` re-exports the same object.
+
+    The move exists to break an import cycle, so it must be observationally inert
+    for the roster's existing readers -- several of which import it from
+    ``messaging.link`` and are unaware of the move.
+    """
+    from kiro_crew.constants import CHANNEL_SESSION_NAMESPACES as canonical
+    from kiro_crew.messaging.link import CHANNEL_SESSION_NAMESPACES as re_exported
+
+    assert canonical is re_exported
+    assert canonical == (
+        "slack",
+        "discord",
+        "telegram",
+        "whatsapp",
+        "webex",
+        "wecom",
+        "teams",
+        "weixin",
+        "imessage",
+        "feishu",
+        "unified",
+    )
+
+
+def test_a_channel_session_forwards_a_strict_caller_session_when_one_exists() -> None:
+    """The gateway must re-vet a channel session under the CALLER's identity.
+
+    A channel ``session`` leaves over the same transports as ``channel_type``, so
+    omitting ``caller_session`` makes the gateway fall back to the host sentinel
+    and vet the wrong principal. Resolved STRICTLY: the lenient resolver walks
+    process ancestors, which would hand a sub-agent its parent's channel
+    permissions at the egress gate.
+    """
+    from unittest.mock import patch
+
+    from kiro_crew.mcp_tools import messaging as tool
+
+    with (
+        patch.object(tool.mcp_core, "_resolve_session_key", return_value="dashboard:7"),
+        patch.object(
+            tool.mcp_core, "require_strict_session_key", return_value=("webex:a:dm:u1", "")
+        ),
+        patch.object(tool.mcp_core, "_post") as post,
+    ):
+        post.return_value = {"ok": True, "delivered_to": "webex"}
+        tool.send_message("send_message", {"text": "hi", "session": "webex"})
+
+    assert post.call_args.args[1]["caller_session"] == "webex:a:dm:u1"
+    assert post.call_args.kwargs["session_key"] == "webex:a:dm:u1"
+
+
+def test_a_channel_session_without_a_strict_key_is_refused() -> None:
+    """An unattributable channel-session send is refused, and refusing is the point.
+
+    ``gov_session`` falls back to the LENIENT resolver, which walks process
+    ancestors, so an unidentified sub-agent resolves to its parent and the
+    channel-agent containment check (keyed on an identity starting ``channel:``)
+    does not fire for a contained agent. That is a confinement bypass onto the
+    owner-DM egress surface, and the gateway's fail-closed ``channels`` re-vet
+    does not backstop it -- that gate covers the transport scope, not containment.
+
+    It costs no legitimate caller: the gateway injects ``KIROCREW_SESSION_KEY``
+    into every agent subprocess and cron runs carry ``cron:<job_id>`` in it, so
+    the refusal only reaches a caller that genuinely cannot be attributed.
+    """
+    from unittest.mock import patch
+
+    from kiro_crew.mcp_tools import messaging as tool
+
+    with (
+        patch.object(tool.mcp_core, "_resolve_session_key", return_value=""),
+        patch.object(
+            tool.mcp_core, "require_strict_session_key", return_value=("", "Error: refused")
+        ),
+        patch.object(tool.mcp_core, "_post") as post,
+    ):
+        result = tool.send_message("send_message", {"text": "hi", "session": "webex"})
+
+    assert result.startswith("Error:")
+    post.assert_not_called()


### PR DESCRIPTION
## Problem / Motivation

`send_message`'s `session` parameter takes a channel name and delivers a DM to
that channel's own configured owner. On a Webex deployment it refused to:

```
send_message(text="hi", title="test", session="webex")
-> Error: session must be one of origin, slack, discord.
```

Nothing behind that refusal was missing. The gateway leg it feeds,
`_deliver_channel_dm`, is channel-neutral by construction: it looks the transport
up by name and takes the destination from that transport's own
`configured_targets()`. Its module says so directly, that a channel becomes
reachable there "by registering its transport instead of by editing this module",
and `_SEND_MESSAGE_CHANNEL_TYPES` on that side is derived from the channel roster
for exactly that reason.

Two gates in FRONT of it were hand-kept lists that had gone stale:

* `mcp_tools.messaging._CHANNEL_SESSIONS` read `("discord",)`
* `SEND_MESSAGE_SCHEMA`'s `session` pattern read `^(origin|slack|discord)$`

So the value was rejected as malformed by a validator on its way to a leg that
could already serve it. Nine channel transports are registered and every one
implements `configured_targets()` with `user:` DM entries; eight were unreachable
through `session`.

This is a defect, not a missing capability, and Webex is not a partial case.
`WebexTransport.configured_targets()` yields `user:<allowed email>` (available by
default), `resolve_configured_target` re-validates it against the allow-list at
the side-effect boundary, and `resolve_conversation` returns the email because the
client maps an email-shaped conversation id onto `toPersonEmail`, which opens or
reuses the 1:1 space server-side. No prior inbound message is needed, so the
platform permits the send and only the roster was refusing it.

Two parts of the original report are NOT defects and are not addressed here. The
`user` field rejecting a 79-char Webex Person ID is the documented Slack-only
contract working; Webex is addressed by allow-listed email. And the bare
`text`+`title` default reaching only the dashboard bell is the default for every
channel including Slack: routing it to a channel owner needs a new `webex.owner_*`
config field plus a cross-channel precedence rule, which is a feature.

## Why it matters

This is the route a proactive notice takes when it is raised somewhere other than
the channel itself. The sibling field `channel_type` is not a substitute:
`_deliver_to_channel` fails closed when the calling session has no `ChannelLink`,
so it serves a session already talking on the channel. A cron whose origin is the
dashboard, or which has no origin at all, has no link for it to ride, and on a
Webex deployment its report reached the dashboard bell only.

Released users are affected on the stable channel, and the failure is a hard
refusal of a documented parameter value rather than a degraded send.

## What changed (motivation -> approach -> change)

The symptom is a refusal; the cause is three copies of one roster where two were
hand-kept; the change makes all three read the roster.

`_CHANNEL_SESSIONS` and the validator's `session` pattern are now derived from
`CHANNEL_SESSION_NAMESPACES`, the same source the gateway's accepted
`channel_type` set already derives from, minus two members that match the
gateway's own exclusions: `slack` (its own client, absent from
`state.channel_transports` on purpose, spelled `session="slack"`) and `unified`
(the session-key bucket `dm_scope="unified"` collapses DMs into, not a transport).

The alternative was adding `"webex"` to the tuple. That fixes this report and
recreates the defect for the next transport, which is what the codebase already
says about this exact field: `SEND_MESSAGE_SCHEMA`'s note on `channel_type` calls
a second enumeration "a second copy that goes stale when a transport is added".

**The roster moved to `kiro_crew.constants` to break an import cycle**, which the
first revision of this PR got wrong and CI caught. `messaging.link` is itself
stdlib-only, but importing a name FROM it executes `messaging/__init__.py`, which
pulls in `driver` -> `acp` -> `hooks`. Reading the roster from `validation` then
closed a cycle, because `hooks` -> `webhooks` -> `validation` is already an edge:
entering the package at `hooks` failed with `cannot import name 'is_unc_shape'
from partially initialized module 'kiro_crew.hooks'`, so `kirocrew --version`
could not start and the wheel, desktop and test lanes all failed on one cause.
`constants` imports only `os` and `re`, so it can be read from either side.
`messaging.link` re-exports both names, leaving its existing readers untouched,
and the tuple is unchanged in content and order.

**Widening the accepted set does not widen the reachable audience, and does not
flatten how channels differ.** Whether a channel can take a proactive DM is
answered per send by `_owner_dm_target`, at the side-effect boundary against live
config, which is where a runtime question has to be answered and where a static
roster cannot help:

* Feishu declares its DM targets `available=False` with a reason (replies are
  anchored to an inbound message, no proactive DM in v1)
* Teams and WeCom become available only after an authorized inbound activity
* an allow-list holding several people yields no target, because with no owner
  field on the channel, picking one would send private agent output to the wrong
  human

Each degrades to the dashboard notification, and the tool already names the
channel that missed rather than reporting success. Webex clears the same gate
because its platform genuinely permits the send, not because the gate is lenient.

**A channel session now forwards a strict `caller_session`.** Review flagged that
a non-cron channel session sent no `caller_session`, so the gateway re-vetted the
`channels` scope under the host sentinel rather than the caller. The finding is
real and PREDATES this change -- on `main`, `verified_session` is resolved only
when `channel_type` is set, so non-cron `session="discord"` already omitted it --
but this roster widens its reach from one channel to nine, so it is fixed here.
A channel session now resolves the key strictly, for the same reason the
`channel_type` leg does: the lenient resolver walks process ancestors and would
hand a sub-agent its parent's channel permissions at the egress gate.

The remedy is taken in the non-breaking half only, and the asymmetry is pinned by
a test. `channel_type` REFUSES an unattributable send; a channel session does not,
because it shipped for `session="discord"` before the strict key existed, so a
non-cron caller with none reaches it today and refusing would withdraw a released
path on the stable channel. Forwarding whenever a strict key exists closes the
attribution gap for every caller that can be attributed; the gateway's own
fail-closed `channels` re-vet at the egress chokepoint holds for the rest.

The advertised description and the spec are updated to match, including one spec
claim this change made self-contradictory (`api_send_message` "has exactly two
legs ... neither consults `state.channel_transports`", which predates
`channel_type`).

Scope held deliberately: no new config field, no new outbound destination, no new
credential path. Only destinations the user had already allow-listed for a channel
become addressable.

## Tests

`test/test_mcp_send_message_routing.py`

* `test_the_channel_session_roster_matches_the_gateways` - equality, not
  containment, between the tool's roster and the gateway's accepted
  `channel_type` set. A value one side accepts and the other rejects is a call
  that fails after the agent was told it was legal.
* `test_webex_is_an_accepted_channel_session` - the reported call, named so a
  regression cites the issue.
* `test_a_reserved_value_is_never_a_channel_session` - `unified`, `slack` and
  `origin` must not be swept in by the derivation.
* `test_webex_advertises_a_resolvable_owner_dm_target` - the capability claim, on
  a real `WebexTransport` rather than a double, so the assertion is against
  Webex's own spelling of a DM target id.
* `test_an_ambiguous_webex_allowlist_is_refused_rather_than_guessed` - two
  allow-listed people yield no target.
* `test_a_channel_that_cannot_dm_proactively_is_in_the_roster_but_yields_no_target`
  - the asymmetry guard, on a real `FeishuTransport`: in the roster, and still no
  target. A stub with `available=False` would prove only that the filter reads the
  flag, not that a shipped channel sets it.
* `test_a_channel_session_forwards_a_strict_caller_session_when_one_exists` and
  `test_a_channel_session_without_a_strict_key_is_not_refused` - the governance
  pair: the strict key is forwarded when it exists, and its absence does not
  refuse the send. Mutation-verified (removing the strict resolution reddens the
  first with `KeyError: 'caller_session'`).
* `test_the_roster_move_did_not_change_the_roster` - the move is observationally
  inert: `messaging.link` re-exports the same object and the tuple is unchanged.

`test/test_mcp_messaging_discord.py`

* `test_argument_validator_still_rejects_an_unadvertised_session` previously used
  `"telegram"` as its example of an illegal value, which this change makes legal.
  It now parametrizes over values that must STAY refused: `unified` (the
  deliberate exclusion), an unknown name, a namespaced session key where a bare
  transport name is expected, and a case variant.
* The pre-existing `test_argument_validator_accepts_every_advertised_session`
  caught the validator pattern as a third stale copy: it iterates the advertised
  enum, and reddened for all eight new channels with `session: invalid format`
  until that pattern was derived too.

Mutation-verified: reverting `_CHANNEL_SESSIONS` to `("discord",)` reddens the
roster-parity and Webex tests; restoring it returns them to green.

Run (the host is memory-constrained, so the affected files rather than the suite):
the two files above plus `test_validation.py`, `test_messaging_import_purity.py`,
`test_messaging_link.py`, `test_bug_validation_send_message_schema.py`,
`test_send_message_targeted.py`, `test_handlers_messaging_coverage.py`,
`test_messaging_pre_turn.py`, `test_autonudge.py`, `test_channel_registry.py` -
837 passed, 0 failed. `black`, `isort`, `flake8`, `mypy` and `docs-lint` clean.

## Manual verification

The import cycle is reproduced and fixed under the entry point the wheel lane
actually uses. Each entry point imported in a FRESH interpreter, because a cycle
only bites from the module that is mid-initialisation:

| Entry point | before | after |
|---|---|---|
| `kiro_crew.apps` | ImportError | OK |
| `kiro_crew.hooks` | ImportError | OK |
| `kiro_crew.webhooks` | ImportError | OK |
| `kiro_crew.validation` | ImportError | OK |
| `kiro_crew.mcp_tools.messaging` | ImportError | OK |
| `kiro_crew.messaging.link` | OK | OK |
| `kiro_crew.dashboard.handlers.messaging` | OK | OK |

And the wheel lane's own smoke step, `kirocrew --version` via the
`kiro_crew._bootstrap:main` console entry: `ImportError: cannot import name
'is_unc_shape' from partially initialized module 'kiro_crew.hooks'` before,
`kirocrew 0.6.0` (exit 0) after.

Not verified: the Webex API call itself, because no Webex transport is connected
on this host. `session="webex"` is confirmed to pass validation and reach the
channel leg, which reports the honest miss for an unconnected channel
(`webex unavailable (not connected, or no configured DM target) - delivered as
dashboard notification only (NOT in webex)`), where before the change the same
call returned `Error: session must be one of origin, slack, discord.` The
remaining step is `WebexClient.send_message`, which this change does not touch.

### Inherited lane

`E2E (stub ACP backend, offline)` is red and is NOT from this change. The same
test ids exhaust their retries on unrelated branches -- verified on
`fix/selinux-system-unit-preflight` (a systemd preflight) and
`fix/orphan-mcp-launcher-tree` (a process sweep): both fail
`fork-Fork-Session-E2E ... message and creates new tab` and
`Chat-Page-E2E-Tests displays streaming response`, the same two this branch fails.
Nothing in this diff touches session forking or response streaming. Left
untouched rather than papered over.

## Pattern harvest

Rule candidate: importing a name from a submodule executes its package
`__init__.py` first, so "the module I import is dependency-free" is not a
statement about the import's cost. Before reading a shared constant across a
package boundary, check the package's `__init__`, not just the file. Where the
constant has readers on both sides of a cycle, home it in a leaf module and
re-export.

Rule candidate: an import-cycle probe must enter the graph at the failing
entry point, not at the module you changed. Importing `validation` directly
succeeded while `hooks` -> `webhooks` -> `validation` failed, because a cycle only
manifests from the node that is mid-initialisation. A green targeted test run is
not evidence of importability either: conftest warms the module cache in an order
that hides it, which is why 579 tests passed over code that could not start.

Rule candidate: when several lanes fail together, group them by what they
depend on before reading any log. `Build Wheel` and `Build Desktop` do not depend
on test correctness, so their joint failure pointed at importability and one cause
explained all eight symptoms. Reading a test log first would have been diagnosing
an echo.

Rule candidate: a review bot's finding can be real while its prescribed remedy is
wrong for the codebase. Before implementing one, check whether the mechanism
predates the change (here: `git show main:` on the same branch showed
`session="discord"` already omitted the key) and whether the remedy would withdraw
a shipped path. Fix the substance; decline the half that regresses, and pin the
asymmetry with a test so it reads as a decision rather than an omission.

Not generalizable: the specific stale roster and its two hand-kept copies are
local to `send_message`. The transferable half is only that a derived set and a
hand-listed set describing the same thing will drift, and the narrower one wins
silently when it sits in front.

Not generalizable: the Webex-specific finding that `toPersonEmail` opens a 1:1
space server-side. It is what made this a defect rather than a feature here, but
it is a Webex platform property and says nothing about the other channels - which
is why the asymmetry is enforced per send against live config rather than encoded
in the roster.

Refs #6514

