### PR TITLE
fix(sandbox): reclaim mount-source dirs on a busy host

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -478,11 +478,41 @@ def _isolate_sandbox_mount_source_roots(_sandbox_mount_source_root, monkeypatch)
     # ``_mount_pinned_source_names`` itself; ``TestMountPinnedSourceNames``
     # imports the function by name at module import, so the parser's own unit
     # tests are unaffected by this module-attribute patch.
+    _SANDBOX_SWEEP_ORIGINALS.setdefault(
+        "_mount_pinned_source_names", sandbox_mod._mount_pinned_source_names
+    )
     monkeypatch.setattr(
         sandbox_mod,
         "_mount_pinned_source_names",
-        lambda proc_root="/proc": (set(), False),
+        lambda proc_root="/proc", **_kw: (set(), False),
     )
+    # Third half, same floor, for the LEGACY (pre-prefix ``tmp*``) sweep. It
+    # resolves its own narrower root chain -- the launcher's two tmpfs roots,
+    # deliberately excluding the redirected system tempdir -- so without this it
+    # would scan the developer's real /run/user/$UID and /dev/shm, and there it
+    # matches names no Kiro Crew build has created since #6268: an unpinned test
+    # could delete a stranger's temp entry on the host. The bind scan is
+    # defaulted fail-closed for the same reason as the pin scan above: a test
+    # that forgets to fix its answer gets an INERT sweep (coverage unproven ->
+    # removes nothing, stamps nothing) rather than one reading host /proc.
+    _SANDBOX_SWEEP_ORIGINALS.setdefault("_launcher_tmpfs_roots", sandbox_mod._launcher_tmpfs_roots)
+    monkeypatch.setattr(
+        sandbox_mod,
+        "_launcher_tmpfs_roots",
+        lambda: [str(_sandbox_mount_source_root)],
+    )
+    _SANDBOX_SWEEP_ORIGINALS.setdefault(
+        "_bound_source_basenames", sandbox_mod._bound_source_basenames
+    )
+
+    def _unproven_bound_sources(proc_root="/proc", *, coverage=None, **_kw):
+        # Fail closed on BOTH claims the legacy gate accepts, so no test can
+        # reach the developer's real runtime tmpfs through it.
+        if coverage is not None:
+            coverage.covered = False
+        return (set(), False)
+
+    monkeypatch.setattr(sandbox_mod, "_bound_source_basenames", _unproven_bound_sources)
 
 
 @pytest.fixture(autouse=True)

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -80,6 +80,43 @@ _MOUNT_SOURCE_MAX_AGE_SECONDS = 24 * 3600
 # that observed a vanish rescans newly appeared pids; past this many passes
 # coverage is reported as unproven instead of looping.
 _PIN_SCAN_MAX_PASSES = 3
+
+
+class _PinScanCoverage:
+    """Whether the pin scan read every task that could hold a sandbox source.
+
+    Filled by :func:`_mount_pinned_source_names` beside its host-wide
+    ``complete`` flag. That flag drops for reasons that cannot involve a
+    sandbox source -- another user's unreadable task, or one departing on the
+    final pass -- and on a busy host it can stay down indefinitely, which is
+    how the directory class came to accumulate without bound. ``covered`` asks
+    the narrower question the gate needs: was every task that could hold a
+    source this uid staged read, and did none depart between the final
+    listing and its read? Those are this uid's tasks (the sandboxed child
+    keeps this uid with NO_NEW_PRIVS), the overflow uid's (how a nested user
+    namespace stats) and root's (root can ``nsenter`` any namespace) -- so a
+    ``hidepid`` procfs, which hides root's tasks, clears it too. A task that
+    departs on the FINAL pass may have handed its namespace to a child forked
+    after that listing, which only a re-listing could have seen and none
+    followed, so such a departure clears ``covered``; one on an earlier pass
+    was followed by a re-listing and is accounted for. When ``covered`` holds
+    the pinned set is authoritative for every possible holder.
+    """
+
+    __slots__ = ("covered",)
+
+    def __init__(self) -> None:
+        self.covered = True
+
+
+def _task_uid(proc_root: str, name: str) -> int | None:
+    """The uid ``/proc/<name>`` stats as, or None once it is gone."""
+    try:
+        return os.stat(os.path.join(proc_root, name)).st_uid
+    except OSError:
+        return None
+
+
 # The overflow uid: what /proc/<pid> stats to for a process whose uid has no
 # mapping in the reader's user namespace. Such a holder CAN be binding our
 # sources, so it is a coverage gap, not a foreign user. The value is a
@@ -3263,7 +3300,12 @@ def main():
             # forward-compatibility — dropping a non-existent cap just returns -1.
             for _cap in range(64):
                 _libc.prctl(_PR_CAPBSET_DROP, _cap, 0, 0, 0)
-            # NO_NEW_PRIVS: prevents regaining caps via exec of setuid/setcap bins
+            # NO_NEW_PRIVS: prevents regaining caps via exec of setuid/setcap bins.
+            # Load-bearing beyond hardening: the mount-source sweep's directory
+            # gate (_cleanup_stale_sandbox_mount_sources) reclaims on the claim
+            # that every launcher descendant still stats as this uid (or the
+            # overflow uid from a nested userns), so a change here that lets a
+            # descendant change uid would turn that gate fail-open.
             _ret = _libc.prctl(_PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
             if _ret != 0:
                 sys.exit("sandbox: BLOCKED — failed to set NO_NEW_PRIVS (prctl returned %d)" % _ret)
@@ -4170,6 +4212,7 @@ def cleanup_stale_sandbox_profiles(*, legacy_dir: str | None = None) -> int:
             pass
 
     removed += _cleanup_stale_sandbox_mount_sources()
+    removed += _cleanup_legacy_mount_source_residue()
     removed += _cleanup_retired_acp_snapshot_dir()
     return removed
 
@@ -4197,7 +4240,12 @@ def _mount_source_candidate_roots() -> list[str]:
     return roots
 
 
-def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool]:
+def _mount_pinned_source_names(
+    proc_root: str = "/proc",
+    *,
+    matcher: Callable[[str], bool] | None = None,
+    coverage: _PinScanCoverage | None = None,
+) -> tuple[set[str], bool]:
     """Entry names of sandbox mount sources referenced by a live mount, plus
     whether the scan positively covered every namespace a PROCESS could be
     binding one from.
@@ -4221,7 +4269,11 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
     - The listing must show pid 1. ``hidepid``/``subset=pid`` procfs hides
       other users' processes entirely — including a root holder that entered
       a sandbox namespace — and pid 1 always exists, so its absence proves
-      the listing is filtered and the scan reports incomplete.
+      the listing is filtered and the scan reports incomplete. It still reads
+      every pid the filtered listing DOES show (this uid's own processes are
+      never hidden from it, and every sandbox descendant keeps this uid), so
+      the pins a visible holder contributes reach the caller regardless: the
+      directory gate honours ``pinned`` before any other evidence.
     - A holder can fork a successor and exit between the pid listing and its
       own mountinfo read (the read then raises FileNotFoundError). The
       successor was forked BEFORE the exit, so it is visible to the very next
@@ -4254,7 +4306,12 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
       sibling never speaks for an unreadable one. When every sibling reads, the
       leader's own departure still makes this a vanish, because a departing task
       may have handed its namespace to a PROCESS forked after this pass's
-      listing and only a re-listing can see that. Any OTHER errno on the leader
+      listing and only a re-listing can see that. A LIVE leader that could be a
+      holder (this uid's, the overflow uid's, root's) has its siblings read the
+      same way, since a thread can ``unshare(CLONE_FS)`` + ``setns`` into a
+      namespace its leader is not in; a sibling that departed mid-read has its
+      whole group re-read on the next pass, one that would not read for any
+      other reason makes coverage unprovable. Any OTHER errno on the leader
       is forgiven only when the pid provably belongs to a DIFFERENT real user
       (its ``/proc/<pid>`` stats to a uid that is not ours, not root, and not
       the host's overflow uid) — such a process cannot be binding a source this
@@ -4265,8 +4322,15 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
     A namespace held only by an nsfs fd or a bind-mounted ``ns/mnt`` — zero
     member processes — has no mountinfo to scan and is out of scope; the
     launcher never creates one. ``complete=False`` means absence-of-pin was
-    NOT established; the caller must not remove directory entries or destroy
-    contents on the strength of it.
+    NOT established host-wide. When the caller passes ``coverage``, the scan
+    also answers the narrower question the directory gate needs
+    (:class:`_PinScanCoverage`): whether every task that could be a launcher
+    descendant — this uid's and the overflow uid's — was read, with none
+    departing between the final listing and its read. Root's tasks count as
+    possible holders too (root can ``nsenter`` any namespace), so a hidden or
+    unreadable root task — a filtered procfs included — lowers coverage along
+    with ``complete``; another user's unreadable or departing task lowers only
+    ``complete``.
     """
     pinned: set[str] = set()
     complete = True
@@ -4274,32 +4338,88 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
     getuid = getattr(os, "getuid", None)
     own_uid = getuid() if getuid is not None else None
     overflow_uid = _overflow_uid()
+    # Default: the keyed ``kirocrew_sb_<pid>_`` shape. ``matcher`` lets the
+    # legacy-residue sweep reuse this traversal — and, critically, its coverage
+    # accounting (zombie leaders via task/, the vanish re-listing, the
+    # foreign-uid forgiveness) — for a different name shape, instead of a
+    # second scan that gets those cases subtly wrong.
+    match = matcher or (lambda name: name.startswith(_MOUNT_SOURCE_PREFIX))
+    # Fast pre-filter per line; only valid for the default shape, since a
+    # custom matcher may accept names without the prefix.
+    line_hint = _MOUNT_SOURCE_PREFIX if matcher is None else None
 
     def _collect(mountinfo_path: str) -> None:
-        """Add every prefix-shaped bind SOURCE named in one mountinfo to ``pinned``.
+        """Add every matching bind SOURCE named in one mountinfo to ``pinned``.
 
         Propagates ``OSError`` exactly as ``open`` would, so each caller decides
