### PR TITLE
fix(acp): stop reaping ACP turns mid-tool on hosts without /proc

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -62,6 +62,7 @@ from kiro_crew.acp._dispatch import (
     redact_text,
 )
 from kiro_crew.acp.liveness import (
+    EVIDENCE_SAMPLING,
     VERDICT_WORKING,
     LivenessOracle,
     _consume_future_exception,
@@ -1100,6 +1101,12 @@ _STALE_TURN_TIMEOUT = 90.0
 # that silently never returns, burning the whole job timeout.  Long real tools
 # keep resetting the timer via tool_call_update progress frames and tool
 # results, so this only trips on a genuine stall.
+#
+# CONTRACT FOR BACKEND AUTHORS: a backend that emits NO frame at all while a
+# tool runs gets exactly this window for the whole tool, so a >10min build must
+# either stream tool_call_update progress frames or ping the session-keepalive
+# endpoint (both reset the clock).  This window — not the ~90s stale-turn
+# cutoff — is what governs an open tool call's silence (issue #8520).
 _TOOL_STALL_TIMEOUT = 600.0
 # After a compaction `failed` status, kiro-cli can leave the turn it was
 # compacting for unanswered: no session/prompt response and no end_turn ever
@@ -5626,8 +5633,18 @@ class AcpClient:
                         # to a non-WORKING verdict on any error (fail toward
                         # reaping). In production, silent reads recur at the
                         # ~_READ_TIMEOUT cadence, giving well-spaced samples.
+                        #
+                        # Snapshot the idle window BEFORE awaiting the consult.
+                        # The walk is OUR OWN probe and a cold one costs tens of
+                        # milliseconds (executor warm-up, then the subtree walk);
+                        # reading the clock AFTER it charges that latency to the
+                        # BACKEND's silence budget, so on a loaded host the first
+                        # silent read could cross the cutoff carrying the only
+                        # verdict the oracle can give before it has a baseline,
+                        # and reap a turn that was streaming a moment earlier.
+                        _idle_secs = time.monotonic() - last_seen
                         verdict, evidence = await self._consult_liveness_model_wait()
-                        if (time.monotonic() - last_seen) > _STALE_TURN_TIMEOUT:
+                        if _idle_secs > _STALE_TURN_TIMEOUT:
                             # Past the cutoff: a backend still doing work (CPU/IO
                             # movement in its subtree — a long model generation or
                             # a spawned build) reads WORKING and we keep waiting.
@@ -5640,19 +5657,68 @@ class AcpClient:
                                     "Stale-turn deferral for req %d — idle %.0fs but "
                                     "backend WORKING (%s)",
                                     req_id,
-                                    time.monotonic() - last_seen,
+                                    _idle_secs,
                                     evidence,
                                 )
                                 continue
-                            logger.warning(
-                                "Stale turn detected for req %d — no data for %.0fs after text was streamed "
-                                "(liveness=%s: %s). Treating as complete.",
-                                req_id,
-                                time.monotonic() - last_seen,
-                                verdict,
-                                evidence,
-                            )
-                            return
+                            if evidence == EVIDENCE_SAMPLING:
+                                # The oracle stored a BASELINE and has nothing to
+                                # compare it against yet, so this verdict is
+                                # structurally incapable of reading WORKING: it
+                                # means "ask me again", not "idle". Reaping on it
+                                # ends a live turn on no evidence at all — the
+                                # per-silent-read consulting above exists to make
+                                # that unlikely, and deferring here makes it
+                                # impossible rather than merely improbable. The
+                                # next silent read has a baseline and answers for
+                                # real, so recovery is delayed by one read, not
+                                # weakened.
+                                logger.debug(
+                                    "Stale-turn deferral for req %d — idle %.0fs but the "
+                                    "liveness baseline is still priming (%s)",
+                                    req_id,
+                                    _idle_secs,
+                                    evidence,
+                                )
+                                continue
+                            if self._tool_dispatched:
+                                # An OPEN TOOL CALL is positive evidence the turn
+                                # is alive, so it defers this cutoff whatever the
+                                # verdict says. Only kiro-cli streams
+                                # tool_call_update progress frames while a tool
+                                # runs; a backend that runs the tool to completion
+                                # and only then reports the result is silent for
+                                # the whole tool, and with text streamed before
+                                # the dispatch this cutoff tore the turn down
+                                # MID-TOOL — reporting truncated work as complete
+                                # (issue #8520). Deliberately NOT a `continue`:
+                                # falling through hands the silence to the
+                                # tool-stall watchdog below, which governs exactly
+                                # this case on its own much longer budget and
+                                # RECOVERS the slot instead of completing the
+                                # turn. Mirrors the compaction-failed budget's
+                                # suspension above; _tool_dispatched is cleared
+                                # when the tool resolves, so the cutoff re-arms
+                                # for the model-wait silence it is actually for.
+                                logger.debug(
+                                    "Stale-turn deferral for req %d — idle %.0fs with a tool "
+                                    "call still open (liveness=%s: %s); tool-stall watchdog "
+                                    "governs",
+                                    req_id,
+                                    _idle_secs,
+                                    verdict,
+                                    evidence,
+                                )
+                            else:
+                                logger.warning(
+                                    "Stale turn detected for req %d — no data for %.0fs after text was streamed "
+                                    "(liveness=%s: %s). Treating as complete.",
+                                    req_id,
+                                    _idle_secs,
+                                    verdict,
+                                    evidence,
+                                )
+                                return
                     # Tool-stall watchdog: a tool was dispatched but NOTHING has
                     # come back (no result, no progress, no permission) for the
                     # stall window.  This is the silent-hang case where

