### PR TITLE
fix(security): count a backtick substitution once, not twice

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -12124,9 +12124,38 @@ _FIND_SUBSTITUTION_BUDGET = 64
 
 
 def _find_substitution_openers(command: str) -> int:
-    """How many substitution openers the command carries, counted in one pass."""
+    """How many substitution openers the command carries, counted in one pass.
+
+    A backtick substitution is delimited by TWO backticks -- an open and a close --
+    while ``$(``, ``<(`` and ``>(`` are one opener per substitution. Counting each
+    backtick as an opener therefore double-counts by construction, which halved the
+    effective ceiling for backtick spellings; that was accepted as "the conservative
+    direction" while the only subject was a shell command line, where nobody writes 33
+    of them.
+
+    It stopped being free once a SOURCE body's literals became subjects
+    (``_source_traversal_subjects``): a markdown code span in a docstring IS a backtick
+    pair, so a docstring with 66 code spans read as 66 nested substitutions and the
+    script was refused on every fire. Counting pairs is both accurate and still
+    conservative -- ``ceil`` keeps an unbalanced trailing backtick, which opens an
+    unterminated substitution, from rounding away, so the result never UNDER-states how
+    many substitutions a shell could see.
+
+    The direction is also the one the measurements support. The budget exists because
+    the view walk is quadratic in ``$(`` NESTING depth, and that is what it measures as:
+    depth 32 costs 3.9 ms, 64 costs 13.6 ms, 128 costs 57.1 ms. Backticks are nowhere
+    near it -- genuinely nested (escaped) backticks stay at ~0.2 ms to depth 32, and 512
+    FLAT backticks cost 19 ms, linear. So the character this halved the ceiling for is
+    the cheap one.
+    """
+    # ``+ 1`` before the floor divide is ceil: an odd count means one unterminated
+    # substitution, which must still be counted rather than rounded away.
+    backtick_substitutions = (command.count("`") + 1) // 2
     return (
-        command.count("$(") + command.count("`") + command.count("<(") + command.count(">(")
+        command.count("$(")
+        + backtick_substitutions
+        + command.count("<(")
+        + command.count(">(")
     )
 
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -11574,12 +11574,51 @@ class TestFindTraversalReachesFence:
         assert security.is_sensitive_bash_command(deep)
         # a realistic amount of nesting is far below the ceiling and still judged normally
         assert security._find_substitution_openers("cat $(find ~ -type f)") == 1
-        # a backtick PAIR counts twice, since both ends match; that halves the effective
-        # ceiling for backtick spellings, which is the conservative direction
-        assert security._find_substitution_openers("echo `date` $(pwd) <(sort a)") == 4
+        # a backtick substitution is delimited by TWO backticks, so a PAIR counts once
+        # -- `date`, $(pwd) and <(sort a) are three substitutions. Counting each end
+        # halved the effective ceiling for backtick spellings, which cost a real refusal
+        # once a source body's docstrings became subjects (a markdown code span is a
+        # pair) and bought nothing measurable: backticks are the cheap character here.
+        assert security._find_substitution_openers("echo `date` $(pwd) <(sort a)") == 3
+        # An unbalanced backtick opens an unterminated substitution, so ceil keeps it.
+        assert security._find_substitution_openers("echo `date") == 1
+        # Flat markdown-style spans no longer approach the ceiling: 66 backticks are 33
+        # substitutions, which is what a prose docstring actually carries.
+        assert security._find_substitution_openers("`x` " * 33) == 33
         nested = "cat $(bash -c 'find ~/.kiro/crew -type f -exec cat {} +')"
         assert security.is_sensitive_bash_command(nested)
         assert security.is_sensitive_bash_command("echo $(date) $(pwd) $(whoami)") is None
