### PR TITLE
fix(cron): scan Python script bodies with source detectors, not shell heuristic

### DIFF
--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -266,9 +266,18 @@ for credential exfiltration by `mcp_cron._vet_script_contents`, because
 `mode="standard"` (which does not hide `~/.aws`). The body is scanned with
 **source-appropriate detectors**: `_CRON_CRED_PATH_RE` (a credential-file path
 such as `~/.aws/credentials`, `.ssh/id_rsa`, `/home/u/.netrc`),
+`_CRON_WIN_IDENTITY_STORE_RE` (the Windows env-var spelling of the kiro-cli /
+amazon-q identity stores, e.g. `%LOCALAPPDATA%\kiro-cli\data.sqlite3` /
+`%APPDATA%\amazon-q\...`, which `_CRON_CRED_PATH_RE`'s POSIX `/`-anchored form
+does not reach — derived from the canonical `identity_stores` table so it stays
+in sync with the shell tier's fence),
 `_CRON_SECRET_ENV_RE` / `_CRON_SECRET_NAME_RE` (a protected secret env var,
 including bare-name `os.environ["AWS_SECRET_ACCESS_KEY"]` access), and
-`scan_exfiltration_urls`. The shell-grammar heuristic (`is_sensitive_bash_command`)
+`scan_exfiltration_urls`. `_CRON_WIN_IDENTITY_STORE_RE` matches an ACCESS (a
+path segment UNDER the store) and NOT a bare mention of the store directory, so
+a benign redaction regex naming the store (`re.compile(r"%LOCALAPPDATA%\kiro-cli")`
+— the original #7912 false positive) stays allowed while a read of a file inside
+the store is blocked. The shell-grammar heuristic (`is_sensitive_bash_command`)
 is deliberately **scoped**: it runs only over a body that does NOT parse as
 Python (`ast.parse` raises `SyntaxError`, or any other unexpected parse error —
 fail-CLOSED), so a raw shell script masquerading as a script file is still

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -277,7 +277,21 @@ including bare-name `os.environ["AWS_SECRET_ACCESS_KEY"]` access), and
 path segment UNDER the store) and NOT a bare mention of the store directory, so
 a benign redaction regex naming the store (`re.compile(r"%LOCALAPPDATA%\kiro-cli")`
 — the original #7912 false positive) stays allowed while a read of a file inside
-the store is blocked. The shell-grammar heuristic (`is_sensitive_bash_command`)
+the store is blocked. Its separator runs accept both `\` and `/`
+(`[\\/]+`), so the forward-slash and mixed-separator spellings of the same
+store read (`%LOCALAPPDATA%/kiro-cli/data.sqlite3`, `%LOCALAPPDATA%\kiro-cli/...`)
+are caught too, matching every separator form the base-HEAD shell tier blocked.
+Two limitations are deliberate. The ACCESS-vs-mention line is drawn on **syntax**
+(is there a trailing segment after the product dir?), not intent: a benign
+redaction regex that anchors *under* the store
+(`re.compile(r"%LOCALAPPDATA%\kiro-cli\S+")`) reads as an access and is blocked,
+because a static source-side pattern cannot distinguish a subtree-matching
+redaction regex from a real read without also letting a genuine
+`%VAR%\product\file` read through; a body that needs to redact under the store
+should anchor on the POSIX store spelling or omit the trailing metacharacter. And
+the detector recognizes only the `%VAR%` / `!VAR!` / `$env:VAR` env-var spellings
+of these two stores — a read of the store via an already-resolved absolute
+Windows path is out of scope for this source detector. The shell-grammar heuristic (`is_sensitive_bash_command`)
 is deliberately **scoped**: it runs only over a body that does NOT parse as
 Python (`ast.parse` raises `SyntaxError`, or any other unexpected parse error —
 fail-CLOSED), so a raw shell script masquerading as a script file is still
@@ -287,9 +301,13 @@ collapse turns a Python backslash ESCAPE (e.g. the raw-string regex
 `r"%LOCALAPPDATA%\kiro-cli"`) into a manufactured credential path, and its
 fail-closed stage/substitution budgets (`_ALT_MAX_STAGES`,
 `_FIND_SUBSTITUTION_BUDGET`) trip on file SIZE because every source line is
-counted as a pipeline stage. A parseable Python body is fully covered by the
-source-appropriate detectors above (which independently catch every credential
-read / secret-env / exfil case). The command-line surface
+counted as a pipeline stage. A parseable Python body is covered by the
+source-appropriate detectors above: they independently catch the credential-file
+reads, the protected secret-env references, the exfiltration URLs, and — after
+the `[\\/]+` separator generalization — every separator spelling of the Windows
+env-var identity-store read that the base-HEAD shell scan blocked. The coverage
+is scoped to those source-appropriate detectors, not the full shell-word grammar
+(see the ACCESS-vs-mention limitation above). The command-line surface
 (`is_sensitive_bash_command` over a real shell `command`) keeps the collapse and
 the budgets unchanged.
 

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -258,6 +258,32 @@ Deterministic cron jobs that bypass the LLM entirely:
 - **Safety**: scripts must live under `~/.kiro/crew/crons/`. `is_sensitive_path()` blocks credential file access. SEL audit on every invocation. Auto-pause after 5 consecutive failures (`_AUTO_PAUSE_THRESHOLD`, single-sourced in `CronJob.record_failure`/`record_success`). The auto-pause is **persistent**: an execution-owned `auto_paused` flag (distinct from `user_paused`) is written by `_save`, propagated by `_merge_job_result`, and folded into the effective `enabled` derivation in `_load` — so a failing job stays paused across a daemon restart; `enable_job(True)` or a later success clears it (SEL-audited transitions). Concurrent execution guard prevents double-fire.
 - **Kind tag**: `cron_list` labels each job as `script`, `command`, or `agent` based on which mode is configured.
 
+#### Script-body credential scan (`_vet_script_contents`)
+
+At authoring time (and re-checked at fire time) a `script` job's BODY is scanned
+for credential exfiltration by `mcp_cron._vet_script_contents`, because
+`resolve_script_path` validates only the *path* and the script runs under
+`mode="standard"` (which does not hide `~/.aws`). The body is scanned with
+**source-appropriate detectors**: `_CRON_CRED_PATH_RE` (a credential-file path
+such as `~/.aws/credentials`, `.ssh/id_rsa`, `/home/u/.netrc`),
+`_CRON_SECRET_ENV_RE` / `_CRON_SECRET_NAME_RE` (a protected secret env var,
+including bare-name `os.environ["AWS_SECRET_ACCESS_KEY"]` access), and
+`scan_exfiltration_urls`. The shell-grammar heuristic (`is_sensitive_bash_command`)
+is deliberately **scoped**: it runs only over a body that does NOT parse as
+Python (`ast.parse` raises `SyntaxError`, or any other unexpected parse error —
+fail-CLOSED), so a raw shell script masquerading as a script file is still
+covered. It is NOT run over a body that parses as Python, because its shell-word
+grammar false-positives on ordinary source two ways: pass 1b's separator-run
+collapse turns a Python backslash ESCAPE (e.g. the raw-string regex
+`r"%LOCALAPPDATA%\kiro-cli"`) into a manufactured credential path, and its
+fail-closed stage/substitution budgets (`_ALT_MAX_STAGES`,
+`_FIND_SUBSTITUTION_BUDGET`) trip on file SIZE because every source line is
+counted as a pipeline stage. A parseable Python body is fully covered by the
+source-appropriate detectors above (which independently catch every credential
+read / secret-env / exfil case). The command-line surface
+(`is_sensitive_bash_command` over a real shell `command`) keeps the collapse and
+the budgets unchanged.
+
 #### Auto-pause applies to `agent` (message) crons too
 
 Auto-pause is not script/command-only. An `agent` cron's turn signals failure

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -14,6 +14,7 @@ Tools:
 
 from __future__ import annotations
 
+import ast
 import fnmatch
 import logging
 import os
@@ -765,7 +766,11 @@ def _vet_script_contents(text: str) -> str | None:
     that false-positive on ordinary Python source, and destructive-op risk is
     covered by the now-required ``cron_add`` approval prompt. Credential
     exfiltration — which a human rubber-stamping the prompt would not catch — is
-    the threat this gate closes.
+    the threat this gate closes. For the same reason the shell-grammar scan
+    (``is_sensitive_bash_command``) is applied only to a body that does NOT parse
+    as Python; a parseable Python body is left to the source-appropriate
+    credential/secret/exfil detectors, because the shell-grammar passes
+    false-positive on Python source (see the inline comment on the scan below).
     """
     if _CRON_CRED_PATH_RE.search(text):
         return (
@@ -774,10 +779,40 @@ def _vet_script_contents(text: str) -> str | None:
         )
     if _CRON_SECRET_ENV_RE.search(text) or _CRON_SECRET_NAME_RE.search(text):
         return "Error: cron script blocked: references a protected secret environment variable"
-    reason = is_sensitive_bash_command(text)
-    if reason:
-        safe_reason = redact(reason)
-        return f"Error: cron script blocked by security policy: {safe_reason}"
+    # Scope the shell-grammar scan (is_sensitive_bash_command) to bodies that do
+    # NOT parse as Python. is_sensitive_bash_command applies shell-word grammar:
+    # pass 1b collapses separator RUNS (correct for a Win32 shell path, but a
+    # backslash run in Python source is an ESCAPE, so the collapse manufactures a
+    # credential path out of e.g. a raw-string regex r"%LOCALAPPDATA%\kiro-cli"),
+    # and its fail-closed structural budgets (_ALT_MAX_STAGES / _FIND_SUBSTITUTION
+    # _BUDGET) stage the text on newline/;/| so a long-but-benign source file is
+    # refused on SIZE alone (every line counted as a pipeline stage). None of
+    # that grammar describes Python source, so running it over a parseable body
+    # is the same category error the docstring above rejects for is_denied: a
+    # shell-grammar heuristic is wrong for a source subject. A parseable body is
+    # instead covered by the source-appropriate detectors run above
+    # (_CRON_CRED_PATH_RE / _CRON_SECRET_ENV_RE / _CRON_SECRET_NAME_RE) and the
+    # exfil scan below, which independently catch the credential-read /
+    # secret-env / exfiltration threats this gate exists to close. We keep the
+    # raw-text shell-grammar scan ONLY as a fail-CLOSED fallback for a body that
+    # does not parse as Python (ast.parse SyntaxError) or that trips any other
+    # unexpected parse error — so a non-Python body (e.g. a raw shell script) is
+    # never quietly exonerated.
+    try:
+        ast.parse(text)
+        parses_as_python = True
+    except SyntaxError:
+        parses_as_python = False
+    except Exception:
+        # Any non-SyntaxError parse failure (e.g. a pathological RecursionError
+        # from a deeply nested body) fails CLOSED to the raw-text scan rather
+        # than crashing the vetting gate / MCP call.
+        parses_as_python = False
+    if not parses_as_python:
+        reason = is_sensitive_bash_command(text)
+        if reason:
+            safe_reason = redact(reason)
+            return f"Error: cron script blocked by security policy: {safe_reason}"
     exfil = scan_exfiltration_urls(text)
     if exfil:
         safe = redact("; ".join(exfil))

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -39,6 +39,7 @@ from kiro_crew.cron import (
 )
 from kiro_crew.cron_script import resolve_script_path
 from kiro_crew.cron_trigger import _JOB_ID_RE, trigger_cron_job
+from kiro_crew.identity_stores import IDENTITY_STORE_ROOTS, Platform
 from kiro_crew.mcp_caller import current_caller
 from kiro_crew.mcp_core import (
     _resolve_session_key,
@@ -98,6 +99,64 @@ _CRON_CRED_PATH_RE = re.compile(
     r"(?:/|\s|['\"]|$)",
     re.IGNORECASE,
 )
+
+
+def _win_identity_store_access_re() -> re.Pattern[str]:
+    """Compile the Windows env-var identity-store ACCESS pattern.
+
+    Windows env-var spelling of the kiro-cli / amazon-q identity stores, e.g.
+    ``%LOCALAPPDATA%\\kiro-cli\\data.sqlite3`` or ``%APPDATA%\\amazon-q\\data.sqlite3``.
+    ``_CRON_CRED_PATH_RE`` only anchors POSIX ``/``-separated paths (via
+    ``_SENSITIVE_HOME_DIRS``), so the ``%VAR%``-plus-backslash form was
+    previously caught for a SCRIPT BODY only by the whole-body shell-grammar scan
+    (``is_sensitive_bash_command``, security.py's %LOCALAPPDATA%/!LOCALAPPDATA!
+    alternation ~L7568). Scoping that scan to non-parsing bodies dropped this one
+    spelling for a parseable Python body, so this source-side detector restores
+    it WITHOUT re-enabling the fail-open shell scan over source.
+
+    Derived from the single canonical store table (``identity_stores``) so it
+    cannot drift from the fence the shell tier enforces: the SAME Windows env
+    vars (LOCALAPPDATA / APPDATA) and the SAME product store names (kiro-cli /
+    amazon-q), mirroring security.py's own table-derived pattern. The var
+    alternation matches ``%VAR%`` / ``%VAR:mod%``, cmd.exe delayed expansion
+    ``!VAR!`` / ``!VAR:mod!``, and the PowerShell ``$env:VAR`` / ``${env:VAR}``
+    spellings, exactly as the shell tier does.
+
+    Crucially this matches an ACCESS (a path segment UNDER the store: at least
+    one more ``\\``-separated component after the product dir), NOT a bare
+    mention of the store directory. That distinction is deliberate and
+    load-bearing: the original #7912 false positive this whole change fixed was a
+    benign REDACTION regex ``re.compile(r"%LOCALAPPDATA%\\kiro-cli")`` that NAMES
+    the store dir without reading anything under it, and it must stay allowed.
+    Requiring a trailing segment reads a store-dir mention as benign and a read
+    of a file inside the store as the credential access it is. Backslash RUNS
+    (``\\+``) absorb the doubled backslash a raw-string source literal carries,
+    so both the source spelling and the resolved single-backslash spelling match.
+    """
+    win_rows = [r for r in IDENTITY_STORE_ROOTS if r.platform is Platform.WIN32]
+    env_vars = sorted({r.env_var for r in win_rows if r.env_var})
+    products = sorted({r.home_relative_dir.rsplit("/", 1)[-1] for r in win_rows})
+    var_alt = "|".join(
+        (
+            rf"%{name}(?::[^%\s]*)?%"
+            rf"|!{name}(?::[^!\s]*)?!"
+            rf"|{re.escape('$env:' + name)}"
+            rf"|{re.escape('${env:' + name + '}')}"
+        )
+        for name in env_vars
+    )
+    prod_alt = "|".join(re.escape(p) for p in products)
+    return re.compile(
+        r"(?:" + var_alt + r")"
+        r"\\+"  # backslash run: absorbs a raw-string source escape's doubled ``\``
+        r"(?:" + prod_alt + r")"
+        r"\\+"  # a SEPARATOR + ...
+        r"\S",  # ... at least one more segment char: an ACCESS, not a bare mention
+        re.IGNORECASE,
+    )
+
+
+_CRON_WIN_IDENTITY_STORE_RE = _win_identity_store_access_re()
 # Protected secret env vars a cron command must not read by name. Union of the
 # sandbox-scrubbed agent keys (Slack tokens, owner id) and well-known cloud /
 # source-control credential env vars. The sandbox strips _AGENT_DENIED_ENV_KEYS