--- a/src/kiro_crew/acp/liveness.py
+++ b/src/kiro_crew/acp/liveness.py
@@ -68,6 +68,8 @@ from concurrent.futures import Executor
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
+from kiro_crew import platform_compat
+
 logger = logging.getLogger(__name__)
 
 # ── Verdicts ──
@@ -97,6 +99,14 @@ EVIDENCE_ESTABLISHED_FLAT = "established_flat"
 # still covered by the "young descendant exists" test below, so the narrowing
 # only shortens a non-lethal cancel, never skips straight to one.
 EVIDENCE_SHELL_CHILD_ABSENT = "shell_child_absent"
+
+# Evidence for a movement probe that stored a BASELINE and has nothing to
+# compare it against yet. Structurally non-informative: it says "ask me again",
+# never "this process is idle". A caller whose non-WORKING branch destroys work
+# must therefore defer on it rather than treat it as a negative verdict — see
+# ``client._prompt_loop``'s stale-turn gate, which reaped a live turn on its
+# first silent read because the priming answer landed past the cutoff.
+EVIDENCE_SAMPLING = "sampling"
 
 # Tool names that are known to wrap a model call (e.g. kiro-cli's use_subagent
 # which starts a sub-agent turn inside the current tool call). The
@@ -137,6 +147,12 @@ _STUCK_INPUT_WCHANS = frozenset({"n_tty_read", "pipe_read", "wait_woken"})
 _READ_SYSCALL_NRS = frozenset({0, 63})
 # Shell wrappers whose bare program name is too generic to count as a match.
 _GENERIC_PROGRAMS = frozenset({"bash", "sh", "zsh", "env", "sudo", "nohup", "timeout"})
+
+# Sample key for the portable (no-procfs) CPU probe. Deliberately not one of the
+# ``/proc`` walk's keys: that counter is jiffies and this one is nanoseconds, so
+# a host whose procfs became readable mid-turn must not diff one against the
+# other.
+_PORTABLE_CPU_KEY = "portable_cpu"
 
 _WAIT_SECONDS_RE = re.compile(r"[\"']?seconds[\"']?\s*[:=]\s*(\d+)")
 
@@ -578,7 +594,7 @@ class LivenessOracle:
         # attribution (empty tool_name or an unknown tool), fall back to the
         # plain mcp_subtree_flat evidence so the full build-scale window holds.
         if (
-            evidence not in ("sampling", "no readable counters")
+            evidence not in (EVIDENCE_SAMPLING, "no readable counters")
             and tool.tool_name in _MODEL_WRAPPING_TOOLS
         ):
             held = socket_inodes(self._proc, runtime_pid)
@@ -771,8 +787,15 @@ class LivenessOracle:
         moved, evidence = self._tree_movement(runtime_pid)
         if moved:
             return VERDICT_WORKING, f"backend activity ({evidence})"
-        if evidence in ("sampling", "no readable counters"):
-            # No baseline yet, or /proc unreadable — cannot attest either way.
+        if evidence == "no readable counters":
+            # No procfs AT ALL (macOS, Windows) — the /proc-shaped evidence is
+            # ABSENT, not negative, so fall back to the portable probe before the
+            # caller takes its conservative branch. Linux-only counters must not
+            # read as "assume dead" on the platform most backends run on: that is
+            # how a macOS turn was declared complete mid-tool (issue #8520).
+            return self._portable_model_wait(runtime_pid)
+        if evidence == EVIDENCE_SAMPLING:
+            # No baseline yet — cannot attest either way.
             return VERDICT_UNKNOWN, evidence
         # Flat counters: distinguish the done-but-lost-frame wedge (no backend
         # connection at all) from a probably-thinking server-side silence
@@ -781,6 +804,27 @@ class LivenessOracle:
         if established:
             return VERDICT_UNKNOWN, f"{EVIDENCE_ESTABLISHED_FLAT}: {evidence}"
         return VERDICT_DEAD, f"no established backend socket and flat counters ({evidence})"
+
+    def _portable_model_wait(self, runtime_pid: int) -> tuple[str, str]:
+        """Model-wait verdict from platform-neutral evidence.
+
+        Reached only when the ``/proc`` walk read no counter whatsoever, i.e. on
+        a host that has no procfs. It can only ever FORGIVE silence: a CPU delta
+        on a live pid reads WORKING, and anything else keeps the UNKNOWN such a
+        host already returned, so the caller's conservative branch is untouched
+        wherever the portable probe cannot attest either. It deliberately never
+        answers DEAD — "no counter here" is not proof of death, and the caller
+        reaps on UNKNOWN anyway, so claiming it would only add a way to be wrong.
+
+        Both halves are load-bearing. The alive check alone would forgive a
+        finished-but-lost-frame backend forever (a wedged process is alive too),
+        trading a 90s truncation for a full-prompt-timeout hang; the CPU delta
+        alone would attest to the work of a RECYCLED pid.
+        """
+        moved, evidence = self._portable_movement(runtime_pid)
+        if moved and platform_compat.pid_exists(runtime_pid):
+            return VERDICT_WORKING, f"backend activity ({evidence}, pid alive)"
+        return VERDICT_UNKNOWN, evidence
 
     def _any_established(self, runtime_pid: int) -> bool:
         for pid in iter_descendants(self._proc, runtime_pid):
@@ -822,7 +866,7 @@ class LivenessOracle:
         if prev_io is None or prev_cpu is None:
             self._samples[io_key] = (now, io_total)
             self._samples[cpu_key] = (now, cpu_total)
-            return False, "sampling"
+            return False, EVIDENCE_SAMPLING
         if now - prev_io[0] < self._sample_min_secs:
             # Too soon for a fresh delta — report against the stored baseline
             # without advancing it.
