### PR TITLE
fix: resolve namespace-qualified pins against bare advertised ids (#8521)

### DIFF
--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1759,11 +1759,61 @@ def model_is_unusable(model_id: str, advertised: Sequence[str] | None) -> bool:
     namespaces would call every legitimate model unusable; that backend
     announces its own substitutions through the ``session/new`` advisory
     instead (see ``_new_session_following_substitution``).
+
+    A pin carrying a stale ``<namespace>::<bare-id>`` qualifier (stored when a
+    catalog advertised the qualified spelling, judged against one advertising
+    the bare id) is the one comparable mismatch, and it is deliberately NOT
+    folded here: this predicate's permissive answer feeds the wire sites, and
+    a still-qualified id on the wire is a spelling the backend never
+    advertised. :func:`resolve_pin_spelling` is the shared fold for that case —
+    it answers with the advertised spelling, so a caller can compare AND send
+    one consistent id.
     """
     if not advertised:
         return False
     wanted = model_id.strip().lower()
     return wanted not in {m.strip().lower() for m in advertised if m and m.strip()}
+
+
+def resolve_pin_spelling(model_id: str, advertised: Sequence[str] | None) -> str:
+    """The advertised spelling *model_id* resolves to, or ``""`` when none.
+
+    The companion to :func:`model_is_unusable` for values that arrive from
+    storage rather than from the live picker: a persisted pin can carry a
+    ``<namespace>::<bare-id>`` qualifier from the catalog that advertised it
+    (issue #8521's ``openrouter::z-ai/glm-5.3-flash``), while the session being
+    judged advertises the BARE id. The literal membership test then misses for
+    a model the backend fully serves. This fold recovers the match without
+    per-provider exemptions: the full id is tried first, and only on a miss is
+    ONE leading ``<namespace>::`` qualifier peeled and the tail retried — so a
+    pin the backend genuinely does not serve still resolves to ``""`` under
+    either spelling, and an id advertised verbatim (qualifier and all) never
+    gets peeled at all.
+
+    Returns the ADVERTISED spelling of the match, not the caller's: the result
+    is meant to be sent on the wire (``session/set_model`` accepts advertised
+    ids), and it keeps the display verdict and the wire withhold answering from
+    one fold so the two cannot disagree about what "usable" means. Matching is
+    case/whitespace-insensitive on both sides, mirroring
+    :func:`model_is_unusable`.
+
+    An empty/unknown *advertised* set returns ``""`` — NOT as a "withheld"
+    answer, but as "nothing to resolve against": callers must keep routing the
+    withhold decision itself through :func:`model_is_unusable`, whose
+    empty-set-means-allow contract (harness-parity H12) this function does not
+    replace.
+    """
+    ids = [m.strip() for m in (advertised or []) if m and m.strip()]
+    if not ids:
+        return ""
+    by_key = {m.lower(): m for m in ids}
+    wanted = model_id.strip().lower()
+    if wanted in by_key:
+        return by_key[wanted]
+    namespace, sep, bare = wanted.partition("::")
+    if sep and namespace and bare in by_key:
+        return by_key[bare]
+    return ""
 
 
 def resolve_usable_model(preferred: str, advertised: Sequence[str] | None) -> str:
@@ -3555,21 +3605,37 @@ class AcpClient:
             logger.info("ACP model: %s (from agent config)", self._model or "auto")
             return
         if self._is_kiro and self._model_is_unusable(self._model):
-            _withheld_log, _ = redact_exfiltration_urls(str(self._model))
-            _withheld_log, _ = redact_credentials(_withheld_log)
-            logger.warning(
-                "ACP model %s is not available to this account; staying on the "
-                "backend default %s (advertised: %s)",
-                _withheld_log,
-                self._resolved_model_id or DEFAULT_MODEL,
-                ", ".join(self._advertised_model_ids()),
-            )
-            # Record the session as running the default rather than the value we
-            # declined: the "!= DEFAULT_MODEL" test above is also what the
-            # warm-pool re-apply path reads (session_provider), so leaving the
-            # unusable id here would re-offer it on every claim.
-            self._model = DEFAULT_MODEL
-            return
+            # A literal miss can be a stale ``<namespace>::`` qualifier on a
+            # model the backend fully serves (#8521): resolve to the advertised
+            # spelling and send THAT, so the session runs the model the pin
+            # names instead of silently dropping to the default. Same fold the
+            # display verdict uses (chat_runner._pinned_model_verdict), so the
+            # chip and the wire cannot disagree about what "usable" means. A
+            # pin absent under either spelling still takes the withhold below.
+            _resolved = resolve_pin_spelling(self._model, self._advertised_model_ids())
+            if _resolved:
+                logger.info(
+                    "ACP model %s resolves to advertised %s; sending the advertised spelling",
+                    self._model,
+                    _resolved,
+                )
+                self._model = _resolved
+            else:
+                _withheld_log, _ = redact_exfiltration_urls(str(self._model))
+                _withheld_log, _ = redact_credentials(_withheld_log)
+                logger.warning(
+                    "ACP model %s is not available to this account; staying on the "
+                    "backend default %s (advertised: %s)",
+                    _withheld_log,
+                    self._resolved_model_id or DEFAULT_MODEL,
+                    ", ".join(self._advertised_model_ids()),
+                )
+                # Record the session as running the default rather than the value we
+                # declined: the "!= DEFAULT_MODEL" test above is also what the
+                # warm-pool re-apply path reads (session_provider), so leaving the
+                # unusable id here would re-offer it on every claim.
+                self._model = DEFAULT_MODEL
+                return
         if self.backend in ACP_BACKENDS_MODEL_VIA_CONFIG_OPTION:
             await self.set_config_option("model", self._model)
         else:

--- a/src/kiro_crew/agent_sdk/drivers/acp.py
+++ b/src/kiro_crew/agent_sdk/drivers/acp.py
@@ -42,8 +42,26 @@ __all__ = [
     "claude_components_resolve",
     "derived_agent_permissions",
     "kiro_cli_resolves",
+    "resolve_pin_spelling",
     "run_kiro_native_commands",
 ]
+
+
+def resolve_pin_spelling(model_id: str, advertised: object) -> str:
+    """The advertised spelling *model_id* resolves to, or ``""`` when none.
+
+    Thin delegation to :func:`kiro_crew.acp.client.resolve_pin_spelling` — the
+    namespace fold for persisted pins carrying a stale ``<namespace>::``
+    qualifier (#8521) — so application code (``session.py``'s
+    ``AllocationDeps`` wiring) reaches it through the SDK surface instead of
+    importing the ACP layer (the agent-sdk-boundary gate refuses a new edge).
+    Plain data in, plain data out: a string and a sequence of strings, a string
+    back — no ACP type crosses the boundary. Function-local import for the same
+    reason as every other runtime-machinery import in this module.
+    """
+    from kiro_crew.acp.client import resolve_pin_spelling as _impl
+
+    return _impl(model_id, advertised)  # type: ignore[arg-type]
 
 
 def derived_agent_permissions(allowed_tools: object, agent_filename: str) -> dict:

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -22,6 +22,7 @@ from kiro_crew.acp.client import (
     _is_safe_oauth_url,
     advertised_model_ids,
     model_is_unusable,
+    resolve_pin_spelling,
 )
 from kiro_crew.acp.types import (
     EVENT_AGENT_SWITCHED,
@@ -936,12 +937,28 @@ def _pinned_model_verdict(client: Any, model: str, provider: str) -> bool | None
     succeeds -- but nothing told the user, and the composer chip plus the picker
     went on reporting a model no turn would ever use (observed after a plan
     downgrade: the chip still read ``claude-opus-5`` while every turn ran on
-    auto). This is the read side of that withhold, using the SAME predicate so
-    the two cannot disagree about what "usable" means.
+    auto). This is the read side of that withhold, using the SAME predicate and
+    the SAME namespace fold (:func:`resolve_pin_spelling`) the wire sites use,
+    so the two cannot disagree about what "usable" means.
 
     A ``True`` verdict is REPORTED, never acted on: the caller does not clear the
     pin. The withhold already keeps the model off the wire, so a stale pin is
     inert and recovers by itself if entitlement returns.
+
+    A pin can carry a stale ``<namespace>::<bare-id>`` qualifier from the
+    catalog that advertised it when it was stored, while the session being
+    judged advertises the BARE id (#8521) -- the same class of namespace
+    mismatch the ``claude_code`` exemption above acknowledges, except here the
+    two spellings ARE comparable once the qualifier is peeled. So a literal
+    miss is retried through :func:`resolve_pin_spelling` (full id first, then
+    one peeled qualifier): the retry can only clear a false withhold, never
+    create one, and a pin the backend genuinely does not serve still answers
+    withheld under either spelling. The qualifier is deliberately NOT matched
+    against ``agent.provider`` -- that config value is a fixed enum (``acp``)
+    and never the vocabulary a catalog qualifies its ids with, so keying on it
+    would leave the fold unreachable. And when this verdict clears, the wire
+    sites clear the same way (they resolve and send the advertised spelling),
+    so a ``False`` here still answers "will a turn use this pin?" truthfully.
     """
     if not model or model == "auto" or is_claude_code(provider):
         return None
@@ -956,7 +973,10 @@ def _pinned_model_verdict(client: Any, model: str, provider: str) -> bool | None
         return None
     if not advertised:
         return None
-    return model_is_unusable(model, advertised)
+    verdict = model_is_unusable(model, advertised)
+    if verdict and resolve_pin_spelling(model, advertised):
+        verdict = False
+    return verdict
 
 
 def _agent_fallback_chain() -> tuple[str, ...]:

--- a/src/kiro_crew/providers/acp.py
+++ b/src/kiro_crew/providers/acp.py
@@ -18,6 +18,7 @@ from kiro_crew.acp.client import (
     AcpError,
     advertised_model_ids,
     model_is_unusable,
+    resolve_pin_spelling,
 )
 from kiro_crew.acp.runtime import AcpRuntime, AcpRuntimeError
 from kiro_crew.acp.session_handle import AcpSessionHandle
@@ -950,7 +951,15 @@ class AcpProvider(LLMProvider):
                 # Leaving it unset keeps the session on the backend's own
                 # default, so the turn succeeds.
                 _advertised = advertised_model_ids(handle.available_models)
+                _send_model = configured_model
                 if model_is_unusable(configured_model, _advertised):
+                    # A literal miss can be a stale `<namespace>::` qualifier on
+                    # a model the backend fully serves (#8521): resolve to the
+                    # advertised spelling and send THAT — same fold the display
+                    # verdict uses, so chip and wire agree. A pin absent under
+                    # either spelling still takes the withhold.
+                    _send_model = resolve_pin_spelling(configured_model, _advertised)
+                if not _send_model:
                     logger.warning(
                         "Configured model %s is not available to this account; "
                         "leaving the session on the backend default (advertised: %s)",
@@ -960,12 +969,12 @@ class AcpProvider(LLMProvider):
                 else:
                     _t_model = time.monotonic()
                     try:
-                        await handle.set_model(configured_model)
-                        logger.info("Kiro runtime model set: %s", configured_model)
+                        await handle.set_model(_send_model)
+                        logger.info("Kiro runtime model set: %s", _send_model)
                     except Exception:
                         logger.warning(
                             "Failed to set model %s on kiro runtime session",
-                            configured_model,
+                            _send_model,
                             exc_info=True,
                         )
                     finally:

--- a/src/kiro_crew/session.py
+++ b/src/kiro_crew/session.py
@@ -111,6 +111,7 @@ from kiro_crew.acp_backends import selectable_backends
 from kiro_crew.agent import kiro_agents_dir_path
 from kiro_crew.agent_discovery import _read_agent_spec, spec_model
 from kiro_crew.agent_sdk.backend_identity import is_claude_backend_name
+from kiro_crew.agent_sdk.drivers.acp import resolve_pin_spelling
 from kiro_crew.config import KiroCrewConfig
 from kiro_crew.config.loader import (
     AUTOCOMPACT_PCT_MAX,
@@ -1027,6 +1028,7 @@ class SessionManager:
             load_watchdog_settings=lambda crew: _load_allocation_watchdog_settings(crew),
             advertised_model_ids=lambda models: advertised_model_ids(models),
             model_is_unusable=lambda model, advertised: model_is_unusable(model, advertised),
+            resolve_pin_spelling=lambda model, advertised: resolve_pin_spelling(model, advertised),
             to_provider_id=lambda model, provider: model_registry.to_provider_id(model, provider),
             to_acp_id=lambda model: model_registry.to_acp_id(model),
             inc_session_created=lambda: Stats().inc_session_created(),

--- a/src/kiro_crew/session_allocation.py
+++ b/src/kiro_crew/session_allocation.py
@@ -100,6 +100,7 @@ class AllocationDeps:
     load_watchdog_settings: Callable[[str], object]
     advertised_model_ids: Callable[[Any], list[str]]
     model_is_unusable: Callable[[str, list[str]], bool]
+    resolve_pin_spelling: Callable[[str, list[str]], str]
     to_provider_id: Callable[[str, str], str]
     to_acp_id: Callable[[str], str]
     inc_session_created: Callable[[], None]
@@ -1319,9 +1320,22 @@ class SessionAllocationService:
                                 )
                             except Exception:  # pragma: no cover - defensive
                                 advertised = []
+                            _send_model = switch_model
                             if advertised and self._deps.model_is_unusable(
                                 switch_model, advertised
                             ):
+                                # A literal miss can be a stale `<namespace>::`
+                                # qualifier on a model the backend fully serves
+                                # (#8521): resolve to the advertised spelling and
+                                # send THAT — the same fold the cold-start spawn
+                                # and the display verdict use, so a warm claim
+                                # runs exactly what a cold start of the same pin
+                                # runs. A pin absent under either spelling still
+                                # takes the withhold below.
+                                _send_model = self._deps.resolve_pin_spelling(
+                                    switch_model, advertised
+                                )
+                            if not _send_model:
                                 self._deps.logger.warning(
                                     "Pool post-claim: model %s is not available to this "
                                     "account; leaving the claimed process on %s",
@@ -1329,10 +1343,10 @@ class SessionAllocationService:
                                     pool_model,
                                 )
                             else:
-                                await cast(Any, provider).client.set_model(switch_model)
+                                await cast(Any, provider).client.set_model(_send_model)
                                 self._deps.logger.info(
                                     "Pool post-claim: switched model to %s",
-                                    switch_model,
+                                    _send_model,
                                 )
                 self._deps.logger.info(
                     "Claimed warm-pool process for %s (agent=%s)",

--- a/test/test_acp_client.py
+++ b/test/test_acp_client.py
@@ -10804,6 +10804,42 @@ class TestModelEntitlementPreflight:
         assert client._model == "claude-opus-4.8"
 
     @pytest.mark.asyncio
+    async def test_startup_resolves_namespaced_pin_to_advertised_spelling(self):
+        """#8521: a stale `<namespace>::` qualifier on a fully served model.
+
+        The pin was stored when a catalog advertised the qualified spelling;
+        this session advertises the bare id. The wire must send the ADVERTISED
+        spelling — running the model the pin names — rather than withholding
+        and silently dropping to the backend default.
+        """
+        client = self._client(["z-ai/glm-5.3-flash"], "openrouter::z-ai/glm-5.3-flash")
+        sent = []
+        client._send_request = _record(sent)
+
+        await client._apply_startup_model()
+
+        assert len(sent) == 1
+        assert sent[0][1]["modelId"] == "z-ai/glm-5.3-flash"
+        # _model records what the session actually runs (the warm-pool re-apply
+        # path reads it), so it must hold the resolved spelling, not the
+        # qualified pin.
+        assert client._model == "z-ai/glm-5.3-flash"
+
+    @pytest.mark.asyncio
+    async def test_startup_still_withholds_namespaced_pin_absent_when_peeled(self):
+        """The resolve is not a rubber stamp: absent under BOTH spellings withholds."""
+        from kiro_crew.acp.client import DEFAULT_MODEL
+
+        client = self._client(["z-ai/glm-5.3-flash"], "openrouter::no-such-model")
+        sent = []
+        client._send_request = _record(sent)
+
+        await client._apply_startup_model()
+
+        assert sent == []
+        assert client._model == DEFAULT_MODEL
+
+    @pytest.mark.asyncio
     async def test_startup_leaves_claude_backend_alone(self):
         """The claude backend advertises BARE ids while _model is prefixed.
 

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -6792,6 +6792,57 @@ class TestPinnedModelWithheld:
         client.available_models = MagicMock(side_effect=RuntimeError("boom"))
         assert _pinned_model_verdict(client, "claude-opus-5", "acp") is None
 
+    def test_namespaced_pin_matches_bare_advertised(self):
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
+
+        # Regression #8521: a persisted pin can carry a `<namespace>::<bare-id>`
+        # qualifier from the catalog that advertised it when it was stored,
+        # while the session being judged advertises the BARE id. The literal
+        # comparison missed for every such pin and the banner claimed a fully
+        # supported model "isn't offered right now". The verdict must peel the
+        # qualifier and resolve to runnable — for ANY namespace vocabulary, not
+        # just `agent.provider` (a fixed enum that no catalog qualifies ids
+        # with, so keying on it would leave the fold unreachable).
+        client = self._client(["auto", "z-ai/glm-5.3-flash"])
+        assert _pinned_model_verdict(client, "openrouter::z-ai/glm-5.3-flash", "acp") is False
+
+    def test_namespaced_pin_judged_even_when_provider_unreadable(self):
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
+
+        # _run_chat passes provider_name="" when the config could not be read.
+        # The fold keys on the pin's own qualifier, not on the provider string,
+        # so an unreadable config must not degrade the verdict back to the
+        # false withhold (nor is it needed for the peel to fire).
+        client = self._client(["auto", "z-ai/glm-5.3-flash"])
+        assert _pinned_model_verdict(client, "openrouter::z-ai/glm-5.3-flash", "") is False
+
+    def test_pin_absent_after_peel_is_still_withheld(self):
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
+
+        # The peel must not turn the verdict into a rubber stamp: a pin the
+        # backend serves under NEITHER spelling still answers withheld.
+        client = self._client(["auto", "z-ai/glm-5.3-flash"])
+        assert _pinned_model_verdict(client, "openrouter::no-such-model", "acp") is True
+
+    def test_only_one_qualifier_level_is_peeled(self):
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
+
+        # The fold peels exactly ONE leading qualifier. A doubly-qualified pin
+        # whose innermost tail happens to be advertised is not a spelling of
+        # that model — unbounded stripping would rubber-stamp arbitrary junk
+        # around any advertised id.
+        client = self._client(["auto", "glm-5.3-flash"])
+        assert _pinned_model_verdict(client, "a::b::glm-5.3-flash", "acp") is True
+
+    def test_pin_advertised_verbatim_needs_no_peel(self):
+        from kiro_crew.dashboard.chat_runner import _pinned_model_verdict
+
+        # A backend that advertises the qualified spelling itself matches on
+        # the first (full) comparison — the peel is a miss-only retry, so it
+        # can only clear a false withhold, never create one.
+        client = self._client(["openrouter::z-ai/glm-5.3-flash"])
+        assert _pinned_model_verdict(client, "openrouter::z-ai/glm-5.3-flash", "acp") is False
+
     def test_slot_reports_no_verdict_until_one_is_recorded(self):
         slot = _ChatSlot("s1")
         slot.model = "claude-opus-5"

--- a/test/test_model_selection_scenarios.py
+++ b/test/test_model_selection_scenarios.py
@@ -27,6 +27,7 @@ from kiro_crew.acp.client import (
     _rejected_model_from_error,
     advertised_model_ids,
     model_is_unusable,
+    resolve_pin_spelling,
     resolve_usable_model,
 )
 
@@ -96,6 +97,63 @@ class TestEntitlementPredicate:
         entries = [{"modelId": "a"}, {"value": "b"}, {"nope": "c"}, "junk", None]
         assert advertised_model_ids(entries) == ["a", "b"]
         assert advertised_model_ids("not-a-list") == []
+
+
+class TestPinSpellingResolver:
+    """`resolve_pin_spelling` — the shared namespace fold (#8521).
+
+    Display verdict (`_pinned_model_verdict`) and the wire withhold sites
+    (`_apply_startup_model`, the runtime path in `providers.acp`) all resolve a
+    persisted pin through this one fold, so the chip and the wire cannot
+    disagree about what "usable" means.
+    """
+
+    _BARE = ["auto", "z-ai/glm-5.3-flash"]
+
+    def test_empty_advertised_resolves_nothing(self):
+        # "" here means "nothing to resolve against", NOT "withheld" — the
+        # withhold decision stays with model_is_unusable's empty-set-means-
+        # allow contract (harness-parity H12).
+        assert resolve_pin_spelling("z-ai/glm-5.3-flash", []) == ""
+        assert resolve_pin_spelling("z-ai/glm-5.3-flash", None) == ""
+
+    def test_full_id_resolves_to_advertised_spelling(self):
+        # The ADVERTISED spelling comes back (it is what goes on the wire),
+        # not the caller's case/whitespace variant.
+        assert resolve_pin_spelling("  Z-AI/GLM-5.3-FLASH ", self._BARE) == "z-ai/glm-5.3-flash"
+
+    def test_namespaced_pin_resolves_to_bare_advertised_spelling(self):
+        got = resolve_pin_spelling("openrouter::z-ai/glm-5.3-flash", self._BARE)
+        assert got == "z-ai/glm-5.3-flash"
+
+    def test_namespaced_resolution_returns_the_advertised_case(self):
+        # Mutation guard: a fold that returns the peeled PIN instead of the
+        # advertised row would hand the wire a spelling the backend may not
+        # accept verbatim.
+        got = resolve_pin_spelling("openrouter::z-ai/glm-5.3-flash", ["Z-AI/GLM-5.3-Flash"])
+        assert got == "Z-AI/GLM-5.3-Flash"
+
+    def test_absent_under_both_spellings_resolves_nothing(self):
+        assert resolve_pin_spelling("openrouter::no-such-model", self._BARE) == ""
+
+    def test_only_one_qualifier_level_is_peeled(self):
+        # Unbounded stripping would rubber-stamp arbitrary junk around any
+        # advertised id; one level matches "a qualifier the catalog added".
+        assert resolve_pin_spelling("a::b::z-ai/glm-5.3-flash", self._BARE) == ""
+        # ...but a pin whose single peel lands on an advertised qualified id
+        # still resolves (the tail is compared verbatim, not re-peeled).
+        assert (
+            resolve_pin_spelling("a::b::z-ai/glm-5.3-flash", ["b::z-ai/glm-5.3-flash"])
+            == "b::z-ai/glm-5.3-flash"
+        )
+
+    def test_empty_namespace_is_not_a_qualifier(self):
+        assert resolve_pin_spelling("::z-ai/glm-5.3-flash", self._BARE) == ""
+
+    def test_qualified_advertised_id_matches_verbatim_without_peel(self):
+        qualified = ["openrouter::z-ai/glm-5.3-flash"]
+        got = resolve_pin_spelling("openrouter::z-ai/glm-5.3-flash", qualified)
+        assert got == "openrouter::z-ai/glm-5.3-flash"
 
 
 class TestExplicitPickRefusal:

--- a/test/test_session_pool.py
+++ b/test/test_session_pool.py
@@ -743,6 +743,40 @@ class TestModelMatchesPoolDefault:
         pooled.client.set_model.assert_not_awaited()
         assert provider is pooled
 
+    @pytest.mark.asyncio
+    async def test_namespaced_pin_resolves_on_claim_like_a_cold_start(self):
+        """#8521: a warm claim must run exactly what a cold start of the pin runs.
+
+        The pin carries a stale `<namespace>::` qualifier while the pooled
+        session advertises the bare id. The cold-start spawn resolves it via
+        resolve_pin_spelling and sends the advertised spelling; withholding it
+        here instead would make whether the pinned model runs depend on whether
+        a pooled process happened to exist — the exact failure class the
+        withhold test above guards from the other direction.
+        """
+        from kiro_crew.providers.acp import AcpProvider
+
+        mgr, factory = _make_manager(pool_agent="kirocrew")
+        pooled = _make_provider()
+        pooled.__class__ = AcpProvider
+        pooled.client = MagicMock()
+        pooled.client.set_model = AsyncMock()
+        pooled.client.resumed = False
+        pooled.client._session_id = "fake-sid"
+        pooled.available_models = MagicMock(return_value=[{"modelId": "z-ai/glm-5.3-flash"}])
+        mgr._drain_and_claim = AsyncMock(return_value=pooled)
+        mgr._schedule_replenish = MagicMock()
+
+        with patch.object(type(mgr), "_resolve_agent_model", return_value="claude-sonnet-4.6"):
+            provider, _is_new, _resumed = await mgr.get_or_create(
+                "test-key", agent="kirocrew", model="openrouter::z-ai/glm-5.3-flash"
+            )
+
+        # Resolved to the ADVERTISED spelling and sent — not withheld, and not
+        # sent under the qualified spelling the backend never advertised.
+        pooled.client.set_model.assert_awaited_once_with("z-ai/glm-5.3-flash")
+        assert provider is pooled
+
 
 # ---------------------------------------------------------------------------
 # Stateless sessions must not claim from pool


### PR DESCRIPTION
Closes #8521

## What

A persisted model pin can carry a `<namespace>::<bare-id>` qualifier from the catalog that advertised it when it was stored (`openrouter::z-ai/glm-5.3-flash`), while the session being judged advertises the **bare** id. The literal membership test then missed for a model the backend fully serves: every such session showed a false "isn't offered right now" banner and silently ran on the backend default every turn.

## How

New shared fold `acp.client.resolve_pin_spelling(model_id, advertised)`: the full id is tried first, and only on a miss is **one** leading `<namespace>::` qualifier peeled and the tail retried; the **advertised spelling** of the match comes back (it is what goes on the wire). Three sites resolve through it, so the chip and the wire cannot disagree about what "usable" means:

- `dashboard/chat_runner._pinned_model_verdict` — the banner/chip verdict clears for a resolvable pin,
- `acp/client._apply_startup_model` — the kiro spawn path sends the advertised spelling instead of withholding, so the turn actually runs the model the pin names,
- `providers/acp.py` runtime path — same treatment,
- warm-pool post-claim (`session_allocation.py`) — via a new `AllocationDeps.resolve_pin_spelling` seam, so a warm claim runs exactly what a cold start of the same pin runs.

Declared surface note: `session.py` reaches the fold through a new thin delegation `agent_sdk/drivers/acp.py::resolve_pin_spelling` (added to that module's `__all__`) rather than importing the ACP layer — the agent-sdk-boundary ratchet refuses a new `kiro_crew.acp` edge on any added line, and the SDK driver is its documented route. Function-local import per the driver's own convention; verified it does not load `kiro_crew.acp` at import time.

Withhold semantics preserved: a pin absent under **either** spelling is still withheld; an empty advertised set keeps the allow contract (harness-parity H12, shared predicate `model_is_unusable` byte-identical); the `claude_code` / claude-backend exemptions and the explicit-pick refusal in `session_provider.set_model` are unchanged (an explicit pick is exact by contract).

**Deliberate deviation from the issue's suggested snippet:** the fold keys on the pin's OWN qualifier, not on `agent.provider`. That config value is a fixed enum (`"acp"`, per `config/sections.py` and the AGENTS.md invariant) and never the vocabulary a catalog qualifies its ids with — a provider-keyed strip is unreachable in any supported config, which the Opus pre-push review lane demonstrated against the first draft (the issue's own `openrouter::` example would have stayed broken).

## Tests

- `TestPinnedModelWithheld` (test_dashboard_chat.py): namespaced pin resolves to runnable (incl. the unreadable-config `provider=""` state the GPT lane flagged), absent-after-peel still withheld, one-qualifier-level-only, verbatim-advertised qualified id needs no peel.
- `TestPinSpellingResolver` (test_model_selection_scenarios.py): 8 resolver unit tests — empty-set contract, advertised-spelling return, case/whitespace fold, single-level peel, empty namespace not a qualifier.
- `TestModelEntitlementPreflight` (test_acp_client.py): startup sends the resolved advertised spelling; absent-under-both-spellings still withholds and stays on the default.
- Mutation-verified: 5 wrong implementations (no peel, unbounded peel, return-pin-not-advertised-spelling, verdict ignores resolver, startup withholds instead of resolving) each caught by a distinct test.
- Local gates: black-baseline, isort, flake8, mypy, subprocess-encoding, sdk-boundary, sync-io-in-async, lockdown, brand, harness-parity, scrub — all green (CI-pinned tool versions). Full pytest: 86 failures on this host are environmental and byte-identical on pristine main (uid-65534 `/local/home`, AF_UNIX path length); 0 branch-only failures.

## Remainder (sibling sites, not in this PR's scope)

Sites that compare persisted/inherited model values against advertised sets without the namespace fold, same class, lower blast radius — filed as [#8616](https://github.com/kirodotdev/KiroCrew/issues/8616): `resolve_usable_model` (background substitution) and `handlers/agents.py` picker narrowing. The warm-pool post-claim re-apply (`session_allocation.py`) was initially deferred there, but the First Principles lane correctly showed it re-applies the SAME pin this PR fixes (whether the pinned model runs must not depend on whether a pooled process existed), so it is folded into this PR: the claim resolves through the same fold and sends the advertised spelling, with a regression test in `test_session_pool.py`.

## Pattern harvest

Rule candidate: when an issue's suggested fix names a key/config value to branch on, verify a producer for that value exists in-tree before implementing — an enum-pinned config value can make the suggested branch unreachable by design, and the tests written for it then pin the bug as correct.
Class: fix keyed on a value the repo forbids (unreachable-by-design branch).

## Tests
See the Tests section above; all listed suites pass locally.
