### PR TITLE
fix(security): owner-gate workspace CRUD and member thread creation

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1481,7 +1481,15 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
     """POST /api/workspaces — create a new workspace."""
     import shutil  # noqa: F811
 
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
     from kiro_crew.validation import WORKSPACE_NAME_RE  # noqa: F811
+
+    # Ahead of the body read: a workspace entry carries a caller-supplied
+    # directory, so the traversal and sensitive-path guards below are defending
+    # against input that only the owner may supply in the first place.
+    owner_denied = await require_owner_dashboard_request(request, "workspace.create")
+    if owner_denied is not None:
+        return owner_denied
 
     # Default cap: the body is a workspace name plus optional dir/copy_from.
     body, body_err = await read_bounded_json(request)
@@ -1637,6 +1645,12 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
 
 async def api_workspaces_update(request: web.Request) -> web.Response:
     """PUT /api/workspaces/{name} — update a workspace."""
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    # Ahead of the 404: whether a workspace exists is not a non-owner's to learn.
+    owner_denied = await require_owner_dashboard_request(request, "workspace.update")
+    if owner_denied is not None:
+        return owner_denied
 
     name = request.match_info["name"]
     cfg = KiroCrewConfig.load()
@@ -1710,6 +1724,13 @@ async def api_workspaces_update(request: web.Request) -> web.Response:
 
 async def api_workspaces_delete(request: web.Request) -> web.Response:
     """DELETE /api/workspaces/{name} — delete a workspace."""
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
+    # Ahead of the 404/409 guards: those are referential, not authorization, and
+    # this handler reaches `cfg.save()` with an entry removed.
+    owner_denied = await require_owner_dashboard_request(request, "workspace.delete")
+    if owner_denied is not None:
+        return owner_denied
 
     name = request.match_info["name"]
     cfg = KiroCrewConfig.load()

