### PR TITLE
fix(release): backport the feed-advance guard to release/0.5.0

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -1002,7 +1002,6 @@ test/test_project_git.py
 test/test_project_git_status_log.py
 test/test_prompt_timeout_follows_ceiling.py
 test/test_provider_dispatch.py
-test/test_publish_feed_contract.py
 test/test_publish_providers.py
 test/test_publish_sync.py
 test/test_queue_during_subagents.py

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -265,10 +265,51 @@ jobs:
           put_immutable "${PREFIX}/SHA256SUMS" "${SUMS_DIR}/SHA256SUMS"
           put_immutable "${PREFIX}/cli-manifest.json" "$MANIFEST_PATH"
 
-          # Signature fields are additive to the legacy channel/version/
-          # wheel_url/sha256 schema, so old clients remain parse-compatible.
-          aws s3 cp "$MANIFEST_PATH" "s3://${BUCKET}/feed/${CHANNEL}/latest-cli.json" \
-            --content-type application/json --cache-control no-cache
+          # Feed monotonicity guard: the channel feed is a mutable
+          # last-writer-wins pointer, and a hotfix cut on an OLD release
+          # line (0.4.1 while the channel serves 0.5.0) must publish its
+          # versioned assets WITHOUT dragging every client on the channel
+          # backward into a downgrade offer. Two signals: the live feed
+          # via the public CDN (the publish role is Put-only on feed/*,
+          # so no S3 read-back; the CDN copy can be up to max-age stale)
+          # and the repo's tags via ls-remote (pushed before any run
+          # starts, closing the staleness window). Any strictly-newer
+          # candidate holds the pointer; equality advances so a re-run
+          # of the current release stays idempotent.
+          FEED_KEY="feed/${CHANNEL}/latest-cli.json"
+          # Fail CLOSED on transport errors: only confirmed absence (404, or
+          # 403 -- S3-backed CloudFront answers 403 for a missing key) reads
+          # as "no feed yet". Treating an outage as absence would advance on
+          # degraded evidence -- the exact rollback this guard prevents.
+          FEED_HTTP=$(curl -sS --retry 3 --retry-delay 2 \
+            -o /tmp/current-feed.json -w '%{http_code}' "${CDN_BASE}/${FEED_KEY}") \
+            || { echo "::error::channel feed fetch failed (transport)"; exit 1; }
+          case "$FEED_HTTP" in
+            200) ;;
+            403|404) : > /tmp/current-feed.json ;;
+            *) echo "::error::channel feed fetch returned HTTP ${FEED_HTTP}"; exit 1 ;;
+          esac
+          # awk does the ^{} peel-ref filtering (awk always exits 0 on empty
+          # input, unlike grep -v); an ls-remote failure aborts via pipefail.
+          git ls-remote --tags origin 'refs/tags/v*' \
+            | awk -F/ '$NF !~ /\^\{\}$/ {print $NF}' > /tmp/repo-tags.txt
+          VERDICT=$(python3 scripts/check_feed_advance.py \
+            --new "${WHEEL_VERSION}" --channel "${CHANNEL}" \
+            --current-file /tmp/current-feed.json \
+            --tags-file /tmp/repo-tags.txt --self "${GITHUB_REF_NAME}" || true)
+          if [ "$VERDICT" = "advance" ]; then
+            # Signature fields are additive to the legacy channel/version/
+            # wheel_url/sha256 schema, so old clients remain parse-compatible.
+            aws s3 cp "$MANIFEST_PATH" "s3://${BUCKET}/${FEED_KEY}" \
+              --content-type application/json --cache-control no-cache
+            FEED_NOTE="\`${FEED_KEY}\`"
+          elif [ "$VERDICT" = "hold" ]; then
+            echo "::notice::${FEED_KEY} already serves a newer version; pointer NOT moved (hotfix on an old line). Versioned assets are published."
+            FEED_NOTE="not moved (channel already serves a newer version)"
+          else
+            echo "::error::feed guard returned neither advance nor hold (got: '${VERDICT}')"
+            exit 1
+          fi
 
           {
             echo "## CLI Published (${CHANNEL})"
@@ -276,7 +317,7 @@ jobs:
             echo "- Version: \`${WHEEL_VERSION}\`"
             echo "- Signed manifest: \`${PREFIX}/cli-manifest.json\`"
             echo "- Key: \`${MANIFEST_KEY_ID}\`"
-            echo "- Feed: \`feed/${CHANNEL}/latest-cli.json\`"
+            echo "- Feed: ${FEED_NOTE}"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Publish PEP 503 simple index

--- a/.github/workflows/publish-linux.yml
+++ b/.github/workflows/publish-linux.yml
@@ -389,6 +389,7 @@ jobs:
       # other. FEED_FILE is resolved fail-closed in the first step.
       - name: Write update feed
         if: env.HAS_SIGNING_SECRETS
+        id: feed
         run: |
           set -euo pipefail
           ARTIFACT_SHA512=$(openssl dgst -sha512 -binary "${ARTIFACT_PATH}" | base64 -w 0)
@@ -411,6 +412,42 @@ jobs:
             exit 1
           fi
           echo "Verified published artifact matches the feed digest."
+
+          # Feed monotonicity guard: a hotfix cut on an OLD release line
+          # must publish its versioned assets without dragging the channel
+          # pointer backward into a downgrade offer for every client.
+          # Feed read goes through the public CDN (publish role is
+          # Put-only on feed/*); repo tags close the CDN staleness window.
+          # Fail CLOSED on transport errors: only confirmed absence (404, or
+          # 403 -- S3-backed CloudFront answers 403 for a missing key) reads
+          # as "no feed yet". Treating an outage as absence would advance on
+          # degraded evidence -- the exact rollback this guard prevents.
+          FEED_HTTP=$(curl -sS --retry 3 --retry-delay 2 \
+            -o /tmp/current-feed.yml -w '%{http_code}' \
+            "${{ vars.CLI_CDN_BASE }}/${FEED_PREFIX}/${FEED_FILE}") \
+            || { echo "::error::channel feed fetch failed (transport)"; exit 1; }
+          case "$FEED_HTTP" in
+            200) ;;
+            403|404) : > /tmp/current-feed.yml ;;
+            *) echo "::error::channel feed fetch returned HTTP ${FEED_HTTP}"; exit 1 ;;
+          esac
+          # awk does the ^{} peel-ref filtering (awk always exits 0 on empty
+          # input, unlike grep -v); an ls-remote failure aborts via pipefail.
+          git ls-remote --tags origin 'refs/tags/v*' \
+            | awk -F/ '$NF !~ /\^\{\}$/ {print $NF}' > /tmp/repo-tags.txt
+          VERDICT=$(python3 scripts/check_feed_advance.py \
+            --new "${VERSION}" --channel "${CHANNEL}" \
+            --current-file /tmp/current-feed.yml \
+            --tags-file /tmp/repo-tags.txt --self "${GITHUB_REF_NAME}" || true)
+          if [ "$VERDICT" = "hold" ]; then
+            echo "advance=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${FEED_PREFIX}/${FEED_FILE} already serves a newer version; pointer NOT moved (hotfix on an old line). Versioned assets are published."
+            exit 0
+          elif [ "$VERDICT" != "advance" ]; then
+            echo "::error::feed guard returned neither advance nor hold (got: '${VERDICT}')"
+            exit 1
+          fi
+          echo "advance=true" >> "$GITHUB_OUTPUT"
           cat > /tmp/"${FEED_FILE}" <<EOF
           version: ${VERSION}
           files:
@@ -432,9 +469,10 @@ jobs:
       # Same mutable-alias semantics as the latest-DMG alias: plain
       # overwrite, max-age=300, written AFTER the versioned key and the
       # feed so it never points at bytes that are not yet live nor ahead
-      # of the go-live switch.
+      # of the go-live switch. Gated on the same monotonicity verdict as
+      # the feed: the alias is a channel pointer too.
       - name: Update latest artifact alias
-        if: env.HAS_SIGNING_SECRETS
+        if: env.HAS_SIGNING_SECRETS && steps.feed.outputs.advance == 'true'
         run: |
           set -euo pipefail
           LATEST_ARTIFACT_KEY="desktop/${CHANNEL}/latest/${LINUX_BASENAME}.${LINUX_EXT}"
@@ -454,6 +492,10 @@ jobs:
             echo "## Publish Linux (${CHANNEL} · ${ARCH})"
             echo "- Version: ${VERSION}"
             echo "- Public artifact: ${{ vars.CLI_CDN_BASE }}/${ARTIFACT_KEY}"
