### PR TITLE
refactor(session-control): flatten the ownership-fence refusal message

### DIFF
--- a/src/kiro_crew/dashboard/session_control.py
+++ b/src/kiro_crew/dashboard/session_control.py
@@ -1461,22 +1461,17 @@ def authorize_target(
         # silently widens to the user's own sessions because of an unrelated
         # opt-in.
         #
-        # For a cron caller this is the whole of what replaced the old
-        # `unattended_caller` refusal: a scheduled job reaches the sessions it
-        # dispatched and nothing else. Fail-closed on an unowned slot, which is
-        # what an ownerless rehydrate looks like.
-        raise deny(
-            (
-                "a scheduled run can only control sessions it created itself"
-                if _cron_caller(caller_key)
-                else (
-                    "a crew member can only control worker sessions it created itself"
-                    if _member_caller(caller_key)
-                    else "an agent-created session can only control sessions it " "created itself"
-                )
-            ),
-            "not_creator",
-        )
+        # For a cron caller this fence stands in place of the `unattended_caller`
+        # refusal every other unattended caller gets: a scheduled job reaches the
+        # sessions it dispatched and nothing else. Fail-closed on an unowned slot,
+        # which is what an ownerless rehydrate looks like.
+        if _cron_caller(caller_key):
+            fence_reason = "a scheduled run can only control sessions it created itself"
+        elif _member_caller(caller_key):
+            fence_reason = "a crew member can only control worker sessions it created itself"
+        else:
+            fence_reason = "an agent-created session can only control sessions it created itself"
+        raise deny(fence_reason, "not_creator")
 
     return slot
 


### PR DESCRIPTION
## Problem / Motivation

`authorize_target` in `src/kiro_crew/dashboard/session_control.py` is a
deny-by-default authorization evaluator with twenty fail-closed guards. Its last
guard — the ownership fence, which restricts an exempted caller to the sessions
it created itself — chose its refusal message with a nested conditional
expression written *inside* the `raise deny(...)` call:

```python
raise deny(
    (
        "a scheduled run can only control sessions it created itself"
        if _cron_caller(caller_key)
        else (
            "a crew member can only control worker sessions it created itself"
            if _member_caller(caller_key)
            else "an agent-created session can only control sessions it " "created itself"
        )
    ),
    "not_creator",
)
```

Three caller populations arrive as one expression the reader has to unwind
inwards to find, and the third arm carried an implicit two-string concatenation
(`"…sessions it " "created itself"`) that existed only to fit the nesting — which
reads at a glance like two separate strings rather than one.

The comment above the guard also claimed the fence was "the whole of what
**replaced the old** `unattended_caller` refusal". That is historical narration
of the kind `AGENTS.md` § Comments forbids, and it is inaccurate: that refusal is
still live at line 1334 for every unattended caller that is not a cron
(`workflow-` slots).

## Why it matters

This is the module the sweep's own detector reports as the last chained ternary
in `dashboard/`, and it sits in the guard a reader is most likely to have to
audit. A reviewer tracing a `not_creator` SEL row has to unwind a two-level
conditional expression inside a call argument to answer "which population was
this?", and a stale comment about a refusal that still exists costs them a second
detour.

## What changed (motivation → approach → change)

Goal: make the fence's three refusal messages readable without changing what the
guard does.

Approach: select the message with an `if`/`elif`/`else` above the `raise`,
binding one local, and leave the guard itself alone. The alternative — extracting
a helper — was rejected: it moves the message text away from the only guard that
uses it, for no gain.

Change, one hunk in one file:

- The nested conditional expression becomes `if _cron_caller(...)` /
  `elif _member_caller(...)` / `else`, assigning `fence_reason`, followed by
  `raise deny(fence_reason, "not_creator")`.
- The comment states current behaviour in the present tense, and narrows the
  `unattended_caller` claim to what is true — that refusal stands for every
  unattended caller *other* than a cron.

**What did not change**, since this is an authorization evaluator:

| | status |
|---|---|
| the guard condition (`_caller_is_ownership_fenced(...) and slot._created_by != caller_key`) | byte-identical |
| the refusal code `not_creator` and its 403 status | unchanged |
| the SEL audit emit in `deny()` (`resources=`, `error=`) | untouched |
| the `redact(target)` / `redact(reason)` chokepoint | untouched |
| all three message strings | byte-identical, including the un-split concatenation |
| predicate order and short-circuiting | cron first; `_member_caller` still reached only when the cron check is False |
| the set and order of the other nineteen guards | unchanged |
| imports | none added, deleted, moved, or hoisted |

The third arm's value is worth spelling out because it is the only place the
rewrite touches a literal: `"…sessions it " "created itself"` and
`"…sessions it created itself"` are the same string, so
`test/test_cron_session_control.py:154`'s `"agent-created session" in message`
still holds.

`src/kiro_crew/dashboard/session_control.py` is not in the sweep detector's
keystone set and was offered as ordinary work; the change is nevertheless kept
strictly inside the guard's body, after the decision has already been made, so
nothing a security reviewer would have to re-derive moved.

## Tests

No new tests. Behaviour is unchanged, so there is nothing new to lock in, and the
existing coverage already pins every arm:

- `test/test_cron_session_control.py:446` — cron arm: `code == "not_creator"` and
  `"scheduled run" in message`.
- `test/test_cron_session_control.py:154` — the `else` arm:
  `"agent-created session" in message`. This is the assertion the un-split
  concatenation had to survive.
- `test/test_member_session_control.py:103`, `:121` — member arm.
- `test/test_cron_session_control.py:486`, `test/test_session_control.py:637`,
  `test/test_queue_drain_revalidation.py:646` — `code == "not_creator"`.

All three branches are exercised, so branch coverage does not regress into a
partial branch.

Run locally on the Python 3.12 CI-parity venv: `flake8`, `isort --check-only`,
`mypy src/kiro_crew` (1288 files, clean), `check_black_formatting.py`,
`check_brand_name.py`, `check_harness_parity.py`, `docs_lint.py --test`,
`docs-lint.sh`, `check_per_file_coverage.py --test`,
`verify_vendor_manifest.py`, `check_subprocess_encoding.py`,
`scrub-lint.sh --no-history` — all exit 0. Targeted:
`test_session_control.py`, `test_cron_session_control.py`,
`test_queue_drain_revalidation.py` — 211 passed. Full backend suite run
separately.

**Note on the flake8 lane:** the first push inherited a red `Lint (flake8)` from
`main` — `test/test_slot_close_recreation_race.py:131` F811, a duplicate
`can_read_body` property introduced on `main` in #8549 and unrelated to this
diff (a pristine `origin/main` failed identically). Rather than fold an unrelated
fix in here, it was fixed in its own PR (#8583, since merged) and this branch was
rebased onto the `main` that carries it. `flake8 src/kiro_crew test conftest.py
xdist_budget.py` is green locally on the rebased head.

## Manual verification

N/A — the change selects a refusal string; the three strings and the refusal code
are byte-identical, so there is no runtime behaviour to observe that the unit
coverage above does not already assert.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only refactor with byte-identical output — no
frontend file is touched and no rendered surface changes. The diff touches nothing
under `website/`, `.github/` or `scripts/`, so CI's `changes` job reports
`only_backend=true` and the frontend suites cannot newly fail.

## Pre-review

Five parallel reviewers ran against this diff before it was opened, each briefed
from a different source: the repo's `AUTOSDE.yaml` blocking rules, behaviour
preservation, import semantics and test observability, the security keystone and
boot path, and comment accuracy plus the deterministic `code-review.yml` grep
rules.

**Two findings survived and are fixed in this commit**, both in a comment the
first draft rewrote too broadly:

- The draft claimed the fence "is the whole of what bounds" a cron caller. False:
  a cron is also gated by `session_control_enabled()` at line 1329 (only
  `_member_caller` bypasses that switch, as `_cron_caller`'s own docstring states)
  and by `_app_owned_cron_refusal` at line 1339, which is cron-*only*
  (`if not _cron_caller(caller_key): return None`). Narrowed back to the single
  refusal the claim is true of.
- The draft said the message tells the operator "which exemption they are on".
  Wrong for the third population: an agent-created session holds no exemption —
  it is fenced *because* the fence follows authority to what a fenced caller
  created, which is what `_caller_is_ownership_fenced`'s docstring and the
  unchanged line 1457 ("plus anything they created") already say. That sentence
  is dropped rather than reworded; the `if`/`elif`/`else` below it needs no gloss.

**Dropped as out of scope for this PR:** one reviewer noted that
`dashboard/session_control.py` is, in substance, keystone — a deny-by-default
evaluator with its own audit emitter and redaction chokepoint — and that the
sweep's detector does not treat it as one. That is a fix to the sweep tooling, not
to this diff; the hunk here stays inside the guard's body precisely because of it.

## Related Issues

no linked issue: routine readability sweep, surfaced by the module-simplification
detector rather than by a report.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