-        what an unreadable task means for coverage.
+        what an unreadable task means for coverage. A source removed while
+        still bound reads ``.../name//deleted``; the suffix is stripped so the
+        real name is what pins.
         """
         with open(mountinfo_path, encoding="utf-8", errors="replace") as fh:
             for line in fh:
-                if _MOUNT_SOURCE_PREFIX not in line:
+                if line_hint is not None and line_hint not in line:
                     continue
                 fields = line.split()
                 if len(fields) > 3:
-                    source = os.path.basename(fields[3])
-                    if source.startswith(_MOUNT_SOURCE_PREFIX):
+                    source = fields[3]
+                    if source.endswith("//deleted"):
+                        source = source[: -len("//deleted")]
+                    source = os.path.basename(source)
+                    if match(source):
                         pinned.add(source)
+
+    # Coverage accounting for ``coverage``. A task of this uid (or the overflow
+    # uid) that could not be read is never re-read (it is in ``seen``), so it
+    # clears coverage for good. One that departed between a pass's listing and
+    # its read may have handed its namespace to a child forked after that
+    # listing: a re-listing shows the child, so a departure on a pass that IS
+    # followed by another pass is accounted for, and only the final pass's
+    # departures reach the caller.
+    unread_sticky = False
+    departed_this_pass = False
+    uids: dict[str, int | None] = {}
+
+    def _could_be_descendant(name: str) -> bool:
+        # A descendant stats as this uid, or as the overflow uid from inside a
+        # nested user namespace; root can ``nsenter`` ANY namespace, so a root
+        # task counts too. Without a uid to compare against (no ``os.getuid``;
+        # an unreadable overflowuid sysctl) every task might be one, so
+        # coverage fails closed rather than open.
+        uid = uids.get(name)
+        if own_uid is None or overflow_uid is None or uid is None:
+            return True
+        return uid == own_uid or uid == overflow_uid or uid == 0
+
+    def _report() -> None:
+        if coverage is not None and (unread_sticky or departed_this_pass):
+            coverage.covered = False
 
     for _ in range(_PIN_SCAN_MAX_PASSES):
         try:
             listed = [n for n in os.listdir(proc_root) if n.isdecimal()]
         except OSError:
+            if coverage is not None:
+                coverage.covered = False
             return pinned, False
         if "1" not in listed and "1" not in seen:
-            return pinned, False  # filtered procfs (hidepid/subset) — coverage unprovable
+            # Filtered procfs (hidepid/subset): coverage is unprovable, but the
+            # pids that ARE listed — this uid's own, which is where every
+            # sandbox descendant lives — still read fine and still pin. Keep
+            # walking so their pins reach the caller: a visible holder retains
+            # its source. Returning here instead would hand the gate an empty
+            # pinned set. Coverage falls with the flag: root's tasks are among
+            # the hidden ones, and root can hold any namespace.
+            complete = False
+            unread_sticky = True
         new_pids = [n for n in listed if n not in seen]
         vanished = False
+        departed_this_pass = False
+        # Learn every new task's uid FIRST, in one tight loop, so a task that
+        # departs during the (much longer) mountinfo walk below can still be
+        # told apart from another user's; one gone before even this read is
+        # treated as possibly ours.
+        uids = {name: _task_uid(proc_root, name) for name in new_pids}
         for name in new_pids:
             seen.add(name)
             try:
@@ -4308,6 +4428,8 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
                 # May have handed its namespace to a child forked before the
                 # exit — visible to the next listing, so take another pass.
                 vanished = True
+                if _could_be_descendant(name):
+                    departed_this_pass = True
             except OSError as exc:
                 if exc.errno == errno.EINVAL:
                     # EINVAL says THIS TASK's nsproxy is gone, so this task is a
@@ -4330,6 +4452,8 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
                         tids = []  # the group is gone entirely
                     except OSError:
                         complete = False  # cannot ask — coverage unprovable
+                        if _could_be_descendant(name):
+                            unread_sticky = True
                         continue
                     unaccounted = 0
                     for tid in tids:
@@ -4360,6 +4484,8 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
                     # one.
                     if unaccounted:
                         complete = False
+                        if _could_be_descendant(name):
+                            unread_sticky = True
                         continue
                     # Otherwise this is a VANISH, unconditionally. Reaching this
                     # branch at all means the LEADER departed, and a departing task
@@ -4373,6 +4499,8 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
                     # while genuine churn exhausts ``_PIN_SCAN_MAX_PASSES`` and
                     # returns complete=False, which retains rather than removes.
                     vanished = True
+                    if _could_be_descendant(name):
+                        departed_this_pass = True
                     continue
                 try:
                     st_uid: int | None = os.stat(os.path.join(proc_root, name)).st_uid
@@ -4387,9 +4515,85 @@ def _mount_pinned_source_names(proc_root: str = "/proc") -> tuple[set[str], bool
                     or st_uid == overflow_uid
                 ):
                     complete = False
+                    # Root's or another user's unreadable task is a host-wide
+                    # gap only; one that could be a launcher descendant also
+                    # clears the narrower coverage the gate relies on.
+                    if _could_be_descendant(name):
+                        unread_sticky = True
+            else:
+                # The leader read. Its THREADS may still hold OTHER mount
+                # namespaces -- a thread can ``unshare(CLONE_FS)`` and then
+                # ``setns`` into a sandbox's namespace while its leader stays
+                # outside, and root has the capability to do so anywhere -- and
+                # ``proc_root`` lists leaders only, so those namespaces are
+                # reachable through ``task/`` alone. Asked only for a possible
+                # holder (another user's threads cannot enter a namespace this
+                # uid staged), which keeps the cost to this uid's and root's
+                # groups: measured 3.5k sibling reads in 0.13s on a dev host.
+                if not _could_be_descendant(name):
+                    continue
+                task_dir = os.path.join(proc_root, name, "task")
+                try:
+                    tids = os.listdir(task_dir)
+                except FileNotFoundError:
+                    # The group went away right after the leader read: a
+                    # departure, with the same successor concern as any other.
+                    vanished = True
+                    departed_this_pass = True
+                    continue
+                except OSError:
+                    complete = False
+                    unread_sticky = True
+                    continue
+                departed = unreadable = False
+                for tid in tids:
+                    if tid == name:
+                        continue
+                    try:
+                        _collect(os.path.join(task_dir, tid, "mountinfo"))
+                    except (FileNotFoundError, ProcessLookupError):
+                        departed = True
+                    except OSError as exc:
+                        if exc.errno == errno.EINVAL:
+                            continue  # a thread mid-exit: it holds no namespace
+                        unreadable = True
+                if unreadable:
+                    complete = False
+                    unread_sticky = True
+                elif departed:
+                    # A thread that exited between the ``tids`` snapshot and its
+                    # read may have left a successor THREAD holding its
+                    # namespace, which the outer re-listing (leaders only)
+                    # cannot show -- so the GROUP is re-read on the next pass
+                    # rather than this being either excused or made sticky.
+                    seen.discard(name)
+                    vanished = True
+                    departed_this_pass = True
         if not vanished:
+            # Every departure so far was followed by a re-listing, so what
+            # remains unaccounted for is the still-present tasks that could not
+            # be read (sticky) plus nothing from this pass's departures.
+            _report()
             return pinned, complete
-    return pinned, False  # still churning after the pass budget — coverage unproven
+    # Still churning after the pass budget — coverage unproven, and the final
+    # pass's departures had no re-listing to catch a successor.
+    _report()
+    return pinned, False
+
+
+#: Wall-clock budget for ONE reclaim pass, keyed and legacy alike. A pile that
+#: cannot be cleared inside it is left for the next pass: the sweep runs on the
+#: maintenance executor, whose threads other housekeeping shares, and reclaim is
+#: resumable by construction (each entry is decided independently, and nothing
+#: depends on a pass finishing). Measured for scale: 939k directories took ~11s
+#: on tmpfs, so this clears a normal backlog in one pass and spreads a
+#: pathological one over a few, instead of occupying a worker for a minute.
+_SWEEP_TIME_BUDGET_SECONDS = 10.0
+
+#: How often the budget is consulted. A clock read per entry would be a
+#: measurable share of the work at these counts; per batch is close enough for a
+#: budget whose only job is to bound the pass.
+_SWEEP_BUDGET_CHECK_EVERY = 4096
 
 
 def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) -> int:
@@ -4417,15 +4621,25 @@ def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) 
     - Plain files: ``os.remove``. A file source's inode is held by the mount
       like an open descriptor, so the masked view is unaffected.
     - Dirs, empty or not: removed only when no readable mount namespace
-      references the entry AND the pin scan positively covered every
-      namespace that could bind one (:func:`_mount_pinned_source_names`).
-      The pin scan, not the pid probe, is the deciding evidence: a recycled
+      references the entry (:func:`_mount_pinned_source_names`) AND absence
+      of a pin is positively established — by the scan proving it covered
+      every namespace on the host, OR by it having read every task that
+      could hold one (:class:`_PinScanCoverage`: this uid's, the overflow
+      uid's and root's tasks, none unreadable, none departed between the
+      final listing and its read). The second is what this fix adds. The
+      host-wide flag also drops for another user's unreadable or departing
+      task, which cannot be holding a source this uid staged (the sandboxed
+      child keeps this uid with NO_NEW_PRIVS; only root can enter a foreign
+      namespace), and requiring it alone is what stranded the directory
+      class permanently on the hosts this sweep exists for (observed:
+      929,540 dirs retained against 511 files reclaimed, the runtime tmpfs
+      back at 100% of its inodes and every spawn failing again). A recycled
       pid reads live yet has no mount, so its entry is still reclaimed after
       the age backstop rather than stranded, while a genuine long-lived
-      sandbox is pinned by its own process and kept. A namespace no PROCESS
-      holds has no mountinfo to report a pin — an fd- or bind-pinned
-      namespace with zero members is out of scope, and the launcher never
-      creates one — so the scan cannot go stale in the deleting direction. The
+      sandbox is pinned by its own process. A namespace no PROCESS holds has
+      no mountinfo to report a pin — an fd- or bind-pinned namespace with
+      zero members is out of scope, and the launcher never creates one — so
+      the pin set cannot go stale in the deleting direction. The
       fresh-and-alive skip above stays load-bearing for the launcher's own
       staging window (after ``mkdtemp``, before ``mount``), when its entries
       are legitimately live and not yet pinned.
@@ -4445,14 +4659,23 @@ def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) 
         Number of entries removed.
     """
     now = time.time()
+    started = time.monotonic()
+    examined = 0
+    budget_spent = False
     if roots is None:
         roots = _mount_source_candidate_roots()
     # (pinned set, scan-was-complete) — built lazily, once, on the first
     # directory candidate (empty ones included: rmdir is gated too).
     pin_scan: tuple[set[str], bool] | None = None
+    # Whether that scan read every task that could be a launcher descendant
+    # (``_PinScanCoverage``) -- the narrower claim the gate accepts when the
+    # host-wide flag is down for reasons that cannot involve a sandbox.
+    coverage = _PinScanCoverage()
     removed = 0
     dirs_held_back = 0
     for root in roots:
+        if budget_spent:
+            break
         try:
             entries = os.listdir(root)
         except OSError:
@@ -4460,6 +4683,16 @@ def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) 
         for entry in entries:
             if not entry.startswith(_MOUNT_SOURCE_PREFIX):
                 continue
