### PR TITLE
fix(memory): guard prune_history against negative keep_days

### DIFF
--- a/src/kiro_crew/memory.py
+++ b/src/kiro_crew/memory.py
@@ -486,6 +486,13 @@ class MemoryStore:
         """Delete daily history files older than *keep_days*. Returns count deleted."""
         if not self._history_dir.exists():
             return 0
+        if keep_days < 0:
+            logger.warning(
+                "prune_history: negative keep_days=%d is not valid; "
+                "using default retention of 365 days to avoid data loss",
+                keep_days,
+            )
+            keep_days = 365
         cutoff = datetime.now().date() - timedelta(days=keep_days)
         deleted = 0
         for f in self._history_dir.glob("*.md"):

--- a/test/test_memory.py
+++ b/test/test_memory.py
@@ -71,6 +71,49 @@ class TestMemoryStore:
         assert "file locking" in history
 
 
+class TestPruneHistory:
+    """prune_history boundary conditions."""
+
+    def _write_old_file(self, history_dir, days_ago: int) -> None:
+        """Write a fake history file dated *days_ago* days in the past."""
+        from datetime import datetime, timedelta
+
+        date = (datetime.now().date() - timedelta(days=days_ago)).isoformat()
+        (history_dir / f"{date}.md").write_text(f"# {date}\nOld entry\n")
+
+    def test_negative_keep_days_does_not_delete_recent_files(self, tmp_path):
+        """A negative keep_days value falls back to 365 — recent files are kept."""
+        store = MemoryStore(workspace=tmp_path)
+        history_dir = store._history_dir
+        history_dir.mkdir(parents=True, exist_ok=True)
+        # Write a file 10 days old — within the 365-day fallback window, so it
+        # must be KEPT when keep_days=-1 triggers the guard.
+        self._write_old_file(history_dir, days_ago=10)
+        deleted = store.prune_history(keep_days=-1)
+        assert deleted == 0, "negative keep_days must not delete files within the 365-day fallback"
+        assert len(list(history_dir.glob("*.md"))) == 1
+
+    def test_zero_keep_days_drops_files_older_than_today(self, tmp_path):
+        """Zero keep_days retains its meaning: drop everything before today."""
+        store = MemoryStore(workspace=tmp_path)
+        history_dir = store._history_dir
+        history_dir.mkdir(parents=True, exist_ok=True)
+        self._write_old_file(history_dir, days_ago=1)
+        deleted = store.prune_history(keep_days=0)
+        assert deleted == 1, "keep_days=0 should delete yesterday's file"
+
+    def test_positive_keep_days_deletes_old_files(self, tmp_path):
+        """Positive keep_days deletes files older than the threshold."""
+        store = MemoryStore(workspace=tmp_path)
+        history_dir = store._history_dir
+        history_dir.mkdir(parents=True, exist_ok=True)
+        self._write_old_file(history_dir, days_ago=10)
+        self._write_old_file(history_dir, days_ago=1)
+        deleted = store.prune_history(keep_days=5)
+        assert deleted == 1, "only the 10-day-old file should be deleted"
+        assert len(list(history_dir.glob("*.md"))) == 1
+
+
 class TestRecentHistoryCache:
     """read_recent_history TTL cache (per-message hot path)."""
 


### PR DESCRIPTION
## Problem / Motivation

`MemoryStore.prune_history()` trusts its `keep_days` argument without validation. A negative `history_max_days` in `config.json` — caused by a hand edit, bad import, or file corruption — makes the heartbeat wipe the entire daily history on every tick.

When `keep_days` is negative, `timedelta(days=keep_days)` computes a future date, so every existing history file appears "older than the cutoff" and gets unlinked.

## Why it matters

Silent, unrecoverable data loss. A single corrupted config value causes the periodic heartbeat to delete all daily history files with only an `INFO` log. The user sees empty memory with no warning.

The dashboard settings path already clamps to min 7 (`dashboard/handlers/memory.py`); this fix closes the same gap on the file-config path (`heartbeat.py` → `prune_history`).

## What changed (motivation → approach → change)

Negative `keep_days` → future cutoff date → all files appear old → everything deleted.

A negative value can never be intentional (you cannot keep a negative number of days of history). Fall back to the default retention of 365 days and emit a `WARNING` log so the operator knows their config value is invalid — instead of silently deleting all history.

Zero retains its current meaning: drop everything before today.

## Tests

Added `TestPruneHistory` class in `test/test_memory.py` with three tests:

- `test_negative_keep_days_does_not_delete_recent_files` — `keep_days=-1` falls back to 365; a 10-day-old file is kept
- `test_zero_keep_days_drops_files_older_than_today` — zero keeps its existing semantics; yesterday's file is deleted
- `test_positive_keep_days_deletes_old_files` — normal path still works; only files older than the threshold are deleted

## Manual verification

N/A — unit coverage sufficient. The code path is `heartbeat._beat() → prune_history(keep_days=config.memory.history_max_days)`; the guard fires on any negative integer regardless of how it arrives.

## Related Issues

Fixes #8245

## Pattern harvest

Rule candidate: lint
Pattern: integer config value passed directly to a time-delta calculation without a lower-bound guard

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff