### PR TITLE
fix: classify a crashed launcher in the unsafe-keys probe (#8493)

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py
@@ -230,6 +230,15 @@ def _origin_urls(repo: Path, *, push: bool) -> list[str] | None:
 
 
 def _repository_is_safe(repo: Path) -> bool:
+    """True iff the clone's Git metadata and local config are safe to reuse.
+
+    Fails CLOSED (``False``) for ambiguous git errors and for any unsafe
+    filesystem shape, but raises :class:`IsolationProbeError` when the
+    unsafe-keys probe's sandbox launcher died before git executed — a crashed
+    launcher exits 1, indistinguishable from git's own "no unsafe keys", so
+    reading the exit code alone would report an unscanned config as safe (the
+    one probe in the isolation chain that failed OPEN, issue #8493).
+    """
     git_dir = repo / ".git"
     if first_linked_ancestor(git_dir) or is_link_or_junction(git_dir):
         return False
@@ -310,6 +319,18 @@ def _repository_is_safe(repo: Path) -> bool:
         )
     except (OSError, subprocess.SubprocessError):
         return False
+    if proc.returncode != 0:
+        # Exit 1 means "no unsafe keys" only when git itself ran. A sandbox
+        # launcher that dies before git executes also exits 1, so reading the
+        # exit code alone makes this the one probe in the isolation chain that
+        # fails OPEN during a launcher outage (issue #8493): metadata unsafety
+        # becomes invisible exactly when the host cannot run the probes. Same
+        # classifier as :func:`_origin_urls` — the structural stderr match is
+        # what keeps git's own output unable to satisfy it, and the raise says
+        # "the probe could not run" instead of an isolation verdict (#8151).
+        detail = _launcher_failure_detail(proc.stderr or "")
+        if detail is not None:
+            raise IsolationProbeError(detail)
     return proc.returncode == 1
 
 
@@ -612,7 +633,15 @@ def _setup_safe_clone(url: str, scratch_root: Path, *, timeout_s: int = 300) -> 
         # can cut a credential in the echoed remote URL mid-match, leaving a fragment
         # no downstream redaction pass recognises.
         return {}, f"git clone failed: {redact_via_context(tail[0])[:200]}"
-    if not _repository_is_safe(dest):
+    try:
+        safe = _repository_is_safe(dest)
+    except IsolationProbeError:
+        # This attempt created `dest` and has not disabled push yet, so unlike
+        # the reuse path there is no good clone to preserve — remove it rather
+        # than leaving a live origin url at the canonical location.
+        rmtree_force(dest)
+        raise
+    if not safe:
         rmtree_force(dest)
         return {}, "cloned repository failed Git metadata safety verification"
 
