### PR TITLE
test(dashboard): tighten owner-gate vacuity floor to 26 (#8505)

### DIFF
--- a/test/test_agent_config_owner_gate_invariant.py
+++ b/test/test_agent_config_owner_gate_invariant.py
@@ -103,12 +103,18 @@ _MAX_KNOWN_UNGATED_ROUTES = 20
 
 # --------------------------------------------------------------------------- #
 # Coherence floor: the walk must find at least this many GATED mutating routes.
-# This is the count of routes that we expect to be owner-gated (from agents.py,
-# files.py, connections.py). If a refactor removes or relocates routes such
-# that fewer than this threshold are gated, the test fails loudly rather than
-# passing vacuously.
+# This is the count of owner-gated routes the walk enforces, measured live at
+# issue #8505 (registered by handlers.agents, handlers.connections,
+# handlers.files, and handlers.members). Keep it equal to the real count -- a
+# slack floor cannot catch a refactor that silently drops routes out of the
+# walk. Hardcoded deliberately: deriving it from the walk itself would
+# reintroduce the vacuity one level up. If routes are intentionally removed,
+# the assertion fails and you must lower the floor in the same commit. If
+# routes are added, the ``>=`` assertion still passes, so raising the floor
+# back to the real count is a manual, unenforced step -- do it whenever you
+# touch this file, or the slack this floor exists to prevent regrows.
 # --------------------------------------------------------------------------- #
-_MINIMUM_GATED_ROUTES = 19
+_MINIMUM_GATED_ROUTES = 26
 
 
 class _FakeState:


### PR DESCRIPTION
Closes #8505

## What

`_MINIMUM_GATED_ROUTES` in `test/test_agent_config_owner_gate_invariant.py` is the vacuity floor guaranteeing the route walk feeding `test_every_gated_route_refuses_non_owner` found a non-trivial gated set. It was hardcoded to 19 while the walk enforces 26 owner-gated mutating routes on current main (re-measured live via `_gated_routes` over `_build_app()`: handlers.agents 15, handlers.connections 6, handlers.files 4, handlers.members 1). Because the assertion is `>=`, those 7 routes of slack meant the floor could not fail even if a refactor silently dropped routes back to 20-25 — exactly the regression the floor exists to catch.

This PR raises the floor to the measured 26 (the issue's Option 1) and rewrites the stale provenance comment to name the actual handler modules and to state plainly that the raise direction is manual and unenforced (`>=` only fails on shrink). The integer stays hardcoded deliberately: deriving it from the walk itself would reintroduce the vacuity one level up, per the issue's explicit warning. The exact-equality alternative (Option 2) is the issue's deferred design choice and is intentionally not made here.

## Tests

- `python -m pytest test/test_agent_config_owner_gate_invariant.py` — 4 passed.
- Mutation-verified the floor is tight: at 27 the floor test fails with "found only 26"; at 26 it passes.
- Full local suite: 86331 passed; the 89 failures are pre-existing host-environment artifacts on this NFS-home dev box (uid-65534 directory ownership, AF_UNIX path length, missing `[voice]` extras, no `gh` install) in files untouched by this change, and the same tests pass on ubuntu CI runners.
- Local CI-pinned gates green: isort 6.0.0, flake8 7.1.0, mypy 1.14.1, black baseline, subprocess-encoding, brand-name, harness-parity.

## Pattern harvest

Rule candidate: a `>=` vacuity floor must be re-tightened to the measured count whenever the guarded set grows; the assertion only fails on shrink, so growth silently re-opens the slack the floor exists to prevent.
Class: coherence-floor drift — a hardcoded lower bound that a growing invariant set outruns, leaving the guard unable to fail.

## Review

Pre-push lanes: GPT (gpt-5.6-sol) NO-FINDINGS with evidence; Opus (claude-opus-5) CONCERNS-ONLY, all three advisory comment-accuracy findings fixed in this head (handler-module provenance verified live, unenforced-raise-direction stated, measurement anchored to #8505 instead of "freshly-measured").