@@ -772,7 +831,7 @@ def _vet_script_contents(text: str) -> str | None:
     credential/secret/exfil detectors, because the shell-grammar passes
     false-positive on Python source (see the inline comment on the scan below).
     """
-    if _CRON_CRED_PATH_RE.search(text):
+    if _CRON_CRED_PATH_RE.search(text) or _CRON_WIN_IDENTITY_STORE_RE.search(text):
         return (
             "Error: cron script blocked: references a credential path "
             "(e.g. .aws/.ssh/.netrc). Cron scripts may not read credential files."
@@ -791,7 +850,8 @@ def _vet_script_contents(text: str) -> str | None:
     # is the same category error the docstring above rejects for is_denied: a
     # shell-grammar heuristic is wrong for a source subject. A parseable body is
     # instead covered by the source-appropriate detectors run above
-    # (_CRON_CRED_PATH_RE / _CRON_SECRET_ENV_RE / _CRON_SECRET_NAME_RE) and the
+    # (_CRON_CRED_PATH_RE / _CRON_WIN_IDENTITY_STORE_RE / _CRON_SECRET_ENV_RE /
+    # _CRON_SECRET_NAME_RE) and the
     # exfil scan below, which independently catch the credential-read /
     # secret-env / exfiltration threats this gate exists to close. We keep the
     # raw-text shell-grammar scan ONLY as a fail-CLOSED fallback for a body that

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -123,15 +123,31 @@ def _win_identity_store_access_re() -> re.Pattern[str]:
     spellings, exactly as the shell tier does.
 
     Crucially this matches an ACCESS (a path segment UNDER the store: at least
-    one more ``\\``-separated component after the product dir), NOT a bare
+    one more separator-delimited component after the product dir), NOT a bare
     mention of the store directory. That distinction is deliberate and
     load-bearing: the original #7912 false positive this whole change fixed was a
     benign REDACTION regex ``re.compile(r"%LOCALAPPDATA%\\kiro-cli")`` that NAMES
     the store dir without reading anything under it, and it must stay allowed.
     Requiring a trailing segment reads a store-dir mention as benign and a read
-    of a file inside the store as the credential access it is. Backslash RUNS
-    (``\\+``) absorb the doubled backslash a raw-string source literal carries,
-    so both the source spelling and the resolved single-backslash spelling match.
+    of a file inside the store as the credential access it is. The separator
+    runs (``[\\/]+``) absorb the doubled backslash a raw-string source literal
+    carries, a resolved single ``\\``, and a POSIX/mixed ``/`` spelling, so every
+    separator form the base-HEAD shell tier blocked is matched here.
+
+    DELIBERATE LIMITATION (v2 review ISSUE 2): the ACCESS-vs-mention line is
+    drawn on SYNTAX (is there a trailing segment after the product dir?), not on
+    intent. A static source-side pattern cannot reliably tell a benign redaction
+    regex that ANCHORS under the store (e.g. ``re.compile(r"%LOCALAPPDATA%\\
+    kiro-cli\\S+")``) from an actual read of a file under the store. We keep
+    blocking the access-shaped spelling: the task's PRIMARY invariant is that the
+    #7912 false positive (a redaction/mention of the store DIR itself) is not
+    re-blocked, and that plain-mention case (no trailing segment) stays allowed
+    here. A redaction regex that reaches UNDER a Windows store is a rare body,
+    and it has a safe rewrite: anchor the redaction on the POSIX spelling of the
+    store path, or drop the trailing metacharacter. Narrowing the detector to let
+    such an under-store regex through would also let a real ``%VAR%\\product\\
+    file`` read through, giving up the coverage that closed the v1 gap. So the
+    conservative (block) direction is chosen and pinned by a test.
     """
     win_rows = [r for r in IDENTITY_STORE_ROOTS if r.platform is Platform.WIN32]
     env_vars = sorted({r.env_var for r in win_rows if r.env_var})
