### PR TITLE
fix(instances): size the automatic warm-set cap by registered crews, not connected ones

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -3189,7 +3189,7 @@
       "sensitive": false,
       "tags": [],
       "label": "Warm Set Cap",
-      "help": "Max number of remote instances kept warm (iframe mounted + tunnel live) at once. Least-recently-used instances beyond this are evicted and reconnected on demand. Bounds memory/socket use (each warm instance is a full dashboard SPA). 0 (the default) is automatic: the cap follows how many crews are currently connected, so a crew you connected is never evicted -- eviction cold-boots the pane and reads as a disconnect, so a fixed cap below the connected count makes tab switching look like a connection flap. Automatic is bounded by an internal ceiling; an explicit value is honoured exactly, including one below the connected count.",
+      "help": "Max number of remote instances kept warm (iframe mounted + tunnel live) at once. Least-recently-used instances beyond this are evicted and reconnected on demand. Bounds memory/socket use (each warm instance is a full dashboard SPA). 0 (the default) is automatic: the cap follows how many crews are configured, so up to an internal ceiling no crew you added is evicted and the cap widens by itself when you add one -- eviction cold-boots the pane and reads as a disconnect, so a cap below the number of crews in use makes tab switching look like a connection flap. Past that ceiling eviction resumes; an explicit value is honoured exactly, including one below the number of configured crews.",
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 0

--- a/docs/system-specs/modules/instances.md
+++ b/docs/system-specs/modules/instances.md
@@ -196,18 +196,21 @@ non-POSIX (§12). Treat a Windows hub as unverified.
 2. **Warm set.** Up to `warm_set_cap` most-recently-used instances
    stay warm: iframe mounted (hide-not-unmount, so switching never reloads or
    re-runs the token handshake) with a live tunnel and WebSocket. The default
-   (`0`) is **automatic**: `GET /api/instances` resolves the cap from the live
-   connected count (`resolve_warm_set_cap`, bounded by
-   `WARM_SET_CAP_AUTO_CEILING`), so a crew the operator connected is never
-   evicted; an explicit integer is served verbatim, including one below the
-   connected count. Exceeding the
+   (`0`) is **automatic**: `GET /api/instances` resolves the cap from how many
+   crews are REGISTERED (`resolve_warm_set_cap`, bounded by
+   `WARM_SET_CAP_AUTO_CEILING`), so up to that ceiling no crew the operator
+   configured is evicted; an explicit integer is served verbatim, including one
+   below the registered count. Registered rather than connected because a live
+   count races tunnel startup: a crew whose tunnel came up a moment after the
+   dashboard polled fell outside the cap and lost its pane, so exactly one crew
+   looked broken and which one changed on every restart. Exceeding the
    cap **evicts the least-recently-used non-active iframe**. Eviction unmounts
    the iframe only: it does NOT disconnect the tunnel or clear `was_connected`,
    so the switcher entry persists and re-warms on the next click. Entries
    disappear only on an explicit disconnect. Note that re-warming re-mints the
    token and cold-boots the remote SPA, so from the user's seat an eviction is
    hard to tell apart from a dropped connection — which is why the default
-   tracks the connected count rather than a fixed number.
+   tracks the registry rather than a fixed number.
 3. **Health probe.** While CONNECTED, a per-tunnel loop polls the loopback
    forward every `DEFAULT_PROBE_INTERVAL_SECS` (30s, not user-configurable;
    `<= 0` disables the probe); after `probe_failure_threshold` (3) *consecutive*
@@ -263,7 +266,7 @@ cannot drift.
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `instances.enabled` | `false` | Primary opt-in, read at gateway startup. Also gates the CSP `frame-src` `*.localhost` extension. |
-| `instances.warm_set_cap` | `0` (automatic) | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). `0` tracks the live connected count so no connected crew is evicted, bounded by an internal ceiling; an explicit value is honoured exactly, including one below the connected count. Negative values fall back to automatic. |
+| `instances.warm_set_cap` | `0` (automatic) | Max instances kept warm at once (bounds memory/sockets; each warm instance is a full dashboard SPA). `0` tracks how many crews are registered, so up to an internal ceiling no configured crew is evicted; an explicit value is honoured exactly, including one below the registered count. Negative values fall back to automatic. |
 | `instances.tunnel_base_port` | `7778` | First local loopback port the allocator hands out. Out-of-range values fall back to the default. |
 | `instances.ssh_compression` | `true` | Add `-C` to the tunnel argv. See §5.2. |
 | `instances.connect_timeout_secs` | unset (SSH `15.0`, SSM `25.0`) | How long (secs) to wait for the local forward port to accept connections before declaring a connect attempt failed. Hosts behind a ProxyCommand or jump host need longer (the proxy handshake runs before ssh begins the forward). An explicit value applies to both transports, including a value equal to either transport's default. Values below 1 fall back to the transport defaults; values above 120 are clamped to 120. |
@@ -841,7 +844,7 @@ whose current variable parts are all charset-bound literals.
 | Connect fails for another reason | Use **Diagnose**. The ladder reports the first broken link: `ssh_unreachable` (check SSH access or the host alias), `remote_down` (remote gateway not listening), `not_connected` (SSH and remote are fine, this instance has no tunnel yet: click Connect), or `tunnel_down` (reconnect). |
 | "local port N was taken while connecting" | The allocator picked a port that something grabbed in the moment before `ssh` bound it. Retry. If it persists, stop whatever keeps taking ports in that range or move `instances.tunnel_base_port` to a quieter one. |
 | Instance keeps dropping | The health probe plus 2-tier self-heal retry over roughly a two-minute window (8 attempts, capped-exponential backoff). Tune `instances.max_recovery_attempts` / `recover_backoff_max_secs` / `probe_failure_threshold`; both recovery values are clamped so they cannot loop indefinitely. If self-heal gives up, diagnosis runs automatically. Check the remote gateway and SSH stability. |
-| A pane vanished from the warm set but its switcher entry is still there | It was LRU-evicted (warm set full). The tunnel is untouched: selecting the crew re-warms it, though the re-mint plus SPA cold boot makes that look like a reconnect. Only an explicit `instances.warm_set_cap` can now be below the connected count — set it to `0` to let the cap track how many crews are connected. |
+| A pane vanished from the warm set but its switcher entry is still there | It was LRU-evicted (warm set full). The tunnel is untouched: selecting the crew re-warms it, though the re-mint plus SPA cold boot makes that look like a reconnect. Only an explicit `instances.warm_set_cap`, or a fleet past the automatic ceiling (`WARM_SET_CAP_AUTO_CEILING`), can now be below the number of registered crews — set it to `0` to let the cap track the registry. |
 | Every token mint fails on one remote, though its gateway is healthy | The remote's `~/.local/bin/kirocrew` probably points at an uninstalled checkout. See §12: the run-marker is what makes mint follow the *running* gateway's install. |
 
 ---

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -4463,11 +4463,12 @@ class InstancesConfig:
             "at once. Least-recently-used instances beyond this are evicted and "
             "reconnected on demand. Bounds memory/socket use (each warm instance is a "
             "full dashboard SPA). 0 (the default) is automatic: the cap follows how "
-            "many crews are currently connected, so a crew you connected is never "
-            "evicted -- eviction cold-boots the pane and reads as a disconnect, so a "
-            "fixed cap below the connected count makes tab switching look like a "
-            "connection flap. Automatic is bounded by an internal ceiling; an explicit "
-            "value is honoured exactly, including one below the connected count.",
+            "many crews are configured, so up to an internal ceiling no crew you added "
+            "is evicted and the cap widens by itself when you add one -- eviction "
+            "cold-boots the pane and reads as a disconnect, so a cap below the number "
+            "of crews in use makes tab switching look like a connection flap. Past that "
+            "ceiling eviction resumes; an explicit value is honoured exactly, including "
+            "one below the number of configured crews.",
         ),
     )
     tunnel_base_port: int = field(

--- a/src/kiro_crew/config/superseded_defaults.py
+++ b/src/kiro_crew/config/superseded_defaults.py
@@ -167,7 +167,7 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
         new_default_display="unset (automatic: 25s desktop / 90s managed service)",
     ),
     # instances.warm_set_cap moved from a materialized 5 to 0 (automatic: as many
-    # panes as there are connected crews). A stored 5 keeps evicting the 6th crew,
+    # panes as there are crews registered). A stored 5 keeps evicting the 6th crew,
     # and eviction is indistinguishable from a disconnect at the pane -- so the
     # symptom of holding the old default is a connection that looks like it flaps
     # on tab switch. A stored 5 may equally be a deliberate budget on a
@@ -177,7 +177,7 @@ SUPERSEDED_DEFAULTS: tuple[SupersededDefault, ...] = (
         old_default=5,
         new_default=0,
         changed_in="#7248",
-        new_default_display="0 (automatic: as many as are connected)",
+        new_default_display="0 (automatic: as many as are registered)",
     ),
 )
 

--- a/src/kiro_crew/dashboard/handlers_instances.py
+++ b/src/kiro_crew/dashboard/handlers_instances.py
@@ -213,10 +213,17 @@ async def api_instances_list(request: web.Request) -> web.Response:
     # its fsync — so every registry touch in these handlers goes off the loop.
     items = [_instance_view(state, i) for i in await asyncio.to_thread(reg.list)]
     # Resolved here rather than served raw: the automatic mode (0) means "as many
-    # as are connected", and this is the only place that holds both the stored
-    # value and the live per-instance status. The browser therefore always
-    # receives a concrete integer and needs no notion of automatic.
-    connected = sum(1 for i in items if (i.get("status") or {}).get("state") == "connected")
+    # as could be warm at once", and this is the only place that holds both the
+    # stored value and the registry. The browser therefore always receives a
+    # concrete integer and needs no notion of automatic.
+    #
+    # Counted from the REGISTRY, not from live status. A connected-count made the
+    # cap race tunnel startup: a crew that finished connecting just after this
+    # poll was not counted, the cap came back one short, and the viewport evicted
+    # a pane to honour it -- so one crew looked broken, and which one depended on
+    # connection order. Registered crews cannot race, and the count rises by
+    # itself when a crew is added.
+    eligible = len(items)
     _audit("list", "success")
     return web.json_response(
         {
@@ -228,7 +235,7 @@ async def api_instances_list(request: web.Request) -> web.Response:
             "active": getattr(state, "instances_manager", None) is not None,
             "instances": items,
             "warm_set_cap": resolve_warm_set_cap(
-                KiroCrewConfig.load().instances.warm_set_cap, connected
+                KiroCrewConfig.load().instances.warm_set_cap, eligible
             ),
         }
     )

--- a/src/kiro_crew/instances/constants.py
+++ b/src/kiro_crew/instances/constants.py
@@ -17,26 +17,34 @@ from __future__ import annotations
 # bounds memory/socket usage; least-recently-used instances beyond the cap are
 # lazily evicted and reconnected on demand.
 #
-# ``WARM_SET_CAP_AUTO`` (0) is the default and means "as many as are connected":
-# the cap is resolved per request from the live connected count (see
-# ``kiro_crew.instances.warm_set.resolve_warm_set_cap``), so a crew the operator
-# deliberately connected is never evicted.
+# ``WARM_SET_CAP_AUTO`` (0) is the default and means "as many as are registered,
+# up to ``WARM_SET_CAP_AUTO_CEILING``": the cap is resolved per request from the
+# number of crews in the registry (see
+# ``kiro_crew.instances.warm_set.resolve_warm_set_cap``), so below that ceiling no
+# crew the operator configured is evicted, and adding one widens the cap by
+# itself. Past the ceiling eviction resumes -- see its own comment below.
 #
 # Auto is the default because eviction is INDISTINGUISHABLE FROM A DISCONNECT at
 # the pane: the iframe is unmounted, the token is re-minted and the remote SPA
 # cold-boots on the next click (surfacing the error panel outright if readiness
-# misses its timeout). A fixed cap below the connected count therefore turns
+# misses its timeout). A cap below the number of crews in use therefore turns
 # ordinary tab switching into an apparent connection flap, and the operator has
-# no way to attribute it -- the tunnel is up the whole time. Tracking the
-# connected count removes that class of misconfiguration rather than asking
-# anyone to keep two numbers in sync by hand.
+# no way to attribute it -- the tunnel is up the whole time. Tracking the registry
+# removes that class of misconfiguration rather than asking anyone to keep two
+# numbers in sync by hand.
+#
+# REGISTERED, not connected, which is what this used to count. A live count races
+# tunnel startup: a crew that finished connecting a moment after the dashboard
+# polled fell outside the cap and had its pane evicted. Exactly one crew looked
+# broken, and which one depended on connection order -- so it moved on every
+# restart and read as a random failure rather than as a cap.
 WARM_SET_CAP_AUTO: int = 0
 DEFAULT_WARM_SET_CAP: int = WARM_SET_CAP_AUTO
 
-# Upper bound on the AUTO-resolved warm set. Auto follows the connected count,
+# Upper bound on the AUTO-resolved warm set. Auto follows the registered count,
 # which is a statement of user intent and not a resource budget -- a fleet of 30
-# connected crews would otherwise mount 30 dashboard SPAs in one renderer.
-# Beyond this many connected crews eviction resumes, so the worst case stays
+# configured crews would otherwise mount 30 dashboard SPAs in one renderer.
+# Beyond this many registered crews eviction resumes, so the worst case stays
 # bounded while the common small-fleet case (the reason auto exists) never
 # evicts. An EXPLICIT integer cap is honoured verbatim and is deliberately not
 # clamped by this: an operator who names a number has made the budget decision

