### PR TITLE
fix: name the lessons a write superseded instead of a bare insert

### DIFF
--- a/docs/system-specs/modules/memory-skills-hooks.md
+++ b/docs/system-specs/modules/memory-skills-hooks.md
@@ -544,21 +544,53 @@ falling back would resurrect lessons the user deleted and ignore the scope gate.
 whose `repo_scope` is present but unusable counts as neither.
 
 **Single write path** — all lesson writes go through `write_lesson()` which provides:
-- Substring dedup: "use dark mode" won't duplicate "always use dark mode"
+- Substring dedup, and it is ASYMMETRIC. A submitted rule contained in a stored one is
+  declined and nothing is mutated (`deduped` / `substring_covered`): "use dark mode"
+  won't duplicate "always use dark mode". A submitted rule that CONTAINS a stored one
+  deletes the stored row instead — "longer wins" — so teaching "when a release is in
+  progress, never force push to a shared branch" retires a stored "never force push to
+  a shared branch". Note the direction of that trade: attaching a condition to a rule
+  makes its text longer and its guidance NARROWER, so the row that survives can be the
+  one that applies in fewer cases.
 - Topic-overlap dedup: "use light mode" replaces "use dark mode" (>50% keyword overlap → newer wins)
 - Allowlist validation, injection scanning, audit logging
+
+Substring-delete and topic-overlap are not independent: verbatim containment at word
+boundaries makes the stored rule's keyword set a subset of the submitted rule's, so
+overlap scores 100% and the topic rule would delete the same row the substring rule
+did. Suppressing either one alone does not keep both lessons — which is why
+`write_lesson` REPORTS its deletions (below) rather than declining to make them, and
+why a caller that must never replace an existing lesson routes to
+`set_semantic_if_absent` instead (see `onboarding_import`, whose comment records that a
+foreign directive could otherwise delete a correction the user taught the agent).
 
 **What a write reports.** `write_lesson()` returns a `LessonWriteResult` naming WHICH
 outcome occurred: `inserted` / `enriched` / `unchanged` / `deduped` / `refused`, plus a
 short reason code (a `SemanticRejectCode` value for a refusal, the dedup rule's name for
 a dedup, `kept_stored_clause` for the one `unchanged` case that is not a byte-identical
-re-submit). The vocabulary is shared with `LessonStore.save_or_enrich()`, which already
-returned the first three words, so both stores describe the same events the same way.
+re-submit), plus `superseded` — the rules this call DELETED. The outcome vocabulary is
+shared with `LessonStore.save_or_enrich()`, which already returned the first three
+words, so both stores describe the same events the same way — but only the vocabulary is
+shared, not the dedup policy: the JSONL store matches on exact rule text plus scope and
+has no rule that supersedes, so it keeps both a general rule and the narrower rule
+containing it.
+
 The distinction matters because two outcomes mean "your lesson did not land"
 (`refused`, `deduped`) while two mean "your lesson is fine, there was nothing to do"
 (`unchanged`, and the kept-clause variant) — a caller reading only a bool cannot tell
 them apart, and the `learn add` CLI guessed wrong, writing a second `lessons.jsonl`
 record on every one of them.
+
+`superseded` exists because every other field describes what happened to the SUBMITTED
+lesson, so a write that tombstoned a stored rule reported a bare `inserted` with
+`reason=None` and the caller was told its lesson was saved with nothing naming the cost.
+The result is the only channel that can carry it: the deleted row is a tombstone, so by
+the time the caller looks it is absent from `get_lessons()`, from `learn_list` and from
+the injected lessons block. It is empty on every path that deleted nothing (including
+`enriched`, which is decided in pass 1 and skips the dedup scan), is forwarded by
+`/api/lessons` as a JSON array, and is rendered in full — not counted, not truncated —
+by the `learn add` CLI and the `learn_add` tool, because that text is the last readable
+copy of the removed rule.
 
 **The result's truth value is the old bool, deliberately.** `bool(result)` is `wrote`,
 byte-for-byte the predicate the previous `-> bool` return answered, so the three callers
@@ -571,7 +603,8 @@ bare assertion would keep passing while asserting nothing — a silent hazard my
 flag, since a bare `if` on any object is legal. `stored` is the separate property for
 "is my lesson in the store" (true for a no-op re-submit, which is NOT a write). Surfaces
 that report to a human or a model — the `learn add` CLI, the `POST /api/lessons` response
-(`ok` / `outcome` / `reason`), the `learn_add` tool result — read `outcome` and `reason`.
+(`ok` / `outcome` / `reason` / `superseded`), the `learn_add` tool result — read `outcome`
+and `reason`, and name the `superseded` rules when there are any.
 The dashboard Memory tab clears its draft and refreshes the list only for `inserted`
 or `enriched`; `unchanged` clears the draft but reports that it was already stored,
 while `deduped` and `refused` preserve the draft and surface the reason so it can be
@@ -608,7 +641,7 @@ lesson beat a contradicting preference in the same prompt.
 |----------|------------|-----------|
 | Lesson contradicts a preference | Lesson wins via the `[Learned corrections]` framing | `context.py` |
 | Two semantic writes to one key | `user_explicit` overrides all; else higher confidence; confidences within 0.1 count as equal so newer wins | `vector_memory._write_semantic()` |
-| Duplicate lessons | Substring dedup, then topic-overlap dedup (≥50% of the smaller keyword set → newer replaces older), then embedding dedup (cosine > 0.85 → longer text wins) | `vector_memory.write_lesson()` |
+| Duplicate lessons | Substring dedup (contained-in-stored declines; contains-a-stored-one DELETES it, "longer wins"), then topic-overlap dedup (≥50% of the smaller keyword set → newer replaces older), then embedding dedup (cosine > 0.85 → longer text wins). Every deletion is named in `LessonWriteResult.superseded` | `vector_memory.write_lesson()` |
 | Contradicting episodic fragments | No explicit resolution: time decay plus MMR surfaces the newer/more relevant fragment | `vector_memory.search_episodic()` |
 | A semantic value is superseded | `_retire_stale_episodic()` tombstones episodic rows that quote the old value | `vector_memory._write_semantic()` step 9 |
 

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -1998,6 +1998,58 @@ def _learn(args: argparse.Namespace) -> None:
             # only way into that branch.
             result = vs.write_lesson(rule, category, negative)
             neg = f" ({negative})" if negative else ""
+            # What the save COST. The store's dedup rules tombstone a stored lesson
+            # the submitted rule contains or heavily overlaps, and this command
+            # printed "Saved:" and the dedup NOTE below without ever naming the rule
+            # it removed -- so adding a conditional rule retired the general rule
+            # inside it and the only trace was a row with is_deleted=1. Printed in
+            # full for every outcome that can carry it, because the row is a
+            # tombstone: `learn list` cannot show it and this is the last readable
+            # copy.
+            lost = ""
+            if result.superseded:
+                # Strip terminal controls FIRST, then redact. The order is the whole
+                # correctness of this function, and the intuitive order is the wrong
+                # one: redacting first leaves `AKIA<CSI>IOSFODNN7EXAMPLE` untouched,
+                # because the escape breaks the token so the credential regex does not
+                # match it -- and the control-strip then REASSEMBLES the complete
+                # credential and prints it. Measured: redact-then-strip leaks that
+                # input verbatim; strip-then-redact masks it. Stripping can only ever
+                # JOIN characters, never split a token, so running it first can only
+                # help the regex, never hide a credential from it.
+                #
+                # Both treatments are needed, and both were added in response to a
+                # real finding: an OSC payload stored in a rule would otherwise be
+                # interpreted by the terminal, and a credential in a lesson would
+                # otherwise be printed. This block prints a rule the user did NOT ask
+                # to see, on the one path guaranteed to surface it.
+                #
+                # Redacting at all (rather than control-stripping only) reversed an
+                # earlier decision here. `learn list` prints every stored lesson with
+                # control-stripping alone, and that looked like the convention to
+                # match -- but it is an EXPLICIT request to see the store, while this
+                # block surfaces a lesson the user is about to lose. The right
+                # comparison is the route, which delivers the SAME field and does
+                # redact, so controls-only made one feature's two delivery paths
+                # disagree about whether a superseded rule may carry a secret. A lesson
+                # written by history consolidation also holds model output the user
+                # never typed, so "their own store" is not "their own knowledge".
+                def _safe(text: str) -> str:
+                    text = _TERMINAL_CTRL_RE.sub("", text)
+                    text, _ = redact_exfiltration_urls(text)
+                    text, _ = redact_credentials(text)
+                    return text
+
+                lines = "".join(f"\n    - {_safe(s)}" for s in result.superseded)
+                lost = (
+                    f"\n  REMOVED {len(result.superseded)} stored "
+                    f"lesson{'s' if len(result.superseded) != 1 else ''} this rule "
+                    f"contains or overlaps:{lines}\n"
+                    "  Those are no longer in effect. A verbatim re-add is DECLINED "
+                    "while this rule is stored, so to restore one exactly, "
+                    "`learn remove` this rule first; wording that shares few "
+                    "significant words with it can coexist."
+                )
             # The category is echoed ONLY where the store adopted the submitted one.
             # It is write-once (vector_memory.py builds an enrichment with the STORED
             # category, falling back to the submitted one only when the row has none),
