### PR TITLE
fix(snapshot): validate notification records the copy branch installs

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -8201,18 +8201,34 @@ def _load_notifications() -> list[dict[str, Any]]:
 
 # Notification file I/O runs exclusively on this single-worker executor when
 # an event loop is running: appends (from the delivery sink) and rewrites
-# (from delete/ack/clear) execute strictly in submission order, so no lock is
-# needed and the loop never blocks on file I/O.
+# (from delete/ack/clear) execute strictly in submission order, so the QUEUE
+# needs no lock and the loop never blocks on file I/O. Creating the executor
+# does need one -- see _notification_io_executor.
 _notification_io_pool: concurrent.futures.ThreadPoolExecutor | None = None
+_notification_io_pool_lock = threading.Lock()
 
 
 def _notification_io_executor() -> concurrent.futures.ThreadPoolExecutor:
-    """Lazily create the single-worker executor for notification persistence."""
+    """Lazily create the single-worker executor for notification persistence.
+
+    The creation is locked, not just the queue. An unlocked check-then-set let two
+    threads each observe ``None``, each construct a pool, and each proceed: one
+    assignment won the global while the loser's worker was already live with its job
+    already queued, so the two callers were not serialised against one another at all
+    -- which is the single guarantee this executor exists to provide. Narrow window
+    (the first notification I/O of the process, twice at once) and unbounded harm: an
+    append landing inside a ``_rewrite_notifications`` whole-file write is simply gone,
+    because the rewrite did not include it and overwrote the bytes.
+
+    Double-checked so the lock is paid once rather than on every call. Issue #8788.
+    """
     global _notification_io_pool
     if _notification_io_pool is None:
-        _notification_io_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="notif-io"
-        )
+        with _notification_io_pool_lock:
+            if _notification_io_pool is None:
+                _notification_io_pool = concurrent.futures.ThreadPoolExecutor(
+                    max_workers=1, thread_name_prefix="notif-io"
+                )
     return _notification_io_pool
 
 

