### PR TITLE
fix(chat): user-message session links switch in place (#8253)

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -747,7 +747,35 @@ function KnowledgeBubbleChip({ knowledge }: { knowledge: { items: number; tokens
   )
 }
 
-export function renderUserContent(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, onFolderOpen?: (path: string) => void, linkPreviews?: boolean) {
+/** One options object for the user-message render helpers (renderUserContent →
+ *  renderUserContentInner → renderFileSegment) instead of ever-growing
+ *  positional signatures. The optional session triple mirrors what the
+ *  assistant / note rows hand MarkdownRenderer, so a `/chat?sid=…` link in a
+ *  USER message switches session in place exactly like every other row kind
+ *  (#8253) instead of falling into the external-link branch and gaining
+ *  `target="_blank"`. */
+export type UserContentRenderOpts = {
+  content: string
+  meta?: Record<string, unknown>
+  onFileOpen: (path: string) => void
+  onFolderOpen?: (path: string) => void
+  linkPreviews?: boolean
+  onSessionOpen?: (key: string) => void
+  sessions?: ReadonlyMap<string, string>
+  activeSession?: string
+}
+
+/** renderFileSegment's own two knobs live on a private extension, not on the
+ *  exported type: renderUserContentInner sets both unconditionally, so a
+ *  caller-supplied value would type-check and silently do nothing. */
+type FileSegmentOpts = UserContentRenderOpts & {
+  /** React key namespace for the segment. */
+  keyBase?: string
+  /** Folder-token label → path map. */
+  dirMap?: Map<string, string>
+}
+
+export function renderUserContent(opts: UserContentRenderOpts) {
   // Per-message containment (defense-in-depth): a render crash in a
   // user/inject bubble must degrade to a per-message fallback, not unwind to
   // the root boundary and blank the whole dashboard.
@@ -757,13 +785,15 @@ export function renderUserContent(content: string, meta: Record<string, unknown>
   // (Done there, not here, so tests that mock MarkdownRenderer don't need the
   // context export.)
   return (
-    <MessageErrorBoundary rawContent={content}>
-      {renderUserContentInner(content, meta, onFileOpen, onFolderOpen, linkPreviews)}
+    <MessageErrorBoundary rawContent={opts.content}>
+      {renderUserContentInner(opts)}
     </MessageErrorBoundary>
   )
 }
 
-function renderUserContentInner(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, onFolderOpen?: (path: string) => void, linkPreviews?: boolean) {
+function renderUserContentInner(opts: UserContentRenderOpts) {
+  const { meta, onFileOpen, onFolderOpen } = opts
+  let content = opts.content
   const pastes = (meta?.pastes as PasteBlock[] | undefined) || []
   const knowledge = meta?.knowledge as { items: number; tokens: number; titles: string[]; content?: { title: string; text: string }[] } | undefined
 
@@ -781,7 +811,7 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
     <KnowledgeBubbleChip knowledge={knowledge} />
   ) : null
 
-  if (!pastes.length) return <>{knowledgeBadge}{renderFileSegment(content, meta, onFileOpen, 'seg', dirMentionMap, onFolderOpen, linkPreviews)}</>
+  if (!pastes.length) return <>{knowledgeBadge}{renderFileSegment({ ...opts, content, keyBase: 'seg', dirMap: dirMentionMap })}</>
 
 
   // History load re-serves the fully-EXPANDED content (what the LLM saw), so a
@@ -802,7 +832,7 @@ function renderUserContentInner(content: string, meta: Record<string, unknown> |
       ranges = findTokenRanges(text, pastes)
     }
   }
-  if (!ranges.length) return <>{knowledgeBadge}{renderFileSegment(text, meta, onFileOpen, 'seg', dirMentionMap, onFolderOpen, linkPreviews)}</>
+  if (!ranges.length) return <>{knowledgeBadge}{renderFileSegment({ ...opts, content: text, keyBase: 'seg', dirMap: dirMentionMap })}</>
 
   // Paste chips are inline by nature, so to keep them flowing with the
   // surrounding text (e.g. "hey [chip] thanks"), render each text segment
@@ -981,7 +1011,8 @@ function FileAttachmentCard({ fullPath, label, onFileOpen }: { fullPath: string;
  *  server stores the token form in `content` AND keeps `meta.files` at once.
  *  Files referenced inline stay inline chips; the rest become block cards.
  *  Images keep their inline `![image](path)` markdown and are excluded here. */
-function renderFileSegment(content: string, meta: Record<string, unknown> | undefined, onFileOpen: (path: string) => void, keyBase: string, dirMap?: Map<string, string>, onFolderOpen?: (path: string) => void, linkPreviews?: boolean) {
+function renderFileSegment(opts: FileSegmentOpts) {
+  const { content, meta, onFileOpen, keyBase = 'seg', dirMap, onFolderOpen, linkPreviews, onSessionOpen, sessions, activeSession } = opts
   const parsedFiles = parseFiles(content, meta)
   const dirKeys = dirMap ? [...dirMap.keys()].filter(k => tokenPresent(content, k)).slice(0, 20) : []
 
@@ -990,6 +1021,8 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
   // compactImages: this is user-message content, so attached images render small.
   // linkPreviews: mirrors the assistant path — a URL the user pasted unfurls
   // under the same opt-in gate as one the model wrote (issue #2580).
+  // The session triple mirrors the assistant path too, so a `/chat?sid=…`
+  // link switches session in place instead of opening a new tab (#8253).
   //
   // A folder token routes the message into the inline chip-split body below,
   // which renders surrounding text as plain whitespace-preserving spans — so
@@ -999,7 +1032,7 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
   // inline-widget seam; a folder-referencing prompt with block markdown is
   // the uncommon combination.
   if (!parsedFiles.length && !dirKeys.length) {
-    return <MarkdownRenderer content={content} softBreaks compactImages linkPreviews={linkPreviews} />
+    return <MarkdownRenderer content={content} softBreaks compactImages linkPreviews={linkPreviews} onSessionOpen={onSessionOpen} sessions={sessions} activeSession={activeSession} />
   }
 
   // Pass the ORIGINAL ordered list (images included) so [attached_file N] token
@@ -1032,7 +1065,7 @@ function renderFileSegment(content: string, meta: Record<string, unknown> | unde
   // then the cards.
   if (!mentionMap.size && !dirKeys.length) {
     const caption = display.trim()
-    return <>{caption ? <MarkdownRenderer key={`${keyBase}-cap`} content={caption} softBreaks compactImages linkPreviews={linkPreviews} /> : null}{cards}</>
+    return <>{caption ? <MarkdownRenderer key={`${keyBase}-cap`} content={caption} softBreaks compactImages linkPreviews={linkPreviews} onSessionOpen={onSessionOpen} sessions={sessions} activeSession={activeSession} /> : null}{cards}</>
   }
 
   // Inline-mention path: the caption keeps files inline, so render it as a
@@ -6267,8 +6300,20 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }), [search.term, search.caseSensitive, search.currentMessageIdx, search.currentOccurrenceIdx])
 
   const renderUserContentCb = useCallback(
-    (c: string, mt: Record<string, unknown> | undefined) => renderUserContent(c, mt, handleFileOpen, handleFolderOpen, linkPreviewsOn),
-    [handleFileOpen, handleFolderOpen, linkPreviewsOn]
+    // The session triple matches what the assistant / note rows hand
+    // MarkdownRenderer (see the AssistantMessage and inject branches below),
+    // so a `/chat?sid=…` link behaves identically across row kinds (#8253).
+    (c: string, mt: Record<string, unknown> | undefined) => renderUserContent({
+      content: c,
+      meta: mt,
+      onFileOpen: handleFileOpen,
+      onFolderOpen: handleFolderOpen,
+      linkPreviews: linkPreviewsOn,
+      onSessionOpen: selectSessionTab,
+      sessions: connected ? sessionTitles : undefined,
+      activeSession: activeSlot || undefined,
+    }),
+    [handleFileOpen, handleFolderOpen, linkPreviewsOn, selectSessionTab, connected, sessionTitles, activeSlot]
   )
 
   const cancelTitleRef = useRef(false)

--- a/website/src/test/ChatPageW3Coverage.test.tsx
+++ b/website/src/test/ChatPageW3Coverage.test.tsx
@@ -257,7 +257,7 @@ const openFolder = vi.fn()
 /** Renders just the exported user-bubble renderer (no ChatPage). */
 function renderBubble(content: string, meta?: Record<string, unknown>, withFolder = true) {
   return render(
-    <div>{renderUserContent(content, meta, openFile, withFolder ? openFolder : undefined)}</div>,
+    <div>{renderUserContent({ content: content, meta: meta, onFileOpen: openFile, onFolderOpen: withFolder ? openFolder : undefined })}</div>,
   )
 }
 

--- a/website/src/test/renderUserContent.dirs.test.tsx
+++ b/website/src/test/renderUserContent.dirs.test.tsx
@@ -13,7 +13,7 @@ function dirChip(container: HTMLElement, fullPath: string): HTMLElement | null {
 describe('renderUserContent — folder references', () => {
   it('fresh message: @rel/ token + meta.dirs renders a folder chip, not plain text', () => {
     const { container } = render(
-      <>{renderUserContent('look in @src/pages/ please', { dirs: ['/repo/src/pages'] }, noop)}</>,
+      <>{renderUserContent({ content: 'look in @src/pages/ please', meta: { dirs: ['/repo/src/pages'] }, onFileOpen: noop })}</>,
     )
     const chip = dirChip(container, '/repo/src/pages')
     expect(chip).toBeInTheDocument()
@@ -23,7 +23,7 @@ describe('renderUserContent — folder references', () => {
   it('clicking the folder chip opens the directory via onFolderOpen', () => {
     const onFolderOpen = vi.fn()
     const { container } = render(
-      <>{renderUserContent('look in @src/pages/ please', { dirs: ['/repo/src/pages'] }, noop, onFolderOpen)}</>,
+      <>{renderUserContent({ content: 'look in @src/pages/ please', meta: { dirs: ['/repo/src/pages'] }, onFileOpen: noop, onFolderOpen: onFolderOpen })}</>,
     )
     const chip = dirChip(container, '/repo/src/pages')
     // Clickable contract: a real focusable button, not a div with a listener.
@@ -34,14 +34,14 @@ describe('renderUserContent — folder references', () => {
 
   it('degrades to an inert chip when no folder handler is provided', () => {
     const { container } = render(
-      <>{renderUserContent('look in @src/pages/ please', { dirs: ['/repo/src/pages'] }, noop)}</>,
+      <>{renderUserContent({ content: 'look in @src/pages/ please', meta: { dirs: ['/repo/src/pages'] }, onFileOpen: noop })}</>,
     )
     expect(dirChip(container, '/repo/src/pages')?.getAttribute('role')).toBeNull()
   })
 
   it('history replay: [attached_dir N] marker resolves to a chip and never leaks raw', () => {
     const { container } = render(
-      <>{renderUserContent('look in [attached_dir 1] /repo/docs please', undefined, noop)}</>,
+      <>{renderUserContent({ content: 'look in [attached_dir 1] /repo/docs please', meta: undefined, onFileOpen: noop })}</>,
     )
     expect(container.textContent).not.toContain('[attached_dir')
     const chip = dirChip(container, '/repo/docs')
@@ -51,7 +51,7 @@ describe('renderUserContent — folder references', () => {
 
   it('meta.dirs wins over the marker fallback for path resolution', () => {
     const { container } = render(
-      <>{renderUserContent('see [attached_dir 1] /repo/my docs now', { dirs: ['/repo/my docs'] }, noop)}</>,
+      <>{renderUserContent({ content: 'see [attached_dir 1] /repo/my docs now', meta: { dirs: ['/repo/my docs'] }, onFileOpen: noop })}</>,
     )
     // Lossless: the spaced path resolves via the meta index, not the \S+ cut.
     expect(dirChip(container, '/repo/my docs')).toBeInTheDocument()
@@ -59,11 +59,7 @@ describe('renderUserContent — folder references', () => {
 
   it('file and folder references coexist and resolve to their own paths', () => {
     const { container } = render(
-      <>{renderUserContent(
-        'compare [attached_file 1] /repo/a.ts with [attached_dir 1] /repo/docs now',
-        { files: ['/repo/a.ts'], dirs: ['/repo/docs'] },
-        noop,
-      )}</>,
+      <>{renderUserContent({ content: 'compare [attached_file 1] /repo/a.ts with [attached_dir 1] /repo/docs now', meta: { files: ['/repo/a.ts'], dirs: ['/repo/docs'] }, onFileOpen: noop })}</>,
     )
     expect(dirChip(container, '/repo/docs')).toBeInTheDocument()
     const fileChip = container.querySelector('[title="/repo/a.ts"]')
@@ -75,11 +71,7 @@ describe('renderUserContent — folder references', () => {
   it('renders the folder chip in a segment adjacent to a paste token', () => {
     const pastes = [{ id: 'p1', seq: 1, lines: 5, content: 'line1\nline2\nline3\nline4\nline5' }]
     const { container } = render(
-      <>{renderUserContent(
-        '[ Paste #1 · 5 lines ]\ncheck [attached_dir 1] /repo/docs too',
-        { pastes, dirs: ['/repo/docs'] },
-        noop,
-      )}</>,
+      <>{renderUserContent({ content: '[ Paste #1 · 5 lines ]\ncheck [attached_dir 1] /repo/docs too', meta: { pastes, dirs: ['/repo/docs'] }, onFileOpen: noop })}</>,
     )
     expect(dirChip(container, '/repo/docs')).toBeInTheDocument()
     expect(container.textContent).not.toContain('[attached_dir')
@@ -87,7 +79,7 @@ describe('renderUserContent — folder references', () => {
 
   it('a plain sentence ending a clause with slash-less mentions is untouched', () => {
     const { container } = render(
-      <>{renderUserContent('email a@b.c/ and read @notes.md now', undefined, noop)}</>,
+      <>{renderUserContent({ content: 'email a@b.c/ and read @notes.md now', meta: undefined, onFileOpen: noop })}</>,
     )
     expect(container.querySelector('[title]')).toBeNull()
   })

--- a/website/src/test/renderUserContent.linkPreviews.test.tsx
+++ b/website/src/test/renderUserContent.linkPreviews.test.tsx
@@ -44,7 +44,7 @@ afterEach(() => {
 
 describe('renderUserContent — link previews (issue #2580)', () => {
   it('unfurls a URL in a user message when linkPreviews is on', async () => {
-    render(<>{renderUserContent(HREF, undefined, noop, undefined, true)}</>)
+    render(<>{renderUserContent({ content: HREF, meta: undefined, onFileOpen: noop, linkPreviews: true })}</>)
     // The card carries the fetched description — its arrival proves the
     // unfurl path ran end to end (gate open → link-meta fetch → card).
     await waitFor(() => expect(screen.queryByText(DESCRIPTION)).not.toBeNull())
@@ -52,13 +52,13 @@ describe('renderUserContent — link previews (issue #2580)', () => {
   })
 
   it('unfurls a markdown link the user pasted when linkPreviews is on', async () => {
-    render(<>{renderUserContent(`[Docs](${HREF})`, undefined, noop, undefined, true)}</>)
+    render(<>{renderUserContent({ content: `[Docs](${HREF})`, meta: undefined, onFileOpen: noop, linkPreviews: true })}</>)
     await waitFor(() => expect(screen.queryByText(DESCRIPTION)).not.toBeNull())
     expect(fetchMock).toHaveBeenCalled()
   })
 
   it('issues NO fetch when linkPreviews is off (explicit false)', async () => {
-    const { container } = render(<>{renderUserContent(HREF, undefined, noop, undefined, false)}</>)
+    const { container } = render(<>{renderUserContent({ content: HREF, meta: undefined, onFileOpen: noop, linkPreviews: false })}</>)
     // The link renders as a plain anchor and nothing is requested.
     await waitFor(() => expect(container.querySelector('a')).not.toBeNull())
     expect(fetchMock).not.toHaveBeenCalled()
@@ -66,7 +66,7 @@ describe('renderUserContent — link previews (issue #2580)', () => {
   })
 
   it('issues NO fetch when linkPreviews is omitted (default off)', async () => {
-    const { container } = render(<>{renderUserContent(HREF, undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: HREF, meta: undefined, onFileOpen: noop })}</>)
     await waitFor(() => expect(container.querySelector('a')).not.toBeNull())
     expect(fetchMock).not.toHaveBeenCalled()
   })
@@ -78,7 +78,7 @@ describe('renderUserContent — link previews (issue #2580)', () => {
     const block = { id: 'b1', seq: 1, lines: 4, content: 'a\nb\nc\nd' }
     const content = `see [ Paste #1 · 4 lines ]\n${HREF}`
     const { container } = render(
-      <>{renderUserContent(content, { pastes: [block] }, noop, undefined, true)}</>,
+      <>{renderUserContent({ content: content, meta: { pastes: [block] }, onFileOpen: noop, linkPreviews: true })}</>,
     )
     // The chip rendered (paste path taken)…
     expect(container.textContent).toContain('Paste #1')

--- a/website/src/test/renderUserContent.sessionLink.test.tsx
+++ b/website/src/test/renderUserContent.sessionLink.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+/**
+ * Regression test for #8253: a `/chat?sid=…` link in a USER message switches
+ * session in place, exactly like the assistant / note rows.
+ *
+ * User-message rows render through renderUserContent → renderFileSegment,
+ * which historically passed only presentation props to MarkdownRenderer.
+ * Without the session triple (`onSessionOpen` / `sessions` / `activeSession`)
+ * `resolveSessionChip` refuses at its first guard, the root-relative href
+ * falls into the external-link branch (`ALLOWED_PROTOCOLS` holds only the
+ * vscode schemes), and the anchor gains `target="_blank"` — a new tab where
+ * every other row kind switches in place.
+ *
+ * These tests exercise the REAL MarkdownRenderer through renderUserContent, so
+ * they pin the whole thread: helper options → renderer props → anchor.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { renderUserContent } from '../pages/ChatPage'
+
+const noop = () => {}
+
+/** Real slot-key shape (`chat-<n>-<unix-ts>`); `sessionKeyFrom` refuses anything else. */
+const HERE = 'chat-1-1788000000'
+const THERE = 'chat-2-1788000001'
+const UNKNOWN = 'chat-9-1788000009'
+
+const SESSIONS: ReadonlyMap<string, string> = new Map([
+  [HERE, 'this one'],
+  [THERE, 'the other one'],
+])
+
+const triple = (onSessionOpen: (key: string) => void) => ({
+  onFileOpen: noop,
+  onSessionOpen,
+  sessions: SESSIONS,
+  activeSession: HERE,
+})
+
+describe('a /chat?sid= link in a user message (#8253)', () => {
+  it('switches session in place: no target="_blank", click invokes onSessionOpen with the key', () => {
+    const onSessionOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent({ content: `see [next](/chat?sid=${THERE})`, meta: undefined, ...triple(onSessionOpen) })}</>,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor).toBeInTheDocument()
+    expect(anchor).not.toHaveAttribute('target')
+    // The href stays real so a modified click (Cmd/Ctrl) still opens a tab.
+    expect(anchor.getAttribute('href')).toContain(`sid=${THERE}`)
+    // The switch tooltip is the chip's visible contract, same as note rows.
+    expect(anchor.getAttribute('title')).toContain('the other one')
+    fireEvent.click(anchor)
+    expect(onSessionOpen).toHaveBeenCalledWith(THERE)
+  })
+
+  it('leaves a link to the ACTIVE session inert with its existing behaviour', () => {
+    // Negative control: resolveSessionChip refuses the active key (a click
+    // would be a visible no-op), so the anchor keeps the pre-existing
+    // external-branch shape — identical to what assistant rows render today.
+    const onSessionOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent({ content: `see [here](/chat?sid=${HERE})`, meta: undefined, ...triple(onSessionOpen) })}</>,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor).toHaveAttribute('target', '_blank')
+    expect(anchor.getAttribute('title')).toBeNull()
+    expect(onSessionOpen).not.toHaveBeenCalled()
+  })
+
+  it('leaves a link whose key names no open session as an ordinary link', () => {
+    const onSessionOpen = vi.fn()
+    const { container } = render(
+      <>{renderUserContent({ content: `see [gone](/chat?sid=${UNKNOWN})`, meta: undefined, ...triple(onSessionOpen) })}</>,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor).toHaveAttribute('target', '_blank')
+    expect(anchor.getAttribute('title')).toBeNull()
+    expect(onSessionOpen).not.toHaveBeenCalled()
+  })
+
+  it('threads the triple through the attachment-caption path too', () => {
+    // A standalone upload routes the caption through the second
+    // MarkdownRenderer call in renderFileSegment; the triple must reach it as
+    // well, or a link in an attachment caption keeps opening a new tab.
+    const onSessionOpen = vi.fn()
+    const content = `[attached_file 1] /home/user/report.docx\nsee [next](/chat?sid=${THERE})`
+    const meta = { files: ['/home/user/report.docx'] }
+    const { container } = render(
+      <>{renderUserContent({ content, meta, ...triple(onSessionOpen) })}</>,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor).toBeInTheDocument()
+    expect(anchor).not.toHaveAttribute('target')
+    fireEvent.click(anchor)
+    expect(onSessionOpen).toHaveBeenCalledWith(THERE)
+  })
+
+  it('offers no chip when the triple is absent (most call sites)', () => {
+    // `sessions` ABSENT is deliberately not the same as an empty map — a
+    // caller that never wired the roster gets the pre-#8253 behaviour.
+    const { container } = render(
+      <>{renderUserContent({ content: `see [next](/chat?sid=${THERE})`, meta: undefined, onFileOpen: noop })}</>,
+    )
+    const anchor = container.querySelector('a')!
+    expect(anchor).toHaveAttribute('target', '_blank')
+  })
+})

--- a/website/src/test/renderUserContent.test.tsx
+++ b/website/src/test/renderUserContent.test.tsx
@@ -6,36 +6,36 @@ const noop = () => {}
 
 describe('renderUserContent — markdown rendering', () => {
   it('renders bold text via markdown', () => {
-    const { container } = render(<>{renderUserContent('hello **bold** world', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: 'hello **bold** world', meta: undefined, onFileOpen: noop })}</>)
     expect(container.querySelector('strong')).toHaveTextContent('bold')
   })
 
   it('renders italic text via markdown', () => {
-    const { container } = render(<>{renderUserContent('hello *italic* world', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: 'hello *italic* world', meta: undefined, onFileOpen: noop })}</>)
     expect(container.querySelector('em')).toHaveTextContent('italic')
   })
 
   it('renders inline code via markdown', () => {
-    const { container } = render(<>{renderUserContent('use `npm install`', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: 'use `npm install`', meta: undefined, onFileOpen: noop })}</>)
     expect(container.querySelector('code')).toHaveTextContent('npm install')
   })
 
   it('renders links via markdown', () => {
-    const { container } = render(<>{renderUserContent('see [docs](https://example.com)', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: 'see [docs](https://example.com)', meta: undefined, onFileOpen: noop })}</>)
     const link = container.querySelector('a')
     expect(link).toHaveTextContent('docs')
     expect(link).toHaveAttribute('href', 'https://example.com')
   })
 
   it('renders unordered lists via markdown', () => {
-    const { container } = render(<>{renderUserContent('- item one\n- item two', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: '- item one\n- item two', meta: undefined, onFileOpen: noop })}</>)
     const items = container.querySelectorAll('li')
     expect(items).toHaveLength(2)
     expect(items[0]).toHaveTextContent('item one')
   })
 
   it('renders code blocks via markdown', async () => {
-    const { container } = render(<>{renderUserContent('```js\nconst x = 1\n```', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: '```js\nconst x = 1\n```', meta: undefined, onFileOpen: noop })}</>)
     const pre = container.querySelector('pre')
     expect(pre).toBeInTheDocument()
     // Pierre owns the block's internals and fills them after mount, so assert the
@@ -44,12 +44,12 @@ describe('renderUserContent — markdown rendering', () => {
   })
 
   it('renders plain text without extra wrapping issues', () => {
-    const { container } = render(<>{renderUserContent('just plain text', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: 'just plain text', meta: undefined, onFileOpen: noop })}</>)
     expect(container).toHaveTextContent('just plain text')
   })
 
   it('renders image markdown', () => {
-    const { container } = render(<>{renderUserContent('![alt](/path/to/img.png)', undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: '![alt](/path/to/img.png)', meta: undefined, onFileOpen: noop })}</>)
     const img = container.querySelector('img')
     expect(img).toBeInTheDocument()
     // MarkdownRenderer rewrites local paths to /api/file-raw?path=<encoded>
@@ -58,7 +58,7 @@ describe('renderUserContent — markdown rendering', () => {
 
   it('renders file chips for attached files with markdown in surrounding text', () => {
     const content = '[attached_file 1] /home/user/file.ts\ncheck this **bold** text'
-    const { container } = render(<>{renderUserContent(content, undefined, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: undefined, onFileOpen: noop })}</>)
     // File chip rendered
     expect(container.querySelector('[title="/home/user/file.ts"]')).toBeInTheDocument()
     // Markdown in remaining text
@@ -69,7 +69,7 @@ describe('renderUserContent — markdown rendering', () => {
     // Empty-caption upload persists as a standalone token line + meta.files.
     const content = '[attached_file 1] /home/user/uploads/x_CHANGE_PCT.docx'
     const meta = { files: ['/home/user/uploads/x_CHANGE_PCT.docx'] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     const card = container.querySelector('.flex-col [title="/home/user/uploads/x_CHANGE_PCT.docx"]')
     expect(card).toBeInTheDocument()
     expect(card).toHaveTextContent('x_CHANGE_PCT.docx')
@@ -87,7 +87,7 @@ describe('renderUserContent — markdown rendering', () => {
       '/home/user/uploads/b_CHANGE_AMT.docx',
       '/home/user/uploads/c_MONTHLY_RT.docx',
     ] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     expect(container.querySelector('[title$="a_CHANGE_PCT.docx"]')).toBeInTheDocument()
     expect(container.querySelector('[title$="b_CHANGE_AMT.docx"]')).toBeInTheDocument()
     expect(container.querySelector('[title$="c_MONTHLY_RT.docx"]')).toBeInTheDocument()
@@ -99,7 +99,7 @@ describe('renderUserContent — markdown rendering', () => {
     const onOpen = (p: string) => { opened = p }
     const content = '[attached_file 1] /home/user/report.docx'
     const meta = { files: ['/home/user/report.docx'] }
-    const { container } = render(<>{renderUserContent(content, meta, onOpen)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: onOpen })}</>)
     const card = container.querySelector('.flex-col [title="/home/user/report.docx"]') as HTMLElement
     expect(card).toBeInTheDocument()
     card.click()
@@ -110,7 +110,7 @@ describe('renderUserContent — markdown rendering', () => {
     // Fresh message: caption @-mentions the file inline; meta.files carries the path.
     const content = 'check @report.docx please'
     const meta = { files: ['/home/user/report.docx'] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     const chip = container.querySelector('.inline-flex[title="/home/user/report.docx"]')
     expect(chip).toBeInTheDocument()
     expect(chip).toHaveTextContent('@report.docx')
@@ -124,7 +124,7 @@ describe('renderUserContent — markdown rendering', () => {
     // Regression guard: the file must render as an inline chip, not a card.
     const content = 'this is [attached_file 1] /home/user/triage/hcm-ozone.csv file'
     const meta = { files: ['/home/user/triage/hcm-ozone.csv'] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     const chip = container.querySelector('.inline-flex[title="/home/user/triage/hcm-ozone.csv"]')
     expect(chip).toBeInTheDocument()
     expect(container.querySelector('.flex-col [title="/home/user/triage/hcm-ozone.csv"]')).not.toBeInTheDocument()
@@ -142,7 +142,7 @@ describe('renderUserContent — markdown rendering', () => {
     // number is the 1-based index into it. The chip target must be the FULL path.
     const content = 'see [attached_file 1] /home/user/Q2 Report.docx here'
     const meta = { files: ['/home/user/Q2 Report.docx'] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     const chip = container.querySelector('[title="/home/user/Q2 Report.docx"]')
     expect(chip).toBeInTheDocument()
     // The truncated path must NOT appear as a click target.
@@ -153,7 +153,7 @@ describe('renderUserContent — markdown rendering', () => {
   it('renders exactly one card for a standalone upload (no duplication)', () => {
     const content = 'here is the file\n[attached_file 1] /home/user/data.csv'
     const meta = { files: ['/home/user/data.csv'] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     const refs = container.querySelectorAll('[title="/home/user/data.csv"]')
     expect(refs.length).toBe(1)
     expect(container.textContent).not.toContain('[attached_file')
@@ -164,7 +164,7 @@ describe('renderUserContent — markdown rendering', () => {
     // spaced path must resolve in full — not truncate at the space.
     const content = '![image](/home/user/pic.png)\n\nsee [attached_file 2] /home/user/Q2 Report.docx here'
     const meta = { files: ['/home/user/pic.png', '/home/user/Q2 Report.docx'] }
-    const { container } = render(<>{renderUserContent(content, meta, noop)}</>)
+    const { container } = render(<>{renderUserContent({ content: content, meta: meta, onFileOpen: noop })}</>)
     expect(container.querySelector('[title="/home/user/Q2 Report.docx"]')).toBeInTheDocument()
     expect(container.querySelector('[title="/home/user/Q2"]')).not.toBeInTheDocument()
     expect(container.textContent).not.toContain('[attached_file')


### PR DESCRIPTION
## Summary

A `/chat?sid=<slot-key>` markdown link switches the dashboard session in place when it appears in an assistant message, a note row, or a completion card — but opened a new browser tab in a USER message. The user-message path (`renderUserContent` → `renderUserContentInner` → `renderFileSegment`) passed only presentation props to `MarkdownRenderer`, so `resolveSessionChip` refused at its first guard and the root-relative href fell into the external-link branch (`ALLOWED_PROTOCOLS` holds only the vscode schemes), gaining `target="_blank"`.

This threads the same session triple (`onSessionOpen` / `sessions` / `activeSession`) the assistant and note rows already pass (`selectSessionTab`, `connected ? sessionTitles : undefined`, `activeSlot || undefined`) down the user-message render path — byte-equivalent wiring to the `WorkflowCompletionCard` / `SubagentCompletionCard` call sites.

Rather than growing the three helpers' positional signatures past 7 parameters, they now take a single typed options object (`UserContentRenderOpts`; `renderFileSegment` extends it privately with `keyBase` / `dirMap`, which `renderUserContentInner` sets unconditionally so they are deliberately not caller-suppliable). All call sites updated, including `renderUserContentCb` (dep array extended with the four new inputs — `sessionTitles` is signature-memoized, so invalidation only occurs on real roster changes) and every test that called `renderUserContent` positionally.

Closes #8253

## Acceptance criteria → tests

New `website/src/test/renderUserContent.sessionLink.test.tsx` (real `MarkdownRenderer`, no mocks — pins the whole thread from helper options to anchor):

1. a `/chat?sid=<open-key>` link in a user message renders with **no** `target="_blank"`, keeps its real href, carries the switch tooltip, and a plain click invokes `onSessionOpen` with the key;
2. a link whose key equals `activeSession` stays inert with its existing external-branch shape (negative control — `resolveSessionChip` refuses the active key);
3. a link whose key names no open session stays an ordinary link;
4. the attachment-caption `MarkdownRenderer` call (second render path in `renderFileSegment`) gets the same triple;
5. absent triple keeps the pre-change behaviour (roster-absent ≠ roster-empty).

## What was tested

- `npx tsc -b` and `npx eslint` on all changed files: clean.
- `scripts/check_brand_name.py` (diff-scoped): pass.
- Full vitest suite runs in CI (this host is restricted to lint/type gates).

## Out of scope (pre-existing, documented trade-off)

The paste-adjacent and inline-@-mention branches render surrounding text as whitespace-preserving plain spans, never through `MarkdownRenderer` — a documented trade-off that predates this change (see the comments in `renderUserContentInner` / `renderFileSegment`). A markdown link of ANY kind there renders as literal text, produces no anchor, and therefore cannot gain `target="_blank"`; the behaviour this issue reports cannot occur in those branches, and this PR does not change them.

## Pre-push adversarial review

Two blind model-pinned lanes on the staged diff. GPT lane raised one Medium (session links inert in the inline-flow branches) — classified as the pre-existing trade-off above, not introduced or reachable as reported (no anchor is produced there); Opus lane verified the same branches independently and returned PASS, plus one Low API-shape finding (caller-suppliable but ignored `keyBase`/`dirMap` on the exported type) which is fixed in this commit via the private `FileSegmentOpts` extension.

<!-- no-visual-delta -->
**Why no screenshot:** the session-link chip a user message now renders is pixel-identical to the existing assistant-row/note-row chip (same `MarkdownRenderer` branch, same class list); the only deltas are the removed `target="_blank"` attribute and the hover tooltip, neither of which changes at-rest rendering.

## Pattern harvest

Rule candidate: a `MarkdownRenderer` call site inside a chat-transcript surface that omits the session triple (`onSessionOpen` / `sessions` / `activeSession`) while sibling row kinds pass it. Same defect class was fixed once before for note rows and completion cards (see `ChatPage.noteSessionLink.test.tsx`); this PR fixes the user-message instance. A grep-able review rule — "new `MarkdownRenderer` in `website/src/pages/chat*` must pass the session triple or carry a comment naming why not" — would catch the next surface added without it.