@@ -148,9 +164,15 @@ def _win_identity_store_access_re() -> re.Pattern[str]:
     prod_alt = "|".join(re.escape(p) for p in products)
     return re.compile(
         r"(?:" + var_alt + r")"
-        r"\\+"  # backslash run: absorbs a raw-string source escape's doubled ``\``
+        # Separator run accepts BOTH ``\`` and ``/``: a raw-string source escape
+        # carries a doubled backslash, a Win32 path uses ``\``, and the shell
+        # tier at base HEAD (security.py's generalized win_gsep) also blocked the
+        # forward-slash and mixed-separator spellings of the SAME store read
+        # (``%LOCALAPPDATA%/kiro-cli/data.sqlite3`` and ``\kiro-cli/...``). Using
+        # ``[\\/]+`` on both separators fully restores that base-HEAD coverage.
+        r"[\\/]+"
         r"(?:" + prod_alt + r")"
-        r"\\+"  # a SEPARATOR + ...
+        r"[\\/]+"  # a SEPARATOR + ...
         r"\S",  # ... at least one more segment char: an ACCESS, not a bare mention
         re.IGNORECASE,
     )

--- a/test/test_mcp_cron_security.py
+++ b/test/test_mcp_cron_security.py
@@ -500,6 +500,19 @@ def test_command_surface_shell_grammar_unchanged():
         'import subprocess\nsubprocess.run(r"type %APPDATA%\\\\kiro-cli\\\\data.sqlite3")\n',
         # cmd.exe delayed-expansion ``!LOCALAPPDATA!`` spelling.
         'import subprocess\nsubprocess.run(r"copy !LOCALAPPDATA!\\\\kiro-cli\\\\data.sqlite3 x")\n',
