### PR TITLE
perf(prepare-pr): cancel the condemned head's CI before editing

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -311,6 +311,32 @@ three in hand, do not push onto a SHA whose checks are green.
 pending head. Superseded runs also *hide* real reds: a genuine failure can live
 inside a run whose conclusion reads `cancelled`.
 
+**Once you have decided to change code, cancel the old head's in-flight runs
+BEFORE you start editing.** Harvest everything you need from them first — the
+failing log, each reviewer lane's verdict — then kill every `queued` /
+`in_progress` run on that SHA. A local fix routinely takes tens of minutes, and
+every one of those runs spends that whole time on a commit you have already
+condemned. The order is read → cancel → edit: a cancelled run's already-written
+logs stay readable, but a cancelled reviewer lane never posts its verdict, so
+anything you still need must be in hand before the cancel.
+
+```bash
+OLD_SHA=$(gh pr view <pr#> --repo <owner>/<repo> --json headRefOid --jq .headRefOid)
+gh api "repos/<owner>/<repo>/actions/runs?head_sha=$OLD_SHA&per_page=100" \
+  --jq '.workflow_runs[] | select(.status=="queued" or .status=="in_progress") | .id' \
+  | while read -r run_id; do gh run cancel "$run_id" --repo <owner>/<repo>; done
+```
+
+Read `OLD_SHA` from the PR rather than reusing a shell variable from an earlier
+step — an unset one silently queries `head_sha=` and cancels nothing. The
+`while read` loop is deliberate: it is a no-op on empty input and, unlike
+`xargs -r`, works on macOS, whose BSD `xargs` has no `-r`.
+
+Two things this rule does NOT cover: a lane whose verdict you are still waiting on
+in order to decide *whether* to fix (leave it running — cancel is for after the
+decision), and a red you classified as a flake (that job gets a targeted
+`gh run rerun <run-id> --failed`, not a kill and not a whole-matrix replay).
+
 1. **Push only the reviewed commit.** Require a clean index/worktree and fail closed unless `[ "$(git rev-parse HEAD)" = "$REVIEWED_SHA" ]`; any intervening mutation returns to Phase 2. Run the post-squash structural guard (`single_commit` only — see the profile section): `python3 $SKILL_DIR/scripts/push_guard.py --base <base> --require-single-on-base` — **0** safe, **40** the squash landed on a stale ref or the branch carries unexpected history (do NOT push), **2** env error.
 
    **SHA-pinned force-with-lease protocol.** Record `LEASE_SHA=$(git rev-parse origin/<branch>)` at iteration start, BEFORE Phase 1's fetch. **When `origin/<branch>` does not exist yet (first push), `LEASE_SHA` is empty — SKIP the clobber check entirely and push with `git push -u origin <branch>`.** Running it anyway fails merely because the ref is absent, which the next rule would misread as a maintainer commit and stop the first push forever. Otherwise run the clobber check against the pre-squash HEAD: `git merge-base --is-ancestor origin/<branch> HEAD` — if it fails, a maintainer commit exists on the remote that local history never had; STOP, re-sync, re-include it before any rewrite. Do **not** re-run that check after the squash: it can never pass on a rewritten branch, and the SHA-pinned lease is the at-push protection. Then `git push -u origin <branch>` (first push) or `git push --force-with-lease=<branch>:$LEASE_SHA origin <branch>`.
@@ -342,7 +368,7 @@ inside a run whose conclusion reads `cancelled`.
    and Phase 4 can arm auto-merge on a review that never happened.
 
    - **0** → Phase 4.
