### PR TITLE
chore(desktop): sync the electron lockfile version to 0.5.0

### DIFF
--- a/website/electron/package-lock.json
+++ b/website/electron/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kirocrew-desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kirocrew-desktop",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.9"


### PR DESCRIPTION
## Problem / Motivation

`website/electron/package-lock.json` still declared `0.4.0` in both its root and `packages[""]` entries, while `website/electron/package.json` declared `0.5.0`.

The drift predates this release line and is harmless in itself — the desktop build stamps only `package.json` (`build-desktop.yml`), `npm ci` reads the lockfile for its dependency tree rather than that field, and no test pins it. Which is exactly why nothing caught it.

It is worth closing before the `0.5.0` release. This is the first release to gate on the version declarations agreeing with the tag ([#8568](https://github.com/kirodotdev/KiroCrew/pull/8568) added that precondition to `stable-gate`), and leaving one file in the desktop package declaring the *previous* release is the kind of stale spelling that gate exists to stop — even though this specific field sits outside its scope. `main` already carries the equivalent fix at `0.6.0`.

## What changed

Two lines. The root `version` and `packages[""].version` go `0.4.0` → `0.5.0`, matching `package.json`. Nothing else in the lockfile is touched or reformatted.

## Verification

The only real risk here is corrupting the lockfile and breaking the desktop build, so the dependency tree was checked rather than assumed:

- **The resolved-URL map across all 309 package entries is byte-identical** to the previous lockfile — zero additions, zero removals.
- `lockfileVersion` still `3`.
- `npm ci --dry-run --ignore-scripts` resolves all **308 packages** cleanly.

## Sequencing

This is the last of three changes landing on `release/0.5.0` before its release candidate: rebuild-by-default (#8568, merged), the feed-advance guard backport ([#8602](https://github.com/kirodotdev/KiroCrew/pull/8602), merged), and this. Once merged, one `v0.5.0-insider.11` covers all three and gives the bare `v0.5.0` tag the successful same-commit prerelease run `stable-gate` requires.
