### PR TITLE
perf(ci): stage the heavy matrix and the fork reviewers behind a Fast Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
   # exists to prevent: a package that builds green and refuses to install.
   linux-packaging:
     name: Linux Packaging (build + smoke-install)
-    needs: changes
+    needs: [changes, await-fast-gate]
     if: ${{ needs.changes.outputs.linux_packaging == 'true' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 45
@@ -245,323 +245,126 @@ jobs:
       - name: Install the packages in their target distros
         run: ./scripts/smoke-linux-packages.sh website/electron/dist
 
-  scrub-lint:
-    name: De-Amazon Scrub Lint
+  # ── Fast gate barrier (see .github/workflows/fast-gate.yml) ──────────
+  # The eleven cheap gates live in their own workflow so the fork reviewers can
+  # key on them, which means ci.yml cannot reach them with `needs:` -- a needs
+  # edge cannot cross a workflow file. This job is that edge: it reads the Fast
+  # Gate run for this exact commit and fails closed, and every heavy job needs
+  # it. One extra ~1-minute job buys the whole matrix the right to not start.
+  #
+  # Fails closed on purpose, in all three ways it can go wrong: a Fast Gate run
+  # that never appears, one that never completes inside the budget, and one that
+  # completes non-success all exit non-zero. A barrier that passed when it could
+  # not read its subject would be worse than no barrier, because the matrix would
+  # run anyway and the log would claim it was cleared to.
+  await-fast-gate:
+    name: Await Fast Gate
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    permissions:
+      # actions:read is what lets this read another workflow's runs. Job-level
+      # permissions REPLACE the top-level grant, so contents:read is restated.
+      actions: read
+      contents: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        # Full history is fetched lazily by the script only for the (skipped)
-        # history scan; the working-tree gate needs just the checkout.
-        with:
-          persist-credentials: false
-      - name: Scan working tree for internal markers
-        # Blocking gate: fails the build on any Amazon-internal marker in the
-        # public tree (internal domains/hosts, ticket ids, aliases, credential
-        # shapes) outside the intentional allowlist, so a sync cannot reintroduce
-        # a coupling. --no-history: git-history rewrite is a separate task.
-        run: ./scripts/scrub-lint.sh --no-history
-
-  vendor-manifest:
-    name: Vendored Tree Integrity
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    # Deliberately NOT gated behind the `changes` job's surface outputs:
-    # everything under src/kiro_crew/_vendor is excluded from semgrep and the
-    # AI reviewers' diff, so this checksum gate is the only content review the
-    # vendored tree gets. Hashing the ~26MB tree takes seconds, and an
-    # always-on job cannot be dodged by a path-filter edge case.
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Verify _vendor tree against the committed sha256 manifest
-        # Blocking gate: fails on any modified, missing, or added file under
-        # src/kiro_crew/_vendor relative to scripts/vendor_manifest.sha256.
-        # Legitimate vendored bumps regenerate the manifest with --write (see
-        # src/kiro_crew/_vendor/README.md) so the change lands as a reviewable
-        # manifest diff. No setup-python step: ubuntu-latest ships Python 3,
-        # same as the other stdlib-only lint jobs in this file.
-        run: python3 scripts/verify_vendor_manifest.py
-
-  brand-lint:
-    name: Brand Name Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # persist-credentials retained: brand-lint/Check the product name on the lines this change adds runs `git fetch origin`
-      # against the same remote, through the shared diff-base resolver script.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Check the product name on the lines this change adds
-        # Diff-scoped on purpose. The tree still carries thousands of prose lines
-        # that join the two words, from before the convention, so a whole-tree
-        # gate would fail every PR until one enormous rename lands and charge the
-        # break to whoever pushed next. Added lines are complete for regression —
-        # a line only reaches main through a diff that added it — and the
-        # whole-tree number is still printed as a non-failing report.
+      - name: Wait for the Fast Gate verdict on this commit
         env:
-          # `base.sha`, not `origin/<base>`: the merge ref this run checks out was
-          # computed against that exact commit, so the diff cannot pick up main
-          # moves that landed after the run started. Same reasoning as the
-          # i18n gates below; see the longer note at their first use.
-          BRAND_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # The head sha, not github.sha: on a pull_request event github.sha is
+          # the ephemeral merge commit, and Fast Gate's own run is keyed to the
+          # same head the PR reports. Matching on `event` too keeps a push run on
+          # the same commit from answering for a pull_request run.
+          SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          EVENT: ${{ github.event_name }}
+          # A head SHA is NOT a unique key for a run. Two pull requests can carry
+          # the same head commit -- a shared branch, a cherry-pick, a fork whose
+          # branch was pushed to a second PR -- and each one gets its own Fast Gate
+          # run on that commit. Keyed on the SHA alone, this job could read the
+          # OTHER PR's verdict and release its own matrix on a gate that never ran
+          # against this PR's base. The head branch plus the head repository is
+          # what makes the triple unique, so both are matched below and then
+          # re-verified on the run that is selected.
+          BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          HEAD_REPO: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
         run: |
-          BRAND_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
-            "$BRAND_BASE_REF" 'the brand-name gate')" || exit 1
-          export BRAND_BASE_REF
-          # Self-test first: it plants one probe per rule family, so a typo that
-          # silently disables an exemption fails here instead of shipping green.
-          python3 scripts/check_brand_name.py --test
-          python3 scripts/check_brand_name.py
+          set -euo pipefail
 
-  focus-cue-lint:
-    name: Focus Cue Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # persist-credentials retained: focus-cue-lint/Check the focus cues on the elements this change touches runs `git fetch origin`
-      # against the same remote, through the shared diff-base resolver script.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+          # Both workflows start from the same webhook, so Fast Gate's run may not
+          # be visible for the first few seconds. APPEAR_BUDGET covers that race;
+          # after it, a missing run is a real misconfiguration and fails.
+          APPEAR_BUDGET=180
+          TOTAL_BUDGET=720
+          started="$(date +%s)"
+          seen=false
 
-      - name: Check the focus cues on the elements this change touches
-        # Diff-scoped on purpose, same reasoning as the brand gate above: the tree
-        # still carries elements that opted out of the focus outline before the
-        # global ring existed, so a whole-tree gate would charge that backlog to
-        # whoever pushed next. Elements a change touched are complete for
-        # regression — a hole only reaches main through a diff that wrote its
-        # className — and the whole-tree number is still printed as a non-failing
-        # report.
-        env:
-          FOCUS_CUE_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          FOCUS_CUE_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
-            "$FOCUS_CUE_BASE_REF" 'the focus-cue gate')" || exit 1
-          export FOCUS_CUE_BASE_REF
-          # Self-test first: it plants one probe per rule family, so a change that
-          # silently promotes a suppressor to a cue — or disables an exemption —
-          # fails here instead of shipping a gate that passes everything.
-          python3 scripts/check_focus_cue.py --test
-          python3 scripts/check_focus_cue.py
+          while :; do
+            elapsed=$(( $(date +%s) - started ))
 
-  feature-map-lint:
-    name: Feature Map Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # persist-credentials retained: feature-map-lint/Check the feature map covers the features this change adds runs `git fetch origin`
-      # against the same remote, through the shared diff-base resolver script.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            runs="$(gh api --method GET \
+              "repos/$REPO/actions/workflows/fast-gate.yml/runs" \
+              -f "head_sha=$SHA" -f "event=$EVENT" -f "branch=$BRANCH" \
+              -f per_page=100 2>/dev/null || true)"
 
-      - name: Check the feature map covers the features this change adds
-        # Structural, not line-scoped, and that is the whole design. A feature
-        # arrives as a FILE appearing under the pages or handlers tree, or a route
-        # entry appearing in the router — so those are what demand a map row.
-        # Editing an existing page is how a feature changes BEHAVIOR, which the map
-        # deliberately does not describe, so an edit-only diff never fires. A gate
-        # that asked for a map review on every UI fix would produce a map nobody
-        # reads. Contract: docs/feature-map/README.md
-        env:
-          # `base.sha` for the same reason as the brand gate above: the merge ref
-          # this run checks out was computed against that exact commit.
-          FEATURE_MAP_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          FEATURE_MAP_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
-            "$FEATURE_MAP_BASE_REF" 'the feature-map gate')" || exit 1
-          export FEATURE_MAP_BASE_REF
-          # Self-test first: it plants one probe per trigger rule, so a widened or
-          # narrowed rule fails here instead of shipping a gate that asks for a map
-          # update on every edit — or never asks at all.
-          python3 scripts/check_feature_map.py --test
-          python3 scripts/check_feature_map.py
+            # `branch=` is passed to the API as a narrowing hint, but the match is
+            # re-asserted here: a filter the server silently ignores would hand
+            # back another PR's run, and selecting max_by(.id) out of an unfiltered
+            # list would pick the NEWEST such run -- the most likely one to be a
+            # different PR's. Filter first, collapse second.
+            latest="$(printf '%s' "$runs" \
+              | jq -c --arg branch "$BRANCH" --arg repo "$HEAD_REPO" \
+                  '[(.workflow_runs // [])[]
+                    | select(.head_branch == $branch)
+                    | select(.head_repository.full_name == $repo)]
+                   | if length == 0 then null else max_by(.id) end' \
+                  2>/dev/null || echo null)"
 
-  changelog-history:
-    name: Changelog History Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # persist-credentials retained: changelog-history/Check that shipped changelog sections survived this change runs `git fetch origin`
-      # against the same remote, through the shared diff-base resolver script.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            if [ "$latest" = "null" ] || [ -z "$latest" ]; then
+              if [ "$elapsed" -ge "$APPEAR_BUDGET" ]; then
+                echo "::error::No Fast Gate run found for $SHA on $HEAD_REPO@$BRANCH" \
+                     "($EVENT) after ${elapsed}s. The gates cannot be confirmed, so the" \
+                     "matrix is not cleared to run."
+                exit 1
+              fi
+              sleep 10
+              continue
+            fi
 
-      - name: Check that shipped changelog sections survived this change
-        # CHANGELOG.md is append-only history: every section already in it
-        # describes software a user has installed, so a line deleted from one is
-        # unrecoverable from that user's artifact. This has already happened
-        # once — a commit titled "docs: add 0.3.0-insider.9 changelog" REPLACED
-        # the file instead of prepending to it (53 insertions, 322 deletions),
-        # taking [0.2.0], [0.1.3] and [0.1.2] with it. It read as plausible in
-        # review because the insertions are what a reader looks at, and the
-        # deletions sat in the same hunk. Nothing failed; a user noticed the
-        # Releases page had gone nearly empty.
-        #
-        # So the judgment half of the rule (commit dumps, prerelease headings,
-        # whether this PR should touch the file at all) stays in AUTOSDE.yaml
-        # where a reviewer applies it, and the mechanical half runs here, where
-        # nobody has to notice anything. release.yml's stable gate is the
-        # complement: it checks the NEW section exists, not that the old ones
-        # survived — which is the half that actually failed.
-        env:
-          # base.sha, not origin/<base>: the merge ref this run checks out was
-          # computed against that exact commit, so the comparison cannot pick up
-          # base moves that landed after the run started. Same reasoning as the
-          # brand-name and i18n gates above.
-          CHANGELOG_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          CHANGELOG_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
-            "$CHANGELOG_BASE_REF" 'the changelog-history gate')" || exit 1
-          export CHANGELOG_BASE_REF
-          # Self-test first: one probe per rule family, so a weakened rule fails
-          # here instead of shipping green and letting a deletion through.
-          python3 scripts/check_changelog_history.py --test
-          python3 scripts/check_changelog_history.py
+            status="$(printf '%s' "$latest" | jq -r '.status')"
+            conclusion="$(printf '%s' "$latest" | jq -r '.conclusion // ""')"
+            url="$(printf '%s' "$latest" | jq -r '.html_url')"
 
-  builtin-skill-scope:
-    name: Builtin Skill Scope Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+            if [ "$seen" = false ]; then
+              echo "Fast Gate run: $url"
+              seen=true
+            fi
 
-      - name: Check for this repository's markers in shipped skill bodies
-        # Everything under src/kiro_crew/builtin_skills/ installs on every
-        # machine that installs Kiro Crew, so a skill body naming THIS
-        # repository -- its GitHub slug, a src/ checkout path, a test file, a
-        # workflow file -- is an instruction that resolves for one user and
-        # points an agent at a path that does not exist for everyone else.
-        # prepare-pr already solved it properly: repository specifics live in a
-        # profile keyed by repository, so the body stays portable. The
-        # kirocrew-dev/ family is exempt by directory (matched directly beneath
-        # builtin_skills/, so a nested or look-alike name cannot inherit it),
-        # because this repository is its subject matter rather than a leak.
-        # Product surface (the kirocrew CLI, ~/.kiro/crew paths, config keys) is
-        # deliberately NOT a marker -- see the script docstring for why the set
-        # is narrow, and for the repository paths it knowingly does not cover.
-        # No baseline: the tree's only two markers were fixed here, so the rule
-        # is absolute and no marker is exempted by record.
-        run: |
-          # Self-test first: one probe per marker class, both sides of the
-          # exemption, and the undecodable-file path, so a rule that silently
-          # stops matching fails here instead of shipping green.
-          python3 scripts/check_builtin_skill_scope.py --test
-          python3 scripts/check_builtin_skill_scope.py
+            if [ "$status" = "completed" ]; then
+              case "$conclusion" in
+                success)
+                  echo "Fast Gate passed. Releasing the heavy jobs."
+                  exit 0
+                  ;;
+                *)
+                  echo "::error::Fast Gate concluded '$conclusion' ($url)." \
+                       "Fix the gate it reports; the heavy jobs are skipped on purpose."
+                  exit 1
+                  ;;
+              esac
+            fi
 
-  loop-bound-locks:
-    name: Loop-Bound Locks Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
+            if [ "$elapsed" -ge "$TOTAL_BUDGET" ]; then
+              echo "::error::Fast Gate still '$status' after ${elapsed}s ($url)." \
+                   "Failing closed rather than starting the matrix unverified."
+              exit 1
+            fi
 