+        # v2 review ISSUE 1: FORWARD-SLASH separator spelling. The base-HEAD shell
+        # tier blocked ``%LOCALAPPDATA%/kiro-cli/data.sqlite3`` too, so the source
+        # detector must accept ``/`` as well as ``\`` to fully restore coverage.
+        'import subprocess\nsubprocess.run("cat %LOCALAPPDATA%/kiro-cli/data.sqlite3")\n',
+        # v2 review ISSUE 1: MIXED separator spelling (``\kiro-cli/...``).
+        'import subprocess\nsubprocess.run("cat %LOCALAPPDATA%\\\\kiro-cli/data.sqlite3")\n',
+        # v2 review ISSUE 2 (chosen direction: block): a redaction regex that
+        # ANCHORS under the store reads as an ACCESS to this syntactic rule and is
+        # blocked. This is deliberate — a static pattern cannot distinguish a
+        # subtree-matching redaction regex from a real read; the workaround is to
+        # anchor the redaction on the POSIX store spelling. The plain store-DIR
+        # mention (no trailing segment) stays allowed (see the mention test).
+        'import re\nS = re.compile(r"%LOCALAPPDATA%\\\\kiro-cli\\\\S+")\n',
     ],
 )
 def test_vet_script_contents_blocks_windows_identity_store_access(body):