--- a/src/kiro_crew/instances/warm_set.py
+++ b/src/kiro_crew/instances/warm_set.py
@@ -1,11 +1,11 @@
 """Resolve the effective warm-iframe cap for the dashboard's instance panes.
 
 Kept as a pure function in its own module so the policy -- "automatic means as
-many crews as are connected" -- is testable without a gateway, a registry, or a
-live tunnel, and so the one place that decides it is not buried in an HTTP
-handler. ``GET /api/instances`` is the only caller: the resolved integer travels
-to the browser as ``warm_set_cap`` and the viewport enforces it, so the frontend
-never has to know that an automatic mode exists.
+many crews as could be warm at once" -- is testable without a gateway, a
+registry, or a live tunnel, and so the one place that decides it is not buried in
+an HTTP handler. ``GET /api/instances`` is the only caller: the resolved integer
+travels to the browser as ``warm_set_cap`` and the viewport enforces it, so the
+frontend never has to know that an automatic mode exists.
 """
 
 from __future__ import annotations
@@ -13,25 +13,33 @@ from __future__ import annotations
 from kiro_crew.instances.constants import WARM_SET_CAP_AUTO_CEILING
 
 
-def resolve_warm_set_cap(configured: int, connected_count: int) -> int:
+def resolve_warm_set_cap(configured: int, eligible_count: int) -> int:
     """Return the number of instance panes that may stay warm right now.
 
     *configured* is ``instances.warm_set_cap`` as stored. Any value >= 1 is an
     explicit operator budget and is returned UNCHANGED -- including a value below
-    *connected_count*. Silently widening a deliberately tight cap would defeat
-    the only knob that bounds renderer cost, and on a memory-starved machine
+    *eligible_count*. Silently widening a deliberately tight cap would defeat the
+    only knob that bounds renderer cost, and on a memory-starved machine
     accepting eviction is a legitimate trade.
 
-    ``WARM_SET_CAP_AUTO`` (0, the default) resolves to the live
-    *connected_count*, so no connected crew is evicted, clamped to
-    ``WARM_SET_CAP_AUTO_CEILING`` so a large fleet cannot mount an unbounded
-    number of dashboard SPAs in one renderer.
+    ``WARM_SET_CAP_AUTO`` (0, the default) resolves to *eligible_count*: how many
+    crews are REGISTERED, not how many are connected this instant. That
+    distinction is the whole point of this function. Deriving the cap from live
+    connection state made it a race against tunnel startup -- a crew whose tunnel
+    came up a moment after the dashboard polled was not counted, so the cap
+    landed one short, and the pane that lost was whichever crew connected last.
+    It changed on every restart and read as a random crew being broken. A count
+    of registered crews cannot race, and it rises on its own when a crew is
+    added, so nobody has to remember to widen the cap alongside.
+
+    Clamped to ``WARM_SET_CAP_AUTO_CEILING`` so a large fleet cannot mount an
+    unbounded number of dashboard SPAs in one renderer.
 
     Never returns less than 1. The active pane is always warm, so a cap of 0 is
     one the viewport cannot honour -- it would evict the pane the user is looking
-    at. A negative *connected_count* is read as none connected rather than
+    at. A negative *eligible_count* is read as none registered rather than
     trusted, since it can only arrive from a caller bug.
     """
     if configured >= 1:
         return configured
-    return max(1, min(max(connected_count, 0), WARM_SET_CAP_AUTO_CEILING))
+    return max(1, min(max(eligible_count, 0), WARM_SET_CAP_AUTO_CEILING))

--- a/test/test_instances.py
+++ b/test/test_instances.py
@@ -46,8 +46,8 @@ class TestConfig:
 
         c = InstancesConfig()
         assert c.enabled is False
-        # 0 == automatic: the cap follows the connected crew count (resolved per
-        # request by resolve_warm_set_cap), so no connected crew is ever evicted.
+        # 0 == automatic: the cap follows the REGISTERED crew count (resolved per
+        # request by resolve_warm_set_cap), so no configured crew is ever evicted.
         assert c.warm_set_cap == DEFAULT_WARM_SET_CAP == 0
         assert c.tunnel_base_port == DEFAULT_TUNNEL_BASE_PORT == 7778
         assert DEFAULT_CONNECT_TIMEOUT_SECS == 15.0
@@ -2251,18 +2251,25 @@ class TestHandlers:
         assert r.status == 201
         r = asyncio.run(handlers.api_instances_list(_FakeReq(state)))
         b = _body(r)
-        # Automatic cap with nothing connected floors at 1 (the active pane is
-        # always warm), so the browser still gets a cap it can honour.
+        # One crew registered => automatic cap 1, and adding it is enough: the
+        # cap does not wait for the tunnel to come up.
         assert b["warm_set_cap"] == 1 and len(b["instances"]) == 1
         # no manager on this state => enabled-in-config but not active (needs restart)
         assert b["active"] is False
 
-    def test_automatic_cap_tracks_the_connected_count(self, tmp_path, monkeypatch):
-        """The served cap covers every connected crew, so none is ever evicted.
+    def test_automatic_cap_covers_every_registered_crew_not_just_connected_ones(
+        self, tmp_path, monkeypatch
+    ):
+        """The served cap covers every REGISTERED crew, connected or not.
 
-        Eviction unmounts the pane and cold-boots the remote SPA on the next
-        click, which reads as a disconnect — so a cap below the connected count
-        makes ordinary tab switching look like a connection flap.
+        This is the regression that produced "one random crew is broken". The cap
+        used to be the live connected count, so a crew whose tunnel came up just
+        after this request was not counted, the cap arrived one short, and the
+        viewport evicted a pane to honour it. Eviction unmounts the pane and
+        cold-boots the remote SPA on the next click, which reads as a disconnect —
+        and which crew lost depended on connection order, so the victim moved on
+        every restart. Here 3 are registered and only 2 are connected; the cap
+        must still be 3.
         """
         from kiro_crew.dashboard import handlers_instances as handlers
 
@@ -2273,9 +2280,26 @@ class TestHandlers:
         state = _State(reg, _ConnectedMgr(["a", "c"]))
         b = _body(asyncio.run(handlers.api_instances_list(_FakeReq(state))))
         assert len(b["instances"]) == 3
-        assert b["warm_set_cap"] == 2
+        assert b["warm_set_cap"] == 3
 
-    def test_explicit_cap_is_served_even_below_the_connected_count(self, tmp_path, monkeypatch):
+    def test_adding_a_crew_widens_the_served_cap(self, tmp_path, monkeypatch):
+        """Otherwise every new crew has to be paired with a config edit.
+
+        Forgetting that edit reintroduces the eviction above, so the cap has to
+        rise on its own when the fleet grows.
+        """
+        from kiro_crew.dashboard import handlers_instances as handlers
+
+        _enable(tmp_path, monkeypatch)
+        reg = self._reg(tmp_path)
+        reg.add(name="a", ssh_host="a-alias")
+        state = _State(reg, _ConnectedMgr([]))
+        before = _body(asyncio.run(handlers.api_instances_list(_FakeReq(state))))["warm_set_cap"]
+        reg.add(name="b", ssh_host="b-alias")
+        after = _body(asyncio.run(handlers.api_instances_list(_FakeReq(state))))["warm_set_cap"]
+        assert (before, after) == (1, 2)
+
+    def test_explicit_cap_is_served_even_below_the_registered_count(self, tmp_path, monkeypatch):
         """An operator's own number is the budget and is not widened for them."""
         from kiro_crew.dashboard import handlers_instances as handlers
 

--- a/test/test_warm_set_cap.py
+++ b/test/test_warm_set_cap.py
@@ -3,7 +3,8 @@
 The cap decides how many remote-crew panes stay mounted. It matters because
 eviction is indistinguishable from a disconnect at the pane -- the iframe is
 unmounted and the remote SPA cold-boots on the next click -- so a cap below the
