### PR TITLE
fix: dedupe overlapping rotated segments at the segment boundary (#8484)

### DIFF
--- a/src/kiro_crew/history_projection.py
+++ b/src/kiro_crew/history_projection.py
@@ -55,7 +55,9 @@ def _facade_strip_markdown_preview(text: str) -> str:
     return _history_facade().strip_markdown_preview(text)
 
 
-def drop_persisted_tail_prefix(full_disk: list[dict], tail: list[dict]) -> list[dict]:
+def drop_persisted_tail_prefix(
+    full_disk: list[dict], tail: list[dict], *, require_mid: bool = False
+) -> list[dict]:
     """`tail` minus whatever of its head `full_disk` already ends with.
 
     Two callers, one shape: a corpus read from disk, followed by rows that MAY
@@ -93,6 +95,13 @@ def drop_persisted_tail_prefix(full_disk: list[dict], tail: list[dict]) -> list[
         b_mid = b_meta.get("mid") if isinstance(b_meta, dict) else None
         if a_mid and b_mid:
             return bool(a_mid == b_mid)
+        if require_mid:
+            # A match here DELETES a row. Callers whose overlap can only come
+            # from a re-archived prefix (whose rows always carry mids) opt in
+            # to mid-proven matching: an id-less coincidence on the fallback
+            # triple must be preserved, because deleting a genuine row is
+            # strictly worse than serving a duplicate.
+            return False
         return (
             a.get("ts", "") == b.get("ts", "")
             and a.get("role") == b.get("role")
@@ -376,6 +385,7 @@ class TranscriptReadProjection:
         if hit is not None and hit[0] == sig:
             return hit[1]
         rows: list[dict] = []
+        prev_seg_rows: list[dict] = []
         # A transient per-segment read failure must not be CACHED as "no
         # archived rows": the stat signature of a finished rotation never
         # changes again, so a poisoned empty entry would outlive the incident
@@ -432,6 +442,7 @@ class TranscriptReadProjection:
                 # (see the docstring). A healthy read skips these too, so this one
                 # must stay a plain skip.
                 continue
+            seg_rows: list[dict] = []
             for ln in lines[1:]:
                 if not ln.strip():
                     continue
@@ -451,7 +462,52 @@ class TranscriptReadProjection:
                 if "_type" not in row:
                     # `_type` rows are deliberate control records, not messages --
                     # skipping them IS the classification this corpus wants.
-                    rows.append(row)
+                    seg_rows.append(row)
+            # Rotation archives the live file's head BEFORE rewriting the live
+            # file. A hard crash between those two writes leaves the archived
+            # rows at the head of the live file too, so the NEXT rotation
+            # re-archives them: this corpus is the index space pagination
+            # cursors and fork indices resolve against, and a duplicated row
+            # silently shifts every index above it. Two proofs may drop a
+            # row here, and an id-less interior coincidence satisfies
+            # neither, because deleting a genuine row is strictly worse than
+            # serving a duplicate:
+            #
+            # 1. PROVENANCE. A failed rewrite leaves segment N's rows at the
+            #    live file's head, so the next rotation re-archives them
+            #    field-for-field: segment N+1 either begins with ALL of N
+            #    (enough new rows accrued) or is itself a shorter verbatim
+            #    prefix of N (the rotation kept a tail). Both reduce to the
+            #    first min(len) rows of ADJACENT segments being identical
+            #    records -- a shape an organic transcript cannot reproduce,
+            #    and one that needs no row ids.
+            # 2. IDENTITY. Beyond that shared prefix, a row is dropped only
+            #    when proven by stable ``meta.mid`` equality
+            #    (``require_mid=True``); the ``(ts, role, content)`` fallback
+            #    does not apply at this seam.
+            #
+            # This covers segment-to-segment overlap only: the archive-to-live
+            # seam in read_messages_chained_full still needs its own
+            # drop_persisted_tail_prefix call.
+            provenance = 0
+            k = min(len(prev_seg_rows), len(seg_rows))
+            if k and seg_rows[:k] == prev_seg_rows[:k]:
+                provenance = k
+            remainder = seg_rows[provenance:]
+            merged = drop_persisted_tail_prefix(rows, remainder, require_mid=True)
+            dropped = provenance + (len(remainder) - len(merged))
+            if dropped:
+                # A fired dedupe is the on-disk signature of a rotation that
+                # crashed inside the archive-to-rewrite window. Every other
+                # anomaly in this reader logs; dropping rows silently would
+                # make a genuine (mis)drop unattributable in the field.
+                _HISTORY_LOGGER.warning(
+                    "rotated segment %s overlaps the corpus: dropped %d duplicate row(s)",
+                    p.name,
+                    dropped,
+                )
+            rows.extend(merged)
+            prev_seg_rows = seg_rows
         if complete:
             if not rows:
                 # Segments exist yet no rotate rows parsed — the exact signature

--- a/test/test_chained_full_rotation_overlap.py
+++ b/test/test_chained_full_rotation_overlap.py
@@ -121,3 +121,172 @@ def test_the_fork_flat_prepend_branch_is_also_guarded() -> None:
         "rotated head, or a crash-window duplication shifts every fork index"
     )
     assert "all_messages = _rotated_head + all_messages" not in body
+
+
+class TestSegmentBoundaryDedupe:
+    """The SAME crash window, one level down: segment N+1 vs segment N.
+
+    Rotation archives the live file's head BEFORE rewriting the live file, so a
+    hard crash between the two writes leaves the archived rows at the head of
+    the live file too — and the NEXT rotation archives that same prefix again.
+    ``read_rotated_messages`` used to concatenate segments blind, so the
+    duplicate was already inside ``rotated`` before the archive-to-live guard
+    ever ran. These pin that each segment is merged through
+    ``drop_persisted_tail_prefix`` at the segment boundary.
+    """
+
+    @staticmethod
+    def _projection(tmp_path):
+        import pathlib
+
+        from kiro_crew import history as history_mod
+        from kiro_crew.history_projection import TranscriptReadProjection
+
+        class _Log:
+            def __init__(self, d: pathlib.Path) -> None:
+                self._dir = pathlib.Path(d)
+
+        proj = TranscriptReadProjection.__new__(TranscriptReadProjection)
+        proj._log = _Log(tmp_path)  # type: ignore[attr-defined]
+        adir = pathlib.Path(history_mod._archive_dir(pathlib.Path(tmp_path)))
+        adir.mkdir(parents=True, exist_ok=True)
+        stem = history_mod._safe_key("slot-a") + history_mod.ARCHIVE_SEGMENT_DELIMITER
+        return proj, adir, stem
+
+    @staticmethod
+    def _segment(adir, stem: str, stamp: str, rows: list) -> None:
+        import json as _json
+
+        lines = [_json.dumps({"_type": "archive", "reason": "rotate"})]
+        lines += [_json.dumps(r) for r in rows]
+        (adir / f"{stem}{stamp}.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _read(self, proj) -> list:
+        from kiro_crew.history_projection import TranscriptReadProjection
+
+        return TranscriptReadProjection.read_rotated_messages(proj, "slot-a")
+
+    def test_overlapping_segments_serve_each_row_once(self, tmp_path) -> None:
+        # Segment N holds 1-3; the crash window re-archived its tail, so
+        # segment N+1 begins with 2,3 before continuing 4,5.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [_m("1"), _m("2"), _m("3")])
+        self._segment(adir, stem, "20260101-000100", [_m("2"), _m("3"), _m("4"), _m("5")])
+        mids = [r["meta"]["mid"] for r in self._read(proj)]
+        assert mids == ["1", "2", "3", "4", "5"], mids
+        assert len(mids) == len(set(mids)), f"a row is served twice: {mids}"
+
+    def test_partial_overlap_drops_only_the_shared_prefix(self, tmp_path) -> None:
+        # Segment N+1 begins with only PART of N's tail: the helper's contract
+        # is longest-prefix, so exactly that part goes, nothing more.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [_m("1"), _m("2"), _m("3")])
+        self._segment(adir, stem, "20260101-000100", [_m("3"), _m("4")])
+        mids = [r["meta"]["mid"] for r in self._read(proj)]
+        assert mids == ["1", "2", "3", "4"], mids
+
+    def test_non_overlapping_segments_lose_nothing(self, tmp_path) -> None:
+        # The normal case: a clean rotation pair. A dedupe that removed anything
+        # here would silently truncate the transcript head.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [_m("1"), _m("2")])
+        self._segment(adir, stem, "20260101-000100", [_m("3"), _m("4")])
+        mids = [r["meta"]["mid"] for r in self._read(proj)]
+        assert mids == ["1", "2", "3", "4"], mids
+
+    def test_the_deduped_corpus_is_what_gets_cached(self, tmp_path) -> None:
+        # The merge happens inside the cached region: a cache hit must serve the
+        # deduped rows, not a raw concatenation captured before the merge.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [_m("1"), _m("2")])
+        self._segment(adir, stem, "20260101-000100", [_m("2"), _m("3")])
+        first = self._read(proj)
+        cached = proj._rotated_cache["slot-a"][1]  # type: ignore[attr-defined]
+        assert [r["meta"]["mid"] for r in cached] == ["1", "2", "3"]
+        assert self._read(proj) == first
+
+    def test_id_less_coincidence_at_a_clean_boundary_is_preserved(self, tmp_path) -> None:
+        """Deletion is worse than duplication at the segment boundary.
+
+        Two DISTINCT id-less rows sharing (ts, role, content) across a clean
+        rotation pair are a coincidence, not a re-archived prefix -- every row
+        the rotation writer archives carries meta.mid, so an overlap that
+        cannot be proven by mid must be preserved. Reported blocking by the
+        GPT review lane (span 8b3eaa01b062): the fallback triple would have
+        silently deleted the later row from the pagination/fork index space.
+        """
+        proj, adir, stem = self._projection(tmp_path)
+        bare = {"ts": "2026-09-04T00:00:00Z", "role": "user", "content": "same words"}
+        self._segment(adir, stem, "20260101-000000", [_m("1"), dict(bare)])
+        self._segment(adir, stem, "20260101-000100", [dict(bare), _m("2")])
+        rows = self._read(proj)
+        contents = [r.get("content") for r in rows]
+        assert contents == ["1", "same words", "same words", "2"], contents
+
+    def test_mid_proven_overlap_still_drops_when_fallback_would_also_match(self, tmp_path) -> None:
+        # The strict mode must not weaken the real case: a re-archived prefix
+        # (mid-bearing) is still deduped exactly as before.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [_m("1"), _m("2")])
+        self._segment(adir, stem, "20260101-000100", [_m("2"), _m("3")])
+        assert [r["meta"]["mid"] for r in self._read(proj)] == ["1", "2", "3"]
+
+    @staticmethod
+    def _bare(content: str, ts: str) -> dict:
+        return {"ts": ts, "role": "user", "content": content}
+
+    def test_id_less_crash_overlap_is_deduped_by_provenance(self, tmp_path) -> None:
+        """The round-2 scenario (GPT span 8b3eaa01b062): id-less crash window.
+
+        A failed rewrite leaves segment N's rows at the live file's head, so
+        rotation N+1 re-archives ALL of them as its verbatim prefix. Those
+        duplicates must be dropped even though no row carries a mid, where
+        identity alone could not prove them.
+        """
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [self._bare("a", "t1"), self._bare("b", "t2")])
+        self._segment(
+            adir,
+            stem,
+            "20260101-000100",
+            [self._bare("a", "t1"), self._bare("b", "t2"), self._bare("c", "t3")],
+        )
+        contents = [r["content"] for r in self._read(proj)]
+        assert contents == ["a", "b", "c"], contents
+
+    def test_id_less_partial_reprefix_is_deduped_by_provenance(self, tmp_path) -> None:
+        # The rotation after the crash kept a tail, so segment N+1 is a
+        # SHORTER verbatim prefix of N -- pure duplicates, no new rows.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(
+            adir,
+            stem,
+            "20260101-000000",
+            [self._bare("a", "t1"), self._bare("b", "t2"), self._bare("c", "t3")],
+        )
+        self._segment(adir, stem, "20260101-000100", [self._bare("a", "t1"), self._bare("b", "t2")])
+        contents = [r["content"] for r in self._read(proj)]
+        assert contents == ["a", "b", "c"], contents
+
+    def test_chained_crash_overlaps_dedupe_each_link(self, tmp_path) -> None:
+        # Two consecutive failed rewrites: N+2 contains N+1 which contains N.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [self._bare("a", "t1")])
+        self._segment(adir, stem, "20260101-000100", [self._bare("a", "t1"), self._bare("b", "t2")])
+        self._segment(
+            adir,
+            stem,
+            "20260101-000200",
+            [self._bare("a", "t1"), self._bare("b", "t2"), self._bare("c", "t3")],
+        )
+        contents = [r["content"] for r in self._read(proj)]
+        assert contents == ["a", "b", "c"], contents
+
+    def test_interior_id_less_coincidence_is_not_provenance(self, tmp_path) -> None:
+        # Segments whose FIRST rows differ share no provenance prefix: an
+        # interior id-less repeat stays, exactly as the round-1 fix pinned.
+        proj, adir, stem = self._projection(tmp_path)
+        self._segment(adir, stem, "20260101-000000", [_m("1"), self._bare("same", "tx")])
+        self._segment(adir, stem, "20260101-000100", [self._bare("same", "tx"), _m("2")])
+        contents = [r.get("content") for r in self._read(proj)]
+        assert contents == ["1", "same", "same", "2"], contents


### PR DESCRIPTION
## Problem / Motivation

`TranscriptReadProjection.read_rotated_messages` builds the rotated-transcript corpus by concatenating every `reason="rotate"` archive segment with no cross-segment identity check. Two segments can legitimately overlap: `HistoryRewriter._maybe_rotate` writes the archive segment BEFORE rewriting the live file (deliberately — archiving is a precondition of the rewrite, so the failure mode is duplication rather than data loss), and a hard crash (SIGKILL, power loss, OOM) between those two writes leaves the dropped rows in both places. The next rotation then archives that same prefix again, so segment N+1 begins with segment N's tail and the reader serves those rows twice.

## Why it matters

This corpus is the index space `before`/`next_before` pagination cursors and the fork index path resolve against. A duplicated row does not merely double-render: it silently shifts every index above it, so a reader pages positions that no longer mean what they meant, and an index-addressed fork copies a different cutoff than the one on screen. Nothing raises. The writer ordering is pre-existing on `main`, so overlapping segment pairs can already exist on disk; #7916 (merged) is what made archived history reachable and therefore made this observable.

## What changed (motivation → approach → change)

Symptom: duplicated rows in the rotated corpus after a crash-window rotation pair. Root cause: the per-segment accumulation appends blind, while the module's identity rule (`drop_persisted_tail_prefix` — `meta.mid` when both rows carry one, `(ts, role, content)` fallback, longest-prefix overlap) is applied only one level up at the archive-to-live seam, by which point the duplicate is already inside `rotated`.

The change applies that same rule one level down, at the segment boundary, under two proofs (a row is only dropped when provenance — adjacent segments sharing a verbatim min-length prefix, the failed-rewrite signature — or stable `meta.mid` identity proves it; the `(ts, role, content)` fallback never applies at this seam): each segment's parsed rows land in a per-segment list, then merge into the accumulator through `drop_persisted_tail_prefix(rows, seg_rows)` before extending. No new comparison is introduced — reusing the helper is the point, since it already encodes why `meta.mid` is preferred and why the fallback must match all three fields. A fired dedupe logs a warning (it is the on-disk signature of a crash-window rotation, and this reader logs every other anomaly). The merge sits inside the cached region, so the deduped corpus is what gets cached.

Everything else in the reader is preserved verbatim: the `_seg_order` numeric-suffix sort, the `reason != "rotate"` classification skip, the damage-vs-classification `complete` handling, the zero-byte-segment skip, the `_type` control-row filter, the 8-entry stat-signature cache, and the raised `OSError` paths. The archive-to-live `drop_persisted_tail_prefix(rotated, live)` in `read_messages_chained_full` is still required and untouched (deduping only shortens `rotated`, which the prefix rule tolerates); the comment at the merge site says so explicitly.

## Tests

Extended `test/test_chained_full_rotation_overlap.py` (the existing overlap-dedupe family) with a `TestSegmentBoundaryDedupe` class:

- `test_overlapping_segments_serve_each_row_once` — segment N+1 begins with N's tail (same `meta.mid`s); pins each row exactly once, in order.
- `test_partial_overlap_drops_only_the_shared_prefix` — N+1 begins with only part of N's tail; pins the longest-prefix contract.
- `test_non_overlapping_segments_lose_nothing` — a clean rotation pair; guards against over-dropping (the vacuity check).
- `test_the_deduped_corpus_is_what_gets_cached` — pins that the cache holds the merged rows, not the raw concatenation.
- `test_id_less_coincidence_at_a_clean_boundary_is_preserved` — two distinct id-less rows sharing `(ts, role, content)` across a clean rotation pair are both served (GPT review, span 8b3eaa01b062: deletion is worse than duplication, so segment-boundary dedupe requires `meta.mid` proof via the new `require_mid=True` mode; the two pre-existing call sites keep the default fallback unchanged).
- `test_mid_proven_overlap_still_drops_when_fallback_would_also_match` — the strict mode does not weaken the real crash-window case.
- `test_id_less_crash_overlap_is_deduped_by_provenance`, `test_id_less_partial_reprefix_is_deduped_by_provenance`, `test_chained_crash_overlaps_dedupe_each_link` — id-less crash overlaps are dropped by segment provenance (adjacent segments sharing a verbatim min-length prefix is the failed-rewrite signature and needs no row ids; GPT review round 2, same span).
- `test_interior_id_less_coincidence_is_not_provenance` — the round-1 preservation guarantee survives: an interior id-less repeat is neither provenance nor mid-proven, and stays.

Mutation-verified: replacing the merge with a blind `rows.extend(seg_rows)` reddens exactly the three overlap tests and nothing else; restoring it returns the file to green (11/11).

## Manual verification

N/A — unit coverage sufficient: the behavior is a pure function of segment file contents, and the tests write real segment files through the same fixture shape the incomplete-archive suite uses.

## Related Issues

Fixes #8484

## Pattern harvest

Rule candidate: review-prompt
Pattern: "an identity/dedupe rule applied at an outer seam while an inner accumulation loop concatenates blind — check every concatenation site of the same corpus applies the same rule"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, reader-internal invariant documented in code comments
- [x] No secrets, credentials, or internal references in the diff
