### PR TITLE
fix(test): give the slot-race request double the aiohttp surface

### DIFF
--- a/test/test_slot_close_recreation_race.py
+++ b/test/test_slot_close_recreation_race.py
@@ -78,11 +78,24 @@ class _Req:
     def __init__(self, state, slot: str = NAME, body: dict | None = None) -> None:
         self.app = {"state": state}
         self.match_info = {"slot": slot}
+        self._has_body = body is not None
         self._body = body if body is not None else {}
 
     def get(self, key: str, default: str = "") -> str:
         del key
         return default
+
+    @property
+    def can_read_body(self) -> bool:
+        """Mirror ``aiohttp.web.BaseRequest.can_read_body``: unread body pending.
+
+        Every caller in this file omits ``body``, so the double must report the
+        same "nothing to read" outcome the real request would for a bodyless
+        request — that is what lets ``read_bounded_json(..., allow_absent=True)``
+        take its empty-object path instead of raising on a stand-in that never
+        modeled this property.
+        """
+        return self._has_body
 
     async def json(self) -> dict:
         return self._body


### PR DESCRIPTION
no linked issue: main-wide CI red on `CI / Backend Tests (Windows) (4)`

## Root cause

`test/test_slot_close_recreation_race.py`'s hand-rolled `_Req` request double
never modeled `can_read_body`. Commit 9975f3d54 ("one owner for the JSON-object
body guard") consolidated the allow-absent-body check into
`read_bounded_json()`:

```python
if allow_absent and not request.can_read_body:
    return {}, None
```

Every call through `api_chat_slots_cleanup` in this file now raises inside the
handler:

```
src\kiro_crew\dashboard\handlers\_shared.py:142: in read_bounded_json
    if allow_absent and not request.can_read_body:
E   AttributeError: '_Req' object has no attribute 'can_read_body'
```

That single crash surfaces as three different CI signatures depending on
scheduling, all traced to the same run:

- The `AttributeError` itself.
- `[gwN] node down: Not properly terminated` / `worker gwN crashed and worker
  restarting disabled` — the crashed worker process dies mid-test under
  `-n auto`.
- `Failed: Timeout >120.0s` — reproduced locally by reverting this fix and
  re-running the identical test under `-n0`; it hung for exactly 120s instead
  of raising (something downstream of the handler's crash never gets the
  event it was waiting on).

`can_read_body` is genuine, long-standing `aiohttp.web.BaseRequest` API
(`not self._payload.at_eof()`), not a version drift — the regression is
entirely on this repo's side: the body-guard sweep added a new required
surface to a shared helper without updating this file's stand-in.

## Fix

Add `can_read_body` to `_Req`, true only when the double is constructed with
an explicit `body`. Every call site in this file omits `body`, so the double
now reports "nothing to read" and `read_bounded_json` takes its
`allow_absent` empty-object path, matching pre-sweep behavior.

## Verification

- Reverted the fix and reran the previously-hanging test under `-n0`: hung at
  `Timeout >120.0s`, confirmed same root cause as the xdist crash signature.
- Restored the fix: same test passes in 0.01s.
- `test/test_slot_close_recreation_race.py` under the repo's exact CI
  addopts (`-n auto --dist loadgroup --max-worker-restart=2`): 42/42 passed.
- `test/test_slot_close_recreation_race.py` + 3 sibling files touching the
  same body-guard path (`test_slot_close_nudge_race.py`,
  `test_read_bounded_json.py`, `test_json_object_body_guard.py`): 130/130
  passed.
- black, isort, flake8, mypy on the changed file: all clean.

## Pattern harvest

Rule candidate: when a shared helper widens the surface it requires of a caller-supplied object, sweep every hand-rolled test double of that object in the same change - a stand-in missing the new attribute fails later, on another branch, under three different signatures.


- **Pattern**: a shared helper sweep (one owner for a cross-cutting guard)
  widened the required surface of the object every caller passes in, but
  test files construct that object as a hand-rolled stand-in rather than
  through a shared fixture — so the sweep's own test suite passed while a
  sibling file with an independent copy of the stand-in silently gained a
  crash.
- **Where else this shape exists**: at least 19 test files under `test/`
  define their own `class _Req`/request double independently (no shared
  helper), so a future required-surface addition to `read_bounded_json` or
  any handler these doubles feed could reproduce this same class of failure
  in a different file. Not fixed here — out of scope for a single red-CI
  heal — but worth a follow-up to give these doubles one shared definition.

