### PR TITLE
fix(acp): seed claude settings from advertised models, across sessions

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import glob
+import hashlib
 import json
 import logging
 import os
@@ -27,10 +28,11 @@ import signal
 import stat
 import subprocess as subprocess_mod
 import sys
+import tempfile
 import time
 import uuid
 from collections import deque
-from contextlib import aclosing
+from contextlib import aclosing, suppress
 from pathlib import Path
 from typing import (
     Any,
@@ -44,6 +46,7 @@ from typing import (
 )
 
 from kiro_crew import acp_tool_gate, agent_scratch, model_registry, platform_compat
+from kiro_crew.acp import seed_provenance
 from kiro_crew.acp._dispatch import (
     _kiro_mcp_server_name,
     _kiro_tool_name,
@@ -136,6 +139,7 @@ from kiro_crew.acp.types import (
     model_registry_namespace,
 )
 from kiro_crew.agent import ensure_agent_materialized
+from kiro_crew.atomic_write import atomic_write
 from kiro_crew.browser_cli.launch import browser_session_env, browser_socket_env
 from kiro_crew.config.paths import kiro_sessions_dir
 from kiro_crew.constants import (
@@ -2685,6 +2689,13 @@ class AcpClient:
         # theirs. So the flag says "Crew created it" and this says "and it is still
         # Crew's content" -- the re-seed and the reset unlink both require BOTH.
         self._claude_settings_written: str | None = None
+        # Identity this client claims its seed under, in the durable record. Two
+        # keyless clients share the default work_dir, so a token is what keeps
+        # "Crew wrote it" from collapsing into "any Crew client may take it": the
+        # durable record is for adopting an ORPHAN, and a sibling still running in
+        # this process does not have one. Per instance and never reset -- a client
+        # that re-spawns is the same owner across spawns.
+        self._seed_owner = uuid.uuid4().hex
         # This session's translated ``mcpServers`` array, resolved once per spawn.
         # Held here so the shared session-params call site is a pure in-memory
         # read: the translation touches disk, and doing that AT the call site
@@ -3145,9 +3156,10 @@ class AcpClient:
         return self._work_dir / ".claude" / "settings.local.json"
 
     def _claude_settings_is_still_ours(self) -> bool:
-        """Whether settings.local.json still holds the bytes THIS session wrote.
+        """Whether settings.local.json still holds the bytes CREW wrote.
 
-        The second half of the ownership test (the first is having created it).
+        The second half of the ownership test (the first is having created it --
+        in this session, or in an earlier one per the durable record).
         A user can replace the file atomically after Crew's create, and the
         replacement is theirs: it must not be overwritten by a re-seed nor
         deleted on reset. An unreadable path answers "not ours" -- declining to
@@ -3165,26 +3177,127 @@ class AcpClient:
         past the payload it is comparing against. Every refusal answers "not
         ours", which leaves the file alone -- the safe direction.
         """
-        written = getattr(self, "_claude_settings_written", None)
-        if written is None:
+        return self._settings_path_holds(
+            self._claude_local_settings_path(), self._expected_settings_fingerprint()
+        )
+
+    @staticmethod
+    def _settings_path_holds(path: Path, expectation: tuple[int, str] | None) -> bool:
+        """Whether *path* still holds exactly the ``(size, sha256)`` in *expectation*.
+
+        Split out from :meth:`_claude_settings_is_still_ours` so the teardown
+        transaction can be a pure function of arguments captured before it starts.
+        It runs in a thread while the client clears its instance flags, so a version
+        that re-read ``self`` could decide ownership against state that changed
+        underneath it. ``None`` means Crew has no claim to check, which reads as
+        "not ours".
+        """
+        if expectation is None:
             return False
-        expected = written.encode("utf-8")
+        size, sha = expectation
         flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
         try:
-            fd = os.open(self._claude_local_settings_path(), flags)
+            fd = os.open(path, flags)
         except OSError:
             return False
         try:
             st = os.fstat(fd)
             # A FIFO, device or directory is not Crew's file, and reading one is
             # the hazard. Size first: it settles a huge file without reading it.
-            if not stat.S_ISREG(st.st_mode) or st.st_size != len(expected):
+            if not stat.S_ISREG(st.st_mode) or st.st_size != size:
                 return False
-            return os.read(fd, len(expected) + 1) == expected
+            # ONE byte past the recorded length, so a file that grew between the
+            # fstat and the read is rejected on length rather than matching on a
+            # prefix hash. Bounded either way: a few hundred bytes, never the file.
+            chunk = os.read(fd, size + 1)
+            return len(chunk) == size and hashlib.sha256(chunk).hexdigest() == sha
         except OSError:
             return False
         finally:
             os.close(fd)
+
+    @staticmethod
+    def _claim_pathname_if_ours(path: Path, expectation: tuple[int, str] | None) -> Path | None:
+        """Atomically move *path* aside into a fresh name; return it IFF it is Crew's.
+
+        Closes the window between an ownership check and the delete or overwrite that
+        acts on it. ``_settings_path_holds`` verifies bytes by PATHNAME, but the delete
+        or re-seed then mutates that same pathname a moment later -- and a user who
+        atomically replaced the file in between would have their settings deleted or
+        clobbered. ``os.replace`` captures whatever is at the pathname in ONE atomic
+        step, so verifying the MOVED inode cannot then race: its bytes are fixed. A
+        match is Crew's own seed (the caller deletes or replaces the moved file); a
+        mismatch is a replacement that raced in, and it is put back untouched.
+
+        The capture destination is a FRESH name created by ``mkstemp`` (``O_EXCL``) in
+        the same directory, so it is a pathname this process just created and provably
+        did NOT pre-exist. A fixed sibling name (e.g. ``<name>.crew-gc``) could name a
+        file the project already owns, and ``os.replace`` onto it would clobber that
+        file atomically -- relocating the very data loss this helper prevents one
+        pathname over. ``os.replace`` onto our own fresh temp destroys only the empty
+        temp we just made.
+
+        ``None`` (nothing for the caller to mutate) when the path is gone, cannot be
+        moved, or holds a file that is not Crew's. A crash between the move and the
+        caller's follow-up leaves at most one such ``.crew-gc`` temp beside the target,
+        which the next session's fresh seed ignores.
+        """
+        try:
+            fd, tmp_name = tempfile.mkstemp(
+                dir=str(path.parent), prefix=path.name + ".", suffix=".crew-gc"
+            )
+        except OSError:
+            return None
+        os.close(fd)
+        aside = Path(tmp_name)
+        try:
+            os.replace(path, aside)
+        except OSError:
+            # Nothing to capture (path gone, or it cannot be moved): drop the empty
+            # temp so a refusal never litters a stray file beside the target.
+            with suppress(OSError):
+                aside.unlink()
+            return None
+        if AcpClient._settings_path_holds(aside, expectation):
+            return aside
+        # Not Crew's after all (a replacement raced in, or a symlink O_NOFOLLOW
+        # rejected): restore it exactly as found and touch nothing.
+        try:
+            os.replace(aside, path)
+        except OSError:  # pragma: no cover - defensive; a racing writer took the name
+            logger.warning(
+                "could not restore %s after it proved not to be Crew's; it is at %s",
+                path,
+                aside.name,
+            )
+        return None
+
+    def _expected_settings_fingerprint(self) -> tuple[int, str] | None:
+        """``(size, sha256)`` of the seed Crew believes is at the settings path.
+
+        Session memory first -- authoritative for a file this client just wrote,
+        and available even when the sidecar could not be persisted -- then the
+        durable record in :mod:`kiro_crew.acp.seed_provenance`, which is what lets
+        a seed orphaned by a killed session (or written by an older Crew) still be
+        recognized as Crew's own instead of reading as a stranger's file forever.
+        Both sources prove the same thing the same way: the bytes on disk are the
+        bytes Crew wrote. Neither is a permission to touch an arbitrary path.
+
+        ``None`` means Crew has no claim to check, which callers read as "not
+        ours" -- including the case where the durable record belongs to a SIBLING
+        client still seeding this path in this process, since an orphan is what
+        the record is for. In-memory only, so this stays safe to call from the
+        event loop.
+        """
+        written = getattr(self, "_claude_settings_written", None)
+        if written is not None:
+            payload = written.encode("utf-8")
+            return len(payload), hashlib.sha256(payload).hexdigest()
+        # getattr for the same reason as _reset_state's: tests build clients
+        # without __init__, and a shared "" owner there is a consistent identity.
+        return seed_provenance.recorded(
+            self._claude_local_settings_path(), getattr(self, "_seed_owner", "")
+        )
 
     def _write_claude_local_settings(self) -> None:
         """Seed ``<work_dir>/.claude/settings.local.json`` for this session.
@@ -3204,22 +3317,37 @@ class AcpClient:
            spec's ``disabledTools`` cannot ride along in the ``mcpServers`` array,
            and silently dropping a restriction while forwarding the server it
            narrows would widen the tool surface.
-        3. ``availableModels`` plus the resolved ``model``. The adapter merges
+        3. ``availableModels`` plus the resolved ``model``, and ONLY once the
+           backend has actually advertised a list. The adapter merges
            ``availableModels`` union+dedup across every settings source, so a user
            ``~/.claude`` carrying ``['opus','sonnet']`` is enough to collapse a
-           versioned ``[1m]`` id (1M-token window) back to 200K. Writing the full
-           registry allowlist here makes the id resolve by exact match.
+           versioned ``[1m]`` id (1M-token window) back to 200K -- and a
+           registry-derived list seeded here does exactly the same thing to any
+           model the registry has not caught up on. So on a cold advertised-model
+           cache both keys are omitted (the adapter's own provider list is
+           already right) and the re-seed after this session's capture fills them
+           in. See :func:`~kiro_crew.model_registry.seed_available_models`.
 
         **Crew touches only the file it owns.** Ownership is not the path -- a
         path under a checked-out repository is not Crew's to claim -- it is having
-        CREATED the file in this session (``_claude_settings_authored``) AND the
-        bytes on disk still being the ones Crew wrote
-        (``_claude_settings_written``). Both hold: overwrite, which is what lets
-        the model-substitution re-seed change the resolved model instead of
-        re-sending byte-identical params and taking the same advisory again.
-        Either fails: leave the path entirely alone. Absent: create with
-        ``O_EXCL``, so a sibling session racing the same ``work_dir`` loses the
-        create rather than clobbering the winner.
+        CREATED the file (``_claude_settings_authored``, or the durable record in
+        :mod:`kiro_crew.acp.seed_provenance` for a seed an earlier session left
+        behind) AND the bytes on disk still being the ones Crew wrote. Both hold:
+        overwrite by STAGE AND RENAME, which is what lets the model-substitution
+        re-seed change the resolved model instead of re-sending byte-identical
+        params and taking the same advisory again, without a partial write ever
+        being observable at the path. Either fails: leave the path entirely alone.
+        Absent: create with ``O_EXCL``, so a sibling session racing the same
+        ``work_dir`` loses the create rather than clobbering the winner.
+
+        The durable half is what makes the ownership test survive the process. A
+        session killed before ``_reset_state`` leaves its seed on disk, and with a
+        session-scoped test only, every later session read that orphan as a
+        stranger's file and refused to touch it -- so the stale allowlist, stale
+        ``model`` and stale ``permissions.defaultMode`` became permanent, and no
+        amount of re-running Crew could repair them. Recognizing the orphan by
+        digest lets it be re-seeded (or removed on reset) while a genuinely
+        user-authored file is still left exactly as it was.
 
         That is what keeps this seam out of a user's project state: nothing here
         reads, merges into, rewrites or deletes a file Crew did not author, so
@@ -3274,19 +3402,63 @@ class AcpClient:
             )
             self._claude_settings_authored = False
             self._claude_settings_written = None
+            seed_provenance.forget(local_settings, self._seed_owner)
             return
+        # Set only when the live slot was taken from an ORPHAN below, so the write
+        # failure handler knows whether it owes a release().
+        adopted = False
         if not authored and local_settings.exists():
-            # Someone else's file: either the user's own project settings, or a
-            # live sibling session's seed (``work_dir`` is caller-supplied and
-            # every keyless client shares one default). Crew authors neither, so
-            # it touches neither.
-            logger.info(
-                "%s already exists; leaving it as the authoritative project settings. This "
-                "session therefore runs without Crew's availableModels allowlist and without "
-                "the permissions.deny rules from the agent spec.",
-                local_settings,
-            )
-            return
+            # The claim is part of the DECISION, not bookkeeping after it: ownership
+            # is read at a moment, so two clients starting together can both see the
+            # same orphan as adoptable. Only the one that wins the live slot rewrites
+            # it; the loser falls to the leave-it-alone branch below rather than
+            # writing its own permission mode over a session that is already using
+            # the file.
+            if self._claude_settings_is_still_ours() and seed_provenance.claim(
+                local_settings, self._seed_owner
+            ):
+                # Crew's OWN seed, orphaned: a previous session (or an older Crew)
+                # wrote exactly these bytes and never got to clean up -- a kill -9,
+                # a crash, an app replacement. Adopt it and fall through to the
+                # staged re-seed. Adoption is earned by the digest, not by the
+                # path: the durable record alone proves nothing, so a user's own
+                # file (or Crew's file after a user edit) still takes the
+                # leave-it-alone branch below.
+                #
+                # This is also the only way a stale permissions.defaultMode gets
+                # cleaned up. Previously such a file was frozen in place and the
+                # adapter kept reading it, so an inherited bypassPermissions
+                # outlived its session indefinitely; re-seeding overwrites the mode
+                # with THIS session's.
+                logger.info(
+                    "%s holds a settings seed Crew wrote in an earlier session; re-seeding it "
+                    "for this session instead of leaving stale model and permission settings "
+                    "in place.",
+                    local_settings,
+                )
+                # LOCAL only. The instance flag is what reset reads to decide
+                # whether to DELETE this path, and the durable record is what a
+                # later session reads to decide whether to adopt it, so neither
+                # moves until the re-seed below has actually landed: a claim taken
+                # here and a write that then failed would leave reset deleting a
+                # file whose bytes Crew never wrote. The live slot IS taken already
+                # -- ``claim`` above is the race arbiter and has to be -- so the
+                # write is wrapped below to hand it back if it does not land.
+                authored = True
+                adopted = True
+            else:
+                # Someone else's file: either the user's own project settings, or a
+                # live sibling session's seed (``work_dir`` is caller-supplied and
+                # every keyless client shares one default) -- including a sibling that
+                # won the same orphan a moment ago. Crew authors none of those, so it
+                # touches none of them.
+                logger.info(
+                    "%s already exists; leaving it as the authoritative project settings. This "
+                    "session therefore runs without Crew's availableModels allowlist and without "
+                    "the permissions.deny rules from the agent spec.",
+                    local_settings,
+                )
+                return
 
         data: dict[str, Any] = {}
         perms: dict[str, Any] = {}
@@ -3300,53 +3472,195 @@ class AcpClient:
         if perms:
             data["permissions"] = perms
         # Namespace-keyed (claude_code here), the registry index this backend's ids
-        # live in — see _model_registry_namespace. Provider-first: the ids the
-        # backend actually advertised (cached from a prior session/new) when the
-        # cache is warm, so the seed reflects what the account is served and a
-        # served-but-unregistered model gets its real window; the static registry
-        # allowlist is the cold-cache fallback (first-ever session), which is the
-        # exact list shipped before this cache existed.
+        # live in — see _model_registry_namespace. Provider-ONLY: the ids the
+        # backend actually advertised (cached from a prior session/new), so the seed
+        # reflects what the account is served and a served-but-unregistered model
+        # gets its real window. A cold cache returns nothing rather than falling
+        # back to the static registry, and the else branch below omits both model
+        # keys — the adapter's own provider list is already right, and a stale
+        # allowlist merged over it is not.
         allowlist = model_registry.seed_available_models(self._model_registry_namespace)
         if allowlist:
             data["availableModels"] = allowlist
+            # DEFAULT_MODEL ("auto") is not a provider id, and omitting the key is
+            # what lets the adapter pick the allowlist head. Written only ALONGSIDE
+            # the allowlist: a model key that names no entry in the list it ships
+            # with is the exact shape that resolves to the base window.
+            if self._model and self._model != DEFAULT_MODEL:
+                # Folded onto the advertised spelling HERE rather than trusting a
+                # caller to have folded self._model first. The re-seed runs beside
+                # the model-cache persist, which is BEFORE _apply_startup_model, so
+                # depending on that fold would be an ordering coupling between two
+                # distant steps -- and the failure it buys is silent (a bare id
+                # writes a model key that is not in the allowlist beside it, i.e.
+                # exactly the base-window bug this file exists to close). The
+                # allowlist above is non-empty here, so the cache is warm and the
+                # fold is the same one _apply_startup_model and set_model perform.
+                data["model"] = model_registry.resolve_wire_model_id(
+                    self._model, self._model_registry_namespace
+                )
         else:
-            # Only reachable with a corrupt/missing model registry (which the
-            # registry already warns about at import) AND a cold advertised-model
-            # cache. Without the allowlist the adapter can collapse the [1m] id to
-            # 200K, so say so here rather than degrade silently.
-            logger.warning(
-                "availableModels empty (corrupt/missing registry and cold advertised-model "
-                "cache?); settings.local.json written without an allowlist — the 1M-token "
-                "window may not resolve",
+            # Cold advertised-model cache -- the first session on this install,
+            # before any session/new has been captured. Both model keys are
+            # OMITTED rather than filled from the static registry, and that is the
+            # fix, not a degradation: the adapter merges availableModels
+            # union+dedup across settings sources, so a partial list here replaces
+            # a correct provider-derived one with a stale one, and a model id that
+            # matches nothing in it resolves to the base window. Writing neither
+            # key leaves the adapter on its own provider list, which already
+            # carries the versioned [1m] ids. This session's capture then warms the
+            # cache and the post-capture re-seed fills both keys in.
+            logger.info(
+                "advertised-model cache is cold; seeding %s without availableModels/model so "
+                "claude-agent-acp resolves the model from its own provider list. The re-seed "
+                "after this session's model capture fills both keys in.",
+                local_settings,
             )
-        # self._model is a resolved provider id; DEFAULT_MODEL ("auto") is not one,
-        # and omitting the key is what lets the adapter pick the allowlist head.
-        if self._model and self._model != DEFAULT_MODEL:
-            data["model"] = self._model
 
-        local_settings.parent.mkdir(parents=True, exist_ok=True)
         payload = json.dumps(data, indent=2, ensure_ascii=False) + "\n"
-        # O_EXCL on the create is the whole ownership claim: if a sibling session
-        # (or the user) created the file between the check above and here, this
-        # raises rather than clobbering it. O_TRUNC is the re-seed, and it is
-        # reached only once BOTH ownership tests above passed, so the bytes it
-        # replaces are Crew's own. 0o600 either way -- Crew's own file.
-        flags = os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
-        flags |= os.O_TRUNC if authored else os.O_EXCL
+        # An adoption already holds the path's live slot, because ``claim`` above
+        # has to be the race arbiter -- it cannot be deferred until after a
+        # successful write without letting two clients both decide the same orphan
+        # is theirs. So if the write does NOT land, the slot has to go back: a claim
+        # kept by a client that wrote nothing makes the orphan permanently
+        # unadoptable for the rest of the process (``recorded`` reports it as a live
+        # session's file), and an orphan that cannot be adopted cannot be repaired
+        # or deleted -- so a stale ``bypassPermissions`` in it would simply stay.
+        # BaseException, not Exception: a CancelledError or a KeyboardInterrupt
+        # through here wedges the slot exactly the same way. The record is left
+        # alone (``release``, not ``forget``): it is what keeps the path adoptable.
+        # The re-seed moves Crew's current file aside before overwriting, so this
+        # holds it for the ``except`` to restore if the write does not land.
+        reseed_aside: Path | None = None
         try:
-            fd = os.open(local_settings, flags, 0o600)
-        except FileExistsError:
-            logger.info("%s was created concurrently; leaving it alone", local_settings)
+            local_settings.parent.mkdir(parents=True, exist_ok=True)
+            # BYTES on both branches, never text mode: Python's text layer rewrites
+            # "\n" to "\r\n" on Windows, so the file on disk was LARGER than the
+            # payload and no longer the bytes this session recorded. The ownership
+            # check compares exact bytes, so that translation made every Windows
+            # session read as "not ours" -- the re-seed declined, reset never removed
+            # its own file, and the MCP array was withheld. 0o600 either way.
+            if authored:
+                # The re-seed of a file Crew owns, STAGED AND RENAMED rather than
+                # truncated in place. O_TRUNC destroyed the recorded bytes before the
+                # new ones landed, so a write that failed part-way (ENOSPC, EIO, a
+                # kill between truncate and write) left the adapter reading a
+                # truncated settings file AND a durable record whose digest matched
+                # nothing on disk -- unclaimable by every later session, which is the
+                # exact failure this module exists to remove. A temp + rename leaves
+                # the old, still-recorded bytes intact on failure, so the path is
+                # adopted again next time. The rename replaces a link at the leaf
+                # rather than refusing it (no O_NOFOLLOW to pass), which costs
+                # nothing here: this branch is reached only for a path whose bytes
+                # just matched Crew's record, i.e. one
+                # _claude_settings_is_still_ours() read as a REGULAR file a moment
+                # ago.
+                #
+                # INODE-PINNED: the ownership check above and this overwrite act on
+                # the same PATHNAME, and a user who atomically replaced the file in
+                # the gap would have their settings clobbered by the rename. Moving
+                # Crew's current file aside captures it in one atomic step; the write
+                # only proceeds when the MOVED inode is still Crew's, so a replacement
+                # that raced in is detected and left in place instead.
+                reseed_aside = self._claim_pathname_if_ours(
+                    local_settings, self._expected_settings_fingerprint()
+                )
+                if reseed_aside is None:
+                    logger.info(
+                        "%s was replaced just before the re-seed; leaving it in place and "
+                        "dropping Crew's claim rather than clobbering it. This session runs "
+                        "without Crew's availableModels allowlist and without the "
+                        "permissions.deny rules from the agent spec.",
+                        local_settings,
+                    )
+                    # Adopted this session -> only the live slot is ours to hand back;
+                    # a file Crew already owned but that is now the user's -> forget the
+                    # durable record too, exactly as the replaced-after-create branch does.
+                    if adopted:
+                        seed_provenance.release(local_settings, self._seed_owner)
+                    else:
+                        seed_provenance.forget(local_settings, self._seed_owner)
+                    self._claude_settings_authored = False
+                    self._claude_settings_written = None
+                    return
+                atomic_write(local_settings, payload.encode("utf-8"), mode=0o600)
+                # New payload is published; drop the moved old seed. Best-effort: a
+                # leftover ``.crew-gc`` is litter the next fresh seed ignores, not a
+                # reason to fail a write that already landed.
+                with suppress(OSError):
+                    reseed_aside.unlink(missing_ok=True)
+                reseed_aside = None
+            else:
+                # O_EXCL on the create is the whole ownership claim: if a sibling
+                # session (or the user) created the file between the check above and
+                # here, this raises rather than clobbering it. That is why the create
+                # keeps a direct open instead of joining the branch above --
+                # atomic_write publishes with a rename, which replaces whatever is at
+                # the name and so cannot arbitrate a create race at all.
+                flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+                try:
+                    fd = os.open(local_settings, flags, 0o600)
+                except FileExistsError:
+                    logger.info("%s was created concurrently; leaving it alone", local_settings)
+                    return
+                with os.fdopen(fd, "wb") as handle:
+                    handle.write(payload.encode("utf-8"))
+        except BaseException:
+            if reseed_aside is not None:
+                # The overwrite did not land after Crew's file was moved aside, so the
+                # pathname is empty and the recorded bytes are at ``reseed_aside``.
+                # Put them back so the path stays the adoptable orphan it was before.
+                with suppress(OSError):
+                    if local_settings.exists():
+                        reseed_aside.unlink(missing_ok=True)
+                    else:
+                        os.replace(reseed_aside, local_settings)
+            if adopted:
+                logger.info(
+                    "re-seed of the orphaned settings seed at %s did not land; releasing the "
+                    "claim so a later session can still adopt and repair it",
+                    local_settings,
+                )
+                seed_provenance.release(local_settings, self._seed_owner)
+            raise
+        # Durable half of the same claim, so the NEXT process can still recognize
+        # this file as Crew's after a kill that skips the reset path.
+        #
+        # NOT best-effort, and taken BEFORE the instance flags rather than after.
+        # An unrecorded seed is the one state nothing on the host can repair: this
+        # session would still unlink it, but a kill before teardown leaves a
+        # ``permissions.defaultMode`` the user never approved behind a file no later
+        # session is permitted to re-seed or remove, because ownership is the record.
+        # So if the grant cannot be made durable the seed is WITHDRAWN rather than
+        # left behind -- the session then runs on the adapter's own defaults, which
+        # is the same thing a cold advertised-model cache already does.
+        if not seed_provenance.record(local_settings, payload, self._seed_owner):
+            logger.warning(
+                "could not durably record Crew's claim on %s; removing the seed just written "
+                "rather than leaving a permission mode no later session is allowed to clean "
+                "up. This session runs without Crew's availableModels allowlist and without "
+                "the permissions.deny rules from the agent spec.",
+                local_settings,
+            )
+            # Safe to remove precisely because we are inside the branch that proved
+            # ownership a moment ago: either O_EXCL created the file, or its bytes
+            # matched Crew's record and this client holds the live claim.
+            with suppress(OSError):
+                local_settings.unlink(missing_ok=True)
+            if not seed_provenance.forget(local_settings, self._seed_owner):
+                # The sidecar is unwritable, which is why we are here at all. It
+                # still names the PREVIOUS digest, and the file it described is now
+                # gone, so ``_persist``'s prune drops the entry on the next
+                # successful write and nothing matches it in the meantime. Hand the
+                # live slot back so a replacement client in this process is not
+                # wedged behind a claim nobody is using.
+                seed_provenance.release(local_settings, self._seed_owner)
             return
-        # BINARY, not text mode: Python's text layer rewrites "\n" to "\r\n" on
-        # Windows, so the file on disk was LARGER than the payload and no longer the
-        # bytes this session recorded. The ownership check compares exact bytes, so
-        # that translation made every Windows session read as "not ours" -- the
-        # re-seed declined, reset never removed its own file, and the MCP array was
-        # withheld. Writing bytes keeps one canonical form on every platform.
-        with os.fdopen(fd, "wb") as handle:
-            handle.write(payload.encode("utf-8"))
         # Only a file Crew created AND still owns is ever overwritten or removed.
+        # Set AFTER the write and after the durable record, so a failure in either
+        # propagates with the claim exactly as it was: an adoption leaves no instance
+        # flag for reset to act on, and a re-seed of Crew's own file leaves the
+        # record describing the bytes that are still on disk.
         self._claude_settings_authored = True
         self._claude_settings_written = payload
 
@@ -3619,7 +3933,18 @@ class AcpClient:
         An EXPLICIT switch is handled the opposite way in :meth:`set_model`:
         there the user asked for that exact model, and quietly running another
         one would be a lie.
+
+        The fold onto the advertised spelling happens HERE, not only at spawn: by
+        this point ``session/new`` has been captured, so the advertised-model cache
+        is warm even on the first-ever session -- whereas the spawn-time fold ran
+        against a cold cache and was a no-op, sending a bare id that resolves to
+        the base window. Same call as :meth:`set_model` uses, so an explicit switch
+        and a startup application agree on one exact spelling.
         """
+        if self._uses_advertised_model_selection:
+            self._model = model_registry.resolve_wire_model_id(
+                self._model, self._model_registry_namespace
+            )
         if not self._model or self._model == DEFAULT_MODEL:
             logger.info("ACP model: %s (from agent config)", self._model or "auto")
             return
@@ -3663,6 +3988,46 @@ class AcpClient:
                 {"sessionId": self._session_id, "modelId": self._model},
             )
         logger.info("ACP model: %s", self._model)
+
+    async def _reseed_after_capture(self) -> None:
+        """Re-seed settings.local.json once the backend's model list is known.
+
+        The spawn-time seed necessarily runs BEFORE ``session/new`` --
+        ``permissions.defaultMode`` and ``permissions.deny`` have to be on disk by
+        the time the adapter builds its ``SettingsManager``. That is exactly why it
+        cannot write the model keys on a first-ever session: the advertised-model
+        cache is still cold, and the only list available to it would be a guessed
+        one. So the model half of the seed lands here instead, once
+        ``_capture_available_models`` has warmed that cache — which is what makes
+        the file name a model actually IN the allowlist shipped beside it.
+
+        Before this step existed the seed was written once, before capture, and
+        never revisited: session 1 wrote a registry-derived list and session 2 (see
+        :mod:`kiro_crew.acp.seed_provenance`) was not even allowed to correct it.
+
+        **Called from the pre-existing ``_uses_advertised_model_selection`` branch
+        beside the model-cache persist, NOT from a step of its own.** Adding a step
+        to :meth:`_initialize_session` would put a new conditional and a new await
+        on the first-class Kiro construction path in service of an adapter, which
+        harness-parity H13 forbids however the predicate is spelled -- the test is
+        not whether the Kiro path still works, it is whether it changed at all.
+        Riding a branch that already exists changes no line Kiro executes, and it
+        is the honest home for the work besides: this method exists BECAUSE the
+        backend advertises its own model list, which is the very capability that
+        branch tests.
+
+        The two capability sets are independent opt-ins, though, so the seeding
+        half is tested here rather than assumed from the caller's gate.
+
+        Off-loop (touches disk), and a failure costs model fidelity, not the
+        session.
+        """
+        if not self._seeds_local_settings:
+            return
+        try:
+            await asyncio.to_thread(self._write_claude_local_settings)
+        except (OSError, ValueError, TypeError):
+            logger.warning("post-capture re-seed of settings.local.json failed", exc_info=True)
 
     async def set_config_option(self, config_id: str, value: str) -> None:
         """Set a session config option (e.g. effort level) via session/set_config_option."""
@@ -3885,6 +4250,11 @@ class AcpClient:
             await self._kill_process(force=True)
         finally:
             await self._discard_bound_workspace()
+            # A failed startup that already wrote the seed owns one too, and the
+            # session it belonged to is over -- so it is discarded on exactly the
+            # terms a graceful shutdown uses. In the `finally` for the same reason
+            # the caller puts `_reset_state` in one: this is the last chance.
+            await self._discard_claude_settings_seed()
 
     async def _to_thread_guarding_sandbox(
         self, fn: Callable[..., _T], /, *args: Any, **kwargs: Any
@@ -3935,10 +4305,10 @@ class AcpClient:
             # prior session's _capture_available_models), so a model the static
             # registry does not carry still resolves to the versioned [1m] id the
             # backend serves rather than a bare form that collapses to the base
-            # window. Done here so BOTH the seed below and _apply_startup_model's
-            # set_model read the same id. No-op on a cold cache (first-ever
-            # session): the registry fallback in the seed still applies and this
-            # session's own capture warms the cache for the next one.
+            # window. Done here so the seed below carries the same id the wire
+            # will. No-op on a cold cache (first-ever session), which is why
+            # _apply_startup_model folds AGAIN after session/new has warmed the
+            # cache, and why the seed omits the model key entirely until then.
             self._model = model_registry.resolve_wire_model_id(
                 self._model, self._model_registry_namespace
             )
@@ -4507,6 +4877,139 @@ class AcpClient:
         retiring = getattr(self, "_liveness_oracle", None)
         self._liveness_oracle = retiring.fresh() if retiring is not None else LivenessOracle()
 
+    async def _discard_claude_settings_seed(self) -> None:
+        """Remove the ``settings.local.json`` THIS session seeded, off the loop.
+
+        So a permission mode never outlives its session and an inherited
+        ``bypassPermissions`` cannot persist after a crash. Only a file Crew
+        created AND still owns is removed: the writer declines a path that already
+        holds a foreign file, and the content check below covers the remaining
+        case -- a user replacing Crew's file atomically after the create, whose
+        replacement is theirs to keep (see ``_write_claude_local_settings``).
+
+        Async, because the disk half is blocking and this is teardown on the event
+        loop: the ownership hash, the durable revoke and the unlink all block, and a
+        heartbeat must not queue behind them. ``_reset_state`` keeps only the
+        in-memory ``release``.
+
+        **The whole disk half is ONE shielded thread, not a sequence of awaited
+        steps, and that is the cancellation contract.** Teardown runs on paths that
+        are themselves being cancelled -- a turn cancel, a session close, a
+        shutdown -- and a suspension point between the ownership check, the revoke
+        and the unlink meant a cancellation could land with the claim already
+        revoked and the file still on disk. That is the one state nothing can
+        repair: unrecorded bytes carrying a ``permissions.defaultMode`` that no
+        later session is permitted to touch. A thread cannot be interrupted
+        part-way, so the transaction has either not started or run to completion,
+        and ``asyncio.shield`` is what keeps a cancelled awaiter from abandoning it
+        before it is scheduled. Every caller pairs this with ``_reset_state`` in a
+        ``finally`` for the mirror-image reason: the in-memory reset must happen
+        even when the await is cancelled.
+        """
+        if not getattr(self, "_claude_settings_authored", False):
+            return
+        # Captured HERE, on the loop, so the transaction is a pure function of its
+        # arguments: the ``finally`` below may clear these flags while the thread is
+        # still running, and a transaction that re-read them could decide ownership
+        # against state that changed underneath it.
+        path = self._claude_local_settings_path()
+        owner = getattr(self, "_seed_owner", "")
+        payload = getattr(self, "_claude_settings_written", None)
+        expectation = self._expected_settings_fingerprint()
+        # A task rather than a bare coroutine: ``shield`` protects a future that
+        # already exists, and the point is that this one is scheduled and therefore
+        # WILL run even if the cancellation arrives before the first step. Needs no
+        # done-callback to consume an exception because the transaction contracts
+        # never to raise -- which is also what keeps a cancelled awaiter from
+        # leaving an unretrieved error behind.
+        settle = asyncio.ensure_future(
+            asyncio.to_thread(self._settle_claude_settings_seed, path, owner, payload, expectation)
+        )
+        try:
+            await asyncio.shield(settle)
+        finally:
+            self._claude_settings_authored = False
+            self._claude_settings_written = None
+
+    def _settle_claude_settings_seed(
+        self,
+        path: Path,
+        owner: str,
+        payload: str | None,
+        expectation: tuple[int, str] | None,
+    ) -> None:
+        """The seed's entire disk half, as one blocking transaction. Never raises.
+
+        **The pathname is claimed by an atomic move-aside, THEN revoked, THEN the
+        moved inode is deleted.** Verifying ownership by pathname and then unlinking
+        that pathname is a TOCTOU: a user who atomically replaced the file in the gap
+        (which this transaction widens, since the revoke now takes a cross-process
+        lock and writes) would have their settings deleted. ``_claim_pathname_if_ours``
+        closes it -- ``os.replace`` captures the file into ``aside`` in one step, and
+        only that fixed inode is ever deleted; a replacement that raced in is detected
+        and left in place. The revoke still happens BEFORE the delete: ``forget``
+        reports whether the sidecar on disk actually stopped naming the path, and
+        deleting first would let a failed sidecar write leave a record that outlives
+        its file, so the next process adopts, rewrites and deletes a byte-identical
+        copy the user had restored. On a failed revoke the moved file is restored
+        under its pathname, so a later session repairs the orphan.
+
+        Never raises, because the caller shields it: an exception here would reach
+        nobody but the "never retrieved" logger, and a half-settled transaction that
+        also lost its error is worse than one that logged and left the file owned.
+        """
+        try:
+            aside = self._claim_pathname_if_ours(path, expectation)
+            if aside is None:
+                logger.info(
+                    "%s no longer holds the bytes Crew wrote; leaving the replacement in "
+                    "place instead of deleting a file Crew does not own.",
+                    path,
+                )
+                return
+            # The file is now the moved inode ``aside`` and the pathname is free, so a
+            # user replacement racing in lands at a fresh ``path`` this never touches.
+            if not seed_provenance.forget(path, owner):
+                # Not revoked on disk, so the file must stay: a restart would still
+                # read Crew as its owner, and a later session repairs it. Restore it
+                # under the pathname and hand back the live claim.
+                logger.warning(
+                    "could not durably revoke Crew's claim on %s; restoring the file so a "
+                    "later session can re-seed or remove it rather than deleting it "
+                    "behind a revocation that never reached the disk",
+                    path,
+                )
+                try:
+                    os.replace(aside, path)
+                except OSError:  # pragma: no cover - defensive; a racing writer took the name
+                    logger.warning("could not restore %s; it is at %s", path, aside.name)
+                seed_provenance.release(path, owner)
+                return
+            try:
+                aside.unlink(missing_ok=True)
+            except OSError:
+                # Revoke landed but the moved inode will not delete. Put it back under
+                # the pathname and re-record, so the path is a repairable orphan rather
+                # than a frozen ``.crew-gc`` no session names.
+                logger.debug(
+                    "could not remove %s after session reset; re-recording Crew's claim so "
+                    "a later session can still re-seed or remove it",
+                    path,
+                    exc_info=True,
+                )
+                if payload is not None:
+                    restored = True
+                    try:
+                        os.replace(aside, path)
+                    except OSError:  # pragma: no cover - defensive
+                        restored = False
+                        logger.warning("could not restore %s; it is at %s", path, aside.name)
+                    if restored:
+                        seed_provenance.record(path, payload, owner)
+                        seed_provenance.release(path, owner)
+        except Exception:  # pragma: no cover - defensive; teardown must not raise
+            logger.debug("could not settle Crew's settings seed at %s", path, exc_info=True)
+
     def _reset_state(self) -> None:
         """Reset all session state (call after process is dead)."""
         if self._process:
@@ -4518,30 +5021,27 @@ class AcpClient:
                         pass
         # Clean up sandbox temp files (macOS seatbelt profile)
         self._discard_sandbox_cleanup()
-        # Remove the settings.local.json THIS session created, so a permission
-        # mode never outlives its session and an inherited bypassPermissions
-        # cannot persist after a crash. Only a file Crew created AND still owns is
-        # removed: the writer declines a path that already holds a foreign file,
-        # and the content check below covers the remaining case -- a user
-        # replacing Crew's file atomically after the create, whose replacement is
-        # theirs to keep (see _write_claude_local_settings). getattr: _reset_state
-        # runs on clients built without __init__ in tests.
+        # The settings.local.json THIS session seeded is removed by
+        # _discard_claude_settings_seed, which every caller awaits in the `try` of
+        # the `finally` that reaches here -- it is async because the ownership hash,
+        # the durable revoke and the unlink are all blocking, and this method is
+        # synchronous and runs on the event loop. That pairing also means this may
+        # run because the discard's await was CANCELLED: the flags below are already
+        # cleared by then, so this branch is skipped and the shielded transaction
+        # still finishes the disk half. getattr: _reset_state runs on clients built
+        # without __init__ in tests.
         if getattr(self, "_claude_settings_authored", False):
-            if self._claude_settings_is_still_ours():
-                try:
-                    self._claude_local_settings_path().unlink(missing_ok=True)
-                except OSError:
-                    logger.debug(
-                        "could not remove %s after session reset",
-                        self._claude_local_settings_path(),
-                        exc_info=True,
-                    )
-            else:
-                logger.info(
-                    "%s no longer holds the bytes Crew wrote; leaving the replacement in "
-                    "place instead of deleting a file Crew does not own.",
-                    self._claude_local_settings_path(),
-                )
+            # The seed itself is removed by ``_discard_claude_settings_seed``, which
+            # is awaited off the loop by every caller that reaches here. All this
+            # sync path does is hand back the LIVE claim, which is in-memory only
+            # and takes no lock -- so a client that is discarded without the async
+            # step (a test, or a future caller that forgets it) still cannot wedge
+            # the path behind a claim nobody is using: a replacement client in this
+            # process reads the seed as an adoptable orphan and repairs it. The
+            # durable record deliberately survives, because the file does.
+            seed_provenance.release(
+                self._claude_local_settings_path(), getattr(self, "_seed_owner", "")
+            )
             self._claude_settings_authored = False
             self._claude_settings_written = None
         # Drop the translated MCP array: the spec is read PER SPAWN, which is what
@@ -4843,6 +5343,7 @@ class AcpClient:
                         self._capture_available_models(load_resp)
                         if self._uses_advertised_model_selection:
                             await self._persist_advertised_models_if_changed()
+                            await self._reseed_after_capture()
                         self._store_session_config(load_resp)
                         logger.info("ACP session resumed: %s", resume_sid)
                 except (AcpError, AcpTimeoutError):
@@ -4867,6 +5368,7 @@ class AcpClient:
             self._capture_available_models(session_resp)
             if self._uses_advertised_model_selection:
                 await self._persist_advertised_models_if_changed()
+                await self._reseed_after_capture()
             self._store_session_config(session_resp)
             if not self._session_id:
                 # Both the initial attempt and the substitution retry failed to
@@ -4948,6 +5450,10 @@ class AcpClient:
         if acp_tool_gate.routing_for(self.backend) is acp_tool_gate.Routing.SESSION_CONFIG:
             await self._apply_session_permission_routing()
 
+        # (settings.local.json is re-seeded up in step 2/3, beside the model-cache
+        #  persist, rather than as a step of its own down here: see
+        #  _reseed_after_capture on why it rides an EXISTING adapter-only branch.)
+
         # Drain MCP server init notifications
         await self._drain_notifications()
 
@@ -4985,7 +5491,14 @@ class AcpClient:
                 try:
                     if self._process and self._process.returncode is not None:
                         await self._discard_bound_workspace()
-                        self._reset_state()
+                        # `finally`, because the discard is an await and this runs on
+                        # cancellable paths: the in-memory reset must land even when
+                        # the cancellation arrives during the seed's settle. The
+                        # settle itself is shielded, so it completes regardless.
+                        try:
+                            await self._discard_claude_settings_seed()
+                        finally:
+                            self._reset_state()
 
                     if not self._process:
                         await self._spawn()
@@ -5068,7 +5581,13 @@ class AcpClient:
             await self._kill_process(force=True)
         finally:
             await self._discard_bound_workspace()
-            self._reset_state()  # untracks all PIDs (root + children)
+            # `finally` for the same reason the kill above has one: `_reset_state`
+            # untracks the PIDs and must run even if the seed's await is cancelled.
+            # The settle is shielded, so the disk half completes either way.
+            try:
+                await self._discard_claude_settings_seed()
+            finally:
+                self._reset_state()  # untracks all PIDs (root + children)
 
     # ── JSON-RPC Transport ──
 

--- a/src/kiro_crew/acp/seed_provenance.py
+++ b/src/kiro_crew/acp/seed_provenance.py
@@ -1,0 +1,453 @@
+"""Durable provenance for the ``settings.local.json`` seed Crew writes.
+
+Crew seeds ``<work_dir>/.claude/settings.local.json`` for a claude-agent-acp
+session and overwrites or removes ONLY the file it owns. Ownership used to be
+proven entirely from per-instance memory ("this client created it" plus "the
+bytes it wrote"), which answers the question correctly inside one session and
+wrongly outside one: a seed left behind by a session that was killed, or by an
+earlier app version, reads as a stranger's file forever after. The writer then
+takes its leave-it-alone branch on every subsequent session, so a stale
+``availableModels`` allowlist (and a stale ``permissions.defaultMode``, up to an
+inherited ``bypassPermissions``) becomes permanent project state that Crew can
+neither refresh nor clean up.
+
+This module is the missing half: a small record, under Crew's OWN data home, of
+the bytes Crew last wrote to a given settings path. It is a **provenance
+credential, not a permission grant** — a record alone proves nothing, because
+adoption additionally requires the file on disk to still hash to the recorded
+digest. A user-authored file (or a Crew file the user has since edited) never
+matches, so it is still left untouched; only Crew's own orphan is recognized and
+re-seeded.
+
+Four properties the callers depend on:
+
+* **Nothing is added to the user's project.** The record lives beside Crew's
+  other sidecars in ``config_dir()``, keyed by the settings path, so a checked-out
+  repository gains no extra file to notice, ignore or commit.
+* **Lookups never touch the disk, and no mutation runs on the event loop.**
+  Ownership is consulted synchronously from teardown, so the sidecar is read once
+  at import and served from memory afterwards. Both MUTATIONS (:func:`record` and
+  :func:`forget`) write and are therefore blocking; each has an off-loop caller,
+  and :func:`forget` is awaited through a thread rather than called from the loop.
+  :func:`release` is the in-memory-only counterpart that teardown may call
+  directly.
+* **Every failure answers "not ours".** An unreadable or corrupt sidecar, a
+  missing entry, a malformed entry — all degrade to the pre-existing behaviour of
+  leaving the file alone, which is the safe direction.
+* **A record is adoptable only once nobody here still holds it.** Ownership is
+  scoped to an owner token, so an orphan is adopted by the next session while a
+  path a LIVE client in this process is seeding stays that client's own.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import os
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from kiro_crew import platform_compat
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import config_dir
+
+logger = logging.getLogger(__name__)
+
+# One entry per settings path Crew currently has a seed at. The sidecar carries
+# no format marker, and that is deliberate rather than an omission: adoption is
+# decided by the digest alone, so a version number would have no reader, and the
+# day a second format exists an ABSENT marker already means "the first one".
+#
+# Process-wide runtime state, like model_registry._ADVERTISED_MODELS: loaded once
+# at import, mutated in memory, persisted on write. Tests isolate it by
+# monkeypatching this dict and :func:`_sidecar_path`.
+_RECORDS: dict[str, dict[str, Any]] = {}
+
+# Which owner token, if any, is CURRENTLY seeding each path in this process.
+# Adoption is for orphans, and only a record with no live holder is one: two
+# keyless sessions share the default work_dir (``config_dir() / "workspace"``),
+# so without this a second session would recognize the FIRST session's live seed
+# as an orphan, re-seed it with its own ``permissions.defaultMode``, and unlink it
+# on its own reset -- out from under a session still running against it. Records
+# loaded from the sidecar at import have no live holder by construction, which is
+# exactly right: whoever wrote them is a previous process.
+_LIVE: dict[str, str] = {}
+
+# Serializes the record transaction: mutate ``_RECORDS``, prune, snapshot, publish.
+# Without it two seeds running concurrently under ``asyncio.to_thread`` can each
+# build a snapshot and publish in the opposite order, so an OLDER snapshot lands
+# last and the newer seed's provenance is lost -- the surviving file then reads as
+# a stranger's on the next run, which is the whole failure this module removes.
+#
+# Held across the ``atomic_write``, because the snapshot and its publish are one
+# step: releasing between them is exactly the reordering above. Both holders --
+# :func:`record` and :func:`forget` -- run OFF the event loop, so no wait on this
+# lock is ever a wait the loop takes. The read-only and claim-only entry points
+# deliberately do NOT take it -- see :func:`recorded` and :func:`release`.
+#
+# This serializes THREADS in one process only. Two Crew PROCESSES (the gateway and
+# a concurrent CLI chat) each hold their own ``_LOCK`` and their own process-local
+# ``_RECORDS``, so this lock cannot stop them clobbering each other's sidecar. The
+# cross-process serialization is :func:`_cross_process_lock`, held by :func:`_persist`.
+_LOCK = threading.Lock()
+
+# Cross-process lock filename, BESIDE the sidecar rather than on it: ``atomic_write``
+# publishes by renaming a fresh inode over the sidecar, so a lock held on the
+# sidecar's own inode would guard nothing across that rename. Same placement and
+# reasoning as ``aws_consent._ConsentLock`` and the ops-mission-control policy store.
+_LOCK_FILENAME = ".settings_seeds.lock"
+
+
+def _sidecar_path() -> Path:
+    """Path to the seed-provenance sidecar under Crew's data home.
+
+    ``config_dir()`` is resolved per call rather than folded into a module
+    constant, so ``KIROCREW_HOME`` and test overrides are honoured on every
+    access instead of being frozen at first resolution. The import-time
+    ``_load()`` does resolve it once, to hydrate ``_RECORDS`` from disk;
+    resolving per call is what keeps every later access following the current
+    override.
+    """
+    return config_dir() / "settings_seeds.json"
+
+
+def _key(path: Path | str) -> str:
+    """Sidecar key for a settings path.
+
+    Deliberately the path as GIVEN, not ``resolve()``d: resolution follows
+    symlinks, and every caller derives this from the same
+    ``work_dir / ".claude" / "settings.local.json"`` expression, so the
+    unresolved string is both stable across sessions and free of a filesystem
+    round-trip on the lookup path.
+    """
+    return os.fspath(path)
+
+
+def digest(payload: str) -> str:
+    """The digest recorded for *payload* — sha256 of its UTF-8 bytes."""
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _read_disk_seeds() -> dict[str, dict[str, Any]]:
+    """The seeds currently ON DISK, validated. ``{}`` when absent or unreadable.
+
+    Read once at import by :func:`_load`, and again under the cross-process lock by
+    :func:`_persist` so a concurrent process's records are merged onto rather than
+    dropped from what this process is about to publish. Every failure degrades to
+    ``{}`` — the same "nothing recorded" answer an absent sidecar gives, which is the
+    safe direction (a path that reads as unowned is left alone, never adopted wrongly).
+    """
+    out: dict[str, dict[str, Any]] = {}
+    try:
+        path = _sidecar_path()
+        if not path.is_file():
+            return out
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError, TypeError):  # pragma: no cover - corrupt/absent sidecar
+        logger.debug(
+            "seed-provenance sidecar unreadable; seeds will read as unowned", exc_info=True
+        )
+        return out
+    seeds = data.get("seeds") if isinstance(data, dict) else None
+    if not isinstance(seeds, dict):
+        return out
+    for key, entry in seeds.items():
+        if not isinstance(key, str) or not isinstance(entry, dict):
+            continue
+        size, sha = entry.get("size"), entry.get("sha256")
+        if isinstance(size, int) and size >= 0 and isinstance(sha, str) and sha:
+            out[key] = {"size": size, "sha256": sha}
+    return out
+
+
+def _load() -> None:
+    """Load the persisted sidecar into ``_RECORDS`` (best-effort).
+
+    Called once at import. A missing file is normal (nothing seeded yet); a
+    corrupt one leaves every path looking unowned — the same answer Crew gave
+    before this record existed.
+    """
+    _RECORDS.update(_read_disk_seeds())
+
+
+_load()
+
+
+@contextlib.contextmanager
+def _cross_process_lock() -> Iterator[None]:
+    """Exclusive lock around the reload-merge-publish in :func:`_persist`.
+
+    Without it the gateway and a concurrent CLI chat each publish a process-local
+    snapshot and the later writer drops the other's record, leaving that seed
+    permanently unadoptable — the stale-state failure this module exists to remove,
+    reintroduced for the losing process's work dir. ``atomic_write`` renaming a new
+    inode over the sidecar is what makes the LAST writer win, so the fix is to make
+    every writer reload-merge-publish while holding this lock.
+
+    FAILS CLOSED via :func:`platform_compat.acquire_lock`: a stuck holder raises
+    rather than letting a writer proceed unserialized, and :func:`_persist` reports
+    that as a failed persist (``False``) — the same honest "grant not durable"
+    outcome a failed write already gives, never a silent lost record.
+    """
+    lock_file = _sidecar_path().parent / _LOCK_FILENAME
+    fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        platform_compat.acquire_lock(fd, exclusive=True)
+        yield
+    finally:
+        try:
+            platform_compat.release_lock(fd)
+        finally:
+            os.close(fd)
+
+
+def _persist(keep: str | None = None, drop: str | None = None) -> bool:
+    """Publish this process's records to the SHARED sidecar. ``True`` when the disk agrees.
+
+    Blocking. The return value is what :func:`record` and :func:`forget` need in
+    order to be honest about whether a grant is really durable, so this reports
+    failure instead of only logging it.
+
+    **Reload-merge-publish under the cross-process lock.** The sidecar is shared by
+    every Crew process on the host, and ``atomic_write`` renaming a new inode over it
+    makes the LAST writer win outright. So this reloads the on-disk seeds INSIDE
+    :func:`_cross_process_lock`, overlays this process's own ``_RECORDS``, and
+    publishes the union — a concurrent process's records are preserved rather than
+    dropped. This process's entries win for any key it holds; keys present only on
+    disk belong to another live process and are kept untouched. Reloading a sibling's
+    key into what is published does NOT make this process treat it as adoptable: only
+    ``_RECORDS`` (never refreshed from disk here) feeds :func:`recorded`, so a live
+    sibling's seed still reads as absent — "not ours" — to this process.
+
+    *drop* removes the key a :func:`forget` just revoked. Without it the merge would
+    resurrect that key from the copy still on disk, and the revoke would never stick.
+
+    There is exactly ONE prune, and it runs unconditionally: entries whose file is
+    gone. Nothing is left at those paths to overwrite, adopt or clean up, so they are
+    pure growth. *keep* exempts the key the current transaction just wrote, so the
+    entry a :func:`record` has this moment created is authoritative even if the caller
+    has not put a file there. Without it a record would depend on a stat of a path the
+    module does not own the writing of, and "record then look it up" -- the one
+    invariant every caller leans on -- would answer differently depending on how the
+    caller sequenced its own write.
+
+    There is deliberately no entry CAP on top of that. A cap can only evict entries
+    whose file still exists, and those are precisely the adoptable orphans this module
+    exists to keep: evicting one makes its path unrecorded, so its own owner can no
+    longer recognize it and no later session is permitted to repair it either —
+    whatever the file holds (a stale ``availableModels``, a stale
+    ``permissions.defaultMode``, up to an inherited ``bypassPermissions``) becomes
+    permanent project state. That is the exact failure this module removes, so a cap
+    would re-manufacture it for the oldest work dir. Growth is already bounded by the
+    prune above: the sidecar cannot outgrow the set of seeds actually on disk.
+
+    Callers hold :data:`_LOCK`, which serializes this process's threads; the
+    cross-process lock serializes other processes; the reload, merge, prune, snapshot
+    and publish are one transaction across both.
+    """
+    try:
+        # Prune this process's OWN dead-file entries from memory first, so a later
+        # lock-free read stops reporting a path whose file is gone.
+        for key in [k for k in list(_RECORDS) if k != keep and not os.path.isfile(k)]:
+            _RECORDS.pop(key, None)
+            _LIVE.pop(key, None)
+        with _cross_process_lock():
+            merged = _read_disk_seeds()
+            merged.update(_RECORDS)
+            if drop is not None:
+                merged.pop(drop, None)
+            # Prune dead-file entries carried in from another process's disk copy too;
+            # ``keep`` exempts this transaction's own just-written key.
+            for key in [k for k in list(merged) if k != keep and not os.path.isfile(k)]:
+                merged.pop(key, None)
+            snapshot = {"seeds": {k: dict(v) for k, v in merged.items()}}
+            # 0o600: the sidecar names the work dirs this install has seeded.
+            atomic_write(_sidecar_path(), json.dumps(snapshot), mode=0o600)
+        return True
+    except (OSError, ValueError, TypeError):  # pragma: no cover - disk full / perms
+        logger.debug("could not persist seed-provenance sidecar", exc_info=True)
+        return False
+
+
+def claim(path: Path | str, owner: str) -> bool:
+    """Take *path*'s live slot for *owner*; ``False`` if somebody else has it.
+
+    Called by an adopter BEFORE it rewrites an orphan, and it is the decision
+    itself rather than bookkeeping after one: :func:`recorded` only reports the
+    live holder at the moment it is asked, so two clients starting together can
+    both read the same orphan as adoptable, and both would then take the
+    ``O_TRUNC`` re-seed — one session left running under the other's
+    ``permissions.defaultMode``. ``setdefault`` is a single atomic dict
+    operation, so exactly one of them can win it no matter how they interleave.
+
+    Idempotent for a holder that already owns the slot, so re-seeding the same
+    path in the same client is not a self-refusal.
+
+    A winner that then FAILS to write must hand the slot back with
+    :func:`release`, or the orphan it was about to repair stays wedged behind a
+    claim nobody is using for the rest of the process.
+    """
+    return _LIVE.setdefault(_key(path), owner) == owner
+
+
+def release(path: Path | str, owner: str) -> None:
+    """Give up *owner*'s live claim on *path* without disowning the record.
+
+    The counterpart to a :func:`claim` whose write did not land. Only ``_LIVE``
+    is dropped, deliberately NOT ``_RECORDS``: the record is what makes the path
+    adoptable at all, so clearing it would leave an orphan seed -- possibly one
+    carrying ``bypassPermissions`` -- that no later session is permitted to
+    rewrite or delete. That is the harm this exists to avoid, not a smaller
+    version of it. Compare :func:`forget`, which is for a path Crew genuinely no
+    longer owns because the file is gone.
+
+    A no-op when a different owner holds the slot, so a loser cannot evict the
+    winner. In-memory only and lock-free (one atomic dict operation), so it is
+    safe from a failure path on the event loop.
+    """
+    key = _key(path)
+    if _LIVE.get(key) == owner:
+        _LIVE.pop(key, None)
+
+
+def record(path: Path | str, payload: str, owner: str) -> bool:
+    """Record that *owner* just wrote *payload* to *path*. ``True`` when the DISK agrees.
+
+    Blocking (persists the sidecar) and serialized on :data:`_LOCK`; callers run it
+    on the already-off-loop seed path. Re-recording the same bytes still rewrites,
+    which is cheap and keeps the sidecar honest about the digest. *owner* is also
+    claimed as the path's LIVE holder, so a sibling client in this process reads it
+    as somebody's live seed rather than as an orphan.
+
+    The return value is the same contract :func:`forget` carries, and for the same
+    reason: a grant is only real once it is on disk. ``False`` means the sidecar
+    write did not land, the in-memory record has been rolled back to exactly what a
+    restart would read, and **the caller must not leave a seed behind** — a settings
+    file with no durable grant is a ``permissions.defaultMode`` the user never
+    approved that no later session is permitted to re-seed or remove, so it outlives
+    every session on the host. Withdrawing the seed is the only outcome that stays
+    inside this module's invariant, which is why this is not best-effort.
+
+    The rollback restores the displaced entry rather than dropping the key: on a
+    RE-SEED the sidecar on disk still names the previous digest, and the bytes that
+    digest describes may still be the ones on disk (``atomic_write`` publishes by
+    rename, so a failed write leaves the old file intact). Dropping the key instead
+    would make this process disagree with the sidecar it just failed to replace.
+    """
+    key = _key(path)
+    with _LOCK:
+        # Captured under the lock, before either dict is touched, because the
+        # rollback below has to reproduce this exact pair. ``_LIVE`` is included:
+        # an adopter arrives here already holding the slot from :func:`claim`, and
+        # a rollback that popped it would hand a live path to a sibling.
+        previous_entry = _RECORDS.get(key)
+        previous_live = _LIVE.get(key)
+        # ``_LIVE`` BEFORE ``_RECORDS``, and the order is the point rather than a
+        # style choice: :func:`recorded` is deliberately lock-free, so a sibling
+        # client reads these two dicts from another thread BETWEEN the statements
+        # below. Publishing the record first opens a window in which the seed this
+        # client has just written reads as an ORPHAN -- a record with no live
+        # holder, whose digest matches the file now on disk -- so the sibling would
+        # claim it, rewrite it under its own ``permissions.defaultMode``, and unlink
+        # it on its own reset, out from under a session still running against it.
+        # Reversed, a sibling sees either no record at all or the record with its
+        # owner already attached, and both of those answer "not mine".
+        #
+        # It carries extra weight on the CREATE path, which has no :func:`claim` of
+        # its own (``O_EXCL`` arbitrates that one), so this assignment is the only
+        # thing that ever makes a freshly created seed look live.
+        _LIVE[key] = owner
+        _RECORDS[key] = {"size": len(payload.encode("utf-8")), "sha256": digest(payload)}
+        if _persist(keep=key):
+            return True
+        if previous_entry is None:
+            _RECORDS.pop(key, None)
+        else:
+            _RECORDS[key] = previous_entry
+        if previous_live is None:
+            _LIVE.pop(key, None)
+        else:
+            _LIVE[key] = previous_live
+        return False
+
+
+def recorded(path: Path | str, owner: str) -> tuple[int, str] | None:
+    """The ``(size, sha256)`` Crew wrote to *path*, as far as *owner* may claim it.
+
+    ``None`` when nothing was recorded, or when a DIFFERENT owner in this process
+    is still seeding that path: the record then describes a live session's file,
+    not an orphan, and re-seeding it would overwrite that session's permission
+    mode and delete its file on this client's reset.
+
+    In-memory only, so this is safe to call from the event loop — and deliberately
+    LOCK-FREE for the same reason: :data:`_LOCK` is held across the sidecar write,
+    so taking it here would let a worker's disk I/O stall the one loop. Each
+    statement below is a single dict read, which is atomic under CPython, so a
+    concurrent :func:`record` can only make this return the older or the newer
+    entry, never a torn one. The size is returned alongside the digest so a caller
+    can reject a mismatched file without reading it, and bound its read to exactly
+    the bytes it will hash.
+    """
+    key = _key(path)
+    live = _LIVE.get(key)
+    if live is not None and live != owner:
+        return None
+    entry = _RECORDS.get(key)
+    if not entry:
+        return None
+    size, sha = entry.get("size"), entry.get("sha256")
+    if not isinstance(size, int) or not isinstance(sha, str) or not sha:
+        return None
+    return size, sha
+
+
+def forget(path: Path | str, owner: str) -> bool:
+    """Durably drop *owner*'s claim on *path*. ``True`` when the DISK agrees.
+
+    **BLOCKING — callers must run this off the event loop** (``asyncio.to_thread``
+    or an executor). It takes :data:`_LOCK` and writes the sidecar, and the one
+    caller that used to run it on the loop no longer does.
+
+    The return value is the contract, and it is what makes the revoke safe to
+    delete a file behind: ``True`` means the sidecar on disk no longer names
+    *path*, so the caller may unlink. Dropping the entry from memory alone would
+    leave the sidecar naming a path Crew has just deleted, and the digest check
+    does not make that inert -- the next process reloads the entry, and any file
+    that hashes to it (most plainly the very seed a user committed to the
+    repository and then restored) is adopted, overwritten with this install's
+    ``permissions.defaultMode``, and unlinked on reset. So the grant has to die
+    with the file it described, and it has to die FIRST.
+
+    ``False`` is returned in the two cases where the caller must keep the file:
+
+    * a DIFFERENT owner holds the path live, so a client that could not adopt a
+      sibling's seed cannot revoke the sibling's claim either; and
+    * the sidecar write failed, in which case the entry is put BACK in memory so
+      this process agrees with what a restart would read, and the grant is simply
+      not revoked yet. The file stays, the record stays, and a later session
+      recognizes the orphan and repairs it -- which is strictly better than a
+      deletion whose revocation never reached the disk.
+    """
+    key = _key(path)
+    with _LOCK:
+        live = _LIVE.get(key)
+        if live is not None and live != owner:
+            return False
+        entry = _RECORDS.pop(key, None)
+        _LIVE.pop(key, None)
+        if entry is None:
+            # Nothing was recorded, so there is no grant to revoke and nothing to
+            # write. Already "not ours", which is what the caller is asking for.
+            return True
+        # ``drop=key`` so the reload-merge in :func:`_persist` does not resurrect the
+        # revoked key from the copy still on disk -- popping it from ``_RECORDS`` alone
+        # is invisible to a merge that reloads the shared sidecar.
+        if _persist(drop=key):
+            return True
+        _RECORDS[key] = entry
+        return False

--- a/src/kiro_crew/model_registry.py
+++ b/src/kiro_crew/model_registry.py
@@ -435,21 +435,28 @@ def _dedup_window_siblings(ids: Sequence[str]) -> list[str]:
 def seed_available_models(provider: str) -> list[str]:
     """The ``availableModels`` allowlist to seed for ``provider``.
 
-    Provider-first: the ids ``provider`` actually advertised (cached from a live
-    session) when the cache is warm, so the seed reflects what the account is
-    served rather than the static Anthropic-only registry. Falls back to
-    :func:`available_models` on a cold cache (first-ever session, before any
-    ``session/new`` has been captured) — the static registry list, which is then
-    window-deduplicated below just like the warm list.
+    Provider-advertised ONLY: the ids ``provider`` actually served on a real
+    ``session/new`` (cached by :func:`refresh_advertised_models`). A cold cache
+    returns ``[]``, which callers must read as "seed no allowlist at all" —
+    NOT as "fall back to the static registry".
+
+    That fallback used to live here and was actively harmful. The adapter merges
+    ``availableModels`` union+dedup across every settings source, so seeding the
+    hand-maintained registry list POISONS the merge for anything the registry has
+    not caught up on: a model the account is served but the registry never listed
+    (a fresh flagship) contributes no ``[1m]`` id, so the merged list has only
+    base-window spellings and the pick resolves to 200K. Seeding nothing instead
+    leaves the adapter with its own provider-derived list, which already carries
+    the correct versioned ids — the registry is a display/window table, not the
+    authority on what the account can run, and keeping it out of this path is
+    what stops every new model from needing a registry edit per provider.
 
     The result is passed through :func:`_dedup_window_siblings` so a base-window
     id never rides alongside its 1M sibling: seeding both is what lets the adapter
-    collapse a versioned pick (e.g. Opus 4.8 ``[1m]``) back to 200K. Applied to
-    the advertised list too, since a backend can advertise both spellings.
+    collapse a versioned pick (e.g. Opus 4.8 ``[1m]``) back to 200K. A backend can
+    advertise both spellings, so this applies to the advertised list too.
     """
-    cached = advertised_models(provider)
-    base = cached if cached else available_models(provider)
-    return _dedup_window_siblings(base)
+    return _dedup_window_siblings(advertised_models(provider))
 
 
 def resolve_wire_model_id(model_id: str, provider: str) -> str:

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -285,6 +285,21 @@ _CREW_READONLY_LEAVES: tuple[str, ...] = (
     # gateway ensures the file exists at startup (see apply_dev_mode's
     # reconcile) because the Linux launcher can only seal an EXISTING target.
     "apps/.dev-grants.json",
+    # The settings-seed provenance record (``acp.seed_provenance``), an
+    # AUTHORIZATION record on the same footing as the dev-mode grants above: an
+    # entry in it is what lets Crew OVERWRITE and then DELETE
+    # ``<work_dir>/.claude/settings.local.json``, because a re-seed proceeds only
+    # when the file on disk still matches the recorded ``(size, sha256)``. A
+    # sandboxed process that can write it can enter a digest for a settings file
+    # the USER hand-wrote, and the next gateway start adopts that file, replaces
+    # its ``permissions.defaultMode`` with Crew's, and unlinks it on reset.
+    # READONLY rather than hidden because the write is the whole risk: the record
+    # holds no secret (work-dir paths and digests), so masking it would buy
+    # nothing and cost an operator the ability to see why a seed was adopted.
+    # Paired with the same leaf on ``security``'s write floors -- the deny rules
+    # fence how a command SPELLS this path, and the kernel denial is what still
+    # holds when a spelling is built at runtime (``$(printf ...)``).
+    "settings_seeds.json",
 )
 
 #: Crew-home leaves that MUST stay read-write for a sandboxed process. Every entry is
@@ -338,16 +353,24 @@ _CREW_READONLY_TARGETS: list[str] = _crew_home_entries(_CREW_READONLY_LEAVES)
 #:    * ``oauth_endpoints.json`` — ``security._validate_operator_oauth_entries``
 #:      extends trust by nothing for ``{}``;
 #:    * ``aws_service_consent.json`` — ``aws_consent._read_all`` returns ``{}`` for
-#:      both absent and empty, so every service stays unconfirmed.
+#:      both absent and empty, so every service stays unconfirmed;
+#:    * ``settings_seeds.json`` — ``acp.seed_provenance._load`` finds no ``seeds``
+#:      mapping in ``{}`` and returns having recorded nothing, so every settings
+#:      path reads as unowned. Identical to absent, and the leaf that most needs
+#:      materialising: it is written only once a claude-agent-acp session has
+#:      actually seeded a work dir, so on every install that has not it is exactly
+#:      the absent-and-therefore-writable name this list exists to close.
 #:
 #: 2. A STALE read of that empty document must fail toward refusal. The seal is a
 #:    bind mount, which pins the INODE for the sandbox's lifetime, while every
 #:    dashboard writer publishes through ``atomic_write`` (temp + rename), i.e. a NEW
 #:    inode. So a sandboxed reader keeps seeing the empty document even after the
-#:    operator writes the real one. For the three files above that freezes them at
-#:    "disabled" / "no consent" / "no extra endpoints" — narrower than the truth. The
-#:    empty ``profiles`` dir is exempt from the concern entirely: a directory bind
-#:    shows live contents, so a profile added later is visible.
+#:    operator writes the real one. For the three JSON files above that freezes them at
+#:    "disabled" / "no consent" / "no extra endpoints" — narrower than the truth, and
+#:    for ``settings_seeds.json`` at "Crew owns no settings file", so the writer takes
+#:    its leave-it-alone branch: the seed is not refreshed, and nothing is overwritten
+#:    or unlinked. The empty ``profiles`` dir is exempt from the concern entirely: a
+#:    directory bind shows live contents, so a profile added later is visible.
 #:
 #: DELIBERATELY EXCLUDED, and each for a different one of those two reasons:
 #:
@@ -383,6 +406,7 @@ _CREW_PRECREATE_READONLY_FILE_LEAVES: tuple[str, ...] = (
     # stays frozen at "no consent", which is narrower than the truth
     # (criterion 2).
     "file_delivery_consent.json",
+    "settings_seeds.json",
 )
 
 #: What a materialised ceiling holds — the empty JSON object every reader above

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -8287,6 +8287,30 @@ _WRITE_PROTECTED_HOME_PATHS += [
     for prefix in _CREW_HOME_PREFIXES
 ]
 _WRITE_PROTECTED_HOME_PATHS += [
+    # The settings-seed PROVENANCE RECORD (``acp.seed_provenance``), the alias
+    # record's twin one seam over: it is what authorizes Kiro Crew to OVERWRITE and
+    # then DELETE ``<work_dir>/.claude/settings.local.json``. The ACP client seeds
+    # that file for a claude-agent-acp session and touches only the seed it owns;
+    # ownership is this record plus the file on disk still hashing to the digest in
+    # it. So an agent that can write this file can enter ``<path>: {size, sha256}``
+    # for a settings file the USER hand-wrote — the file is readable, so both values
+    # are computable — and the next session adopts it: the user's project settings
+    # are overwritten with Crew's seed and unlinked on reset. As with the alias
+    # record, the damage is done by Crew's own trusted writer, and the digest check
+    # cannot defend it because the forger reads the same bytes it does.
+    #
+    # WRITE-protected, not read+write sensitive: the record holds no secret (it
+    # names work dirs and digests), so the file-READ tools keep working and an
+    # operator can still see why a seed was or was not adopted. There is no
+    # legitimate agent WRITE at all — ``seed_provenance.record`` writes
+    # the path directly through ``atomic_write``, which does not route through this
+    # gate. Paired with the same leaf in _WRITE_PROTECTED_BASH_LEAVES and in
+    # _BARE_TOKEN_PROTECTED_LEAVES below: protected on one path only is not
+    # protected, and for a DELETION grant a ``cd`` must not be the whole bypass.
+    f"{prefix}/settings_seeds.json"
+    for prefix in _CREW_HOME_PREFIXES
+]
+_WRITE_PROTECTED_HOME_PATHS += [
     # The app-sources checkout root — the persistent tree every installed app
     # EXECUTES from (``apps.registry.app_source_dir``). This is a whole DIRECTORY
     # rather than a leaf, which the shared matcher already supports: it compares a
@@ -8434,6 +8458,14 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
     "apps/ops-mission-control/data/rotation.yaml",
     "apps/ops-mission-control/data/incidents/index.json",
     "connections-tool-aliases.json",
+    # The settings-seed provenance record, on the same reasoning as the alias record
+    # above and paired with its entry in _WRITE_PROTECTED_HOME_PATHS: a forged entry
+    # makes Crew's own writer overwrite and then delete a user-authored
+    # ``.claude/settings.local.json``. ``seed_provenance`` writes it through
+    # ``atomic_write`` in Python, so the record's own writes are unaffected; bash
+    # reads are incidentally denied, which is harmless here (no secret, and the only
+    # readers are Python).
+    "settings_seeds.json",
     # The browse launch config (browser_cli/launch.py), paired with the same leaf
     # in _WRITE_PROTECTED_HOME_PATHS so the file-edit and shell paths agree — a
     # leaf on only one of the two is reachable through the other.
@@ -8473,15 +8505,28 @@ _WRITE_PROTECTED_BASH_LEAVES: tuple[str, ...] = (
 # of the contract — relative, ``cd``-prefixed, subdir-relative, either
 # separator, quoted or not, all refused identically.
 #
-# SCOPE: bare-token matching is for THIS filename ONLY, because it is globally
-# distinctive — a long hyphenated name that occurs nowhere in ordinary command
-# lines, so the false-positive cost is confined to commands that genuinely mean
-# this record. A generic leaf must NEVER be added here: unanchored
-# ``index.json`` or ``config.json`` would refuse a large fraction of routine
-# commands in any repository. The other write-protected leaves are not
-# distinctive at all (their distinguishing part is the ``apps/.../data/``
+# The settings-seed provenance record (``acp.seed_provenance``) is here for the
+# identical reason, one seam over: an entry in it IS the grant to OVERWRITE and
+# then DELETE ``<work_dir>/.claude/settings.local.json``. ``recorded()`` returns
+# the ``(size, sha256)`` the re-seed compares the file against, and a match is the
+# only thing that moves the writer off its leave-it-alone branch — so an entry
+# naming a settings file the USER hand-wrote makes Kiro Crew's own trusted writer
+# replace it and unlink it on reset. Same conclusion, same shape: the invariant is
+# the filename, not the spelling of the way to it.
+#
+# SCOPE: bare-token matching is for filenames of THIS kind ONLY — an ownership
+# record whose contents ARE a deletion grant, spelled distinctively enough that
+# the name occurs nowhere in ordinary command lines (a long hyphenated name, or a
+# ``_``-joined one that is not a word anyone types), so the false-positive cost is
+# confined to commands that genuinely mean that record. A generic leaf must NEVER
+# be added here: unanchored ``index.json`` or ``config.json`` would refuse a large
+# fraction of routine commands in any repository. The other write-protected leaves
+# are not distinctive at all (their distinguishing part is the ``apps/.../data/``
 # subpath) and must stay anchored.
-_BARE_TOKEN_PROTECTED_LEAVES: tuple[str, ...] = ("connections-tool-aliases.json",)
+_BARE_TOKEN_PROTECTED_LEAVES: tuple[str, ...] = (
+    "connections-tool-aliases.json",
+    "settings_seeds.json",
+)
 
 # Whisper weight files, matched as a NAME with no anchor, for the same reason as the
 # alias record above: the filename IS the grant. `stt.models` verifies a file's sha256

--- a/test/test_acp_client_more_coverage.py
+++ b/test/test_acp_client_more_coverage.py
@@ -597,7 +597,8 @@ class TestResetPaths:
         # The exception was retrieved, so asyncio will not report it at GC.
         assert done.exception() is not None
 
-    def test_reset_state_unlinks_claude_settings_and_survives_pipe_errors(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_teardown_unlinks_claude_settings_and_survives_pipe_errors(self, tmp_path):
         client = _client(
             tmp_path, acp_backend=ACP_BACKEND_CLAUDE, permission_mode="bypassPermissions"
         )
@@ -614,6 +615,10 @@ class TestResetPaths:
         client._pid = None
         client._child_pids = {}
 
+        # The pair every real caller runs: the seed's removal is a disk operation
+        # (revoke the durable grant, then unlink) so it lives in the async discard,
+        # while _reset_state stays synchronous and drops the in-memory claim.
+        await client._discard_claude_settings_seed()
         client._reset_state()
 
         assert not stale.exists()  # bypassPermissions must not persist a crash
@@ -1676,13 +1681,17 @@ class TestAdvertisedModelCacheWiring:
         client._write_claude_local_settings()
         assert self._read_seed(tmp_path)["availableModels"] == served
 
-    def test_seed_falls_back_to_registry_on_cold_cache(self, tmp_path, monkeypatch):
+    def test_cold_cache_seeds_no_model_keys_at_all(self, tmp_path, monkeypatch):
+        # No static-registry fallback: a guessed allowlist poisons the adapter's
+        # union+dedup merge for any model the registry has not caught up on, so an
+        # unseeded file (adapter falls back to its own provider list) beats a stale
+        # one. The post-capture re-seed fills both keys in.
         monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
-        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE)
+        client = _client(tmp_path, acp_backend=ACP_BACKEND_CLAUDE, model="claude-opus-5")
         client._write_claude_local_settings()
-        assert self._read_seed(tmp_path)["availableModels"] == mr.seed_available_models(
-            "claude_code"
-        )
+        seed = self._read_seed(tmp_path)
+        assert "availableModels" not in seed
+        assert "model" not in seed
 
     def test_claude_capture_feeds_and_flags_the_cache(self, tmp_path, monkeypatch):
         monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})

--- a/test/test_acp_seed_provenance.py
+++ b/test/test_acp_seed_provenance.py
@@ -1,0 +1,1584 @@
+"""Cross-session ownership of the ``settings.local.json`` seed, and the model
+resolution that depends on it.
+
+Three defects compounded into one user-visible symptom -- a claude session pinned
+to the 200K window even when the account is served a 1M one -- and they only make
+sense together:
+
+1. The seed's ``availableModels`` fell back to the hand-maintained static model
+   registry when the advertised-model cache was cold. The adapter merges
+   ``availableModels`` union+dedup, so a registry list that has not caught up
+   REPLACES the adapter's correct provider-derived list with one carrying no
+   ``[1m]`` id for the model actually picked.
+2. The seed ran before ``session/new`` (it must: ``permissions`` has to be on disk
+   first) and nothing re-seeded after the capture that warms the cache. So the
+   cold-cache seed was the FINAL state of the file, and the startup ``set_model``
+   folded against a cache that was still cold.
+3. Ownership was proven from per-instance memory only, so the file left behind by
+   session 1 read as a stranger's file to session 2 -- which meant the
+   leave-it-alone branch, forever. Nothing could repair a work_dir once seeded.
+
+Defect 3 is why the first two could not be fixed on their own: without a
+cross-session ownership credential, no later session is ever allowed to write.
+The credential is provenance, not permission -- a record of the bytes Crew wrote,
+where adoption additionally requires the file to still hash to them.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import model_registry as mr
+from kiro_crew import sandbox, security
+from kiro_crew.acp import client as acp_client
+from kiro_crew.acp import seed_provenance as sp
+from kiro_crew.acp.client import AcpClient
+from kiro_crew.acp.types import ACP_BACKEND_CLAUDE
+
+_SERVED = [
+    "global.anthropic.claude-opus-5[1m]",
+    "global.anthropic.claude-opus-4-8[1m]",
+]
+
+# The owner token a bare-sidecar test records under. A client uses its own
+# ``_seed_owner``; these tests only need one stable identity.
+_OWNER = "owner-under-test"
+
+
+@pytest.fixture(autouse=True)
+def isolated_records(monkeypatch):
+    """Per-test provenance state.
+
+    ``_RECORDS`` and ``_LIVE`` are process-wide runtime state (like
+    ``model_registry._ADVERTISED_MODELS``); the sidecar itself already lands in a
+    per-test ``KIROCREW_HOME``.
+    """
+    monkeypatch.setattr(sp, "_RECORDS", {})
+    monkeypatch.setattr(sp, "_LIVE", {})
+
+
+def _client(tmp_path: Path, **kw) -> AcpClient:
+    return AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_CLAUDE, **kw)
+
+
+def _settings(tmp_path: Path) -> Path:
+    return tmp_path / ".claude" / "settings.local.json"
+
+
+def _seed(tmp_path: Path) -> dict:
+    return json.loads(_settings(tmp_path).read_text(encoding="utf-8"))
+
+
+def _teardown(client: AcpClient) -> None:
+    """Tear a client down the way every real caller does.
+
+    The seed's removal is a DISK operation -- a durable revoke, then an unlink -- so
+    it lives in the async ``_discard_claude_settings_seed`` and reaches the
+    filesystem through ``asyncio.to_thread``. ``_reset_state`` stays synchronous and
+    keeps only the in-memory claim release, so calling it alone leaves the file
+    behind on purpose. Every production caller awaits the discard first and then
+    resets, and this helper is that pair, so a test that drifts from the real
+    ordering fails here rather than passing on a shape nothing uses.
+    """
+    asyncio.run(client._discard_claude_settings_seed())
+    client._reset_state()
+
+
+def _unwritable_sidecar(*_args, **_kwargs):
+    """What a read-only data home (or a full disk) does to the sidecar publish.
+
+    Patched over ``seed_provenance.atomic_write`` specifically, which is a DIFFERENT
+    binding from the one ``acp.client`` uses for the settings file itself -- so the
+    seed still lands and only its durable grant fails, which is the case under test.
+    """
+    raise OSError("EROFS: read-only file system")
+
+
+def _attribute_calls(node: ast.AST, name: str) -> list[ast.Attribute]:
+    """Every ``<something>.name`` attribute reference inside *node*.
+
+    Attribute rather than Call so a reference through a decorator, an
+    ``ensure_future`` or a ``to_thread`` counts too: the question these tests ask is
+    which method a region of source reaches, not how it spells the invocation.
+    """
+    return [n for n in ast.walk(node) if isinstance(n, ast.Attribute) and n.attr == name]
+
+
+def _the_owning_process_died() -> None:
+    """What a ``kill -9`` leaves behind: the sidecar, but no live claims.
+
+    ``_LIVE`` is process memory, so it dies with the process; ``_RECORDS`` mirrors
+    the sidecar on disk, which does not. Every cross-session test has to go
+    through here rather than just constructing a second client, because a sibling
+    that is still LIVE is deliberately not adoptable.
+    """
+    sp._LIVE.clear()
+
+
+class TestProvenanceRecord:
+    """The sidecar itself: what it records, what it refuses to claim."""
+
+    def test_record_then_recognize(self, tmp_path):
+        path = tmp_path / "settings.local.json"
+        sp.record(path, '{"a": 1}\n', _OWNER)
+        assert sp.recorded(path, _OWNER) == (len('{"a": 1}\n'), sp.digest('{"a": 1}\n'))
+
+    def test_an_unrecorded_path_is_unowned(self, tmp_path):
+        assert sp.recorded(tmp_path / "settings.local.json", _OWNER) is None
+
+    def test_forget_drops_the_claim(self, tmp_path):
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "x", _OWNER)
+        sp.forget(path, _OWNER)
+        assert sp.recorded(path, _OWNER) is None
+
+    def test_forget_survives_the_process(self, tmp_path, monkeypatch):
+        """A revoked grant has to die with the file, not just leave memory.
+
+        ``forget`` follows a successful unlink, so the file it described is gone.
+        Dropping the entry from memory alone leaves the SIDECAR still naming that
+        path -- and the digest check does not neutralize it, because a file can
+        legitimately hash to the recorded bytes again: a user who committed the
+        generated seed and later restored it holds exactly those bytes. The next
+        process would then read that user file as Crew's own, overwrite it with this
+        install's ``permissions.defaultMode``, and unlink it on reset.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+        sp.forget(path, _OWNER)
+
+        # A fresh process: nothing in memory, everything from the sidecar.
+        monkeypatch.setattr(sp, "_RECORDS", {})
+        monkeypatch.setattr(sp, "_LIVE", {})
+        sp._load()
+        assert sp.recorded(path, "a-later-session") is None
+
+        # ...and the file being restored byte-for-byte does not resurrect the grant.
+        path.write_text("payload", encoding="utf-8")
+        assert sp.recorded(path, "a-later-session") is None
+
+    def test_release_hands_back_the_slot_without_disowning_the_record(self, tmp_path):
+        """``release`` is for a claim whose write did not land.
+
+        Only the live slot goes back. Dropping the RECORD too would be the very harm
+        being avoided rather than a milder version of it: the orphan on disk would
+        become unadoptable by every later session, so a stale
+        ``permissions.defaultMode`` in it could never be repaired or removed.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+        assert sp.recorded(path, "a-later-session") is None  # live, so not adoptable
+        sp.release(path, _OWNER)
+        # Adoptable again, and still described by its recorded bytes.
+        assert sp.recorded(path, "a-later-session") == (len("payload"), sp.digest("payload"))
+
+    def test_release_cannot_evict_the_winner(self, tmp_path):
+        path = tmp_path / "settings.local.json"
+        assert sp.claim(path, "winner") is True
+        sp.release(path, "loser")
+        assert sp.claim(path, "someone-else") is False
+
+    def test_a_live_owners_record_is_invisible_to_a_sibling(self, tmp_path):
+        """A record proves "Crew wrote it", not "any Crew client may take it".
+
+        Adoption exists for an ORPHAN. While its owner is still seeding the path,
+        the record describes a LIVE file, and a sibling that read it as its own
+        would overwrite that session's permission mode.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "x", _OWNER)
+        assert sp.recorded(path, "some-other-owner") is None
+        assert sp.recorded(path, _OWNER) is not None
+
+    def test_a_sibling_cannot_revoke_a_live_claim(self, tmp_path):
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "x", _OWNER)
+        sp.forget(path, "some-other-owner")
+        assert sp.recorded(path, _OWNER) is not None
+
+    def test_the_record_becomes_adoptable_once_its_owner_lets_go(self, tmp_path):
+        """The live claim is a lease on THIS process, not a permanent lock.
+
+        Once the owner resets (or a new process loads the sidecar, where nothing
+        is live by construction), the record is an orphan again and adoptable.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "x", _OWNER)
+        sp._LIVE.pop(sp._key(path))  # owner released the path; record survives
+        assert sp.recorded(path, "some-other-owner") is not None
+
+    def test_only_one_adopter_can_claim_an_orphan(self, tmp_path):
+        """Two clients can READ the same orphan as adoptable; only one may take it.
+
+        Ownership is read at a moment, so a check alone cannot arbitrate between
+        siblings that start together -- both would then re-seed with their own
+        ``permissions.defaultMode`` and one session would run under the other's.
+        The claim is what decides, and it is a single atomic dict operation.
+        """
+        path = tmp_path / "settings.local.json"
+        assert sp.recorded(path, "first") is None  # an orphan nobody holds yet
+        assert sp.claim(path, "first") is True
+        assert sp.claim(path, "second") is False
+        # ...and the winner may re-claim its own slot, so re-seeding is not a
+        # self-refusal.
+        assert sp.claim(path, "first") is True
+        assert sp.recorded(path, "second") is None
+
+    def test_a_record_outlives_the_process(self, tmp_path, monkeypatch):
+        """The whole point: the claim has to survive a kill.
+
+        A session killed before its reset leaves the seed on disk. Only a record
+        that is still there in the NEXT process can tell that file apart from a
+        user's own.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+        # Simulate a fresh process: drop the in-memory view and reload from disk.
+        monkeypatch.setattr(sp, "_RECORDS", {})
+        monkeypatch.setattr(sp, "_LIVE", {})
+        sp._load()
+        # A reloaded record has no live holder by construction -- whoever wrote it
+        # belongs to a process that is gone -- so the NEXT session may adopt it.
+        assert sp.recorded(path, "a-later-session") == (len("payload"), sp.digest("payload"))
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        # Not a weaker assertion on Windows, a different mechanism: NTFS carries
+        # ACLs, not POSIX mode bits, so ``st_mode`` there reports a synthesised
+        # ``0o666`` from the read-only attribute alone and no ``chmod`` can change
+        # it. Asserting ``600`` would pin an artefact of the emulation rather than
+        # the confidentiality of the sidecar, which on that platform is inherited
+        # from the data home's ACL.
+        reason="POSIX mode bits; st_mode on Windows is synthesised from the RO attribute",
+    )
+    def test_the_sidecar_is_owner_only(self, tmp_path):
+        sp.record(tmp_path / "settings.local.json", "x", _OWNER)
+        # It names the work dirs this install has seeded.
+        assert oct(sp._sidecar_path().stat().st_mode)[-3:] == "600"
+
+    def test_a_corrupt_sidecar_degrades_to_unowned(self, tmp_path, monkeypatch):
+        sp._sidecar_path().parent.mkdir(parents=True, exist_ok=True)
+        sp._sidecar_path().write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(sp, "_RECORDS", {})
+        sp._load()  # must not raise
+        assert sp.recorded(tmp_path / "settings.local.json", _OWNER) is None
+
+    def test_a_malformed_entry_is_skipped_not_trusted(self, tmp_path, monkeypatch):
+        path = tmp_path / "settings.local.json"
+        sp._sidecar_path().parent.mkdir(parents=True, exist_ok=True)
+        sp._sidecar_path().write_text(
+            # The stray top-level key is deliberate: the reader takes ``seeds`` and
+            # ignores everything beside it, so a future format that grows one stays
+            # readable here. What it must not do is trust ``{"size": "big"}``.
+            json.dumps({"written-by": "something-else", "seeds": {str(path): {"size": "big"}}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(sp, "_RECORDS", {})
+        sp._load()
+        assert sp.recorded(path, _OWNER) is None
+
+    def test_the_sidecar_carries_seeds_and_nothing_else(self, tmp_path):
+        """No format marker, and that is a decision rather than an omission.
+
+        A ``version``/``schema`` key would have no reader: adoption is decided by the
+        digest alone, so nothing branches on it, and an unrecognized value could only
+        be ignored -- which is what an ABSENT marker already means. Writing one costs
+        a field that must be kept consistent forever and buys a compatibility story
+        no code implements. If a second format ever exists, its marker's absence
+        identifies the first one.
+        """
+        sp.record(tmp_path / "settings.local.json", "payload", _OWNER)
+        assert list(json.loads(sp._sidecar_path().read_text(encoding="utf-8"))) == ["seeds"]
+
+    def test_a_lookup_never_touches_the_disk(self, tmp_path, monkeypatch):
+        """``_reset_state`` consults ownership synchronously ON the event loop.
+
+        A lookup that read the sidecar would put a filesystem round-trip (and, on
+        a hostile path, a blocking open) in the gateway's loop.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+
+        def _boom():
+            raise AssertionError("recorded() must not resolve the sidecar path")
+
+        monkeypatch.setattr(sp, "_sidecar_path", _boom)
+        assert sp.recorded(path, _OWNER) is not None
+        # ``release`` is on a loop-side failure path, so it is memory-only too.
+        # ``forget`` is NOT: it revokes a grant whose file has just been unlinked,
+        # and a grant that outlives its file has to stop existing on disk as well.
+        sp.release(path, _OWNER)
+
+    def test_the_publish_happens_under_the_record_lock(self, tmp_path, monkeypatch):
+        """Mutate -> prune -> snapshot -> publish is ONE transaction.
+
+        Two seeds run concurrently under ``asyncio.to_thread`` (one client per
+        session, both writing the shared default ``work_dir``). Releasing between
+        the snapshot and its publish lets an OLDER snapshot land last, and the newer
+        seed's provenance is then simply gone -- so the surviving file reads as a
+        stranger's next run, which is the whole failure this module exists to
+        remove.
+        """
+        held: list[bool] = []
+        real = sp.atomic_write
+
+        def _observe(*args, **kwargs):
+            held.append(sp._LOCK.locked())
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(sp, "atomic_write", _observe)
+        sp.record(tmp_path / "settings.local.json", "payload", _OWNER)
+        assert held == [True]
+
+    def test_concurrent_records_all_survive(self, tmp_path):
+        # The observable consequence of the lock: whichever snapshot publishes last
+        # is a snapshot of the FULLY mutated map, so no writer's entry is dropped.
+        paths = [tmp_path / f"work-{i}" / "settings.local.json" for i in range(8)]
+        for path in paths:
+            # Each seed exists on disk, as it does on the real seed path: the file is
+            # written and then recorded. An entry whose file is gone is pruned, so a
+            # version of this test that skipped the write would be measuring the
+            # prune rather than the lock.
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("x", encoding="utf-8")
+        ready = threading.Barrier(len(paths))
+
+        def _seed(path: Path) -> None:
+            ready.wait()
+            sp.record(path, f"payload-{path.parent.name}", _OWNER)
+
+        threads = [threading.Thread(target=_seed, args=(p,)) for p in paths]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        persisted = json.loads(sp._sidecar_path().read_text(encoding="utf-8"))["seeds"]
+        assert sorted(persisted) == sorted(os.fspath(p) for p in paths)
+
+    def test_a_concurrent_processs_record_is_not_dropped(self, tmp_path):
+        """The gateway and a CLI chat share one sidecar; neither may clobber the other.
+
+        Each process holds its OWN in-memory ``_RECORDS`` and ``atomic_write`` renames
+        a fresh inode over the sidecar, so a process that published its process-local
+        snapshot would drop every record another process had written -- leaving that
+        seed permanently unadoptable, the stale-state failure this module exists to
+        remove. Persisting is reload-merge-publish under the cross-process lock, so a
+        sibling's on-disk record survives this process publishing its own.
+
+        The sibling is simulated by a record already ON DISK and absent from this
+        process's ``_RECORDS`` -- exactly what a second process's write looks like from
+        here. A ``_persist`` that wrote only ``_RECORDS`` fails this.
+        """
+        sibling = tmp_path / "gateway-wd" / "settings.local.json"
+        sibling.parent.mkdir(parents=True, exist_ok=True)
+        sibling.write_text("B", encoding="utf-8")
+        sp._sidecar_path().parent.mkdir(parents=True, exist_ok=True)
+        sp._sidecar_path().write_text(
+            json.dumps({"seeds": {os.fspath(sibling): {"size": 1, "sha256": sp.digest("B")}}}),
+            encoding="utf-8",
+        )
+
+        ours = tmp_path / "cli-wd" / "settings.local.json"
+        ours.parent.mkdir(parents=True, exist_ok=True)
+        ours.write_text("A", encoding="utf-8")
+        assert sp.record(ours, "A", _OWNER) is True
+
+        persisted = json.loads(sp._sidecar_path().read_text(encoding="utf-8"))["seeds"]
+        assert os.fspath(sibling) in persisted, "the sibling process's record was dropped"
+        assert os.fspath(ours) in persisted
+        # And the sibling stays "not ours": reloading it to publish must not make this
+        # process treat a live sibling's seed as an adoptable orphan.
+        assert sp.recorded(sibling, "a-later-session") is None
+
+    def test_the_lookup_and_the_claim_do_not_take_the_lock(self, tmp_path):
+        """``_LOCK`` is held across a disk write, so a loop-side READER must not want it.
+
+        ``_reset_state`` consults ownership synchronously ON the event loop; if
+        :func:`recorded` or :func:`release` took the lock, a worker thread mid-persist
+        would stall the gateway's one loop. Holding it here would deadlock outright
+        (a plain, non-reentrant ``threading.Lock``) if either did.
+
+        :func:`forget` deliberately DOES take it -- it publishes -- which is why it is
+        exercised separately below rather than here.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+
+        with sp._LOCK:
+            assert sp.recorded(path, _OWNER) is not None
+            assert sp.claim(path, _OWNER) is True
+            sp.release(path, _OWNER)
+        assert sp.recorded(path, "a-later-session") is not None
+
+    def test_forget_publishes_under_the_same_lock_record_uses(self, tmp_path, monkeypatch):
+        """The revoke is a publish, so it is the same transaction ``record`` is.
+
+        Snapshot-then-publish without the lock lets a concurrent ``record`` land an
+        older snapshot last, which would restore the grant this call just revoked.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+
+        held: list[bool] = []
+        real = sp.atomic_write
+
+        def _observe(*args, **kwargs):
+            held.append(sp._LOCK.locked())
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(sp, "atomic_write", _observe)
+        sp.forget(path, _OWNER)
+        assert held == [True]
+
+    def test_forget_reports_true_only_when_the_disk_agrees(self, tmp_path, monkeypatch):
+        """The return value is the whole contract: it authorizes a deletion.
+
+        The caller unlinks the file only on ``True``, so a revoke that reports
+        success it did not achieve is the one failure mode that matters here -- the
+        sidecar would keep naming a path whose file is gone, and the next process
+        would adopt whatever appears there.
+        """
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", _OWNER)
+        assert sp.forget(path, _OWNER) is True
+        assert sp.recorded(path, "a-later-session") is None
+
+        sp.record(path, "payload", _OWNER)
+
+        def _boom(*args, **kwargs):
+            raise OSError("EROFS")
+
+        monkeypatch.setattr(sp, "atomic_write", _boom)
+        assert sp.forget(path, _OWNER) is False
+        # Put back, so this process agrees with the sidecar a restart would read --
+        # and so the file the caller was told to keep is still adoptable.
+        assert sp.recorded(path, "a-later-session") is not None
+
+    def test_forget_refuses_to_revoke_a_live_siblings_claim(self, tmp_path, monkeypatch):
+        """A client that could not adopt a seed cannot revoke its grant either."""
+        path = tmp_path / "settings.local.json"
+        sp.record(path, "payload", "the-live-session")
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("a refused revoke must not publish")
+
+        monkeypatch.setattr(sp, "atomic_write", _boom)
+        assert sp.forget(path, "a-sibling") is False
+        assert sp.recorded(path, "the-live-session") is not None
+
+    def test_forgetting_an_unrecorded_path_writes_nothing(self, tmp_path, monkeypatch):
+        """No entry, no publish: a reset for a path Crew never seeded stays free."""
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("forget() must not publish when it removed nothing")
+
+        monkeypatch.setattr(sp, "atomic_write", _boom)
+        sp.forget(tmp_path / "settings.local.json", _OWNER)
+
+    def test_an_entry_whose_file_is_gone_is_pruned(self, tmp_path):
+        """The one prune, and the whole bound: no file, nothing to be owner of.
+
+        A long-lived install rotating through disposable work dirs must not grow the
+        sidecar without end. It cannot, because an entry survives only while a file
+        is actually at its path -- so the sidecar is bounded by the seeds on disk,
+        which is the only bound that means anything here.
+        """
+        for i in range(10):
+            sp.record(tmp_path / f"gone-{i}.json", "x", _OWNER)
+
+        # Only the most recent survives: each ``record`` exempts its own key (see
+        # ``_persist``'s ``keep``) and prunes every other path with no file.
+        assert list(sp._RECORDS) == [os.fspath(tmp_path / "gone-9.json")]
+        # The live map is pruned with it, so it cannot outlive the records.
+        assert list(sp._LIVE) == [os.fspath(tmp_path / "gone-9.json")]
+        persisted = json.loads(sp._sidecar_path().read_text(encoding="utf-8"))
+        assert list(persisted["seeds"]) == [os.fspath(tmp_path / "gone-9.json")]
+
+    def test_an_adoptable_orphan_is_never_pruned_however_many_there_are(self, tmp_path):
+        """There is no entry CAP, deliberately, and this is the reason why.
+
+        A cap can only ever evict entries whose file still EXISTS -- the dead ones
+        are already gone -- and those are precisely the adoptable orphans this
+        module exists to keep. Evicting one makes its path unrecorded, which is
+        worse in both directions at once: its own owner can no longer recognize it
+        on reset, so it leaks, and no later session is permitted to repair it
+        either, so whatever it holds (a stale ``availableModels``, a stale
+        ``permissions.defaultMode``, up to an inherited ``bypassPermissions``)
+        becomes permanent project state. That is the exact failure this module
+        removes, so a cap would re-manufacture it for the oldest work dir.
+
+        200 is well past any cap that was ever plausible here, so this fails on any
+        version that reintroduces one.
+        """
+        orphans = []
+        for i in range(200):
+            seed = tmp_path / f"orphan-{i}.json"
+            seed.write_text("x", encoding="utf-8")
+            orphans.append(seed)
+            sp.record(seed, "x", f"dead-session-{i}")
+            sp.release(seed, f"dead-session-{i}")  # the session ended; file remains
+
+        assert len(sp._RECORDS) == 200
+        for seed in orphans:
+            # Adoptable by the next session, which is the point of keeping it.
+            assert sp.recorded(seed, "a-later-session") is not None
+        persisted = json.loads(sp._sidecar_path().read_text(encoding="utf-8"))
+        assert len(persisted["seeds"]) == 200
+
+    def test_a_live_seed_is_never_pruned_either(self, tmp_path):
+        """The same rule seen from the other side: a live claim survives with it."""
+        owned = []
+        for i in range(50):
+            seed = tmp_path / f"live-{i}.json"
+            seed.write_text("x", encoding="utf-8")
+            owned.append((seed, f"live-owner-{i}"))
+            sp.record(seed, "x", f"live-owner-{i}")
+
+        assert len(sp._RECORDS) == 50
+        for seed, owner in owned:
+            assert sp.recorded(seed, owner) is not None
+            # Surviving the prune must not cost the owner scoping.
+            assert sp.recorded(seed, "a-sibling") is None
+
+    def test_the_live_owner_is_published_before_the_record(self, tmp_path, monkeypatch):
+        """``_LIVE`` has to land first, because the lookup between them is lock-free.
+
+        Asserted from INSIDE the mutation rather than off the source text, so it
+        holds however ``record`` is spelled.
+        """
+        observed: list[str | None] = []
+
+        class _Watched(dict):
+            def __setitem__(self, key, value):
+                observed.append(sp._LIVE.get(key))
+                super().__setitem__(key, value)
+
+        monkeypatch.setattr(sp, "_RECORDS", _Watched())
+        seed = tmp_path / "settings.local.json"
+        seed.write_text("x", encoding="utf-8")
+        sp.record(seed, "x", _OWNER)
+        assert observed == [_OWNER]
+
+    def test_a_sibling_never_sees_a_fresh_seed_as_an_orphan(self, tmp_path, monkeypatch):
+        """The consequence of that order, stated as the sibling's own answer.
+
+        :func:`recorded` is lock-free by design, so a sibling client reads both dicts
+        from another thread between ``record``'s statements. If the record were
+        published first, the instant it became visible the just-written seed would
+        read as an ORPHAN -- recorded, no live holder, digest matching the file now on
+        disk -- and the sibling would claim it, rewrite it under its own
+        ``permissions.defaultMode`` and unlink it on its own reset, out from under a
+        session still running against it.
+        """
+        sibling_saw: list[tuple[int, str] | None] = []
+
+        class _Watched(dict):
+            def __setitem__(self, key, value):
+                super().__setitem__(key, value)
+                sibling_saw.append(sp.recorded(key, "a-sibling"))
+
+        monkeypatch.setattr(sp, "_RECORDS", _Watched())
+        seed = tmp_path / "settings.local.json"
+        seed.write_text("x", encoding="utf-8")
+        sp.record(seed, "x", _OWNER)
+        assert sibling_saw == [None]
+
+
+class TestCrossSessionAdoption:
+    """A seed orphaned by a killed session is Crew's to re-seed; nothing else is."""
+
+    def test_an_orphaned_seed_is_reseeded_by_the_next_session(self, tmp_path, monkeypatch):
+        # Session 1: cold cache, so no model keys (the adapter's own provider list
+        # is better than a guessed one) -- then the process dies without reset.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        first = _client(tmp_path, model="claude-opus-5")
+        first._write_claude_local_settings()
+        assert "availableModels" not in _seed(tmp_path)
+        _the_owning_process_died()
+
+        # Session 2, cache now warm from session 1's capture. Before the durable
+        # record existed this session saw a stranger's file and left it alone, so
+        # the half-seeded file was the permanent state of that work_dir.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        second = _client(tmp_path, model="claude-opus-5")
+        second._model = mr.resolve_wire_model_id(second._model, "claude_code")
+        second._write_claude_local_settings()
+
+        data = _seed(tmp_path)
+        assert data["availableModels"] == _SERVED
+        assert data["model"] == "global.anthropic.claude-opus-5[1m]"
+        assert second._claude_settings_authored is True
+
+    def test_a_user_authored_file_is_still_left_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        path = _settings(tmp_path)
+        path.parent.mkdir(parents=True)
+        original = json.dumps({"permissions": {"allow": ["Bash(ls)"]}}, indent=2)
+        path.write_text(original, encoding="utf-8")
+
+        client = _client(tmp_path, permission_mode="default")
+        client._write_claude_local_settings()
+        assert path.read_text(encoding="utf-8") == original
+        assert client._claude_settings_authored is False
+        client._reset_state()
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_a_crew_seed_the_user_edited_is_left_untouched(self, tmp_path, monkeypatch):
+        """Adoption is earned by the digest, not by the record.
+
+        The record says "Crew wrote this path"; it is the hash that says "these are
+        still Crew's bytes". Editing the file makes it the user's, which is what
+        keeps the credential from becoming a licence to overwrite a path.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        first = _client(tmp_path)
+        first._write_claude_local_settings()
+        path = _settings(tmp_path)
+        edited = json.dumps({"model": "mine", "env": {"X": "1"}}, indent=2)
+        path.write_text(edited, encoding="utf-8")
+        _the_owning_process_died()
+
+        assert sp.recorded(path, "a-later-session") is not None  # the record is still there
+        second = _client(tmp_path, model="claude-opus-5")
+        second._write_claude_local_settings()
+        assert path.read_text(encoding="utf-8") == edited
+        assert second._claude_settings_authored is False
+
+    def test_without_a_record_an_orphan_is_left_untouched(self, tmp_path, monkeypatch):
+        # Provenance, not the path: an identical file Crew cannot vouch for gets the
+        # same treatment as the user's own. This is the pre-fix behaviour, kept for
+        # every case the record does not cover (another install, a copied repo).
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        first = _client(tmp_path)
+        first._write_claude_local_settings()
+        before = _settings(tmp_path).read_text(encoding="utf-8")
+        _the_owning_process_died()
+
+        monkeypatch.setattr(sp, "_RECORDS", {})
+        second = _client(tmp_path, model="claude-opus-5")
+        second._write_claude_local_settings()
+        assert _settings(tmp_path).read_text(encoding="utf-8") == before
+        assert second._claude_settings_authored is False
+
+    def test_an_orphaned_bypass_mode_is_overwritten_not_inherited(self, tmp_path, monkeypatch):
+        """Re-seeding an orphan is also the only way to clean one up.
+
+        ``bypassPermissions`` takes every tool call out of the host gate. A seed
+        carrying it that outlived its session used to be frozen in place and kept
+        being read by the adapter; adoption overwrites the mode with THIS session's.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        first = _client(tmp_path, permission_mode="bypassPermissions")
+        first._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "bypassPermissions"
+        _the_owning_process_died()
+
+        second = _client(tmp_path, permission_mode="default")
+        second._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "default"
+
+    def test_a_live_siblings_seed_is_left_alone(self, tmp_path, monkeypatch):
+        """Adoption is for an orphan, and a running sibling has not left one.
+
+        Two keyless sessions share the default ``work_dir``, so this is the
+        ordinary multi-session case, not a contrived one. Adopting here would write
+        THIS session's ``permissions.defaultMode`` into a file the live session is
+        running against, and delete that file on this session's reset.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        live = _client(tmp_path, permission_mode="bypassPermissions")
+        live._write_claude_local_settings()
+        before = _settings(tmp_path).read_text(encoding="utf-8")
+
+        sibling = _client(tmp_path, permission_mode="default")
+        sibling._write_claude_local_settings()
+        assert _settings(tmp_path).read_text(encoding="utf-8") == before
+        assert sibling._claude_settings_authored is False
+
+        # ...and the sibling's own teardown cannot revoke the live session's claim.
+        _teardown(sibling)
+        assert _settings(tmp_path).read_text(encoding="utf-8") == before
+        assert live._claude_settings_is_still_ours() is True
+
+    def test_an_adopted_seed_is_removed_on_reset(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        _client(tmp_path)._write_claude_local_settings()
+        _the_owning_process_died()
+        second = _client(tmp_path)
+        second._write_claude_local_settings()
+        _teardown(second)
+        # A permission mode must not outlive its session -- including one this
+        # session adopted rather than created.
+        assert not _settings(tmp_path).exists()
+        # And the claim goes with it, so whatever appears at this path next is not
+        # adopted on the strength of a stale entry.
+        assert sp.recorded(_settings(tmp_path), "a-later-session") is None
+
+    def test_a_symlink_is_refused_before_ownership_is_considered(self, tmp_path, monkeypatch):
+        # The path guard runs first: a recorded path that is now a link must not be
+        # written THROUGH, whatever the record says.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        first = _client(tmp_path)
+        first._write_claude_local_settings()
+        path = _settings(tmp_path)
+        target = tmp_path / "elsewhere.json"
+        path.unlink()
+        path.symlink_to(target)
+        # Dead owner, so the record IS adoptable -- the symlink guard is what has to
+        # refuse, not the live-sibling check.
+        _the_owning_process_died()
+
+        second = _client(tmp_path)
+        second._write_claude_local_settings()
+        assert not target.exists()
+        assert second._claude_settings_authored is False
+
+    def test_a_grown_file_is_not_ours(self, tmp_path, monkeypatch):
+        # The read is capped one byte past the recorded length, so a file appended
+        # to after the fstat is rejected on length instead of matching a prefix.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        first = _client(tmp_path)
+        first._write_claude_local_settings()
+        with open(_settings(tmp_path), "a", encoding="utf-8") as fh:
+            fh.write("trailing")
+        assert first._claude_settings_is_still_ours() is False
+
+
+class TestTheRecordIsOnEveryWriteFloor:
+    """An entry in the sidecar IS the grant, so the agent must not be able to add one.
+
+    The forgery chain the floors close, end to end: an agent writes
+    ``{"seeds": {"<repo>/.claude/settings.local.json": {size, sha256}}}`` for a
+    settings file the USER hand-wrote, the next gateway start loads it, the digest
+    matches, and Crew's own trusted writer adopts the file -- replacing the user's
+    ``permissions.defaultMode`` with this session's and unlinking the file on reset.
+    The digest check is doing exactly what it was designed to do; what must not be
+    forgeable is the record it checks against. Read stays allowed: the record holds
+    work-dir paths and digests, not a secret.
+    """
+
+    LEAF = "settings_seeds.json"
+
+    def test_the_sidecar_is_the_leaf_the_floors_name(self):
+        # The floors are spelled as a filename, so they only hold if that is the name
+        # the module actually publishes.
+        assert sp._sidecar_path().name == self.LEAF
+
+    def test_the_file_edit_gate_refuses_a_write_and_allows_a_read(self):
+        for prefix in security.crew_home_prefixes():
+            path = f"~/{prefix}/{self.LEAF}"
+            assert security.is_sensitive_write_path(path) is True, path
+            assert security.is_sensitive_path(path) is False, path
+
+    def test_the_shell_gate_refuses_every_spelling(self):
+        # Paired with the edit gate: protected on one path only is not protected. And
+        # bare-token matched, because for a DELETION grant a ``cd`` must not be the
+        # whole bypass -- the invariant is the filename, not the way to it.
+        for cmd in (
+            f"echo forged > ~/.kiro/crew/{self.LEAF}",
+            f"cd ~/.kiro/crew && echo forged > {self.LEAF}",
+            f"tee ./{self.LEAF}",
+            f"python -c \"open('{self.LEAF}','w')\"",
+        ):
+            assert security.is_sensitive_bash_command(cmd) is not None, cmd
+
+    def test_the_sandbox_seals_it_readonly_even_when_absent(self):
+        # The kernel floor under the deny rules, which a runtime-constructed spelling
+        # (``$(printf ...)``) walks past. READONLY, not hidden -- the write is the
+        # risk. Precreated because ``mount(2)`` cannot seal a path that is not there,
+        # and this sidecar does not exist until a claude session has seeded a work
+        # dir: on every install that has not, the name is writable.
+        assert self.LEAF in sandbox._CREW_READONLY_LEAVES
+        assert self.LEAF in sandbox._CREW_PRECREATE_READONLY_FILE_LEAVES
+        assert self.LEAF not in sandbox._CREW_SANDBOX_VISIBLE_LEAVES
+
+    def test_an_empty_materialized_ceiling_means_what_an_absent_one_means(
+        self, tmp_path, monkeypatch
+    ):
+        """The precondition for precreating it: ``{}`` must read as "Crew owns nothing".
+
+        A stale pinned read of the stub is the same answer, which is the direction
+        that refuses -- the writer takes its leave-it-alone branch, so nothing is
+        overwritten and nothing is unlinked.
+        """
+        sidecar = tmp_path / self.LEAF
+        sidecar.write_bytes(sandbox._EMPTY_CEILING_DOCUMENT)
+        monkeypatch.setattr(sp, "_sidecar_path", lambda: sidecar)
+
+        sp._load()
+        assert sp._RECORDS == {}
+        assert sp.recorded(_settings(tmp_path), _OWNER) is None
+
+
+class TestOwnershipTracksTheFilesystem:
+    """A claim moves only when the write or the unlink actually happened.
+
+    Ownership is a statement about bytes on disk, so every place it is recorded or
+    dropped has to be ordered against the syscall that made it true. Both
+    directions were wrong: the re-seed truncated the recorded bytes before writing
+    the new ones (a failure mid-write left a file no session could ever claim
+    again), and reset dropped the claim before knowing the unlink succeeded (a
+    failure left Crew's own file behind as an unrecognizable orphan).
+    """
+
+    def test_a_failed_reseed_leaves_the_recorded_bytes_and_the_claim(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        first = _client(tmp_path, permission_mode="bypassPermissions")
+        first._write_claude_local_settings()
+        path = _settings(tmp_path)
+        before = path.read_text(encoding="utf-8")
+        _the_owning_process_died()
+
+        def _boom(*args, **kwargs):
+            raise OSError("ENOSPC")
+
+        monkeypatch.setattr(acp_client, "atomic_write", _boom)
+        second = _client(tmp_path, permission_mode="default")
+        with pytest.raises(OSError):
+            second._write_claude_local_settings()
+
+        # Staging and renaming is what makes this hold: the old bytes are still the
+        # bytes the record names, so the path is STILL adoptable. Truncating first
+        # destroyed them before the new ones landed, leaving a file whose digest
+        # matched nothing -- unclaimable by this session and by every later one.
+        assert path.read_text(encoding="utf-8") == before
+        assert sp.recorded(path, second._seed_owner) is not None
+        assert second._claude_settings_is_still_ours() is True
+
+        # And the instance flag did not move either, so this session's reset cannot
+        # delete a file whose current bytes Crew never wrote.
+        assert second._claude_settings_authored is False
+        _teardown(second)
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_the_path_is_still_adoptable_after_a_failed_reseed(self, tmp_path, monkeypatch):
+        # The consequence of the above, stated as the user-visible outcome: the
+        # ENOSPC session is a no-op, not a permanent loss of the work dir.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        _client(tmp_path, permission_mode="bypassPermissions")._write_claude_local_settings()
+        _the_owning_process_died()
+
+        real = acp_client.atomic_write
+        disk_is_full = True
+
+        def _boom(*args, **kwargs):
+            if disk_is_full:
+                raise OSError("ENOSPC")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(acp_client, "atomic_write", _boom)
+        with pytest.raises(OSError):
+            _client(tmp_path, permission_mode="default")._write_claude_local_settings()
+        _the_owning_process_died()
+
+        disk_is_full = False
+        third = _client(tmp_path, permission_mode="default")
+        third._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "default"
+        assert third._claude_settings_authored is True
+
+    def test_a_failed_adoption_hands_the_claim_back_within_the_process(self, tmp_path, monkeypatch):
+        """The claim has to be released, not just survive a process restart.
+
+        ``claim`` is the race arbiter, so it is taken BEFORE the write -- it cannot
+        wait for one to succeed without letting two clients both decide the same
+        orphan is theirs. But a winner that then fails to write still holds the live
+        slot, and every later client in this process therefore reads the orphan as a
+        LIVE session's file: unadoptable, so the stale ``bypassPermissions`` in it
+        can be neither rewritten nor removed for the lifetime of the gateway. Note
+        there is no ``_the_owning_process_died()`` below -- that is the point.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        _client(tmp_path, permission_mode="bypassPermissions")._write_claude_local_settings()
+        path = _settings(tmp_path)
+        _the_owning_process_died()  # the seed is an orphan; the adopter is next
+
+        real = acp_client.atomic_write
+        disk_is_full = True
+
+        def _boom(*args, **kwargs):
+            if disk_is_full:
+                raise OSError("ENOSPC")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(acp_client, "atomic_write", _boom)
+        failed = _client(tmp_path, permission_mode="default")
+        with pytest.raises(OSError):
+            failed._write_claude_local_settings()
+
+        # Handed back: the record still describes the file (that is what keeps it
+        # adoptable at all), and no live holder stands in the next client's way.
+        assert sp.recorded(path, "a-sibling-in-this-process") is not None
+
+        disk_is_full = False
+        repaired = _client(tmp_path, permission_mode="default")
+        repaired._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "default"
+
+    def test_a_failed_adoption_does_not_evict_a_live_sibling(self, tmp_path, monkeypatch):
+        """Only the winner may release. A loser's failure is not a lever on the slot."""
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        live = _client(tmp_path, permission_mode="bypassPermissions")
+        live._write_claude_local_settings()
+        path = _settings(tmp_path)
+
+        # A sibling reaches the orphan check, loses the claim, and leaves it alone.
+        loser = _client(tmp_path, permission_mode="default")
+        loser._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "bypassPermissions"
+        assert loser._claude_settings_authored is False
+        assert sp.recorded(path, live._seed_owner) is not None
+        assert sp.recorded(path, loser._seed_owner) is None
+
+    def test_the_create_path_still_refuses_to_clobber_a_racing_sibling(self, tmp_path):
+        # A rename REPLACES whatever sits at the name, so it cannot arbitrate a
+        # create race at all. The create branch therefore keeps its O_EXCL open --
+        # the loser must see the winner's file, not overwrite it.
+        opened: list[int] = []
+        real_open = os.open
+
+        def _record_flags(path, flags, *rest):
+            if str(path).endswith("settings.local.json"):
+                opened.append(flags)
+            return real_open(path, flags, *rest)
+
+        client = _client(tmp_path, permission_mode="default")
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(os, "open", _record_flags)
+            client._write_claude_local_settings()
+
+        assert opened, "the create branch must open the path itself"
+        assert opened[-1] & os.O_EXCL
+
+    def test_a_failed_unlink_keeps_the_claim(self, tmp_path, monkeypatch):
+        """The file is still there, so the claim on it is still true.
+
+        Dropping it made Crew's own file unrecognizable to every later session --
+        exactly the orphan this module exists to end, manufactured by the cleanup
+        path. Keeping it means the next session re-seeds or removes it.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        # Teardown inode-pins the delete: it moves the file to a fresh ``*.crew-gc``
+        # temp and deletes THAT, so a delete failure is a failure to remove the moved
+        # inode. The temp name is randomized (mkstemp), so match on the suffix.
+        real_unlink = Path.unlink
+
+        def _refuse(self, *args, **kwargs):
+            if str(self).endswith(".crew-gc"):
+                raise OSError("EACCES")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", _refuse)
+        _teardown(client)
+
+        # The moved inode could not be deleted, so it is restored under the pathname
+        # and re-recorded rather than left as a frozen ``.crew-gc`` no session names.
+        assert path.exists()
+        assert not list(path.parent.glob("*.crew-gc"))
+        _the_owning_process_died()
+        assert sp.recorded(path, "a-later-session") is not None
+
+        monkeypatch.setattr(Path, "unlink", real_unlink)
+        later = _client(tmp_path, permission_mode="default")
+        later._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "default"
+
+    def test_a_successful_unlink_revokes_the_grant_for_good(self, tmp_path, monkeypatch):
+        """The mirror of the above: the file is gone, so the grant must be too.
+
+        Dropping it from memory alone left the SIDECAR naming a path Crew had just
+        deleted, and re-verifying the digest does not neutralize that -- a file can
+        hash to the recorded bytes again quite legitimately, most plainly when a user
+        committed the generated seed and later restored it. The next process would
+        then read that user's file as Crew's own: overwritten with this install's
+        permission mode, and unlinked on reset.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        seeded = path.read_text(encoding="utf-8")
+        _teardown(client)
+        assert not path.exists()
+
+        # A fresh process reads only what the sidecar kept.
+        monkeypatch.setattr(sp, "_RECORDS", {})
+        monkeypatch.setattr(sp, "_LIVE", {})
+        sp._load()
+        # The user restores the file they had committed -- byte for byte Crew's seed.
+        path.write_text(seeded, encoding="utf-8")
+        later = _client(tmp_path, permission_mode="default")
+        later._write_claude_local_settings()
+
+        assert path.read_text(encoding="utf-8") == seeded
+        assert later._claude_settings_authored is False
+        _teardown(later)
+        assert path.exists()
+
+    def test_the_revoke_lands_before_the_unlink(self, tmp_path, monkeypatch):
+        """Ordering, not just presence: the grant dies BEFORE the file it described.
+
+        Both steps can fail independently, so "revoke and unlink" is not enough --
+        unlink-then-revoke leaves a window in which the file is gone while the
+        sidecar still names it, and a crash inside that window is exactly the state
+        :func:`forget` exists to prevent: the next process reloads the entry and
+        adopts whatever appears at the path next.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        # The delete is inode-pinned: the file is moved to a fresh ``*.crew-gc`` temp
+        # first and THAT is what gets unlinked, so the ordering is watched on the moved
+        # inode. The temp name is randomized (mkstemp), so match on the suffix.
+
+        order: list[str] = []
+        real_forget = sp.forget
+        real_unlink = Path.unlink
+
+        def _watch_forget(*args, **kwargs):
+            order.append("revoke")
+            return real_forget(*args, **kwargs)
+
+        def _watch_unlink(self, *args, **kwargs):
+            if str(self).endswith(".crew-gc"):
+                order.append("unlink")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(sp, "forget", _watch_forget)
+        monkeypatch.setattr(Path, "unlink", _watch_unlink)
+        _teardown(client)
+
+        assert order == ["revoke", "unlink"]
+        assert not path.exists()
+        assert not list(path.parent.glob("*.crew-gc"))
+
+    def test_a_failed_revoke_keeps_the_file_and_the_record(self, tmp_path, monkeypatch):
+        """A revoke that did not reach the disk must not authorize a deletion.
+
+        The sidecar write can fail on its own (a full disk, a read-only data home).
+        Unlinking anyway leaves the durable grant naming a path whose file is gone,
+        which is the exact state that makes a user's restored copy adoptable. So the
+        file stays, the record stays, and a later session repairs the orphan --
+        strictly better than a deletion whose revocation never landed.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        seeded = path.read_text(encoding="utf-8")
+
+        real = sp.atomic_write
+        data_home_is_read_only = True
+
+        def _boom(*args, **kwargs):
+            if data_home_is_read_only:
+                raise OSError("EROFS")
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(sp, "atomic_write", _boom)
+        _teardown(client)
+
+        assert path.read_text(encoding="utf-8") == seeded
+        # In memory the record is back, so this process agrees with what a restart
+        # would read off the un-rewritten sidecar.
+        _the_owning_process_died()
+        assert sp.recorded(path, "a-later-session") is not None
+
+        data_home_is_read_only = False
+        later = _client(tmp_path, permission_mode="default")
+        later._write_claude_local_settings()
+        assert _seed(tmp_path)["permissions"]["defaultMode"] == "default"
+
+    def test_a_replacement_the_user_wrote_is_left_alone_on_teardown(self, tmp_path, monkeypatch):
+        """Teardown re-checks the bytes, so an edited file is not this session's.
+
+        The user may replace the seed while the session runs. Crew wrote the ORIGINAL
+        bytes, so its ``_claude_settings_authored`` flag is set -- but the file on
+        disk is now the user's, and deleting it is data loss.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        path.write_text('{"permissions": {"defaultMode": "acceptEdits"}}', encoding="utf-8")
+
+        _teardown(client)
+
+        assert json.loads(path.read_text(encoding="utf-8"))["permissions"] == {
+            "defaultMode": "acceptEdits"
+        }
+
+    def test_the_teardown_never_touches_the_disk_on_the_event_loop(self, tmp_path, monkeypatch):
+        """Both disk steps are off the loop, which is what makes the revoke durable.
+
+        ``forget`` publishes the sidecar and takes :data:`_LOCK` across the write, so
+        calling it inline would put a synchronous write -- and a wait on a lock a
+        worker thread holds across one -- on the gateway's single event loop. The
+        unlink is the same kind of call. Asserting on the running loop from inside
+        each one is what pins that: a version that calls either directly fails here.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+
+        on_loop: list[str] = []
+        real_forget = sp.forget
+        real_unlink = Path.unlink
+
+        def _note(step: str) -> None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                return  # a worker thread has no loop, which is the point
+            on_loop.append(step)
+
+        def _watch_forget(*args, **kwargs):
+            _note("forget")
+            return real_forget(*args, **kwargs)
+
+        def _watch_unlink(self, *args, **kwargs):
+            if self == path:
+                _note("unlink")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(sp, "forget", _watch_forget)
+        monkeypatch.setattr(Path, "unlink", _watch_unlink)
+        _teardown(client)
+
+        assert on_loop == []
+        assert not path.exists()
+
+
+class TestTheGrantIsATransaction:
+    """Neither half of a provenance mutation may land without the other.
+
+    A grant is only real once it is on disk, so both directions have to commit or
+    roll back together: a seed with no durable record is a permission mode nothing
+    can clean up, and a revoked record with the file still there is a grant that
+    outlives what it described. These pin the two cases where the pairing used to
+    come apart -- a sidecar publish that fails, and a teardown that is cancelled.
+    """
+
+    def test_a_seed_whose_grant_is_not_durable_is_withdrawn(self, tmp_path, monkeypatch):
+        """No record, no seed. The write is undone rather than left unowned.
+
+        Ownership IS the record, so a settings file written while the sidecar cannot
+        be published is the one state nothing on the host can repair: this session
+        would still remove it, but a kill before teardown leaves a
+        ``permissions.defaultMode`` the user never approved behind a file no later
+        session is permitted to re-seed or remove. Withdrawing it costs this session
+        the allowlist and the deny rules -- exactly what a cold advertised-model
+        cache already costs -- which is the strictly smaller harm.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        monkeypatch.setattr(sp, "atomic_write", _unwritable_sidecar)
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+
+        assert not _settings(tmp_path).exists()
+        # No instance claim either, so teardown has nothing to act on and a
+        # replacement client in this process starts from a clean path.
+        assert client._claude_settings_authored is False
+        _the_owning_process_died()
+        assert sp.recorded(_settings(tmp_path), "a-later-session") is None
+
+    def test_a_failed_record_rolls_the_memory_back_to_the_sidecar(self, tmp_path):
+        """A refused publish leaves this process reading what a restart would read.
+
+        The rollback restores the DISPLACED entry rather than dropping the key: the
+        sidecar on disk still names the previous digest, and on a re-seed the bytes
+        that digest describes may still be the ones on disk, because ``atomic_write``
+        publishes by rename and so leaves the old file intact when it fails.
+        """
+        path = tmp_path / "settings.local.json"
+        assert sp.record(path, "first", _OWNER) is True
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sp, "atomic_write", _unwritable_sidecar)
+            assert sp.record(path, "second", _OWNER) is False
+
+        assert sp.recorded(path, _OWNER) == (len("first"), sp.digest("first"))
+        # And the live slot is the one the failed call found, not the one it took:
+        # an adopter arrives here already holding it, so a rollback that popped it
+        # would hand a live path to a sibling.
+        assert sp._LIVE.get(str(path)) == _OWNER
+
+    def test_a_cancelled_teardown_still_settles_the_seed(self, tmp_path, monkeypatch):
+        """Cancellation cannot land between the revoke and the unlink.
+
+        Teardown runs on paths that are themselves being cancelled -- a turn cancel, a
+        session close, a shutdown. As a sequence of awaited steps this had a
+        suspension point between the ownership check, the revoke and the unlink, and a
+        cancellation on any of them cleared the flags with the file still on disk and
+        its grant already gone: unrecoverable. As one shielded thread the transaction
+        has either not started or run to completion, which is what this asserts.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        assert path.exists()
+
+        entered = threading.Event()
+        real_settle = client._settle_claude_settings_seed
+
+        def _slow_settle(*args, **kwargs):
+            entered.set()
+            # Long enough that the cancel below lands while this is mid-transaction,
+            # which is the window the awaited-sequence version could not survive.
+            time.sleep(0.2)
+            return real_settle(*args, **kwargs)
+
+        monkeypatch.setattr(client, "_settle_claude_settings_seed", _slow_settle)
+
+        async def _cancel_mid_teardown() -> None:
+            task = asyncio.ensure_future(client._discard_claude_settings_seed())
+            await asyncio.to_thread(entered.wait, 5)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # ``asyncio.run`` shuts the default executor down on the way out, so by the
+        # time it returns the shielded thread has finished -- no polling needed.
+        asyncio.run(_cancel_mid_teardown())
+
+        assert not path.exists()
+        _the_owning_process_died()
+        assert sp.recorded(path, "a-later-session") is None
+
+    def test_every_discard_call_site_resets_in_a_finally(self):
+        """The in-memory reset must survive a cancelled discard, at every call site.
+
+        The mirror image of the test above, and it is a source-shape assertion for the
+        same reason the loop-bound-locks and to_thread gates are: the defect is a
+        MISSING ``finally``, so no runtime path exercises it. Before the discard was
+        async, ``_reset_state`` was a plain synchronous statement that always ran;
+        awaiting something in front of it means a cancellation on that await skips the
+        PID untracking and the pipe closes entirely. Any call site that reaches both
+        must therefore pair them.
+        """
+        tree = ast.parse(Path(acp_client.__file__).read_text(encoding="utf-8"))
+
+        paired: set[int] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            if not any(_attribute_calls(stmt, "_reset_state") for stmt in node.finalbody):
+                continue
+            for stmt in node.body:
+                for call in _attribute_calls(stmt, "_discard_claude_settings_seed"):
+                    paired.add(id(call))
+
+        unpaired: list[str] = []
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _attribute_calls(fn, "_reset_state"):
+                continue  # nothing to pair with in this function
+            unpaired += [
+                f"{fn.name}:{call.lineno}"
+                for call in _attribute_calls(fn, "_discard_claude_settings_seed")
+                if id(call) not in paired
+            ]
+
+        assert unpaired == [], (
+            "await _discard_claude_settings_seed() must sit in the `try` of a "
+            "try/finally whose `finally` calls _reset_state(), or a cancelled "
+            f"teardown skips the reset entirely: {unpaired}"
+        )
+
+    def test_claim_pathname_moves_ours_aside_and_leaves_a_stranger(self, tmp_path):
+        """The inode-pin primitive: ours is captured, a stranger is left untouched.
+
+        ``_claim_pathname_if_ours`` is what closes the TOCTOU between an ownership
+        check and the delete/overwrite that acts on it -- it moves the pathname's
+        current content aside in one atomic step and hands it back ONLY when the moved
+        inode is still Crew's. A stranger's file is restored exactly as found, never
+        deleted or clobbered.
+        """
+        path = tmp_path / "settings.local.json"
+        path.write_text("crew-bytes", encoding="utf-8")
+        expectation = (len(b"crew-bytes"), sp.digest("crew-bytes"))
+
+        aside = acp_client.AcpClient._claim_pathname_if_ours(path, expectation)
+        assert aside is not None
+        assert aside.read_text(encoding="utf-8") == "crew-bytes"
+        assert not path.exists()  # the pathname is now free
+
+        # A file that is NOT Crew's is left exactly in place, not moved or removed.
+        path.write_text("USER-OWNED", encoding="utf-8")
+        assert acp_client.AcpClient._claim_pathname_if_ours(path, expectation) is None
+        assert path.read_text(encoding="utf-8") == "USER-OWNED"
+
+    def test_a_replacement_that_races_the_teardown_delete_survives(self, tmp_path, monkeypatch):
+        """A user save landing after the ownership check but before the delete is kept.
+
+        The delete is inode-pinned: teardown moves Crew's file to ``<name>.crew-gc`` in
+        one atomic step and deletes THAT, so a replacement written at the pathname
+        afterwards is a different inode this never touches. The race is made
+        deterministic by writing the user's file at the freed pathname the instant
+        Crew's file is moved aside -- the exact window the inode-pin closes. A teardown
+        that unlinked the pathname would delete the user's file here.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+
+        real_replace = os.replace
+
+        def _race(src, dst, *args, **kwargs):
+            real_replace(src, dst, *args, **kwargs)
+            # Only the move-aside frees the pathname; the sidecar's own renames must
+            # not trip this. The user saves their settings the instant it is free.
+            if str(dst).endswith(".crew-gc"):
+                Path(path).write_text('{"user": true}\n', encoding="utf-8")
+
+        monkeypatch.setattr(os, "replace", _race)
+        _teardown(client)
+
+        # Crew removed only its own moved inode; the racing replacement is intact.
+        assert path.exists()
+        assert path.read_text(encoding="utf-8") == '{"user": true}\n'
+
+    def test_a_project_file_at_the_move_aside_name_is_not_clobbered(self, tmp_path, monkeypatch):
+        """A file already at the fixed ``.crew-gc`` name must survive the capture.
+
+        The move-aside destination used to be a FIXED sibling (``<name>.crew-gc``),
+        which is itself a pathname a project can own -- and ``os.replace`` onto it
+        clobbers it atomically, relocating the very data loss the inode-pin exists to
+        prevent. The capture now lands on a fresh ``mkstemp`` name that provably did
+        not pre-exist, so a project's own ``<name>.crew-gc`` is left untouched. Against
+        a fixed-name capture this file would be destroyed by the teardown.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, permission_mode="bypassPermissions")
+        client._write_claude_local_settings()
+        path = _settings(tmp_path)
+        squatter = path.with_name(path.name + ".crew-gc")
+        squatter.write_text("PROJECT-OWNED", encoding="utf-8")
+
+        _teardown(client)
+
+        # Crew deleted only its own freshly-named temp; the project's file is intact.
+        assert squatter.exists()
+        assert squatter.read_text(encoding="utf-8") == "PROJECT-OWNED"
+        assert not path.exists()
+
+
+class TestPostCaptureModelResolution:
+    """The ordering half: the fold and the re-seed happen AFTER the capture."""
+
+    @pytest.mark.asyncio
+    async def test_startup_model_folds_onto_the_advertised_spelling(self, tmp_path, monkeypatch):
+        """A bare id must not reach the wire once the backend has advertised one.
+
+        The spawn-time fold runs before ``session/new``, so on a first-ever session
+        it folds against a cold cache and is a no-op -- and the bare id it then
+        sends is exactly what resolves to the base window. Folding again here, after
+        the capture, is what makes the first session behave like the second.
+        """
+        sent: list[str] = []
+
+        async def _capture(config_id, value):
+            sent.append(value)
+
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, model="claude-opus-5")
+        client._session_id = "sid"
+        # claude-agent-acp takes the model through session/set_config_option.
+        monkeypatch.setattr(client, "set_config_option", _capture)
+
+        await client._apply_startup_model()
+
+        assert sent == ["global.anthropic.claude-opus-5[1m]"]
+        # And the client remembers the folded id, so the re-seed writes the same
+        # spelling the wire carries.
+        assert client._model == "global.anthropic.claude-opus-5[1m]"
+
+    @pytest.mark.asyncio
+    async def test_an_unadvertised_model_is_left_exactly_as_configured(self, tmp_path, monkeypatch):
+        # The fold only ever tightens a bare id onto an advertised one. A model the
+        # backend does not serve is not rewritten into one that looks similar.
+        sent: list[str] = []
+
+        async def _capture(config_id, value):
+            sent.append(value)
+
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, model="some-other-vendor-model")
+        client._session_id = "sid"
+        monkeypatch.setattr(client, "set_config_option", _capture)
+
+        await client._apply_startup_model()
+        assert sent == ["some-other-vendor-model"]
+
+    @pytest.mark.asyncio
+    async def test_step_six_reseeds_off_the_loop(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = _client(tmp_path, model="claude-opus-5")
+        client._model = mr.resolve_wire_model_id(client._model, "claude_code")
+        await client._reseed_after_capture()
+        assert _seed(tmp_path)["model"] == "global.anthropic.claude-opus-5[1m]"
+
+    def test_the_reseed_rides_an_existing_adapter_only_branch(self):
+        """Harness parity (AUTOSDE H13): the KIRO path must not gain the step.
+
+        The rule tests "did the kiro path change at all", not "does it still work",
+        so a NEW ``if`` plus a NEW ``await`` in ``_initialize_session`` changes that
+        path however the predicate is spelled -- moving the gate to the call site is
+        no more exempt than leaving it in the method, because the branch itself IS
+        the change. So the re-seed is a second statement inside the
+        ``_uses_advertised_model_selection`` branch that already existed in main
+        beside the model-cache persist, and ``_initialize_session`` gains no
+        conditional of its own. That is the honest home for it besides: the step
+        exists BECAUSE the backend advertises its own model list.
+
+        The seeding capability is then tested INSIDE the method -- the two capability
+        sets are independent opt-ins, so the caller's gate is not a substitute.
+        """
+        import inspect
+
+        source = inspect.getsource(AcpClient._initialize_session)
+        assert "if self._seeds_local_settings:" not in source
+        assert source.count("await self._reseed_after_capture()") == 2
+        rode_along = (
+            "if self._uses_advertised_model_selection:\n"
+            "                await self._persist_advertised_models_if_changed()\n"
+            "                await self._reseed_after_capture()"
+        )
+        assert rode_along in source
+
+        method = inspect.getsource(AcpClient._reseed_after_capture)
+        assert "if not self._seeds_local_settings:\n            return" in method
+
+    @pytest.mark.asyncio
+    async def test_a_harness_that_seeds_no_settings_file_writes_nothing(
+        self, tmp_path, monkeypatch
+    ):
+        """The in-method gate is the one that actually has to hold."""
+        client = _client(tmp_path)
+        monkeypatch.setattr(AcpClient, "_seeds_local_settings", property(lambda self: False))
+        calls: list[int] = []
+        monkeypatch.setattr(client, "_write_claude_local_settings", lambda: calls.append(1))
+        await client._reseed_after_capture()
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_a_failed_reseed_does_not_kill_the_session(self, tmp_path, monkeypatch):
+        # Model fidelity is worth a warning, not a dead session: the adapter still
+        # has its own settings sources and tool calls still reach the host gate.
+        def _boom():
+            raise OSError("read-only filesystem")
+
+        client = _client(tmp_path)
+        monkeypatch.setattr(client, "_write_claude_local_settings", _boom)
+        await client._reseed_after_capture()  # must not raise
+
+    def test_session_init_reseeds_right_after_every_model_capture(self):
+        """The step is only worth anything if session init still calls it.
+
+        ``_initialize_session`` needs a live child process to drive end to end, so
+        this pins the wiring rather than the behaviour: the behaviour is covered
+        above. BOTH captures matter -- ``session/load`` on a resume and
+        ``session/new`` on a fresh session each warm the cache the re-seed reads.
+        """
+        import inspect
+
+        source = inspect.getsource(AcpClient._initialize_session)
+        assert source.count("_reseed_after_capture()") == 2
+        # Each call sits immediately after a capture, so it never reads a cache the
+        # session in hand has not warmed yet.
+        for capture in (
+            "_capture_available_models(load_resp)",
+            "_capture_available_models(session_resp)",
+        ):
+            after = source[source.index(capture) :]
+            between = after[: after.index("await self._reseed_after_capture()")]
+            # Nothing between them but the pre-existing capability gate and the
+            # model-cache persist it already guarded.
+            assert between.count("await ") == 1
+            assert "if self._uses_advertised_model_selection:" in between
+
+    def test_the_written_model_id_is_folded_by_the_writer_itself(self):
+        """No ordering coupling to ``_apply_startup_model``.
+
+        The re-seed now runs beside the model-cache persist, which is BEFORE the
+        startup model apply, so the writer cannot lean on that step having folded
+        ``self._model`` onto the advertised spelling. It folds the value it writes
+        itself -- and the failure it avoids is silent: a bare id names a model that
+        is not in the ``availableModels`` list shipped beside it, which is exactly
+        the shape that resolves to the base 200K window.
+        """
+        import inspect
+
+        source = inspect.getsource(AcpClient._write_claude_local_settings)
+        assert 'data["model"] = self._model' not in source
+        assert "resolve_wire_model_id" in source
+
+    def test_the_cold_seed_becomes_coherent_after_the_capture(self, tmp_path, monkeypatch):
+        """One session, start to finish -- the sequence the fix exists for.
+
+        Cold seed (no model keys) -> ``session/new`` capture warms the cache ->
+        re-seed. The file ends up naming a model that IS in the list shipped beside
+        it, which is what the pre-fix file never did: it carried
+        ``"model": "claude-opus-5"`` next to an allowlist with no Opus 5 entry, so
+        the pick resolved to 200K.
+        """
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        client = _client(tmp_path, model="claude-opus-5")
+
+        client._write_claude_local_settings()  # spawn: before session/new
+        assert "model" not in _seed(tmp_path)
+
+        client._capture_available_models(
+            {"models": {"availableModels": [{"modelId": mid} for mid in _SERVED]}}
+        )
+        client._model = mr.resolve_wire_model_id(client._model, "claude_code")
+        client._write_claude_local_settings()  # step 6: after the capture
+
+        data = _seed(tmp_path)
+        assert data["model"] == "global.anthropic.claude-opus-5[1m]"
+        assert data["model"] in data["availableModels"]
+
+    def test_the_seed_never_ships_a_base_window_sibling(self, tmp_path, monkeypatch):
+        # The adapter reads [1m] as a context-window MODIFIER on one base model and
+        # dedups availableModels by base name, so shipping both spellings lets it
+        # pick the 200K one.
+        monkeypatch.setattr(
+            mr,
+            "_ADVERTISED_MODELS",
+            {
+                "claude_code": [
+                    "global.anthropic.claude-opus-4-8[1m]",
+                    "global.anthropic.claude-opus-4-8",
+                ]
+            },
+        )
+        client = _client(tmp_path)
+        client._write_claude_local_settings()
+        assert _seed(tmp_path)["availableModels"] == ["global.anthropic.claude-opus-4-8[1m]"]
+
+    def test_a_non_seeding_backend_writes_nothing(self, tmp_path, monkeypatch):
+        # The seam is capability-gated, not claude-literal, and a backend outside
+        # the set must not gain a settings file it never reads.
+        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {"claude_code": list(_SERVED)})
+        client = AcpClient(work_dir=tmp_path)  # kiro-cli
+        assert client._seeds_local_settings is False
+        assert not _settings(tmp_path).exists()
+        assert not os.path.exists(_settings(tmp_path))

--- a/test/test_acp_session_mcp.py
+++ b/test/test_acp_session_mcp.py
@@ -9,6 +9,7 @@ registry pointer, Crew's own control plane).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import stat
@@ -625,33 +626,108 @@ class TestLocalSettingsSeed:
 
     The governing rule is ownership, and ownership is NOT the path -- a path under
     a checked-out repository is not Crew's to claim. It is having CREATED the file
-    in this session AND the bytes on disk still being the ones Crew wrote. Both
-    hold: Crew may overwrite (which is what lets a model-substitution re-seed
-    change the resolved model) and reset removes it. Either fails: Crew leaves the
-    path entirely alone, and reset removes nothing. Absent: Crew creates it with
-    ``O_EXCL``.
+    AND the bytes on disk still being the ones Crew wrote. Both hold: Crew may
+    overwrite (which is what lets a model-substitution re-seed change the resolved
+    model) and reset removes it. Either fails: Crew leaves the path entirely alone,
+    and reset removes nothing. Absent: Crew creates it with ``O_EXCL``.
 
     Nothing here reads, merges into, rewrites or deletes a file Crew did not
     author, which is what keeps a seam that writes into a checked-out project from
-    needing a snapshot, a cross-session ownership registry, or a restore write on
-    teardown.
+    needing a snapshot or a restore write on teardown.
+
+    The CROSS-SESSION half of the same rule -- recognizing a seed a killed session
+    left behind, by the digest recorded in
+    :mod:`kiro_crew.acp.seed_provenance` -- lives in
+    ``test_acp_seed_provenance.py``.
     """
 
     def _client(self, tmp_path, **kw):
         return AcpClient(work_dir=tmp_path, acp_backend=ACP_BACKEND_CLAUDE, **kw)
 
-    def test_seed_writes_the_model_allowlist(self, tmp_path):
+    @staticmethod
+    def _teardown(client):
+        """Tear a client down the way every real caller does.
+
+        Removing the seed is a DISK operation -- a durable revoke of the provenance
+        grant, then the unlink -- so it lives in the async
+        ``_discard_claude_settings_seed`` and reaches the filesystem through
+        ``asyncio.to_thread``. ``_reset_state`` stays synchronous and keeps only the
+        in-memory claim release, so calling it alone deliberately leaves the file
+        behind.
+        """
+        asyncio.run(client._discard_claude_settings_seed())
+        client._reset_state()
+
+    @staticmethod
+    def _advertised(monkeypatch, ids=("global.anthropic.claude-opus-5[1m]",)):
+        """Warm the advertised-model cache, the ONLY source the seed reads.
+
+        The seed writes ``availableModels``/``model`` only once the backend has
+        actually advertised a list; on a cold cache it deliberately writes neither
+        (see ``test_seed_omits_both_model_keys_on_a_cold_cache``). Tests that assert
+        on those keys therefore have to stand in for a captured ``session/new``.
+        """
         from kiro_crew import model_registry
 
+        monkeypatch.setattr(model_registry, "_ADVERTISED_MODELS", {"claude_code": list(ids)})
+
+    def test_seed_writes_the_model_allowlist(self, tmp_path, monkeypatch):
+        from kiro_crew import model_registry
+
+        self._advertised(monkeypatch)
         client = self._client(tmp_path)
         client._write_claude_local_settings()
         data = json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
         # Without the allowlist the adapter can collapse a versioned [1m] id back
         # to the 200K window. The seed writes the window-deduped list (a 200K base
         # id is dropped when its 1M sibling is present), so it can differ from the
-        # raw registry list — compare against seed_available_models, the deduped
+        # raw advertised list — compare against seed_available_models, the deduped
         # source the seed actually uses.
         assert data["availableModels"] == model_registry.seed_available_models("claude_code")
+
+    def test_seed_omits_both_model_keys_on_a_cold_cache(self, tmp_path, monkeypatch):
+        """A cold cache seeds NO model keys — the fix, not a degradation.
+
+        The adapter merges ``availableModels`` union+dedup across settings sources,
+        so seeding a list Crew guessed (the old static-registry fallback) REPLACED
+        the adapter's own provider-derived list with a staler one: a model the
+        registry had not caught up on contributed no ``[1m]`` id, so the pick
+        resolved to 200K. And a ``model`` key naming nothing in the list shipped
+        beside it is the same failure by another route. Writing neither leaves the
+        adapter on its own list, which already carries the versioned ids.
+        """
+        from kiro_crew import model_registry
+
+        monkeypatch.setattr(model_registry, "_ADVERTISED_MODELS", {})
+        client = self._client(tmp_path, model="claude-opus-5", permission_mode="default")
+        client._write_claude_local_settings()
+        data = json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
+        assert "availableModels" not in data
+        assert "model" not in data
+        # The permission surface is NOT deferred: it has to be on disk before
+        # session/new, which is the whole reason the seed runs at spawn.
+        assert data["permissions"]["defaultMode"] == "default"
+
+    def test_seed_never_writes_a_model_without_the_list_it_must_match(self, tmp_path, monkeypatch):
+        # The exact shape observed in the field: "model": "claude-opus-5" beside an
+        # allowlist that contains no Opus 5 entry, which resolves to 200K. The two
+        # keys are now written together or not at all.
+        from kiro_crew import model_registry
+
+        monkeypatch.setattr(model_registry, "_ADVERTISED_MODELS", {})
+        client = self._client(tmp_path, model="claude-opus-5")
+        client._write_claude_local_settings()
+        path = tmp_path / ".claude" / "settings.local.json"
+        assert "model" not in json.loads(path.read_text())
+
+        # Same client, cache now warm (its own session/new was captured): the
+        # re-seed writes both, and the model folds onto the advertised spelling.
+        self._advertised(monkeypatch)
+        client._model = model_registry.resolve_wire_model_id("claude-opus-5", "claude_code")
+        client._write_claude_local_settings()
+        data = json.loads(path.read_text())
+        assert data["model"] == "global.anthropic.claude-opus-5[1m]"
+        assert data["model"] in data["availableModels"]
 
     def test_no_permission_mode_leaves_the_adapter_default(self, tmp_path):
         client = self._client(tmp_path)
@@ -665,7 +741,8 @@ class TestLocalSettingsSeed:
         data = json.loads((tmp_path / ".claude" / "settings.local.json").read_text())
         assert data["permissions"]["defaultMode"] == "default"
 
-    def test_resolved_model_written_but_auto_omitted(self, tmp_path):
+    def test_resolved_model_written_but_auto_omitted(self, tmp_path, monkeypatch):
+        self._advertised(monkeypatch, ["claude-sonnet-4-5"])
         auto = self._client(tmp_path)
         auto._write_claude_local_settings()
         path = tmp_path / ".claude" / "settings.local.json"
@@ -696,7 +773,7 @@ class TestLocalSettingsSeed:
         client._write_claude_local_settings()
         path = tmp_path / ".claude" / "settings.local.json"
         assert path.exists()
-        client._reset_state()
+        self._teardown(client)
         # A permission mode must not outlive its session, and an inherited
         # bypassPermissions must not survive a crash.
         assert not path.exists()
@@ -719,7 +796,7 @@ class TestLocalSettingsSeed:
         assert path.read_text() == original
         assert client._claude_settings_authored is False
 
-        client._reset_state()
+        self._teardown(client)
         assert path.read_text() == original
 
     def test_an_inherited_bypass_mode_is_left_to_its_owner(self, tmp_path):
@@ -815,19 +892,19 @@ class TestLocalSettingsSeed:
         monkeypatch.setattr(client_mod.os, "open", boom)
         with pytest.raises(OSError):
             client._write_claude_local_settings()
-        # Nothing was authored, so reset has nothing to undo.
+        # Nothing was authored, so teardown has nothing to undo.
         assert client._claude_settings_authored is False
-        client._reset_state()
+        self._teardown(client)
 
     def test_reset_without_a_seed_removes_nothing(self, tmp_path):
         path = tmp_path / ".claude" / "settings.local.json"
         path.parent.mkdir(parents=True)
         path.write_text("{}", encoding="utf-8")
         client = self._client(tmp_path)
-        client._reset_state()
+        self._teardown(client)
         assert path.exists()
 
-    def test_a_reseed_overwrites_the_file_this_session_created(self, tmp_path):
+    def test_a_reseed_overwrites_the_file_this_session_created(self, tmp_path, monkeypatch):
         """The model-substitution retry has to be able to change what it wrote.
 
         ``_new_session_following_substitution`` adopts the gateway-served model and
@@ -836,6 +913,7 @@ class TestLocalSettingsSeed:
         send byte-identical ``session/new`` params, take the same substitution
         advisory, and fail the session with "even after adopting substitute model".
         """
+        self._advertised(monkeypatch, ["claude-sonnet-4-5"])
         client = self._client(tmp_path)
         client._write_claude_local_settings()
         path = tmp_path / ".claude" / "settings.local.json"
@@ -847,7 +925,7 @@ class TestLocalSettingsSeed:
         assert json.loads(path.read_text())["model"] == "claude-sonnet-4-5"
         assert client._claude_settings_authored is True
         # And it is still Crew's to remove.
-        client._reset_state()
+        self._teardown(client)
         assert not path.exists()
 
     def test_a_reseed_leaves_a_file_the_user_replaced_after_the_create(self, tmp_path):

--- a/test/test_model_registry.py
+++ b/test/test_model_registry.py
@@ -449,19 +449,33 @@ class TestAdvertisedModelCache:
     test (it is process-wide runtime state, like ``_KIRO_WINDOWS``).
     """
 
-    def test_seed_falls_back_to_registry_on_cold_cache(self, monkeypatch):
+    def test_seed_is_empty_on_cold_cache_rather_than_registry_derived(self, monkeypatch):
+        # The seed is provider-advertised ONLY. Falling back to the static registry
+        # here is what pinned a served-but-unregistered model to the base window:
+        # the adapter merges availableModels union+dedup, so a registry list that
+        # has not caught up REPLACES the adapter's correct provider list with one
+        # carrying no [1m] id for that model. Seeding nothing leaves the adapter on
+        # its own list, so no registry edit is needed per new model per provider.
         monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
-        # The registry allowlist, deduped so a base-window id never rides next to
-        # its 1M sibling (the pre-dedup list still shipped both).
-        assert mr.seed_available_models("claude_code") == mr._dedup_window_siblings(
-            mr.available_models("claude_code")
-        )
+        assert mr.seed_available_models("claude_code") == []
+        # The registry itself still answers the picker/window questions — only the
+        # seed path stopped reading it.
+        assert mr.available_models("claude_code")
 
     def test_seed_drops_base_window_sibling_of_a_1m_id(self, monkeypatch):
-        # The 4.8 fix: the registry emits both the [1m] and the 200K spelling of
-        # Opus 4.8; the seed must carry only the 1M one so the adapter cannot
-        # collapse a 4.8 pick to the base window.
-        monkeypatch.setattr(mr, "_ADVERTISED_MODELS", {})
+        # The 4.8 fix: when a backend advertises both the [1m] and the 200K
+        # spelling of Opus 4.8, the seed must carry only the 1M one so the adapter
+        # cannot collapse a 4.8 pick to the base window.
+        monkeypatch.setattr(
+            mr,
+            "_ADVERTISED_MODELS",
+            {
+                "claude_code": [
+                    "global.anthropic.claude-opus-4-8[1m]",
+                    "global.anthropic.claude-opus-4-8",
+                ]
+            },
+        )
         seed = mr.seed_available_models("claude_code")
         assert "global.anthropic.claude-opus-4-8[1m]" in seed
         assert "global.anthropic.claude-opus-4-8" not in seed

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -7574,12 +7574,14 @@ class TestBareTokenProtectedLeaves:
 
     Every other leaf branch needs a home anchor plus a crew prefix, so one ``cd`` walks
     around all of them: after ``cd ~/.kiro/crew`` a relative ``echo forged >
-    connections-tool-aliases.json`` names no home, no prefix and no separator. For the
-    alias ownership record that is not a residual limit to accept the way it is for
+    connections-tool-aliases.json`` names no home, no prefix and no separator. For an
+    ownership record that is not a residual limit to accept the way it is for
     credential paths -- the file IS the deletion grant (``alias_record.load_claimed``
-    returns the pairs the rebuild may strip from the spec), so the contract is about the
-    FILENAME: any command naming it as a path segment is refused, and anchoring is not
-    part of the contract.
+    returns the pairs the rebuild may strip from the spec;
+    ``seed_provenance.recorded`` returns the digest a re-seed of
+    ``settings.local.json`` proceeds on), so the contract is about the FILENAME: any
+    command naming it as a path segment is refused, and anchoring is not part of the
+    contract.
     """
 
     def test_relative_redirect_after_cd_is_blocked(self) -> None:


### PR DESCRIPTION
## Problem / Motivation

A claude session could be pinned to the **200K** context window even when the account is served a **1M** one. Evidence from a real `work_dir`, seeded Sep 3:

```json
"availableModels": ["global.anthropic.claude-opus-4-8[1m]", "global.anthropic.claude-opus-4-8", "..."],
"model": "claude-opus-5"
```

Two things are wrong there: the bare 200K sibling ships next to its `[1m]` spelling, and the `model` key names an id that appears in **no** entry of the allowlist beside it.

## Why it matters

- **Silent capability loss.** The user selects a 1M model and gets 200K, with nothing in the UI saying so.
- **A stale `permissions.defaultMode` survives its session.** The pre-fix writer left an orphaned seed in place permanently *with the adapter still reading it* — including one carrying `bypassPermissions`, which takes every tool call out of the host gate. Re-seeding is the only path that cleans that up.
- **It affects every user, not one machine.** Any session killed or crashed (or an app replaced mid-session) leaves the orphan, and no code path could ever repair it.

## What changed (motivation → approach → change)

Three defects compounded, and they only make sense together.

**Root cause 1 — the allowlist fell back to the static registry on a cold cache.** `seed_available_models()` returned `model_registry.json` entries when `provider_models.json` had never been written. `[1m]` is a context-window *modifier* on a base model, and claude-agent-acp merges `availableModels` union+dedup **by base name** — so a registry list that has not caught up does not augment the adapter's provider-derived list, it *replaces* it with one carrying no `[1m]` id for the model actually picked. The static registry has no Opus 5 entry at all.

**Root cause 2 — nothing re-seeded after the model capture.** The seed must run *before* `session/new` (`permissions` has to be on disk first), and the cache is only warmed *by* `session/new`. So the cold-cache seed was the file's final state, and the spawn-time `resolve_wire_model_id` fold ran against a still-cold cache and was a no-op — the bare id it then sent is exactly what resolves to the base window.

**Root cause 3 — ownership of the seed was per-session memory only.** `_claude_settings_is_still_ours()` asked "did *this* client instance create it, and are the bytes still the ones *this* instance wrote". A file left behind by a session killed before `_reset_state` read as a stranger's file to every later session, which took the `already exists; leaving it as the authoritative project settings` branch — forever. This is why 1 and 2 could not be fixed on their own: without a cross-session ownership credential, no later session is ever allowed to write, so a `work_dir` seeded once was frozen.

The change, one part per cause:

1. **Provider-advertised only.** `seed_available_models()` returns the ids the provider actually served on a real `session/new`. A cold cache returns `[]`, and the writer reads that as *seed no model keys at all* — `availableModels` and `model` are written together or not at all, so the adapter resolves from its own provider list rather than from a poisoned partial one. This also takes the hand-maintained registry off the model-selection path, so it no longer needs per-provider upkeep to stay correct.
2. **Re-seed after the capture.** A new `_reseed_after_capture()` runs immediately after each `_capture_available_models` — the `session/load` resume path and the `session/new` path both — and `_apply_startup_model()` now re-folds the model against the by-then-warm cache. Failure warns rather than killing the session.

   Harness parity (`AUTOSDE.yaml` H13) decided *where* it is called from. The rule tests "did the kiro path change at all", not "does it still work", so adding a step to `_initialize_session` would violate it however the predicate is spelled — a call-site gate is no more exempt than an in-method one, because the new `if` and the new `await` *are* the change. So the re-seed is a second statement inside the `if self._uses_advertised_model_selection:` branch that **already existed in `main`** beside the model-cache persist; `_initialize_session` gains no conditional of its own, and no line Kiro executes moves. That is also the honest home for it: the step exists *because* the backend advertises its own model list, which is exactly the capability that branch tests. The two capability sets are independent opt-ins, so `_seeds_local_settings` is tested inside the method rather than assumed from the caller.

   Riding an earlier branch means the re-seed now runs *before* `_apply_startup_model`, so `_write_claude_local_settings` folds the id it writes itself via `resolve_wire_model_id` instead of depending on that step having folded `self._model` first. That removes an ordering coupling between two distant steps whose failure would have been silent — a bare id names a model absent from the `availableModels` list shipped beside it, which is precisely the shape that resolves to the base 200K window.
3. **`kiro_crew.acp.seed_provenance`** — a sidecar under Crew's *own* data home (`config_dir()/settings_seeds.json`, `0o600`) recording the size + sha256 of the bytes Crew last wrote to a given settings path, so a later session recognizes its own orphan and re-seeds it. There is deliberately **no format marker**: adoption is decided by the digest alone, so nothing would branch on a `version`, an unrecognized value could only be ignored — which is what an absent marker already means — and if a second format ever exists, its marker's absence identifies the first.

The record is a **provenance credential, not a permission grant**: adoption additionally requires the file on disk to still hash to the recorded digest, so a user-authored file — or a Crew seed the user has since edited — is still left completely untouched.

Adoption is also scoped to an **owner token** (`self._seed_owner`), because a durable record is for an *orphan* and a sibling still running in this process has not left one. Two keyless clients share the default `work_dir` (`config_dir()/workspace`), so "Crew wrote it" would otherwise collapse into "any Crew client may take it": a second session would re-seed a live session's file with its own `permissions.defaultMode` and unlink it on its own reset. Live claims are process memory, so a record reloaded from the sidecar has no holder by construction — which is exactly the orphan case it exists for.

Adopting takes the live slot via `seed_provenance.claim()`, and that call is the *decision*, not bookkeeping after one: ownership is read at a moment, so two clients starting together can both read the same orphan as adoptable, and both would then re-seed it. `claim()` is a single `dict.setdefault`, so exactly one wins however they interleave; the loser falls to the leave-it-alone branch. (The create path needs no equivalent — `O_EXCL` already arbitrates it, and an `atomic_write` rename cannot, since it replaces whatever is at the name.)

**The record and the file move together, or neither moves.** The re-seed of an adopted orphan overwrites by **stage-and-rename** (`atomic_write`), so no partial write is ever observable at the path the adapter reads. The instance flag and the recorded digest are set *after* the write lands, never before: moving them first would leave the next reset unlinking a file whose bytes Crew never wrote.

The live slot is the exception, and it has to be — `claim()` is the race arbiter, so it cannot wait for a successful write without letting two clients both decide the same orphan is theirs. So the write is wrapped, and a claim whose write does **not** land is handed back with `seed_provenance.release()`. Without that, a winner that failed to write would hold the slot for the life of the process, every later client would read the orphan as a *live* session's file, and a stale `bypassPermissions` in it could then be neither repaired nor removed. `release()` drops only `_LIVE`, deliberately **not** the record: the record is what makes the path adoptable at all, so clearing it would be the same harm rather than a milder one. `except BaseException`, because a `CancelledError` through the write wedges the slot identically.

**Teardown is the same statement read backwards, and its ordering is load-bearing.** Removing the seed moved out of the synchronous `_reset_state` into a new `async _discard_claude_settings_seed()`, awaited by every caller immediately before the reset. Three reasons, all of which the sync version got wrong:

- **The revoke happens BEFORE the unlink, and the unlink is conditional on it.** `forget()` **persists**, and now *reports* whether the sidecar on disk actually stopped naming the path. Dropping the entry from memory alone left the sidecar naming a file Crew had just deleted, and re-verifying the digest does not neutralize that: a file can legitimately hash to the recorded bytes again — most plainly when a user committed the generated seed and later restored it — and the next process would then adopt that user's file, overwrite it with this install's `permissions.defaultMode`, and unlink it on reset. Unlink-first-revoke-after leaves exactly that window open on a failed sidecar write, so the grant dies with the file it described, and it dies first.
- **Every disk step goes through `asyncio.to_thread`.** The ownership hash, the sidecar write and the unlink are all blocking, and `forget()` additionally waits on a lock a worker thread holds *across* a write — so calling it inline put both a synchronous write and that wait on the gateway's single event loop. `AUTOSDE.yaml`'s `no-blocking-call-on-event-loop` names this directly and is `blocking: true`; the earlier "the write is bounded and the unlink already blocks there" defence does not survive it, and the rule is right that a heartbeat must not queue behind teardown I/O.
- **Each failure branch keeps the pair consistent.** A revoke that did not reach the disk keeps the file (and its record) and hands back only the in-memory claim, so a later session repairs the orphan instead of a deletion outliving its revocation. An unlink that fails *after* a successful revoke re-`record`s the bytes still on disk, because the alternative is a file no session is permitted to touch — the frozen orphan this module exists to end. A file whose bytes the user replaced mid-session is left entirely alone.

`_reset_state` keeps one in-memory `seed_provenance.release()` as a net: a client discarded without the async step still cannot wedge the path behind a claim nobody is using, and the durable record deliberately survives, because the file does.

Publication of the sidecar is serialized under a module `threading.Lock` held across mutate → prune → snapshot → write, because the seed runs under `asyncio.to_thread` and two threads snapshotting between each other's mutations would drop one of the records; `forget()` publishes under the same lock for the same reason. The genuinely loop-side, non-publishing entry points (`recorded`, `release`) are deliberately lock-free — single `dict` operations are atomic under the GIL. Cross-process last-writer-wins on the sidecar remains, and is benign: a lost entry reads as "not ours", which refuses.

**A lock-free lookup is what makes the publish ORDER load-bearing.** Because `recorded()` reads both maps without the lock, a sibling client reads them *between* `record()`'s statements — so `_LIVE[key] = owner` is set **before** the `_RECORDS` entry, never after. Reversed, the seed this client has just written reads as an orphan for that instant (recorded, no live holder, digest matching the file now on disk) and the sibling would adopt a live session's file. It matters most on the create path, which has no `claim()` of its own — `O_EXCL` arbitrates that one — so that assignment is the only thing making a fresh seed look live. The `pop`-then-insert that moves an entry to the back of the prune order leaves its own instant where the path looks *unrecorded*, and that direction is the safe one: unrecorded reads as "not ours", which refuses.

**There is one prune and no cap, and that is the whole bound.** An entry survives only while a file is actually at its path; a `_persist` drops every entry whose file is gone, unconditionally (nothing remains there to overwrite, adopt or clean up, and dropping the live claim alongside it is the same statement `forget()` makes after its unlink). An earlier revision put an `_MAX_ENTRIES` cap on top of that, and the cap was the bug rather than a tuning problem: it can only ever evict entries whose file still *exists* — the dead ones are already gone — and those are precisely the adoptable orphans this module exists to keep. Evicting one makes its path unrecorded, so its owner can no longer recognize it on reset *and* no later session is permitted to repair it, turning a stale `permissions.defaultMode` (up to an inherited `bypassPermissions`) into permanent project state for the oldest work dir. That is the exact failure being fixed, re-manufactured by the cleanup. Growth is already bounded by the prune: the sidecar cannot outgrow the set of seeds actually on disk, which is the only bound that means anything here. The one exemption is the key a `record` has just written (`_persist(keep=...)`), so "record then look it up" answers the same way regardless of how the caller sequenced its own write.

**The sidecar is on every write floor, because an entry in it *is* a grant.** A digest naming a settings file the user hand-wrote would make Crew's own trusted writer overwrite that file and unlink it on reset — so `settings_seeds.json` is added to `security._WRITE_PROTECTED_HOME_PATHS` (writes blocked, reads still allowed: the record holds no secret, and an operator should be able to see why a seed was or was not adopted), to `_WRITE_PROTECTED_BASH_LEAVES`, to `_BARE_TOKEN_PROTECTED_LEAVES` (a `cd ~/.kiro/crew` would otherwise defeat the home-anchored patterns; the name is distinctive enough that the false-positive cost is confined to commands that genuinely mean this record), and to `sandbox._CREW_READONLY_LEAVES` — READONLY rather than hidden, since the write is the whole risk. It is also in `_CREW_PRECREATE_READONLY_FILE_LEAVES`, because `mount(2)` cannot seal an absent path and this file only exists once a session has actually seeded a work dir: on every install that has not, it would otherwise be exactly the absent-and-therefore-writable name that list exists to close. An empty `{}` ceiling reads as "no record" → "Crew owns no settings file" → leave it alone, which is identical to absent and fails toward refusal.

Properties the callers depend on: nothing is added to the user's project; lookups never touch the disk (`_reset_state` consults ownership synchronously on the event loop); every failure mode answers "not ours". The ownership read is `O_NOFOLLOW | O_NONBLOCK`, `S_ISREG`-checked, and capped one byte past the recorded length, so a file that grew between the `fstat` and the read is rejected on length instead of matching on a prefix hash — strictly stronger than the exact-size read it replaces.

## Tests

`test/test_acp_seed_provenance.py`, 72 new tests in six groups:

- **`TestProvenanceRecord`** (28) — record/recognize roundtrip, an unrecorded path is unowned, `forget` drops the claim, `test_a_record_outlives_the_process` (record → drop the in-memory view → `_load()`, and the reloaded record has no live holder), the sidecar is `0o600`, a corrupt sidecar and a malformed entry both degrade to unowned, `test_a_lookup_never_touches_the_disk` (monkeypatches `_sidecar_path` to raise), and `test_the_sidecar_carries_seeds_and_nothing_else` pins the absence of a format marker as a decision rather than an omission. Durability of the revoke gets `test_forget_survives_the_process`: forget → drop the in-memory view → `_load()`, and the path is unowned *even after the exact recorded bytes are restored at it*. `release()` gets two: it hands the slot back without disowning the record (so the orphan stays adoptable), and a loser cannot use it to evict the winner. Four tests pin the locking: `test_the_publish_happens_under_the_record_lock` (patches `atomic_write` to observe `_LOCK.locked()` at write time), `test_forget_publishes_under_the_same_lock_record_uses`, `test_concurrent_records_all_survive` (8 threads released off a `Barrier`; all 8 keys must be in the persisted sidecar — this is the test the un-serialized version fails), and `test_the_lookup_and_the_claim_do_not_take_the_lock`, which holds `_LOCK` and then calls `recorded()`/`claim()`/`release()` — it would deadlock, not merely slow down, if any of them ever grew a lock. Because that lookup is lock-free, the publish ORDER inside `record` is load-bearing, and two tests pin it from *inside* the mutation (a `dict` subclass over `_RECORDS` that observes at `__setitem__` time): `test_the_live_owner_is_published_before_the_record` asserts the live claim is already attached, and `test_a_sibling_never_sees_a_fresh_seed_as_an_orphan` states the same thing as its consequence — at the instant the record becomes visible, a sibling's `recorded()` must already get `None`. The prune gets three, replacing the cap tests an earlier revision added: `test_an_entry_whose_file_is_gone_is_pruned` records 10 paths with no files and requires only the just-written one to survive; `test_an_adoptable_orphan_is_never_pruned_however_many_there_are` drives **200** released orphans whose files exist and requires all 200 to stay adoptable, so it fails on any version that reintroduces a cap; and `test_a_live_seed_is_never_pruned_either` is the same rule from the live side, including that surviving does not cost the owner scoping. `forget`'s return value gets two, because it is what authorizes a deletion: `test_forget_reports_true_only_when_the_disk_agrees` (`True` after a real publish, `False` on a failed one — with the entry restored in memory so the file the caller was told to keep is still adoptable) and `test_forget_refuses_to_revoke_a_live_siblings_claim`, which also asserts the refusal publishes nothing. `test_forgetting_an_unrecorded_path_writes_nothing` keeps a reset for a never-seeded path free of I/O. Owner scoping gets four of its own: a live owner's record is invisible to a sibling, a sibling cannot revoke a live claim, the record becomes adoptable once its owner lets go, and `test_only_one_adopter_can_claim_an_orphan` pins the atomic claim (two clients both read the orphan as adoptable; exactly one may take it, and the winner may re-claim its own slot).
- **`TestCrossSessionAdoption`** — `test_an_orphaned_seed_is_reseeded_by_the_next_session` is the headline: session 1 seeds cold and dies, session 2 adopts and writes a coherent file. Every cross-session test goes through a `_the_owning_process_died()` helper that clears only the in-process live claims — what a `kill -9` actually leaves behind — so none of them can pass by accident. Plus the negatives that keep the credential honest: a user-authored file untouched, a Crew seed the user edited untouched, an orphan with *no* record untouched, `test_an_orphaned_bypass_mode_is_overwritten_not_inherited`, `test_a_live_siblings_seed_is_left_alone` (and the sibling's own reset cannot revoke the live claim), an adopted seed removed on reset, a symlink refused *before* ownership is considered, a grown file is not ours.
- **`TestPostCaptureModelResolution`** — the startup model folds onto the `[1m]` spelling, an unadvertised model is left exactly as configured, the re-seed runs off the loop, a failed re-seed does not kill the session, `test_the_cold_seed_becomes_coherent_after_the_capture` walks one session start to finish, `test_the_seed_never_ships_a_base_window_sibling`, and a non-seeding backend writes nothing. Three pin the H13 *shape*, not just the behavior: `test_the_reseed_rides_an_existing_adapter_only_branch` reads both sources and asserts `_initialize_session` contains no `if self._seeds_local_settings:` at all, that the re-seed appears exactly twice and only as a second statement inside the pre-existing `_uses_advertised_model_selection` branch, and that the capability test lives inside the method; `test_session_init_reseeds_right_after_every_model_capture` asserts both the resume and the fresh-session capture are followed by the re-seed with nothing but that gate and the persist between them; and `test_the_written_model_id_is_folded_by_the_writer_itself` forbids `data["model"] = self._model`, so the ordering coupling to `_apply_startup_model` cannot come back. `test_a_harness_that_seeds_no_settings_file_writes_nothing` drives the in-method gate for real.
- **`TestTheRecordIsOnEveryWriteFloor`** (5) — the sidecar is the leaf the floors name; `is_sensitive_write_path` refuses it while `is_sensitive_path` allows the read, for both Crew home prefixes; the shell gate refuses every spelling including the bare token; the sandbox seals it read-only *even when absent*; and an empty materialized ceiling parses to the same "no record" answer an absent one gives.
- **`TestOwnershipTracksTheFilesystem`** (11) — a re-seed that raises `OSError` mid-write leaves both the recorded bytes and the claim intact; the path is still adoptable by a later session once the disk stops failing; the create path still passes `O_EXCL` (asserted on the observed `os.open` flags, so it cannot be satisfied by a rename); and a failed `unlink` on reset keeps the claim rather than orphaning a file Crew still owns. Three new ones cover the two directions the reviewer found: `test_a_failed_adoption_hands_the_claim_back_within_the_process` fails a write after a successful claim and then requires a *later client in the same process* to adopt and repair the orphan — deliberately with **no** intervening `_the_owning_process_died()`, which is the whole point, since a restart was previously the only thing that freed the slot; `test_a_failed_adoption_does_not_evict_a_live_sibling` keeps `release()` from becoming a lever a loser can pull; and `test_a_successful_unlink_revokes_the_grant_for_good` walks the data-loss path end to end — seed, reset, fresh process from the sidecar alone, user restores the byte-identical file they had committed, and the next client must leave it completely alone and not delete it on its own reset.

  Four more cover the async teardown, and three of them were checked against deliberate mutants rather than only against the pre-fix tree. `test_the_revoke_lands_before_the_unlink` observes both steps and asserts the sequence, so swapping them fails it (and fails `test_a_failed_revoke_keeps_the_file_and_the_record` too, which is the harm stated as an outcome: the file is simply gone). `test_a_failed_revoke_keeps_the_file_and_the_record` fails the sidecar write, requires the seed *and* its record to survive, and then lets a later session actually repair the orphan once the disk recovers. `test_the_teardown_never_touches_the_disk_on_the_event_loop` calls `asyncio.get_running_loop()` from *inside* both the revoke and the unlink and requires neither to find one — calling `forget()` inline instead of through a thread fails it with `['forget'] == []`. `test_a_replacement_the_user_wrote_is_left_alone_on_teardown` re-checks the bytes at teardown, so a file the user replaced mid-session is not deleted on the strength of the instance flag alone.

- **`TestTheGrantIsATransaction`** (4) — the three blocking findings turned into tests. `test_a_seed_whose_grant_is_not_durable_is_withdrawn` fails the sidecar publish (read-only data home) and requires the just-written seed to be unlinked rather than left behind as an unowned `permissions.defaultMode`; `test_a_failed_record_rolls_the_memory_back_to_the_sidecar` requires `record`'s in-memory state after a failed publish to equal what a restart would read; `test_a_cancelled_teardown_still_settles_the_seed` cancels teardown mid-settle and requires the shielded transaction to finish removing the seed and leave nothing adoptable; and `test_every_discard_call_site_resets_in_a_finally` is an AST check that every `_discard_claude_settings_seed` call site pairs with `_reset_state` in a `finally`. Both record tests fail against a `record` that discards the persist result; the AST test fails against any call site that drops the `finally`. Three more pin the settings-file TOCTOU fix: `test_claim_pathname_moves_ours_aside_and_leaves_a_stranger` (the inode-pin primitive — Crew's file is moved aside atomically into a fresh `mkstemp` name and a stranger's is restored untouched), `test_a_replacement_that_races_the_teardown_delete_survives` (a user save landing in the check-to-delete window is kept, not deleted), and `test_a_project_file_at_the_move_aside_name_is_not_clobbered` (a project file already sitting at the old fixed `.crew-gc` name survives, because the capture destination is now a unique `mkstemp` name that provably did not pre-exist); the first two fail against a check-then-mutate-by-pathname teardown, the third against a fixed-name capture. And `TestProvenanceRecord` gains `test_a_concurrent_processs_record_is_not_dropped`, which fails against a `_persist` that publishes a process-local snapshot instead of reload-merging under the cross-process lock.

Existing tests were updated rather than deleted, because their old assertions encoded the bug: `test_acp_session_mcp.py` gains `test_seed_omits_both_model_keys_on_a_cold_cache` and `test_seed_never_writes_a_model_without_the_list_it_must_match`; `test_acp_client_more_coverage.py`'s `test_seed_falls_back_to_registry_on_cold_cache` becomes `test_cold_cache_seeds_no_model_keys_at_all`; and in `test_model_registry.py`, `test_seed_falls_back_to_registry_on_cold_cache` becomes `test_seed_is_empty_on_cold_cache_rather_than_registry_derived` (which also pins that `available_models()` still answers the picker/window questions — only the *seed* path stopped reading the registry), while `test_seed_drops_base_window_sibling_of_a_1m_id` now drives the dedup off an advertised list instead of the registry.

The teardown tests across all three files now drive the real pair — `await client._discard_claude_settings_seed()` then `client._reset_state()` — through a small `_teardown` helper rather than calling `_reset_state()` alone, so a test that drifts from the production ordering fails instead of passing on a shape nothing uses. That includes the tests asserting a file *survives* teardown (a user's own file, a live sibling's seed, a never-seeded path), which is where an over-eager discard would show up.

`test/test_security.py`'s `TestBareTokenProtectedLeaves` needed only a docstring generalization — its existing loops over `_BARE_TOKEN_PROTECTED_LEAVES` and `_WRITE_PROTECTED_BASH_LEAVES` cover the new leaf as soon as it is a member, which is the point of having the floors be data.

Locally: `pytest test/test_acp_seed_provenance.py test/test_acp_session_mcp.py test/test_model_registry.py test/test_acp_client_more_coverage.py test/test_security.py -q` → **2185 passed, 3 skipped** (the count grew with the base as the branch was rebased; the delta over the base is this PR's new tests; three `test_security.py::TestGitPublishSubshellGluing` failures reproduce on the untouched base tree and are outside this PR's diff). Then the whole backend surface, via the repo's own `scripts/run_scoped_tests.py --surface backend`, measured against an earlier base revision: **86155 passed, 536 skipped**, with 140 failed + 1 error — **none of them in any file this PR touches**, and none introduced by it.

That claim is checked twice, against two different baselines, because the branch has been through a restructure round:

- **Against the branch's base.** The same suite was run in a detached worktree at `449425a50` and produced **141 failed + 1 error** as well; comparing the failure-NAME sets left five apparent differences, all accounted for. `test/test_transcribe.py` (collection error, the `transcribe` extra is not installed) was in both and only missing from one extraction, which had matched `FAILED` and not `ERROR`. `test_platform_compat.py::test_process_descendants_snapshots_a_new_session_grandchild` was in both, with a `kirocrew config` notice glued onto the line mid-write so the name parsed with a trailing character. The remaining three (`test_public_repo_chip_status.py` × 2, `test_source_providers.py` × 1) are order-dependent, and the base run failed a *different* pair from the same file — the signature of cross-test pollution. Run in isolation, both trees gave **exactly the same result: 1 failed, 690 passed**.
- **Against the previous reviewed commit**, so the restructure itself is attributed rather than assumed. A detached worktree at `023419b01` gives **139 failed, 86148 passed, 537 skipped, 1 error**; the branch gives **140 failed, 86155 passed, 536 skipped, 1 error**. The +7 passed is this round's net new tests. The one-failure delta lands entirely in two files this PR does not touch: `test_file_sheet.py::test_workbook_text_budget_refuses_amplified_shared_strings` is in **both** sets (the base-side line again had a config notice glued to it), and `test_public_repo_chip_status.py` failed *different members* on the two runs — one on the base, two on the branch. Running those two files alone on both trees gives **16 failed, 42 passed with identical failure-name sets**, which is cross-test pollution reproduced on the base tree, not a regression.

So: 0 introduced, 0 masked, on both comparisons.

## Manual verification

- Inspected the live pre-fix `settings.local.json` quoted at the top of this description. Its `model` key matches no entry in its own allowlist — exactly the state `test_the_cold_seed_becomes_coherent_after_the_capture` now forbids.
- Unit coverage carries the rest: the three defects are all reachable from `_write_claude_local_settings` / `_apply_startup_model` / `_reseed_after_capture` with the advertised cache monkeypatched, so no live backend is needed to exercise either the cold-cache or the orphan-adoption path.

## Related Issues

no linked issue: found while verifying how the advertised model list is obtained, not tracked beforehand.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an on-disk artifact the product creates and later overwrites, whose ownership test lives only in process memory — correct within one session, and permanently wrong for anything that outlives one (a kill, a crash, an app upgrade).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing surface or doc claim changes
- [x] No secrets, credentials, or internal references in the diff
