### PR TITLE
fix(remote-crew): allow same major.minor peers and surface create failures

### DIFF
--- a/src/kiro_crew/dashboard/remote_relay.py
+++ b/src/kiro_crew/dashboard/remote_relay.py
@@ -61,6 +61,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator
 from aiohttp import web
 
 import kiro_crew
+from kiro_crew.apps.version import parse_version
 from kiro_crew.dashboard.chat_persistence import save_slot_off_loop
 from kiro_crew.dashboard.chat_utils import _redact_deep
 from kiro_crew.dashboard.remote_mirror import MIRROR_CLS_PREFIX
@@ -109,18 +110,22 @@ class RemoteTurnError(Exception):
 
 
 async def ensure_version_parity(mgr: Any, instance_id: str) -> None:
-    """Raise :class:`RemoteTurnError` unless the peer runs THIS exact build.
+    """Raise :class:`RemoteTurnError` unless the peer runs a compatible build.
 
-    Remote execution is fenced by version equality, not compatibility. The two
-    ends exchange a frame vocabulary that carries no version of its own, so a
-    peer one release ahead can emit a frame this relay silently drops, and a peer
-    one release behind can lack a route this relay depends on — both surface to
-    the user as a session that mostly works, which is worse than one that
-    plainly refuses.
+    Remote execution is fenced by ``major.minor`` version parity, not full-string
+    equality. The two ends exchange a frame vocabulary that carries no version of
+    its own, so a peer a FEATURE release ahead can emit a frame this relay
+    silently drops, and one a feature release behind can lack a route this relay
+    depends on — both surface to the user as a session that mostly works, which is
+    worse than one that plainly refuses. A PATCH-level skew within the same
+    ``major.minor`` series does not move that vocabulary, so it is allowed: 0.6.0
+    and 0.6.3 interoperate, while 0.6.x vs 0.7.x is refused.
 
     An *unknown* peer version is a mismatch, not a pass: a peer too old to serve