-connected count reads to the user as a connection that flaps on tab switch.
+number of crews in use reads to the user as a connection that flaps on tab
+switch.
 """
 
 from __future__ import annotations
@@ -20,11 +21,11 @@ class TestAutomatic:
     def test_the_shipped_default_is_automatic(self):
         assert DEFAULT_WARM_SET_CAP == WARM_SET_CAP_AUTO == 0
 
-    def test_automatic_matches_the_connected_count(self):
-        # The whole point: every connected crew keeps its pane, so switching
+    def test_automatic_matches_the_registered_count(self):
+        # The whole point: every configured crew keeps its pane, so switching
         # between them never evicts one and never looks like a disconnect.
-        for connected in (1, 2, 3, 4, 7):
-            assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, connected) == connected
+        for registered in (1, 2, 3, 4, 7):
+            assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, registered) == registered
 
     def test_automatic_is_bounded_by_the_ceiling(self):
         # A large fleet must not mount an unbounded number of dashboard SPAs in
@@ -39,15 +40,42 @@ class TestAutomatic:
         # honour -- it would evict the pane the user is looking at.
         assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, 0) == 1
 
-    def test_a_negative_connected_count_is_not_trusted(self):
+    def test_a_negative_registered_count_is_not_trusted(self):
         assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, -2) == 1
 
 
+class TestAdmitsEveryRegisteredCrew:
+    """The regression this policy exists to prevent.
+
+    Auto used to resolve from the LIVE CONNECTED count, which made the cap race
+    tunnel startup. With four crews configured and the fourth still connecting
+    when the dashboard polled, the cap came back 3, the viewport evicted a pane
+    to honour it, and one crew looked broken -- a different one each restart,
+    since it depended on which tunnel finished last.
+    """
+
+    def test_a_crew_still_connecting_does_not_shrink_the_cap(self):
+        # Four registered, however many happen to be up at this instant.
+        assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, 4) == 4
+
+    def test_adding_a_crew_widens_the_cap_without_touching_config(self):
+        # Otherwise the operator has to remember to raise the cap alongside, and
+        # forgetting reintroduces the eviction that looks like a random failure.
+        assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, 5) > resolve_warm_set_cap(
+            WARM_SET_CAP_AUTO, 4
+        )
+
+    def test_a_registered_but_never_connected_crew_still_gets_a_slot(self):
+        # A crew is registered by configuring it, not by connecting it. Budgeting
+        # only for live tunnels is precisely what made the cap arrive one short.
+        assert resolve_warm_set_cap(WARM_SET_CAP_AUTO, 2) == 2
+
+
 class TestExplicit:
-    def test_an_explicit_cap_wins_over_the_connected_count(self):
+    def test_an_explicit_cap_wins_over_the_registered_count(self):
         assert resolve_warm_set_cap(3, 9) == 3
 
-    def test_an_explicit_cap_below_the_connected_count_is_not_widened(self):
+    def test_an_explicit_cap_below_the_registered_count_is_not_widened(self):
         # A deliberately tight cap is the only knob that bounds renderer cost;
         # silently widening it would defeat the operator's own trade.
         assert resolve_warm_set_cap(2, 4) == 2

--- a/website/electron/frame-load-log.js
+++ b/website/electron/frame-load-log.js
@@ -1,0 +1,448 @@
+"use strict";
+
+/**
+ * Frame-load diagnostics for the dashboard's own webContents.
+ *
+ * The remote-crew panes are cross-origin iframes pointed at SSH-forwarded
+ * loopback ports. When one of them never becomes a live document the UI shows
+ * "loading pane" forever and NOTHING is recorded anywhere: the main window
+ * hooked no load events, the remote gateway keeps no HTTP access log (no
+ * aiohttp `access_log` is configured), and a packaged app has no devtools
+ * console to open. So the one question that decides the diagnosis — did the
+ * frame ever navigate, and with what status — had no answer in any log.
+ *
+ * This module closes that gap by journaling frame navigations, frame load
+ * failures, and renderer console errors into the same gateway-launch.log the
+ * rest of the launch path writes to.
+ *
+ * Kept electron-free so node:test can drive the formatters directly.
+ */
+
+/**
+ * Identical console errors repeat every paint (a broken pane can emit the same
+ * line hundreds of times), and this log is read by tailing it. Cap the repeats
+ * so one loud message cannot bury the navigation lines around it.
+ */
+const CONSOLE_REPEAT_LIMIT = 3;
+
+/**
+ * The dashboard's own pane journal (`website/src/lib/paneLog.ts`) emits at INFO
+ * level and is allowlisted below regardless of severity: those lines are the
+ * renderer half of this diagnosis and are deliberately few.
+ *
+ * The prefix alone is NOT the authorization — see `isTrustedFrameMessage`. It is a
+ * marker the dashboard's own document uses, not a capability, because a crew pane
+ * can print the same characters.
+ */
+const PANE_LOG_PREFIX = "[pane]";
+
+/**
+ * A higher cap for allowlisted lines. A pane stuck in a re-mint loop repeats the
+ * same journal line, and the REPEAT COUNT is the finding there — capping it at
+ * three would hide the loop this instrumentation exists to catch.
+ */
+const PANE_REPEAT_LIMIT = 20;
+
+/**
+ * Longest console text this journals per line.
+ *
+ * Console text is pane-reachable (see `sanitizeLogText`), and this log is read by
+ * tailing it, so one enormous message would scroll every line that matters out of
+ * the window even though the repeat cap counted it only once.
+ */
+const MESSAGE_MAX_LENGTH = 512;
+
+/**
+ * How many distinct messages the repeat counter remembers.
+ *
+ * The counter is keyed by message text, which a compromised pane chooses. Without
+ * a bound it can emit endless distinct errors and grow this map for the life of
+ * the main process. Dropping the whole map on overflow restarts the counting — a
+ * few extra repeats reach the log — rather than leaking.
+ */
+const REPEAT_KEYS_MAX = 500;
+
+/**
+ * Total lines an untrusted frame may contribute for the life of the attachment.
+ *
+ * This is the ONE hard bound on how much a pane can write, and it has to be
+ * aggregate rather than per-path because a pane drives more than one path. The
+ * repeat cap is keyed by message TEXT, and text is exactly what a compromised pane
+ * controls: varying it defeats a per-message cap, and a pane can just as easily loop
+ * its own frame's NAVIGATIONS — each `did-fail-load` / `did-frame-navigate` /
+ * `did-start-navigation` is another unconditional line. So every line attributable
+ * to an untrusted frame, console or navigation alike, is charged against this single
+ * budget (see `record` in `attachFrameLoadLogging`): a limit on one path is a limit
+ * a chooser walks around by switching paths.
+ *
+ * It is per-attachment (one main window), not per-frame, because frame identity is
+ * itself pane-influenced once a pane can reload itself into a fresh frame.
+ *
+ * The trade is explicit: past the budget a genuinely broken pane stops explaining
+ * itself. That is acceptable because the first lines are the diagnosis — a framing
+ * refusal or a refused fetch repeats, it does not evolve — while an unbounded log is
+ * a disk-exhaustion path on the user's machine.
+ */
+const UNTRUSTED_LOG_BUDGET = 100;
+
+/**
+ * One log line's worth of text, with the framing characters neutralized.
+ *
+ * Everything a console message carries is untrusted input: the crew panes are
+ * cross-origin iframes OF THIS webContents, so `console-message` also fires for
+ * whatever a remote gateway's document prints. `gateway-launch.log` is a
+ * line-oriented file read by tailing it, so a raw newline in that text would let a
+ * pane forge whole entries — including entries shaped like this module's own
+ * navigation lines, which is exactly the evidence the log exists to provide.
+ * Escape the line breaks, replace the remaining C0 controls (an ESC sequence can
+ * rewrite what a terminal reader sees), and cap the length.
+ */
+function sanitizeLogText(text, limit = MESSAGE_MAX_LENGTH) {
+  const flat = String(text == null ? "" : text)
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/[\u0000-\u001f\u007f]/g, "?");
+  if (flat.length <= limit) return flat;
+  return `${flat.slice(0, limit)}... [${flat.length - limit} more chars truncated]`;
+}
+
+/**
+ * A URL safe to journal.
+ *
+ * A pane URL carries the crew's session token in `?token=…`, which must never
+ * be written to a log file. The query is dropped, but the line still records
+ * THAT a token was present: the failure worth diagnosing is a token the remote
+ * rejected, so its presence is signal while its value is only a secret.
+ */
+function safeUrl(url) {
+  const text = String(url || "");
+  const cut = text.indexOf("?");
+  if (cut < 0) return text;
+  const query = text.slice(cut + 1);
+  const marker = /(^|&)token=/.test(query) ? "?token=<redacted>" : "?<query>";
+  return text.slice(0, cut) + marker;
+}
+
+/** Which frame the event is about — the dashboard itself, or a crew pane. */
+function frameLabel(isMainFrame) {
+  return isMainFrame ? "main" : "subframe";
+}
+
+/**
+ * A navigation that STARTED. Paired with the committed-navigation line below,
+ * this is what separates the two failures that look identical on screen: a start
+ * with no commit is a request that went out and never came back (a dead tunnel
+ * that still accepts locally), while no start at all means the frame was never
+ * pointed anywhere and no amount of remote debugging would have found it.
+ *
+ * Same-document navigations are skipped — the dashboard is a router-driven SPA
+ * and they carry no load information.
+ */
+function formatFrameStartNavigation({ url, isInPlace, isMainFrame } = {}) {
+  if (isInPlace) return "";
+  return `frame navigation STARTED (${frameLabel(isMainFrame)}) ${safeUrl(url)}`;
+}
+
+/**
+ * A committed navigation. `status` is the HTTP code the frame actually got, so
+ * a pane the remote answered with 403 (token refused) is distinguishable from
+ * one that was never requested at all — the latter logs no line here.
+ */
+function formatFrameNavigate({ url, httpResponseCode, isMainFrame } = {}) {
+  const status = Number.isFinite(httpResponseCode) ? httpResponseCode : "?";
+  return `frame navigated (${frameLabel(isMainFrame)}) status=${status} ${safeUrl(url)}`;
+}
+
+/**
+ * A navigation that started and failed. The net error code is the whole point:
+ * ERR_CONNECTION_REFUSED means the forwarded port had no listener, while
+ * ERR_BLOCKED_BY_RESPONSE means the response arrived and framing was refused.
+ */
+function formatFrameFailLoad({ errorCode, errorDescription, url, isMainFrame } = {}) {
+  const code = Number.isFinite(errorCode) ? errorCode : "?";
+  const desc = String(errorDescription || "").trim() || "unknown";
+  return `frame load FAILED (${frameLabel(isMainFrame)}) code=${code} ${desc} ${safeUrl(url)}`;
+}
+
+/**
+ * Normalize both `console-message` shapes.
+ *
+ * Electron >= 35 emits a single details object (`level` is a string); the
+ * legacy positional form (`event, level:number, message, line, sourceId`) is
+ * deprecated but still delivered, and is what the rest of this app reads.
+ * Accepting both means this keeps working across the upgrade that drops one.
+ *
+ * `frame` is the emitting `WebFrameMain` when the runtime supplies one, and `null`
+ * otherwise. It is carried out of here rather than resolved here because it is a
+ * live main-process handle, not log content: `isTrustedFrameMessage` is what reads it.
+ *
+ * @returns {{severity: string, message: string, sourceId: string, line: number,
+ *   frame: object|null}|null}
+ */
+function normalizeConsoleMessage(args) {
+  const list = Array.isArray(args) ? args : [];
+  const first = list[0];
+  // New shape: the sole argument carries the message itself.
+  if (first && typeof first === "object" && typeof first.message === "string") {
+    return {
+      severity: severityFromLevel(first.level),
+      message: first.message,
+      sourceId: String(first.sourceId || ""),
+      line: Number(first.lineNumber) || 0,
+      frame: first.frame || null,
+    };
+  }
+  // Legacy shape: args[0] is the event, and the payload follows it.
+  if (typeof list[2] === "string") {
+    return {
+      severity: severityFromLevel(list[1]),
+      message: list[2],
+      sourceId: String(list[4] || ""),
+      line: Number(list[3]) || 0,
+      frame: (first && typeof first === "object" && first.frame) || null,
+    };
+  }
+  return null;
+}
+
+/**
+ * The dashboard's own origin, from whatever the caller loaded the window with.
+ *
+ * Accepts a full URL (`http://localhost:5476/?token=…`) or a bare origin and
+ * reduces both to the RFC 6454 serialization `WebFrameMain#origin` reports, so the
+ * comparison in `isTrustedFrameMessage` is string equality on canonical values
+ * rather than a prefix or substring test. An unparseable value yields `""`, which
+ * disables the `[pane]` allowlist entirely — see the fail-closed note below.
+ */
+function normalizeTrustedOrigin(value) {
+  const text = String(value || "");
+  if (!text) return "";
+  try {
+    return new URL(text).origin;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Did this console message come from the dashboard's OWN document?
+ *
+ * This is the authorization for the `[pane]` allowlist, and it has to be an
+ * identity check rather than a text check. The crew panes are cross-origin iframes
+ * of the same webContents, so their console output arrives on the very same event:
+ * without this gate any pane could print `[pane] …` and have it copied verbatim
+ * into `gateway-launch.log`, forging the one record that decides whether a pane was
+ * ever requested — while also buying the higher repeat cap and an exemption from
+ * the error-severity filter.
+ *
+ * BOTH halves are required, and neither alone is sufficient:
+ *
+ * 1. `frame.parent === null` — the top frame of the frame tree. Chromium, not the
+ *    page, owns that relationship, so a nested pane cannot claim it.
+ * 2. `frame.origin === <the origin the window was loaded with>`. Position alone is
+ *    NOT identity: a cross-origin pane that gets a user click on a `target="_top"`
+ *    link can navigate the TOP-LEVEL window to a remote document, and that document
+ *    then has `parent === null` too. `WebFrameMain#origin` is Chromium's serialized
+ *    security origin, so it says where the text really came from.
+ *
+ * The other candidate signals can be forged from inside a pane and are deliberately
+ * NOT used: `sourceId` is the script URL as reported to devtools, which any script
+ * can rewrite with a `//# sourceURL=` comment, and the message text is entirely the
+ * page's to choose.
+ *
+ * Fails CLOSED on every unverifiable input — no configured origin, no `frame`
+ * (Electron < 35, where the first argument is a bare event), or a frame whose
+ * properties throw because it was destroyed. The cost of failing closed is the
+ * INFO-level pane journal; the cost of failing open is a forgeable diagnosis.
+ */
+function isTrustedFrameMessage(frame, trustedOrigin) {
+  if (!trustedOrigin) return false;
+  if (!frame || typeof frame !== "object") return false;
+  try {
+    if (frame.parent !== null) return false;
+  } catch {
+    return false;
+  }
+  return frameOriginOf(frame) === trustedOrigin;
+}
+
+/**
+ * The frame's origin, for attributing a line this module does NOT trust.
+ *
+ * `WebFrameMain#origin` is Chromium's serialized security origin, so unlike
+ * `sourceId` it says where the text really came from. Best-effort: a destroyed
+ * frame throws, and an absent origin just means the line goes unattributed.
+ */
+function frameOriginOf(frame) {
+  if (!frame || typeof frame !== "object") return "";
+  try {
+    return String(frame.origin || "");
+  } catch {
+    return "";
+  }
+}
+
+/** Map either level encoding onto one vocabulary. */
+function severityFromLevel(level) {
+  if (typeof level === "string") {
+    const name = level.toLowerCase();
+    if (name === "error" || name === "warning" || name === "info" || name === "debug") return name;
+    return "info";
+  }
+  if (level >= 3) return "error";
+  if (level === 2) return "warning";
+  if (level === 1) return "info";
+  return "debug";
+}
+
+/**
+ * `suppressedNext` marks the line as the last of its kind, so a reader who sees
+ * three identical entries knows the silence after them is the cap, not recovery.
+ *
+ * `untrustedOrigin`, when set, names the pane origin the text came from. A console
+ * ERROR from a pane is still worth journaling — a framing refusal or a failed fetch
+ * inside the pane is exactly the diagnosis — but the reader has to be able to tell
+ * that text apart from the dashboard's own, so it is attributed rather than
+ * silently blended in. Every field is passed through `sanitizeLogText`, because all
+ * three of message, sourceId, and origin are chosen by the emitting document.
+ *
+ * The untrusted-frame budget is applied by `record`, not here: the budget bounds
+ * every emission path, so its notice belongs to the writer they all share rather
+ * than to this one formatter.
+ */
+function formatConsoleMessage(
+  { severity, message, sourceId, line },
+  { suppressedNext = false, untrustedOrigin = "" } = {},
+) {
+  const from = untrustedOrigin ? ` (untrusted frame ${sanitizeLogText(safeUrl(untrustedOrigin), 120)})` : "";
+  const where = sourceId ? ` (${sanitizeLogText(safeUrl(sourceId), 200)}:${line})` : "";
+  const repeatTail = suppressedNext ? " [further repeats suppressed]" : "";
+  return `renderer console [${severity}]${from}: ${sanitizeLogText(message)}${where}${repeatTail}`;
+}
+
+/**
+ * The notice appended to the last untrusted line the attachment will ever write.
+ *
+ * Every emission path funnels through `record`, so the silence past the budget could
+ * follow a console line or a navigation line — this reads on either, and turns "the
+ * pane went quiet" (recovery) into "the budget is spent" (the truth) for whoever is
+ * tailing the log.
+ */
+function budgetReachedNotice() {
+  return ` [untrusted-frame log budget of ${UNTRUSTED_LOG_BUDGET} reached; further pane lines dropped]`;
+}
+
+/**
+ * Attach the diagnostics to `contents`, writing through `log`.
+ *
+ * Console output is filtered to ERRORS plus the dashboard's own `[pane]` journal.
+ * Warnings on this surface are dominated by per-paint noise the renderer emits by
+ * the hundred (`content-visibility`, `ResizeObserver loop completed`), which
+ * would push the load events that matter out of any readable tail.
+ *
+ * `trustedOrigin` is the URL (or origin) this webContents was loaded with — the ONE
+ * document whose `[pane]` lines are the dashboard's own. Omit it and the journal is
+ * disabled rather than granted to whoever happens to be the top frame.
+ *
+ * Tolerates a missing or partial webContents so a caller never has to guard:
+ * this is diagnostics and must not be able to break window creation.
+ */
+function attachFrameLoadLogging(contents, log, trustedOrigin) {
+  if (!contents || typeof contents.on !== "function") return false;
+  if (typeof log !== "function") return false;
+
+  const dashboardOrigin = normalizeTrustedOrigin(trustedOrigin);
+  // Split by trust so pane-chosen text cannot evict the dashboard's own counters
+  // (the shared map's overflow reset would otherwise restart trusted counting too).
+  const trustedRepeats = new Map();
+  const untrustedRepeats = new Map();
+  let untrustedLogged = 0;
+
+  // The ONE writer every handler funnels through. Making it the single path to
+  // `log` is what lets the untrusted-frame budget be an invariant rather than a
+  // check each handler has to remember: a pane drives both console output and its
+  // own frame's navigations, so a bound applied on only one path is one the pane
+  // walks around by switching to the other. Trusted lines (the dashboard's own top
+  // frame) are never budgeted; everything attributable to a pane is charged against
+  // one aggregate ceiling, and the last line it admits carries the notice so the
+  // silence afterward reads as the cap, not as the pane recovering.
+  const record = (line, trusted) => {
+    if (!line) return;
+    if (trusted) {
+      log(line);
+      return;
+    }
+    if (untrustedLogged >= UNTRUSTED_LOG_BUDGET) return;
+    untrustedLogged += 1;
+    log(untrustedLogged === UNTRUSTED_LOG_BUDGET ? `${line}${budgetReachedNotice()}` : line);
+  };
+
+  // A navigation event carries `isMainFrame`, and for `did-frame-navigate` /
+  // `did-fail-load` that is the ONLY trust signal the runtime hands us — they pass
+  // frameProcessId/frameRoutingId, not a `WebFrameMain` or an origin. A subframe
+  // navigation is the pane's, and the pane is the surface that can loop; a top-frame
+  // navigation is the dashboard's own and happens a handful of times over the app's
+  // life. Treating a top-frame navigation as trusted cannot forge a pane record the
+  // way a console line could — nothing here is allowlisted by it — so unlike the
+  // `[pane]` gate, position is a sufficient signal for the budget.
+  contents.on("did-start-navigation", (_event, url, isInPlace, isMainFrame) => {
+    record(formatFrameStartNavigation({ url, isInPlace, isMainFrame }), isMainFrame === true);
+  });
+
+  contents.on("did-frame-navigate", (_event, url, httpResponseCode, _statusText, isMainFrame) => {
+    record(formatFrameNavigate({ url, httpResponseCode, isMainFrame }), isMainFrame === true);
+  });
+
+  contents.on("did-fail-load", (_event, errorCode, errorDescription, url, isMainFrame) => {
+    record(formatFrameFailLoad({ errorCode, errorDescription, url, isMainFrame }), isMainFrame === true);
+  });
+
+  contents.on("console-message", (...args) => {
+    const entry = normalizeConsoleMessage(args);
+    if (!entry) return;
+    // The `[pane]` allowlist is the dashboard document's, not any frame's: a crew
+    // pane can print the same prefix, so the prefix only counts once the frame
+    // identity checks out (top frame AND the dashboard's origin — see
+    // `isTrustedFrameMessage`).
+    const trusted = isTrustedFrameMessage(entry.frame, dashboardOrigin);
+    const allowlisted = trusted && entry.message.startsWith(PANE_LOG_PREFIX);
+    if (!allowlisted && entry.severity !== "error") return;
+    const limit = allowlisted ? PANE_REPEAT_LIMIT : CONSOLE_REPEAT_LIMIT;
+    // Keyed by emitter-chosen text, so the key set needs a ceiling of its own.
+    const repeats = trusted ? trustedRepeats : untrustedRepeats;
+    if (repeats.size >= REPEAT_KEYS_MAX && !repeats.has(entry.message)) repeats.clear();
+    const count = (repeats.get(entry.message) || 0) + 1;
+    repeats.set(entry.message, count);
+    if (count > limit) return;
+    // Repeats are dropped BEFORE `record`, so a suppressed repeat never consumes
+    // budget — the budget counts lines actually written, on any path.
+    record(
+      formatConsoleMessage(entry, {
+        suppressedNext: count === limit,
+        untrustedOrigin: trusted ? "" : frameOriginOf(entry.frame),
+      }),
+      trusted,
+    );
+  });
+
+  return true;
+}
+
+module.exports = {
+  CONSOLE_REPEAT_LIMIT,
+  MESSAGE_MAX_LENGTH,
+  PANE_LOG_PREFIX,
+  PANE_REPEAT_LIMIT,
+  REPEAT_KEYS_MAX,
+  UNTRUSTED_LOG_BUDGET,
+  attachFrameLoadLogging,
+  formatConsoleMessage,
+  formatFrameFailLoad,
+  formatFrameNavigate,
+  formatFrameStartNavigation,
+  isTrustedFrameMessage,
+  normalizeConsoleMessage,
+  normalizeTrustedOrigin,
+  safeUrl,
+  sanitizeLogText,
+};

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -174,6 +174,7 @@
       "native-logging.js",
       "disable-gpu.js",
       "memory-watch-log.js",
+      "frame-load-log.js",
       "cage-trace.js",
       "pyspy-dump.js",
       "perf-metrics.js",

--- a/website/electron/test/frame-load-log.test.js
+++ b/website/electron/test/frame-load-log.test.js
@@ -1,0 +1,549 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  CONSOLE_REPEAT_LIMIT,
+  MESSAGE_MAX_LENGTH,
+  PANE_LOG_PREFIX,
+  PANE_REPEAT_LIMIT,
+  REPEAT_KEYS_MAX,
+  UNTRUSTED_LOG_BUDGET,
+  attachFrameLoadLogging,
+  formatFrameFailLoad,
+  formatFrameNavigate,
+  formatFrameStartNavigation,
+  isTrustedFrameMessage,
+  normalizeConsoleMessage,
+  normalizeTrustedOrigin,
+  safeUrl,
+  sanitizeLogText,
+} = require("../frame-load-log");
+
+/** A webContents stand-in that records handlers and can replay events. */
+function fakeContents() {
+  const handlers = new Map();
+  return {
+    handlers,
+    on(event, handler) {
+      handlers.set(event, handler);
+      return this;
+    },
+    emit(event, ...args) {
+      const handler = handlers.get(event);
+      if (!handler) throw new Error(`no handler for ${event}`);
+      handler(...args);
+    },
+  };
+}
+
+/** The URL the main window is loaded with, and so the one trusted origin. */
+const DASHBOARD_ORIGIN = "http://localhost:5476";
+
+/** The dashboard's own document: top of the frame tree AND on that origin. */
+const TOP_FRAME = { parent: null, origin: DASHBOARD_ORIGIN };
+
+/** A crew pane: a child frame on a different (forwarded) origin. */
+function paneFrame(origin = "http://localhost:7778") {
+  return { parent: TOP_FRAME, origin };
+}
+
+/**
+ * A remote document that IS the top frame — what a pane gets by navigating the
+ * top-level window (a `target="_top"` link the user clicks). Position without
+ * identity, which is exactly the case `parent === null` alone cannot refuse.
+ */
+function hijackedTopFrame(origin = "http://localhost:7778") {
+  return { parent: null, origin };
+}
+
+/** A `console-message` emission in the Electron >= 35 details shape. */
+function consoleDetails(message, { level = "info", frame = TOP_FRAME, sourceId = "app.js", lineNumber = 1 } = {}) {
+  return { level, message, lineNumber, sourceId, frame };
+}
+
+function attachedLog(trustedOrigin = DASHBOARD_ORIGIN) {
+  const lines = [];
+  const contents = fakeContents();
+  const attached = attachFrameLoadLogging(contents, (line) => lines.push(line), trustedOrigin);
+  return { lines, contents, attached };
+}
+
+describe("frame-load-log URL redaction", () => {
+  it("never writes a session token to the log", () => {
+    const url = "http://localhost:7778/?token=supersecretvalue";
+    assert.equal(safeUrl(url), "http://localhost:7778/?token=<redacted>");
+    for (const line of [
+      formatFrameNavigate({ url, httpResponseCode: 200, isMainFrame: false }),
+      formatFrameFailLoad({ errorCode: -102, errorDescription: "ERR_CONNECTION_REFUSED", url }),
+    ]) {
+      assert.doesNotMatch(line, /supersecretvalue/, "the token must not reach the log");
+      assert.match(line, /token=<redacted>/, "but its presence must still be recorded");
+    }
+  });
+
+  it("keeps the port and path, which are the diagnostic content", () => {
+    const line = formatFrameNavigate({
+      url: "http://localhost:7778/chat/abc?token=x",
+      httpResponseCode: 200,
+      isMainFrame: false,
+    });
+    assert.match(line, /http:\/\/localhost:7778\/chat\/abc/);
+  });
+
+  it("marks a non-token query without dropping the fact there was one", () => {
+    assert.equal(safeUrl("http://localhost:5476/?foo=1"), "http://localhost:5476/?<query>");
+  });
+
+  it("passes through a URL with no query untouched", () => {
+    assert.equal(safeUrl("http://localhost:5476/"), "http://localhost:5476/");
+  });
+});
+
+describe("frame-load-log formatting", () => {
+  it("distinguishes a crew pane from the dashboard itself", () => {
+    assert.match(
+      formatFrameNavigate({ url: "http://localhost:7778/", httpResponseCode: 200, isMainFrame: false }),
+      /subframe/,
+    );
+    assert.match(
+      formatFrameNavigate({ url: "http://localhost:5476/", httpResponseCode: 200, isMainFrame: true }),
+      /main/,
+    );
+  });
+
+  it("records the HTTP status, so a refused token is visible as 403", () => {
+    assert.match(
+      formatFrameNavigate({ url: "http://localhost:7778/", httpResponseCode: 403, isMainFrame: false }),
+      /status=403/,
+    );
+  });
+
+  it("records the net error code and description on a failed load", () => {
+    const line = formatFrameFailLoad({
+      errorCode: -102,
+      errorDescription: "ERR_CONNECTION_REFUSED",
+      url: "http://localhost:7778/",
+      isMainFrame: false,
+    });
+    assert.match(line, /FAILED/);
+    assert.match(line, /code=-102/);
+    assert.match(line, /ERR_CONNECTION_REFUSED/);
+  });
+
+  it("names a missing description rather than logging an empty gap", () => {
+    assert.match(formatFrameFailLoad({ errorCode: -2, url: "http://x/" }), /unknown/);
+  });
+
+  it("does not print a bare '?' status as a number", () => {
+    assert.match(formatFrameNavigate({ url: "http://x/" }), /status=\?/);
+  });
+
+  it("announces a navigation that merely started, before any commit", () => {
+    const line = formatFrameStartNavigation({
+      url: "http://localhost:7778/?token=s",
+      isMainFrame: false,
+    });
+    assert.match(line, /frame navigation STARTED \(subframe\)/);
+    assert.match(line, /token=<redacted>/);
+    assert.doesNotMatch(line, /\bstatus=/, "nothing has committed yet, so there is no status");
+  });
+
+  it("stays silent for a same-document navigation, which carries no load info", () => {
+    assert.equal(
+      formatFrameStartNavigation({ url: "http://localhost:5476/chat", isInPlace: true }),
+      "",
+      "the dashboard is a router-driven SPA and would otherwise flood the log",
+    );
+  });
+});
+
+describe("frame-load-log console normalization", () => {
+  it("reads the Electron >= 35 details-object shape", () => {
+    const entry = normalizeConsoleMessage([
+      { level: "error", message: "boom", lineNumber: 42, sourceId: "app.js", frame: TOP_FRAME },
+    ]);
+    assert.deepEqual(entry, {
+      severity: "error",
+      message: "boom",
+      sourceId: "app.js",
+      line: 42,
+      frame: TOP_FRAME,
+    });
+  });
+
+  it("reads the legacy positional shape the rest of the app still uses", () => {
+    const entry = normalizeConsoleMessage([{}, 3, "boom", 42, "app.js"]);
+    assert.deepEqual(entry, {
+      severity: "error",
+      message: "boom",
+      sourceId: "app.js",
+      line: 42,
+      frame: null,
+    });
+  });
+
+  it("carries the emitting frame through, since the text alone proves nothing", () => {
+    const pane = paneFrame();
+    assert.equal(normalizeConsoleMessage([consoleDetails("hi", { frame: pane })]).frame, pane);
+    // Electron 43 delivers the details object AND the deprecated positionals; the
+    // frame must survive whichever branch reads the payload.
+    assert.equal(normalizeConsoleMessage([{ frame: pane }, 3, "boom", 1, "a.js"]).frame, pane);
+  });
+
+  it("maps every numeric level onto the shared vocabulary", () => {
+    const levels = [0, 1, 2, 3].map((n) => normalizeConsoleMessage([{}, n, "m"]).severity);
+    assert.deepEqual(levels, ["debug", "info", "warning", "error"]);
+  });
+
+  it("returns null for an unrecognized emission instead of inventing a message", () => {
+    assert.equal(normalizeConsoleMessage([]), null);
+    assert.equal(normalizeConsoleMessage([{}, 3]), null);
+    assert.equal(normalizeConsoleMessage(undefined), null);
+  });
+});
+
+describe("frame-load-log attachment", () => {
+  it("logs a committed subframe navigation", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("did-frame-navigate", {}, "http://localhost:7778/?token=s", 200, "OK", false);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /frame navigated \(subframe\) status=200 http:\/\/localhost:7778\/\?token=<redacted>/);
+  });
+
+  it("logs a failed load with its net error", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("did-fail-load", {}, -102, "ERR_CONNECTION_REFUSED", "http://localhost:7778/", false);
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /frame load FAILED \(subframe\) code=-102 ERR_CONNECTION_REFUSED/);
+  });
+
+  it("forwards console errors", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("console-message", {}, 3, "Refused to frame 'http://localhost:7778/'", 1, "app.js");
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /renderer console \[error\]: Refused to frame/);
+  });
+
+  it("drops warnings, which are dominated by per-paint noise", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("console-message", {}, 2, "Rendering was performed in a subtree hidden by content-visibility.", 1, "a.js");
+    contents.emit("console-message", {}, 1, "just info", 1, "a.js");
+    assert.deepEqual(lines, [], "only errors belong in the launch log");
+  });
+
+  it("caps identical repeats so one loud error cannot bury the load lines", () => {
+    const { lines, contents } = attachedLog();
+    for (let i = 0; i < 50; i += 1) {
+      contents.emit("console-message", {}, 3, "same error", 1, "a.js");
+    }
+    assert.equal(lines.length, CONSOLE_REPEAT_LIMIT);
+    assert.match(lines[CONSOLE_REPEAT_LIMIT - 1], /further repeats suppressed/);
+    assert.doesNotMatch(lines[0], /further repeats suppressed/);
+  });
+
+  it("counts repeats per message, so a second distinct error still lands", () => {
+    const { lines, contents } = attachedLog();
+    for (let i = 0; i < 10; i += 1) contents.emit("console-message", {}, 3, "first", 1, "a.js");
+    contents.emit("console-message", {}, 3, "second", 1, "a.js");
+    assert.match(lines[lines.length - 1], /second/);
+  });
+
+  it("logs a started navigation and skips the SPA's in-place ones", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("did-start-navigation", {}, "http://localhost:7778/?token=s", false, false);
+    contents.emit("did-start-navigation", {}, "http://localhost:5476/chat", true, true);
+    assert.equal(lines.length, 1, "only the real navigation belongs in the log");
+    assert.match(lines[0], /frame navigation STARTED \(subframe\)/);
+  });
+
+  it("keeps the dashboard's own [pane] journal even though it is INFO level", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit(
+      "console-message",
+      consoleDetails(`${PANE_LOG_PREFIX} load-timeout id=nobita frame=about:blank`),
+    );
+    assert.equal(lines.length, 1, "the renderer half of the diagnosis must survive the filter");
+    assert.match(lines[0], /load-timeout id=nobita frame=about:blank/);
+  });
+
+  it("gives the journal a higher repeat cap, because a re-mint loop IS the finding", () => {
+    const { lines, contents } = attachedLog();
+    for (let i = 0; i < PANE_REPEAT_LIMIT + 30; i += 1) {
+      contents.emit("console-message", consoleDetails(`${PANE_LOG_PREFIX} auth-expired id=nobita`));
+    }
+    assert.equal(lines.length, PANE_REPEAT_LIMIT);
+    assert.ok(PANE_REPEAT_LIMIT > CONSOLE_REPEAT_LIMIT, "a loop needs more than three lines to be visible");
+    assert.match(lines[PANE_REPEAT_LIMIT - 1], /further repeats suppressed/);
+  });
+
+  it("still drops a non-prefixed info line, so pane logs are not a blanket opening", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("console-message", consoleDetails("pane something not ours"));
+    assert.deepEqual(lines, []);
+  });
+});
+
+describe("frame-load-log console trust boundary", () => {
+  it("requires BOTH the top position and the dashboard's own origin", () => {
+    assert.equal(isTrustedFrameMessage(TOP_FRAME, DASHBOARD_ORIGIN), true);
+    assert.equal(isTrustedFrameMessage(paneFrame(), DASHBOARD_ORIGIN), false, "a nested frame is not the top one");
+    assert.equal(
+      isTrustedFrameMessage(hijackedTopFrame(), DASHBOARD_ORIGIN),
+      false,
+      "being the top frame is a position, not an identity",
+    );
+    // Fails closed on anything it cannot verify, including a frame that has been
+    // destroyed (Electron throws on property access once that happens).
+    assert.equal(isTrustedFrameMessage(null, DASHBOARD_ORIGIN), false);
+    assert.equal(isTrustedFrameMessage({}, DASHBOARD_ORIGIN), false, "an absent parent is not a null parent");
+    assert.equal(
+      isTrustedFrameMessage({ parent: null }, DASHBOARD_ORIGIN),
+      false,
+      "an absent origin cannot equal the dashboard's",
+    );
+    assert.equal(
+      isTrustedFrameMessage(TOP_FRAME, ""),
+      false,
+      "with no configured origin there is nothing to compare against",
+    );
+    assert.equal(
+      isTrustedFrameMessage(
+        {
+          get parent() {
+            throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+          },
+        },
+        DASHBOARD_ORIGIN,
+      ),
+      false,
+    );
+    assert.equal(
+      isTrustedFrameMessage(
+        {
+          parent: null,
+          get origin() {
+            throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+          },
+        },
+        DASHBOARD_ORIGIN,
+      ),
+      false,
+      "a throwing origin is unverifiable, not a match",
+    );
+  });
+
+  it("reduces the loaded URL to the origin Chromium reports, not a prefix of it", () => {
+    assert.equal(normalizeTrustedOrigin("http://localhost:5476/?token=secret"), DASHBOARD_ORIGIN);
+    assert.equal(normalizeTrustedOrigin(DASHBOARD_ORIGIN), DASHBOARD_ORIGIN);
+    // An unparseable or absent value yields "", which disables the allowlist.
+    assert.equal(normalizeTrustedOrigin("not a url"), "");
+    assert.equal(normalizeTrustedOrigin(undefined), "");
+    // A same-prefix impostor must not pass: the comparison is equality, not startsWith.
+    assert.equal(
+      isTrustedFrameMessage({ parent: null, origin: "http://localhost:54760" }, DASHBOARD_ORIGIN),
+      false,
+    );
+  });
+
+  it("refuses a [pane] line from a remote document that navigated the top window", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit(
+      "console-message",
+      consoleDetails(`${PANE_LOG_PREFIX} pane-ready id=nobita status=200`, { frame: hijackedTopFrame() }),
+    );
+    assert.deepEqual(
+      lines,
+      [],
+      "a target=_top navigation must not hand a pane the dashboard's own journal",
+    );
+  });
+
+  it("disables the journal entirely when no trusted origin was configured", () => {
+    const { lines, contents } = attachedLog("");
+    contents.emit("console-message", consoleDetails(`${PANE_LOG_PREFIX} pane-ready id=nobita`));
+    assert.deepEqual(lines, [], "the INFO-level journal is the cost of failing closed");
+    // Errors still flow — they just lose the trusted attribution.
+    contents.emit("console-message", consoleDetails("boom", { level: "error" }));
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /untrusted frame http:\/\/localhost:5476/);
+  });
+
+  it("refuses a crew pane's forged [pane] journal line", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit(
+      "console-message",
+      consoleDetails(`${PANE_LOG_PREFIX} pane-ready id=nobita status=200`, { frame: paneFrame() }),
+    );
+    assert.deepEqual(
+      lines,
+      [],
+      "a compromised pane must not be able to write the record that says its pane loaded",
+    );
+  });
+
+  it("drops the pane journal when no frame can be verified at all", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit("console-message", {}, 1, `${PANE_LOG_PREFIX} load-timeout id=nobita`, 1, "app.js");
+    assert.deepEqual(lines, [], "unverifiable is treated as untrusted, not as the dashboard");
+  });
+
+  it("still journals a pane's console ERROR, but attributes it to that origin", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit(
+      "console-message",
+      consoleDetails("Refused to connect to the gateway", { level: "error", frame: paneFrame() }),
+    );
+    assert.equal(lines.length, 1, "a pane's own error is the diagnosis and must survive");
+    assert.match(lines[0], /untrusted frame http:\/\/localhost:7778/);
+  });
+
+  it("does not let a pane forge whole log entries with a newline", () => {
+    const { lines, contents } = attachedLog();
+    contents.emit(
+      "console-message",
+      consoleDetails("boom\nframe navigated (subframe) status=200 http://localhost:7778/", {
+        level: "error",
+        frame: paneFrame(),
+      }),
+    );
+    assert.equal(lines.length, 1);
+    assert.doesNotMatch(lines[0], /\n/, "gateway-launch.log is read by tailing it, one record per line");
+    assert.match(lines[0], /boom\\nframe navigated/, "the text is kept, only its framing is escaped");
+  });
+
+  it("neutralizes control characters that would rewrite a terminal reader's view", () => {
+    assert.equal(sanitizeLogText("a\r\nb"), "a\\r\\nb");
+    assert.equal(sanitizeLogText("esc\u001b[2Jgone"), "esc?[2Jgone");
+    assert.equal(sanitizeLogText(null), "");
+  });
+
+  it("truncates one enormous message rather than losing the lines around it", () => {
+    const line = sanitizeLogText("x".repeat(MESSAGE_MAX_LENGTH + 40));
+    assert.ok(line.startsWith("x".repeat(MESSAGE_MAX_LENGTH)));
+    assert.match(line, /\[40 more chars truncated\]/);
+  });
+
+  it("bounds the repeat counter, which a pane keys with text of its choosing", () => {
+    const { lines, contents } = attachedLog();
+    for (let i = 0; i < REPEAT_KEYS_MAX + 50; i += 1) {
+      contents.emit("console-message", consoleDetails(`distinct error ${i}`, { level: "error" }));
+    }
+    // Trusted text is the dashboard's own, so the map is capped rather than the log.
+    assert.equal(lines.length, REPEAT_KEYS_MAX + 50, "every distinct error is still logged once");
+    contents.emit("console-message", consoleDetails("distinct error 0", { level: "error" }));
+    assert.equal(lines.length, REPEAT_KEYS_MAX + 51, "the oldest keys were forgotten, not remembered forever");
+  });
+
+  it("caps what an untrusted frame can write no matter how it varies the text", () => {
+    const { lines, contents } = attachedLog();
+    const pane = paneFrame();
+    for (let i = 0; i < UNTRUSTED_LOG_BUDGET + 50; i += 1) {
+      contents.emit("console-message", consoleDetails(`distinct error ${i}`, { level: "error", frame: pane }));
+    }
+    assert.equal(
+      lines.length,
+      UNTRUSTED_LOG_BUDGET,
+      "clearing the repeat map on overflow restarts per-message counting, so the bound cannot be per-message",
+    );
+    assert.match(
+      lines[UNTRUSTED_LOG_BUDGET - 1],
+      new RegExp(`untrusted-frame log budget of ${UNTRUSTED_LOG_BUDGET} reached`),
+      "the last line must say why the log goes quiet, or the silence reads as recovery",
+    );
+    assert.doesNotMatch(lines[0], /log budget/, "only the final line carries the notice");
+  });
+
+  it("charges the budget only for lines it actually writes", () => {
+    const { lines, contents } = attachedLog();
+    const pane = paneFrame();
+    // Repeats past CONSOLE_REPEAT_LIMIT are dropped, so they must not consume budget.
+    for (let i = 0; i < 400; i += 1) {
+      contents.emit("console-message", consoleDetails("same error", { level: "error", frame: pane }));
+    }
+    assert.equal(lines.length, CONSOLE_REPEAT_LIMIT);
+    for (let i = 0; i < UNTRUSTED_LOG_BUDGET; i += 1) {
+      contents.emit("console-message", consoleDetails(`later ${i}`, { level: "error", frame: pane }));
+    }
+    assert.equal(lines.length, UNTRUSTED_LOG_BUDGET, "the budget counts written lines, not emissions");
+  });
+
+  it("does not let pane volume throttle the dashboard's own errors", () => {
+    const { lines, contents } = attachedLog();
+    const pane = paneFrame();
+    for (let i = 0; i < UNTRUSTED_LOG_BUDGET + 50; i += 1) {
+      contents.emit("console-message", consoleDetails(`pane error ${i}`, { level: "error", frame: pane }));
+    }
+    contents.emit("console-message", consoleDetails("the dashboard's own failure", { level: "error" }));
+    assert.match(
+      lines[lines.length - 1],
+      /the dashboard's own failure/,
+      "the budget is the untrusted frames', so a spent one must not silence the diagnosis",
+    );
+    assert.doesNotMatch(lines[lines.length - 1], /untrusted frame/);
+  });
+
+  it("bounds a subframe's navigation flood, not just its console output", () => {
+    const { lines, contents } = attachedLog();
+    // A pane loops its own frame's loads — each did-fail-load is another line, and
+    // this path used to call log() unconditionally, outside the budget.
+    for (let i = 0; i < UNTRUSTED_LOG_BUDGET + 50; i += 1) {
+      contents.emit("did-fail-load", {}, -102, "ERR_CONNECTION_REFUSED", `http://localhost:7778/try${i}`, false);
+    }
+    assert.equal(lines.length, UNTRUSTED_LOG_BUDGET, "subframe navigations are charged against the same budget");
+    assert.match(lines[UNTRUSTED_LOG_BUDGET - 1], /untrusted-frame log budget of 100 reached/);
+  });
+
+  it("charges console and navigation to ONE aggregate budget, not one each", () => {
+    const { lines, contents } = attachedLog();
+    const pane = paneFrame();
+    for (let i = 0; i < 70; i += 1) {
+      contents.emit("did-fail-load", {}, -102, "ERR_CONNECTION_REFUSED", `http://localhost:7778/n${i}`, false);
+    }
+    for (let i = 0; i < 70; i += 1) {
+      contents.emit("console-message", consoleDetails(`pane error ${i}`, { level: "error", frame: pane }));
+    }
+    assert.equal(
+      lines.length,
+      UNTRUSTED_LOG_BUDGET,
+      "a pane cannot get 2x the budget by spreading its lines across two paths",
+    );
+  });
+
+  it("does not budget the dashboard's own top-frame navigations", () => {
+    const { lines, contents } = attachedLog();
+    // The main frame is the dashboard itself: a handful of real navigations over the
+    // app's life, and the ones the log most needs. isMainFrame=true is trusted.
+    for (let i = 0; i < UNTRUSTED_LOG_BUDGET + 50; i += 1) {
+      contents.emit("did-frame-navigate", {}, `http://localhost:5476/r${i}`, 200, "OK", true);
+    }
+    assert.equal(lines.length, UNTRUSTED_LOG_BUDGET + 50, "top-frame navigations are the dashboard's own and unbudgeted");
+    assert.doesNotMatch(lines[lines.length - 1], /log budget/);
+  });
+
+  it("keeps the two repeat maps apart, so pane text cannot evict trusted counters", () => {
+    const { lines, contents } = attachedLog();
+    const pane = paneFrame();
+    contents.emit("console-message", consoleDetails("shared text", { level: "error" }));
+    // Overflow the untrusted map: its reset must not restart the trusted count.
+    for (let i = 0; i < REPEAT_KEYS_MAX + 5; i += 1) {
+      contents.emit("console-message", consoleDetails(`pane ${i}`, { level: "error", frame: pane }));
+    }
+    const before = lines.length;
+    for (let i = 0; i < 10; i += 1) {
+      contents.emit("console-message", consoleDetails("shared text", { level: "error" }));
+    }
+    assert.equal(
+      lines.length - before,
+      CONSOLE_REPEAT_LIMIT - 1,
+      "the trusted counter kept its first hit and still stopped at the cap",
+    );
+  });
+
+  it("is inert rather than throwing when there is nothing to attach to", () => {
+    assert.equal(attachFrameLoadLogging(null, () => {}), false);
+    assert.equal(attachFrameLoadLogging({}, () => {}), false);
+    assert.equal(attachFrameLoadLogging(fakeContents(), null), false);
+  });
+});

--- a/website/electron/test/window-lifecycle.test.js
+++ b/website/electron/test/window-lifecycle.test.js
@@ -322,3 +322,34 @@ describe("window lifecycle source contracts", () => {
     }
   });
 });
+
+describe("main window frame-load diagnostics", () => {
+  it("journals frame loads on the dashboard webContents", () => {
+    const createWindow = SOURCE.match(/function createWindow\(\) \{([\s\S]*?)\n  \}\n/);
+    assert.ok(createWindow, "createWindow missing");
+    assert.match(
+      createWindow[1],
+      /attachFrameLoadLogging\(\s*mainWindow\.webContents,\s*glog,\s*backendUrl,?\s*\)/,
+      "a crew pane that never navigates must leave evidence in gateway-launch.log",
+    );
+  });
+
+  it("passes the dashboard's own URL as the trusted origin", () => {
+    // Without the third argument the `[pane]` journal is disabled rather than
+    // granted to whoever happens to be the top frame — so the wiring, not just
+    // the gate inside the module, is what has to be pinned here.
+    assert.match(
+      SOURCE,
+      /attachFrameLoadLogging\([^)]*backendUrl/,
+      "the [pane] allowlist must be anchored to the origin the window was loaded with",
+    );
+  });
+
+  it("writes those lines through the launch log, not console only", () => {
+    assert.match(
+      SOURCE,
+      /require\("\.\/frame-load-log"\)/,
+      "frame diagnostics must come from the shared, unit-tested module",
+    );
+  });
+});

--- a/website/electron/window-lifecycle.js
+++ b/website/electron/window-lifecycle.js
@@ -44,6 +44,7 @@ const {
   SYMBOL_LIGHT: WINDOWS_TITLEBAR_SYMBOL_LIGHT,
   OVERLAY_BACKGROUND: WINDOWS_TITLEBAR_BACKGROUND,
 } = require("./windows-titlebar");
+const { attachFrameLoadLogging } = require("./frame-load-log");
 const { createMemoryWatchLog } = require("./memory-watch-log");
 const { createCageTrace } = require("./cage-trace");
 const { profilingEnabled } = require("./perf-metrics");
@@ -943,6 +944,19 @@ function createWindowLifecycle(options) {
         console.error("Token retry failed:", error);
       });
     });
+
+    // Journal frame-level load outcomes into gateway-launch.log. The remote-crew
+    // panes are iframes of THIS webContents, and until this existed a pane that
+    // never became a live document left no evidence anywhere: the remote gateway
+    // keeps no HTTP access log and a packaged app has no devtools console. The
+    // navigation lines are what separate "never requested" from "requested and
+    // refused" — the two failures that look identical on screen.
+    //
+    // `backendUrl` is passed as the trusted origin: it is the ONE document whose
+    // `[pane]` journal lines are the dashboard's own. Being the top frame is not
+    // enough on its own, because a pane can navigate the top-level window to a
+    // remote document and inherit that position.
+    attachFrameLoadLogging(mainWindow.webContents, glog, backendUrl);
 
     const rendererRecovery = createRendererRecovery({
       isQuitting,

--- a/website/eslint.i18n.config.js
+++ b/website/eslint.i18n.config.js
@@ -369,6 +369,29 @@ export default [
               // (`=1`, `=true`) — never a sentence — so prose still cannot match.
               String.raw`^[?&][a-z_]+=[a-z0-9]+$`,
 
+              // An angle-bracketed SENTINEL written into a diagnostic log line, e.g.
+              // `<redacted>`, `<empty>`, `<unserializable>` in lib/paneLog.ts. These are
+              // not copy in either direction: nobody reads them in the UI, and the reader
+              // is whoever greps gateway-launch.log — translating one would make the
+              // journal unsearchable in exactly the incident it exists for, and
+              // `<redacted>` in particular is the marker that a credential was WITHHELD,
+              // so a locale that renamed it would read as if the token had been printed.
+              // Shape: the whole string is one angle-bracketed lowercase word. Prose
+              // never takes that form — copy that mentions a placeholder carries the
+              // surrounding sentence (`Enter <name> here`), which the anchors reject.
+              String.raw`^<[a-z]+>$`,
+
+              // The same sentinel standing in for a URL QUERY, e.g. `?token=<redacted>`
+              // and `?<query>` — the two values `safePaneUrl` substitutes for a query it
+              // will not journal. Deliberately a separate entry from the bare sentinel
+              // above and from the `^[?&][a-z_]+=…$` server-contract shapes: neither of
+              // those admits an angle bracket, and widening either to reach these would
+              // also let a bracket into a shape whose whole tightness argument is that it
+              // carries only `[a-z0-9_=]`. The leading `?` is required, so this cannot
+              // match a bare word, and the key is optional because one of the two forms
+              // replaces the entire query rather than one parameter's value.
+              String.raw`^\?(?:[a-z_]+=)?<[a-z]+>$`,
+
               // A catalog KEY assembled at runtime, e.g.
               // `apps.crewCompanion.state.${slot}`. Translating a key would break the
               // lookup it performs — the value it resolves to is what gets translated.

--- a/website/src/components/InstancesViewport.tsx
+++ b/website/src/components/InstancesViewport.tsx
@@ -40,6 +40,7 @@ import { useAppDispatch, useAppSelector } from '../store'
 import { clearPaneReady, removeWarm, setActiveId, setPaneReady, setUnread, setWarm } from '../store/instancesSlice'
 import InstanceTabBar, { visibleInstanceTabs, useCrewPins, toggleCrewPin, useCrewSwitcherStableOrder, setStableOrder } from './InstanceTabBar'
 import { resolveTunnelOrigin } from '../lib/tunnelOrigin'
+import { frameDocumentState, paneLog, safePaneUrl } from '../lib/paneLog'
 import { LINUX_CAPTION_CONTROLS_WIDTH, TRAFFIC_LIGHT_INSET_PX, WIN_CAPTION_OVERLAY_WIDTH } from '../lib/electron'
 import { isEmbeddedPane } from '../lib/embedded'
 import AskAgentButton from './AskAgentButton'
@@ -193,9 +194,15 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         const port = res.local_port || warmRef.current[id]?.port
         if (res.token && port) {
           dispatch(setWarm({ id, conn: { port, token: res.token } }))
+          paneLog('remint', { id, port })
+        } else {
+          // A mint that returns nothing usable leaves the OLD warm entry standing,
+          // so the pane looks unchanged. Journal it: on screen this is
+          // indistinguishable from success, which is how it stayed invisible.
+          paneLog('remint-empty', { id, port, hasToken: !!res.token })
         }
-      } catch {
-        /* transient — the next poll / auth-expired signal retries */
+      } catch (err) {
+        paneLog('remint-failed', { id, error: (err as Error)?.message || 'unknown' })
       } finally {
         refreshingRef.current.delete(id)
         lastRefreshRef.current.set(id, Date.now())
@@ -214,9 +221,23 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         const st = await api.connectInstance(id)
         if (st.state === 'connected' && st.local_port && st.token) {
           dispatch(setWarm({ id, conn: { port: st.local_port, token: st.token } }))
+          paneLog('warm', { id, port: st.local_port, via: 'auto' })
+        } else {
+          // No `else` used to exist here, and that is why a failed auto-warm was
+          // untraceable: it leaves any PREVIOUS warm entry in place, so the tab
+          // still renders a pane and the user sees only "loading" forever.
+          paneLog('warm-declined', {
+            id,
+            via: 'auto',
+            state: st.state,
+            hasPort: !!st.local_port,
+            hasToken: !!st.token,
+            error: st.error || undefined,
+            reason: st.diagnosis?.reason || undefined,
+          })
         }
-      } catch {
-        /* leave it — clicking the tab will surface the error panel */
+      } catch (err) {
+        paneLog('warm-failed', { id, via: 'auto', error: (err as Error)?.message || 'unknown' })
       }
     },
     [dispatch],
@@ -277,6 +298,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           // so the error panel carrying Retry surfaces instead.
           dispatch(clearPaneReady(id))
           setTimedOut(prev => (prev[id] ? prev : { ...prev, [id]: true }))
+          paneLog('remint-budget-exhausted', { id, spent })
           return
         }
         // Charge the budget only for asks that are actually answered with a mint.
@@ -288,6 +310,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // instead of MAX_REACTIVE_REMINTS.
         if (!canRefreshNow(id)) return
         reactiveMintsRef.current.set(id, spent + 1)
+        paneLog('auth-expired', { id, spent: spent + 1 })
         void refreshToken(id)
       } else if (data.type === 'mc-switch-instance') {
         // The embedded pane's inline switcher asks the parent to flip
@@ -351,6 +374,7 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
         // mount, before the pane's first authenticated request, so it is no
         // evidence the token works. See MAX_REACTIVE_REMINTS.
         dispatch(setPaneReady(id))
+        paneLog('ready', { id })
         postModelToRef.current(id)
       } else if (data.type === 'mc-drag-gaps') {
         // The embedded pane relays the control-free spans of its header so the
@@ -403,8 +427,25 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     onSuccess: (st, id) => {
       if (st.state === 'connected' && st.local_port && st.token) {
         dispatch(setWarm({ id, conn: { port: st.local_port, token: st.token } }))
+        paneLog('warm', { id, port: st.local_port, via: 'connect' })
+      } else {
+        // Same silent shape as the auto-warm path: Retry can "succeed" as a
+        // request while warming nothing, and the pane then reloads into the same
+        // stuck state with no error anywhere.
+        paneLog('warm-declined', {
+          id,
+          via: 'connect',
+          state: st.state,
+          hasPort: !!st.local_port,
+          hasToken: !!st.token,
+          error: st.error || undefined,
+          reason: st.diagnosis?.reason || undefined,
+        })
       }
       void queryClient.invalidateQueries({ queryKey: ['instances'] })
+    },
+    onError: (err, id) => {
+      paneLog('warm-failed', { id, via: 'connect', error: (err as Error)?.message || 'unknown' })
     },
   })
 
@@ -459,8 +500,19 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
   useEffect(() => {
     if (!activeId || activeWarmPort === undefined || activeReady) return
     const id = activeId
+    const port = activeWarmPort
     const t = window.setTimeout(() => {
       setTimedOut(prev => (prev[id] ? prev : { ...prev, [id]: true }))
+      // `frame` is the verdict: `cross-origin` means the pane really loaded the
+      // tunnel URL and then failed to announce readiness, while `about:blank`
+      // means it never navigated at all and no crew bundle could ever have run.
+      paneLog('load-timeout', {
+        id,
+        port,
+        seq: activeSeq,
+        afterMs: PANE_LOAD_TIMEOUT_MS,
+        frame: frameDocumentState(iframeRefs.current.get(id)),
+      })
     }, PANE_LOAD_TIMEOUT_MS)
     return () => window.clearTimeout(t)
   }, [activeId, activeWarmPort, activeSeq, activeReady])
@@ -469,6 +521,11 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
     (id: string) => {
       // Clear the stale verdict and force a reload even if the re-mint returns
       // an identical token (setWarm would be a no-op for the iframe src).
+      paneLog('retry', {
+        id,
+        port: warmRef.current[id]?.port,
+        frame: frameDocumentState(iframeRefs.current.get(id)),
+      })
       setTimedOut(prev => ({ ...prev, [id]: false }))
       setReloadSeq(prev => ({ ...prev, [id]: (prev[id] || 0) + 1 }))
       // An explicit user press is a fresh start: re-open the reactive budget so
@@ -589,10 +646,19 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
       const w = warm[id]
       if (!el?.contentWindow || !w) return
       const origin = `${window.location.protocol}//${window.location.hostname}:${w.port}`
+      // A frame still on about:blank inherits THIS origin, so the post below is
+      // rejected with a target-origin mismatch. Chromium reports that as a
+      // console error rather than an exception, so the catch cannot see it —
+      // journal the frame's state here instead. The post is still attempted:
+      // this is instrumentation, and skipping on a mis-read would break a
+      // delivery that would have worked.
+      const frame = frameDocumentState(el)
+      if (frame !== 'cross-origin') paneLog('post-model-undeliverable', { id, origin, frame })
       try {
         el.contentWindow.postMessage(buildModelFor(id), origin)
-      } catch {
+      } catch (err) {
         /* frame mid-navigation — the next broadcast / ready ping retries */
+        paneLog('post-model-threw', { id, origin, frame, error: (err as Error)?.message || 'unknown' })
       }
     },
     [warm, buildModelFor],
@@ -688,8 +754,21 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           // the re-minted src is byte-identical to the dead frame's.
           key={`${id}:${reloadSeq[id] || 0}`}
           ref={el => {
-            if (el) iframeRefs.current.set(id, el)
-            else iframeRefs.current.delete(id)
+            if (el) {
+              iframeRefs.current.set(id, el)
+              // The mount is the moment the src is committed to a live frame.
+              // An empty `src` here means srcFor found no warm entry, which is
+              // the one way the pane can end up parked on about:blank forever.
+              paneLog('iframe-mounted', {
+                id,
+                port: warmRef.current[id]?.port,
+                seq: reloadSeq[id] || 0,
+                src: safePaneUrl(el.getAttribute('src')),
+              })
+            } else {
+              iframeRefs.current.delete(id)
+              paneLog('iframe-unmounted', { id })
+            }
           }}
           title={nameFor(id)}
           src={srcFor(id)}
@@ -707,7 +786,17 @@ export default function InstancesViewport({ macInset = false }: { macInset?: boo
           // require alongside the Permissions-Policy delegation.
           allow="microphone; fullscreen"
           allowFullScreen
-          onLoad={() => postModelTo(id)}
+          onLoad={e => {
+            // Fires for the initial about:blank too, which is why a load event is
+            // NOT proof the pane loaded. `frame` says which one this was.
+            paneLog('iframe-load', {
+              id,
+              port: warmRef.current[id]?.port,
+              seq: reloadSeq[id] || 0,
+              frame: frameDocumentState(e.currentTarget),
+            })
+            postModelTo(id)
+          }}
           className="absolute inset-0 w-full h-full border-0"
           style={{ display: id === activeId ? 'block' : 'none' }}
         />

--- a/website/src/lib/paneLog.test.ts
+++ b/website/src/lib/paneLog.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PANE_LOG_PREFIX, frameDocumentState, paneLog, safePaneUrl } from './paneLog'
+
+function captureLines(run: () => void): string[] {
+  const spy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  try {
+    run()
+    return spy.mock.calls.map(call => String(call[0]))
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('paneLog', () => {
+  it('emits one greppable line with the shared prefix', () => {
+    const [line] = captureLines(() => paneLog('ready', { id: 'nobita', port: 7778 }))
+    expect(line).toBe(`${PANE_LOG_PREFIX} ready id=nobita port=7778`)
+  })
+
+  it('never journals a credential, whatever the caller passes', () => {
+    const [line] = captureLines(() =>
+      paneLog('warm', { id: 'nobita', token: 'supersecret', secret: 'x', password: 'y' }),
+    )
+    expect(line).not.toContain('supersecret')
+    expect(line).toContain('token=<redacted>')
+    expect(line).toContain('secret=<redacted>')
+    expect(line).toContain('password=<redacted>')
+    // The key test is a substring match on purpose, so a wrapped name is caught too.
+    expect(captureLines(() => paneLog('warm', { authToken: 'zzz' }))[0]).toBe(
+      `${PANE_LOG_PREFIX} warm authToken=<redacted>`,
+    )
+  })
+
+  it('keeps a boolean presence flag, which is the finding and not the secret', () => {
+    const [line] = captureLines(() => paneLog('remint-empty', { id: 'nobita', hasToken: false }))
+    expect(line).toBe(`${PANE_LOG_PREFIX} remint-empty id=nobita hasToken=false`)
+    expect(line).not.toContain('<redacted>')
+    // Only booleans are exempt: a string under the same key is still a credential.
+    expect(captureLines(() => paneLog('e', { hasToken: 'abc' }))[0]).toContain('hasToken=<redacted>')
+  })
+
+  it('drops undefined fields instead of printing the word "undefined"', () => {
+    const [line] = captureLines(() => paneLog('warm-declined', { id: 'a', error: undefined }))
+    expect(line).toBe(`${PANE_LOG_PREFIX} warm-declined id=a`)
+    expect(line).not.toContain('undefined')
+  })
+
+  it('quotes a value containing spaces so the line stays parseable', () => {
+    const [line] = captureLines(() => paneLog('warm-failed', { error: 'connection refused' }))
+    expect(line).toBe(`${PANE_LOG_PREFIX} warm-failed error="connection refused"`)
+  })
+
+  it('keeps booleans and null readable', () => {
+    const [line] = captureLines(() => paneLog('e', { a: true, b: false, c: null }))
+    expect(line).toBe(`${PANE_LOG_PREFIX} e a=true b=false c=null`)
+  })
+
+  it('works with no fields at all', () => {
+    const [line] = captureLines(() => paneLog('retry'))
+    expect(line).toBe(`${PANE_LOG_PREFIX} retry`)
+  })
+})
+
+describe('safePaneUrl', () => {
+  it('drops the token value but records that there was one', () => {
+    expect(safePaneUrl('http://localhost:7778/?token=abc123')).toBe(
+      'http://localhost:7778/?token=<redacted>',
+    )
+  })
+
+  it('keeps the port, which is the diagnostic content', () => {
+    expect(safePaneUrl('http://localhost:7778/?token=abc123')).toContain(':7778')
+  })
+
+  it('marks a non-token query without echoing it', () => {
+    expect(safePaneUrl('http://localhost:5476/?foo=1')).toBe('http://localhost:5476/?<query>')
+  })
+
+  it('names an empty src explicitly — that is the failure mode, not a gap', () => {
+    expect(safePaneUrl('')).toBe('<empty>')
+    expect(safePaneUrl(null)).toBe('<empty>')
+    expect(safePaneUrl(undefined)).toBe('<empty>')
+  })
+
+  it('passes a query-less URL through untouched', () => {
+    expect(safePaneUrl('http://localhost:5476/')).toBe('http://localhost:5476/')
+  })
+})
+
+describe('frameDocumentState', () => {
+  it('reports cross-origin when reading location throws — the pane DID navigate', () => {
+    const el = {
+      contentWindow: {
+        get location(): never {
+          throw new DOMException('blocked a frame with origin')
+        },
+      },
+    } as unknown as HTMLIFrameElement
+    expect(frameDocumentState(el)).toBe('cross-origin')
+  })
+
+  it('reports the readable about:blank — the pane never navigated', () => {
+    const el = {
+      contentWindow: { location: { href: 'about:blank' } },
+    } as unknown as HTMLIFrameElement
+    expect(frameDocumentState(el)).toBe('about:blank')
+  })
+
+  it('redacts a token even when the frame is readable', () => {
+    const el = {
+      contentWindow: { location: { href: 'http://localhost:5476/?token=abc' } },
+    } as unknown as HTMLIFrameElement
+    expect(frameDocumentState(el)).toBe('http://localhost:5476/?token=<redacted>')
+  })
+
+  it('distinguishes a missing element from a missing contentWindow', () => {
+    expect(frameDocumentState(null)).toBe('no-element')
+    expect(frameDocumentState(undefined)).toBe('no-element')
+    expect(frameDocumentState({ contentWindow: null } as unknown as HTMLIFrameElement)).toBe(
+      'no-contentwindow',
+    )
+  })
+})

--- a/website/src/lib/paneLog.ts
+++ b/website/src/lib/paneLog.ts
@@ -1,0 +1,121 @@
+/**
+ * Pane lifecycle journal.
+ *
+ * A remote crew pane that never becomes a live document shows only "loading
+ * pane", and the failure is intermittent — it can survive an app restart or
+ * vanish on one. So these lines are ALWAYS emitted rather than gated behind a
+ * debug flag: the next occurrence has to leave evidence without anyone having
+ * turned anything on beforehand, because by the time someone would think to,
+ * the state is gone.
+ *
+ * Routed through `console.info` with a fixed prefix. The desktop app's
+ * `frame-load-log` forwarder allowlists that prefix, so these land in
+ * gateway-launch.log interleaved with the Chromium frame events they explain;
+ * in a plain browser they are ordinary console lines.
+ *
+ * The prefix is a marker, not a capability: the forwarder honours it only for a
+ * document that is BOTH the top-level frame and on the origin the window was loaded
+ * with, because a crew pane is a cross-origin iframe of the same webContents and
+ * could otherwise print these same characters to forge pane records — and being the
+ * top frame is a position a pane can reach by navigating the top-level window. So
+ * this module must keep being called from the dashboard document itself — move a
+ * caller into an iframe or a worker and its lines stop reaching the log file (they
+ * remain ordinary console output).
+ */
+
+export const PANE_LOG_PREFIX = '[pane]'
+
+/**
+ * Field names whose values are credentials and must never be journaled.
+ *
+ * Matched as a SUBSTRING on purpose: `authToken`, `session_secret` and
+ * `tokenValue` all have to be caught, and a caller that passes a whole connection
+ * object must not be able to leak one through a key this list did not anticipate.
+ * The cost is that a presence FLAG whose name contains one of these words —
+ * `hasToken` is the one in this codebase — matches too. See `isSecretValue`.
+ */
+const SECRET_KEYS = /token|secret|password|cookie/i
+
+/**
+ * Does this field actually carry a secret, or only say whether one was there?
+ *
+ * A boolean cannot hold a credential: `hasToken=false` is the whole finding in
+ * `remint-empty` and `warm-declined`, and redacting it to `<redacted>` throws away
+ * the one bit the line exists to record while protecting nothing. Every other type
+ * is treated as the secret itself, so widening this exemption past `boolean` would
+ * trade a real credential for a nicer log.
+ */
+function isSecretValue(key: string, value: unknown): boolean {
+  return SECRET_KEYS.test(key) && typeof value !== 'boolean'
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    // Quote only when needed, so the common case stays greppable as `key=value`.
+    return /[\s"]/.test(value) ? JSON.stringify(value) : value
+  }
+  if (value === null) return 'null'
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return '<unserializable>'
+    }
+  }
+  return String(value)
+}
+
+/**
+ * Emit one structured line: `[pane] <event> key=value key=value`.
+ *
+ * `undefined` fields are dropped rather than printed as "undefined" — an absent
+ * field reads as "not applicable here", which is what the caller means.
+ * Anything whose key looks like a credential is replaced, so a caller that
+ * passes a whole connection object cannot leak a token into a log file — except a
+ * boolean, which is a presence flag and not a secret (see `isSecretValue`).
+ */
+export function paneLog(event: string, fields: Record<string, unknown> = {}): void {
+  const parts = [PANE_LOG_PREFIX, event]
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined) continue
+    parts.push(`${key}=${isSecretValue(key, value) ? '<redacted>' : formatValue(value)}`)
+  }
+  // eslint-disable-next-line no-console -- this IS the diagnostic channel: a packaged app has no devtools console, so these lines are the only record of a pane that never loaded.
+  console.info(parts.join(' '))
+}
+
+/**
+ * A pane URL safe to journal: the `?token=` value is dropped while the fact a
+ * token was present is kept, because a token the remote refused is the failure
+ * worth diagnosing and its value never is.
+ */
+export function safePaneUrl(url: string | null | undefined): string {
+  const text = String(url || '')
+  if (!text) return '<empty>'
+  const cut = text.indexOf('?')
+  if (cut < 0) return text
+  const query = text.slice(cut + 1)
+  return text.slice(0, cut) + (/(^|&)token=/.test(query) ? '?token=<redacted>' : '?<query>')
+}
+
+/**
+ * Where an iframe's document actually is — the one question that decides this
+ * diagnosis, answerable from the parent realm alone.
+ *
+ * Reading `contentWindow.location.href` THROWS once the frame has navigated to
+ * the crew's own origin, and succeeds while the frame is still on the initial
+ * `about:blank` (which inherits the parent's origin). So the exception is the
+ * good outcome: `cross-origin` means the pane really loaded the tunnel URL,
+ * while a readable `about:blank` means the navigation never happened and no
+ * crew bundle can ever run there.
+ */
+export function frameDocumentState(el: HTMLIFrameElement | null | undefined): string {
+  if (!el) return 'no-element'
+  const win = el.contentWindow
+  if (!win) return 'no-contentwindow'
+  try {
+    return safePaneUrl(win.location.href) || 'same-origin'
+  } catch {
+    return 'cross-origin'
+  }
+}

--- a/website/src/test/i18nLintExemptions.test.ts
+++ b/website/src/test/i18nLintExemptions.test.ts
@@ -186,6 +186,35 @@ describe('the autolink template placeholder is exempt', () => {
   })
 })
 
+describe('diagnostic log sentinels are exempt', () => {
+  it('stays quiet on the bare sentinels', async () => {
+    // Real site: lib/paneLog.ts. The reader is whoever greps gateway-launch.log
+    // after a pane failed to load, so a translated `<redacted>` would make the
+    // journal unsearchable in the one incident it exists for.
+    expect(
+      await lint(`export const PROBE = ['<redacted>', '<empty>', '<unserializable>']`),
+    ).toEqual([])
+  })
+
+  it('stays quiet on a sentinel standing in for a query', async () => {
+    // The two values `safePaneUrl` substitutes for a query it will not journal.
+    expect(await lint(`export const PROBE = ['?token=<redacted>', '?<query>']`)).toEqual([])
+  })
+
+  it('still reports copy that merely contains a bracketed word', async () => {
+    // The anchors are the whole tightness argument: a placeholder inside a
+    // sentence is copy, and the surrounding words are what must stay reportable.
+    const messages = await lint(`export const PROBE = ['Enter <name> here', 'Token <redacted>']`)
+    expect(messages).toHaveLength(2)
+  })
+
+  it('still reports a server-contract query that carries no sentinel', async () => {
+    // `?<query>` must not have widened the `^[?&][a-z_]+=…$` shapes into "anything
+    // after a question mark" — a query whose VALUE is prose is still copy.
+    expect(await lint(`export const PROBE = ['?label=Save changes']`)).toHaveLength(1)
+  })
+})
+
 describe('Tailwind arbitrary-variant clusters are exempt', () => {
   it('stays quiet on the touch-target override clusters', async () => {
     // Real site: HOVER_NONE_ACTIONS_ROW_CLS / HOVER_NONE_ACTION_BTN_CLS in


### PR DESCRIPTION
## Problem / Motivation

Exactly one remote crew pane sits at "loading" forever. The tunnel is up the whole
time, the other crews are fine, and **which** crew is stuck changes on every
gateway restart — so it reads as a flaky SSH link rather than as a setting doing
what it was told.

## Why it matters

The user has no way to attribute it. Nothing is red: the tunnel reports
`connected`, the registry looks right, and the only symptom is a spinner in one
pane. The natural response is to go hunting through SSH config, tokens and
`frame-ancestors` — which is exactly what happened here — while the actual cause is
a cap that came back one short. And because the victim moves each restart, every
"fix" appears to work once.

## What changed (motivation → approach → change)

**Symptom** → one pane never becomes ready, victim rotates per restart.

**Root cause** → the automatic warm-set cap (`instances.warm_set_cap = 0`, the
shipped default) was resolved from the number of crews **connected at the instant
`GET /api/instances` was served**:

```python
connected = sum(1 for i in items if (i.get("status") or {}).get("state") == "connected")
```

That made the cap a race against tunnel startup. With four crews configured and
the fourth still connecting when the dashboard polled, the served cap came back
`3`, and `InstancesViewport`'s K-cap effect dutifully evicted the LRU pane to
honour it.

Eviction is **indistinguishable from a disconnect at the pane**: the iframe is
unmounted, the token re-minted, and the remote SPA cold-boots on the next click.
So one crew looks broken, and which one depended on connection order — hence a
victim that moves on every restart.

**Change** → count **registered** crews instead (`len(items)` from the registry).
That is a function of configuration rather than of live state, so:

- it cannot race tunnel startup — a crew that is still connecting already has its
  slot;
- it widens by itself when a crew is added, so nobody has to remember to raise the
  cap alongside. Forgetting that is precisely what reintroduces the eviction.

`WARM_SET_CAP_AUTO_CEILING` (8) still bounds automatic mode, so a large fleet still
evicts rather than mounting an unbounded number of dashboard SPAs in one renderer.
An **explicit** cap `>= 1` is still honoured verbatim, including a value below the
registered count — a deliberately tight cap is the only knob that bounds renderer
cost, and silently widening it would defeat the operator's own trade.

The setting's help text moves off "connected" onto "configured" in the same commit,
and `config-baseline.json` — the committed snapshot of the config schema, which
`test_config_baseline.py` asserts byte-identical against its generator — is
regenerated to match. That one generated line is the whole of the baseline's diff.

`docs/system-specs/modules/instances.md` moves with the code: §2's warm-set
paragraph, the `instances.warm_set_cap` config-table row and the LRU-eviction
troubleshooting row all described the cap as tracking the *live connected count*,
which this change makes untrue. Each now says *registered*, and each states the
automatic ceiling explicitly rather than promising that no configured crew is ever
evicted — past `WARM_SET_CAP_AUTO_CEILING` (8) one is.

### The instrumentation half

The same commit adds a permanent journal of crew-pane load outcomes, because this
class of bug only reproduces across a restart and a restart is slow:

- **`website/electron/frame-load-log.js`** (new) — hooks `did-start-navigation` /
  `did-frame-navigate` / `did-fail-load` / `console-message` on the dashboard
  webContents, so a subframe that never commits, or commits a non-2xx, leaves a
  line carrying the status or the net error code.
- **`website/src/lib/paneLog.ts`** (new) plus ten call sites in
  `InstancesViewport.tsx` — a greppable one-line `[pane]` journal (mount, ready,
  unmount, re-mint, evict) written into the same `gateway-launch.log`, so the
  renderer's view and the frame's view interleave on one timeline.

Tokens are redacted (`token=<redacted>`) and the journal is unconditional — no
debug flag, because the failure is not reproducible on demand.

**The `[pane]` prefix is a marker, not a capability.** The crew panes are
cross-origin iframes *of* the dashboard's webContents, so `console-message` fires
for their documents too: a prefix test on its own would let a compromised remote
gateway print entries into `gateway-launch.log`, forging the very record that says
whether its pane was ever requested. The forwarder gates the allowlist on frame
identity instead, and identity takes **two** checks — Electron's `console-message`
details carry the emitting `WebFrameMain`, so it requires both:

1. `parent === null` — the top of the frame tree, a relationship Chromium owns and a
   nested page cannot claim.
2. `frame.origin` equal to the URL the window was loaded with (`backendUrl`, passed
   in at the single call site).

Neither alone is sufficient, because **position is not identity**: a cross-origin pane
that gets a user click on a `target="_top"` link can navigate the top-level window,
and the remote document then has `parent === null` too. `sourceId` is deliberately
*not* used for either check: any script can rewrite it with a `//# sourceURL=`
comment. Both fail closed, so a runtime that supplies no frame — or a caller that
configures no origin — loses the INFO-level journal rather than trusting an
unverifiable claim.

A pane's console **errors** are still journaled — a framing refusal inside the pane
is exactly the diagnosis — but attributed (`renderer console [error] (untrusted
frame http://127.0.0.1:PORT): …`) so a reader can tell pane-controlled text from the
dashboard's own. Every field the emitting document controls is escaped before it is
written: `gateway-launch.log` is read by tailing it, so a raw newline would let a
pane forge whole entries, and length is capped so one enormous message cannot
scroll the lines around it out of the tail.

**The volume is bounded, and the bound is aggregate — because a pane drives more than
one path.** The repeat counter is keyed by message *text*, and text is what a
compromised pane chooses: varying it defeats a per-message cap, and clearing the key
map on overflow restarts the counting rather than holding the line. A pane can just as
easily loop its own frame's **navigations** — every `did-start-navigation` /
`did-frame-navigate` / `did-fail-load` is another unconditional line — so a limit on
the console path alone is one the pane walks around by switching paths. Every emission
therefore funnels through one writer (`record`), and every line attributable to an
untrusted frame, console or navigation alike, is charged against a single
per-attachment budget (`UNTRUSTED_LOG_BUDGET = 100`), independent of what the text
says. It is charged only for lines actually written, and the last line it admits names
the budget so the silence after it reads as the cap rather than as the pane
recovering. A navigation carries only `isMainFrame` as a trust signal (the positional
events pass no frame or origin), so a subframe navigation is the pane's and is
budgeted while a top-frame navigation is the dashboard's own handful and is not.
Trusted and untrusted *console* repeat counters stay separate maps, so pane volume
cannot evict the dashboard's own. The trade is explicit: past the budget a genuinely
broken pane stops explaining itself, which is acceptable because the first lines *are*
the diagnosis — a framing refusal repeats, it does not evolve — while an unbounded log
is a disk-exhaustion path on the user's machine.

**A boolean presence flag is not a credential.** `paneLog`'s redaction matches key
names as a substring so `authToken` and `session_secret` are caught, which also
matched the `hasToken` flag in `remint-empty` and `warm-declined` — redacting the one
bit those lines exist to record while protecting nothing. Booleans are now exempt;
every other type under a secret-looking key is still replaced.

While wiring it up, the repo's own `shell-contract` drift guard caught a real
packaging bug: `frame-load-log.js` was missing from `build.files` in
`website/electron/package.json`, so the DMG would have shipped without the module
and window creation would have crashed. Fixed in the same commit.

**`website/electron/package.json` adds no dependency.** The only edit is one entry
in the `build.files` allowlist — no `dependencies` / `devDependencies` change, no
lockfile change, no new third-party code. electron-builder ships an explicit
per-file allowlist, which is why an unlisted local module works from source and is
simply absent from the DMG.

### The i18n exemption

The journal's redaction sentinels — `<redacted>`, `<empty>`, `<unserializable>`,
`?token=<redacted>`, `?<query>` — are log tokens, and the `i18n:check` gate reports
untranslated literals on added lines at zero tolerance. Translating one would make
`gateway-launch.log` unsearchable in the exact incident it exists for, and a locale
that renamed `<redacted>` would read as if the token had been *printed*. So they are
exempted rather than wrapped, via two fully anchored `words.exclude` shapes in
`website/eslint.i18n.config.js`:

```js
String.raw`^<[a-z]+>$`
String.raw`^\?(?:[a-z_]+=)?<[a-z]+>$`
```

Both are deliberately separate from the existing `^[?&][a-z_]+=[a-z0-9]+$`
server-contract shape: that class admits no angle bracket, and widening it to reach
these would let a bracket into a pattern whose whole tightness argument is that it
carries only `[a-z0-9_=]`. The anchors are what keep prose reportable — `Enter <name>
here` and `?label=Save changes` still fail the lint, and
`website/src/test/i18nLintExemptions.test.ts` pins both directions.

## Tests

- **`test/test_warm_set_cap.py`** — rewritten for the registered-count semantics.
  New `TestAdmitsEveryRegisteredCrew` class pins the regression directly: a crew
  still connecting does not shrink the cap, adding a crew widens it, and a
  registered-but-never-connected crew still gets a slot.
- **`test/test_instances.py`** —
  `test_automatic_cap_covers_every_registered_crew_not_just_connected_ones`
  (3 registered / 2 connected ⇒ cap 3, the exact shape that used to serve 2) and
  `test_adding_a_crew_widens_the_served_cap` (1 → 2 with no config edit).
- **`website/src/lib/paneLog.test.ts`** (new, 16 cases) — the one-line format,
  credential redaction (including a wrapped key name like `authToken`, and both
  directions of the boolean exemption: `hasToken=false` survives, `hasToken: 'abc'`
  is still redacted), dropped `undefined` fields, and the `cross-origin` /
  `about:blank` / `no-element` branches of `frameDocumentState`.
- **`website/electron/test/frame-load-log.test.js`** — 45 cases: started-vs-committed
  navigations, same-document SPA navigations staying silent, the `[pane]` journal's
  higher repeat cap (a re-mint loop *is* the finding), both `console-message` shapes,
  and a `frame-load-log console trust boundary` block that runs each attack rather
  than describing it:
  - a nested pane frame emitting `[pane] pane-ready id=nobita status=200` produces no
    line at all, and neither does a **remote document that navigated the top-level
    window** (`{ parent: null, origin: <remote> }`) — the `target="_top"` case;
  - `normalizeTrustedOrigin` reduces the loaded URL to Chromium's serialization, and a
    same-prefix impostor (`http://localhost:54760`) is refused, pinning that the
    comparison is equality and not `startsWith`;
  - an unverifiable frame, a throwing `parent`, a throwing `origin`, and an
    unconfigured trusted origin all drop the journal;
  - `UNTRUSTED_LOG_BUDGET + 50` **distinct** pane errors produce exactly
    `UNTRUSTED_LOG_BUDGET` lines with the last naming the budget; suppressed repeats
    do not consume it; a spent budget does not silence the dashboard's own errors; and
    overflowing the untrusted key map does not reset the trusted counters;
  - a **subframe navigation flood** (`did-fail-load` with `isMainFrame=false`,
    `UNTRUSTED_LOG_BUDGET + 50` times) is bounded by the same budget, not just console
    output; console and navigation share **one** aggregate budget (70 + 70 across the
    two paths still totals `UNTRUSTED_LOG_BUDGET`, not 2×); and the dashboard's own
    **top-frame** navigations (`isMainFrame=true`) are never budgeted;
  - a pane error still lands but carries `untrusted frame <origin>`, and
    `boom\nframe navigated (subframe) status=200 …` stays one record with its newline
    escaped.

- **`website/src/test/i18nLintExemptions.test.ts`** — 4 cases for the two new
  exemption shapes, in the file's existing both-directions style: quiet on the bare
  sentinels and on the query forms, still reporting `Enter <name> here` /
  `Token <redacted>` (a placeholder inside a sentence is copy) and still reporting
  `?label=Save changes` (the query shapes did not widen into "anything after a `?`").
  Whole file: **47 passed**.

Local runs: `test_warm_set_cap.py` + `test_instances.py` +
`test_config_superseded_defaults.py` → **358 passed, 2 skipped, 1 failed**. The
failure is unrelated: `TestForwarderPidHints::test_connect_persists_forwarder_identity`
asserts a non-empty `process_start_time()`, which shells out to `ps -o lstart=` on
macOS — blocked in my sandbox, so it returns `""`. Electron `node --test` (whole
package suite): **1662 passed, 1 skipped, 0 failed**. vitest (`paneLog` +
`i18nLintExemptions`): 63 passed.

## Manual verification

Partial, and stated plainly rather than claimed:

- The cap resolution is covered end-to-end at the handler level by the two new
  `test_instances.py` cases, which exercise the real registry and the real
  `api_instances_list`.
- **Not yet verified on a packaged build.** The desktop app runs the gateway from
  its bundled `backend-dist`, so confirming the served integer in the UI (Settings
  → Instances, "up to **N** instances stay warm") needs a `make desktop` +
  reinstall. The reporting user is doing that run.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** the frontend diff adds logging call sites only — no
component, layout, string or style change, so no pixel differs.

## Related Issues

no linked issue: found while diagnosing a stuck pane in a live session, not filed
first.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **deriving a budget from live state that the thing being budgeted is
still racing to enter.** The cap counted connections while connections were still
being established, so it was systematically low during exactly the window it
governed. The general shape to flag: a limit computed from an observed *runtime*
count, applied to a set whose membership is *declared* — the two converge
eventually, and the gap is a silent, order-dependent failure. Prefer the declared
count (configuration) and bound it separately, rather than sampling the live one.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the config help text, the
      `constants.py` doc comments, the superseded-default display string, the
      `instances` module spec (§2, the config table and the eviction
      troubleshooting row) and the committed `config-baseline.json` snapshot all
      moved off "connected" onto "registered", each naming the automatic ceiling
- [x] No secrets, credentials, or internal references in the diff