--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -216,9 +216,19 @@ async def api_member_thread(request: web.Request) -> web.Response:
     re-created (the slot key is a pure derivation of the slug, so re-creation
     always converges on the same thread).
     """
+    from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
+
     denied = _deny_app_caller(request, "members.thread")
     if denied is not None:
         return denied
+    # An app token is already refused above with the module's existence-hiding
+    # 404. This gate covers the other half: a dashboard token with an empty app
+    # identity but a non-owner subject (the `!dashboard` Slack case), which
+    # would otherwise bind a session slot to a crew member. Kept below the app
+    # denial so app callers keep the 404 they get on every other member route.
+    owner_denied = await require_owner_dashboard_request(request, "members.thread")
+    if owner_denied is not None:
+        return owner_denied
     state: DashboardState | None = request.app.get("state")
     if state is None:
         return web.json_response(

--- a/test/test_agent_config_owner_gate_invariant.py
+++ b/test/test_agent_config_owner_gate_invariant.py
@@ -92,25 +92,6 @@ _KNOWN_UNGATED_ROUTES: frozenset[tuple[str, str]] = frozenset(
         ("PUT", "/api/config/kirocrew"),
         ("PATCH", "/api/config/kirocrew"),
         ("PUT", "/api/config/theme"),
-        # --- Workspace CRUD (files.py) ---
-        # Found BY this walk, not by the migration: none of the three carries an
-        # owner gate, and ``api_workspaces_delete`` removes a workspace from
-        # config.json for any authenticated dashboard session -- including the
-        # session token minted for an allow-listed Slack user, which has an empty
-        # app identity and so is authenticated but not the owner.
-        #
-        # Listed rather than gated HERE because gating them changes WHO may manage
-        # workspaces, which is a product decision, not the mechanical migration
-        # this change is: tracked as #6470. The DELETE is the highest-priority
-        # entry in this set.
-        ("POST", "/api/workspaces"),
-        ("PUT", "/api/workspaces/{name}"),
-        ("DELETE", "/api/workspaces/{name}"),
-        # --- Member thread creation (members.py) ---
-        # Also found by this walk. Creates a thread against a crew member for any
-        # authenticated caller. Same disposition as the workspace routes above
-        # (#6470).
-        ("POST", "/api/members/{slug}/thread"),
     }
 )
 
@@ -118,7 +99,7 @@ _KNOWN_UNGATED_ROUTES: frozenset[tuple[str, str]] = frozenset(
 # ``test_known_ungated_routes_not_growing``. Raising it is the reviewable act
 # that adding a new ungated route costs; lower it whenever an entry is gated and
 # removed, so the ratchet stays tight.
-_MAX_KNOWN_UNGATED_ROUTES = 24
+_MAX_KNOWN_UNGATED_ROUTES = 20
 
 # --------------------------------------------------------------------------- #
 # Coherence floor: the walk must find at least this many GATED mutating routes.

--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -144,6 +144,12 @@ def _make_members_app(state) -> web.Application:
     async def _auth(request: web.Request, handler):
         if "app" not in request:
             request["app"] = ""
+        # POST /api/members/{slug}/thread is owner-gated. ``local-app`` is the
+        # standalone-local owner subject the gate accepts when no owner_id is
+        # configured; set only when a test has not already chosen a caller, so
+        # the non-owner and app-token cases can still pick their own.
+        if "user" not in request:
+            request["user"] = "local-app"
         return await handler(request)
 
     app = web.Application(middlewares=[_auth])

--- a/test/test_workspace_absolute_paths.py
+++ b/test/test_workspace_absolute_paths.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import as_owner
 
 from kiro_crew.dashboard.handlers import api_workspaces_create, api_workspaces_update
 
@@ -16,7 +17,9 @@ def _make_app() -> web.Application:
     app = web.Application()
     app.router.add_post("/api/workspaces", api_workspaces_create)
     app.router.add_put("/api/workspaces/{name}", api_workspaces_update)
-    return app
+    # Both routes are owner-gated; without an owner identity every test below
+    # would answer 403 on the gate instead of on the path handling it names.
+    return as_owner(app)
 
 
 @pytest.fixture()

--- a/test/test_workspace_crud_handlers.py
+++ b/test/test_workspace_crud_handlers.py
@@ -14,6 +14,7 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import make_mocked_request
 from body_stream_helpers import BodyStreamPayload
+from dashboard_owner_helpers import NoConfiguredOwner
 
 from kiro_crew.config.loader import (
     KiroCrewAgentConfig,
@@ -30,17 +31,30 @@ from kiro_crew.dashboard.handlers import (
 
 
 def _req(body: dict | None = None, match_info: dict | None = None) -> web.Request:
-    """Build a mocked aiohttp.web.Request carrying real body bytes."""
+    """Build a mocked aiohttp.web.Request carrying real body bytes.
+
+    The three handlers are owner-gated, and the gate reads ``request.app["state"]``
+    plus the claims the token-auth middleware normally populates. Without them
+    every test here would answer on the gate rather than on the branch it names,
+    so the request is dressed as the owner. The gate's own refusal behaviour is
+    covered at route level in ``test_workspace_member_thread_owner_gate``.
+    """
     # ``body=None`` means "malformed JSON": the capped read parses the bytes
     # itself, so the malformed case is expressed as malformed bytes.
     raw = json.dumps(body).encode() if body is not None else b"{bad json"
-    return make_mocked_request(
+    app = web.Application()
+    app["state"] = NoConfiguredOwner()
+    request = make_mocked_request(
         "POST",
         "/api/workspaces",
         match_info=match_info or {},
         headers={"Content-Length": str(len(raw))},
         payload=BodyStreamPayload(raw),
+        app=app,
     )
+    request["user"] = "local-app"
+    request["app"] = ""
+    return request
 
 
 def _cfg(**kw: object) -> KiroCrewConfig:

--- a/test/test_workspace_member_thread_owner_gate.py
+++ b/test/test_workspace_member_thread_owner_gate.py
@@ -1,0 +1,267 @@
+"""Owner gate on the workspace CRUD routes and ``POST /api/members/{slug}/thread``.
+
+Both halves are here on purpose. A file that proved only refusal could not tell a
+working gate from one that rejects the owner too, and a file that proved only
+that the owner still works could not tell a working gate from no gate at all. So
+every route below is asserted twice: the non-owner is refused, and the owner
+reaches the handler's own outcome.
+
+Ordering is asserted too, because a gate placed below a referential guard leaks
+what it was added to protect. Before this change (#6470) any authenticated
+dashboard session reached all four -- including the token minted for an
+allow-listed Slack user by ``!dashboard``, which carries an empty app identity
+and so is authenticated but is not the owner.
+
+The read path is the control: ``GET /api/workspaces`` is NOT gated, and a test
+that did not pin that could not tell this change from one that gated the whole
+resource.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from dashboard_owner_helpers import NoConfiguredOwner, as_owner
+
+from kiro_crew.dashboard.handlers import (
+    api_member_thread,
+    api_workspaces,
+    api_workspaces_create,
+    api_workspaces_delete,
+    api_workspaces_update,
+)
+
+# A caller that authenticated but is not the owner: the `!dashboard` shape, an
+# empty app identity with a subject that is nobody's owner id.
+NON_OWNER = {"X-Test-User": "someone-else"}
+# An app token, for the members route's pre-existing existence-hiding denial.
+APP_TOKEN = {"X-Test-App": "some-app"}
+
+
+def _workspace_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/workspaces", api_workspaces)
+    app.router.add_post("/api/workspaces", api_workspaces_create)
+    app.router.add_put("/api/workspaces/{name}", api_workspaces_update)
+    app.router.add_delete("/api/workspaces/{name}", api_workspaces_delete)
+    return as_owner(app)
+
+
+def _members_app() -> web.Application:
+    app = web.Application()
+    # Not None, so the handler's 503 state branch is not what answers; the gate
+    # and then the slug grammar are.
+    app["state"] = NoConfiguredOwner()
+    app.router.add_post("/api/members/{slug}/thread", api_member_thread)
+    return as_owner(app)
+
+
+@pytest.fixture()
+def cfg_env(tmp_path, monkeypatch):
+    """A config dir carrying a default workspace plus one deletable extra."""
+    cfg_dir = tmp_path / ".kirocrew"
+    cfg_dir.mkdir()
+    cfg_file = cfg_dir / "config.json"
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "workspaces": {
+                    "default": {"dir": "workspace"},
+                    "spare": {"dir": "workspace-spare"},
+                },
+                "default_workspace": "default",
+            }
+        )
+    )
+    monkeypatch.setattr("kiro_crew.config.loader.config_path", lambda: cfg_file)
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: cfg_dir)
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.config_dir", lambda: cfg_dir)
+    monkeypatch.setattr("kiro_crew.dashboard.handlers.files.data_home", lambda: tmp_path)
+    return cfg_dir
+
+
+@pytest.fixture(autouse=True)
+def _quiet_sel():
+    """Keep both the handlers' success audit and the gate's denial audit off disk."""
+    with (
+        patch("kiro_crew.dashboard.handlers.sel") as handler_sel,
+        patch("kiro_crew.sel.sel") as gate_sel,
+    ):
+        handler_sel.return_value = MagicMock()
+        gate_sel.return_value = MagicMock()
+        yield
+
+
+async def _json(resp):
+    return await resp.json()
+
+
+class TestWorkspaceCreateOwnerGate:
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused(self, cfg_env, tmp_path):
+        target = tmp_path / "made-by-a-non-owner"
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.post(
+                "/api/workspaces",
+                json={"name": "intruder", "dir": str(target)},
+                headers=NON_OWNER,
+            )
+            assert resp.status == 403
+            assert (await _json(resp))["code"] == "owner_only"
+        # The refusal is the whole refusal: nothing was created on the way to it.
+        assert not target.exists()
+        assert "intruder" not in json.loads((cfg_env / "config.json").read_text())["workspaces"]
+
+    @pytest.mark.asyncio
+    async def test_owner_still_creates(self, cfg_env, tmp_path):
+        target = tmp_path / "made-by-the-owner"
+        target.mkdir()
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.post("/api/workspaces", json={"name": "owned", "dir": str(target)})
+            assert resp.status == 200, await resp.text()
+            assert (await _json(resp))["ok"] is True
+        assert "owned" in json.loads((cfg_env / "config.json").read_text())["workspaces"]
+
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused_before_the_body_is_parsed(self, cfg_env):
+        """A malformed body must still answer 403, not 400.
+
+        400 here would mean the gate sits below the body read, which is how a
+        non-owner learns the shape of a route they may not use.
+        """
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.post(
+                "/api/workspaces",
+                data="{",
+                headers={"Content-Type": "application/json", **NON_OWNER},
+            )
+            assert resp.status == 403
+
+
+class TestWorkspaceUpdateOwnerGate:
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused(self, cfg_env):
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.put(
+                "/api/workspaces/spare", json={"dir": "moved"}, headers=NON_OWNER
+            )
+            assert resp.status == 403
+            assert (await _json(resp))["code"] == "owner_only"
+        stored = json.loads((cfg_env / "config.json").read_text())["workspaces"]
+        assert stored["spare"]["dir"] == "workspace-spare"
+
+    @pytest.mark.asyncio
+    async def test_owner_still_updates(self, cfg_env):
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.put("/api/workspaces/spare", json={"dir": "moved"})
+            assert resp.status == 200, await resp.text()
+        stored = json.loads((cfg_env / "config.json").read_text())["workspaces"]
+        assert stored["spare"]["dir"] == "moved"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_403_not_404_for_an_unknown_workspace(self, cfg_env):
+        """Whether a workspace exists is not a non-owner's to learn."""
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.put(
+                "/api/workspaces/no-such-workspace", json={"dir": "x"}, headers=NON_OWNER
+            )
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_owner_still_gets_the_404(self, cfg_env):
+        """The control for the test above: the 404 is intact, just owner-only."""
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.put("/api/workspaces/no-such-workspace", json={"dir": "x"})
+            assert resp.status == 404
+
+
+class TestWorkspaceDeleteOwnerGate:
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused(self, cfg_env):
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.delete("/api/workspaces/spare", headers=NON_OWNER)
+            assert resp.status == 403
+            assert (await _json(resp))["code"] == "owner_only"
+        stored = json.loads((cfg_env / "config.json").read_text())["workspaces"]
+        assert "spare" in stored, "the non-owner delete must not have reached cfg.save()"
+
+    @pytest.mark.asyncio
+    async def test_owner_still_deletes(self, cfg_env):
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.delete("/api/workspaces/spare")
+            assert resp.status == 200, await resp.text()
+        stored = json.loads((cfg_env / "config.json").read_text())["workspaces"]
+        assert "spare" not in stored
+
+    @pytest.mark.asyncio
+    async def test_non_owner_gets_403_not_409_for_the_default_workspace(self, cfg_env):
+        """The 409 guards are referential, so they must not answer first."""
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.delete("/api/workspaces/default", headers=NON_OWNER)
+            assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_owner_still_gets_the_409(self, cfg_env):
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.delete("/api/workspaces/default")
+            assert resp.status == 409
+
+
+class TestWorkspaceReadStaysOpen:
+    """The control: this change gates the mutations, not the resource."""
+
+    @pytest.mark.asyncio
+    async def test_get_is_not_gated(self, cfg_env):
+        async with TestClient(TestServer(_workspace_app())) as client:
+            resp = await client.get("/api/workspaces", headers=NON_OWNER)
+            assert resp.status == 200
+            names = [w["name"] for w in (await _json(resp))["workspaces"]]
+            assert "spare" in names
+
+
+class TestMemberThreadOwnerGate:
+    """``NotASlug`` fails the slug grammar (``^[a-z0-9]...``), so the owner's 400
+    proves the request reached the handler's own validation rather than the gate.
+    Full owner-success for this route -- a thread actually created and bound --
+    is covered by ``test_members_dm_thread``, whose app now supplies the owner.
+    """
+
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused(self):
+        async with TestClient(TestServer(_members_app())) as client:
+            resp = await client.post("/api/members/code-reviewer/thread", headers=NON_OWNER)
+            assert resp.status == 403
+            assert (await _json(resp))["code"] == "owner_only"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_is_refused_before_the_slug_is_validated(self):
+        async with TestClient(TestServer(_members_app())) as client:
+            resp = await client.post("/api/members/NotASlug/thread", headers=NON_OWNER)
+            assert resp.status == 403
+            assert (await _json(resp))["code"] == "owner_only"
+
+    @pytest.mark.asyncio
+    async def test_owner_reaches_the_handler(self):
+        """Same request, owner identity: past the gate and into slug validation."""
+        async with TestClient(TestServer(_members_app())) as client:
+            resp = await client.post("/api/members/NotASlug/thread")
+            assert resp.status == 400
+            assert (await _json(resp))["code"] == "invalid_member_slug"
+
+    @pytest.mark.asyncio
+    async def test_app_tokens_keep_the_existing_404(self):
+        """The gate is ADDED below ``_deny_app_caller``, not in place of it.
+
+        An app token still gets the module's existence-hiding 404 rather than
+        the gate's 403, so this change does not alter what an app can infer.
+        """
+        async with TestClient(TestServer(_members_app())) as client:
+            resp = await client.post(
+                "/api/members/code-reviewer/thread", headers={**APP_TOKEN, **NON_OWNER}
+            )
+            assert resp.status == 404
+            assert (await _json(resp))["code"] == "not_found"