@@ -524,6 +537,10 @@ def test_vet_script_contents_allows_windows_identity_store_mention():
     # Store dir named, no path segment under it: allowed.
     assert _vet_script_contents('import re\nS = re.compile(r"%LOCALAPPDATA%\\\\kiro-cli")\n') is None
     assert _vet_script_contents('import re\nS = re.compile(r"%APPDATA%\\\\amazon-q")\n') is None
+    # v2 review ISSUE 1: a FORWARD-SLASH bare mention (no segment under the store)
+    # must also stay allowed — generalizing the separator to ``[\\/]+`` must not
+    # re-block a plain store-dir reference spelled with ``/``.
+    assert _vet_script_contents('import re\nS = re.compile(r"%LOCALAPPDATA%/kiro-cli")\n') is None
 
 
 def test_vet_script_contents_nonsyntax_parse_error_falls_closed(monkeypatch):

--- a/test/test_mcp_cron_security.py
+++ b/test/test_mcp_cron_security.py
@@ -32,6 +32,7 @@ from kiro_crew.mcp_cron import (
     _vet_script_file,
     _vet_shell_command,
 )
+from kiro_crew.security import is_sensitive_bash_command
 
 # ── Fix 1: command deny-list (pure function) ──────────────────────────────
 
@@ -432,6 +433,21 @@ BENIGN_SCRIPTS = [
     "import subprocess\ndef run(ctx):\n    subprocess.run(['git','push'])\n",
     "import os\nr=os.environ.get('AWS_REGION','us-east-1')\n",
     "import urllib.request\nurllib.request.urlopen('https://api.example.com/status')\n",
+    # Issue #7912 reproduction bodies. These are all valid Python source that the
+    # old whole-file shell-grammar scan (is_sensitive_bash_command) falsely
+    # denied:
+    #   - a long-but-benign body tripped the fail-closed stage budget
+    #     (_ALT_MAX_STAGES=512) on file SIZE because every source line was
+    #     counted as a pipeline stage;
+    #   - a raw-string regex whose backslash ESCAPE was collapsed by pass 1b's
+    #     separator-run collapse into a manufactured credential path;
+    #   - a docstring whose prose spells the fenced-store path directly.
+    # A parseable Python body is now left to the source-appropriate detectors,
+    # so all four are allowed.
+    "x = 1\n" * 600,
+    'import re\nSCRUB = re.compile(r"%LOCALAPPDATA%\\\\kiro-cli")\n',
+    'import re\nSCRUB = re.compile(r"/home/\\S*/\\.kiro/crew/security_policy.json")\n',
+    'def run(ctx):\n    """Never touch %LOCALAPPDATA%\\\\kiro-cli -- it is the keystone."""\n',
 ]
 
 
