### PR TITLE
fix(chat): stop a mobile POP restoring the session just left

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -16,7 +16,7 @@ import { isHiddenInvisibleAssistantRow } from '../utils/invisibleText'
 // pure test need not pull ChatPage's module graph.
 export { isBrowseCommand }
 import { useDrawerSwipe, animateDrawer, registerDrawerTargets, takeOverDrawer, safeAreaLeft } from '../hooks/useDrawerSwipe'
-import { shouldReplaceSessionUrl } from '../utils/sessionUrlHistory'
+import { shouldReplaceSessionUrl, popMaySwitchSession } from '../utils/sessionUrlHistory'
 import type { ResizeInfo } from '../utils/resizeImage'
 import { useAppSelector, useAppDispatch, store } from '../store'
 import { useConnected } from '../hooks/useConnected'
@@ -4267,6 +4267,14 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
    * naming the session actually on screen at the pre-drawer stack depth.
    */
   const drawerPopRef = useRef(false)
+  /** Keys of history entries a session-switch PUSH created or left behind — the
+   *  only ones a POP may legitimately return to as a session. Written by the
+   *  `activeSlot -> ?sid` sync effect, read by the POP reader; see
+   *  `popMaySwitchSession`. */
+  const pushedSessionEntryKeys = useRef<Set<string>>(new Set())
+  /** A push has been issued and its destination key is not minted yet — the sync
+   *  effect records it on the commit that push lands in. */
+  const pushedEntryPending = useRef(false)
   const [sidError, setSidError] = useState('')
   const [newSlotFailed, setNewSlotFailed] = useState(false)
   const [highlightTs, setHighlightTs] = useState<string | null>(null)
@@ -4391,6 +4399,25 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // "the host drives ?sid" and would switch the panel onto whatever session the
     // host route happens to carry.
     if (noUrlSync) return
+    // Rewrite the entry we are STANDING ON so its `?sid=` names the session
+    // actually on screen. Shared by the two POP paths that must not honour a
+    // stale sid, because the alternative — leaving the URL wrong and relying on
+    // the `activeSlot -> ?sid` effect below to catch up — is what #8209 had to
+    // come back and fix once already. Replacing (never pushing) keeps the stack
+    // depth the pop just restored, and `activeSlotRef` is the render-current
+    // value even when the pop originated in this same commit.
+    const repairPoppedSid = () => {
+      const target = activeSlotRef.current
+      const urlSlot = searchParams.get('sid') || searchParams.get('slot')
+      if (!target || target === urlSlot) return
+      const next = new URLSearchParams(searchParams)
+      next.set('sid', target)
+      next.delete('slot')
+      navigate(
+        { pathname: location.pathname, search: `?${next}`, hash: location.hash },
+        { replace: true },
+      )
+    }
     // Our own drawer-entry consumption, not a Back/Forward the user asked for.
     // Correct the POP's stale outgoing `?sid=` HERE, in the effect that owns the
     // POP, rather than relying on the separate activeSlot -> URL effect below.
@@ -4409,17 +4436,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       drawerPopRef.current = false
       lastLocKeyRef.current = location.key
       popInFlightRef.current = false
-      const target = activeSlotRef.current
-      const urlSlot = searchParams.get('sid') || searchParams.get('slot')
-      if (target && target !== urlSlot) {
-        const next = new URLSearchParams(searchParams)
-        next.set('sid', target)
-        next.delete('slot')
-        navigate(
-          { pathname: location.pathname, search: `?${next}`, hash: location.hash },
-          { replace: true },
-        )
-      }
+      repairPoppedSid()
       return
     }
     // Embed: host app drives the URL — react to any ?sid change.
@@ -4443,11 +4460,21 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     if (!connected) return
     const urlSid = searchParams.get('sid') || searchParams.get('slot')
     if (!urlSid || urlSid === activeSlot) return
+    // Mobile replaces on every session switch, so an entry here was pushed by a
+    // switch only if the write side recorded it as one — see
+    // `popMaySwitchSession`. Repair an unrecorded stale sid rather than obeying
+    // it, which is what walked the pane back into the outgoing chat when the
+    // sessions drawer's pop arrived a commit late (#8207).
+    const entryPushedBySwitch = pushedSessionEntryKeys.current.has(location.key)
+    if (!embedMode && !popMaySwitchSession({ isMobile, entryPushedBySwitch })) {
+      repairPoppedSid()
+      return
+    }
     if (filteredSlots.some(s => s.key === urlSid)) {
       popInFlightRef.current = true
       dispatch(switchSlot(urlSid))
     }