### PR DESCRIPTION
## Problem / Motivation

Four mutating dashboard routes carried no identity gate at all:

| Route | Handler |
|---|---|
| `POST /api/workspaces` | `handlers/files.py::api_workspaces_create` |
| `PUT /api/workspaces/{name}` | `handlers/files.py::api_workspaces_update` |
| `DELETE /api/workspaces/{name}` | `handlers/files.py::api_workspaces_delete` |
| `POST /api/members/{slug}/thread` | `handlers/members.py::api_member_thread` |

None of the four is in `_STRICT_INTERNAL_API_PATHS` (`server.py:347-460`) or
`_MIXED_INTERNAL_API_PATHS` (`server.py:697`), so `internal_path_matches`
(`token_auth.py:2318-2323`) resolves `_matches_internal` to False and the request
falls through to the general token gate (`token_auth.py:2557`). That gate refuses
an unauthenticated caller (`_deny` at `:2643` / `:2700`), then sets
`request["user"]` and `request["app"]` (`:2862-2863`) and calls the handler. The
handlers themselves add nothing: `grep -n 'require_owner_dashboard_request|is_owner_dashboard_request'`
on `handlers/files.py` returns only the two lines inside `api_dashboard_config`,
and on `handlers/members.py` returns nothing. `api_workspaces_delete` reaches
`del cfg.workspaces[name]` + `cfg.save()` and then audits the delete as
`outcome="success"`.

