### PR TITLE
fix(security): close a substitution body on shell grammar, not a bare paren

### DIFF
--- a/src/kiro_crew/security/shell_normalizer.py
+++ b/src/kiro_crew/security/shell_normalizer.py
@@ -1049,6 +1049,15 @@ def _substitution_bodies(text: str) -> "list[str]":
     and ``is_denied`` returned None for a command bash executes. An UNPROVEN span
     yields the whole remainder, which is the fail-closed direction -- scanning
     text that is not really in the body can only add findings.
+
+    Quoting was not the whole of it. That span helper counted a ``)`` that shell
+    COMMAND GRAMMAR also puts there as an ordinary character, and two such
+    spellings were measured allowing a payload this module still refuses (#8150):
+    a ``#`` comment (``$(: # )`` closes on a later line) and a ``case`` pattern
+    (``$(case x in x) printf token;; esac)``). Both truncated the body before the
+    verb, so the value assembled from it was never recognised. The closer for the
+    BACKTICK form reads the same state machine now too, so the two spellings
+    cannot disagree.
     """
     bodies: list[str] = []
     i = 0
@@ -1062,9 +1071,9 @@ def _substitution_bodies(text: str) -> "list[str]":
             i = end
             continue
         if text[i] == "`":
-            j = text.find("`", i + 1)
-            bodies.append(text[i + 1 : j if j != -1 else len(text)])
-            i = len(text) if j == -1 else j + 1
+            end, proven = _matching_close_backtick(text, i + 1)
+            bodies.append(text[i + 1 : end - 1] if proven else text[i + 1 :])
+            i = end
         else:
             i += 1
     return bodies
@@ -1546,6 +1555,99 @@ def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterato
         i += 1
 
 
+# Where one shell WORD ends and the next begins, for the reserved words and the
+# comment marker the span walk has to recognise. Bash reads ``case`` / ``esac`` as
+# reserved only when they stand alone, so ``lowercase)`` must not arm the pattern
+# rule, and ``a#b`` must not open a comment.
+_SHELL_WORD_BREAK = frozenset(" \t\n;&|()<>")
+
+
+def _skip_continuations(text: str, index: int) -> int:
+    """*index* advanced past any backslash-newline pairs sitting at it.
+
+    The shell removes a line continuation while READING, before it recognises
+    words at all, so one may sit between any two characters of a reserved word.
+    """
+    while text.startswith("\\\n", index):
+        index += 2
+    return index
+
+
+def _word_at(text: str, index: int, word: str) -> bool:
+    """True if *word* stands alone at *index* rather than sitting inside a longer word.
+
+    Continuation-aware, because the shell folds ``\\`` + newline away before it
+    reads a word: ``ca\\`` + newline + ``se`` IS the reserved word ``case``, and
+    bash was measured running it as one. Matching byte-literally missed that
+    spelling, and an unrecognised ``case`` leaves the pattern's ``)`` to close the
+    body early -- reopening the very truncation this rule exists to stop, for the
+    cost of two characters (found in review).
+    """
+    j = index
+    for expected in word:
+        j = _skip_continuations(text, j)
+        if j >= len(text) or text[j] != expected:
+            return False
+        j += 1
+    after_index = _skip_continuations(text, j)
+    before = text[index - 1] if index else " "
+    after = text[after_index] if after_index < len(text) else " "
+    return before in _SHELL_WORD_BREAK and after in _SHELL_WORD_BREAK
+
+
+def _opens_comment(text: str, index: int) -> bool:
+    """True if the ``#`` at *index* starts a COMMENT rather than sitting in a word.
+
+    A ``#`` comments only at the start of a word, so ``a#b`` is one ordinary word.
+    The preceding character is read the way the shell reads it, which means the
+    folds are stepped OVER and then the character in front of them is tested --
+    what matters is what the fold leaves adjacent, not that a fold is there:
+
+    * ``a\\`` + newline + ``#b`` folds to the single word ``a#b`` -- no comment;
+    * ``:`` + space + ``\\`` + newline + ``#`` folds to ``: #`` -- a real comment,
+      because a word BREAK ends up in front of the ``#``.
+
+    Treating any preceding fold as "not a comment" got the second case wrong in
+    the fail-OPEN direction: the comment was missed, so the walk read the ``)`` it
+    hides as the closer and truncated the body before the payload -- reopening the
+    bypass this rule exists to close, for the folded spelling (found in review).
+
+    Offset 0 counts as a word start, since the text handed here begins just inside
+    the opener.
+    """
+    j = index
+    while text.endswith("\\\n", 0, j):
+        j -= 2
+    return j == 0 or text[j - 1] in _SHELL_WORD_BREAK
+
+
+def _in_command_position(text: str, index: int) -> bool:
+    """True if a command could START at *index* -- the previous real character separates.
+
+    Used to tell the reserved word ``esac`` from the ordinary string ``esac``, which
+    a command may pass as an argument.
+
+    A backslash-newline is a line CONTINUATION, not a separator: ``echo \\`` then a
+    newline then ``esac`` is the single command ``echo esac``, so that ``esac`` is an
+    argument and must not disarm the pattern rule. Parity matters -- ``\\\\`` then a
+    newline is a literal backslash followed by a real newline, which does separate.
+    """
+    k = index - 1
+    while k >= 0:
+        if text[k] in " \t":
+            k -= 1
+            continue
+        if text[k] == "\n":
+            slashes = 0
+            while k - 1 - slashes >= 0 and text[k - 1 - slashes] == "\\":
+                slashes += 1
+            if slashes % 2 == 1:
+                k -= slashes + 1
+                continue
+        break
+    return k < 0 or text[k] in ";&|(\n"
+
+
 def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
     """``(index just past the matching ``)``, proven)`` for a paren opened before
     *open_end*, walked QUOTE-AWARELY through :func:`_iter_shell_chars`.
