### PR TITLE
ci(release): add opt-in stable-rebuild lane so v0.5.0 ships a clean 0.5.0 stamp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,13 @@ on:
     tags: ["v*"]
 
 # Prerelease tags build, sign, publish, and record one immutable promotion
-# bundle. A bare stable tag never rebuilds source: it resolves the newest
-# successful prerelease run for this exact commit/release line, verifies the
-# GitHub artifact archive by its API-recorded digest, and promotes those exact
-# bytes. Reusable workflows own the per-lane publish details.
+# bundle. A bare stable tag REBUILDS that same commit under the bare version, so
+# the shipped bytes advertise "X.Y.Z" rather than the candidate's stamp; it still
+# requires a successful prerelease run for this exact commit, so stable only ever
+# ships code that soaked. Setting vars.STABLE_PROMOTE_BYTES to that base version
+# switches to republishing the candidate's exact bytes instead, at the cost of
+# shipping its prerelease version. Reusable workflows own the per-lane publish
+# details.
 
 # Serialize release runs: insider/stable feed writes are last-writer-wins;
 # two tags pushed close together must publish in order or the channel feed
@@ -32,16 +35,16 @@ jobs:
       base_version: ${{ steps.channel.outputs.base_version }}
       channel: ${{ steps.channel.outputs.channel }}
       wheel_version: ${{ steps.channel.outputs.wheel_version }}
-      # rebuild: "true" only when this is a stable tag AND the opt-in repo
-      # variable STABLE_REBUILD names exactly this base version. Then stable is
-      # BUILT fresh from source (like insider, but on the stable channel with a
-      # bare version) instead of PROMOTED, so the shipped bytes carry the clean
-      # "X.Y.Z" stamp rather than the candidate's "-insider.N". Default stable
-      # (variable unset or mismatched) is unchanged: promotion of soaked bytes.
+      # rebuild: "true" for an ordinary stable release. Stable is BUILT fresh
+      # from the cleared commit under the bare "X.Y.Z" the tag names, because
+      # republishing the candidate's bytes would ship its "-insider.N"/"rcN"
+      # stamp to stable users and nothing downstream can re-stamp them.
       rebuild: ${{ steps.channel.outputs.rebuild }}
-      # promote_mode: "true" for the ordinary stable path (promote soaked bytes).
-      # Every downstream "stable ? promotion : fresh" choice keys off THIS, so a
-      # rebuild takes the fresh/insider-shaped branch on the stable channel.
+      # promote_mode: "true" only when STABLE_PROMOTE_BYTES names this exact base
+      # version -- the escape hatch that republishes the candidate's own bytes so
+      # stable runs the exact binary insiders validated, at the cost of an
+      # RC-stamped version number. Every downstream "promotion or fresh?" choice
+      # keys off THIS, never off channel, so the two modes cannot half-apply.
       promote_mode: ${{ steps.channel.outputs.promote_mode }}
     steps:
       - name: Derive version + channel from tag
@@ -50,7 +53,7 @@ jobs:
           # Scoped to ONE version on purpose (mirrors STABLE_GATE_OVERRIDE): it
           # must equal the base being released, so it cannot be left switched on
           # for every future stable tag.
