### PR TITLE
test(cron): give the repeat-suppression runs distinct stamps (#8502)

### DIFF
--- a/test/test_dashboard_cron_to_chat.py
+++ b/test/test_dashboard_cron_to_chat.py
@@ -801,6 +801,18 @@ class TestInjectCronResultToDashboard:
         job.set_run_result("run one")
         _inject(state, job, "run one", history=[])
         job.set_run_result("run two")
+        # Pin the second run's identity past the first run's, as the sibling
+        # test setting ``last_result_ts`` explicitly already does. This test is
+        # about the ``history=None`` steady state, not about clock resolution:
+        # ``set_run_result`` stamps at wall-clock time, and on a coarse clock
+        # (Windows/CPython <= 3.12 resolves ~15.6 ms) two back-to-back calls
+        # can return the identical float, rendering both runs a byte-identical
+        # marker -- so the dedupe would CORRECTLY drop run two as a repeat and
+        # the test would assert against a single-run transcript it never meant
+        # to build. Two real runs are separated by a schedule interval; the
+        # explicit stamp gives the test the two distinct identities it needs.
+        job.last_result_ts += 1.0
+        job.last_result_stamp = job._render_run_stamp(job.last_result_ts)
         _inject(state, job, "run two", history=None)
 
         prompts = [


### PR DESCRIPTION
<!-- Fill in each section below. -->

## Problem / Motivation

`test/test_dashboard_cron_to_chat.py::TestInjectCronResultToDashboard::test_a_repeat_is_suppressed_even_though_history_is_none`
fails intermittently on the Backend Tests (Windows) shard with `assert 1 == 2`. The test runs two cron results
back to back with no sleep and relies on `time.time()` advancing between the two calls so the two run-boundary
markers differ and both prompt rows survive dedupe.

## Why it matters

On Windows/CPython <= 3.12, `time.time()` resolves only to the ~15.6 ms system timer tick, so two
microsecond-apart calls can return the identical float. Both runs then render a byte-identical
`<!-- cron-run:... -->` marker, dedupe correctly drops the second row as a repeat, and the test sees 1 prompt
instead of 2. The CI Windows shard pins Python 3.12 -- exactly the configuration that reproduces it -- so
unrelated PRs red on this shard depending on machine load and shard ordering. Production is not affected: real
runs of one job are separated by a schedule interval far larger than a tick.

## What changed (motivation -> approach -> change)

Symptom: 1 prompt where the test expects 2. Root cause: the test needs two distinct run identities but does
not ensure it gets them -- it delegates that to clock resolution, which is platform-dependent. Change: after the
second `set_run_result`, the test pins `job.last_result_ts` explicitly past the first run's stamp and
re-renders `job.last_result_stamp` with it -- the exact pairing `CronJob.set_run_result` itself performs, and
the same explicit-epoch technique the sibling test
`test_a_placeholder_is_not_a_surviving_copy_of_the_prompt` already documents. The assertion is unchanged; the
`history=None` suppression case the test is named for is still genuinely exercised on every platform.
Test-only: no production semantics change (the strictly-increasing-stamp option in the issue is a separate
product decision the reporter scoped out).

## Tests

The changed test itself is the deliverable. Verified three arms with the issue's coarse-clock plugin
(quantizes `time.time()` to the 1/64 s Windows tick):

- original test + coarse clock: FAILS with the identical `assert 1 == 2` (reproduces the CI failure
  deterministically on Linux)
- fixed test + coarse clock: PASSES
- fixed test + normal clock: PASSES

Full file `python -m pytest test/test_dashboard_cron_to_chat.py`: 55 passed.

## Manual verification

N/A -- unit coverage sufficient: the deterministic coarse-clock reproduction above exercises exactly the CI
failure mode.

## Related Issues

Closes #8502

## Pattern harvest

Rule candidate: review-prompt
Pattern: a test that needs two distinct wall-clock identities without forcing them apart depends on platform
timer resolution (Windows tick ~15.6 ms) and fails only on coarse-clock shards.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, test-only
- [x] No secrets, credentials, or internal references in the diff
