### PR TITLE
test(agent-config): enumerate the app-namespace region's axis matrix

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -291,6 +291,22 @@ wins and reverts a correction the registration path had made. Fixing that revers
 the editor-snapshot-wins contract kept in #5899, and unlike resurrection it
 self-heals on the next gateway start, so it is left to a separate ruling.
 
+What the ruling is weighing, since "less severe than resurrection" understates it:
+the reverted value is the exact artefact `_register_mcp_servers` refuses to write
+and scrubs on sight — a `backend.port:"auto"` app's illustrative manifest port,
+i.e. a reachable-LOOKING dead URL whose cost that path states as breaking *every*
+kiro session, not just this app's. Two facts set the window. The PUT's own tail
+calls `_reset_all_sessions`, which drains every active session **and** the warm
+pool, so the next cold start reads the reverted row rather than the revert lying
+dormant. And the only writer that puts the live port back is
+`reconcile_enabled_app_resources`, whose single call site is the gateway boot path
+(`dashboard/server.py`) — the mid-turn rung `_recover_app_agent_binding` is gated
+on an UNRESOLVED agent binding, which a reverted port does not produce. So the
+self-heal is a restart, and nothing shorter. Both axes above plus this open cell
+are enumerated in one table by
+`test_the_app_namespace_region_decides_every_axis_it_claims_to`, so a change to
+any of them has to come through it.
+
 Writer: `apps/bridges.py::_apply_agent_mcp_policy`, `_mcp_json_path`,
 `_scrub_legacy_shared_mcp`;
 `dashboard/handlers/agents.py::_merge_unowned_servers` and

--- a/test/test_agent_config_merge_on_write.py
+++ b/test/test_agent_config_merge_on_write.py
@@ -1440,3 +1440,106 @@ async def test_an_unreadable_spec_still_persists_a_namespaced_entry(tmp_path):
         "an unreadable spec deleted what the client submitted: this axis must be "
         "best-effort so the raw editor stays the repair path for a corrupt spec"
     )
+
+
+# ── (g) the region's axis matrix, and the one cell still open (#7470) ──────────
+
+
+@pytest.mark.asyncio
+async def test_the_app_namespace_region_decides_every_axis_it_claims_to(tmp_path):
+    """Every axis of the app-namespace region in ONE table, so a missing one shows.
+
+    THE FAILURE THIS EXISTS TO CATCH is a rule set that reads as complete and is
+    not. #6975 shipped the ABSENT axis; the PRESENT axis was not missing from that
+    review's conclusions so much as never enumerated, and it survived review to
+    become #7089 months later. A per-axis test cannot prevent that on its own --
+    each one passes in isolation -- so the axes are gathered here, and a region
+    whose behaviour changes on any axis has to come through this table.
+
+    The three cells and who decides each:
+
+    * EXISTENCE, name ABSENT from the submission -> ON DISK decides
+      (``_merge_unowned_servers``, #6664): an owned bridge is kept.
+    * EXISTENCE, name PRESENT in the submission with no row on disk -> ON DISK
+      decides (``_drop_unbacked_app_entries``, #7089): the addition is dropped.
+    * CONTENT, name on BOTH sides -> the SUBMISSION decides. **This cell is
+      OPEN** (#7470): a stale editor snapshot reverts a definition the platform
+      had already corrected. It is asserted here as it BEHAVES, not as it should,
+      because reversing it reverses the editor-snapshot-wins contract kept in
+      #5899 and re-affirmed for #6664 -- a maintainer ruling, not a review-time
+      call. When that ruling lands, this is the assertion that changes.
+    """
+    submitted_only = {"name": "kirocrew", "mcpServers": {"demo:ghost": {"command": "ghost"}}}
+    matrix = [
+        (
+            "existence / absent from the submission -> on disk decides",
+            {"demo:notes": {"command": "live"}},
+            {"name": "kirocrew", "mcpServers": {}},
+            {"demo:notes": {"command": "live"}},
+            "an owned bridge the submission omits was not preserved",
+        ),
+        (
+            "existence / present in the submission, absent from disk -> on disk decides",
+            {},
+            submitted_only,
+            {},
+            "a namespaced name with no row on disk was created through this PUT",
+        ),
+        (
+            "content / on both sides -> the submission decides (OPEN, #7470)",
+            {"demo:notes": {"command": "live"}},
+            {"name": "kirocrew", "mcpServers": {"demo:notes": {"command": "stale"}}},
+            {"demo:notes": {"command": "stale"}},
+            "the content axis changed verdict without the ruling #7470 is waiting on",
+        ),
+    ]
+
+    for axis, on_disk, submitted, expected, why in matrix:
+        response, written = await _put(
+            tmp_path,
+            on_disk={"name": "kirocrew", "mcpServers": on_disk},
+            submitted=submitted,
+        )
+
+        assert response.status == 200, f"{axis}: PUT failed"
+        assert written["mcpServers"] == expected, f"{axis}: {why}"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_snapshot_reverts_a_live_http_bridge_to_a_dead_url(tmp_path):
+    """What the open content cell costs, in the instance that makes it load-bearing.
+
+    A ``backend.port:"auto"`` app gets a free port at spawn time and
+    ``_register_mcp_servers`` rewrites its manifest url to that live port
+    (``_resolve_live_mcp_url``). An editor tab opened before that rewrite still
+    holds the manifest's ILLUSTRATIVE port, and saving it writes that port back.
+
+    The reverted value is therefore the exact artefact the registration path
+    refuses to write and scrubs on sight -- a reachable-LOOKING dead URL -- whose
+    cost ``_drop_unbacked_app_entries`` states as breaking every kiro session,
+    not just this app's. Two things narrow it and neither removes it: the PUT's
+    own tail drains every session and the warm pool, so the next cold start reads
+    the reverted row; and the only writer that restores the live port is
+    ``reconcile_enabled_app_resources``, whose single call site is the gateway
+    boot path -- so the window is until the next restart.
+
+    Asserted as it BEHAVES. This is the same open cell as the content row of
+    :func:`test_the_app_namespace_region_decides_every_axis_it_claims_to`, kept
+    separate because the severity, not the verdict, is what it records.
+    """
+    live = "http://127.0.0.1:9137/mcp"  # the port the backend actually got
+    illustrative = "http://127.0.0.1:9100/mcp"  # what the manifest, and the tab, hold
+
+    response, written = await _put(
+        tmp_path,
+        on_disk={"name": "kirocrew", "mcpServers": {"demo:notes": {"url": live}}},
+        submitted={"name": "kirocrew", "mcpServers": {"demo:notes": {"url": illustrative}}},
+    )
+
+    assert response.status == 200
+    assert written["mcpServers"]["demo:notes"]["url"] == illustrative, (
+        "the live url survived a stale snapshot: the content axis now decides from "
+        "on-disk state, which is the reversal #7470 is waiting on a ruling for -- "
+        "update this test and the decision table in "
+        "docs/system-specs/modules/app-kit-platform.md together with it"
+    )