-   - **20** → run `pr_findings.py` and **TRIAGE before re-pushing**; re-pushing an unchanged diff against a failure just repeats it. **(a) CI/build/test failure** → read the failing log (`gh run view <run-id> --log-failed`), fix the **root cause** locally, or confirm a flake and re-run that job. **(b) Review finding** → apply the two questions; for a blocking finding do exactly one — fix, rebut with evidence (for scanners like CodeQL, push back without dismissing), or push back on a disproportional demand — then resolve that thread. **(c) Conflict / behind base** → Phase 1's re-sync handles it. Then **loop back to Phase 1** → 2 → 3 carrying those fixes.
+   - **20** → run `pr_findings.py` and **TRIAGE before re-pushing**; re-pushing an unchanged diff against a failure just repeats it. **(a) CI/build/test failure** → read the failing log (`gh run view <run-id> --log-failed`), then — once the decision to fix is made — cancel the head's remaining in-flight runs per Phase 3's read → cancel → edit rule, and fix the **root cause** locally; or confirm a flake and re-run **only the failing job**, never the whole run — `gh run rerun <run-id> --failed` (or `--job <job-id>` for one of several reds), since a bare `gh run rerun <run-id>` replays the entire matrix to re-decide one shard, and no cancel applies here. **(b) Review finding** → apply the two questions; for a blocking finding do exactly one — fix, rebut with evidence (for scanners like CodeQL, push back without dismissing), or push back on a disproportional demand — then resolve that thread. **(c) Conflict / behind base** → Phase 1's re-sync handles it. Then **loop back to Phase 1** → 2 → 3 carrying those fixes.
    - **10** → **arm `monitor_start` and END THE TURN.** Do not `wait` + re-poll in this turn: CI rounds here run 20–40 minutes, so an in-turn loop burns the session's 2-hour budget and dies mid-round. `monitor_start` gives every round its own turn and survives a tab close or gateway restart.
 
      **Before the call, settle two things.** (a) With MCP Tool Search active the


### PR DESCRIPTION
## Problem / Motivation

When the prepare-pr loop reads a CI red and decides to fix it, the condemned head's runs keep going. GitHub's `cancel-in-progress` only fires on the *next push*, so every workflow still queued or in flight on the old SHA burns machine time for the entire duration of the local fix — and a real root-cause fix routinely takes tens of minutes. The loop's own instructions never told it to stop them.

The same section told the loop to "re-run that job" on a flake. Bare `gh run rerun <run-id>` replays the **entire** matrix, so re-deciding one flaky shard costs a full `ci.yml` run.

## Why it matters

Both are pure waste on a shared runner pool, and both scale with how much the loop is used: the cancel gap is paid once per fix iteration (up to 10 per PR), and the flake replay turns a one-shard re-decide into a full-suite run. Neither buys any signal — the old head's verdict is already irrelevant the moment the diff is going to change, and the passing shards of a flaky run were already green.

## What changed (motivation → approach → change)

Superseded runs cost real minutes → the only window `cancel-in-progress` cannot cover is decision-to-push, because it is keyed on the push → so the loop must cancel that window itself, explicitly, and in an order that does not destroy evidence.

Phase 3 gains a `read → cancel → edit` rule: harvest the failing log and every reviewer lane's verdict **first**, then cancel every `queued` / `in_progress` run on that SHA, then start editing. The ordering is load-bearing — a cancelled run's already-written logs stay readable, but a cancelled reviewer lane never posts its verdict, so anything still needed must be in hand before the cancel. Two carve-outs are stated so the rule cannot be over-applied: a lane whose verdict is still deciding *whether* to fix keeps running, and a confirmed flake gets a re-run rather than a kill.

The exit-20 triage branch (a) now points at that rule at the moment the fix decision is made, and pins the flake path to `gh run rerun <run-id> --failed` (or `--job <job-id>` when several jobs are red).

## Tests

None. This is prose in a skill's instruction file; the repo's existing tests for this skill pin its `scripts/` behaviour (`test/test_git_divergence.py`, `test/test_prepare_pr_monitor_armed.py`), and no test asserts its prose — adding one would pin wording rather than behaviour.

## Manual verification

- Ran the diff-scoped gates with an explicit base ref (without which they silently report-only): `check_brand_name.py`, `check_focus_cue.py`, `check_changelog_history.py`, `check_harness_parity.py` — all pass.
- `scripts/check_builtin_skill_scope.py` and `scripts/docs-lint.sh` (261 markdown files) pass.
- `pytest test/test_prepare_pr_monitor_armed.py test/test_skill_home_paths.py` — 18 passed.
- Verified the premise against this repo's own workflows: `ci.yml` and all four reviewer lanes already set `cancel-in-progress: true` for `pull_request`, which is why the new rule is scoped to the decision-to-push window and not sold as a replacement for push-time supersede.

## Related Issues

N/A — no filed issue; found while auditing where the local loop spends CI.