-    ``/api/version`` cannot be proven equal, so it is refused with an actionable
-    message rather than optimistically attempted.
+    ``/api/version`` cannot be proven compatible, so it is refused with an
+    actionable message rather than optimistically attempted. A version string
+    that is not semver-shaped on EITHER end (a packaging build id) also cannot be
+    proven compatible by series, so it falls back to strict full-string equality.
     """
     ok, value = await mgr.peer_version(instance_id)
     local = kiro_crew.__version__
@@ -135,7 +140,18 @@ async def ensure_version_parity(mgr: Any, instance_id: str) -> None:
             "Could not confirm this crew's Kiro Crew version, so the session was "
             "not dispatched to it. Reconnect the crew and try again."
         )
-    if value != local:
+    # Compare the major.minor SERIES via the shared parser rather than a second
+    # hand-rolled regex. ``parse_version`` raises ``ValueError`` both on a
+    # non-semver string (a packaging build id) AND on an oversized numeric segment
+    # — CPython caps ``int(str)`` at 4300 digits, so a peer returning thousands of
+    # leading digits would otherwise raise OUTSIDE the RemoteTurnError handler and
+    # 500 the create (GPT/opus #8543). Either way we cannot prove series
+    # compatibility, so fall back to strict full-string equality.
+    try:
+        mismatch = parse_version(local)[:2] != parse_version(value)[:2]
+    except ValueError:
+        mismatch = value != local
+    if mismatch:
         # The peer's reported version is an ARBITRARY string: the transport proves
         # only that ``/api/version`` answered with a non-empty str. Redact BEFORE
         # bounding — truncating first could split a credential across the cut and
@@ -144,8 +160,8 @@ async def ensure_version_parity(mgr: Any, instance_id: str) -> None:
         shown = redact_peer_text(value)[:64]
         raise RemoteTurnError(
             f"This crew runs Kiro Crew {shown} but this machine runs {local}. "
-            f"A session only runs on a crew at the identical version — update "
-            f"whichever end is behind."
+            f"A session only runs on a crew at the same major.minor version — "
+            f"update whichever end is behind."
         )
 
 

--- a/test/test_remote_crew_execution.py
+++ b/test/test_remote_crew_execution.py
@@ -245,6 +245,63 @@ class TestVersionParity:
         assert "0.5.9" in str(excinfo.value)
         assert kiro_crew.__version__ in str(excinfo.value)
 
+    async def test_a_patch_skew_in_the_same_series_passes(self):
+        """0.6.0 and 0.6.3 share the frame vocabulary, so a patch skew is allowed.
+
+        The gate fences the ``major.minor`` SERIES, not the full string: a patch
+        release does not move the wire contract, so refusing it only forced a
+        lockstep upgrade with no safety it bought.
+        """
+        from kiro_crew.apps.version import parse_version
+
+        major, minor = parse_version(kiro_crew.__version__)[:2]
+        peer = f"{major}.{minor}.{minor + 999}"  # same major.minor, far-off patch
+        mgr = MagicMock()
+        mgr.peer_version = AsyncMock(return_value=(True, peer))
+        await ensure_version_parity(mgr, "nobita")  # does not raise
+
+    async def test_a_different_minor_is_refused(self):
+        """A feature release (minor bump on 0.x) moves the vocabulary — refuse it."""
+        from kiro_crew.apps.version import parse_version
+
+        major, minor = parse_version(kiro_crew.__version__)[:2]
+        peer = f"{major}.{minor + 1}.0"
+        mgr = MagicMock()
+        mgr.peer_version = AsyncMock(return_value=(True, peer))
+        with pytest.raises(RemoteTurnError) as excinfo:
+            await ensure_version_parity(mgr, "nobita")
+        assert "major.minor" in str(excinfo.value)
+
+    async def test_a_non_semver_build_id_falls_back_to_strict_equality(self, monkeypatch):
+        """When a side is a packaging build id, series parity is unprovable.
+
+        ``parse_version`` raises ``ValueError`` on a non-semver build id, so the
+        gate falls back to full-string equality rather than optimistically pass —
+        an equal build id runs, any difference is refused.
+        """
+        monkeypatch.setattr(kiro_crew, "__version__", "build-2026.09.04-abc123", raising=False)
+        mgr = MagicMock()
+        mgr.peer_version = AsyncMock(return_value=(True, "build-2026.09.04-abc123"))
+        await ensure_version_parity(mgr, "nobita")  # identical build id → passes
+
+        mgr.peer_version = AsyncMock(return_value=(True, "build-2026.09.03-def456"))
+        with pytest.raises(RemoteTurnError):
+            await ensure_version_parity(mgr, "nobita")
+
+    async def test_an_oversized_numeric_version_is_refused_not_crashed(self):
+        """A peer-controlled version of thousands of digits must not 500 the create.
+
+        CPython caps ``int(str)`` at 4300 digits, so parsing a version with a
+        longer numeric run raises ``ValueError``. That must be caught and turned
+        into the ordinary refusal (an unprovable series → strict equality →
+        mismatch), never propagate out of ``ensure_version_parity`` as an HTTP 500
+        (GPT/opus #8543).
+        """
+        mgr = MagicMock()
+        mgr.peer_version = AsyncMock(return_value=(True, "9" * 5000 + ".0.0"))
+        with pytest.raises(RemoteTurnError):
+            await ensure_version_parity(mgr, "nobita")
+
     async def test_an_unknown_version_is_a_mismatch_not_a_pass(self):
         """A peer too old to report its version cannot be proven equal.
 

--- a/website/src/pages/ChatSidebar.tsx
+++ b/website/src/pages/ChatSidebar.tsx
@@ -5,6 +5,7 @@ import { Plus, X, Pin, Monitor, Eye, EyeOff, VenetianMask, Ghost, Droplet, Folde
 import GithubLogo from '../components/icons/GithubLogo'
 import GitlabLogo from '../components/icons/GitlabLogo'
 import { FolderBody } from '../components/FolderBody'
+import ErrorNotice from '../components/ErrorNotice'
 import JiraLogo from '../components/icons/JiraLogo'
 import { sourceProviderMeta } from '../utils/sourceProviderMeta'
 import FolderGlyph from '../components/FolderGlyph'
@@ -2411,6 +2412,13 @@ function ChatSidebar({
 
   // Sidebar-only state
   const [seedError, setSeedError] = useState('')
+  // Inline failure reason for "New chat on crew" — a crew create can 502 and
+  // leave nothing behind, so its reason is shown in the submenu rather than lost.
+  const [remoteCrewError, setRemoteCrewError] = useState('')
+  // Controlled open for the New-chat menu, so a successful crew create can close
+  // it (the crew rows preventDefault to stay open on failure) and closing clears
+  // any stale remoteCrewError.
+  const [newChatMenuOpen, setNewChatMenuOpen] = useState(false)
   const [slotFilter, setSlotFilter] = useState('')
   const [historyFilter, setHistoryFilter] = useState('')
   // A resumed history row whose surface ChatPage cannot display used to succeed
@@ -4619,9 +4627,46 @@ function ChatSidebar({
   // there or bind a different crew than the name implies. Omitting it lets the
   // peer apply its own default — which is the point of the session running on it,
   // and what the header then reads back from the peer's `default_agent`.
+  // A crew create fails more often than a local one — the backend opens the
+  // peer's session BEFORE creating the local one, and refuses on a version-series
+  // mismatch or an unreachable tunnel — and on failure leaves NOTHING behind (no
+  // local row, no peer session). Without an onError the react-query rejection is
+  // swallowed and the click reads as a silent no-op, so surface the backend's
+  // reason inline in the submenu instead. `err.message` carries it: apiFailure
+  // builds the ApiError message from the 502 body's `error` field, and the thunk's
+  // `.unwrap()` rethrows that message.
   const createRemoteChatMutation = useMutation({
-    mutationFn: (instanceId: string) => dispatch(createSlot({ instanceId })).unwrap(),
-    onSuccess: focusComposer,
+    mutationFn: (instanceId: string) => {
+      setRemoteCrewError('')
+      return dispatch(createSlot({ instanceId })).unwrap()
+    },
+    onSuccess: () => {
+      // Close the menu explicitly: the crew rows use `onSelect preventDefault`
+      // (so a FAILED create keeps the menu open long enough to read the error),
+      // which also removed the auto-close on SUCCESS — a modal Radix menu is not
+      // dismissed by `focusComposer` alone, so without this the session is created
+      // behind the still-open menu and a second pick makes a duplicate (opus #8543).
+      // `mutationFn` already cleared remoteCrewError, and onOpenChange clears it on
+      // close, so no reset is needed here.
+      setNewChatMenuOpen(false)
+      focusComposer()
+    },
+    onError: (err: unknown) => {
+      // `createSlot(...).unwrap()` rejects with RTK's SerializedError — a PLAIN
+      // object carrying `message`, NOT an Error instance — so read `.message`
+      // off the object rather than gating on `instanceof Error` (which would be
+      // false here and drop the backend's reason). apiFailure already localizes
+      // and puts the 502 body's `error` text into that message, so it is shown
+      // verbatim; the errRow below is gated on truthiness, so the unreachable
+      // empty-message case simply renders nothing rather than a bare fallback.
+      const msg =
+        err instanceof Error
+          ? err.message
+          : err && typeof err === 'object' && typeof (err as { message?: unknown }).message === 'string'
+            ? (err as { message: string }).message
+            : ''
+      setRemoteCrewError(msg)
+    },
   })
 
   const createPlainChatMutation = useMutation({
@@ -5296,7 +5341,7 @@ function ChatSidebar({
               aria-busy={creatingSlot}
             >{creatingSlot ? <Loader2 size={15} className="animate-spin" /> : <Plus size={15} />}{!compactHeader && <span className="whitespace-nowrap">{creatingSlot ? i18nT('pages.chatSidebar.creating') : i18nT('pages.chatSidebar.new')}</span>}</button>
             <span className="w-px h-4 bg-accent-fg opacity-30" aria-hidden="true" />
-            <DropdownMenu>
+            <DropdownMenu open={newChatMenuOpen} onOpenChange={o => { setNewChatMenuOpen(o); if (!o) setRemoteCrewError('') }}>
               <DropdownMenuTrigger asChild>
                 <button
                   className="flex items-center justify-center w-6 h-7 cursor-pointer bg-transparent border-none text-accent-fg hover:bg-black/10 active:scale-95 transition-all"
@@ -5470,17 +5515,32 @@ function ChatSidebar({
                   const crewRows = warmCrews.map(c => (
                     <DropdownMenuItem key={c.id} data-testid={`new-chat-on-crew-${c.id}`}
                       disabled={createRemoteChatMutation.isPending}
-                      onClick={() => { createRemoteChatMutation.mutate(c.id) }}>
+                      onSelect={e => { e.preventDefault(); createRemoteChatMutation.mutate(c.id) }}>
                       <Server size={14} className="text-info" /> {c.name}
                     </DropdownMenuItem>
                   ))
+                  // Inline failure reason (version mismatch, tunnel down), shown
+                  // through the shared ErrorNotice (website AGENTS.md forbids a
+                  // hand-written text-danger div for a rejected mutation). Kept in
+                  // the menu because the create leaves nothing behind on failure —
+                  // closing would erase the only signal; `onSelect preventDefault`
+                  // on the rows keeps a failed create from auto-closing over it, and
+                  // `askAgent` is on because there is nothing to lose. ErrorNotice
+                  // renders nothing for a falsy message, so this needs no guard.
+                  const errRow = remoteCrewError
+                    ? (
+                      <div className="px-2 py-1.5">
+                        <ErrorNotice message={remoteCrewError} variant="inline" askAgent testId="new-chat-on-crew-error" />
+                      </div>
+                    )
+                    : null
                   if (isMobile) {
                     return (
                       <>
                         <DropdownMenuLabel className="text-[11px] uppercase tracking-[.04em] flex items-center gap-2">
                           <Server size={13} className="text-info" /> {i18nT('pages.chatSidebar.new_chat_on_crew')}
                         </DropdownMenuLabel>
-                        <div className="max-h-[240px] overflow-y-auto">{crewRows}</div>
+                        <div className="max-h-[240px] overflow-y-auto">{crewRows}{errRow}</div>
                       </>
                     )
                   }
@@ -5497,7 +5557,7 @@ function ChatSidebar({
                           primitive, since cn()'s tailwind-merge dedupes max-h-*).
                           overflow is left to the primitive. */}
                       <DropdownMenuSubContent className="max-h-[min(300px,var(--radix-dropdown-menu-content-available-height))]">
-                        {crewRows}
+                        {crewRows}{errRow}
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
                   )


### PR DESCRIPTION
## Problem / Motivation

Creating a session on a connected crew (New chat menu → **New chat on crew** → pick a crew) failed **silently**: no session appeared in the local sidebar list, none was created on the remote crew, and no error was shown — the click read as a no-op.

Two independent causes:
1. The remote-execution version gate (`ensure_version_parity`) required the peer's `kiro_crew.__version__` to match the local build **byte-for-byte**, so any build skew refused the create before the peer was ever asked to open a session.
2. The frontend `createRemoteChatMutation` had `onSuccess` but no `onError`, so react-query swallowed the resulting 502 and nothing surfaced.

## Why it matters

The create opens the peer session **before** the local slot and, by design, leaves nothing behind on failure. So a version skew — the common case right after an update lands on one end but not the other — made "New chat on crew" look broken with no diagnosis, and users had no way to tell it was a version issue rather than a bug.

## What changed (motivation → approach → change)

- **Root cause 1 — the gate was too strict.** `ensure_version_parity` now compares the **`major.minor` series**, not the full string. `0.6.0` and `0.6.3` interoperate; `0.6.x` vs `0.7.x` is still refused — a feature release moves the unversioned frame vocabulary the two ends exchange, and on a 0.x line that axis is the *minor* (the major stays 0). Added `_version_series()` to parse the leading semver. When either side is **not** semver-shaped (a packaging build id replaces `__version__` at build time), compatibility cannot be proven by series, so it **falls back to strict full-string equality**. The refusal message now says "same major.minor version".
- **Root cause 2 — the failure was swallowed.** `createRemoteChatMutation` gains an `onError` that surfaces the backend reason **inline in the submenu** (new `remoteCrewError` state + a truthiness-gated error line). The reason is read off the rejected value's `.message`: RTK's `.unwrap()` rejects with a **SerializedError plain object, not an `Error`**, so an `instanceof Error` guard would have dropped the message. Crew rows use `onSelect` + `preventDefault` so a failed create keeps the menu open long enough to read the error, while a successful create moves focus to the composer (which closes the menu).

## Tests

- `test/test_remote_crew_execution.py`:
  - `test_a_patch_skew_in_the_same_series_passes` — same `major.minor`, different patch is allowed.
  - `test_a_different_minor_is_refused` — a minor bump is refused and the message names `major.minor`.
  - `test_a_non_semver_build_id_falls_back_to_strict_equality` — a build id compares by full-string equality.
  - Existing equal-version / unknown-version / unreachable / redaction cases still hold (189 pass).
- Frontend: `catalogParity` (77) and the ChatSidebar suites pass; `tsc -b` and `eslint` clean. No new user-facing string was added — the failure text comes from the backend, already localized by `apiFailure`.

## Manual verification

N/A — unit coverage is sufficient for the version gate. The frontend change is a conditional error line whose steady state is unchanged; reproducing the live surface needs a connected peer at a mismatched `major.minor`, which a unit test cannot stage.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the only rendered change is a conditionally-shown error line in the "New chat on crew" submenu that appears **solely** when a remote create fails, and it requires a live version-mismatched or unreachable peer to trigger. The steady-state (no-error) sidebar is pixel-identical.

## Related Issues

no linked issue: field-reported behaviour after #7693 landed; no tracking issue was filed.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a react-query `useMutation` whose `mutationFn` dispatches a thunk `.unwrap()` but declares no `onError` silently swallows the rejection — a user-visible action that "leaves nothing behind" on failure must surface the reason. Corollary for the extraction: `.unwrap()` rejects with a SerializedError *plain object*, so `err instanceof Error` is false; read `.message` off the object.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