-          STABLE_REBUILD: ${{ vars.STABLE_REBUILD }}
+          STABLE_PROMOTE_BYTES: ${{ vars.STABLE_PROMOTE_BYTES }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
@@ -86,20 +89,27 @@ jobs:
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "wheel_version=$WHEEL_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Opt-in stable REBUILD lane. A bare stable tag normally promotes the
-          # soaked prerelease bytes (which carry the candidate's -insider.N
-          # stamp). When STABLE_REBUILD names this exact base version, stable is
-          # instead built fresh from source so the shipped app advertises the
-          # clean "$BASE" -- the only way a promoted client can display a bare
-          # stable version, since promotion never re-stamps. Everything else on
-          # the stable channel keys off promote_mode.
-          REBUILD="false"
-          if [ "$CHANNEL" = "stable" ] && [ "${STABLE_REBUILD:-}" = "$BASE" ]; then
-            REBUILD="true"
-          fi
+          # A stable release ships a BARE "$BASE" version, so it REBUILDS from
+          # the cleared commit by default. Promotion -- republishing the
+          # candidate's own bytes -- cannot do that: those bytes were stamped
+          # from the prerelease tag, so a promoted stable ships "0.5.0rc9" in
+          # the wheel name, the feed, `pip show` and `kirocrew --version`, and
+          # nothing downstream can re-stamp them without invalidating the
+          # recorded digests and macOS signatures.
+          #
+          # Byte-for-byte promotion stays reachable, because it is the only mode
+          # that guarantees stable runs the exact binary insiders validated. It
+          # is an escape hatch rather than the default precisely because that
+          # guarantee costs an RC-stamped version number: it must NAME the base
+          # version being released (mirroring STABLE_GATE_OVERRIDE), so it
+          # cannot be left switched on and silently stamp every later release.
           PROMOTE_MODE="false"
-          if [ "$CHANNEL" = "stable" ] && [ "$REBUILD" != "true" ]; then
+          if [ "$CHANNEL" = "stable" ] && [ "${STABLE_PROMOTE_BYTES:-}" = "$BASE" ]; then
             PROMOTE_MODE="true"
+          fi
+          REBUILD="false"
+          if [ "$CHANNEL" = "stable" ] && [ "$PROMOTE_MODE" != "true" ]; then
+            REBUILD="true"
           fi
           echo "rebuild=$REBUILD" >> "$GITHUB_OUTPUT"
           echo "promote_mode=$PROMOTE_MODE" >> "$GITHUB_OUTPUT"
@@ -250,6 +260,9 @@ jobs:
         env:
           CHANNEL: ${{ needs.version.outputs.channel }}
           VERSION: ${{ needs.version.outputs.version }}
+          # Which of the two stable modes this run took, so the gate can say in
+          # the log whether the shipped bytes will carry a bare version.
+          PROMOTE_MODE: ${{ needs.version.outputs.promote_mode }}
           # Scoped to ONE version on purpose: it must equal the version being
           # released, so it cannot be left switched on for every future tag.
           OVERRIDE: ${{ vars.STABLE_GATE_OVERRIDE }}
@@ -325,8 +338,53 @@ jobs:
             fi
           fi
 
+          # ── 3. Source declares the BARE stable version ──────────────────
+          # A stable release must declare "$VERSION" in all three version files,
+          # with no RC spelling left over from the line it soaked under. This is
+          # the 0.4.0 near-miss made mechanical: that promotion was nearly tagged
+          # on a commit still declaring `0.4.0-rc.9`, because only the tag name
+          # was checked and nothing compared the declarations to it.
+          #
+          # It matters even though a rebuild re-stamps these files at build time.
+          # The stamp makes the ARTIFACT right; this check makes the BRANCH right.
+          # A mismatch means the drop-RC-suffix PR the runbook requires never
+          # landed, so a source install, a `pip install -e .` and every later
+          # RC on this branch still advertise the stale spelling.
+          for spec in \
+            "src/kiro_crew/__init__.py:^__version__ = \"\\(.*\\)\"$" \
+            "pyproject.toml:^version = \"\\(.*\\)\"$" \
+            "website/electron/package.json:^  \"version\": \"\\(.*\\)\",$"
+          do
+            file="${spec%%:*}"
+            pattern="${spec#*:}"
+            # Guarded rather than left to `set -e`: an absent file would abort
+            # the script on sed's own error, skipping both the failure summary
+            # and the override path -- the same trap the tag lookup above avoids.
+            if [ ! -f "$file" ]; then
+              echo "::error::$file is missing from the tagged tree, so its version declaration cannot be verified."
+              failures=$((failures + 1))
+              continue
+            fi
+            declared="$(sed -n "s/${pattern}/\\1/p" "$file" | head -n 1)"
+            if [ "$declared" = "$VERSION" ]; then
+              echo "version stamp: $file declares $VERSION"
+            else
+              echo "::error::$file declares '${declared:-<no version line matched>}', not the bare '$VERSION' this stable tag names. Land the drop-RC-suffix PR on the release branch before tagging."
+              failures=$((failures + 1))
+            fi
+          done
+
+          # Not a failure, but it must be visible in the log which mode shipped:
+          # promotion republishes the candidate's bytes, so a promoted stable
+          # advertises that candidate's RC-stamped version to stable users.
+          if [ "$PROMOTE_MODE" = "true" ]; then
+            echo "::warning::STABLE_PROMOTE_BYTES names $VERSION, so this release republishes the candidate's bytes and will ship an RC-stamped version (wheel name, feed, pip show, kirocrew --version). Unset the variable to rebuild and ship a bare $VERSION instead."
+          else
+            echo "mode: rebuilding from source so the shipped bytes carry the bare $VERSION"
+          fi
+
           if [ "$failures" -eq 0 ]; then
-            echo "stable gate: both preconditions satisfied for $VERSION"
+            echo "stable gate: all preconditions satisfied for $VERSION"
             exit 0
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,25 @@ jobs:
       base_version: ${{ steps.channel.outputs.base_version }}
       channel: ${{ steps.channel.outputs.channel }}
       wheel_version: ${{ steps.channel.outputs.wheel_version }}
+      # rebuild: "true" only when this is a stable tag AND the opt-in repo
+      # variable STABLE_REBUILD names exactly this base version. Then stable is
+      # BUILT fresh from source (like insider, but on the stable channel with a
+      # bare version) instead of PROMOTED, so the shipped bytes carry the clean
+      # "X.Y.Z" stamp rather than the candidate's "-insider.N". Default stable
+      # (variable unset or mismatched) is unchanged: promotion of soaked bytes.
+      rebuild: ${{ steps.channel.outputs.rebuild }}
+      # promote_mode: "true" for the ordinary stable path (promote soaked bytes).
+      # Every downstream "stable ? promotion : fresh" choice keys off THIS, so a
+      # rebuild takes the fresh/insider-shaped branch on the stable channel.
+      promote_mode: ${{ steps.channel.outputs.promote_mode }}
     steps:
       - name: Derive version + channel from tag
         id: channel
+        env:
+          # Scoped to ONE version on purpose (mirrors STABLE_GATE_OVERRIDE): it
+          # must equal the base being released, so it cannot be left switched on
+          # for every future stable tag.
+          STABLE_REBUILD: ${{ vars.STABLE_REBUILD }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
@@ -69,7 +85,25 @@ jobs:
           echo "base_version=$BASE" >> "$GITHUB_OUTPUT"
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "wheel_version=$WHEEL_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Releasing $VERSION on channel $CHANNEL (base: $BASE, wheel: $WHEEL_VERSION)"
+
+          # Opt-in stable REBUILD lane. A bare stable tag normally promotes the
+          # soaked prerelease bytes (which carry the candidate's -insider.N
+          # stamp). When STABLE_REBUILD names this exact base version, stable is
+          # instead built fresh from source so the shipped app advertises the
+          # clean "$BASE" -- the only way a promoted client can display a bare
+          # stable version, since promotion never re-stamps. Everything else on
+          # the stable channel keys off promote_mode.
+          REBUILD="false"
+          if [ "$CHANNEL" = "stable" ] && [ "${STABLE_REBUILD:-}" = "$BASE" ]; then
+            REBUILD="true"
+          fi
+          PROMOTE_MODE="false"
+          if [ "$CHANNEL" = "stable" ] && [ "$REBUILD" != "true" ]; then
+            PROMOTE_MODE="true"
+          fi
+          echo "rebuild=$REBUILD" >> "$GITHUB_OUTPUT"
+          echo "promote_mode=$PROMOTE_MODE" >> "$GITHUB_OUTPUT"
+          echo "Releasing $VERSION on channel $CHANNEL (base: $BASE, wheel: $WHEEL_VERSION, rebuild: $REBUILD, promote_mode: $PROMOTE_MODE)"
 
   # Release tags do not trigger ci.yml, so prerelease candidates run a
   # dedicated backend test gate against the exact commit being packaged. The
@@ -127,7 +161,7 @@ jobs:
 
   resolve-promotion:
     name: Resolve Tested Candidate
-    if: needs.version.outputs.channel == 'stable'
+    if: needs.version.outputs.promote_mode == 'true'
     needs: version
     runs-on: ubuntu-latest
     permissions:
@@ -310,7 +344,7 @@ jobs:
 
   build-wheel:
     name: Build Wheel
-    if: needs.version.outputs.channel == 'insider'
+    if: needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true'
     needs: [version, dependency-vulnerability-gate]
     uses: ./.github/workflows/build-wheel.yml
     with:
@@ -318,7 +352,7 @@ jobs:
 
   build-desktop:
     name: Build Desktop
-    if: needs.version.outputs.channel == 'insider'
+    if: needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true'
     needs: [version, dependency-vulnerability-gate]
     uses: ./.github/workflows/build-desktop.yml
     with:
@@ -357,8 +391,8 @@ jobs:
     needs: [version, stable-gate, build-wheel, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-wheel.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-wheel.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -367,8 +401,8 @@ jobs:
     with:
       channel: ${{ needs.version.outputs.channel }}
       version: ${{ needs.version.outputs.version }}
-      wheel_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      wheel_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets: inherit
 
@@ -399,8 +433,8 @@ jobs:
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -408,12 +442,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: x64
       format: appimage
       publish: true
-      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      build_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -423,8 +457,8 @@ jobs:
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -432,12 +466,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: arm64
       format: appimage
       publish: true
-      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      build_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -447,8 +481,8 @@ jobs:
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -456,12 +490,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: x64
       format: deb
       publish: true
-      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      build_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -471,8 +505,8 @@ jobs:
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -480,12 +514,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: arm64
       format: deb
       publish: true
-      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      build_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -495,8 +529,8 @@ jobs:
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -504,12 +538,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: x64
       format: rpm
       publish: true
-      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      build_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-x64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -519,8 +553,8 @@ jobs:
     needs: [version, stable-gate, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       id-token: write
@@ -528,12 +562,12 @@ jobs:
     uses: ./.github/workflows/publish-linux.yml
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       arch: arm64
       format: rpm
       publish: true
-      build_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      build_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-linux-arm64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -558,8 +592,8 @@ jobs:
     needs: [version, stable-gate, build-windows, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          (needs.version.outputs.channel == 'insider' ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true' ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       # A called workflow cannot exceed the caller job's grants, so the probe's
@@ -587,10 +621,10 @@ jobs:
       # is the insider one, so the feed has to advertise that same version or
       # every client's version comparison is made against a number the binary
       # does not carry. Mirrors publish-linux.yml's caller exactly.
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       publish: true
-      installer_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-windows-x64' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
+      installer_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'build-windows-x64' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
     secrets:
       AWS_SIGNING_ROLE_ARN: ${{ secrets.AWS_SIGNING_ROLE_ARN }}
@@ -606,8 +640,8 @@ jobs:
     needs: [version, stable-gate, build-wheel, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-wheel.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-wheel.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       contents: read
       packages: write
@@ -622,9 +656,9 @@ jobs:
       # anonymously, so a release that lands behind a private package is a
       # broken release. Fail the lane rather than advertise an unpullable tag.
       require_public_access: true
-      wheel_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
-      promote_digest: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.docker_digest || '' }}
+      wheel_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || 'cli-wheel' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
+      promote_digest: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.docker_digest || '' }}
     # No `secrets: inherit`: the lane authenticates with GITHUB_TOKEN only
     # (implicitly available to reusable workflows). Inheriting would expose
     # every repo secret (signing, CDN) to a lane documented as needing none.
@@ -640,8 +674,8 @@ jobs:
     needs: [version, stable-gate, build-wheel, build-desktop, resolve-promotion]
     if: >-
       ${{ always() && needs.version.result == 'success' && needs.stable-gate.result == 'success' &&
-          ((needs.version.outputs.channel == 'insider' && needs.build-wheel.result == 'success' && needs.build-desktop.result == 'success') ||
-           (needs.version.outputs.channel == 'stable' && needs.resolve-promotion.result == 'success')) }}
+          (((needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true') && needs.build-wheel.result == 'success' && needs.build-desktop.result == 'success') ||
+           (needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.result == 'success')) }}
     permissions:
       id-token: write
       contents: read
@@ -650,10 +684,10 @@ jobs:
     secrets: inherit
     with:
       channel: ${{ needs.version.outputs.channel }}
-      version: ${{ needs.version.outputs.channel == 'stable' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
+      version: ${{ needs.version.outputs.promote_mode == 'true' && needs.resolve-promotion.outputs.source_version || needs.version.outputs.version }}
       write_feed: true
-      promote: ${{ needs.version.outputs.channel == 'stable' }}
-      promotion_artifact: ${{ needs.version.outputs.channel == 'stable' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || '' }}
+      promote: ${{ needs.version.outputs.promote_mode == 'true' }}
+      promotion_artifact: ${{ needs.version.outputs.promote_mode == 'true' && format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version) || '' }}
       promotion_base_version: ${{ needs.version.outputs.base_version }}
 
   # `needs` alone is not enough here. With no `if:`, the default condition is
@@ -688,7 +722,7 @@ jobs:
           path: artifacts
 
       - name: Verify promoted release bytes
-        if: needs.version.outputs.channel == 'stable'
+        if: needs.version.outputs.promote_mode == 'true'
         run: |
           python3 scripts/release_promotion.py verify \
             --bundle-dir "artifacts/KiroCrew-notarized-stable-${{ needs.version.outputs.version }}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,10 +237,15 @@ One logical change per commit.
 
 > **Releasing or promoting a version? Read `docs/build/release.md` first.** It is
 > the authority on the channel model, version stamping, and the **RC → stable
-> promotion runbook** — including why anything a stable user will see (a clean
-> version number, a finalized changelog) must be baked into the RC bytes *before
-> the RC is cut*, since promotion never rebuilds. This section covers only the
-> changelog rules.
+> runbook**. The one rule to carry in before reading it: **a stable release must
+> never ship a version number carrying a prerelease suffix.** Stable is therefore
+> BUILT fresh from the cleared commit under the bare `X.Y.Z`, not published by
+> reusing the candidate's bytes — those bytes are stamped from the prerelease tag
+> and nothing downstream can re-stamp them without invalidating the recorded
+> digests and macOS signatures. Byte-for-byte reuse survives as an escape hatch
+> (`vars.STABLE_PROMOTE_BYTES`, named per version) for when stable must run the
+> identical binary insiders validated, and its cost is exactly that RC-stamped
+> version. This section covers only the changelog rules.
 
 `CHANGELOG.md` is written **only when a version is bumped**, and everything
 already in it is immutable. Two halves enforce that: the

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -33,41 +33,64 @@ deciding to promote, and merging back are human steps the pipeline knows nothing
 about, which is why there is no cut/promote/rollback workflow (see "Deliberately
 not built").
 
-## Stable promotion: exact tested bytes, never a rebuild
+## Stable release: a fresh build at the bare version, never a byte republish
 
-Stable must ship the bytes insiders actually validated, not a same-commit
-rebuild that hopes for reproducibility. The mechanism:
+A stable release must ship bytes whose own embedded version is a bare `X.Y.Z`,
+with no prerelease suffix anywhere in the artifact, its filename, or the feed.
+That is what rules out republishing the candidate's bytes: they were stamped
+from the prerelease tag, and nothing downstream can re-stamp them without
+invalidating the recorded digests and the macOS signatures. So a bare tag
+rebuilds from the commit the candidate cleared, rather than reusing what the
+candidate produced. The mechanism:
 
-- **A successful prerelease run records the candidate.** After every publish
-  lane succeeds, `record-promotion` assembles the exact wheel/sdist, AppImage,
-  notarized zip/DMG, and the attested OCI manifest digest into a
+- **A successful prerelease run clears the candidate commit.** After every
+  publish lane succeeds, `record-promotion` assembles the exact wheel/sdist,
+  AppImage, notarized zip/DMG, and the attested OCI manifest digest into a
   `stable-promotion-<x.y.z>` GitHub artifact (90-day retention) whose manifest
   (`scripts/release_promotion.py create`) carries per-file SHA-256/SHA-512/size
-  plus the source SHA, tag, run id, and versions.
-- **A bare `vX.Y.Z` tag resolves and verifies that record.** The
-  `resolve-promotion` job finds the newest **successful** same-commit,
-  same-base-version prerelease run, verifies the artifact ZIP against GitHub's
-  API-recorded digest, safely extracts it, and verifies every manifest field
-  and file digest (`scripts/release_promotion.py verify`). Only then do the
-  publish lanes move stable pointers/tags to those bytes. The stable run never
-  invokes the build workflows, CDSigner, Apple notarization, or the OCI
-  builder.
-- **Everything fails closed.** A missing, expired, ambiguous, or
-  digest-mismatched record aborts the promotion: cut and validate a fresh RC
-  rather than rebuilding stable.
-- **Promoted binaries retain the candidate's embedded version** (see "Version
-  stamping"), because rewriting embedded metadata would produce bytes users
-  never baked and invalidate the recorded digests and macOS signatures. The
-  bare git tag, GitHub Release, and stable channel are the final release
-  identity. pip users selecting a promoted (prerelease-versioned) wheel by
-  version must allow prereleases; the stable channel feed remains
-  channel-sticky.
-- **Stable DISPLAYS a clean base version even though the bytes keep the RC
-  stamp.** The embedded version cannot change under promotion, so the remedy is
-  at the read layer, and it is a CONTRACT over every surface, not a fix at two
-  spots — the 0.4.0 promotion shipped with only the running-version fold wired,
-  and users then reported the raw stamp on four other surfaces one by one (the
-  About panel's available-update line, the version chip, the Settings footer,
+  plus the source SHA, tag, run id, and versions. Its primary role is evidence
+  that this commit shipped clean on insider; the bytes it carries are only
+  consumed by the byte-reuse escape hatch below.
+- **A bare `vX.Y.Z` tag rebuilds that commit at the bare version.** `stable-gate`
+  confirms a **successful** same-commit prerelease run exists, so stable still
+  only ships code that soaked. Then the ordinary build path runs on the stable
+  channel — `build-wheel.yml`, `build-desktop.yml`, `build-windows.yml`,
+  `sign-and-notarize.yml`, the OCI builder — receiving `X.Y.Z` exactly the way an
+  insider build receives `X.Y.Z-rc.N`. What a stable release gives up is byte
+  identity with the binary insiders ran; what it never gives up is that the
+  commit soaked.
+- **Byte-for-byte reuse remains available, and names its own cost.** Setting
+  `vars.STABLE_PROMOTE_BYTES` to exactly the base version being released takes
+  the promotion path instead: `resolve-promotion` verifies the recorded bundle
+  and the publish lanes move stable pointers to those exact bytes. Use it when
+  stable must run the identical binary that was validated. The cost is the whole
+  reason it is not the default — those bytes advertise the candidate's `rcN`
+  stamp in the wheel name, the feed, `pip show`, and `kirocrew --version`. The
+  variable is scoped to one version so it cannot be left switched on, and the
+  gate prints a warning naming the consequence.
+- **Everything fails closed.** No successful same-commit prerelease run, an
+  undocumented version, or a release branch still declaring the RC spelling all
+  abort the release before any lane publishes. On the byte-reuse path a missing,
+  expired, ambiguous, or digest-mismatched record aborts it too.
+- **The bare version is stamped in at build time, not patched afterwards** (see
+  "Version stamping"). There is no metadata-rewrite step to trust. `stable-gate`
+  additionally compares the tag against all three declaration files, because a
+  rebuild would otherwise paper over a release branch that never landed its
+  drop-RC-suffix PR: the artifact would be right while every source install and
+  every later RC on that branch still read the stale spelling. The 0.4.0
+  promotion was nearly tagged in exactly that state, because only the tag name
+  was checked.
+- **A stable wheel installs without `--pre`**, because its own version carries no
+  prerelease suffix. A wheel published through the byte-reuse hatch does need it.
+- **The display fold still exists, and stable is no longer its main job.** A
+  rebuilt stable has nothing to fold — its stamp is already bare. The fold
+  remains load-bearing for insider and nightly, where the prerelease number is
+  meaningful information, and for any install shipped before this policy that is
+  still running promoted RC-stamped bytes. It is a CONTRACT over every surface,
+  not a fix at two spots — the 0.4.0 promotion shipped with only the
+  running-version fold wired, and users then reported the raw stamp on four other
+  surfaces one by one (the About panel's available-update line, the version chip,
+  the Settings footer,
   and the proactive update popup), each needing its own hotfix.
 
   The contract:
@@ -103,10 +126,13 @@ rebuild that hopes for reproducibility. The mechanism:
   `update_latest_version_display` tests in
   `test/test_dashboard_status_snapshot.py`, and the AboutPanel /
   UpdateFoundModal / SettingsPage frontend tests are the regression gates.
-  **The whole fold family must ride in the RC bytes**: promotion never
-  rebuilds, so a display change added after the RC is cut can never reach the
-  promoted stable. Land it before the RC is cut, or stable shows the RC stamp
-  with no in-band remedy.
+  **A display change still wants to land before the RC is cut**, so the surface
+  it fixes is exercised during the soak rather than first appearing in the
+  release. It is no longer unrecoverable if it does not: stable is rebuilt from
+  the commit, so a fold landed on the release branch before the bare tag does
+  reach stable. Under the byte-reuse hatch the original constraint holds in
+  full — those bytes are the RC's, so a fold added after the RC was cut can
+  never reach that release.
 - **Hot patches follow the same rule**: at least one recorded RC before the
   bare patch tag. A hot patch is the NEXT three-segment version (`0.4.0` →
   `0.4.1`): the release workflow's Derive-Version step rejects a four-segment
@@ -144,17 +170,25 @@ there is no build step at stable-tag time to add it.
    available-update line, AND the update popup); no existing bare
    `vX.Y.Z` tag. Then tag `vX.Y.Z-insider.N`.
 3. **Soak.** Ship the RC on insider and let real users run it. **Do not push any
-   byte-affecting change to the release branch between soak and promote** — the
-   guarantee is that stable gets exactly the soaked bytes.
-4. **Promote (bare tag).** Confirm the `vX.Y.Z-insider.N` run at the target
-   commit is SUCCESS (`resolve-promotion` finds the candidate by it). Push a bare
-   `vX.Y.Z` tag on that commit. The build lanes skip; `resolve-promotion`
-   re-verifies the recorded bundle and republishes it to stable.
-   `Create GitHub Release` runs (the `if:` fix) and renders GitHub's own
-   contributor block — **do not hand-write a contributors list in the body**
-   (that duplicated the native block on v0.3.0). Verify: stable feed points at
-   the RC's version, About shows the clean `X.Y.Z` via the fold, CHANGELOG shows
-   no draft heading.
+   change to the release branch between soak and release** — stable is rebuilt
+   from this commit, so a commit that lands after the soak ships code nobody ran.
+4. **Release (bare tag).** Confirm the `vX.Y.Z-insider.N` run at the target
+   commit is SUCCESS — `stable-gate` requires it, so a candidate whose run was
+   cancelled or failed cannot be released. Push a bare `vX.Y.Z` tag on that
+   commit. The build lanes RUN: stable is rebuilt from this commit with `X.Y.Z`
+   stamped in, so the shipped wheel is `kirocrew-X.Y.Z-py3-none-any.whl` and
+   `kirocrew --version` prints `X.Y.Z`. Expect the full build time, not a
+   pointer move. `Create GitHub Release` runs (the `if:` fix) and renders
+   GitHub's own contributor block — **do not hand-write a contributors list in
+   the body** (that duplicated the native block on v0.3.0). Verify: stable feed
+   carries the bare `X.Y.Z`, the wheel filename has no `rc`, About shows
+   `X.Y.Z`, CHANGELOG shows no draft heading.
+
+   To ship the candidate's exact bytes instead — the only mode where stable runs
+   the identical binary that was validated — set `vars.STABLE_PROMOTE_BYTES` to
+   exactly `X.Y.Z` before pushing the tag, and unset it afterwards. That release
+   will advertise the candidate's `rcN` version everywhere its bytes are read,
+   and the gate warns about it in the run log.
 
 ## Workflows in the release path
 
@@ -753,10 +787,15 @@ nothing to re-download.
 the bytes.** `channelForVersion()` classifies the version stamp and `nightly`
 stays pinned by it, but for the two production lanes `resolveChannel()` honours
 the persisted Settings → About preference and defaults to **stable** when none is
-set. It cannot read the lane out of the stamp, because stable is PROMOTED: the
-stable and insider downloads of a promoted version are the same notarized file
-carrying the same `-insider.N` stamp, so a stamp-derived channel would send every
-promoted-stable install to the insider feed. The consequences to know:
+set. It cannot read the lane out of the stamp, and a rebuilt stable does not
+change that. For every install shipped while stable was PROMOTED, the stable and
+insider downloads of a release were the same notarized file carrying the same
+`-insider.N` stamp, so a stamp-derived channel would send all of those installs
+to the insider feed. Those binaries are still in the field, and `resolveChannel()`
+has to keep answering correctly for them. A stable build produced by a rebuild
+does carry its own bare stamp, but reading the lane from it would only be safe
+once no promoted install remains — which is not a condition this code can check.
+The consequences to know:
 
 - **Insider is an explicit opt-in.** Any install with no recorded preference
   follows stable — including one installed from the insider DMG, and including an

--- a/test/test_publish_docker_contract.py
+++ b/test/test_publish_docker_contract.py
@@ -165,7 +165,9 @@ def test_promotion_requires_a_recorded_digest_and_disables_rebuild_paths() -> No
 
     release = yaml.safe_load(CALLERS[1].read_text(encoding="utf-8"))
     call = release["jobs"]["publish-docker"]["with"]
-    assert call["promote"].endswith(" == 'stable' }}")
+    # promote_mode, not channel: a stable rebuild runs ON the stable channel and
+    # must build its own image rather than re-tag the candidate's digest.
+    assert call["promote"] == "${{ needs.version.outputs.promote_mode == 'true' }}"
     assert "resolve-promotion.outputs.docker_digest" in call["promote_digest"]
 
 

--- a/test/test_release_promotion_contract.py
+++ b/test/test_release_promotion_contract.py
@@ -3,15 +3,18 @@
 The executable manifest tests prove digest and archive handling. These tests
 pin the GitHub Actions wiring for the two ways a bare stable tag can ship:
 
-* PROMOTE (the default) republishes the soaked candidate's exact bytes, which
-  carry that candidate's ``-insider.N`` / ``rcN`` stamp.
-* REBUILD (opt in per version via the ``STABLE_REBUILD`` repo variable) builds
-  fresh from source on the stable channel so the shipped bytes carry a bare
-  ``X.Y.Z``, which promotion can never produce because it never re-stamps.
+* REBUILD (the default) builds fresh from the cleared commit on the stable
+  channel, so the shipped bytes carry a bare ``X.Y.Z``.
+* PROMOTE (opt in per version via the ``STABLE_PROMOTE_BYTES`` repo variable)
+  republishes the soaked candidate's exact bytes, so stable runs the identical
+  binary insiders validated -- at the cost of shipping that candidate's
+  ``-insider.N`` / ``rcN`` stamp, which nothing downstream can re-stamp.
 
-The modes are mutually exclusive and every downstream "promotion or fresh?"
-choice reads ``promote_mode``, never ``channel``, so a rebuild cannot half-apply
-and leave one lane republishing candidate bytes into a rebuilt release.
+Rebuild is the default because the version a stable user sees must not carry a
+prerelease suffix, and promotion can never deliver that. The modes are mutually
+exclusive and every downstream "promotion or fresh?" choice reads
+``promote_mode``, never ``channel``, so neither mode can half-apply and leave
+one lane disagreeing with the rest of the release.
 """
 
 from __future__ import annotations
@@ -94,14 +97,17 @@ def test_stable_tag_resolves_candidate_and_never_enters_build_jobs() -> None:
     assert handoff["with"]["if-no-files-found"] == "error"
 
 
-def test_stable_rebuild_is_opt_in_per_version_and_excludes_promotion() -> None:
-    """A rebuild must be impossible to enable by accident, or for the wrong version.
+def test_stable_rebuild_is_the_default_and_promotion_is_opt_in_per_version() -> None:
+    """Stable must not be able to ship an RC-stamped version by omission.
 
-    Shipping rebuilt bytes to stable gives up the promote-what-was-tested
-    guarantee that stable runs byte-identical to what insiders received, so it
-    is deliberately not a default and not a boolean: the repo variable has to
-    NAME the base version being released. That is what stops it from being left
-    switched on and silently rebuilding every future stable tag.
+    Promotion republishes the candidate's own bytes, which carry its ``rcN``
+    stamp in the wheel name, the feed, ``pip show`` and ``kirocrew --version``.
+    That mode still exists -- it is the only one where stable runs the exact
+    binary insiders validated -- but it cannot be the default, because then
+    forgetting a setting silently ships a prerelease-looking version to stable
+    users. So rebuild is what a bare stable tag does with no configuration, and
+    byte reuse has to NAME the base version being released (mirroring
+    ``STABLE_GATE_OVERRIDE``) so it cannot be left switched on.
     """
     jobs = _workflow(RELEASE)["jobs"]
     outputs = jobs["version"]["outputs"]
@@ -109,16 +115,19 @@ def test_stable_rebuild_is_opt_in_per_version_and_excludes_promotion() -> None:
     assert outputs["promote_mode"] == "${{ steps.channel.outputs.promote_mode }}"
 
     derive = _step(RELEASE, "version", "Derive version + channel from tag")
-    assert derive["env"]["STABLE_REBUILD"] == "${{ vars.STABLE_REBUILD }}"
+    assert derive["env"]["STABLE_PROMOTE_BYTES"] == "${{ vars.STABLE_PROMOTE_BYTES }}"
     run = derive["run"]
 
-    # Scoped to one exact base version, and only ever on the stable channel.
-    assert '[ "$CHANNEL" = "stable" ] && [ "${STABLE_REBUILD:-}" = "$BASE" ]' in run
-    # Mutually exclusive: promote_mode is stable-and-not-rebuild, so no tag can
-    # take both paths and no tag can take neither.
-    assert '[ "$CHANNEL" = "stable" ] && [ "$REBUILD" != "true" ]' in run
+    # Byte reuse is scoped to one exact base version, and only on stable.
+    assert '[ "$CHANNEL" = "stable" ] && [ "${STABLE_PROMOTE_BYTES:-}" = "$BASE" ]' in run
+    # Rebuild is the fallthrough: stable-and-not-promoting. Mutually exclusive,
+    # and no stable tag can end up taking neither path.
+    assert '[ "$CHANNEL" = "stable" ] && [ "$PROMOTE_MODE" != "true" ]' in run
     assert 'echo "rebuild=$REBUILD" >> "$GITHUB_OUTPUT"' in run
     assert 'echo "promote_mode=$PROMOTE_MODE" >> "$GITHUB_OUTPUT"' in run
+    # The old spelling must not linger anywhere: a leftover STABLE_REBUILD would
+    # read as the switch that turns rebuild ON, when rebuild is now the default.
+    assert "STABLE_REBUILD" not in run
 
     # A rebuild publishes freshly built artifacts, so it must NOT reach for the
     # promotion handoff on any lane.
@@ -131,11 +140,32 @@ def test_stable_rebuild_is_opt_in_per_version_and_excludes_promotion() -> None:
             "${{ needs.version.outputs.promote_mode == 'true' &&"
         ), lane
 
-    # The soak evidence check is NOT waived for a rebuild: stable still only
-    # ships a commit that already produced a successful prerelease run, so what
-    # a rebuild gives up is byte identity, never the soak itself.
-    gate = _step(RELEASE, "stable-gate", "Verify stable publication preconditions")["run"]
-    assert "startswith(\"v\" + env.VERSION" in gate
+
+def test_stable_gate_requires_the_three_version_files_to_declare_the_bare_version() -> None:
+    """The branch must agree with the tag, not just the artifact.
+
+    A rebuild re-stamps the version at build time, so the ARTIFACT is right even
+    when the release branch still declares the RC spelling. That is exactly how
+    the 0.4.0 promotion was nearly tagged on a commit still declaring
+    ``0.4.0-rc.9``: only the tag name was checked. This gate compares the tag to
+    all three declarations so a missing drop-RC-suffix PR fails the release
+    instead of leaving source installs on a stale version.
+    """
+    gate = _step(RELEASE, "stable-gate", "Verify stable publication preconditions")
+    assert gate["env"]["PROMOTE_MODE"] == "${{ needs.version.outputs.promote_mode }}"
+    run = gate["run"]
+    for path in (
+        "src/kiro_crew/__init__.py",
+        "pyproject.toml",
+        "website/electron/package.json",
+    ):
+        assert path in run, path
+    # Compared against the tag's own version, and a mismatch is a failure rather
+    # than a warning.
+    assert 'if [ "$declared" = "$VERSION" ]; then' in run
+    assert "Land the drop-RC-suffix PR on the release branch before tagging." in run
+    # Promotion is allowed but must announce the cost in the run log.
+    assert "will ship an RC-stamped version" in run
 
 
 def test_every_stable_lane_consumes_the_verified_handoff() -> None:

--- a/test/test_release_promotion_contract.py
+++ b/test/test_release_promotion_contract.py
@@ -1,8 +1,17 @@
-"""Structural contracts for promote-what-was-tested stable releases.
+"""Structural contracts for stable releases, in both of their modes.
 
 The executable manifest tests prove digest and archive handling. These tests
-pin the GitHub Actions wiring so a future simplification cannot route a bare
-stable tag back through source builds or accidentally attest rebuilt bytes.
+pin the GitHub Actions wiring for the two ways a bare stable tag can ship:
+
+* PROMOTE (the default) republishes the soaked candidate's exact bytes, which
+  carry that candidate's ``-insider.N`` / ``rcN`` stamp.
+* REBUILD (opt in per version via the ``STABLE_REBUILD`` repo variable) builds
+  fresh from source on the stable channel so the shipped bytes carry a bare
+  ``X.Y.Z``, which promotion can never produce because it never re-stamps.
+
+The modes are mutually exclusive and every downstream "promotion or fresh?"
+choice reads ``promote_mode``, never ``channel``, so a rebuild cannot half-apply
+and leave one lane republishing candidate bytes into a rebuilt release.
 """
 
 from __future__ import annotations
@@ -30,6 +39,9 @@ PROMOTION_ARTIFACT = "KiroCrew-notarized-stable-${{ needs.version.outputs.versio
 PROMOTION_ARTIFACT_FORMAT = (
     "format('KiroCrew-notarized-stable-{0}', needs.version.outputs.version)"
 )
+#: Every lane's ``promote`` input reads promote_mode, never channel, so an
+#: opt-in stable rebuild flips all of them together or none of them.
+PROMOTE_EXPRESSION = "${{ needs.version.outputs.promote_mode == 'true' }}"
 
 
 def _workflow(path: Path) -> dict:
@@ -54,13 +66,20 @@ def test_release_base_requires_exact_three_component_numeric_version() -> None:
 def test_stable_tag_resolves_candidate_and_never_enters_build_jobs() -> None:
     jobs = _workflow(RELEASE)["jobs"]
 
-    assert jobs["resolve-promotion"]["if"] == "needs.version.outputs.channel == 'stable'"
+    # promote_mode, not channel: a stable REBUILD also runs on the stable
+    # channel, and it must take the fresh/insider-shaped branch instead.
+    assert jobs["resolve-promotion"]["if"] == "needs.version.outputs.promote_mode == 'true'"
     assert jobs["resolve-promotion"]["permissions"] == {
         "actions": "read",
         "contents": "read",
     }
-    assert jobs["build-wheel"]["if"] == "needs.version.outputs.channel == 'insider'"
-    assert jobs["build-desktop"]["if"] == "needs.version.outputs.channel == 'insider'"
+    # The build lanes stay off the PROMOTION path. They gain exactly one extra
+    # entrance -- an opt-in rebuild -- and nothing else may widen them.
+    build_gate = (
+        "needs.version.outputs.channel == 'insider' || needs.version.outputs.rebuild == 'true'"
+    )
+    assert jobs["build-wheel"]["if"] == build_gate
+    assert jobs["build-desktop"]["if"] == build_gate
 
     resolve = _step(RELEASE, "resolve-promotion", "Resolve and verify immutable candidate bundle")[
         "run"
@@ -75,6 +94,50 @@ def test_stable_tag_resolves_candidate_and_never_enters_build_jobs() -> None:
     assert handoff["with"]["if-no-files-found"] == "error"
 
 
+def test_stable_rebuild_is_opt_in_per_version_and_excludes_promotion() -> None:
+    """A rebuild must be impossible to enable by accident, or for the wrong version.
+
+    Shipping rebuilt bytes to stable gives up the promote-what-was-tested
+    guarantee that stable runs byte-identical to what insiders received, so it
+    is deliberately not a default and not a boolean: the repo variable has to
+    NAME the base version being released. That is what stops it from being left
+    switched on and silently rebuilding every future stable tag.
+    """
+    jobs = _workflow(RELEASE)["jobs"]
+    outputs = jobs["version"]["outputs"]
+    assert outputs["rebuild"] == "${{ steps.channel.outputs.rebuild }}"
+    assert outputs["promote_mode"] == "${{ steps.channel.outputs.promote_mode }}"
+
+    derive = _step(RELEASE, "version", "Derive version + channel from tag")
+    assert derive["env"]["STABLE_REBUILD"] == "${{ vars.STABLE_REBUILD }}"
+    run = derive["run"]
+
+    # Scoped to one exact base version, and only ever on the stable channel.
+    assert '[ "$CHANNEL" = "stable" ] && [ "${STABLE_REBUILD:-}" = "$BASE" ]' in run
+    # Mutually exclusive: promote_mode is stable-and-not-rebuild, so no tag can
+    # take both paths and no tag can take neither.
+    assert '[ "$CHANNEL" = "stable" ] && [ "$REBUILD" != "true" ]' in run
+    assert 'echo "rebuild=$REBUILD" >> "$GITHUB_OUTPUT"' in run
+    assert 'echo "promote_mode=$PROMOTE_MODE" >> "$GITHUB_OUTPUT"' in run
+
+    # A rebuild publishes freshly built artifacts, so it must NOT reach for the
+    # promotion handoff on any lane.
+    for name in ("publish-cli", "publish-docker"):
+        assert jobs[name]["with"]["wheel_artifact"].startswith(
+            "${{ needs.version.outputs.promote_mode == 'true' &&"
+        ), name
+    for lane in LINUX_LANES:
+        assert jobs[lane]["with"]["build_artifact"].startswith(
+            "${{ needs.version.outputs.promote_mode == 'true' &&"
+        ), lane
+
+    # The soak evidence check is NOT waived for a rebuild: stable still only
+    # ships a commit that already produced a successful prerelease run, so what
+    # a rebuild gives up is byte identity, never the soak itself.
+    gate = _step(RELEASE, "stable-gate", "Verify stable publication preconditions")["run"]
+    assert "startswith(\"v\" + env.VERSION" in gate
+
+
 def test_every_stable_lane_consumes_the_verified_handoff() -> None:
     jobs = _workflow(RELEASE)["jobs"]
     for name in ("publish-cli", *LINUX_LANES, "publish-docker", "sign-and-notarize"):
@@ -83,21 +146,21 @@ def test_every_stable_lane_consumes_the_verified_handoff() -> None:
         assert "needs.resolve-promotion.result == 'success'" in job["if"]
 
     assert PROMOTION_ARTIFACT_FORMAT in jobs["publish-cli"]["with"]["wheel_artifact"]
-    assert jobs["publish-cli"]["with"]["promote"].endswith(" == 'stable' }}")
+    assert jobs["publish-cli"]["with"]["promote"] == PROMOTE_EXPRESSION
 
     for lane in LINUX_LANES:
         assert PROMOTION_ARTIFACT_FORMAT in jobs[lane]["with"]["build_artifact"], lane
         assert "resolve-promotion.outputs.source_version" in jobs[lane]["with"]["version"], lane
-        assert jobs[lane]["with"]["promote"].endswith(" == 'stable' }}"), lane
+        assert jobs[lane]["with"]["promote"] == PROMOTE_EXPRESSION, lane
 
     docker_inputs = jobs["publish-docker"]["with"]
-    assert docker_inputs["promote"].endswith(" == 'stable' }}")
+    assert docker_inputs["promote"] == PROMOTE_EXPRESSION
     assert "resolve-promotion.outputs.docker_digest" in docker_inputs["promote_digest"]
 
     mac_inputs = jobs["sign-and-notarize"]["with"]
     assert PROMOTION_ARTIFACT_FORMAT in mac_inputs["promotion_artifact"]
     assert "resolve-promotion.outputs.source_version" in mac_inputs["version"]
-    assert mac_inputs["promote"].endswith(" == 'stable' }}")
+    assert mac_inputs["promote"] == PROMOTE_EXPRESSION
 
 
 def test_github_release_selects_explicit_versioned_macos_handoff() -> None:

--- a/test/test_stable_release_gate.py
+++ b/test/test_stable_release_gate.py
@@ -104,6 +104,7 @@ def _make_repo(
     *,
     changelog_headings: Iterable[str] = (),
     stable_tag: str | None = None,
+    declared_version: str | None = "1.2.3",
 ) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -113,7 +114,32 @@ def _make_repo(
         f"{heading}\n\nnotes for {heading}\n\n" for heading in changelog_headings
     )
     (repo / "CHANGELOG.md").write_text(body, encoding="utf-8")
-    _git(repo, "add", "CHANGELOG.md")
+    tracked = ["CHANGELOG.md"]
+
+    # The gate also compares the tag against all three version declarations, so
+    # a fixture repo needs them or every case would fail on the missing files
+    # rather than on the behaviour under test. ``declared_version=None`` omits
+    # them deliberately, for the case that pins the missing-file failure.
+    if declared_version is not None:
+        (repo / "src" / "kiro_crew").mkdir(parents=True)
+        (repo / "src" / "kiro_crew" / "__init__.py").write_text(
+            f'__version__ = "{declared_version}"\n', encoding="utf-8"
+        )
+        (repo / "pyproject.toml").write_text(
+            f'[project]\nname = "kirocrew"\nversion = "{declared_version}"\n', encoding="utf-8"
+        )
+        (repo / "website" / "electron").mkdir(parents=True)
+        (repo / "website" / "electron" / "package.json").write_text(
+            '{\n  "name": "kirocrew-desktop",\n' f'  "version": "{declared_version}",\n' "}\n",
+            encoding="utf-8",
+        )
+        tracked += [
+            "src/kiro_crew/__init__.py",
+            "pyproject.toml",
+            "website/electron/package.json",
+        ]
+
+    _git(repo, "add", *tracked)
     _git(repo, "commit", "-q", "-m", "first")
     if stable_tag:
         _git(repo, "tag", stable_tag)
@@ -127,6 +153,7 @@ def _run(
     version: str,
     override: str = "",
     gh: str = "match",
+    promote_mode: str = "false",
 ) -> subprocess.CompletedProcess[str]:
     """Execute the real gate step with a ``gh`` shim on PATH.
 
@@ -160,6 +187,7 @@ def _run(
             "HOME": str(repo),
             "CHANNEL": channel,
             "VERSION": version,
+            "PROMOTE_MODE": promote_mode,
             "OVERRIDE": override,
             "GITHUB_REPOSITORY": "kirodotdev/KiroCrew",
             "GH_TOKEN": "shim",
@@ -299,10 +327,68 @@ def test_documented_and_promoted_release_passes(tmp_path: Path) -> None:
     result = _run(repo, channel="stable", version="1.2.3")
     assert result.returncode == 0, result.stdout + result.stderr
     assert MATCHING_RUN in result.stdout
-    assert "both preconditions satisfied" in result.stdout
+    assert "all preconditions satisfied" in result.stdout
 
 
 # ── behaviour: each precondition fails on its own ─────────────────────────
+
+
+def test_a_release_branch_still_declaring_the_rc_spelling_blocks(tmp_path: Path) -> None:
+    """The tag being bare is not evidence that the branch is.
+
+    A rebuild re-stamps the artifact, so a stale declaration would ship correct
+    bytes while leaving every source install and later RC on the old spelling.
+    The 0.4.0 promotion was nearly tagged in exactly this state because only the
+    tag name was checked.
+    """
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+        declared_version="1.2.3-rc.9",
+    )
+    result = _run(repo, channel="stable", version="1.2.3")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "declares '1.2.3-rc.9', not the bare '1.2.3'" in result.stdout
+    assert "Land the drop-RC-suffix PR" in result.stdout
+
+
+def test_a_missing_version_file_fails_closed_rather_than_aborting(tmp_path: Path) -> None:
+    """An absent declaration must be a verdict, not a crash.
+
+    Left to ``set -e``, sed's own error would abort the script mid-way and skip
+    both the failure summary and the override path -- the same trap the tag
+    lookup is guarded against.
+    """
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+        declared_version=None,
+    )
+    result = _run(repo, channel="stable", version="1.2.3")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "is missing from the tagged tree" in result.stdout
+    # Still reached the summary rather than dying inside the loop.
+    assert "unmet precondition(s)" in result.stdout
+
+
+def test_promoting_bytes_warns_that_the_shipped_version_keeps_the_rc_stamp(
+    tmp_path: Path,
+) -> None:
+    """Byte reuse is allowed, but the cost has to be visible in the run log."""
+    repo = _make_repo(
+        tmp_path,
+        changelog_headings=["## [1.2.3] — 2026-08-07"],
+        stable_tag="v1.2.3",
+    )
+    result = _run(repo, channel="stable", version="1.2.3", promote_mode="true")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "will ship an RC-stamped version" in result.stdout
+
+    rebuilt = _run(repo, channel="stable", version="1.2.3", promote_mode="false")
+    assert rebuilt.returncode == 0, rebuilt.stdout + rebuilt.stderr
+    assert "carry the bare 1.2.3" in rebuilt.stdout
 
 
 def test_missing_changelog_section_blocks(tmp_path: Path) -> None:

--- a/test/test_windows_signing_contract.py
+++ b/test/test_windows_signing_contract.py
@@ -366,15 +366,17 @@ def test_the_updater_offers_exactly_the_channels_that_publish_windows() -> None:
         for job in _workflow("release.yml")["jobs"].values()
         if str(job.get("uses", "")).endswith("publish-windows.yml")
     )
-    # Both of release.yml's channels publish, and stable must reach the lane
-    # through PROMOTION rather than a fresh build: it republishes the bundle
-    # resolve-promotion verified, so the caller has to gate on that job and pass
-    # promote plus the base version the manifest is checked against.
+    # Both of release.yml's channels publish. Stable reaches the lane by either
+    # mode: a rebuild builds and signs a fresh installer, while byte reuse
+    # republishes the bundle resolve-promotion verified -- so the caller gates on
+    # rebuild OR on that job, and passes promote plus the base version the
+    # manifest is checked against.
     assert "channel == 'insider'" in release["if"]
-    assert "channel == 'stable'" in release["if"]
+    assert "outputs.rebuild == 'true'" in release["if"]
+    assert "outputs.promote_mode == 'true'" in release["if"]
     assert "needs.resolve-promotion.result == 'success'" in release["if"]
     assert "resolve-promotion" in release["needs"]
-    assert "channel == 'stable'" in release["with"]["promote"]
+    assert "promote_mode == 'true'" in release["with"]["promote"]
     assert release["with"]["promotion_base_version"], "stable promotion needs a base version"
     # The stable installer comes from the verified handoff artifact, never from a
     # fresh build-windows upload.

--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1844,9 +1844,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -23,7 +23,7 @@
     "electron-builder": "26.15.3"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "js-yaml": "4.3.1"
   },
   "build": {


### PR DESCRIPTION
## Problem / Motivation

Stable publishes by **promotion**: a bare `v0.5.0` tag republishes the exact bytes of the soaked candidate `v0.5.0-insider.9`. Those bytes carry the candidate's stamp, so stable would advertise `0.5.0rc9` (wheel, `pip show`, CLI `--version`, CDN path) and `0.5.0-insider.9` (desktop feed) — the new stable version would not read as `0.5.0`.

The display fold (#6633) already folds every dashboard surface to a clean `0.5.0`, but it cannot change the embedded stamp, the wheel filename, or the feed's `version` field, because promotion never re-stamps and re-stamping would invalidate the digest-verified promotion chain.

## What changed

Ports the opt-in **stable-rebuild lane** from [#4871](https://github.com/kirodotdev/KiroCrew/pull/4871), which shipped on `release/0.3.0` for the v0.3.0 re-release and was never carried forward to the 0.4 or 0.5 lines.

Gated by the repo variable `STABLE_REBUILD`: when it names **exactly** the base version of a bare stable tag, that tag builds fresh from source (like insider, but on the stable channel with a bare version) instead of promoting. The reusable publish/sign workflows already branch on `promote`, not `channel`, so a rebuild reuses the proven insider build → sign → notarize → publish path with `promote=false`.

- `version` job emits `rebuild` / `promote_mode`; every "stable ? promotion : fresh" decision keys off these instead of `channel`
- `build-wheel` / `build-desktop` also run on a rebuild
- `resolve-promotion` and `github-release`'s promotion-verify step skip on a rebuild
- **All 10 publish/sign lanes** updated — including the `deb`/`rpm` (×2 arch) and `publish-windows-x64` lanes that did not exist when #4871 was written
- Deliberately unchanged: `release-candidate-tests` (the commit was already tested by its RC), the `prerelease:` flag on the GitHub Release (a rebuild is still a real release), and `record-promotion` (a fresh build produces no promotion bundle)

### One deliberate deviation from #4871

#4871 also skipped `stable-gate`'s insider-soak evidence check on a rebuild. **This PR keeps that check.** Retaining it means a rebuild can still only happen on a commit that already shipped a successful RC — it costs nothing for `v0.5.0` (commit `41ef55594` has a successful `v0.5.0-insider.9` run) and preserves the guarantee that stable only ever ships soaked code. The CHANGELOG-section check is likewise untouched.

## Behaviour matrix

| Tag | `rebuild` | `promote_mode` | build lanes | `resolve-promotion` | `promote` | shipped version |
|---|---|---|---|---|---|---|
| `v0.5.0-insider.10` | false | false | run | skip | false | `0.5.0rc10` |
| bare `v0.5.0`, variable unset | false | **true** | skip | run | true | `0.5.0rc9` (**identical to today**) |
| bare `v0.5.0`, `STABLE_REBUILD=0.5.0` | **true** | false | **run** | skip | false | **`0.5.0`** |

Default stable with the variable unset or mismatched is byte-for-byte unchanged, so this cannot alter any future stable tag that does not explicitly opt in. The variable is scoped to one exact base version (mirroring `STABLE_GATE_OVERRIDE`) so it cannot be left switched on.

## Verification

- Every substitution was applied under an assertion that it matched an exact expected count; a silent no-op replace would have failed the run.
- Post-checks: `channel == 'stable'` now appears **0** times (was 41, all migrated to `promote_mode`); `rebuild == 'true'` appears 12 times (2 build gates + 10 lane gates); the 3 deliberately-unchanged `channel == 'insider'` tests are confirmed still in place.
- All 9 reads of `resolve-promotion.outputs.*` were verified to sit behind `promote_mode == 'true' &&`, so a rebuild (where that job is skipped) never consumes an empty output — it falls through to the bare `needs.version.outputs.version`.
- `release.yml` parses as YAML; 20 jobs; `version` exports `rebuild` and `promote_mode`.

## How to use it for v0.5.0

Set the repo variable `STABLE_REBUILD` to exactly `0.5.0`, then push the bare `v0.5.0` tag on `41ef55594`. Unset it after the release.


---

## Also in this PR: unpin `fast-uri` (release blocker)

The production dependency audit on this branch fails closed with four **high** advisories against `fast-uri` 3.1.5 — `GHSA-5jgf-p345-68v8`, `GHSA-f65p-4m7j-42xc`, `GHSA-fph4-wmhf-6fwf`, `GHSA-jqff-g426-hqxp` (two SSRF, two host confusion). The pin is what held the vulnerable version; 3.1.7 carries the fixes.

**This is a release blocker, not merely a red PR check.** `release.yml`'s `dependency-vulnerability-gate` has no channel condition, and `build-wheel`, `build-desktop` and `build-windows` all `needs:` it — so on a stable **rebuild** an unpatched advisory would skip every build lane and fail the 0.5.0 release outright. Under plain promotion it would not have been noticed, because the build lanes are skipped anyway.

- `website/electron/package.json`: `overrides.fast-uri` `3.1.5` → `3.1.7`
- `website/electron/package-lock.json`: the `node_modules/fast-uri` entry follows (version + resolved + integrity)

Values are **byte-identical** to the same fix already merged to `main` in [#7936](https://github.com/kirodotdev/KiroCrew/pull/7936), so this is a backport of an already-CI-validated change rather than a new resolution. Only the `fast-uri` entry is touched — the lockfile's root `version` field is deliberately left as-is (pre-existing drift on this branch, unrelated to this fix, and `release/0.5.0` must not inherit main's `0.6.0`).

The local audit could not be run in this environment (the host npm resolves against an authenticated internal registry and returns `E401`, which the script correctly treats as fail-closed); CI is the authoritative check.


---

## Policy change: stable rebuilds by DEFAULT (not opt-in)

An opt-in lane cannot deliver "a stable release never ships an RC-suffixed version" — whoever forgets the variable ships `0.5.0rc9` again, which is exactly how **0.4.0 and 0.4.1 both went out RC-stamped** (`kirocrew-0.4.0rc14`, `kirocrew-0.4.1rc1` are on the CDN today). So the default is inverted:

| Tag | mode | shipped version |
|---|---|---|
| `vX.Y.Z-insider.N` | insider build | `X.Y.ZrcN` |
| bare `vX.Y.Z` (no config) | **rebuild** | **bare `X.Y.Z`** |
| bare `vX.Y.Z` + `STABLE_PROMOTE_BYTES=X.Y.Z` | byte reuse | `X.Y.ZrcN`, warned in the run log |

Byte-for-byte reuse survives because it is the only mode where stable runs the *identical* binary insiders validated. It is no longer the default because that guarantee costs an RC-stamped version. The variable must NAME the base version, so it cannot be left switched on.

**What this gives up, stated precisely:** byte identity with what insiders ran. **What it does not give up:** that the commit soaked — `stable-gate` still requires a successful same-commit prerelease run, and this PR deliberately does not waive that check for a rebuild.

### CI enforcement (third stable-gate precondition)

`stable-gate` now also compares the tag against **all three** version declarations. A rebuild re-stamps the artifact, so without this a release branch that never landed its drop-RC-suffix PR would ship correct bytes while every source install and later RC kept the stale spelling — the exact state the 0.4.0 promotion was nearly tagged in, "because only the tag name was checked". A missing file fails closed with a readable error rather than aborting the script on `sed`'s error (the same trap the tag lookup is guarded against).

This is the only layer that can catch it: a `scripts/check_*.py` gate or a pytest test sees repo source, not the release about to become irreversible.

### Docs moved with the code

- `docs/build/release.md`: the stable section (retitled), its runbook steps 3–4, the fold contract, the forced-update-floor note, and the file-top comment in `release.yml`
- `AGENTS.md`: its release pointer stated the old model inline ("must be baked into the RC bytes *before the RC is cut*, since promotion never rebuilds") — now states the new rule
- The `resolveChannel()` note is **time-boxed, not rewritten**: promoted RC-stamped binaries are still in the field and that code must keep resolving correctly for them. The display fold is kept for the same reason, plus insider/nightly where the prerelease number is real information.

### Contract tests restated rather than relaxed

Four test files pinned the old wiring; each is updated to pin BOTH modes and their mutual exclusion, with `promote` asserted by equality instead of a suffix match so a lane left reading `channel` is caught:

`test_release_promotion_contract.py`, `test_stable_release_gate.py`, `test_publish_docker_contract.py`, `test_windows_signing_contract.py`

New cases: a branch still declaring the RC spelling blocks; a missing version file fails closed; promotion warns that its shipped version keeps the RC stamp.

## Verification

**Full suite run locally, and against a clean `release/0.5.0` baseline for comparison** (`pytest -q -n 4 --timeout=120 --no-cov`, the same command `Test Release Candidate SHA` runs):

| | failed | passed |
|---|---|---|
| this branch | **110** | 75235 |
| clean baseline | **110** | 75230 |

The real test-id failure sets are **identical, 112 entries each, line for line** — no regression and nothing newly passing by accident. All of them are local-environment noise (`AF_UNIX path too long` from a long scratch path, missing optional deps, unprivileged userns unavailable) and **none is a release/version test**. The +5 passing on this branch are the cases added here.

Mutation-verified separately: dropping the mode variable, widening the gate from naming the version to merely being set, leaving one lane reading `channel`, and reintroducing the RC spelling each turn the relevant test red.