### PR DESCRIPTION
## What is the problem?

`PUT /api/agent/config` persists a whole-file snapshot the editor read earlier.
For the `<app>:<server>` region of `mcpServers`, on-disk state already decides
both directions of *existence* -- #6975 stopped the PUT clobbering a bridge the
submission omits, #7089 stopped it resurrecting one the submission still carries.
The *content* axis is still decided by the submission, so a stale snapshot
reverts a bridge definition the platform had already corrected.

Reproduced by execution, not inferred (issue #7470's own scenario):

| | value |
| --- | --- |
| on disk (what `_resolve_live_mcp_url` wrote) | `http://127.0.0.1:9137/mcp` |
| submitted (the manifest's illustrative port, held by a tab opened earlier) | `http://127.0.0.1:9100/mcp` |
| **persisted** | `http://127.0.0.1:9100/mcp` -- HTTP 200, nothing logged |

Separately, the rule set that governs this region is three rules that each pass
in isolation. That is not a hypothetical weakness: #6975 shipped the absent axis,
review read it as complete, and the present axis survived to become #7089 months
later.

## Why this issue matters to the user

The reverted value is the exact artefact `_register_mcp_servers` refuses to write
and scrubs on sight -- a `backend.port:"auto"` app's illustrative manifest port,
i.e. a reachable-*looking* dead URL. That path states the cost itself: kiro-cli
dials every server in the agent config on each request, so a dead URL breaks
**every** kiro session, not just that app's.

Two facts about the window, both of which the spec did not state and which make
this worse than "less severe than resurrection" suggests:

- The PUT's own tail calls `_reset_all_sessions`, which drains every active
  session **and** the warm pool. The revert does not lie dormant -- the next cold
  start reads it.
- The only writer that restores the live port is
  `reconcile_enabled_app_resources`, whose single call site is the gateway boot
  path (`dashboard/server.py`). The mid-turn recovery rung
  `_recover_app_agent_binding` is gated on an *unresolved* agent binding, which a
  reverted port does not produce. So the self-heal is a restart, and nothing
  shorter.

## How our fix solves it

**It does not fix the revert, deliberately, and this PR does not close #7470.**
Closing the content axis reverses the editor-snapshot-wins contract kept in #5899
and re-affirmed for #6664 (maintainer decision 2026-08-30). That is the ruling
the issue is waiting on, and it is not a review-time call. What lands here is the
part that needs no ruling:

1. `test_the_app_namespace_region_decides_every_axis_it_claims_to` gathers all
   three cells -- existence-absent (on disk decides), existence-present (on disk
   decides), content (the submission decides, **open**) -- into one table. A
   per-axis test cannot catch a *missing* axis, because each one passes on its
   own; one table can, because a region whose behaviour changes on any axis has
   to come through it. This is the ratchet the issue body asks for.
2. `test_a_stale_snapshot_reverts_a_live_http_bridge_to_a_dead_url` records the
   instance that makes the open cell load-bearing. The existing pin
   (`test_app_owned_entry_present_in_the_snapshot_is_updated`) uses a benign
   stdio `command` row; nothing in the suite covered an HTTP url, which is the
   case with the blast radius above.
3. The spec's "Not closed here" paragraph gains the two window facts, so the
   decider has them without re-deriving them.

Both new tests assert the behaviour **as it is**. When the ruling lands, they are
where the assertion flips, and each says so in its own failure message.

### For the decider: what the two candidate shapes actually cost

The house style for a lost update here is **server-side** reconciliation or a
server-held generation CAS -- never a client-echoed precondition. There is no
`If-Match` on any write path in `dashboard/handlers/`; the only ETag uses are
HTTP *caching* validators (`apps/routes.py` static assets, `source_providers.py`
conditional GETs against GitHub). The two CAS precedents both keep the compared
value on the server (`artifacts.py::set_icon_if_epoch`,
`autonudge.py::expected_existing_config_generation`). The sibling raw editor
answered the same whole-snapshot problem with a narrower verb --
`PATCH /api/config/kirocrew`, one field at a time.

- **Substitute on-disk rows** (the issue's shape 1) is the third application of
  the pattern this handler already uses twice, and needs no client change.
  Prototyped locally and measured: it closes the revert, and it does **not**
  block a legitimate up-to-date PUT, a plain client-owned edit, or the host axis.
  Its entire cost is the contract: exactly one existing assertion inverts.
- **Optimistic concurrency** (shape 2) has no field to stand on. A server-side
  CAS needs a monotonic version *in the record*, and one cannot be put there:
  kiro-cli validates `~/.kiro/agents/*.json` with serde `deny_unknown_fields`, so
  "an extra key makes kiro-cli reject the whole file and the user loses every
  tool" (`connections/alias_record.py`, on exactly this constraint;
  `agent_state.lift_and_strip_bookkeeping` exists to strip KiroCrew keys back out
  before the spec write). It therefore needs a **new sidecar schema** plus the GET
  returning it plus the client echoing it -- which collapses into shape 1's client
  cost and then some.
- **The caller set is one.** `saveAgentConfig` (`website/src/api/client.ts`) sends
  `{ config }` and nothing else; the sole UI consumer is
  `overview/AgentCfgTab.tsx`. No Python, CLI or script caller exists. That client
  fills its edit buffer **once** (`if (loadedCfg && !cfg)`) and never refreshes
  it, and `onError` is a bare alert -- so a stale-PUT rejection has nowhere to
  land today: the user would see an alert with the stale text still in the box and
  no reload affordance. An `If-Match` fix without a client change would leave the
  editor unable to save at all after any bridge rewrite.

## What tests we did

Positive control, both directions, via the module's own `_put` harness:

- **Without any fix** -- the revert reproduces: on-disk `:9137` -> persisted
  `:9100`, status 200. The new test fails for exactly that reason on unmodified
  `main`, which is why it is asserted as-is rather than inverted.
- **Mutation-verified the gate bites** -- applying the shape-1 prototype to
  `_drop_unbacked_app_entries` reds exactly 3 of 48: both new tests plus the
  pre-existing `test_app_owned_entry_present_in_the_snapshot_is_updated`. The
  other 45 stay green, which is the evidence that shape 1 breaks nothing except
  the contract itself.
- **Inverse controls, with the prototype applied** -- an up-to-date PUT still
  succeeds, a plain client-owned content edit still lands, and a host-owned key
  containing `:` is still the client's. So the guard would not block normal
  writes.
- `test/test_agent_config_merge_on_write.py` -- **48 passed** on this head
  (46 before). black, isort, flake8 clean. No production code changed, so no
  behaviour is altered by this PR.

Not verified: that a reverted URL breaks a live kiro session end-to-end. The
assertion stops at what the handler persists; the consequence is quoted from
`_register_mcp_servers`' own docstring rather than measured here.

## Any other suggestions on the work

`Refs #7470`, not `Closes` -- deliberate, so the issue stays open for the ruling.
The decision needed is narrow: **may the content axis be reversed at all**, and
if so, shape 1 is costed above and is ~6 lines plus one inverted assertion in a
test that already names this issue. If the answer is no, the two tests here are
the permanent record of why, and nothing further is needed.

## Pattern harvest

Rule candidate: when an endpoint's rules are per-axis and each passes in
isolation, a missing axis cannot be caught by adding another isolated test --
gather the axes into one table so the enumeration itself is the artefact under
review.

Not generalizable: the `deny_unknown_fields` constraint that rules out an in-spec
version field is specific to files kiro-cli validates; it says nothing about
KiroCrew's own config, which does carry versioned migration state.

Refs #7470
