### PR TITLE
fix(apps): stop reading a broken metadata path as "app not installed"

### DIFF
--- a/src/kiro_crew/apps/hook_reconcile.py
+++ b/src/kiro_crew/apps/hook_reconcile.py
@@ -75,8 +75,9 @@ from kiro_crew.apps.hooks_integration import (
     record_loaded_hook_signature,
 )
 from kiro_crew.apps.lifecycle import app_has_retained_startup, apps_with_retained_startup
-from kiro_crew.apps.manager import app_lifecycle_lock, get_app, list_apps
+from kiro_crew.apps.manager import app_enabled_state, app_lifecycle_lock, get_app, list_apps
 from kiro_crew.apps.module_loader import unload_app_modules
+from kiro_crew.apps.teardown import forget_app_hooks
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +261,29 @@ async def _reconcile_app(name: str, snapshot_info: dict[str, Any] | None) -> Non
         loaded = loaded_hook_signature(name)
 
         # --- teardown branch: loaded, but now gone / disabled / hookless ---
+        # ``get_app`` cannot tell "no metadata" from "metadata I could not read":
+        # ``_read_installed`` leads with ``Path.is_file()``, which answers a silent
+        # False for a dangling symlink, a directory or fifo in the file's place, a
+        # symlink loop and a non-directory parent component, and then folds every
+        # OSError and a corrupt JSON body into the same None. This branch DELETES a
+        # live app's runtime -- routes, modules, and now its hook registries -- so
+        # acting on that collapsed answer means one broken path, or a transient read
+        # fault, unloads a healthy app every 15s until the fault clears.
+        #
+        # ``app_enabled_state`` is the tri-state read that keeps the two apart, so
+        # absence is CONFIRMED through it before it is acted on. Only a definite False
+        # is "the app is gone"; unknown defers the whole app to the next tick, which is
+        # the same fail-to-unknown direction ``_disable_loaded`` already takes when
+        # startup ownership cannot be proven clear. Off-loop for the same reason
+        # ``get_app`` is.
         gone = current is None
+        if gone and await asyncio.to_thread(app_enabled_state, name) is not False:
+            logger.warning(
+                "hook reconcile: %s has no readable metadata and its absence cannot "
+                "be confirmed; leaving its runtime in place and retrying next tick",
+                name,
+            )
+            return
         turned_off = current is not None and (
             not current.get("enabled") or not manifest_declares_hooks(current)
         )
@@ -272,6 +295,22 @@ async def _reconcile_app(name: str, snapshot_info: dict[str, Any] | None) -> Non
         if (loaded is not None or retained) and (gone or turned_off):
             if await _disable_loaded(name, current):
                 logger.info("hook reconcile: tore down hooks for %s", name)
+                # UNINSTALL only, matching the asymmetry forget_app_hooks
+                # documents: these registries are repopulated from each app's own
+                # watchdog rather than by the gateway, so clearing them on a
+                # DISABLE would leave a window after a re-enable in which a
+                # dismissal silently fails to reach a live worker. Nothing
+                # re-registers behind an uninstall.
+                #
+                # Reached only from here, because the dashboard uninstall handler
+                # is the sole other caller and a CLI uninstall never touches it.
+                # Without this the app's slot-close hook survives in this process
+                # as a closure over a store the uninstall deleted, and
+                # notify_slot_closed reporting its failure is what
+                # api_chat_slot_delete turns into a tab the user cannot dismiss
+                # for an app that no longer exists.
+                if gone:
+                    forget_app_hooks(name)
             return
 
         # Past teardown, every remaining branch (re)starts app code. Once the