+            examined += 1
+            if (
+                examined % _SWEEP_BUDGET_CHECK_EVERY == 0
+                and (time.monotonic() - started) > _SWEEP_TIME_BUDGET_SECONDS
+            ):
+                # Out of budget: stop cleanly and let the next pass continue.
+                # Reclaim is resumable per entry, so a partial pass is progress,
+                # never an inconsistent state.
+                budget_spent = True
+                break
             pid_str, sep, _rest = entry[len(_MOUNT_SOURCE_PREFIX) :].partition("_")
             pid = _parse_pid_segment(pid_str) if sep else None
             if pid is None:
@@ -4480,11 +4713,17 @@ def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) 
                 continue
             if os.path.isdir(path) and not os.path.islink(path):
                 # ANY dir removal — even rmdir of an empty one — S_DEADs a
-                # live mount's root inode, so the pin scan gates it all.
+                # live mount's root inode, so absence of a pin must be
+                # POSITIVELY established: either the host-wide scan proved its
+                # coverage, or it read every task that could be a launcher
+                # descendant (``coverage.covered``). The second is what keeps
+                # another user's unreadable or departing task from retaining
+                # the class forever — it cannot be holding a source this uid
+                # staged.
                 if pin_scan is None:
-                    pin_scan = _mount_pinned_source_names()
+                    pin_scan = _mount_pinned_source_names(coverage=coverage)
                 pinned, scan_complete = pin_scan
-                if entry in pinned or not scan_complete:
+                if entry in pinned or not (scan_complete or coverage.covered):
                     dirs_held_back += 1
                     continue
                 try:
@@ -4512,17 +4751,290 @@ def _cleanup_stale_sandbox_mount_sources(*, roots: Sequence[str] | None = None) 
         # working one while the dominant (directory) leak class re-accumulates
         # — surface it so an operator can tell retention from reclamation.
         scan_complete = pin_scan is not None and pin_scan[1]
+        covered = scan_complete or coverage.covered
         # WARNING for the incomplete case, INFO for the benign pinned one.
         # Holding entries back because a live namespace binds them is normal