@@ -650,9 +679,9 @@ def list_clone_branches(clone: Path, *, timeout_s: int = 30) -> tuple[list[str],
     clone = Path(clone)
     if not (clone / ".git").is_dir():
         return [], f"Not a git clone: {clone}"
-    if not _repository_is_safe(clone):
-        return [], "clone Git metadata failed safety verification"
     try:
+        if not _repository_is_safe(clone):
+            return [], "clone Git metadata failed safety verification"
         disabled = _push_disabled(clone)
     except IsolationProbeError as exc:
         return [], str(exc)
@@ -925,9 +954,9 @@ def checkout_branch(clone: Path, branch: str, *, timeout_s: int = 120) -> tuple[
     bare = branch.split("/", 1)[1] if branch.startswith("origin/") else branch
     if not bare or not is_valid_branch_name(bare):
         return False, f"invalid branch name: {branch!r}"
-    if not _repository_is_safe(clone):
-        return False, "clone Git metadata failed safety verification"
     try:
+        if not _repository_is_safe(clone):
+            return False, "clone Git metadata failed safety verification"
         disabled = _push_disabled(clone)
     except IsolationProbeError as exc:
         return False, str(exc)

--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/driver.py
@@ -356,7 +356,11 @@ class Driver:
         case this needs to additionally allow is a clone whose push is somehow live AND a
         valid direct-commit authorization; a protected/blank branch is refused by
         :func:`.push_policy.authorize_direct_push` regardless. We fail CLOSED: any
-        ambiguity → the original refusal stands."""
+        ambiguity → the original refusal stands. Both probes below propagate
+        ``clone_setup.IsolationProbeError`` when their sandbox launcher crashed
+        before git executed — a stricter refusal (the run still does not start),
+        never a relaxation, surfacing the sandbox failure instead of a
+        misleading isolation verdict."""
         from ..backend.clone_setup import _repository_is_safe
 
         if not _repository_is_safe(self.clone):

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_isolation_probe_crash.py
@@ -11,6 +11,10 @@ remotes were never read. These tests pin the distinction:
 * an unambiguous launcher signature on stderr + nonzero exit →
   :class:`IsolationProbeError` naming the sandbox failure (still refuses to
   start — the surfaced REASON is what changes);
+* the same classification applies to ``_repository_is_safe``'s unsafe-keys
+  probe (issue #8493): its ``returncode == 1`` tail meant "no unsafe keys"
+  and a crashed launcher also exits 1, so this was the one probe in the
+  isolation chain that failed OPEN during a launcher outage;
 * every other nonzero exit keeps its existing fail-closed meaning — git's own
   exit 1 for an absent config key, a launcher WARNING that coexists with a
   genuine git exit code, an ambiguous fatal, and (the Opus finding on this
@@ -52,6 +56,15 @@ def _proc(returncode: int, stderr: str = "", stdout: str = "") -> subprocess.Com
     return subprocess.CompletedProcess(
         args=["git"], returncode=returncode, stdout=stdout, stderr=stderr
     )
+
+
+def _metadata_safe_clone(tmp_path: Path) -> Path:
+    """A clone dir whose filesystem shape passes ``_repository_is_safe``'s
+    metadata scan, so the verdict comes down to the config probe alone."""
+    clone = tmp_path / "clone"
+    for sub in ("objects/info", "info", "refs"):
+        (clone / ".git" / sub).mkdir(parents=True)
+    return clone
 
 
 @pytest.fixture
@@ -148,6 +161,76 @@ class TestProbeCrashShape:
         assert issubclass(clone_setup.IsolationProbeError, RuntimeError)
 
 
+class TestRepositoryIsSafeCrashShape:
+    """The unsafe-keys probe must classify a crashed launcher, not read it as
+    "no unsafe keys" (issue #8493 — the one probe that failed OPEN)."""
+
+    def test_launcher_traceback_raises_probe_error(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        with pytest.raises(clone_setup.IsolationProbeError) as excinfo:
+            clone_setup._repository_is_safe(clone)
+        message = str(excinfo.value)
+        assert "sandbox launcher" in message
+        assert "ModuleNotFoundError: No module named 'platform'" in message
+
+    def test_launcher_blocked_message_raises_probe_error(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(
+            1, stderr="sandbox: BLOCKED — failed to install seccomp-BPF filter (prctl returned -1)"
+        )
+        with pytest.raises(clone_setup.IsolationProbeError):
+            clone_setup._repository_is_safe(clone)
+
+    def test_genuine_exit_1_still_means_safe(self, probe_result: dict, tmp_path: Path) -> None:
+        """git's own exit 1 (no unsafe key matched, empty stderr) keeps meaning safe."""
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(1)
+        assert clone_setup._repository_is_safe(clone) is True
+
+    def test_launcher_warning_does_not_reclassify_git_exit(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(
+            1, stderr="sandbox: WARNING — cannot read /home/user/.aws/config (denied)"
+        )
+        assert clone_setup._repository_is_safe(clone) is True
+
+    def test_ambiguous_git_error_stays_fail_closed(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(128, stderr="fatal: not a git repository")
+        assert clone_setup._repository_is_safe(clone) is False
+
+    def test_unsafe_key_found_stays_unsafe(self, probe_result: dict, tmp_path: Path) -> None:
+        """Exit 0 (an unsafe key matched) keeps its fail-closed meaning."""
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(0, stdout="core.hookspath\n")
+        assert clone_setup._repository_is_safe(clone) is False
+
+    def test_a_repo_named_like_the_launcher_cannot_spoof_the_signature(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        """An echoed clone path holding the launcher filename must stay an
+        ambiguous git error (fail closed) — this probe's ``False`` is what
+        drives clone retirement, so a repository NAME must not be able to turn
+        the retire-worthy verdict into "the probe could not run"."""
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(
+            128,
+            stderr=(
+                "fatal: bad config line 1 in file " "/scratch/owner--kirocrew_sandbox_x/.git/config"
+            ),
+        )
+        assert clone_setup._repository_is_safe(clone) is False
+
+
 class TestTupleEntryPointsStaySoft:
     """(result, err) / (ok, note) surfaces must not leak the raise."""
 
@@ -181,3 +264,26 @@ class TestTupleEntryPointsStaySoft:
         ok, note = clone_setup.checkout_branch(tmp_path, "main")
         assert ok is False
         assert "sandbox launcher" in note
+
+    def test_list_clone_branches_converts_metadata_probe_crash(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        """The raise from ``_repository_is_safe`` itself (issue #8493) is
+        converted, not leaked — the safety probe runs FIRST, so on a crashed
+        launcher it is the one that surfaces."""
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        branches, err = clone_setup.list_clone_branches(clone)
+        assert branches == []
+        assert "sandbox launcher" in err
+        assert _PUSH_ISOLATION_MESSAGE not in err
+
+    def test_checkout_branch_converts_metadata_probe_crash(
+        self, probe_result: dict, tmp_path: Path
+    ) -> None:
+        clone = _metadata_safe_clone(tmp_path)
+        probe_result["proc"] = _proc(1, stderr=_LAUNCHER_TRACEBACK)
+        ok, note = clone_setup.checkout_branch(clone, "main")
+        assert ok is False
+        assert "sandbox launcher" in note
+        assert _PUSH_ISOLATION_MESSAGE not in note


### PR DESCRIPTION
## Problem / Motivation

`_repository_is_safe` in `src/kiro_crew/apps/builtins/auto_improvement/backend/clone_setup.py` ends its unsafe-keys `git config --get-regexp` probe with `return proc.returncode == 1`. Exit 1 means "no unsafe keys" when git itself ran -- but a crashed namespace-sandbox launcher also exits 1, so on a host whose launcher is broken (the #8151 AppArmor case) this probe reads the crash as SAFE. It was the one probe in the isolation chain that failed OPEN: #8478 gave `_origin_urls` a structural launcher-failure classifier but did not apply it here.

## Why it matters

During a launcher outage, metadata unsafety (hook paths, include directives, credential helpers planted in the clone's config) becomes invisible exactly when the host cannot run the probes. The residual exposure is legibility rather than a live push (both call sites are followed by the push-disabled probe, which raises the typed error under the same crash), but a safety probe that reports "safe" for a config it never scanned is the wrong shape to leave in place.

## What changed (motivation → approach → change)

Symptom: on a broken-launcher host, `_repository_is_safe` returns True for a config it never scanned. Root cause: the probe's tail collapses two opposite meanings of exit 1 -- git's own "no unsafe keys" and a launcher that died before git executed. Change: apply the classifier #8478 already built for `_origin_urls`, then make every consumer of the new raise sound:

- `_repository_is_safe`: on nonzero exit, classify stderr with `_launcher_failure_detail`; a structural launcher signature raises `IsolationProbeError`, everything else keeps the exact `returncode == 1` semantics (exit 0 = unsafe key found, still False; ambiguous fatals still fail closed). Added the two-outcome contract docstring matching its siblings.
- `list_clone_branches` / `checkout_branch`: widened their existing `except IsolationProbeError` blocks to cover the safety probe, so the raise converts to their error-string return instead of escaping a worker thread.
- Fresh-clone path in `_setup_safe_clone`: on the new raise, remove the just-created clone before propagating -- unlike the reuse path there is no good clone to preserve, and leaving one with a live origin url at the canonical location would be new residue.
- `driver.assert_push_disabled` docstring: documents that both probes propagate the typed error (a stricter refusal, never a relaxation).
- Every other bool-consuming caller audited: `_repository_is_isolated` consumers (`commit.py`, `pr_recipe.py`, `routes.py`, `driver._retire_if_unsafe`) already catch it; `runner._build_driver_locked` flows to the run-start route's existing 409 `sandbox_launcher_failed` handler, the same path its sibling `_push_disabled` raise takes today.

`IsolationProbeError.detail` still has zero consumers (handlers use `str(exc)`); dropping the attribute was considered and skipped to keep this diff minimal.

## Tests

New in `test_isolation_probe_crash.py`:

- `TestRepositoryIsSafeCrashShape`: launcher traceback and `sandbox: BLOCKED` raise `IsolationProbeError`; genuine exit 1 still means safe; a launcher WARNING does not reclassify git's exit; ambiguous exit 128 and exit 0 stay fail-closed; a repo named like the launcher cannot spoof the signature (this probe's False drives clone retirement, so a repo NAME must not suppress it).
- Tuple entry-point tests where the raise originates in the safety probe itself (not monkeypatched) for both `list_clone_branches` and `checkout_branch`.

Local gates all green: black baseline gate, subprocess-encoding gate, isort, flake8, `mypy src/kiro_crew/` (1288 files), 340 tests across the three touched app test modules, brand gate, harness-parity gate.

## Manual verification

N/A -- unit coverage sufficient: the change is a subprocess exit-code classification with no UI or external-service surface, and the crash shape (launcher stderr signatures) is pinned by the canned-process tests exactly as the existing `_origin_urls` coverage does.

## Related Issues

Closes #8493

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a probe chain hardened against a failure mode must be audited for the ONE member that still collapses that failure into its success/benign exit code -- the fix that introduced the classifier names the siblings it did not touch"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