-      - name: Check for bare module-global asyncio primitives
-        # An asyncio.Lock/Event/Queue created at module scope binds to the
-        # import-time (or first-use) event loop and raises RuntimeError when
-        # acquired from another loop (Python 3.10+). #4800 converted every
-        # module-global lock to kiro_crew.loop_lock.LoopBoundLock; this gate
-        # keeps the declaration form of the class extinct (the registry form
-        # — dicts holding lazily-created locks — is a review concern; see the
-        # script docstring). Whole-tree, not diff-scoped: the backlog is zero
-        # after the conversion, so there is nothing to charge to whoever
-        # pushes next.
-        run: |
-          # Self-test first: it plants one probe per rule family, so a rule
-          # that silently stops matching fails here instead of shipping green.
-          python3 scripts/check_loop_bound_locks.py --test
-          python3 scripts/check_loop_bound_locks.py
-
-  testpaths-coverage:
-    name: Testpaths Coverage Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Check that every pytest test file sits under a collected root
-        # setup.cfg pins `testpaths`, so a test_*.py file created outside those
-        # roots is silently never run — green by omission — and rots against
-        # the code it claims to cover (#6577: twelve files sat uncollected in a
-        # root-level tests/ dir). Whole-tree, not diff-scoped: the backlog is
-        # zero after #6577's move, so there is nothing to charge to whoever
-        # pushes next. Nested distributions with their own pyproject/setup.cfg
-        # and marker-exempted manual scripts are excluded; see the script
-        # docstring.
-        run: |
-          # Self-test first: it plants one probe per rule family, so a rule
-          # that silently stops matching fails here instead of shipping green.
-          python3 scripts/check_testpaths_coverage.py --test
-          python3 scripts/check_testpaths_coverage.py
-
-  harness-parity:
-    name: Harness Parity Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      # persist-credentials retained: harness-parity/Check harness identity tests on the lines this change adds runs `git fetch origin`
-      # against the same remote, through the shared diff-base resolver script.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Check harness identity tests on the lines this change adds
-        # Kiro Crew drives one first-class harness (kiro-cli) and adapts the
-        # others. The defect class is a call site that spells "this is kiro" as
-        # the ABSENCE of another harness: correct with two backends, and then it
-        # hands the third a capability or a sandbox waiver nobody granted it.
-        # It fails toward the permissive answer, so nothing else goes red.
-        #
-        # Diff-scoped for the same reason as the brand gate above: the tree
-        # carries pre-existing negative tests in the dormant claude seam, and
-        # converting them is a separate change with its own review. Added lines
-        # are complete for regression, and the whole-tree count is still printed
-        # as a non-failing report. Invariants:
-        # docs/system-specs/modules/harness-parity.md
-        env:
-          # `base.sha` for the same reason as the brand gate: the merge ref this
-          # run checks out was computed against that exact commit.
-          HARNESS_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-        run: |
-          HARNESS_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
-            "$HARNESS_BASE_REF" 'the harness-parity gate')" || exit 1
-          export HARNESS_BASE_REF
-          # Self-test first: it plants one probe per rule, so a regex typo that
-          # silently disables a rule fails here instead of shipping green.
-          python3 scripts/check_harness_parity.py --test
-          python3 scripts/check_harness_parity.py
-
-  docs-lint:
-    name: Docs Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Verify the linter's own checks still fire
-        # Self-test first: a gate that has silently stopped detecting anything is
-        # worse than no gate, because it reads as a green signal. Each check is
-        # exercised against a planted defect in a throwaway tree.
-        run: python3 scripts/docs_lint.py --test
-
-      - name: Lint documentation trees
-        # Blocking gate: every internal link resolves, every doc is reachable from
-        # its directory index, every directory holding docs has one, no code comment
-        # cites a doc that does not exist, no doc cites a source LINE past the end of
-        # the file it names, no module spec names a source file that exists nowhere,
-        # and no doc whose filename is hardcoded in code has been renamed out from
-        # under its consumer.
-        # No setup-python step: ubuntu-latest ships Python 3 and the script is
-        # stdlib-only.
-        run: ./scripts/docs-lint.sh
+            sleep 10
+          done
 
   backend-lint:
     name: Backend Lint & Type Check
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     # black/flake8/isort/mypy read no file under website/, so a frontend-only
     # diff cannot change this verdict. Gated on only_frontend (not on a
     # positive "python changed" allowlist) so that anything the selector could
@@ -681,7 +484,7 @@ jobs:
 
   backend-test:
     name: Backend Tests
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     runs-on: ubuntu-latest
     # The slowest 3.12 shard runs ~29 minutes, so a 30-minute cap kills the
     # job at the coverage step with every test green and Coverage Gate then
@@ -889,6 +692,7 @@ jobs:
   # only).
   backend-test-windows:
     name: Backend Tests (Windows)
+    needs: [await-fast-gate]
     runs-on: windows-latest
     # Same 40-minute budget as backend-test; windows-latest runs the same
     # shards measurably slower, so this job has the least headroom of the two.
@@ -996,6 +800,7 @@ jobs:
   # about 4 seconds, so the job's wall time is essentially dependency install.
   backend-test-macos:
     name: Gateway Tests (macOS)
+    needs: [await-fast-gate]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -1079,6 +884,7 @@ jobs:
   #
   backend-test-sandbox:
     name: Backend Tests (namespace sandbox)