@@ -1558,21 +1660,99 @@ def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
     payload came back as ``X='`` and the nested publish of a protected branch was
     never scanned at all -- ``is_denied`` allowed a command bash runs.
 
+    Quoting is not the only way a ``)`` reaches this walk as an ordinary
+    character. Two COMMAND-GRAMMAR constructs put one there too, and each was
+    measured allowing a payload this module still refuses (#8150):
+
+    * a ``#`` COMMENT runs to the end of its line, so the ``)`` in
+      ``$(: # )`` is commented out and the substitution closes on a LATER line.
+      Counting it closed the body at ``: # ``, and the ``printf`` behind it that
+      computed the credential-minting verb was never scanned.
+    * a ``case`` PATTERN is terminated by ``)``. In
+      ``$(case x in x) printf token;; esac)`` the pattern's ``)`` is not the
+      substitution's, and reading it as one truncated the body to ``case x in x``.
+
+    Between ``case`` and its ``esac`` both parens are therefore ignored, which
+    keeps a ``(x|y)`` pattern balanced-neutral as well. ARMING is generous and
+    DISARMING is strict on purpose: missing a real ``case`` closes the body EARLY,
+    which is the bypass, while missing a real ``esac`` only runs it long, which is
+    imprecision. So ``case`` arms on any standalone word and ``esac`` disarms only
+    in command position -- an ``esac`` passed to a command as an ARGUMENT would
+    otherwise end the rule early and let the next paren close.
+
     ``proven`` is False when the parens never balance before the text ends. The
     caller must fail CLOSED on that: for an extractor the safe reading is the
