### PR TITLE
fix(dashboard): accept .tsv and .jsonl uploads

### DIFF
--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -1133,6 +1133,7 @@ _ALLOWED_TEXT_EXT = {
     ".xwiki",
     ".md",
     ".json",
+    ".jsonl",
     # Excalidraw scene JSON — the composer's sketch pad attaches one per
     # sketch, and the dashboard has a dedicated read-only renderer for it
     # (FileRenderers routes on this exact extension). Content-wise it is
@@ -1143,6 +1144,7 @@ _ALLOWED_TEXT_EXT = {
     ".yml",
     ".xml",
     ".csv",
+    ".tsv",
     ".log",
     ".py",
     ".js",

--- a/test/test_handlers_files_upload.py
+++ b/test/test_handlers_files_upload.py
@@ -351,6 +351,36 @@ async def test_upload_plain_text_alias_is_accepted(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "payload"),
+    [
+        ("table-export.tsv", b"Files\tRecords\tCodec\n51000\t204000\tsnappy\n"),
+        ("events.jsonl", b'{"event": "start"}\n{"event": "stop"}\n'),
+    ],
+)
+async def test_upload_tsv_and_jsonl_are_accepted(
+    upload_dir: Path,
+    mock_sel,
+    filename: str,
+    payload: bytes,
+) -> None:
+    form = aiohttp.FormData()
+    form.add_field(
+        "file",
+        payload,
+        filename=filename,
+        content_type="text/plain",
+    )
+    async with TestClient(TestServer(_make_app())) as client:
+        resp = await client.post("/api/upload/file", data=form)
+        assert resp.status == 200, await resp.text()
+        body = await resp.json()
+    saved = Path(body["paths"][0])
+    assert saved.name.endswith(f"_{filename}")
+    assert saved.read_bytes() == payload
+
+
+@pytest.mark.asyncio
 async def test_upload_unrelated_extension_still_rejected(
     upload_dir: Path,
     mock_sel,

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -111,7 +111,7 @@ const IMAGE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp,image/bmp,image/
 // test_accept_list_covers_every_accepted_extension pins this set against the
 // server's, from the Python side, since a vitest cannot read the Python constant.
 const VIDEO_ACCEPT = 'video/mp4,video/x-m4v,video/quicktime,video/webm'
-const FILE_ACCEPT = IMAGE_ACCEPT + ',' + VIDEO_ACCEPT + ',.txt,.text,.xwiki,.md,.json,.excalidraw,.har,.yaml,.yml,.xml,.csv,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh,.bash,.rb,.go,.rs,.java,.c,.cpp,.h,.hpp,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.rtf,.zip,.tar,.gz'
+const FILE_ACCEPT = IMAGE_ACCEPT + ',' + VIDEO_ACCEPT + ',.txt,.text,.xwiki,.md,.json,.jsonl,.excalidraw,.har,.yaml,.yml,.xml,.csv,.tsv,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh,.bash,.rb,.go,.rs,.java,.c,.cpp,.h,.hpp,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.odt,.ods,.odp,.rtf,.zip,.tar,.gz'
 
 import ApprovalModePicker, { APPROVAL_MODE_ADJUSTED_LS_KEY } from './ApprovalModePicker'
 // Effort vocabulary lives in lib/effort.ts (mirrors backend effort.py).


### PR DESCRIPTION
## Problem / Motivation

Uploading a `.tsv` or `.jsonl` file in the dashboard fails with `Upload failed: Unsupported file type`. Files with the `.csv` and `.json` extensions are accepted.

## Why it matters

TSV is what a table copied from a spreadsheet or chat client produces, and JSONL is a common export format for logs and event streams. Users have to rename the file to `.txt` to get it through.

## What changed (motivation → approach → change)

The upload allowlist `_ALLOWED_TEXT_EXT` in `src/kiro_crew/dashboard/handlers/files.py` does not list either extension, and the file picker filter `FILE_ACCEPT` in `website/src/components/ChatInput.tsx` has the same gap, so the picker greys the files out. Added `.jsonl` next to `.json` and `.tsv` next to `.csv` in both lists. The picker filter only affects which files the native dialog offers. The server still validates every upload.

## Tests

One parametrized test uploads both types end to end through `api_upload_file` and asserts they upload successfully. With the allowlist change reverted and the test kept, both cases fail with the reported error.

## Manual verification

On a local instance of this branch: dragged a `.tsv` into the composer (accepted, see screenshots) and confirmed the native file picker now lists `.tsv` and `.jsonl` files as selectable.

## Screenshots / video

Before, on the current release: dragging a `.tsv` into the composer is rejected.

![Upload failed: Unsupported file type: .tsv](https://github.com/user-attachments/assets/ef3f3135-3088-4d96-a973-555d97d4fd71)

After, on this branch: the same file attaches to the composer.

![table-specs.tsv attached to the composer](https://github.com/user-attachments/assets/ca4e9987-e9f4-44b9-8da4-4d92f95561a7)

The native file picker on this branch lists `.tsv` and `.jsonl` files.

![File picker showing events.jsonl and table-specs.tsv selectable](https://github.com/user-attachments/assets/ffa8817f-b2ec-467a-a138-b51725fc29ff)

## Related Issues

no linked issue: discovered by direct use of the dashboard upload.

## Pattern harvest

Not generalizable: adds two missing members to a deliberate allowlist, no defect class to detect mechanically.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable): no doc enumerates the upload allowlist
- [x] No secrets, credentials, or internal references in the diff
