### PR TITLE
fix: drop the shadowed can_read_body double on the slot-race request

### DIFF
--- a/test/test_slot_close_recreation_race.py
+++ b/test/test_slot_close_recreation_race.py
@@ -116,10 +116,6 @@ class _Req:
         self.content = _Stream(self._raw)
 
     @property
-    def can_read_body(self) -> bool:
-        return bool(self._raw)
-
-    @property
     def content_length(self) -> int | None:
         return len(self._raw) or None
 


### PR DESCRIPTION
## Problem / Motivation

`main` is red on the blocking lint gate. `flake8 src/kiro_crew test conftest.py
xdist_budget.py` reports:

```
test/test_slot_close_recreation_race.py:131:5: F811 redefinition of unused 'can_read_body' from line 119
```

`_Request`, the request double in that file, defines `can_read_body` twice —
once at line 118 (`return bool(self._raw)`, no docstring) and again at line 130
(`return self._has_body`, with the docstring explaining what the double has to
mirror). Python keeps the second, so the first is dead code that only flake8 can
see.

A pristine `origin/main` fails identically, so this is not branch-specific.

## Why it matters

The Lint job runs over the whole tree, so this reds the `Lint (flake8)` check on
**every open PR** — the repo currently carries 340+ — and it will keep doing so
until the duplicate is removed. Nothing else reports it: the file's own 42 tests
pass, because they exercise the definition that won.

## What changed (motivation → approach → change)

Symptom: F811 on `main`. Root cause: a duplicate property, one of which is
unreachable. The change deletes the unreachable one.

Which one to delete is not arbitrary — Python already resolved to the second, so
deleting the **first** is the option that changes no behaviour at all. Deleting
the second would have been a behaviour change dressed as a lint fix.

The two are also equivalent for every call site in this file, so nothing shifts
even in principle: `self._has_body` is `body is not None`, and `self._raw` is
`b""` exactly when `body is None`, so both answer `False` for the bodyless
requests every test here constructs.

## Tests

No new tests. This deletes unreachable code; there is no new behaviour to lock
in, and adding a test for a property that already had one would only pin the
duplicate's absence, which flake8 now does.

The surviving definition is what the existing coverage already exercises:
`test/test_slot_close_recreation_race.py` — 42 passed. That file's module
docstring explains why the property matters at all: without `can_read_body` the
handler raises before reaching the save the race tests park on, so the `entered`
event never fires and every interleaved test hangs to its timeout instead of
reporting a one-line attribute error.

Also run on the Python 3.12 CI-parity venv: `flake8 src/kiro_crew test
conftest.py xdist_budget.py` (now exit 0), `isort --check-only`, and
`check_black_formatting.py` — all clean.

## Manual verification

N/A — unit coverage sufficient: the change removes a shadowed definition, and
the gate that was red is now green locally with the same invocation CI uses.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** test-only deletion, no rendered surface and no `website/`
file touched.

## Related Issues

no linked issue: lint breakage on `main`, found while gating an unrelated branch.

## Pattern harvest

Rule candidate: lint

Pattern: a duplicated class member added alongside the one it was meant to
replace, where the shadowed copy is invisible to every test because the language
silently resolves to the later definition. F811 is already the right detector
for this and already fires — the gap is that a red repo-wide lint gate on `main`
is not attributed to the commit that introduced it, so it is discovered by the
next contributor gating an unrelated diff rather than by its author.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