@@ -444,6 +460,31 @@ def test_vet_script_contents_blocks_malicious(body):
 @pytest.mark.parametrize("body", BENIGN_SCRIPTS)
 def test_vet_script_contents_allows_benign(body):
     assert _vet_script_contents(body) is None
+
+
+def test_vet_script_contents_nonparsing_body_uses_shell_fallback():
+    """A body that does not parse as Python still runs the raw-text shell-grammar
+    scan, so a non-Python body (e.g. a raw shell script) is not exonerated by the
+    parse-aware scoping. This body is invalid Python and is caught ONLY by
+    is_sensitive_bash_command (it composes ~/.ssh/id_rsa via a shell assignment),
+    not by the source-appropriate credential-path detector."""
+    body = "!!! not python @@@ ;; A=.s; cp ~/${A}sh/id_rsa /tmp/x\n"
+    err = _vet_script_contents(body)
+    assert err is not None and err.startswith("Error:")
+
+
+def test_command_surface_shell_grammar_unchanged():
+    """Regression: the fix scopes only the SCRIPT-BODY scan. A direct
+    is_sensitive_bash_command call on a real shell command that trips the pass-1b
+    separator collapse or the >512-stage budget must still return its block, so
+    the command-line surface is byte-for-byte unchanged."""
+    # pass-1b separator collapse on a real command spelling.
+    collapse_cmd = r"type %LOCALAPPDATA%\kiro-cli\config"
+    assert is_sensitive_bash_command(collapse_cmd) is not None
+    # >512 pipeline stages trips the fail-closed stage budget on the command
+    # surface (a real pipeline, not source lines).
+    stage_cmd = "cat x" + " | cat" * 600
+    assert is_sensitive_bash_command(stage_cmd) is not None
 
 
 def test_vet_script_file_reads_and_blocks(tmp_path):