@@ -2006,7 +2058,10 @@ def _learn(args: argparse.Namespace) -> None:
             # the same defect this PR fixes on the reporting side. `learn list` is
             # where stored values belong.
             if result.outcome is LessonWriteOutcome.INSERTED:
-                print(f"Saved: {rule}{neg} [{category}]\n{_LEARN_EMBED_NOTE}\n{_LEARN_DEDUP_NOTE}")
+                print(
+                    f"Saved: {rule}{neg} [{category}]\n{_LEARN_EMBED_NOTE}\n"
+                    f"{_LEARN_DEDUP_NOTE}{lost}"
+                )
             elif result.outcome is LessonWriteOutcome.ENRICHED:
                 # No _LEARN_DEDUP_NOTE here: an enrichment matched its existing row in
                 # pass 1, which SKIPS the generic dedup scan. Instead say what the
@@ -2026,14 +2081,18 @@ def _learn(args: argparse.Namespace) -> None:
                     "changing one means `learn remove` then `learn add`."
                 )
             elif result.outcome is LessonWriteOutcome.DEDUPED:
-                print(f"Not saved: an existing lesson already covers this ({result.reason})")
+                covered = f"Not saved: an existing lesson already covers this ({result.reason})"
+                print(f"{covered}{lost}")
             else:
                 # REFUSED -- and any outcome a later change adds, which is deliberate:
                 # every branch above names ONE outcome, so a new one lands here and
                 # exits non-zero rather than being silently reported as a success. A
                 # non-zero exit so a script driving this command sees the failure.
                 reason = f" ({result.reason})" if result.reason else ""
-                print(f"NOT saved: the memory store refused this lesson{reason}", file=sys.stderr)
+                print(
+                    f"NOT saved: the memory store refused this lesson{reason}{lost}",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
 
         elif action == "list":

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -2030,6 +2030,15 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         outcome = result.outcome.value
         reason = result.reason
         stored = result.stored
+        # Redacted through the SAME chain this handler already applies to a lesson's
+        # rule and category below (`_redact_memory_field`, which walks a list). A
+        # superseded rule is stored user text leaving the process, so a credential or
+        # an exfiltration URL that a user once put in a lesson must not be handed back
+        # in a response -- and this path is worse than a read, because the row is being
+        # deleted, so this response is the one place that text is echoed at all.
+        # Redacting HERE covers both readers: the dashboard and the ``learn_add`` tool
+        # each see only what this route sends.
+        superseded = _redact_memory_field(list(result.superseded))
         if result.wrote:
             candidates = await asyncio.to_thread(
                 vs.find_contradiction_candidates, rule, 0.4, 0.85, rule_emb, repo_scope
@@ -2072,6 +2081,14 @@ async def api_lessons_create(request: web.Request) -> web.Response:
         outcome = await asyncio.to_thread(store.save_or_enrich, lesson)
         reason = None
         stored = True
+        # A genuine empty, not an unfilled field. ``_insert_or_enrich`` has no dedup
+        # rule that supersedes: it matches on exact rule text plus scope and either
+        # attaches a clause or reports ``unchanged``, appending every other record
+        # untouched -- so this store keeps both a general rule and the narrower rule
+        # containing it, which the vector store does not. (It can still drop the
+        # oldest record to the ``_MAX_LESSONS_TOTAL`` cap, but that is an eviction,
+        # not this write superseding a rule it overlaps.)
+        superseded = []
     # Refreshed unconditionally, and deliberately so. An earlier revision of this
     # change gated the push on the write having landed, which is wrong: a DECLINING
     # outcome can still have mutated the store. ``write_lesson``'s second pass
@@ -2091,8 +2108,14 @@ async def api_lessons_create(request: web.Request) -> web.Response:
     # caller its lesson was saved even when the store had refused the value; the
     # ``learn_add`` tool and the CLI both reported "Saved" on that response.
     # ``outcome`` and ``reason`` are additive, so a client that only reads ``ok``
-    # keeps working.
-    return web.json_response({"ok": stored, "outcome": outcome, "reason": reason})
+    # keeps working. ``superseded`` is additive for the same reason, and it is the
+    # only channel that can carry the rules this write DELETED: they are tombstoned,
+    # so a client that re-reads /api/lessons after this response cannot see what it
+    # lost. Always present, empty when nothing was superseded, so a client does not
+    # have to tell "no deletions" from "this gateway is too old to say".
+    return web.json_response(
+        {"ok": stored, "outcome": outcome, "reason": reason, "superseded": superseded}
+    )
 
 
 async def api_lessons_delete(request: web.Request) -> web.Response:

--- a/src/kiro_crew/mcp_tools/learn.py
+++ b/src/kiro_crew/mcp_tools/learn.py
@@ -194,16 +194,49 @@ def learn_add(name: str, args: dict[str, Any]) -> str:
     outcome = d.get("outcome")
     reason = d.get("reason")
     detail = f" ({reason})" if isinstance(reason, str) and reason else ""
+    # What this write DESTROYED, which no wording below could report before. The
+    # store's dedup rules delete a stored lesson when the submitted rule contains it
+    # or overlaps it heavily, and the route reported a plain success -- so teaching a
+    # narrower rule ("when a release is in progress, never force push...") retired
+    # the general one it contains ("never force push...") and the model was told the
+    # save succeeded. Deleting is the designed behaviour; not saying so was not.
+    #
+    # Filtered to strings from a list rather than trusted: this crosses HTTP, and an
+    # older or a hand-rolled gateway can send anything or nothing. Absent reads as
+    # "none reported", which is what every gateway said before this field existed.
+    raw_superseded = d.get("superseded")
+    dropped = (
+        [s for s in raw_superseded if isinstance(s, str) and s.strip()]
+        if isinstance(raw_superseded, list)
+        else []
+    )
+    lost = ""
+    if dropped:
+        # Named in full, not counted and not truncated to a preview: the point of
+        # this sentence is that the user can get the rule back, and a rule the model
+        # cannot read out is a rule nobody can restore -- the row is a tombstone, so
+        # this text is the last copy anything can reach.
+        shown = "".join(f"\n  - {s}" for s in dropped)
+        lost = (
+            f"\n\nWARNING -- saving this REMOVED {len(dropped)} stored "
+            f"lesson{'s' if len(dropped) != 1 else ''} whose wording this rule "
+            f"contains or overlaps:{shown}\n"
+            "Those are no longer in effect and will not appear in learn_list. Tell the "
+            "user which ones were dropped. A verbatim re-add is DECLINED while this "
+            "rule is stored, so restoring one exactly means removing this rule first; "
+            "wording that shares few significant words with it can coexist."
+        )
     if outcome == "refused":
         return (
             f"Lesson was NOT saved{scope_note}: the memory store refused this "
             f"value{detail}. Nothing was stored, so the correction is not in effect. "
             "Re-state it in plainer wording, or tell the user it could not be saved."
+            f"{lost}"
         )
     if outcome == "deduped":
         return (
             f"Lesson was NOT saved as a new entry{detail}: an existing stored lesson "
-            f"already covers it, and that lesson stays in effect. Rule: {rule}"
+            f"already covers it, and that lesson stays in effect. Rule: {rule}{lost}"
         )
     if outcome == "unchanged":
         # No exact-match claim here, because ``unchanged`` does not mean the stored row
@@ -220,16 +253,23 @@ def learn_add(name: str, args: dict[str, Any]) -> str:
                 f"Lesson was already stored{scope_note}, and it carries a NOT-clause "
                 f"this submission did not include -- the stored clause was kept, not "
                 f"removed. Nothing was written, and the lesson remains in effect: {rule}"
+                f"{lost}"
             )
         return (
             f"Lesson was already stored{scope_note} and nothing was written. A "
             f"re-submit does not rewrite the stored category or NOT-clause, so those "
             f"keep the values they already had -- changing one means removing the "
-            f"lesson and adding it again. It remains in effect: {rule}"
+            f"lesson and adding it again. It remains in effect: {rule}{lost}"
         )
     if outcome == "enriched":
-        return f"Updated the stored lesson{scope_note} with the new clause: {rule}"
-    return f"Saved lesson{scope_note}: {rule}"
+        return f"Updated the stored lesson{scope_note} with the new clause: {rule}{lost}"
+    # ``lost`` is interpolated on EVERY branch, including the two that cannot carry it
+    # (``unchanged`` and ``enriched`` are decided before the dedup scan runs, so they
+    # delete nothing). It renders to the empty string when nothing was superseded, so
+    # the uniform interpolation costs nothing and means no future outcome can drop the
+    # warning by being added to a branch that forgot it -- which is the mistake that
+    # made this field necessary in the first place.
+    return f"Saved lesson{scope_note}: {rule}{lost}"
 
 
 def learn_list(name: str, args: dict[str, Any]) -> str:

--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -165,6 +165,17 @@ class LessonWriteResult:
     ``/api/lessons`` response, the ``learn_add`` tool result) need the reason; the
     ones that only branch on success do not.
 