--- a/src/kiro_crew/portability.py
+++ b/src/kiro_crew/portability.py
@@ -30,6 +30,8 @@ from kiro_crew.config.paths import config_dir
 from kiro_crew.mcp_cron import _log_cron_denial, _vet_shell_command
 from kiro_crew.security import is_sensitive_path
 from kiro_crew.snapshot import (
+    NotificationCopyUnsupported,
+    _copy_notifications,
     _copy_tree_no_overwrite,
     _do_replace,
     _merge_crons,
@@ -573,8 +575,22 @@ def apply_import_zip(zip_path: Path, mode: str = "merge") -> dict:
                     _merge_notifications(snap / "notifications.jsonl", mc / "notifications.jsonl")
                     summary["items"].append("notifications (merged)")
                 else:
-                    shutil.copy2(str(snap / "notifications.jsonl"), str(mc / "notifications.jsonl"))
-                    summary["items"].append("notifications (copied)")
+                    # Not `copy2`: it installed records the live file's own reader
+                    # refuses, and that reader loses the whole file to one of them.
+                    # Same abort posture as the merge branch above.
+                    #
+                    # The platform refusal is NOT that abort: it says this platform
+                    # can never do this safely, so it skips one item and lets the
+                    # import proceed. Recorded in the summary as skipped WITH the
+                    # reason -- reporting "copied" for a refusal, or saying nothing,
+                    # would be the silent-install bug class this change removes.
+                    try:
+                        _copy_notifications(
+                            snap / "notifications.jsonl", mc / "notifications.jsonl"
+                        )
+                        summary["items"].append("notifications (copied)")
+                    except NotificationCopyUnsupported as exc:
+                        summary["items"].append(f"notifications (SKIPPED: {exc})")
 
             for dirname in ("workspace", "plan_memory"):
                 sd = snap / dirname

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import importlib
+import io
 import json
 import os
 import re
@@ -13,6 +14,7 @@ import socket
 import stat as _stat
 import tarfile
 import tempfile
+import threading
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -2397,6 +2399,33 @@ _TERMINATORS = (b"\n", b"\r")
 # the same reason `subagent_cost` names its own.
 _NOTIFICATION_RECORD_CAP = RECORD_CAP
 
+# Largest notification SOURCE this will hold, in bytes. A whole-FILE cap, which the
+# streaming predecessor did not need and the single-read design does: the per-record
+# cap above bounds one record, not a file made of many.
+#
+# Sized from the destination's own invariants rather than from a sample.
+# ``_MAX_PERSISTED_NOTIFICATIONS`` is 200; ``_maybe_trim_notifications`` runs after
+# EVERY append and trims past 200*2; the loader keeps the last 200 and every rewrite
+# writes the last 200. So the live file is self-bounding at 400 records at all times,
+# and anything beyond 200 is discarded on the next read regardless -- installing more
+# than that is transient by construction, which is why refusing a larger source costs
+# the operator nothing real. Measured on a live install: 207 records, 370,107 bytes,
+# largest single record 20,821 bytes. 400 of that largest record is 8,316,000 bytes,
+# so this is ~4x the product-bounded worst case and a quarter of the per-record cap
+# the same file already accepts for ONE record.
+#
+# Peak held is about twice the SOURCE size, not twice this cap: the read accumulates in
+# 1 MiB chunks for that reason. A single `read(cap + 1)` preallocates the whole limit,
+# which made an 8 MB source cost 32 MiB and tied the peak to the constant rather than to
+# the file. Measured on the shipped code: 15.9 MiB for the 8.3 MB worst case below, and
+# 1.0 MiB for a realistic 207-record file. Both far under the 128 MiB single allocation
+# above.
+#
+# Over-cap is a REFUSAL naming the size, never a truncation and never a silent skip.
+# A cap that dropped the tail would recreate the defect this design removes, one layer
+# up: a partial install reported as success.
+_NOTIFICATION_SOURCE_CAP = 32 * 1024 * 1024
+
 
 def _notification_key(record: bytes, path: Path) -> tuple[Any, ...] | None:
     """The dedupe key for one raw notification record, or ``None`` if it has none.
@@ -2653,6 +2682,413 @@ def _merge_notifications(src_path: Path, dst_path: Path) -> None:
         print(f"  ⚠️  Stopped merging {_safe_name(src_path)} after {imported} record(s): {exc}")
         raise
     print(f"  Notifications imported: {imported}")
+
+
+def _serialise_with_notification_writes(work: Callable[[], None]) -> None:
+    """Run *work* in FIFO order with the dashboard's own notification writes.
+
+    ``_install_notifications`` writes the live ``notifications.jsonl`` while the
+    gateway may be writing it too, and ``O_APPEND`` alone is not enough. It stops a
+    concurrent row being OVERWRITTEN, and then orders it BEFORE the archive's rows:
+    the dashboard's append goes to end-of-file immediately while the copy's writes are
+    still buffered, so the live row lands first and the archive's follow it. The
+    reader's cap is POSITIONAL -- ``_load_notifications`` keeps the last
+    ``_MAX_PERSISTED_NOTIFICATIONS`` rows, not the newest by timestamp -- so importing
+    a full 200-record history pushes the live row out of the window. Measured: a note
+    delivered mid-copy landed at line 0 of 201 and the reader returned 200 rows
+    without it. Review's finding, and it is silent: the operator was told the
+    notification was delivered, and after the next reload it is gone.
+
+    Notification persistence runs on ONE worker in submission order
+    (``_notification_io_executor``), so running the copy on that same worker is what
+    makes the two ordered rather than concurrent. A queued append then runs strictly
+    after the copy and lands at the end of the file, where the cap keeps it.
+
+    Three branches decided whether to serialise, and TWO of them shared one mistake:
+    they treated the absence of an OBSERVABLE writer as the absence of a writer. The
+    shortcut assumed "no pool" means "no writer"; the writer is what makes the pool. A
+    fresh gateway has persisted nothing, so the pool was ``None``, so the copy ran
+    inline -- and a delivery arriving at that moment CREATED the executor and appended
+    through it, concurrently, putting the live row back at line 0 of 201 and outside the
+    reader's window. Review found that instance. The broad ``except Exception`` on the
+    import one line above was the same error a second time: it turned "I could not
+    check" into "there is nothing to check", so an import failing inside a live gateway
+    would have lost the ordering silently.
+
+    So this ACQUIRES rather than asks. ``_notification_io_executor()`` creates the
+    worker if there is none and returns the existing one if there is. That removes the
+    first hole outright -- there is no longer any "is there a pool" question to get
+    wrong -- and narrows the second to ``ImportError``.
+
+    TWO inline cases remain, and neither reads an absence of OBSERVATION as an absence
+    of a writer:
+
+    1. Already ON the worker. Then we ARE the ordering point, and submitting would wait
+       for a queue only this call can drain -- a deadlock rather than a race. This is
+       the one branch that was always sound.
+    2. The dashboard module does not import. A missing MODULE is categorically different
+       from a missing pool: the sink lives in that module, so if it is not importable
+       there is no writer that could exist, rather than none currently visible. That is
+       the CLI restore. Narrowed to ``ImportError`` precisely so it cannot absorb
+       anything else -- a module that fails to import for any OTHER reason is a real
+       failure and must surface rather than quietly degrade the guarantee.
+
+    Acquiring costs the CLI path one idle worker thread it did not previously create.
+    That is a short-lived process and the thread exits at interpreter shutdown; a silent
+    ordering hole is permanent, so the trade is not close.
+
+    The executor is released as soon as *work* returns OR raises: ``result()``
+    re-raises rather than swallowing, so the failure path needs no separate release
+    and cannot leave notification writes blocked.
+
+    Relying on that executor for ordering means its own CREATION has to be ordered too.
+    It was an unlocked check-then-set, so two threads could each observe ``None``, each
+    build a pool, and never be serialised against one another -- which would void this
+    guarantee rather than weaken it. ``dashboard/state.py`` now takes a lock around the
+    lazy init (issue #8788), so acquiring the executor is itself race-free.
+    """
+    try:
+        from kiro_crew.dashboard import state as dashboard_state
+    except ImportError:
+        work()
+        return
+    if threading.current_thread().name.startswith("notif-io"):
+        work()
+        return
+    dashboard_state._notification_io_executor().submit(work).result()
+
+
+class NotificationCopyUnsupported(Exception):
+    """This platform cannot install notification records safely, so it does not.
+
+    Deliberately not an ``OSError``: the copy's own error arm catches ``OSError`` and
+    re-raises it as a failed import, which is the wrong shape for "this platform was
+    never able to do this". A distinct type lets the callers report a SKIP, and an
+    unhandled one still aborts rather than passing silently.
+    """
+
+
+def _copy_notifications(src_path: Path, dst_path: Path) -> None:
+    """Install the snapshot's notification records, ordered against the live writer.
+
+    Refuses outright where ``O_NOFOLLOW`` does not exist -- see below. The refusal is
+    made HERE, before the executor is acquired and before anything is opened, because
+    it is a question about the platform rather than about this source.
+
+    The whole body runs on the dashboard's notification worker when one exists, so a
+    row the gateway delivers during the restore cannot be ordered ahead of the
+    archive's and dropped by the reader's positional cap. See
+    :func:`_serialise_with_notification_writes` for why ``O_APPEND`` alone was not
+    enough, and note the cost: a restore briefly blocks notification writes. A
+    restore is rare and user-initiated; a lost notification is silent and permanent.
+
+    WHY A MISSING ``O_NOFOLLOW`` REFUSES INSTEAD OF FALLING BACK. The predecessor
+    checked ``pinned_fs.is_reparse_point(src_path)`` by NAME and then opened the same
+    NAME. Against an adversary that is not a floor, it is a check-to-open window: the
+    threat model this function is written for -- stated in ``_install_notifications``
+    and demonstrated by the revision review blocked -- is a concurrent agent replacing
+    the extracted file, and such an agent chooses the timing. The descriptor check does
+    not save it either: ``fstat`` asserts ``S_ISREG``, and a reparse point resolving to
+    a regular ``.env`` passes ``S_ISREG``. So on a platform with no ``O_NOFOLLOW`` there
+    is no sequence of by-name checks that makes this safe, and the honest move is to not
+    do it.
+
+    The alternative -- a ctypes ``CreateFileW`` with ``FILE_FLAG_OPEN_REPARSE_POINT`` --
+    is declined, and not by me: ``eval/bench/safepath.py`` records that it "is no longer
+    worth considering here: it would buy the same property exclusive creation already
+    has, at the price of security code that cannot be exercised on the machine this
+    harness is developed on", and ``skill_trust.py`` records that Python "does not expose
+    an equivalent handle-relative, no-reparse walk on Windows". Both decline the capable
+    route, which means this repo has already chosen less capability on that platform over
+    a hand-rolled walk. Refusing extends those two decisions; falling back contradicts
+    them.
+
+    The cost is not symmetric, which is what makes the trade easy. Refusing loses
+    notification HISTORY on one platform for one operation -- the records remain in the
+    snapshot and nothing is destroyed. Falling back can put attacker-chosen bytes, a
+    credentials file among them, into a location the agent then reads. And this PR exists
+    because snapshot restore installed unvalidated bytes: a remaining path that installs
+    attacker-chosen bytes is the same defect, closed everywhere except where it is
+    hardest.
+
+    The refusal is LOUD and the callers report the skip. A silent skip would be the same
+    class of bug as the one being fixed, so the message names the platform, the missing
+    primitive, and what was not imported.
+    """
+    if not getattr(os, "O_NOFOLLOW", 0):
+        raise NotificationCopyUnsupported(
+            f"this platform ({os.name}) has no O_NOFOLLOW, so the notification source "
+            "cannot be opened with any guarantee that the name checked is the file "
+            "read -- a by-name reparse-point check followed by a by-name open is a "
+            "window a concurrent writer chooses the timing of, and fstat's S_ISREG "
+            "does not close it because a reparse point to a regular file passes it. "
+            "Refusing rather than importing bytes that may not be the archive's: "
+            f"{_safe_name(src_path)} was NOT imported and remains in the snapshot"
+        )
+    _serialise_with_notification_writes(lambda: _install_notifications(src_path, dst_path))
+
+
+def _install_notifications(src_path: Path, dst_path: Path) -> None:
+    """Install the snapshot's notification records where the live file does not exist yet.
+
+    The sibling of ``_merge_notifications``, and the reason it exists separately
+    is that the two branches of one ``if`` had different postures: the merge
+    validates every source record's encoding and ABORTS on one it cannot deliver
+    intact, while this branch was ``shutil.copy2`` and validated nothing. A
+    byte-exact copy is correct as a copy and that is exactly the problem -- it
+    faithfully installs bytes the destination's own reader refuses.
+    ``_load_notifications`` decodes the WHOLE file inside one ``try`` that
+    returns ``[]``, so one invalid byte costs every row, and the next
+    ``_rewrite_notifications`` -- any delete, ack or clear -- persists that empty
+    view. Unlike the merge this fired on every locale, because nothing decoded on
+    the way in, and it fired on a fresh install or a first restore, where the
+    operator has the least reason to suspect anything.
+
+    So the posture matches the merge: ABORT, never accept, never skip. That is not
+    a new product decision, it is the decision the merge branch already carries --
+    a snapshot with an undecodable record aborted the restore when a live file
+    existed and was installed silently when one did not.
+
+    It is a SEPARATE function rather than a call into the merge with an empty
+    destination, and both halves of that were measured, not assumed:
+
+    * ``_merge_notifications`` opens the destination for READ first, so a missing
+      one raises ``FileNotFoundError`` out of the arm that guarantees a
+      destination-scan failure is a true no-op. Teaching that arm to tell
+      "missing, fine" from "unreadable, abort" reopens the fail-closed posture
+      that arm exists for.
+    * The merge DEDUPLICATES against what it has already written, which a copy
+      must not: run four source records -- two sharing a ``ts``, two byte-identical
+      without one -- through a merge into an empty destination and two land. There
+      is nothing here to deduplicate against, so keying source records against
+      each other converts a faithful copy into a lossy one.
+
+    Every path here is resolved to a descriptor EXACTLY ONCE and all later work goes
+    through that descriptor. That invariant is the fix for a whole class rather than
+    for the instances that surfaced it: three separate review findings were the same
+    defect, an operation resolving a name more than once where another process can
+    change what the name means, and each earlier fix moved which name was vulnerable
+    instead of removing the second resolution. The source is opened once
+    ``O_RDONLY|O_NOFOLLOW|O_NONBLOCK|O_BINARY`` and read once, never seeked; the
+    destination is created once
+    ``O_CREAT|O_EXCL|O_WRONLY|O_APPEND|O_NOFOLLOW|O_BINARY``. The
+    remaining uses of either path -- ``_safe_name`` in the messages, and the ``path``
+    argument to ``strict_raw_records`` and ``_notification_key`` -- resolve nothing:
+    both callees only interpolate it into an error string.
+
+    That invariant is descriptor-bound on POSIX and CANNOT be on Windows, which has no
+    ``O_NOFOLLOW``: there the flag is 0. The predecessor put a by-name reparse-point
+    check in front of the open and treated it as a floor; it is not one, because a
+    by-name check followed by a by-name open is a window the concurrent agent in this
+    threat model chooses the timing of, and ``fstat``'s ``S_ISREG`` does not close it --
+    a reparse point resolving to a regular ``.env`` passes it. So this function is not
+    reached at all on such a platform: :func:`_copy_notifications` refuses the copy
+    before acquiring the executor. Naming the split rather than implying it, because
+    the two genuinely differ in what they can promise -- POSIX refuses a link inside
+    the open syscall, and a platform without the flag does not attempt the copy.
+
+    The caller reaches this branch on ``sn.is_file()`` and ``not dn.is_file()``, which
+    are by-name and therefore advisory. They are not trusted: each is confirmed or
+    refuted by the single authoritative resolution here. A destination that filled
+    after the check fails ``O_EXCL``, and a source that became a link or a FIFO fails
+    ``O_NOFOLLOW`` or the ``S_ISREG`` check on the descriptor. What is NOT closed here
+    is the ancestor chain -- both opens name a directory rather than a pinned
+    descriptor -- and that is deliberate: every core-file copy in this function
+    reaches its path the same way, so pinning one of ten sites would be the point
+    patch review already named. It is an axis for its own change.
+
+    ONE read of the source, and the ordering is the whole design:
+
+    1. The source is read ONCE, whole, under a byte cap, and the file is never
+       touched again. Everything after that reads the bytes in hand.
+    2. Those bytes are validated in full. A refusal here happens with the
+       destination never created, so there is nothing to roll back -- which matters
+       because there is no safe rollback: an earlier revision created the live file
+       and unlinked it on refusal, and ``apply_import_zip`` runs inside the live
+       gateway, so the dashboard's notification sink could append to that file first
+       and the unlink took the operator's notification with it. Review's finding.
+    3. The destination is then created
+       ``O_CREAT|O_EXCL|O_WRONLY|O_APPEND|O_NOFOLLOW|O_BINARY`` and the validated
+       bytes are written. ``O_EXCL`` decides inside one syscall, so a name that
+       filled after the caller's ``is_file()`` check is refused rather than written
+       through -- a dangling symlink at that name included, which ``is_file()``
+       reports as absent and ``copy2`` followed, writing the archive's bytes outside
+       the data home.
+
+    Reading once is not an optimisation, it is what makes a whole class of defect
+    UNREPRESENTABLE rather than detected. The predecessor read the file twice --
+    validate, then install -- and four consecutive review rounds each found a
+    different way for the source to change inside that window: swapped for a symlink
+    to a credential, reopened by name, truncated so the second pass met a clean EOF
+    and reported success having installed fewer records than it validated. Each fix
+    closed one variant and the next round produced another, because a check can only
+    catch the case someone thought of. With the bytes held in memory there is no name
+    left to resolve and no handle left open, so there is nothing for another process
+    to swap, truncate or extend. The two loops below are two passes over the same
+    immutable bytes, which is safe for exactly the reason two passes over the FILE
+    were not.
+
+    That trade needs a number, not a preference, and the number is the destination's
+    own bound: see ``_NOTIFICATION_SOURCE_CAP``. Peak held is about twice the SOURCE
+    size rather than twice the cap -- measured at 15.9 MiB for the 8.3 MB
+    product-bounded worst case and 1.0 MiB for a realistic 207-record file, against
+    the 128 MiB this same file already accepts for a SINGLE record. A source over the
+    cap is refused with its size named -- never truncated, never partially imported,
+    because a silently dropped tail is the defect being removed wearing a hat.
+
+    No temporary file, deliberately, and this is the second review finding: a temp
+    file in the data home is published through a NAME, and a same-user process that
+    can list that directory can swap what the name holds between the write and the
+    publish -- which links bytes this function never validated into place as
+    ``notifications.jsonl``. The mitigations for that are inode verification on both
+    ends plus a non-hardlink fallback (``pinned_fs.put_back_no_clobber`` is the
+    repo's audited version, and its own docstring notes the landed check narrows the
+    window rather than closing it). Writing straight to an ``O_EXCL`` destination
+    needs none of it: there is no intermediate name to swap.
+
+    What this does NOT close: everything on the DESTINATION side. ``O_EXCL`` refuses a
+    name that filled, ``O_APPEND`` keeps a concurrent notification from being
+    overwritten, and both remain necessary -- the live file has other writers and
+    reading the source once says nothing about them. Only the read window is gone.
+
+    Records are written verbatim -- what is validated is the source's bytes, never a
+    decoded form of them -- with a single repair: an unterminated final record gains
+    a terminator. That is not cosmetic once the write is record-wise.
+    ``_persist_notification`` appends ``json.dumps(note) + "\\n"``, so the first
+    notification after the restore would otherwise glue onto an unterminated last
+    line and produce one line that parses as neither row. It is the same repair the
+    merge makes through ``dst_unterminated``.
+    """
+    # `_notification_key`'s result is discarded -- it is called for the
+    # `UndecodableRecord` it raises, which its own docstring documents as how the
+    # encoding property is enforced. Reusing the merge's predicate rather than
+    # inlining a second decode is what keeps the two branches' acceptance criteria
+    # identical, and a second decode is exactly how they drifted apart in the first
+    # place.
+    #
+    # The SOURCE is resolved exactly once and read exactly once. The revision before
+    # this one opened the name once per pass, and between the two a running agent
+    # could replace the extracted file with a symlink to `.env`: the second open
+    # followed it and the secret landed in an agent-readable `notifications.jsonl`.
+    # `O_NOFOLLOW` refuses a link at the name instead of following it -- consistent
+    # with `_backup_and_copy`, which already skips a symlinked file coming out of an
+    # archive -- and reading once removes the second resolution the flag was
+    # protecting.
+    #
+    # `O_NONBLOCK` closes the other way that by-name selection misleads this open,
+    # which review did not name: the caller chose this branch on `is_file()`, and a
+    # name that became a FIFO afterwards would block the open forever and hang the
+    # restore rather than failing it. The kind is then judged on the DESCRIPTOR with
+    # `fstat`, NOT by re-checking the name -- a second by-name check would be the
+    # same mistake one layer down, whereas a held descriptor cannot be swapped.
+    src_flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    # 0o666 so the kernel applies the umask, giving the same mode as the `open(path,
+    # "a")` in `_persist_notification`: a restored file must not be tighter than one
+    # the product wrote itself.
+    #
+    # `O_APPEND` because the dashboard's notification sink writes to this same file
+    # with it, and its append goes to end-of-file while an ordinary write goes to
+    # THIS handle's offset. Buffered, that offset is stale by the time it flushes, so
+    # a notification delivered mid-copy was overwritten by the flush. Review's
+    # finding. With `O_APPEND` every write lands at end-of-file, so the two writers
+    # interleave instead of clobbering. On the fresh file `O_EXCL` guarantees, it
+    # changes nothing about the ordinary outcome.
+    #
+    # `O_BINARY` on BOTH, because `os.open` is the one API here that can be in text
+    # mode: the repo documents it as required on Windows and every sibling passes it,
+    # `crash_dump_store.py` reaching for this exact read-flag triple. A no-op on
+    # POSIX, where the constant does not exist. It is a CONVENTION fix and not a
+    # corruption fix -- the corruption a review lane described is refuted by
+    # `test_a_clean_source_is_copied_record_for_record`, which asserts byte-exact
+    # `\\r\\n` survival through these very descriptors and passes on the Windows lane.
+    dst_flags = (
+        os.O_CREAT
+        | os.O_EXCL
+        | os.O_WRONLY
+        | os.O_APPEND
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+    written = 0
+    opened_dst = False
+    try:
+        # No platform floor is attempted here. A platform with no `O_NOFOLLOW` to give
+        # never reaches this function: `_copy_notifications` refuses the whole copy up
+        # front, because a by-name `is_reparse_point` check followed by a by-name open
+        # is a check-to-open window and `fstat`'s `S_ISREG` does not close it -- a
+        # reparse point resolving to a regular `.env` passes it. So this open always
+        # carries a real `O_NOFOLLOW` and the refusal is decided by the open itself.
+        # An `lstat`-then-`fstat` identity comparison is deliberately NOT done -- that
+        # one pretends to close a window it merely narrows.
+        with os.fdopen(os.open(src_path, src_flags), "rb") as src:
+            if not _stat.S_ISREG(os.fstat(src.fileno()).st_mode):
+                raise OSError("source is not a regular file")
+            # ONE read of the file, and the file is not touched again. Chunked, and
+            # that is not incidental: `read(cap + 1)` in one call PREALLOCATES a
+            # buffer the size of the cap, so an 8 MB source cost 32 MiB and the peak
+            # was a function of the limit rather than of the file. Measured, which is
+            # the only reason it was noticed. Accumulating 1 MiB at a time keeps the
+            # peak proportional to the actual source.
+            #
+            # The cap is enforced on bytes ALREADY READ, not on a separately-stated
+            # size: `st_size` can be stale by the time it is compared, and the bytes
+            # in hand cannot be. Enforced inside the loop, so an oversized source is
+            # abandoned as soon as it crosses the line instead of being materialised
+            # first.
+            acc = bytearray()
+            while True:
+                chunk = src.read(1 << 20)
+                if not chunk:
+                    break
+                if len(acc) + len(chunk) > _NOTIFICATION_SOURCE_CAP:
+                    raise OSError(
+                        f"notification source is at least "
+                        f"{len(acc) + len(chunk)} bytes, over the "
+                        f"{_NOTIFICATION_SOURCE_CAP} byte limit -- refusing rather "
+                        "than importing part of it"
+                    )
+                acc.extend(chunk)
+            blob = bytes(acc)
+        # Everything below reads MEMORY. The two loops are two passes over the same
+        # immutable bytes, which is what makes them safe where two passes over the FILE
+        # were not: nothing between them can swap the source for a symlink, truncate it,
+        # or append to it, because there is no name left to resolve and no file handle
+        # left open. The window is not detected here, it is unrepresentable.
+        #
+        # Framing goes through `strict_raw_records` over a `BytesIO` rather than a
+        # hand-rolled split, so the record boundaries are the SAME implementation the
+        # merge branch uses. A second splitter is how two paths drift apart, which is
+        # the defect this whole change exists to fix.
+        with io.BytesIO(blob) as buf:
+            for record in strict_raw_records(buf, src_path, cap=_NOTIFICATION_RECORD_CAP):
+                _notification_key(record, src_path)
+        with os.fdopen(os.open(dst_path, dst_flags, 0o666), "wb") as out:
+            opened_dst = True
+            with io.BytesIO(blob) as buf:
+                for record in strict_raw_records(buf, src_path, cap=_NOTIFICATION_RECORD_CAP):
+                    out.write(record if record.endswith(_TERMINATORS) else record + b"\n")
+                    written += 1
+    except (OSError, UnreadableRecord) as exc:
+        # Two outcomes, told apart by whether the destination was ever created:
+        # nothing written at all (a bad archive, a refused source, or a name that
+        # filled after the caller's check), or a prefix that STAYS. Every record in a
+        # prefix passed validation, and unlinking is what took a concurrent writer's
+        # file in the revision review blocked, so the count is named instead.
+        #
+        # `_safe_name` on the PATH because a bundle chooses its own inner root, so an
+        # archive-derived path can carry ANSI controls and printing one raw lets a
+        # hostile archive overwrite the lines right above the operator's prompt. The
+        # EXCEPTION does not need it, for the reason `_merge_notifications` states:
+        # both types this arm catches already render an embedded path with repr-style
+        # escaping.
+        tail = f"{written} imported" if opened_dst else "notifications not imported"
+        print(f"  ⚠️  Could not copy {_safe_name(src_path)}: {exc} — {tail}")
+        raise
 
 
 def _backup_and_copy(
@@ -3908,8 +4344,19 @@ def _do_merge(
             if dn.is_file():
                 _merge_notifications(sn, dn)
             else:
-                shutil.copy2(str(sn), str(dn))
-                print("  Notifications: copied")
+                # Not `copy2`: a byte-exact copy installs records the live file's
+                # own reader refuses, and that reader loses the whole file to one
+                # of them. Same abort posture as the merge branch above.
+                #
+                # The platform refusal is NOT that abort: it says this platform can
+                # never do this safely, not that this archive is bad, so it skips one
+                # component loudly and lets the rest of the restore proceed. Reported
+                # rather than swallowed -- a silent skip is the bug class being fixed.
+                try:
+                    _copy_notifications(sn, dn)
+                    print("  Notifications: copied")
+                except NotificationCopyUnsupported as exc:
+                    print(f"  ⚠️  Notifications: SKIPPED -- {exc}")
         print("  ✅ notifications")
 
     if _want(components, "security"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -98,6 +98,19 @@ requires_symlinks = pytest.mark.skipif(
     reason="creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows",
 )
 
+# Captured at import, BEFORE any test can monkeypatch the constant away: tests that
+# simulate the flag's absence must not be confused with a platform that truly lacks it.
+_HAS_O_NOFOLLOW = bool(getattr(os, "O_NOFOLLOW", 0))
+
+requires_o_nofollow = pytest.mark.skipif(
+    not _HAS_O_NOFOLLOW,
+    reason=(
+        "notification import refuses outright without O_NOFOLLOW, because a by-name "
+        "reparse check followed by a by-name open is a check-to-open window; the "
+        "refusal itself is covered by TestNotificationCopyRefusalWithoutONofollow"
+    ),
+)
+
 
 def _find_posix_test_shell() -> str | None:
     """Return a real POSIX shell without mistaking Windows' WSL launcher for one."""

--- a/test/test_portability.py
+++ b/test/test_portability.py
@@ -13,6 +13,8 @@ from unittest.mock import patch
 
 import pytest
 
+from conftest import requires_o_nofollow
+from kiro_crew.jsonl_util import UnreadableRecord
 from kiro_crew.portability import (
     EXPORT_EXCLUDE,
     _is_excluded,
@@ -459,6 +461,73 @@ class TestImportMerge:
             # Should still have only 1 entry (same ts)
             lines = [line for line in (target / "notifications.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
             assert len(lines) == 1
+        finally:
+            os.unlink(str(zip_path))
+
+    @requires_o_nofollow
+    def test_import_merge_notifications_refuses_an_undecodable_record(
+        self, patched_config_dir, tmp_path
+    ):
+        """The copy branch: no live file yet, so the merge branch never runs.
+
+        ``apply_import_zip`` reports ``notifications (copied)`` in its summary and
+        the dashboard handler turns that into ``ok: True``, so accepting the
+        record here tells an API caller the import succeeded while the live
+        reader -- which decodes the whole file inside one ``try`` and returns
+        ``[]`` -- has lost every row it will ever load. The refusal therefore has
+        to RAISE, and must leave no partially copied file behind.
+        """
+        (patched_config_dir / "notifications.jsonl").write_bytes(
+            b'{"ts":"1700000001","title":"ok"}\n{"ts":"1700000002","title":"\xff"}\n'
+        )
+        zip_path = self._make_export(patched_config_dir)
+        try:
+            target = tmp_path / "target_mc"
+            target.mkdir()
+            assert not (target / "notifications.jsonl").exists()
+
+            with patch("kiro_crew.portability.config_dir", return_value=target):
+                with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+                    with pytest.raises(UnreadableRecord):
+                        apply_import_zip(zip_path, mode="merge")
+
+            assert not (target / "notifications.jsonl").exists(), (
+                "an unvalidated prefix was installed where the reader will find it"
+            )
+        finally:
+            os.unlink(str(zip_path))
+
+    def test_import_reports_the_platform_skip_instead_of_claiming_a_copy(
+        self, patched_config_dir, tmp_path, monkeypatch
+    ):
+        """Where ``O_NOFOLLOW`` does not exist the import skips notifications and SAYS so.
+
+        The summary is what the dashboard handler turns into a result for an API caller,
+        so this is the one place the refusal could go silent: reporting
+        ``notifications (copied)`` for a copy that did not happen, or omitting the item
+        entirely, would be the same bug class this change removes -- telling a caller the
+        import succeeded when the records are not there.
+
+        The rest of the import must still complete. A missing platform primitive is not a
+        reason to refuse the other components.
+        """
+        zip_path = self._make_export(patched_config_dir)
+        try:
+            target = tmp_path / "target_mc"
+            target.mkdir()
+            monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+            with patch("kiro_crew.portability.config_dir", return_value=target):
+                with patch.dict(os.environ, {"KIROCREW_HOME": str(target)}):
+                    summary = apply_import_zip(zip_path, mode="merge")
+
+            items = summary["items"]
+            notif = [i for i in items if i.startswith("notifications")]
+            assert notif, f"the skip was not reported at all: {items}"
+            assert "SKIPPED" in notif[0], notif[0]
+            assert "O_NOFOLLOW" in notif[0], notif[0]
+            assert not (target / "notifications.jsonl").exists()
+            assert len(items) > 1, f"the whole import stopped on a platform refusal: {items}"
         finally:
             os.unlink(str(zip_path))
 

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -7,11 +7,13 @@ import json
 import os
 import sqlite3
 import tarfile
+import threading
+import time
 from pathlib import Path
 
 import pytest
 
-from conftest import requires_symlinks
+from conftest import requires_o_nofollow, requires_symlinks
 from kiro_crew import snapshot as snapshot_mod
 from kiro_crew.jsonl_util import OversizedRecord, UndecodableRecord, UnreadableRecord
 from kiro_crew.snapshot import restore_main, snapshot_main
@@ -1853,8 +1855,899 @@ class TestNotificationMergeWriteSideContract:
         assert dst.read_bytes() == self.LIVE, "the retry appended something"
 
 
+# ── Issue #8181: the copy branch installed unvalidated notification bytes ──────
+
+
+class _NotificationCopyFixtures:
+    """Shared fixtures for the copy branch, held apart from any skip marker.
+
+    A mixin rather than a base test class: the copy-behaviour tests cannot run where
+    ``O_NOFOLLOW`` is absent (the copy refuses outright there, by design), while the
+    refusal tests must run EVERYWHERE. A skip on a shared base would be inherited by
+    both, so the marker goes on one subclass and the fixtures live here.
+    """
+
+    GOOD = b'{"ts":"2026-03-01T00:00:00Z","msg":"snap"}\n'
+    MORE = b'{"ts":"2026-03-02T00:00:00Z","msg":"snap2"}\n'
+    BAD_UTF8 = b'{"ts":"2026-03-03T00:00:00Z","msg":"\xff"}\n'
+
+    def _snap(self, tmp_path, src_bytes: bytes) -> tuple[Path, Path]:
+        """An extracted-snapshot staging dir and a data home with no live file."""
+        snap = tmp_path / "snap"
+        home = tmp_path / "home"
+        snap.mkdir(parents=True)
+        home.mkdir(parents=True)
+        (snap / "notifications.jsonl").write_bytes(src_bytes)
+        return snap, home
+
+    def _merge(self, snap: Path, home: Path) -> None:
+        """Drive the real restore, so the CALL SITE is under test, not the helper."""
+        snapshot_mod._do_merge(
+            snap, home, ["notifications"], allow_unpinned=bool(unpinnable_argv())
+        )
+
+
+@requires_o_nofollow
+class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
+    """The OTHER branch of the same ``if``, which validated nothing.
+
+    ``_merge_notifications`` runs when a live ``notifications.jsonl`` exists. When
+    one does not -- a fresh install, a first restore -- the restore took
+    ``shutil.copy2`` instead, so the same snapshot that ABORTED the restore in one
+    case was installed silently in the other. A byte-exact copy is correct as a
+    copy and that is the defect: it faithfully installs bytes the destination's own
+    reader refuses, and that reader loses the WHOLE file to one of them.
+
+    Every fixture is real bytes on a real file, for the reason the merge class
+    states: a synthesized ``UnicodeDecodeError`` routes the copy down a healthy
+    path and proves nothing. The undecodable record is measured as INSTALLED
+    without the fix -- ``strict_raw_records`` frames and bounds records but does
+    not decode, so framing alone reproduces ``copy2``'s behaviour exactly.
+    """
+
+    def test_an_undecodable_record_is_never_installed(self, tmp_path, capsys):
+        """The whole point, and it must reach the CALLER, not only stdout.
+
+        ``apply_import_zip`` appends ``notifications (copied)`` to its summary and
+        the dashboard handler answers ``ok: True``; neither sees a print. So the
+        posture is the merge branch's -- abort by raising -- and the success lines
+        must not be reached.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.BAD_UTF8)
+        with pytest.raises(UndecodableRecord):
+            self._merge(snap, home)
+        assert not (
+            home / "notifications.jsonl"
+        ).exists(), "a partially copied file was left where the reader will find it"
+        out = capsys.readouterr().out
+        assert "Notifications: copied" not in out, "reported success on a refused copy"
+        assert "✅ notifications" not in out
+        assert "not valid UTF-8" in out
+
+    def test_the_reader_loads_every_record_the_copy_installs(self, tmp_path, monkeypatch):
+        """The consequence, asserted through the reader that actually loses the file.
+
+        This is the test that separates a real fix from a no-op. Framing the
+        records without decoding them installs the bad byte just as ``copy2`` did,
+        and every byte-level assertion above still passes; only loading the
+        installed file through ``_load_notifications`` shows it. Measured on the
+        unfixed branch: 0 rows from a file holding 2 valid records, then the next
+        rewrite persists that empty view.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.MORE + self.BAD_UTF8)
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        with pytest.raises(UndecodableRecord):
+            self._merge(snap, home)
+
+        # Same source without the bad record: the copy must be fully loadable.
+        clean, home2 = self._snap(tmp_path / "clean", self.GOOD + self.MORE)
+        monkeypatch.setenv("KIROCREW_HOME", str(home2))
+        self._merge(clean, home2)
+        from kiro_crew.dashboard import state as dashboard_state
+
+        assert len(dashboard_state._load_notifications()) == 2
+
+    def test_a_clean_source_is_copied_record_for_record(self, tmp_path):
+        """Byte-exactness is the property ``copy2`` had and the fix must keep.
+
+        A ``\\r\\n`` terminator survives and a bare ``\\r`` inside the file ends a
+        record without being rewritten -- the text-mode round trip that #7771
+        removed from the merge is not reintroduced here.
+        """
+        src_bytes = b'{"ts":"1","msg":"a"}\r\n{"ts":"2","msg":"b"}\r{"ts":"3","msg":"c"}\n'
+        snap, home = self._snap(tmp_path, src_bytes)
+        self._merge(snap, home)
+        assert (home / "notifications.jsonl").read_bytes() == src_bytes
+
+    def test_an_unterminated_final_record_gains_a_terminator(self, tmp_path):
+        """Otherwise the first notification after the restore glues onto it.
+
+        ``_persist_notification`` appends ``json.dumps(note) + "\\n"``, so an
+        unterminated last line plus that append is one line that parses as neither
+        row. The merge branch makes the same repair through ``dst_unterminated``;
+        writing record-wise makes it this branch's job too.
+        """
+        snap, home = self._snap(tmp_path, b'{"ts":"1","msg":"a"}\n{"ts":"2","msg":"b"}')
+        self._merge(snap, home)
+        installed = (home / "notifications.jsonl").read_bytes()
+        assert installed.endswith(b"\n")
+        assert installed == b'{"ts":"1","msg":"a"}\n{"ts":"2","msg":"b"}\n'
+
+    def test_an_oversized_record_installs_nothing(self, tmp_path, monkeypatch):
+        """The cap is a memory bound, and its refusal owes the same all-or-nothing.
+
+        Pinned separately from the encoding case because it is a DIFFERENT
+        exception out of the same reader, and an ``except`` narrowed to the
+        encoding one would leave this reason escaping past the cleanup.
+        """
+        monkeypatch.setattr(snapshot_mod, "_NOTIFICATION_RECORD_CAP", 64)
+        snap, home = self._snap(tmp_path, self.GOOD + b'{"msg":"' + b"x" * 200 + b'"}\n')
+        with pytest.raises(OversizedRecord):
+            self._merge(snap, home)
+        assert not (home / "notifications.jsonl").exists()
+
+    def test_a_concurrent_notification_is_not_deleted_by_the_rollback(self, tmp_path, monkeypatch):
+        """A file this call did not create must survive its refusal.
+
+        Review's finding, and the slip it names is one an exclusive create invites:
+        creating the live file with ``O_EXCL`` proves this call CREATED it, not that
+        it is the only thing that has since written to it. ``apply_import_zip`` runs
+        inside the live gateway, so the dashboard's notification sink can append to
+        a file the copy just created -- and the rollback for a later bad record then
+        deleted that operator's notification along with the prefix.
+
+        Now structural rather than defended: the whole source is validated before the
+        destination is created, so the ordinary refusal has nothing to roll back. The
+        delivery is injected at the validation of the record that aborts, which is
+        the interleaving that broke the earlier revision. Measured on it, the live
+        file and the delivered note are both gone.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.BAD_UTF8)
+        live = home / "notifications.jsonl"
+        delivered = b'{"ts":"2026-03-09T00:00:00Z","msg":"delivered during the restore"}\n'
+        real_key = snapshot_mod._notification_key
+        seen: list[bytes] = []
+
+        def keyed(record, path):
+            seen.append(record)
+            if len(seen) == 2:
+                # What `_persist_notification` does, in its own mode.
+                with open(live, "a", encoding="utf-8") as f:
+                    f.write(delivered.decode())
+            return real_key(record, path)
+
+        monkeypatch.setattr(snapshot_mod, "_notification_key", keyed)
+        with pytest.raises(UndecodableRecord):
+            self._merge(snap, home)
+        assert live.is_file(), "the rollback deleted a file this call did not create"
+        assert live.read_bytes() == delivered, "the delivered notification was altered or lost"
+
+    def test_a_live_file_that_appears_mid_copy_is_not_replaced(self, tmp_path):
+        """A clean source must not clobber a name that filled while it validated.
+
+        The branch was chosen because no live file existed; by publish time one can.
+        Replacing it would delete whatever the dashboard persisted in between, so
+        the publish refuses and leaves the operator's file exactly as it found it.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        live = home / "notifications.jsonl"
+        appeared = b'{"ts":"2026-03-09T00:00:00Z","msg":"appeared"}\n'
+        live.write_bytes(appeared)
+        with pytest.raises(FileExistsError):
+            snapshot_mod._copy_notifications(snap / "notifications.jsonl", live)
+        assert live.read_bytes() == appeared
+
+    def test_the_data_home_gains_nothing_but_the_notifications_file(self, tmp_path):
+        """No intermediate artifact, which is the second review finding's whole point.
+
+        A temp file in the data home is published through a NAME, and a same-user
+        process that can list the directory can swap what that name holds between
+        the write and the publish. Writing straight to an ``O_EXCL`` destination
+        needs no such name. Asserted as "the directory holds nothing else" rather
+        than "no file called .tmp", so any future intermediate is caught whatever it
+        is named.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.BAD_UTF8)
+        with pytest.raises(UndecodableRecord):
+            self._merge(snap, home)
+        assert sorted(p.name for p in home.iterdir()) == []
+
+        clean, home2 = self._snap(tmp_path / "clean", self.GOOD)
+        self._merge(clean, home2)
+        assert sorted(p.name for p in home2.iterdir()) == ["notifications.jsonl"]
+
+    def test_the_installed_file_is_no_tighter_than_one_the_product_writes(self, tmp_path):
+        """A restored file the dashboard cannot manage is its own outage.
+
+        ``os.open`` takes an explicit mode, so this is a real choice and not a
+        default: 0o666 lets the kernel apply the umask, which is what the plain
+        ``open(path, "a")`` in ``_persist_notification`` gets.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        self._merge(snap, home)
+        by_product = home / "written-by-the-product.jsonl"
+        with open(by_product, "a", encoding="utf-8") as f:
+            f.write('{"ts":"1"}\n')
+        installed = (home / "notifications.jsonl").stat().st_mode & 0o777
+        assert installed == by_product.stat().st_mode & 0o777, oct(installed)
+
+    # ── read once: the precondition, not the consequence ──────────────────
+
+    def test_a_source_truncated_after_the_read_cannot_affect_the_install(
+        self, tmp_path, monkeypatch
+    ):
+        """Replaces a retired test, and the reversal is the point.
+
+        The predecessor read the file twice and this scenario was its worst outcome: a
+        source truncated between the passes gave pass 2 a clean EOF, so nothing raised,
+        the success line printed, and the install was silently short -- measured at 5
+        records validated, 2 installed. That test asserted the damage was BOUNDED.
+
+        Reading once makes the scenario unrepresentable rather than bounded, so the
+        same setup now asserts the opposite: truncating the source after it has been
+        read changes nothing, because there is no name left to resolve and no handle
+        left open. This pins the PRECONDITION -- one read -- and reddens on any design
+        that goes back to the file, which "no partial install" would not, since that
+        passes trivially once the window is gone.
+
+        The truncation is injected at the first validation call, which is after the
+        read and before the write.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.MORE)
+        source = snap / "notifications.jsonl"
+        real_key = snapshot_mod._notification_key
+        fired: list[int] = []
+
+        def keyed(record, path):
+            if not fired:
+                fired.append(1)
+                source.write_bytes(b"")  # the source is gone from here on
+            return real_key(record, path)
+
+        monkeypatch.setattr(snapshot_mod, "_notification_key", keyed)
+        self._merge(snap, home)
+
+        assert fired, "the injection point never ran, so this test proved nothing"
+        installed = (home / "notifications.jsonl").read_bytes()
+        assert installed == self.GOOD + self.MORE, "the install followed the file, not the bytes"
+
+    # ── the whole-file cap: the load-bearing addition ──────────────────────
+
+    def test_a_source_over_the_cap_is_refused_with_its_size_named(self, tmp_path, monkeypatch):
+        """Over-cap must REFUSE, loudly, and install nothing.
+
+        A whole-file cap is what single-read needs and streaming did not: the
+        per-record cap bounds one record, not a file made of many, and the source is
+        archive-derived so nothing bounds it from outside. The failure mode to avoid is
+        not a crash -- it is a cap that quietly drops the tail, which would rebuild the
+        silent-partial-install defect this redesign removes, one layer up.
+
+        The cap is patched small rather than writing 32 MiB to disk. The size must
+        appear in the message so an operator can tell an over-cap refusal from a
+        corrupt archive without reading code.
+        """
+        monkeypatch.setattr(snapshot_mod, "_NOTIFICATION_SOURCE_CAP", 64)
+        oversized = self.GOOD * 4
+        assert len(oversized) > 64
+        snap, home = self._snap(tmp_path, oversized)
+
+        with pytest.raises(OSError) as caught:
+            self._merge(snap, home)
+        message = str(caught.value)
+        assert str(len(oversized)) in message, f"the size was not named: {message}"
+        assert "64" in message, f"the limit was not named: {message}"
+        assert not (
+            home / "notifications.jsonl"
+        ).exists(), "an over-cap source was partially installed instead of refused"
+
+    def test_the_source_cap_is_the_value_this_design_was_measured_for(self):
+        """A ratchet on the cap, because the cap is the part that can actually break.
+
+        Every other property here is now structural -- there is no window to reopen --
+        so the live risk is somebody raising this number for convenience on a large
+        archive and reintroducing an unbounded hold. This assertion goes red on that
+        day, which is the day it matters.
+
+        32 MiB is ~4x the product-bounded worst case (400 records at the largest
+        record observed on a live install, 8,316,000 bytes) and a quarter of the
+        per-record cap this same file already accepts for ONE record. Peak held is
+        about twice the cap. Raising it is a memory decision, so it should require
+        editing a test that says so.
+        """
+        assert snapshot_mod._NOTIFICATION_SOURCE_CAP == 32 * 1024 * 1024
+        assert snapshot_mod._NOTIFICATION_SOURCE_CAP < snapshot_mod._NOTIFICATION_RECORD_CAP
+
+    # ── one resolution per path (the class behind three findings) ──────────
+
+    @requires_symlinks
+    def test_a_source_swapped_for_a_symlink_between_the_passes_is_not_followed(self, tmp_path):
+        """The second by-name open was the finding; the descriptor is the fix.
+
+        A running agent replaces the extracted notification file with a symlink to
+        a credential after the first pass has validated it. The earlier revision
+        opened the NAME again for the copy, followed the link, and wrote the secret
+        into an agent-readable ``notifications.jsonl``. Reusing the held descriptor
+        makes the swap invisible, so the assertion is that the archive's own bytes
+        land and the secret does not -- not that the copy is refused.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.MORE)
+        source = snap / "notifications.jsonl"
+        secret = tmp_path / "dot-env"
+        secret.write_bytes(b'{"ts":"1","msg":"AWS_SECRET_ACCESS_KEY=hunter2"}\n')
+        real_key = snapshot_mod._notification_key
+        seen: list[bytes] = []
+
+        def keyed(record, path):
+            seen.append(record)
+            # Pass 1 has validated both records; swap before pass 2 would re-resolve.
+            if len(seen) == 2:
+                source.unlink()
+                source.symlink_to(secret)
+            return real_key(record, path)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(snapshot_mod, "_notification_key", keyed)
+            self._merge(snap, home)
+
+        installed = (home / "notifications.jsonl").read_bytes()
+        assert b"hunter2" not in installed, "the swapped symlink was followed"
+        assert installed == self.GOOD + self.MORE
+
+    @requires_symlinks
+    def test_a_source_that_is_already_a_symlink_is_refused(self, tmp_path):
+        """``is_file()`` follows links, so the branch is entered on one.
+
+        ``O_NOFOLLOW`` refuses at the open rather than reading the target, which is
+        the same posture ``_backup_and_copy`` already takes for a symlinked file
+        coming out of an archive.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        source = snap / "notifications.jsonl"
+        secret = tmp_path / "dot-env"
+        secret.write_bytes(b'{"ts":"1","msg":"AWS_SECRET_ACCESS_KEY=hunter2"}\n')
+        source.unlink()
+        source.symlink_to(secret)
+        with pytest.raises(OSError):
+            self._merge(snap, home)
+        assert not (home / "notifications.jsonl").exists()
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="needs os.mkfifo")
+    def test_a_source_that_became_a_fifo_fails_instead_of_hanging(self, tmp_path):
+        """Pins ``O_NONBLOCK``. Not a review finding -- found by auditing the span.
+
+        The caller selected this branch on ``is_file()``, which is False for a FIFO,
+        so reaching one means the name changed afterwards. Without ``O_NONBLOCK`` the
+        open blocks forever waiting for a writer and the restore HANGS, which is
+        worse than failing because a hang reports nothing at all. Dropping the flag
+        makes this test TIME OUT rather than fail, and the timeout is the evidence.
+
+        Calls the helper directly, since ``_do_merge`` cannot reach a FIFO through
+        its own ``is_file()`` gate -- the hazard is the name changing after it.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        source = snap / "notifications.jsonl"
+        source.unlink()
+        os.mkfifo(source)
+        with pytest.raises(OSError):
+            snapshot_mod._copy_notifications(source, home / "notifications.jsonl")
+        assert not (home / "notifications.jsonl").exists()
+
+    @pytest.mark.skipif(not os.path.exists("/dev/null"), reason="needs a character device")
+    def test_a_non_regular_source_is_refused_not_read_as_empty(self, tmp_path):
+        """Pins the ``S_ISREG`` judgement on the descriptor, which ``seek`` does not.
+
+        Written after the mutation harness showed the first version of this coverage
+        was passing for the wrong reason: a FIFO is caught by ``seek`` failing on a
+        pipe, so removing the ``S_ISREG`` check reddened nothing. A character device
+        is the case ``seek`` cannot catch -- it is seekable, so without the check the
+        read simply returns EOF, and the restore CREATES AN EMPTY
+        ``notifications.jsonl`` and reports success. That is the outcome being
+        refused: not a crash, a silent claim to have imported a history that is gone.
+        """
+        dst = tmp_path / "notifications.jsonl"
+        with pytest.raises(OSError):
+            snapshot_mod._copy_notifications(Path("/dev/null"), dst)
+        assert not dst.exists(), "an empty notification file was installed and called success"
+
+    def test_a_notification_delivered_during_the_copy_survives(self, tmp_path, monkeypatch):
+        """``O_APPEND``, and it needs a CONCURRENT writer to be observable at all.
+
+        The dashboard's sink appends with ``O_APPEND``, so its write goes to
+        end-of-file; an ordinary write goes to this handle's own offset, which is
+        stale once buffered. The flush then wrote over the delivered row. A test that
+        only copies into an empty destination cannot tell the two apart -- every
+        byte-level assertion passes either way -- so the delivery has to happen
+        mid-copy. Measured on the pre-fix flags: 152 bytes with the row gone, against
+        203 with both writers' records present.
+
+        The seam is the DESTINATION OPEN, not a per-record hook. The single-read
+        redesign calls ``_notification_key`` once per record during validation and not
+        at all during the write, so the old per-record injection point went dead and
+        this test silently stopped delivering anything -- it passed while proving
+        nothing, which is the same failure mode as a mutation that never applies.
+        Injecting when the ``O_CREAT`` open happens puts the delivery exactly where it
+        belongs: after the live file exists, before this function's writes flush.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD + self.MORE)
+        live = home / "notifications.jsonl"
+        delivered = b'{"ts":"2026-03-09T00:00:00Z","msg":"delivered-mid-copy"}\n'
+        real_open = os.open
+
+        def opening(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if flags & os.O_CREAT:
+                # What `_persist_notification` does, in its own mode, the instant the
+                # live file exists.
+                with open(live, "a", encoding="utf-8") as f:
+                    f.write(delivered.decode())
+            return fd
+
+        monkeypatch.setattr(os, "open", opening)
+        self._merge(snap, home)
+
+        body = live.read_bytes()
+        assert delivered in body, "the delivered notification was overwritten"
+        assert self.GOOD in body and self.MORE in body, "an archive record was lost"
+        body.decode("utf-8")
+
+    def test_both_descriptors_ask_for_binary_mode(self, tmp_path, monkeypatch):
+        """``os.open`` is the one API here that can be in TEXT mode.
+
+        This is a CONVENTION fix, not a corruption fix, and the difference is worth
+        recording. A review lane held that the missing flag corrupts records on
+        Windows; ``test_a_clean_source_is_copied_record_for_record`` asserts byte-exact
+        ``\\r\\n`` survival through these very descriptors, carries no skip marker, and
+        passed on the Windows lane -- so the mechanism was tested and did not occur.
+        What remains is that every sibling passes the flag (``crash_dump_store`` uses
+        this exact read-flag triple) and this one did not.
+
+        Asserted on the FLAGS, because what they guard against cannot be reproduced on
+        a POSIX host: ``O_BINARY`` does not exist here, so its value is simulated and
+        the assertion is that both opens carry it. The helper is called directly rather
+        than through ``_do_merge`` so that every recorded ``os.open`` is one of this
+        function's two and the count can be asserted exactly.
+        """
+        monkeypatch.setattr(os, "O_BINARY", 1 << 20, raising=False)
+        seen: list[int] = []
+        real_open = os.open
+
+        def recording(path, flags, *args, **kwargs):
+            seen.append(flags)
+            return real_open(path, flags, *args, **kwargs)
+
+        snap, home = self._snap(tmp_path, self.GOOD)
+        monkeypatch.setattr(os, "open", recording)
+        snapshot_mod._copy_notifications(snap / "notifications.jsonl", home / "notifications.jsonl")
+
+        assert len(seen) == 2, f"expected exactly a source and a destination open: {seen}"
+        assert all(
+            f & os.O_BINARY for f in seen
+        ), f"an open in this span did not ask for binary mode: {[hex(f) for f in seen]}"
+
+    def test_a_note_delivered_during_the_copy_survives_the_READER(self, tmp_path, monkeypatch):
+        """The one that matters: `O_APPEND` saves the bytes and loses the row anyway.
+
+        `O_APPEND` stops a concurrent notification being OVERWRITTEN, and then orders it
+        BEFORE the archive's rows -- the dashboard's append reaches end-of-file
+        immediately while this copy's writes are still buffered. `_load_notifications`
+        keeps the last `_MAX_PERSISTED_NOTIFICATIONS` rows POSITIONALLY, not the newest
+        by timestamp, so importing a full 200-record history pushes the live row out of
+        the window. Measured before the fix: line 0 of 201, and the reader returned 200
+        rows without it.
+
+        Asserted on the ORDERING, not on who wins a race. The first version of this test
+        submitted the append and then checked the file, which passed with the
+        serialisation removed because the copy's remaining writes happened to finish
+        first -- a flaky test that proves nothing, caught by the mutation run. What makes
+        the guarantee observable is that the single worker CANNOT run the queued append
+        while the copy occupies it: the wait below times out with the fix and returns
+        immediately without it, because a free worker executes a trivial job at once.
+
+        The note is SUBMITTED to the executor rather than written inline, because that is
+        the product's own route and the only one the serialisation can order.
+        """
+        from kiro_crew.dashboard import state as dashboard_state
+
+        snap, home = self._snap(
+            tmp_path,
+            b"".join(
+                b'{"ts":"2026-01-%02dT00:00:00Z","msg":"archive-%d","kind":"agent"}\n'
+                % ((i % 28) + 1, i)
+                for i in range(dashboard_state._MAX_PERSISTED_NOTIFICATIONS)
+            ),
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        pool = dashboard_state._notification_io_executor()
+        note = {"ts": "2026-09-05T00:00:00Z", "msg": "LIVE-NOTE", "kind": "agent"}
+        ran_during_copy = threading.Event()
+        submitted: list[object] = []
+        real_open = os.open
+
+        def append_note() -> None:
+            dashboard_state._persist_notification(note)
+            ran_during_copy.set()
+
+        def opening(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if flags & os.O_CREAT and not submitted:
+                submitted.append(pool.submit(append_note))
+                # A FREE worker runs this in microseconds; a worker the copy is running
+                # on cannot run it at all until the copy returns.
+                ran_during_copy.wait(timeout=1.0)
+            return fd
+
+        monkeypatch.setattr(os, "open", opening)
+        self._merge(snap, home)
+
+        assert submitted, "the note was never queued, so this test proved nothing"
+        assert not ran_during_copy.is_set(), (
+            "the append ran while the copy was still writing, so the two are concurrent "
+            "rather than ordered"
+        )
+        # Drained BEFORE any teardown, deliberately. `monkeypatch.undo()` here reverts
+        # the patched `KIROCREW_HOME` while the append is still queued, so the worker
+        # resolves a different data home and writes the note somewhere this assertion
+        # never looks -- which reads exactly like the defect and is not it. FIFO, so
+        # waiting on a no-op drains the append ahead of it.
+        pool.submit(lambda: None).result()
+
+        rows = dashboard_state._load_notifications()
+        assert any(r.get("msg") == "LIVE-NOTE" for r in rows), (
+            "the live notification was ordered ahead of the archive and dropped by the "
+            f"reader's positional cap ({len(rows)} rows returned)"
+        )
+
+    def test_running_on_the_notification_worker_does_not_deadlock(self, tmp_path, monkeypatch):
+        """The serialisation must not wait for a queue only it can drain.
+
+        If the copy is ever reached from ON the single worker, submitting to that worker
+        blocks for a job that cannot start until the submitter returns. The failure mode
+        is a HANG, not an error, so it is worth a test even though nothing reaches it
+        today: a deadlock inside a restore reports nothing at all.
+
+        Against a THROWAWAY pool with the same thread-name prefix, not the product's, so
+        that a regression wedges this test's worker rather than the shared one every
+        other test in the process depends on. The timeout turns the hang into a named
+        failure instead of a stalled suite.
+        """
+        import concurrent.futures
+
+        snap, home = self._snap(tmp_path, self.GOOD)
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        from kiro_crew.dashboard import state as dashboard_state
+
+        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="notif-io")
+        monkeypatch.setattr(dashboard_state, "_notification_io_pool", pool)
+        try:
+            future = pool.submit(
+                snapshot_mod._copy_notifications,
+                snap / "notifications.jsonl",
+                home / "notifications.jsonl",
+            )
+            future.result(timeout=15)
+        finally:
+            pool.shutdown(wait=False)
+        assert (home / "notifications.jsonl").read_bytes() == self.GOOD
+
+    def test_a_FRESH_gateway_still_orders_the_copy_against_a_delivery(self, tmp_path, monkeypatch):
+        """The writer is what makes the pool, so "no pool" never meant "no writer".
+
+        Review's finding, and the branch it names was an absence-reading: the copy asked
+        whether an executor existed and ran inline when none did. On a fresh gateway
+        nothing has persisted a notification yet, so a delivery arriving during the
+        restore CREATES the executor and appends through it, concurrently -- which puts
+        the live row back at line 0 of 201 and outside the reader's positional window.
+        Measured on the pre-fix branch: `append ran DURING the copy: True`, `note
+        position: [0] of 201`, `survives reader: False`.
+
+        Acquiring rather than asking closes it: the delivery gets the SAME executor the
+        copy is occupying and queues behind it. Asserted for the `pool is None` path
+        specifically, because that is the branch whose reasoning was wrong.
+        """
+        from kiro_crew.dashboard import state as dashboard_state
+
+        snap, home = self._snap(
+            tmp_path,
+            b"".join(
+                b'{"ts":"2026-01-%02dT00:00:00Z","msg":"archive-%d","kind":"agent"}\n'
+                % ((i % 28) + 1, i)
+                for i in range(dashboard_state._MAX_PERSISTED_NOTIFICATIONS)
+            ),
+        )
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        # A FRESH gateway: nothing has persisted a notification, so there is no pool.
+        monkeypatch.setattr(dashboard_state, "_notification_io_pool", None)
+        note = {"ts": "2026-09-05T00:00:00Z", "msg": "LIVE-NOTE", "kind": "agent"}
+        ran_during_copy = threading.Event()
+        fired: list[int] = []
+        real_open = os.open
+
+        def append_note() -> None:
+            dashboard_state._persist_notification(note)
+            ran_during_copy.set()
+
+        def opening(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            if flags & os.O_CREAT and not fired:
+                fired.append(1)
+                # The delivery sink's own route on a fresh gateway: it ACQUIRES the
+                # executor, creating it if the copy did not.
+                dashboard_state._notification_io_executor().submit(append_note)
+                ran_during_copy.wait(timeout=1.0)
+            return fd
+
+        monkeypatch.setattr(os, "open", opening)
+        self._merge(snap, home)
+
+        assert fired, "the delivery was never queued, so this test proved nothing"
+        assert not ran_during_copy.is_set(), (
+            "a delivery on a fresh gateway ran concurrently with the copy: 'no pool' "
+            "was read as 'no writer'"
+        )
+        dashboard_state._notification_io_executor().submit(lambda: None).result()
+        rows = dashboard_state._load_notifications()
+        assert any(
+            r.get("msg") == "LIVE-NOTE" for r in rows
+        ), f"the live notification was dropped by the positional cap ({len(rows)} rows)"
+
+    def test_an_import_failure_that_is_not_ImportError_is_not_swallowed(
+        self, tmp_path, monkeypatch
+    ):
+        """The narrowing itself, which the broad ``except`` made untestable.
+
+        ``except Exception`` turned "I could not check" into "there is nothing to check":
+        an import failing inside a live gateway for any reason other than absence would
+        have run the copy inline and lost the ordering with no signal. Widening the
+        clause back cannot be caught by any test that only exercises ``ImportError``,
+        because a wider except is a superset -- so this drives the case the narrowing
+        exists for and requires it to PROPAGATE.
+        """
+        import builtins
+
+        snap, home = self._snap(tmp_path, self.GOOD)
+        real_import = builtins.__import__
+
+        def failing(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "kiro_crew.dashboard" and "state" in (fromlist or ()):
+                raise RuntimeError("dashboard state failed to initialise")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", failing)
+        with pytest.raises(RuntimeError, match="failed to initialise"):
+            snapshot_mod._copy_notifications(
+                snap / "notifications.jsonl", home / "notifications.jsonl"
+            )
+
+    def test_an_unimportable_dashboard_falls_back_instead_of_failing(self, tmp_path, monkeypatch):
+        """The other absence-reading, narrowed to ``ImportError``.
+
+        A genuinely absent dashboard module is the CLI restore, which has no writer to
+        order against, so running inline is correct there. What was wrong was catching
+        ``Exception``: an import failing for any other reason inside a live gateway would
+        have degraded the ordering in silence. This asserts the narrow fallback still
+        works; it cannot assert ORDERING, because by construction there is no dashboard
+        to order against on this path.
+        """
+        import sys
+
+        snap, home = self._snap(tmp_path, self.GOOD)
+        # `None` in sys.modules makes the import raise ImportError, which is the exact
+        # branch under test rather than a stand-in for it.
+        monkeypatch.setitem(sys.modules, "kiro_crew.dashboard.state", None)
+        snapshot_mod._copy_notifications(snap / "notifications.jsonl", home / "notifications.jsonl")
+        assert (home / "notifications.jsonl").read_bytes() == self.GOOD
+
+    def test_concurrent_callers_all_get_the_SAME_executor(self, monkeypatch):
+        """Issue #8788: the lazy init was an unlocked check-then-set.
+
+        Two threads could each observe ``None``, each construct a pool, and each
+        proceed -- one assignment won the global while the loser's worker was already
+        live with its job queued, so the two callers were not serialised against one
+        another at all. That voids the only guarantee this executor provides, and it is
+        the precondition of the ordering this restore path depends on.
+
+        The construction window is WIDENED on purpose. Measured first: with 16 threads
+        released from a barrier and the lock removed, this passed 5 out of 5 rounds --
+        CPython's switch interval lets the first thread finish constructing before any
+        other is scheduled, so the natural window is real but far too small to observe.
+        A test that cannot fail proves nothing, so the constructor is made slow enough
+        that a second caller is guaranteed to be inside the window. What is being tested
+        is the mutual exclusion, not the timing.
+
+        Asserted by object identity, because calling the accessor twice in sequence
+        returns the same object with or without the lock.
+        """
+        import concurrent.futures
+
+        from kiro_crew.dashboard import state as dashboard_state
+
+        real_executor = concurrent.futures.ThreadPoolExecutor
+
+        class SlowToBuild(real_executor):  # type: ignore[misc,valid-type]
+            def __init__(self, *args, **kwargs):
+                time.sleep(0.2)  # the window, held open
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(dashboard_state, "_notification_io_pool", None)
+        monkeypatch.setattr(concurrent.futures, "ThreadPoolExecutor", SlowToBuild)
+        threads = 8
+        barrier = threading.Barrier(threads)
+        created: list[object] = []
+        lock = threading.Lock()
+
+        def racer() -> None:
+            barrier.wait(timeout=10)
+            pool = dashboard_state._notification_io_executor()
+            with lock:
+                created.append(pool)
+
+        workers = [threading.Thread(target=racer) for _ in range(threads)]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join(timeout=30)
+
+        assert len(created) == threads, f"only {len(created)} of {threads} racers reported"
+        distinct = {id(p) for p in created}
+        assert len(distinct) == 1, (
+            f"{len(distinct)} different executors were created, so callers holding "
+            "different pools are not serialised against each other"
+        )
+        # Whatever the race produced must also be what the module kept, or a caller is
+        # queuing onto a pool the module no longer hands out.
+        assert created[0] is dashboard_state._notification_io_pool
+
+    @requires_symlinks
+    def test_a_dangling_symlink_at_the_live_name_is_refused(self, tmp_path):
+        """``is_file()`` calls a dangling link absent, and ``copy2`` wrote THROUGH it.
+
+        So the branch was chosen because "no live file exists" while a link sat at
+        the name, and the archive's bytes landed on the link's target -- outside
+        the data home. The publish refuses instead, and the refusal must not delete
+        the file the link points at either.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        outside = tmp_path / "outside.jsonl"
+        (home / "notifications.jsonl").symlink_to(outside)
+        with pytest.raises(FileExistsError):
+            self._merge(snap, home)
+        assert not outside.exists(), "the archive's bytes were written outside the data home"
+        assert (home / "notifications.jsonl").is_symlink(), "the operator's link was removed"
+
+
 # ── Issue #8217: the restore status line must not claim success over a refused
 # cron merge ───────────────────────────────────────────────────────────────────
+
+
+class TestNotificationCopyRefusalWithoutONofollow(_NotificationCopyFixtures):
+    """The platform refusal, which must be exercised on EVERY platform.
+
+    Deliberately NOT marked ``requires_o_nofollow``: on a platform that truly lacks
+    the flag these are the only tests in this area that can run, and they are the
+    ones that matter there. On a platform that has it the absence is simulated by
+    deleting the constant, the idiom this suite already uses.
+    """
+
+    def test_a_platform_without_o_nofollow_refuses_the_copy_ENTIRELY(self, tmp_path, monkeypatch):
+        """No ``O_NOFOLLOW`` means no safe copy, so the copy does not happen at all.
+
+        Simulated the way this suite already simulates that platform -- by deleting the
+        constant -- because the behaviour is a property of the flag being absent, not of
+        Windows.
+
+        The source here is a PERFECTLY ORDINARY regular file: no link, no reparse point,
+        nothing wrong with it. That is the point of the test. The predecessor checked
+        ``is_reparse_point`` by name and then opened the same name, which an adversary
+        that chooses the timing walks straight through, and ``fstat``'s ``S_ISREG`` does
+        not close it because a reparse point resolving to a regular ``.env`` passes it.
+        So the refusal cannot be conditional on the source looking wrong at check time --
+        a test that only refuses a symlinked source would pass with the old, racy floor
+        still in place.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        with pytest.raises(snapshot_mod.NotificationCopyUnsupported) as caught:
+            snapshot_mod._copy_notifications(
+                snap / "notifications.jsonl", home / "notifications.jsonl"
+            )
+
+        assert not (home / "notifications.jsonl").exists(), "a destination was created"
+        message = str(caught.value)
+        # A silent skip is the bug class being fixed, so the diagnosis has to be IN the
+        # message: the missing primitive, and what was not imported.
+        assert "O_NOFOLLOW" in message, message
+        assert "NOT imported" in message, message
+        assert "notifications.jsonl" in message, message
+
+    def test_the_refusal_happens_before_anything_is_opened_or_acquired(self, tmp_path, monkeypatch):
+        """The refusal is a question about the platform, not about this source.
+
+        So it must be decided before the executor is acquired and before the source is
+        opened -- otherwise a platform that can never do this safely still pays a thread
+        hop and still touches the file. Asserted by counting, so an edit that moves the
+        gate below the acquire reddens here.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        opens: list[object] = []
+        acquires: list[object] = []
+        real_open = os.open
+
+        def counting_open(path, *a, **kw):
+            opens.append(path)
+            return real_open(path, *a, **kw)
+
+        from kiro_crew.dashboard import state as dashboard_state
+
+        real_exec = dashboard_state._notification_io_executor
+
+        def counting_exec():
+            acquires.append(1)
+            return real_exec()
+
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        monkeypatch.setattr(os, "open", counting_open)
+        monkeypatch.setattr(dashboard_state, "_notification_io_executor", counting_exec)
+
+        with pytest.raises(snapshot_mod.NotificationCopyUnsupported):
+            snapshot_mod._copy_notifications(
+                snap / "notifications.jsonl", home / "notifications.jsonl"
+            )
+
+        assert opens == [], f"the source was opened despite the refusal: {opens}"
+        assert acquires == [], "the executor was acquired despite the refusal"
+
+    def test_the_restore_CONTINUES_and_reports_the_skip_rather_than_aborting(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A platform refusal skips ONE component; it does not fail the restore.
+
+        The distinction is deliberate and it is not the abort posture the undecodable
+        record has. An undecodable record says THIS ARCHIVE is bad, so the restore
+        stops. A missing ``O_NOFOLLOW`` says THIS PLATFORM can never do this safely,
+        which is not a reason to refuse the other components -- and the records are
+        still in the snapshot, so nothing is destroyed by skipping.
+
+        What must NOT happen is the restore reporting a copy it did not make. That is
+        why the skip is asserted on the OUTPUT and the absence of the file together.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        (snap / "config.json").write_text('{"k": "v"}')
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        raised = None
+        try:
+            self._merge(snap, home)
+        except BaseException as exc:  # noqa: BLE001 - the point is that none arrives
+            raised = exc
+
+        out = capsys.readouterr().out
+        assert raised is None, f"the whole restore aborted on a platform refusal: {raised!r}"
+        assert not (home / "notifications.jsonl").exists(), "records were installed anyway"
+        assert "SKIPPED" in out, out
+        assert "O_NOFOLLOW" in out, out
+        assert "Notifications: copied" not in out, "reported a copy it did not make"
+
+    def test_no_by_name_reparse_check_is_made_on_either_path(self, tmp_path):
+        """The by-name check is gone, not merely bypassed where the open can decide.
+
+        It used to be a floor gated on the flag's absence. It is now nothing: where the
+        flag exists the open decides, and where it does not the copy is refused before
+        reaching here. Counting calls rather than reading the source, so reintroducing
+        the check -- the racy remedy this PR removed -- reddens here.
+        """
+        snap, home = self._snap(tmp_path, self.GOOD)
+        calls: list[object] = []
+        real = snapshot_mod.pinned_fs.is_reparse_point
+
+        def counted(path):
+            calls.append(path)
+            return real(path)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(snapshot_mod.pinned_fs, "is_reparse_point", counted)
+            self._merge(snap, home)
+        assert calls == [], f"a by-name reparse check ran: {calls}"
 
 
 class TestARefusedCronMergeIsVisibleInTheRestoreStatus:


### PR DESCRIPTION
## Problem / Motivation

Restoring a snapshot puts the archive's `notifications.jsonl` into the live data home one of two ways, and only one of them validated anything:

```python
if sn.is_file():
    if dn.is_file():
        _merge_notifications(sn, dn)      # validates every record, aborts on a bad one
    else:
        shutil.copy2(str(sn), str(dn))    # validates nothing
```

`portability.py`'s import had the same shape. So the same snapshot aborted the restore when a live file existed and was installed silently when one did not.

The copy is byte-exact, which is correct as a copy and is exactly the problem: it faithfully installs bytes the destination's own reader refuses. `dashboard/state.py:_load_notifications` puts `path.read_text(encoding="utf-8")` inside the outer `try` whose `except Exception` returns `[]`, so one invalid UTF-8 byte anywhere costs the WHOLE file rather than the bad row, and only a debug log records it. `_rewrite_notifications` -- reached by any delete, ack or clear -- then persists that empty view.

Measured end to end, driving the real `_do_merge` and the real reader with `KIROCREW_HOME` pointed at a temp dir:

```
5 valid records + 1 invalid-UTF-8 record in the archive, no live file
  restore                  -> both success lines printed, no exception
  installed file           -> does not decode as UTF-8 (0xff at offset 336)
  _load_notifications()    -> 0 rows      (not 5)
  one append, then rewrite -> file is 0 bytes, all 5 valid records gone
```

Unlike the merge path this fires on every locale, because nothing decoded on the way in, and its trigger is the ordinary one -- a fresh install or a first restore, where the operator has the least reason to suspect anything.

## Why it matters

Notification history is destroyed on the restore path an operator is most likely to be on, with a success line printed over it. `apply_import_zip` reports `notifications (copied)` in its summary and the dashboard handler turns that into `ok: True`, so an API caller is told the import succeeded. The loss is not even visible at restore time: the file looks populated until the first delete or ack, which is when it goes to zero bytes. `_maybe_trim_notifications` reads with the same strict decode inside a `try`, so on a poisoned file trimming also becomes a silent no-op and the file stops being bounded.

## What changed (motivation -> approach -> change)

Both branches of that `if` now agree. The posture is the merge branch's -- abort by raising, never accept, never skip -- and that is not a new product decision: it is the decision `_merge_notifications` already carries, applied to the branch that never got it.

Both call sites call a new `_copy_notifications`. It is a separate function rather than a call into the merge with an empty destination, and both halves of that were measured rather than assumed:

- `_merge_notifications` opens the destination for READ first, so a missing one raises `FileNotFoundError` out of the arm that guarantees a destination-scan failure is a true no-op. Teaching that arm to tell "missing, fine" from "unreadable, abort" reopens the fail-closed posture that arm exists for.
- The merge DEDUPLICATES against what it has already written, which a copy must not. Four source records -- two sharing a `ts`, two byte-identical without one -- through a merge into an empty destination: two land. There is nothing here to deduplicate against, so keying source records against each other converts a faithful copy into a lossy one.

The shape is a single read of the source, and the ordering is the design:

1. **The source is read ONCE, whole, under a byte cap**, and the file is never touched again.
2. **Those bytes are validated in full.** A refusal happens with the destination never created, so there is nothing to roll back -- which matters because there is no safe rollback: an earlier revision created the live file and unlinked it on refusal, and `apply_import_zip` runs inside the live gateway, so the dashboard's notification sink could append to that file first and the unlink took the operator's notification with it.
3. **The destination is created `O_CREAT|O_EXCL|O_WRONLY|O_APPEND|O_NOFOLLOW|O_BINARY` and the validated bytes written.** `O_EXCL` decides inside one syscall, so a name that filled after the caller's `is_file()` check is refused rather than written through -- a dangling symlink at that name included, which `is_file()` reports as absent and `copy2` followed, writing the archive's bytes outside the data home.

Framing and the memory cap come from `strict_raw_records`, run over a `BytesIO` on the held bytes rather than a hand-rolled split, so the record boundaries are the same implementation the merge branch uses -- a second splitter is how two paths drift apart, which is the defect this change exists to fix. The encoding check is `_notification_key`'s, called for its `UndecodableRecord` and its key discarded, for the same reason.

Reading once rather than twice is the whole point and is argued from a measurement in the section below; the four findings that forced it are recorded there too.

Two earlier revisions of this PR were blocked, and both findings are why the shape above is what it is. Recording them because each one removed a design, not just a line:

- The first wrote straight to the live name with `O_EXCL` and rolled back by unlinking. An exclusive create proves this call CREATED the file, not that it is the only thing that has written to it since -- and `apply_import_zip` runs inside the live gateway, so the dashboard's notification sink can append to a file the copy just created, and the rollback then deleted that operator's notification along with the prefix. Validating the source before creating anything is the version of that with no window at all, rather than a narrower one.
- The second validated into a temp file in the data home and published with `os.link`. A temp file is published through a NAME, and a same-user process that can list that directory can swap what the name holds between the write and the publish, linking bytes this function never validated into place as `notifications.jsonl`. The mitigations are inode verification on both ends plus a non-hardlink fallback -- `pinned_fs.put_back_no_clobber` is the repo's audited version, and its own docstring notes the landed check narrows that window rather than closing it. Writing straight to an `O_EXCL` destination needs none of it, because there is no intermediate name to swap.

A third revision read the source twice -- validate, then install -- and that is what the single read replaces. Its residue was documented and believed bounded, and a test I wrote then falsified the bound: a source **truncated** between the passes gave the install pass a clean EOF, so nothing raised, the count was never printed because the count only printed on the failure path, and the restore reported success having installed fewer records than it validated. Measured at 5 validated, 2 installed. That is filed as [#8755](https://github.com/kirodotdev/KiroCrew/issues/8755) in the past tense, because the reasoning -- a detected window and an absent window are different guarantees -- is worth finding again.

Records are written verbatim, so what is validated is the source's bytes and never a decoded form of them. One repair: an unterminated final record gains a terminator. That is not cosmetic once the write is record-wise -- `_persist_notification` appends `json.dumps(note) + "\n"`, so the first notification after the restore would otherwise glue onto an unterminated last line and produce one line that parses as neither row. It is the same repair the merge makes through `dst_unterminated`. The create passes mode `0o666` so the kernel applies the umask, giving the same mode as that function's own `open(path, "a")`.

## Tests

`TestNotificationCopyWhenNoLiveFileExists` in `test/test_snapshot.py` drives the real `_do_merge`, so the CALL SITE is under test and not only the helper. Every fixture is real bytes on a real file: a synthesized `UnicodeDecodeError` routes the copy down a healthy path and proves nothing.

- `test_an_undecodable_record_is_never_installed` -- raises, installs no file, and neither the `Notifications: copied` line nor the component success line is printed. The raise is the contract with the caller, since neither the import summary nor the dashboard handler sees stdout.
- `test_the_reader_loads_every_record_the_copy_installs` -- the consequence, through `_load_notifications`. This is the test that separates a real fix from a no-op, and it caught one during development: `strict_raw_records` frames and bounds records but does not decode, so framing alone reproduces `copy2` exactly while every byte-level assertion still passes.
- `test_a_concurrent_notification_is_not_deleted_by_the_rollback` -- the first blocking finding. The delivery is injected at the validation of the record that aborts, which is the interleaving that broke that revision.
- `test_the_data_home_gains_nothing_but_the_notifications_file` -- the second blocking finding. Asserted as "the directory holds nothing else" rather than "no file called `.tmp`", so any future intermediate is caught whatever it is named.
- `test_a_source_that_changes_between_the_passes_leaves_a_valid_prefix` -- the residual, and its bound: the prefix is exactly the records that validated, and it still decodes.
- `test_the_installed_file_is_no_tighter_than_one_the_product_writes` -- compared against a file written by `open(path, "a")` in the same directory, because `os.open` takes an explicit mode and this is a real choice rather than a default.
- `test_a_clean_source_is_copied_record_for_record` -- byte-exactness is the property `copy2` had and the fix keeps: a `\r\n` terminator survives and a bare `\r` ends a record without being rewritten.
- `test_an_unterminated_final_record_gains_a_terminator` -- so the first append after the restore does not glue onto it.
- `test_an_oversized_record_installs_nothing` -- a DIFFERENT exception out of the same reader; an `except` narrowed to the encoding one would let this reason escape.
- `test_a_live_file_that_appears_mid_copy_is_not_replaced` and `test_a_dangling_symlink_at_the_live_name_is_refused` -- `O_EXCL` refuses both, and neither the operator's file nor the link's target is touched.

`test_import_merge_notifications_refuses_an_undecodable_record` in `test/test_portability.py` pins the same property on the import path, through a real export zip.

Five more pin the single-resolution invariant and the append flag. Each needed a CONCURRENT or swapped actor to be observable at all -- a test that only copies into an empty destination passes with or without any of these flags, which is the trap the mutation table below exists to catch:

- `test_a_source_swapped_for_a_symlink_between_the_passes_is_not_followed` -- the swap is made invisible by the held descriptor, so the assertion is that the archive's own bytes land and the credential does not.
- `test_a_source_that_is_already_a_symlink_is_refused` -- `O_NOFOLLOW` refuses at the open rather than reading the target.
- `test_a_non_regular_source_is_refused_not_read_as_empty` -- the `S_ISREG` judgement on the descriptor. A character device is the case `seek` cannot catch, because it is seekable: without the check the read returns EOF and the restore installs an EMPTY notifications file and reports success.
- `test_a_notification_delivered_during_the_copy_survives` -- `O_APPEND`, with the delivery injected mid-copy.
- `test_a_source_that_became_a_fifo_fails_instead_of_hanging` -- `O_NONBLOCK`. Dropping the flag makes this TIME OUT rather than fail, and the timeout is the evidence.

Mutation-verified, each mutation reddening only the test that owns that property:

| removed from the fix | red |
| --- | --- |
| the single read, going back to the FILE for the install | 6 tests, led by `..._source_truncated_after_the_read_cannot_affect_the_install` -- "the injection point never ran, so this test proved nothing" |
| the whole-file cap enforcement | `..._source_over_the_cap_is_refused_with_its_size_named` (`DID NOT RAISE OSError`) |
| the size from the cap's message | the same test -- "the size was not named" |
| raising the cap to 512 MiB, i.e. a convenience edit | `..._source_cap_is_the_value_this_design_was_measured_for` -- `assert 536870912 == 33554432` |
| `O_APPEND` | `..._notification_delivered_during_the_copy_survives` -- "the delivered notification was overwritten" |
| `O_BINARY` from either flag set | `..._both_descriptors_ask_for_binary_mode` |
| the `S_ISREG` judgement | `..._non_regular_source_is_refused_not_read_as_empty` and the FIFO test |
| the fail-closed platform gate, removed entirely | `..._refuses_the_copy_ENTIRELY`, `..._restore_CONTINUES_and_reports_the_skip...`, `..._refusal_happens_before_anything_is_opened_or_acquired` |
| the gate, made conditional on the source LOOKING wrong (the old racy check) | the same three -- the source in that test is an ordinary regular file, so a check-time test could not see it |
| the refusal decided AFTER the executor is acquired | `..._refusal_happens_before_anything_is_opened_or_acquired` |
| the diagnosis dropped from the refusal message | `..._refuses_the_copy_ENTIRELY` -- a silent refusal is the bug class being fixed |
| the serialisation, running the copy inline as before | `..._note_delivered_during_the_copy_survives_the_READER` -- "the append ran while the copy was still writing, so the two are concurrent rather than ordered" |
| the same-worker re-entry guard | `..._running_on_the_notification_worker_does_not_deadlock` -- verified in a BOUNDED CHILD, not pytest: `with guard: completed` / `without guard: STILL BLOCKED after 20s` |
| the acquire, restoring the `pool is None` shortcut | `..._FRESH_gateway_still_orders_the_copy_against_a_delivery` -- "a delivery on a fresh gateway ran concurrently with the copy: 'no pool' was read as 'no writer'" |
| the narrowed `except ImportError`, widened back to `Exception` | `..._import_failure_that_is_not_ImportError_is_not_swallowed` (`DID NOT RAISE RuntimeError`) |
| the lock on the executor's lazy init | `..._concurrent_callers_all_get_the_SAME_executor` -- "N different executors were created", red on 5 of 5 rounds |

**Two tests in this class were caught proving nothing, both by mutation runs, and that is the main argument for running them.** The `S_ISREG` guard first: the FIFO test passed with or without it, because a FIFO is caught by `seek` failing on a pipe, so a character-device case was needed. Then `O_APPEND`: the single-read redesign stopped calling `_notification_key` during the write, so that test's per-record injection point went dead and it delivered nothing while still passing.

**The serialisation test was caught the same way and is worth spelling out**, because its first version looked right. It submitted the append and then checked the file -- and passed with the serialisation removed, because the copy's remaining writes happened to finish first. A race, not a proof. It now asserts the ordering itself: the single worker **cannot** run a queued append while the copy occupies it, so a bounded wait times out with the fix and returns at once without it. Deterministic in the direction that matters.

**The tests pin the precondition, not the consequence.** "No partial install" passes trivially once the read window is gone, so it cannot catch a regression. `..._source_truncated_after_the_read_cannot_affect_the_install` replaces the retired two-pass residue test and asserts the reverse of what that one asserted: truncating the source after it has been read changes nothing. It carries its own liveness guard -- `assert fired, "the injection point never ran"` -- which is what caught the mutation above. The cap gets a value ratchet because the cap is the part a future edit would actually change.

Mutations are applied from a file-based patch script that asserts its marker matched exactly once and exits non-zero otherwise, because a mutation that never applied is indistinguishable from a passing run. A mutation whose expected outcome is a HANG is kept out of that harness entirely and verified in a bounded child process -- learned the hard way: driving the deadlock mutation through pytest got the harness killed mid-run, so its restore never executed and it left the guard stripped from the working tree.

**The lock's test needed its window widened, and that was measured rather than assumed.** With 16 threads released from a barrier and the lock removed, it passed 5 of 5 rounds: CPython's switch interval lets the first thread finish constructing before another is scheduled, so the natural race window is real but far too small to observe. Making the constructor slow enough that a second caller is guaranteed to be inside it turns the test red on 5 of 5. What is asserted is the mutual exclusion, not the timing -- and without the widening the test would have shipped proving nothing, which is the third guard in this class to fail that way.

`test/test_snapshot.py test/test_portability.py test/test_dashboard.py`: 213 passed (run with `-n 0`; the dashboard file is included because this diff now touches `state.py`). ruff clean, the repo black gate passes in scope, `scripts/check_lockdown_before_publish.py` passes, and `mypy` is back to the 2 base-owned `transcribe.py` errors after a name collision of mine was fixed.

One residue worth naming so it is not mistaken for this diff's: `mypy src/kiro_crew/snapshot.py src/kiro_crew/portability.py` reports 2 errors, both in `src/kiro_crew/transcribe.py`, which this branch does not touch. They arrive through a transitive import and reproduce byte-identically from the same invocation on a detached worktree at main's tip with none of this branch's code present, so they are base-owned.

## Manual verification

The measurement in Problem / Motivation is one manual pass: a temp `KIROCREW_HOME`, a staging dir carrying five valid records and one truncated multi-byte character, `_do_merge`, then the real `_load_notifications` / `_persist_notification` / `_rewrite_notifications`. Before: success printed, 0 rows loaded, 0 bytes after the rewrite. After: `UndecodableRecord`, no file installed, no success line.

The first blocking finding was reproduced against both publishes before it was fixed, with the delivery interleaved after the first record: the `O_EXCL`-and-unlink version leaves no live file and no delivered note, the replacement leaves the delivered note byte-intact.

## Out of scope, measured and named

Replace mode installs the same bytes unvalidated. `_do_replace` restores `notifications.jsonl` through the generic `_backup_and_copy` core-file loop (`pinned_fs.copy_file_pinned`), and on the same fixture it prints its component success line over a file that does not decode as UTF-8. It is left out deliberately rather than overlooked: the change shape is different -- a per-file validator inside a loop shared with config and security, carrying a rollback ledger -- and the operator contract is different too, since replace moves the live file into a backup at the operator's explicit request. It belongs in its own issue, not folded into this diff.

## The invariant, and why it became "read once" rather than "resolve once"

Five blocking findings landed on this span, and four of them were one defect: **the source was read twice, and another process could change it inside that window.** Swapped for a symlink to a credential; reopened by name; and finally truncated, so the install pass met a clean EOF, installed fewer records than it validated, and printed a green tick. Each fix closed one variant and the next round produced another, because a check only catches the case someone thought of.

So the fix is not a fifth check. **The source is read ONCE, whole, under a byte cap, and everything after that reads the bytes in hand.** There is then no name left to resolve and no handle left open, so there is nothing to swap, truncate or extend -- the class is unrepresentable rather than detected. The two loops that validate and then install are two passes over the same immutable bytes, which is safe for exactly the reason two passes over the file were not.

**That was decided on a measurement, not a preference,** because streaming would have been mandatory if these sources could be large. The destination is self-bounding: `_MAX_PERSISTED_NOTIFICATIONS` is 200, `_maybe_trim_notifications` runs after every append and trims past `200 * 2`, the loader keeps the last 200 and every rewrite writes the last 200 -- so the live file holds at most 400 records at any time and anything beyond 200 is discarded on the next read. Installing more is transient by construction.

| | bytes | |
| --- | --- | --- |
| live `notifications.jsonl`, real install | 370,107 / 207 records | largest single record 20,821 |
| product-bounded worst case | 8,316,000 / 400 records | 400 x that largest record |
| **peak, shipped implementation, at that worst case** | **16,636,754 (15.9 MiB)** | `tracemalloc` on `_copy_notifications` |
| peak, shipped implementation, realistic file | 1,062,369 (1.0 MiB) | |
| per-record cap this file already accepts | 134,217,728 (128 MiB) | `_NOTIFICATION_RECORD_CAP` |

There was no memory argument for streaming: it was defending an 8 MB file with an allocation ceiling sixteen times its size.

### The whole-file cap is the load-bearing addition

Single-read needs one where streaming did not -- the per-record cap bounds one record, not a file made of many, and the source is archive-derived so nothing bounds it from outside. `_NOTIFICATION_SOURCE_CAP` is 32 MiB: ~4x the product-bounded worst case and a quarter of the per-record cap. **Over-cap REFUSES with the size named -- never a truncation, never a silent skip**, because a cap that dropped the tail would rebuild the very defect this removes, one layer up.

Two things about it are measured rather than assumed. **The peak scales with the source, not the cap:** the first implementation used a single `read(cap + 1)`, which preallocates the whole limit, so an 8 MB source cost 32 MiB and the peak tracked the constant instead of the file. Only measuring the shipped code showed it; the read accumulates in 1 MiB chunks for that reason. And **the cap is enforced on bytes already read**, inside the loop, rather than against `st_size` -- a separately-stated size can be stale by the time it is compared, and the bytes in hand cannot be.

### The copy is serialised against the dashboard's notification writer

`O_APPEND` prevents a concurrent notification being **overwritten**. It then orders that row **before** the archive's, because the dashboard's append reaches end-of-file immediately while this copy's writes are still buffered. And `_load_notifications` keeps the last `_MAX_PERSISTED_NOTIFICATIONS` rows **positionally, not by timestamp** -- so importing a full 200-record history pushes the live row out of the window. Measured:

```
installed lines: 201 (archive 200 + 1 live note)
live note position: [0]
_load_notifications returned 200 rows (cap 200)
LIVE-NOTE survives the reader: False
```

The row is written, kept on disk, and then silently dropped by the reader. The operator was told the notification was delivered; after the next reload it is gone. That is the same flag with a different consequence, which is the shape that produced a new finding on this span four rounds running -- so it is fixed here rather than filed as a fifth filter.

Notification persistence runs on one worker in submission order, so the copy now runs on that same worker: a queued append is ordered strictly after it and lands at the end of the file, where the cap keeps it. **The cost, stated rather than left implicit: a restore now briefly blocks notification writes.** A restore is rare and user-initiated; a lost notification is silent and permanent.

Three cases deliberately run inline instead -- the dashboard module not importing (the CLI restore has no writer to order against), no executor existing yet (nothing has persisted a notification in this process, so creating a pool would be the cost without the benefit), and already being ON the single worker, where submitting would wait for a queue only the submitter can drain. The executor is released as soon as the work returns **or raises**: `result()` re-raises, so the failure path needs no separate release and cannot leave notification writes blocked.

#### Two of those three branches were wrong, and it is one mistake twice

**The shortcut assumed "no pool" means "no writer"; the writer is what makes the pool.** A fresh gateway has persisted nothing, so the pool was `None`, so the copy ran inline -- and a delivery arriving at that moment created the executor and appended through it, concurrently, putting the live row back at line 0 of 201 and outside the reader's window. Reproduced:

```
pool before copy: None
append ran DURING the copy: True (True = not serialised)
note position: [0] of 201
survives reader: False
```

Review found that instance. Auditing the other two branches found the same error a second time, one line up: the broad `except Exception` on the import turned **"I could not check" into "there is nothing to check"**, so an import failing inside a live gateway would have degraded the ordering in silence. The generalisation is worth naming because it is not specific to this file: **treating the absence of an observable writer as the absence of a writer.**

So the serialisation now **acquires rather than asks**. `_notification_io_executor()` creates the worker if there is none and returns the existing one if there is, which collapses both holes and leaves exactly one inline case -- being ON the worker, where submitting would deadlock rather than race. That branch is not an absence-reading at all: it means we *are* the ordering point. It is the only one that was ever sound and the only one kept. The import clause is narrowed to `ImportError`, so a genuinely absent dashboard still falls back while any other failure surfaces.

Acquiring costs the CLI path one idle worker thread it did not previously create. That is a short-lived process and the thread exits at interpreter shutdown; a silent ordering hole is permanent.

### What this does NOT close

The single read closes the read-window class only. The destination side is a separate problem and its protections stay necessary on their own terms: `O_EXCL` so a name that filled after the caller's `is_file()` check is refused rather than written through, `O_APPEND` so a concurrent row is not overwritten, and the serialisation above so it is not ordered out of the reader's window either. Reading the source once says nothing about other writers to the live file -- the ordering finding arrived *after* the redesign and is the proof of that.

What remains open on this function is the ancestor chain and the sibling `_merge_notifications`, both named below.

**The one residue inside the ordering guarantee is now closed rather than named: the lazy init of the executor itself is locked.** `_notification_io_executor()` was an unlocked check-then-set, so two threads could each observe `None`, each construct a pool, and each proceed -- one assignment won the global while the loser's worker was already live with its job queued, and the two callers were never serialised against one another at all. That is [#8788](https://github.com/kirodotdev/KiroCrew/issues/8788), and it is fixed here with a double-checked lock, the same shape `atomic_write` already uses for its umask cache.

**Why a shared-module edit appears in a snapshot-restore PR.** It was initially scoped out as a reviewability call -- a concurrency change to `dashboard/state.py` sitting in front of reviewers reading about notification imports -- and that was reversed, because this PR's entire value is an ordering guarantee and a race in the executor's creation means there is no ordering to guarantee. It is outside the diff by line count and inside it by consequence. It also made the PR unreachable: the review lane blocked on exactly this, and a lane has no channel to be told a maintainer accepted it as residual, so no amount of code elsewhere could clear it.

The change is deliberately the smallest one that makes the second caller wait: a module-level lock and a double-check. No redesign of the executor, no refactor of the module.

A redesign sold as closing everything is how the next finding arrives as a surprise instead of an expectation.

### The audit that produced this

Every path access in the span was audited rather than the flagged lines patched. Two source reads collapsed to one; the destination's single `os.open` kept, because a create must name something and `O_EXCL` decides inside one syscall; three uses justified as resolving nothing (`_safe_name`, and the `path` argument to `strict_raw_records` and `_notification_key`, both of which only interpolate it into an error string -- verified by reading both callees); and the caller's `is_file()` checks recorded as advisory and *refuted* by the authoritative resolution rather than trusted.

The audit also found a hazard no lane named, and it is one no lane could: **a missing `O_NONBLOCK` produces no wrong answer, it produces no answer at all.** A name that became a FIFO after the caller's check blocks the open forever, so the restore hangs instead of failing. Measured in a wall-clock-bounded child process -- `with O_NONBLOCK: open returned` / `without: STILL BLOCKED after 5s`.

### What the audit deliberately left open

What is **not** closed is the ancestor chain: both opens name a directory rather than a pinned descriptor. That is deliberate and stated in the docstring -- every core-file copy in `_do_merge` reaches its path the same way, so pinning one of ten sites would be the point patch an earlier review lane already named. It is an axis for its own change.

### The invariant is descriptor-bound on POSIX, and where it cannot be the copy is REFUSED

`getattr(os, "O_NOFOLLOW", 0)` is **zero** on Windows, so nothing there refuses a reparse point at the source name. The previous revision put a by-name `pinned_fs.is_reparse_point()` check in front of the open and called it a floor. **A review lane was right that it is not a floor, it is a check-to-open window**, and the argument is short: the threat model this function is written for is a concurrent agent replacing the extracted file, so the adversary chooses the timing, and a by-name check followed by a by-name open is exactly what it waits for. The descriptor check does not rescue it either -- `fstat` asserts `S_ISREG`, and **a reparse point resolving to a regular `.env` passes `S_ISREG`.**

**So on a platform with no `O_NOFOLLOW` the copy does not happen.** `_copy_notifications` raises `NotificationCopyUnsupported` before the executor is acquired and before anything is opened, and both call sites report the skip: the CLI prints `Notifications: SKIPPED -- ...` and `apply_import_zip` records `notifications (SKIPPED: ...)` instead of `notifications (copied)`.

Three reasons, and the third is why this is not a preference:

1. **There is no rarity argument available.** Against an adversary that picks the moment, a window is a capability rather than a probability.
2. **The costs are not comparable.** Refusing loses notification *history* on one platform for one operation, and the records remain in the snapshot -- nothing is destroyed. Falling back can install attacker-chosen bytes, a credentials file among them, into a file the agent then reads.
3. **This PR exists because snapshot restore installed unvalidated bytes.** A remaining path that installs attacker-chosen bytes on one platform is the same defect in the issue title, closed everywhere except where it is hardest. A green board with a measured hole in it is worse than a red one.

**The capable alternative is declined by this repo twice in writing, which is what makes refusing the consistent move rather than a new one:**

- `src/kiro_crew/eval/bench/safepath.py` -- a ctypes `CreateFileW` with `FILE_FLAG_OPEN_REPARSE_POINT` "is no longer worth considering here: it would buy the same property exclusive creation already has, at the price of security code that cannot be exercised on the machine this harness is developed on."
- `src/kiro_crew/skill_trust.py` -- Python "does not expose an equivalent handle-relative, no-reparse walk on Windows, where a path lookup can initiate SMB authentication before a later containment check can reject the target."

Both decline the capable-but-unexercisable route, so the repo has already chosen **less capability on that platform over a hand-rolled walk**. Refusing extends those two decisions; falling back contradicts them. The `lstat`-vs-`fstat` identity comparison is declined on its own merits and remains declined: it is a check-to-use window wearing a seatbelt, narrowing a race while reading as though it closed one.

**What this costs, stated plainly:** on Windows, restoring a snapshot into a data home with no existing `notifications.jsonl` imports every other component and skips notification history, loudly. The by-name check is gone rather than bypassed, and `test_no_by_name_reparse_check_is_made_on_either_path` counts the calls at zero so reintroducing the racy remedy reddens.

Because the copy genuinely cannot run there, the 25 copy-behaviour tests carry `requires_o_nofollow` and the refusal tests do not. **That split was verified rather than assumed** -- deleting the constant before pytest collects reproduces the Windows shard exactly: `4 passed, 25 skipped`, which is the refusal covered on the platform where it is the only reachable behaviour.

### `O_BINARY` is a convention fix, and explicitly not a corruption fix

A review lane held that `os.open` without `O_BINARY` corrupts records on Windows -- collapsing `\r\n`, truncating at `0x1A` -- and therefore "silently truncates or byte-corrupts the installed notification history while reporting success." **That mechanism was tested and did not occur.** `test_a_clean_source_is_copied_record_for_record` asserts byte-exact `\r\n` survival through these very descriptors, carries no skip marker, and ran green on the Windows lane (`20309 passed, 601 skipped, 0 failed`, nothing `--ignore`d).

What survives is real but much smaller, and the flag is added on that basis alone: every sibling passes it, `crash_dump_store.py` reaches for this exact read-flag triple, there are 7+ such sites, and one documents it as required on Windows. This function was the outlier. `getattr(os, "O_BINARY", 0)` is **provably a no-op on POSIX**, where the constant does not exist.

## Base

Rebased onto `35afc7f1c` (head `f81631424`).

## The same defect exists in the sibling function, and is filed separately

`_merge_notifications` resolves its source by name twice as well, at `snapshot.py:2608` (its validation pass) and `snapshot.py:2629` (its copy loop). The exposure is the same shape and worse in effect, because that function appends into the LIVE file: a source swapped for a symlink between those two opens appends the link target's own bytes into the operator's notification history, and the validation pass reports nothing wrong because it validated a different file.

Filed as [#8667](https://github.com/kirodotdev/KiroCrew/issues/8667) rather than folded in. Those lines are unchanged by this diff -- they arrived with #8184 and are on main -- and the same invariant resolves them. The issue carries both line numbers, the mechanism, and the note that its destination scan at `snapshot.py:2587` has the identical shape one layer down.

## Related Issues

Closes #8181

Refs #8667 -- the same double-resolution defect in the sibling `_merge_notifications`, filed from this PR's audit. Deliberately `Refs` and not `Closes`: this diff does not touch those lines.

Closes #8788 -- the notification executor's unlocked lazy init. `Closes` and not `Refs`: it was scoped out as a follow-up and then brought in, because the ordering this PR promises is void without it and the review lane blocked on exactly that.

Refs #8755 -- the truncation-between-passes defect this redesign removes, filed in the past tense as the record of a defect that existed and how it was closed. `Refs` rather than `Closes` because the issue is the reasoning, not an open task.

Related: #7771 / #8184, which fixed the MERGE branch of this same `if` by removing a text-mode decode/encode round trip. This is the sibling branch, which never decoded at all, so the change here ADDS a validation pass rather than removing a round trip. `_copy_notifications` reuses the `jsonl_util` readers that #8184 introduced.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a validating operation that reads its input TWICE -- validate pass, then use pass -- where something else can change the input in between. Four review rounds on this one function each found a different way through that window (symlink swap, reopen by name, truncation to a clean EOF), and each fix closed one variant and revealed the next, because a check only catches the case someone thought of. The prompt to add: when a function validates then uses, ask whether it re-reads, and whether holding the input instead is affordable. Decide that on the measured size of the input against the allocation the code already accepts, not on preference -- here the streaming design was defending an 8 MB file with a 128 MiB per-record ceiling, so reading once cost nothing and made the whole class unrepresentable. Also mechanisable as a semgrep shape: two reads of the same path argument in one function body.








