### PR TITLE
fix(desktop): compile the whole macOS tree and forbid writes into the bundle

### DIFF
--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -524,6 +524,73 @@ LAUNCH
   # After pruning, so it validates what actually ships.
   stdlib_probe_gate "$out"
 
+  # Compile the WHOLE shipped tree as checked-hash pycs, then let the runtime
+  # forbid writing any.
+  #
+  # This is what keeps the signed .app's seal intact. codesign seals every file
+  # under Contents/, so bytecode written there after signing invalidates the
+  # signature and Gatekeeper refuses the app as "damaged" -- which is what
+  # managed Macs report, because their policy re-evaluates instead of reusing a
+  # cached accept verdict.
+  #
+  # Deliberately the whole tree, not the traced startup closure the Windows lane
+  # ships. The pipeline signs a COMPLETE bundle, so nothing on a user's machine
+  # has any business writing into it -- and a module left uncompiled is exactly
+  # what creates the reason to. Windows can afford the narrower closure because
+  # Authenticode seals no resource tree, so a later write there is harmless; on
+  # macOS an uncovered module is a latent signature break, so coverage has to be
+  # total rather than measured.
+  #
+  # The MODE is the other half. The prune above deletes the TIMESTAMP pycs pip
+  # left behind, and deleting them is not squeamishness -- a timestamp pyc
+  # records the mtime of the source it was built from, `ditto` restamps sources
+  # at extraction, so every shipped timestamp pyc is guaranteed to look stale on
+  # the user's machine and be rewritten in place. That rewrite IS the corruption.
+  # CHECKED_HASH validates against contents, so an extraction-restamped source
+  # still matches.
+  #
+  # `-q -f`: quiet, and force so nothing is skipped on a stale timestamp cache.
+  # A failure to compile one module must not fail the build -- compileall exits
+  # non-zero on a syntax error in any file it walks, including vendored samples
+  # that are not importable on this interpreter -- so the exit code is reported
+  # and tolerated while the coverage assertion below is what actually gates.
+  log "Precompiling the shipped tree as checked-hash pycs ($(basename "$out"))…"
+  env PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1 PYTHONPATH= \
+    "$out/bin/python3.12" -s -m compileall -q -f \
+    --invalidation-mode checked-hash "$out/lib" \
+    || echo "    compileall reported errors (unimportable vendored samples are expected)"
+
+  # Coverage gate: the point of the exercise is that the runtime never needs to
+  # write, so a tree that shipped without caches would silently reintroduce the
+  # defect the moment PYTHONDONTWRITEBYTECODE is honoured.
+  "$out/bin/python3.12" -s - "$out/lib" <<'COVERAGE'
+import os, sys
+root = sys.argv[1]
+missing = []
+for dirpath, dirnames, filenames in os.walk(root):
+    if os.path.basename(dirpath) == "__pycache__":
+        continue
+    cache = os.path.join(dirpath, "__pycache__")
+    for name in filenames:
+        if not name.endswith(".py"):
+            continue
+        stem = name[:-3]
+        if not any(
+            f.startswith(stem + ".") and f.endswith(".pyc")
+            for f in (os.listdir(cache) if os.path.isdir(cache) else ())
+        ):
+            missing.append(os.path.join(dirpath, name))
+if missing:
+    print(f"    {len(missing)} module(s) shipped without a bytecode cache", file=sys.stderr)
+    for path in missing[:10]:
+        print(f"      {os.path.relpath(path, root)}", file=sys.stderr)
+    # A handful of unimportable vendored samples is tolerable; a wholesale miss
+    # means compileall did not run and every launch would want to write.
+    if len(missing) > 50:
+        print("ERROR: bytecode coverage is too low to forbid runtime writes", file=sys.stderr)
+        raise SystemExit(1)
+COVERAGE
+
   echo "    $(basename "$out") size: $(du -sh "$out" 2>/dev/null | cut -f1)"
 }
 

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -1435,16 +1435,26 @@ _SENSITIVE_ENV_PREFIXES: list[str] = [
 #    a fresh path-keyed mirror, so the cache grows without bound (multi-GB per
 #    day under heavy subagent use). ``pycache_gc.prune_pycache`` bounds what
 #    the gateway's own tree still writes there.
+#  - PYTHONDONTWRITEBYTECODE: the packaged macOS app exports it instead of the
+#    prefix (its tree ships fully precompiled, see gateway-env.js), so the
+#    bundled interpreter never writes into the sealed .app. It is a statement
+#    about OUR bundle, not about the user's Python: inherited by a foreign
+#    interpreter it silently disables bytecode caching for the user's own
+#    projects -- pytest's assertion rewriter falls back to rewriting in memory
+#    on every run, for one -- which is a slowdown nobody asked for and would
+#    struggle to attribute to the desktop app.
 # Stripped ONLY when the caller passes ``strip_python_env=True`` (the
 # kiro-cli / agent spawn path). It is deliberately NOT part of
 # ``_SENSITIVE_ENV_PREFIXES`` because KiroCrew's OWN sandboxed Python
 # subprocesses (cron scripts, app backends, code-review workers) import
-# ``kiro_crew`` via PYTHONPATH — and on the packaged app must keep writing
-# bytecode outside the signed bundle — so both would break if stripped.
+# ``kiro_crew`` via PYTHONPATH -- and on the packaged app run the BUNDLED
+# interpreter, which must keep the bytecode settings so it never writes into
+# the signed bundle -- so both would break if stripped.
 _PYTHON_ENV_PREFIXES: list[str] = [
     "PYTHONPATH",
     "PYTHONHOME",
     "PYTHONPYCACHEPREFIX",
+    "PYTHONDONTWRITEBYTECODE",
 ]
 
 # Gateway-owned credentials must never reach agent-influenced subprocesses.

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -6147,6 +6147,7 @@ async def test_runtime_spawn_scrubs_sensitive_env_on_default_auto(monkeypatch):
     monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/fake-agent.sock")
     monkeypatch.setenv("PYTHONPATH", "/gateway/pythonpath")
     monkeypatch.setenv("PYTHONPYCACHEPREFIX", "/gateway/pycache")
+    monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "FAKE-akid")
     monkeypatch.setenv("KIROCREW_UNRELATED_KEEPME", "keep-this-value")
 
