### PR TITLE
fix(chat): surface interrupted sessions in the sidebar

### DIFF
--- a/website/scripts/capture-session-status-marker.mjs
+++ b/website/scripts/capture-session-status-marker.mjs
@@ -42,6 +42,8 @@ import { MARKER_SELECTORS } from './lib/session-row-marker.mjs'
 
 const OUT = process.argv[2] || '../temp-screenshots/session-status-marker'
 const ACTIVE = 'chat-run'
+/** The fixture that must render the manual-attention interruption marker. */
+const INTERRUPTED = 'chat-interrupted'
 /** The fixture that must render the unread dot — seeded into `mc-unread-slots`. */
 const UNREAD = 'chat-unread'
 const BASELINE = process.env.MARKER_BASELINE === '1'
@@ -80,6 +82,11 @@ const slots = [
     folder_id: '', last_message: 'Compared three schedulers.',
   },
   {
+    key: INTERRUPTED, title: 'Deployment follow-up after restart', running: false, interrupted: true,
+    messages: 7, agent: 'kirocrew', modified: now - 18 * 60, last_ts: ago(18), last_turn_ts: ago(18),
+    folder_id: '', last_message: 'Checking the deployment.',
+  },
+  {
     // Unread and idle: the one marker whose words (`last_message`) do not name it,
     // so it is the one that keeps an accessible name after the move — and the one
     // whose box only exists as a flex item, which is why it is seeded and ASSERTED
@@ -101,8 +108,9 @@ const problems = []
 const check = msg => { if (BASELINE) problems.push(msg); else throw new Error(msg) }
 
 /** Fixtures that own a status marker, so a missing one is a failure, not a skip:
- *  the running spinner, the approval shield, the question mark, and the unread dot. */
-const MARKER_ROWS = new Set([ACTIVE, 'chat-approve', 'chat-ask', UNREAD])
+ *  the running spinner, approval shield, question mark, interruption warning,
+ *  and unread dot. */
+const MARKER_ROWS = new Set([ACTIVE, 'chat-approve', 'chat-ask', INTERRUPTED, UNREAD])
 
 async function main() {
   const { srv, base } = await serveDist()

--- a/website/scripts/lib/session-row-marker.mjs
+++ b/website/scripts/lib/session-row-marker.mjs
@@ -22,5 +22,6 @@ export const MARKER_SELECTORS = [
   'svg.lucide-goal',                             // goal loop
   'svg.lucide-bot',                              // sub-agents (running or awaiting approval)
   'svg.lucide-workflow',                         // dynamic workflow run
+  'svg.lucide-triangle-alert',                   // interrupted turn — manual attention
   'span.rounded-full',                           // unread — "your turn"
 ]

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -68,7 +68,7 @@ import { normalizeRunSessionKey } from '../apps/workflows/runModel'
 import { sanitizeLlmOutput } from '../utils/sanitize'
 import type { PaletteBoost } from '../utils/sessionColors'
 import type { ChatFolder, ChatTag, TagColumn, TagColumnMode, SessionLink, SourceProviderId } from '../types'
-import { SESSION_LANES, inferLane } from './chat/sessionLane'
+import { SESSION_LANES, hasLiveSessionWork, inferLane } from './chat/sessionLane'
 import { decideUnreadDrain } from './unreadDrain'
 import {
   type RecentUnit,
@@ -578,6 +578,13 @@ interface Slot {
   // button. Always false while a turn runs. Read by the goal-loop subtitle so a
   // stalled loop stops pulsing as if it were working.
   interrupted?: boolean
+  // The slot snapshot can report live child work before the detailed activity
+  // map hydrates after reconnect. Never present that gap as an idle interruption.
+  subagents_running?: boolean
+  // Autopilot orchestration and queued turns are also server-rejected Resume
+  // states, even when the slot's own turn is currently idle.
+  orchestrating?: boolean
+  queue_depth?: number
   mode?: string
   agent?: string
   // The agent that will actually answer, when it is NOT `agent`. The backend
@@ -1571,7 +1578,19 @@ const SessionRow = memo(function SessionRow({
     // warn dot with an explicit "interrupted" instead. Guarded on the raw turn
     // flag plus workflow/subagent activity: while any of those run, the loop IS
     // working and `s.interrupted` only describes a superseded turn.
-    const goalLoopStalled = !!goalLoop && !!s.interrupted && !s.running && !wfActive && subagentCount === 0
+    const snapshotOnlyLiveWork = !s.running && hasLiveSessionWork(s)
+    const snapshotLiveWorkLabel = i18nT('pages.chatSidebar.filter_running')
+    const liveWorkSupersedesInterruption = hasLiveSessionWork(s, {
+      workflowActive: !!wfActive,
+      detailedSubagentsRunning: subagentCount > 0,
+    })
+    const goalLoopStalled = !!goalLoop && !!s.interrupted && !liveWorkSupersedesInterruption
+    // Ordinary sessions need the same reboot/error visibility as goal loops,
+    // without claiming that an older interrupted parent turn has stopped live
+    // child work. A goal loop keeps its richer cycle-specific treatment below;
+    // active workflows, subagents, turns, orchestration, and queued work keep
+    // their progress indicators.
+    const turnNeedsAttention = !goalLoop && !!s.interrupted && !liveWorkSupersedesInterruption
     // Whatever this row would have said if no loop were running, reused as the
     // loop line's trailing detail. This is why the loop branch can outrank the
     // working signals below without swallowing them: live workflow/subagent/tool
@@ -1584,7 +1603,9 @@ const SessionRow = memo(function SessionRow({
         ? subagentLabel
         : s.running
           ? slotStatusText(statusDetail, simplifiedToolNames, uiLang)
-          : (s.last_message || '')
+          : snapshotOnlyLiveWork
+            ? snapshotLiveWorkLabel
+            : (s.last_message || '')
     const ci = s.color_index != null && s.color_index >= 0 && s.color_index < paletteColors.length ? s.color_index : null
     // The row's ONE status marker and the words beside it, resolved together: the
     // glyph is built INSIDE the branch's `subtitle`, immediately in front of the
@@ -1682,6 +1703,24 @@ const SessionRow = memo(function SessionRow({
         ),
       },
       {
+        // An ordinary session whose last turn ended without a reply needs a
+        // visible handoff after a gateway restart or terminal error. Static
+        // danger ink distinguishes "manual action required" from every pulsing
+        // or spinning progress state. Live child work suppresses this branch via
+        // `turnNeedsAttention`, and goal loops retain their cycle-specific row.
+        key: 'interrupted',
+        when: turnNeedsAttention,
+        build: () => {
+          const label = `${i18nT('pages.chat.recoveryCard.turn_interrupted')} · ${i18nT('components.chatInput.resume')}`
+          return (
+            <div className={ROW_STATUS_LINE_CLS} title={label}>
+              <TriangleAlert size={ROW_ICON_PX} className="shrink-0 text-danger" aria-hidden />
+              <span className="truncate font-medium text-danger">{label}</span>
+            </div>
+          )
+        },
+      },
+      {
         // A dynamic-workflow run launched from this session is still executing
         // — surface it even though the parent turn has ended (`s.running` is
         // false while the run executes in the background). Outranks the
@@ -1707,6 +1746,20 @@ const SessionRow = memo(function SessionRow({
           <div className={ROW_STATUS_LINE_ACCENT_CLS} title={subagentLabel}>
             <Bot size={ROW_ICON_PX} className="shrink-0 text-accent animate-pulse" aria-hidden />
             <span className="truncate">{subagentLabel}</span>
+          </div>
+        ),
+      },
+      {
+        // Reconnect snapshots can report orchestration, queued work, or running
+        // children before their detailed activity records arrive. The shared
+        // predicate suppresses stale Resume; this branch replaces the equally
+        // stale last-message fallback with an honest localized working state.
+        key: 'snapshot_live_work',
+        when: snapshotOnlyLiveWork,
+        build: () => (
+          <div className={ROW_STATUS_LINE_ACCENT_CLS} title={snapshotLiveWorkLabel}>
+            <Loader size={ROW_ICON_PX} className="shrink-0 text-accent animate-spin" aria-hidden />
+            <span className="truncate">{snapshotLiveWorkLabel}</span>
           </div>
         ),
       },
@@ -3505,8 +3558,9 @@ function ChatSidebar({
       // while sitting in Idle.
       return inferLane(slot, {
         subagentAwaiting: Math.min(subagentApprovalCounts[slot.key] || 0, running),
-        backgroundWork: workflowActiveSet.has(normalizeRunSessionKey(slot.key))
-          || goalLoopSet.has(slot.key),
+        workflowActive: workflowActiveSet.has(normalizeRunSessionKey(slot.key)),
+        goalLoopActive: goalLoopSet.has(slot.key),
+        detailedSubagentsRunning: running > 0,
       }) === col.state_key
     }
     const slotTags = slot.tags || []

--- a/website/src/pages/chat/sessionLane.ts
+++ b/website/src/pages/chat/sessionLane.ts
@@ -45,13 +45,28 @@ export interface LaneSlotFields {
  *  tracked per slot in the dashboard store, never on the slot payload. */
 export interface LaneExtras {
   subagentAwaiting?: number
-  /** Live work that outlives the slot's own `running` flag: an armed monitor /
-   *  goal loop that will wake the session on its own, or a dynamic workflow
-   *  executing against it. Both are tracked in the dashboard store rather than
-   *  on the slot payload, and the row status chain already reads them, so a lane
-   *  that ignored them would file a session as idle while its own row renders a
-   *  spinner. */
-  backgroundWork?: boolean
+  /** A dynamic workflow is active for this slot. Unlike an armed goal loop,
+   *  this is current execution and supersedes an older interrupted turn. */
+  workflowActive?: boolean
+  /** An armed goal loop is work while healthy, but not while its last turn is
+   *  interrupted — that stalled state remains Waiting until the next cycle. */
+  goalLoopActive?: boolean
+  /** Detailed child activity can lead or lag the slot snapshot during reconnect. */
+  detailedSubagentsRunning?: boolean
+}
+
+/** Current execution that makes an older `interrupted` flag stale. Shared by
+ *  the sidebar row and board lane so Resume and Working cannot disagree. An
+ *  armed goal loop is deliberately excluded: it is future work, not execution. */
+export function hasLiveSessionWork(slot: LaneSlotFields, extras: LaneExtras = {}): boolean {
+  return !!(
+    slot.running ||
+    slot.orchestrating ||
+    slot.subagents_running ||
+    (slot.queue_depth ?? 0) > 0 ||
+    extras.workflowActive ||
+    extras.detailedSubagentsRunning
+  )
 }
 
 export interface SessionLaneDef {
@@ -85,17 +100,12 @@ export function inferLane(slot: LaneSlotFields, extras: LaneExtras = {}): Sessio
   if (slot.pending_approval || (extras.subagentAwaiting ?? 0) > 0) return 'needs_approval'
   // Parked on a human answer. Deliberately NOT `waiting_for_input`, which is
   // true of every finished turn and would swallow the whole idle lane: only an
-  // explicit unanswered question, an options card, or an interrupted turn the
-  // user must resume counts as waiting ON them.
-  if (slot.needs_input || slot.has_options || slot.interrupted) return 'waiting'
-  if (
-    slot.running ||
-    slot.orchestrating ||
-    slot.subagents_running ||
-    (slot.queue_depth ?? 0) > 0 ||
-    extras.backgroundWork
-  ) {
-    return 'working'
-  }
+  // explicit unanswered question or options card outranks live work.
+  if (slot.needs_input || slot.has_options) return 'waiting'
+  if (hasLiveSessionWork(slot, extras)) return 'working'
+  // An interrupted turn waits on the user only when no newer work supersedes
+  // it. An armed goal loop does not supersede its own stalled turn.
+  if (slot.interrupted) return 'waiting'
+  if (extras.goalLoopActive) return 'working'
   return 'idle'
 }

--- a/website/src/test/ChatSidebar.goalLoop.test.tsx
+++ b/website/src/test/ChatSidebar.goalLoop.test.tsx
@@ -255,3 +255,75 @@ describe('chat sidebar — interrupted goal loop', () => {
     expect(container.querySelector('.lucide-goal.animate-pulse')).toBeTruthy()
   })
 })
+
+describe('chat sidebar — interrupted ordinary session', () => {
+  it('flags an idle interrupted turn as needing manual attention', () => {
+    const slots = [{
+      key: 'k', title: 'deployment follow-up', running: false, messages: 5,
+      interrupted: true, last_message: 'Checking the deployment',
+    }]
+    const { getByTitle, queryByTitle, container } = renderSidebar(
+      slots,
+      {},
+      { unreadSlots: ['k'] },
+    )
+
+    const row = container.querySelector('[data-session-row="k"]')
+    expect(row?.textContent).toContain('Turn interrupted · Resume')
+    expect(getByTitle('Turn interrupted · Resume')).toBeTruthy()
+    expect(container.querySelector('.lucide-triangle-alert.text-danger')).toBeTruthy()
+    // The specific attention state replaces the generic unread marker.
+    expect(queryByTitle(UNREAD_DOT_TITLE)).toBeNull()
+  })
+
+  it('keeps live subagent activity above stale parent-turn interruption', () => {
+    const slots = [{ key: 'k', title: 'delegated work', running: false, messages: 5, interrupted: true }]
+    const { getByText, queryByText } = renderSidebar(slots, {
+      slotActivity: { k: { toolLog: [], subagents: { a: sa('running') } } },
+    })
+
+    expect(getByText(/1 agent running/)).toBeTruthy()
+    expect(queryByText('Turn interrupted')).toBeNull()
+  })
+
+  it('trusts snapshot child activity before reconnect details hydrate', () => {
+    const slots = [
+      {
+        key: 'plain', title: 'delegated work', running: false, messages: 5,
+        interrupted: true, subagents_running: true, last_message: 'Delegating',
+      },
+      {
+        key: 'loop', title: 'loop work', running: false, messages: 5,
+        interrupted: true, subagents_running: true, last_message: 'Delegating',
+      },
+      {
+        key: 'orchestrating', title: 'planning', running: false, messages: 5,
+        interrupted: true, orchestrating: true, last_message: 'Planning',
+      },
+      {
+        key: 'queued', title: 'queued turn', running: false, messages: 5,
+        interrupted: true, queue_depth: 1, last_message: 'Queued',
+      },
+    ]
+    const { container } = renderSidebar(slots, {
+      goalLoops: { loop: { cycle_count: 9, max_cycles: 24 } },
+    })
+
+    expect(container.querySelector('[data-session-row="plain"]')?.textContent).not.toContain('Turn interrupted')
+    expect(container.querySelector('[data-session-row="plain"]')?.textContent).toContain('In progress')
+    expect(container.querySelector('[data-session-row="loop"]')?.textContent).not.toContain('interrupted')
+    expect(container.querySelector('[data-session-row="loop"]')?.textContent).toContain('In progress')
+    expect(container.querySelector('[data-session-row="orchestrating"]')?.textContent).not.toContain('Turn interrupted')
+    expect(container.querySelector('[data-session-row="orchestrating"]')?.textContent).toContain('In progress')
+    expect(container.querySelector('[data-session-row="queued"]')?.textContent).not.toContain('Turn interrupted')
+    expect(container.querySelector('[data-session-row="queued"]')?.textContent).toContain('In progress')
+  })
+
+  it('leaves completed ordinary sessions unflagged', () => {
+    const slots = [{ key: 'k', title: 'complete', running: false, messages: 5, interrupted: false, last_message: 'Done' }]
+    const { getByText, queryByText } = renderSidebar(slots, {})
+
+    expect(getByText('Done')).toBeTruthy()
+    expect(queryByText('Turn interrupted')).toBeNull()
+  })
+})

--- a/website/src/test/sessionLane.test.ts
+++ b/website/src/test/sessionLane.test.ts
@@ -62,6 +62,12 @@ describe('inferLane precedence', () => {
     expect(inferLane({ interrupted: true })).toBe('waiting')
   })
 
+  it('ranks live snapshot subagents above stale interruption', () => {
+    // Reconnect can hydrate the slot summary before detailed child activity.
+    // The board must agree with the sidebar that live work supersedes the old turn.
+    expect(inferLane({ interrupted: true, subagents_running: true })).toBe('working')
+  })
+
   it('ranks an approval above a question', () => {
     expect(inferLane({ pending_approval: true, needs_input: true })).toBe('needs_approval')
   })
@@ -87,18 +93,31 @@ describe('inferLane working signals', () => {
   it('counts an armed monitor loop between cycles', () => {
     // The loop wakes the session on its own, so it is working rather than idle
     // even in the gap where no turn is in flight.
-    expect(inferLane({}, { backgroundWork: true })).toBe('working')
+    expect(inferLane({}, { goalLoopActive: true })).toBe('working')
+  })
+
+  it('keeps an interrupted armed loop waiting until live work resumes', () => {
+    expect(inferLane({ interrupted: true }, { goalLoopActive: true })).toBe('waiting')
   })
 
   it('counts a dynamic workflow running against an otherwise-idle slot', () => {
     // A workflow is tracked in the store, not on the slot payload, so `running`
     // is false while it executes. Without it the board files the session as Idle
     // while its own row renders a workflow spinner.
-    expect(inferLane({ running: false }, { backgroundWork: true })).toBe('working')
+    expect(inferLane({ running: false }, { workflowActive: true })).toBe('working')
   })
 
-  it('does not treat absent background work as work', () => {
-    expect(inferLane({}, { backgroundWork: false })).toBe('idle')
+  it.each([
+    ['orchestration', { orchestrating: true }, {}],
+    ['queued work', { queue_depth: 1 }, {}],
+    ['dynamic workflow', {}, { workflowActive: true }],
+    ['detailed subagents', {}, { detailedSubagentsRunning: true }],
+  ])('ranks %s above stale interruption', (_name, slot, extras) => {
+    expect(inferLane({ interrupted: true, ...slot }, extras)).toBe('working')
+  })
+
+  it('does not treat absent live work as work', () => {
+    expect(inferLane({}, { workflowActive: false, goalLoopActive: false })).toBe('idle')
   })
 
   it('does not treat a zero queue depth as work', () => {


### PR DESCRIPTION
## Problem / Motivation

KiroCrew already detects interrupted turns and offers recovery after the user opens the affected conversation. The composer displays an interruption placeholder and Resume action, and recovery notices can provide a Continue action.

Ordinary interrupted sessions were not identified in the Sessions sidebar. Their rows fell back to the previous message, making them look idle and forcing users to open sessions individually after a gateway restart or timeout.

Goal loops had an interruption treatment, but ordinary chats did not.

## Why it matters

A gateway restart can leave several conversations requiring manual attention. Without a visible list-level state, users cannot quickly determine which sessions stopped and which completed normally.

Surfacing the existing interruption signal in the sidebar makes recovery discoverable without changing turn execution or replay behavior.

## What changed (motivation → approach → change)

The sidebar's ordered status resolver now includes an ordinary interrupted-turn branch.

The new branch:

- renders a static danger-colored warning icon;
- displays `Turn interrupted · Resume`;
- replaces the generic unread marker for that session;
- applies only when the session is idle and no workflow or subagent is still active;
- leaves pending approvals and unanswered questions at their existing higher precedence;
- preserves the stronger goal-loop-specific treatment while suppressing stale loop interruption during snapshot-only child activity;
- uses one shared live-work predicate across the sidebar and board for running turns, orchestration, queued work, workflows, and subagents;
- renders snapshot-only busy states as localized `In progress` instead of a stale last message;
- keeps an armed-but-stalled goal loop in Waiting while healthy armed loops remain Working;
- leaves completed sessions unchanged.

The implementation reuses the existing slot-summary `interrupted` field and localized recovery strings. It does not introduce a second interruption state or recovery endpoint.

The session-status Chromium fixture now includes an interrupted ordinary session and recognizes its warning icon as a status marker.

## Tests

Updated `ChatSidebar.goalLoop.test.tsx` with coverage that verifies:

- an idle interrupted ordinary session displays `Turn interrupted · Resume`;
- the warning replaces the generic unread indicator;
- live subagent activity takes precedence over stale parent-turn interruption state, including snapshot-only reconnect hydration;
- the board lane also ranks live snapshot subagents above stale interruption;
- completed ordinary sessions remain unflagged.

Local validation on current head `19c7f9a92414a25e22695ad70e71da0fb7f843a7`:

- 42 focused sidebar and session-lane tests passed;
- TypeScript passed;
- changed-file lint passed;
- i18n checks passed;
- production frontend build passed;
- Chromium light/dark marker geometry passed with 0 px overlap.

The backend cross-surface suite encountered host-only ownership and service-manager failures on this development host; the patch has no backend or backend-test diff, and CI will run that unchanged backend tree on its standard runner.

## Manual verification

Rendered the production frontend through the deterministic Chromium session-status harness. Verified in light and dark themes that the interrupted row is legible and distinct, surrounding status states remain intact, and the warning marker does not overlap the recency stripe.

## Screenshots / video

### Sessions sidebar — light theme

![Interrupted session in the light theme](https://github.com/Pearcekieser/KiroCrew/blob/e999b5900bdfccce94ffb323042a5df60b1e9000/gh-pr-images/pr-4/1788550671-1057817-1-01-session-rows-light.png?raw=true)

### Sessions sidebar — dark theme

![Interrupted session in the dark theme](https://github.com/Pearcekieser/KiroCrew/blob/e999b5900bdfccce94ffb323042a5df60b1e9000/gh-pr-images/pr-4/1788550672-1057817-2-01-session-rows-dark.png?raw=true)

### Opened session — existing Continue and Resume recovery controls

![Interrupted conversation with Continue and Resume controls](https://github.com/Pearcekieser/KiroCrew/blob/e999b5900bdfccce94ffb323042a5df60b1e9000/gh-pr-images/pr-4/1788550672-1057817-3-04-errored-after.png?raw=true)

## Related Issues

Fixes #8541

## Pattern harvest

Not generalizable: the sidebar already has a centralized ordered status resolver and the backend already exposes the interruption signal. This defect was a missing presentation branch for one existing state rather than a reusable unsafe coding pattern.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — no user documentation contract changed)
- [x] No secrets, credentials, or internal references in the diff