The "authenticated non-owner" is not hypothetical. `!dashboard`
(`slack/handler.py:1700`) calls `send_dashboard_link`, which mints the token via
`generate_token(user_id, session_ttl)` (`slack/allowlist.py:216`). `app` is a
keyword argument defaulting to `""` (`token_auth.py:757-764`) and is not passed,
so the minted token carries `app == ""` with a Slack user id as its subject: a
valid dashboard session that clears every app-token check while belonging to
someone who is not the owner. `handlers_instances.py:748` already names this exact
caller class verbatim as the reason for its own stricter gate.

## Why it matters

Any allow-listed Slack user who has ever typed `!dashboard` could delete a
workspace from `config.json`, repoint an existing workspace's directory, or bind a
session slot to a crew member. The workspace create and update handlers accept a
caller-supplied path and carry traversal / sensitive-path / config-root guards
precisely because that input is dangerous; those guards were defending input that
no one had established the caller was entitled to supply at all.

## What changed (motivation -> approach -> change)

Symptom: a non-owner mutates workspace config. Root cause: these routes predate
ownership semantics, sit in the general auth bucket, and no handler-level gate was
ever added. Change: apply the existing shared helper,
`require_owner_dashboard_request` (`handlers/_shared.py:1890`), to all four. No new
authorisation mechanism is introduced and no bypass flag is added -- this is the
same helper, called the same way (function-local import, awaited,
`if owner_denied is not None: return owner_denied`), that already gates
`api_dashboard_config`, `api_connections_mint`, `api_connections_test`,
`api_connections_cancel`, `api_mcp_oauth_relay` and `api_mcp_apps_call`.

