### PR TITLE
fix(connections): validate grants before a connect reports connected

### DIFF
--- a/docs/architecture/design-notes/connections-status-tiers.md
+++ b/docs/architecture/design-notes/connections-status-tiers.md
@@ -176,17 +176,53 @@ gateway failure never surfaces as a Cancel that appeared not to work.
 ## Mint outcome telemetry
 
 Every `connections_oauth_mint` audit event records the facts of its route
-directly: `reason=already_granted` when a live grant was re-verified without
-spawning, and `url_minted=<bool>` on a completed spawn — `True` when the
-dedicated kiro-cli spawn produced an approval URL, `False` when it found no
-challenge (an open endpoint, or a grant that landed concurrently). The route a
-Connect took is derivable from those fields; no separate label is emitted. A
-latency-tier vocabulary belongs to the warm-runtime seam (a URL already held; an
-activation on a shared warm process) and ships with that seam, where its routes
-exist as code and its consumers exist as dashboards.
+directly: `reason=validated_grant` when an on-disk grant was re-verified and
+proven usable without spawning a fresh consent flow, and `url_minted=<bool>` on
+a completed spawn — `True` when the dedicated kiro-cli spawn produced an
+approval URL, `False` when it found no challenge (an open endpoint, or a grant
+that landed concurrently). The route a Connect took is derivable from those
+fields; no separate label is emitted. A latency-tier vocabulary belongs to the
+warm-runtime seam (a URL already held; an activation on a shared warm process)
+and ships with that seam, where its routes exist as code and its consumers
+exist as dashboards.
 
 Note that `Provider.tier` in the registry (1–3) is provider *categorization* and
 is unrelated to mint latency.
+
+## A grant on disk is not a grant that works
+
+`grant_observed` (the artifact-pair stat both this module and `mint.py` share)
+answers "does the pair exist", never "does it still work". The pair survives a
+provider-side revoke and a dead refresh token exactly as it survives a live
+one, because nothing in that stat asks kiro-cli to actually use it. Reporting a
+mint `granted` on presence alone let a Connect click on an already-configured
+provider flip the card to Connected instantly, only for the explicit Test
+action's real authenticated check to reveal the pair was already dead and the
+card to fall back to "not authorized" — a lie the card told for however long it
+took the user to notice.
+
+So a Connect or Reconnect mint that finds an existing artifact pair no longer
+reports `granted` on that alone. It spawns the identical single-server
+ephemeral session a fresh mint would spawn, and asks kiro-cli's own `/mcp` +
+`/tools` — the same promptless, model-free command pair the Test button already
+uses, classified through the same predicate (`tool_test._classify`) so both
+surfaces agree on what "usable" means. A `usable` verdict reports `granted`
+with `reason=validated_grant`; anything else — `no_tools`, `failed`, a spawn
+that never completes — falls through to the ordinary fresh-mint spawn loop
+below rather than returning early. That fallthrough is deliberate: the
+validation spawn already proved the existing pair does not answer, so the next
+thing Connect should do is exactly what a user clicking it expects — open a
+real consent page — rather than surface a coarse error for a mint the button
+was never asked to abandon.
+
+**This validation is a mint-time decision, never a poll-time one.** The
+30-second status poll (`collect_connection_statuses`) still answers from the
+cheap artifact stat alone, because that badge only has to be *eventually*
+honest and a per-poll authenticated spawn would turn an idle dashboard tab into
+a standing cost with no click behind it. Validation runs exactly once, at the
+moment a Connect or Reconnect click asks the mint to decide whether a URL is
+needed — the one place the cost is bounded by a real user action and the one
+place the answer changes what the click actually does.
 
 ## Runtime baseline
 

--- a/src/kiro_crew/connections/mint.py
+++ b/src/kiro_crew/connections/mint.py
@@ -62,8 +62,9 @@ from kiro_crew.acp.client import AcpClient
 from kiro_crew.agent_discovery import _read_agent_spec
 from kiro_crew.agent_files import AGENT_FILENAME, OWNED_KIRO_AGENT_FILES
 from kiro_crew.config.loader import data_home
+from kiro_crew.connections.tool_test import _classify as _classify_tool_inventory
 from kiro_crew.loop_lock import LoopBoundLock
-from kiro_crew.mcp_grant import grant_observed
+from kiro_crew.mcp_grant import grant_fingerprint, grant_observed
 from kiro_crew.mcp_utils import mcp_server_alias
 from kiro_crew.security import oauth_url_contains_credential
 from kiro_crew.sel import sel
@@ -74,6 +75,10 @@ logger = logging.getLogger(__name__)
 _MINT_READY_TIMEOUT_SECONDS = 90.0
 _MINT_TTL_SECONDS = 600.0
 _MINT_GRANT_POLL_SECONDS = 5.0
+# How often the watcher's no-baseline fallback may spawn a revalidation. Bounds a
+# rare degraded path (the disproof's capture stat failed) to at most one process
+# per interval across the mint's TTL, instead of one per grant poll.
+_GRANT_REVALIDATION_INTERVAL_SECONDS = 60.0
 # Tight, because the window it closes is the one where the orphan sweep can kill a
 # still-initializing mint. Cheap: an attribute read, no I/O.
 _MINT_PID_CLAIM_POLL_SECONDS = 0.05
@@ -473,31 +478,100 @@ async def _dispose_mint(entry: MintState) -> None:
         await asyncio.shield(asyncio.to_thread(_remove_mint_agent_spec, spec_path))
 
 
-async def _mint_watcher(slug: str, mcp_url: str, token: str) -> None:
+async def _grant_change_proven(
+    slug: str,
+    mcp_url: str,
+    baseline: tuple[int, int] | None,
+    last_revalidation: list[float],
+) -> bool:
+    """Whether the credential can be POSITIVELY proven to work now. Fail-closed.
+
+    Reached only for an attempt whose pre-existing grant a validation already
+    disproved, so presence carries no information: the disproven pair is still on
+    disk and answers "present" exactly as a fresh one would.
+
+    Two admissible proofs, and nothing else:
+
+    * the token artifact CHANGED against the baseline captured at disproof time --
+      completing the exchange makes kiro-cli rewrite it, so a different
+      ``(mtime_ns, size)`` is observable evidence of a new credential;
+    * a fresh authenticated validation returns a proven verdict, used only when no
+      baseline exists (the capture stat failed), because change cannot be observed
+      without one.
+
+    The revalidation fallback is RATE-LIMITED rather than tried once, and the
+    difference matters: the disproven pair is on disk from the start, so presence
+    is true on the first tick and a once-only attempt would always land before the
+    user could finish consenting -- spending the one spawn and then degrading to
+    never-grant for the rest of the TTL. ``last_revalidation`` is a one-slot ledger
+    the caller owns, so at most one spawn per
+    ``_GRANT_REVALIDATION_INTERVAL_SECONDS`` occurs on this rare degraded path
+    while a consent completed later can still resolve.
+
+    An unreadable current stat is False, and so is an unproven revalidation:
+    "could not look" is not proof, and this predicate is the last thing standing
+    between a stale pair and a Connected badge.
+    """
+    current = await asyncio.to_thread(grant_fingerprint, mcp_url)
+    if baseline is not None:
+        return current is not None and current != baseline
+    now = time.monotonic()
+    if last_revalidation and now - last_revalidation[-1] < _GRANT_REVALIDATION_INTERVAL_SECONDS:
+        return False
+    last_revalidation.append(now)
+    logger.info("OAuth mint for %r has no grant baseline; revalidating before granting", slug)
+    return await _validate_existing_grant(slug, mcp_url)
+
+
+async def _mint_watcher(
+    slug: str,
+    mcp_url: str,
+    token: str,
+    require_proof: bool = False,
+    baseline: tuple[int, int] | None = None,
+) -> None:
     """Hold the mint until consent completes or the TTL expires.
 
     ``token`` identifies the row this watcher belongs to. A superseding mint
     replaces the row, so every write re-checks the token rather than trusting
     that the slug still names the same flow.
+
+    ``require_proof`` says a validation DISPROVED the grant that was on disk when
+    this attempt started, and ``baseline`` is that artifact's fingerprint if it
+    could be read. Presence alone cannot answer this watcher's question once that
+    is known: nothing deletes a credential on the strength of one failed check, so
+    the disproven pair is still on disk and a bare ``grant_observed`` would see it
+    on the FIRST tick, five seconds in, flip the row to ``granted`` and dispose the
+    process holding the PKCE verifier and the loopback listener. That is the very
+    lie this flow exists to prevent, plus a consent URL that can no longer be
+    redeemed. ``require_proof`` is carried SEPARATELY from ``baseline`` on purpose:
+    an unreadable capture stat yields no baseline, and inferring "no disproof" from
+    that absence is what let the resurrection path reopen.
     """