-  }, [searchParams, filteredSlots, activeSlot, dispatch, embedMode, navigationType, location.key, location.pathname, location.hash, connected, noUrlSync, navigate])
+  }, [searchParams, filteredSlots, activeSlot, dispatch, embedMode, navigationType, location.key, location.pathname, location.hash, connected, noUrlSync, navigate, isMobile])
   // Timeout: if slot never appears after 5s, show error.
   // Gated on `connected` so the timer only runs while the gateway is reachable
   // — otherwise an offline tab would burn its 5s while the resolve effects
@@ -4497,6 +4524,15 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // localStorage hydration, WS updates) which would unwantedly bounce
     // the user back into chat view.
     if (embedMode === 'sessions') return
+    // Land the key claimed by our own push below. This effect re-runs on
+    // `location.key`, so the first run after that navigate is standing ON the
+    // entry the push created — the Forward target. Placed ahead of every early
+    // return: the run that lands here is exactly the one where the URL already
+    // agrees with `activeSlot`, which is the earliest bail.
+    if (pushedEntryPending.current) {
+      pushedEntryPending.current = false
+      pushedSessionEntryKeys.current.add(location.key)
+    }
     const sp = searchParamsRef.current
     // Back/Forward (POP) activation in flight: the browser already set the URL to
     // the target session and activeSlot is catching up via the switchSlot the
@@ -4538,7 +4574,27 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     // pushes. Kept as a named predicate rather than an inline boolean so the
     // reasoning has somewhere to live and a test can pin it.
     const isSessionSwitch = !!current && current !== activeSlot
-    navigate(`${basePath}${slug ? '/' + slug : ''}?${next}`, { replace: shouldReplaceSessionUrl({ isSessionSwitch, isMobile }) })
+    const replace = shouldReplaceSessionUrl({ isSessionSwitch, isMobile })
+    // A push leaves the entry we are standing on behind, still naming the session
+    // it was showing, and CREATES another naming the session switched to. Both
+    // were made by a session switch, so both are legitimate history targets — the
+    // first for Back, the second for Forward — and the POP reader must honour
+    // either even if the layout has since crossed the mobile breakpoint. Recorded
+    // here because this is the only place that knows a push happened; the reader
+    // would otherwise have to guess from the viewport, which is read at a
+    // different time (see `popMaySwitchSession`). Per-mount, like every other ref
+    // this reader keeps: a reload starts the history bookkeeping over anyway.
+    //
+    // The destination's key does not exist yet — the router mints it — so it is
+    // claimed here and recorded by the block at the top of this effect on the
+    // commit the push lands in. Recording only the entry left behind made Forward
+    // read as stale, and the reader REPAIRS what it declines, so Forward
+    // overwrote the very session it should have restored.
+    if (!replace) {
+      pushedSessionEntryKeys.current.add(location.key)
+      pushedEntryPending.current = true
+    }
+    navigate(`${basePath}${slug ? '/' + slug : ''}?${next}`, { replace })
     // `location.key` and not just `location.pathname`: consuming the mobile
     // drawer's history entry lands on a DIFFERENT entry whose pathname is
     // IDENTICAL (the entry was a duplicate), so pathname alone reports no change