### Before / after reachability

| Route | Before | After | Mechanism |
|---|---|---|---|
| `POST /api/workspaces` | any authenticated dashboard session | owner only | gate ahead of `read_bounded_json` |
| `PUT /api/workspaces/{name}` | any authenticated dashboard session | owner only | gate ahead of the 404 |
| `DELETE /api/workspaces/{name}` | any authenticated dashboard session | owner only | gate ahead of the 404 and both 409s |
| `POST /api/members/{slug}/thread` | any authenticated session except app tokens (404 via `_deny_app_caller`) | owner only; app tokens keep the 404 | gate added below `_deny_app_caller` |
| `GET /api/workspaces` | any authenticated dashboard session | unchanged | not gated; pinned by a test |

Unauthenticated was already refused on all four by the general token gate and is
unchanged. The refusal a non-owner now gets is the standard
`403 {"error": "owner authorization required", "code": "owner_only"}`.

Placement is deliberate: the gate runs before body parsing and before the
referential 404/409 guards, matching 5 of the 6 existing call sites. A gate below
the 404 would let a non-owner enumerate which workspaces exist. On the member
thread route the gate sits BELOW the pre-existing `_deny_app_caller` so an app
token keeps the existence-hiding 404 it gets on every other member route; nothing
an app can currently infer changes.