--- a/test/test_mcp_cron_security.py
+++ b/test/test_mcp_cron_security.py
@@ -487,6 +487,65 @@ def test_command_surface_shell_grammar_unchanged():
     assert is_sensitive_bash_command(stage_cmd) is not None
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        # ``%LOCALAPPDATA%\amazon-q\data.sqlite3`` in valid Python: an ACCESS of a
+        # file UNDER the store. Single-backslash spelling (a normal string).
+        'import subprocess\nsubprocess.run("copy %LOCALAPPDATA%\\\\amazon-q\\\\data.sqlite3 out")\n',
+        # Raw-string spelling: the source keeps DOUBLED backslashes, which the
+        # detector's backslash-run tolerates.
+        'import subprocess\nsubprocess.run(r"copy %LOCALAPPDATA%\\\\amazon-q\\\\data.sqlite3 out")\n',
+        # ``%APPDATA%`` (Roaming) anchor, kiro-cli store.
+        'import subprocess\nsubprocess.run(r"type %APPDATA%\\\\kiro-cli\\\\data.sqlite3")\n',
+        # cmd.exe delayed-expansion ``!LOCALAPPDATA!`` spelling.
+        'import subprocess\nsubprocess.run(r"copy !LOCALAPPDATA!\\\\kiro-cli\\\\data.sqlite3 x")\n',
+    ],
+)
+def test_vet_script_contents_blocks_windows_identity_store_access(body):
+    """Regression for the v1 review coverage gap: a valid-Python body that reads a
+    file UNDER a kiro-cli / amazon-q identity store via the Windows env-var path
+    spelling (``%LOCALAPPDATA%\\<product>\\data.sqlite3``) was blocked at base HEAD
+    by the whole-body shell-grammar scan and must stay blocked now that that scan
+    is scoped to non-parsing bodies. ``_CRON_CRED_PATH_RE`` only anchors POSIX
+    paths, so ``_CRON_WIN_IDENTITY_STORE_RE`` restores this one spelling on the
+    source-detector layer without re-enabling the shell scan over source."""
+    err = _vet_script_contents(body)
+    assert err is not None and err.startswith("Error:")
+
+
+def test_vet_script_contents_allows_windows_identity_store_mention():
+    """The distinction the source-side detector draws: a bare MENTION of a store
+    directory (``%LOCALAPPDATA%\\kiro-cli`` with nothing under it) is a benign
+    redaction/prose reference and stays ALLOWED, while an ACCESS of a file under
+    it is blocked (see test above). This is the exact #7912 false positive the
+    whole task fixed -- a benign REDACTION regex naming the store dir -- so it
+    must NOT be re-blocked by the new detector."""
+    # Store dir named, no path segment under it: allowed.
+    assert _vet_script_contents('import re\nS = re.compile(r"%LOCALAPPDATA%\\\\kiro-cli")\n') is None
+    assert _vet_script_contents('import re\nS = re.compile(r"%APPDATA%\\\\amazon-q")\n') is None
+
+
+def test_vet_script_contents_nonsyntax_parse_error_falls_closed(monkeypatch):
+    """The ``except Exception`` (non-``SyntaxError``) branch of the parse-aware
+    scoping must fail CLOSED to the raw-text shell scan, not crash the gate. A
+    pathological body can make ``ast.parse`` raise something other than
+    ``SyntaxError`` (e.g. ``RecursionError``); when it does, the body is treated
+    as non-parsing and the raw-text ``is_sensitive_bash_command`` fallback still
+    runs, so a shell credential read is not quietly exonerated."""
+    import kiro_crew.mcp_cron as mcp_cron
+
+    def _boom(*_args, **_kwargs):
+        raise RecursionError("simulated deep-nesting parse failure")
+
+    monkeypatch.setattr(mcp_cron.ast, "parse", _boom)
+    # Caught only by the shell scan (composes ~/.ssh/id_rsa via a shell
+    # assignment); the source-appropriate detectors do not match it.
+    body = "!!! not python @@@ ;; A=.s; cp ~/${A}sh/id_rsa /tmp/x\n"
+    err = _vet_script_contents(body)
+    assert err is not None and err.startswith("Error:")
+
+
 def test_vet_script_file_reads_and_blocks(tmp_path):
     f = tmp_path / "evil.py"
     f.write_text("import os\nopen(os.path.expanduser('~/.aws/credentials')).read()\n")