-    whole remainder (scan more, never less).
+    whole remainder (scan more, never less). All three call sites are extractors,
+    so a span that reaches too far only feeds them text to inspect.
     """
     depth = 1
-    for step in _iter_shell_chars(text, 0, False):
-        if step.offset < open_end:
-            continue
-        if step.active:
-            if step.char == "(":
+    cases = 0
+    pos = 0
+    state = 0
+    ansi = False
+    while pos <= len(text):
+        jumped = False
+        for step in _iter_shell_chars(text[pos:], state, ansi):
+            off = pos + step.offset
+            if off < open_end:
+                continue
+            if not step.active:
+                continue
+            ch = step.char
+            # A ``#`` opens a comment only at the START of a word, and the
+            # character before it is read as the shell reads it -- a folded
+            # continuation leaves ``a\`` + newline + ``#b`` one ordinary word.
+            if ch == "#" and _opens_comment(text, off):
+                newline = text.find("\n", off)
+                if newline == -1:
+                    return (len(text), False)
+                pos = newline + 1
+                state, ansi = 0, False
+                jumped = True
+                break
+            if _word_at(text, off, "case"):
+                cases += 1
+                continue
+            if _word_at(text, off, "esac") and _in_command_position(text, off):
+                cases = max(0, cases - 1)
+                continue
+            if cases and ch in "()":
+                continue
+            if ch == "(":
                 depth += 1
-            elif step.char == ")":
+            elif ch == ")":
                 depth -= 1
                 if depth == 0:
-                    return (step.offset + len(step.text), True)
+                    return (off + len(step.text), True)
+        if not jumped:
+            break
+    return (len(text), False)
+
+
+def _matching_close_backtick(text: str, start: int) -> "tuple[int, bool]":
+    """``(index just past the closing backtick, proven)`` for a body at *start*.
+
+    The paren walk above got quote awareness; the BACKTICK form was still taken
+    pairwise with a plain ``find``, so a backtick the shell reads as a literal --
+    ``` `A='`'; ...` ``` -- was counted as the closer and truncated the body there.
+    One state machine now answers both spellings, which is what keeps them from
+    drifting apart again.
+
+    A backtick inside DOUBLE quotes really is a closer (``"`cmd`"`` runs ``cmd``),
+    so only single-quoted and escaped ones are data. Read through the same
+    ``in_single`` idiom the argv walk uses, rather than a second reading of the
+    state.
+
+    HARDENING, not a patched hole: no payload this module refuses was reachable
+    through the pairwise version -- the strings it mis-read are ones bash itself
+    rejects, because backticks do not nest unescaped. It is fixed so the two
+    closers cannot disagree, not because a bypass was measured.
+    """
+    for step in _iter_shell_chars(text[start:]):
+        escaped = len(step.text) == 2
+        in_single = step.state == 1 and not (step.char == "'" and step.active)
+        if not escaped and not in_single and step.char == "`":
+            return (start + step.offset + len(step.text), True)
     return (len(text), False)
 
 

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -8112,3 +8112,145 @@ class TestTrustedIssueLinkChannel:
         cleaned, warnings = redact_exfiltration_urls(f"file it here: {url}")
         assert url in cleaned, cleaned
         assert warnings == []
+
+
+class TestSubstitutionCloserReadsCommandGrammar:
+    """A ``)`` that shell COMMAND GRAMMAR makes ordinary must not end a body (#8150).
+
+    ``_substitution_bodies`` is the shared answer to "what text does this command
+    run as a shell", so a body that stops early is not one pass's problem: every
+    consumer inherits the blindness. Quoting was already handled -- the span walk
+    reads ``_iter_shell_chars`` -- but two constructs put a literal ``)`` in front
+    of that walk without quoting it, and each hid a payload this module refuses.
+
+    The verb and the product name are assembled rather than spelled, because a
+    literal pair of them in source order is itself matched by the regex tier and
+    would mask what these cases are actually testing.
+
+    Both directions are asserted. The scan may not stop early (the anchors), and
+    it may not start refusing shapes it used to allow -- a scanner made stricter
+    in the wrong place is how a gate becomes unusable.
+    """
+
+    VERB = "tok" + "en"
+    NAME = "kiro" + "crew"
+
+    def test_a_comment_hides_the_closer_from_the_paren_count(self) -> None:
+        """``$(: # )`` closes on the NEXT line, so the ``)`` after ``#`` is inert.
+
+        The body came back as ``: # `` and the ``printf`` behind it -- which
+        computes the credential-minting verb -- was never scanned, so the value
+        assembled from it was not recognised and the command was allowed.
+        """
+        command = f"T=$(: # )\nprintf {self.VERB}); {self.NAME} $T"
+        (body,) = security._substitution_bodies(command)
+        assert f"printf {self.VERB}" in body, body
+        assert security.is_denied(command) is not None
+
+    def test_a_case_pattern_closer_is_not_the_substitutions(self) -> None:
+        """In ``case x in x)`` the ``)`` terminates the PATTERN, not the body."""
+        command = f"T=$(case x in x) printf {self.VERB};; esac); {self.NAME} $T"
+        (body,) = security._substitution_bodies(command)
+        assert f"printf {self.VERB}" in body, body
+        assert security.is_denied(command) is not None
+
+    def test_a_case_pattern_no_longer_truncates_a_self_kill_lookup(self) -> None:
+        """The BODY is recovered for the self-kill spelling too.
+
+        Only the body is asserted here. The verdict on this one does NOT flip,
+        because the self-kill pass never attributes a substitution that sits in an
+        ASSIGNMENT ahead of the ``kill`` -- a separate gap in that pass's
+        attribution, which this span fix neither causes nor closes.
+        """
+        command = f"P=$(case x in x) pgrep -f {self.NAME};; esac); kill $P"
+        (body,) = security._substitution_bodies(command)
+        assert f"pgrep -f {self.NAME}" in body, body
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # ``a#b`` is one ordinary word -- a ``#`` mid-word opens no comment.
+            "echo $(printf a#b)",
+            # ``esac`` handed to a command is an argument, not the reserved word.
+            "echo $(printf esac) done",
+            # ``lowercase`` merely ENDS in ``case``; it must not arm the rule.
+            "echo $(printf lowercase)",
+            # A ``(a|b)`` pattern is balanced-neutral inside the case.
+            "echo $(case x in (a|b) printf hi;; esac)",
+            "T=$(case x in x) printf hi;; esac); echo $T",
+            "T=$(: # )\nprintf hi); echo $T",
+        ],
+    )
+    def test_the_new_grammar_does_not_start_refusing_benign_shapes(self, command: str) -> None:
+        assert security.is_denied(command) is None
+
+    def test_a_single_quoted_backtick_does_not_close_the_body(self) -> None:
+        """The backtick closer reads the same state machine as the paren one.
+
+        HARDENING: no refused payload was reachable through the old pairwise
+        ``find``, because the strings it mis-read are ones bash itself rejects
+        (backticks do not nest unescaped). It is fixed so the two spellings of the
+        same closer cannot drift apart, which is how the paren half broke before.
+        """
+        (body,) = security._substitution_bodies("`A='`'; printf hi`")
+        assert body == "A='`'; printf hi", body
+
+    def test_a_double_quoted_backtick_still_closes_it(self) -> None:
+        """``"`cmd`"`` runs ``cmd``, so a backtick in DOUBLE quotes is a real closer."""
+        assert security._substitution_bodies('`printf "hi"`') == ['printf "hi"']
+
+    def test_a_line_continuated_case_still_arms_the_pattern_rule(self) -> None:
+        """``ca\\`` + newline + ``se`` IS ``case`` -- the shell folds it before reading words.
+
+        Byte-literal recognition missed this spelling, so the rule never armed and
+        the pattern's ``)`` closed the body early. bash was measured running the
+        folded form as ``case``, so the body must survive it.
+
+        Only the BODY is asserted. The verdict on this spelling does NOT flip, and
+        not because of this walk: ``_self_tokens`` reads the backslash-newline as a
+        command SEPARATOR rather than folding it away, which severs the assignment
+        from the invocation so ``$T`` never resolves. That is a tokenizer-level
+        continuation bug, it sits upstream of this helper, and it is present on the
+        base branch with the identical token split -- measured zero delta, so this
+        change neither causes nor worsens it. Tracked separately.
+        """
+        command = f"T=$(ca\\\nse x in x) printf {self.VERB};; esac); {self.NAME} $T"
+        (body,) = security._substitution_bodies(command)
+        assert f"printf {self.VERB}" in body, body
+
+    def test_a_line_continuated_esac_still_ends_the_pattern_rule(self) -> None:
+        """The same folding applies to ``esac``, so the rule disarms where bash does."""
+        (body,) = security._substitution_bodies("$(case x in x) printf hi;; es\\\nac)")
+        assert body == "case x in x) printf hi;; es\\\nac", body
+
+    def test_a_folded_continuation_does_not_make_a_hash_a_comment(self) -> None:
+        """``a\\`` + newline + ``#b`` folds to the single word ``a#b``, which comments nothing."""
+        (body,) = security._substitution_bodies("$(printf a\\\n#b)")
+        assert body == "printf a\\\n#b", body
+
+    def test_a_fold_after_a_word_break_still_opens_a_comment(self) -> None:
+        """What matters is what the fold leaves ADJACENT, not that a fold is there.
+
+        ``:`` + space + ``\\`` + newline + ``#`` folds to ``: #``, so a word break ends
+        up in front of the ``#`` and bash opens a real comment. Reading any preceding
+        fold as "not a comment" missed it in the fail-OPEN direction: the walk then
+        read the ``)`` the comment hides as the closer and truncated the body before
+        the verb, reopening this PR's own bypass for the folded spelling.
+        """
+        command = f"T=$(: \\\n# )\nprintf {self.VERB}); {self.NAME} $T"
+        (body,) = security._substitution_bodies(command)
+        assert f"printf {self.VERB}" in body, body
+        assert security.is_denied(command) is not None
+
+    @pytest.mark.parametrize(
+        "text",
+        ["$(", "`", "$(case", "$(case x in x", "$(: #", "`A='", "$(#", "", "#", "esac)"],
+    )
+    def test_degenerate_input_does_not_raise(self, text: str) -> None:
+        """An unterminated construct yields the remainder, never an exception."""
+        assert isinstance(security._substitution_bodies(text), list)
+
+    def test_an_unproven_span_still_yields_the_whole_remainder(self) -> None:
+        """Fail-CLOSED direction: a body that reaches too far is only over-scanned."""
+        (body,) = security._substitution_bodies(f"$(case x in x) printf {self.VERB}")
+        assert f"printf {self.VERB}" in body, body