@@ -834,6 +878,34 @@ class LivenessOracle:
         self._samples[io_key] = (now, io_total)
         self._samples[cpu_key] = (now, cpu_total)
         return (io_delta != 0 or cpu_delta != 0), f"io {io_delta:+d}B cpu {cpu_delta:+d}t"
+
+    def _portable_movement(self, root_pid: int) -> tuple[bool, str]:
+        """(moved, evidence) for *root_pid*'s CPU delta, without ``/proc``.
+
+        Same two-sample contract as :meth:`_tree_movement` — the first call after
+        a boundary stores a baseline and reports ``(False, "sampling")``, and a
+        second call inside ``sample_min_secs`` compares against that baseline
+        without advancing it — but it reads ONE portable counter
+        (:func:`platform_compat.proc_cpu_nanos_for_pid`) instead of walking
+        procfs, so it answers where that walk is blind.
+
+        Root pid only, so a busy DESCENDANT under an idle root reads flat here.
+        That is the conservative direction (it never invents movement), and the
+        case where the work lives in a child — an open tool call — is governed by
+        the caller's tool-stall policy rather than by this probe.
+        """
+        cpu = platform_compat.proc_cpu_nanos_for_pid(root_pid)
+        if cpu is None:
+            return False, "no readable counters"
+        now = self._now()
+        prev = self._samples.get(_PORTABLE_CPU_KEY)
+        if prev is None:
+            self._samples[_PORTABLE_CPU_KEY] = (now, cpu)
+            return False, EVIDENCE_SAMPLING
+        if now - prev[0] < self._sample_min_secs:
+            return cpu != prev[1], f"cpu {cpu - prev[1]:+d}ns (early)"
+        self._samples[_PORTABLE_CPU_KEY] = (now, cpu)
+        return cpu != prev[1], f"cpu {cpu - prev[1]:+d}ns"
 
 
 # ── Offloaded-consult guard (shared by AcpClient and AcpSessionHandle) ──

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -939,6 +939,17 @@ _DARWIN_PROC_BSDINFO_SIZE = 136
 _DARWIN_PBI_START_TVSEC_OFFSET = 120
 _DARWIN_PBI_START_TVUSEC_OFFSET = 128
 
+# ``proc_pidinfo(PROC_PIDTASKINFO)`` fills a ``proc_taskinfo`` struct that opens
+# with six uint64 fields — ``pti_virtual_size``, ``pti_resident_size``,
+# ``pti_total_user``, ``pti_total_system``, ``pti_threads_user``,
+# ``pti_threads_system`` (48 bytes) — followed by twelve int32 counters (48),
+# for a struct size of 96. Only the two total-CPU fields matter here, and both
+# are already NANOSECONDS; the total size doubles as the layout check.
+_DARWIN_PROC_PIDTASKINFO = 4
+_DARWIN_PROC_TASKINFO_SIZE = 96
+_DARWIN_PTI_TOTAL_USER_OFFSET = 16
+_DARWIN_PTI_TOTAL_SYSTEM_OFFSET = 24
+
 _darwin_libproc: Any = None
 _darwin_libproc_loaded = False
 
@@ -1038,6 +1049,41 @@ def _darwin_process_start_microtime(pid: int) -> str | None:
         if sec <= 0:
             return None
         return f"{sec}.{usec:06d}"
+    except Exception:
+        return None
+
+
+def _darwin_process_cpu_nanos(pid: int) -> int | None:
+    """macOS total (user+system) CPU nanoseconds of *pid* via ``libproc``.
+
+    Same contract as the start-time probe above: no entitlement is needed for a
+    same-uid process, nothing is exec'd, and a fill size other than the exact
+    struct size means the assumed layout no longer matches, so the answer is
+    refused rather than sliced out of the wrong place.
+    """
+    lib = _darwin_libproc_handle()
+    if lib is None:
+        return None
+    try:
+        buf = ctypes.create_string_buffer(_DARWIN_PROC_TASKINFO_SIZE)
+        filled = lib.proc_pidinfo(
+            pid,
+            _DARWIN_PROC_PIDTASKINFO,
+            0,
+            buf,
+            _DARWIN_PROC_TASKINFO_SIZE,
+        )
+        if filled != _DARWIN_PROC_TASKINFO_SIZE:
+            return None
+        # Both x86_64 and arm64 macOS are little-endian.
+        user = int.from_bytes(
+            buf.raw[_DARWIN_PTI_TOTAL_USER_OFFSET:_DARWIN_PTI_TOTAL_SYSTEM_OFFSET], "little"
+        )
+        system = int.from_bytes(
+            buf.raw[_DARWIN_PTI_TOTAL_SYSTEM_OFFSET : _DARWIN_PTI_TOTAL_SYSTEM_OFFSET + 8],
+            "little",
+        )
+        return user + system
     except Exception:
         return None
 
@@ -4729,6 +4775,75 @@ def _proc_cpu_jiffies(pid: int) -> int:
             return _parse_cpu_jiffies(fh.read())
     except OSError:
         return 0
