### PR TITLE
fix(test): feed read_bounded_json's stream contract in the slot-close race stub

### DIFF
--- a/test/test_slot_close_recreation_race.py
+++ b/test/test_slot_close_recreation_race.py
@@ -41,6 +41,7 @@ and the three predicate tests are that pin.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 
 import pytest
@@ -73,12 +74,20 @@ class _Req:
     interleaving of the concurrent recreate has to be scheduled deterministically
     inside the teardown window, and a client's own awaits would let it run before
     the handler even reached the pop.
+
+    The handlers under test read their body through ``read_bounded_json``
+    (``_shared.py``), whose docstring requires stand-ins to feed
+    ``content``/``content_length`` rather than mocking ``json`` — so this stub
+    carries the full quartet it touches: ``can_read_body``, ``content_length``,
+    ``charset``, and a ``content`` stream serving the serialized body.
+    ``json()`` is kept for any direct callers.
     """
 
     def __init__(self, state, slot: str = NAME, body: dict | None = None) -> None:
         self.app = {"state": state}
         self.match_info = {"slot": slot}
         self._body = body if body is not None else {}
+        self._raw = json.dumps(self._body).encode() if body is not None else b""
 
     def get(self, key: str, default: str = "") -> str:
         del key
@@ -86,6 +95,34 @@ class _Req:
 
     async def json(self) -> dict:
         return self._body
+
+    @property
+    def can_read_body(self) -> bool:
+        return bool(self._raw)
+
+    @property
+    def content_length(self) -> int | None:
+        return len(self._raw) if self._raw else None
+
+    charset: str | None = None
+
+    @property
+    def content(self) -> "_ReqStream":
+        return _ReqStream(self._raw)
+
+
+class _ReqStream:
+    """The slice of aiohttp's StreamReader that ``read_bounded_json`` iterates."""
+
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    async def _gen(self, n: int):
+        for i in range(0, len(self._raw), n):
+            yield self._raw[i : i + n]
+
+    def iter_chunked(self, n: int):
+        return self._gen(n)
 
 
 def _state_with_slot(tmp_path, name: str = NAME):


### PR DESCRIPTION
## Summary

Unblocker for #8518: `test/test_slot_close_recreation_race.py` fails on every PR merge commit — worker crashes on the Windows shard, `AttributeError: '_Req' object has no attribute 'can_read_body'` plus timeouts on Linux — reddening `Backend Tests (Windows) (4)`, `Backend Tests (3.12, 4)` and the Coverage Gate on every open PR's merge ref.

Closes #8518

## Root cause

Two independently-green PRs crossed on main: the race-test module landed with a `_Req` stub that mocks `json()`, and the tranche-3 `read_bounded_json` sweep (#7308, commit `9d3d279ac`) converted `api_chat_slot_delete` / `api_chat_slots_cleanup` — the handlers this module drives — to read their body through `read_bounded_json(request, allow_absent=True)`, which touches `request.can_read_body` (`_shared.py:142`) before ever calling `json()`. Each PR's own merge ref predated the other, so neither CI run could see the collision.

## Fix

`read_bounded_json`'s own docstring names the stand-in contract: "must feed `content`/`content_length` rather than mocking `json`". The stub now carries exactly the surface the helper touches — `can_read_body`, `content_length`, `charset`, and a `content` stream whose `iter_chunked` serves the serialized body — so it satisfies both the `allow_absent` short-circuit (bodiless request → `{}`) and the capped stream-read path (explicit `body=` → served in chunks). `json()` is kept for direct callers.

Test-file-only change; no runtime code touched.

## What was tested

- `flake8`, `isort --check-only`, diff-scoped black gate: pass. Test execution is delegated to CI per host policy (the failing jobs themselves are the verification: this module is the only red).

## Pattern harvest

Rule candidate: an aiohttp request stand-in that mocks `json()` without implementing `can_read_body`/`content` breaks silently when its handler is later swept onto `read_bounded_json`. `_shared.py`'s docstring already states the contract; a shared `test/` fixture (one canonical `FakeRequest`) would make the next sweep collision impossible instead of documented.

<!-- no-visual-delta -->
**Why no screenshot:** backend test-stub change only; nothing renders.
