### PR TITLE
fix(ci): re-measure the drifted App-chunk bundle ceiling

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -88,7 +88,14 @@ export const CHUNK_BUDGETS = {
   // The app-core chunk: the dashboard shell plus everything eagerly imported
   // from it. The vendor split in vite.config.ts already extracts the heaviest
   // libraries; what remains is first-party code with no clean lazy boundary.
-  App: 3200 * KB, // measured 3121 KB
+  // Re-measured 2026-09-04: main drifted to 3201 KB (3,277,346 B, 546 B over
+  // the previous 3200 KB ceiling), so the gate began failing on the merge ref
+  // of every open PR rather than on a new library or surface — the same
+  // recurrence the `t` entry above documents. Attribution was measured, not
+  // assumed: main's tip alone, with no PR code, reproduces the failure.
+  // 5% headroom, matching the `all` and `t` entries' convention, so ordinary
+  // first-party growth does not re-trip this within days.
+  App: 3360 * KB, // measured 3201 KB on main @ 701f8f981 (~5% headroom)
 
   // Markdown/math/syntax rendering stack (katex, highlight.js, remark/rehype)
   // -- one deliberate `manualChunks` bucket, see vite.config.ts.


### PR DESCRIPTION
## Summary

Unblocker: main's `App` chunk drifted past its own bundle-size ceiling, so the Bundle Size Gate fails on the **merge ref of every open PR** instead of on the new library or surface it exists to catch. This re-measures the ceiling with the ~5% headroom convention the `all` and `t` entries already use.

no linked issue: gate breakage found while driving PR #8510; filed as a direct unblocker per the `t`-entry precedent (#8412, merged this morning for the identical recurrence on the `t` chunk).

## Attribution (measured, not assumed)

- main @ `701f8f981` alone, with **no PR code**, builds `assets/App-CqSksnwP.js` at 3,277,346 B — 546 B over the 3200 KB (3,276,800 B) ceiling. Reproduced locally with `npx vite build --mode analyze` + `node scripts/check-bundle-size.mjs` on a pristine main worktree.
- An earlier main commit (`bad30a003`, ~4h older) measured 3,276,213 B — under by 587 B. The growth is main's own accumulated first-party code, merged across several PRs whose individual merge refs each stayed under.
- New ceiling: 3360 KB = measured 3201 KB + ~5% headroom, matching the convention documented on the `all` and `t` entries (the `t` entry's comment records this exact recurrence class and why headroom is the fix).

## What was tested

- `node scripts/check-bundle-size.mjs` against a fresh `--mode analyze` build of main @ `701f8f981`: fails 546 B over before this change, `805 chunks within budget` after.

## Pattern harvest

Not generalizable: the `t` entry's comment already documents this recurrence class (a ceiling with <1% headroom fails on drift, not on defects) and the 5% headroom convention is the standing remedy; this PR applies it to the one remaining tight entry.

<!-- no-visual-delta -->
**Why no screenshot:** CI gate constant only; no runtime code or rendering change.