+    ``superseded`` names the stored rules THIS CALL DELETED. Every field above
+    describes what happened to the SUBMITTED lesson, and that was the whole
+    vocabulary -- so a write that tombstoned somebody else's stored rule reported
+    a plain ``inserted`` with ``reason=None``, and the caller was told its lesson
+    was saved with nothing naming what the save cost. Supersede-on-dedup is
+    deliberate (see :meth:`VectorMemoryStore.write_lesson`, and the docstring's
+    "longer wins" / "newer replaces older"), and this field does not change it:
+    the same rows are deleted as before, and the caller is now told which. It is
+    empty on every path that deleted nothing, so a surface can render it with a
+    bare ``if`` and say nothing when there is nothing to say.
+
     **Truthiness is deliberate, and it is the reason this replaced the old ``bool``
     outright instead of shipping beside it.** ``write_lesson`` used to answer
     ``True``/``False``, and three callers plus ~55 assertions read that answer with a
@@ -180,6 +191,12 @@ class LessonWriteResult:
 
     outcome: LessonWriteOutcome
     reason: str | None = None
+    #: Rules this call tombstoned. A tuple, not a list, because the dataclass is
+    #: frozen and a mutable default would let a caller edit a write's own record of
+    #: what it destroyed. Defaults to empty so the ~60 existing construction sites
+    #: -- ``LessonWriteResult(OUTCOME)`` and ``LessonWriteResult(OUTCOME, reason)``
+    #: -- are unchanged, and any surface that ignores the field keeps its behaviour.
+    superseded: tuple[str, ...] = ()
 
     def __bool__(self) -> bool:
         """``wrote`` -- the exact predicate the old ``bool`` return answered.
@@ -2575,6 +2592,24 @@ class VectorMemoryStore:
         - Topic overlap: if >50% of significant words match, newer replaces older
         - Semantic similarity: if >85% cosine similarity, longer wins
 
+        Two of those three rules DELETE a stored lesson, and the "longer wins" tie
+        break means a submitted rule can retire a stored one that is more general
+        than it -- attaching a condition to a rule makes the text longer and the
+        guidance NARROWER, so the row that survives can be the one that applies less
+        often. That is the designed behaviour and this method keeps it: the
+        alternative is a store that accumulates near-identical rules, which is what
+        these three rules exist to prevent, and the onboarding import already shows
+        the sanctioned way to opt out of it (route to ``set_semantic_if_absent``,
+        which cannot replace anything -- see ``onboarding_import``).
+
+        What it does NOT keep is the silence. Every rule that deletes now records the
+        rule text it removed in :attr:`LessonWriteResult.superseded`, so a caller is
+        no longer handed a bare ``inserted`` for a call that destroyed a lesson the
+        user still wanted. The result is the only place that can carry this: the
+        deleted row is a tombstone, so it is gone from ``get_lessons``, from
+        ``learn_list`` and from the injected lessons block by the time the caller
+        looks.
+
         Pass ``rule_emb`` to reuse an embedding already computed by the caller
         and avoid a second blocking embed of the identical text. A caller doing
         that MUST also read :attr:`space_generation` BEFORE it embeds and pass it
@@ -2758,6 +2793,25 @@ class VectorMemoryStore:
             text = _lesson_embed_text(json.loads(row["value_json"]))
             return text or None
 
+        def _as_report_text(row: dict) -> str | None:
+            """The row's value as the text a SUPERSEDE REPORT must name.
+
+            Deliberately NOT ``_as_text``. That one renders through
+            ``_lesson_embed_text``, which returns a mapping row's ``rule`` field
+            ALONE -- the NOT-clause is stripped, because dedup has to compare rules
+            on the same basis embedding similarity does. Correct for comparing, and
+            wrong for reporting: a stored lesson's clause carries its sharpest
+            guidance ("prefer ruff -- NOT: for type checking"), so naming only the
+            bare rule hands the user back a lesson they cannot restore. The row is a
+            tombstone, so there is no second place to read the clause from.
+
+            ``_lesson_display_text`` is the recomposition every other human-facing
+            renderer uses (the injected prompt, ``learn list``), so a restored rule
+            reads exactly as it did when stored.
+            """
+            text = _lesson_display_text(json.loads(row["value_json"]))
+            return text or None
+
         matched = False
         for existing in lesson_rows:
             decoded = json.loads(existing["value_json"])
@@ -2861,18 +2915,68 @@ class VectorMemoryStore:
         # for every row) rather than per candidate — see _stored_similarity_scorer.
         similarity = self._stored_similarity_scorer(rule_emb) if rule_emb else None
 
+        # Every row this scan tombstones, in the order it went. Collected rather
+        # than counted: a count tells the caller a lesson is gone without telling it
+        # WHICH, and the row is a tombstone by the time the caller could look it up.
+        # Populated at all three delete sites below, never at pass 1's -- pass 1
+        # rewrites one row under its own key and deletes nothing, and ``matched``
+        # skips this scan entirely, so an ``enriched`` result always reports none.
+        superseded: list[str] = []
+
         for existing in [] if matched else lesson_rows:
             existing_text = _as_text(existing)
             if existing_text is None:
                 continue
             existing_lower = existing_text.lower()
+            # Two renderings of one row, and the split is the point. Every COMPARISON
+            # below stays on ``existing_text`` (the embed rendering) so no dedup
+            # decision changes; only what a deletion REPORTS uses the display
+            # rendering, which keeps the NOT-clause. Falls back to the comparison text
+            # when a row has no display form, so the report can never be emptier than
+            # the row it names.
+            existing_report = _as_report_text(existing) or existing_text
 
             # Substring dedup
             if rule_lower in existing_lower:
-                logger.info("Lesson dedup: %r already covered by %r", rule[:60], existing["key"])
+                logger.info(
+                    "Lesson dedup: %s already covered by %s [%s]", key, existing["key"], category
+                )
                 _flush_backfills()
-                return LessonWriteResult(LessonWriteOutcome.DEDUPED, "substring_covered")
+                return LessonWriteResult(
+                    LessonWriteOutcome.DEDUPED, "substring_covered", tuple(superseded)
+                )
             if existing_lower in rule_lower:
+                # This branch was the only one of the four here that deleted a row
+                # WITHOUT saying so at any level: its three siblings each log, and
+                # this one went straight to delete_semantic. So the deletion left no
+                # trace a user or an operator could find -- not in the result, not in
+                # the log, and not in the store, since the row is tombstoned and
+                # every read path filters it. Log like the siblings do.
+                #
+                # IDENTITIES, never content, and that is the point of this whole scan's
+                # logging rather than a limitation of this line. A lesson holds whatever
+                # the user once told the agent -- credentials, paths, names -- so a log
+                # line carrying its text turns a silent-deletion bug into a disclosure
+                # bug, on a sink that persists to disk and may reach a notification
+                # channel. Both keys ARE the store's own row ids (``lesson.<digest>``),
+                # so an operator can join this line to the tombstoned row, to the
+                # delete_semantic audit record, and to the matching ``superseded`` entry
+                # in the result -- which is the read path where the text belongs, and
+                # where it is redacted at every surface.
+                #
+                # The id is logged rather than a fresh digest deliberately: a
+                # newly-computed hash would correlate with nothing. Nothing here HASHES
+                # anything, so this adds no weak-hashing exposure -- ``_lesson_key``
+                # already derived these ids, and CodeQL flags that derivation at its own
+                # site, not at a line that merely logs the result.
+                logger.info(
+                    "Lesson supersede: %s contains and replaces %s [%s], %d so far",
+                    key,
+                    existing["key"],
+                    category,
+                    len(superseded) + 1,
+                )
+                superseded.append(existing_report)
                 self.delete_semantic(existing["key"], source)
                 continue
 
@@ -2884,11 +2988,13 @@ class VectorMemoryStore:
                     ratio = len(overlap) / min(len(rule_words), len(existing_words))
                     if ratio >= 0.5:
                         logger.info(
-                            "Lesson conflict: %r replaces %r (%.0f%% overlap)",
-                            rule[:60],
-                            existing_text[:60],
+                            "Lesson conflict: %s replaces %s [%s] (%.0f%% overlap)",
+                            key,
+                            existing["key"],
+                            category,
                             ratio * 100,
                         )
+                        superseded.append(existing_report)
                         self.delete_semantic(existing["key"], source)
                         continue
 
@@ -2930,18 +3036,27 @@ class VectorMemoryStore:
                                 for b, k, g in pending_backfills
                                 if k != existing["key"]
                             ]
+                            superseded.append(existing_report)
                             self.delete_semantic(existing["key"], source)
                         else:
                             _flush_backfills()
                             return LessonWriteResult(
-                                LessonWriteOutcome.DEDUPED, "semantic_similarity"
+                                LessonWriteOutcome.DEDUPED,
+                                "semantic_similarity",
+                                tuple(superseded),
                             )
 
         _flush_backfills()
 
         err = self.set_semantic(key, value, confidence, source)
         if err is not None:
-            return LessonWriteResult(LessonWriteOutcome.REFUSED, err[0].value)
+            # Carries ``superseded`` too, and this is the path where it matters most:
+            # the scan above already deleted, so a refusal here means rows were
+            # destroyed and NOTHING was stored in their place. The preflight was
+            # added to keep this unreachable for the values it can screen; a refusal
+            # that gets past it must still name the cost rather than report a bare
+            # refusal for a call that emptied part of the store.
+            return LessonWriteResult(LessonWriteOutcome.REFUSED, err[0].value, tuple(superseded))
         if rule_emb:
             emb_blob = struct.pack(f"{len(rule_emb)}f", *rule_emb)
             with self._db_lock:
@@ -2962,7 +3077,8 @@ class VectorMemoryStore:
         # superseded an older row first, since the caller's lesson did not exist under
         # this key before. Same two words the JSONL store uses for the same events.
         return LessonWriteResult(
-            LessonWriteOutcome.ENRICHED if matched else LessonWriteOutcome.INSERTED
+            LessonWriteOutcome.ENRICHED if matched else LessonWriteOutcome.INSERTED,
+            superseded=tuple(superseded),
         )
 
     @staticmethod

--- a/test/test_lesson_write_outcome.py
+++ b/test/test_lesson_write_outcome.py
@@ -34,6 +34,14 @@ def _store(tmp_path) -> VectorMemoryStore:
     return store
 
 
+def _rule_of(row) -> str:
+    """The rule text of a lesson row, in either storage shape."""
+    import json as _json
+
+    value = _json.loads(row["value_json"])
+    return value["rule"] if isinstance(value, dict) else value
+
+
 class TestWriteLessonOutcomes:
     """Each declining path names WHICH rule declined, not just that one did."""
 
@@ -386,7 +394,12 @@ class TestLessonsRouteReportsTheOutcome:
         import json as _json
 
         body = _json.loads(resp.text)
-        assert body == {"ok": False, "outcome": "refused", "reason": "injection_blocked"}
+        assert body == {
+            "ok": False,
+            "outcome": "refused",
+            "reason": "injection_blocked",
+            "superseded": [],
+        }
 
     async def test_no_op_stays_ok_but_names_the_outcome(self):
         resp, state = await self._post(LessonWriteResult(LessonWriteOutcome.UNCHANGED))
@@ -442,7 +455,12 @@ class TestLessonsRouteReportsTheOutcome:
         import json as _json
 
         body = _json.loads(resp.text)
-        assert body == {"ok": True, "outcome": "unchanged", "reason": None}
+        assert body == {
+            "ok": True,
+            "outcome": "unchanged",
+            "reason": None,
+            "superseded": [],
+        }
 
 
 class TestLearnAddToolReportsTheOutcome:
@@ -502,3 +520,511 @@ class TestLearnAddToolReportsTheOutcome:
         """Version skew during an update must not turn a real save into a scare."""
         text = self._call({"ok": True})
         assert text == "Saved lesson: a rule"
+
+
+class TestASupersedingWriteNamesWhatItRemoved:
+    """The store deletes a stored lesson the submitted rule contains, and said nothing.
+
+    From the issue: teach "never force push to a shared branch", then teach "when a
+    release is in progress, never force push to a shared branch, and tell the release
+    manager first". The second rule's text CONTAINS the first, so the substring rule
+    tombstones the general lesson -- and the call returned a plain ``inserted`` with
+    ``reason=None``. The user was told the save succeeded and there was no longer any
+    rule against force pushing outside a release.
+
+    Deleting is deliberate (``write_lesson``'s docstring: "longer wins" / "newer
+    replaces older"), and these tests do NOT assert it stopped. They assert the write
+    now NAMES the rule it destroyed, which is the only recoverable trace: the row is
+    tombstoned, so it is gone from ``get_lessons``, ``learn_list`` and the injected
+    lessons block.
+
+    POSITIVE CONTROL for these tests: they fail on unpatched ``main``, where
+    ``LessonWriteResult`` has no ``superseded`` field at all -- ``result.superseded``
+    raises ``AttributeError``. That is a fail for the right reason (the field does not
+    exist), and it is distinct from a fail on the wording of a message.
+    """
+
+    GENERAL = "never force push to a shared branch"
+    NARROWER = (
+        "when a release is in progress, never force push to a shared branch, "
+        "and tell the release manager first"
+    )
+
+    def test_the_general_rule_is_still_deleted(self, tmp_path):
+        """Pinned deliberately: the fix REPORTS the supersede, it does not prevent it.
+
+        Without this, a later change could "fix" the issue by loosening the
+        containment test, and the tests below would still pass while the dedup rule
+        that keeps the store from filling with near-identical lessons had quietly
+        stopped saying no. This is the assertion that makes that visible.
+        """
+        store = _store(tmp_path)
+        try:
+            store.write_lesson(self.GENERAL, "tool")
+            store.write_lesson(self.NARROWER, "tool")
+            live = [_rule_of(row) for row in store.get_lessons()]
+            assert self.GENERAL not in live, "supersede-on-containment must still delete"
+            assert self.NARROWER in live
+        finally:
+            store.close()
+
+    def test_the_write_names_the_rule_it_superseded(self, tmp_path):
+        store = _store(tmp_path)
+        try:
+            store.write_lesson(self.GENERAL, "tool")
+            result = store.write_lesson(self.NARROWER, "tool")
+            # Still an insert, still truthy -- the submitted lesson did land.
+            assert result.outcome is LessonWriteOutcome.INSERTED
+            assert bool(result) is True
+            # ...and the call no longer hides what that cost.
+            assert result.superseded == (self.GENERAL,)
+        finally:
+            store.close()
+
+    def test_a_write_that_supersedes_nothing_reports_nothing(self, tmp_path):
+        """The field must not be a warning that fires on every write.
+
+        A surface renders it with a bare ``if``, so a non-empty value on an ordinary
+        insert would put a data-loss warning in front of the user for a write that
+        lost nothing -- and a warning that always fires is read as noise, which is how
+        a real one gets ignored.
+        """
+        store = _store(tmp_path)
+        try:
+            first = store.write_lesson(self.GENERAL, "tool")
+            assert first.superseded == ()
+            unrelated = store.write_lesson("write commit messages in the imperative", "tool")
+            assert unrelated.superseded == ()
+        finally:
+            store.close()
+
+    def test_one_write_names_every_rule_it_removed_not_just_the_first(self, tmp_path):
+        """The delete branch ``continue``s, so a single call can tombstone several rows.
+
+        A count would be a smaller lie than silence but still a lie: the user cannot
+        restore a rule the report does not name.
+
+        The two stored rules are deliberately unrelated to each other -- they share no
+        significant word, so neither supersedes the other and both are live when the
+        third write arrives. A chain of progressively longer rules could not set this
+        up, because each write already collapses the one before it.
+        """
+        store = _store(tmp_path)
+        try:
+            store.write_lesson("prefer tabs", "preference")
+            store.write_lesson("run ruff", "tool")
+            assert len(store.get_lessons()) == 2, "the two rules must not dedup each other"
+            result = store.write_lesson("prefer tabs and run ruff on every python file", "tool")
+            assert set(result.superseded) == {"prefer tabs", "run ruff"}
+            live = [_rule_of(row) for row in store.get_lessons()]
+            assert live == ["prefer tabs and run ruff on every python file"]
+        finally:
+            store.close()
+
+    def test_the_refuse_direction_is_unchanged_and_deletes_nothing(self, tmp_path):
+        """The OTHER direction of the same test must keep refusing.
+
+        Submitting a rule CONTAINED IN a stored one is genuinely covered by it, so it
+        is declined without mutating anything. Loosening the containment test to save
+        the general lesson would have changed this too -- accumulating a near-identical
+        row for every re-phrasing. It is pinned here so that cannot happen quietly.
+        """
+        store = _store(tmp_path)
+        try:
+            store.write_lesson("always run the linter before pushing a branch", "tool")
+            result = store.write_lesson("run the linter", "tool")
+            assert result.outcome is LessonWriteOutcome.DEDUPED
+            assert result.reason == "substring_covered"
+            assert result.superseded == ()
+            live = [_rule_of(row) for row in store.get_lessons()]
+            assert live == ["always run the linter before pushing a branch"]
+        finally:
+            store.close()
+
+    def test_the_report_keeps_the_not_clause_of_the_rule_it_removed(self, tmp_path):
+        """A report that drops the clause hands back a rule the user cannot restore.
+
+        Dedup compares rules through ``_lesson_embed_text``, which returns the ``rule``
+        field ALONE so the comparison basis matches the embedding space. Reporting on
+        that same rendering silently dropped the NOT-clause -- so the clause, which
+        carries the sharpest part of the guidance, became unrecoverable at the exact
+        moment the row was tombstoned. The report uses the display rendering instead;
+        the comparisons still use the embed one, so no dedup decision moves.
+        """
+        store = _store(tmp_path)
+        try:
+            store.write_lesson("prefer ruff over flake8", "tool", "for type checking")
+            result = store.write_lesson(
+                "in CI prefer ruff over flake8 and fail the build on any finding", "tool"
+            )
+            assert result.outcome is LessonWriteOutcome.INSERTED
+            assert len(result.superseded) == 1
+            reported = result.superseded[0]
+            assert reported.startswith("prefer ruff over flake8")
+            assert "for type checking" in reported, "the NOT-clause was dropped from the report"
+            assert reported == "prefer ruff over flake8 \u2014 NOT: for type checking"
+        finally:
+            store.close()
+
+    def test_a_clause_less_rule_is_reported_verbatim_with_no_separator(self, tmp_path):
+        """The display rendering must not decorate a row that has no clause."""
+        store = _store(tmp_path)
+        try:
+            store.write_lesson(self.GENERAL, "tool")
+            result = store.write_lesson(self.NARROWER, "tool")
+            assert result.superseded == (self.GENERAL,)
+            assert "NOT:" not in result.superseded[0]
+        finally:
+            store.close()
+
+    def test_the_advice_it_prints_describes_a_recovery_the_policy_permits(self, tmp_path):
+        """The warning's purpose is restorability, so its advice must actually work.
+
+        Measured, because the wording was weaker than this before: a VERBATIM re-add of
+        the superseded rule is declined by the substring branch (the narrower rule now
+        contains it), so telling the user only to "re-add it" would send them into a
+        refusal. Two recoveries do work, and both are what the text now names.
+        """
+        store = _store(tmp_path)
+        try:
+            store.write_lesson(self.GENERAL, "tool")
+            store.write_lesson(self.NARROWER, "tool")
+
+            # 1. Verbatim re-add: declined, and it changes nothing.
+            again = store.write_lesson(self.GENERAL, "tool")
+            assert again.outcome is LessonWriteOutcome.DEDUPED
+            assert again.reason == "substring_covered"
+            assert again.superseded == ()
+            assert [_rule_of(r) for r in store.get_lessons()] == [self.NARROWER]
+
+            # 2. Wording sharing few significant words: coexists, nothing superseded.
+            other = store.write_lesson(
+                "protected branches reject a forced update at all times", "tool"
+            )
+            assert other.outcome is LessonWriteOutcome.INSERTED
+            assert other.superseded == (), "a non-overlapping rule must not ping-pong"
+            assert len(store.get_lessons()) == 2
+        finally:
+            store.close()
+
+    def test_removing_the_narrower_rule_first_restores_the_general_one_exactly(self, tmp_path):
+        """The other recovery the text names, and the only one that restores verbatim."""
+        store = _store(tmp_path)
+        try:
+            store.write_lesson(self.GENERAL, "tool")
+            store.write_lesson(self.NARROWER, "tool")
+            narrower_key = next(
+                r["key"] for r in store.get_lessons() if _rule_of(r) == self.NARROWER
+            )
+            store.delete_semantic(narrower_key, "user_explicit")
+            restored = store.write_lesson(self.GENERAL, "tool")
+            assert restored.outcome is LessonWriteOutcome.INSERTED
+            assert [_rule_of(r) for r in store.get_lessons()] == [self.GENERAL]
+        finally:
+            store.close()
+
+    def test_removing_only_the_substring_branch_would_not_have_saved_the_lesson(self):
+        """Why the fix reports instead of preventing: the collapse is over-determined.
+
+        Verbatim containment at word boundaries makes the stored rule's keyword set a
+        SUBSET of the submitted rule's, so the topic-overlap rule three lines below
+        scores 100% and deletes the same row anyway. Deleting the substring branch
+        alone therefore changes nothing a user would notice -- the general lesson is
+        still gone, just via the next rule down. Preventing the collapse means editing
+        all three dedup rules, which is the design call the issue reserved for
+        maintainers.
+
+        Computed from the store's own keyword helper so it cannot drift from the
+        arithmetic the branch actually performs.
+        """
+        keywords = VectorMemoryStore._lesson_keywords
+        general = keywords(self.GENERAL.lower())
+        narrower = keywords(self.NARROWER.lower())
+        assert general, "the general rule must contribute keywords for the branch to run"
+        assert general <= narrower, "containment should make the keyword set a subset"
+        ratio = len(general & narrower) / min(len(narrower), len(general))
+        assert ratio == 1.0
+        assert ratio >= 0.5, "topic overlap would delete the general lesson regardless"
+
+
+class TestSupersedeReachesTheSurfacesAHumanReads:
+    """A field nothing renders is not a fix. These pin the two report surfaces."""
+
+    @pytest.mark.asyncio
+    async def test_the_route_forwards_the_superseded_rules(self):
+        """Drives the real route, so it fails on main where the response omits the key."""
+        resp, _state = await TestLessonsRouteReportsTheOutcome()._post(
+            LessonWriteResult(
+                LessonWriteOutcome.INSERTED,
+                None,
+                ("never force push to a shared branch",),
+            )
+        )
+        import json as _json
+
+        body = _json.loads(resp.text)
+        assert body["ok"] is True, "the submitted lesson did land"
+        assert body["outcome"] == "inserted"
+        assert body["superseded"] == ["never force push to a shared branch"]
+
+    def _tool_call(self, response):
+        from kiro_crew.mcp_tools import learn
+
+        with (
+            patch.object(learn.mcp_core, "_post", return_value=response),
+            patch.object(learn.mcp_core, "_resolve_session_key", return_value="dashboard:ui"),
+            patch.object(learn.mcp_core, "_vet_memory_writes_governance", return_value=None),
+        ):
+            return learn.learn_add("learn_add", {"rule": "a rule", "category": "tool"})
+
+    def test_the_tool_warns_and_quotes_the_removed_rule_in_full(self):
+        text = self._tool_call(
+            {
+                "ok": True,
+                "outcome": "inserted",
+                "reason": None,
+                "superseded": ["never force push to a shared branch"],
+            }
+        )
+        assert "Saved lesson" in text
+        assert "REMOVED 1 stored lesson" in text
+        # Quoted in full, not counted or previewed: this text is the last readable
+        # copy of a tombstoned row.
+        assert "never force push to a shared branch" in text
+
+    def test_the_tool_says_nothing_when_nothing_was_superseded(self):
+        text = self._tool_call({"ok": True, "outcome": "inserted", "reason": None})
+        assert "Saved lesson" in text
+        assert "REMOVED" not in text
+
+    def test_the_tool_ignores_a_superseded_field_that_is_not_a_list_of_text(self):
+        """It crosses HTTP, so the shape is not this tool's to trust.
+
+        A malformed value must read as "none reported" -- which is what every gateway
+        older than this field says -- rather than rendering a repr into a warning.
+        """
+        for junk in ({"a": 1}, "a string", [None, 3, "  "], 7):
+            text = self._tool_call(
+                {"ok": True, "outcome": "inserted", "reason": None, "superseded": junk}
+            )
+            assert "REMOVED" not in text, f"rendered a warning for {junk!r}"
+
+
+class TestASupersededRuleIsSanitizedBeforeItIsShown:
+    """The reported rule is stored USER TEXT, so echoing it raw is a new exposure.
+
+    Reporting a superseded rule means printing text a user typed once, on a path that
+    did not print it before. Both surfaces already had the right treatment for stored
+    text and this write path was simply not routed through it -- `learn list` strips
+    terminal control sequences on every print, and `api_lessons_create` already sends
+    the lesson's own rule through `_redact_memory_field`.
+    """
+
+    def test_the_cli_strips_terminal_control_sequences_from_a_removed_rule(self, tmp_path):
+        """An OSC payload stored in a lesson must not be executed by reporting it.
+
+        This is the one write path guaranteed to print a rule the user is NOT looking
+        at, so an escape sequence here retitles the window or writes the clipboard for
+        a rule the user never asked to see.
+        """
+        import argparse
+
+        from kiro_crew import cli_commands
+
+        store = _store(tmp_path)
+        # A stored general rule carrying an OSC window-title payload and a CSI clear.
+        evil = "never \x1b]0;pwned\x07force \x1b[2Jpush"
+        store.write_lesson(evil, "tool")
+        args = argparse.Namespace(
+            learn_action="add",
+            rule=f"during a release {evil} and tell the release manager",
+            category="tool",
+            negative=None,
+        )
+        with (
+            patch.object(cli_commands, "VectorMemoryStore", return_value=store),
+            patch.object(cli_commands, "LessonStore", return_value=MagicMock()),
+            patch.object(cli_commands.KiroCrewConfig, "load", return_value=MagicMock()),
+        ):
+            import io
+            from contextlib import redirect_stdout
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli_commands._learn(args)
+            out = buf.getvalue()
+        assert "REMOVED 1 stored lesson" in out, "the supersede must still be reported"
+        # Scoped to the REMOVED block, which is what this change prints. The `Saved:`
+        # line above it echoes the rule the user just typed on their own command line,
+        # unsanitized on main and unchanged here -- a different threat model (their own
+        # input, in the same breath) from a STORED rule, which consolidation, an import
+        # or a subagent may have written and which this block prints when the user is
+        # not looking at it. Masking a string the user literally just typed would tell
+        # them nothing and hide their own command from them.
+        removed_block = out[out.index("REMOVED") :]
+        # The readable rule survives around the sequences. "pwned" is deliberately NOT
+        # asserted present: it is the OSC sequence's own payload, and the regex consumes
+        # a whole OSC run, so removing it is correct rather than over-broad.
+        assert "never" in removed_block and "push" in removed_block
+        assert "pwned" not in removed_block, "the OSC payload itself must not survive"
+        assert "\x1b]" not in removed_block, "raw OSC reached the terminal"
+        assert "\x1b[" not in removed_block, "raw CSI reached the terminal"
+        assert "\x07" not in removed_block
+
+    def test_the_cli_redacts_a_credential_in_a_removed_rule(self, tmp_path):
+        """The CLI must agree with the route about whether a superseded rule may leak.
+
+        Both deliver the same field, so a secret redacted on one path and printed on the
+        other is one feature disagreeing with itself. A lesson written by history
+        consolidation carries model output the user never typed, so this is not
+        "their own secret in their own terminal".
+        """
+        import argparse
+        import io
+        from contextlib import redirect_stdout
+
+        from kiro_crew import cli_commands
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        store = _store(tmp_path)
+        store.write_lesson(f"never commit {secret} to the repository", "tool")
+        args = argparse.Namespace(
+            learn_action="add",
+            rule=f"during a release never commit {secret} to the repository and tell the lead",
+            category="tool",
+            negative=None,
+        )
+        with (
+            patch.object(cli_commands, "VectorMemoryStore", return_value=store),
+            patch.object(cli_commands, "LessonStore", return_value=MagicMock()),
+            patch.object(cli_commands.KiroCrewConfig, "load", return_value=MagicMock()),
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli_commands._learn(args)
+            out = buf.getvalue()
+        assert "REMOVED 1 stored lesson" in out, "the supersede must still be reported"
+        removed_block = out[out.index("REMOVED") :]
+        assert secret not in removed_block, "raw credential printed for a removed rule"
+        assert "never commit" in removed_block, "the rule is redacted, not dropped"
+
+    def test_the_cli_cannot_reassemble_a_credential_split_by_a_control_sequence(self, tmp_path):
+        """Pins the ORDER of the two treatments, which is where this went wrong once.
+
+        The intuitive order is the unsafe one. Redacting first leaves
+        ``AKIA<CSI>IOSFODNN7EXAMPLE`` untouched -- the escape breaks the token so the
+        credential regex does not match -- and the control-strip then REASSEMBLES the
+        complete credential and prints it. Stripping first can only JOIN characters,
+        never split a token, so the regex sees the whole credential.
+
+        This is why the two earlier tests are not enough between them: each shows one
+        treatment happens, neither shows they compose in the safe order. A stored
+        credential is planted pre-split here so a future reordering reddens.
+        """
+        import argparse
+        import io
+        from contextlib import redirect_stdout
+
+        from kiro_crew import cli_commands
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        split = "AKIA\x1b[0mIOSFODNN7EXAMPLE"
+        store = _store(tmp_path)
+        store.write_lesson(f"never commit {split} to the repository", "tool")
+        args = argparse.Namespace(
+            learn_action="add",
+            rule=f"during a release never commit {split} to the repository and tell the lead",
+            category="tool",
+            negative=None,
+        )
+        with (
+            patch.object(cli_commands, "VectorMemoryStore", return_value=store),
+            patch.object(cli_commands, "LessonStore", return_value=MagicMock()),
+            patch.object(cli_commands.KiroCrewConfig, "load", return_value=MagicMock()),
+        ):
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                cli_commands._learn(args)
+            out = buf.getvalue()
+        assert "REMOVED 1 stored lesson" in out, "the supersede must still be reported"
+        removed_block = out[out.index("REMOVED") :]
+        assert secret not in removed_block, "control stripping reassembled the credential"
+        assert split not in removed_block, "the split credential was printed as stored"
+
+    @pytest.mark.asyncio
+    async def test_the_route_redacts_a_credential_in_a_removed_rule(self):
+        """A credential a user once put in a lesson must not be echoed on deletion.
+
+        Worse than a read: the row is being deleted, so this response is the only place
+        that text is returned at all, and it reaches both the dashboard and the
+        ``learn_add`` tool.
+        """
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        resp, _state = await TestLessonsRouteReportsTheOutcome()._post(
+            LessonWriteResult(
+                LessonWriteOutcome.INSERTED, None, (f"never commit the key {secret}",)
+            )
+        )
+        import json as _json
+
+        body = _json.loads(resp.text)
+        assert len(body["superseded"]) == 1, "the supersede must still be reported"
+        assert secret not in body["superseded"][0], "raw credential returned in a response"
+        assert secret not in resp.text
+
+    def test_no_dedup_log_line_carries_lesson_text(self, tmp_path, caplog):
+        """The whole scan logs IDENTITIES, never content, on every branch.
+
+        A lesson holds whatever the user once told the agent -- credentials, paths,
+        names -- so a log line carrying its text turns a silent-deletion bug into a
+        disclosure bug, on a sink that persists to disk and may reach a notification
+        channel. Filtering the text on the way out only narrows that; logging the
+        store's own row ids removes it, and those ids are what let an operator join the
+        line to the tombstoned row and to the ``delete_semantic`` audit record.
+
+        The result is the read path where the text belongs, and the last assertion
+        checks it still carries the full rule -- so this test cannot be satisfied by
+        losing the recovery channel along with the exposure.
+
+        Each of the three dedup branches is driven separately, and every record emitted
+        is checked, because the three lines are independent and only one of them was
+        added by this change.
+        """
+        import logging
+
+        secret = "AKIAIOSFODNN7EXAMPLE"
+        cases = {
+            # label -> (stored rule, submitted rule) selecting one branch each
+            "substring-delete": (
+                f"never commit {secret} to the repository",
+                f"during a release never commit {secret} to the repository and tell the lead",
+            ),
+            "substring-covered": (
+                f"always rotate {secret} on the first of the month",
+                f"rotate {secret}",
+            ),
+            "topic-overlap": (
+                f"rotate the deployment key {secret} monthly and audit the log",
+                f"rotate the deployment key {secret} weekly instead",
+            ),
+        }
+        for label, (stored, submitted) in cases.items():
+            store = _store(tmp_path / label.replace("-", "_"))
+            try:
+                store.write_lesson(stored, "tool")
+                caplog.clear()
+                with caplog.at_level(logging.DEBUG, logger="kiro_crew.vector_memory"):
+                    result = store.write_lesson(submitted, "tool")
+                emitted = [r.getMessage() for r in caplog.records]
+                assert emitted, f"{label}: no log record, so this asserts nothing"
+                for message in emitted:
+                    assert secret not in message, f"{label}: a credential reached the log"
+                    assert "rotate" not in message, f"{label}: rule text reached the log"
+                    assert "commit" not in message, f"{label}: rule text reached the log"
+                    assert "lesson." in message, f"{label}: rows should be named by id"
+                if label == "substring-delete":
+                    # The recovery channel still carries the full text.
+                    assert result.superseded, "the supersede must have happened"
+                    assert secret in result.superseded[0], "the result carries the text"
+            finally:
+                store.close()


### PR DESCRIPTION
## What is the problem?

`write_lesson` dedupes on substring containment. In the direction where the SUBMITTED
rule contains a STORED one, the stored row is tombstoned:

```python
if existing_lower in rule_lower:
    self.delete_semantic(existing["key"], source)
    continue
```

Reproduced on a throwaway store at `origin/main`:

```
1) write "never force push to a shared branch"                    -> INSERTED, 1 live row
2) write "when a release is in progress, never force push to a
   shared branch, and tell the release manager first"             -> INSERTED, reason=None, truthy
3) live rows: 1   (only the second rule)
4) is the general rule still stored? False   (is_deleted=1)
5) log records emitted by the deleting write: NONE
```

Both halves of the report hold, and the second is worse than reported. The write is
silent at **every** level:

- `LessonWriteResult` has `outcome` / `reason` / `stored` / `wrote` -- every field
  describes the SUBMITTED lesson. Nothing can carry a deleted row.
- This branch was the **only one of the four** in the dedup scan that deleted without
  logging. Its three siblings each log (`Lesson dedup:`, `Lesson conflict:`,
  `Lesson semantic dedup:`).
- The delete is a tombstone, so the row is gone from `get_lessons`, `learn_list` and the
  injected lessons block.

**The deletion itself is deliberate**, and this PR does not change it. Three independent
records establish intent: the docstring (`longer wins`, `newer replaces older`), the spec
dedup table, and -- decisively -- `onboarding_import.py:4269-4274`, which routes to
`set_semantic_if_absent` precisely because

> `write_lesson` ... deletes an existing lesson on exact-substring OR >50% topic overlap
> ... which for an import means a foreign directive can delete a correction the USER
> taught the agent.

A contract described that exactly is not an accident, and the remedy chosen there was to
**avoid** the function rather than change it.

## Why this issue matters to the user

The lesson store is the surface where a user teaches the agent. Attaching a condition to
a rule makes the text longer and the guidance **narrower**, so "longer wins" retires the
rule that applies in more cases and keeps the one that applies in fewer. The user never
retracted the general rule, was told the save succeeded, and cannot find the loss: the
tombstone is filtered by every read path. On the reporter's own store 291 rows carry
`is_deleted = 1`, and there is currently no way to attribute any of them.

## How our fix solves it

Symptom -> cause -> fix:

- **Symptom**: `learn_add` says "Saved lesson" for a call that destroyed a lesson.
- **Cause**: not the deletion (deliberate) but that no channel could report it. The
  result type had no field for it, and this one branch did not even log.
- **Fix**: `LessonWriteResult` gains `superseded: tuple[str, ...] = ()`, populated at
  **all three** delete sites (substring, topic-overlap, semantic). One result object
  cannot report some of its deletions and stay trustworthy -- a field that is truthful
  for one branch and silently empty for another is worse than no field. Defaulted, so
  the ~60 existing construction sites are unchanged.
- Carried on **every** return path after the scan, including `REFUSED` -- that is the path
  where it matters most, since rows were deleted and nothing was stored in their place.
  `ENRICHED` is decided in pass 1 and skips the scan, so it always reports none.
- The substring branch gets the log line its three siblings already have.
- Rendered by `/api/lessons` (a JSON array, always present), the `learn add` CLI, and the
  `learn_add` tool -- **in full, not counted and not truncated**, because that text is the
  last readable copy of a tombstoned row.

**Why not loosen the containment test.** It would have been wrong twice. It does not
work: verbatim containment at word boundaries makes the stored rule's keyword set a
SUBSET of the submitted rule's, so topic-overlap scores **100%** and deletes the same row
three lines below. Measured by excising the branch from source -- the general rule is
still gone, with `Lesson conflict: ... (100% overlap)`. And it would cost the check its
ability to say no, accumulating a near-identical row for every re-phrasing. **Nothing
here is loosened. The same rows are deleted as before.**

Two of the reporter's three questions are untouched by design -- whether text length may
stand in for scope, and whether the delete direction should exist at all. Both are
behaviour changes to stores users already have, and #6175 extends the same supersede
policy to the semantic branch, so they belong together and with the maintainers. Only
the reporting question is answered here. Refs #7206.

**The report names the whole stored lesson, clause included.** Dedup compares rules
through `_lesson_embed_text`, which returns a mapping row's `rule` field alone so the
comparison basis matches the embedding space. Reporting on that same rendering dropped
the stored NOT-clause, which is the sharpest half of the guidance -- so the clause became
unrecoverable at the exact moment the row was tombstoned, inside the mechanism that
exists to stop that. The three report sites now use `_lesson_display_text`, the
recomposition the injected prompt and `learn list` already use, so a restored rule reads
exactly as it was stored. Every COMPARISON stays on the embed rendering, so no dedup
decision moves: `existing_lower`, the keyword set, the `len()` tiebreak and both log
lines are untouched.

**Sanitizing the reported text.** Reporting a superseded rule prints stored USER text on
a path that never printed it before, so both output surfaces are routed through the
treatment each already applies to stored text -- neither is a new mechanism:

- The CLI strips terminal control sequences with `_TERMINAL_CTRL_RE`, THEN redacts
  credentials and exfiltration URLs. The order is the whole correctness of this, and the
  intuitive order is the unsafe one. An earlier revision redacted first, on the stated
  reasoning that an escape inside a credential would break the regex if the controls went
  first -- that was exactly backwards. Measured: with `AKIA<CSI>IOSFODNN7EXAMPLE` stored,
  redact-then-strip prints `AKIAIOSFODNN7EXAMPLE` verbatim, because the escape stops the
  credential regex matching and the control-strip then REASSEMBLES the token;
  strip-then-redact masks it. Stripping can only ever JOIN characters, never split a
  token, so running it first can only help the regex. A test plants the pre-split
  credential so a future reordering reddens -- the two single-treatment tests each show
  one treatment happens and neither shows they compose in the safe order.

  An earlier revision of this change was control-stripping only, on the grounds that
  `learn list` prints every stored lesson to the same terminal with the same treatment.
  That was the wrong comparison and is reversed here: `learn list` is an EXPLICIT request
  to see the store, while this block surfaces a lesson the user did not ask for and is
  about to lose. The right comparison is the route, which delivers the SAME field and does
  redact -- so controls-only made one feature's two delivery paths disagree about whether
  a superseded rule may carry a secret. A lesson written by history consolidation also
  carries model output the user never typed, so "their own store" is not "their own
  knowledge".

**The recovery it advises is one the policy actually permits.** Earlier wording said only
"re-add it with wording that does not overlap this one", which is incomplete in a way that
sends the user into a refusal: a VERBATIM re-add of the superseded rule is declined by the
substring branch, since the narrower rule now contains it. Measured, all three cases:
verbatim re-add -> `deduped`/`substring_covered`, nothing restored; wording sharing few
significant words -> `inserted`, both rules coexist, nothing superseded (so it does NOT
ping-pong); removing the narrower rule first -> the general rule inserts and is restored
verbatim. The text now names the two that work and says plainly that a verbatim re-add is
declined, and both are pinned by tests.
- `POST /api/lessons` sends the array through `_redact_memory_field`, the shared chain
  this handler already applies to the lesson's own rule and category. Redacting at the
  route covers both readers, since the dashboard and the `learn_add` tool each see only
  what the route sends. This path is worse than a read: the row is being deleted, so this
  response is the only place that text is echoed at all.

- **Every log line in this dedup scan now carries IDENTITIES, never lesson content.**
  A lesson holds whatever the user once told the agent -- credentials, paths, names -- so
  a log line reproducing its text converts a silent-deletion bug into a disclosure bug,
  on a sink that persists to disk and may reach a notification channel. All three lines
  log the store's own row ids (`lesson.<digest>`), the category, and a count or the
  overlap ratio: enough for an operator to see THAT a general rule was replaced and
  WHICH one, joined to the tombstoned row, the `delete_semantic` audit record, and the
  matching `superseded` entry. The text lives only in the result -- the read path the
  lessons themselves use -- where every surface redacts it.

  The id is logged rather than a freshly computed digest deliberately: a new hash would
  correlate with nothing. Nothing here hashes anything, so no weak-hashing exposure is
  added -- `_lesson_key` already derived these ids, and CodeQL flags that derivation at
  its own site (`vector_memory.py:445` on main, alert #643), not at a line that logs the
  result.

  Two of the three lines are main's, and they are touched for one reason: they are the
  two alerts CodeQL attributes to this PR. `git blame` on the merge commit CI analysed
  puts both on `64e47961a` (the fork import), and the MD5 alert on `d1aa30999` -- this
  PR's commit appears in none of them; they are reported because the surrounding hunks
  changed. An earlier revision instead wrapped them in `redact_and_truncate`, which was
  worse twice over: it tripped
  `test_security_posture.py::TestGateSideLogRedactorSpelling` (a gate-side log line must
  read `redact_log_via_context`, not the companion-blind baseline pass) AND added CodeQL
  alerts, because wrapping a tainted value in a call CodeQL does not model as a sanitizer
  makes the flow visible where a bare slice was not tracked. Removing the text answers
  both gates without arguing with either, and the census stays at 0 found / 0 expected.

- The CLI strips terminal control sequences with `_TERMINAL_CTRL_RE`, THEN redacts
  credentials and exfiltration URLs. The order is the whole correctness of this, and the
  intuitive order is the unsafe one. An earlier revision redacted first, on the stated
  reasoning that an escape inside a credential would break the regex if the controls went
  first -- that was exactly backwards. Measured: with `AKIA<CSI>IOSFODNN7EXAMPLE` stored,
  redact-then-strip prints `AKIAIOSFODNN7EXAMPLE` verbatim, because the escape stops the
  credential regex matching and the control-strip then REASSEMBLES the token;
  strip-then-redact masks it. Stripping can only ever JOIN characters, never split a
  token, so running it first can only help the regex. A test plants the pre-split
  credential so a future reordering reddens -- the two single-treatment tests each show
  one treatment happens and neither shows they compose in the safe order.

  An earlier revision of this change was control-stripping only, on the grounds that
  `learn list` prints every stored lesson to the same terminal with the same treatment.
  That was the wrong comparison and is reversed here: `learn list` is an EXPLICIT request
  to see the store, while this block surfaces a lesson the user did not ask for and is
  about to lose. The right comparison is the route, which delivers the SAME field and does
  redact -- so controls-only made one feature's two delivery paths disagree about whether
  a superseded rule may carry a secret. A lesson written by history consolidation also
  carries model output the user never typed, so "their own store" is not "their own
  knowledge".

**The recovery it advises is one the policy actually permits.** Earlier wording said only
"re-add it with wording that does not overlap this one", which is incomplete in a way that
sends the user into a refusal: a VERBATIM re-add of the superseded rule is declined by the
substring branch, since the narrower rule now contains it. Measured, all three cases:
verbatim re-add -> `deduped`/`substring_covered`, nothing restored; wording sharing few
significant words -> `inserted`, both rules coexist, nothing superseded (so it does NOT
ping-pong); removing the narrower rule first -> the general rule inserts and is restored
verbatim. The text now names the two that work and says plainly that a verbatim re-add is
declined, and both are pinned by tests.
- `POST /api/lessons` sends the array through `_redact_memory_field`, the shared chain
  this handler already applies to the lesson's own rule and category. Redacting at the
  route covers both readers, since the dashboard and the `learn_add` tool each see only
  what the route sends. This path is worse than a read: the row is being deleted, so this
  response is the only place that text is echoed at all.

- The log line this change adds identifies both rows by their md5 KEY, never by text.
  A log is a persistent sink, so a credential in a lesson would sit in `gateway.log`
  indefinitely; filtering it on the way out only narrows that, while logging keys removes
  it. An operator can still tie the line to the `superseded` entry in the result and to
  the `delete_semantic` audit row, and the RESULT is the recovery channel -- it carries
  the full text, redacted at each surface.

  An earlier revision instead wrapped three log sites in `redact_and_truncate`, including
  the two pre-existing sibling lines. That is withdrawn and those two are byte-identical
  to main again. It failed two gates at once, and both were right: this repo's own
  ratchet (`test_security_posture.py::TestGateSideLogRedactorSpelling`) requires a
  gate-side log line to read `redact_log_via_context` rather than the companion-blind
  baseline pass, and CodeQL raised three new `py/clear-text-logging` alerts because
  wrapping a tainted value in a call it does not model as a sanitizer made the flow
  visible where a bare slice was not tracked. Removing the text answers both without
  arguing with either, and it leaves the pre-existing lines' behaviour untouched -- they
  still log `rule[:60]` raw, as on main, which the test asserts explicitly rather than
  leaving implicit.

- The CLI redacts credentials and exfiltration URLs, then strips terminal control
  sequences with `_TERMINAL_CTRL_RE`. Both, in that order: an escape sequence embedded
  inside a credential would break the credential regex if the controls went first, so the
  secret would escape redaction. Same two redactors, same order, this file already applies
  to a verdict reason at `cli_commands.py:1893`.

  An earlier revision of this change was control-stripping only, on the grounds that
  `learn list` prints every stored lesson to the same terminal with the same treatment.
  That was the wrong comparison and is reversed here: `learn list` is an EXPLICIT request
  to see the store, while this block surfaces a lesson the user did not ask for and is
  about to lose. The right comparison is the route, which delivers the SAME field and does
  redact -- so controls-only made one feature's two delivery paths disagree about whether
  a superseded rule may carry a secret. A lesson written by history consolidation also
  carries model output the user never typed, so "their own store" is not "their own
  knowledge".
- `POST /api/lessons` sends the array through `_redact_memory_field`, the shared chain
  this handler already applies to the lesson's own rule and category. Redacting at the
  route covers both readers, since the dashboard and the `learn_add` tool each see only
  what the route sends. This path is worse than a read: the row is being deleted, so this
  response is the only place that text is echoed at all.

- Every lesson text this scan logs goes through `redact_and_truncate` (already imported
  and used in this file), which redacts BEFORE slicing so a credential straddling 60
  chars cannot leak as an unredacted fragment. A log is a persistent sink, so a raw
  `[:60]` would keep a credential-bearing lesson in `gateway.log` indefinitely.

  Applied to all three lesson-text log sites in the scan, not only the one this change
  added, and that widening is deliberate: the supersede path runs through the substring
  AND topic-overlap branches, so a guarantee holding on one and not the other is worth
  nothing. It is the same argument as populating `superseded` at every delete site. The
  two pre-existing sites logged raw text on main; the helper is an existing one, so no
  mechanism is introduced.

Every path that carries a superseded rule now redacts credentials: the CLI, the route,
the `learn_add` tool (via the route), and all three log lines. The audit is closed on the
text this change introduces.

The one thing deliberately left as it is on main is the `Saved:` line's echo of the rule
the user just typed. It is their own input in the same breath -- masking a string they
literally just put on their own command line would tell them nothing and hide their own
command from them -- where a STORED rule may have been written by consolidation, an
import, or a subagent, and is printed when they are not looking at it.

**Base.** Rebased onto `origin/main` at `6b7847856f6c2cb7926a768c3039ae1d6827a3ac`, stated here so a red never costs an
argument about whose it is. Only a push moves the base -- a re-run recomputes against the
base recorded in the original event -- so any inherited red older than this sha is not
this PR's. `main`'s own push-event CI was green on `c791f0f1d` (12:27:52Z), which this base
contains; the tip's own push CI had not reported when the rebase was taken.

**The one CodeQL red is not this PR's, and here is why without re-deriving it.**

- The single alert is `py/weak-sensitive-data-hashing` at `src/kiro_crew/vector_memory.py:462`, which is `main`'s own OPEN alert **#643** at line 445 -- this PR's `+116` net lines in that file are exactly what moves 445 to 462, and the diff adds **zero** hashing calls.
- Measured on a freshly built merge commit `52eb59f39` (head `d4f81c42b` merged into `origin/main` `b6716378a`), `git blame` puts line 462 on `d1aa30999` (patrigao, "fix(lessons): attach a NOT-clause..."); this PR's commit appears nowhere in that blame.
- The repository has twice dismissed this rule on this same file as a false positive -- alerts **#431** (`:2050`) and **#503** (`:3437`) -- and `CodeQL` is not a required context here: the commit STATUS on this head is `success`. Clearing the alert would need security-events write, which no participant in this PR has.

## What tests we did

`test/test_lesson_write_outcome.py`, 10 new tests in two classes.

**Positive control.** Run against pristine `origin/main` with only the test file copied
in: **6 failed, 4 passed**. Four fail with
`AttributeError: 'LessonWriteResult' object has no attribute 'superseded'`, one with
`assert 'REMOVED 1 stored lesson' in 'Saved lesson: a rule'` -- main's own words for a
write that removed a lesson -- and one on the route omitting the key. The 4 that pass are
deliberate characterization pins that must hold **both** ways:

- `test_the_general_rule_is_still_deleted` -- asserts the supersede still happens, so a
  later "fix" cannot loosen containment while the reporting tests stay green.
- `test_the_refuse_direction_is_unchanged_and_deletes_nothing` -- the other direction of
  the same test keeps declining and mutating nothing.
- `test_removing_only_the_substring_branch_would_not_have_saved_the_lesson` -- computes
  the overlap ratio from the store's own `_lesson_keywords` so it cannot drift from the
  arithmetic the branch performs.
- `test_the_tool_ignores_a_superseded_field_that_is_not_a_list_of_text` -- the field
  crosses HTTP; a malformed value must read as "none reported".

**Security fixes carry their own positive control.** Stashing only the two `src` changes
and re-running the same tests: `AssertionError: raw credential returned in a response` and
`AssertionError: the OSC payload itself must not survive`. Both fail without their fix.

**Suites run** (only files touching this path; never the full suite):
`test_lesson_write_outcome` `test_lesson_contradiction` `test_lesson_project_scope`
`test_api_input_validation` `test_json_object_body_guard` (244 passed) *
`test_vector_memory` `test_vector_memory_coverage` `test_onboarding_import`
`test_lesson_ranking` `test_memory_smoke` `test_embedding_model_apply` (762 passed,
11 skipped) * `test_cli_commands_coverage -k "learn or lesson"` (11 passed) *
`test_ephemeral_sessions` `test_mcp_core_more_coverage`
`test_instance_credential_pairing` `test_history` `test_history_coverage` (799 passed).
**1816 passed, 0 failed.**

Gates: black gate (diff-scoped) * flake8 * isort * mypy (4 files) * `docs-lint.sh`
(261 files) -- all green.

Two pre-existing exact-body assertions on `POST /api/lessons` were updated for the added
key; they are the only deletions in the test diff.

## Any other suggestions on the work

- **The dashboard Memory tab is a deliberate follow-up, not an oversight.** First
  Principles is right that `MemoryTab.tsx` receives `superseded` and renders none of it,
  so the reported silence survives on that surface. It is deferred on two measured
  grounds. First, the string is user-facing, and this repo translates through a formal
  pipeline (`website/src/i18n/TRANSLATION-PROMPT.md`: "the prompt is the pipeline", with
  per-locale style guides, a glossary, and CI-validated shards across 14 catalogs) --
  hand-writing nine translations would bypass a documented process. Second, `website/`
  has no installed `node_modules` on this machine, so `tsc`, `vitest` and the three i18n
  gates cannot run here, and `OverviewMemoryTabCov80.test.tsx` mocks `createLesson` and
  would need updating. Shipping a frontend change I cannot verify into an otherwise
  verified PR is the wrong trade. The route already sends the field, so the follow-up is
  a self-contained UI change: response type, render, test.
- **Attribution is still missing.** `delete_semantic` records no reason, so a tombstone
  from this branch is indistinguishable from a `learn_remove`. That is why the
  reporter's 291-tombstone figure cannot be attributed, and it stays true after this PR
  -- the report reaches the caller in the moment, not the historical record. A reason at
  tombstone time is worth having whichever way the policy questions are decided.
- **The two stores disagree, and only one is documented.** `LessonStore._insert_or_enrich`
  matches on exact rule text plus scope and has no rule that supersedes, so the JSONL
  store keeps both the general rule and the narrower one. The same two `learn_add` calls
  leave 2 lessons in JSONL and 1 in the vector store. Noted in the spec here; whether
  they should agree is a policy question.
- **#6175 does not conflict.** It edits the semantic-similarity region below the
  substring branch. But it aligns that branch *with* the policy under question, so if the
  delete direction is ever withdrawn, both need deciding together.
- Recovery is SQL-only. A `learn list --deleted` or an undo would turn this warning into
  something the user can act on directly.

## Pattern harvest

Rule candidate: when a report says an operation is "silent", check every level
independently -- result value, log, and store -- and check whether the sibling branches in
the same loop announce themselves. Here three of four dedup branches logged and one did
not, and that asymmetry inside a single function separated the deliberate policy
(deleting) from the accident (not saying so), which decided what the fix had to be.

Rule candidate: before loosening a check to save data it destroys, excise the check and
measure. The collapse here was over-determined -- the next rule down deleted the same row
at 100% overlap -- so the tempting fix would have changed nothing a user could see while
costing the check its ability to say no.

Refs #7206









