### PR TITLE
style: black-format 10 whole-tree ratchet offenders (#8346)

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/enable_automerge.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/enable_automerge.py
@@ -21,6 +21,7 @@ Exit:   0  auto-merge enabled (or already enabled)
            rule, method not permitted, missing permission, or PR closed/merged)
         2  environment / usage error (gh missing, not authed, no PR resolved)
 """
+
 import json
 import subprocess
 import sys

--- a/src/kiro_crew/workflows/validate.py
+++ b/src/kiro_crew/workflows/validate.py
@@ -145,15 +145,33 @@ DETERMINISM_MODULES = frozenset({"time", "random", "uuid", "datetime", "secrets"
 FORBIDDEN_ATTRS = frozenset(
     {
         # generator / coroutine / async-generator introspection
-        "gi_frame", "gi_code", "gi_yieldfrom", "gi_running",
-        "cr_frame", "cr_code", "cr_await", "cr_running", "cr_origin",
-        "ag_frame", "ag_code", "ag_await", "ag_running",
+        "gi_frame",
+        "gi_code",
+        "gi_yieldfrom",
+        "gi_running",
+        "cr_frame",
+        "cr_code",
+        "cr_await",
+        "cr_running",
+        "cr_origin",
+        "ag_frame",
+        "ag_code",
+        "ag_await",
+        "ag_running",
         # frame object
-        "f_back", "f_globals", "f_builtins", "f_locals", "f_code", "f_trace",
+        "f_back",
+        "f_globals",
+        "f_builtins",
+        "f_locals",
+        "f_code",
+        "f_trace",
         # traceback object
-        "tb_frame", "tb_next",
+        "tb_frame",
+        "tb_next",
         # function object (py2-era aliases still resolve on some builds)
-        "func_globals", "func_code", "func_builtins",
+        "func_globals",
+        "func_code",
+        "func_builtins",
     }
 )
 
@@ -450,9 +468,7 @@ class _Validator(ast.NodeVisitor):
         # use, and tying the check to call-site analysis would reopen the gap.
         if isinstance(node.value, str):
             for reason in _format_field_reasons(node.value):
-                self.errors.append(
-                    f"line {node.lineno}: {reason} (in a format string)"
-                )
+                self.errors.append(f"line {node.lineno}: {reason} (in a format string)")
         self.generic_visit(node)
 
     def visit_BinOp(self, node: ast.BinOp) -> None:  # noqa: N802 (ast.NodeVisitor API)
@@ -466,8 +482,7 @@ class _Validator(ast.NodeVisitor):
             if combined is not None:
                 for reason in _format_field_reasons(combined):
                     self.errors.append(
-                        f"line {node.lineno}: {reason} "
-                        f"(in a concatenated format string)"
+                        f"line {node.lineno}: {reason} " f"(in a concatenated format string)"
                     )
         self.generic_visit(node)
 

--- a/test/test_channel_persist_agent_metadata.py
+++ b/test/test_channel_persist_agent_metadata.py
@@ -51,9 +51,9 @@ def test_persist_turn_records_agent_in_session_metadata(channel, mod_name, tmp_p
 
     listed = log.list_sessions()
     assert listed, f"{channel}: _persist_turn should persist a session file"
-    assert listed[0].get("agent") == "sales-agent", (
-        f"{channel}: session metadata must carry the agent the turn ran under"
-    )
+    assert (
+        listed[0].get("agent") == "sales-agent"
+    ), f"{channel}: session metadata must carry the agent the turn ran under"
 
 
 @pytest.mark.parametrize("channel,mod_name", _CHANNELS)

--- a/test/test_computer_use_ffi.py
+++ b/test/test_computer_use_ffi.py
@@ -1524,7 +1524,7 @@ def test_post_text_sends_unicode_and_still_zeroes_the_flags(fakes: _Fakes):
 
 def test_post_text_delivers_an_astral_character_as_one_event(fakes: _Fakes):
     """A surrogate pair goes out in ONE event, not as two lone surrogates."""
-    macos_ffi.post_text(637, "\U0001F600")
+    macos_ffi.post_text(637, "\U0001f600")
     counts = [
         count
         for (_e, count, _text) in fakes.calls_named(fakes.cg, "CGEventKeyboardSetUnicodeString")
@@ -1553,12 +1553,12 @@ def test_post_text_types_NOTHING_when_a_character_cannot_be_encoded(fakes: _Fake
 
 def test_post_text_still_types_the_whole_string_when_every_char_encodes(fakes: _Fakes):
     """The guard must not reject legitimate text (astral + accented + ASCII)."""
-    macos_ffi.post_text(637, "a\U0001F600é")
+    macos_ffi.post_text(637, "a\U0001f600é")
     typed = [
         text
         for (_e, _count, text) in fakes.calls_named(fakes.cg, "CGEventKeyboardSetUnicodeString")
     ]
-    assert typed == ["a", "a", "\U0001F600", "\U0001F600", "é", "é"]
+    assert typed == ["a", "a", "\U0001f600", "\U0001f600", "é", "é"]
 
 
 # ── scroll: the variadic hazard and the AX fallback ──

--- a/test/test_dashboard_peer_auth.py
+++ b/test/test_dashboard_peer_auth.py
@@ -750,14 +750,12 @@ async def test_non_loopback_mixed_denial_names_which_credential_was_wrong(
     assert resp.status == 403
 
     denials = [
-        c
-        for c in calls
-        if c.get("operation") == "internal_auth" and c.get("outcome") == "denied"
+        c for c in calls if c.get("operation") == "internal_auth" and c.get("outcome") == "denied"
     ]
     assert len(denials) == 1
     err = denials[0]["error"]
     assert "non-loopback mixed" in err, err
-    assert "received=absent" in err, (
-        "the mixed arm still cannot say an absent credential from a wrong one"
-    )
+    assert (
+        "received=absent" in err
+    ), "the mixed arm still cannot say an absent credential from a wrong one"
     assert f"expected={ta._credential_fingerprint(SECRET)}" in err, err

--- a/test/test_dashboard_source_links_expand.py
+++ b/test/test_dashboard_source_links_expand.py
@@ -105,13 +105,17 @@ def _request(slot_key: str, slots: dict, *, app: str = ""):
 
 
 async def _get(slot_key: str, slots: dict, *, owner: bool = True, app: str = "") -> web.Response:
-    with patch(
-        "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
-        return_value=None,
-    ), patch(
-        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
-        return_value=owner,
-    ), patch("kiro_crew.dashboard.chat_handlers.sel"):
+    with (
+        patch(
+            "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
+            return_value=None,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            return_value=owner,
+        ),
+        patch("kiro_crew.dashboard.chat_handlers.sel"),
+    ):
         return await api_chat_slot_source_links(_request(slot_key, slots, app=app))
 
 
@@ -148,12 +152,15 @@ class TestSourceLinksEndpoint:
     async def test_a_cold_gitlab_allowlist_failure_still_answers(self):
         """The warm-up is best-effort: a self-hosted MR may be missing for one
         round, but the expand must not fail outright over it."""
-        with patch(
-            "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
-            side_effect=RuntimeError("cold"),
-        ), patch(
-            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
-            return_value=False,
+        with (
+            patch(
+                "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
+                side_effect=RuntimeError("cold"),
+            ),
+            patch(
+                "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+                return_value=False,
+            ),
         ):
             resp = await api_chat_slot_source_links(_request("s1", {"s1": _slot()}))
 
@@ -198,12 +205,16 @@ class TestAppTokenIsolation:
         actually read a slot's links -- the ALLOW is a permission decision."""
         slot = _slot()
         slot._app = "design_critique"