+    revalidation: list[float] = []
     try:
         deadline = time.monotonic() + _MINT_TTL_SECONDS
         while time.monotonic() < deadline:
             await asyncio.sleep(_MINT_GRANT_POLL_SECONDS)
-            if await grant_observed(mcp_url):
-                doomed: MintState | None = None
-                async with _mints_lock:
-                    entry = _mints.get(slug)
-                    if entry is not None and entry.get("token") == token:
-                        entry["state"] = "granted"
-                        # Captured under the lock, released after it: a wedged
-                        # teardown waits on a process shutdown, and holding the
-                        # table that long stalls Connect for every provider.
-                        doomed = entry
-                if doomed is not None:
-                    await _dispose_mint(doomed)
-                logger.info("OAuth mint for %r completed (grant present)", slug)
-                return
+            if not await grant_observed(mcp_url):
+                continue
+            if require_proof and not await _grant_change_proven(
+                slug, mcp_url, baseline, revalidation
+            ):
+                continue
+            doomed: MintState | None = None
+            async with _mints_lock:
+                entry = _mints.get(slug)
+                if entry is not None and entry.get("token") == token:
+                    entry["state"] = "granted"
+                    # Captured under the lock, released after it: a wedged
+                    # teardown waits on a process shutdown, and holding the
+                    # table that long stalls Connect for every provider.
+                    doomed = entry
+            if doomed is not None:
+                await _dispose_mint(doomed)
+            logger.info("OAuth mint for %r completed (grant present)", slug)
+            return
         doomed = None
         async with _mints_lock:
             entry = _mints.get(slug)
@@ -610,6 +684,100 @@ async def _claim_mint_pid_when_spawned(client: Any, holdings: MintState) -> None
 
 _MINT_URL_REJECTION_ATTEMPTS = 2
 