--- a/src/kiro_crew/apps/manager.py
+++ b/src/kiro_crew/apps/manager.py
@@ -48,6 +48,7 @@ from kiro_crew.config.loader import (
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.pinned_fs import supports_pinned_walk
 from kiro_crew.platform import current_context, safe_context_call
+from kiro_crew.platform_compat import is_link_or_junction
 from kiro_crew.sel import sel
 
 logger = logging.getLogger(__name__)
@@ -1672,6 +1673,39 @@ def get_app_manifest(name: str) -> AppManifest | None:
         return None
 
 
+def _absence_is_genuine(meta_path: Path) -> bool:
+    """Whether nothing at *meta_path* really means nothing is there.
+
+    The nearest ancestor that exists has to be a DIRECTORY. If something else
+    occupies part of the path, the file cannot exist for a reason that is NOT
+    absence, and that must not read as "the app was uninstalled".
+
+    Separated from the exception class deliberately: POSIX reports this as
+    ``NotADirectoryError`` while Windows raises ``FileNotFoundError``, so the class
+    identifies the platform rather than the condition.
+
+    ``is_link_or_junction`` is checked for the same reason, one predicate over:
+    ``is_symlink`` is False for a Windows directory junction, so a DANGLING junction
+    would present as ``is_dir=False, exists=False, is_symlink=False`` and this walk
+    would step over the thing occupying the path. Something IS at that component, so
+    the answer is unknown, not absence.
+
+    Walks upward because the non-directory component need not be the immediate
+    parent. Terminates: the filesystem root exists and is a directory. An ancestor
+    that cannot be inspected at all is treated as not-genuine, which is the same
+    fail-to-unknown direction as the rest of this function.
+    """
+    for ancestor in meta_path.parents:
+        try:
+            if ancestor.is_dir():
+                return True
+            if ancestor.exists() or ancestor.is_symlink() or is_link_or_junction(ancestor):
+                return False
+        except OSError:
+            return False
+    return True
+
+
 def app_enabled_state(name: str) -> bool | None:
     """Tri-state enablement: True, False, or None when the metadata cannot be READ.
 
@@ -1683,12 +1717,66 @@ def app_enabled_state(name: str) -> bool | None:
     unrecoverable. This keeps the two apart.
 
     A missing metadata file is a definite False — the app is not installed — not a
-    failure to read one.
+    failure to read one, and NOTHING ELSE is. Leading with ``Path.is_file()`` broke
+    that: it answers a silent False for five path shapes that are not absence, all
+    verified against this interpreter — a dangling symlink, a directory in the file's
+    place, a fifo in its place, a symlink loop (ELOOP), and a non-directory parent
+    component (ENOTDIR). Only a genuine ``stat`` fault such as EACCES was reported
+    correctly, because ``is_file`` re-raises that and the handler below turns it into
+    None.
+
+    Absence is decided from the path's SHAPE, never from the exception class, because
+    one condition does not produce one class across platforms: a non-directory parent
+    component raises ``NotADirectoryError`` (ENOTDIR) on POSIX but
+    ``FileNotFoundError`` on Windows, which maps ERROR_PATH_NOT_FOUND to ENOENT — the
+    same class a genuinely missing file raises. Keying "definitely not installed" on
+    ``FileNotFoundError`` therefore told the truth on Linux and not on Windows, where
+    a wrong-shape parent still read as a deliberate uninstall. See
+    :func:`_absence_is_genuine`; ``_spawn_exec_shim`` records the same lesson for
+    ``chdir`` ("the errno is not the thing to key on").
+
+    The cost of the wrong answer is asymmetric, which is why the callers that already
+    respect the tri-state are the ones that make this worth fixing. ``apps.backend``
+    reads it before DELETING materialized resources -- ``_drop_disabled_app_resources``
+    on a False, ``_undo_promotion_of_disabled_app`` likewise -- and its own comments
+    say a None "must not be collapsed into disabled" and is retried instead. That
+    contract was already written correctly; it was this function that did not honour
+    it, so a dangling symlink or a directory in the metadata's place deleted an app's
+    agent files.
+
+    ``apps.hook_reconcile`` consumes it too, and only because this fix put it there.
+    Its unattended 15s teardown decides "gone" from ``get_app`` -> ``_read_installed``,
+    which has the same ``Path.is_file()`` collapse and additionally folds a corrupt
+    JSON body into None -- so before this change every one of those shapes unloaded a
+    healthy app's routes and modules on the next tick. That reader has 24 callers and
+    ``get_app``/``list_apps`` 63, so it is not made tri-state here; the reconciler
+    confirms absence through THIS function instead and defers on unknown.
     """
     meta_path = app_dir(name) / INSTALLED_META_FILENAME
     try:
-        if not meta_path.is_file():
+        try:
+            st = meta_path.stat()
+        except FileNotFoundError:
+            # A dangling link is a path that EXISTS and whose target cannot be
+            # seen, which is not the same as nothing being there. Both predicates
+            # are asked because is_symlink is False for a Windows junction, and
+            # _absence_is_genuine below walks the PARENTS -- never meta_path itself.
+            if meta_path.is_symlink() or is_link_or_junction(meta_path):
+                logger.warning("Metadata path %s is a dangling link or junction", meta_path)
+                return None
+            # This class is reached for TWO different conditions depending on the
+            # platform, so it cannot decide the verdict on its own.
+            if not _absence_is_genuine(meta_path):
+                logger.warning(
+                    "Metadata path %s cannot exist: a component of it is not a "
+                    "directory",
+                    meta_path,
+                )
+                return None
             return False
+        if not stat.S_ISREG(st.st_mode):
+            logger.warning("Metadata path %s is not a regular file", meta_path)
+            return None
         data = json.loads(meta_path.read_text(encoding="utf-8"))
         return bool(InstalledApp.from_dict(data).enabled)
     # No `json.JSONDecodeError` member: it subclasses ValueError, so pairing the two is

--- a/test/test_app_manager.py
+++ b/test/test_app_manager.py
@@ -6,6 +6,8 @@ import asyncio
 import json
 import os
 import shutil
+import stat
+from pathlib import Path
 
 import pytest
 from hypothesis import given, settings
@@ -19,6 +21,7 @@ from kiro_crew.apps.manager import (
     _read_installed,
     _validate_source_path,
     _write_installed,
+    app_enabled_state,
     disable_app,
     enable_app,
     get_app,
@@ -1748,6 +1751,196 @@ def _ship_test_builtin(monkeypatch, root, manifest_data):
     )
     monkeypatch.setattr(execution, "_BUILTINS_DIR", shipped)
     return shipped_app
+
+
+class TestEnabledStateTellsUnreadableFromNotInstalled:
+    """``app_enabled_state`` exists to keep those apart, and ``is_file()`` cannot.
+
+    ``Path.is_file()`` answers a silent False for five path shapes that are not
+    absence -- a dangling symlink, a directory or fifo in the file's place, a symlink
+    loop, and a non-directory parent component -- so leading with it made each of them
+    indistinguishable from a deliberate uninstall. A genuine ``stat`` fault such as
+    EACCES was already correct, because ``is_file`` re-raises it.
+
+    The cost is asymmetric now that ``hook_reconcile`` consumes this state unattended
+    on a 15s tick: a wrong ``False`` fires an automatic teardown of a live app's
+    routes and modules, while a ``None`` defers to the next tick.
+    """
+
+    def test_a_dangling_symlink_is_unknown(self, app_home):
+        app_root = app_home / "apps" / "shape-probe"
+        app_root.mkdir(parents=True)
+        (app_root / "installed.json").symlink_to(app_root / "gone.json")
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_a_directory_in_its_place_is_unknown(self, app_home):
+        (app_home / "apps" / "shape-probe" / "installed.json").mkdir(parents=True)
+
+        assert app_enabled_state("shape-probe") is None
+
+    @pytest.mark.skipif(
+        not hasattr(os, "mkfifo"),
+        reason="a FIFO is a POSIX-only path shape; os.mkfifo does not exist on Windows",
+    )
+    def test_a_fifo_in_its_place_is_unknown(self, app_home):
+        app_root = app_home / "apps" / "shape-probe"
+        app_root.mkdir(parents=True)
+        os.mkfifo(app_root / "installed.json")
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_a_symlink_loop_is_unknown(self, app_home):
+        app_root = app_home / "apps" / "shape-probe"
+        app_root.mkdir(parents=True)
+        (app_root / "installed.json").symlink_to(app_root / "other.json")
+        (app_root / "other.json").symlink_to(app_root / "installed.json")
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_a_non_directory_parent_is_unknown(self, app_home):
+        """Something occupies the app directory's own path."""
+        (app_home / "apps").mkdir(parents=True, exist_ok=True)
+        (app_home / "apps" / "shape-probe").write_text("not a directory", encoding="utf-8")
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_a_non_directory_parent_is_unknown_under_the_windows_error_class(
+        self, app_home, monkeypatch
+    ):
+        """The verdict must come from the path's SHAPE, not the exception class.
+
+        One condition, two classes: POSIX raises NotADirectoryError (ENOTDIR) while
+        Windows maps ERROR_PATH_NOT_FOUND to ENOENT and raises FileNotFoundError --
+        the same class a genuinely missing file raises. Keying absence on that class
+        told the truth on Linux and not on Windows, where a wrong-shape parent still
+        read as a deliberate uninstall and the hook reconciler would tear a LIVE app
+        down for it.
+
+        The Windows mapping is injected so this runs on every platform; the natural
+        path is covered by the test above on whichever platform produces it.
+        """
+        (app_home / "apps").mkdir(parents=True, exist_ok=True)
+        (app_home / "apps" / "shape-probe").write_text("not a directory", encoding="utf-8")
+
+        real_stat = Path.stat
+
+        def as_windows(self, *args, **kwargs):
+            try:
+                return real_stat(self, *args, **kwargs)
+            except NotADirectoryError as exc:
+                raise FileNotFoundError(2, "No such file or directory", str(self)) from exc
+
+        monkeypatch.setattr(Path, "stat", as_windows)
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_genuine_absence_stays_false_under_the_windows_error_class(
+        self, app_home, monkeypatch
+    ):
+        """The control for the above: the shape check must not swallow real absence.
+
+        Uninstall depends on this False, so a fix for the wrong-shape case that also
+        reported unknown for a missing file would break the caller it exists to serve.
+        """
+        (app_home / "apps" / "shape-probe").mkdir(parents=True)
+
+        real_stat = Path.stat
+
+        def as_windows(self, *args, **kwargs):
+            try:
+                return real_stat(self, *args, **kwargs)
+            except NotADirectoryError as exc:
+                raise FileNotFoundError(2, "No such file or directory", str(self)) from exc
+
+        monkeypatch.setattr(Path, "stat", as_windows)
+
+        assert app_enabled_state("shape-probe") is False
+
+    def test_a_dangling_windows_junction_ancestor_is_unknown(self, app_home, monkeypatch):
+        """A dangling junction occupies the path while looking absent to every predicate.
+
+        The same mistake as the error-class one, one predicate over: ``is_symlink`` is
+        False for a Windows directory junction, so a junction whose target is gone
+        presents as ``is_dir=False, exists=False, is_symlink=False`` -- indistinguishable
+        from nothing at all, which is why this walk stepped over it and reported genuine
+        absence. ``app_enabled_state`` then answers False and the hook reconciler tears a
+        LIVE app down.
+
+        Fed as a SHAPE rather than a real junction: os.mkfifo has a POSIX equivalent to
+        skip for, but a junction has none at all, so requiring one would mean this case
+        is only ever exercised on the platform it breaks. The three ordinary predicates
+        are already False for a path that does not exist, which IS the dangling
+        junction's shape, so only the junction probe has to be stood in for.
+        """
+        (app_home / "apps").mkdir(parents=True, exist_ok=True)
+        junction = app_home / "apps" / "shape-probe"
+        assert not junction.exists() and not junction.is_symlink() and not junction.is_dir()
+
+        monkeypatch.setattr(
+            "kiro_crew.apps.manager.is_link_or_junction",
+            lambda path: Path(path) == junction,
+        )
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_a_dangling_junction_at_the_metadata_path_is_unknown(self, app_home, monkeypatch):
+        """The same shape ON the metadata path, which the ancestor walk cannot reach.
+
+        ``Path.parents`` excludes the path itself, so `_absence_is_genuine` inspects
+        every ancestor and never `installed.json`. The self-check beside it asked only
+        `is_symlink`, which a junction answers False, so a junction occupying the
+        metadata path read as a deliberate uninstall while every ancestor was a healthy
+        directory.
+        """
+        (app_home / "apps" / "shape-probe").mkdir(parents=True)
+        meta = app_home / "apps" / "shape-probe" / "installed.json"
+        assert not meta.exists() and not meta.is_symlink() and not meta.is_dir()
+
+        monkeypatch.setattr(
+            "kiro_crew.apps.manager.is_link_or_junction",
+            lambda path: Path(path) == meta,
+        )
+
+        assert app_enabled_state("shape-probe") is None
+
+    def test_an_unreadable_directory_was_already_correct(self, app_home):
+        """The boundary: is_file() RE-RAISES EACCES, so this case never regressed.
+
+        Kept so the distinction is pinned -- the bug was path SHAPES reading as
+        absence, not permission faults.
+        """
+        app_root = app_home / "apps" / "shape-probe"
+        app_root.mkdir(parents=True)
+        (app_root / "installed.json").write_text('{"enabled": true}', encoding="utf-8")
+        os.chmod(app_root, 0o000)
+        try:
+            if os.access(app_root / "installed.json", os.R_OK):
+                pytest.skip("this user bypasses directory permissions")
+            assert app_enabled_state("shape-probe") is None
+        finally:
+            os.chmod(app_root, stat.S_IRWXU)
+
+    def test_nothing_there_is_still_a_definite_false(self, app_home):
+        """The one case that DOES mean not installed, which uninstall relies on."""
+        (app_home / "apps" / "shape-probe").mkdir(parents=True)
+
+        assert app_enabled_state("shape-probe") is False
+
+    def test_a_readable_record_still_reports_its_flag(self, app_home):
+        app_root = app_home / "apps" / "shape-probe"
+        app_root.mkdir(parents=True)
+        (app_root / "installed.json").write_text(
+            '{"name": "shape-probe", "enabled": false}', encoding="utf-8"
+        )
+
+        assert app_enabled_state("shape-probe") is False
+
+        (app_root / "installed.json").write_text(
+            '{"name": "shape-probe", "enabled": true}', encoding="utf-8"
+        )
+
+        assert app_enabled_state("shape-probe") is True
 
 
 class TestBootSkillReconcile:

--- a/test/test_hook_reconcile.py
+++ b/test/test_hook_reconcile.py
@@ -22,6 +22,7 @@ import pytest
 
 import kiro_crew.apps.hook_reconcile as hr
 import kiro_crew.apps.hooks_integration as hi
+import kiro_crew.apps.teardown as teardown
 
 
 @pytest.fixture(autouse=True)
@@ -568,6 +569,139 @@ async def test_loaded_app_uninstalled_is_torn_down(_harness):
     await hr.reconcile_once([])
     assert calls == [("disable", "watchtower")]
     assert hi.loaded_hook_signature("watchtower") is None
+
+
+@pytest.mark.asyncio
+async def test_unreadable_metadata_does_not_read_as_uninstalled(_harness, tmp_path):
+    """``get_app`` returning None does not mean the app is gone.
+
+    ``_read_installed`` leads with ``Path.is_file()``, which answers a silent False
+    for a dangling symlink, a directory or fifo in the metadata's place, a symlink
+    loop and a non-directory parent -- and folds every OSError and a corrupt JSON
+    body into the same None. Acting on that collapsed answer means one broken path
+    unloads a HEALTHY app's routes and modules on the next tick, every tick, until
+    the fault clears. Absence is confirmed through the tri-state read instead.
+    """
+    calls, (set_current, _, _) = _harness
+    # A real broken shape on disk: something occupies the app directory's own path,
+    # so app_enabled_state reports unknown rather than a definite False.
+    apps = tmp_path / "home" / "apps"
+    apps.mkdir(parents=True, exist_ok=True)
+    (apps / "watchtower").write_text("not a directory", encoding="utf-8")
+
+    set_current()  # get_app -> None, which alone would look like an uninstall
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+
+    await hr.reconcile_once([])
+
+    assert calls == [], "a healthy app was torn down on an unreadable metadata path"
+    assert hi.loaded_hook_signature("watchtower") is not None
+
+
+@pytest.mark.asyncio
+async def test_a_confirmed_absence_still_tears_down(_harness, tmp_path):
+    """The control: a genuinely missing record must still be acted on.
+
+    Deferring on unknown must not become deferring on everything, or the teardown
+    this reconciler exists to perform would never run.
+    """
+    calls, (set_current, _, _) = _harness
+    # The app directory exists and is a directory; installed.json is simply absent.
+    (tmp_path / "home" / "apps" / "watchtower").mkdir(parents=True, exist_ok=True)
+
+    set_current()
+    await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+
+    await hr.reconcile_once([])
+
+    assert calls == [("disable", "watchtower")]
+    assert hi.loaded_hook_signature("watchtower") is None
+
+
+@pytest.mark.asyncio
+async def test_uninstall_drops_the_apps_in_process_hook_registries(_harness):
+    """A surviving slot-close hook makes an uninstalled app's tabs undismissable.
+
+    ``forget_app_hooks`` had exactly one caller -- the DASHBOARD uninstall handler --
+    so a CLI uninstall reached this reconciler's teardown and left the registries
+    behind. The stale hook closes over a store the uninstall deleted, and
+    ``notify_slot_closed`` reporting its failure is what ``api_chat_slot_delete``
+    turns into a tab the user cannot dismiss for an app that no longer exists.
+    """
+
+    async def _stale(_key: str) -> None:
+        raise RuntimeError("store is gone")
+
+    calls, (set_current, _, _) = _harness
+    teardown.register_slot_close_hook("watchtower", _stale)
+    try:
+        assert await teardown.notify_slot_closed("watchtower", "slot-1") is False
+
+        set_current()  # get_app -> None, i.e. uninstalled
+        await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+        await hr.reconcile_once([])
+
+        assert calls == [("disable", "watchtower")]
+        # No hook registered is the path that returns True and lets the close through.
+        assert await teardown.notify_slot_closed("watchtower", "slot-1") is True
+    finally:
+        teardown.forget_app_hooks("watchtower")
+
+
+@pytest.mark.asyncio
+async def test_a_plain_disable_keeps_the_hook_registries(_harness):
+    """The asymmetry forget_app_hooks documents: only uninstall is terminal.
+
+    These registries are repopulated from the app's own watchdog, not by the
+    gateway, so clearing them on a disable would leave a window after a re-enable
+    in which a dismissal silently fails to reach a live worker.
+    """
+    seen: list[str] = []
+
+    async def _live(key: str) -> None:
+        seen.append(key)
+
+    calls, (set_current, _, _) = _harness
+    teardown.register_slot_close_hook("watchtower", _live)
+    try:
+        app_off = _app_info("watchtower", enabled=False)
+        set_current(app_off)
+        await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+        await hr.reconcile_once([app_off])
+
+        assert calls == [("disable", "watchtower")]
+        assert await teardown.notify_slot_closed("watchtower", "slot-1") is True
+        assert seen == ["slot-1"], "the app's own hook was not consulted"
+    finally:
+        teardown.forget_app_hooks("watchtower")
+
+
+@pytest.mark.asyncio
+async def test_an_unsettled_uninstall_keeps_them_for_the_retry(_harness):
+    """Unsettled means app code is still running, so its off-switch stays.
+
+    The reconciler retries next tick and drops them once teardown settles.
+    """
+
+    seen: list[str] = []
+
+    async def _live(key: str) -> None:
+        seen.append(key)
+
+    calls, (set_current, set_disable_result, _) = _harness
+    teardown.register_slot_close_hook("watchtower", _live)
+    try:
+        set_current()  # uninstalled
+        set_disable_result({"startup_cleanup": "failed: detached startup hook is still running"})
+        await hi.record_loaded_hook_signature("watchtower", _app_info("watchtower"))
+        await hr.reconcile_once([])
+
+        assert calls == [("disable", "watchtower")]
+        # Still registered, so the app's off-switch is still reachable.
+        assert await teardown.notify_slot_closed("watchtower", "slot-1") is True
+        assert seen == ["slot-1"]
+    finally:
+        teardown.forget_app_hooks("watchtower")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What is the problem?

Two residual gaps around the hook reconciler that #7892 added, both reachable
from a CLI-driven lifecycle change that the gateway only learns about
second-hand.

**1. `app_enabled_state` reads a bad metadata path as "app not installed".**

That function exists to keep "not installed" apart from "could not be read",
because the first is a reason to delete an app's runtime and the second is not.
Its own docstring says so. It then led with `Path.is_file()`, which answers a
silent `False` for five path shapes that are not absence. Measured against this
interpreter rather than assumed:

| path shape | `Path.is_file()` | base verdict |
|---|---|---|
| dangling symlink | `False` | not installed |
| directory in the file's place | `False` | not installed |
| fifo in its place | `False` | not installed |
| symlink loop (ELOOP) | `False` | not installed |
| non-directory parent component (ENOTDIR) | `False` | not installed |
| unreadable directory (EACCES) | **raises** | unknown -- already correct |

The last row is the boundary and it matters: a genuine `stat` fault was always
reported correctly, because `is_file` re-raises it and the existing handler turns
it into `None`. The bug is path SHAPES, not permissions.

And the verdict cannot be read off the exception class, because one condition does
not produce one class across platforms. A non-directory parent component raises
`NotADirectoryError` (ENOTDIR) on POSIX but `FileNotFoundError` on Windows, which
maps `ERROR_PATH_NOT_FOUND` to ENOENT -- the same class a genuinely missing file
raises. The first version of this fix keyed "definitely not installed" on that
class, so it was correct on Linux and still wrong on Windows; its own Windows test
caught it, failing with `assert False is None`.

Review then found the same mistake one predicate over, and it is the general form of
this defect: I keyed a decision on something whose meaning changes by platform.
`is_symlink` is False for a Windows directory junction, so a DANGLING junction
presents as `is_dir=False, exists=False, is_symlink=False` -- indistinguishable from
nothing at all -- and the ancestor walk stepped over the thing occupying the path and
reported genuine absence. That answer is the escalation this PR exists for: with
#7892's reconciler now a live consumer, a `False` here is not a cosmetic misreport,
it unloads a RUNNING app's routes and modules and lets `apps.backend` delete its
materialized agent files. The repo had already built the answer -- `is_link_or_junction`
in `platform_compat`, 131 call sites outside its own module, whose docstring states the
premise: "os.path.islink returns False for a junction, so a caller that only checks
islink would treat a junction as a real directory." This was the one call site that
skipped it. The first fix was correct and incomplete, not wrong.

**2. A CLI uninstall never drops the app's in-process hook registries.**
`forget_app_hooks` had exactly one caller -- the dashboard uninstall handler --
so a CLI uninstall reached the reconciler's teardown branch and left them behind.

**3. The reconciler's own "gone" verdict has the same collapse.** It decides teardown
from `get_app` -> `_read_installed`, which leads with the identical `Path.is_file()`
check and additionally folds a corrupt JSON body into `None`. So a broken path
unloaded a healthy app's routes and modules every tick until the fault cleared -- and
with gap 2's registry drop, would take its disable and slot-close hooks with it.

## Why this issue matters to the user

Gap 1's cost is asymmetric, and the callers that already respect the tri-state are
what make it worth fixing. `apps.backend` reads it before **deleting materialized
resources** -- `_drop_disabled_app_resources` on a `False`, and
`_undo_promotion_of_disabled_app` likewise -- and its own comments say a `None`
"must not be collapsed into disabled" and is retried instead. That contract was
already written correctly; this function did not honour it, so a dangling symlink or
a directory in the metadata's place **deleted an app's agent files**.

Gap 3 is where the unattended harm lives: the 15s reconciler tears a **live** app's
routes and modules down on a misread, repeatedly. An earlier revision of this PR
attributed that harm to `app_enabled_state` and was wrong -- the reconciler never
called it. Three reviewers caught the same error; the fix now makes the claim true
rather than deleting it.

Gap 2 leaves the user with a tab they cannot get rid of. The surviving
slot-close hook is a closure over a store the uninstall deleted, so it raises;
`notify_slot_closed` reports that failure rather than swallowing it, and
`api_chat_slot_delete` refuses the dismissal on a false return. The app is gone
and its tab stays.

## How our fix solves it

- **Only nothing being at the path is absence, decided from the path's SHAPE.**
  `stat()` is called directly so it raises instead of lying, and the absent branch
  is then confirmed structurally rather than by error class: `_absence_is_genuine`
  walks to the nearest existing ancestor and requires it to be a directory. A
  dangling symlink is `None` (a path that exists whose target cannot be seen), any
  other `OSError` is `None`, and a successful `stat` on a non-regular file is
  `None`. That makes every one of the six rows above give the same answer on POSIX
  and Windows. No behaviour change for a healthy record, and genuine absence is
  still a definite `False` -- uninstall depends on it.
- **The reconciler confirms absence before acting on it.** On `get_app` returning
  `None` it reads `app_enabled_state` off-loop and proceeds only on a definite
  `False`; unknown defers the whole app to the next tick, the same direction
  `_disable_loaded` already takes when startup ownership cannot be proven clear.
  `_read_installed` is deliberately NOT made tri-state -- it has 24 callers and
  `get_app`/`list_apps` 63, which is a far wider change than this PR should carry.
- **`forget_app_hooks` on the UNINSTALL shape only**, in the reconciler's
  teardown branch where `gone` is already computed. The asymmetry is the one
  `forget_app_hooks` documents: these registries are repopulated from each app's
  own watchdog rather than by the gateway, so clearing them on a DISABLE would
  leave a window after a re-enable in which a dismissal silently fails to reach a
  live worker. Gated on a settled teardown, so an app whose code is still running
  keeps its own off-switch and the reconciler drops the registries on the retry
  that settles.

**Every path predicate in these two functions, enumerated.** Review found this class
twice -- once on the ancestor walk, once on the metadata path itself -- so the useful
statement is not "one more instance is fixed" but "there are four, and here is why
three of them were never wrong":

| where | predicate | junction-safe, and why |
|---|---|---|
| `app_enabled_state` | `meta_path.stat()` | n/a -- it raises, and the handler below decides |
| `app_enabled_state` | `meta_path.is_symlink() or is_link_or_junction(meta_path)` | FIXED -- `Path.parents` excludes the path itself, so the ancestor walk can never reach a junction sitting ON `installed.json` |
| `app_enabled_state` | `stat.S_ISREG(st.st_mode)` | safe -- only reached when `stat` SUCCEEDED, so the path resolved and there is no dangling reparse point left to miss |
| `_absence_is_genuine` | `ancestor.is_dir()` | safe -- an INTACT junction to a directory genuinely leads to a directory, which is the right answer here |
| `_absence_is_genuine` | `ancestor.exists() or ancestor.is_symlink() or is_link_or_junction(ancestor)` | FIXED -- a dangling junction is False for all three ordinary predicates |

The general form of the defect, stated once: a decision must not be keyed on
something whose meaning changes by platform. The exception class was the first
instance, `is_symlink` versus a junction the second and third. Each earlier fix was
correct and incomplete rather than wrong.

## What tests we did

`test/test_app_manager.py` -- five tests, one per measured shape, plus the
already-correct EACCES boundary kept deliberately so the distinction is pinned,
plus a control that a healthy record still reports its own `enabled` flag.
`test/test_hook_reconcile.py` -- three tests on main's own reconciler harness:
an uninstall makes a previously-refused slot close succeed, a plain disable
leaves the app's hook reachable and consulted, and an unsettled uninstall keeps
it for the retry.

Ten mutation probes, each killed:

| mutant | result |
|---|---|
| restore `Path.is_file()` | 5 tests red, one per shape |
| drop the shape check, keying absence on the class again | 1 test red, `assert False is None` -- byte-identical to the Windows CI failure |
| drop the junction clause from the ancestor walk | 1 test red, `assert False is None` again -- the same signature one predicate over |
| drop the junction probe from the metadata-path check | 1 test red, `assert False is None` a third time -- the same class on the path itself |
| shape check never accepts a directory | 2 tests red, both controls for real absence |
| inspect only the immediate parent, never walk up | 1 test red |
| drop `forget_app_hooks` from the reconciler | 1 test red |
| call it on disable too | 1 test red |
| drop the reconciler's absence confirmation | 1 test red -- a healthy app torn down on a broken path |
| defer on anything but a definite True | 12 tests red -- teardown would never run |

`test_app_manager.py` + `test_hook_reconcile.py`: 179 passed. The FIFO case carries an
explicit `skipif(not hasattr(os, "mkfifo"))` with its reason -- a FIFO is a POSIX-only
path shape, so there is nothing to assert on Windows; the non-directory-parent case is
NOT skipped, because that shape exists on both platforms and skipping it would have
hidden the defect above. The dangling junction is fed as a SHAPE rather than a real
junction, for the same reason inverted: a junction has no POSIX equivalent at all, so
requiring one would leave the case exercised only on the platform it breaks. A path
that does not exist is already False for all three ordinary predicates, which IS the
dangling junction's shape, so only the junction probe is stood in for. isort, flake8, mypy, the black gate and the sync-io-in-async gate all
clean; `test_app_manager.py` is in the black baseline, so it was edited without
running black over it (a bare run reformats 39 unrelated pre-existing lines).

## Manual verification

`#7926`'s symptom is already fixed on `main` by #7892, verified before rescoping
this PR: a throwaway worktree at `origin/main` with **none of this branch's code
present**, driving `hook_reconcile.reconcile_once` from a two-process harness
that uses the real CLI as a subprocess against the same `KIROCREW_HOME`:

| verb | after the CLI | after the reconciler's tick | a second, untouched app |
|---|---|---|---|
| `app disable` | HTTP 200 | **HTTP 404** | 200 |
| `app uninstall` | HTTP 200 | **HTTP 404** | 200 |

That is why this PR says `Refs #7926` and not `Closes` -- #7892 fixed the
reported issue, and this carries only the two gaps that survived it.

## Any other suggestions on the work

This PR previously proposed a second, independent reconciliation sweep for the
same symptom. #7892 landed the mechanism first, so that work was dropped rather
than merged alongside it: a fix that is not needed is cheaper to drop than to
maintain. What remains are the two defects that #7892 did not cover, and one of
them is more dangerous because of it.

## Pattern harvest

Rule candidate: when a tri-state read exists specifically to separate "absent"
from "unknown", the absent branch must be confirmed from the path's SHAPE, not from
a predicate like `Path.is_file()` that collapses several failure modes into `False`
and not from the exception class either -- one filesystem condition does not map to
one class across platforms, so a class-keyed branch is a platform check wearing a
semantic disguise. This repository already learned that for `chdir`
(`_spawn_exec_shim`: "the errno is not the thing to key on") and the same trap was
walked into here.