+
+
+def proc_cpu_nanos_for_pid(pid: int) -> int | None:
+    """Total (user+system) CPU time of *pid* in NANOSECONDS, or None.
+
+    The per-pid, cross-platform counterpart to :func:`proc_cpu_seconds`, which
+    can only measure the CALLING process. A caller samples this twice and
+    consumes the DELTA as evidence that a process is doing work; ``None`` means
+    no per-pid counter is readable on this host, which is evidence of neither
+    work nor death.
+
+    - Linux: ``_proc_cpu_jiffies`` scaled by ``SC_CLK_TCK``. Never None — an
+      unreadable pid reads 0 there, which a delta correctly sees as flat.
+    - macOS: ``libproc.proc_pidinfo(PROC_PIDTASKINFO)``, already nanoseconds.
+    - Windows: ``GetProcessTimes`` kernel+user (100-ns units) over a query-only
+      handle.
+    - Any other platform: None.
+
+    Root pid ONLY — deliberately no subtree walk, because neither macOS nor
+    Windows has a child enumeration cheap enough for a probe on a read loop's
+    cadence. A caller that needs the subtree total and knows it is on Linux uses
+    :func:`proc_subtree_sample` instead.
+    """
+    if type(pid) is not int or pid <= 0:
+        return None
+    if IS_LINUX:
+        try:
+            ticks = os.sysconf("SC_CLK_TCK") or 100
+        except (AttributeError, OSError, ValueError):
+            ticks = 100
+        return _proc_cpu_jiffies(pid) * (1_000_000_000 // ticks)
+    if IS_MACOS:
+        return _darwin_process_cpu_nanos(pid)
+    if not IS_WINDOWS:
+        return None
+    handle = _open_process_query_handle(pid)
+    if handle is None:
+        return None
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)  # type: ignore[attr-defined]
+        kernel32.GetProcessTimes.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+            ctypes.POINTER(wintypes.FILETIME),
+        ]
+        kernel32.GetProcessTimes.restype = wintypes.BOOL
+        creation = wintypes.FILETIME()
+        exited = wintypes.FILETIME()
+        kernel = wintypes.FILETIME()
+        user = wintypes.FILETIME()
+        if not kernel32.GetProcessTimes(
+            wintypes.HANDLE(handle),
+            ctypes.byref(creation),
+            ctypes.byref(exited),
+            ctypes.byref(kernel),
+            ctypes.byref(user),
+        ):
+            return None
+
+        def _hundred_ns(value: "wintypes.FILETIME") -> int:
+            return (value.dwHighDateTime << 32) | value.dwLowDateTime
+
+        return (_hundred_ns(kernel) + _hundred_ns(user)) * 100
+    except Exception:
+        return None
+    finally:
+        _close_process_handle(handle)
 
 
 class SubtreeSample(NamedTuple):

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -32,6 +32,7 @@ from kiro_crew.acp.client import (
     parse_slash_command,
 )
 from kiro_crew.acp.liveness import (
+    EVIDENCE_SAMPLING,
     VERDICT_DEAD,
     VERDICT_UNKNOWN,
     VERDICT_WORKING,
@@ -2167,6 +2168,171 @@ class TestAcpClientStaleTurnOracleGate:
 
         assert tracked.done()
         assert tracked._log_traceback is False
+
+
+class TestStaleTurnOpenToolCall:
+    """An OPEN tool call defers the stale-turn cutoff (issue #8520).
+
+    Only kiro-cli streams ``tool_call_update`` progress frames while a tool
+    runs; a third-party backend that runs a tool to completion and only then
+    reports the result is silent for the whole tool. Text streamed before the
+    dispatch leaves ``_stale_eligible`` set, and off Linux the liveness oracle
+    can only answer UNKNOWN, so the cutoff declared that turn complete and tore
+    it down MID-TOOL. An open tool call is positive evidence the turn is alive:
+    the silence is handed to the tool-stall watchdog, which owns a much longer
+    budget and RECOVERS the slot instead of reporting a truncated turn as done.
+    """
+
+    def _silent_client(self, tmp_path, *, tool_dispatched: bool):
+        client = AcpClient(work_dir=tmp_path)
+        client._read_message = AsyncMock(return_value=None)
+        client._is_process_alive = MagicMock(return_value=True)
+        client._stale_eligible = True
+        client._tool_dispatched = tool_dispatched
+        client._last_activity = time.monotonic()
+        # The verdict every /proc-less host returns — the reporter's own log line.
+        client._consult_liveness_model_wait = AsyncMock(
+            return_value=(VERDICT_UNKNOWN, "no readable counters")
+        )
+        return client
+
+    @pytest.mark.asyncio
+    async def test_open_tool_call_defers_the_cutoff(self, tmp_path, caplog, monkeypatch):
+        monkeypatch.setattr(acp_client, "_TOOL_STALL_TIMEOUT", 30.0)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+        client = self._silent_client(tmp_path, tool_dispatched=True)
+
+        t0 = time.monotonic()
+        with patch("kiro_crew.acp.client._STALE_TURN_TIMEOUT", 0.05):
+            with caplog.at_level("WARNING", logger="kiro_crew.acp.client"):
+                actions = []
+                async for action, _msg in client._prompt_loop(req_id=85, timeout=0.4):
+                    actions.append(action)
+        elapsed = time.monotonic() - t0
+
+        assert actions == []
+        assert "Stale turn detected" not in caplog.text
+        assert elapsed >= 0.3, f"loop exited at {elapsed:.2f}s — the cutoff reaped an open tool"
+
+    @pytest.mark.asyncio
+    async def test_a_resolved_tool_re_arms_the_cutoff(self, tmp_path, caplog, monkeypatch):
+        """Deferral is not a disarm: once the tool resolves, the cutoff fires."""
+        monkeypatch.setattr(acp_client, "_TOOL_STALL_TIMEOUT", 30.0)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+        client = self._silent_client(tmp_path, tool_dispatched=True)
+
+        async def _resolve_then_stay_silent(*_args, **_kwargs):
+            await asyncio.sleep(0.02)
+            # What _dispatch_events does when the tool's result frame arrives.
+            client._tool_dispatched = False
+            return None
+
+        client._read_message = AsyncMock(side_effect=_resolve_then_stay_silent)
+
+        with patch("kiro_crew.acp.client._STALE_TURN_TIMEOUT", 0.05):
+            with caplog.at_level("WARNING", logger="kiro_crew.acp.client"):
+                actions = []
+                async for action, _msg in client._prompt_loop(req_id=86, timeout=5.0):
+                    actions.append(action)
+
+        assert actions == []
+        assert "Stale turn detected" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_stalled_open_tool_is_still_killed(self, tmp_path, monkeypatch):
+        """The deferral must not swallow the tool-stall watchdog.
+
+        Past ITS budget the wedged child is killed and AcpProcessDied raised, so
+        the slot cold-starts on the next prompt — the recovery the bare stale
+        ``return`` never performed.
+        """
+        monkeypatch.setattr(acp_client, "_TOOL_STALL_TIMEOUT", 0.1)
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+        client = self._silent_client(tmp_path, tool_dispatched=True)
+        client._kill_process = AsyncMock()
+
+        with patch("kiro_crew.acp.client._STALE_TURN_TIMEOUT", 0.05):
+            with pytest.raises(AcpProcessDied, match="tool stalled"):
+                async for _action, _msg in client._prompt_loop(req_id=87, timeout=5.0):
+                    pass
+
+        client._kill_process.assert_awaited_once()
+
+
+class TestStaleTurnProbeAccounting:
+    """The stale cutoff must measure BACKEND silence, not our own probe.
+
+    Two ways the gate used to end a live turn on no evidence at all:
+
+    * the idle clock was read AFTER awaiting the liveness consult, so a cold
+      walk's latency (executor warm-up plus the subtree read) was charged to the
+      backend's silence budget;
+    * the oracle's baseline-priming answer (``EVIDENCE_SAMPLING``) counted as a
+      negative verdict, although it is structurally incapable of reading WORKING
+      -- it means "ask me again", not "idle".
+
+    Together they reaped a turn on its FIRST silent read, which is the
+    truncation the per-silent-read consulting exists to avoid.
+    """
+
+    def _silent_client(self, tmp_path):
+        client = AcpClient(work_dir=tmp_path)
+        client._read_message = AsyncMock(return_value=None)
+        client._is_process_alive = MagicMock(return_value=True)
+        client._stale_eligible = True
+        client._last_activity = time.monotonic()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_priming_verdict_defers_then_real_evidence_reaps(
+        self, tmp_path, caplog, monkeypatch
+    ):
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.02)
+        client = self._silent_client(tmp_path)
+        client._consult_liveness_model_wait = AsyncMock(
+            side_effect=[
+                (VERDICT_UNKNOWN, EVIDENCE_SAMPLING),  # no baseline yet
+                (VERDICT_UNKNOWN, "flat counters"),  # a real answer
+            ]
+        )
+
+        # Cutoff 0 so every silent read is past it: the only thing that can keep
+        # the turn alive on the first read is the priming deferral.
+        with patch("kiro_crew.acp.client._STALE_TURN_TIMEOUT", 0.0):
+            with caplog.at_level("WARNING", logger="kiro_crew.acp.client"):
+                async for _action, _msg in client._prompt_loop(req_id=88, timeout=5.0):
+                    pass
+
+        assert "Stale turn detected" in caplog.text  # recovery still fires
+        assert (
+            client._consult_liveness_model_wait.await_count == 2
+        ), "the turn was ended on the priming answer instead of on real evidence"
+
+    @pytest.mark.asyncio
+    async def test_consult_latency_is_not_charged_to_the_silence_budget(
+        self, tmp_path, caplog, monkeypatch
+    ):
+        """A consult slower than the cutoff must not itself end the turn."""
+        monkeypatch.setattr(acp_client, "_READ_TIMEOUT", 0.01)
+        client = self._silent_client(tmp_path)
+        consults = {"n": 0}
+
+        async def _slow_consult():
+            consults["n"] += 1
+            await asyncio.sleep(0.15)  # 3x the cutoff patched below
+            return VERDICT_UNKNOWN, "flat counters"
+
+        client._consult_liveness_model_wait = _slow_consult
+
+        with patch("kiro_crew.acp.client._STALE_TURN_TIMEOUT", 0.05):
+            with caplog.at_level("WARNING", logger="kiro_crew.acp.client"):
+                async for _action, _msg in client._prompt_loop(req_id=89, timeout=5.0):
+                    pass
+
+        assert "Stale turn detected" in caplog.text
+        assert (
+            consults["n"] >= 2
+        ), "the first consult's own 0.15s runtime was counted as backend silence"
 
 
 class TestAcpClientReadMessage:

--- a/test/test_acp_liveness.py
+++ b/test/test_acp_liveness.py
@@ -784,6 +784,102 @@ def test_model_wait_flat_with_established_socket_is_unknown_tagged(tmp_path):
     assert evidence.startswith(EVIDENCE_ESTABLISHED_FLAT)
 
 
+# ── Portable model-wait fallback (no procfs) — issue #8520 ───────────────────
+#
+# macOS and Windows have no ``/proc``, so the tree walk reads NO counter at all
+# and the verdict was "unknown: no readable counters" — which the AcpClient's
+# stale cutoff treats as reap. Absent evidence must not read as death on the
+# platform most third-party backends run on.
+
+
+def _no_procfs_oracle(clock: _Clock, tmp_path) -> LivenessOracle:
+    """An oracle whose ``/proc`` root does not exist — i.e. any non-Linux host."""
+    return LivenessOracle(str(tmp_path / "nonexistent"), now=clock, sample_min_secs=1.0)
+
+
+def test_model_wait_portable_cpu_delta_is_working(tmp_path, monkeypatch):
+    """A CPU delta on a live pid forgives silence where the /proc walk is blind."""
+    from kiro_crew import platform_compat
+
+    clock = _Clock()
+    cpu = {"ns": 5_000_000_000}
+    monkeypatch.setattr(platform_compat, "proc_cpu_nanos_for_pid", lambda _pid: cpu["ns"])
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda _pid: True)
+    oracle = _no_procfs_oracle(clock, tmp_path)
+
+    assert oracle.check_model_wait(100) == (VERDICT_UNKNOWN, "sampling")  # baseline
+    cpu["ns"] += 250_000_000
+    clock.advance(2.0)
+    verdict, evidence = oracle.check_model_wait(100)
+    assert verdict == VERDICT_WORKING
+    assert "backend activity" in evidence
+
+
+def test_model_wait_portable_flat_cpu_stays_unknown(tmp_path, monkeypatch):
+    """An idle process is not evidence of work — today's cutoff is preserved."""
+    from kiro_crew import platform_compat
+
+    clock = _Clock()
+    monkeypatch.setattr(platform_compat, "proc_cpu_nanos_for_pid", lambda _pid: 5_000_000_000)
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda _pid: True)
+    oracle = _no_procfs_oracle(clock, tmp_path)
+
+    oracle.check_model_wait(100)  # baseline
+    clock.advance(2.0)
+    assert oracle.check_model_wait(100)[0] == VERDICT_UNKNOWN
+
+
+def test_model_wait_portable_movement_needs_a_live_pid(tmp_path, monkeypatch):
+    """A moving counter for a pid that is gone must not attest to work.
+
+    Both halves are required: the alive check alone would forgive a
+    finished-but-lost-frame backend forever (a wedged process is alive too),
+    trading a 90s truncation for a full-prompt-timeout hang.
+    """
+    from kiro_crew import platform_compat
+
+    clock = _Clock()
+    cpu = {"ns": 1_000_000_000}
+    monkeypatch.setattr(platform_compat, "proc_cpu_nanos_for_pid", lambda _pid: cpu["ns"])
+    monkeypatch.setattr(platform_compat, "pid_exists", lambda _pid: False)
+    oracle = _no_procfs_oracle(clock, tmp_path)
+
+    oracle.check_model_wait(100)  # baseline
+    cpu["ns"] += 900_000_000
+    clock.advance(2.0)
+    assert oracle.check_model_wait(100)[0] == VERDICT_UNKNOWN
+
+
+def test_model_wait_without_any_portable_counter_is_unknown(tmp_path, monkeypatch):
+    """No counter readable anywhere → the pre-fix verdict, unchanged."""
+    from kiro_crew import platform_compat
+
+    clock = _Clock()
+    monkeypatch.setattr(platform_compat, "proc_cpu_nanos_for_pid", lambda _pid: None)
+    oracle = _no_procfs_oracle(clock, tmp_path)
+
+    assert oracle.check_model_wait(100) == (VERDICT_UNKNOWN, "no readable counters")
+
+
+def test_model_wait_prefers_procfs_when_it_is_readable(tmp_path, monkeypatch):
+    """On Linux the portable probe is never consulted — the tree walk answers."""
+    from kiro_crew import platform_compat
+
+    def _never(_pid):
+        raise AssertionError("portable probe consulted while /proc was readable")
+
+    monkeypatch.setattr(platform_compat, "proc_cpu_nanos_for_pid", _never)
+    clock = _Clock()
+    fake = FakeProc(tmp_path / "proc")
+    fake.add_pid(100, io_bytes=1000)
+    oracle = _oracle(fake, clock, sample_min=1.0)
+
+    oracle.check_model_wait(100)  # baseline
+    fake.set_io(100, 9000)
+    clock.advance(2.0)
+    assert oracle.check_model_wait(100)[0] == VERDICT_WORKING
+
+
 # ── Fail-safe behavior ───────────────────────────────────────────────────────
 
 

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -806,6 +806,19 @@ class TestResourceShims:
         # truncated without argtypes, so GetProcessTimes failed and this read 0.0.
         assert pc.proc_cpu_seconds() > 0.0
 