The four entries leave `_KNOWN_UNGATED_ROUTES` and the ceiling
`_MAX_KNOWN_UNGATED_ROUTES` drops 24 -> 20, as the shrink-only ratchet requires.
This also puts all four under the walk in
`test_every_gated_route_refuses_non_owner`, which previously skipped them.

### Callers checked before gating

Adding an authorisation gate is a breaking change at runtime, not at test time,
so every caller was enumerated first:

| Caller | Route + verb | Surface | Identity it carries |
|---|---|---|---|
| `website/src/components/WorkspacePicker.tsx:76` | POST `/api/workspaces` | workspace picker "create" | owner dashboard cookie; `post()` attaches only `X-Session-Key: dashboard:ui` |
| `website/src/pages/KiroCrewAgentsPage.tsx:150` | POST `/api/workspaces` | Crew Agents page create form | same |
| `website/src/pages/members/MembersPage.tsx:316` | POST `/api/members/{slug}/thread` | `/members`, on opening a member | same |
| `website/src/api/client.ts` `updateWorkspace` / `deleteWorkspace` | PUT / DELETE | none -- defined but invoked only from `ApiClient.coverage.test.tsx` | would be the owner cookie if ever called |

Ruled out, each with the positive control run rather than assumed:

- **No Python HTTP caller.** A positive would have been a `session.post("/api/workspaces"...)` style call in `src/`. The grep returns 12 lines, all of which are `"code": "member_thread_agent_pinned"` literals, the handler import in `handlers/__init__.py:225`, route registrations, or SEL `operation=` strings. None issues a request.
- **The CLI is not an HTTP caller.** `kirocrew workspace create/update` mutates `KiroCrewConfig` in-process in `cli_commands.py` and never reaches these routes, so the CLI path is untouched.
- **No app manifest reaches them.** `grep -rn -E "api/workspaces|members/.*thread" src --include=*.json` returns no matches, so no `permissions.api` allowlist authorises an app token here. Consistent with `_deny_app_caller` already refusing app callers on the members route.

**No unexplained callers.** Every live consumer is the browser dashboard itself,
which for a signed-in owner already satisfies `is_owner_dashboard_request`, so a
signed-in owner sees no behaviour change. What changes: a non-owner dashboard
subject loses workspace creation from the picker and the Crew Agents page, and
loses opening a crew member thread from `/members`. Reads stay open, so the
workspace list still renders for them.

## Tests

New file `test/test_workspace_member_thread_owner_gate.py` (16 tests) asserts both
halves on every route, because a suite proving only refusal cannot detect a gate
that rejects the owner too, and one proving only owner success cannot detect a gate
that is not there:

- non-owner gets `403` + `code == "owner_only"` on all four routes
- owner still succeeds: create writes the entry to `config.json`, update rewrites
  `dir`, delete removes the entry
- the non-owner refusal leaves no residue: the target directory does not exist and
  `config.json` is unchanged after a refused create and a refused delete
- ordering: a malformed body still answers `403` not `400`; an unknown workspace
  answers `403` not `404`; the default workspace answers `403` not `409`; an
  invalid member slug answers `403` not `400`
- the owner-side control for each of those: the same requests as owner still get
  their real `404` / `409` / `400`, so the referential guards are intact
- app tokens still get `404 not_found` on the members route, pinning that the gate
  was added below `_deny_app_caller` rather than in place of it
- `GET /api/workspaces` still answers `200` to a non-owner

Ratchet updated in `test/test_agent_config_owner_gate_invariant.py`: four entries
removed, ceiling 24 -> 20.

Three existing suites called these handlers with no owner identity and would have
started answering on the gate instead of on their own subject. Each was given the
owner identity the token middleware normally supplies, using the existing
`test/dashboard_owner_helpers.py` helper where it applies:
`test_workspace_crud_handlers.py` (`_req` builds an app with state and sets the
owner claims), `test_workspace_absolute_paths.py` (`_make_app` wrapped in
`as_owner`), `test_members_dm_thread.py` (`_auth` defaults the caller to the owner
subject, still letting the app-token and non-owner tests choose their own).

`170 passed` across the seven touched or referencing files
(`test_workspace_member_thread_owner_gate`, `test_agent_config_owner_gate_invariant`,
`test_workspace_crud_handlers`, `test_workspace_absolute_paths`,
`test_members_dm_thread`, `test_json_object_body_guard`,
`test_agents_endpoints_owner_auth`). Those seven are the complete set: the positive
control was `grep -rln` for the handler names and route paths across `test/`, which
names exactly these files and nothing else.

**Mutation-checked, so neither half is vacuous.** Forcing
`require_owner_dashboard_request` to return `None` unconditionally (gate open to
everyone) turns 9 tests red -- the 8 refusal assertions plus the ratchet's
`test_every_gated_route_refuses_non_owner`. Forcing it to always deny (gate closed
to everyone, including the owner) turns 35 red across the new file and the two
suites that exercise owner success. `handlers/_shared.py` is byte-identical to
`main` in the committed diff; the mutations were reverted and verified with
`git diff --stat origin/main -- src/kiro_crew/dashboard/handlers/_shared.py`
returning empty.

Nothing was weakened to make a test pass, and no local-development bypass was
added.

## Manual verification

N/A -- the change is a server-side authorisation gate with no UI surface of its
own, and both the refusal and the success path are covered end to end through the
real router with `TestClient`/`TestServer`.

## Related Issues

Refs #6470

The issue's first acceptance item asked for a ruling: workspace CRUD owner-only, or
owner-only for `DELETE`/`PUT` with `POST` left open. This PR takes owner-only for
all three, and owner-only for the member thread. Two reasons for the ruling, both
open to a reviewer overriding: an open `POST` is close to an open `PUT` in effect,
since a new entry can be pointed at an existing workspace's directory; and a split
would put two different authorisation answers on one resource, which is how one of
them is later forgotten. The blast-radius survey above found no non-owner caller
that depends on any of the three.

## Pattern harvest

Rule candidate: review-prompt

Pattern: an authorisation gate added below a referential guard (404 / 409) leaks
the existence of the resource it was added to protect. All four gates here are
placed above the referential guards, and each has a paired test asserting the
non-owner gets `403` where the owner gets the real `404` / `409` / `400`. The
generalisable review question is: for any newly added identity gate, what is the
first status a refused caller can observe, and does that status differ by resource
state? The class is broader than this fix -- `_KNOWN_UNGATED_ROUTES` still lists 20
routes, and each will face the same placement question when it is gated.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no doc surface changes
- [x] No secrets, credentials, or internal references in the diff