--- a/website/src/test/ChatPage.drawerBackClose.test.tsx
+++ b/website/src/test/ChatPage.drawerBackClose.test.tsx
@@ -36,7 +36,7 @@ import { MemoryRouter, Routes, Route, useLocation, useNavigate, useNavigationTyp
 import { createTestStore } from './helpers'
 import { ThemeProvider } from '../hooks/useTheme'
 import { sseSlots, sseConnected } from '../store/dashboardSlice'
-import { createSlot, setActiveSlot } from '../store/chatSlice'
+import { createSlot, setActiveSlot, switchSlot } from '../store/chatSlice'
 import { api } from '../api/client'
 
 /** Completion callbacks handed to framer's `animate`, fired manually so a close
@@ -94,7 +94,10 @@ vi.mock('../hooks/useAgents', () => {
 })
 vi.mock('../hooks/useFilteredDropdown', () => ({ useFilteredDropdown: () => ({ filtered: [], query: '', setQuery: vi.fn(), selectedIndex: 0, setSelectedIndex: vi.fn(), onKeyDown: vi.fn() }) }))
 vi.mock('../hooks/useVoiceInput', () => ({ useVoiceInput: () => ({ recording: false, transcribing: false, toggle: vi.fn() }), voiceInputSupported: false }))
-vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => true }))
+/** Mutable so one test can cross the mobile breakpoint mid-session, which is the
+ *  whole point of the resize case below. Reset to mobile in `beforeEach`. */
+const viewport = vi.hoisted(() => ({ isMobile: true }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => viewport.isMobile }))
 vi.mock('../api/client', () => ({
   api: Object.fromEntries(
     ['sessions', 'chatSlotDetail', 'createChatSlot', 'deleteChatSlot', 'resumeChatSlot',
@@ -143,6 +146,7 @@ function NavProbe() {
         data-navtype={navType}
       />
       <button data-testid="platform-back" onClick={() => navigate(-1)}>back</button>
+      <button data-testid="platform-forward" onClick={() => navigate(1)}>forward</button>
     </div>
   )
 }
@@ -154,7 +158,7 @@ let backNav: (() => void) | null = null
  * observable rather than an inert no-op at the bottom of the stack — that is
  * the whole defect in #5795.
  */
-function renderChat() {
+function renderChat(initialEntries: string[] = ['/before-chat', '/chat?sid=slot-0']) {
   const store = createTestStore()
   act(() => {
     // BEFORE the slots: `sseConnected` also clears `slotsLoaded`. Connected is
@@ -173,7 +177,7 @@ function renderChat() {
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
         <ThemeProvider>
-          <MemoryRouter initialEntries={['/before-chat', '/chat?sid=slot-0']}>
+          <MemoryRouter initialEntries={initialEntries}>
             <NavProbe />
             <Routes>
               <Route path="/before-chat" element={<div data-testid="off-chat" />} />
@@ -193,6 +197,7 @@ const drawerMounted = () => screen.queryAllByTestId('sidebar-stub').length > 0
 /** Two controls carry this label on mobile; either opens a closed drawer. */
 const openDrawer = () => fireEvent.click(screen.getAllByLabelText('Toggle sessions')[0])
 const platformBack = () => fireEvent.click(screen.getByTestId('platform-back'))
+const platformForward = () => fireEvent.click(screen.getByTestId('platform-forward'))
 /** Back WITHOUT a DOM click — see `NavProbe`. Required after a drag, whose
  *  release arms the hook's click swallower. */
 const platformBackNoClick = () => act(() => { backNav?.() })
@@ -222,6 +227,7 @@ const finishSlide = () => act(() => { pendingSettles.splice(0).forEach(fn => fn(
 describe('ChatPage — mobile sessions drawer answers Back (#5795)', () => {
   beforeEach(() => {
     pendingSettles.length = 0
+    viewport.isMobile = true
     Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 390 })
     Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 844 })
   })
@@ -340,5 +346,89 @@ describe('ChatPage — mobile sessions drawer answers Back (#5795)', () => {
     expect(onChat()).toBe(true)
     expect(screen.queryByTestId('off-chat')).toBeNull()
     expect(drawerMounted()).toBe(false)
+  })
+
+  /**
+   * The general form of the drawer defect, and the reason the drawer's own
+   * one-shot claim was never enough (#8207).
+   *
+   * On mobile a session switch REPLACES — `shouldReplaceSessionUrl` — so no entry
+   * in this stack was ever pushed BY a switch, and a POP landing on a `?sid=`
+   * that differs from the session on screen cannot be one the user retraced. The
+   * only such entry that exists is the one under the drawer's duplicate, still
+   * naming the pre-drawer session. Obeying it is what walked the pane back into
+   * the outgoing conversation; the timing only decided how often.
+   *
+   * Stated as a bare stale entry rather than through the drawer, because that is
+   * the invariant: it holds for whatever pushes at this URL next, and it is the
+   * one form of the assertion a synchronous harness can hold honestly — the
+   * drawer route depends on a pop that MemoryRouter, jsdom and headless Chromium
+   * all settle before React can commit, so a test written through the drawer
+   * passes on the broken tree.
+   */
+  it('a POP onto a stale ?sid does not switch sessions on mobile', () => {
+    const store = renderChat(['/chat?sid=slot-1', '/chat?sid=slot-0'])
+    expect(store.getState().chat.activeSlot).toBe('slot-0')
+
+    platformBack()
+
+    expect(store.getState().chat.activeSlot).toBe('slot-0')
+    // And the entry is corrected in place, so a reload does not restore the
+    // session the URL was still naming.
+    expect(probe().dataset.sid).toBe('slot-0')
+  })
+
+  /**
+   * The other side of that rule, and the regression the first cut of it shipped.
+   *
+   * The layout is read at POP time; the entry was written earlier, possibly on
+   * the other side of the breakpoint — switch sessions on a wide window, then
+   * narrow it (an iPad Mini rotating into portrait does exactly this). Reading
+   * the CURRENT viewport as the entry's provenance suppressed a Back onto an
+   * entry a real push had created, and because the reader repairs the sid it
+   * declines, it did not merely make that Back inert: it overwrote a legitimate
+   * history target. So the push records what it left behind and the reader
+   * honours it whatever the layout has since become.
+   */
+  it('honours a Back onto an entry a desktop push created, even after narrowing to mobile', async () => {
+    viewport.isMobile = false
+    const store = renderChat(['/before-chat', '/chat?sid=slot-0'])
+
+    // A real desktop session switch — this is the write that PUSHES, leaving the
+    // slot-0 entry behind as a Back target.
+    await act(async () => { await store.dispatch(switchSlot('slot-1')) })
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+    expect(probe().dataset.sid).toBe('slot-1')
+
+    // The window narrows (or the tablet rotates) — same session, same stack.
+    viewport.isMobile = true
+    platformBack()
+
+    expect(store.getState().chat.activeSlot).toBe('slot-0')
+    expect(probe().dataset.sid).toBe('slot-0')
+  })
+
+  /**
+   * And the Forward half of the same stack. A push makes TWO history targets —
+   * the entry it leaves behind (Back) and the entry it creates (Forward) — so
+   * recording only the first left Forward looking like an unrecorded stale entry.
+   * Because the reader repairs what it declines, Forward did not merely fail to
+   * restore slot-1: it overwrote that entry with slot-0 and destroyed it.
+   */
+  it('restores the pushed destination on Forward after narrowing to mobile', async () => {
+    viewport.isMobile = false
+    const store = renderChat(['/before-chat', '/chat?sid=slot-0'])
+
+    await act(async () => { await store.dispatch(switchSlot('slot-1')) })
+    expect(probe().dataset.sid).toBe('slot-1')
+
+    viewport.isMobile = true
+    platformBack()
+    expect(store.getState().chat.activeSlot).toBe('slot-0')
+
+    platformForward()
+
+    expect(store.getState().chat.activeSlot).toBe('slot-1')
+    expect(probe().dataset.sid).toBe('slot-1')
   })
 })

--- a/website/src/test/sessionUrlHistory.test.ts
+++ b/website/src/test/sessionUrlHistory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldReplaceSessionUrl } from '../utils/sessionUrlHistory'
+import { shouldReplaceSessionUrl, popMaySwitchSession } from '../utils/sessionUrlHistory'
 
 describe('shouldReplaceSessionUrl', () => {
   it('pushes a real session switch on desktop, so Back retraces sessions', () => {
@@ -21,5 +21,38 @@ describe('shouldReplaceSessionUrl', () => {
     // navigations the user performed, so neither may leave an entry.
     expect(shouldReplaceSessionUrl({ isSessionSwitch: false, isMobile: false })).toBe(true)
     expect(shouldReplaceSessionUrl({ isSessionSwitch: false, isMobile: true })).toBe(true)
+  })
+})
+
+describe('popMaySwitchSession', () => {
+  it('honours a POP on desktop, where a session switch pushed the entry', () => {
+    expect(popMaySwitchSession({ isMobile: false, entryPushedBySwitch: false })).toBe(true)
+  })
+
+  it('never honours an unrecorded POP entry on mobile', () => {
+    // The two predicates are one decision read from both ends, and #8207 is what
+    // their disagreement cost: the write side stopped pushing session entries on
+    // mobile while the read side kept treating any POP `?sid=` as a session the
+    // user retraced. The only mobile entry carrying a foreign sid is the one
+    // under the sessions drawer's duplicate, so honouring a POP there walked the
+    // pane back into the conversation the user had just left.
+    expect(popMaySwitchSession({ isMobile: true, entryPushedBySwitch: false })).toBe(false)
+  })
+
+  it('honours a pushed entry on mobile, because the layout is not its provenance', () => {
+    // A window narrowed after the push, or an iPad Mini rotated into portrait.
+    // The layout is read now; the entry was written earlier, possibly on the
+    // other side of the breakpoint. Declining here would not merely make Back
+    // inert — the reader REPAIRS the sid it declines, so it would overwrite a
+    // real history target and destroy it.
+    expect(popMaySwitchSession({ isMobile: true, entryPushedBySwitch: true })).toBe(true)
+  })
+
+  it('agrees with the write side: what mobile never pushes, mobile never pops', () => {
+    // Stated as the coupling rather than two constants, so flipping either one
+    // alone fails here instead of silently reopening the gap between them.
+    const isMobile = true
+    expect(shouldReplaceSessionUrl({ isSessionSwitch: true, isMobile })).toBe(true)
+    expect(popMaySwitchSession({ isMobile, entryPushedBySwitch: false })).toBe(false)
   })
 })

--- a/website/src/utils/sessionUrlHistory.ts
+++ b/website/src/utils/sessionUrlHistory.ts
@@ -27,3 +27,44 @@ export function shouldReplaceSessionUrl({
 }: { isSessionSwitch: boolean; isMobile: boolean }): boolean {
   return !isSessionSwitch || isMobile
 }
+
+/**
+ * Whether a Back/Forward (POP) carrying a `?sid=` may switch the active session.
+ *
+ * The mirror of `shouldReplaceSessionUrl`, and it exists because the two were
+ * allowed to disagree. Reading a POP's `?sid=` as "the user retraced to this
+ * session" is only sound where a session switch PUSHED the entry being landed
+ * on — and on mobile nothing ever pushes one. So on mobile a POP whose `?sid=`
+ * differs from the session on screen is never an intent; it is a stale entry
+ * pushed by something else at the same URL. Exactly one such entry exists: the
+ * duplicate the sessions drawer mints so Back can dismiss it, whose predecessor
+ * still names the session the user was on before they opened the drawer.
+ *
+ * Honouring it is #8207 — tap "+ New", and the pop that closes the drawer walks
+ * the pane straight back into the conversation just left, stranding the new
+ * empty session in the list. That was patched at the drawer's own pop with a
+ * one-shot claim armed before `navigate(-1)`, which only holds while nothing
+ * else re-runs the reader in between; a phone browser does not deliver the pop
+ * inside the caller's task, so the window is real there and nowhere else. This
+ * predicate removes the window instead of racing it: on mobile the reader has
+ * nothing to honour, whatever order things land in.
+ *
+ * Embeds are not covered — a host page drives `?sid=` itself, so there the
+ * param IS the instruction and the reader must follow it.
+ *
+ * `entryPushedBySwitch` is why the layout alone does not decide. The layout is
+ * read NOW; the entry was written EARLIER, possibly on the other side of the
+ * breakpoint — switch sessions on a wide window, then narrow it (an iPad Mini
+ * rotating does exactly this), and Back lands on an entry a real push created.
+ * Suppressing there would not merely make Back inert: the reader repairs the sid
+ * it declines, so it would overwrite a legitimate history target and destroy it.
+ * So provenance comes from the write side, which knows what it pushed.
+ */
+export function popMaySwitchSession({
+  /** Narrow/mobile layout — where a session switch replaces instead of pushing. */
+  isMobile,
+  /** This entry was pushed BY a session switch, recorded when the push happened. */
+  entryPushedBySwitch,
+}: { isMobile: boolean; entryPushedBySwitch: boolean }): boolean {
+  return !isMobile || entryPushedBySwitch
+}


### PR DESCRIPTION
<!-- no-visual-delta -->

Closes the remaining half of #8207 — mobile **+ New** could still land the
pane back in the previous conversation, leaving an unused *New Session* row
in the list. Reproduced on a real phone against a build that already carried
the earlier repair.

## The disagreement

`shouldReplaceSessionUrl` decided some time ago that a session switch on
mobile **replaces**, so a phone never pushes a `?sid=` history entry — its own
docstring puts it as "Back there means exactly one thing: leave the chat
route".

The POP reader in `ChatPage` never learned that rule. It still treats any
`?sid=` a Back/Forward carries as a session the user retraced. On mobile the
only entry holding a foreign sid is the one *beneath* the sessions drawer's
duplicate, which still names the session that was open before the drawer was
opened — so the pop that closes the drawer hands the reader a stale sid, and
it obeys.

That pop was already special-cased, with a one-shot claim armed just before
`navigate(-1)`. The claim is only sound while nothing else re-runs the reader
between arming and the pop landing, and a phone browser does not deliver the
pop inside the caller's task. So the window is real there and nowhere else:
MemoryRouter, jsdom and headless Chromium each settle the pop before React can
commit, which is why the earlier fix read as complete everywhere it could be
observed.

## The change

`popMaySwitchSession({ isMobile })` lands next to its write-side twin in
`sessionUrlHistory.ts`, and the reader now repairs the stale sid rather than
obeying it. Ordering-independent — it removes the window instead of racing it,
so no claim has to survive a commit. The two POP paths that must not honour a
stale sid also share one repair helper now, instead of the reader relying on
the separate `activeSlot -> ?sid` effect to catch up.

Embeds are untouched: a host page drives `?sid=` itself, so there the param is
the instruction and the reader must follow it.

## Tested

- New integration test in `ChatPage.drawerBackClose.test.tsx` is **red on the
  base** with the defect's exact shape (`activeSlot` becomes the URL's stale
  `slot-1`) and green with the change. Written as a bare stale entry rather
  than through the drawer on purpose: the drawer route depends on a pop that
  every synchronous harness settles too early, so a test written that way
  passes on the broken tree.
- Mutation check: forcing `popMaySwitchSession` to return `true` reddens
  exactly that test. Removing the `repairPoppedSid()` call from the new arm
  stays green — the `activeSlot -> ?sid` effect corrects the URL there anyway,
  so that half is belt-and-braces and is **not** pinned. It is kept because
  that fallback is gated by `popInFlightRef`, and leaning on it is what the
  earlier repair had to come back and fix.
- Three predicate tests pin the coupling between the read and write sides, so
  flipping either one alone fails rather than silently reopening the gap.
- `npx tsc -b` clean, `eslint` clean on the four changed files, and 59 tests
  across the chat/session URL suites pass.
- Deployed to a live gateway and confirmed by the reporter on the phone the
  original recording came from.

**Why no screenshot:** the change only decides whether a Back/Forward is
allowed to switch sessions and rewrites a query param — no element, style or
layout is touched, so there is no rendered delta to capture.

## Review round 1

**GPT 5.6's blocking finding was legitimate and is fixed.** The first cut asked the
CURRENT layout whether an entry could have been pushed by a session switch, but the
layout is read at POP time while the entry was written earlier — possibly on the other
side of the breakpoint. Switch sessions on a wide window, then narrow it (an iPad Mini
rotating into portrait crosses 768px), and Back landed on an entry a real push created;
because the reader repairs the sid it declines, that did not merely make Back inert, it
overwrote a legitimate history target. `popMaySwitchSession` now takes
`entryPushedBySwitch`, recorded by the push itself, so provenance comes from the write
side. Both halves are mutation-pinned: forcing the reader to ignore the record, and
stopping the push from writing it, each redden only the new resize test.

**Bundle Size Gate was main's drift, not this diff.** Measured in one environment, this
branch's `App` chunk was 3,287,633 B against its base's 3,287,506 B — 127 B — while the
ceiling was already exceeded on the base alone. That is now moot: #8519 landed the same
re-measure on main, so this PR carries no budget change and has been rebased onto it.

**Rebased onto current main**, dropping the redundant budget commit. One commit, four files,
all frontend. The `Backend Tests (Windows) (4)` red seen on the previous head is unrelated:
the failures are xdist `worker 'gwN' crashed` in `test/test_slot_close_recreation_race.py`,
and this diff touches no Python at all.

## Pattern harvest

Rule candidate: a one-shot "the next callback is mine" claim, armed immediately before
an asynchronous platform callback (`navigate(-1)` / `history.go` / `postMessage`) and
consumed inside a React effect whose deps include anything else. The claim is only sound
while nothing re-runs that effect between arming and delivery, which is untestable in
every synchronous harness and true in a real browser — so it fails exactly where it
cannot be caught. Prefer a rule the reader can evaluate from durable facts (here: a
provenance record written where the push happens) over a token that has to survive a
commit.

Second, narrower: paired read/write predicates over one invariant must live in the same
module and be pinned by a test that states the COUPLING, not by two independent
constants. This defect existed because `shouldReplaceSessionUrl` was extracted and
tested on its own while the read half stayed an inline condition sixty lines away in an
effect, so a change to one side could not fail the other. Both now sit in
`website/src/utils/sessionUrlHistory.ts` with a coupling test.

