### PR TITLE
fix(website): clamp picker maxHeight to available space (#8252)

### DIFF
--- a/website/src/lib/pickerMenu.ts
+++ b/website/src/lib/pickerMenu.ts
@@ -7,9 +7,25 @@
 //   1. menuGeometry — where the menu opens relative to the anchored input.
 //   2. bottomUpOrder — display order + initial selection when it opens above.
 // Keyboard nav + scroll-into-view live in the shared useListKeyboardNav hook.
+//
+// The returned maxHeight is CLAMPED to the space actually available on the
+// chosen side (never above MENU_MAX_HEIGHT, and floored at one row + padding
+// + extraH). The side choice itself still comes from the count*rowH estimate,
+// which under-reads real rows (a two-line @file row measures ~53px against
+// the 48px estimate) — the clamp makes that inaccuracy irrelevant to
+// clipping: a menu whose real height exceeds the clamp scrolls inside the
+// viewport instead of extending past its top (opens-above pins the bottom
+// edge and grows upward) or its bottom. The floor takes precedence when the
+// chosen side offers less than one row, so the no-clip guarantee holds only
+// while that side has at least minSensibleHeight; when it does not and the
+// OTHER side offers more, the side flips there (still pure rect math — no
+// post-mount measurement).
 
-/** Max menu height (px); matches the maxHeight the portals render with. */
+/** Max menu height (px); the ceiling of the clamped maxHeight the portals render with. */
 export const MENU_MAX_HEIGHT = 320
+
+/** Gap (px) between the anchor and the menu edge on either side. */
+const MARGIN = 4
 
 export interface MenuGeometry {
   /** True when the menu opens ABOVE the anchor (the common case — chat input
@@ -26,6 +42,9 @@ export interface MenuGeometry {
   left: number
   /** Anchor width — callers clamp their own max (e.g. Math.min(width, 420)). */
   width: number
+  /** Height cap for the portal's scrolling container: MENU_MAX_HEIGHT clamped
+   *  to the space actually available on the chosen side, floored at one row
+   *  plus padding so a degenerate anchor never yields a zero-height menu. */
   maxHeight: number
 }
 
@@ -36,22 +55,46 @@ export interface MenuGeometry {
  *
  * The estimate chooses the SIDE only. An opens-above menu is then placed by
  * `bottom`, so its real rendered height — which the estimate cannot know for
- * a wrapping zero-row announcement — can never overhang the composer.
+ * a wrapping zero-row announcement — can never overhang the composer. The
+ * returned maxHeight is clamped to the space the chosen side actually has
+ * (above: rect.top − margin, itself capped at the viewport for an anchor
+ * scrolled past the bottom edge; below: viewport − rect.bottom − margin), so
+ * a menu whose real height beats the estimate scrolls instead of clipping.
+ * When neither the estimate nor even one row fits the estimate's side and
+ * the other side offers more room, the side flips there — otherwise the
+ * floor (one row + padding + extraH) wins and the box may overhang a
+ * viewport that simply has no room anywhere.
  */
 export function menuGeometry(
   anchor: HTMLElement, count: number, rowH: number, extraH = 0,
 ): MenuGeometry {
   const rect = anchor.getBoundingClientRect()
   const menuH = Math.min((count || 1) * rowH + 8 + extraH, MENU_MAX_HEIGHT)
-  const aboveTop = rect.top - menuH - 4
-  const above = aboveTop > 0
+  // Space each side actually offers. spaceAbove is additionally capped at the
+  // viewport: an anchor scrolled past the bottom edge pins the menu's bottom
+  // at y=viewport (the returned `bottom` floors at 0), so the box can only
+  // ever use the viewport itself, not the anchor's off-screen rect.top.
+  const spaceAbove = Math.min(rect.top - MARGIN, window.innerHeight)
+  const spaceBelow = window.innerHeight - rect.bottom - MARGIN
+  // One row plus padding plus the pinned chrome: a degenerate anchor must
+  // never produce a zero-height menu, and the floor must still deliver one
+  // usable row after extraH (e.g. the skill picker's scope footer) is paid.
+  const minSensibleHeight = rowH + 8 + extraH
+  // The estimate picks the side; when its side cannot even show one row and
+  // the other side is roomier, flip (pure rect math, no post-mount measuring).
+  let above = rect.top - menuH - MARGIN > 0
+  const chosen = above ? spaceAbove : spaceBelow
+  if (chosen < minSensibleHeight && (above ? spaceBelow : spaceAbove) > chosen) {
+    above = !above
+  }
+  const available = above ? spaceAbove : spaceBelow
   return {
     above,
-    top: above ? aboveTop : rect.bottom + 4,
-    bottom: Math.max(window.innerHeight - rect.top + 4, 0),
+    top: above ? rect.top - menuH - MARGIN : rect.bottom + MARGIN,
+    bottom: Math.max(window.innerHeight - rect.top + MARGIN, 0),
     left: rect.left,
     width: rect.width,
-    maxHeight: MENU_MAX_HEIGHT,
+    maxHeight: Math.max(minSensibleHeight, Math.min(MENU_MAX_HEIGHT, available)),
   }
 }
 

--- a/website/src/test/pickerMenu.test.ts
+++ b/website/src/test/pickerMenu.test.ts
@@ -9,12 +9,27 @@ function anchorAt(top: number, left = 40, width = 600, height = 44): HTMLElement
   return el
 }
 
+/** Run `fn` with window.innerHeight pinned to `h`, restoring it afterwards. */
+function withViewportHeight(h: number, fn: () => void) {
+  // Restore the ORIGINAL descriptor (happy-dom's accessor), not a frozen data
+  // property — a leaked data property would make later suites order-dependent.
+  const desc = Object.getOwnPropertyDescriptor(window, 'innerHeight')
+  Object.defineProperty(window, 'innerHeight', { value: h, configurable: true, writable: true })
+  try {
+    fn()
+  } finally {
+    if (desc) Object.defineProperty(window, 'innerHeight', desc)
+    else delete (window as unknown as Record<string, unknown>).innerHeight
+  }
+}
+
 describe('menuGeometry', () => {
   it('opens above when there is room, positioning by the row-height estimate', () => {
     const g = menuGeometry(anchorAt(500), 3, 48)
     expect(g.above).toBe(true)
     // menuH = 3*48 + 8 = 152; top = 500 - 152 - 4
     expect(g.top).toBe(500 - 152 - 4)
+    // 496px available above — plenty, so the clamp leaves the full cap.
     expect(g.maxHeight).toBe(MENU_MAX_HEIGHT)
   })
 
@@ -56,6 +71,85 @@ describe('menuGeometry', () => {
     const g = menuGeometry(anchorAt(100, 40, 600, 44), 3, 48, 28)
     expect(g.above).toBe(false)
     expect(g.top).toBe(100 + 44 + 4)
+  })
+
+  it('clamps an opens-above menu to the space above the anchor', () => {
+    // (a) Short rect.top: only rect.top - margin px exist above, so the menu
+    // cannot extend past the viewport top however tall its real rows render.
+    const g = menuGeometry(anchorAt(200), 1, 48)
+    expect(g.above).toBe(true)
+    expect(g.maxHeight).toBe(200 - 4)
+    expect(g.maxHeight).toBeLessThan(MENU_MAX_HEIGHT)
+  })
+
+  it('clamps an opens-below menu to the space under the anchor', () => {
+    // (b) Near the viewport bottom: available = viewportH - rect.bottom - margin.
+    withViewportHeight(300, () => {
+      const g = menuGeometry(anchorAt(40, 40, 600, 44), 3, 48)
+      expect(g.above).toBe(false)
+      expect(g.maxHeight).toBe(300 - (40 + 44) - 4)
+      expect(g.maxHeight).toBeLessThan(MENU_MAX_HEIGHT)
+    })
+  })
+
+  it('keeps the full MENU_MAX_HEIGHT cap when either side has generous space', () => {
+    // (c) Above: 496px available at rect.top=500. Below: 670px under rect.bottom=94.
+    expect(menuGeometry(anchorAt(500), 3, 48).maxHeight).toBe(MENU_MAX_HEIGHT)
+    const below = menuGeometry(anchorAt(50, 40, 600, 44), 3, 48)
+    expect(below.above).toBe(false)
+    expect(below.maxHeight).toBe(MENU_MAX_HEIGHT)
+  })
+
+  it('pins the issue #8252 worked example: 3 rows at rect.top=160 opens above with maxHeight 156', () => {
+    // (d) menuH = 3*48+8 = 152; aboveTop = 160-152-4 = 4 > 0 → above. The real
+    // height (~167px at 53px/row) beats the estimate, but only 156px exist
+    // above — the clamp makes the menu scroll instead of crossing the top edge.
+    const g = menuGeometry(anchorAt(160), 3, 48)
+    expect(g.above).toBe(true)
+    expect(g.maxHeight).toBe(156)
+  })
+
+  it('flips to the roomier side when the chosen side cannot show even one row', () => {
+    // 200px viewport, composer-like anchor low in it: the estimate picks below
+    // (152 > 136 above), but below has only 12px — under one row — while 136px
+    // sit unused above. Pure rect math flips the side; the menu scrolls there.
+    withViewportHeight(200, () => {
+      const g = menuGeometry(anchorAt(140, 40, 600, 44), 3, 48)
+      expect(g.above).toBe(true)
+      expect(g.maxHeight).toBe(140 - 4)
+    })
+  })
+
+  it('caps an opens-above clamp at the viewport for an anchor scrolled past the bottom edge', () => {
+    // rect.top (800) exceeds the 300px viewport: `bottom` floors at 0 so the
+    // menu's bottom edge pins to the viewport bottom — the box can only ever
+    // use the viewport itself, never the off-screen rect.top - margin.
+    withViewportHeight(300, () => {
+      const g = menuGeometry(anchorAt(800), 3, 48)
+      expect(g.above).toBe(true)
+      expect(g.bottom).toBe(0)
+      expect(g.maxHeight).toBe(300)
+    })
+  })
+
+  it('includes extraH in the floor so the pinned chrome cannot eat the one guaranteed row', () => {
+    // Skill picker with its 30px scope footer at a hopeless viewport: the
+    // floor must fund one row PLUS the footer, not have the footer eat it.
+    withViewportHeight(100, () => {
+      const g = menuGeometry(anchorAt(40, 40, 600, 44), 3, 48, 30)
+      expect(g.maxHeight).toBe(48 + 8 + 30)
+    })
+  })
+
+  it('floors maxHeight at one row plus padding when no side has room', () => {
+    // 100px viewport: below offers 12px, above 36px — the flip lands above
+    // (roomier), but even that side is under one row, so the floor wins and
+    // the menu must not degrade to a zero- or sliver-height box.
+    withViewportHeight(100, () => {
+      const g = menuGeometry(anchorAt(40, 40, 600, 44), 3, 48)
+      expect(g.above).toBe(true)
+      expect(g.maxHeight).toBe(48 + 8)
+    })
   })
 })
 


### PR DESCRIPTION
# Summary

`menuGeometry` (shared by the @file, $skill, and /command pickers) returned a constant `maxHeight: MENU_MAX_HEIGHT` (320), trusting the `count * rowH` estimate to fit the chosen side. Real rows render taller than the estimate (~53px measured vs the 48px constant), and since #7673 pins an opens-above menu's bottom edge to grow upward, the surplus extends past the viewport TOP at short viewports (issue worked example: 3 rows at `rect.top = 160` — 156px available, ~167px real height, 11px off-screen).

This implements the reporter's preferred option 1: **clamp `maxHeight` to the space the chosen side actually has**, so estimate accuracy becomes irrelevant to clipping — an over-tall menu scrolls inside its container instead. All three pickers already apply `maxHeight` to an `overflow-y-auto` container (FilePicker/SlashCommand on the portal itself, SkillPicker on the inner listbox), so no component changes were needed.

## What changed (`website/src/lib/pickerMenu.ts` only, plus its test)

- `maxHeight = max(minSensibleHeight, min(MENU_MAX_HEIGHT, available))` where `available` is `rect.top − margin` above (capped at the viewport, for an anchor scrolled past the bottom edge) or `innerHeight − rect.bottom − margin` below.
- `minSensibleHeight = rowH + 8 + extraH`: one row plus padding plus pinned chrome (the skill picker's scope footer must not eat the one guaranteed row), so a degenerate anchor never yields a sliver-height menu.
- **Fits-neither fallback**: the side choice is still the existing estimate (`rect.top − menuH − margin > 0`); only when the chosen side cannot show even one row and the other side is roomier does the side flip there. Pure rect math — no post-mount measurement or reflow machinery (which the issue's option 1 deliberately avoids). Without this, a composer low in a 200px viewport opened below into 12px while 136px sat unused above.
- Module doc comment now states the clamp honestly: the floor takes precedence when no side has one row of space, so the no-clip guarantee holds only while the chosen side has at least `minSensibleHeight`.

## Tests (`website/src/test/pickerMenu.test.ts`)

All #7673 placement tests kept passing unchanged; new cases pin:

- (a) opens-above at short `rect.top` → `maxHeight == rect.top − margin` (< 320) — no top clip
- (b) opens-below near the viewport bottom → `maxHeight == innerHeight − rect.bottom − margin`
- (c) generous space on either side → full `MENU_MAX_HEIGHT`
- (d) the issue's worked example: 3 rows, `rect.top = 160`, `rowH = 48` → `above === true`, `maxHeight === 156`
- fits-neither flip: 200px viewport, anchor low → opens above with `maxHeight = 136` instead of below into 12px
- anchor scrolled past the viewport bottom (`bottom` floors at 0) → clamp capped at the viewport, not the off-screen `rect.top`
- `extraH` funds the floor: skill-picker footer at a hopeless viewport → `maxHeight = rowH + 8 + extraH`
- absolute floor when no side has room → `rowH + 8`

Verified locally: `npx tsc -b` and `eslint` clean. Vitest runs in CI (this host does not run test suites locally by operator policy).

## Screenshots

Not applicable: the change is invisible at default viewport sizes — with normal space above the composer the clamp resolves to the same 320px cap as before, and the fixed defect (a menu edge a few px past the viewport boundary at short viewports) was itself derived from measurements rather than visually observed (see the issue: "the clipping itself is derived, not observed"). The geometry is pinned exactly by the unit-test matrix above, including the issue's worked example.

## Review

Three model-pinned pre-push reviewers (2× GPT lane, 1× Opus lane). Converged finding fixed in this commit: the fits-neither case previously floored past the available space and could still clip; also fixed the viewport over-read for off-screen anchors, the `extraH`-less floor, an overstated doc claim, and a test helper that leaked a data property over happy-dom's `innerHeight` accessor. One cosmetic finding (clamped above-menu renders flush at y=0) rebutted: adding a top gap would break the issue's pinned worked example (`maxHeight === 156`).

## Pattern harvest

Rule candidate: review checklist — a positioning helper that returns a FIXED pixel bound (`maxHeight`, `maxWidth`) while placing an element against a viewport edge must derive that bound from the space actually available on the chosen side, not from a constant; a constant bound silently trusts whatever size estimate chose the side. Same shape as this defect: `menuGeometry` clamped at a 320px constant while the side choice used an estimate that under-read real content. Grep-able signal: `maxHeight: <CONSTANT>` returned from a function that also reads `getBoundingClientRect()`.

Closes #8252