+    needs: [await-fast-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1468,7 +1274,7 @@ jobs:
 
   frontend-lint:
     name: Frontend Lint & Type Check
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     # eslint/tsc/i18n over website/** only; a backend-only diff leaves every
     # input byte-identical. only_backend is the catch-all side of the same
     # decision, so an unclassifiable path still runs this.
@@ -1644,7 +1450,7 @@ jobs:
   # class, and without a job on the floor nothing would notice.
   lockfile-engines-floor:
     name: Lockfile Installs On Declared Node Floor
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     # Reads website/package.json + website/package-lock.json and nothing else.
     if: needs.changes.outputs.only_backend != 'true'
     runs-on: ubuntu-latest
@@ -1692,7 +1498,7 @@ jobs:
 
   cfn-lint:
     name: CloudFormation Lint
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     # The templates it lints live under src/kiro_crew/deploy/, which the
     # paths-filter counts as backend, so a frontend-only diff cannot touch one.
     if: needs.changes.outputs.only_frontend != 'true'
@@ -1733,6 +1539,7 @@ jobs:
   # packaging/installer-assets/* references it pins.
   electron-test:
     name: Electron Shell Tests
+    needs: [await-fast-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -1764,7 +1571,7 @@ jobs:
 
   frontend-test:
     name: Frontend Tests
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     runs-on: ubuntu-latest
     # Per-shard budget. The whole suite was ~23 min on one runner; split four
     # ways each shard is well under this, and a hung shard fails fast.
@@ -1904,7 +1711,16 @@ jobs:
     # coverage-free subset, so there is nothing to merge and the Coverage Gate
     # skips the frontend lane.) `!cancelled()` lets it still stitch a report
     # when a shard failed, so the failure surfaces in one place.
-    if: ${{ !cancelled() && needs.changes.outputs.only_backend != 'true' }}
+    #
+    # The `!= 'skipped'` clause is what keeps that `!cancelled()` honest now that
+    # the shards sit behind await-fast-gate: a red fast gate skips frontend-test,
+    # and without this the merge would still run, find no coverage artifact, and
+    # go red for a reason that has nothing to do with the gate the developer has
+    # to fix. A skipped shard set has nothing to stitch; a FAILED one still does.
+    if: >-
+      ${{ !cancelled()
+      && needs.frontend-test.result != 'skipped'
+      && needs.changes.outputs.only_backend != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1969,7 +1785,7 @@ jobs:
 
   bundle-size:
     name: Bundle Size Gate
-    needs: [changes]
+    needs: [changes, await-fast-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     # A backend-only diff cannot change the frontend bundle, so this gate has
@@ -2010,6 +1826,7 @@ jobs:
 
   e2e:
     name: E2E (stub ACP backend, offline)
+    needs: [await-fast-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/fast-gate.yml
+++ b/.github/workflows/fast-gate.yml
@@ -1,0 +1,355 @@
+name: Fast Gate
+
+# The eleven cheap, blocking gates, split out of ci.yml so two consumers can key
+# on them BEFORE the expensive matrix runs.
+#
+# They cost 198 job-seconds in total, 70% of which is runner acquisition and
+# checkout, and they finish in ~44 seconds wall clock because they run in
+# parallel. ci.yml's heavy jobs (the eight backend shards alone are 73.7% of CI's
+# job-minutes) used to start alongside them, so a gate that went red in 20
+# seconds still let ~220 job-minutes of tests run to completion.
+#
+# Two things now depend on this workflow finishing first:
+#   1. ci.yml's `await-fast-gate` job, which the heavy jobs need -- so a red gate
+#      skips the matrix instead of racing it.
+#   2. The five fork-*-review.yml lanes, which used to trigger on
+#      `workflow_run: ["CI"] completed`. Waiting for all of CI put a fork PR's AI
+#      verdict ~54 minutes out (CI's median wall clock) when the gates it
+#      actually needed were green after one. They now trigger on this workflow.
+#
+# Trigger parity with ci.yml is deliberate, including `branches: [main]`: the fork
+# reviewers key on this workflow now, so a wider filter here would newly review
+# fork PRs opened against a non-main base -- which today get no review at all,
+# because they wait on a CI run that ci.yml's own branch filter never starts.
+# Widening that is a separate decision from moving the gates.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Same rule as ci.yml: a PR only needs a verdict on its tip commit, main keeps
+  # its in-flight run. Divergence here would let a superseded gate run outlive
+  # the CI run that is waiting on it.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  scrub-lint:
+    name: De-Amazon Scrub Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # Full history is fetched lazily by the script only for the (skipped)
+        # history scan; the working-tree gate needs just the checkout.
+        with:
+          persist-credentials: false
+      - name: Scan working tree for internal markers
+        # Blocking gate: fails the build on any Amazon-internal marker in the
+        # public tree (internal domains/hosts, ticket ids, aliases, credential
+        # shapes) outside the intentional allowlist, so a sync cannot reintroduce
+        # a coupling. --no-history: git-history rewrite is a separate task.
+        run: ./scripts/scrub-lint.sh --no-history
+
+  vendor-manifest:
+    name: Vendored Tree Integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Deliberately NOT gated behind the `changes` job's surface outputs:
+    # everything under src/kiro_crew/_vendor is excluded from semgrep and the
+    # AI reviewers' diff, so this checksum gate is the only content review the
+    # vendored tree gets. Hashing the ~26MB tree takes seconds, and an
+    # always-on job cannot be dodged by a path-filter edge case.
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify _vendor tree against the committed sha256 manifest
+        # Blocking gate: fails on any modified, missing, or added file under
+        # src/kiro_crew/_vendor relative to scripts/vendor_manifest.sha256.
+        # Legitimate vendored bumps regenerate the manifest with --write (see
+        # src/kiro_crew/_vendor/README.md) so the change lands as a reviewable
+        # manifest diff. No setup-python step: ubuntu-latest ships Python 3,
+        # same as the other stdlib-only lint jobs in this file.
+        run: python3 scripts/verify_vendor_manifest.py
+
+  brand-lint:
+    name: Brand Name Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # persist-credentials retained: brand-lint/Check the product name on the lines this change adds runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check the product name on the lines this change adds
+        # Diff-scoped on purpose. The tree still carries thousands of prose lines
+        # that join the two words, from before the convention, so a whole-tree
+        # gate would fail every PR until one enormous rename lands and charge the
+        # break to whoever pushed next. Added lines are complete for regression —
+        # a line only reaches main through a diff that added it — and the
+        # whole-tree number is still printed as a non-failing report.
+        env:
+          # `base.sha`, not `origin/<base>`: the merge ref this run checks out was
+          # computed against that exact commit, so the diff cannot pick up main
+          # moves that landed after the run started. Same reasoning as the
+          # i18n gates below; see the longer note at their first use.
+          BRAND_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          BRAND_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$BRAND_BASE_REF" 'the brand-name gate')" || exit 1
+          export BRAND_BASE_REF
+          # Self-test first: it plants one probe per rule family, so a typo that
+          # silently disables an exemption fails here instead of shipping green.
+          python3 scripts/check_brand_name.py --test
+          python3 scripts/check_brand_name.py
+
+  focus-cue-lint:
+    name: Focus Cue Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # persist-credentials retained: focus-cue-lint/Check the focus cues on the elements this change touches runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check the focus cues on the elements this change touches
+        # Diff-scoped on purpose, same reasoning as the brand gate above: the tree
+        # still carries elements that opted out of the focus outline before the
+        # global ring existed, so a whole-tree gate would charge that backlog to
+        # whoever pushed next. Elements a change touched are complete for
+        # regression — a hole only reaches main through a diff that wrote its
+        # className — and the whole-tree number is still printed as a non-failing
+        # report.
+        env:
+          FOCUS_CUE_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          FOCUS_CUE_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$FOCUS_CUE_BASE_REF" 'the focus-cue gate')" || exit 1
+          export FOCUS_CUE_BASE_REF
+          # Self-test first: it plants one probe per rule family, so a change that
+          # silently promotes a suppressor to a cue — or disables an exemption —
+          # fails here instead of shipping a gate that passes everything.
+          python3 scripts/check_focus_cue.py --test
+          python3 scripts/check_focus_cue.py
+
+  feature-map-lint:
+    name: Feature Map Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # persist-credentials retained: feature-map-lint/Check the feature map covers the features this change adds runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check the feature map covers the features this change adds
+        # Structural, not line-scoped, and that is the whole design. A feature
+        # arrives as a FILE appearing under the pages or handlers tree, or a route
+        # entry appearing in the router — so those are what demand a map row.
+        # Editing an existing page is how a feature changes BEHAVIOR, which the map
+        # deliberately does not describe, so an edit-only diff never fires. A gate
+        # that asked for a map review on every UI fix would produce a map nobody
+        # reads. Contract: docs/feature-map/README.md
+        env:
+          # `base.sha` for the same reason as the brand gate above: the merge ref
+          # this run checks out was computed against that exact commit.
+          FEATURE_MAP_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          FEATURE_MAP_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$FEATURE_MAP_BASE_REF" 'the feature-map gate')" || exit 1
+          export FEATURE_MAP_BASE_REF
+          # Self-test first: it plants one probe per trigger rule, so a widened or
+          # narrowed rule fails here instead of shipping a gate that asks for a map
+          # update on every edit — or never asks at all.
+          python3 scripts/check_feature_map.py --test
+          python3 scripts/check_feature_map.py
+
+  changelog-history:
+    name: Changelog History Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # persist-credentials retained: changelog-history/Check that shipped changelog sections survived this change runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check that shipped changelog sections survived this change
+        # CHANGELOG.md is append-only history: every section already in it
+        # describes software a user has installed, so a line deleted from one is
+        # unrecoverable from that user's artifact. This has already happened
+        # once — a commit titled "docs: add 0.3.0-insider.9 changelog" REPLACED
+        # the file instead of prepending to it (53 insertions, 322 deletions),
+        # taking [0.2.0], [0.1.3] and [0.1.2] with it. It read as plausible in
+        # review because the insertions are what a reader looks at, and the
+        # deletions sat in the same hunk. Nothing failed; a user noticed the
+        # Releases page had gone nearly empty.
+        #
+        # So the judgment half of the rule (commit dumps, prerelease headings,
+        # whether this PR should touch the file at all) stays in AUTOSDE.yaml
+        # where a reviewer applies it, and the mechanical half runs here, where
+        # nobody has to notice anything. release.yml's stable gate is the
+        # complement: it checks the NEW section exists, not that the old ones
+        # survived — which is the half that actually failed.
+        env:
+          # base.sha, not origin/<base>: the merge ref this run checks out was
+          # computed against that exact commit, so the comparison cannot pick up
+          # base moves that landed after the run started. Same reasoning as the
+          # brand-name and i18n gates above.
+          CHANGELOG_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          CHANGELOG_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$CHANGELOG_BASE_REF" 'the changelog-history gate')" || exit 1
+          export CHANGELOG_BASE_REF
+          # Self-test first: one probe per rule family, so a weakened rule fails
+          # here instead of shipping green and letting a deletion through.
+          python3 scripts/check_changelog_history.py --test
+          python3 scripts/check_changelog_history.py
+
+  builtin-skill-scope:
+    name: Builtin Skill Scope Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check for this repository's markers in shipped skill bodies
+        # Everything under src/kiro_crew/builtin_skills/ installs on every
+        # machine that installs Kiro Crew, so a skill body naming THIS
+        # repository -- its GitHub slug, a src/ checkout path, a test file, a
+        # workflow file -- is an instruction that resolves for one user and
+        # points an agent at a path that does not exist for everyone else.
+        # prepare-pr already solved it properly: repository specifics live in a
+        # profile keyed by repository, so the body stays portable. The
+        # kirocrew-dev/ family is exempt by directory (matched directly beneath
+        # builtin_skills/, so a nested or look-alike name cannot inherit it),
+        # because this repository is its subject matter rather than a leak.
+        # Product surface (the kirocrew CLI, ~/.kiro/crew paths, config keys) is
+        # deliberately NOT a marker -- see the script docstring for why the set
+        # is narrow, and for the repository paths it knowingly does not cover.
+        # No baseline: the tree's only two markers were fixed here, so the rule
+        # is absolute and no marker is exempted by record.
+        run: |
+          # Self-test first: one probe per marker class, both sides of the
+          # exemption, and the undecodable-file path, so a rule that silently
+          # stops matching fails here instead of shipping green.
+          python3 scripts/check_builtin_skill_scope.py --test
+          python3 scripts/check_builtin_skill_scope.py
+
+  loop-bound-locks:
+    name: Loop-Bound Locks Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check for bare module-global asyncio primitives
+        # An asyncio.Lock/Event/Queue created at module scope binds to the
+        # import-time (or first-use) event loop and raises RuntimeError when
+        # acquired from another loop (Python 3.10+). #4800 converted every
+        # module-global lock to kiro_crew.loop_lock.LoopBoundLock; this gate
+        # keeps the declaration form of the class extinct (the registry form
+        # — dicts holding lazily-created locks — is a review concern; see the
+        # script docstring). Whole-tree, not diff-scoped: the backlog is zero
+        # after the conversion, so there is nothing to charge to whoever
+        # pushes next.
+        run: |
+          # Self-test first: it plants one probe per rule family, so a rule
+          # that silently stops matching fails here instead of shipping green.
+          python3 scripts/check_loop_bound_locks.py --test
+          python3 scripts/check_loop_bound_locks.py
+
+  testpaths-coverage:
+    name: Testpaths Coverage Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check that every pytest test file sits under a collected root
+        # setup.cfg pins `testpaths`, so a test_*.py file created outside those
+        # roots is silently never run — green by omission — and rots against
+        # the code it claims to cover (#6577: twelve files sat uncollected in a
+        # root-level tests/ dir). Whole-tree, not diff-scoped: the backlog is
+        # zero after #6577's move, so there is nothing to charge to whoever
+        # pushes next. Nested distributions with their own pyproject/setup.cfg
+        # and marker-exempted manual scripts are excluded; see the script
+        # docstring.
+        run: |
+          # Self-test first: it plants one probe per rule family, so a rule
+          # that silently stops matching fails here instead of shipping green.
+          python3 scripts/check_testpaths_coverage.py --test
+          python3 scripts/check_testpaths_coverage.py
+
+  harness-parity:
+    name: Harness Parity Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # persist-credentials retained: harness-parity/Check harness identity tests on the lines this change adds runs `git fetch origin`
+      # against the same remote, through the shared diff-base resolver script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check harness identity tests on the lines this change adds
+        # Kiro Crew drives one first-class harness (kiro-cli) and adapts the
+        # others. The defect class is a call site that spells "this is kiro" as
+        # the ABSENCE of another harness: correct with two backends, and then it
+        # hands the third a capability or a sandbox waiver nobody granted it.
+        # It fails toward the permissive answer, so nothing else goes red.
+        #
+        # Diff-scoped for the same reason as the brand gate above: the tree
+        # carries pre-existing negative tests in the dormant claude seam, and
+        # converting them is a separate change with its own review. Added lines
+        # are complete for regression, and the whole-tree count is still printed
+        # as a non-failing report. Invariants:
+        # docs/system-specs/modules/harness-parity.md
+        env:
+          # `base.sha` for the same reason as the brand gate: the merge ref this
+          # run checks out was computed against that exact commit.
+          HARNESS_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          HARNESS_BASE_REF="$(bash "$GITHUB_WORKSPACE/.github/scripts/resolve-i18n-base.sh" \
+            "$HARNESS_BASE_REF" 'the harness-parity gate')" || exit 1
+          export HARNESS_BASE_REF
+          # Self-test first: it plants one probe per rule, so a regex typo that
+          # silently disables a rule fails here instead of shipping green.
+          python3 scripts/check_harness_parity.py --test
+          python3 scripts/check_harness_parity.py
+
+  docs-lint:
+    name: Docs Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify the linter's own checks still fire
+        # Self-test first: a gate that has silently stopped detecting anything is
+        # worse than no gate, because it reads as a green signal. Each check is
+        # exercised against a planted defect in a throwaway tree.
+        run: python3 scripts/docs_lint.py --test
+
+      - name: Lint documentation trees
+        # Blocking gate: every internal link resolves, every doc is reachable from
+        # its directory index, every directory holding docs has one, no code comment
+        # cites a doc that does not exist, no doc cites a source LINE past the end of
+        # the file it names, no module spec names a source file that exists nowhere,
+        # and no doc whose filename is hardcoded in code has been renamed out from
+        # under its consumer.
+        # No setup-python step: ubuntu-latest ships Python 3 and the script is
+        # stdlib-only.
+        run: ./scripts/docs-lint.sh

--- a/.github/workflows/fork-design-review.yml
+++ b/.github/workflows/fork-design-review.yml
@@ -27,8 +27,18 @@ name: Fork Design Review
 # verdict fails the check.
 
 on:
+  # Fast Gate, not CI. This lane is stage 2 of the fork design -- it may not start
+  # until a trusted workflow has vouched for the head commit -- but waiting for
+  # ALL of CI put the verdict ~54 minutes out (CI's median wall clock), and 73.7%
+  # of that is the backend matrix, which tells this reviewer nothing. Fast Gate
+  # carries the eleven cheap blocking gates and finishes in about a minute.
+  #
+  # This does not weaken the fork trust boundary: the steps below still harden the
+  # runner, check out the BASE commit, and read the fork's diff as data that never
+  # reaches the tree. CI's green was a quality precondition here, never a security
+  # one.
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Fast Gate"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/fork-first-principles-review.yml
+++ b/.github/workflows/fork-first-principles-review.yml
@@ -27,8 +27,18 @@ name: Fork First Principles Review
 # NEUTRAL (never hard-fails); only a real BLOCK verdict fails the check.
 
 on:
+  # Fast Gate, not CI. This lane is stage 2 of the fork design -- it may not start
+  # until a trusted workflow has vouched for the head commit -- but waiting for
+  # ALL of CI put the verdict ~54 minutes out (CI's median wall clock), and 73.7%
+  # of that is the backend matrix, which tells this reviewer nothing. Fast Gate
+  # carries the eleven cheap blocking gates and finishes in about a minute.
+  #
+  # This does not weaken the fork trust boundary: the steps below still harden the
+  # runner, check out the BASE commit, and read the fork's diff as data that never
+  # reaches the tree. CI's green was a quality precondition here, never a security
+  # one.
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Fast Gate"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -29,8 +29,18 @@ name: Fork GPT 5.6 Review
 # lane reads them from the checked-out tree, which is the trusted BASE.
 
 on:
+  # Fast Gate, not CI. This lane is stage 2 of the fork design -- it may not start
+  # until a trusted workflow has vouched for the head commit -- but waiting for
+  # ALL of CI put the verdict ~54 minutes out (CI's median wall clock), and 73.7%
+  # of that is the backend matrix, which tells this reviewer nothing. Fast Gate
+  # carries the eleven cheap blocking gates and finishes in about a minute.
+  #
+  # This does not weaken the fork trust boundary: the steps below still harden the
+  # runner, check out the BASE commit, and read the fork's diff as data that never
+  # reaches the tree. CI's green was a quality precondition here, never a security
+  # one.
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Fast Gate"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/fork-opus-review.yml
+++ b/.github/workflows/fork-opus-review.yml
@@ -26,8 +26,18 @@ name: Fork Opus 4.8 Review
 # fork and same-repo prompts cannot drift.)
 
 on:
+  # Fast Gate, not CI. This lane is stage 2 of the fork design -- it may not start
+  # until a trusted workflow has vouched for the head commit -- but waiting for
+  # ALL of CI put the verdict ~54 minutes out (CI's median wall clock), and 73.7%
+  # of that is the backend matrix, which tells this reviewer nothing. Fast Gate
+  # carries the eleven cheap blocking gates and finishes in about a minute.
+  #
+  # This does not weaken the fork trust boundary: the steps below still harden the
+  # runner, check out the BASE commit, and read the fork's diff as data that never
+  # reaches the tree. CI's green was a quality precondition here, never a security
+  # one.
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Fast Gate"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/fork-ux-review.yml
+++ b/.github/workflows/fork-ux-review.yml
@@ -26,8 +26,18 @@ name: Fork UX Review
 # "UX Review" so either path satisfies the same status name.
 
 on:
+  # Fast Gate, not CI. This lane is stage 2 of the fork design -- it may not start
+  # until a trusted workflow has vouched for the head commit -- but waiting for
+  # ALL of CI put the verdict ~54 minutes out (CI's median wall clock), and 73.7%
+  # of that is the backend matrix, which tells this reviewer nothing. Fast Gate
+  # carries the eleven cheap blocking gates and finishes in about a minute.
+  #
+  # This does not weaken the fork trust boundary: the steps below still harden the
+  # runner, check out the BASE commit, and read the fork's diff as data that never
+  # reaches the tree. CI's green was a quality precondition here, never a security
+  # one.
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Fast Gate"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -19,6 +19,10 @@ on:
   workflow_run:
     workflows:
       - CI
+      # The eleven cheap blocking gates, split out of CI so the fork reviewers can
+      # key on them. It is a lane in its own right -- a red gate must red the PR --
+      # and its completion is also what releases CI's heavy jobs.
+      - Fast Gate
       - Build
       - Code Review
       - Opus 4.8 Review
@@ -519,10 +523,16 @@ jobs:
 
           if [ "$stacked" = "true" ]; then
             skipped+=("CI (only runs on PRs to $DEFAULT_BRANCH)")
+            skipped+=("Fast Gate (only runs on PRs to $DEFAULT_BRANCH)")
             skipped+=("Build (only runs on PRs to $DEFAULT_BRANCH)")
           else
             workflow_specs+=(
               "ci.yml|CI"
+              # Fast Gate carries the same `branches:` filter as CI, so it belongs
+              # in this carve-out for the same reason: on a stacked PR it never
+              # starts, and a lane that reads "(not started)" freezes the verdict
+              # at pending forever.
+              "fast-gate.yml|Fast Gate"
               "build.yml|Build"
             )
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,10 @@ An agent contributing to Kiro Crew loads this suite and follows the same
 worktree → build gate → prepare-pr → review loop human contributors use, so
 the PR process stays consistent regardless of who is writing the code. If you
 change the workflow, change it THERE — those files are the single source of
-truth (with `.github/workflows/ci.yml` canonical for the gate list).
+truth (with `.github/workflows/ci.yml` plus
+`.github/workflows/fast-gate.yml` canonical for the gate list — the eleven cheap
+blocking gates live in the second one so a red gate can skip the expensive matrix
+instead of racing it).
 
 ## Building
 
@@ -527,8 +530,10 @@ Some of our checks are not "does this pass or fail" tests but *ratchets*: a gate
 that records the current count of a thing we are burning down and then fails if
 that count grows, so the number is only ever allowed to shrink. The idea is that
 we never make a known problem worse, and every PR either holds the line or pays
-some of it down. A few examples (`.github/workflows/ci.yml` stays canonical for
-the full list, so this is illustration, not an inventory):
+some of it down. A few examples (`.github/workflows/ci.yml` and
+`.github/workflows/fast-gate.yml` stay canonical for the full list — most of the
+diff-scoped ratchets are in the second — so this is illustration, not an
+inventory):
 
 - the black formatting **baseline** (`.github/black-baseline.txt`) and the
   config-baseline snapshot (`config-baseline.json`, checked by

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -4,7 +4,7 @@ Everything that gates a pull request.
 
 | Document | Covers |
 |---|---|
-| [ci-and-reviews.md](ci-and-reviews.md) | The CI jobs, the AI review workflows, and the aggregate readiness status. |
+| [ci-and-reviews.md](ci-and-reviews.md) | The Fast Gate barrier, the CI jobs, the AI review workflows, and the aggregate readiness status. |
 | [e2e-gate.md](e2e-gate.md) | The offline browser E2E gate (`python setup.py test_e2e`). |
 | [harness-parity-gate.md](harness-parity-gate.md) | The added-line gate keeping the Kiro harness first-class: the six rules, and why it reports rather than enforces whole-tree. |
 | [i18n-gates.md](i18n-gates.md) | The i18n gate chain: what fails, what only reports, and the ratchet rule. |

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -15,10 +15,17 @@ is [CONTRIBUTING.md](../../CONTRIBUTING.md).
 ## Shape
 
 CI is a **fan-out of independent workflows that one aggregator folds into a single
-verdict**:
+verdict**, with exactly one ordering edge inside it: the eleven cheap blocking
+gates run in their own workflow, and both the expensive matrix and the fork
+reviewers wait for its verdict rather than racing it.
 
 ```
 pull_request
+  |-- fast-gate.yml     "Fast Gate"    the 11 cheap blocking gates (~44s wall clock)
+  |     |
+  |     |-- ci.yml's `await-fast-gate` job releases the heavy jobs
+  |     '-- the five fork-*-review.yml lanes trigger on its completion
+  |
   |-- ci.yml            "CI"           lint, sharded tests, coverage gate, e2e
   |-- build.yml         "Build"        wheel + desktop artifacts still build
   |-- code-review.yml   "Code Review"  grep rules, woke, Semgrep, PR hygiene, dep audit
@@ -35,8 +42,20 @@ pull_request
   '-> pr-readiness.yml  "PR Readiness"  one commit status + one readiness: label
 ```
 
-Two structural facts explain most of the rest:
+Three structural facts explain most of the rest:
 
+- **The cheap gates decide whether the expensive ones get to run.** The eleven
+  gates in `Fast Gate` cost 198 job-seconds between them, about 70% of which is
+  runner acquisition and checkout, and they finish in ~44 seconds because they run
+  in parallel. A median CI run is 240 job-minutes and 54 minutes of wall clock, and
+  the eight `backend-test` shards alone are 73.7% of those job-minutes. While the
+  gates lived in `ci.yml` the matrix started alongside them, so a gate that went red
+  in twenty seconds still let the whole matrix run to completion. They are now a
+  separate workflow with the same triggers, and `ci.yml`'s `await-fast-gate` job —
+  which every heavy job needs — is the edge that makes a red gate SKIP the matrix
+  instead of racing it. A `needs:` edge cannot cross a workflow file, which is why
+  that barrier is a job that reads the other workflow's run rather than a
+  dependency GitHub resolves for us.
 - **The real merge gate is human approval plus armed auto-merge.** `PR Readiness`
   is the one status worth watching; individual red checks are strong signals a
   human can weigh.
@@ -146,18 +165,54 @@ Out-of-band lanes that never gate a PR:
   `test/test_workflow_pr_create_handoff.py` holds them in step and fails a new
   `gh pr create` step that skips the guard.
 
-## `ci.yml`: correctness
+## `fast-gate.yml`: the cheap blocking gates
 
-Every job here is blocking.
+Every job here is blocking, and nothing here is behind a path filter — the
+workflow has no `changes` job at all, because a gate that costs a few seconds is
+cheaper to always run than to decide about, and a filter is one more thing that can
+be dodged by an edge case in its own globs.
+
+They live in their own workflow for two reasons that both come down to who has to
+wait for them. `ci.yml`'s heavy jobs now wait through `await-fast-gate`, so a red
+gate skips ~220 job-minutes of tests it was previously running beside. And the five
+`fork-*-review.yml` lanes need SOME trusted workflow to vouch for a fork's head
+commit before they start (see [Fork PRs](#fork-prs)); waiting for all of `CI` put a
+fork PR's AI verdict ~54 minutes out, when the gates that verdict actually needs are
+green after one.
+
+The trigger set is copied from `ci.yml` deliberately, `branches: [main]` included.
+The fork reviewers key on this workflow now, so a wider filter here would newly
+review fork PRs opened against a non-main base — which today get no review at all,
+because they wait on a `CI` run that `ci.yml`'s own branch filter never starts.
+Widening that is a separate decision from moving the gates.
 
 | Job | What it enforces |
 |---|---|
 | `scrub-lint` | `scripts/scrub-lint.sh --no-history`. Fails on any internal marker in this public tree, so a sync cannot reintroduce a coupling |
-| `vendor-manifest` | `scripts/verify_vendor_manifest.py`. Hashes every file under `src/kiro_crew/_vendor` against the committed `scripts/vendor_manifest.sha256` — the tree is excluded from semgrep and the AI reviewers' diff, so this checksum is its only content review. Always-on (not behind the `changes` path filter) |
-| `backend-lint` | `isort --check-only`, `flake8`, `mypy` on Python 3.10 and 3.12, plus `scripts/check_black_formatting.py` — black enforced on every file outside `.github/black-baseline.txt`, which can only shrink — and `scripts/check_subprocess_encoding.py` (self-test first) — no text-mode subprocess call without an explicit `encoding=`, `**UTF8_TEXT`, or a `# subprocess-encoding: locale` marker, outside `.github/subprocess-encoding-baseline.txt`, which can only shrink — and `scripts/check_sync_io_in_async.py` (self-test first) — no blocking db / subprocess / http / `time.sleep` call inside an `async def` under `src/`, outside `.github/sync-io-in-async-baseline.txt`, which can only shrink. A stall past `dashboard.loop_stall_exit_after_secs` (25s) makes the watchdog kill the gateway and drop every in-flight turn (#3057, #1572); the escape is an offload (`await asyncio.to_thread(...)`, or a named lane from `src/kiro_crew/executors.py`) or a `# on-loop-io-ok: <why it cannot block>` marker whose reason is mandatory. All four baselined gates in this job read their diff scope from the one shared resolver in `scripts/ratchet_scope.py`, so they cannot disagree about which lines a change added; the env-base gates (`check_brand_name.py`, `check_harness_parity.py`, `check_focus_cue.py`) share the same diff parsing through its explicit-base entry points while keeping their `*_BASE_REF` base semantics |
-| `harness-parity` | `scripts/check_harness_parity.py`, self-test first. Fails on a newly added line that expresses "this is the Kiro harness" as the absence of another one — a shape that fails toward the permissive answer, so nothing else goes red. Diff-scoped; the whole-tree backlog is a non-failing report |
-| `feature-map` | `scripts/check_feature_map.py`, self-test first. Fails when a file is ADDED or DELETED under `website/src/pages/` or `src/kiro_crew/dashboard/handlers/`, or a `<Route>` entry arrives or leaves `website/src/App.tsx`, while `docs/feature-map/README.md` stays untouched. The blocking root AUTOSDE rule `feature-map-correctness` is the semantic half: it verifies changed rows against the code, rejects unrelated or cosmetic map churn, and checks that the map's net diff matches the PR's stated scope. Structural on purpose: an edit to an existing page changes a feature's behavior, which the map does not describe, so an edit-only diff never fires — a gate demanding a map review on every UI fix produces a map nobody reads. Fails OPEN on an unreadable diff, unlike the gates above: this one guards a documentation habit, not an invariant a bad line carries into `main` forever |
+| `vendor-manifest` | `scripts/verify_vendor_manifest.py`. Hashes every file under `src/kiro_crew/_vendor` against the committed `scripts/vendor_manifest.sha256` — the tree is excluded from semgrep and the AI reviewers' diff, so this checksum is its only content review. Hashing the ~26MB tree takes seconds, so it is always-on like the rest of this workflow |
+| `brand-lint` | `scripts/check_brand_name.py`, self-test first. Fails on a newly added line that joins the two words of the product name. Diff-scoped: the tree still carries thousands of pre-convention prose lines, so a whole-tree gate would charge that backlog to whoever pushed next; the whole-tree count is still printed as a non-failing report |
+| `focus-cue-lint` | `scripts/check_focus_cue.py`, self-test first. Fails when a change writes the `className` of an element that then has no visible focus cue. Diff-scoped for the same reason as `brand-lint`, and reports whole-tree |
+| `feature-map-lint` | `scripts/check_feature_map.py`, self-test first. Fails when a file is ADDED or DELETED under `website/src/pages/` or `src/kiro_crew/dashboard/handlers/`, or a `<Route>` entry arrives or leaves `website/src/App.tsx`, while `docs/feature-map/README.md` stays untouched. The blocking root AUTOSDE rule `feature-map-correctness` is the semantic half: it verifies changed rows against the code, rejects unrelated or cosmetic map churn, and checks that the map's net diff matches the PR's stated scope. Structural on purpose: an edit to an existing page changes a feature's behavior, which the map does not describe, so an edit-only diff never fires — a gate demanding a map review on every UI fix produces a map nobody reads. Fails OPEN on an unreadable diff, unlike the other gates here: this one guards a documentation habit, not an invariant a bad line carries into `main` forever |
+| `changelog-history` | `scripts/check_changelog_history.py`, self-test first. Fails when a shipped `CHANGELOG.md` section loses lines. Every section already in that file describes software a user has installed, and it has been silently truncated once already — a commit titled "docs: add 0.3.0-insider.9 changelog" REPLACED the file (53 insertions, 322 deletions) and nothing noticed until the Releases page had gone nearly empty |
+| `builtin-skill-scope` | `scripts/check_builtin_skill_scope.py`, self-test first. Fails on a marker for THIS repository (its GitHub slug, a `src/` checkout path, a test or workflow file) inside a skill body under `src/kiro_crew/builtin_skills/`, because those install on every machine and resolve for exactly one of them. The `kirocrew-dev/` family is exempt by directory, since this repository is its subject matter |
 | `loop-bound-locks` | `scripts/check_loop_bound_locks.py`, self-test first. Fails on any module-global `asyncio.Lock()`/`Event()`/`Queue()` declaration — those bind to the import-time (or first-use) event loop and raise `RuntimeError` when acquired from another loop (Python 3.10+). #4800 converted the tree to `kiro_crew.loop_lock.LoopBoundLock`; whole-tree, since the backlog is zero |
+| `testpaths-coverage` | `scripts/check_testpaths_coverage.py`, self-test first. Fails on a `test_*.py` file outside the roots `setup.cfg` pins in `testpaths` — such a file is never collected, so it is green by omission and rots against the code it claims to cover (#6577 found twelve). Whole-tree, since the backlog is zero |
+| `harness-parity` | `scripts/check_harness_parity.py`, self-test first. Fails on a newly added line that expresses "this is the Kiro harness" as the absence of another one — a shape that fails toward the permissive answer, so nothing else goes red. Diff-scoped; the whole-tree backlog is a non-failing report |
+| `docs-lint` | `scripts/docs_lint.py --test` then `scripts/docs-lint.sh`. Every internal link resolves, every doc is reachable from its directory index, every directory holding docs has one, no code comment cites a doc that does not exist, no doc cites a source LINE past the end of the file it names, no module spec names a source file that exists nowhere, and no doc whose filename is hardcoded in code has been renamed out from under its consumer |
+
+Each of these runs its own self-test in the same step, ahead of the real check. A
+gate that has silently stopped matching reads as a green signal, which is worse than
+no gate, so every rule is exercised against a planted probe first.
+
+## `ci.yml`: correctness
+
+Every job here is blocking. Every job that costs real runner time also `needs:`
+`await-fast-gate`, so on a red gate it does not run at all.
+
+| Job | What it enforces |
+|---|---|
+| `await-fast-gate` | Polls the `Fast Gate` run for this exact head commit and **fails closed** in all three ways it can go wrong: a run that never appears (180s budget), one that never completes (720s budget), and one that completes non-success. A barrier that passed when it could not read its subject would be worse than none, because the matrix would run anyway and the log would claim it was cleared to. One extra ~1-minute job buys the whole matrix the right to not start |
+| `backend-lint` | `isort --check-only`, `flake8`, `mypy` on Python 3.10 and 3.12, plus `scripts/check_black_formatting.py` — black enforced on every file outside `.github/black-baseline.txt`, which can only shrink — and `scripts/check_subprocess_encoding.py` (self-test first) — no text-mode subprocess call without an explicit `encoding=`, `**UTF8_TEXT`, or a `# subprocess-encoding: locale` marker, outside `.github/subprocess-encoding-baseline.txt`, which can only shrink — and `scripts/check_sync_io_in_async.py` (self-test first) — no blocking db / subprocess / http / `time.sleep` call inside an `async def` under `src/`, outside `.github/sync-io-in-async-baseline.txt`, which can only shrink. A stall past `dashboard.loop_stall_exit_after_secs` (25s) makes the watchdog kill the gateway and drop every in-flight turn (#3057, #1572); the escape is an offload (`await asyncio.to_thread(...)`, or a named lane from `src/kiro_crew/executors.py`) or a `# on-loop-io-ok: <why it cannot block>` marker whose reason is mandatory. All four baselined gates in this job read their diff scope from the one shared resolver in `scripts/ratchet_scope.py`, so they cannot disagree about which lines a change added; the env-base gates (`check_brand_name.py`, `check_harness_parity.py`, `check_focus_cue.py`) share the same diff parsing through its explicit-base entry points while keeping their `*_BASE_REF` base semantics |
 | `backend-test` | 2 Python versions x 4 duration-balanced pytest-split shards (8 jobs), `-n auto` within each. Coverage only on 3.12 (3.10 passes `--no-cov` for a trace-free run) |
 | `backend-test-windows` | windows-latest, 4 shards, `--no-cov`, 180s per-test timeout. The backend supports Windows natively via `platform_compat`, and nothing else in CI holds that line |
 | `backend-test-macos` | macos-14, deliberately SCOPED (gateway, socketsec, platform-compat, pod and MCP-apps suites via a glob). A full macOS run needs its own exclusion burn-down first, and a job that is red on arrival trains people to ignore it |
@@ -182,10 +237,24 @@ Details worth knowing:
   namespace, the job fails instead of letting the suite silently skip and the gate
   go green having asserted nothing. This is what gives the `hooks.py`
   sensitive-path keystone real CI coverage.
-- **`coverage-gate` is fail-closed.** It runs `if: always()` and its first step
-  converts any non-success upstream result into an explicit failure, because GitHub
-  treats a **skipped** required check as satisfied. It also compares the raw
-  line-rate and rounds only for display, so 89.95% cannot pass a 90% floor.
+- **`coverage-gate` is fail-closed, and the split made that load-bearing.** It runs
+  `if: always()` and its first step converts any non-success upstream result into an
+  explicit failure, because GitHub treats a **skipped** required check as satisfied.
+  That was already the right shape when the only way to skip a test job was a path
+  filter or a failed dependency. It is now the mechanism that keeps the whole
+  `await-fast-gate` design honest: a red gate deliberately SKIPS `backend-test` and
+  `frontend-test`, and without this step a required Coverage Gate would skip with
+  them and be reported as satisfied — so the barrier that exists to save runner time
+  would also have quietly removed the coverage floor. The `if: always()` is what
+  makes it emit a real verdict, and the first step is what makes that verdict red.
+  `frontend-coverage-merge` carries the other half of the same problem and solves it
+  the opposite way: its `!cancelled()` needed an explicit
+  `needs.frontend-test.result != 'skipped'` clause, because a skipped shard set has
+  nothing to stitch and the merge would otherwise go red for missing an artifact
+  instead of for the gate the developer actually has to fix. A FAILED shard set still
+  has something to stitch, which is why the clause names `skipped` and not both. It
+  also compares the raw line-rate and rounds only for display, so 89.95% cannot pass
+  a 90% floor.
 - **`coverage-gate` enforces two different shapes.** The project floors
   (`BACKEND_MIN`, `FRONTEND_MIN`) compare one lane-wide average; the per-file floor
   (`PER_FILE_MIN`, `scripts/check_per_file_coverage.py`) requires *every measured
@@ -617,7 +686,13 @@ It executes no tests. It resolves the PR's current head SHA, **drops stale event
 queries the latest run per monitored workflow, and publishes **one `PR Readiness`
 commit status plus one `readiness:` label**.
 
-- **Always required:** CI, Build, Code Review.
+- **Always required:** Fast Gate, CI, Build, Code Review. `Fast Gate` is a lane in
+  its own right and not merely CI's precondition — a red gate must red the PR, and
+  `await-fast-gate` reports `failure` rather than the gate that actually broke, so
+  the readable verdict has to come from the gate workflow itself. It carries CI's
+  `branches: [main]` filter, so it sits in the same stacked-PR carve-out: on a PR
+  whose base is not the default branch it never starts, and a monitored lane that
+  reads `(not started)` would freeze the verdict at pending forever.
 - **Additionally required on a same-repo PR:** CodeQL, Opus 4.8 Review, GPT 5.6
   Review, and completion of Design Review, UX Review and First Principles Review.
 - **UX Review and First Principles Review are completion-required but advisory:**
@@ -757,17 +832,27 @@ eligible automated validation passed for this revision. Human approval and branc
 protection remain separate gates.
 
 **The `fork-*` pipeline gives fork PRs AI review anyway, in two stages.**
-`fork-opus-review.yml`, `fork-gpt-review.yml`, `fork-design-review.yml` and
-`fork-ux-review.yml` each trigger on the **completion of CI** (stage 1) and run
-privileged from the default branch (stage 2), gated on
+`fork-opus-review.yml`, `fork-gpt-review.yml`, `fork-design-review.yml`,
+`fork-ux-review.yml` and `fork-first-principles-review.yml` each trigger on the
+**completion of `Fast Gate`** (stage 1) and run privileged from the default branch
+(stage 2), gated on
 `workflow_run.head_repository.full_name != github.repository`. Each posts a check-run
 named exactly like its same-repo twin (`Opus 4.8 Review`, `GPT 5.6 Review`,
-`Design Review`, `UX Review`), so branch protection is satisfied on either path, and
-it opens that check-run as early as possible keyed to `head_sha` so a job that dies
-still leaves a fail-closed result. On a fork PR this lane is the **only** publisher
-of that name -- the same-repo twin renames itself (see the reviewer-job security
-posture above) -- so the protected status can only be reported by a review that
-actually ran.
+`Design Review`, `UX Review`, `First Principles Review`), so branch protection is
+satisfied on either path, and it opens that check-run as early as possible keyed to
+`head_sha` so a job that dies still leaves a fail-closed result.
+
+Stage 1 is `Fast Gate` rather than `CI` because what stage 2 needs from stage 1 is a
+TRUSTED workflow's word on the head commit, and `Fast Gate` gives that in about a
+minute where `CI` took ~54. That is a latency change, not a trust change: the
+security properties below hold whatever stage 1 is, since none of them depend on
+`CI` having gone green. `CI`'s verdict was a quality precondition here, never a
+security one — and `fork-workflow-guard.yml`, which IS a security lane, still keys on
+`CI` and is unaffected.
+
+On a fork PR this lane is the **only** publisher of that name -- the same-repo twin
+renames itself (see the reviewer-job security posture above) -- so the protected
+status can only be reported by a review that actually ran.
 
 `fork-gpt-review.yml` publishes its GPT verdict by editing one marker comment in
 place, so an incomplete run must never bury a posted verdict (the class of bug tracked

--- a/docs/ci/harness-parity-gate.md
+++ b/docs/ci/harness-parity-gate.md
@@ -11,7 +11,7 @@ judgment-only ones it cannot, are catalogued in
 
 | Where | Command | Fails the build |
 |---|---|---|
-| CI job `harness-parity` in `ci.yml` | `check_harness_parity.py --test` then the diff-scoped run | yes — `CI` is a required check, so every job in it is blocking |
+| Job `harness-parity` in `fast-gate.yml` | `check_harness_parity.py --test` then the diff-scoped run | yes — `Fast Gate` is a required check of its own, so every job in it is blocking |
 | CI job `test` (ordinary pytest) | `test/test_harness_parity.py` | yes — 22 structural pins, groups A and C |
 | The four AI review lanes | the `harness-parity` rule in `AUTOSDE.yaml`, `blocking: true` | yes — a violation of a blocking rule blocks |
 | Locally | `HARNESS_BASE_REF=origin/main python3 scripts/check_harness_parity.py` | exit 1 on any violation |

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/kirocrew-worktree-dev/SKILL.md
@@ -59,8 +59,11 @@ To clean up after merging: `git worktree remove ../kirocrew-wt-<name>`
 
 ## Rule 2 — The build gate (ALL must pass before PR)
 
-**`.github/workflows/ci.yml` is the canonical gate list** — it is what actually
-gates the PR; if this skill and CI disagree, CI wins. What this rule adds is
+**`.github/workflows/ci.yml` plus `.github/workflows/fast-gate.yml` are the
+canonical gate list** — they are what actually gates the PR; if this skill and
+CI disagree, CI wins. The eleven cheap blocking gates live in `fast-gate.yml`
+and `ci.yml` blocks on it through `await-fast-gate`, so reading only `ci.yml`
+shows you the expensive half of the gate list and none of the fast half. What this rule adds is
 the worktree-specific gotchas (parallelism, mypy CI-parity, dist ordering),
 not a replacement gate list.
 
@@ -102,7 +105,8 @@ python -m pytest -q --override-ini="addopts=--ignore=build/private -n auto --dis
 
 Never a bare `--override-ini=addopts=` (it silently drops `--dist loadgroup`).
 For the full gate list itself, don't trust any restated copy (including this
-one) — read `.github/workflows/ci.yml`, which is what actually gates the PR.
+one) — read `.github/workflows/ci.yml` AND `.github/workflows/fast-gate.yml`,
+which together are what actually gates the PR.
 
 **Triaging failures: blame your change last, but verify.** Some hosts carry
 environment-specific failures (permissions, missing optional binaries) that are

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/references/gate-floor.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/references/gate-floor.md
@@ -38,6 +38,15 @@ scan. CI runs `check_brand_name.py --test` before the scan and `docs_lint.py
 while the scan stays clean, so a floor carrying only the scan passes locally and
 fails after push. Both self-tests sit ahead of their scans in `gates[]`.
 
+Note that "CI" here means both workflows. The eleven cheapest blocking gates —
+`scrub-lint`, `vendor-manifest`, `brand-lint`, `focus-cue-lint`,
+`feature-map-lint`, `changelog-history`, `builtin-skill-scope`,
+`loop-bound-locks`, `testpaths-coverage`, `harness-parity` and `docs-lint` — run
+in `.github/workflows/fast-gate.yml`, not `ci.yml`, so `ci.yml` gaining a
+blocking scan is no longer the only way the floor can fall behind. The commands
+are unchanged, so `gates[]` needs no edit for the move itself; what the split
+costs is described under "Scan by every shape a step can take" below.
+
 ## Derive a ratchet; never transcribe it
 
 `npx eslint src/ --max-warnings <n>` is not interchangeable with the repo's own
@@ -136,6 +145,13 @@ a blocking scan fails a test rather than surfacing as a review round on a later
 PR. A check written as a bare binary (`cfn-lint`, `mypy`, `flake8`) is invisible to
 a `scripts/`-and-`npm run` scan, so the parity test also enumerates the **tool
 names** `ci.yml` invokes and makes each one either a gate or a named exemption.
+
+That test reads `ci.yml` and only `ci.yml`, which the Fast Gate split turned into a
+hole rather than a failure: the eleven gates it moved are all still in `gates[]`, so
+nothing goes red, but a NEW blocking gate added to `fast-gate.yml` would no longer
+fail this test when the floor misses it — exactly the review round the parity test
+exists to prevent. Extend the scan to both workflow files before adding a gate
+there.
 
 Strip comment-only lines before any such scan. `ci.yml` names commands in prose as
 well as running them — the Type check step's comment explains why it spells out

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -17,6 +17,15 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 # Both first-principles lanes carry byte-identical reasoning, so every
 # contract assertion runs against the pair.
 FP_LANES = ("first-principles-review.yml", "fork-first-principles-review.yml")
+# Every privileged Stage-2 fork reviewer. They share one trigger contract, so the
+# trigger assertions run against the whole set rather than one sampled lane.
+FORK_REVIEW_LANES = (
+    "fork-opus-review.yml",
+    "fork-gpt-review.yml",
+    "fork-design-review.yml",
+    "fork-ux-review.yml",
+    "fork-first-principles-review.yml",
+)
 REVIEW_PROMPTS = ROOT / ".github" / "review-prompts"
 PREPARE_PR_SKILL = ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "prepare-pr" / "SKILL.md"
 PREPARE_PR_FINDINGS = ROOT / "src" / "kiro_crew" / "builtin_skills" / "kirocrew-dev" / "prepare-pr" / "scripts" / "pr_findings.py"
@@ -774,6 +783,12 @@ class TestPrReadiness:
         assert "      - CodeQL" in workflow
         for workflow_name in (
             "ci.yml|CI",
+            # Fast Gate carries the eleven cheap blocking gates that used to sit
+            # inside CI. Splitting them out gave the fork reviewers something to
+            # key on in ~1 minute instead of CI's ~54, but a split-out lane that
+            # readiness does not aggregate is a gate that can go red without
+            # turning the PR red -- so it is pinned here exactly like CI.
+            "fast-gate.yml|Fast Gate",
             "build.yml|Build",
             "code-review.yml|Code Review",
             "dynamic/github-code-scanning/codeql|CodeQL",
@@ -783,6 +798,21 @@ class TestPrReadiness:
         ):
             assert workflow_name in workflow
         assert 'success|skipped) passed+=("$label")' in workflow
+
+    def test_readiness_listens_for_the_fast_gate_run_and_carves_it_out_when_stacked(
+        self,
+    ) -> None:
+        # Aggregating a lane is only half the wiring: readiness re-evaluates on
+        # `workflow_run: completed`, so a lane missing from the trigger allowlist
+        # is read at whatever state the LAST unrelated trigger saw it in.
+        workflow = _workflow("pr-readiness.yml")
+
+        assert "      - Fast Gate" in workflow
+        # Fast Gate inherits CI's `branches:` filter, so on a stacked PR it never
+        # starts -- and a pinned lane that never starts freezes the verdict at
+        # pending forever. It must ride in the same carve-out as CI and Build.
+        assert 'skipped+=("CI (only runs on PRs to $DEFAULT_BRANCH)")' in workflow
+        assert 'skipped+=("Fast Gate (only runs on PRs to $DEFAULT_BRANCH)")' in workflow
 
     def test_fork_readiness_reads_ai_reviews_from_check_runs(self) -> None:
         # A fork head cannot run default-setup CodeQL, but the AI code reviews
@@ -1168,7 +1198,15 @@ class TestFirstPrinciplesReview:
         assert "ref: ${{ steps.pr.outputs.base_sha }}" in workflow
         assert "never applied to the tree" in workflow
         assert "egress-policy: block" in workflow
-        assert 'workflows: ["CI"]' in workflow
+        # Stage 2 still starts only after a TRUSTED workflow has vouched for the
+        # head commit -- that workflow is now Fast Gate rather than CI. CI's
+        # green was a quality precondition here, never a security one: the trust
+        # boundary is harden-runner + the base checkout + the diff-as-data read
+        # asserted above. Waiting for all of CI put this verdict ~54 minutes out
+        # (CI's median wall clock), 73.7% of it the backend matrix, which tells
+        # this reviewer nothing.
+        assert 'workflows: ["Fast Gate"]' in workflow
+        assert 'workflows: ["CI"]' not in workflow
         assert (
             "github.event.workflow_run.head_repository.full_name != github.repository"
             in workflow
@@ -3121,6 +3159,88 @@ class TestLedgerReadFailureFailsClosed:
         assert 'issues/$PR/comments" --paginate 2>/dev/null' not in block
         assert "|| true" not in block
         assert "|| printf" not in block
+
+
+class TestForkReviewersAreStageTwoOfFastGate:
+    """The fork reviewers hold `pull-requests: write` and `id-token: write` on a
+    PR whose author is untrusted, so they may not be reachable from any
+    fork-controlled event: `workflow_run` is the ONLY trigger, and it fires only
+    after a workflow on the DEFAULT branch has already run against the head
+    commit.
+
+    Which trusted workflow that is, is a cost decision, not a security one. It
+    used to be CI, whose median wall clock is ~54 minutes -- 73.7% of it the
+    backend matrix, which tells a code reviewer nothing. It is now Fast Gate,
+    the eleven cheap blocking gates split out of CI, which finishes in about a
+    minute. The trust boundary is unchanged and lives in the steps: harden-runner
+    with a blocked egress policy, a checkout of the BASE commit, and the fork's
+    diff read as data that is never applied to the tree.
+    """
+
+    def _triggers(self, name: str) -> dict:
+        spec = yaml.safe_load(_workflow(name))
+        # `on` is a YAML 1.1 boolean, so PyYAML keys the trigger block on True.
+        on = spec.get("on", spec.get(True))
+        assert isinstance(on, dict), name
+        return on
+
+    @pytest.mark.parametrize("name", FORK_REVIEW_LANES)
+    def test_lane_waits_for_fast_gate_and_nothing_else(self, name: str) -> None:
+        on = self._triggers(name)
+
+        # Exactly one trigger, and it is the trusted-vouch one. Any additional
+        # entry here (`pull_request_target`, `issue_comment`, `workflow_call`) is
+        # a fork-reachable door into a privileged lane.
+        assert set(on) == {"workflow_run"}, name
+        assert on["workflow_run"]["workflows"] == ["Fast Gate"], name
+        assert on["workflow_run"]["types"] == ["completed"], name
+
+    @pytest.mark.parametrize("name", FORK_REVIEW_LANES)
+    def test_lane_is_not_reachable_from_a_fork_controlled_event(self, name: str) -> None:
+        on = self._triggers(name)
+        workflow = _workflow(name)
+
+        for fork_controlled in (
+            "pull_request",
+            "pull_request_target",
+            "issue_comment",
+            "pull_request_review",
+            "pull_request_review_comment",
+        ):
+            assert fork_controlled not in on, f"{name}: {fork_controlled}"
+        # And the job still only proceeds for a head that is actually a fork, so
+        # a same-repo PR cannot double-publish through this lane.
+        assert (
+            "github.event.workflow_run.head_repository.full_name != github.repository"
+            in workflow
+        ), name
+
+    @pytest.mark.parametrize("name", FORK_REVIEW_LANES)
+    def test_swapping_the_trusted_gate_did_not_relax_the_trust_boundary(
+        self, name: str
+    ) -> None:
+        # Fast Gate is cheaper than CI, so the security properties that were
+        # never CI's job to provide must be visibly still here.
+        workflow = _workflow(name)
+
+        assert "egress-policy: block" in workflow, name
+        assert "ref: ${{ steps.pr.outputs.base_sha }}" in workflow, name
+        assert "actions/checkout" in workflow, name
+        # The head SHA comes from the event payload GitHub sets, never from
+        # fork-authored text.
+        assert "github.event.workflow_run.head_sha" in workflow, name
+
+    @pytest.mark.parametrize("name", FORK_REVIEW_LANES)
+    def test_lane_records_why_it_no_longer_waits_for_ci(self, name: str) -> None:
+        # A future reader seeing a security-sensitive lane keyed on a one-minute
+        # gate will otherwise "restore" the CI dependency and pay 54 minutes for
+        # a precondition that was never load-bearing.
+        flat = _flat(_workflow(name))
+
+        assert "Fast Gate, not CI" in flat, name
+        assert "median wall clock" in flat, name
+        assert "backend matrix" in flat, name
+        assert "never a security" in flat, name
 
 
 class TestProtectedCheckNameHasOnePublisherPerPrType:

--- a/test/test_builtin_skill_scope.py
+++ b/test/test_builtin_skill_scope.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import yaml
 from skill_script_helpers import load_skill_script
 
 from conftest import requires_symlinks
@@ -299,7 +300,28 @@ class TestTheCommittedTreeAgrees:
 
     def test_the_gate_is_wired_into_ci(self) -> None:
         """A scanner nothing runs is documentation. Also pinned in the prepare-pr
-        gate floor by test_prepare_pr_profiles.py."""
-        ci = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-        assert "python3 scripts/check_builtin_skill_scope.py --test" in ci
-        assert "python3 scripts/check_builtin_skill_scope.py\n" in ci
+        gate floor by test_prepare_pr_profiles.py.
+
+        The gate lives in fast-gate.yml, not ci.yml: the eleven cheap blocking
+        gates were split into their own workflow so ci.yml's heavy matrix can
+        wait on their verdict instead of racing it. ci.yml still BLOCKS on this
+        gate transitively, through its ``await-fast-gate`` job, so the wiring
+        assertion has to read the file that now carries the invocation.
+        """
+        gate = (ROOT / ".github" / "workflows" / "fast-gate.yml").read_text(encoding="utf-8")
+        assert "python3 scripts/check_builtin_skill_scope.py --test" in gate
+        assert "python3 scripts/check_builtin_skill_scope.py\n" in gate
+
+    def test_the_gate_is_unconditional(self) -> None:
+        """Both halves of the wiring: the invocation above, and the job carrying
+        it running on every event the workflow fires on. A ``needs:`` would let a
+        failed sibling skip it, and an ``if:`` (a path filter's surface output,
+        say) would let a diff shape dodge it -- either one turns the absolute,
+        baseline-free rule into one that only sometimes runs.
+        """
+        workflow = yaml.safe_load(
+            (ROOT / ".github" / "workflows" / "fast-gate.yml").read_text(encoding="utf-8")
+        )
+        job = workflow["jobs"]["builtin-skill-scope"]
+        assert "needs" not in job, "builtin-skill-scope gained a dependency and can now be skipped"
+        assert "if" not in job, "builtin-skill-scope gained a condition and can now be dodged"

--- a/test/test_fast_gate_barrier.py
+++ b/test/test_fast_gate_barrier.py
@@ -1,0 +1,419 @@
+"""The Fast Gate barrier: what `await-fast-gate` must guarantee for the split to be safe.
+
+The eleven cheap blocking gates live in ``.github/workflows/fast-gate.yml`` so that
+two consumers can key on them before the expensive work starts: ci.yml's heavy jobs
+wait through ``await-fast-gate``, and the five fork reviewers trigger on the
+workflow's completion. A ``needs:`` edge cannot cross a workflow file, so that
+barrier is a job that READS the other workflow's run -- and everything that makes a
+read trustworthy has to be asserted, because none of it is enforced by GitHub.
+
+Three properties, each of which fails silently rather than loudly if it regresses:
+
+1. The barrier identifies the run by the full identity triple. A head SHA is not a
+   unique key: two pull requests can carry the same head commit, and each gets its
+   own Fast Gate run on it. Keyed on the SHA alone the barrier reads whichever run
+   is newest -- possibly another PR's -- and releases this PR's matrix on a gate
+   that never ran against its base. Raised as a blocking finding by GPT 5.6 on the
+   commit that introduced the barrier.
+
+2. The barrier fails CLOSED in every direction. A barrier that passes when it could
+   not read its subject is worse than no barrier, because the matrix runs anyway
+   and the log claims it was cleared to.
+
+3. Every job that costs real runner time waits on it, and the jobs that must NOT
+   wait on it still do not -- `changes` because it produces the outputs the gating
+   conditions read, and the two coverage reporters because a skipped required check
+   reads to GitHub as satisfied.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_FAST_GATE = _REPO_ROOT / ".github" / "workflows" / "fast-gate.yml"
+
+# The eleven gates the split moved. Named explicitly rather than derived from the
+# file, so a gate silently DROPPED during a future edit fails here.
+_GATE_JOBS = (
+    "scrub-lint",
+    "vendor-manifest",
+    "brand-lint",
+    "focus-cue-lint",
+    "feature-map-lint",
+    "changelog-history",
+    "builtin-skill-scope",
+    "loop-bound-locks",
+    "testpaths-coverage",
+    "harness-parity",
+    "docs-lint",
+)
+
+# DENY-BY-DEFAULT: every job in ci.yml must wait for the barrier unless it is
+# exempt here for a reason that is not about cost. An enumeration of the jobs that
+# MUST carry the edge goes stale the moment someone adds a job -- the new one would
+# race the gates while this file stayed green, which is precisely the defect class
+# this change harvested. Inverting it makes a new job fail until its author either
+# wires the edge or records why it cannot have one.
+# Must not reach the barrier at all, by any path.
+_MUST_NOT_REACH: dict[str, str] = {
+    "changes": (
+        "produces the surface outputs every gating `if:` reads; behind the barrier "
+        "those outputs are empty strings and each consumer silently flips"
+    ),
+    "await-fast-gate": "is the barrier",
+}
+
+# These DO reach the barrier, unavoidably -- they consume the shards' artifacts. What
+# protects them is not the absence of the dependency but a guard that still emits a
+# verdict when an upstream is skipped, asserted in
+# test_the_coverage_reporters_survive_a_gate_skipped_upstream below. Listing them here
+# says "reaching the barrier is expected", not "unchecked".
+_REACHES_BUT_SURVIVES_A_SKIP: dict[str, str] = {
+    "coverage-gate": (
+        "runs `if: always()` so a required check emits a real verdict -- GitHub "
+        "reports a SKIPPED required check as satisfied, so a silent skip here would "
+        "remove the coverage floor exactly when the barrier skips the shards"
+    ),
+    "frontend-coverage-merge": (
+        "`!cancelled()` plus an explicit `!= 'skipped'` so a FAILED shard set still "
+        "gets stitched while a skipped one does not produce an empty merge"
+    ),
+}
+
+_EDGE_EXEMPT: dict[str, str] = {**_MUST_NOT_REACH, **_REACHES_BUT_SURVIVES_A_SKIP}
+
+
+def _workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def ci() -> dict:
+    return _workflow(_CI)
+
+
+@pytest.fixture(scope="module")
+def fast_gate() -> dict:
+    return _workflow(_FAST_GATE)
+
+
+@pytest.fixture(scope="module")
+def barrier_step(ci: dict) -> dict:
+    steps = ci["jobs"]["await-fast-gate"]["steps"]
+    assert len(steps) == 1, "the barrier is one step; update this contract if it grows"
+    return steps[0]
+
+
+class TestTheGatesLiveInTheGateWorkflow:
+    def test_all_eleven_gates_are_in_fast_gate_and_none_left_in_ci(
+        self, ci: dict, fast_gate: dict
+    ) -> None:
+        missing = [job for job in _GATE_JOBS if job not in fast_gate["jobs"]]
+        assert not missing, f"gate job(s) absent from fast-gate.yml: {missing}"
+        # The other direction matters just as much: a gate re-added to ci.yml would
+        # run beside the matrix again, which is the arrangement this split removed.
+        strays = [job for job in _GATE_JOBS if job in ci["jobs"]]
+        assert not strays, f"gate job(s) back in ci.yml, racing the matrix again: {strays}"
+
+    @pytest.mark.parametrize("job", _GATE_JOBS)
+    def test_every_gate_is_unconditional(self, fast_gate: dict, job: str) -> None:
+        # A `needs:` lets a failed sibling skip it and an `if:` lets a diff shape
+        # dodge it. These gates are cheap precisely so that neither is needed.
+        spec = fast_gate["jobs"][job]
+        assert "needs" not in spec, f"{job} gained a dependency and can now be skipped"
+        assert "if" not in spec, f"{job} gained a condition and can now be dodged"
+
+    def test_the_gate_workflow_matches_ci_triggers(self, ci: dict, fast_gate: dict) -> None:
+        # `on` is a YAML 1.1 boolean, so PyYAML keys the trigger block on True.
+        ci_on = ci.get("on", ci.get(True))
+        fg_on = fast_gate.get("on", fast_gate.get(True))
+        assert fg_on == ci_on, (
+            "Fast Gate's triggers drifted from ci.yml's. They must match: a WIDER "
+            "filter newly reviews fork PRs on a non-main base (the fork reviewers key "
+            "on this workflow), and a NARROWER one leaves await-fast-gate waiting for "
+            "a run that never starts."
+        )
+
+
+class TestTheBarrierIdentifiesTheRightRun:
+    def test_the_lookup_binds_branch_and_head_repository_not_just_the_sha(
+        self, barrier_step: dict
+    ) -> None:
+        env, script = barrier_step["env"], barrier_step["run"]
+
+        # The identity triple has to be available to the step at all...
+        for var in ("SHA", "EVENT", "BRANCH", "HEAD_REPO"):
+            assert var in env, f"the barrier no longer resolves {var}"
+        # ...and every part of it has to reach the query or the selection.
+        assert "head_sha=$SHA" in script
+        assert "event=$EVENT" in script
+        assert "branch=$BRANCH" in script, (
+            "the run lookup dropped the branch filter: two PRs sharing a head commit "
+            "would then read each other's Fast Gate verdict"
+        )
+        assert ".head_branch == $branch" in script, (
+            "the branch match must be re-asserted on the selected run, not left to a "
+            "server-side filter that could be ignored"
+        )
+        assert ".head_repository.full_name == $repo" in script, (
+            "without the head-repository match, a fork pushing the same branch name at "
+            "the same commit answers for this PR"
+        )
+
+    def test_the_sha_is_the_head_not_the_merge_commit(self, barrier_step: dict) -> None:
+        # github.sha on a pull_request event is the ephemeral merge commit, which no
+        # Fast Gate run is ever keyed to.
+        sha = barrier_step["env"]["SHA"]
+        assert "github.event.pull_request.head.sha" in sha
+        assert "github.sha" in sha, "the push path still needs a sha"
+
+    def test_the_run_is_selected_after_filtering_never_before(self, barrier_step: dict) -> None:
+        # Scoped to the jq program, not the whole step: the prose above it names
+        # max_by(.id) while explaining why the order matters, and searching the raw
+        # script would match that comment and "prove" the ordering from a sentence.
+        selector = TestTheSelectorBehavesOnRealPayloadShapes._selector(barrier_step["run"])
+        select_at = selector.find(".head_repository.full_name == $repo")
+        collapse_at = selector.find("max_by(.id)")
+        assert select_at != -1, "the selector lost its head-repository match"
+        assert collapse_at != -1, "the selector lost its collapse"
+        assert select_at < collapse_at, (
+            "max_by(.id) runs before the identity filter, so the NEWEST run wins "
+            "regardless of whose it is -- the exact collision this guards"
+        )
+
+
+class TestTheBarrierFailsClosed:
+    def test_all_three_unreadable_outcomes_exit_non_zero(self, barrier_step: dict) -> None:
+        script = barrier_step["run"]
+        # A run that never appears, one that never completes, and one that completed
+        # non-success are three distinct paths, and each must be an error exit.
+        assert (
+            script.count("::error::") >= 3
+        ), "one of the barrier's failure paths stopped reporting an error"
+        assert script.count("exit 1") >= 3, (
+            "one of the barrier's failure paths stopped exiting non-zero -- a barrier "
+            "that returns 0 when it could not confirm the gates clears the matrix on "
+            "no evidence"
+        )
+        assert "exit 0" in script, "the success path must still release the matrix"
+
+    def test_the_only_success_path_is_a_successful_conclusion(self, barrier_step: dict) -> None:
+        script = barrier_step["run"]
+        head, _, tail = script.partition("success)")
+        assert tail, "the conclusion case statement lost its success branch"
+        # `exit 0` may appear only under that branch; anything earlier would release
+        # the matrix before the conclusion was read.
+        assert "exit 0" not in head, "the barrier can exit 0 before reading a conclusion"
+
+    def test_the_budgets_are_bounded_and_the_job_has_a_timeout(
+        self, ci: dict, barrier_step: dict
+    ) -> None:
+        script = barrier_step["run"]
+        assert "APPEAR_BUDGET=" in script and "TOTAL_BUDGET=" in script
+        # The job cap has to outlast the poll budget, or the step is killed before it
+        # can report its own fail-closed verdict and the job reports a timeout instead.
+        total = int(script.split("TOTAL_BUDGET=", 1)[1].split("\n", 1)[0].strip())
+        cap_seconds = int(ci["jobs"]["await-fast-gate"]["timeout-minutes"]) * 60
+        assert cap_seconds > total, (
+            f"timeout-minutes ({cap_seconds}s) must exceed TOTAL_BUDGET ({total}s) so "
+            "the step reports the verdict rather than being killed mid-poll"
+        )
+
+    def test_reading_another_workflows_runs_is_granted_explicitly(self, ci: dict) -> None:
+        # Job-level permissions REPLACE the top-level grant, so actions:read has to be
+        # restated here or the API read 404s and the barrier fails closed on every run.
+        perms = ci["jobs"]["await-fast-gate"]["permissions"]
+        assert perms.get("actions") == "read"
+        assert perms.get("contents") == "read"
+
+
+class TestTheEdgeReachesEveryExpensiveJob:
+    @staticmethod
+    def _needs(ci: dict, job: str) -> list[str]:
+        needs = ci["jobs"][job].get("needs") or []
+        return [needs] if isinstance(needs, str) else list(needs)
+
+    @classmethod
+    def _waits_for_barrier(cls, ci: dict, job: str) -> bool:
+        """Is the barrier reachable from this job through `needs`?
+
+        Reachability, not a direct edge: coverage-combine needs backend-test, which
+        carries the edge, so a red gate skips backend-test and coverage-combine skips
+        with it. Requiring the edge on its own `needs:` would force either a redundant
+        edge or an exemption -- and an exemption granted to a job that is in fact
+        gated is how a genuine hole gets waved through later.
+        """
+        seen: set[str] = set()
+        frontier = [job]
+        while frontier:
+            current = frontier.pop()
+            for parent in cls._needs(ci, current):
+                if parent == "await-fast-gate":
+                    return True
+                if parent not in seen and parent in ci["jobs"]:
+                    seen.add(parent)
+                    frontier.append(parent)
+        return False
+
+    def test_every_job_waits_for_the_barrier_unless_it_is_exempt(self, ci: dict) -> None:
+        unguarded = [
+            job
+            for job in ci["jobs"]
+            if job not in _EDGE_EXEMPT and not self._waits_for_barrier(ci, job)
+        ]
+        assert not unguarded, (
+            f"job(s) in ci.yml start without the Fast Gate verdict: {sorted(unguarded)}. "
+            "Add `await-fast-gate` to their `needs:`, or -- if one genuinely must run "
+            "before the gates are known -- add it to _EDGE_EXEMPT with the reason."
+        )
+
+    def test_the_exemption_list_measures_something(self, ci: dict) -> None:
+        # A stale exemption is how deny-by-default rots back into an allowlist: a
+        # renamed job leaves an entry that exempts nothing while the real job goes
+        # unchecked.
+        stale = sorted(set(_EDGE_EXEMPT) - set(ci["jobs"]))
+        assert not stale, f"_EDGE_EXEMPT names job(s) that no longer exist: {stale}"
+        # And the inversion only means anything if it is actually guarding jobs.
+        guarded = [job for job in ci["jobs"] if job not in _EDGE_EXEMPT]
+        assert len(guarded) >= 10, (
+            f"only {len(guarded)} job(s) are subject to the edge requirement; the "
+            "exemption list has grown until the contract checks almost nothing"
+        )
+
+    @pytest.mark.parametrize("job", sorted(_MUST_NOT_REACH))
+    def test_a_job_that_must_not_reach_the_barrier_does_not(self, ci: dict, job: str) -> None:
+        # Load-bearing in the other direction: wiring the edge into `changes` breaks
+        # every gating condition in a way that reads as extra safety. Checked
+        # transitively, because inheriting the wait through a parent is just as fatal
+        # as declaring it.
+        assert not self._waits_for_barrier(
+            ci, job
+        ), f"{job} must not depend on the barrier -- {_MUST_NOT_REACH[job]}"
+
+    @pytest.mark.parametrize("job", sorted(_REACHES_BUT_SURVIVES_A_SKIP))
+    def test_a_reporter_that_reaches_the_barrier_can_survive_a_skip(
+        self, ci: dict, job: str
+    ) -> None:
+        # These are allowed to reach it, so the guard is what has to be present: a
+        # bare `success()` here turns a red gate into a SKIPPED required check, which
+        # GitHub reports as satisfied.
+        guard = str(ci["jobs"][job].get("if", ""))
+        assert "always()" in guard or "!cancelled()" in guard, (
+            f"{job} reaches the barrier but has no always()/!cancelled() guard, so a "
+            f"red gate would skip it silently -- {_REACHES_BUT_SURVIVES_A_SKIP[job]}"
+        )
+
+    def test_the_coverage_reporters_survive_a_gate_skipped_upstream(self, ci: dict) -> None:
+        # coverage-gate keeps always() because GitHub reports a SKIPPED required check
+        # as satisfied: without it, a red gate would skip the shards and take the
+        # coverage floor with them.
+        assert "always()" in str(ci["jobs"]["coverage-gate"]["if"])
+        # frontend-coverage-merge solves the mirror-image problem the other way: it
+        # still runs when a shard FAILED (there is a report to stitch) but not when the
+        # shards were skipped (there is not), so it cannot go red for a reason
+        # unrelated to the gate the author has to fix.
+        merge_if = str(ci["jobs"]["frontend-coverage-merge"]["if"])
+        assert "!cancelled()" in merge_if
+        assert "needs.frontend-test.result != 'skipped'" in merge_if
+
+
+class TestTheSelectorBehavesOnRealPayloadShapes:
+    """The assertions above pin the selector's TEXT. This one runs it.
+
+    A jq program can contain every required clause and still pick the wrong run, so
+    the extracted program is executed against payloads shaped like the real
+    ``/actions/workflows/{id}/runs`` response.
+    """
+
+    _BRANCH = "feature/mine"
+    _REPO = "kirodotdev/KiroCrew"
+
+    @staticmethod
+    def _selector(script: str) -> str:
+        start = script.find("'[(.workflow_runs")
+        assert start != -1, "could not locate the selector program in the barrier step"
+        end = script.find("'", start + 1)
+        assert end != -1
+        return script[start + 1 : end]
+
+    @staticmethod
+    def _run(rid: int, branch: str, repo: str) -> dict:
+        return {
+            "id": rid,
+            "head_branch": branch,
+            "status": "completed",
+            "conclusion": "success",
+            "html_url": f"https://github.com/x/actions/runs/{rid}",
+            "head_repository": {"full_name": repo},
+        }
+
+    def _select(self, script: str, payload: dict) -> int | None:
+        if shutil.which("jq") is None:  # pragma: no cover - CI images ship jq
+            pytest.skip("jq is not installed")
+        proc = subprocess.run(
+            [
+                "jq",
+                "-c",
+                "--arg",
+                "branch",
+                self._BRANCH,
+                "--arg",
+                "repo",
+                self._REPO,
+                self._selector(script),
+            ],
+            input=json.dumps(payload),
+            capture_output=True,
+            check=True,
+            # jq emits JSON, which is UTF-8 by specification, so its encoding is
+            # knowable and pinning it is correct. Bare `text=True` would decode with
+            # the locale code page -- the Windows ANSI page on the windows-latest
+            # shard this test also runs on.
+            **UTF8_TEXT,
+        )
+        chosen = json.loads(proc.stdout.strip())
+        return chosen["id"] if isinstance(chosen, dict) else None
+
+    def test_a_colliding_run_on_another_branch_is_refused(self, barrier_step: dict) -> None:
+        payload = {"workflow_runs": [self._run(900, "other/pr", self._REPO)]}
+        assert self._select(barrier_step["run"], payload) is None
+
+    def test_a_fork_reusing_the_branch_name_is_refused(self, barrier_step: dict) -> None:
+        payload = {"workflow_runs": [self._run(901, self._BRANCH, "attacker/KiroCrew")]}
+        assert self._select(barrier_step["run"], payload) is None
+
+    def test_a_newer_colliding_run_does_not_outrank_my_older_one(self, barrier_step: dict) -> None:
+        payload = {
+            "workflow_runs": [
+                self._run(904, self._BRANCH, self._REPO),
+                self._run(999, "other/pr", self._REPO),
+            ]
+        }
+        assert self._select(barrier_step["run"], payload) == 904
+
+    def test_my_own_rerun_collapses_to_the_newest(self, barrier_step: dict) -> None:
+        payload = {
+            "workflow_runs": [
+                self._run(905, self._BRANCH, self._REPO),
+                self._run(906, self._BRANCH, self._REPO),
+            ]
+        }
+        assert self._select(barrier_step["run"], payload) == 906
+
+    @pytest.mark.parametrize("payload", [{"workflow_runs": []}, {}])
+    def test_an_empty_or_absent_list_yields_nothing_rather_than_erroring(
+        self, barrier_step: dict, payload: dict
+    ) -> None:
+        # The caller treats null as "keep waiting", so a jq error here would turn a
+        # transient empty page into a hard failure on the first poll.
+        assert self._select(barrier_step["run"], payload) is None

--- a/test/test_main_ratchet_audit.py
+++ b/test/test_main_ratchet_audit.py
@@ -14,7 +14,8 @@ run that finishes after a newer push must not write its verdict there:
   since been fixed, so main reads as dirty when it is clean.
 
 Two further ways the lane could report a verdict that means less than it looks
-are pinned at the bottom of this module: a gate ADDED to ``ci.yml`` and not
+are pinned at the bottom of this module: a gate ADDED to ``ci.yml`` or to
+``fast-gate.yml`` (the split-out cheap blocking gates ci.yml waits on) and not
 mirrored here would never be measured on the integrated tree, and a gate step
 left on the default ``success()`` condition would skip every later gate as soon
 as one drifted.
@@ -335,7 +336,14 @@ class TestIssueBodyRendering:
 
 
 class TestGateParityWithCi:
-    """A ``scripts/check_*.py`` gate in ci.yml is measured here or accounted for.
+    """A ``scripts/check_*.py`` gate CI blocks on is measured here or accounted for.
+
+    "CI" is two workflow files since the Fast Gate split: ci.yml keeps the heavy
+    matrix, and fast-gate.yml holds the eleven cheap blocking gates that ci.yml's
+    ``await-fast-gate`` job now waits on. Both are read below. Reading only
+    ci.yml would have left eight of the enumerated gates outside the scan the
+    moment they moved -- the subset assertion would still pass, while the
+    accounting sets it checks against silently stopped describing anything.
 
     Scoped to script-invoking gates on purpose. The lane's two pytest-side
     ratchets (the redactor census and the config baseline) are an ORIGINAL
@@ -352,8 +360,8 @@ class TestGateParityWithCi:
     # A gate script cannot merely be absent from this lane; it must be absent for
     # a RECORDED reason. Scoping the pin to ci.yml's `backend-lint` would have
     # missed the repo's dominant shape -- one gate per standalone job -- so the
-    # whole of ci.yml is read and every gate lands in exactly one of the three
-    # sets below. That is what makes a gate added tomorrow a red test rather than
+    # whole of ci.yml AND of fast-gate.yml is read and every gate lands in
+    # exactly one of the three sets below. That is what makes a gate added tomorrow a red test rather than
     # a silent omission.
 
     # No whole-tree question exists to ask on main: each of these judges a CHANGE
@@ -392,20 +400,33 @@ class TestGateParityWithCi:
 
     def test_every_ci_gate_is_mirrored_or_recorded(self) -> None:
         # The silent direction: a renamed script errors its step loudly, but a
-        # gate ADDED to ci.yml and not mirrored here just never runs on main --
+        # gate ADDED to CI and not mirrored here just never runs on main --
         # and its drift then surfaces on an unrelated PR, which is #7511's
-        # failure mode reproduced for every future gate.
-        ci = yaml.safe_load((_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text("utf-8"))
+        # failure mode reproduced for every future gate. Both blocking workflows
+        # count: fast-gate.yml is where the cheap gates live, and ci.yml blocks
+        # on it through `await-fast-gate`, so a gate added to either is a gate CI
+        # enforces.
         audit = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
 
         in_ci: set[str] = set()
-        for job in ci["jobs"].values():
-            in_ci |= self._gate_scripts(job)
+        for name in ("ci.yml", "fast-gate.yml"):
+            workflow = yaml.safe_load(
+                (_REPO_ROOT / ".github" / "workflows" / name).read_text("utf-8")
+            )
+            for job in workflow["jobs"].values():
+                in_ci |= self._gate_scripts(job)
+        # The scan must actually see the moved gates: if a rename or another split
+        # empties it, the subset assertion below passes by measuring nothing.
+        assert self._DEFERRED_WHOLE_TREE_GATES <= in_ci, (
+            "gate script(s) recorded as deferred are no longer run by ci.yml or "
+            f"fast-gate.yml: {sorted(self._DEFERRED_WHOLE_TREE_GATES - in_ci)}. Either they "
+            "moved to a third workflow this scan must read, or the record is stale."
+        )
         measured = self._gate_scripts(audit["jobs"]["ratchet-gates"])
         classified = measured | self._PR_ONLY_BY_CONSTRUCTION | self._DEFERRED_WHOLE_TREE_GATES
 
         assert in_ci <= classified, (
-            "ci.yml runs gate script(s) this lane neither measures nor accounts for: "
+            "CI runs gate script(s) this lane neither measures nor accounts for: "
             f"{sorted(in_ci - classified)}. Mirror the step into ratchet-gates, or record "
             "the reason in _PR_ONLY_BY_CONSTRUCTION (it judges a diff, not a tree) or "
             "_DEFERRED_WHOLE_TREE_GATES. An unclassified gate is never measured on main's "

--- a/test/test_pr_readiness_evaluate.py
+++ b/test/test_pr_readiness_evaluate.py
@@ -783,8 +783,12 @@ class TestAwaitingApprovalIsAttributedToTheMaintainer:
         assert outputs["state"] == "action_required"
         assert outputs["status_state"] == "failure"
         assert outputs["label"] == "readiness: action required"
+        # Four, not three: Fast Gate joined CI, Build and Code Review as a
+        # monitored lane when the cheap blocking gates were split out of ci.yml.
+        # The stub routes every non-ci.yml workflow to green_runs.json, so it is
+        # covered by the same `action_required` fixture as the other two.
         assert outputs["description"] == (
-            "3 workflow(s) awaiting maintainer approval; none has run yet"
+            "4 workflow(s) awaiting maintainer approval; none has run yet"
         )
         assert len(outputs["description"]) <= 140
         summary = (runner.temp / "pr-readiness-summary.md").read_text()
@@ -793,7 +797,9 @@ class TestAwaitingApprovalIsAttributedToTheMaintainer:
         assert "**Waiting**" in summary
         log_line = self._lane_state(proc)
         assert "failed=[]" in log_line
-        assert "awaiting_approval=[CI Build Code Review]" in log_line
+        # Fast Gate sits between CI and Build in the spec order, matching the
+        # order pr-readiness.yml appends the lanes.
+        assert "awaiting_approval=[CI Fast Gate Build Code Review]" in log_line
 
     def test_real_failure_and_approval_wait_are_reported_separately(self, runner: Runner):
         (runner.fixtures / "ci_runs.json").write_text(
@@ -807,8 +813,10 @@ class TestAwaitingApprovalIsAttributedToTheMaintainer:
 
         assert proc.returncode == 0, proc.stderr
         assert outputs["status_state"] == "failure"
+        # Three awaiting, not two: ci.yml is the one blocking item here, and
+        # Build, Code Review and Fast Gate are the lanes left waiting.
         assert outputs["description"] == (
-            "1 blocking readiness item(s); 2 awaiting maintainer approval"
+            "1 blocking readiness item(s); 3 awaiting maintainer approval"
         )
         summary = (runner.temp / "pr-readiness-summary.md").read_text()
         assert "**Blocking**" in summary

--- a/test/test_prepare_pr_profiles.py
+++ b/test/test_prepare_pr_profiles.py
@@ -283,17 +283,28 @@ def test_charter_budgets_match_the_ci_workflows():
 
 
 def _ci_workflow_run_text() -> str:
-    """ci.yml with comment-only lines removed.
+    """Every blocking CI workflow, with comment-only lines removed.
 
     Every scan here matches a COMMAND, never a comment. ci.yml explains in
     prose why the Type check step uses `tsc -b` and not `npm run typecheck`,
     so a naive grep for `npm run <script>` finds a script CI deliberately does
     NOT run -- the same trap as reading a ratchet number out of a comment.
+
+    Both blocking workflows are read, not just ci.yml. The cheap lint gates now
+    live in fast-gate.yml and ci.yml blocks on it through `await-fast-gate`, so a
+    gate in either one is a gate CI enforces and the floor must mirror. Reading
+    ci.yml alone silently dropped eleven jobs' worth of gates out of this scan's
+    view, which is the exact rot this test exists to catch.
     """
-    text = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
+    parts = []
+    for name in ("ci.yml", "fast-gate.yml"):
+        text = (REPO_ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+        parts.append(
+            "\n".join(
+                line for line in text.splitlines() if not line.lstrip().startswith("#")
+            )
+        )
+    return "\n".join(parts)
 
 
 def test_every_floor_command_names_a_real_target():
@@ -355,9 +366,28 @@ def test_ci_blocking_scans_are_covered_by_the_floor():
     }
 
     invoked = set(re.findall(r"\bscripts/[A-Za-z0-9_.-]+\.(?:py|sh)", run_text))
+    # The scan must actually see the gates that live in fast-gate.yml. If a
+    # rename or a further workflow split drops them out of `run_text`, every
+    # assertion below passes by measuring nothing -- green because it looked at
+    # an empty set, which is indistinguishable from green because the floor is
+    # complete. Name a few of the moved gates outright so that silence fails.
+    moved_to_fast_gate = {
+        "scripts/scrub-lint.sh",
+        "scripts/verify_vendor_manifest.py",
+        "scripts/check_brand_name.py",
+        "scripts/docs_lint.py",
+    }
+    assert moved_to_fast_gate <= invoked, (
+        "these gates are no longer visible to this scan: "
+        f"{sorted(moved_to_fast_gate - invoked)}. They ran in ci.yml, then moved to "
+        "fast-gate.yml; if they have moved again, add that workflow to "
+        "_ci_workflow_run_text() -- otherwise this test silently stops checking the "
+        "floor against them."
+    )
+
     missing = sorted(s for s in invoked - exempt_scripts if s not in floor)
     assert not missing, (
-        "ci.yml runs these scripts but the prepare-pr floor does not: "
+        "ci.yml/fast-gate.yml run these scripts but the prepare-pr floor does not: "
         f"{missing}. Add them to profiles/kirocrew.json gates[] in their "
         "CI-exact form, or exempt them here with a reason."
     )

--- a/test/test_vendor_manifest.py
+++ b/test/test_vendor_manifest.py
@@ -6,8 +6,8 @@ lint/format configs all skip it — so a modified vendored ``.py``, a swapped
 native library, or an added rogue file would pass every review gate unnoticed.
 ``scripts/verify_vendor_manifest.py`` closes that gap: a committed sha256
 manifest (``scripts/vendor_manifest.sha256``, deliberately OUTSIDE the
-excluded tree) pins every file's content, and the ``vendor-manifest`` CI job
-fails any PR whose tree diverges from it.
+excluded tree) pins every file's content, and the ``vendor-manifest`` job in
+``.github/workflows/fast-gate.yml`` fails any PR whose tree diverges from it.
 
 These tests exercise the script's LOGIC against small temp-dir fixture trees:
 detection of each divergence class (modified / missing / unexpected),
@@ -28,6 +28,7 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _SCRIPT = _REPO_ROOT / "scripts" / "verify_vendor_manifest.py"
@@ -261,9 +262,24 @@ def test_vendor_text_payloads_are_checkout_byte_stable(pattern: str) -> None:
 
 
 def test_ci_wires_the_manifest_gate() -> None:
-    """ci.yml must run the verifier unconditionally — the vendored tree gets
-    no other content review, so a gate that exists but is not wired (or is
+    """fast-gate.yml must run the verifier unconditionally — the vendored tree
+    gets no other content review, so a gate that exists but is not wired (or is
     hidden behind a path filter's surface outputs) guards nothing.
+
+    The job moved out of ci.yml into fast-gate.yml, which holds the eleven cheap
+    blocking gates so ci.yml's heavy matrix waits on their verdict rather than
+    racing it; ci.yml still blocks on it transitively via ``await-fast-gate``.
+    Unconditionality is asserted structurally rather than as a substring, because
+    the property this test protects is not that the script name appears
+    somewhere — it is that no ``needs:`` and no ``if:`` can keep the job from
+    running on a given diff.
     """
-    text = (_REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    assert "scripts/verify_vendor_manifest.py" in text, "ci.yml does not run the manifest gate"
+    path = _REPO_ROOT / ".github" / "workflows" / "fast-gate.yml"
+    text = path.read_text(encoding="utf-8")
+    assert (
+        "scripts/verify_vendor_manifest.py" in text
+    ), "fast-gate.yml does not run the manifest gate"
+
+    job = yaml.safe_load(text)["jobs"]["vendor-manifest"]
+    assert "needs" not in job, "vendor-manifest gained a dependency and can now be skipped"
+    assert "if" not in job, "vendor-manifest gained a condition and can now be dodged"

--- a/website/src/test/renderVerdict.test.ts
+++ b/website/src/test/renderVerdict.test.ts
@@ -321,17 +321,39 @@ describe('CI supplies a base commit on both paths', () => {
   // nothing. That makes the workflow wiring load-bearing: if a push to main stopped
   // passing `github.event.before`, merges would silently go unchecked and the unit
   // tests above would still pass.
-  const ci = readFileSync(resolve(process.cwd(), '../.github/workflows/ci.yml'), 'utf-8')
+  // Both blocking workflows, not just ci.yml. The cheap diff-scoped gates moved
+  // into fast-gate.yml, which ci.yml blocks on through `await-fast-gate`; reading
+  // ci.yml alone would have silently dropped five of the nine wirings out of this
+  // file's view while every assertion below still passed on the remaining four.
+  const workflowSources = ['ci.yml', 'fast-gate.yml'].map((name) => ({
+    name,
+    text: readFileSync(resolve(process.cwd(), `../.github/workflows/${name}`), 'utf-8'),
+  }))
   // Any `*_BASE_REF` wiring, not just the i18n ones: `brand-lint` passes
   // `BRAND_BASE_REF` and `harness-parity` passes `HARNESS_BASE_REF` through the
   // same resolver and both need the same guarantees.
-  const wirings = ci.match(/^\s*[A-Z0-9_]*BASE_REF: \$\{\{.*$/gm) || []
+  const wiringsBySource = workflowSources.map((source) => ({
+    name: source.name,
+    lines: source.text.match(/^\s*[A-Z0-9_]*BASE_REF: \$\{\{.*$/gm) || [],
+  }))
+  const wirings = wiringsBySource.flatMap((source) => source.lines)
 
   it('wires every diff-scoped gate step', () => {
-    // A count, not a set: the point is that a gate ADDED to ci.yml cannot skip
-    // this file's `base.sha` assertion below by going unnoticed. Bump it when a
-    // diff-scoped gate lands, and check the new wiring is in the loop.
+    // A count, not a set: the point is that a gate ADDED to either workflow
+    // cannot skip this file's `base.sha` assertion below by going unnoticed. Bump
+    // it when a diff-scoped gate lands, and check the new wiring is in the loop.
     expect(wirings).toHaveLength(9)
+  })
+
+  it('still sees a wiring in each workflow it reads', () => {
+    // The count above is the only thing standing between a moved gate and an
+    // unchecked one, and a total can be met while one source contributes zero --
+    // which is exactly what a further split would do. Naming each source keeps
+    // the scan honest instead of merely non-empty.
+    for (const source of wiringsBySource) {
+      expect(source.lines.length, `${source.name} contributed no BASE_REF wiring`)
+        .toBeGreaterThan(0)
+    }
   })
 
   it('diffs a PR against the commit its merge ref was built on, not the branch tip', () => {
@@ -355,8 +377,15 @@ describe('CI supplies a base commit on both paths', () => {
   it('routes each step through the shared resolver', () => {
     // Relative, not a stored total: a step that wires a base ref must also route
     // through the shared resolver, so the two move together as gates are added
-    // and neither number has to be maintained by hand.
-    expect(ci.match(/resolve-i18n-base\.sh/g) || []).toHaveLength(wirings.length)
+    // and neither number has to be maintained by hand. Counted PER WORKFLOW, so a
+    // gate wired in one file cannot be paid for by a resolver call in the other.
+    for (const source of wiringsBySource) {
+      const text = workflowSources.find((s) => s.name === source.name)!.text
+      expect(
+        text.match(/resolve-i18n-base\.sh/g) || [],
+        `${source.name} wires ${source.lines.length} base ref(s) but does not route each one`,
+      ).toHaveLength(source.lines.length)
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

Every CI job starts at once. A gate that goes red in twenty seconds still lets the whole expensive matrix run to completion beside it, and a fork PR's AI verdict waits for that matrix to finish before it starts.

Measured on this repo (GitHub Actions API, 16 completed CI pull_request runs plus a 12-run cancelled sample):

- The eleven cheap blocking gates cost **198 job-seconds** between them, ~70% of which is runner acquisition and checkout. Their parallel critical path is **~44 seconds**.
- A median CI run is **240 job-minutes** and **54 minutes** of wall clock. The eight `backend-test` shards alone are **73.7%** of those job-minutes.
- In 2 of 16 completed runs a blocking AI reviewer went red while the backend shards were still running, burning **153 and 133 backend job-minutes after the verdict was already known** — 79% of those runs' backend minutes, 10.1% across the sample.
- Fork lanes trigger on `workflow_run: ["CI"] completed`, so a fork PR's AI verdict arrives ~54 minutes in, and 73.7% of that wait is a matrix that tells a code reviewer nothing.

## Change

The eleven gates move **verbatim** into a new `Fast Gate` workflow, triggers copied from `ci.yml` unchanged (`branches: [main]` included). Two consumers now wait on it.

**`ci.yml` gains one `await-fast-gate` job**, and every job that costs real runner time waits on it. A `needs:` edge cannot cross a workflow file, which is why the barrier is a job that reads the other workflow's run rather than a dependency GitHub resolves. It **fails closed** in all three ways it can go wrong — a run that never appears (180s budget), one that never completes (720s budget), one that completes non-success — because a barrier that passed when it could not read its subject would be worse than none: the matrix would run anyway and the log would claim it was cleared to.

**The lookup does not key on the head SHA alone.** A head SHA is not a unique run identity: two PRs can carry the same head commit (a shared branch, a cherry-pick, a fork branch pushed to a second PR) and each gets its own Fast Gate run on it. Keyed on the SHA alone the barrier would read whichever run is newest — possibly another PR's — and release this PR's matrix on a gate that never ran against its base. It matches head branch and head repository too, and re-asserts both on the selected run, because `branch=` is a server-side hint and a filter the API silently ignored would leave `max_by(.id)` picking the newest colliding run. Filter first, collapse second.

**The five fork reviewers** move their `workflow_run` source from `CI` to `Fast Gate`. They remain stage 2 of the two-stage design and remain unreachable from any fork-controlled event. This is a latency change, not a trust change: the boundary is harden-runner with a blocked egress policy, a checkout of the **base** commit, and the fork's diff read as data that never reaches the tree. CI's green was a quality precondition here, never a security one — and `fork-workflow-guard.yml`, which **is** a security lane, still keys on `CI`.

**Fast Gate is a readiness lane in its own right**, not merely CI's precondition: a red gate must red the PR, and `await-fast-gate` reports its own failure rather than naming the gate that broke, so the readable verdict has to come from the gate workflow. It inherits CI's branch filter, so it joins CI and Build in the stacked-PR carve-out — a pinned lane that never starts would freeze the verdict at pending forever.

### Two skip-propagation hazards, both handled

`coverage-gate` keeps its `always()`. A red gate now deliberately **skips** `backend-test` and `frontend-test`, and GitHub reports a skipped required check as *satisfied* — so without that step the barrier built to save runner time would have quietly removed the coverage floor.

`frontend-coverage-merge` needed the opposite fix. Its `!cancelled()` gained an explicit `needs.frontend-test.result != 'skipped'` clause: a skipped shard set has nothing to stitch, while a **failed** one still does, so the clause names `skipped` and not both. Without it the merge would go red for a reason unrelated to the gate the author has to fix.

### The arrangement is pinned, deny-by-default

`test/test_fast_gate_barrier.py` (33 tests) exists because none of this is enforced by GitHub: all eleven gates are present in the gate workflow and none has crept back into `ci.yml`, each is unconditional, the two workflows' triggers stay identical, the lookup binds the full identity triple and filters before it collapses, all three unreadable outcomes exit non-zero, the job cap outlasts the poll budget, and `actions:read` is restated at job level.

The edge requirement is **deny-by-default and measured by reachability**. Every job in `ci.yml` must be able to reach the barrier through `needs` unless it is listed with a reason — an enumeration of the jobs that *must* carry the edge goes stale the moment someone adds a job, and the new one would race the gates while the file stayed green. Reachability rather than a direct edge, because `coverage-combine` already inherits the wait through `backend-test`, and demanding its own edge would have forced either a redundant one or an exemption that later hides a real hole.

Writing it that way also split "exempt" into the two invariants it had been conflating: `changes` must not reach the barrier by **any** path, since it produces the surface outputs every gating condition reads, while the two coverage reporters unavoidably reach it (they consume shard artifacts) and are protected instead by the `always()`/`!cancelled()` guard that makes them emit a verdict when an upstream skips.

The jq selector is also **executed** against payloads shaped like the real `/actions/workflows/{id}/runs` response — a colliding run on another branch, a fork reusing the branch name, a newer colliding run beside an older own run, an own re-run, an empty page — because a jq program can contain every required clause and still pick the wrong run.

## What was deliberately NOT done

The eleven gates are **not merged into fewer jobs**. Measured, that saves 0.9% of a run and costs a `persist-credentials` conflict (six jobs pin `false` as hardening; five diff-scoped gates deliberately keep credentials for `resolve-i18n-base.sh`, whose failure path is `exit 1`), plus breakage in indentation- and job-id-pinned contracts. Not worth it.

The same-repo reviewers are **not** gated. They already fire at `t=0` on `pull_request` and their 2–6 minute verdicts are the loop's fastest real signal; converting them to `workflow_run` would change their run `event` and `pr-readiness.yml` filters on `event=pull_request`, freezing those lanes at "(not started)" forever.

Cancelling an in-flight CI run when a blocking reviewer goes red — the 10.1% above — is a **separate** change, deliberately not in this PR. GitHub can only cancel a whole run, so it would discard that round's lint/frontend/e2e results too, and a false-positive verdict would throw away a good run. It needs its own design and its own review.

## Pattern harvest

Defect class: a test that locates its subject by reading ONE hardcoded workflow file, or that enumerates the members it expects to find, keeps passing when the subject moves or a new member appears — green because it measured an empty or stale set, indistinguishable from green because the property holds.

Five instances landed in this change, and **which ones failed is the lesson.** The two whose assertion is a subset check passed **vacuously**: `test_main_ratchet_audit.py` lost eight gate scripts from its view while `in_ci <= classified` still held, and `test_prepare_pr_profiles.py` lost twelve, silently stopping enforcement of the prepare-pr gate floor. The two whose assertion is a **stored total** failed loudly and were caught by CI: `renderVerdict.test.ts` counts nine `*_BASE_REF` wirings and saw four, and `test_pr_readiness_evaluate.py` pins the monitored-lane count at three and saw four. The fifth was this change's **own** new test file, whose hardcoded list of gated jobs would not have required the edge of any job added later — found by rebasing onto a main commit that touched `ci.yml`, and fixed by inverting it.

Rule candidate: a test whose assertion is a subset, containment, or enumeration over a set it *discovers* must either assert the set is non-empty and names an expected member, or be inverted into deny-by-default so an unlisted member fails rather than passes.

## Verification

- 746 tests pass across the sixteen CI-contract files, including the 33 barrier tests.
- Nine mutations revert-verified on the barrier contract: drop the `branch=` filter, drop the head-repo match, let the unreadable path exit 0, shrink the job cap below the poll budget, drop `actions:read`, remove the edge from `backend-test`, **add a new expensive job with no edge**, give `changes` a barrier dependency, drop `coverage-gate`'s `always()`. All nine turn it red; the restored tree is green.
- Revert-verified on the two count fixes: narrowing either widened scan back to `("ci.yml",)` fails it, and restoring the monitored-lane count of three fails.
- Coverage of the fork trigger contract went **up**: it was pinned on one lane, now on all five, and `workflow_run` being their *sole* trigger is pinned too.
- All 8 diff-scoped gates run with their `*_BASE_REF` exported (unset reverts them to report mode and fake-green). Black gate clean, `tsc -b`, `eslint`, `isort`, `flake8` clean, `docs-lint.sh` clean over 260 files, all workflows parse.

## Rebased onto main to clear two inherited reds

- `Bundle Size Gate` — `449425a50` (#8519) re-measures the drifted App-chunk ceiling from 3200 KB to 3360 KB, and records that main's tip alone reproduces the failure with no PR code. The earlier revision of this PR hit it with a byte-identical bundle (same `App-DNyuWkPi.js` content hash as main run 33911144067).
- `test_slot_close_recreation_race.py` timeouts and the `can_read_body` double — `35426b9ea` (#8583).

`scrub-lint` reports `/home/tést` in `test/test_atomic_write_named_duplicates.py:155,157` when run locally, and that line is still on main. It is **green in CI** on this PR and on main, so it is not a PR problem; the local/CI divergence is noted here rather than diagnosed, since nothing in this change touches that file or that gate.

## Known stale, not fixed

The split removes a net 218 lines from `ci.yml` above line 245, so `ci.yml:<line>` citations at or past 245 in `docs/task-specs/2026/09/task-fleet-probe-coverage-investigation/analysis.md` (33 citations) and `docs/request-for-change/rfc-i18n-measurement.md:16` now point at the wrong content. `docs_lint.py` only fails a citation past EOF, so these stay green. They are left alone on purpose: both are point-in-time analysis artifacts, and repointing them at a file that changed after they were written would misrepresent the analysis rather than repair it.