+    def test_proc_cpu_nanos_for_pid_reads_a_running_process(self):
+        # Linux /proc, macOS libproc, Windows GetProcessTimes: a live interpreter
+        # has consumed CPU on all three. None is reserved for a platform with no
+        # per-pid counter at all, where the caller keeps its prior behavior.
+        ns = pc.proc_cpu_nanos_for_pid(os.getpid())
+        if ns is None:
+            pytest.skip("no per-pid CPU counter on this platform")
+        assert ns > 0
+
+    def test_proc_cpu_nanos_for_pid_refuses_a_reserved_pid(self):
+        assert pc.proc_cpu_nanos_for_pid(0) is None
+        assert pc.proc_cpu_nanos_for_pid(-1) is None
+
     def test_raise_nofile_soft_limit_is_safe(self):
         # No-op on Windows; best-effort raise on POSIX. Must never raise.
         pc.raise_nofile_soft_limit(4096)
@@ -1545,6 +1558,40 @@ class TestOwnProcessStartTime:
 
         monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: _ShortLib())
         assert pc._darwin_process_start_microtime(4242) is None
+
+    def test_darwin_cpu_nanos_parses_the_taskinfo_layout(self, monkeypatch):
+        """user+system CPU are sliced from the pinned ``proc_taskinfo`` offsets."""
+
+        class _FakeLib:
+            @staticmethod
+            def proc_pidinfo(_pid, _flavor, _arg, buf, size):
+                raw = bytearray(size)
+                raw[pc._DARWIN_PTI_TOTAL_USER_OFFSET : pc._DARWIN_PTI_TOTAL_USER_OFFSET + 8] = (
+                    7_000_000_000
+                ).to_bytes(8, "little")
+                raw[pc._DARWIN_PTI_TOTAL_SYSTEM_OFFSET : pc._DARWIN_PTI_TOTAL_SYSTEM_OFFSET + 8] = (
+                    500_000_000
+                ).to_bytes(8, "little")
+                buf.raw = bytes(raw)
+                return size
+
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: _FakeLib())
+        assert pc._darwin_process_cpu_nanos(4242) == 7_500_000_000
+
+    def test_darwin_cpu_nanos_refuses_a_mismatched_struct_size(self, monkeypatch):
+        """Same layout check as the start-time probe: a partial fill answers None."""
+
+        class _ShortLib:
+            @staticmethod
+            def proc_pidinfo(_pid, _flavor, _arg, _buf, _size):
+                return 64
+
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: _ShortLib())
+        assert pc._darwin_process_cpu_nanos(4242) is None
+
+    def test_darwin_cpu_nanos_without_libproc_is_none(self, monkeypatch):
+        monkeypatch.setattr(pc, "_darwin_libproc_handle", lambda: None)
+        assert pc._darwin_process_cpu_nanos(4242) is None
 
     def test_reads_the_platform_once_then_serves_the_cache(self, monkeypatch):
         first = pc.own_process_start_time()  # populate the cache for THIS pid