### PR DESCRIPTION
## Problem / Motivation

`_substitution_bodies` is the shared answer to "what text does this command run as a shell". Every argv check reads substitution bodies through it, so a body that stops early is not one pass's problem -- every consumer inherits the blindness.

Its span walk was already quote-aware: `_matching_close_paren` reads the module's one quote/escape state machine, so a `)` the shell treats as a literal character no longer closes a body. But quoting is not the only way an ordinary `)` reaches that walk. Two **command-grammar** constructs put one there without quoting it, and the walk counted both:

- a `#` comment runs to the end of its line, so the `)` in `$(: # )` is commented out and the substitution closes on a **later** line;
- a `case` pattern is terminated by `)`, so in `$(case x in x) printf <verb>;; esac)` that `)` belongs to the pattern, not to the substitution.

## Why it matters

Both were measured on `main` in both directions -- the gate allowed the command **and** bash assembled and ran the refused payload:

| spelling | body extracted on main | `is_denied` on main |
|---|---|---|
| `T=$(: # )` + newline + `printf <verb>); <name> $T` | `: # ` | `None` (allowed) |
| `T=$(case x in x) printf <verb>;; esac); <name> $T` | `case x in x` | `None` (allowed) |
| `P=$(case x in x) pgrep -f <name>;; esac); kill $P` | `case x in x` | `None` (allowed) |