+
+    def test_flat_backtick_spans_are_not_refused_for_the_budget(self) -> None:
+        """66 backticks are 33 substitutions, so prose full of code spans is judged.
+
+        This is the shape that made the double-count expensive: a source body's
+        docstrings are subjects of this pass (``_source_traversal_subjects``), and a
+        markdown code span is a backtick PAIR, so an ordinary docstring with 33 spans
+        read as 66 nested substitutions and refused the whole script on every fire.
+
+        The ceiling itself is unmoved -- the ``$(`` depth it exists for still refuses,
+        and a traversal hiding among the spans is still denied.
+        """
+        prose = "Mint a URL. " + " ".join(f"`field{i}`" for i in range(33))
+        assert prose.count("`") == 66
+        assert security._find_substitution_openers(prose) == 33
+        assert security.is_sensitive_bash_command(prose) is None
+
+        # The budget still refuses what it was built for: `$(` nesting is the quadratic
+        # dimension (measured 3.9 ms at depth 32, 57.1 ms at 128).
+        deep = "echo " + "$(" * 200 + "find /tmp -type f" + ")" * 200
+        assert security.is_sensitive_bash_command(deep) is not None
+
+        # And a real traversal among the spans is not laundered by them.
+        hidden = prose + " ; find ~/.kiro/crew -name '.env' -exec cat {} +"
+        assert security.is_sensitive_bash_command(hidden) is not None
+
+        # A backtick count high enough to reach the ceiling on PAIRS still refuses, so
+        # the bound is preserved rather than removed.
+        very_wide = "echo " + "`x`" * 65
+        assert security._find_substitution_openers(very_wide) == 65
+        assert security.is_sensitive_bash_command(very_wide) is not None
 
     def test_the_store_clause_still_holds_across_many_roots(self) -> None:
         """The store forms are resolved once for the whole call, not once per root.


### PR DESCRIPTION
## Problem / Motivation

`_find_substitution_openers` counts **every backtick** as a substitution opener:

```python
command.count("$(") + command.count("`") + command.count("<(") + command.count(">(")
```

A backtick substitution is delimited by **two** backticks — an open and a close —
while `$(`, `<(` and `>(` are one opener per substitution. So the count double-counts
by construction and halves the effective ceiling for backtick spellings. The test that
pinned it said exactly that and accepted it:

> a backtick PAIR counts twice, since both ends match; that halves the effective
> ceiling for backtick spellings, which is the conservative direction

That was free while the only subject was a shell command line — nobody hand-writes 33
substitutions. It stopped being free once a **source body's literals** became subjects
of this pass: a markdown code span in a docstring *is* a backtick pair, so an ordinary
docstring with 33 code spans reads as 66 nested substitutions and the whole cron script
is refused, at every fire, with a message about shell substitutions, for prose. Measured
on one real install, that is what refuses a 1107-line script whose offending literal is
a 2315-character docstring carrying 66 backticks and zero `$(`.

## Why it matters

The double-count was free while the only subject was a shell command line — nobody hand-writes 33
substitutions, so halving that ceiling cost nothing observable. It stopped being free the moment a
source body's string literals became subjects of this pass, and the thing it now refuses is the most
ordinary text there is: a docstring with markdown code spans.

The cost lands where it is hardest to read. The refusal happens at **every fire** of the cron job,
and it names *nested shell substitutions* for a body whose offending literal is English prose with
33 backticked words — so the message points the reader at shell syntax that is not there.

It is also the wrong direction on the measurement: the ceiling exists for `$(` nesting, which is
quadratic (57 ms at depth 128), while backticks are linear and cheap (19 ms for 512 flat, 0.2 ms
nested to depth 32). The spelling whose budget was halved is the one that costs the least.

## What changed

Count backtick-derived substitutions as **pairs**, `ceil`-rounded:

```python
backtick_substitutions = (command.count("`") + 1) // 2
```

`ceil` rather than floor because an unbalanced trailing backtick opens an unterminated
substitution, so it must still count — the result never **under**-states how many
substitutions a shell could see.

## Why this direction is the measured one

The budget exists because the view walk is quadratic in `$(` **nesting depth**, and
that is what it measures as. Backticks are not close:

| subject | openers | wall |
|---|---|---|
| `$(` nesting, depth 32 | 32 | 3.9 ms |
| `$(` nesting, depth 64 | 64 | 13.6 ms |
| `$(` nesting, depth 128 | 128 | 57.1 ms |
| backtick nesting (escaped), depth 32 | 64 → 32 | **0.2 ms** |
| 512 **flat** backticks (markdown spans) | 512 → 256 | **19 ms**, linear |

So the character whose ceiling the double-count halved is the cheap one, and the
expensive dimension the ceiling exists for is untouched.

Nesting depth is still bounded by pairs — every level of an escaped-backtick nest
consumes an open and a close — so `ceil(n/2)` remains a sound upper bound on
backtick-derived depth, not merely a cheaper one.

## Tests

`test/test_security.py::TestFindTraversalReachesFence`:

- the pinned count is corrected with its comment: `` echo `date` $(pwd) <(sort a) ``
  is **3** substitutions, not 4;
- an unbalanced `` echo `date `` still counts 1 (ceil);
- a new case, `test_flat_backtick_spans_are_not_refused_for_the_budget`, pins the
  behaviour end to end — 66 backticks are 33 openers and a prose subject is judged
  rather than refused, **while** `$(` nesting past the ceiling still refuses, a
  backtick count that reaches the ceiling on pairs (65 spans) still refuses, and a real
  `find … -exec cat` sitting among the code spans is still denied rather than laundered
  by them.

Mutation-verified: restoring the per-backtick count reddens 2 cases.

Regression: **2479 passed, 1 skipped** across `test_security.py`,
`test_security_alt_traversal.py` and `test_mcp_cron_security.py`. The over-budget
`wide` case in the existing budget test is built from `$(`, so it is unaffected (75
openers, still over).

Gates: `isort`, `flake8` 7.1.0, `mypy`, `scripts/check_black_formatting.py`,
`scripts/check_subprocess_encoding.py`, `scripts/docs_lint.py` — all pass.

## Relationship to #8550

Independent and independently justified: the double-count is wrong for a shell command
line too, and this PR stands on that plus the measurements above. It does not depend on
#8550 and does not touch its hunks.

The two together are what recover the install measured in #8550: 11 of 13 scripts with
#8550 alone, and this removes the budget refusal on a twelfth. Ordering does not matter
for correctness of either.

Refs #7912.

## Pattern harvest

Rule candidate: semgrep.

**Pattern: counting a SAME-CHARACTER-paired delimiter's occurrences as if each occurrence were an opener.** The defect is visible in one expression:

```python
command.count("$(") + command.count("`") + command.count("<(") + command.count(">(")
```

Three of those four terms count a delimiter whose opener differs from its closer, so each hit is one construct. The backtick term counts a delimiter whose open and close are the SAME character, so each construct contributes two — the term double-counts by construction, and mixing it into the same sum silently halves the budget for that one spelling. A budget is exactly where this hurts, because the error is invisible until some subject legitimately carries many of them (here, markdown code spans in a docstring).

Candidate check: flag a sum of `str.count(...)` terms in which at least one argument is a single character that is its own closer (`` ` ``, `"`, `'`) while another argument is a multi-character opener whose closer differs (`$(`, `<(`, `${`, `[[`). The shape is fully static — the literals are right there — and the fix is always the same: divide the self-closing term by two, rounding up so an unbalanced trailing delimiter still counts.

Sibling worth checking under the same rule, not touched here: `_alt_pipeline_stages_bounded` and the brace-expansion budget also derive their counts from delimiter occurrences; whether either mixes the two kinds has not been measured.

Not generalizable: the specific ceiling value (64) is unchanged and was not the defect.
