### PR TITLE
fix(members): dispatch server carries the gateway home override

### DIFF
--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -209,12 +209,20 @@ def member_dispatch_session_server(session_key: str) -> dict[str, object] | None
     asked for" and is persisted, while this is the transient fact of what got
     bound.
 
+    It also carries the same home override every managed Crew server carries
+    (``_managed_mcp_env``): the server resolves *which gateway* to call from
+    its data home, so on an install where ``KIROCREW_HOME`` is set (a pod, a
+    second profile) an entry without it would present this member's identity to
+    the default home's gateway, which has no such slot and refuses every verb
+    as ``caller_unidentified``. On a default install the helper returns nothing
+    and the entry is unchanged.
+
     ``None`` when the server command cannot be resolved — the member thread
     then runs as plain chat and the caller logs the degradation.
     """
     # circular import: agent's module graph is heavy and imports config, which
     # sits below this module for the thread-endpoint path.
-    from kiro_crew.agent import _kirocrew_mcp_invocation
+    from kiro_crew.agent import _kirocrew_mcp_invocation, _managed_mcp_env
 
     # circular import, same shape: port_resolution reaches config.loader, whose
     # provider-backend path imports this module.
@@ -227,7 +235,15 @@ def member_dispatch_session_server(session_key: str) -> dict[str, object] | None
         return None
     if not command:
         return None
-    env: list[dict[str, str]] = [{"name": "KIROCREW_SESSION_KEY", "value": session_key}]
+    # The SAME home override every managed Crew server carries
+    # (``_managed_mcp_env``): the server resolves the gateway to call from its
+    # data home, so on an install with ``KIROCREW_HOME`` set (a pod, a second
+    # profile) an entry without it would authenticate as this member to the
+    # DEFAULT home's gateway — where the member slot does not exist and every
+    # verb is refused as ``caller_unidentified``. Empty on a default install.
+    env: list[dict[str, str]] = [{"name": k, "value": v} for k, v in _managed_mcp_env().items()]
+    # Then the identity key.
+    env.append({"name": "KIROCREW_SESSION_KEY", "value": session_key})
     # resolve_serving_port() reads KIROCREW_BOUND_PORT first and only then falls
     # through the client order, so one call covers both "the gateway exported the
     # port it bound" and "derive it" — and a malformed export is ignored rather

--- a/test/test_member_dispatch_mount.py
+++ b/test/test_member_dispatch_mount.py
@@ -4,8 +4,8 @@ Pins the four seams the member-dispatch mount rides on:
 
 - ``members.member_dispatch_session_server`` — the session-level ``mcpServers``
   element, carrying strict identity via ``KIROCREW_SESSION_KEY`` in its env
-  plus the gateway's bound port, which the from-scratch env would otherwise
-  drop.
+  plus the gateway's bound port and its ``KIROCREW_HOME`` override, both of
+  which the from-scratch env would otherwise drop.
 - ``kas_agents.to_client_custom_agent(member_dispatch=True)`` — the KAS wire
   projection widening: the server joins ``tools`` and the conductor's
   approval-free dashboard verbs join the ``allowedTools`` input BEFORE the
@@ -104,6 +104,36 @@ class TestMemberDispatchSessionServer:
         assert "KIROCREW_SESSION_KEY" in names
         assert "KIROCREW_BOUND_PORT" in names
         assert "KIROCREW_PORT" not in names
+
+    def test_env_carries_the_gateway_home_override(self, monkeypatch):
+        """On an install with ``KIROCREW_HOME`` set (a pod, a second profile) the
+        server must resolve THIS gateway from that home. Without the override it
+        would present the member's identity to the default home's gateway, where
+        the member slot does not exist, and every verb would be refused as
+        ``caller_unidentified``. Same helper the managed Crew servers use, so the
+        two cannot drift."""
+        import kiro_crew.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "_managed_mcp_env", lambda: {"KIROCREW_HOME": "/pods/x"})
+        entry = member_dispatch_session_server(MEMBER_KEY)
+        assert entry is not None
+        assert {"name": "KIROCREW_HOME", "value": "/pods/x"} in entry["env"]
+        assert {"name": "KIROCREW_SESSION_KEY", "value": MEMBER_KEY} in entry["env"]
+
+    def test_default_install_carries_no_home_override(self, monkeypatch):
+        """No ``KIROCREW_HOME`` override on a default install: the env is exactly
+        the identity pair plus the bound port — byte-identical to before the
+        override was threaded through."""
+        import kiro_crew.agent as agent_mod
+
+        monkeypatch.setattr(agent_mod, "_managed_mcp_env", lambda: {})
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7779")
+        entry = member_dispatch_session_server(MEMBER_KEY)
+        assert entry is not None
+        assert entry["env"] == [
+            {"name": "KIROCREW_SESSION_KEY", "value": MEMBER_KEY},
+            {"name": "KIROCREW_BOUND_PORT", "value": "7779"},
+        ]
 
     def test_unresolvable_command_degrades_to_none(self, monkeypatch):
         import kiro_crew.agent as agent_mod


### PR DESCRIPTION
## Summary

The crew member DM session's `kirocrew-dashboard` MCP entry (the one that mounts `session_create` / `session_send` / …) carried only `KIROCREW_SESSION_KEY` (and, since #8837, `KIROCREW_BOUND_PORT`). The server resolves *which gateway to call* from its data home, so on any install where `KIROCREW_HOME` is set — a pod, a second profile — it presented the member's identity to the **default** home's gateway rather than the one that spawned it. That gateway has no such member slot, so every verb came back `caller_unidentified` while `tools/list` looked perfectly healthy.

Fix: carry the same home override every managed Crew server already carries (`_managed_mcp_env`), through the same helper so the two cannot drift. On a default install the helper returns `{}` and the emitted entry is byte-identical to before.

Complementary to and non-overlapping with #8837 (bound port): the env is now `[home override…, KIROCREW_SESSION_KEY, KIROCREW_BOUND_PORT]`.

## Scope (one commit, two files)

Per @bolichen97's review: the per-member conversation index (#8612 — `crew_conversation.py`, its spec and README row) **no longer rides in this PR**. It travels with its consumer, #8613 (`session_send target="user"`), which is stacked directly on this branch and whose diff now carries it. Nothing is lost: the index was reviewed and approved in #8612 and the commit (`731830518`) is intact in #8613's branch. This PR is back to the 2-file fix, independent of the rest of the stack and mergeable on its own under its `fix` title.

## How it showed up

On an isolated pod (`kirocrew pod up <wt>`), a member's `session_create` and `session_send` both failed with "caller session could not be identified"; the same calls on the live `:5476` install succeeded. The pod's own log never saw the request — it had gone to the live gateway.

## Tests

- `test/test_member_dispatch_mount.py`:
  - `test_env_carries_the_gateway_home_override` — with the override set, the entry carries `KIROCREW_HOME` alongside the session key.
  - `test_default_install_carries_no_home_override` — with no override, the env is exactly the identity pair plus the bound port (the pre-fix shape).
  - #8837's three bound-port cases are unchanged.

## Manual verification

N/A — the seam is a pure dict builder; the pod symptom above is what the override test reconstructs.

## Pattern harvest

Rule candidate: a host-injected per-session MCP entry must carry the same home override the managed servers carry (`_managed_mcp_env`) — any server that resolves its gateway from the data home otherwise talks to the default install on every `KIROCREW_HOME` override (pods, second profiles), and does so silently because `tools/list` needs no gateway. Candidate ratchet: a test that every entry built from `_kirocrew_mcp_invocation` includes `_managed_mcp_env()` in its env when the override is set.

no linked issue: reported directly from a pod session, no tracking issue was filed.
