### PR TITLE
fix: steer the approval-timeout decline into the running turn (#8219)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -578,7 +578,6 @@ test/test_cse_2026_08_07_fixes.py
 test/test_custom_embedding_model.py
 test/test_dashboard.py
 test/test_dashboard_approval.py
-test/test_dashboard_approval_window.py
 test/test_dashboard_branding.py
 test/test_dashboard_config_gitlab_hosts.py
 test/test_dashboard_cron_approval.py

--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -213,6 +213,19 @@ kiro-cli's wrong attribution and no correction, while queueing wrongly costs one
 turn the model is told twice — which is what this path cost before in-band
 delivery existed.
 
+**An approval prompt that expires unanswered takes the same in-band path**, with
+its own cause (`approval_timeout`): before the auto-decline is answered on the
+wire, the agent is told the prompt expired and that the user did NOT deny the
+call — for attended and unattended slots alike, since both are handed the same
+generic denial string. It deliberately joins no fallback recovery, and its
+notice is tracked outside the turn's refusal ledger so it cannot skew
+`should_queue_refusal_recovery`'s count-based decision: the timed-out decline
+answers the permission as an ordinary rejection (the recovery continuation
+stays reserved for system-side blocks), so on a harness without steer the
+unattended transcript line remains the only agent-facing explanation. The
+timeout card stays the sole user-visible surface — this steer paints no
+tool-blocked row.
+
 The recovery classification for the last two is **structural**: the queue entry
 carries `kind == "synthetic_recovery"` (`SYNTHETIC_RECOVERY_KIND`), set at insert
 time. Metadata survives every queue transformation (merge, prefixing, truncation)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -130,6 +130,7 @@ from kiro_crew.dashboard.session_directive_apply import apply_session_directive
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
+    DENY_CAUSE_APPROVAL_TIMEOUT,
     DENY_CAUSE_BATCH_CASCADE,
     DENY_CAUSE_HOOK_ERROR,
     DENY_CAUSE_INVALID_NAME,
@@ -615,6 +616,15 @@ async def _credential_tool_hint_for(reason: str, cause: str, subject: str = "") 
     return await resolve_credential_tool_hint()
 
 
+#: Upper bound on any in-band steer-notice write. The notice is best-effort,
+#: but the AWAIT must not be: every deny path runs reject_tool + a SEL audit
+#: write after :func:`_steer_policy_notice`, and unbounded, a backpressured ACP
+#: stdin could hold the await until the turn deadline cancelled the coroutine —
+#: skipping both. Sized to a pipe write with margin, far below the 60s approval
+#: reporting margin, and applied inside the helper so every caller inherits it.
+_STEER_NOTICE_BOUND_SECS = 5.0
+
+
 async def _steer_policy_notice(
     client: Any,
     title: str,
@@ -661,7 +671,15 @@ async def _steer_policy_notice(
     if not notice:
         return False
     try:
-        sent = await client.steer(notice)
+        # BOUNDED: every deny path runs reject_tool + a SEL audit write after
+        # this helper, and an unbounded await on a backpressured ACP stdin
+        # could ride until the turn deadline cancelled the coroutine — skipping
+        # both, so the UI would read rejected while the wire and the audit
+        # trail never heard about it. Bounding HERE makes every caller inherit
+        # the guard instead of each deny site re-discovering it.
+        # asyncio.TimeoutError is an Exception, so the handler below already
+        # treats expiry as the ordinary best-effort failure it is.
+        sent = await asyncio.wait_for(client.steer(notice), timeout=_STEER_NOTICE_BOUND_SECS)
     except Exception:
         logger.debug("policy-notice steer failed; falling back to recovery turn", exc_info=True)
         return False
@@ -680,7 +698,7 @@ async def _steer_policy_notice(
             # The cause rides the MARKER line, following the
             # HOOK_HALTED_RECOVERY_PREFIX precedent (`… #<depth>`): the card's
             # always-visible summary has to name the right cause. Rendering one
-            # "safety policy blocked the call" line for all three would tell the
+            # "safety policy blocked the call" line for every cause would tell the
             # person to go audit a security rule that does not exist — the same
             # cause-blind wording this change removes for the model, left in place
             # for the human.
@@ -9186,6 +9204,44 @@ async def _run_chat(
                         "the approval prompt for an earlier tool in this batch "
                         f"went unanswered for {int(_approval_window)}s, so the "
                         "host declined it"
+                    )
+                    # The AGENT's channel, sent for attended and unattended slots
+                    # alike: the rejection below reaches the model as kiro-cli's
+                    # generic "User denied tool execution", so without this it
+                    # concludes the human actively refused a call nobody judged.
+                    # Steered HERE, before the reject goes on the wire in the
+                    # rejected branch below — the still-unanswered permission
+                    # request is what proves the turn is in flight, so the notice
+                    # is queued instead of dropped (same ordering as the policy
+                    # deny paths). Best-effort like every _steer_policy_notice
+                    # call: a harness without steer keeps today's behaviour.
+                    # This notice covers the tool whose prompt expired; the
+                    # cascaded remainder of its batch is corrected separately by
+                    # the DENY_CAUSE_BATCH_CASCADE steer, keyed on
+                    # _host_deny_cause above.
+                    #
+                    # A THROWAWAY list, deliberately not _refusal_notices: this
+                    # path appends no _refusal_reasons entry (an expired prompt
+                    # is answered as an ordinary rejection, never by a recovery
+                    # continuation), and should_queue_refusal_recovery compares
+                    # the two lists by COUNT, not by pairing. Threading the turn
+                    # ledger here would let an unsettled timeout notice force a
+                    # duplicate recovery turn — or let a settled one mask a real
+                    # deny whose own steer failed, handing the model an
+                    # uncorrected "User denied tool execution".
+                    #
+                    # No slot/state either: the ⏱️ timeout card appended in the
+                    # finally below is already the human's explanation, so the
+                    # display row the policy paths add would paint the same
+                    # event twice.
+                    _timeout_notices: list[str] = []
+                    await _steer_policy_notice(
+                        client,
+                        _redact_display_text(event.title),
+                        f"the approval prompt expired after "
+                        f"{max(1, round(_approval_window))}s with no answer",
+                        _timeout_notices,
+                        cause=DENY_CAUSE_APPROVAL_TIMEOUT,
                     )
                     if _unattended_wait:
                         # The card is for the human; this line is for the AGENT.

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2889,6 +2889,7 @@ DENY_CAUSE_POLICY = "policy"
 DENY_CAUSE_INVALID_NAME = "invalid_name"
 DENY_CAUSE_HOOK_ERROR = "hook_error"
 DENY_CAUSE_BATCH_CASCADE = "batch_cascade"
+DENY_CAUSE_APPROVAL_TIMEOUT = "approval_timeout"
 
 #: cause → (clause completing "The tool call you just made …", what to do next).
 _DENY_CAUSE_TEXT: dict[str, tuple[str, str]] = {
@@ -2917,6 +2918,15 @@ _DENY_CAUSE_TEXT: dict[str, tuple[str, str]] = {
         "whole. Address what declined that earlier tool (the reason above), then "
         "re-issue the calls you still need; if you genuinely cannot proceed "
         "without them, say so and stop with the reason.",
+    ),
+    DENY_CAUSE_APPROVAL_TIMEOUT: (
+        "was auto-declined because its approval prompt expired unanswered",
+        "nobody answered within the window, so the action itself was never judged — "
+        "do not abandon it or route around it on this evidence. State the "
+        "permission you need and why, then continue with what you can do without "
+        "it. Do not immediately reissue the same call: the person who did not "
+        "answer is still away, and re-prompting re-arms the same wait for the "
+        "same silence.",
     ),
 }
 
@@ -2949,10 +2959,10 @@ def build_refusal_steer_notice(
     *cause* selects the wording. The distinction is not cosmetic: a policy block
     is a verdict the model must route around, an invalid tool name is the model's
     own malformed output and is the one case it can simply fix, a hook fault
-    judged nothing at all, and a batch cascade cut the group short without
-    judging its members. Telling the model "safety policy" for any non-policy
-    cause would send it looking for an allowed alternative to an action nobody
-    refused.
+    judged nothing at all, a batch cascade cut the group short without judging
+    its members, and an expired approval prompt means nobody answered. Telling
+    the model "safety policy" for any non-policy cause would send it looking for
+    an allowed alternative to an action nobody refused.
     An unknown cause degrades to the policy wording rather than raising: a wrong
     noun is recoverable, and losing the notice would hand the model back
     kiro-cli's "user denied" with nothing to correct it.
@@ -2966,10 +2976,10 @@ def build_refusal_steer_notice(
     what = f"{title}: {reason}" if reason else title
     # Class-specific remediation, for the policy cause only. The non-policy
     # causes judged nothing about the action — an invalid tool name is the
-    # model's own malformed output, a hook fault is a host fault, and a cascaded
-    # batch member was never reached — so naming a sanctioned alternative there
-    # would answer a question nobody asked and imply the action itself had been
-    # refused.
+    # model's own malformed output, a hook fault is a host fault, a cascaded
+    # batch member was never reached, and an expired approval prompt was simply
+    # never answered — so naming a sanctioned alternative there would answer a
+    # question nobody asked and imply the action itself had been refused.
     remediation = (
         remediation_for(reason, title, credential_tool_hint=credential_tool_hint)
         if cause == DENY_CAUSE_POLICY

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -994,11 +994,16 @@ class TestBatchCascadeAttribution:
             await _run_chat(state, slot, "hello")
 
         # Nobody answered: the first tool was declined by the host, the second
-        # by the cascade — and the cascade corrected the attribution in-band.
+        # by the cascade — and each decline corrected its own attribution
+        # in-band. Two notices, two distinct facts: the expired prompt covers
+        # tool_a (#8219), the cascade notice covers the remainder (#8818).
         client.reject_tool.assert_any_call("req-1")
         client.reject_tool.assert_any_call("req-2")
-        client.steer.assert_called_once()
-        notice = client.steer.call_args[0][0]
+        assert client.steer.call_count == 2
+        timeout_notice = client.steer.call_args_list[0][0][0]
+        assert "approval prompt expired" in timeout_notice
+        assert "every remaining call in its batch" not in timeout_notice
+        notice = client.steer.call_args_list[1][0][0]
         assert "every remaining call in its batch" in notice
         assert "unanswered" in notice
         assert "User denied tool execution" in notice
@@ -1076,7 +1081,15 @@ class TestBatchCascadeAttribution:
             await _run_chat(state, slot, "hello")
 
         assert client.reject_tool.call_count == 3
-        client.steer.assert_called_once()
+        # One notice for the expired prompt on tool_1, then exactly ONE for the
+        # cascaded remainder — never one per cascaded member.
+        assert client.steer.call_count == 2
+        cascade_notices = [
+            c[0][0]
+            for c in client.steer.call_args_list
+            if "every remaining call in its batch" in c[0][0]
+        ]
+        assert len(cascade_notices) == 1
 
     @pytest.mark.asyncio
     async def test_provenance_dies_with_the_group_it_belongs_to(self, tmp_path):
@@ -1108,9 +1121,11 @@ class TestBatchCascadeAttribution:
         await _drain(approver)
 
         # The revised call was prompted and approved — never cascaded, so the
-        # cascade notice was never sent.
+        # cascade notice was never sent. The expired prompt on tool_a still
+        # steers its own notice (#8219); what must be absent is the cascade one.
         client.approve_tool.assert_any_call("req-2")
-        client.steer.assert_not_called()
+        assert client.steer.call_count == 1
+        assert "every remaining call in its batch" not in client.steer.call_args[0][0]
         assert slot._batch_rejected_cause == ""
 
 

--- a/test/test_dashboard_approval_window.py
+++ b/test/test_dashboard_approval_window.py
@@ -162,9 +162,7 @@ class TestPerSlotWindowIsAlsoBudgetBounded:
         return min(state.approval_timeout_for(slot), td.tool_approval_timeout_secs())
 
     @pytest.mark.asyncio
-    async def test_attended_window_is_the_configured_one_not_the_flat_constant(
-        self, cfg
-    ) -> None:
+    async def test_attended_window_is_the_configured_one_not_the_flat_constant(self, cfg) -> None:
         # 7200 is what `approval_timeout_for` returns for an attended slot; the
         # window that actually applies is the configurable, bounded one.
         cfg(window=600, turn=7200)
@@ -267,6 +265,127 @@ class TestStallSignalReachesTheLoop:
             "the stall signal is nested inside `if _unattended_wait:` — an "
             "attended slot's monitoring loop would never be told"
         )
+
+
+class TestTimeoutTellsTheAgentInBand:
+    """The timeout branch must correct the agent's "user denied" attribution.
+
+    kiro-cli reports the auto-decline below as its generic "User denied tool
+    execution", so without an in-band notice the agent concludes the human
+    actively refused a call nobody answered, and changes course on a decision
+    that was never made. The policy-deny paths already steer their reason into
+    the running turn before rejecting; this pins the same wiring — same helper,
+    same before-the-reject ordering — onto the approval-timeout branch.
+    """
+
+    @staticmethod
+    def _timeout_branch() -> list[str]:
+        from kiro_crew.dashboard import chat_runner
+
+        lines = inspect.getsource(chat_runner._run_chat).split("\n")
+        start = next(
+            i for i, ln in enumerate(lines) if ln.strip() == "except asyncio.TimeoutError:"
+        )
+        indent = len(lines[start]) - len(lines[start].lstrip())
+        body = []
+        for ln in lines[start + 1 :]:
+            if ln.strip() and (len(ln) - len(ln.lstrip())) <= indent:
+                break
+            body.append(ln)
+        return body
+
+    def test_the_branch_steers_the_timeout_cause(self) -> None:
+        body = "\n".join(self._timeout_branch())
+        assert "_steer_policy_notice(" in body, (
+            "the approval-timeout branch sends no in-band notice; the agent is "
+            "left holding kiro-cli's generic 'User denied tool execution'"
+        )
+        assert "cause=DENY_CAUSE_APPROVAL_TIMEOUT" in body, (
+            "the notice must carry the timeout cause, not inherit the policy "
+            "wording — 'blocked by a safety policy' is false here"
+        )
+
+    def test_the_notice_stays_out_of_the_turn_ledger(self) -> None:
+        """The steer must NOT thread `_refusal_notices`.
+
+        `should_queue_refusal_recovery` compares that list against
+        `_refusal_reasons` by COUNT, and this path deliberately appends no
+        reasons entry (an expired prompt is answered as an ordinary rejection,
+        never by a recovery continuation). Threading the shared ledger would
+        let an unsettled timeout notice force a duplicate recovery turn — or
+        let a settled one mask a real deny whose own steer failed.
+        """
+        # Scanned over CODE lines only: the comment above the call site names
+        # _refusal_notices while explaining why it is NOT used, and a comment
+        # must neither satisfy nor trip a wiring assertion.
+        code = "\n".join(ln for ln in self._timeout_branch() if not ln.lstrip().startswith("#"))
+        assert (
+            "_timeout_notices" in code
+        ), "expected a local throwaway notice list for the timeout steer"
+        assert "_refusal_notices" not in code, (
+            "the timeout steer must not participate in the recovery-fallback "
+            "accounting — it pairs with no _refusal_reasons entry"
+        )
+
+    def test_the_steer_is_not_gated_on_the_unattended_flag(self) -> None:
+        """BOTH attended and unattended slots get the notice.
+
+        The unattended transcript line stays unattended-only, but an attended
+        slot's AGENT is handed the exact same generic denial string — nesting
+        the steer under the flag would leave the attended case exactly as
+        broken as before this change.
+        """
+        body = self._timeout_branch()
+        gate = next(i for i, ln in enumerate(body) if ln.strip() == "if _unattended_wait:")
+        gate_indent = len(body[gate]) - len(body[gate].lstrip())
+        call = next(i for i, ln in enumerate(body) if "_steer_policy_notice(" in ln)
+        owner = next(
+            i
+            for i in range(call, -1, -1)
+            if body[i].strip()
+            and not body[i].lstrip().startswith("#")
+            and (len(body[i]) - len(body[i].lstrip())) <= gate_indent
+        )
+        assert (len(body[owner]) - len(body[owner].lstrip())) == gate_indent, (
+            "the in-band steer is nested inside a gate — an attended (or "
+            "unattended) slot's agent would never be corrected"
+        )
+
+    def test_the_steer_is_bounded_so_reject_and_audit_cannot_be_skipped(self) -> None:
+        """The steer await must be bounded INSIDE the helper.
+
+        Every deny path runs reject_tool + a SEL audit write after
+        `_steer_policy_notice`; unbounded, a backpressured ACP stdin could hold
+        the await until the turn deadline cancelled it — skipping both, so the
+        UI would read rejected while the wire and the audit trail never heard
+        about it. The bound lives in the helper (not per call site) so all
+        five deny paths inherit it and a sixth cannot be added without it.
+        """
+        from kiro_crew.dashboard import chat_runner
+
+        helper = inspect.getsource(chat_runner._steer_policy_notice)
+        assert "asyncio.wait_for(" in helper, "the steer notice is awaited unbounded"
+        assert "_STEER_NOTICE_BOUND_SECS" in helper
+        # The branch itself must NOT re-wrap the call: a second, per-site bound
+        # is exactly the duplication moving it into the helper removed.
+        code = "\n".join(ln for ln in self._timeout_branch() if not ln.lstrip().startswith("#"))
+        assert "asyncio.wait_for(" not in code
+
+    def test_the_reject_still_happens_after_the_steer(self) -> None:
+        """The notice explains the decline; it must not replace it.
+
+        Ordering is the mechanism: the steer is written while the permission
+        request is still unanswered, and the generic rejected branch (the one
+        a timed-out approval falls into, identified by its ``_reject_label``
+        append) answers it afterwards.
+        """
+        from kiro_crew.dashboard import chat_runner
+
+        src = inspect.getsource(chat_runner._run_chat)
+        steer = src.index("cause=DENY_CAUSE_APPROVAL_TIMEOUT")
+        reject = src.index('slot.append("tool", _reject_label, "msg msg-tool")')
+        assert steer < reject, "the steer must precede the rejection going on the wire"
+        assert "await client.reject_tool(event.request_id)" in src[steer:reject]
 
 
 class TestResolver:

--- a/test/test_refusal_inband_notice.py
+++ b/test/test_refusal_inband_notice.py
@@ -27,6 +27,8 @@ from kiro_crew.dashboard.chat_runner import (
     _steer_policy_notice,
 )
 from kiro_crew.dashboard.state import (
+    _DENY_CAUSE_TEXT,
+    DENY_CAUSE_APPROVAL_TIMEOUT,
     DENY_CAUSE_BATCH_CASCADE,
     DENY_CAUSE_HOOK_ERROR,
     DENY_CAUSE_INVALID_NAME,
@@ -397,6 +399,28 @@ class TestCauseSpecificWording:
         assert "nothing judged the call" in out
         assert "safety policy" not in out
 
+    def test_approval_timeout_says_expired_not_denied_or_blocked(self):
+        out = build_refusal_steer_notice(
+            "bash", "prompt expired after 600s", cause=DENY_CAUSE_APPROVAL_TIMEOUT
+        )
+        assert "expired unanswered" in out
+        assert "never judged" in out
+        # The action was never judged, so neither a policy verdict nor the
+        # policy guidance ("find an allowed alternative") may appear: both
+        # would send the model routing around a call nobody refused.
+        assert "safety policy" not in out
+        assert "allowed alternative" not in out
+        # No-reissue is justified by the ABSENT RESPONDER, not by turn budget:
+        # under the default config (600s window, 7200s ceiling) a reissued call
+        # recomputes min(approval_timeout_for, tool_approval_timeout_secs()) and
+        # gets a fresh full window, so a budget claim would be false. The honest
+        # rationale — the person who did not answer is still away — also agrees
+        # with the unattended transcript line ("instead of retrying the same
+        # call").
+        assert "state the permission you need" in out.lower()
+        assert "do not immediately reissue" in out.lower()
+        assert "budget" not in out.lower()
+
     def test_policy_wording_is_unchanged_by_default(self):
         # Every pre-existing caller passes no cause; the policy text must be
         # byte-identical to what shipped, or the model's correction changes
@@ -430,13 +454,10 @@ class TestCauseSpecificWording:
 
     def test_every_cause_keeps_the_invariant_half(self):
         # The half that does the actual work -- naming the string being corrected
-        # and forbidding a hand-back -- must not vary with the cause.
-        for cause in (
-            DENY_CAUSE_POLICY,
-            DENY_CAUSE_INVALID_NAME,
-            DENY_CAUSE_HOOK_ERROR,
-            DENY_CAUSE_BATCH_CASCADE,
-        ):
+        # and forbidding a hand-back -- must not vary with the cause. Iterated
+        # over the table itself so a cause added later inherits this guard
+        # instead of silently escaping a hand-enumerated tuple.
+        for cause in _DENY_CAUSE_TEXT:
             out = build_refusal_steer_notice("bash", "why", cause=cause)
             assert "User denied tool execution" in out, cause
             assert "NOT a user action" in out, cause
@@ -447,12 +468,7 @@ class TestCauseSpecificWording:
         # The tag has to be true for every cause. Saying "policy notice" above
         # a sentence that explains the call was NOT a policy matter contradicts the
         # body one line later, and the body is the part doing the correcting.
-        for cause in (
-            DENY_CAUSE_POLICY,
-            DENY_CAUSE_INVALID_NAME,
-            DENY_CAUSE_HOOK_ERROR,
-            DENY_CAUSE_BATCH_CASCADE,
-        ):
+        for cause in _DENY_CAUSE_TEXT:
             out = build_refusal_steer_notice("bash", "why", cause=cause)
             assert out.startswith("[Kiro Crew host notice]"), cause
             # "policy" may still appear in the POLICY cause's own clause; what must


### PR DESCRIPTION
## Summary

When a tool-approval prompt expires (the `asyncio.TimeoutError` branch of the approval wait in `chat_runner.py`), the dashboard auto-declines: the user gets the timeout card, but the agent receives only kiro-cli's generic `"User denied tool execution"`. It concludes the human actively refused a call nobody answered, and changes course on a decision that was never made. An agent-facing transcript line existed only for unattended slots, and even that lands in the transcript rather than steering the in-flight turn.

This mirrors the policy-deny sibling:

- The `TimeoutError` branch now steers an in-band notice into the running turn **before** the rejection goes on the wire — while the unanswered permission request still proves the turn is in flight — for **attended and unattended slots alike**.
- The notice routes through the existing `build_refusal_steer_notice` helper via a new `DENY_CAUSE_APPROVAL_TIMEOUT` entry in `_DENY_CAUSE_TEXT`, not a second hand-rolled mechanism. Its guidance tells the agent the action was never judged, to state the permission it needs, to continue with what it can do without it, and not to immediately reissue the call — because the person who did not answer is still away, so re-prompting re-arms the same wait for the same silence (a reissued call does get a fresh window under the default config; absence, not budget, is the reason not to spam it).
- The notice is tracked in a **local throwaway list**, not the turn's `_refusal_notices` ledger: this path appends no `_refusal_reasons` entry, and `should_queue_refusal_recovery` compares the two lists by count — threading the shared ledger could force a duplicate recovery turn, or mask a real deny whose own steer failed.
- **The steer write inside `_steer_policy_notice` is now bounded** (`asyncio.wait_for`, `_STEER_NOTICE_BOUND_SECS = 5.0`). This is a deliberate behavior change to **all five** deny paths that use the helper (policy, invalid-name, hook-error, the recovery path, and this timeout branch), not only the new one: unbounded, a backpressured ACP stdin could hold the await until the turn deadline cancelled it, skipping the `reject_tool` + SEL audit that every caller runs afterwards. Expiry is absorbed by the helper's existing best-effort handler, so a bounded-out notice degrades to the pre-steer fallback behavior each path already had.
- The steer paints **no tool-blocked display row** (the ⏱️ timeout card is already the human's explanation), so the cause token never reaches the dashboard and no frontend change ships.
- The user-facing timeout card and the unattended transcript line are unchanged; the decline still answers the permission as an ordinary rejection. Harnesses without steer support keep today's behaviour exactly.
- `docs/system-specs/common/injected-messages.md` documents the new path in the same commit.

Related but distinct from #2660 (policy denies). Does **not** implement #7659 (wait-indefinitely mode).

Closes #8219

## Testing

- Cause-wording unit tests for the new entry (`test_refusal_inband_notice.py`), with the invariant-half and marker-tag guards now iterating `_DENY_CAUSE_TEXT` itself so a future cause inherits them automatically.
- Source-level branch guards (`test_dashboard_approval_window.py`, following this file's existing pattern for this deep branch): the steer carries `cause=DENY_CAUSE_APPROVAL_TIMEOUT`, is **not** nested under the `_unattended_wait` gate (both attended and unattended slots), stays **out of** the `_refusal_notices` ledger, and precedes the rejection going on the wire.
- Local gates green: black gate (one graduated baseline entry pruned), isort, flake8, mypy (1281 files), brand, harness-parity, subprocess-encoding, docs-lint, scrub-lint.
- Pre-push review: two concurrent model-pinned reviewer lanes (GPT + Opus). Both blocking findings fixed (notice-ledger isolation; guidance contradiction with the notice's invariant half), advisories applied (stale cause-count comments, `max(1, round())` for the seconds figure, table-driven test loops). An earlier draft added a frontend cause label + 13-locale i18n key; with the display row suppressed that surface is dead code, so it was reverted.

## Known adjacent gap (out of scope)

Three sibling host-decline branches still send no in-band notice for the *originating* tool, so the wrong-attribution defect survives there: the no-budget branch (`_approval_window <= 0`, declined without waiting) and the two Slack-delivery branches (`_slack_approval_ts is None`, and the `except Exception` around `post_linked_approval`). Left out deliberately: #8219 names the expired-prompt branch, and the general fix — one `_host_deny_cause`-keyed steer at the shared rejected branch, replacing this per-branch call — changes a branch that user refusals also traverse and needs two more cause wordings. Tracked in #8977 (`deferred-finding`, Due 2026-09-20). Note that #8887 (#8818), which merged while this PR was open, already corrects the *cascaded remainder* of a batch for all four host causes; on a timed-out multi-tool batch this PR's notice (originating tool) and #8887's notice (remainder) are therefore both sent, and `test_dashboard_approval.py::TestBatchCascadeAttribution` pins that pair.

## Pattern harvest

Rule candidate: source-level wiring guard (the existing `TestEveryHostDenyCallSiteIsWired` pattern)
Pattern: a host-side auto-decline path that answers `session/request_permission` without first steering a cause-specific notice, leaving the model holding kiro-cli's generic "User denied tool execution". This is the third instance of the class (policy/hook/invalid-name denies via #2660's mechanism, this expired-prompt branch, and the three still-open host-decline origins tracked in #8977). Candidate guard: extend the call-site scan to every `client.reject_tool` site outside the interactive user-denial branch, requiring each to name its deny cause or be explicitly exempted.