### PR DESCRIPTION
Fixes #7912.

## Problem

`mcp_cron._vet_script_contents` scanned a cron script **body** (Python source) by running `security.is_sensitive_bash_command` over the raw whole file. That is a shell-grammar heuristic, and it falsely denied benign Python source two ways:

1. **Pass 1b separator-run collapse** turns a source backslash *escape* into a manufactured credential path. `re.compile(r"%LOCALAPPDATA%\\kiro-cli")`, a regex literal `r"/home/\S*/\.kiro/..."`, and even a docstring mentioning a store were all denied as though they *read* a credential path.
2. **Fail-closed structural budgets** (`_ALT_MAX_STAGES=512`, `_FIND_SUBSTITUTION_BUDGET=64`) trip on file **size**, because `_alt_collect_stages` treats every source line as a pipeline stage. A few hundred lines of ordinary Python exceed 512 stages with no shell content, so the job is refused on every tick indefinitely (the fire-time gate keeps the job and does not feed the auto-pause counter).

Note: PR #7913 (referenced in the issue thread) is **not merged** into current `main`; there is no `subject_is_shell_grammar` flag or literal-walk vehicle present, so this fix was built from scratch.

## Fix

Scope the shell-grammar scan to the surface it is designed for. `_vet_script_contents` now:
- Runs `is_sensitive_bash_command` **only on a body that does NOT parse as Python** (via `ast.parse`). `SyntaxError` and any other parse error fail **closed** to the raw-text scan, so a non-Python body is never exonerated.
- A parseable Python body relies on the source-appropriate detectors already present (`_CRON_CRED_PATH_RE`, `_CRON_SECRET_ENV_RE`, `_CRON_SECRET_NAME_RE`, exfiltration URL scan), which independently catch every existing malicious script.
- Adds `_CRON_WIN_IDENTITY_STORE_RE`, a table-derived detector (built from `identity_stores.IDENTITY_STORE_ROOTS` WIN32 rows) that restores blocking of the Windows env-var identity-store **access** spelling (`%LOCALAPPDATA%`/`%APPDATA%`, `kiro-cli`/`amazon-q`) across backslash, forward-slash and mixed separators, while a bare store-dir **mention** stays allowed.

`security.py` is **intentionally not modified**, so the command-line surface (pass 1b collapse + both budgets) is byte-for-byte unchanged. This avoids the fail-open direction the issue explicitly warned against (exempting a source subject from the budgets would let budget exhaustion re-express as "inspect less").

## Testing

- All four issue reproductions now return `None` from `_vet_script_contents` (the `"x = 1\n" * 600` size body and the three pass-1b bodies).
- The primary #7912 invariant holds: a benign store mention `re.compile(r"%LOCALAPPDATA%\\kiro-cli")` stays allowed.
- All must-stay-blocked bodies still blocked (POSIX credential read, `AWS_SECRET_ACCESS_KEY` exfil, `/home/u/.netrc`); a non-parsing body containing a shell credential read is still blocked via the raw-text fallback (incl. non-`SyntaxError` parse errors, pinned by a monkeypatch test).
- A command-surface regression test asserts `is_sensitive_bash_command` still blocks a real `%LOCALAPPDATA%` command and a >512-stage pipeline.
- `pytest test/test_mcp_cron_security.py test/test_security.py` => 1998 passed, 1 skipped (baseline 1983; +15 new tests). flake8 / mypy / isort clean on changed files.

## Files changed

- `src/kiro_crew/mcp_cron.py` — parse-aware scan scoping + table-derived Windows store detector
- `test/test_mcp_cron_security.py` — +15 tests
- `docs/system-specs/modules/learn-cron-dashboard.md` — documents the previously-undocumented body scan and its scoping

## Accepted limitation (documented)

A benign redaction regex anchored *under* a Windows store (e.g. `r"%LOCALAPPDATA%\\kiro-cli\\S+"`) is blocked as access-shaped: a static source pattern cannot distinguish it from a real read. Workaround is to anchor the redaction on the POSIX spelling. This is a narrow, low-severity edge (cron bodies run under `sh -c` where the `%VAR%` spelling does not resolve).