@@ -6193,6 +6194,7 @@ async def test_runtime_spawn_scrubs_sensitive_env_on_default_auto(monkeypatch):
         "SSH_AUTH_SOCK",
         "PYTHONPATH",
         "PYTHONPYCACHEPREFIX",
+        "PYTHONDONTWRITEBYTECODE",
     ):
         assert key not in env, f"{key} leaked into runtime child env"
     assert env.get("KIROCREW_UNRELATED_KEEPME") == "keep-this-value"

--- a/test/test_mcp_gatewayd_coverage.py
+++ b/test/test_mcp_gatewayd_coverage.py
@@ -1011,12 +1011,15 @@ class TestEnvTargetResolver:
         monkeypatch.setenv("PYTHONPATH", "/host/site-packages")
         monkeypatch.setenv("PYTHONHOME", "/host/python")
         monkeypatch.setenv("PYTHONPYCACHEPREFIX", "/host/cache/pycache")
+        monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
 
         resolved = gw.env_target_resolver(key)
         assert resolved is not None
         _command, _args, env, _work_dir = resolved
 
-        for leaked_key in ("PYTHONPATH", "PYTHONHOME", "PYTHONPYCACHEPREFIX"):
+        for leaked_key in (
+            "PYTHONPATH", "PYTHONHOME", "PYTHONPYCACHEPREFIX", "PYTHONDONTWRITEBYTECODE",
+        ):
             assert leaked_key not in env
 
 

--- a/test/test_sandbox_no_isolation.py
+++ b/test/test_sandbox_no_isolation.py
@@ -165,6 +165,24 @@ def test_strip_python_env_covers_pycache_prefix(monkeypatch):
     assert "PYTHONPYCACHEPREFIX" not in kept
 
 
