### PR TITLE
fix(test): drop duplicate can_read_body on the slot-race request double

### DIFF
--- a/test/test_slot_close_recreation_race.py
+++ b/test/test_slot_close_recreation_race.py
@@ -116,10 +116,6 @@ class _Req:
         self.content = _Stream(self._raw)
 
     @property
-    def can_read_body(self) -> bool:
-        return bool(self._raw)
-
-    @property
     def content_length(self) -> int | None:
         return len(self._raw) or None
 


### PR DESCRIPTION
## Problem / Motivation

`main`'s `Backend Lint & Type Check (3.12)` is red for every PR: flake8 F811 in
`test/test_slot_close_recreation_race.py` — `can_read_body` is defined twice on
the `_Req` request double (lines 119 and 131).

## Why it matters

Two parallel fixes for the same missing property merged in close succession;
each added its own definition and backing attribute. Python keeps the second,
so the first is dead code — but the F811 fails main-wide lint and cascades into
every open PR's merge-ref round.

## What changed

Deleted the shadowed first definition (`bool(self._raw)`). The surviving
`_has_body`-backed definition keeps the present-vs-absent semantics and the
explanatory docstring. No behavior changes: the second definition was already
the effective one.

## Tests

- `flake8 test/test_slot_close_recreation_race.py` — clean.
- 42/42 tests in the file pass under the repo addopts (`-n auto --dist loadgroup`).

## Manual verification

N/A — lint-only dead-code removal; the effective property is unchanged.

## Related Issues

no linked issue: unblocks main-wide lint after two parallel flake fixes merged.

## Pattern harvest

Rule candidate: when two open PRs fix the same defect, the second to merge must
be re-linted against the merged first — a semantically duplicate fix can be
conflict-free for git yet still break a redefinition lint.

## Checklist

- [x] At most two commits with a Conventional Commits title
- [x] Existing tests pass
- [x] Self-review completed
- [x] No secrets, credentials, or internal references in the diff