+# The two native commands the validation asks. Bounded together with readiness by
+# ONE ``_MINT_READY_TIMEOUT_SECONDS`` deadline: each command carries its own
+# independent transport timeout, so bounding only readiness would let a provider
+# that answers slowly three times over hold Connect in ``minting`` for the sum of
+# all three waits rather than the one budget the card is told to expect.
+_GRANT_VALIDATION_COMMANDS = ("/mcp", "/tools")
+
+#: Verdicts that PROVE kiro-cli's stored grant still works. ``no_tools`` belongs
+#: here with ``usable``: it is reported only when the MCP server reached status
+#: ``running``, which for an OAuth provider means kiro-cli authenticated and
+#: completed ``tools/list`` with the stored bearer. A server that exposes no tools
+#: is a provider-prerequisite or agent-exposure question, NOT a dead credential,
+#: and treating it as unproven would send a user with a perfectly good grant to a
+#: consent page that cannot fix what they actually have.
+_GRANT_PROVEN_VERDICTS = frozenset({"usable", "no_tools"})
+
+
+async def _validate_existing_grant(slug: str, mcp_url: str) -> bool:
+    """Prove an on-disk grant is actually usable before a mint reports ``granted``.
+
+    ``grant_observed`` answers only "does the artifact PAIR exist" -- true for a
+    stale or provider-revoked pair as much as a live one, because a remote revoke
+    never touches the local file kiro-cli wrote. Reporting the card connected on
+    that alone is how a Connect click on Stripe or Vercel flipped instantly to
+    Connected, then fell to "not authorized" once the expensive Test action forced
+    kiro-cli's own refresh and the pair turned out to be dead.
+
+    This spawns the SAME single-server ephemeral session a fresh mint would spawn
+    (see :func:`_write_mint_agent_spec`) and reads kiro-cli's native ``/mcp`` and
+    ``/tools`` results the way :func:`kiro_crew.connections.tool_test.test_connection_tools`
+    does for the explicit Test button -- promptless, no model call, one process.
+    Unlike Test, this call owns its OWN process rather than reaching for the
+    shared ``kirocrew`` agent: mounting every configured server to check one
+    would turn a bounded reconnect into the cost of a cold start elsewhere, and a
+    single-server spec is exactly what a fresh mint attempt would spawn anyway if
+    this validation finds the grant unusable.
+
+    Returns True only for a verdict in :data:`_GRANT_PROVEN_VERDICTS`. A False here
+    does not assert the grant is GONE -- it asserts it could not be proven to work
+    right now -- which is why the caller's answer is a fresh consent mint rather
+    than deleting the credential: a transient provider outage or an unreachable
+    kiro-cli would otherwise destroy a live refresh token that is not recoverable
+    locally.
+
+    Bounded to one attempt inside one deadline: this is a reconnect confirming a
+    grant that is supposed to already work, not a retry loop.
+
+    Never raises. EVERY step lives inside the guarded block, including the client
+    factory and the spec write -- ``_write_mint_agent_spec`` raises ``OSError`` on
+    an unusable main spec or an unrecordable manifest row, and this runs on a
+    fire-and-forget task BEFORE the caller's own try, so an escape would kill the
+    flow and strand the row at ``minting`` with no terminal state for the card to
+    read. ``holdings`` is therefore initialized before the try, so the ``finally``
+    can release whatever had been taken when the raise landed.
+    """
+    holdings: MintState = {}
+    try:
+        acp_client_cls = _acp_client_factory()
+        mint_work_dir = await asyncio.to_thread(data_home)
+        agent_name, spec_path = await asyncio.to_thread(_write_mint_agent_spec, slug)
+        holdings["agent"] = agent_name
+        holdings["spec_path"] = spec_path
+        client = acp_client_cls(
+            work_dir=mint_work_dir / "connections" / "mint",
+            model="auto",
+            agent=agent_name,
+            sandbox_mode="auto",
+            session_key=f"connections-mint-validate-{slug}",
+        )
+        holdings["client"] = client
+        claim = asyncio.get_running_loop().create_task(
+            _claim_mint_pid_when_spawned(client, holdings)
+        )
+
+        async def _ready_and_read() -> tuple[dict[str, Any], ...]:
+            await client.ensure_ready()
+            return tuple([await client.command_result(cmd) for cmd in _GRANT_VALIDATION_COMMANDS])
+
+        try:
+            # ONE deadline over readiness AND both commands, so the whole
+            # validation costs at most what a cold mint spawn is already allowed.
+            results = await asyncio.wait_for(_ready_and_read(), timeout=_MINT_READY_TIMEOUT_SECONDS)
+        finally:
+            claim.cancel()
+            _claim_mint_pid(client, holdings)
+    except Exception:  # noqa: BLE001 — validation must never raise into the mint flow
+        logger.debug("Grant validation for %r could not complete", slug, exc_info=True)
+        return False
+    finally:
+        await _dispose_mint(holdings)
+
+    verdict = _classify_tool_inventory(results, slug, mcp_server_alias(slug))
+    return verdict["verdict"] in _GRANT_PROVEN_VERDICTS
+
 
 async def start_oauth_mint(
     slug: str,
@@ -639,24 +807,54 @@ async def start_oauth_mint(
     # aged orphans. Off-loop: it reads and rewrites the manifest, and may unlink.
     await asyncio.to_thread(_sweep_mint_specs)
 
+    # Whether a validation DISPROVED the pair that was on disk when this attempt
+    # started, tracked SEPARATELY from the fingerprint below. The fingerprint can
+    # legitimately be ``None`` (the capture stat failed), and inferring "no
+    # disproof" from that absence is what would let the pair reassert itself: the
+    # watcher's proof requirement keys on this flag, never on the fingerprint's
+    # presence.
+    validation_failed = False
+    # The disproven artifact's identity when it could be read. ``None`` means the
+    # stat failed, NOT that nothing was disproved -- the watcher then demands a
+    # positive revalidation instead of a change it cannot observe.
+    disproven_grant: tuple[int, int] | None = None
+
     if await grant_observed(mcp_url):
-        # Consent already exists (a reconnect): no URL is needed.
-        async with _mints_lock:
-            if _mints.get(slug, {}).get("token") == my_token:
-                _mints[slug] = {
-                    "state": "granted",
-                    "started": time.monotonic(),
-                    "token": my_token,
-                }
-        # Every POST logs outcome=started, so every path has to log a completion or
-        # the audit trail shows starts that never finished.
-        await asyncio.to_thread(
-            _log_mint_outcome,
-            slug,
-            "ok",
-            "reason=already_granted",
-        )
-        return
+        # An artifact PAIR on disk is not proof the grant still works: it survives
+        # a provider-side revoke and a stale refresh token exactly as it survives
+        # a live one, because nothing here has asked kiro-cli to actually use it
+        # yet. Reporting `granted` on presence alone is what let Connect flip a
+        # dead pair to Connected and then fall to "not authorized" once the
+        # explicit Test action forced the real check. Validate BEFORE claiming
+        # anything, and fall through to a fresh mint on anything short of a
+        # proven-working verdict -- the spawn loop below is exactly what a
+        # user expects Connect to do when consent still needs proving.
+        if await _validate_existing_grant(slug, mcp_url):
+            async with _mints_lock:
+                if _mints.get(slug, {}).get("token") == my_token:
+                    _mints[slug] = {
+                        "state": "granted",
+                        "started": time.monotonic(),
+                        "token": my_token,
+                    }
+            # Every POST logs outcome=started, so every path has to log a
+            # completion or the audit trail shows starts that never finished.
+            await asyncio.to_thread(
+                _log_mint_outcome,
+                slug,
+                "ok",
+                "reason=validated_grant",
+            )
+            return
+        # Set BEFORE the stat, so a failing stat cannot erase the disproof.
+        validation_failed = True
+        # Read AFTER the verdict, so it fingerprints the artifact the validation
+        # actually disproved. Nothing is deleted: one failed check can be a
+        # provider outage or an unreachable runtime, and a refresh token destroyed
+        # on that evidence is not recoverable locally. The fingerprint is what lets
+        # the flow distrust the pair without removing it.
+        disproven_grant = await asyncio.to_thread(grant_fingerprint, mcp_url)
+        logger.info("OAuth mint for %r found an unproven grant on disk; minting fresh", slug)
 
     # Accumulates what this flow owns, so every exit path releases all of it.
     holdings: MintState = {}
@@ -751,21 +949,34 @@ async def start_oauth_mint(
                         "state": "waiting",
                         "oauth_url": oauth_url,
                         "watcher": asyncio.get_running_loop().create_task(
-                            _mint_watcher(slug, mcp_url, my_token)
+                            _mint_watcher(
+                                slug,
+                                mcp_url,
+                                my_token,
+                                validation_failed,
+                                disproven_grant,
+                            )
                         ),
                     }
                 )
                 holdings = {}
             else:
-                # No challenge means one of two things, and they are not the same
+                # No challenge means one of THREE things, and they are not the same
                 # outcome. An open endpoint (or a grant that landed concurrently)
                 # is genuinely granted. A slug with no entry left to initialize
                 # produced no challenge because there was nothing to challenge --
                 # reporting THAT as granted shows a connected card with no server
                 # behind it and no way back, so it has to be a retryable failure.
+                # And when a validation already DISPROVED the stored grant, an
+                # absence of challenge is not proof either: publishing `granted`
+                # from it would republish the exact authorization this attempt just
+                # refuted, so it is the same retryable failure rather than a claim.
                 if entry_missing:
                     entry["state"] = "failed"
                     entry["reason"] = "mint_server_absent"
+                elif validation_failed:
+                    entry["state"] = "failed"
+                    entry["reason"] = "mint_grant_unproven"
                 else:
                     entry["state"] = "granted"
 
@@ -779,6 +990,10 @@ async def start_oauth_mint(
             return
         if entry_missing:
             await asyncio.to_thread(_log_mint_outcome, slug, "error", "reason=mint_server_absent")
+        elif validation_failed and not oauth_url:
+            # The refuted-grant no-challenge branch above: a failure, so it audits
+            # as one rather than riding the ok/url_minted line.
+            await asyncio.to_thread(_log_mint_outcome, slug, "error", "reason=mint_grant_unproven")
         else:
             # ``url_minted`` records whether the spawn produced an approval URL
             # or found no challenge (an open endpoint, or a grant that landed

--- a/src/kiro_crew/mcp_grant.py
+++ b/src/kiro_crew/mcp_grant.py
@@ -140,6 +140,37 @@ def grant_presence(mcp_url: str, *, cache_dir: Path | None = None) -> bool | Non
     return True
 
 
+def grant_fingerprint(mcp_url: str, *, cache_dir: Path | None = None) -> tuple[int, int] | None:
+    """``(mtime_ns, size)`` of the TOKEN artifact, or ``None`` when it cannot be read.
+
+    Presence answers "is there a grant"; this answers "is it the SAME grant". The
+    distinction matters wherever a caller has already established that the pair
+    currently on disk does not work: presence alone cannot then tell a completed
+    consent from the dead pair it is waiting to replace, because both are simply
+    "present". Completing an OAuth exchange makes kiro-cli REWRITE the token
+    artifact, so a changed fingerprint is the observable event.
+
+    Only the token artifact is fingerprinted. The registration is written once at
+    dynamic-client-registration time and is not rewritten by a token exchange, so
+    including it would add a value that never changes and dilute the signal.
+
+    Stats only -- the artifact is never opened, so no token byte can enter the
+    process, the same boundary :func:`grant_presence` keeps. ``None`` on any
+    failure INCLUDING absence: a caller comparing two readings must treat
+    "unknown" as "no evidence of change" rather than as a change, and collapsing
+    absence into a sentinel tuple would manufacture one.
+
+    Blocking for the same reason as :func:`grant_presence`, so async callers route
+    it off the event loop.
+    """
+    token_path, _registration = grant_artifact_paths(mcp_url, cache_dir=cache_dir)
+    try:
+        stat = token_path.stat()
+    except OSError:
+        return None
+    return (stat.st_mtime_ns, stat.st_size)
+
+
 def _labelled_grant_artifacts(
     mcp_url: str, *, cache_dir: Path | None = None
 ) -> tuple[tuple[str, Path], ...]:

--- a/test/test_connections_mint.py
+++ b/test/test_connections_mint.py
@@ -39,6 +39,22 @@ class _FakeClient:
 
     instances: list["_FakeClient"] = []
     next_pid = 424242
+    #: Scripted (`/mcp`, `/tools`) results for the grant-validation path, class-wide
+    #: so a test can arm it before the mint spawns any instance. Defaults to a
+    #: usable Notion server -- most tests never touch validation and must not have
+    #: to script it just to reach the mint spawn loop.
+    command_results: dict[str, dict[str, Any]] = {
+        "/mcp": {
+            "data": {
+                "servers": [
+                    {"name": "notion", "status": "running", "toolCount": 1, "authenticating": False}
+                ]
+            }
+        },
+        "/tools": {
+            "data": {"tools": [{"name": "search", "source": "mcp:notion", "status": "allowed"}]}
+        },
+    }
 
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
@@ -50,10 +66,18 @@ class _FakeClient:
         self.requests: list[dict[str, str]] = [
             {"serverName": "notion", "oauthUrl": _AUTHORIZE},
         ]
+        self.commands: list[str] = []
         _FakeClient.instances.append(self)
 
     async def ensure_ready(self) -> None:
         self.ready = True
+
+    async def command_result(self, command: str, args: dict | None = None) -> dict[str, Any]:
+        self.commands.append(command)
+        outcome = _FakeClient.command_results.get(command, {})
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
 
     def pop_pending_oauth_requests(self) -> list[dict[str, str]]:
         out = list(self.requests)
@@ -112,6 +136,18 @@ def _isolated_mint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setattr(mint, "_mints", {})
     monkeypatch.setattr(mint, "_mints_lock", asyncio.Lock())
     _FakeClient.instances.clear()
+    _FakeClient.command_results = {
+        "/mcp": {
+            "data": {
+                "servers": [
+                    {"name": "notion", "status": "running", "toolCount": 1, "authenticating": False}
+                ]
+            }
+        },
+        "/tools": {
+            "data": {"tools": [{"name": "search", "source": "mcp:notion", "status": "allowed"}]}
+        },
+    }
     monkeypatch.setattr(mint, "_acp_client_factory", lambda: _FakeClient)
     return agents_dir
 
@@ -164,7 +200,7 @@ async def test_the_mint_runs_on_a_dedicated_single_server_spec():
 
 
 @pytest.mark.asyncio
-async def test_an_existing_grant_short_circuits_without_spawning(
+async def test_an_existing_grant_short_circuits_only_after_validating_it(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
@@ -172,7 +208,395 @@ async def test_an_existing_grant_short_circuits_without_spawning(
     await mint.start_oauth_mint("notion", _URL)
 
     assert _state_only(mint.pending_mint_for("notion")) == {"state": "granted"}
-    assert _FakeClient.instances == []
+    # The validation spawn happened -- it is the process that got shut down --
+    # and it asked the same two commands the Test button asks, promptless.
+    assert len(_FakeClient.instances) == 1
+    validator = _FakeClient.instances[-1]
+    assert validator.commands == ["/mcp", "/tools"]
+    assert validator.shutdowns == 1
+
+
+@pytest.mark.asyncio
+async def test_a_stale_grant_on_disk_falls_through_to_a_fresh_mint_instead_of_lying(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The artifact pair exists (a provider-side revoke never touches it), but the
+    # authenticated check proves the server is not actually usable. Reporting
+    # `granted` here is exactly the defect: Connect flips to Connected, then Test
+    # later reveals the pair was dead all along.
+    monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
+    _FakeClient.command_results["/mcp"] = {
+        "data": {
+            "servers": [
+                {"name": "notion", "status": "failed", "toolCount": 0, "authenticating": False}
+            ]
+        }
+    }
+
+    await mint.start_oauth_mint("notion", _URL)
+
+    # Fell through to a REAL fresh mint: a second process was spawned (the
+    # validator, then the cold mint) and the card gets an approval URL, not a
+    # coarse failure -- exactly what a user clicking Connect on a dead grant
+    # expects the button to do.
+    assert len(_FakeClient.instances) == 2
+    validator, fresh = _FakeClient.instances
+    assert validator.commands == ["/mcp", "/tools"]
+    assert validator.shutdowns == 1
+    assert _state_only(mint.pending_mint_for("notion")) == {
+        "state": "waiting",
+        "oauth_url": _AUTHORIZE,
+    }
+    assert fresh.shutdowns == 0
+    await mint._dispose_mint(mint._mints["notion"])
+
+
+@pytest.mark.asyncio
+async def test_a_grant_with_zero_exposed_tools_is_proven_working_not_reconsented(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # `no_tools` is reported only once the MCP server reached status `running`,
+    # which for an OAuth provider means kiro-cli authenticated and completed
+    # tools/list with the stored bearer. The credential WORKS; a zero-tools server
+    # is a provider-prerequisite question. Sending this user to a consent page
+    # would ask them to re-authorize something already authorized, and could not
+    # fix what they actually have.
+    monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
+    _FakeClient.command_results["/tools"] = {"data": {"tools": []}}
+
+    await mint.start_oauth_mint("notion", _URL)
+
+    assert _state_only(mint.pending_mint_for("notion")) == {"state": "granted"}
+    # One process -- the validator -- and no fresh consent spawn behind it.
+    assert len(_FakeClient.instances) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_spec_write_failure_during_validation_never_strands_the_row(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # `_write_mint_agent_spec` raises OSError on an unusable main spec or an
+    # unrecordable manifest row, and the validation runs on a fire-and-forget task
+    # BEFORE the caller's own try. An escape would kill the flow and leave the row
+    # at `minting` forever -- a card spinning with no terminal state to read.
+    monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
+    calls: list[str] = []
+    real = mint._write_mint_agent_spec
+
+    def _fail_first(slug: str):
+        calls.append(slug)
+        if len(calls) == 1:
+            raise OSError("main agent spec unusable")
+        return real(slug)
+
+    monkeypatch.setattr(mint, "_write_mint_agent_spec", _fail_first)
+
+    await mint.start_oauth_mint("notion", _URL)
+
+    # The flow survived the raise and reached a terminal state the card can act on.
+    view = mint.pending_mint_for("notion")
+    assert view is not None
+    assert view["state"] != "minting"
+    assert _state_only(view) == {"state": "waiting", "oauth_url": _AUTHORIZE}
+    await mint._dispose_mint(mint._mints["notion"])
+
+
+@pytest.mark.asyncio
+async def test_validation_bounds_readiness_and_both_commands_with_one_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Each command carries its own transport timeout, so bounding only readiness
+    # would let a provider that answers slowly three times over hold Connect in
+    # `minting` for the sum of all three waits.
+    monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
+    monkeypatch.setattr(mint, "_MINT_READY_TIMEOUT_SECONDS", 0.05)
+
+    class _SlowCommand(_FakeClient):
+        async def command_result(self, command: str, args: dict | None = None):
+            await asyncio.sleep(10)
+            raise AssertionError("unreachable")
+
+    attempts = iter([_SlowCommand, _FakeClient])
+    monkeypatch.setattr(mint, "_acp_client_factory", lambda: next(attempts))
+
+    await asyncio.wait_for(mint.start_oauth_mint("notion", _URL), timeout=5)
+
+    # The deadline fired inside the commands, the verdict read as unproven, and the
+    # flow fell through to a real consent mint instead of hanging.
+    assert _state_only(mint.pending_mint_for("notion")) == {
+        "state": "waiting",
+        "oauth_url": _AUTHORIZE,
+    }
+    await mint._dispose_mint(mint._mints["notion"])
+
+
+# ── the watcher must not resurrect a disproven pair ──
+
+
+@pytest.mark.asyncio
+async def test_the_watcher_never_reports_granted_from_the_pair_it_disproved(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int]
+):
+    # THE regression these fixes exist to prevent. Nothing deletes a credential on
+    # one failed check, so the disproven pair is still on disk. A watcher polling
+    # bare presence sees it on its FIRST tick, five seconds in, flips the row to
+    # `granted` and disposes the process holding the PKCE verifier -- reproducing
+    # the exact lie AND destroying the consent URL.
+    monkeypatch.setattr(mint, "_MINT_GRANT_POLL_SECONDS", 0.001)
+    _write_paired_grant_artifacts(_URL)
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+
+    await mint.start_oauth_mint("notion", _URL)
+    entry = mint._mints["notion"]
+    assert entry["state"] == "waiting"
+    fresh = _FakeClient.instances[-1]
+
+    # Several poll intervals with the disproven pair sitting on disk, untouched.
+    await asyncio.sleep(0.05)
+
+    assert mint._mints["notion"]["state"] == "waiting"
+    assert mint._mints["notion"]["oauth_url"] == _AUTHORIZE
+    # The process holding the verifier and the loopback listener is still alive,
+    # so the URL the card is showing can still actually be redeemed.
+    assert fresh.shutdowns == 0
+    await mint._dispose_mint(entry)
+
+
+@pytest.mark.asyncio
+async def test_the_watcher_reports_granted_once_the_disproven_artifact_changes(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int]
+):
+    # Completing the exchange makes kiro-cli REWRITE the token artifact, so a
+    # changed fingerprint is the honest completion signal -- the flow must still
+    # resolve, or a real consent would hang to the TTL.
+    monkeypatch.setattr(mint, "_MINT_GRANT_POLL_SECONDS", 0.001)
+    _write_paired_grant_artifacts(_URL)
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+
+    await mint.start_oauth_mint("notion", _URL)
+    entry = mint._mints["notion"]
+    assert entry["state"] == "waiting"
+
+    # The user completes consent: the token artifact is rewritten.
+    key = mcp_grant.grant_key(_URL)
+    token_path = mcp_grant.kiro_oauth_cache_dir() / f"{key}.token.json"
+    token_path.write_text('{"fresh": true, "padding": "xxxxxxxx"}', encoding="utf-8")
+    later = time.time() + 5
+    os.utime(token_path, (later, later))
+
+    await asyncio.wait_for(entry["watcher"], timeout=5)
+
+    assert mint._mints["notion"]["state"] == "granted"
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_fingerprint_still_fails_closed_after_a_disproof(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int]
+):
+    # The disproof and the fingerprint are SEPARATE facts. `grant_fingerprint`
+    # answers None on any failed stat, so keying the watcher's proof requirement on
+    # "fingerprint is not None" let an unreadable capture read as "nothing was
+    # disproved" -- reopening the resurrection path the fingerprint exists to close.
+    monkeypatch.setattr(mint, "_MINT_GRANT_POLL_SECONDS", 0.001)
+    _write_paired_grant_artifacts(_URL)
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+    # The capture stat fails, so no baseline can be recorded.
+    monkeypatch.setattr(mint, "grant_fingerprint", lambda url, **kw: None)
+
+    await mint.start_oauth_mint("notion", _URL)
+    entry = mint._mints["notion"]
+    assert entry["state"] == "waiting"
+    fresh = _FakeClient.instances[-1]
+
+    await asyncio.sleep(0.05)
+
+    # No baseline and no proven revalidation: the stale pair must NOT be published,
+    # and the process holding the redeemable URL must survive.
+    assert mint._mints["notion"]["state"] == "waiting"
+    assert mint._mints["notion"]["oauth_url"] == _AUTHORIZE
+    assert fresh.shutdowns == 0
+    await mint._dispose_mint(entry)
+
+
+@pytest.mark.asyncio
+async def test_no_baseline_grants_only_on_a_positive_revalidation(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int]
+):
+    # With no baseline, change cannot be observed, so the ONLY admissible proof is
+    # a fresh authenticated validation -- and it must actually be consulted, or a
+    # real consent completed in this window could never resolve.
+    monkeypatch.setattr(mint, "_MINT_GRANT_POLL_SECONDS", 0.001)
+    _write_paired_grant_artifacts(_URL)
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+    monkeypatch.setattr(mint, "grant_fingerprint", lambda url, **kw: None)
+
+    await mint.start_oauth_mint("notion", _URL)
+    entry = mint._mints["notion"]
+    assert entry["state"] == "waiting"
+
+    # The user completes consent; a fresh validation now proves it works. The
+    # fallback is rate-limited, not once-only, so a consent that lands after the
+    # first probe still resolves.
+    monkeypatch.setattr(mint, "_GRANT_REVALIDATION_INTERVAL_SECONDS", 0.0)
+    verdicts = iter([False, True, True, True])
+    monkeypatch.setattr(
+        mint, "_validate_existing_grant", lambda slug, url: _async_value(next(verdicts))
+    )
+
+    await asyncio.wait_for(entry["watcher"], timeout=5)
+
+    assert mint._mints["notion"]["state"] == "granted"
+
+
+@pytest.mark.asyncio
+async def test_the_revalidation_fallback_is_rate_limited(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int]
+):
+    # Each fallback spawns a process, so it must not fire on every grant poll for
+    # the whole TTL. With the interval left at its real value, many ticks yield
+    # exactly one probe.
+    monkeypatch.setattr(mint, "_MINT_GRANT_POLL_SECONDS", 0.001)
+    _write_paired_grant_artifacts(_URL)
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+    monkeypatch.setattr(mint, "grant_fingerprint", lambda url, **kw: None)
+
+    await mint.start_oauth_mint("notion", _URL)
+    entry = mint._mints["notion"]
+    calls: list[str] = []
+
+    def _never_proves(slug: str, url: str):
+        calls.append(slug)
+        return _async_value(False)
+
+    monkeypatch.setattr(mint, "_validate_existing_grant", _never_proves)
+
+    await asyncio.sleep(0.05)
+
+    assert len(calls) == 1
+    assert mint._mints["notion"]["state"] == "waiting"
+    await mint._dispose_mint(entry)
+
+
+@pytest.mark.asyncio
+async def test_a_refuted_grant_with_no_challenge_is_not_republished_as_granted(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The fresh spawn producing no challenge is not proof either: publishing
+    # `granted` from it republishes the exact authorization this attempt just
+    # refuted. It has to be the retryable failure instead.
+    _write_paired_grant_artifacts(_URL)
+    logged: list[str] = []
+    monkeypatch.setattr(
+        mint,
+        "_log_mint_outcome",
+        lambda slug, outcome, detail: logged.append(f"{outcome} {detail}"),
+    )
+
+    class _RefutedThenSilent(_FakeClient):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            self.requests = []  # no challenge on the fresh spawn
+
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+    attempts = iter([_FakeClient, _RefutedThenSilent])
+    monkeypatch.setattr(mint, "_acp_client_factory", lambda: next(attempts))
+
+    await mint.start_oauth_mint("notion", _URL)
+
+    view = mint.pending_mint_for("notion")
+    assert view is not None
+    assert _state_only(view) == {"state": "failed", "reason": "mint_grant_unproven"}
+    assert logged == ["error reason=mint_grant_unproven"]
+
+
+def _async_value(value: bool):
+    """A ready coroutine returning ``value``, for patching an async predicate."""
+
+    async def _coro() -> bool:
+        return value
+
+    return _coro()
+
+
+def test_the_grant_fingerprint_changes_when_the_token_artifact_is_rewritten(tmp_path: Path):
+    key = mcp_grant.grant_key(_URL)
+    token = tmp_path / f"{key}.token.json"
+    (tmp_path / f"{key}.registration.json").write_text("{}", encoding="utf-8")
+
+    # Absent reads as None -- "no evidence of change", never a sentinel a caller
+    # could mistake for a real reading.
+    assert mcp_grant.grant_fingerprint(_URL, cache_dir=tmp_path) is None
+
+    token.write_text("{}", encoding="utf-8")
+    first = mcp_grant.grant_fingerprint(_URL, cache_dir=tmp_path)
+    assert first is not None
+
+    token.write_text('{"rotated": true}', encoding="utf-8")
+    later = time.time() + 5
+    os.utime(token, (later, later))
+
+    assert mcp_grant.grant_fingerprint(_URL, cache_dir=tmp_path) != first
+
+
+@pytest.mark.asyncio
+async def test_a_validation_spawn_that_never_completes_falls_through_rather_than_raising(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
+
+    class _ValidatorBoom(_FakeClient):
+        async def ensure_ready(self) -> None:
+            raise RuntimeError("provider unreachable")
+
+    attempts = iter([_ValidatorBoom, _FakeClient])
+    monkeypatch.setattr(mint, "_acp_client_factory", lambda: next(attempts))
+
+    await mint.start_oauth_mint("notion", _URL)
+
+    # The validator's own failure never raises out of the mint flow, and the
+    # fresh cold mint that follows still succeeds normally.
+    assert _state_only(mint.pending_mint_for("notion")) == {
+        "state": "waiting",
+        "oauth_url": _AUTHORIZE,
+    }
+    await mint._dispose_mint(mint._mints["notion"])
+
+
+@pytest.mark.asyncio
+async def test_validation_never_holds_its_own_process_win_or_lose(
+    monkeypatch: pytest.MonkeyPatch, protected_pids: set[int]
+):
+    # Unlike a cold mint's URL-holding process, the validation session has no
+    # consent to protect once it answers -- it must always dispose itself, on
+    # both a usable and an unusable verdict, and never leave a PID shielded.
+    monkeypatch.setattr(mcp_grant, "grant_presence", lambda url, **kw: True)
+
+    await mint.start_oauth_mint("notion", _URL)  # usable verdict
+
+    assert protected_pids == set()
+    await mint._dispose_mint(mint._mints["notion"])
+    protected_pids.clear()
+
+    _FakeClient.command_results["/mcp"] = {
+        "data": {"servers": [{"name": "notion", "status": "failed", "toolCount": 0}]}
+    }
+    await mint.start_oauth_mint("notion", _URL)  # unusable verdict, falls through
+
+    validator = _FakeClient.instances[0]
+    assert validator._pid not in protected_pids
+    await mint._dispose_mint(mint._mints["notion"])
 
 
 @pytest.mark.asyncio
@@ -1166,7 +1590,11 @@ async def test_the_reconnect_short_circuit_reads_a_real_grant_off_the_loop(
     await mint.start_oauth_mint("notion", _URL)
 
     assert _state_only(mint.pending_mint_for("notion")) == {"state": "granted"}
-    assert _FakeClient.instances == []
+    # The artifact stat is still what decides whether to VALIDATE at all -- it
+    # spawns no process by itself. Validation itself spawns one (and disposes it
+    # once the verdict is in), which is a separate, deliberate cost from this stat.
+    assert len(_FakeClient.instances) == 1
+    assert _FakeClient.instances[-1].shutdowns == 1
     assert seen and threading.get_ident() not in seen
 
 
@@ -1555,7 +1983,7 @@ _FS_ATTRS = frozenset(
 # that create the directory they answer for, and the audit singleton -- whose FIRST
 # call in a process constructs the log (trust dir, key, backward scan) on the
 # caller's thread, even though every call after that only enqueues.
-_FS_NAMES = frozenset({"open", "data_home", "sel"})
+_FS_NAMES = frozenset({"open", "data_home", "sel", "grant_fingerprint"})
 
 
 def _called_names(node: Any) -> set[str]:
@@ -2160,7 +2588,7 @@ async def test_a_cold_spawn_records_that_it_minted_a_url(monkeypatch: pytest.Mon
 
 
 @pytest.mark.asyncio
-async def test_a_reconnect_with_a_live_grant_records_already_granted(
+async def test_a_reconnect_with_a_validated_grant_records_validated_grant(
     monkeypatch: pytest.MonkeyPatch,
 ):
     _write_paired_grant_artifacts(_URL)  # kiro-cli already holds a grant
@@ -2171,4 +2599,4 @@ async def test_a_reconnect_with_a_live_grant_records_already_granted(
 
     await mint.start_oauth_mint("notion", _URL)
 
-    assert any("reason=already_granted" in detail for detail in details)
+    assert any("reason=validated_grant" in detail for detail in details)

--- a/website/src/pages/connections/ConnectionsPage.tsx
+++ b/website/src/pages/connections/ConnectionsPage.tsx
@@ -292,6 +292,19 @@ export function connectionStateFor(
   // A completed OAuth flow in THIS session outranks a possibly-lagging status
   // poll: the grant was just written, the feed may not have re-read yet.
   if (oauth?.completed) return 'connected'
+  // A pending attempt THIS TAB is holding, or the backend's own mint table
+  // saying a flow is in flight right now, outranks the cached probe verdicts
+  // below. The mint side of this fix validates an existing grant before ever
+  // reporting a mint `granted`, so a live `awaitingConsent`/`locallyWaiting`
+  // here means either a genuinely fresh consent flow (the old grant did not
+  // hold up) or a not-yet-decided reconnect -- never a flow the backend itself
+  // already knows is stale. Reading `server.status === 'ok'` first, as this
+  // branch used to, is exactly what let Connect flip Stripe and Vercel to
+  // Connected on a cached probe the instant the click landed, well before the
+  // mint had validated anything: the card claimed an authorization no fresher
+  // fact yet backed. `oauth?.oauthUrl` is kept alongside the mint signal for
+  // the chat-message delivery path, which never sets `awaitingConsent`.
+  if (locallyWaiting || awaitingConsent || oauth?.oauthUrl) return 'waiting-for-approval'
   if (server.status === 'ok') {
     // The reachability probe is cached, so `ok` outlives a revoked grant. A
     // CONFIRMED absent grant (grantPresent === false, never the indeterminate
@@ -300,7 +313,6 @@ export function connectionStateFor(
     // authorization that no longer exists.
     return probeIndicatesConnected(server.status, grantPresent) ? 'connected' : 'not-verified'
   }
-  if (locallyWaiting || awaitingConsent || oauth?.oauthUrl) return 'waiting-for-approval'
   // The status probe carries no OAuth token — kiro-cli owns token custody and
   // Kiro Crew stores no credential — so a remote OAuth server answers it with 401
   // and the gateway reports `needs_auth`. Two very different situations produce

--- a/website/src/test/ConnectionsPage.test.tsx
+++ b/website/src/test/ConnectionsPage.test.tsx
@@ -70,13 +70,50 @@ describe('Connections card states', () => {
       .toBe('waiting-for-approval')
     expect(connectionStateFor(server('needs_auth'), undefined, false, false, true))
       .toBe('waiting-for-approval')
-    // Precedence is unchanged: a live grant (cached-ok probe, no confirmed
-    // absence) still outranks a stale awaiting verdict from the 30s poll.
-    expect(connectionStateFor(server('ok'), undefined, false, true, true)).toBe('connected')
+    // A live mint attempt now outranks a cached-ok probe too: the mint side of
+    // this fix validates an existing grant before ever reporting `granted`, so a
+    // genuinely fresh `awaitingConsent` here means the old grant did not hold up
+    // and a real consent flow is in progress. Claiming Connected from the stale
+    // probe over that is the exact defect this fix closes.
+    expect(connectionStateFor(server('ok'), undefined, false, true, true))
+      .toBe('waiting-for-approval')
     // And a refused grant is still a real failure, not a spinner.
     expect(connectionStateFor(server('needs_auth'), {
       completed: false, failed: true, oauthUrl: '', error: 'denied', timestamp: 1,
     }, false, false, true)).toBe('needs-attention')
+  })
+
+  /**
+   * The reported defect: clicking Connect on Stripe or Vercel (an already
+   * -configured provider whose `/api/mcp` probe answers `ok` from a cached
+   * handshake) flipped the card to Connected instantly, before the mint had
+   * validated whether that old grant still worked. Test then forced kiro-cli's
+   * real refresh, the pair turned out dead, and the card fell to not-authorized
+   * — an authorization claim the card made with nothing behind it.
+   *
+   * A fresh mint attempt in THIS tab (`locallyWaiting`) or one the backend's
+   * mint table reports in flight (`awaitingConsent`) must hold the card in the
+   * waiting state regardless of what the 30-second status poll cached, until
+   * the mint itself resolves the attempt one way or the other.
+   */
+  it('holds the waiting card through a fresh Connect click even over a cached-ok probe', () => {
+    // The exact shape of the bug: server.status is the stale cached 'ok', and
+    // this tab just started its own attempt. The click, not the cache, owns
+    // the card until the mint answers.
+    expect(connectionStateFor(server('ok'), undefined, true)).toBe('waiting-for-approval')
+    // Same shape via the backend's mint table rather than local tab state —
+    // covers a second tab watching the same provider's attempt.
+    expect(connectionStateFor(server('ok'), undefined, false, true, true))
+      .toBe('waiting-for-approval')
+    // Once the flow completes in THIS session, completed evidence still wins
+    // over everything, exactly as it always has.
+    expect(connectionStateFor(server('ok'), { completed: true }, true))
+      .toBe('connected')
+    // And a refusal during that same attempt is a real failure, not a spinner
+    // that quietly reverts to the stale cached 'ok'.
+    expect(connectionStateFor(server('ok'), {
+      completed: false, failed: true, oauthUrl: '', error: 'denied', timestamp: 1,
+    }, true)).toBe('needs-attention')
   })
 
   it('lets live OAuth evidence outrank a tokenless needs_auth probe', () => {


### PR DESCRIPTION
## Problem

A Connections card claimed **Connected** for a grant nobody had checked.

`grant_observed` — the paired artifact stat the mint shares with the status
module — answers "does the pair exist on disk", never "does the grant still
work". The pair survives a provider-side revoke and a dead refresh token exactly
as it survives a live one, because nothing in that stat asks kiro-cli to use it.
`start_oauth_mint` short-circuited to `state=granted` (`reason=already_granted`)
on that presence alone.

Observed in a live pod and corroborated by the SEL trail: clicking **Connect** on
Stripe and Vercel flipped both cards to Connected *instantly*, no consent page
opened, then **Test** — which does the real authenticated enumeration — failed,
and the cards fell to "not authorized".

The frontend had the mirror-image defect. `connectionStateFor` read
`server.status === 'ok'` (a cached `/api/mcp` reachability verdict) *before* it
read whether this tab was holding a pending connect, so the cached probe
outranked the click and the badge could go Connected before the mint had decided
anything.

## Why

Both halves are one lie told twice: an authorization claim backed by a fact that
is not about authorization. A stat is not evidence a grant works, and a cached
reachability probe is not evidence about the attempt the user just started.

**Presence is not liveness, and distrusting a fact is not the same as removing
it.** The first cut of this change validated the grant and then fell through to a
fresh mint while leaving the disproven pair on disk — which handed the same false
fact straight to `_mint_watcher`, whose five-second poll reads bare presence. Its
first tick would flip the row back to `granted` and dispose the process holding
the PKCE verifier, reproducing the exact lie *and* destroying the consent URL.
Deleting the credential instead is not available on this evidence: one failed
check can be a provider outage or an unreachable runtime, a refresh token
destroyed on that basis is not recoverable locally, and it is not this flow's to
delete (the ownership census in `connections/ownership.py` exists because the
artifact pair is endpoint-keyed and can be shared by another agent spec). So the
flow distrusts the pair without removing it, and the watcher is told which pair
was disproved.

## What changed

**Backend — validate before claiming (`src/kiro_crew/connections/mint.py`).**
A Connect/Reconnect mint that finds an existing artifact pair spawns the *same*
single-server ephemeral session a fresh mint would spawn
(`_write_mint_agent_spec`) and reads kiro-cli's native `/mcp` + `/tools`,
classified through `tool_test._classify` — the same predicate the Test button
uses, so both surfaces agree on what "usable" means. Promptless, no model call,
one process, one attempt.

- `usable` **or** `no_tools` → `state=granted`, audited `reason=validated_grant`.
  `no_tools` is reported only once the server reached status `running`, which for
  an OAuth provider means kiro-cli authenticated and completed `tools/list` with
  the stored bearer — the credential works, and a zero-tools server is a
  provider-prerequisite question. Sending that user to a consent page would ask
  them to re-authorize what they already have and could not fix it.
- anything else → fall through to the ordinary fresh-consent spawn loop, and
  stamp the disproven token artifact's fingerprint onto the attempt.

**The watcher no longer trusts a pair it was told is dead.** `_mint_watcher`
takes the disproven fingerprint and, when it holds one, requires the token
artifact to **change** rather than merely be present. Completing the exchange
makes kiro-cli rewrite that artifact, so a changed fingerprint is the honest
completion signal; an unreadable stat counts as no evidence of change, so a
failed stat can never publish a Connected badge. `mcp_grant.grant_fingerprint` is
stats-only, next to the existing artifact-layout single source — no artifact is
opened, so no token byte enters the process.

**One deadline, and nothing escapes.** Readiness and both commands run under a
single `_MINT_READY_TIMEOUT_SECONDS` budget (each command carries its own
transport timeout, so bounding readiness alone let a slow provider hold Connect
in `minting` for the sum of three waits). Every step including the client factory
and the spec write now lives inside the guarded block: this runs on a
fire-and-forget task *before* the caller's own `try`, and
`_write_mint_agent_spec` raises `OSError` on an unusable main spec or an
unrecordable manifest row, so an escape killed the flow and stranded the row at
`minting` with no terminal state for the card to read.

**Not on the status poll.** The 30-second `collect_connection_statuses` keeps the
cheap artifact stat for the badge. A per-poll authenticated spawn would turn an
idle dashboard tab into a standing cost with no click behind it; validation runs
once, at the moment a click asks the mint to decide.

**Frontend — the click outranks the cache
(`website/src/pages/connections/ConnectionsPage.tsx`).** `connectionStateFor`
checks `locallyWaiting || awaitingConsent || oauth?.oauthUrl` *before* the cached
`ok` / `needs_auth` branches, keeping `oauth?.failed` and `oauth?.completed` at
their existing precedence.

**Docs (`docs/architecture/design-notes/connections-status-tiers.md`)**, updated
in the same commit: the `reason=validated_grant` telemetry rename, a new "A grant
on disk is not a grant that works" section, and the mint-time-only cost boundary.

`warm.py` is untouched; warm adoption (`adopt_shared_mint`) and the cold path are
covered by the suites below.

## Tests

Every behaviour below was proved red-first against the unfixed code.

- **Backend focused suites: 359 passed, 0 failed** — `test_connections_mint.py`,
  `test_connections_status.py`, `test_connections_tool_test.py`,
  `test_connections_warm.py`, `test_connections_handoff.py`,
  `test_connections_premint.py`, `test_connections_disconnect.py`.
- The watcher regression, pinned both ways: it must NOT report `granted` from the
  pair it disproved (row stays `waiting`, URL intact, holding process alive), and
  it MUST report `granted` once that artifact is rewritten — otherwise a real
  consent would hang to the TTL.
- A spec-write failure during validation never strands the row at `minting`.
- One deadline bounds readiness and both commands.
- `no_tools` is a proven-working grant, not a re-consent.
- `grant_fingerprint` changes on a rewrite and answers `None` for an absent
  artifact.
- Validation runs before the short-circuit and asks `["/mcp", "/tools"]`; a stale
  pair falls through to a fresh mint that yields an approval URL; a validation
  spawn that fails never raises; the validation process is always disposed and
  never leaves a PID shielded, on both a proven and an unproven verdict.
- The module's AST drift guard now covers `grant_fingerprint`, so a future direct
  call from a coroutine fails the suite instead of silently blocking the loop.
- **Frontend: 164 passed** across `ConnectionsPage.test.tsx` and
  `ConnectionsPage.coverage.test.tsx`, including a regression that holds the
  waiting card through a fresh Connect click over a cached-`ok` probe via both
  `locallyWaiting` and `awaitingConsent`. One existing assertion that pinned the
  *old* precedence was inverted with its rationale.
- Gates: black-baseline, isort, flake8, mypy `--platform linux` over 1,287 files,
  `npx tsc -b`, `npm run build`.
- **Bundle Size Gate needs no budget change.** The earlier red was a base race,
  not this PR's bytes: those runs were created at 22:14 and built merge refs
  carrying the pre-#8519 App ceiling, while #8519 re-measured that ceiling to
  `3360 * KB` at 22:38. Rebasing onto current main picks the new ceiling up. The
  branch was verified against it locally rather than assumed — `vite build --mode
  analyze` measures the App chunk at 3,292,800 B (3215 KB) and
  `node scripts/check-bundle-size.mjs` reports `805 chunks within budget`, leaving
  roughly 145 KB of headroom. `CHUNK_BUDGETS` is therefore untouched; the gate's
  bump contract does not apply to a ceiling this change does not exceed.
- The rebase is content-identical to the reviewed commit: `git patch-id --stable`
  is `6da45ab66be2035ab25bf5793e677fd636415552` both before and after.

## Manual verification

<!-- no-visual-delta -->

**Why no screenshot:** the frontend change is a precedence reorder inside
`connectionStateFor`, a pure function returning one of the five existing
`ConnectionCardState` values — every one of those states keeps its existing
rendering, copy and layout byte-for-byte, so a before and after frame would both
show card renderings that already ship on main unchanged. What changed is *which*
already-designed state a given input selects, a state-machine fact rather than a
pixel one, and it is pinned by the unit tests above.

The originating defect was found by manual pod testing on Stripe and Vercel
(instant Connected → Test fails → not authorized). Re-running that pod flow
against this branch is the remaining end-to-end confirmation and is listed as
unproven below.

no linked issue: found during manual G2 pod smoke testing of the Connections
page; the defect and both root causes are recorded in the Problem section above
rather than in a tracker.

## Pattern harvest

Rule candidate: When a fix decides that a stored fact is false, enumerate
every reader of that fact before shipping. Distrusting it in one code path while
leaving it in place hands the same lie to the next reader, and a poller that acts
on it can undo the fix within seconds — here the mint short-circuit was fixed
while `_mint_watcher` and the status badge kept reading the same stale pair, so
the first five-second tick restored the exact defect and destroyed the consent URL
with it. Either correct the fact at its source or carry the disproof to every
consumer that would otherwise re-trust it.

- **A presence check is not a liveness check, and the gap is invisible until
  something expensive proves it.** The stat and the authenticated enumeration
  disagreed only for stale grants, so the cheap answer looked right in every test
  and every happy-path click. When two facts are used interchangeably, name which
  question each one answers before letting either back a user-facing claim.
- **"Delete the false fact" is not always available, and the reason is
  ownership.** The artifact pair is endpoint-keyed and can be shared by an agent
  spec outside Kiro Crew, and one failed check is not proof of death. Carrying a
  disproof forward is the honest move when the evidence does not authorize a
  destructive one.
- **Reuse the classifier, not just the idea.** Validation calls
  `tool_test._classify` rather than re-deriving "usable". A second copy would have
  drifted from the Test button silently, and the whole defect was two surfaces
  disagreeing about whether a provider was connected.
- **A verdict vocabulary can be wrong in the safe-looking direction.** Treating
  `no_tools` as unproven would have sent users with working credentials to a
  consent page that cannot fix a missing provider prerequisite — a "fail safe"
  that fails the user.
- **Bound the whole operation, not its first step.** `wait_for` around readiness
  read as bounded while two independently-timed commands ran after it.

## Checklist

- [x] Red-first regression for every behaviour change
- [x] Focused backend suites pass (359)
- [x] Frontend suites pass (164)
- [x] black-baseline / isort / flake8 / mypy clean
- [x] `tsc -b` and `npm run build` clean
- [x] Design note updated in the same commit
- [x] SEL audit contract preserved (one completion per started mint, registered read-ids only)
- [x] Boot-path import guard still green (handlers package does not import the mint engine)
- [x] No credential is deleted, and no token artifact is opened
- [x] No new user-facing strings, so no catalog changes required
- [x] `warm.py` untouched; warm adoption and cold path covered
- [x] Single commit, clean worktree