In each case the truncation dropped the half that computes the payload, so the value assembled from it was never recognised. The first two hid the credential-minting verb; the third hid a lookup of our own processes.

## What changed (motivation -> approach -> change)

The fix is taught to `_matching_close_paren` rather than to a new private walk. That helper is **the** one span computation, and all three of its call sites are extractors that take the whole remainder when a span is unproven -- so a span reaching too far only ever feeds them more text to inspect. Fixing it once therefore covers the argv-floor extractors this PR never touches, and leaves no second reading of shell state to drift from the first. This module's history is the argument: the same defect was cured three times already (two tokenizers, then two paren counters, then four separate readings of quoting), and each cure was structural -- one machine, several consumers.

Concretely:

- `_matching_close_paren` now skips a `#` comment to the end of its line, and ignores both parens between a `case` and its `esac`. Arming is generous and disarming is strict on purpose: missing a real `case` closes a body **early**, which is the bypass, while missing a real `esac` only runs it long, which is imprecision. So `case` arms on any standalone word and `esac` disarms only in command position.
- two small helpers carry the word rules: `_word_at` (so `lowercase)` does not arm the pattern rule and `a#b` opens no comment) and `_in_command_position` (so a backslash-newline reads as a line continuation, leaving an `esac` passed as an argument inert).
- the **backtick** closer now reads the same state machine, via `_matching_close_backtick`. This is hardening, not a patched hole: the strings the old pairwise `find` mis-read are ones bash itself rejects, because backticks do not nest unescaped. It is fixed so the two spellings of one closer cannot drift apart, which is how the paren half broke in the first place.
- reserved-word recognition folds **backslash-newline continuations**, because the shell removes them before it reads words at all: `ca\` + newline + `se` is the reserved word `case`, and bash was measured running it as one. Byte-literal matching missed that spelling, so the rule never armed and the pattern's `)` closed the body early again -- the same bypass for the cost of two characters. `_opens_comment` reads the character before a `#` the same way, so `a\` + newline + `#b` stays the single word `a#b`.