-        with patch("kiro_crew.dashboard.chat_handlers.sel") as sel, patch(
-            "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
-            return_value=None,
-        ), patch(
-            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
-            return_value=False,
+        with (
+            patch("kiro_crew.dashboard.chat_handlers.sel") as sel,
+            patch(
+                "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+                return_value=False,
+            ),
         ):
             resp = await api_chat_slot_source_links(
                 _request("s1", {"s1": slot}, app="design_critique")
@@ -225,12 +236,16 @@ class TestAppTokenIsolation:
         events the trail exists for."""
         slot = _slot()
         slot._app = ""
-        with patch("kiro_crew.dashboard.chat_handlers.sel") as sel, patch(
-            "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
-            return_value=None,
-        ), patch(
-            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
-            return_value=True,
+        with (
+            patch("kiro_crew.dashboard.chat_handlers.sel") as sel,
+            patch(
+                "kiro_crew.dashboard.handlers.source_providers.ensure_gitlab_hosts_loaded",
+                return_value=None,
+            ),
+            patch(
+                "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+                return_value=True,
+            ),
         ):
             resp = await api_chat_slot_source_links(_request("s1", {"s1": slot}, app=""))
 

--- a/test/test_desktop_icns_assets.py
+++ b/test/test_desktop_icns_assets.py
@@ -14,6 +14,7 @@ someone regenerates the icons with a converter that reintroduces
 generation to electron-builder again). Pure byte parsing — no macOS-only tools,
 so it runs on Linux CI too.
 """
+
 from __future__ import annotations
 
 import json
@@ -44,8 +45,7 @@ def _slots(icns: Path) -> dict[str, bytes]:
     magic, declared_len = struct.unpack(">4sI", data[:8])
     assert magic == b"icns", f"{icns.name}: not an icns file (magic={magic!r})"
     assert declared_len == len(data), (
-        f"{icns.name}: truncated — header declares {declared_len} bytes, "
-        f"file is {len(data)}"
+        f"{icns.name}: truncated — header declares {declared_len} bytes, " f"file is {len(data)}"
     )
     out: dict[str, bytes] = {}
     offset = 8
@@ -61,9 +61,7 @@ def _slots(icns: Path) -> dict[str, bytes]:
 @pytest.mark.parametrize("filename", _ICNS_FILES)
 def test_icns_exists_and_parses(filename: str) -> None:
     icns = _ELECTRON_DIR / filename
-    assert icns.is_file(), (
-        f"{filename} is missing — regenerate it with packaging/make-icns.sh"
-    )
+    assert icns.is_file(), f"{filename} is missing — regenerate it with packaging/make-icns.sh"
     assert _slots(icns), f"{filename}: no icon representations found"
 
 
@@ -132,9 +130,7 @@ def test_nightly_icon_override_points_at_icns() -> None:
     """The nightly variant overrides mac.icon on the CLI — keep it an .icns."""
     # encoding is explicit: the script contains non-ASCII (em dashes), which
     # Windows' default cp1252 locale cannot decode.
-    script = (_REPO_ROOT / "packaging" / "build-desktop.sh").read_text(
-        encoding="utf-8"
-    )
+    script = (_REPO_ROOT / "packaging" / "build-desktop.sh").read_text(encoding="utf-8")
     assert "-c.mac.icon=icon-nightly.icns" in script, (
         "packaging/build-desktop.sh must override the nightly icon with "
         "icon-nightly.icns, not a .png"

--- a/test/test_prepare_pr_prove.py
+++ b/test/test_prepare_pr_prove.py
@@ -322,8 +322,7 @@ def test_a_non_python_production_file_is_still_reverted(tmp_path: Path) -> None:
     _git(repo, "config", "user.name", "prove")
     (repo / "limits.json").write_text('{"max": 1}\n')
     (repo / "mod.py").write_text(
-        "import json\n\n\ndef limit():\n"
-        "    return json.load(open('limits.json'))['max']\n"
+        "import json\n\n\ndef limit():\n" "    return json.load(open('limits.json'))['max']\n"
     )
     (repo / "test_mod.py").write_text(
         "from mod import limit\n\n\ndef test_one():\n    assert limit() == 1\n"

--- a/test/test_subagent_error_detail.py
+++ b/test/test_subagent_error_detail.py
@@ -37,9 +37,7 @@ class TestDescribeException:
         SQLITE_MISUSE. Rendered without its class it reads as an unspecified
         argument bug and sends a reader looking in the wrong subsystem.
         """
-        rendered = _describe_exception(
-            sqlite3.InterfaceError("bad parameter or other API misuse")
-        )
+        rendered = _describe_exception(sqlite3.InterfaceError("bad parameter or other API misuse"))
         assert rendered == "sqlite3.InterfaceError: bad parameter or other API misuse"
 
     def test_builtins_are_not_module_qualified(self):
@@ -105,9 +103,7 @@ class TestDescribeException:
 
 class TestTombstoneCarriesTheReason:
     def _tombstone(self, agent_root, agent_id):
-        return json.loads(
-            (agent_root / agent_id / "tombstone.json").read_text(encoding="utf-8")
-        )
+        return json.loads((agent_root / agent_id / "tombstone.json").read_text(encoding="utf-8"))
 
     def test_records_the_specific_reason_not_just_the_bucket(self, agent_root):
         """``cause`` is a bucket; without ``detail`` the reason dies with the process."""
@@ -166,11 +162,13 @@ class TestTerminalArmUsesTheDescription:
         async def _raise_sqlite_misuse(*_a, **_kw):
             raise sqlite3.InterfaceError("bad parameter or other API misuse")
 
-        with patch.object(manager, "_run_inner", _raise_sqlite_misuse), \
-             patch("kiro_crew.subagent.Stats"), \
-             patch("kiro_crew.subagent.sel"), \
-             patch.object(manager, "_fire_event", new_callable=AsyncMock), \
-             patch.object(manager, "_on_done", new_callable=AsyncMock):
+        with (
+            patch.object(manager, "_run_inner", _raise_sqlite_misuse),
+            patch("kiro_crew.subagent.Stats"),
+            patch("kiro_crew.subagent.sel"),
+            patch.object(manager, "_fire_event", new_callable=AsyncMock),
+            patch.object(manager, "_on_done", new_callable=AsyncMock),
+        ):
             await asyncio.wait_for(manager._run(info), timeout=10)
 
         assert info.error == "sqlite3.InterfaceError: bad parameter or other API misuse"

--- a/test/test_windows_job_limits.py
+++ b/test/test_windows_job_limits.py
@@ -37,8 +37,7 @@ _WINDOWS_ONLY = pytest.mark.skipif(
 
 # The job member waits for a go-signal (so the job is applied before it forks),
 # then reports how many child spawns succeeded and the error that stopped it.
-_MEMBER_SRC = textwrap.dedent(
-    """
+_MEMBER_SRC = textwrap.dedent("""
     import subprocess, sys
     sys.stdin.readline()
     ok, err, kids = 0, "", []
@@ -56,8 +55,7 @@ _MEMBER_SRC = textwrap.dedent(
             k.wait(timeout=5)
         except Exception:
             pass
-    """
-)
+    """)
 
 _ERROR_NOT_ENOUGH_QUOTA = 1816
 


### PR DESCRIPTION
## Summary

The Main Ratchet Audit (`main-ratchet-audit.yml`) runs the black gate whole-tree (`RATCHET_SCOPE_WHOLE_TREE=1`), while the PR-side gate is diff-scoped and only judges files a PR touches. Files that are neither black-clean nor listed in `.github/black-baseline.txt` therefore accumulate on main until the audit flags them. Run 33821499153 reported 11 such offenders at `711544f3d`.

Re-running the whole-tree gate on current main (`5bc2fc796`) reports 10 remaining offenders (`test/test_cron_patch_name_validation.py` has since been resolved upstream). This PR formats exactly those 10 files with the pinned `black==26.3.1` (`--target-version py310`):

- `src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/enable_automerge.py`
- `src/kiro_crew/workflows/validate.py`
- `test/test_channel_persist_agent_metadata.py`
- `test/test_computer_use_ffi.py`
- `test/test_dashboard_peer_auth.py`
- `test/test_dashboard_source_links_expand.py`
- `test/test_desktop_icns_assets.py`
- `test/test_prepare_pr_prove.py`
- `test/test_subagent_error_detail.py`
- `test/test_windows_job_limits.py`

The diff is black output only — no semantic change, no hand edits. `.github/black-baseline.txt`, the black pin, and `scripts/check_black_formatting.py` are untouched.

## Verification

- `RATCHET_SCOPE_WHOLE_TREE=1 python3 scripts/check_black_formatting.py` — passed, 0 new offenders, 0 graduated entries to prune (none of the formatted files were baselined)
- Diff-scoped `python3 scripts/check_black_formatting.py` after commit — passed
- `isort --check-only src/kiro_crew test` — passed
- `flake8 src/kiro_crew test` — passed
- `mypy src/kiro_crew/` — passed (no issues in 1288 files)
- Test correctness is proven by CI (the diff touches 8 test files with formatter output only; two independent model-pinned reviews verified per-hunk semantic equivalence)

no linked issue keyword: intentionally `Refs` not `Closes` — the Main Ratchet Audit workflow closes the tracking issue itself on the next all-green push to main, and a `Closes` keyword would race it.

Refs #8346