-            echo "- Feed: \`${FEED_PREFIX}/${FEED_FILE}\`"
-            echo "- Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_ARTIFACT_KEY}"
+            if [ "${{ steps.feed.outputs.advance }}" = "true" ]; then
+              echo "- Feed: \`${FEED_PREFIX}/${FEED_FILE}\`"
+              echo "- Latest alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_ARTIFACT_KEY}"
+            else
+              echo "- Feed: not moved (channel already serves a newer version)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -348,6 +348,7 @@ jobs:
       # pointer-host / byte-host split.
       - name: Write update feed
         if: env.HAS_SIGNING_SECRETS && steps.locate.outputs.staged
+        id: feed
         run: |
           set -euo pipefail
           INSTALLER_SHA512=$(openssl dgst -sha512 -binary "${INSTALLER_PATH}" | base64 -w 0)
@@ -362,6 +363,42 @@ jobs:
             echo "::error::published installer does not match the artifact this feed would advertise."
             exit 1
           fi
+
+          # Feed monotonicity guard: a hotfix cut on an OLD release line
+          # must publish its versioned assets without dragging the channel
+          # pointer backward into a downgrade offer for every client.
+          # Feed read goes through the public CDN (publish role is
+          # Put-only on feed/*); repo tags close the CDN staleness window.
+          # Fail CLOSED on transport errors: only confirmed absence (404, or
+          # 403 -- S3-backed CloudFront answers 403 for a missing key) reads
+          # as "no feed yet". Treating an outage as absence would advance on
+          # degraded evidence -- the exact rollback this guard prevents.
+          FEED_HTTP=$(curl -sS --retry 3 --retry-delay 2 \
+            -o /tmp/current-feed.yml -w '%{http_code}' \
+            "${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/${FEED_FILE}") \
+            || { echo "::error::channel feed fetch failed (transport)"; exit 1; }
+          case "$FEED_HTTP" in
+            200) ;;
+            403|404) : > /tmp/current-feed.yml ;;
+            *) echo "::error::channel feed fetch returned HTTP ${FEED_HTTP}"; exit 1 ;;
+          esac
+          # awk does the ^{} peel-ref filtering (awk always exits 0 on empty
+          # input, unlike grep -v); an ls-remote failure aborts via pipefail.
+          git ls-remote --tags origin 'refs/tags/v*' \
+            | awk -F/ '$NF !~ /\^\{\}$/ {print $NF}' > /tmp/repo-tags.txt
+          VERDICT=$(python3 scripts/check_feed_advance.py \
+            --new "${VERSION}" --channel "${CHANNEL}" \
+            --current-file /tmp/current-feed.yml \
+            --tags-file /tmp/repo-tags.txt --self "${GITHUB_REF_NAME}" || true)
+          if [ "$VERDICT" = "hold" ]; then
+            echo "advance=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::feed/${CHANNEL}/${FEED_FILE} already serves a newer version; pointer NOT moved (hotfix on an old line). Versioned assets are published."
+            exit 0
+          elif [ "$VERDICT" != "advance" ]; then
+            echo "::error::feed guard returned neither advance nor hold (got: '${VERDICT}')"
+            exit 1
+          fi
+          echo "advance=true" >> "$GITHUB_OUTPUT"
 
           cat > /tmp/"${FEED_FILE}" <<EOF
           version: ${VERSION}
@@ -380,8 +417,10 @@ jobs:
 
       # Written LAST: the alias is what a human downloads, so it only ever
       # points at a version whose immutable key and feed are already live.
+      # Gated on the same monotonicity verdict as the feed: the alias is a
+      # channel pointer too.
       - name: Update latest installer alias
-        if: env.HAS_SIGNING_SECRETS && steps.locate.outputs.staged
+        if: env.HAS_SIGNING_SECRETS && steps.locate.outputs.staged && steps.feed.outputs.advance == 'true'
         run: |
           set -euo pipefail
           aws s3api put-object \
@@ -399,6 +438,10 @@ jobs:
             echo ""
             echo "- channel: \`${CHANNEL}\` · arch: \`x64\` · version: \`${VERSION}\`"
             echo "- installer: ${{ vars.CLI_CDN_BASE }}/${INSTALLER_KEY}"
-            echo "- latest alias: ${{ vars.CLI_CDN_BASE }}/desktop/${CHANNEL}/latest/${WINDOWS_BASENAME}.exe"
-            echo "- feed: ${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/${FEED_FILE}"
+            if [ "${{ steps.feed.outputs.advance }}" = "true" ]; then
+              echo "- latest alias: ${{ vars.CLI_CDN_BASE }}/desktop/${CHANNEL}/latest/${WINDOWS_BASENAME}.exe"
+              echo "- feed: ${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/${FEED_FILE}"
+            else
+              echo "- feed: not moved (channel already serves a newer version)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sign-and-notarize.yml
+++ b/.github/workflows/sign-and-notarize.yml
@@ -515,8 +515,16 @@ jobs:
       # Pinned published basename -- see the notarize job's env comment.
       ARTIFACT_BASENAME: KiroCrew
     steps:
+      # UNCONDITIONAL, and it has to stay that way. This used to be gated on
+      # `inputs.promote` because only the promotion path read repo files
+      # (scripts/release_promotion.py). The feed monotonicity guard changed
+      # that: the "Write update feed" step runs on EVERY publish and needs
+      # both scripts/check_feed_advance.py and a git repo for
+      # `git ls-remote --tags origin`. Re-gating this checkout would make a
+      # normal nightly/insider publish red-fail in that step -- after the
+      # immutable assets were already uploaded. Pinned by
+      # test_check_feed_advance.py::test_guard_jobs_check_out_the_repository.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: inputs.promote
         with:
           persist-credentials: false
 
@@ -686,6 +694,7 @@ jobs:
       # the human first-install download.
       - name: Write update feed
         if: env.HAS_SIGNING_SECRETS
+        id: feed
         run: |
           set -euo pipefail
           ZIP_SHA512=$(openssl dgst -sha512 -binary work/notarized.zip | base64 -w 0)
@@ -719,6 +728,44 @@ jobs:
           }
           verify_published "${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}" "$ZIP_SHA512" "ZIP"
           verify_published "${{ vars.CLI_CDN_BASE }}/${DMG_KEY}" "$DMG_SHA512" "DMG"
+
+          # Feed monotonicity guard: a hotfix cut on an OLD release line
+          # must publish its versioned assets without dragging the channel
+          # pointer backward into a downgrade offer for every client.
+          # Feed read goes through the public CDN (the publish role is
+          # Put-only on feed/*, see the head-object note below); repo
+          # tags close the CDN's max-age staleness window. The legacy
+          # feed and DMG alias steps are gated on this verdict too.
+          # Fail CLOSED on transport errors: only confirmed absence (404, or
+          # 403 -- S3-backed CloudFront answers 403 for a missing key) reads
+          # as "no feed yet". Treating an outage as absence would advance on
+          # degraded evidence -- the exact rollback this guard prevents.
+          FEED_HTTP=$(curl -sS --retry 3 --retry-delay 2 \
+            -o /tmp/current-feed.yml -w '%{http_code}' \
+            "${{ vars.CLI_CDN_BASE }}/feed/${CHANNEL}/latest-mac.yml") \
+            || { echo "::error::channel feed fetch failed (transport)"; exit 1; }
+          case "$FEED_HTTP" in
+            200) ;;
+            403|404) : > /tmp/current-feed.yml ;;
+            *) echo "::error::channel feed fetch returned HTTP ${FEED_HTTP}"; exit 1 ;;
+          esac
+          # awk does the ^{} peel-ref filtering (awk always exits 0 on empty
+          # input, unlike grep -v); an ls-remote failure aborts via pipefail.
+          git ls-remote --tags origin 'refs/tags/v*' \
+            | awk -F/ '$NF !~ /\^\{\}$/ {print $NF}' > /tmp/repo-tags.txt
+          VERDICT=$(python3 scripts/check_feed_advance.py \
+            --new "${VERSION}" --channel "${CHANNEL}" \
+            --current-file /tmp/current-feed.yml \
+            --tags-file /tmp/repo-tags.txt --self "${GITHUB_REF_NAME}" || true)
+          if [ "$VERDICT" = "hold" ]; then
+            echo "advance=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::feed/${CHANNEL}/latest-mac.yml already serves a newer version; pointer NOT moved (hotfix on an old line). Versioned assets are published."
+            exit 0
+          elif [ "$VERDICT" != "advance" ]; then
+            echo "::error::feed guard returned neither advance nor hold (got: '${VERDICT}')"
+            exit 1
+          fi
+          echo "advance=true" >> "$GITHUB_OUTPUT"
           cat > /tmp/latest-mac.yml <<EOF
           version: ${VERSION}
           files:
@@ -781,7 +828,7 @@ jobs:
       # first electron-updater release remain. Pinned by
       # test/test_publish_feed_contract.py so it cannot be dropped silently.
       - name: Write legacy update feed (pre-electron-updater clients)
-        if: env.HAS_SIGNING_SECRETS
+        if: env.HAS_SIGNING_SECRETS && steps.feed.outputs.advance == 'true'
         run: |
           set -euo pipefail
           cat > /tmp/latest-mac.json <<EOF
@@ -835,7 +882,7 @@ jobs:
       # Uploads the local body (not an S3 copy): the publish role's
       # desktop/* grant is Put-only.
       - name: Update latest DMG alias
-        if: env.HAS_SIGNING_SECRETS
+        if: env.HAS_SIGNING_SECRETS && steps.feed.outputs.advance == 'true'
         run: |
           set -euo pipefail
           LATEST_DMG_KEY="desktop/${CHANNEL}/latest/${ARTIFACT_BASENAME}.dmg"
@@ -856,6 +903,10 @@ jobs:
             echo "- Version: ${VERSION}"
             echo "- Public zip: ${{ vars.CLI_CDN_BASE }}/${DESKTOP_KEY}"
             echo "- Public DMG: ${{ vars.CLI_CDN_BASE }}/${DMG_KEY}"
-            echo "- Latest DMG alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_DMG_KEY}"
-            echo "- Feed: \`feed/${CHANNEL}/latest-mac.yml\`"
+            if [ "${{ steps.feed.outputs.advance }}" = "true" ]; then
+              echo "- Latest DMG alias: ${{ vars.CLI_CDN_BASE }}/${LATEST_DMG_KEY}"
+              echo "- Feed: \`feed/${CHANNEL}/latest-mac.yml\`"
+            else
+              echo "- Feed: not moved (channel already serves a newer version)"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -138,6 +138,33 @@ candidate produced. The mechanism:
   `0.4.1`): the release workflow's Derive-Version step rejects a four-segment
   base like `0.4.0.1` outright, and re-using the shipped version is impossible —
   its published keys are immutable.
+- **A hot patch is cut on the branch of the line stable is CURRENTLY serving,
+  never on an older one.** With `0.5.0` on stable, `0.5.1` is cut from
+  `release/0.5.0`; `release/0.4.0` is finished and publishes nothing further.
+  This is what keeps the stable feed monotonic at the process level, because a
+  bare `v0.4.2` tag published while stable served `0.5.0` WOULD move that pointer
+  backward — the feed-advance guard below refuses the write, so the outcome is a
+  failed publish rather than a downgraded channel, but the release is wasted
+  either way. The rule is not "the branch where the bug was introduced": a fix
+  needed on stable lands on `main` first and is backported to the CURRENT release
+  branch, exactly like any other release-branch backport.
+- **A hotfix RC never moves the insider channel backward.** The channel feeds
+  are mutable last-writer-wins pointers, and the insider line is usually AHEAD
+  of the line being hotfixed — when `v0.4.1-insider.1` published while insider
+  served `0.5.0-insider.1`, the feed rolled back and every insider client was
+  offered a downgrade (electron-updater accepts one whenever the installed
+  version carries a prerelease suffix). Every publish workflow now runs
+  `scripts/check_feed_advance.py` before its pointer writes: the versioned
+  assets and the GitHub release always publish (that is what the stable gate
+  and promotion consume), but the feed, the legacy mac feed, and the `latest/`
+  aliases are rewritten only when this run's version is the newest the channel
+  has seen — judged against the live feed (via the public CDN; the publish
+  role is Put-only on `feed/*`) AND the repo's tags, which close the CDN's
+  `max-age` staleness window. Equal versions advance, so re-running a
+  half-finished publish stays idempotent. A stable release is unaffected either
+  way: whether it rebuilds or republishes the candidate's bytes, its version is
+  newer than everything the stable feed has served.
+  `test/test_check_feed_advance.py` pins the verdicts and the wiring.
 
 ### Runbook: promoting an RC to stable
 

--- a/scripts/check_feed_advance.py
+++ b/scripts/check_feed_advance.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Decide whether a channel feed pointer may advance to a new version.
+
+The CDN's channel feed files (``feed/<channel>/latest-cli.json``,
+``latest-mac.yml``, ``latest-linux*.yml``, ``latest.yml``) are mutable
+last-writer-wins pointers. A hotfix release cut on an OLD release line
+(e.g. tagging ``v0.4.1-insider.1`` while the insider channel already
+serves ``0.5.0-insider.1``) must still build, sign, and publish its
+immutable per-version assets -- but it must NOT move the channel pointer
+backward, or every client on the channel is offered a downgrade
+(electron-updater accepts it when the installed version carries a
+prerelease suffix).
+
+Usage::
+
+    check_feed_advance.py --new <version> --channel <channel>
+        [--current-file <path>] [--tags-file <path>] [--self <tag>]
+
+Two independent "what does the channel currently serve" signals, because
+neither alone is trustworthy from a publish job:
+
+* ``--current-file``: the live feed fetched through the PUBLIC CDN (the
+  publish role is Put-only on ``feed/*``, so S3 read-back is not an
+  option). CloudFront serves it with ``max-age=300``, so a read can be
+  up to five minutes stale -- exactly the window in which two
+  back-to-back serialized release runs would miss each other.
+* ``--tags-file``: the repository's tags (one per line, ``v`` prefix
+  optional). Tags are pushed before the run that publishes them starts,
+  so they close the CDN staleness window. Only consulted for the insider
+  and stable channels (nightly builds are untagged); ``--self`` names
+  the tag THIS run publishes so it never holds against itself.
+
+Verdict: HOLD when any candidate is STRICTLY newer than ``--new``;
+ADVANCE otherwise. Equality advances deliberately: a re-run of the
+current release (recovering a run that died between the versioned upload
+and the feed write) must be able to complete the pointer write, and
+rewriting the pointer with the version it already names is a no-op.
+
+* exit 0  -- advance (prints ``advance``)
+* exit 3  -- hold (prints ``hold``)
+* exit 2  -- bad invocation
+
+Version spellings accepted (all appear across the feeds and tags):
+
+* ``X.Y.Z``                  (bare stable)
+* ``X.Y.Z-<label>.N``        (tag/desktop prerelease, e.g. 0.5.0-insider.1)
+* ``X.Y.Z<label>N``          (PEP 440 wheel stamp, e.g. 0.5.0rc1)
+* ``X.Y.Z-nightly.<D>t<T>``  (desktop nightly stamp; date+time both order)
+* ``X.Y.Z.devN``             (PEP 440 nightly wheel stamp)
+* ``X.Y.Z-<anything>``       (any other prerelease spelling release.yml
+  accepts, e.g. 0.5.0-beta-preview.1 or 0.5.0-beta)
+
+That last row is a PARITY requirement, not generosity. ``release.yml``
+triggers on ``v*`` and validates only the part BEFORE the first hyphen
+(``^[0-9]+\\.[0-9]+\\.[0-9]+$``); the prerelease remainder is free-form,
+and it derives the wheel's ``rcN`` from the text after the LAST dot,
+falling back to ``0`` when that is not numeric. So a tag like
+``v0.5.0-beta-preview.1`` builds, signs, and reaches the publish jobs.
+The desktop publishers pass the RAW tag version to ``--new``, so any
+spelling this parser rejects makes the guard exit 2 with empty stdout --
+which those jobs treat as "neither advance nor hold" and fail. A guard
+narrower than the tag surface therefore converts an odd-but-accepted tag
+into a hard publish outage, so the fallback below mirrors release.yml's
+own trailing-number rule exactly rather than inventing a stricter one.
+
+Ordering: release parts compare numerically; a bare release outranks any
+prerelease of the SAME base (0.5.0 > 0.5.0-insider.9); prereleases of
+the same base compare by their trailing number, label-insensitively
+(``-insider.N`` and ``rcN`` are the same lane spelled two ways).
+
+Deliberately dependency-free: this runs on bare CI runners where neither
+``packaging`` nor the repo's own wheel is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# X.Y.Z with an optional prerelease in one of three spellings:
+#   -<label>.N[tN]  (tag/desktop form; label alphanumeric, e.g. insider, rc,
+#                    nightly -- the nightly stamp carries a tHHMMSS time part
+#                    that MUST participate in ordering, or two same-day
+#                    nightlies compare equal and a rerun of the earlier one
+#                    could advance over the later one)
+#   <label>N        (PEP 440 wheel form appended without a dash, e.g. rc1)
+#   .devN           (PEP 440 nightly wheel form, e.g. .dev20260830065756)
+_VERSION_RE = re.compile(
+    r"^(\d+)\.(\d+)\.(\d+)"
+    r"(?:-(?P<dashlabel>[A-Za-z]+)\.(?P<dashnum>\d+)(?:t(?P<dashtime>\d+))?"
+    r"|\.dev(?P<devnum>\d+)"
+    r"|(?P<taglabel>[A-Za-z]+)(?P<tagnum>\d+))?$"
+)
+
+# Fallback for every OTHER prerelease spelling release.yml accepts: a valid
+# X.Y.Z base, a hyphen, and a free-form remainder (hyphenated labels like
+# `beta-preview.1`, dotless labels like `beta`, multi-dot labels). Tried only
+# after _VERSION_RE, so the structured forms above keep their richer ordering
+# (notably the nightly tHHMMSS time part).
+_LOOSE_PRERELEASE_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)-(?P<pre>.*)$")
+
+
+def _loose_pre_number(pre: str) -> int:
+    """release.yml's own rule: the text after the LAST dot, else 0.
+
+    Mirrors the shell in the Derive Version + Channel job
+    (``N="${PRE##*.}"``; non-numeric ``N`` becomes ``0``), so the guard's
+    idea of "which prerelease is this" cannot disagree with the wheel
+    version the same tag publishes under.
+    """
+    tail = pre.rsplit(".", 1)[-1]
+    return int(tail) if tail.isdigit() else 0
+
+
+def parse_version(text: str) -> tuple[int, int, int, int, int] | None:
+    """Comparable tuple: (major, minor, patch, is_release, pre_number).
+
+    ``is_release`` is 1 for a bare X.Y.Z and 0 for any prerelease, so a
+    release sorts above every prerelease of the same base. The prerelease
+    LABEL is deliberately ignored for ordering -- ``0.5.0-insider.1`` and
+    ``0.5.0rc1`` are the same build spelled two ways, and a nightly's two
+    spellings (``-nightly.YYYYMMDDtHHMMSS`` and ``.devYYYYMMDDHHMMSS``)
+    concatenate to the same 14-digit number.
+    """
+    text = text.strip()
+    if text.startswith("v"):
+        text = text[1:]
+    m = _VERSION_RE.match(text)
+    if not m:
+        loose = _LOOSE_PRERELEASE_RE.match(text)
+        if not loose:
+            return None
+        return (
+            int(loose.group(1)),
+            int(loose.group(2)),
+            int(loose.group(3)),
+            0,
+            _loose_pre_number(loose.group("pre")),
+        )
+    major, minor, patch = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    if m.group("devnum") is not None:
+        return (major, minor, patch, 0, int(m.group("devnum")))
+    if m.group("dashnum") is not None:
+        pre = m.group("dashnum") + (m.group("dashtime") or "")
+        return (major, minor, patch, 0, int(pre))
+    if m.group("tagnum") is not None:
+        return (major, minor, patch, 0, int(m.group("tagnum")))
+    return (major, minor, patch, 1, 0)
+
+
+def extract_feed_version(content: str) -> str | None:
+    """Pull the version string out of a feed file, JSON or YAML.
+
+    Tries JSON first (``latest-cli.json``, legacy ``latest-mac.json``);
+    falls back to a line-anchored ``version:`` scan for the
+    electron-updater YAML feeds. Returns None when nothing parseable is
+    found -- the caller treats that as "no current version".
+    """
+    body = content.strip()
+    if not body:
+        return None
+    try:
+        data = json.loads(body)
+    except ValueError:
+        data = None
+    if isinstance(data, dict):
+        version = data.get("version")
+        return str(version) if version else None
+    for line in body.splitlines():
+        # electron-updater feeds put the version at top level; the files
+        # are flat so a left-anchored match cannot hit a nested key.
+        m = re.match(r"^version:\s*['\"]?([^'\"\s]+)['\"]?\s*$", line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def tag_candidates(tags: list[str], channel: str, self_tag: str) -> list[str]:
+    """Tags that speak for the channel's current level, minus this run's own.
+
+    * stable: bare ``vX.Y.Z`` tags only -- each is a stable release.
+    * insider: every version tag counts. Prerelease tags are that lane's
+      own releases; a BARE tag also caps it, because once ``0.5.0``
+      shipped stable, cutting more ``0.5.0-insider.N`` is a hotfix on an
+      old line by definition.
+    * nightly: none -- nightly builds are untagged, the feed is the only
+      signal.
+    """
+    if channel == "nightly":
+        return []
+    self_norm = self_tag.lstrip("v")
+    out = []
+    for tag in tags:
+        norm = tag.strip().lstrip("v")
+        if not norm or norm == self_norm:
+            continue
+        key = parse_version(norm)
+        if key is None:
+            continue
+        if channel == "stable" and key[3] != 1:
+            continue
+        out.append(norm)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--new", required=True, help="version this run wants to publish")
+    parser.add_argument("--channel", required=True, choices=("nightly", "insider", "stable"))
+    parser.add_argument(
+        "--current-file",
+        default="",
+        help="path to the current feed content fetched via the CDN ('' = none)",
+    )
+    parser.add_argument(
+        "--tags-file",
+        default="",
+        help="path to a newline list of repo tags ('' = none)",
+    )
+    parser.add_argument(
+        "--self",
+        default="",
+        dest="self_tag",
+        help="the tag this run publishes, excluded from tag candidates",
+    )
+    args = parser.parse_args(argv)
+
+    new_key = parse_version(args.new)
+    if new_key is None:
+        print(f"error: unparseable --new version: {args.new!r}", file=sys.stderr)
+        return 2
+
+    candidates: list[tuple[str, str]] = []  # (source, version)
+
+    if args.current_file:
+        try:
+            with open(args.current_file, encoding="utf-8") as fh:
+                feed_version = extract_feed_version(fh.read())
+        except OSError:
+            feed_version = None
+        if feed_version is not None:
+            candidates.append(("feed", feed_version))
+
+    if args.tags_file:
+        try:
+            with open(args.tags_file, encoding="utf-8") as fh:
+                tags = fh.read().splitlines()
+        except OSError:
+            tags = []
+        for tag in tag_candidates(tags, args.channel, args.self_tag):
+            candidates.append(("tag", tag))
+
+    newer = [
+        (source, version)
+        for source, version in candidates
+        if (key := parse_version(version)) is not None and key > new_key
+    ]
+    if newer:
+        # parse_version is non-None for every entry in `newer` (filtered above);
+        # the fallback tuple only satisfies the type checker.
+        source, version = max(newer, key=lambda item: parse_version(item[1]) or (0, 0, 0, 0, 0))
+        print("hold")
+        print(
+            f"feed-guard: channel already carries {version} (from {source}), "
+            f"newer than {args.new}; holding the feed pointer -- versioned "
+            "assets publish, the channel does not move backward",
+            file=sys.stderr,
+        )
+        return 3
+
+    print("advance")
+    checked = ", ".join(f"{v} ({s})" for s, v in candidates) or "none found"
+    print(
+        f"feed-guard: {args.new} is newest among candidates [{checked}]; advancing",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/test/test_check_feed_advance.py
+++ b/test/test_check_feed_advance.py
@@ -1,0 +1,405 @@
+"""The feed monotonicity guard: a channel pointer never moves backward.
+
+``scripts/check_feed_advance.py`` decides, at publish time, whether a
+release run may rewrite its channel's mutable feed pointer. The scenario
+it exists for is a hotfix cut on an OLD release line (``v0.4.1-insider.1``
+while insider serves ``0.5.0-insider.1``): the run must publish its
+immutable versioned assets, but rewriting the pointer would offer every
+client on the channel a downgrade -- which electron-updater ACCEPTS when
+the installed version carries a prerelease suffix. This happened live on
+2026-08-28 and required an emergency ``v0.5.0-insider.2`` to undo.
+
+Structural pins on the four publish workflows keep the guard wired to
+every pointer write; a plausible refactor that drops one silently
+re-opens the rollback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_feed_advance.py"
+
+_spec = importlib.util.spec_from_file_location("check_feed_advance", SCRIPT)
+assert _spec is not None and _spec.loader is not None
+guard = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(guard)
+
+
+class TestParseVersion:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("0.4.1", (0, 4, 1, 1, 0)),
+            ("v0.4.1", (0, 4, 1, 1, 0)),
+            ("0.4.1-insider.1", (0, 4, 1, 0, 1)),
+            ("0.4.1rc1", (0, 4, 1, 0, 1)),
+            ("0.5.0-rc.2", (0, 5, 0, 0, 2)),
+            # Desktop nightly: date AND time both order (same-day nightlies
+            # must not compare equal, or a rerun of the earlier one could
+            # advance over the later one).
+            ("0.1.0-nightly.20260731t065756", (0, 1, 0, 0, 20260731065756)),
+            ("0.1.0-nightly.20260731", (0, 1, 0, 0, 20260731)),
+            # Nightly wheel (PEP 440): same run, same comparable number.
+            ("0.1.0.dev20260731065756", (0, 1, 0, 0, 20260731065756)),
+            # Free-form prerelease labels release.yml accepts and builds.
+            # A hyphen in the label used to make the guard exit 2 with empty
+            # stdout, which the desktop publishers read as "neither advance
+            # nor hold" and fail -- a hard publish outage on a valid tag.
+            ("0.5.0-beta-preview.1", (0, 5, 0, 0, 1)),
+            ("v0.5.0-beta-preview.1", (0, 5, 0, 0, 1)),
+            ("0.5.0-insider.4", (0, 5, 0, 0, 4)),
+            # Dotless label: release.yml's trailing-number rule yields 0, so
+            # the guard says 0 too rather than refusing to parse.
+            ("0.5.0-beta", (0, 5, 0, 0, 0)),
+            ("0.5.0-alpha.beta.3", (0, 5, 0, 0, 3)),
+        ],
+    )
+    def test_spellings(self, text: str, expected: tuple) -> None:
+        assert guard.parse_version(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "not-a-version",
+            "0.4",
+            "0.4.1.2",
+            "0.5.0rc",
+            "0.5.0_insider.1",
+            "",
+        ],
+    )
+    def test_malformed_is_rejected(self, text: str) -> None:
+        # Broadening the prerelease surface must not make the base optional:
+        # anything without a numeric X.Y.Z base is still unparseable.
+        assert guard.parse_version(text) is None
+
+    def test_hyphenated_label_matches_its_own_wheel_stamp(self) -> None:
+        # release.yml maps 0.5.0-beta-preview.1 to the wheel 0.5.0rc1, and
+        # publish-cli passes the wheel while the desktop jobs pass the raw
+        # tag -- both must land on the same comparable key or one channel
+        # holds while another advances.
+        assert guard.parse_version("0.5.0-beta-preview.1") == guard.parse_version("0.5.0rc1")
+
+    def test_release_yml_still_validates_only_the_base(self) -> None:
+        # Parity pin: the guard is deliberately as permissive as the tag
+        # surface. If release.yml ever starts validating the prerelease part
+        # too, this assertion fails and the loose fallback can be narrowed.
+        body = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        assert r'"$BASE" =~ ^[0-9]+\.[0-9]+\.[0-9]+$' in body
+        assert 'N="${PRE##*.}"' in body
+
+    def test_release_outranks_its_own_prereleases(self) -> None:
+        assert guard.parse_version("0.5.0") > guard.parse_version("0.5.0-insider.9")
+
+    def test_labels_are_lane_spellings_of_the_same_build(self) -> None:
+        # The wheel stamp 0.4.1rc1 IS the tag 0.4.1-insider.1.
+        assert guard.parse_version("0.4.1rc1") == guard.parse_version("0.4.1-insider.1")
+
+    def test_nightly_wheel_and_desktop_stamps_are_the_same_run(self) -> None:
+        assert guard.parse_version("0.1.0.dev20260830065756") == guard.parse_version(
+            "0.1.0-nightly.20260830t065756"
+        )
+
+    def test_same_day_nightlies_order_by_time(self) -> None:
+        earlier = guard.parse_version("0.1.0-nightly.20260830t010000")
+        later = guard.parse_version("0.1.0-nightly.20260830t065756")
+        assert earlier < later
+
+    def test_the_live_incident_ordering(self) -> None:
+        # v0.4.1-insider.1 must NOT outrank the 0.5.0 insider the channel served.
+        assert guard.parse_version("0.4.1-insider.1") < guard.parse_version("0.5.0-insider.1")
+
+
+class TestExtractFeedVersion:
+    def test_json_feed(self) -> None:
+        assert guard.extract_feed_version('{"version": "0.5.0rc1"}') == "0.5.0rc1"
+
+    def test_yaml_feed(self) -> None:
+        body = "version: 0.5.0-insider.1\nfiles:\n  - url: https://x/y.zip\n"
+        assert guard.extract_feed_version(body) == "0.5.0-insider.1"
+
+    def test_empty_and_unparseable(self) -> None:
+        assert guard.extract_feed_version("") is None
+        assert guard.extract_feed_version("<html>404</html>") is None
+
+    def test_nested_yaml_keys_cannot_shadow(self) -> None:
+        # Only a left-anchored top-level `version:` counts.
+        body = "files:\n  version: 9.9.9\nversion: 0.5.0-insider.1\n"
+        assert guard.extract_feed_version(body) == "0.5.0-insider.1"
+
+
+def _run(args: list[str], feed: str = "", tags: str = "", tmp_path: Path | None = None):
+    cmd = [sys.executable, str(SCRIPT)] + args
+    files = []
+    if tmp_path is not None:
+        feed_file = tmp_path / "feed"
+        feed_file.write_text(feed, encoding="utf-8")
+        tags_file = tmp_path / "tags"
+        tags_file.write_text(tags, encoding="utf-8")
+        files = ["--current-file", str(feed_file), "--tags-file", str(tags_file)]
+    return subprocess.run(cmd + files, capture_output=True, text=True, encoding="utf-8", timeout=30)
+
+
+class TestVerdicts:
+    def test_hotfix_on_old_line_holds_against_the_feed(self, tmp_path: Path) -> None:
+        """The exact live incident: insider serves 0.5.0, hotfix publishes 0.4.1."""
+        res = _run(
+            ["--new", "0.4.1-insider.1", "--channel", "insider", "--self", "v0.4.1-insider.1"],
+            feed="version: 0.5.0-insider.1\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 3
+        assert res.stdout.strip() == "hold"
+
+    def test_hotfix_holds_on_tags_even_when_the_cdn_feed_is_stale(self, tmp_path: Path) -> None:
+        """The CDN copy lags up to max-age; the pushed tag does not."""
+        res = _run(
+            ["--new", "0.4.1-insider.1", "--channel", "insider", "--self", "v0.4.1-insider.1"],
+            feed="version: 0.4.0-insider.14\n",  # stale CDN copy
+            tags="v0.4.0\nv0.4.1-insider.1\nv0.5.0-insider.1\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 3
+        assert res.stdout.strip() == "hold"
+
+    def test_normal_release_advances(self, tmp_path: Path) -> None:
+        res = _run(
+            ["--new", "0.5.0-insider.2", "--channel", "insider", "--self", "v0.5.0-insider.2"],
+            feed="version: 0.4.1-insider.1\n",
+            tags="v0.4.1-insider.1\nv0.5.0-insider.1\nv0.5.0-insider.2\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 0
+        assert res.stdout.strip() == "advance"
+
+    def test_rerun_of_the_current_release_is_idempotent(self, tmp_path: Path) -> None:
+        """Equality advances: a re-run recovering a half-finished publish
+        must be able to complete the pointer write."""
+        res = _run(
+            ["--new", "0.5.0-insider.2", "--channel", "insider", "--self", "v0.5.0-insider.2"],
+            feed="version: 0.5.0-insider.2\n",
+            tags="v0.5.0-insider.2\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 0
+
+    def test_first_publish_on_a_channel_advances(self, tmp_path: Path) -> None:
+        res = _run(
+            ["--new", "0.1.0-insider.1", "--channel", "insider", "--self", "v0.1.0-insider.1"],
+            feed="",
+            tags="v0.1.0-insider.1\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 0
+
+    def test_hyphenated_label_tag_reaches_a_verdict(self, tmp_path: Path) -> None:
+        """A tag release.yml accepts must never exit 2 with empty stdout.
+
+        The desktop publishers capture stdout and fail the job on anything
+        that is neither ``advance`` nor ``hold``, so an unparseable --new
+        turns a valid-but-unusual tag into a hard publish failure.
+        """
+        res = _run(
+            [
+                "--new",
+                "0.5.0-beta-preview.1",
+                "--channel",
+                "insider",
+                "--self",
+                "v0.5.0-beta-preview.1",
+            ],
+            feed="version: 0.5.0-insider.1\n",
+            tags="v0.5.0-insider.1\nv0.5.0-beta-preview.1\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 0
+        assert res.stdout.strip() == "advance"
+
+    def test_hyphenated_label_tag_still_holds_on_an_old_line(self, tmp_path: Path) -> None:
+        """Broadening the parser must not weaken the guard itself."""
+        res = _run(
+            [
+                "--new",
+                "0.4.1-beta-preview.1",
+                "--channel",
+                "insider",
+                "--self",
+                "v0.4.1-beta-preview.1",
+            ],
+            feed="version: 0.5.0-insider.1\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 3
+        assert res.stdout.strip() == "hold"
+
+    def test_unparseable_new_version_is_still_a_bad_invocation(self, tmp_path: Path) -> None:
+        res = _run(
+            ["--new", "not-a-version", "--channel", "insider"],
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 2
+
+    def test_stable_promotion_advances_past_its_own_rc_stamp(self, tmp_path: Path) -> None:
+        """Promoting 0.4.1: the stable feed carries the previous release's
+        wheel stamp and the repo carries the bare v0.4.1 tag (self)."""
+        res = _run(
+            ["--new", "0.4.1rc1", "--channel", "stable", "--self", "v0.4.1"],
+            feed='{"version": "0.4.0rc14"}',
+            tags="v0.4.0\nv0.4.1\nv0.4.1-insider.1\nv0.5.0-insider.1\n",
+            tmp_path=tmp_path,
+        )
+        # 0.5.0-insider.1 is NOT a stable candidate; 0.4.1 is self. Advance.
+        assert res.returncode == 0
+
+    def test_stable_hotfix_holds_against_a_newer_stable_tag(self, tmp_path: Path) -> None:
+        res = _run(
+            ["--new", "0.4.2rc1", "--channel", "stable", "--self", "v0.4.2"],
+            feed='{"version": "0.4.1rc1"}',  # stale CDN copy
+            tags="v0.4.1\nv0.4.2\nv0.5.0\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 3
+
+    def test_insider_line_is_capped_by_a_shipped_bare_release(self, tmp_path: Path) -> None:
+        """Once 0.5.0 shipped stable, another 0.5.0-insider.N is a hotfix
+        on an old line by definition."""
+        res = _run(
+            ["--new", "0.5.0-insider.3", "--channel", "insider", "--self", "v0.5.0-insider.3"],
+            feed="version: 0.5.0-insider.2\n",
+            tags="v0.5.0\nv0.5.0-insider.2\nv0.5.0-insider.3\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 3
+
+    def test_nightly_ignores_tags(self, tmp_path: Path) -> None:
+        """Nightly builds are untagged; a newer release tag must not block
+        the nightly feed (nightly versions have their own base)."""
+        res = _run(
+            ["--new", "0.1.0-nightly.20260830", "--channel", "nightly", "--self", "main"],
+            feed="version: 0.1.0-nightly.20260829\n",
+            tags="v9.9.9\n",
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 0
+
+    def test_unparseable_new_version_fails_loud(self, tmp_path: Path) -> None:
+        res = _run(
+            ["--new", "garbage", "--channel", "insider"],
+            tmp_path=tmp_path,
+        )
+        assert res.returncode == 2
+
+
+class TestWorkflowsAreWired:
+    """Every publish workflow's pointer writes sit behind the guard."""
+
+    def test_every_pointer_writing_workflow_calls_the_guard(self) -> None:
+        for name in (
+            "publish-cli.yml",
+            "publish-linux.yml",
+            "publish-windows.yml",
+            "sign-and-notarize.yml",
+        ):
+            body = (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+            assert "check_feed_advance.py" in body, f"{name} lost the feed guard"
+
+    def test_guard_jobs_check_out_the_repository(self) -> None:
+        """The guard needs repo CONTENTS on every run it gates.
+
+        It shells out to ``scripts/check_feed_advance.py`` and to
+        ``git ls-remote --tags origin``, so the job holding it must have
+        checked the repository out whenever the guard step itself runs.
+        ``sign-and-notarize.yml``'s publish job used to check out only on
+        the promotion path (``if: inputs.promote``) -- with that gating the
+        guard step red-fails on a normal nightly/insider publish, AFTER the
+        immutable assets are already uploaded. So a checkout in a
+        guard-bearing job must be either unconditional or gated no more
+        narrowly than the guard step it feeds.
+        """
+        for name in (
+            "publish-cli.yml",
+            "publish-linux.yml",
+            "publish-windows.yml",
+            "sign-and-notarize.yml",
+        ):
+            doc = yaml.safe_load(
+                (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+            )
+            for job_name, job in doc["jobs"].items():
+                steps = job.get("steps") or []
+                guard_steps = [
+                    s for s in steps if "check_feed_advance.py" in str(s.get("run") or "")
+                ]
+                if not guard_steps:
+                    continue
+                checkouts = [s for s in steps if "actions/checkout" in str(s.get("uses") or "")]
+                assert checkouts, f"{name}:{job_name} runs the guard with no checkout"
+                guard_if = str(guard_steps[0].get("if") or "").strip()
+                for co in checkouts:
+                    co_if = str(co.get("if") or "").strip()
+                    assert co_if in ("", guard_if), (
+                        f"{name}:{job_name} checkout is gated on {co_if!r} while the guard "
+                        f"step runs on {guard_if!r} -- the guard would run without "
+                        f"scripts/ or a git repo"
+                    )
+
+    def test_signal_fetches_fail_closed_on_transport_errors(self) -> None:
+        """Only confirmed absence (403/404) reads as "no feed yet". A guard
+        that converted a fetch OUTAGE into empty evidence would advance on
+        degraded signals -- reproducing the incident it exists to prevent."""
+        for name in (
+            "publish-cli.yml",
+            "publish-linux.yml",
+            "publish-windows.yml",
+            "sign-and-notarize.yml",
+        ):
+            body = (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+            assert "403|404)" in body, f"{name}: absence must be explicit 403/404 only"
+            assert (
+                "channel feed fetch failed (transport)" in body
+            ), f"{name}: a transport error must abort, never read as absence"
+            assert (
+                "channel feed fetch returned HTTP" in body
+            ), f"{name}: an unexpected HTTP status must abort, never read as absence"
+            # The old fail-open spellings must not come back.
+            assert (
+                "|| : > /tmp/current-feed" not in body
+            ), f"{name}: feed fetch silently degrades to empty on error"
+            assert (
+                "|| : > /tmp/repo-tags.txt" not in body
+            ), f"{name}: tag fetch silently degrades to empty on error"
+
+    @pytest.mark.parametrize(
+        ("name", "gated_steps"),
+        [
+            ("publish-linux.yml", ["Update latest artifact alias"]),
+            ("publish-windows.yml", ["Update latest installer alias"]),
+            (
+                "sign-and-notarize.yml",
+                ["Write legacy update feed", "Update latest DMG alias"],
+            ),
+        ],
+    )
+    def test_downstream_pointer_steps_are_gated_on_the_verdict(
+        self, name: str, gated_steps: list[str]
+    ) -> None:
+        """The 'latest' aliases and the legacy feed are channel pointers
+        too; skipping only the primary feed while still moving them would
+        leave the downgrade reachable through the alias URL."""
+        lines = (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8").splitlines()
+        for step in gated_steps:
+            idx = next(
+                i for i, line in enumerate(lines) if line.strip().startswith(f"- name: {step}")
+            )
+            window = "\n".join(lines[idx : idx + 3])
+            assert (
+                "steps.feed.outputs.advance == 'true'" in window
+            ), f"{name} step {step!r} is not gated on the feed guard verdict"

--- a/test/test_cli_manifest_signature.py
+++ b/test/test_cli_manifest_signature.py
@@ -972,11 +972,17 @@ def test_installer_publish_refuses_an_unconfigured_trust_root() -> None:
 def test_publish_workflow_writes_immutable_manifest_before_signed_feed() -> None:
     run = _workflow_step("Publish wheel and signed channel manifest")["run"]
     immutable = 'put_immutable "${PREFIX}/cli-manifest.json" "$MANIFEST_PATH"'
-    feed = 'aws s3 cp "$MANIFEST_PATH" "s3://${BUCKET}/feed/${CHANNEL}/latest-cli.json"'
+    # The feed write targets ${FEED_KEY} (feed/<channel>/latest-cli.json),
+    # and sits behind the monotonicity guard's advance verdict -- but its
+    # ORDER relative to the immutable manifest put is unchanged: the pointer
+    # may only ever name a manifest that is already live.
+    feed_key = 'FEED_KEY="feed/${CHANNEL}/latest-cli.json"'
+    feed = 'aws s3 cp "$MANIFEST_PATH" "s3://${BUCKET}/${FEED_KEY}"'
 
     assert immutable in run
+    assert feed_key in run
     assert feed in run
-    assert run.index(immutable) < run.index(feed)
+    assert run.index(immutable) < run.index(feed_key) < run.index(feed)
     assert "cat > /tmp/latest-cli.json" not in run
     assert "--cache-control no-cache" in run
 

--- a/test/test_publish_feed_contract.py
+++ b/test/test_publish_feed_contract.py
@@ -122,9 +122,11 @@ def _assert_updater_layout(feed: dict) -> None:
     assert feed["version"] == _SUBS["VERSION"], "version must be the raw ${VERSION}, no v-prefix"
     assert isinstance(feed["files"], list) and feed["files"], "files must be a non-empty list"
     for entry in feed["files"]:
-        assert set(entry.keys()) == {"url", "sha512", "size"}, (
-            f"files[] entry keys {sorted(entry)} diverge from url+sha512+size"
-        )
+        assert set(entry.keys()) == {
+            "url",
+            "sha512",
+            "size",
+        }, f"files[] entry keys {sorted(entry)} diverge from url+sha512+size"
         assert isinstance(entry["size"], int), "size must be an unquoted integer"
     # releaseDate must be QUOTED in the heredoc: unquoted ISO timestamps are
     # YAML-typed as datetime by some parsers, and electron-updater expects a
@@ -193,9 +195,9 @@ def test_feed_urls_are_absolute_byte_host_urls() -> None:
         # And the rendered urls point at the byte prefix, not the feed prefix.
         feed = _rendered_feed(_feed_step(path, job)["run"])
         for entry in feed["files"]:
-            assert entry["url"].startswith(f"{_CDN_BASE}/desktop/"), (
-                f"{path.name}: {entry['url']!r} must reference the desktop/ byte prefix"
-            )
+            assert entry["url"].startswith(
+                f"{_CDN_BASE}/desktop/"
+            ), f"{path.name}: {entry['url']!r} must reference the desktop/ byte prefix"
 
 
 def test_feed_destination_is_pointer_prefix_yaml() -> None:
@@ -289,18 +291,16 @@ def test_pr_desktop_matrix_gates_macos_but_never_linux() -> None:
         "build.yml must resolve the desktop matrix via a desktop-matrix job so "
         "macos-15 can be gated"
     )
-    compute = next(
-        (s for s in jobs["desktop-matrix"]["steps"] if s.get("id") == "compute"), None
-    )
+    compute = next((s for s in jobs["desktop-matrix"]["steps"] if s.get("id") == "compute"), None)
     assert compute is not None, "desktop-matrix must have a `compute` step emitting os="
     os_lines = [ln for ln in compute["run"].splitlines() if "os=[" in ln]
     assert os_lines, "the compute step must emit at least one os= matrix list"
 
     # Linux is UNCONDITIONAL: both arches appear in every branch the script emits.
     for ln in os_lines:
-        assert '"ubuntu-22.04"' in ln and '"ubuntu-22.04-arm"' in ln, (
-            f"both Linux arches must be in every PR desktop matrix branch: {ln}"
-        )
+        assert (
+            '"ubuntu-22.04"' in ln and '"ubuntu-22.04-arm"' in ln
+        ), f"both Linux arches must be in every PR desktop matrix branch: {ln}"
     # macOS is GATED: it must be buildable (packaging-relevant PR / push) but must
     # NOT appear in every branch, or the 10x build still runs on every PR.
     with_mac = [ln for ln in os_lines if '"macos-15"' in ln]
@@ -406,10 +406,23 @@ def test_linux_publish_order_bytes_then_feed_then_alias() -> None:
 
 
 def test_feed_chain_steps_share_one_skip_gate() -> None:
-    """Every step in the go-live chain must carry the SAME condition. A feed
-    step gated differently from its byte steps could run while the bytes were
-    skipped -- advertising artifacts that were never uploaded."""
-    for path, job, names in (
+    """The go-live chain is all-or-nothing in the direction that matters: a
+    feed step gated differently from its byte steps could run while the bytes
+    were skipped -- advertising artifacts that were never uploaded.
+
+    The BYTE steps and the "Write update feed" step share one base gate. The
+    downstream POINTER steps (latest aliases, the mac legacy feed) carry the
+    same base gate AND the feed step's monotonicity verdict
+    (``steps.feed.outputs.advance``): when a hotfix on an old release line
+    HOLDS the feed pointer, the aliases must hold with it -- an alias is a
+    channel pointer too, and moving it alone would leave the downgrade
+    reachable through the alias URL. An alias that skips while the bytes
+    published is safe (it keeps pointing at the previous, still-live
+    release); an alias that moves while the feed held is the rollback this
+    guard exists to prevent."""
+    base = "env.HAS_SIGNING_SECRETS"
+    guarded = "env.HAS_SIGNING_SECRETS && steps.feed.outputs.advance == 'true'"
+    for path, job, base_names, guarded_names in (
         (
             MAC_WORKFLOW,
             "publish",
@@ -417,6 +430,9 @@ def test_feed_chain_steps_share_one_skip_gate() -> None:
                 "Publish notarized artifact to distribution bucket",
                 "Publish DMG to distribution bucket",
                 "Write update feed",
+            ),
+            (
+                "Write legacy update feed (pre-electron-updater clients)",
                 "Update latest DMG alias",
             ),
         ),
@@ -426,19 +442,23 @@ def test_feed_chain_steps_share_one_skip_gate() -> None:
             (
                 "Publish artifact to distribution bucket",
                 "Write update feed",
-                "Update latest artifact alias",
             ),
+            ("Update latest artifact alias",),
         ),
     ):
         steps = _steps(path, job)
-        gates = {name: _step(steps, name).get("if") for name in names}
-        assert all(g == "env.HAS_SIGNING_SECRETS" for g in gates.values()), (
-            f"{path.name}: go-live chain must be all-or-nothing on the same gate, got {gates}"
-        )
-        for name in names:
-            assert "continue-on-error" not in _step(steps, name), (
-                f"{path.name}: {name!r} must fail the job, never continue past a failure"
-            )
+        for name in base_names:
+            assert (
+                _step(steps, name).get("if") == base
+            ), f"{path.name}: {name!r} must carry the base go-live gate"
+        for name in guarded_names:
+            assert (
+                _step(steps, name).get("if") == guarded
+            ), f"{path.name}: {name!r} must be gated on the feed guard verdict too"
+        for name in (*base_names, *guarded_names):
+            assert "continue-on-error" not in _step(
+                steps, name
+            ), f"{path.name}: {name!r} must fail the job, never continue past a failure"
 
 
 # ---------------------------------------------------------------------------
@@ -453,9 +473,9 @@ def test_versioned_keys_are_immutable_and_conditionally_written() -> None:
         (LINUX_WORKFLOW, "publish-linux", "Publish artifact to distribution bucket"),
     ):
         run = _step(_steps(path, job), name)["run"]
-        assert "public, max-age=31536000, immutable" in run, (
-            f"{path.name}/{name}: versioned keys are immutable-cached for a year"
-        )
+        assert (
+            "public, max-age=31536000, immutable" in run
+        ), f"{path.name}/{name}: versioned keys are immutable-cached for a year"
         assert "--if-none-match" in run, (
             f"{path.name}/{name}: the conditional write is the never-republish "
             "guarantee -- a republished immutable key diverges across CloudFront edges"
@@ -468,9 +488,9 @@ def test_latest_aliases_use_short_ttl_and_plain_overwrite() -> None:
         (LINUX_WORKFLOW, "publish-linux", "Update latest artifact alias"),
     ):
         run = _step(_steps(path, job), name)["run"]
-        assert "public, max-age=300" in run, (
-            f"{path.name}/{name}: mutable latest aliases roll over within minutes"
-        )
+        assert (
+            "public, max-age=300" in run
+        ), f"{path.name}/{name}: mutable latest aliases roll over within minutes"
         assert "--if-none-match" not in run, (
             f"{path.name}/{name}: aliases are mutable by design; a conditional write "
             "would freeze them at the first publish"
@@ -499,9 +519,9 @@ def test_feeds_carry_an_explicit_cache_control() -> None:
             f"{path.name}: feed written without an explicit Cache-Control -- "
             "heuristic freshness caused the #709 stale-feed incident"
         )
-        assert re.search(r"max-age=(\d+)", run), (
-            f"{path.name}: feed Cache-Control must pin an explicit max-age"
-        )
+        assert re.search(
+            r"max-age=(\d+)", run
+        ), f"{path.name}: feed Cache-Control must pin an explicit max-age"
         ttl = int(re.search(r"max-age=(\d+)", run).group(1))
         assert 0 < ttl <= 600, (
             f"{path.name}: feed TTL is {ttl}s -- the feed is the go-live switch, so a "
@@ -522,9 +542,9 @@ def test_mac_legacy_bridge_matches_the_modern_feed_cache_control() -> None:
     modern_cc = re.search(r'--cache-control "([^"]+)"', steps[modern]["run"]).group(1)
     legacy_cc = re.search(r'--cache-control "([^"]+)"', steps[legacy]["run"]).group(1)
     print(f"feed Cache-Control: modern={modern_cc!r} legacy={legacy_cc!r}")
-    assert modern_cc == legacy_cc, (
-        f"feed and legacy bridge disagree on Cache-Control ({modern_cc!r} vs {legacy_cc!r})"
-    )
+    assert (
+        modern_cc == legacy_cc
+    ), f"feed and legacy bridge disagree on Cache-Control ({modern_cc!r} vs {legacy_cc!r})"
 
 
 def test_mac_feed_verifies_the_header_clients_receive() -> None:
@@ -536,15 +556,13 @@ def test_mac_feed_verifies_the_header_clients_receive() -> None:
     -- a guard that fails on permissions instead of on the condition it guards.
     """
     run = _feed_step(MAC_WORKFLOW, "publish")["run"]
-    assert "curl" in run and "-I" in run, (
-        "feed step must verify the served Cache-Control through the CDN"
-    )
+    assert (
+        "curl" in run and "-I" in run
+    ), "feed step must verify the served Cache-Control through the CDN"
     # Strip comment lines before checking for the forbidden call: the step
     # DOCUMENTS why head-object is wrong, so a naive substring match would
     # trip on its own rationale.
-    code = "\n".join(
-        line for line in run.splitlines() if not line.strip().startswith("#")
-    )
+    code = "\n".join(line for line in run.splitlines() if not line.strip().startswith("#"))
     assert "head-object" not in code, (
         "must not verify via s3api head-object -- the publish role lacks GetObject "
         "on feed/*, so the guard would fail on permissions after publishing"
@@ -585,16 +603,16 @@ def test_linux_missing_artifact_fails_loudly() -> None:
         "a missing artifact must fail the job -- a silent skip would leave a green "
         "run serving a stale feed"
     )
-    assert "Expected exactly one ${LINUX_EXT}" in run, (
-        "ambiguous artifacts must also fail loudly rather than feeding an arbitrary file"
-    )
+    assert (
+        "Expected exactly one ${LINUX_EXT}" in run
+    ), "ambiguous artifacts must also fail loudly rather than feeding an arbitrary file"
 
 
 def test_mac_notarize_attaches_gated_artifact_fail_closed() -> None:
     step = _step(_steps(MAC_WORKFLOW, "notarize"), "Attach notarized artifact to workflow run")
-    assert step["with"]["if-no-files-found"] == "error", (
-        "the gated artifact upload must error when empty -- it is the publish job's sole input"
-    )
+    assert (
+        step["with"]["if-no-files-found"] == "error"
+    ), "the gated artifact upload must error when empty -- it is the publish job's sole input"
 
 
 # ---------------------------------------------------------------------------
@@ -643,9 +661,9 @@ def test_installer_channel_name_is_the_literal_path_segment() -> None:
     feed", with no hint that the channel itself is fine.
     """
     code = _installer_code()
-    assert re.search(r'^CHANNEL_PATH="\$CHANNEL"$', code, re.M), (
-        "cli.sh must use the channel verbatim as the storage prefix"
-    )
+    assert re.search(
+        r'^CHANNEL_PATH="\$CHANNEL"$', code, re.M
+    ), "cli.sh must use the channel verbatim as the storage prefix"
     assert "beta" not in code, (
         "cli.sh has executable code referencing a `beta` prefix; the published "
         "path segment is `insider` (docs/build/release.md)"
@@ -657,12 +675,12 @@ def test_installer_rejects_an_unknown_channel_before_hitting_the_cdn() -> None:
     src = _installer_source()
     guard = re.search(r"^case \"\$CHANNEL\" in\n\s*([a-z|]+)\) ;;", src, re.M)
     assert guard, "cli.sh must validate --channel against a known set"
-    assert tuple(guard.group(1).split("|")) == _PUBLISHED_CHANNELS, (
-        "cli.sh's accepted channels must match what publish-cli.yml publishes"
-    )
+    assert (
+        tuple(guard.group(1).split("|")) == _PUBLISHED_CHANNELS
+    ), "cli.sh's accepted channels must match what publish-cli.yml publishes"
     # The rejection has to name the alternatives; that message is the whole
     # point of validating locally instead of letting the fetch 403.
     for channel in _PUBLISHED_CHANNELS:
-        assert channel in src.split("unknown channel", 1)[1][:200], (
-            f"the unknown-channel error must list '{channel}'"
-        )
+        assert (
+            channel in src.split("unknown channel", 1)[1][:200]
+        ), f"the unknown-channel error must list '{channel}'"


### PR DESCRIPTION
## Problem / Motivation

`release/0.5.0` was cut before [#6689](https://github.com/kirodotdev/KiroCrew/pull/6689) landed on `main`, so it carries **none** of the feed-advance guard — `scripts/check_feed_advance.py` does not exist on this branch and every pointer write is an unconditional `aws s3 cp`.

That becomes live the moment `0.5.0` is on stable, because the runbook requires a hot patch to soak an RC first. Tagging `v0.5.1-insider.1` once insider has moved on to the `0.6.0` line would roll the **insider** feed backward and offer every insider client a downgrade (electron-updater accepts one whenever the installed version carries a prerelease suffix).

This is not hypothetical. It happened on **2026-08-28** with `v0.4.1-insider.1` published against an insider channel serving `0.5.0-insider.1`, and needed an emergency `v0.5.0-insider.2` to undo.

Note the branch discipline does *not* remove the need for this guard — it is precisely the correct procedure that triggers it. A `0.5.x` hot patch belongs on `release/0.5.0` (this branch), and its mandatory RC step is what would move the insider pointer backward.

## What changed

Cherry-picked `92d1a0654` with **no conflicts**: `scripts/check_feed_advance.py`, `test/test_check_feed_advance.py`, and the pointer gating in `publish-cli.yml` / `publish-linux.yml` / `publish-windows.yml` / `sign-and-notarize.yml`.

Versioned assets and the GitHub release still always publish — that is what the stable gate and byte-reuse promotion consume. Only the channel feed, the legacy mac feed and the `latest/` aliases are held when this run's version is not the newest the channel has seen.

Two adjustments on top of the pick:

- The backported paragraph said "**Promotion** is unaffected", which no longer names how stable ships after #8568. Reworded to cover both modes; the verdict is unchanged, because a stable release is newer than anything the stable feed has served whether it rebuilds or republishes.
- **The runbook said a hot patch is the next three-segment version but never said which BRANCH it is cut on.** That was the one rule keeping the stable feed monotonic at the process level, and it existed only in conversation. Now written down: a hot patch is cut on the branch of the line stable is *currently* serving, never an older one, and it is explicitly not "the branch where the bug was introduced" — a stable-bound fix lands on `main` first and is backported to the current release branch like any other.

## Verification

Tested against the guard itself, not only its unit tests:

| scenario | new | channel serves | verdict |
|---|---|---|---|
| future `0.5.1` hot patch RC after insider moved on | `0.5.1-insider.1` | `0.6.0-insider.3` | **`hold`** (exit 3) |
| the actual 2026-08-28 incident | `0.4.1-insider.1` | `0.5.0-insider.1` | **`hold`** |
| **the 0.5.0 release in flight** | `0.5.0` | `0.4.1rc1` (live) | **`advance`** (exit 0) |
| normal insider progression | `0.5.0-insider.11` | `0.5.0-insider.10` | `advance` |
| idempotent re-run | `0.5.0-insider.10` | `0.5.0-insider.10` | `advance` |

The third row is the one that matters for timing: **this backport cannot interfere with the 0.5.0 stable release currently being prepared.**

All five touched workflows still parse. **232 passed** across the guard's own tests plus every release/publish contract test on this branch (`test_check_feed_advance.py`, `test_publish_feed_contract.py`, `test_cli_manifest_signature.py`, `test_release_promotion_contract.py`, `test_stable_release_gate.py`, `test_publish_docker_contract.py`, `test_windows_signing_contract.py`, `test_stable_version_display.py`, `test_release_channel.py`).

## Not included

`release/0.4.0` deliberately does not get this backport. Under the branch discipline recorded here it is a finished line that publishes nothing further, so the guard would have nothing to protect.
