### PR TITLE
fix(test): drop the shadowed can_read_body double on the slot-race request

### DIFF
--- a/test/test_slot_close_recreation_race.py
+++ b/test/test_slot_close_recreation_race.py
@@ -116,10 +116,6 @@ class _Req:
         self.content = _Stream(self._raw)
 
     @property
-    def can_read_body(self) -> bool:
-        return bool(self._raw)
-
-    @property
     def content_length(self) -> int | None:
         return len(self._raw) or None
 


### PR DESCRIPTION
## Problem / Motivation

Backend Lint fails on main. flake8 reports:

```
test/test_slot_close_recreation_race.py:131:5: F811 redefinition of unused 'can_read_body' from line 119
```

Reproduced against main's tip in a clean worktree, so this is main's own code and not one PR's diff. Every open PR inherits it through its merge ref.

## Why it matters

The gate stops naming a defect and starts naming whichever PR happened to run next. It cost one PR a red `Backend Lint & Type Check` today whose diff contains zero Python files at all, and it will do the same to every other open PR until it clears.

There is also a smaller latent problem underneath the lint finding: the class declares the same property twice, so one of the two definitions is dead code and which one is live depends on declaration order rather than on anything a reader would notice.

## What changed (motivation -> approach -> change)

Two changes added the same property independently -- #8536 gave the `_Req` double a body surface, then #8549 gave it a `can_read_body` surface -- and the class ended up declaring `can_read_body` twice. Python keeps the later definition, so the earlier one was already dead with the later one silently in effect.

Removing the earlier one is behaviour-preserving rather than a choice between two behaviours, and that is measurable rather than asserted. `_raw` is `b""` exactly when `body is None` and a JSON encoding otherwise, so `bool(self._raw)` (removed) and `self._has_body` (kept) return the same answer on every constructor path:

| `body` | removed definition | kept definition | agree |
|---|---|---|---|
| `None` | False | False | yes |
| `{}` | True | True | yes |
| `{"a": 1}` | True | True | yes |

The definition kept is the documented one, whose docstring states the contract the `__init__` comment reasons about: a bodyless request must report nothing to read, so `read_bounded_json(..., allow_absent=True)` takes its empty-object path instead of raising.

## Tests

N/A for new tests -- this removes dead code from an existing test helper and adds no behaviour. It is verified by the existing suite and the linter, below.

## Manual verification

- `flake8 test/test_slot_close_recreation_race.py` -- clean; the F811 is gone.
- `pytest test/test_slot_close_recreation_race.py` -- **42 passed**.
- Equivalence of the two definitions checked over all three constructor paths, as tabled above, so nothing depends on which one survived.

## Related Issues

Follows #8536 and #8549, which each added the property. Found while driving another PR's checks, where the same failure appeared on a diff with no Python in it.

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: **two changes adding the same member to the same class produce a silent shadow, not a conflict.** Neither PR conflicts textually, because each inserts at a different point in the class body, so git merges both cleanly and the language keeps only the last one. The result passes every behavioural test -- the surviving definition is one the authors intended -- and shows up only as a lint finding at a line neither author wrote in isolation.

The generalizable check is for the reviewer of the SECOND such PR: when a change adds a property or method to a test double or shim to satisfy a contract, grep the class for that member first. A duplicate is invisible in the diff, because the diff shows only the added block and not the one already there a dozen lines up.
