### PR TITLE
fix(members): offload deny-path SEL audits off the event loop (#8523)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -69,22 +69,33 @@ def _sel():
     return _pkg.sel()
 
 
-def _deny_app_caller(request: web.Request, operation: str) -> web.Response | None:
+async def _deny_app_caller(request: web.Request, operation: str) -> web.Response | None:
     """404 for app-token callers; ``None`` for the dashboard user.
 
     404 rather than 403, matching the slot-access denials: a distinct status
     would confirm the surface exists to a caller that may not know about it.
+
+    The audit is offloaded with the ``_sel()`` accessor INSIDE the thread: on
+    a fresh gateway the first SEL touch performs synchronous filesystem
+    initialization (HMAC key load/create, chain-head read), which must never
+    run on the event loop. The fast allow path (no app token) stays on-loop
+    with no thread hop.
     """
     request_app = request.get("app", "")
     if not request_app:
         return None
-    _sel().log_api_access(
-        caller=request_app,
-        operation=operation,
-        outcome="denied",
-        source="app_isolation",
-        error="apps cannot access member threads",
-    )
+    try:
+        await asyncio.to_thread(
+            lambda: _sel().log_api_access(
+                caller=request_app,
+                operation=operation,
+                outcome="denied",
+                source="app_isolation",
+                error="apps cannot access member threads",
+            )
+        )
+    except Exception:  # pragma: no cover - audit must never change the outcome
+        logger.debug("SEL audit for %s app denial failed", operation, exc_info=True)
     return web.json_response({"error": "not found", "code": "not_found"}, status=404)
 
 
@@ -118,7 +129,7 @@ async def api_members(request: web.Request) -> web.Response:
     already-subscribed WS ``slots`` frames on the frontend, so this endpoint
     only fills the cold-start gap.
     """
-    denied = _deny_app_caller(request, "members.list")
+    denied = await _deny_app_caller(request, "members.list")
     if denied is not None:
         return denied
     state: DashboardState | None = request.app.get("state")
@@ -222,7 +233,7 @@ async def api_member_thread(request: web.Request) -> web.Response:
     """
     from kiro_crew.dashboard.handlers._shared import require_owner_dashboard_request
 
-    denied = _deny_app_caller(request, "members.thread")
+    denied = await _deny_app_caller(request, "members.thread")
     if denied is not None:
         return denied
     # An app token is already refused above with the module's existence-hiding
@@ -271,14 +282,19 @@ async def api_member_thread(request: web.Request) -> web.Response:
             # key off the BINDING itself. Fail closed, leave dm.json
             # untouched (re-entrant), and let the user resolve it in the
             # crew manager.
-            _sel().log_api_access(
-                caller=request.remote or "",
-                operation="member_thread_open",
-                outcome="denied",
-                source="member_pin",
-                resources=f"slug={slug}",
-                error="binding names a crew outside the slug's owners",
-            )
+            try:
+                await asyncio.to_thread(
+                    lambda: _sel().log_api_access(
+                        caller=request.remote or "",
+                        operation="member_thread_open",
+                        outcome="denied",
+                        source="member_pin",
+                        resources=f"slug={slug}",
+                        error="binding names a crew outside the slug's owners",
+                    )
+                )
+            except Exception:  # pragma: no cover - audit must never change the outcome
+                logger.debug("SEL audit for member_pin denial failed", exc_info=True)
             return web.json_response(
                 {
                     "error": "the thread is bound to a crew the registry no longer names",
@@ -305,14 +321,19 @@ async def api_member_thread(request: web.Request) -> web.Response:
             # successor the moment its metadata line is corrupt.
             _history_exists = await asyncio.to_thread(_log.has_log, _history_key)
             if _history_exists:
-                _sel().log_api_access(
-                    caller=request.remote or "",
-                    operation="member_thread_open",
-                    outcome="denied",
-                    source="member_pin",
-                    resources=f"slug={slug}",
-                    error="orphan history: binding gone, transcript survives",
-                )
+                try:
+                    await asyncio.to_thread(
+                        lambda: _sel().log_api_access(
+                            caller=request.remote or "",
+                            operation="member_thread_open",
+                            outcome="denied",
+                            source="member_pin",
+                            resources=f"slug={slug}",
+                            error="orphan history: binding gone, transcript survives",
+                        )
+                    )
+                except Exception:  # pragma: no cover - audit must never change the outcome
+                    logger.debug("SEL audit for member_pin denial failed", exc_info=True)
                 return web.json_response(
                     {
                         "error": "this thread's history exists but its binding is gone",
@@ -368,14 +389,19 @@ async def api_member_thread(request: web.Request) -> web.Response:
         # the binding untouched, keeping this branch re-entrant: the user
         # resolves it in the crew manager (restore the name, or delete the
         # thread), and until then the thread refuses to speak as anyone else.
-        _sel().log_api_access(
-            caller=request.remote or "",
-            operation="member_thread_open",
-            outcome="denied",
-            source="member_pin",
-            resources=f"slug={slug}",
-            error="live slot pinned to a crew the registry no longer names",
-        )
+        try:
+            await asyncio.to_thread(
+                lambda: _sel().log_api_access(
+                    caller=request.remote or "",
+                    operation="member_thread_open",
+                    outcome="denied",
+                    source="member_pin",
+                    resources=f"slug={slug}",
+                    error="live slot pinned to a crew the registry no longer names",
+                )
+            )
+        except Exception:  # pragma: no cover - audit must never change the outcome
+            logger.debug("SEL audit for member_pin denial failed", exc_info=True)
         return web.json_response(
             {
                 "error": "the thread is pinned to a crew the registry no longer names",
@@ -429,7 +455,7 @@ async def api_member_activity(request: web.Request) -> web.Response:
     events; making the parameter required makes the mixed read impossible
     by construction rather than a caller obligation.
     """
-    denied = _deny_app_caller(request, "members.activity")
+    denied = await _deny_app_caller(request, "members.activity")
     if denied is not None:
         return denied
     slug = request.match_info["slug"]

--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -16,6 +16,7 @@ Covers spec task 2 of the Crew Members page:
 from __future__ import annotations
 
 import json
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1478,3 +1479,166 @@ class TestMemberActivityRoute:
                 data = await resp.json()
         assert data["capped"] is True
         assert len(data["entries"]) == handler_mod._ACTIVITY_LIMIT
+
+
+class TestDenialAuditOffload:
+    """Deny-path SEL audits must never run on the event loop (issue #8523).
+
+    On a fresh gateway the first ``_sel()`` touch performs synchronous
+    filesystem initialization (HMAC key load/create, chain-head read); a
+    denial that audits inline therefore stalls every gateway task. Each test
+    records the thread the audit actually ran on and fails if it is the
+    event-loop thread — reverting any call site to a bare
+    ``_sel().log_api_access(...)`` turns the recorded ident back into the
+    loop's and fails these.
+    """
+
+    @staticmethod
+    def _recording_sel(record: dict):
+        class _RecordingSel:
+            def log_api_access(self, **kwargs):
+                record["thread_ident"] = threading.get_ident()
+                record["kwargs"] = kwargs
+
+        return _RecordingSel()
+
+    @pytest.mark.asyncio
+    async def test_app_denial_audit_runs_off_the_event_loop(self, tmp_path, monkeypatch):
+        state = _make_state(tmp_path)
+        record: dict = {}
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: self._recording_sel(record))
+
+        @web.middleware
+        async def _as_app(request: web.Request, handler):
+            request["app"] = "some-app"
+            return await handler(request)
+
+        app = _make_members_app(state)
+        app.middlewares.insert(0, _as_app)
+        loop_ident = threading.get_ident()
+        with _patched_config([CREW]):
+            async with TestClient(TestServer(app)) as client:
+                assert (await client.get("/api/members")).status == 404
+        assert record["kwargs"]["outcome"] == "denied"
+        assert record["kwargs"]["source"] == "app_isolation"
+        assert record["kwargs"]["operation"] == "members.list"
+        # The audit — including the ``_sel()`` accessor — ran off-loop.
+        assert record["thread_ident"] != loop_ident
+
+    @pytest.mark.asyncio
+    async def test_member_pin_denial_audit_runs_off_the_event_loop(self, tmp_path, monkeypatch):
+        """The pin-mismatch denial (binding names a non-owner) audits off-loop."""
+        state = _make_state(tmp_path)
+        record: dict = {}
+        monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: self._recording_sel(record))
+        # ``Code_Reviewer`` slugifies to CREW's slug (so the binding reads back
+        # as present) but is NOT a config-registered owner → pin mismatch.
+        write_dm_binding(CREW, member="Code_Reviewer", slot_key=member_slot_key(CREW))
+        loop_ident = threading.get_ident()
+        with _patched_config([CREW]):
+            async with TestClient(TestServer(_make_members_app(state))) as client:
+                resp = await client.post(f"/api/members/{CREW}/thread")
+                assert resp.status == 409
+                assert (await resp.json())["code"] == "member_pin_mismatch"
+        assert record["kwargs"]["source"] == "member_pin"
+        assert record["kwargs"]["outcome"] == "denied"
+        assert record["thread_ident"] != loop_ident
+        assert not state._slots
+
+    @pytest.mark.asyncio
+    async def test_first_sel_touch_initializes_off_the_event_loop(self, tmp_path, monkeypatch):
+        """A deny-path audit that is SEL's FIRST touch initializes off-loop.
+
+        Uses a real ``SecurityEventLog`` against a fresh directory so the
+        first-touch work (HMAC key create, chain-head read) genuinely runs,
+        and records the thread ``_init_locked`` executes on.
+        """
+        from kiro_crew import sel as sel_mod
+
+        state = _make_state(tmp_path)
+        sel_dir = tmp_path / "sel-home"
+        init_record: dict = {}
+        real_init = sel_mod.SecurityEventLog._init_locked
+
+        def _recording_init(inst, base_dir, sync):
+            init_record["thread_ident"] = threading.get_ident()
+            return real_init(inst, base_dir, sync)
+
+        monkeypatch.setattr(sel_mod.SecurityEventLog, "_init_locked", _recording_init)
+        # sync=True keeps the append inline in the worker thread (no background
+        # writer to leak); the FIRST-TOUCH construction below is still real.
+        monkeypatch.setattr(
+            sel_mod, "sel", lambda: sel_mod.SecurityEventLog(base_dir=sel_dir, sync=True)
+        )
+        # Displace-then-RESTORE the process singleton, the ``sel_private_root``
+        # convention (that fixture itself is unusable here: it pre-builds the
+        # instance, which would consume the very first touch this test needs).
+        # The reset is immediately followed by the try so a failure can never
+        # lose ``prior_instance`` (see conftest's ordering warning).
+        prior_instance = sel_mod.SecurityEventLog._instance
+        sel_mod.SecurityEventLog._instance = None
+        sel_mod.SecurityEventLog._initialized = False
+        try:
+
+            @web.middleware
+            async def _as_app(request: web.Request, handler):
+                request["app"] = "some-app"
+                return await handler(request)
+
+            app = _make_members_app(state)
+            app.middlewares.insert(0, _as_app)
+            loop_ident = threading.get_ident()
+            with _patched_config([CREW]):
+                async with TestClient(TestServer(app)) as client:
+                    assert (await client.get("/api/members")).status == 404
+            # First touch happened HERE (singleton was reset above) …
+            assert init_record["thread_ident"] is not None
+            # … did its filesystem initialization for real …
+            assert (sel_dir / "trust" / "sel_hmac.key").is_file()
+            # … and never on the event loop.
+            assert init_record["thread_ident"] != loop_ident
+        finally:
+            # Restore the PRIOR singleton (not ``None``): leaving ``None`` would
+            # make the next default ``sel()`` mint a SECOND instance — and a
+            # second writer thread — on the worker's session-shared directory.
+            sel_mod.SecurityEventLog._instance = prior_instance
+            sel_mod.SecurityEventLog._initialized = False
+
+    def test_every_members_sel_audit_is_offloaded(self):
+        """AST guard: no ``log_api_access`` call in members.py runs on-loop.
+
+        Every such call — regardless of how the receiver is spelled
+        (``_sel().log_api_access``, a hoisted ``s = _sel()``, a module-level
+        ``sel()``) — must sit inside a lambda handed to ``asyncio.to_thread``,
+        covering the sites the thread-ident tests do not exercise individually
+        (orphan-history, live-slot mismatch) and any site added later.
+        """
+        import ast
+        import inspect
+
+        from kiro_crew.dashboard.handlers import members as members_mod_py
+
+        tree = ast.parse(inspect.getsource(members_mod_py))
+        offloaded: set[int] = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "to_thread"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "asyncio"
+            ):
+                for arg in node.args:
+                    if isinstance(arg, ast.Lambda):
+                        for inner in ast.walk(arg):
+                            offloaded.add(id(inner))
+        audits = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "log_api_access"
+        ]
+        assert audits, "expected log_api_access audit sites in members.py"
+        on_loop = [node.lineno for node in audits if id(node) not in offloaded]
+        assert not on_loop, f"synchronous _sel().log_api_access at lines {on_loop}"


### PR DESCRIPTION
Closes #8523

## Problem

`_deny_app_caller` and the three member-pin denial sites in `src/kiro_crew/dashboard/handlers/members.py` called `_sel().log_api_access(...)` synchronously from async handlers. On a fresh gateway the first `_sel()` touch performs synchronous filesystem initialization — HMAC key load/create and the chain-head read — ON the event loop, stalling every gateway task (AUTOSDE `no-blocking-call-on-event-loop`).

## Fix

Every deny-path audit in the module now offloads the whole call — the `_sel()` accessor INCLUDED — via `await asyncio.to_thread(lambda: ...)`, the shape `_shared.py`'s non-owner denial and `autonudge.py`'s authorization audit already use, and each site is wrapped in the same `except Exception` guard those precedents carry ("audit must never change the outcome"): an executor shut down mid-teardown or an audit write failure degrades to a debug log, never to a 500 replacing the 404/409. The helper's fast allow path (no app token) stays on-loop with no thread hop. `_deny_app_caller` became `async`; its three call sites await it. No status code, body, or ordering of any response changed: every new await sits immediately before its `return`, with no state read across the suspension point.

## Tests

- `TestDenialAuditOffload::test_app_denial_audit_runs_off_the_event_loop` — thread-ident assertion on the app-token denial (helper site), plus kwargs contract.
- `TestDenialAuditOffload::test_member_pin_denial_audit_runs_off_the_event_loop` — same for the pin-mismatch denial (409 path), and asserts no slot was minted.
- `TestDenialAuditOffload::test_first_sel_touch_initializes_off_the_event_loop` — a real `SecurityEventLog` first touch (HMAC key create verified on disk) driven through the deny path, recording the thread `_init_locked` runs on; catches the accessor being hoisted out of the lambda. Displaces then RESTORES the prior process singleton per the `sel_private_root` convention (the fixture itself would pre-consume the first touch).
- `TestDenialAuditOffload::test_every_members_sel_audit_is_offloaded` — AST guard: every `log_api_access` call in the module, regardless of receiver spelling, must sit inside an `asyncio.to_thread` lambda.

Mutation-verified: reverting each of the four sites to a sync call, and hoisting the accessor out of the lambda, are each caught by a distinct test. Local gates green (isort 6.0.0 / flake8 7.1.0 / mypy 1.14.1 / black 26.3.1 CI pins, black-baseline, brand, subprocess-encoding, harness parity). Full pytest: 86341 passed; the 89 failures reproduce identically on clean main (host-environment: `/local/home` uid ownership, AF_UNIX path length, userns EPERM) — none touch this diff.

Pre-push review lanes: GPT (gpt-5.6-sol) 1 BLOCKING (singleton restore-to-None in the first-touch test) and Opus (claude-opus-5) 1 BLOCKING + 3 CONCERNS (black gate offender, same singleton restore, missing audit exception guard vs the three in-repo precedents, AST guard pinning the spelling rather than the operation) — all five verified real on-source and fixed in this commit.

## Pattern harvest

Class: deny-path audit added before the offload convention landed keeps running on-loop while new success-path audits in sibling files offload.

Rule candidate: any `log_api_access` reachable from an async handler must go through `asyncio.to_thread`/`run_in_executor` with the SEL accessor inside the offloaded callable, wrapped so an audit failure never changes the response.
