### PR TITLE
fix(session-control): let a dispatched session inherit its creator's trust

### DIFF
--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -65,6 +65,59 @@ loses nothing — existence is confirmed read-only under the folder-store lock
 only after the filing has landed, so a refused create leaves no folder-tree
 mutation behind.
 
+### What a created child inherits
+
+Creation copies two different kinds of state, and the split is deliberate.
+
+**Identity** — the child is created in the caller's workspace (the memory
+boundary; a child left in `default` would be both a boundary crossing and
+unaddressable by its own creator), inherits the caller's agent when none is
+named, takes that workspace's project directory as its cwd, and is attributed to
+the caller via `created_by` so the per-creator slot ceiling is countable.
+
+**Approval posture** — the caller's `_trust` and `_trust_reads` transfer, so a
+trusted operator's dispatched worker does not stall on a prompt nobody is
+watching. This is the posture `parent_trusted` already gives a `spawn_run`
+subagent, which reads the parent's stored `"auto"` policy; a `session_create`
+child previously started from `_ChatSlot.__init__`'s empty defaults, so the same
+delegation behaved differently depending only on whether it got a sidebar tab.
+No session-store write happens at creation: the child has no ACP session yet
+(`set_approval_policy` no-ops on a missing session), and `chat_runner` already
+derives the persistable policy from `_trust` on every session create/resume, so
+the subagent spawn gate sees it from the child's first turn.
+
+Two grants are excluded, and the exclusions are load-bearing:
+
+| Not inherited | Why |
+|---|---|
+| `_trusted_patterns` | Per-command grants ("`npm test` is fine"), not a posture. A pattern is judged against the session the operator was LOOKING at, while a dispatched worker runs model-authored work they have not seen, so the same glob can admit a command the grant was never asked about. Inheriting them also pays for itself in neither direction: with `_trust` set the child already auto-approves via `_slot_is_trusted`, so the list is dead weight, and because `chat_runner` matches patterns independently of `_trust` it changes an outcome only when the operator withheld session trust and approved single commands instead — the case that must keep asking |
+| `_trust_scope` | A TTL-bounded, SEL-audited `SafetyOverride` scope, re-checked on every approval. Forking the key would hand a second session a credential whose revocation this path cannot observe, so the child would keep auto-approving after the scope that justified it is gone. An unattended worker that needs one gets its own, from whatever owns its lifecycle |
+
+The posture that transfers is the one held at **allocation**, read off the
+re-resolved caller in the synchronous window after the last gate — not the one
+read on entry. Creation suspends three times before the slot exists (project
+directory, config load, folder confirmation), and an operator selecting `normal`
+in any of those windows would otherwise have a revoked posture resurrected by a
+create already in flight. Revoking mid-call yields an untrusted child.
+
+Nothing about trust is persisted at birth. The birth metadata carries
+`tab_id`, `origin`, `created_at`, `workspace`, `agent`, `project`, `title`,
+`memory_mode`, and `folder_id` / `created_by` when set — no trust field — so a
+restart returns the child to interactive along with its creator.
+
+The create's SEL record carries `agent`, `folder_id`, and what the child was
+born with: `inherited_trust` and `inherited_trust_reads`, present on both
+outcomes so `"false"` is positive evidence the posture did not transfer. That is
+what makes an auto-approved tool call in a dispatched session traceable to the
+creator's posture rather than unexplained.
+
+**Known gap.** Inheritance is transitive — a trusted child is itself an eligible
+creator — and revoking the creator's trust afterwards does not cascade to
+already-born workers, so one click covers a dispatch tree that outlives the
+click's scope. Bounded by the slot caps, by trust being in-memory only, and by
+the global Trust picker (no slot selected), which sets `normal` across every live
+slot. A per-slot revoke that walks `created_by` is tracked in issue #8589.
+
 `kirocrew-dashboard` rather than `kirocrew-core`, because these tools are not a
 capability every session should carry. That server is an **assignable set**: it
 is absent from the default agent's spec and loads only for an agent whose own