### PR DESCRIPTION
## Problem / Motivation

A third-party ACP backend on macOS has its harness process killed mid-work, so a
session "dies out of the blue" and the user must send another message to resume.
The reporter's gateway log (issue #8520):

```
19:57:27  Stale turn detected for req 3 — no data for 100s after text was streamed
          (liveness=unknown: no readable counters). Treating as complete.
19:53:11  ACP error in slot chat-3: [AcpError] ACP process not running
```

`_prompt_loop`'s ~90s stale-turn cutoff ends a turn on any liveness verdict other
than `WORKING`, and **three different kinds of NON-evidence were reaching it as if
they were a negative verdict**:

1. **No verdict is possible off Linux.** `LivenessOracle._check_model_wait` can
   only produce `WORKING` from procfs counters (`_tree_movement` →
   `read_io_bytes` / `read_pid_stat`). On a host with no `/proc` the walk reads
   nothing at all, so the verdict is `UNKNOWN, "no readable counters"` and the
   conservative branch fires — exactly the reporter's line.
2. **An open tool call was never consulted.** `_stale_eligible` is cleared when a
   `tool_call` frame is yielded, but any later text chunk sets it again while
   `_tool_dispatched` is still true (it is cleared only by the tool's own result),
   so a backend that goes quiet during a long tool is reaped at 90s and the turn
   is reported complete mid-tool.
3. **The client's own probe latency counted as backend silence, and the oracle's
   baseline-priming answer counted as a negative verdict.** The idle window was
   read *after* awaiting the consult:

   ```python
   verdict, evidence = await self._consult_liveness_model_wait()   # cold walk: tens of ms
   if (time.monotonic() - last_seen) > _STALE_TURN_TIMEOUT:        # charged to the BACKEND
   ```

   and the only verdict the oracle can give before it has a baseline is
   `unknown: sampling`, which is structurally incapable of reading `WORKING`.
   Together those two reap a live turn on its **first** silent read — the
   truncation the per-silent-read consulting was added to make unlikely. Measured
   on a loaded 16-worker run: `Stale turn detected for req 42 — no data for 0s
   after text was streamed (liveness=unknown: sampling). Treating as complete.`

## Why it matters

macOS is the primary KiroCrew platform, and only kiro-cli streams
`tool_call_update` progress frames while a tool runs — a contract implied by the
watchdog's design and stated nowhere a backend author would read. Any third-party
ACP backend that runs a real build or test command loses its process, which makes
custom backends unusable for build/test-style agent work. The failure is silently
wrong rather than loud: the truncated turn is reported as **complete**, and the
next prompt fails with `AcpError: ACP process not running`. Cause 3 is not
platform-specific — it can end any turn on any host whose first `/proc` walk is
slow, which is why `test_real_oracle_movement_defers_via_fake_proc` was
intermittently red on a busy machine before this change.

## What changed (motivation → approach → change)

**A. Portable liveness.** Absent `/proc` evidence is *missing*, not negative, so
when `_tree_movement` reads no counter whatsoever the oracle now consults a
platform-neutral probe before the caller takes its conservative branch: a per-pid
CPU-time delta plus `pid_exists`. Both halves are load-bearing — the alive check
alone would forgive a finished-but-lost-frame backend forever (a wedged process is
alive too), trading a 90s truncation for a full-prompt-timeout hang, and the CPU
delta alone would attest to a recycled pid's work. The fallback can only *forgive*
silence: it never returns `DEAD`, and anything it cannot attest keeps the `UNKNOWN`
such a host already returned, so every existing verdict is preserved. `psutil` is
deliberately not used (the gateway venv does not ship it); the new
`platform_compat.proc_cpu_nanos_for_pid` is the per-pid counterpart to
`proc_cpu_seconds` and reads `/proc/<pid>/stat` on Linux, `libproc`
`proc_pidinfo(PROC_PIDTASKINFO)` on macOS (no entitlement, no `exec`, so it works
under the app sandbox — the same primitive the existing start-time probe uses),
and `GetProcessTimes` over a query-only handle on Windows.

**B. An open tool call counts as activity.** An in-flight tool is positive
evidence the turn is alive, so it now defers the cutoff whatever the verdict says.
This is deliberately **not** a `continue`: control falls through to the
`_TOOL_STALL_TIMEOUT` watchdog immediately below, which governs exactly this
silence on its own much longer budget and *recovers* the slot (kills the wedged
child, raises `AcpProcessDied` so the session resets) instead of reporting a
truncated turn as complete. This mirrors the compaction-failed budget's existing
`and not self._tool_dispatched` suspension a few lines above, and it is not a
disarm: `_tool_dispatched` is cleared when the tool resolves, so the cutoff
re-arms for the model-wait silence it is actually for.

**C. The cutoff now measures backend silence only.** The idle window is
snapshotted *before* awaiting the consult, so our own probe's latency is no longer
charged to the backend; and the baseline-priming verdict is deferred rather than
reaped on, because `sampling` means "ask me again", not "idle". Recovery is
delayed by at most one read (~`_READ_TIMEOUT`) and never weakened: the idle clock
keeps growing with real silence, and any other `UNKNOWN`/`DEAD`/`STUCK_INPUT`
evidence still ends the turn. The priming answer is now the named
`liveness.EVIDENCE_SAMPLING` instead of a literal repeated across two modules.

**D (comment only).** The progress-frame contract is stated on
`_TOOL_STALL_TIMEOUT`: a backend emitting no frames gets that one window for the
whole tool, and streaming `tool_call_update` frames or pinging session-keepalive
resets it. No docs-site change; the issue's suggested one-time runtime warning is
left out as a separate concern.

No timeout default changed, and no configuration was added.

## Tests

Each new test was proven RED against the unfixed code first.

`test/test_acp_client.py::TestStaleTurnOpenToolCall`
- `test_open_tool_call_defers_the_cutoff` — silent reads, `UNKNOWN` verdict,
  `_tool_dispatched` set: no "Stale turn detected", loop runs to its own deadline.
  RED before: `Stale turn detected for req 85 — no data for 0s after text was
  streamed (liveness=unknown: no readable counters). Treating as complete.`
- `test_a_genuinely_stalled_open_tool_is_still_killed` — the deferral must not
  swallow the watchdog: past `_TOOL_STALL_TIMEOUT` the child is killed and
  `AcpProcessDied` raised. RED before: `DID NOT RAISE AcpProcessDied`.
- `test_a_resolved_tool_re_arms_the_cutoff` — once the tool resolves the cutoff
  fires again (pins that the deferral is not a permanent disarm).

`test/test_acp_client.py::TestStaleTurnProbeAccounting`
- `test_priming_verdict_defers_then_real_evidence_reaps` — with the cutoff at 0,
  the priming answer defers and the *next*, real verdict ends the turn. RED
  before: `AssertionError: the turn was ended on the priming answer instead of on
  real evidence`.
- `test_consult_latency_is_not_charged_to_the_silence_budget` — a consult 3× the
  cutoff must not itself end the turn. RED before: `AssertionError: the first
  consult's own 0.15s runtime was counted as backend silence`.

`test/test_acp_liveness.py`
- `test_model_wait_portable_cpu_delta_is_working` — a CPU delta on a live pid
  reads `WORKING` where the `/proc` walk is blind.
- `test_model_wait_portable_flat_cpu_stays_unknown` — an idle process is not
  evidence of work; today's cutoff is preserved.
- `test_model_wait_portable_movement_needs_a_live_pid` — movement for a pid that
  is gone must not read `WORKING`.
- `test_model_wait_without_any_portable_counter_is_unknown` — no counter anywhere
  gives the pre-fix verdict verbatim.
- `test_model_wait_prefers_procfs_when_it_is_readable` — on Linux the portable
  probe is never consulted (the stub raises if it is).

`test/test_platform_compat.py`
- `test_proc_cpu_nanos_for_pid_reads_a_running_process`,
  `test_proc_cpu_nanos_for_pid_refuses_a_reserved_pid`.
- `test_darwin_cpu_nanos_parses_the_taskinfo_layout`,
  `..._refuses_a_mismatched_struct_size`, `..._without_libproc_is_none` — the
  macOS branch is exercised on every platform by faking the `libproc` handle (the
  existing idiom in that class), so the pinned struct offsets are verified
  without a Mac.

Runs (Windows host, Python 3.13, 16 xdist workers), each repeated 4×:

```
pytest test/test_acp_client.py -q         -> 549 passed, 30 skipped   (0/4 failed)
# same command with test/test_acp_client.py reverted to origin/main:
pytest test/test_acp_client.py -q         -> 544 passed, 30 skipped   (0/4 failed)
pytest test/test_acp_liveness.py test/test_platform_compat.py -q
                                          -> 272 passed, 55 skipped
python scripts/check_black_formatting.py  -> black gate passed
python -m flake8 <touched files>          -> clean
```

The second run is the one that mattered. An earlier revision of this PR made
`test_real_oracle_movement_defers_via_fake_proc` — main's own unmodified test —
fail 3 of 6 full-file runs (base: 1 of 6), and this description previously called
that a pre-existing flake. That was wrong: the test's 50 ms budget was being
consumed by the client's own cold liveness walk, so the change made a real latent
defect reproducible. Cause 3 above is the fix, and with it both runs above are
green 4/4.

## Manual verification

N/A — the failing behavior is a timing branch inside `_prompt_loop` and a platform
branch inside the oracle, both driven directly by the tests above (including one
that exercises the real oracle over a fake procfs rather than a mocked verdict).
Reproducing it by hand needs a macOS host plus a backend that stays silent for
100s mid-tool, which the parametrized tests substitute for exactly.

## Related Issues

Refs #8520

## Pattern harvest

Rule candidate: review-prompt
Pattern: a probe whose answer can be "I cannot tell" must not have that answer
consumed as a negative verdict by a caller whose negative branch destroys work —
check the not-yet-primed, unsupported-platform and probe-still-running cases, and
never charge the probe's own latency to the budget it is measuring.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