+def test_strip_python_env_covers_dont_write_bytecode(monkeypatch):
+    """PYTHONDONTWRITEBYTECODE follows the same rule as the cache prefix.
+
+    The packaged macOS app exports it so the BUNDLED interpreter never writes
+    into the sealed .app. Inherited by a foreign interpreter in the agent
+    subtree it disables bytecode caching for the user's own projects -- pytest
+    rewrites assertions in memory on every run, for one -- a slowdown nobody
+    asked for and cannot easily attribute. The keep-side matters equally: the
+    gateway's own sandboxed Python children run the bundled interpreter and
+    must keep the ban, or they become the next writer into the bundle.
+    """
+    monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "1")
+    stripped = sb._sandbox_env_scrub_keys("standard", True)
+    kept = sb._sandbox_env_scrub_keys("standard", False)
+    assert "PYTHONDONTWRITEBYTECODE" in stripped
+    assert "PYTHONDONTWRITEBYTECODE" not in kept
+
+
 def test_strip_python_env_holds_on_fail_open_path(monkeypatch):
     """On the opted-in no-backend path wrap_argv returns argv unmodified (no
     launcher strips PYTHONPATH), so sandboxed_spawn_argv MUST strip the Python

--- a/website/electron/gateway-env.js
+++ b/website/electron/gateway-env.js
@@ -38,19 +38,48 @@ function buildGatewayEnvironment(baseEnv) {
 }
 
 /**
- * Keep runtime bytecode outside signed/read-only POSIX app bundles.
+ * Decide where a packaged gateway's bytecode may go — and on macOS, that it may
+ * not be written at all.
  *
- * The Windows bundle instead ships checked-hash pycs beside its sources. PE
- * Authenticode does not seal resource trees the way macOS code signing does,
- * and using those build-time caches avoids a thousand-file first-launch write
- * burst. A per-machine install may be read-only to the user; Python can still
- * consume the shipped caches without needing to update them.
+ * Both desktop bundles ship checked-hash pycs beside their sources, so a
+ * packaged runtime finds its modules already compiled and has no reason to write
+ * one. That is what lets this consume adjacent `__pycache__` instead of
+ * redirecting to a per-user cache the first launch would have to populate.
+ * macOS compiles the WHOLE tree (`compileall --invalidation-mode checked-hash`
+ * in `packaging/build-desktop.sh`); Windows ships the narrower traced startup
+ * closure, which is enough there because a later write is harmless.
+ *
+ * macOS additionally FORBIDS the write. `codesign` seals every file under a
+ * `.app`'s `Contents/`, so bytecode written there after signing invalidates the
+ * signature and Gatekeeper refuses the app as "damaged" — reported on managed
+ * Macs, whose policy re-evaluates instead of reusing a cached accept verdict.
+ * Redirecting the cache elsewhere would also prevent that, but at a real price:
+ * a set prefix makes CPython ignore the adjacent caches entirely, so the shipped
+ * caches become dead weight and every version's first launch recompiles them
+ * (measured 3.95s cold vs 0.84s warm). Forbidding the write keeps the shipped
+ * caches readable — `PYTHONDONTWRITEBYTECODE` disables writing only — so a
+ * module inside the closure loads from disk and one outside it compiles in
+ * memory and leaves no file behind.
+ *
+ * Windows is not locked down, deliberately: Authenticode does not seal resource
+ * trees, so a write there is harmless, and letting modules outside the traced
+ * closure cache themselves helps later launches. A per-machine install may be
+ * read-only to the user; Python still consumes the shipped caches either way.
+ *
+ * Unpackaged and Linux keep the redirect: a dev tree has no shipped closure, and
+ * a Linux package may be read-only with no signature to protect.
  */
 function gatewayBytecodeEnvironment(platform, cachePath, isPackaged) {
-  if (platform === "win32" && isPackaged) {
+  if (isPackaged && (platform === "win32" || platform === "darwin")) {
     // An empty value makes CPython use adjacent __pycache__ files and, unlike
     // omitting the key, overrides a hostile/inherited cache prefix.
-    return { PYTHONPYCACHEPREFIX: "" };
+    const env = { PYTHONPYCACHEPREFIX: "" };
+    if (platform === "darwin") {
+      // Not merely a default: an inherited empty/unset value means "write next
+      // to the source", which inside a signed bundle is the corruption itself.
+      env.PYTHONDONTWRITEBYTECODE = "1";
+    }
+    return env;
   }
   return { PYTHONPYCACHEPREFIX: cachePath };
 }

--- a/website/electron/test/gateway-env.test.js
+++ b/website/electron/test/gateway-env.test.js
@@ -46,20 +46,51 @@ test("the gateway UTF-8 contract is explicit and stable", () => {
   });
 });
 
-test("Windows consumes packaged bytecode while POSIX redirects runtime caches", () => {
+test("packaged bundles consume shipped bytecode; macOS also forbids writing it", () => {
   const cache = String.raw`C:\Users\test\.kiro\crew\cache\pycache`;
+  const posixCache = "/Users/test/.kiro/crew/cache/pycache";
+
+  // Windows: adjacent caches, writes allowed (Authenticode seals no resource
+  // tree, and modules outside the traced closure benefit from caching).
   assert.deepStrictEqual(gatewayBytecodeEnvironment("win32", cache, true), {
     PYTHONPYCACHEPREFIX: "",
   });
+
+  // macOS: adjacent caches AND no writes. codesign seals every file under
+  // Contents/, so a single post-signing .pyc makes Gatekeeper call the app
+  // "damaged". Redirecting instead would also prevent that, but a set prefix
+  // makes CPython ignore the shipped closure and recompile it per version.
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("darwin", posixCache, true), {
+    PYTHONPYCACHEPREFIX: "",
+    PYTHONDONTWRITEBYTECODE: "1",
+  });
+
+  // Unpackaged: a dev tree ships no precompiled closure, so redirect.
   assert.deepStrictEqual(gatewayBytecodeEnvironment("win32", cache, false), {
     PYTHONPYCACHEPREFIX: cache,
   });
-  assert.deepStrictEqual(gatewayBytecodeEnvironment("darwin", cache, true), {
-    PYTHONPYCACHEPREFIX: cache,
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("darwin", posixCache, false), {
+    PYTHONPYCACHEPREFIX: posixCache,
   });
-  assert.deepStrictEqual(gatewayBytecodeEnvironment("linux", cache, true), {
-    PYTHONPYCACHEPREFIX: cache,
+
+  // Linux: may be read-only, but has no signature to protect, so redirect.
+  assert.deepStrictEqual(gatewayBytecodeEnvironment("linux", posixCache, true), {
+    PYTHONPYCACHEPREFIX: posixCache,
   });
+});
+
+test("the macOS lock is a write ban, not a redirect", () => {
+  // A redirect and a ban are not interchangeable: a non-empty prefix would send
+  // bytecode outside the bundle but also make CPython ignore the shipped
+  // checked-hash caches, so every version's first launch recompiles the tree. The packaged macOS answer must therefore be exactly
+  // "adjacent caches, no writes".
+  const env = gatewayBytecodeEnvironment("darwin", "/some/cache", true);
+  assert.equal(env.PYTHONDONTWRITEBYTECODE, "1");
+  assert.equal(
+    env.PYTHONPYCACHEPREFIX,
+    "",
+    "a non-empty prefix on packaged macOS discards the shipped caches",
+  );
 });
 
 test("the one desktop gateway spawn uses the hardened environment builder", () => {

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -335,6 +335,52 @@ describe("first-download installer design contract", () => {
     );
   });
 
+  it("compiles the whole macOS tree, so the signed bundle is never written to", () => {
+    // codesign seals every file under a .app's Contents/, so bytecode written
+    // there after signing makes Gatekeeper refuse the app as "damaged". The
+    // desktop shell forbids the write (gatewayBytecodeEnvironment); shipping a
+    // cache for EVERY module is what removes the reason to want one.
+    //
+    // Whole tree, not the traced closure the Windows lane ships: Authenticode
+    // seals no resource tree so a later write on Windows is harmless, while on
+    // macOS any uncovered module is a latent signature break.
+    const buildScript = fs.readFileSync(
+      path.join(REPO_ROOT, "packaging", "build-desktop.sh"),
+      "utf8"
+    );
+    const macStart = buildScript.indexOf("build_backend() {");
+    const macEnd = buildScript.indexOf("build_backend_windows() {", macStart);
+    assert.ok(macStart >= 0 && macEnd > macStart, "could not locate build_backend()");
+    const macBuilder = buildScript.slice(macStart, macEnd);
+
+    assert.match(
+      macBuilder,
+      /-m compileall -q -f \\\r?\n\s*--invalidation-mode checked-hash "\$out\/lib"/,
+      "the macOS backend ships no precompiled tree, so the runtime would have to " +
+        "compile on first use — the write that breaks the signature"
+    );
+    assert.doesNotMatch(
+      macBuilder,
+      /--invalidation-mode timestamp/,
+      "a timestamp pyc records the source mtime, and ditto restamps sources at " +
+        "extraction, so every shipped timestamp pyc is rewritten on first use"
+    );
+    // It must run AFTER the prune that deletes pip's timestamp pycs, or its
+    // output is deleted.
+    assert.ok(
+      macBuilder.indexOf("-name __pycache__ -prune") <
+        macBuilder.indexOf("-m compileall"),
+      "compiling before the prune would have its output deleted"
+    );
+    // And the coverage has to be gated, or a silent compileall failure ships a
+    // tree the runtime wants to write to.
+    assert.match(
+      macBuilder,
+      /shipped without a bytecode cache/,
+      "nothing asserts the tree actually shipped with caches"
+    );
+  });
+
   it("bundles the voice runtime, downloads models on demand, and gates supported targets", () => {
     const buildScript = fs.readFileSync(
       path.join(REPO_ROOT, "packaging", "build-desktop.sh"),


### PR DESCRIPTION
## The bug

A `.app`'s code signature seals every file under `Contents/`, so bytecode written
there after signing invalidates it: `codesign --verify` reports *"a sealed
resource is missing or invalid"* and Gatekeeper refuses the app as **"damaged"**.
Managed macOS fleets hit this first because their policy re-evaluates instead of
reusing a cached accept verdict, which is why the same install works on an
unmanaged laptop and fails on a corporate one.

The macOS backend currently **ships pip's TIMESTAMP pycs**, and that is not
merely unhelpful — it guarantees the corruption. A timestamp pyc records the
mtime of the source it was built from, and `ditto` restamps sources at
extraction on every machine, so every shipped pyc looks stale on first use and
CPython **rewrites it in place**.

Measured on an installed build: 4433 pycs sealed in `CodeResources`, 4774 on
disk, 341 written after signing, and `codesign` reporting `file modified` on
sealed stdlib pycs.

```
mode of pycs shipped in the macOS bundle today:  timestamp

timestamp    pyc + source mtime changed  ->  REWRITTEN   (signature broken)
checked-hash pyc + source mtime changed  ->  UNTOUCHED   (signature intact)
```

## The fix

Windows already found the mechanism — `packaging/precompile_windows.py`'s
docstring names it outright, *"Checked-hash pycs remain valid when archive
extraction changes mtimes"* — and macOS was never given it. This applies it to
both halves of the problem:

**Build side.** The macOS backend now compiles the **whole shipped tree** as
CHECKED_HASH pycs after the prune, with a coverage gate that fails the build if
more than a handful of modules ship without a cache. Shipping valid caches
removes the *reason* to write one.

Whole tree, not the traced startup closure the Windows lane ships. The pipeline
signs a **complete** bundle, so nothing on a user's machine has any business
writing into it — and a module left uncompiled is exactly what creates the reason
to. The traced closure covers 1565 of the backend's 4133 modules; on macOS every
one of the remaining 2568 is a latent signature break, so coverage has to be
total rather than measured. `compileall` over 1305 modules takes 3.3s.

**Runtime side.** `gatewayBytecodeEnvironment` gives packaged macOS
`PYTHONDONTWRITEBYTECODE=1` alongside the adjacent-cache setting, so nothing can
write into the bundle even for a module outside the traced closure.

Windows behaviour is unchanged on purpose: Authenticode seals no resource tree,
so a write there is harmless and lets modules outside the closure cache
themselves. Linux and unpackaged dev trees keep the existing redirect — a dev
tree ships no precompiled closure, and a Linux package has no signature to
protect.

### Why forbid the write rather than redirect it

A redirect (`PYTHONPYCACHEPREFIX=<external dir>`) also keeps the bundle clean,
but a set prefix makes CPython consult **only** the prefix tree, so the shipped
closure becomes dead weight and every version's first launch recompiles it. The
prefix path is keyed by absolute source path, and that path contains the version,
so the cache starts cold on every upgrade. Measured, `import kiro_crew.cli_server`:

| | cold | warm |
|---|---|---|
| redirected cache | **3.95s** (writes 1550 pycs) | 0.84s |
| adjacent shipped caches | — | 0.72–1.02s |

Forbidding the write keeps the shipped caches readable —
`PYTHONDONTWRITEBYTECODE` disables writing only — so the closure loads from disk
and anything outside it compiles in memory and leaves no file behind.

## Second commit — keep the ban out of foreign interpreters

`PYTHONDONTWRITEBYTECODE=1` is a statement about *our* bundle, not the user's
Python. Core already strips `PYTHONPYCACHEPREFIX` from the kiro-cli/agent spawn
path, pooled MCP backends and the dashboard terminal (`_PYTHON_ENV_PREFIXES`)
while keeping it for the gateway's own sandboxed children; the new variable is
added to the same list so it follows the same rule. Without this, a user's
`pytest` run through the agent would silently lose assertion-rewrite caching on
every run. The three tests that pin the scrub set assert the new key on both
sides.

## Verification

Whole-tree compile dry-run against the **real shipped 0.6.0.11 arm64 backend**
(pycs redirected to scratch so the bundle was untouched — verified by count
before/after): **4133 / 4133 compiled, 0 failures, 8.2s**. The coverage gate's
threshold of 50 therefore has zero headroom pressure today.


Measured against a real bundled 3.12 interpreter from a shipped build:

- a CHECKED_HASH pyc is **byte-identical** after the source's mtime changes; a
  TIMESTAMP pyc is rewritten (this is the whole bug, isolated);
- under `PYTHONDONTWRITEBYTECODE=1` a shipped checked-hash pyc is still **used**
  (`__cached__` points at it) and left untouched;
- a module with **no** pyc still imports under that flag and writes nothing.

Suites: `npm test --prefix website/electron` → **1601 passed**, 1 skipped, 0
failed. `pytest test/test_precompile_bytecode.py` → 1 passed.
(`test/test_transcribe.py` fails to import on this machine for a missing
`imageio_ffmpeg`, pre-existing and unrelated.)

New/updated assertions:

- packaged macOS resolves to exactly `{PYTHONPYCACHEPREFIX: "", PYTHONDONTWRITEBYTECODE: "1"}`,
  with a separate test pinning that a redirect is **not** an acceptable
  substitute (it would discard the shipped caches);
- the macOS builder compiles with `--invalidation-mode checked-hash`, never
  `timestamp`, runs **after** the prune (compiling first would have its output
  deleted), and gates on coverage.

The coverage gate was exercised standalone against real trees: exit 1 with no
caches at all, silent after `compileall`, warn-only for a single miss.

**Not verified here:** I cannot run the real macOS packaging pipeline locally, so
the build-side step is unexercised end to end. The invocation mirrors the Windows
one line for line and sits two steps after the existing self-containment gate
that already runs the same interpreter, so the risk is a build-time failure that
CI surfaces loudly rather than a silent behaviour change.

## Follow-up (not in this PR)

Two things for the internal companion, once this lands and reaches it via
subtree pull:

1. Its macOS toolbox wrapper currently exports `PYTHONPYCACHEPREFIX` in the CLI
   branch as a stopgap for this same defect; that becomes redundant and should be
   replaced with the same `PYTHONDONTWRITEBYTECODE=1` so both launch paths agree.
2. Its release pipeline pip-installs the companion into the app **after**
   `build-desktop.sh` runs and before signing, so this build-side `compileall`
   cannot cover the companion's 147 modules. The same compile has to run again in
   that window, or those modules ship uncached and each launch recompiles them in
   memory (~2.5ms/module measured). That is a correctness requirement for the
   internal edition, not an optimization.


## Pattern harvest
Rule candidate: CI gate
Pattern: any file written under a signed `.app` after `codesign` breaks the seal. Generalizable check: after the release build's signing step, `codesign --verify --deep --strict` the launched-once bundle in CI and fail if any path under `Contents/` differs from the sealed `CodeResources` inventory. The specific instance here (CPython rewriting TIMESTAMP `.pyc` files) is one writer; the same gate would catch any other post-signing writer (log files, caches, `.pth` edits).