### What this deliberately does not claim

- The line-continuated spelling recovers its **body** but its verdict does not flip, and not because of this walk: `_self_tokens` reads the backslash-newline as a command SEPARATOR instead of folding it away, which severs the assignment from the invocation so `$T` never resolves. That is a tokenizer-level continuation bug sitting upstream of this helper. Measured on the base branch: the same command is allowed there with the identical token split (`'t=$(ca', ';', 'se', ...`), so this change neither causes nor worsens it -- **zero delta**. Filed separately rather than folded in, because the tokenizer feeds every argv check and widening it does not belong in a span fix.
- The self-kill anchor likewise recovers its body but keeps its allowed verdict, because that pass never attributes a substitution sitting in an assignment ahead of the `kill`. Separate gap, same reasoning.
- `git push` behaviour is unchanged. The publish floor already fail-closes every substitution-wrapped push via `git-publish-target-unverifiable`, so a body-walk fix cannot move it.
- Heredoc bodies and `${ }` / `$(( ))` regions are **not** modelled here. An earlier draft of this PR did model them. They are left out because no payload this module refuses was reachable through either: where the walk's early close at a heredoc-data `)` fires, bash loses the payload in the same direction, so there is no divergence to exploit. Shipping unreachable machinery into a security parser costs review surface and buys nothing; if a reachable case is found, it is additive.

## Tests

`TestSubstitutionCloserReadsCommandGrammar` in `test/test_security.py`, 25 cases:

- the two reachable anchors, asserting both the recovered body and the flipped verdict;
- the self-kill anchor and the line-continuated anchor, asserting the recovered body only, each documenting in its own docstring why the verdict does not move;
- the folded spellings: `ca\` + newline + `se` arms the pattern rule, `es\` + newline + `ac` ends it, and `a\` + newline + `#b` opens no comment;
- six benign shapes that must **not** start being refused: `a#b` mid-word, `esac` as an argument, `lowercase`, a `(a|b)` pattern alternation, and the benign twins of both anchors;
- the backtick pair -- a single-quoted backtick is data, a double-quoted one is still a real closer, because `"`cmd`"` runs `cmd`;
- ten degenerate inputs (`$(case x in x`, `$(: #`, `` `A=' ``, ...) that must yield a list rather than raise;
- the fail-closed direction: an unproven span still yields the whole remainder.

## Manual verification

- 1769 passing in `test/test_security.py`, `test/test_push_branch_gate.py`, `test/test_denied_commands_security.py`, `test/test_security_facade.py`; zero failures.
- Mutation-checked against unmodified `main` by running the identical inputs through both source trees: main allows all three anchors with truncated bodies, this branch denies two and recovers the third's body. The 12 benign controls are byte-identical across both trees.
- bash reachability confirmed with a shim that only echoes its argv and a harmless marker in place of the verb, for both the plain and the line-continuated `case` spellings. No real credential read, kill or push was executed.
- `black`, `isort`, `flake8` clean on both changed files; `mypy` reports zero errors in them.

## Related Issues

Refs #8150

## Pattern harvest

Rule candidate: when a span helper is wrong, ask first whether it is *the* span helper -- if it is, and every one of its consumers fails closed on an unproven span, teaching it beats adding a sibling that will drift out of agreement with it.

A second reading of shell state is the recurring defect in this module, and the cure has been structural every time: two tokenizers, then two paren counters, then four separate readings of quoting. This PR is the same shape one level up -- the reachable bypasses were closed by teaching the shared walk, not by giving `_substitution_bodies` a private one.

Two corollaries earned in review. The draft that modelled heredocs and arithmetic looked stronger but could not be tied to a single reachable payload, and unreachable complexity in a parser that decides refusals is a cost, not a safety margin. And a reserved word is not a byte string: the shell folds line continuations before it reads words, so any recognition that matches literally has a two-character bypass in it -- worth checking every other reserved-word match in this module against that.