--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -845,6 +845,15 @@ async def create_session(
     matter because a caller refusal missing here, or a workspace not inherited,
     would hand back a session outside the boundary the other verbs enforce.
 
+    The caller's session POSTURE (``_trust`` / ``_trust_reads``) transfers to the
+    child, so a trusted operator's dispatched worker does not stall on a prompt
+    nobody is watching -- the posture ``parent_trusted`` already gives a
+    ``spawn_run`` subagent. Per-command grants (``_trusted_patterns``) and a
+    ``SafetyOverride`` scoped grant (``_trust_scope``) are both deliberately
+    excluded, and the transferred value is the one held at allocation time rather
+    than at entry, so revoking mid call yields an untrusted child. See the block
+    around the assignment.
+
     ``folder_id`` files the slot as part of creation (#6118): it is assigned in
     the same synchronous window that configures the slot, the whole
     allocation-to-persist span runs under ``suspend_slots_push`` so the slot's
@@ -1140,6 +1149,60 @@ async def create_session(
         # unattributed, so ordinary human use never consumes an automated caller's
         # share.
         slot._created_by = caller_key
+        # The creator's interactive auto-approve grant follows the work it is
+        # handing off. Without this a trusted operator dispatches a worker that
+        # then blocks on an approval prompt nobody is watching -- the same failure
+        # `parent_trusted` already closes for `spawn_run` subagents, which read the
+        # parent's stored policy and start auto-approved. A dispatched session is
+        # the same delegation with a sidebar tab, so it takes the same posture.
+        #
+        # Read off `live_caller`, not the entry-time `caller_slot`: the two are
+        # identity-checked to be the same object above, but the grant itself is
+        # mutable state the operator can revoke inside any of the suspensions this
+        # coroutine took, so the value that transfers is the one held NOW, in the
+        # synchronous window that follows the last gate. Revoking before the create
+        # lands means the child is born untrusted, which is the direction that
+        # fails safe.
+        #
+        # What transfers is SESSION POSTURE, and only that. Two fields carry, two
+        # deliberately do not, and the exclusions are the load-bearing part:
+        #
+        # * `_trust` -- the human's "trust this session" click. It does not expire,
+        #   the click is its own audit record, and copying it changes no property
+        #   of the grant. The session-store half needs no write here: the child has
+        #   no ACP session yet (`set_approval_policy` would silently no-op on a
+        #   missing session), and `chat_runner` already assigns the persistable
+        #   policy from `_trust` on every session create/resume, so the subagent
+        #   spawn gate sees it from the child's first turn.
+        # * `_trust_reads` -- the same posture, narrowed to read-only bash. It has
+        #   to carry too, or the setting a CAUTIOUS operator picks is the one whose
+        #   own workers still stall. Bounded by construction: what it admits has no
+        #   side effects, which is what separates it from the command grants below.
+        #
+        # * `_trusted_patterns` -- NOT inherited. These are per-command grants
+        #   ("`npm test` is fine"), not a posture, and the distinction decides it:
+        #   a pattern is judged against the session the operator was LOOKING at,
+        #   while a dispatched worker runs model-authored work they have not seen,
+        #   so the same glob can admit a command the grant was never asked about.
+        #   Inheriting them also buys nothing where it would be safe -- with
+        #   `_trust` set the child already auto-approves via `_slot_is_trusted`, so
+        #   the pattern list is dead weight; it changes the outcome ONLY when the
+        #   operator withheld session trust and granted single commands instead,
+        #   which is exactly the case that must keep asking. So the child starts
+        #   with `_ChatSlot.__init__`'s empty set and earns its own grants.
+        # * `_trust_scope` -- NOT inherited. It names a TTL-bounded, SEL-audited
+        #   `SafetyOverride` grant that is re-checked on every approval; forking
+        #   the key would hand a second session a credential whose revocation
+        #   nothing here can observe. An unattended worker that needs one gets its
+        #   own, armed by whatever owns its lifecycle.
+        #
+        # Not persisted at birth, matching every other slot: trust is in-memory by
+        # construction, so a restart returns the child to interactive along with
+        # its creator.
+        inherited_trust = bool(getattr(live_caller, "_trust", False))
+        inherited_trust_reads = bool(getattr(live_caller, "_trust_reads", False))
+        slot._trust = inherited_trust
+        slot._trust_reads = inherited_trust_reads
         # cwd must follow the workspace too, or file search and project-scoped agents
         # resolve against a directory the slot does not claim -- the same
         # authorization-vs-execution split as the agent binding, one layer down.
@@ -1251,7 +1314,15 @@ async def create_session(
         operation="create",
         slot_key=slot.key,
         outcome="allowed",
-        detail={"agent": slot.agent or "", "folder_id": slot.folder_id or ""},
+        detail={
+            "agent": slot.agent or "",
+            "folder_id": slot.folder_id or "",
+            # What the child was BORN with, so an auto-approved tool call in it is
+            # traceable to the creator's grant rather than appearing unexplained.
+            # Always present: "false" is the record that the grant did not transfer.
+            "inherited_trust": "true" if inherited_trust else "false",
+            "inherited_trust_reads": "true" if inherited_trust_reads else "false",
+        },
     )
     return {
         "ok": True,

--- a/test/test_session_control.py
+++ b/test/test_session_control.py
@@ -2210,6 +2210,178 @@ def test_created_session_gets_its_workspace_project_dir(tmp_path):
     assert child.project == loader.default_project_dir(child.workspace)
 
 
+# ── session_create: the creator's trust grant ───────────────────────────────
+
+
+def test_created_session_inherits_the_callers_trust(tmp_path):
+    """A trusted creator's worker starts trusted, or dispatch stalls on a prompt.
+
+    The whole point of dispatching a session is that the work proceeds without the
+    operator sitting on it, and `spawn_run` subagents already start auto-approved
+    off the parent's policy (`parent_trusted`). A child born interactive blocks on
+    the first tool call with nobody watching -- the same failure, one layer up.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust = True
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child is not None
+    assert child._trust is True, "the creator's posture must follow the work"
+
+
+def test_command_grants_never_transfer_even_under_full_trust(tmp_path):
+    """`_trusted_patterns` are per-command grants, not a posture, so they stay put.
+
+    A pattern is judged against the session the operator was LOOKING at, while a
+    dispatched worker runs model-authored work they have not seen -- so the same
+    glob can admit a command the grant was never asked about. Inheriting them also
+    buys nothing where it would be safe: with `_trust` set the child already
+    auto-approves through `_slot_is_trusted`, so the list is dead weight here and
+    changes the outcome only in the case that must keep asking (see the sibling
+    test below).
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust = True
+    caller._trusted_patterns = {"npm test", "git status"}
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child._trusted_patterns == set(), "command grants must not be delegated"
+    # And nothing was aliased on the way past: the caller keeps its own grants.
+    assert caller._trusted_patterns == {"npm test", "git status"}
+
+
+def test_a_pattern_only_creator_produces_a_child_that_still_asks(tmp_path):
+    """The case the exclusion exists for: grants without session trust.
+
+    An operator who approved single commands and deliberately did NOT click trust
+    has said "ask me". `chat_runner` matches `_trusted_patterns` independently of
+    `_trust` (so an inherited pattern would auto-approve on its own), which is why
+    a child of such a caller must be born with nothing.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust = False
+    caller._trusted_patterns = {"npm test"}
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child._trust is False
+    assert child._trusted_patterns == set(), "a withheld posture must not leak as a grant"
+
+
+def test_created_session_inherits_trust_reads(tmp_path):
+    """`trust_reads` is a grant too, and it is the narrower one.
+
+    Inheriting only the full grant would leave the read-only mode -- the setting a
+    cautious operator picks -- as the one that still stalls its own workers.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust = False
+    caller._trust_reads = True
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child._trust_reads is True
+    assert child._trust is False, "the narrow grant must not widen on the way down"
+
+
+def test_an_untrusted_creator_makes_an_untrusted_child(tmp_path):
+    """Negative control: nothing is granted that the creator did not hold.
+
+    Without this the inheritance could be a constant `True` and every test above
+    would still pass.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child._trust is False
+    assert child._trust_reads is False
+    assert child._trusted_patterns == set()
+
+
+def test_the_scoped_safety_override_grant_is_never_inherited(tmp_path):
+    """`_trust_scope` is a revocable credential, not a setting to copy.
+
+    Its entire value is being re-checked on every approval against a TTL-bounded,
+    SEL-audited `SafetyOverride` scope. Forking the key hands a second session a
+    grant whose revocation the create path cannot observe -- and the child would
+    keep auto-approving after the scope that justified it is gone.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust_scope = "app:worker:abc123"
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child._trust_scope == "", "a scoped grant must not fork onto the child"
+    assert child._trust is False, "nor may it be laundered into the durable flag"
+
+
+def test_trust_revoked_mid_create_is_not_inherited(tmp_path, monkeypatch):
+    """The grant that transfers is the one held at ALLOCATION, not at entry.
+
+    `create_session` suspends several times before the slot exists (project dir,
+    config load, folder confirmation), and the operator can pick `normal` in any
+    of those windows. Reading the entry-time slot would hand the child a grant
+    that no longer exists. Simulated by revoking inside the project-dir
+    resolution, the same interleaving the folder-delete test uses.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust = True
+
+    def _revoke_then_resolve(_workspace):
+        caller._trust = False
+        caller._trust_reads = False
+        return str(tmp_path)
+
+    monkeypatch.setattr(sc, "default_project_dir", _revoke_then_resolve)
+
+    created = asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+    child = state.get_slot(created["target"])
+
+    assert child._trust is False, "a revoked grant must not be resurrected by a create"
+    assert child._trust_reads is False
+
+
+def test_the_create_audit_records_what_the_child_was_born_with(tmp_path):
+    """An auto-approval in the child must be traceable to the creator's grant.
+
+    Without it, the SEL shows a session whose tools approve themselves and no
+    record of where that authority came from. Recorded on both outcomes, so
+    "false" is positive evidence the grant did not transfer.
+    """
+    state = _make_state(tmp_path)
+    caller = _slot(state, "chat-1")
+    caller._trust = True
+
+    seen: dict[str, object] = {}
+
+    def _capture(**kwargs):
+        seen.update(kwargs)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(sc, "_audit", _capture)
+        asyncio.run(sc.create_session(state, caller_session_key=_key(caller)))
+
+    detail = seen["detail"]
+    assert detail["inherited_trust"] == "true"
+    assert detail["inherited_trust_reads"] == "false"
+
+
 # ── session_create: filing at birth (#6118) ─────────────────────────────────
 
 


### PR DESCRIPTION
## Problem / Motivation

A conductor session running with "trust this session" dispatches worker sessions via `session_create`, and every one of them is born interactive. The worker then blocks on its first tool-approval prompt with nobody watching it — which is precisely the case trust was enabled for. The dashboard's global Trust does not cover it either: that path iterates the slots that exist at click time, so a session dispatched a minute later is untouched.

`spawn_run` subagents already do the right thing here. `SubagentManager`'s admission gate reads `sessions.get_approval_policy(parent)` (`parent_trusted`) and starts the subagent auto-approved. A `session_create` child took its trust state from `_ChatSlot.__init__`'s empty defaults instead, so the same delegation behaved differently depending only on whether it got a sidebar tab.

## Why it matters

It breaks unattended dispatch. Conductor patrol is autonudge-driven: it wakes itself, finds a worker parked on an approval nobody answered, and the goal makes no progress until a human opens the tab and clicks. The operator already granted the authority; the grant simply did not reach the session doing the work.

## What changed (motivation → approach → change)

Root cause: `create_session` inherits workspace, agent, project dir and folder, and nothing about approval posture — trust is per-slot state with no transfer path.

`create_session` now carries the creator's session **posture** to the child, and only that:

- **`_trust`** — the "trust this session" grant.
- **`_trust_reads`** — the same posture narrowed to read-only bash. It has to carry too, or the setting a *cautious* operator picks is the one whose own workers still stall. It is bounded by construction: what it admits has no side effects.

The session-store half needs no write here. The child has no ACP session yet, where `set_approval_policy` silently no-ops on a missing session, and `chat_runner` already assigns the persistable policy from `_trust` on every session create/resume — so the subagent spawn gate sees it from the child's first turn, through the existing seam rather than a second one.

Two exclusions carry the safety, and they are why this is not just "copy the trust fields":

**`_trusted_patterns` is not inherited.** These are per-command grants ("`npm test` is fine"), not a posture, and that distinction decides it: a pattern is judged against the session the operator was *looking at*, while a dispatched worker runs model-authored work they have not seen, so the same glob can admit a command the grant was never asked about. Inheriting them could not pay for itself in either direction — with `_trust` set the child already auto-approves through `_slot_is_trusted`, so the list was dead weight; and because `chat_runner` matches patterns independently of `_trust`, it changed an outcome *only* when the operator had withheld session trust and approved single commands instead, which is exactly the case that must keep asking. Raised as BLOCKING by the GPT 5.6 lane on `2fd95999` and fixed in `277f98eb`; dispositioned in-thread.

**`_trust_scope` is not inherited.** It names a TTL-bounded, SEL-audited `SafetyOverride` scope whose entire value is being re-checked on every approval. Forking the key would hand a second session a credential whose revocation this path cannot observe, so the child would keep auto-approving after the scope that justified it is gone. An unattended worker that needs one gets its own, from whatever owns its lifecycle.

**The value transferred is read at allocation, not at entry.** `create_session` suspends three times before the slot exists (project dir, config load, folder confirmation). Reading the entry-time slot would let an operator pick `normal` mid-call and still have the revoked posture resurrected by a create already in flight. It reads `live_caller` in the synchronous window after the last re-gate, so revoking mid-call yields an untrusted child — the direction that fails safe.

Nothing is persisted at birth: trust is in-memory by construction, so a restart returns the child to interactive along with its creator. The blast radius is bounded as before — `allow_create`'s per-caller rate window and `MAX_SLOTS_PER_CREATOR` (50) already exist because `session_create` is auto-approved for the conductor (#6109).

The create audit records what the child was born with (`inherited_trust`, `inherited_trust_reads`) on **both** outcomes, so an auto-approved tool call in a dispatched session is traceable to the creator's posture instead of appearing unexplained, and `"false"` is positive evidence it did not transfer.

## Tests

8 tests in `test/test_session_control.py` — five that fail without the change, three negative controls that make those five mean something.

| Test | Locks in | Red against |
| --- | --- | --- |
| `test_created_session_inherits_the_callers_trust` | `_trust` transfers | pristine main |
| `test_created_session_inherits_trust_reads` | the narrower read-only posture transfers, and does not widen to full trust | pristine main |
| `test_the_create_audit_records_what_the_child_was_born_with` | both audit fields present and correct | pristine main |
| `test_command_grants_never_transfer_even_under_full_trust` | `_trusted_patterns` stays empty on the child even with `_trust=True`, and the caller keeps its own | rev `2fd95999` |
| `test_a_pattern_only_creator_produces_a_child_that_still_asks` | the `_trust=False` + patterns case from the GPT finding: child born with nothing | rev `2fd95999` |
| `test_an_untrusted_creator_makes_an_untrusted_child` | nothing is granted the creator did not hold (without it, a constant `True` passes the first three) | — |
| `test_the_scoped_safety_override_grant_is_never_inherited` | `_trust_scope` does not fork, and is not laundered into `_trust` | — |
| `test_trust_revoked_mid_create_is_not_inherited` | a posture revoked inside the project-dir resolution is not inherited (the entry-time-read bug) | — |

Red-before verified by reverting `session_control.py` alone with the tests in place: 3 failed against pristine main, and 2 failed against this branch's first revision.

## Manual verification

N/A — unit coverage sufficient. The transfer is two synchronous assignments inside `create_session`; both consumers of the flags (`_slot_is_trusted` per approval, `_persistable_session_policy` for the stored policy) are already covered, and the mid-call revoke window is exercised deterministically by monkeypatching the suspension rather than by timing.

## Related Issues

no linked issue: reported directly from a conductor run, so there is no tracked issue for this to close.

## Docs

`docs/system-specs/modules/session-control.md` gains a "What a created child inherits" section — the identity-versus-posture split, the two exclusions and why each is excluded, the allocation-time read, the birth metadata (showing no trust field is persisted), the two audit `detail` fields, and the transitive-grant gap recorded as a Known gap pointing at #8589. Required in the same commit by AGENTS.md, and raised by the Design Review lane.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a control-plane verb that creates a child copies identity-shaped state (workspace, agent, project) and must decide **separately** about authority-shaped state. Split that authority by whether it is a **posture** ("auto-approve while I supervise this") or a per-object **grant** ("this specific command is safe"): a posture describes the supervision relationship and can follow the delegation, while a grant was judged against content the child does not share and must not. Anything revocable or TTL-bounded is excluded from the copy rather than forked. The tell that a copy is wrong: it is redundant in the case where it would be safe, and load-bearing only in the case where it is not.
