### PR TITLE
docs: record launcher self-poisoning as an accepted risk (#417)

### DIFF
--- a/docs/architecture/security-deep-dive.md
+++ b/docs/architecture/security-deep-dive.md
@@ -522,3 +522,35 @@ fork bombs and memory balloons requires Linux with cgroup delegation; where it i
 unavailable (macOS, older Linux, no user session) it is a no-op with a loud
 warning and only the file-descriptor limit applies. See
 [`resource-protection.md`](resource-protection.md).
+
+**Launcher self-poisoning by the same user is accepted, not defended (CWE-345;
+tracked as CWE-778 by
+[#371](https://github.com/kirodotdev/KiroCrew/pull/371) /
+[#417](https://github.com/kirodotdev/KiroCrew/issues/417)).** The resolved
+`kiro-cli` launcher is executed in place with no signature, hash, ownership or
+install-source check — the only gate is `platform_compat.is_executable_file`
+(`kiro_cli.py`) — so an agent running as the invoking user can overwrite its own
+launcher and have those bytes executed on the next spawn. **Status: ACCEPTED.**
+The mechanism that would close it is *rejected by design*, not missing by
+oversight: see
+[`security.md` § Kiro prerequisite setup boundary](../system-specs/modules/security.md),
+which records that trust is "the CLI runs, and it has a valid login" regardless
+of install source, owner, or fixed path, because Kiro Crew is not the authority
+on where Kiro CLI lives and its own self-updater legitimately rewrites those
+bytes as the user — an owner / path / Developer-ID gate would strand real
+installs (toolbox, Homebrew, winget, a self-updated `/Applications` bundle) with
+no in-product recovery path. The same section records the sibling resolve-to-exec
+byte-binding copy as deliberately removed ("Do NOT reintroduce it") once Kiro CLI
+became a multi-call binary. The accepted tradeoff is therefore **install-model
+compatibility over a same-UID integrity check**: the attack presupposes local
+write access as the operator, which is outside this product's threat model (an
+attacker holding the operator's UID already owns the account) and is not
+defended against anywhere else — `~/.bashrc`, above, is the same class. Residual
+blast radius is bounded on the confined spawn paths (Linux namespace, macOS
+seatbelt) which run even a poisoned launcher inside Kiro Crew's own sandbox;
+only macOS internal-sandbox delegation exec's it directly. A multi-tenant or
+enterprise posture would need signing infrastructure, key management and an
+install-layout decision, and any such gate must default **off** — the
+`KIROCREW_PROVIDER_BIN_STRICT` precedent
+(`github_runner.py:validate_provider_executable`) records that requiring a
+root-owned copy made every stock package-manager install fail.


### PR DESCRIPTION
## Problem / Motivation

The engineering position on agent-launcher trust was already decided and written
into the mechanism spec, but never closed out as a formal accepted risk.

`docs/system-specs/modules/security.md` (§ Kiro prerequisite setup boundary)
records the reasoned rejection of exactly the mechanism #417 proposes: trust is
"the CLI runs, and it has a valid login" *regardless of install source, owner, or
fixed path*, because an owner / path / Developer-ID gate "would strand real
installs (toolbox, Homebrew, winget, a self-updated `/Applications` bundle)" with
no in-product recovery path. The sibling resolve-to-exec byte-binding copy is
recorded in the same place as deliberately removed ("Do NOT reintroduce it").

What was missing is the paperwork:

- `grep -rn "CWE-778" docs/` returned **zero** hits on main — no accepted-risk
  record existed anywhere in the repo.
- The "Known gaps" list in `docs/architecture/security-deep-dive.md` carried
  **no** launcher-substitution or self-poisoning entry at all.

So a reader auditing the residual found a decision buried in a mechanism spec and
an empty gaps list, which is exactly the state #417's last triage pass describes.

## Why it matters

The gaps list is the document a reviewer, auditor, or new maintainer reads to
learn what Kiro Crew deliberately does not defend. A residual that is *decided*
but not *recorded* reads as an oversight, and reopens the same code question every
time someone runs a scanner over the launcher path — which is how #417 arrived and
why it has been reopened for review three times since PR #371.

## What changed (motivation → approach → change)

Goal: close the accepted-risk record without reopening the rejected code question.

Approach: one entry appended to the existing "Known gaps" list, following that
list's established shape (bold lead, then *why the obvious fix is not already in
place*). It **links** to `security.md`'s rationale rather than duplicating the
prose, so the decision keeps one home.

Change — the entry states:

- the residual: the resolved launcher is executed in place with no signature,
  hash, ownership or install-source check, the only gate being
  `platform_compat.is_executable_file`, so a same-UID agent can overwrite its own
  launcher and have those bytes executed on the next spawn;
- **Status: ACCEPTED**, explicitly;
- the tradeoff by name: install-model compatibility (toolbox / Homebrew / winget /
  self-updated bundle, plus Kiro CLI's own self-updater rewriting its bytes as the
  user) over a same-UID integrity check;
- why it is in-model: the attack presupposes local write access as the operator,
  which is outside this product's threat model and is not defended against
  elsewhere either — the `~/.bashrc` gap immediately above is the same class;
- the bounded blast radius: confined spawn paths (Linux namespace, macOS seatbelt)
  run even a poisoned launcher inside Kiro Crew's own sandbox; only macOS
  internal-sandbox delegation exec's it directly;
- what a future enterprise posture would need, and that any such gate must default
  **off**, citing the `KIROCREW_PROVIDER_BIN_STRICT` precedent
  (`github_runner.py:validate_provider_executable`), whose docstring records that
  requiring a root-owned copy made every stock package-manager install fail.

**No behavior change. No code touched.** `kiro_cli.py` and the launcher path are
untouched by design: #417's own history is that the proposed code fix was
descoped in PR #371 and the copy-then-exec variant deleted in PR #609. This PR
closes the paperwork gap, not the code question.

### On the CWE (deliberate deviation from the issue's label)

The issue asks to "close CWE-778 as accepted-risk". **CWE-778 is Insufficient
Logging, which is not what this residual is** — nothing here is a logging gap, and
force-fitting it would leave the gaps list misclassifying its own entry.

The residual is that the launcher's bytes are executed with no verification of
their integrity or authenticity, which is **CWE-345 (Insufficient Verification of
Data Authenticity)**. The entry is therefore filed under CWE-345 and *also* names
CWE-778 as the tracker label carried from #371/#417 — so `grep CWE-778` now
resolves (the closure #417 asks for) while the classification is honest. CWE-778
most plausibly attached to the SEL-audited-denial half of PR #371's defense rather
than to substitution itself.

Flagging this explicitly for reviewer judgement: if CSE prefers the entry filed
under the tracker label alone, that is a one-word change.

## Tests

N/A — documentation only, no code paths changed.

Gate run: `./scripts/docs-lint.sh` → `scanned 261 markdown files … All
documentation checks passed` (exit 0), plus `python3 scripts/docs_lint.py --test`
→ `Self-test passed`. This is the job `ci.yml`'s `docs-lint` runs.

## Manual verification

- Confirmed on this branch's base (`688d67cff`) that `grep -rn "CWE-778" docs/`
  returned zero hits before the change, and that the "Known gaps" list had no
  launcher entry.
- Verified every symbol the entry cites actually exists on main:
  `platform_compat.is_executable_file` (`src/kiro_crew/kiro_cli.py:245`),
  `validate_provider_executable` (`src/kiro_crew/github_runner.py:295`),
  `STRICT_PROVIDER_BIN_ENV = "KIROCREW_PROVIDER_BIN_STRICT"`
  (`src/kiro_crew/github_runner.py:82`).
- Verified the quoted rationale is present verbatim in
  `docs/system-specs/modules/security.md` (the "valid login" sentence and the
  "Do NOT reintroduce it" line), and that the section title used in the link
  (§ Kiro prerequisite setup boundary) is the enclosing subsection.
- Link target resolves: docs-lint enforces "every link resolves" and passed.

## Related Issues

Closes #417.

## Checklist

- [x] At most two commits (one), Conventional Commits title (`docs: …`)
- [x] Existing tests pass and new tests added for new functionality (N/A — docs)
- [x] Self-review completed; follows the gaps list's existing style
- [x] Documentation updated (this PR *is* the documentation update)
- [x] No secrets, credentials, or internal references in the diff