-        # operation; holding them back because coverage is unprovable is a
-        # FAULT that stops directory reclamation host-wide until the runtime
-        # tmpfs is out of inodes. At INFO it also does not reach a default
-        # deployment's log at all, which is how the leak this guards against
-        # ran unobserved while this very line fired on every sweep.
-        (logger.info if scan_complete else logger.warning)(
+        # operation; holding them back on an unprovable scan is a FAULT — now
+        # survivable, because a candidate whose staging group is gone is
+        # reclaimed anyway, so what remains here is confined to entries whose
+        # tree still looks alive. Coverage of every task that could be a
+        # launcher descendant counts as proven for this purpose.
+        (logger.info if covered else logger.warning)(
             "sandbox mount-source sweep: %d dir candidate(s) held back (%s)",
             dirs_held_back,
-            ("pinned by a live mount namespace" if scan_complete else "pin scan incomplete"),
+            (
+                "pinned by a live mount namespace"
+                if covered
+                else "pin scan incomplete and descendant coverage unproven"
+            ),
+        )
+    if budget_spent:
+        logger.info(
+            "sandbox mount-source sweep: paused at the %.0fs budget after %d entries "
+            "(%d reclaimed this pass); the next pass resumes",
+            _SWEEP_TIME_BUDGET_SECONDS,
+            examined,
+            removed,
+        )
+    return removed
+
+
+#: Pre-#6268 builds staged their bind-mount sources with ``tempfile``'s DEFAULT
+#: names, so those entries carry no pid and the pid-keyed sweep above cannot
+#: reason about them at all. Every install that upgraded through that change
+#: therefore carries a permanent pile — 1,836,596 entries measured on one host,
+#: enough on its own to exhaust the runtime tmpfs's inodes and stop every
+#: ``systemd-run --scope``-wrapped spawn. This is ``tempfile``'s exact shape:
+#: the ``tmp`` prefix plus 8 characters of its own alphabet.
+_LEGACY_MOUNT_SOURCE_RE = re.compile(r"^tmp[a-z0-9_]{8}$")
+
+#: How many legacy-shaped candidates a root must hold before the legacy pass
+#: touches ANY of them. An unkeyed name carries no provenance, so the pile IS
+#: the provenance: no program's ordinary scratch use leaves dozens of empty,
+#: 0o700, day-old ``tmp*`` directories in the session runtime dir, whereas the
+#: leak this pass exists for left 1.8 million on one host. Below the threshold
+#: every candidate is retained and the pass retires — there is no pile to heal.
+_LEGACY_PILE_THRESHOLD = 64
+
+#: Written once a legacy pass has completed, so the scan is not repeated for the
+#: life of the install: no current build creates these names, so a completed
+#: pass is final.
+_LEGACY_RESIDUE_MARKER = ".legacy-mount-source-residue-swept"
+
+
+def _launcher_tmpfs_roots() -> list[str]:
+    """The root the legacy pass may walk: the session runtime dir alone.
+
+    Deliberately narrower than :func:`_mount_source_candidate_roots`. The legacy
+    sweep matches an unkeyed ``tmp*`` name, so it may only walk a root where
+    that shape is far more likely ours than a stranger's. ``/run/user/$UID`` is
+    the launcher's first pick, is scoped to this uid's login session (nothing
+    keeps durable state there), and is where the observed pile lived.
+    ``/dev/shm`` is NOT walked even though the launcher falls back to it: it is
+    a host-wide tmpfs where any same-uid program's ``tempfile`` scratch
+    legitimately lives, and an empty day-old scratch dir there can still be a
+    live program's — a host whose launcher fell back to ``/dev/shm`` keeps the
+    manual note in the issue instead. The shared system tempdir is excluded
+    for the same reason, more so.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        return []
+    return [f"/run/user/{getuid()}"]
+
+
+def _bound_source_basenames(
+    proc_root: str = "/proc", *, coverage: _PinScanCoverage | None = None
+) -> tuple[set[str], bool]:
+    """Basenames of legacy-shaped bind sources named by any live mount, plus
+    whether coverage was positively established.
+
+    The same traversal as :func:`_mount_pinned_source_names` — zombie leaders
+    consulted through ``task/``, the vanish re-listing, foreign-uid forgiveness
+    — with the name predicate swapped for tempfile's shape, because the legacy
+    residue carries no recognizable prefix. A first cut re-implemented the walk
+    and got two things wrong that this delegation cannot: it filtered on the
+    root field's DIRNAME, which is the source's path *within its own
+    filesystem* (``/tmpab12cd34``, never ``/run/user/$UID/tmpab12cd34``) so the
+    fence silently matched nothing; and it reported every ``EINVAL`` as a
+    coverage gap, which on a real host with a couple of dozen zombie leaders
+    made the pass permanently inert.
+
+    Keyed by basename only, which is why no root is taken: a same-named entry
+    on another filesystem shares the pin, which errs toward retention.
+    """
+    return _mount_pinned_source_names(
+        proc_root,
+        matcher=lambda name: bool(_LEGACY_MOUNT_SOURCE_RE.match(name)),
+        coverage=coverage,
+    )
+
+
+def _cleanup_legacy_mount_source_residue() -> int:
+    """One-shot reclaim of the pre-#6268, pid-less bind-mount source residue.
+
+    An install that upgraded past #6268 gained a sweep that can never touch what
+    the OLD build left behind, so the pile it inherited keeps the runtime tmpfs
+    at its inode ceiling and every agent spawn keeps failing — an upgrade that
+    ships the reclaim fix but not this leaves such a host exactly as broken as
+    before. Runs from the same entry point as the keyed sweep, so the gateway's
+    first cleanup pass after an update heals the host without an operator ever
+    learning what ``Failed to start transient scope unit: No space left on
+    device`` meant.
+
+    An unkeyed name cannot be PROVEN to be ours, so every fence here is about
+    keeping a stranger's entry rather than reclaiming ours:
+
+    - only on the session runtime tmpfs the launcher picks first
+      (:func:`_launcher_tmpfs_roots`), never ``/dev/shm`` or the shared system
+      tempdir, where another same-uid program's ``tempfile`` scratch lives;
+    - only ``tempfile``'s exact shape (:data:`_LEGACY_MOUNT_SOURCE_RE`);
+    - only DIRECTORIES owned by THIS uid with the exact mode ``mkdtemp``
+      creates (0o700) — a hand-made or umask-shaped entry is not one of
+      these, and the old build's ``mkstemp`` file sources are left alone: an
+      unlinked file another program still holds open loses what it writes
+      next, which no fence here can rule out, while an empty dir holds
+      nothing to lose;
+    - only past ``_MOUNT_SOURCE_MAX_AGE_SECONDS``, which every real member of
+      this class is by construction (no build has created the shape since
+      #6268) while a live program's scratch dir usually is not;
+    - only when no live mount names the entry as its source, and only when
+      that absence was POSITIVELY established (:func:`_bound_source_basenames`
+      complete, or every possible holder read — the same two claims as the
+      keyed dir gate, since ``/run/user/$UID`` is reachable by this uid and
+      root alone);
+    - only once a root shows the PILE this pass exists for
+      (:data:`_LEGACY_PILE_THRESHOLD` candidates passing every fence above):
+      a stray scratch dir or two never trips it and is retained outright,
+      while the leak class arrives by the hundred thousand;
+    - dirs go through ``os.rmdir``, which REFUSES a non-empty directory: that
+      is the emptiness fence, so a populated stranger's dir survives without a
+      listing, and so does the legacy SSH shadow dir (it holds a known-hosts
+      copy) — left for the human note in the issue rather than removed here;
+    - the one-shot marker is stamped only by a pass that reached the end AND
+      found nothing retained for age alone, so a host upgrading within a day
+      of its last old-build spawn does not retire the pass on that cohort.
+
+    Returns:
+        Number of entries removed.
+    """
+    marker = config_dir() / _LEGACY_RESIDUE_MARKER
+    try:
+        if marker.exists():
+            return 0
+    except OSError:
+        return 0
+    roots = _launcher_tmpfs_roots()
+    coverage = _PinScanCoverage()
+    bound, complete = _bound_source_basenames(coverage=coverage)
+    if not (complete or coverage.covered):
+        # Absence-of-bind not established — retry on the next sweep rather than
+        # remove on the strength of an unproven scan, and do NOT stamp the
+        # marker, or one bad scan would retire the pass forever. The same two
+        # claims the keyed dir gate accepts: ``/run/user/$UID`` is 0o700 and
+        # this uid's, so its entries are reachable by this uid and root alone,
+        # which is exactly what ``covered`` vouches for. Say so at WARNING,
+        # like the keyed sweep's held-back report: on a host whose /proc never
+        # settles this pass stays inert every tick, and a silent return would
+        # be the same invisible-at-default-log-level failure the keyed sweep's
+        # diagnostic exists to end.
+        logger.warning(
+            "sandbox mount-source sweep: legacy pass retained everything — bind "
+            "coverage of /proc could not be established (pin scan incomplete, "
+            "holder coverage unproven); the pass retries on the next tick"
+        )
+        return 0
+    now = time.time()
+    started = time.monotonic()
+    examined = 0
+    budget_spent = False
+    getuid = getattr(os, "getuid", None)
+    own_uid = getuid() if getuid is not None else None
+    removed = 0
+
+    young_retained = False
+
+    def _reclaim(path: str) -> bool:
+        try:
+            os.rmdir(path)  # refuses a non-empty dir by design
+        except OSError:
+            return False
+        return True
+
+    for root in roots:
+        if budget_spent:
+            break
+        try:
+            entries = os.scandir(root)
+        except OSError:
+            continue
+        # Candidates are buffered until the root proves it holds the pile;
+        # below the threshold nothing in the buffer is touched. Once it is
+        # reached the buffer is drained and reclaim streams from then on.
+        pending: list[str] = []
+        engaged = False
+        with entries:
+            for entry in entries:
+                if not _LEGACY_MOUNT_SOURCE_RE.match(entry.name) or entry.name in bound:
+                    continue
+                examined += 1
+                if (
+                    examined % _SWEEP_BUDGET_CHECK_EVERY == 0
+                    and (time.monotonic() - started) > _SWEEP_TIME_BUDGET_SECONDS
+                ):
+                    budget_spent = True
+                    break
+                try:
+                    info = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                if own_uid is not None and info.st_uid != own_uid:
+                    continue
+                # Directories only. The old build staged a mkstemp FILE per
+                # masked file too, but an unlinked file another program still
+                # holds open loses whatever it writes next, and nothing here
+                # can tell such a file from ours; an empty directory holds no
+                # data to lose and a stranger's mkdtemp dir gets ENOENT on its
+                # next create, an error rather than silent loss.
+                if not stat.S_ISDIR(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o700:
+                    continue
+                if (now - info.st_mtime) <= _MOUNT_SOURCE_MAX_AGE_SECONDS:
+                    young_retained = True  # ages into candidacy on a later pass
+                    continue
+                if engaged:
+                    removed += _reclaim(entry.path)
+                    continue
+                pending.append(entry.path)
+                if len(pending) >= _LEGACY_PILE_THRESHOLD:
+                    engaged = True
+                    for queued in pending:
+                        removed += _reclaim(queued)
+                    pending = []
+        if pending and not engaged:
+            logger.info(
+                "sandbox mount-source sweep: %d legacy-shaped entries under %s are below "
+                "the pile threshold (%d); retained as not provably ours",
+                len(pending),
+                root,
+                _LEGACY_PILE_THRESHOLD,
+            )
+    if budget_spent:
+        logger.info(
+            "sandbox mount-source sweep: legacy pass paused at the %.0fs budget after "
+            "%d entries (%d reclaimed); the next pass resumes",
+            _SWEEP_TIME_BUDGET_SECONDS,
+            examined,
+            removed,
+        )
+    elif young_retained:
+        logger.info(
+            "sandbox mount-source sweep: legacy pass complete but not retired — "
+            "legacy-shaped entries under the age fence remain; the next pass "
+            "that finds none stamps the marker"
+        )
+    else:
+        # Stamp only a pass that reached the end of the residue AND left no
+        # cohort behind for age, or a budget-truncated walk's remainder — or a
+        # host upgrading within a day of its last old-build spawn — would be
+        # retired unswept.
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            # Create-only and never through a symlink: a planted link at this
+            # path must fail the stamp (the pass just repeats) rather than
+            # have the gateway write wherever it points.
+            fd = os.open(marker, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+            try:
+                os.write(fd, f"{int(now)} removed={removed}\n".encode())
+            finally:
+                os.close(fd)
+        except OSError:
+            # An unstampable marker only costs a repeat pass, which is idempotent.
+            logger.debug("legacy mount-source sweep: could not stamp %s", marker, exc_info=True)
+    if removed:
+        logger.info(
+            "sandbox mount-source sweep: reclaimed %d pre-prefix legacy entries "
+            "(one-shot; these carry no pid and no earlier build could reclaim them)",
+            removed,
         )
     return removed
 

--- a/src/kiro_crew/session_cleanup.py
+++ b/src/kiro_crew/session_cleanup.py
@@ -431,6 +431,25 @@ class SessionCleanup:
         self.state.idle_timeout = timeout
         interval = max(timeout // 6, 60) if idle_sweep_enabled else 300
 
+        # One reclaim pass at START, and deliberately NOT awaited here. Every
+        # other sweep in this loop is housekeeping that can wait an interval, but
+        # this one reclaims the runtime-tmpfs entries whose exhaustion makes
+        # `systemd-run --scope` fail, and a host in that state cannot spawn an
+        # agent AT ALL -- so an update that installs the fix must apply it now,
+        # not in 5-10 minutes. Fire-and-forget for two reasons: the loop's other
+        # sweeps (idle sessions, PIDs, MCPs) must not queue behind it, and a pass
+        # slowed by a pathological pile or a stalled filesystem must not be able
+        # to keep this loop from ever starting. The work itself is bounded twice
+        # over: it runs in the maintenance executor (never on the event loop) and
+        # the sweep enforces its own wall-clock budget per pass, resuming on the
+        # next tick. Cancelled on shutdown with the loop.
+        boot_reclaim = asyncio.create_task(self._sweep_sandbox_artifacts())
+        try:
+            await self._run_cleanup_ticks(interval)
+        finally:
+            boot_reclaim.cancel()
+
+    async def _run_cleanup_ticks(self, interval: float) -> None:
         while not self._deps.get_shutdown_signal().is_set():
             try:
                 await asyncio.wait_for(

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -49,6 +49,33 @@ _POSIX_ONLY = pytest.mark.skipif(
 )
 
 
+@pytest.fixture()
+def systemd_run_resolvable(monkeypatch):
+    """Make ``trusted_system_bin("systemd-run")`` resolve on a host without systemd.
+
+    The cgroup-scope tests below mock ``_probe_cgroup_scope`` to "available" and
+    assert the argv ``cgroup_scope_argv`` BUILDS. That argv is only built when
+    the wrapper also resolves from a trusted system directory, and on macOS /
+    a container without systemd it never does -- so the code degraded (no
+    ceiling, loud warning), and seven tests about argv SHAPE failed for a reason
+    that has nothing to do with argv shape. Only ``systemd-run`` is faked; every
+    other name still goes through the real resolver, so the tests that assert
+    degradation when it is ABSENT (they patch the resolver to ``None``
+    themselves, inside their own ``with``) are unaffected -- an inner patch
+    wins and reverts to this one.
+    """
+    from kiro_crew import platform_compat
+
+    real = platform_compat.trusted_system_bin
+
+    def _resolve(name: str) -> str | None:
+        if name == "systemd-run":
+            return "/usr/bin/systemd-run"
+        return real(name)
+
+    monkeypatch.setattr(sandbox_mod.platform_compat, "trusted_system_bin", _resolve)
+
+
 @pytest.fixture(autouse=True)
 def clean_backend(monkeypatch):
     """Reset cached backend between tests.
@@ -1990,6 +2017,7 @@ class TestSessionHostPreexec:
             self._reset_cache()
 
 
+@pytest.mark.usefixtures("systemd_run_resolvable")
 class TestCgroupScopeArgv:
     """cgroup_scope_argv() wraps agent spawns in a transient systemd --user
     --scope with pids.max + memory.max — the default-on fork-bomb / memory-DoS
@@ -2289,6 +2317,7 @@ class TestCgroupScopeArgv:
             self._reset_probe()
 
 
+@pytest.mark.usefixtures("systemd_run_resolvable")
 class TestAgentsSliceLimits:
     """ensure_agents_slice_limits() puts an AGGREGATE MemoryMax/TasksMax on
     kirocrew-agents.slice — the parent of every per-spawn scope — so N
@@ -2645,6 +2674,7 @@ class TestAgentsSliceLimits:
             sb._CGROUP_SCOPE_PROBE = None
 
 
+@pytest.mark.usefixtures("systemd_run_resolvable")
 class TestCgroupScopeBusEnv:
     """The systemd-run scope prepended by cgroup_scope_argv needs the user
     session bus in the environment it is spawned with. Callers that build that
@@ -3336,6 +3366,7 @@ class TestMacOsNestingDetection:
             sandbox_mod._macos_sandbox_state.cache_clear()
 
 
+@pytest.mark.usefixtures("systemd_run_resolvable")
 class TestAgentSliceMemoryHigh:
     """_ensure_agent_slice_memory_high() reconciles the AGGREGATE MemoryHigh
     ceiling on kirocrew-agents.slice — bounding the SUM of all concurrent agent

--- a/test/test_sandbox_mount_source_sweep.py
+++ b/test/test_sandbox_mount_source_sweep.py
@@ -16,12 +16,17 @@ Two halves lock the fix in:
       drift above the fork, at every sandbox level, with the script staying
       parseable;
   (b) ``_cleanup_stale_sandbox_mount_sources`` reclaims layered by cost: plain
-      files and empty dirs on dead pid or over-age; non-empty dirs (contents
-      are visible inside a live mount namespace) only when the mountinfo pin
-      scan positively establishes no namespace references the entry — the pin
-      scan, not the pid probe, is the deciding evidence, so a recycled pid is
-      reclaimed while a genuine long-lived sandbox is kept. Foreign ``tmp*``
-      names, probe names, planted hostile pid segments, and
+      files and empty dirs on dead pid or over-age; dirs (whose contents are
+      visible inside a live mount namespace, and whose removal S_DEADs it)
+      only once absence-of-pin is POSITIVELY established — by the mountinfo
+      pin scan proving host-wide coverage, or by it having read every task
+      that could hold a source this uid staged (this uid's, the overflow
+      uid's, root's, and their sibling threads: ``_PinScanCoverage``).
+      Another user's unreadable or departing task lowers only the host-wide
+      flag, and requiring that flag alone retained the directory class until
+      the runtime tmpfs ran out of inodes. A readable pin always wins, a
+      recycled pid is reclaimed rather than stranded. Foreign
+      ``tmp*`` names, probe names, planted hostile pid segments, and
       ``kirocrew_sandbox_*`` launcher scripts are preserved, without the sweep
       ever raising.
 """
@@ -44,8 +49,10 @@ import pytest
 from kiro_crew.sandbox import (
     _MOUNT_SOURCE_MAX_AGE_SECONDS,
     _build_launcher_script,
+    _cleanup_legacy_mount_source_residue,
     _cleanup_stale_sandbox_mount_sources,
     _mount_pinned_source_names,
+    _PinScanCoverage,
     cleanup_stale_sandbox_profiles,
 )
 
@@ -54,6 +61,13 @@ from kiro_crew.sandbox import (
 requires_posix = pytest.mark.skipif(
     not hasattr(os, "getuid"),
     reason="_build_launcher_script uses POSIX-only os.getuid (#2041)",
+)
+# The legacy-residue pass fences on the exact POSIX mode ``mkdtemp``/``mkstemp``
+# create (0o700 / 0o600) and on ``st_uid``; neither is meaningful on Windows,
+# where ``_launcher_tmpfs_roots`` yields no root for it to walk anyway.
+requires_posix_modes = pytest.mark.skipif(
+    not hasattr(os, "getuid"),
+    reason="legacy-residue fences compare POSIX mode bits and st_uid",
 )
 
 _DEAD_PID = 4_194_305  # above Linux PID_MAX_LIMIT (2**22) — never a live process
@@ -80,12 +94,30 @@ def _make_file(root: Path, name: str, *, old: bool = False) -> Path:
     return path
 
 
-def _pin(monkeypatch: pytest.MonkeyPatch, names: set[str], *, complete: bool = True) -> None:
-    """Fix the pin scan's answer for one test (signature-matched to the real one)."""
-    monkeypatch.setattr(
-        "kiro_crew.sandbox._mount_pinned_source_names",
-        lambda proc_root="/proc": (names, complete),
-    )
+def _pin(
+    monkeypatch: pytest.MonkeyPatch,
+    names: set[str],
+    *,
+    complete: bool = True,
+    covered: bool | None = None,
+) -> None:
+    """Fix the pin scan's answer for one test (signature-matched to the real one).
+
+    ``covered`` fills the caller's ``coverage`` the way the real scan does. By
+    default it tracks ``complete``: an INCOMPLETE scan is also UNCOVERED -- a
+    task of this uid departed on the final pass, the churn shape -- so a test
+    that means "incomplete only because of root / other-user / hidepid gaps"
+    passes ``covered=True`` explicitly.
+    """
+    if covered is None:
+        covered = complete
+
+    def _fake(proc_root: str = "/proc", *, coverage=None, **_kw):
+        if coverage is not None and not covered:
+            coverage.covered = False
+        return (names, complete)
+
+    monkeypatch.setattr("kiro_crew.sandbox._mount_pinned_source_names", _fake)
 
 
 def _raise_einval_for(monkeypatch: pytest.MonkeyPatch, target: Path) -> None:
@@ -197,15 +229,16 @@ class TestMountSourceSweep:
         assert removed == 1
         assert not recycled.exists()
 
-    def test_incomplete_pin_scan_blocks_dir_removal(
+    def test_incomplete_and_uncovered_pin_scan_blocks_dir_removal(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
         """Absence-of-pin must be POSITIVELY established before any dir goes.
 
-        A partial /proc scan (fd exhaustion, an unmappable-uid holder) cannot
-        prove an entry is unreferenced, so the sweep must fail closed for
-        dirs — empty ones included, since rmdir of a live source S_DEADs the
-        mount — while plain files are unaffected by the scan.
+        With NEITHER line of evidence available — a partial /proc scan, and a
+        task of this uid that departed on its final pass (so a holder may exist
+        unread) — the sweep must fail closed for dirs, empty ones included,
+        since rmdir of a live source S_DEADs the mount. Plain files are
+        unaffected by the scan.
         """
         _pin(monkeypatch, set(), complete=False)
         held = _make_dir(tmp_path, f"kirocrew_sb_{_DEAD_PID}_part01", populate=True)
@@ -218,6 +251,28 @@ class TestMountSourceSweep:
         assert (held / "known_hosts").exists()
         assert empty.exists()
         assert not plain.exists()
+
+    def test_dirs_are_reclaimed_once_every_own_uid_task_was_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The regression this PR fixes: the pile must not wait on the
+        host-wide flag.
+
+        A scan left incomplete ONLY by what cannot hold a source this uid
+        staged -- another user's unreadable or departing tasks -- has still
+        read every task of this uid (and root's), so the pinned set is
+        authoritative for a sandbox descendant: a stale unpinned dir goes, a
+        pinned one stays.
+        """
+        _pin(monkeypatch, set(), complete=False, covered=True)
+        stale = _make_dir(tmp_path, f"kirocrew_sb_{_DEAD_PID}_inherit1", populate=True, old=True)
+        live_name = f"kirocrew_sb_{_DEAD_PID}_inherit2"
+        live = _make_dir(tmp_path, live_name, populate=True, old=True)
+        _pin(monkeypatch, {live_name}, complete=False, covered=True)
+
+        assert _cleanup_stale_sandbox_mount_sources(roots=[str(tmp_path)]) == 1
+        assert not stale.exists()
+        assert (live / "known_hosts").exists()
 
     def test_preserves_fresh_live_pid_entry(self, tmp_path: Path):
         live = _make_dir(tmp_path, f"kirocrew_sb_{_LIVE_PID}_live01")
@@ -820,19 +875,231 @@ class TestMountPinnedSourceNames:
         assert pinned == set()
         assert complete is False
 
-    def test_filtered_procfs_without_pid_1_reports_incomplete(self, tmp_path: Path):
+    def test_filtered_procfs_without_pid_1_reports_incomplete_but_still_pins(self, tmp_path: Path):
         """hidepid/subset=pid procfs hides other users' processes entirely —
         including a root holder — and pid 1 always exists, so a listing
-        without it proves filtering and must fail closed."""
+        without it proves filtering and must fail closed on COVERAGE.
+
+        It must NOT stop reading: this uid's own processes stay visible under
+        hidepid, and every sandbox descendant is one. An early return would
+        hand the directory gate an empty pinned set with nothing to reason
+        from. Caught by GPT 5.6 review of PR #8559.
+        """
         proc = tmp_path / "proc"
         d = proc / "106"
         d.mkdir(parents=True)
-        (d / "mountinfo").write_text("")
+        (d / "mountinfo").write_text(
+            f"1932 1355 0:55 /kirocrew_sb_{_DEAD_PID}_live1 /home/u/.ssh rw - tmpfs tmpfs rw\n"
+        )
 
         pinned, complete = _mount_pinned_source_names(proc_root=str(proc))
 
-        assert pinned == set()
         assert complete is False
+        assert pinned == {f"kirocrew_sb_{_DEAD_PID}_live1"}
+
+    @staticmethod
+    def _proc_task(
+        proc: Path, pid: int, *, mountinfo: str | None, threads: dict[int, str | None] | None = None
+    ) -> None:
+        """Plant ``/proc/<pid>`` with its ``task/`` group; a missing
+        ``mountinfo`` reads as a task that departed between the listing and
+        its read. ``threads`` plants sibling tids the same way."""
+        d = proc / str(pid)
+        d.mkdir(parents=True)
+        if mountinfo is not None:
+            (d / "mountinfo").write_text(mountinfo)
+            (d / "task" / str(pid)).mkdir(parents=True)
+            (d / "task" / str(pid) / "mountinfo").write_text(mountinfo)
+        for tid, text in (threads or {}).items():
+            (d / "task" / str(tid)).mkdir(parents=True)
+            if text is not None:
+                (d / "task" / str(tid) / "mountinfo").write_text(text)
+
+    def test_a_sibling_thread_in_another_namespace_pins(self, tmp_path: Path):
+        """A thread can ``unshare(CLONE_FS)`` + ``setns`` into a sandbox's
+        namespace while its leader stays outside; leaders-only reading would
+        miss its binds. Raised by GPT review of PR #8559."""
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        line = "100 99 0:40 /kirocrew_sb_777_home /root/home rw - tmpfs tmpfs rw\n"
+        self._proc_task(proc, 500, mountinfo="", threads={501: line})
+
+        coverage = _PinScanCoverage()
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert "kirocrew_sb_777_home" in pinned
+        assert complete is True and coverage.covered is True
+
+    def test_a_sibling_thread_departing_on_the_final_pass_clears_coverage(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A thread gone between the ``task/`` snapshot and its read may have
+        left a successor thread holding its namespace; only re-reading the
+        group can tell, and the final pass has no next pass."""
+        monkeypatch.setattr("kiro_crew.sandbox._PIN_SCAN_MAX_PASSES", 1)
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 500, mountinfo="", threads={501: None})
+
+        coverage = _PinScanCoverage()
+        _, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert complete is False and coverage.covered is False
+
+    def test_a_sibling_thread_departure_is_re_read_on_the_next_pass(self, tmp_path: Path):
+        """With a pass to spare the group is re-read; a settled group then
+        proves coverage."""
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 500, mountinfo="", threads={501: None})
+        real_listdir = os.listdir
+        calls = {"n": 0}
+
+        def _settling_listdir(path):
+            names = real_listdir(path)
+            if str(path).endswith(os.sep + "500" + os.sep + "task"):
+                calls["n"] += 1
+                if calls["n"] > 1:
+                    names = [n for n in names if n != "501"]  # the thread is gone
+            return names
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("kiro_crew.sandbox.os.listdir", _settling_listdir)
+            coverage = _PinScanCoverage()
+            _, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert calls["n"] == 2
+        assert complete is True and coverage.covered is True
+
+    def test_final_pass_departure_clears_coverage(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A task of this uid that departs on the FINAL pass may have handed its
+        namespace to a child forked after that pass's listing, which no
+        re-listing will catch — coverage of launcher descendants is unproven.
+        """
+        monkeypatch.setattr("kiro_crew.sandbox._PIN_SCAN_MAX_PASSES", 1)
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 4242, mountinfo=None)  # departed before its read
+        self._proc_task(proc, 4300, mountinfo="")
+
+        coverage = _PinScanCoverage()
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert complete is False
+        assert coverage.covered is False
+
+    def test_departure_followed_by_a_relisting_keeps_coverage(self, tmp_path: Path):
+        """A departure on a NON-final pass is followed by a re-listing that
+        would show any successor, so coverage stands."""
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 4242, mountinfo=None)
+
+        coverage = _PinScanCoverage()
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        # Pass 1 saw the departure and re-listed; pass 2 saw nothing new and no
+        # departure, so both the host-wide flag and coverage hold.
+        assert complete is True
+        assert coverage.covered is True
+
+    def test_filtered_procfs_clears_coverage(self, tmp_path: Path):
+        """``hidepid`` hides root's tasks along with pid 1, and root can hold
+        any namespace (``nsenter``), so coverage falls with the host-wide flag
+        rather than licensing removal on this uid's tasks alone. Raised by
+        GPT review of PR #8559."""
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 106, mountinfo="")
+        self._proc_task(proc, 107, mountinfo="")
+
+        coverage = _PinScanCoverage()
+        pinned, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert complete is False
+        assert coverage.covered is False
+
+    @staticmethod
+    def _stat_uid_of(monkeypatch: pytest.MonkeyPatch, pid: int, uid: int) -> None:
+        """Make ``/proc/<pid>`` stat as ``uid`` for the scan's uid pre-read."""
+        real_stat = os.stat
+
+        def _fake_stat(path, *a, **kw):
+            st = real_stat(path, *a, **kw)
+            if str(path).endswith(os.sep + str(pid)):
+                return os.stat_result(tuple(st)[:4] + (uid,) + tuple(st)[5:])
+            return st
+
+        monkeypatch.setattr("kiro_crew.sandbox.os.stat", _fake_stat)
+
+    @pytest.mark.skipif(
+        not hasattr(os, "getuid"), reason="without os.getuid every task is a possible holder"
+    )
+    def test_foreign_uid_departure_keeps_coverage(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Another user's task departing on the final pass lowers only the
+        host-wide flag: it cannot hold a source this uid staged."""
+        monkeypatch.setattr("kiro_crew.sandbox._PIN_SCAN_MAX_PASSES", 1)
+        monkeypatch.setattr("kiro_crew.sandbox._overflow_uid", lambda: 65534)
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 4242, mountinfo=None)
+        self._stat_uid_of(monkeypatch, 4242, (os.getuid() if hasattr(os, "getuid") else 1000) + 1)
+
+        coverage = _PinScanCoverage()
+        _, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert complete is False
+        assert coverage.covered is True
+
+    def test_root_departure_clears_coverage(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Root can ``nsenter`` a sandbox's namespace, so a root task departing
+        on the final pass is a possible holder gone unread."""
+        monkeypatch.setattr("kiro_crew.sandbox._PIN_SCAN_MAX_PASSES", 1)
+        monkeypatch.setattr("kiro_crew.sandbox._overflow_uid", lambda: 65534)
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 4242, mountinfo=None)
+        self._stat_uid_of(monkeypatch, 4242, 0)
+
+        coverage = _PinScanCoverage()
+        _, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert complete is False
+        assert coverage.covered is False
+
+    def test_unknown_overflow_uid_makes_a_foreign_departure_clear_coverage(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A holder inside a nested user namespace stats as the overflow uid.
+        When that uid cannot be learned (sysctl unreadable), a departing task of
+        ANY other uid may have been such a holder, so coverage fails closed.
+        Raised by GPT review of PR #8559."""
+        monkeypatch.setattr("kiro_crew.sandbox._PIN_SCAN_MAX_PASSES", 1)
+        monkeypatch.setattr("kiro_crew.sandbox._overflow_uid", lambda: None)
+        proc = tmp_path / "proc"
+        self._proc_task(proc, 1, mountinfo="")
+        self._proc_task(proc, 4242, mountinfo=None)
+        self._stat_uid_of(monkeypatch, 4242, (os.getuid() if hasattr(os, "getuid") else 1000) + 1)
+        coverage = _PinScanCoverage()
+        _, complete = _mount_pinned_source_names(proc_root=str(proc), coverage=coverage)
+
+        assert complete is False
+        assert coverage.covered is False
+
+    def test_gate_retains_a_pinned_dir_under_an_incomplete_but_covered_scan(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A pin from an incomplete scan still retains: a ``setsid()``
+        descendant's own mountinfo, being this uid's, is readable and wins."""
+        name = f"kirocrew_sb_{_DEAD_PID}_setsid1"
+        _pin(monkeypatch, {name}, complete=False, covered=True)
+        held = _make_dir(tmp_path, name)
+
+        assert _cleanup_stale_sandbox_mount_sources(roots=[str(tmp_path)]) == 0
+        assert held.exists()
 
     @pytest.mark.skipif(
         not os.path.isdir("/proc/1"),
@@ -858,6 +1125,395 @@ class TestMountPinnedSourceNames:
                 "(e.g. the test itself runs sandboxed) — fail-closed retention applies"
             )
         assert complete is True
+
+
+@requires_posix_modes
+class TestLegacyResidueSweep:
+    """The pre-#6268 ``tmp*`` residue is reclaimed once, behind every fence.
+
+    An install that upgraded past #6268 inherited a pile the keyed sweep cannot
+    reason about (no pid in the name), so shipping only the reclaim fix leaves
+    such a host at its inode ceiling and every spawn still failing. These names
+    cannot be PROVEN to be ours, so each test below pins one fence that keeps a
+    stranger's entry.
+    """
+
+    def _fence(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        root: Path,
+        *,
+        bound: set[str] | None = None,
+        complete: bool = True,
+        covered: bool | None = None,
+    ) -> None:
+        if covered is None:
+            covered = complete
+        monkeypatch.setattr("kiro_crew.sandbox._launcher_tmpfs_roots", lambda: [str(root)])
+
+        def _fake(proc_root="/proc", *, coverage=None, **_kw):
+            if coverage is not None and not covered:
+                coverage.covered = False
+            return (bound or set(), complete)
+
+        monkeypatch.setattr("kiro_crew.sandbox._bound_source_basenames", _fake)
+        # Each test below pins ONE fence; the pile threshold has its own tests.
+        monkeypatch.setattr("kiro_crew.sandbox._LEGACY_PILE_THRESHOLD", 1)
+
+    def _legacy_dir(self, root: Path, name: str = "tmpab12cd34", *, old: bool = True) -> Path:
+        path = root / name
+        path.mkdir(mode=0o700)
+        os.chmod(path, 0o700)  # umask can shave bits off the mkdir mode  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501  # fmt: skip
+        if old:
+            stale = time.time() - _MOUNT_SOURCE_MAX_AGE_SECONDS - 100
+            os.utime(path, (stale, stale))
+        return path
+
+    def _legacy_file(self, root: Path, name: str = "tmpef56gh78", *, old: bool = True) -> Path:
+        path = root / name
+        path.write_text("")
+        os.chmod(path, 0o600)
+        if old:
+            stale = time.time() - _MOUNT_SOURCE_MAX_AGE_SECONDS - 100
+            os.utime(path, (stale, stale))
+        return path
+
+    def test_reclaims_the_unkeyed_residue_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._fence(monkeypatch, tmp_path)
+        empty = self._legacy_dir(tmp_path)
+        plain = self._legacy_file(tmp_path)
+
+        removed = _cleanup_legacy_mount_source_residue()
+
+        assert removed == 1
+        assert not empty.exists()
+        # The old build's mkstemp FILE sources are left alone: an unlinked file
+        # another program still holds open loses what it writes next, and no
+        # fence can tell such a file from ours. Raised by GPT review of #8559.
+        assert plain.exists()
+        # Second call is a no-op: no current build creates the shape, so a
+        # completed pass is final and must not re-walk the tmpfs forever.
+        assert _cleanup_legacy_mount_source_residue() == 0
+
+    def test_a_planted_symlink_at_the_marker_is_not_followed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The stamp is create-only and O_NOFOLLOW: a dangling link at the
+        marker path fails the stamp (the pass repeats) instead of making the
+        gateway write at the link's target. Raised by GPT review of #8559."""
+        from kiro_crew.sandbox import _LEGACY_RESIDUE_MARKER, config_dir
+
+        self._fence(monkeypatch, tmp_path)
+        marker = config_dir() / _LEGACY_RESIDUE_MARKER
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        target = marker.parent / "security_policy.json"
+        marker.symlink_to(target)
+        self._legacy_dir(tmp_path)
+
+        assert _cleanup_legacy_mount_source_residue() == 1
+        assert not target.exists()
+        assert marker.is_symlink()  # untouched, so the pass is not retired
+
+    def test_incomplete_but_covered_scan_still_heals(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The same two claims as the keyed dir gate: ``/run/user/$UID`` is
+        reachable by this uid and root alone, so every-possible-holder-read is
+        enough when another user's task keeps the host-wide flag down. Raised
+        by First Principles review of #8559."""
+        self._fence(monkeypatch, tmp_path, complete=False, covered=True)
+        empty = self._legacy_dir(tmp_path)
+
+        assert _cleanup_legacy_mount_source_residue() == 1
+        assert not empty.exists()
+
+    def test_a_cohort_under_the_age_fence_withholds_the_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A host upgrading within a day of its last old-build spawn must not
+        retire the pass on the cohort that is merely too young yet. Raised by
+        Design review of #8559."""
+        self._fence(monkeypatch, tmp_path)
+        old = self._legacy_dir(tmp_path)
+        young = self._legacy_dir(tmp_path, "tmpyoung001", old=False)
+
+        assert _cleanup_legacy_mount_source_residue() == 1
+        assert not old.exists() and young.exists()
+        stale = time.time() - _MOUNT_SOURCE_MAX_AGE_SECONDS - 100
+        os.utime(young, (stale, stale))
+        # Not retired: the aged cohort is reclaimed by the next pass, which
+        # then finds nothing young and stamps.
+        assert _cleanup_legacy_mount_source_residue() == 1
+        assert not young.exists()
+        assert _cleanup_legacy_mount_source_residue() == 0
+
+    def test_unproven_bind_coverage_removes_nothing_and_does_not_retire_the_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """A failed scan must cost a retry, never the whole pass — and it must
+        be VISIBLE at the default log level, or a host whose /proc never settles
+        leaves this pass inert with nothing in the log to say so."""
+        self._fence(monkeypatch, tmp_path, complete=False)
+        held = self._legacy_dir(tmp_path)
+
+        with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
+            assert _cleanup_legacy_mount_source_residue() == 0
+        assert held.exists()
+        retained = [r for r in caplog.records if "legacy pass retained" in r.getMessage()]
+        assert len(retained) == 1
+        assert retained[0].levelno == logging.WARNING
+
+        self._fence(monkeypatch, tmp_path, complete=True)
+        assert _cleanup_legacy_mount_source_residue() == 1
+
+    def test_bound_entry_is_preserved(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Removing a live mount's source dir S_DEADs it — the bind scan decides."""
+        name = "tmpbound123"
+        self._fence(monkeypatch, tmp_path, bound={name})
+        held = self._legacy_dir(tmp_path, name)
+
+        assert _cleanup_legacy_mount_source_residue() == 0
+        assert held.exists()
+
+    def test_non_empty_dir_survives(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """``os.rmdir`` refusing a populated dir IS the emptiness fence.
+
+        It keeps both a stranger's working scratch dir and the legacy SSH shadow
+        dir, which holds a known-hosts copy.
+        """
+        self._fence(monkeypatch, tmp_path)
+        populated = self._legacy_dir(tmp_path, "tmpshadow12")
+        (populated / "known_hosts").write_text("example.com ssh-ed25519 AAAA\n")
+
+        assert _cleanup_legacy_mount_source_residue() == 0
+        assert (populated / "known_hosts").exists()
+
+    def test_bound_scan_keys_on_the_tmpfs_relative_root_field(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sandbox_sweep_original
+    ):
+        """mountinfo names a source relative to ITS filesystem, never by host path.
+
+        A source staged on the /run/user/$UID tmpfs reads as ``/tmpab12cd34``,
+        so any filter on the field's dirname matches nothing and silently
+        disarms the fence — which is exactly what the first cut of this scan did.
+        The synthetic lines below mirror a real host's (including a source
+        deleted while still bound, which reads ``//deleted``).
+        """
+        # The autouse floor pins both module attributes fail-closed; the real
+        # functions are reachable only through the conftest accessor, and the
+        # bound scan delegates to the pinned scan by NAME, so that one must be
+        # restored on the module for the delegation to reach the real walk.
+        bound_scan = sandbox_sweep_original("_bound_source_basenames")
+        monkeypatch.setattr(
+            "kiro_crew.sandbox._mount_pinned_source_names",
+            sandbox_sweep_original("_mount_pinned_source_names"),
+        )
+
+        proc = tmp_path / "proc"
+        (proc / "1").mkdir(parents=True)
+        (proc / "1" / "mountinfo").write_text("38 35 8:1 / / rw - ext4 /dev/sda1 rw\n")
+        (proc / "202").mkdir()
+        (proc / "202" / "mountinfo").write_text(
+            "1930 1355 0:55 /tmpab12cd34 /home/u/.gnupg rw,nosuid - tmpfs tmpfs rw\n"
+            "1931 1355 0:55 /tmpef56gh78//deleted /home/u/.aws rw,nosuid - tmpfs tmpfs rw\n"
+            "1932 1355 0:55 /kirocrew_sb_7_x /home/u/.ssh rw,nosuid - tmpfs tmpfs rw\n"
+            "1933 1355 0:55 /notlegacy /home/u/x rw - tmpfs tmpfs rw\n"
+        )
+
+        bound, complete = bound_scan(proc_root=str(proc))
+
+        assert complete is True
+        assert bound == {"tmpab12cd34", "tmpef56gh78"}
+
+    def test_fresh_foreign_and_wrong_shaped_entries_survive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Age, mode and name shape each keep an entry this sweep must not own."""
+        self._fence(monkeypatch, tmp_path)
+        fresh = self._legacy_dir(tmp_path, "tmpfresh1234"[:11], old=False)
+        loose = self._legacy_dir(tmp_path, "tmploose5678")
+        os.chmod(loose, 0o755)  # not a mkdtemp mode — hand-made or umask-shaped  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501  # fmt: skip
+        sized = self._legacy_file(tmp_path, "tmpsized9012")
+        sized.write_text("payload")
+        os.utime(sized, (time.time() - _MOUNT_SOURCE_MAX_AGE_SECONDS - 100,) * 2)
+        named = tmp_path / "tmp-not-mkdtemp"
+        named.mkdir(mode=0o700)
+        keyed = _make_dir(tmp_path, f"kirocrew_sb_{_DEAD_PID}_keyed01")
+
+        assert _cleanup_legacy_mount_source_residue() == 0
+        for path in (fresh, loose, sized, named, keyed):
+            assert path.exists(), path
+
+    def test_below_the_pile_threshold_everything_is_retained_and_the_pass_retires(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """An unkeyed name has no provenance; the PILE is the provenance.
+
+        A handful of empty, day-old ``tmp*`` dirs is what another same-uid
+        program's ``tempfile`` scratch looks like, and one it may still write
+        into — so below the threshold nothing is touched. There is also no
+        pile to heal, so the one-shot pass retires rather than re-walking the
+        tmpfs on every sweep. Caught by GPT 5.6 review of PR #8559.
+        """
+        self._fence(monkeypatch, tmp_path)
+        monkeypatch.setattr("kiro_crew.sandbox._LEGACY_PILE_THRESHOLD", 4)
+        strays = [self._legacy_dir(tmp_path, f"tmpstray00{i}") for i in range(3)]
+
+        assert _cleanup_legacy_mount_source_residue() == 0
+        for stray in strays:
+            assert stray.exists(), stray
+        # Retired: a later pass is a no-op even once more candidates appear.
+        self._legacy_dir(tmp_path, "tmpstray003")
+        assert _cleanup_legacy_mount_source_residue() == 0
+
+    def test_at_the_pile_threshold_the_buffered_candidates_are_reclaimed_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Candidates seen BEFORE the threshold is reached are not stranded."""
+        self._fence(monkeypatch, tmp_path)
+        monkeypatch.setattr("kiro_crew.sandbox._LEGACY_PILE_THRESHOLD", 4)
+        pile = [self._legacy_dir(tmp_path, f"tmppile000{i}") for i in range(6)]
+
+        assert _cleanup_legacy_mount_source_residue() == 6
+        for entry in pile:
+            assert not entry.exists(), entry
+
+    @pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only root chain")
+    def test_legacy_roots_exclude_dev_shm(self, sandbox_sweep_original):
+        """``/dev/shm`` is host-wide and where other programs' ``tempfile``
+        scratch legitimately lives; the unkeyed pass must never walk it, even
+        though the launcher falls back to it for staging."""
+        real = sandbox_sweep_original("_launcher_tmpfs_roots")
+        assert real() == [f"/run/user/{os.getuid()}"]
+
+    def test_wired_into_the_periodic_entry_point(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """It must run from the same call the gateway already makes, or a
+        just-updated host stays broken until someone finds it by hand."""
+        self._fence(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "kiro_crew.sandbox._mount_source_candidate_roots", lambda: [str(tmp_path)]
+        )
+        legacy = self._legacy_dir(tmp_path)
+
+        removed = cleanup_stale_sandbox_profiles(legacy_dir=str(tmp_path / "absent"))
+
+        assert removed >= 1
+        assert not legacy.exists()
+
+    def test_reclaim_starts_at_boot_without_holding_the_loop(self):
+        """The cleanup loop must START the reclaim, and must not WAIT on it.
+
+        Two failures this pins apart. Deferring the reclaim to the first interval
+        leaves a just-updated gateway unable to spawn anything for 5-10 minutes
+        with the fix already installed. Awaiting it instead queues every other
+        sweep in that loop behind a pass that a pathological pile or a stalled
+        filesystem can make arbitrarily slow -- so the reclaim is dispatched as
+        its own task, before the tick loop is entered.
+
+        Asserted structurally: the ORDER and the non-await are the contract, and
+        both are one edit away from silently regressing.
+        """
+        import kiro_crew.session_cleanup as cleanup_mod
+
+        tree = ast.parse(Path(cleanup_mod.__file__).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.AsyncFunctionDef) or node.name != "_cleanup_loop":
+                continue
+            body = [ast.dump(stmt) for stmt in node.body]
+            ticks = [i for i, dumped in enumerate(body) if "_run_cleanup_ticks" in dumped]
+            if not ticks:
+                continue  # the Protocol stub (`async def _cleanup_loop(self) -> None: ...`)
+            dispatch = [i for i, dumped in enumerate(body) if "_sweep_sandbox_artifacts" in dumped]
+            assert dispatch, "_cleanup_loop does not start the sandbox reclaim"
+            assert min(dispatch) < min(ticks), "the reclaim must be dispatched before the ticks"
+            assert (
+                "create_task" in body[min(dispatch)]
+            ), "the reclaim must be dispatched as a task, not awaited inline"
+            return
+        raise AssertionError("no _cleanup_loop implementation found in session_cleanup")
+
+
+class TestSweepTimeBudget:
+    """One pass is bounded; the remainder is the next pass's work.
+
+    The sweep shares the maintenance executor with other housekeeping, so a
+    multi-million-entry backlog must not hold a worker for a minute. Reclaim is
+    decided per entry, so a truncated pass is progress rather than an
+    inconsistent state.
+    """
+
+    def _spent_budget(self) -> pytest.MonkeyPatch:
+        """A SCOPED patcher for the budget knobs, deliberately not the test's own.
+
+        ``monkeypatch.undo()`` would also revert the autouse host-isolation floor
+        — including the ``KIROCREW_HOME`` pin — and this sweep then stamps its
+        one-shot marker into the operator's REAL data home. Caught in review of
+        this very test. Every knob here is therefore undone through its own
+        context, never the shared fixture.
+
+        Budget already spent, checked every SECOND entry: the check runs before
+        the entry it counts, so checking on the first would stop a pass having
+        done nothing, and a pass that can never progress is a different bug.
+        """
+        budget = pytest.MonkeyPatch()
+        budget.setattr("kiro_crew.sandbox._SWEEP_TIME_BUDGET_SECONDS", -1.0)
+        budget.setattr("kiro_crew.sandbox._SWEEP_BUDGET_CHECK_EVERY", 2)
+        return budget
+
+    def test_keyed_pass_stops_at_the_budget_and_resumes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        _pin(monkeypatch, set())
+        for index in range(4):
+            _make_file(tmp_path, f"kirocrew_sb_{_DEAD_PID}_file{index:02d}")
+
+        budget = self._spent_budget()
+        try:
+            with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
+                first = _cleanup_stale_sandbox_mount_sources(roots=[str(tmp_path)])
+        finally:
+            budget.undo()
+
+        assert first == 1
+        assert any("paused at the" in r.getMessage() for r in caplog.records)
+        assert len(list(tmp_path.iterdir())) == 3
+
+        # Budget restored: the remainder is reclaimed, nothing is stranded.
+        assert _cleanup_stale_sandbox_mount_sources(roots=[str(tmp_path)]) == 3
+        assert not list(tmp_path.iterdir())
+
+    @requires_posix_modes
+    def test_truncated_legacy_pass_does_not_stamp_the_one_shot_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Stamping a partial pass would retire the rest of the residue unswept."""
+        monkeypatch.setattr("kiro_crew.sandbox._launcher_tmpfs_roots", lambda: [str(tmp_path)])
+        monkeypatch.setattr(
+            "kiro_crew.sandbox._bound_source_basenames",
+            lambda proc_root="/proc", **_kw: (set(), True),
+        )
+        monkeypatch.setattr("kiro_crew.sandbox._LEGACY_PILE_THRESHOLD", 1)
+        stale = time.time() - _MOUNT_SOURCE_MAX_AGE_SECONDS - 100
+        for name in ("tmpaaaaaaaa", "tmpbbbbbbbb", "tmpcccccccc"):
+            path = tmp_path / name
+            path.mkdir(mode=0o700)
+            os.chmod(path, 0o700)  # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions  # noqa: E501  # fmt: skip
+            os.utime(path, (stale, stale))
+
+        budget = self._spent_budget()
+        try:
+            assert _cleanup_legacy_mount_source_residue() == 1
+        finally:
+            budget.undo()
+        assert len(list(tmp_path.iterdir())) == 2
+
+        # The marker was NOT stamped, so the next pass finishes the residue.
+        assert _cleanup_legacy_mount_source_residue() == 2
+        assert not list(tmp_path.iterdir())
 
 
 class TestHeldBackDiagnostic:

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -3039,12 +3039,16 @@ class TestCleanupLoop:
             with caplog.at_level(logging.INFO, logger="kiro_crew.session"):
                 await mgr._cleanup_loop()
 
-        # Verify: sweep was called (production wiring)
-        mock_sweep.assert_called_once()
-        # Verify the offload: ran on a maintenance-executor worker thread,
-        # not the event loop thread (run_in_executor path).
+        # Verify: sweep was called (production wiring). At least once, not
+        # exactly once: the loop now also dispatches one reclaim pass at START
+        # (a host whose runtime tmpfs is out of inodes cannot spawn at all, so
+        # that pass must not wait out an interval), so a run can legitimately
+        # record the boot pass, the tick pass, or both.
+        assert mock_sweep.call_count >= 1
+        # Verify the offload: EVERY call ran on a maintenance-executor worker
+        # thread, not the event loop thread (run_in_executor path).
         assert sweep_threads, "sweep never executed"
-        assert sweep_threads[0] != threading.main_thread().name
+        assert all(name != threading.main_thread().name for name in sweep_threads)
         assert sweep_threads[0].startswith("mc-maint")
         # Verify: non-zero return produces the info log
         assert "removed 3 stale sandbox artifacts" in caplog.text


### PR DESCRIPTION
## Problem / Motivation

Every agent spawn on a busy Linux host dies with `AcpRuntimeDead: process exited (rc=None)`; with `agent.log_level=WARNING` the cause surfaces as `Failed to start transient scope unit: No space left on device`. `/run/user/$UID` is out of **inodes** (3,244,965 / 3,244,965), so `systemd-run --user --scope` cannot allocate a unit and `cgroup_scope_argv`'s wrapped spawn exits before the ACP handshake.

What filled it is our own sandbox launcher's bind-mount sources. #6268 added a sweep for them, but it reclaims the FILE class only. Measured after ~21h of hourly sweeps on one host:

```
 929540 d
    511 f      # find /run/user/$UID -maxdepth 1 -name 'kirocrew_sb_*' -printf '%y\n' | sort | uniq -c
```

The same host also carried 1,836,596 pre-#6268 `tmp*` sources with no pid in the name, which the sweep documents as out of scope.

## Why it matters

Self-inflicted, total DoS of the agent surface — chat slots, eager spawns, warm pool, subagents — on any Linux host that spawns continuously. Nothing reclaims the tmpfs automatically (only ending the systemd user session does), the fix-forward sweep cannot reason about the legacy pile, and the failure is invisible at the default log level. An operator who updates to a build with only the dir-gate fix stays exactly as broken as before.

## What changed (motivation → approach → change)

**Root cause.** The sweep's dir branch gated every removal on `_mount_pinned_source_names()`'s host-wide `scan_complete` flag, and that flag drops for reasons that cannot involve a sandbox. Reproduced on the affected host with the installed build's own scan: `complete=False` on every call, because 29 zombie thread-group leaders answer `EINVAL` for `mountinfo` (#8090 on main reads their live siblings through `task/`; the installed 0.6.0.11 predates it). The same flag also drops for another user's unreadable task, or one departing during the final pass — hosts #8090 does not help. It asks the wrong question: a source is bindable only by a launcher descendant, which keeps *this* uid (`NO_NEW_PRIVS`; a nested user namespace stats as the overflow uid), or by root, so the gate needs a narrower claim than host-wide coverage.

**1. The dir gate accepts a narrower coverage claim.**
```python
pinned, scan_complete = _mount_pinned_source_names(coverage=coverage)
if entry in pinned or not (scan_complete or coverage.covered):
```
`_PinScanCoverage.covered` holds when every task that could hold a source this uid staged — this uid's, the overflow uid's, root's (root can `nsenter` any namespace), or one gone before its uid could be read — was read, none was unreadable, and none departed between the *final* pass's listing and its read; a departure on an earlier pass is followed by a re-listing that shows any child it handed the namespace to, the final pass has none. Another user's unreadable or departing task lowers `complete` but not `covered`; a `hidepid` procfs, which hides root's tasks, lowers both. Without a uid to compare against (no `os.getuid`, unreadable overflowuid sysctl) every task counts, so coverage fails closed. A readable pin always wins. A live leader that could be a holder also has every sibling thread's `task/<tid>/mountinfo` read (a thread can `unshare(CLONE_FS)` + `setns` into a namespace its leader is not in; `/proc` lists leaders only), a sibling departed mid-read re-reads its group on the next pass — 3.5k sibling reads in 0.25s on the incident host, surfacing 21 pins leaders alone missed. On a filtered procfs the scan now keeps reading every pid the listing does show before reporting incomplete, instead of returning an empty set; both scans strip a `//deleted` suffix so a source removed while still bound pins by its real name.

No per-entry process-group probe. An earlier cut of this branch keyed sources on a group id and accepted "no such group" as evidence; review showed that unsound three ways (the fork child's pid is not a group id, a `setsid()` descendant leaves the group, and its group cannot be attributed once it has departed). The coverage claim above subsumes the only case the probe existed for, so it is gone along with the `g<pgid>` name shape — names stay `kirocrew_sb_<pid>_*` exactly as on main.

**Field validation (shipped gate, read-only dry run)** on two hosts carrying inherited piles: 193,203 and 49,231 dirs all reclaimable (`complete=True`, `covered=True`; scan 0.25s with sibling threads), 32 and 6 live-pinned kept, 90 fresh-live skipped. The 938,864 figure from an earlier cut used the since-removed group probe and is history, not a claim about this code.

**2. One-shot reclaim of the pre-#6268 residue** (`_cleanup_legacy_mount_source_residue`), so an already-stuck host heals on update. An unkeyed name cannot be proven ours, so every fence keeps a stranger's entry: the session runtime tmpfs `/run/user/$UID` only (never `/dev/shm` or the shared tempdir), tempfile's exact shape, own uid, **directories only** in `mkdtemp`'s exact 0o700 (the old build's `mkstemp` file sources are left alone: an unlinked file another program still holds open loses what it writes next, which no fence can rule out, while an empty dir holds nothing to lose), past the 24h backstop, unbound per a scan that is complete **or** read every possible holder (`/run/user/$UID` is 0o700 and this uid's, so the same `covered` claim as the dir gate applies), a PILE threshold (`_LEGACY_PILE_THRESHOLD` = 64 candidates passing every other fence before any is touched — the pile is the only provenance an unkeyed name has; a stray scratch dir or two is retained outright), and `os.rmdir`'s refusal on a populated dir as the emptiness fence. A marker retires the pass once it has reached the end with nothing retained for age alone (a host upgrading within a day of its last old-build spawn keeps the pass until that cohort ages out), or once a root proves it holds no pile. When bind coverage cannot be established the pass retains everything and says so at WARNING (the keyed sweep's held-back report already does), instead of going inert silently. The bind scan delegates to `_mount_pinned_source_names` via a new `matcher` predicate rather than re-walking `/proc` (a first cut filtered on the mountinfo root field's dirname — that field is tmpfs-relative, so the fence matched nothing — and treated every `EINVAL` as a gap, which 29 zombie leaders on the real host would have made permanently inert). Both scans strip a `//deleted` suffix.

**3. Startup and boundedness.** The cleanup loop DISPATCHES one reclaim pass at start (a task, not awaited) instead of waiting out its 5–10 min interval; gateway readiness is untouched. Both passes honour a 10s wall-clock budget per pass — reclaim is per-entry, so a truncated pass is progress and the next tick resumes, and the legacy marker is stamped only by a pass that reached the end.

**Also:** seven pre-existing `test_sandbox_argv.py` failures on hosts without systemd — the cgroup-scope tests mock `_probe_cgroup_scope` but `cgroup_scope_argv` also needs `trusted_system_bin("systemd-run")` to resolve. A `systemd_run_resolvable` fixture fakes only that name; tests asserting degradation when it is absent patch the resolver themselves and are unaffected.

## Tests

`test/test_sandbox_mount_source_sweep.py` (73 passed on Linux):
- `test_dirs_are_reclaimed_once_every_own_uid_task_was_read` — the regression (incomplete but covered scan: stale dir goes, pinned dir stays); `test_incomplete_and_uncovered_pin_scan_blocks_dir_removal` — fail-closed when neither claim holds.
- `TestMountPinnedSourceNames` coverage cases: final-pass departure clears `covered`, an earlier-pass one is re-listed and keeps it; a foreign-uid departure keeps it while a root one, an unknown overflow uid and a filtered procfs clear it; a sibling thread's pin counts, its mid-read departure re-reads the group.
- `TestLegacyResidueSweep` — each fence individually (dirs only; files survive), the `covered` gate, one-shot marker withheld while an age-fenced cohort remains, wiring into the periodic entry point, boot dispatch as a non-awaited task (AST-asserted), and `test_bound_scan_keys_on_the_tmpfs_relative_root_field` with a synthetic `/proc` mirroring a real host's mountinfo lines (`//deleted` included).
- `TestSweepTimeBudget` — truncation resumes on the next pass and does not stamp the legacy marker.

`conftest.py`: the host-isolation floor now also pins `_launcher_tmpfs_roots` and defaults `_bound_source_basenames` fail-closed (without it the suite scans the developer's real `/run/user/$UID` and `/dev/shm`). Budget tests use a scoped `MonkeyPatch`: `monkeypatch.undo()` reverts the floor including the `KIROCREW_HOME` pin and the sweep then stamps its marker in the real data home — observed while writing them.

`test_session.py::test_cleanup_loop_runs_sandbox_sweep_via_executor` now asserts `call_count >= 1` (the boot dispatch is a legitimate second pass) and checks the executor offload for every call. `test_sandbox_argv.py` 189 passed.

## Manual verification

Ran the patched dir gate against the real 939k-entry pile on the affected host, reusing the installed module's own name parsing, pin scan and pid probe so only the gate differed: `pin scan complete=False` (the defect, live), `removed dirs=938864 files=87, held_back pinned=6, fresh_and_alive=187, failed=0`, `/run/user/$UID` 1% of inodes afterwards, 654 transient scopes started in the following 3 minutes with no further `AcpRuntime dead`. Verified the legacy bind scan on the same host: `complete=False` before the delegation fix, `complete=True` after (0.05s).

## Related Issues

Fixes #8558

## Pattern harvest

Rule candidate: review-prompt
Pattern: a host-wide / aggregate coverage or completeness flag used to gate a per-entry decision (the flag can never settle on a busy host, so the gate silently retains forever).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behaviour documented in the sweep's docstrings
- [x] No secrets, credentials, or internal references in the diff

