### PR TITLE
fix(auth): bind refresh chains to the tailnet peer that opened them

### DIFF
--- a/config-baseline.json
+++ b/config-baseline.json
@@ -5849,6 +5849,7 @@
           "trust_identity": false,
           "allowed_logins": [],
           "pin_scope": "node",
+          "bind_refresh_chains": true,
           "keep_awake": true
         },
         "restore_sessions": false,
@@ -5937,6 +5938,7 @@
         "trust_identity": false,
         "allowed_logins": [],
         "pin_scope": "node",
+        "bind_refresh_chains": true,
         "keep_awake": true
       }
     },
@@ -6009,6 +6011,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": "node"
+    },
+    {
+      "path": "dashboard.tailscale.bind_refresh_chains",
+      "kind": "core",
+      "type": "boolean",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Bind Refresh Chains To The Device",
+      "help": "Bind a session's 30-day refresh chain to the tailnet peer that opened it, so a stolen refresh cookie cannot be replayed from a different allowed device. On by default. Only turn it off if you need one session to roam between your DEVICES while pin_scope is 'node' — with pin_scope 'login' the pin is your identity, not the device, so roaming already works. Turning it off means a stolen refresh cookie renews from any allowed node. Existing chains keep the binding they were opened with; the change applies to sessions started after the next gateway start.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": true
     },
     {
       "path": "dashboard.tailscale.keep_awake",

--- a/docs/guides/remote-and-mobile.md
+++ b/docs/guides/remote-and-mobile.md
@@ -555,7 +555,7 @@ an error. `kirocrew token` defaults straight to `20h`. The 5-minute click window
 is not the session length: it only means a link left sitting in a DM overnight is
 dead and you need a fresh one.
 
-**When you do need a fresh link.** Four things end a refresh chain:
+**When you do need a fresh link.** Five things end a refresh chain:
 
 - **30 days idle** — nothing opened the dashboard inside the window.
 - **Signing out in the dashboard** (`POST /api/auth/logout`) — revokes that
@@ -569,9 +569,25 @@ dead and you need a fresh one.
   (RFC 6819 §5.2.2.3). The frontend reports `refresh_chain_revoked` and stops
   scheduling refreshes; the mint screen appears once the remaining access session
   runs out.
+- **Turning tailnet identity trust off**, for a chain that was opened under it.
+  See device binding below; the chain is refused rather than revoked, so one
+  fresh link restores you.
 
-Chains persist in `~/.kiro/crew/refresh_chains.json` (mode `0600`), so they
-survive a gateway restart. On a gateway old enough to predate the feature,
+**Device binding (tailnet identity trust only).** With
+`dashboard.tailscale.trust_identity` on, a chain is bound to the tailnet peer
+that opened it and only that peer can renew it, so a stolen refresh cookie
+cannot be replayed from another one of your allowed machines. What counts as
+"that peer" is `pin_scope`: at the default `node` it is the one device, at
+`login` it is your Tailscale identity, so one session follows you between your
+own devices. If you need one session to roam between devices at `node` scope, set
+`dashboard.tailscale.bind_refresh_chains: false` — the tradeoff is that a stolen
+refresh cookie then renews from any allowed node, which is what the binding
+exists to stop. Sessions that already exist keep whatever binding they were
+opened with; a chain bound this way stops renewing if you later turn identity
+trust off, and a fresh `kirocrew token` link gets you going again.
+
+Chains persist in `~/.kiro/crew/refresh_chains.json` (mode `0600`) — including
+the device binding above — so they survive a gateway restart. On a gateway old enough to predate the feature,
 `GET /api/auth/me` returns 404; the frontend logs once and falls back to the
 20-hour URL-mint behaviour.
 

--- a/docs/system-specs/features/dashboard-token-auth.md
+++ b/docs/system-specs/features/dashboard-token-auth.md
@@ -159,6 +159,42 @@ differently:
   new QR scan. Any child mobile/QR link minted by a peer-bound session carries
   the same `require_peer` + `peer_key` pair, so delegation cannot widen it.
 
+`require_peer` is no longer exclusive to the QR shape. An **ordinary** session
+whose `?token=` exchange resolved a daemon-verified allowed peer also opens its
+refresh chain with `require_peer` + that peer's `peer_key`, and the binding is
+recorded server-side in `refresh_chains.json` (`chain_peers`) as a second
+authority the presented token cannot influence. Rotation must satisfy every key
+either authority names, so a refresh cookie stolen from allowed node A and
+replayed from allowed node B is refused (`peer_identity_mismatch`) instead of
+rotating and re-pinning the replacement access token to B. A refusal does not
+revoke the chain — an unresolvable identity is a daemon blip as often as a theft,
+and burning a 30-day credential over one would turn a recoverable hiccup into a
+re-mint.
+
+Three properties bound the change:
+
+- **Roaming** is `pin_scope`'s decision, not this binding's. At `login` scope the
+  pin key is the identity (`ts:login:<login>`), so a person's other device
+  rotates normally. At `node` scope the ACCESS token was already device-pinned,
+  so an unbound chain was the only thing making cross-device use appear to work —
+  by laundering a fresh pin, which is the defect. `dashboard.tailscale.bind_refresh_chains`
+  (default `true`) is the explicit opt-out for an operator who needs cross-device
+  roaming at node scope and accepts that a stolen refresh cookie then renews from
+  any allowed node.
+- **Migration** is absence. A chain with neither the signed claim nor a
+  `chain_peers` record is unbound, which is every chain outstanding at upgrade
+  and every session opened with no verified peer, so nobody is logged out by the
+  change itself.
+- **Turning identity trust off later ends these sessions**, not just their
+  rotation. The claim is carried onto BOTH halves of the rotated pair — dropping
+  it on the access cookie would leave that credential with the same laundering
+  shape one credential over, re-pinned to whichever allowed node presented it
+  first after a restart — and an access cookie carrying `require_peer` fails
+  closed when no peer resolves. So a session bound this way needs one re-mint via
+  the `kirocrew token` URL after identity trust is switched off. This is the same
+  fail-closed posture the `require_peer` QR shape already has, and the reason the
+  claim is carried rather than confined to the refresh cookie.
+
 The guided setup writes the base `config.json`, then reloads the merged effective
 configuration. If user-owned `config.local.json` overrides any required identity
 or persistence field, the endpoint returns `409 config_overlay_conflict` with the

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -2023,6 +2023,21 @@ class TailscaleConfig:
             "effect on the next gateway start.",
         ),
     )
+    bind_refresh_chains: bool = field(
+        default=True,
+        metadata=_meta(
+            "Bind Refresh Chains To The Device",
+            "Bind a session's 30-day refresh chain to the tailnet peer that "
+            "opened it, so a stolen refresh cookie cannot be replayed from a "
+            "different allowed device. On by default. Only turn it off if you "
+            "need one session to roam between your DEVICES while pin_scope is "
+            "'node' — with pin_scope 'login' the pin is your identity, not the "
+            "device, so roaming already works. Turning it off means a stolen "
+            "refresh cookie renews from any allowed node. Existing chains keep "
+            "the binding they were opened with; the change applies to sessions "
+            "started after the next gateway start.",
+        ),
+    )
     keep_awake: bool = field(
         default=True,
         metadata=_meta(
@@ -2198,6 +2213,11 @@ def _tailscale_config_from(
         trust_identity=trust_identity,
         allowed_logins=allowed_logins,
         pin_scope=pin_scope,
+        # Defaults TRUE, and a non-boolean resolves to TRUE as well: this is a
+        # narrowing-only field like the two rules above, so an operator typo may
+        # only ever leave the binding ON, never silently reopen the replay path
+        # the binding closes (issue #2417).
+        bind_refresh_chains=_safe_bool(data.get("bind_refresh_chains"), True),
         keep_awake=_safe_bool(data.get("keep_awake"), True),
     )
 

--- a/src/kiro_crew/dashboard/handlers/auth_refresh.py
+++ b/src/kiro_crew/dashboard/handlers/auth_refresh.py
@@ -401,6 +401,14 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     Implements the rotation-on-use semantics: each call consumes the
     presented refresh ``jti`` and issues a NEW one with the same ``chain_id``.
     Reuse outside the multi-tab grace window auto-revokes the chain.
+
+    A chain opened by a daemon-verified tailnet peer may only be rotated FOR
+    THAT PEER (issue #2417). The binding is read from two independent
+    authorities -- the HMAC-signed ``peer_key`` claim on the presented token and
+    the server-side record in ``refresh_chains.json`` -- and the request must
+    satisfy every key either of them names. A chain with neither is unbound,
+    which is every chain that predates the record and every session opened with
+    no verified peer.
     """
     # Defense-in-depth CSRF check. SameSite=Lax already blocks the
     # canonical cross-site POST attack, but a malicious origin loaded
@@ -444,8 +452,12 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
 
     state = _get_state()
 
-    # An identity-bound chain (the persistent QR session shape) may only be USED
-    # while a daemon-verified tailnet peer can be established. Placed here, ahead
+    # An identity-bound chain may only be USED while a daemon-verified tailnet
+    # peer can be established -- and while it matches the one that OPENED the
+    # chain. Two shapes are bound: the persistent QR session, whose credential is
+    # bounded by identity rather than by this process's lifetime, and (since issue
+    # #2417) any ordinary Phase-3 session whose chain was opened by a verified
+    # peer. Placed here, ahead
     # of BOTH the reuse branch and the mint, because every path below this line
     # hands the caller a live credential: the grace-replay branch re-serves the
     # cached pair and re-sets both cookies without minting anything, so a check
@@ -468,11 +480,32 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     # address pin would read as a pin while excluding nobody.
     carried_require_peer = refresh_token_requires_peer(refresh_token)
     carried_peer_key = refresh_token_peer_key(refresh_token) if carried_require_peer else ""
+    # Second authority: the server-side chain record in refresh_chains.json
+    # (issue #2417). The signed claim above cannot be forged, but it only binds a
+    # chain whose MINT path remembered to set it -- and this gap existed because
+    # one mint path did and every other one did not. A record the presented token
+    # cannot influence is what makes the next forgetful mint path fail closed
+    # rather than silently unbound.
+    #
+    # Absent means unbound, which is both "this chain had no verified peer" and
+    # "this chain predates the record" -- the migration rule: an upgrade must not
+    # invalidate the outstanding 30-day window.
+    recorded_peer_key = state.chain_peer(chain_id)
+    require_peer = carried_require_peer or bool(recorded_peer_key)
+    # Tightest-wins. When both authorities name a key they agree, because every
+    # rotation re-stamps the record from the same value it signs. If they ever
+    # DISAGREE that is our own state contradicting itself, so neither is trusted
+    # over the other: the request must satisfy both, and a mismatch is refused.
+    expected_peer_keys = {key for key in (carried_peer_key, recorded_peer_key) if key}
     verified_peer_key = (
-        await _verified_peer_key(request, carried_peer_key) if carried_require_peer else ""
+        await _verified_peer_key(request, carried_peer_key or recorded_peer_key)
+        if require_peer
+        else ""
     )
-    if carried_require_peer and (
-        not verified_peer_key or not carried_peer_key or verified_peer_key != carried_peer_key
+    if require_peer and (
+        not verified_peer_key
+        or not expected_peer_keys
+        or any(key != verified_peer_key for key in expected_peer_keys)
     ):
         if not verified_peer_key:
             outcome = "peer_unverified"
@@ -481,7 +514,7 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
                 "This device could not be verified on the tailnet, so the session "
                 "cannot be renewed. Reconnect to the tailnet and try again."
             )
-        elif not carried_peer_key:
+        elif not expected_peer_keys:
             outcome = "peer_binding_missing"
             code = "peer_binding_missing"
             message = (
@@ -565,7 +598,15 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
     _carried_claims: dict[str, str] = {}
     if carried_boot:
         _carried_claims["boot"] = carried_boot
-    if carried_require_peer:
+    # The key the checks above proved this request satisfies. Taken from the
+    # presented credential rather than re-derived from the resolved peer, for the
+    # same reason ``carried_boot`` is: the rotated pair then says what the
+    # credential said, so a future change that admits a partially-validated token
+    # degrades to unbound instead of silently minting a live binding for it. The
+    # record is the fallback, so a claimless-but-recorded chain rotates FORWARD
+    # into a properly claimed one rather than staying claimless.
+    bound_peer_key = carried_peer_key or recorded_peer_key
+    if require_peer:
         # Carried onto BOTH halves of the rotated pair. Dropping it on either one
         # would make the FIRST rotation silently downgrade an identity-bound
         # session to an ordinary one — the same shape of defect as the review
@@ -575,7 +616,7 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
         user_id,
         ttl_seconds=MAX_SESSION_TTL_SECS,
         register_nonce=False,
-        peer_key=carried_peer_key,
+        peer_key=bound_peer_key,
         extra=_carried_claims or None,
     )
     new_session_exp = now + MAX_SESSION_TTL_SECS
@@ -583,8 +624,8 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
         user_id,
         chain_id=chain_id,
         boot=carried_boot,
-        require_peer=carried_require_peer,
-        peer_key=carried_peer_key,
+        require_peer=require_peer,
+        peer_key=bound_peer_key,
     )
 
     public_payload = {
@@ -611,13 +652,19 @@ async def api_auth_refresh(request: web.Request) -> web.Response:
         exp=now + MAX_REFRESH_TTL_SECS,
         ip=client_ip,
         replacement=json.dumps(grace_payload, separators=(",", ":")),
+        # Re-stamped in the SAME write as the consumption, so a rotation can
+        # never record that the old jti is spent while losing the binding that
+        # decides who may spend the new one. Empty for an unbound chain, which
+        # ``mark_consumed`` treats as "leave it alone" rather than storing a
+        # blank -- absent must stay distinguishable from bound-but-lost.
+        peer_key=bound_peer_key,
     )
 
-    if carried_require_peer:
+    if require_peer:
         # The signed claim, not a second whois result, is authoritative. The
         # request already proved it matches ``verified_peer_key`` above; mirror
         # that exact key into the hot in-memory map for posture/reporting.
-        bind_token_peer(new_access_token, carried_peer_key, new_session_exp)
+        bind_token_peer(new_access_token, bound_peer_key, new_session_exp)
     else:
         await _rebind_rotated_token_to_peer(
             request, new_access_token, new_session_exp, boot_bound=bool(carried_boot)

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -1843,6 +1843,11 @@ _EDITABLE_CONFIG: dict[str, dict] = {
     # empty allowlist stays off; an unrecognised pin_scope falls back to node).
     "dashboard.tailscale.trust_identity": {"type": "bool"},
     "dashboard.tailscale.pin_scope": {"type": "str", "max_len": 8},
+    # Refresh-chain peer binding (issue #2417). Editable here because the only
+    # direction a caller can move it is the one an operator may legitimately
+    # need for roaming, and the loader resolves anything non-boolean back to the
+    # bound default — so a malformed write cannot reopen the replay path.
+    "dashboard.tailscale.bind_refresh_chains": {"type": "bool"},
     # Local OTEL metric collection — the Privacy panel's recording switch. Safe
     # to expose where beacon_endpoint is not: turning this on writes JSONL under
     # ~/.kiro/crew/metrics. It is NOT unconditionally local, though —

--- a/src/kiro_crew/dashboard/refresh_tokens.py
+++ b/src/kiro_crew/dashboard/refresh_tokens.py
@@ -15,6 +15,8 @@ Design (full spec in ``docs/system-specs/features/dashboard-token-auth.md``):
 - Reuse detection (RFC 6819 §5.2.2.3): a consumed ``jti`` presented again
   outside the multi-tab grace window auto-revokes the entire chain.
 - 60-second same-IP grace window absorbs benign multi-tab races.
+- Peer binding: a chain opened by a daemon-verified tailnet peer records that
+  peer, and only that peer may rotate it (see ``bind_chain_peer``).
 - Persistence: ``~/.kiro/crew/refresh_chains.json`` (mode ``0600``).
 """
 
@@ -116,6 +118,70 @@ REFRESH_GRACE_SECS = 60
 # imports stay cheap).
 _STATE_FILE_NAME = "refresh_chains.json"
 
+#: The persisted record lists, in the order ``_persist`` writes them. Named once
+#: so ``_load`` cannot check a different set than ``_persist`` produces.
+_RECORD_KEYS = ("consumed_jtis", "revoked_chains", "chain_peers")
+
+
+# --- Persisted-record decoding -----------------------------------------------
+
+
+def _record_list(data: object, key: str) -> list[dict] | None:
+    """Return ``data[key]``'s mapping records, or ``None`` if it is CORRUPT.
+
+    The one place every persisted record list is decoded, and the one place that
+    distinguishes the two cases a bare ``.get(key, [])`` collapses together:
+
+    - **absent** (no such key) -> ``[]``. A fresh install has no records, and an
+      install that never revoked anything has no ``revoked_chains``. Nothing was
+      lost, so empty is the truth.
+    - **present but not a list** (``{"revoked_chains": null}``, a scalar, an
+      object) -> ``None``, meaning CORRUPT. Records existed and cannot be read.
+
+    That distinction is load-bearing, because these lists are security controls,
+    not a cache. Reading a corrupt ``revoked_chains`` as empty makes
+    ``is_chain_revoked`` answer False for a chain that ``POST /api/auth/logout``
+    already killed, so a stolen refresh cookie rotates into fresh credentials --
+    and nothing self-corrects it: reuse detection only re-fires on a jti replay
+    the attacker need not cause, so the window persists until an unrelated logout
+    or restart. Same shape for ``consumed_jtis`` (RFC 6819 §5.2.2.3 reuse
+    detection) and ``chain_peers`` (the device binding, whose loss makes a chain
+    replayable from any allowed node). :meth:`_load` therefore marks the store
+    DEGRADED on ``None`` and :func:`validate_refresh_token` refuses to rotate,
+    rather than silently dropping the control.
+
+    A non-mapping ELEMENT is different again and is simply filtered: the callers'
+    per-field guards already skip it, and one junk entry beside good ones is not
+    evidence the good ones are untrustworthy.
+
+    Note what this does NOT change: an unparseable or unreadable FILE keeps
+    starting empty (see :meth:`_load`). ``atomic_write`` makes a torn write
+    impossible, so a file that will not parse at all is better read as "not our
+    state" than as "our records, lost" -- and that behaviour is pinned by
+    ``test_tr_i_17_corrupted_state_file_starts_empty``.
+
+    Deliberately a chokepoint rather than three guards: the original crash was
+    reported against ``chain_peers`` alone, but it was never specific to that
+    key, and guarding only the reported one leaves the identical defect on its
+    two siblings.
+    """
+    if not isinstance(data, dict):
+        return None
+    if key not in data:
+        return []
+    raw = data.get(key)
+    if not isinstance(raw, list):
+        # Logs the JSON field NAME and a type name, never a record value. The
+        # rule fires on the format string itself, whose "refresh_tokens:"
+        # prefix contains "token".
+        logger.warning(  # nosemgrep: python-logger-credential-disclosure
+            "refresh_tokens: %s is %s, not a list; refusing to rotate until repaired",
+            key,
+            type(raw).__name__,
+        )
+        return None
+    return [entry for entry in raw if isinstance(entry, dict)]
+
 
 # --- State manager -----------------------------------------------------------
 
@@ -123,9 +189,9 @@ _STATE_FILE_NAME = "refresh_chains.json"
 class RefreshStateManager:
     """Thread-safe state for refresh-token rotation and chain revocation.
 
-    Persists consumed-``jti`` and revoked-``chain_id`` records to disk so
-    reuse-detection state survives gateway restarts. Atomic-rename writes guard
-    against truncation on crash.
+    Persists consumed-``jti``, revoked-``chain_id`` and per-chain peer-binding
+    records to disk so reuse-detection and identity-binding state survive
+    gateway restarts. Atomic-rename writes guard against truncation on crash.
 
     The multi-tab grace state (``_grace_replacements``) is deliberately
     IN-MEMORY only — it is never serialized by ``_persist()``/``_load()``.
@@ -142,6 +208,13 @@ class RefreshStateManager:
         self._consumed_jtis: dict[str, float] = {}
         # chain_id -> exp (the latest member's session_exp)
         self._revoked_chains: dict[str, float] = {}
+        # chain_id -> (peer_key, exp) for a chain opened by a daemon-verified
+        # tailnet peer. A peer key is an IDENTIFIER, not a credential (see
+        # tailnet.peer_pin_key), so unlike the grace replacements this is safe to
+        # persist — and it MUST be, or a gateway restart would silently downgrade
+        # every bound chain to unbound, which is the shape of gap this record
+        # exists to close.
+        self._chain_peers: dict[str, tuple[str, float]] = {}
         # chain_id -> (jti, ts, ip, replacement_pair_json) for the single
         # most-recently-consumed jti on the chain (the CHAIN HEAD). The
         # multi-tab grace window re-serves this replacement pair instead of
@@ -156,6 +229,11 @@ class RefreshStateManager:
         # head token, so re-serving it can never roll a shared cookie jar back
         # to an already-consumed jti.
         self._grace_replacements: dict[str, tuple[str, float, str, str]] = {}
+        # Record keys whose persisted value was present but unreadable. Non-empty
+        # means the security controls this store enforces cannot be trusted, so
+        # ``validate_refresh_token`` refuses every rotation until the file is
+        # repaired -- see ``_record_list`` for why empty is not a safe reading.
+        self._corrupt_keys: tuple[str, ...] = ()
         self._state_path = state_path
         self._load()
 
@@ -168,11 +246,17 @@ class RefreshStateManager:
         exp: float,
         ip: str,
         replacement: str,
+        peer_key: str = "",
     ) -> None:
         """Record that ``jti`` was used to mint ``replacement``.
 
         ``replacement`` is the JSON-encoded payload we returned to the
         client (so the multi-tab grace window can return the same pair).
+
+        ``peer_key`` re-stamps the chain's peer binding with the rotation's own
+        expiry. Passed here rather than through a second call so one rotation
+        still costs exactly one state write — and so a bound chain can never
+        record a consumption without also carrying its binding forward.
 
         Auto-evicts expired entries on each call so the on-disk file
         cannot grow without bound (e.g. an attacker pumping rotations
@@ -180,6 +264,8 @@ class RefreshStateManager:
         """
         with self._lock:
             self._consumed_jtis[jti] = exp
+            if peer_key:
+                self._chain_peers[chain_id] = (peer_key, exp)
             # Chain-head-only: record ONLY this (the newest) consumed jti as
             # the grace authenticator, overwriting any prior entry for the
             # chain. An older rotated jti therefore can no longer authenticate
@@ -192,12 +278,63 @@ class RefreshStateManager:
         with self._lock:
             return jti in self._consumed_jtis
 
+    def bind_chain_peer(self, chain_id: str, peer_key: str, exp: float) -> None:
+        """Record that ``chain_id`` may only be rotated for ``peer_key``.
+
+        Called at initial mint (the ``?token=`` exchange) and re-stamped on each
+        rotation. The binding is ALSO signed into the refresh token itself; this
+        server-side copy is a second, independent authority, because the gap this
+        closes (issue #2417) was one mint path carrying the signed claim while
+        every other one silently did not. A record the presented token cannot
+        influence is what makes the next forgetful mint path fail closed rather
+        than unbound.
+
+        An empty ``peer_key`` is a no-op rather than a stored empty: absent means
+        "unbound, today's semantics", and writing a blank record would make an
+        unbound chain indistinguishable from a bound one whose key was lost.
+        """
+        if not peer_key:
+            return
+        with self._lock:
+            self._chain_peers[chain_id] = (peer_key, exp)
+        self.evict_expired()
+        self._persist()
+
+    def degraded_reason(self) -> str:
+        """Why this store cannot be trusted, or ``""`` when it can.
+
+        Non-empty when a persisted record list was present but unreadable, which
+        would otherwise read as "no revocations, no consumed jtis, no device
+        bindings" -- i.e. as every control being satisfied. Callers fail closed on
+        it, mirroring how ``validate_refresh_token`` already treats an unreadable
+        revocation counter.
+        """
+        with self._lock:
+            if not self._corrupt_keys:
+                return ""
+            return "unreadable persisted state: " + ", ".join(self._corrupt_keys)
+
+    def chain_peer(self, chain_id: str) -> str:
+        """The peer key ``chain_id`` is bound to, or ``""`` when unbound.
+
+        ``""`` covers both a chain opened with no verified peer and every chain
+        that predates this record — the migration rule from issue #2417: absent
+        binding means today's unbound semantics, so an upgrade does not log out
+        the whole outstanding 30-day window.
+        """
+        with self._lock:
+            entry = self._chain_peers.get(chain_id)
+            return entry[0] if entry else ""
+
     def revoke_chain(self, chain_id: str, exp: float) -> None:
         with self._lock:
             self._revoked_chains[chain_id] = exp
             # Drop any grace replacement so a revoked chain cannot
             # be served from cache.
             self._grace_replacements.pop(chain_id, None)
+            # The chain is dead; its binding has nothing left to authorize and
+            # must not outlive it for a future chain_id that collides.
+            self._chain_peers.pop(chain_id, None)
         self.evict_expired()
         self._persist()
 
@@ -265,6 +402,9 @@ class RefreshStateManager:
             for chain_id, exp in list(self._revoked_chains.items()):
                 if exp < now:
                     self._revoked_chains.pop(chain_id, None)
+            for chain_id, peer_entry in list(self._chain_peers.items()):
+                if peer_entry[1] < now:
+                    self._chain_peers.pop(chain_id, None)
             for chain_id, entry in list(self._grace_replacements.items()):
                 # Grace entries are short-lived: drop any whose recorded
                 # timestamp is older than 2x the grace window.
@@ -276,6 +416,7 @@ class RefreshStateManager:
         with self._lock:
             self._consumed_jtis.clear()
             self._revoked_chains.clear()
+            self._chain_peers.clear()
             self._grace_replacements.clear()
         self._persist()
 
@@ -294,31 +435,96 @@ class RefreshStateManager:
                 e,
             )
             return
+        if not isinstance(data, dict):
+            # Valid JSON, wrong shape (a list or scalar at the top level). It
+            # parsed, so this is not the "unreadable file" case above: something
+            # replaced our records with a document that cannot hold any. Refuse
+            # rather than read it as "no records" -- see ``_record_list``.
+            #
+            # Logs the state-file PATH and a type name, never a record value; the
+            # rule fires on the format string's "refresh_tokens:" prefix.
+            logger.error(  # nosemgrep: python-logger-credential-disclosure
+                "refresh_tokens: state in %s is %s, not an object; refusing to "
+                "rotate any refresh token until it is repaired or removed",
+                self._state_path,
+                type(data).__name__,
+            )
+            self._corrupt_keys = ("<document>",)
+            return
+        # Decoded BEFORE the lock so a corrupt list is detected before any record
+        # is admitted: a partial load must not leave the store looking populated.
+        records = {key: _record_list(data, key) for key in _RECORD_KEYS}
+        corrupt = tuple(key for key, value in records.items() if value is None)
+        if corrupt:
+            # Logs the unreadable KEY NAMES and the state-file path, never a
+            # record value; the rule fires on the "refresh_tokens:" prefix.
+            logger.error(  # nosemgrep: python-logger-credential-disclosure
+                "refresh_tokens: %s in %s could not be read; refusing to rotate "
+                "any refresh token until it is repaired or removed. Reading it as "
+                "empty would drop revocations and reuse-detection state.",
+                ", ".join(corrupt),
+                self._state_path,
+            )
+            self._corrupt_keys = corrupt
+            return
         with self._lock:
             # A single corrupt `exp` (e.g. "abc" or null) must not brick the
             # store: float() raises TypeError/ValueError, and this runs in the
             # RefreshStateManager constructor, so an unguarded coercion made
             # _get_state() — and thus EVERY /api/auth/refresh call — 500 until
             # the file was hand-repaired. Skip the malformed entry instead.
-            for entry in data.get("consumed_jtis", []):
-                if isinstance(entry, dict) and "jti" in entry and "exp" in entry:
+            for entry in records["consumed_jtis"] or []:
+                if "jti" in entry and "exp" in entry:
                     try:
                         self._consumed_jtis[str(entry["jti"])] = float(entry["exp"])
                     except (TypeError, ValueError):
                         logger.warning(
                             "refresh_tokens: dropping consumed_jti with bad exp: %r", entry
                         )
-            for entry in data.get("revoked_chains", []):
-                if isinstance(entry, dict) and "chain_id" in entry and "exp" in entry:
+            for entry in records["revoked_chains"] or []:
+                if "chain_id" in entry and "exp" in entry:
                     try:
                         self._revoked_chains[str(entry["chain_id"])] = float(entry["exp"])
                     except (TypeError, ValueError):
                         logger.warning(
                             "refresh_tokens: dropping revoked_chain with bad exp: %r", entry
                         )
+            # Peer bindings. Absent for every chain written before this record
+            # existed, which IS the migration: no record means unbound, i.e. the
+            # pre-change semantics, so an upgrade does not invalidate the
+            # outstanding 30-day window. A malformed record is DROPPED rather
+            # than read as unbound-but-present for the same reason the two loops
+            # above skip theirs: one bad entry must not take the file with it.
+            for entry in records["chain_peers"] or []:
+                if not ("chain_id" in entry and entry.get("peer_key") and "exp" in entry):
+                    if entry:
+                        logger.warning("refresh_tokens: dropping malformed chain_peer: %r", entry)
+                    continue
+                try:
+                    self._chain_peers[str(entry["chain_id"])] = (
+                        str(entry["peer_key"]),
+                        float(entry["exp"]),
+                    )
+                except (TypeError, ValueError):
+                    logger.warning("refresh_tokens: dropping chain_peer with bad exp: %r", entry)
 
     def _persist(self) -> None:
         if self._state_path is None:
+            return
+        if self._corrupt_keys:
+            # Writing here would replace the operator's unreadable file with our
+            # (empty) in-memory state: the records would be gone for good, and the
+            # NEXT start would load a clean empty store and silently resume
+            # rotating -- turning a refusal into exactly the bypass it prevents.
+            # Leave the file alone so it can be inspected and repaired.
+            # Logs the state-file path and the unreadable KEY NAMES, never a
+            # record value; the rule fires on the "refresh_tokens:" prefix.
+            logger.warning(  # nosemgrep: python-logger-credential-disclosure
+                "refresh_tokens: not persisting over unreadable state in %s "
+                "(%s); repair or remove the file, then restart the gateway",
+                self._state_path,
+                ", ".join(self._corrupt_keys),
+            )
             return
         # Hold the lock across the FULL serialize+write+rename so concurrent
         # writers cannot clobber each other's atomic-rename. Per a security
@@ -336,6 +542,10 @@ class RefreshStateManager:
                 ],
                 "revoked_chains": [
                     {"chain_id": cid, "exp": exp} for cid, exp in self._revoked_chains.items()
+                ],
+                "chain_peers": [
+                    {"chain_id": cid, "peer_key": key, "exp": exp}
+                    for cid, (key, exp) in self._chain_peers.items()
                 ],
             }
             try:
@@ -386,6 +596,19 @@ def _get_state() -> RefreshStateManager:
             if _state_singleton is None:
                 _state_singleton = RefreshStateManager(state_path=config_dir() / _STATE_FILE_NAME)
     return _state_singleton
+
+
+def bind_chain_peer(chain_id: str, peer_key: str, exp: float) -> None:
+    """Record a chain's peer binding on the module singleton.
+
+    A module-level entry point so ``token_auth`` can record the binding at
+    initial mint without reaching into the private singleton accessor, keeping
+    the import direction one-way (``token_auth`` → ``refresh_tokens``).
+
+    Does synchronous file I/O — callers on the event loop must wrap it in
+    ``asyncio.to_thread``.
+    """
+    _get_state().bind_chain_peer(chain_id, peer_key, exp)
 
 
 # --- Token generation / validation -------------------------------------------
@@ -511,6 +734,14 @@ def validate_refresh_token(token: str) -> tuple[bool, str, str, str, str, float]
     if not chain_id or not jti:
         return False, "", "missing claims", "", "", 0.0
     state = _get_state()
+    # Fail closed when the persisted state could not be read. Placed BEFORE the
+    # revocation check because that check is the one being bypassed: a corrupt
+    # ``revoked_chains`` read as empty makes ``is_chain_revoked`` answer False for
+    # a chain logout already killed, and nothing self-corrects it. Same posture
+    # and same wording shape as the unreadable-revocation-counter check below.
+    degraded = state.degraded_reason()
+    if degraded:
+        return False, user_id, f"refresh state unavailable ({degraded})", chain_id, jti, session_exp
     if state.is_chain_revoked(chain_id):
         return False, user_id, "chain revoked", chain_id, jti, session_exp
     # Revocation generation: mirrors the access-cookie semantics in
@@ -566,11 +797,12 @@ def refresh_token_boot(token: str) -> str:
 def refresh_token_requires_peer(token: str) -> bool:
     """Whether this chain may only rotate for a daemon-verified tailnet peer.
 
-    Set on the QR "persistent" session shape, whose credential is bounded by
-    identity rather than by this process's lifetime. Same read-only,
-    validate-first contract as :func:`refresh_token_boot`, and the same
-    conservative failure direction is NOT available here: a decode failure must
-    answer ``True``, not ``False``. Answering ``False`` would let an
+    Set on the QR "persistent" session shape and on every ordinary Phase-3
+    session whose chain was opened by a verified peer (issue #2417), i.e. on any
+    chain whose safety rests on identity rather than on this process's lifetime.
+    Same read-only, validate-first contract as :func:`refresh_token_boot`, and
+    the same conservative failure direction is NOT available here: a decode
+    failure must answer ``True``, not ``False``. Answering ``False`` would let an
     undecodable-but-signed token rotate without the identity check the chain was
     minted to require, which is the one outcome this claim exists to prevent.
     """

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -3561,6 +3561,7 @@ async def start_dashboard(
         _ts_cfg.trust_identity,
         tailnet_effective_allowed_logins(_cfg.degraded_sections, _ts_cfg.allowed_logins),
         _ts_cfg.pin_scope,
+        bind_refresh_chains=_ts_cfg.bind_refresh_chains,
         # An unreadable tailnet policy resolves allowed_logins to [] and so
         # trust_identity to False, which is "no login restriction". The values
         # alone cannot tell that from "never configured"; degraded_sections can.
@@ -4343,6 +4344,7 @@ async def start_api_server(
         _ts_cfg.trust_identity,
         tailnet_effective_allowed_logins(_cfg.degraded_sections, _ts_cfg.allowed_logins),
         _ts_cfg.pin_scope,
+        bind_refresh_chains=_ts_cfg.bind_refresh_chains,
         identity_unknown=tailnet_identity_unknown(_cfg.degraded_sections),
         unreadable_files=tuple(degraded_config_files(_cfg.degraded_sections)),
     )

--- a/src/kiro_crew/dashboard/tailnet.py
+++ b/src/kiro_crew/dashboard/tailnet.py
@@ -908,6 +908,16 @@ class TailnetTrust:
     trust_identity: bool = False
     allowed_logins: tuple[str, ...] = ()
     pin_scope: str = PIN_SCOPE_NODE
+    #: Bind a refresh CHAIN to the peer that opened it, so a stolen refresh
+    #: cookie cannot be replayed from a different allowed node (issue #2417).
+    #: Default ON: without it the chain is the laundering path around the access
+    #: token's own pin -- a cookie stolen from node A rotates from node B and the
+    #: replacement access token comes back pinned to B. Turning it OFF restores
+    #: that behaviour, and is only the right answer for an operator who needs
+    #: cross-DEVICE roaming at ``pin_scope: "node"``; at ``"login"`` scope the
+    #: pin key is the identity rather than the device, so roaming between a
+    #: person's own devices already works with the binding on.
+    bind_refresh_chains: bool = True
     #: The operator wrote a tailnet identity policy that config load could not
     #: read (see ``DEGRADED_TAILSCALE``). Distinct from ``trust_identity=False``,
     #: which means they never asked for one: an unreadable narrowing must DENY,
@@ -1229,6 +1239,7 @@ async def governed_tailnet_trust(
     allowed_logins: tuple[str, ...],
     pin_scope: str,
     *,
+    bind_refresh_chains: bool = True,
     identity_unknown: bool = False,
     unreadable_files: tuple[str, ...] = (),
 ) -> TailnetTrust:
@@ -1254,6 +1265,11 @@ async def governed_tailnet_trust(
     calls at all, and with the integration off there is no allowlist left to
     fail closed on.
 
+    ``bind_refresh_chains`` is the availability escape hatch for refresh-chain
+    peer binding (issue #2417). It defaults to the SAFER value at every layer,
+    including here, so a caller that has not been taught about it cannot
+    accidentally construct the unbound posture.
+
     ``unreadable_files`` names the config file(s) involved, for the refusal to
     quote. It matters more than it looks: the file is often
     ``config.local.json`` rather than ``config.json``, and an operator who has
@@ -1264,6 +1280,7 @@ async def governed_tailnet_trust(
         trust_identity=trust_identity,
         allowed_logins=allowed_logins,
         pin_scope=pin_scope,
+        bind_refresh_chains=bind_refresh_chains,
         identity_unknown=identity_unknown,
     )
     if trust.enforces_identity and await asyncio.to_thread(

--- a/src/kiro_crew/dashboard/token_auth.py
+++ b/src/kiro_crew/dashboard/token_auth.py
@@ -35,6 +35,7 @@ from kiro_crew.dashboard.origin import (
 from kiro_crew.dashboard.refresh_tokens import (
     MAX_REFRESH_TTL_SECS,
     REFRESH_COOKIE_PATH,
+    bind_chain_peer,
     cookie_jar_needs_pruning,
     foreign_port_cookies,
     generate_refresh_token,
@@ -2976,14 +2977,55 @@ def token_auth_middleware(
                     # at restart while a 30-day refresh credential beside it
                     # re-minted a fresh session on the next visit, and "ends at
                     # restart" would be false by one rotation.
+                    #
+                    # Peer binding for the CHAIN (issue #2417). The QR "persistent"
+                    # session shape brought its own ``require_peer`` claim on the
+                    # link; an ordinary Phase-3 session did not, so its chain was
+                    # minted UNBOUND even though its access token was pinned to a
+                    # verified peer. That asymmetry was the laundering path: a
+                    # refresh cookie stolen from allowed node A, replayed from
+                    # allowed node B, rotated cleanly and handed back an access
+                    # token pinned to B. Binding here closes it at the mint, so
+                    # the chain says who owns it from its first byte rather than
+                    # relying on the rotation handler to infer it.
+                    #
+                    # Gated on a RESOLVED peer, not on ``peer_key``: that helper
+                    # answers ``ip:<addr>`` when no peer resolved, and binding a
+                    # chain to the tunnel's shared loopback address would read as
+                    # a pin while excluding nobody. ``bind_refresh_chains`` is the
+                    # operator's documented opt-out for cross-device roaming at
+                    # node scope.
+                    _refresh_require_peer = str(data.get("require_peer", "")) == "1"
+                    _refresh_peer_key = _session_peer_key
+                    if (
+                        not _refresh_require_peer
+                        and peer is not None
+                        and tailnet_trust is not None
+                        and tailnet_trust.bind_refresh_chains
+                        and peer_key.startswith("ts:")
+                    ):
+                        _refresh_require_peer = True
+                        _refresh_peer_key = peer_key
                     refresh_token, chain_id, _jti, refresh_exp = generate_refresh_token(
                         user_id,
                         boot=str(data.get("boot", "")),
-                        require_peer=str(data.get("require_peer", "")) == "1",
-                        peer_key=_session_peer_key,
+                        require_peer=_refresh_require_peer,
+                        peer_key=_refresh_peer_key,
                     )
                     refresh_remaining = int(refresh_exp - time.time())
                     if refresh_remaining > 0:
+                        if _refresh_peer_key:
+                            # Server-side twin of the signed claim above. The
+                            # claim is authoritative and cannot be forged, but it
+                            # only binds chains whose mint path remembered to set
+                            # it — and this issue exists because one did and the
+                            # others did not. A record the presented token cannot
+                            # influence makes the next forgetful mint path fail
+                            # closed instead of silently unbound. Offloaded
+                            # because it writes refresh_chains.json.
+                            await asyncio.to_thread(
+                                bind_chain_peer, chain_id, _refresh_peer_key, refresh_exp
+                            )
                         resp.set_cookie(
                             refresh_cookie_name(_cookie_port_from_host(request, port)),
                             refresh_token,

--- a/test/test_refresh_peer_binding.py
+++ b/test/test_refresh_peer_binding.py
@@ -1,0 +1,691 @@
+"""Refresh chains are bound to the tailnet peer that opened them (issue #2417).
+
+Phase 3 pins ACCESS sessions to a daemon-verified tailnet peer, and PR #2411 made
+rotation carry that pin forward onto the replacement access token. What it did NOT
+do was bind the refresh CHAIN itself for ordinary sessions: the peer-bound
+rotation mechanism (``require_peer`` / ``peer_key``) was armed for exactly one
+producer, the persistent QR phone session. Every other Phase-3 session minted an
+UNBOUND chain, so a refresh cookie stolen from allowed node A and replayed from
+allowed node B rotated cleanly and re-pinned the fresh access token to B — the
+theft path this module pins shut.
+
+What is asserted here:
+
+* the exploit, end to end: a chain opened on node A cannot be rotated from node
+  B, and the refusal neither consumes the jti nor revokes the chain (a refusal is
+  not a theft signal — see ``api_auth_refresh``);
+* the mint side: an ordinary Phase-3 exchange now writes the binding onto BOTH
+  the signed refresh token and the server-side chain record;
+* roaming: ``pin_scope: "login"`` still lets the same identity rotate from a
+  different device, which is the operator's roaming knob and the resolution of
+  the availability tradeoff raised on the issue;
+* the opt-out: ``bind_refresh_chains: false`` restores the pre-change unbound
+  chain for an operator who needs cross-node roaming at node scope;
+* migration: a chain with neither a signed claim nor a persisted record (every
+  chain that exists on an upgraded install) keeps today's unbound semantics;
+* the server-side record as an independent authority: a chain recorded as
+  peer-bound is refused for another peer even when the presented token carries no
+  claim at all, so a future mint path that forgets the claim fails closed rather
+  than silently unbound — which is the exact class of bug this issue is.
+
+Non-tailnet installs are untouched: every assertion below that expects a binding
+first arranges a daemon-verified, allowlisted peer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from kiro_crew.dashboard import refresh_tokens as rt
+from kiro_crew.dashboard import token_auth as ta
+from kiro_crew.dashboard.handlers import auth_refresh as h
+from kiro_crew.dashboard.refresh_tokens import (
+    RefreshStateManager,
+    generate_refresh_token,
+    refresh_cookie_name,
+    refresh_token_peer_key,
+    refresh_token_requires_peer,
+)
+from kiro_crew.dashboard.tailnet import ForwardedPeer, TailnetTrust
+from kiro_crew.dashboard.token_auth import generate_token
+
+PORT = 5476
+LAPTOP_KEY = "ts:node:user@example.com|laptop.tail.ts.net"
+PHONE_KEY = "ts:node:user@example.com|phone.tail.ts.net"
+LOGIN_KEY = "ts:login:user@example.com"
+
+
+def _peer(node: str) -> ForwardedPeer:
+    return ForwardedPeer(login="user@example.com", node=node, address="100.64.0.5")
+
+
+def _trust(*, pin_scope: str = "node", bind_refresh_chains: bool = True) -> TailnetTrust:
+    return TailnetTrust(
+        trust_identity=True,
+        allowed_logins=("user@example.com",),
+        pin_scope=pin_scope,
+        bind_refresh_chains=bind_refresh_chains,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_token_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Keep the real middleware's PROCESS-GLOBAL auth state inside this test.
+
+    ``_exchange`` below drives the real ``token_auth_middleware``, not a stub, and
+    that is the point -- the mint-side gap this module tests lives in the
+    middleware. The cost is that a genuine exchange writes process-global state:
+    it binds into the ``ta._state`` singleton (nonces, peer bindings, consumed
+    tokens) and revokes the link nonce through ``_get_revoked_store()``, whose
+    singleton is built ONCE per process from whatever ``KIROCREW_HOME`` the first
+    caller happened to see. Left alone, a store created here outlives the test and
+    a LATER test writes through it into this test's already-deleted tmp home,
+    while stale peer bindings make a later posture read report sessions that no
+    test established.
+
+    Reset on the way in as well as out: the leak can arrive from an earlier module
+    just as easily as leave for a later one. ``_state.clear_all()`` rather than
+    ``revoke_all_sessions()`` so the revocation generation is not bumped between
+    unrelated tests -- a bump would reject every token minted before it.
+
+    Deliberately the same fixture ``test/test_token_auth.py`` already uses for
+    this, down to the pinned ``_gen``, rather than a second isolation shape for
+    the same singletons.
+    """
+    import kiro_crew.dashboard.revocation_gen as _rg
+
+    monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+    monkeypatch.setattr(_rg, "_gen", 0)
+    monkeypatch.setattr(ta, "_revoked_store_singleton", None)
+    ta._state.clear_all()
+    ta._app_perms_cache.clear()
+    yield
+    monkeypatch.setattr(_rg, "_gen", 0)
+    monkeypatch.setattr(ta, "_revoked_store_singleton", None)
+    ta._state.clear_all()
+    ta._app_perms_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(h, "_refresh_rate_buckets", {})
+    monkeypatch.setattr(h, "_refresh_rate_last_sweep", float("-inf"))
+
+
+@pytest.fixture()
+def state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> RefreshStateManager:
+    """Pin the refresh-state singleton at a tmp_path-backed manager."""
+    mgr = RefreshStateManager(state_path=tmp_path / "refresh_chains.json")
+    monkeypatch.setattr(rt, "_state_singleton", mgr)
+    return mgr
+
+
+@pytest.fixture(autouse=True)
+def _quiet_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep SEL out of it — these tests assert on HTTP outcomes, not the trail."""
+    monkeypatch.setattr(h, "_audit", lambda *a, **k: None)
+    monkeypatch.setattr(ta, "_sel_fn", lambda: MagicMock())
+
+
+def _refresh_request(
+    refresh_cookie: str,
+    *,
+    trust: TailnetTrust | None = None,
+    remote: str = "127.0.0.1",
+) -> web.Request:
+    """A POST /api/auth/refresh carrying *refresh_cookie*."""
+    app = web.Application()
+    app["port"] = PORT
+    app["allowed_origins"] = {f"http://localhost:{PORT}"}
+    if trust is not None:
+        app["tailnet_trust"] = trust
+    transport = MagicMock()
+    transport.get_extra_info = lambda key, default=None: (
+        (remote, 44444) if key == "peername" else default
+    )
+    return make_mocked_request(
+        "POST",
+        "/api/auth/refresh",
+        headers={
+            "Host": f"localhost:{PORT}",
+            "Cookie": f"{refresh_cookie_name(str(PORT))}={refresh_cookie}",
+        },
+        app=app,
+        transport=transport,
+    )
+
+
+async def _ok_handler(_request: web.Request) -> web.Response:
+    return web.Response(text="ok")
+
+
+async def _exchange(
+    trust: TailnetTrust,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    node: str,
+    user: str = "user",
+) -> web.StreamResponse:
+    """Drive a real ``?token=`` link -> session exchange for a verified peer.
+
+    This is the ORDINARY Phase-3 access session — no ``require_peer`` claim on the
+    link, no ``no_refresh`` bound. It is the mint path the issue is about.
+    """
+    monkeypatch.setattr(ta, "resolve_forwarded_peer", AsyncMock(return_value=_peer(node)))
+    mw = ta.token_auth_middleware(port=PORT, tailnet_trust=trust)
+    link = generate_token(user, ttl_seconds=3600)
+    app = web.Application()
+    app["port"] = PORT
+    transport = MagicMock()
+    transport.get_extra_info = lambda key, default=None: (
+        ("127.0.0.1", 44444) if key == "peername" else default
+    )
+    request = make_mocked_request(
+        "GET",
+        f"/?token={link}",
+        headers={"Host": f"localhost:{PORT}"},
+        app=app,
+        transport=transport,
+    )
+    return await mw(request, _ok_handler)
+
+
+def _refresh_cookie_of(response: web.StreamResponse) -> str:
+    morsel = response.cookies.get(refresh_cookie_name(str(PORT)))
+    assert morsel is not None, "the exchange minted no refresh cookie"
+    return morsel.value
+
+
+def _body(response: web.StreamResponse) -> Any:
+    assert isinstance(response, web.Response)
+    raw = response.body
+    assert isinstance(raw, bytes)
+    return json.loads(raw.decode("utf-8"))
+
+
+# --- the exploit -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stolen_refresh_cookie_cannot_rotate_from_another_allowed_node(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The issue, end to end: steal from laptop, replay from phone.
+
+    Before this change the replay returned 200 and pinned the replacement access
+    token to the PHONE, laundering a laptop-scoped session onto another device.
+    """
+    trust = _trust()
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    stolen = _refresh_cookie_of(minted)
+
+    # The thief's node is allowlisted — same login, different device. That is
+    # precisely the case the issue is filed against.
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("phone.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(stolen, trust=trust))
+
+    assert response.status == 401
+    assert _body(response)["code"] == "peer_identity_mismatch"
+    assert "Set-Cookie" not in response.headers
+    # A refusal is not a theft signal: the legitimate laptop must still be able
+    # to rotate, so nothing is consumed and the chain is not revoked.
+    _valid, _uid, _reason, chain_id, jti, _exp = rt.validate_refresh_token(stolen)
+    assert not state.is_consumed(jti)
+    assert not state.is_chain_revoked(chain_id)
+
+
+@pytest.mark.asyncio
+async def test_the_original_node_still_rotates_its_own_chain(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The binding must not cost the legitimate device its own session."""
+    trust = _trust()
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    cookie = _refresh_cookie_of(minted)
+
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("laptop.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(cookie, trust=trust))
+
+    assert response.status == 200
+    rotated = _refresh_cookie_of(response)
+    # The binding survives the rotation on both halves of the new pair, or the
+    # SECOND rotation would silently be unbound again.
+    assert refresh_token_requires_peer(rotated) is True
+    assert refresh_token_peer_key(rotated) == LAPTOP_KEY
+    _v, _u, _r, chain_id, _j, _e = rt.validate_refresh_token(rotated)
+    assert state.chain_peer(chain_id) == LAPTOP_KEY
+
+
+# --- the mint side -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ordinary_phase3_exchange_binds_the_chain_it_opens(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gap was at the mint: an ordinary session opened an UNBOUND chain."""
+    response = await _exchange(_trust(), monkeypatch, node="laptop.tail.ts.net")
+    cookie = _refresh_cookie_of(response)
+
+    assert refresh_token_requires_peer(cookie) is True
+    assert refresh_token_peer_key(cookie) == LAPTOP_KEY
+    _v, _u, _r, chain_id, _j, _e = rt.validate_refresh_token(cookie)
+    assert state.chain_peer(chain_id) == LAPTOP_KEY
+
+
+@pytest.mark.asyncio
+async def test_the_chain_binding_is_persisted_for_the_next_gateway(
+    state: RefreshStateManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``refresh_chains.json`` carries the binding, so a restart keeps it."""
+    response = await _exchange(_trust(), monkeypatch, node="laptop.tail.ts.net")
+    _v, _u, _r, chain_id, _j, _e = rt.validate_refresh_token(_refresh_cookie_of(response))
+
+    on_disk = json.loads((tmp_path / "refresh_chains.json").read_text())
+    assert {"chain_id": chain_id, "peer_key": LAPTOP_KEY} == {
+        k: v for k, v in on_disk["chain_peers"][0].items() if k != "exp"
+    }
+    # A fresh manager over the same file reads it back — the restart case.
+    reloaded = RefreshStateManager(state_path=tmp_path / "refresh_chains.json")
+    assert reloaded.chain_peer(chain_id) == LAPTOP_KEY
+
+
+@pytest.mark.asyncio
+async def test_a_non_tailnet_exchange_still_opens_an_unbound_chain(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No identity trust, no binding — the ordinary token+IP install is untouched."""
+    monkeypatch.setattr(ta, "resolve_forwarded_peer", AsyncMock(return_value=None))
+    mw = ta.token_auth_middleware(port=PORT)
+    link = generate_token("alice", ttl_seconds=3600)
+    app = web.Application()
+    app["port"] = PORT
+    transport = MagicMock()
+    transport.get_extra_info = lambda key, default=None: (
+        ("127.0.0.1", 44444) if key == "peername" else default
+    )
+    request = make_mocked_request(
+        "GET",
+        f"/?token={link}",
+        headers={"Host": f"localhost:{PORT}"},
+        app=app,
+        transport=transport,
+    )
+    response = await mw(request, _ok_handler)
+
+    cookie = _refresh_cookie_of(response)
+    assert refresh_token_requires_peer(cookie) is False
+    _v, _u, _r, chain_id, _j, _e = rt.validate_refresh_token(cookie)
+    assert state.chain_peer(chain_id) == ""
+
+
+# --- the rotated ACCESS token ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_rotated_access_token_carries_the_signed_device(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both halves of the rotated pair, not just the refresh cookie.
+
+    The signed claim is what survives a gateway restart: before it, the rotated
+    access cookie relied on the in-memory pin map, which is empty after a restart
+    and re-pinned to whichever allowed node presented the cookie first. The pair
+    is bound together on purpose — a rotation that bound only the chain would
+    leave the access cookie with the same laundering shape one credential over.
+
+    The cost of this is stated in the spec and worth pinning here: an access
+    cookie carrying ``require_peer`` fails closed when no peer resolves, so
+    turning identity trust off later ends these sessions until one re-mint.
+    """
+    from kiro_crew.dashboard.token_auth import required_peer_key_unverified
+
+    trust = _trust()
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("laptop.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(_refresh_cookie_of(minted), trust=trust))
+
+    assert response.status == 200
+    access = response.cookies[f"mc_token_{PORT}"].value
+    assert required_peer_key_unverified(access) == LAPTOP_KEY
+
+
+@pytest.mark.asyncio
+async def test_a_rotated_access_token_is_refused_for_another_node_after_restart(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The signed claim beats an empty pin map — no first-arrival takeover.
+
+    A restart clears the in-memory bindings, which is precisely when a stolen
+    access cookie used to be re-pinned to whoever presented it. The claim the
+    rotation now signs is what makes the ORIGINAL device the only answer, and it
+    must not cost that device its own session.
+    """
+    from kiro_crew.dashboard.token_auth import _state as token_state
+
+    trust = _trust()
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("laptop.tail.ts.net"))
+    )
+    rotated = await h.api_auth_refresh(_refresh_request(_refresh_cookie_of(minted), trust=trust))
+    access = rotated.cookies[f"mc_token_{PORT}"].value
+
+    # The restart: every hot binding is gone, only the signed claims remain.
+    token_state._peer_bindings.clear()
+
+    async def _authenticate(node: str) -> int:
+        monkeypatch.setattr(ta, "resolve_forwarded_peer", AsyncMock(return_value=_peer(node)))
+        mw = ta.token_auth_middleware(port=PORT, tailnet_trust=trust)
+        app = web.Application()
+        app["port"] = PORT
+        transport = MagicMock()
+        transport.get_extra_info = lambda key, default=None: (
+            ("127.0.0.1", 44444) if key == "peername" else default
+        )
+        request = make_mocked_request(
+            "GET",
+            "/api/sessions",
+            headers={"Host": f"localhost:{PORT}", "Cookie": f"mc_token_{PORT}={access}"},
+            app=app,
+            transport=transport,
+        )
+        return (await mw(request, _ok_handler)).status
+
+    # 403, not 401: the middleware's deny for an authenticated-but-wrong-device
+    # caller is a permission refusal, not a missing credential.
+    assert await _authenticate("phone.tail.ts.net") == 403
+    assert await _authenticate("laptop.tail.ts.net") == 200
+
+
+# --- roaming and the opt-out -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_scope_still_roams_between_the_users_own_devices(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``pin_scope: "login"`` is the roaming knob, and the binding respects it.
+
+    This is the resolution of the availability tradeoff raised on the issue: at
+    login scope the pin key is the identity, not the device, so the same person's
+    other device rotates normally. At node scope the ACCESS token was already
+    device-pinned, so the chain being unbound was the only thing making
+    cross-node use "work" — by laundering, which is the defect.
+    """
+    trust = _trust(pin_scope="login")
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    cookie = _refresh_cookie_of(minted)
+    assert refresh_token_peer_key(cookie) == LOGIN_KEY
+
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("phone.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(cookie, trust=trust))
+
+    assert response.status == 200
+    assert refresh_token_peer_key(_refresh_cookie_of(response)) == LOGIN_KEY
+
+
+@pytest.mark.asyncio
+async def test_the_opt_out_restores_the_unbound_chain(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``bind_refresh_chains: false`` is the documented availability escape hatch."""
+    trust = _trust(bind_refresh_chains=False)
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    cookie = _refresh_cookie_of(minted)
+    assert refresh_token_requires_peer(cookie) is False
+
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("phone.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(cookie, trust=trust))
+    assert response.status == 200
+
+
+# --- migration and the server-side record ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_pre_upgrade_chain_keeps_todays_unbound_semantics(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Migration rule from the issue: absent binding = unbound, as today.
+
+    Every chain that already exists on an upgraded install has neither the signed
+    claim nor a persisted record. Refusing those would log the whole 30-day
+    window out on upgrade, which is not what a hardening change may do silently.
+    """
+    legacy, chain_id, _jti, _exp = generate_refresh_token("alice")
+    assert state.chain_peer(chain_id) == ""
+
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("phone.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(legacy, trust=_trust()))
+    assert response.status == 200
+
+
+@pytest.mark.asyncio
+async def test_the_persisted_record_alone_refuses_a_different_peer(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Defense in depth: the record is authority even with no claim on the token.
+
+    This issue exists because ONE mint path carried the claim and the others did
+    not. A server-side record the token cannot influence is what makes the next
+    forgetful mint path fail closed instead of silently unbound.
+    """
+    claimless, chain_id, jti, exp = generate_refresh_token("alice")
+    state.bind_chain_peer(chain_id, LAPTOP_KEY, exp)
+
+    monkeypatch.setattr(
+        h, "resolve_forwarded_peer", AsyncMock(return_value=_peer("phone.tail.ts.net"))
+    )
+    response = await h.api_auth_refresh(_refresh_request(claimless, trust=_trust()))
+
+    assert response.status == 401
+    assert _body(response)["code"] == "peer_identity_mismatch"
+    assert not state.is_consumed(jti)
+    assert not state.is_chain_revoked(chain_id)
+
+
+@pytest.mark.asyncio
+async def test_a_bound_chain_cannot_rotate_while_identity_is_unverifiable(
+    state: RefreshStateManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail closed on an unresolvable peer, and do NOT revoke over a daemon blip."""
+    trust = _trust()
+    minted = await _exchange(trust, monkeypatch, node="laptop.tail.ts.net")
+    cookie = _refresh_cookie_of(minted)
+
+    monkeypatch.setattr(h, "resolve_forwarded_peer", AsyncMock(return_value=None))
+    response = await h.api_auth_refresh(_refresh_request(cookie, trust=trust))
+
+    assert response.status == 401
+    assert _body(response)["code"] == "peer_identity_unverified"
+    _v, _u, _r, chain_id, jti, _e = rt.validate_refresh_token(cookie)
+    assert not state.is_consumed(jti)
+    assert not state.is_chain_revoked(chain_id)
+
+
+def test_revoking_a_chain_drops_its_peer_record(state: RefreshStateManager) -> None:
+    """A dead chain must not leave a binding behind for a recycled chain_id."""
+    _token, chain_id, _jti, exp = generate_refresh_token("alice")
+    state.bind_chain_peer(chain_id, LAPTOP_KEY, exp)
+    assert state.chain_peer(chain_id) == LAPTOP_KEY
+    state.revoke_chain(chain_id, exp)
+    assert state.chain_peer(chain_id) == ""
+
+
+def test_an_expired_chain_binding_is_evicted(state: RefreshStateManager) -> None:
+    """Bindings age out with their chain, so the state file stays bounded."""
+    state.bind_chain_peer("deadbeef", LAPTOP_KEY, 1.0)
+    state.evict_expired(now=2.0)
+    assert state.chain_peer("deadbeef") == ""
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        pytest.param({"chain_peers": None}, id="chain_peers-null"),
+        pytest.param({"chain_peers": {"a": "b"}}, id="chain_peers-object"),
+        pytest.param({"consumed_jtis": None}, id="consumed_jtis-null"),
+        pytest.param({"revoked_chains": None}, id="revoked_chains-null"),
+        pytest.param([], id="document-is-a-list"),
+        pytest.param("nonsense", id="document-is-a-string"),
+        pytest.param(None, id="document-is-null"),
+    ],
+)
+def test_a_wrong_shaped_state_file_neither_crashes_nor_reads_as_empty(
+    tmp_path: Path, document: object
+) -> None:
+    """Both halves of the review argument on this span, in one assertion pair.
+
+    Round 1 (GPT, BLOCKING): iterating a present-but-null key raised inside the
+    constructor, which runs from ``_get_state()``, so one malformed byte-range
+    500'd EVERY ``/api/auth/refresh``. A ``.get(key, [])`` default does not cover
+    it -- the key exists, so the default is never consulted.
+
+    Round 3 (GPT + Opus adjudication, UPHOLD-FENCED): reading it as EMPTY is the
+    opposite defect. These lists are security controls, so empty means "nothing
+    revoked, nothing consumed, nothing bound" -- i.e. every control satisfied.
+
+    So the store must do neither: construct without raising, and report itself
+    degraded rather than clean.
+    """
+    path = tmp_path / "refresh_chains.json"
+    path.write_text(json.dumps(document))
+
+    mgr = RefreshStateManager(state_path=path)
+
+    assert mgr.degraded_reason(), "a wrong-shaped file must not read as clean state"
+
+
+def test_an_absent_record_key_is_not_corruption(tmp_path: Path) -> None:
+    """Absence is fine; only a PRESENT unreadable record degrades the store.
+
+    This is the line that keeps the fail-closed posture from swallowing normal
+    installs: a fresh state file has no ``revoked_chains`` because nothing has
+    been revoked, and reading that as corruption would refuse every rotation on a
+    healthy system.
+    """
+    path = tmp_path / "refresh_chains.json"
+    path.write_text(json.dumps({"consumed_jtis": [], "revoked_chains": []}))
+    assert RefreshStateManager(state_path=path).degraded_reason() == ""
+
+    path.write_text(json.dumps({}))
+    assert RefreshStateManager(state_path=path).degraded_reason() == ""
+
+
+def test_an_unparseable_file_still_starts_empty(tmp_path: Path) -> None:
+    """The pinned behaviour this change deliberately does NOT touch.
+
+    ``test_tr_i_17_corrupted_state_file_starts_empty`` pins that a file which will
+    not parse starts empty rather than crashing, and its docstring records that it
+    was settled "per review-bot finding (post 34)". ``atomic_write`` makes a torn
+    write impossible, so a file that will not parse at all is better read as "not
+    our state" than as "our records, lost". Asserted here so a future round of the
+    fail-closed argument cannot quietly widen into it.
+    """
+    path = tmp_path / "refresh_chains.json"
+    path.write_text("not valid json {[")
+    mgr = RefreshStateManager(state_path=path)
+    assert mgr.degraded_reason() == ""
+    assert mgr.is_consumed("anything") is False
+
+
+def test_a_corrupt_revoked_chains_list_cannot_revive_a_revoked_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact harm the Opus adjudication upheld as non-self-healing.
+
+    Revoke a chain, then corrupt the list that records it. Read as empty,
+    ``is_chain_revoked`` answers False and the stolen cookie rotates into fresh
+    credentials -- and reuse detection does not save you, because it only re-fires
+    on a jti replay the attacker need not cause. So the token must be refused.
+    """
+    path = tmp_path / "refresh_chains.json"
+    live = RefreshStateManager(state_path=path)
+    monkeypatch.setattr(rt, "_state_singleton", live)
+
+    token, chain_id, _jti, exp = generate_refresh_token("alice")
+    live.revoke_chain(chain_id, exp)
+    assert rt.validate_refresh_token(token)[2] == "chain revoked"
+
+    # The record that carried the revocation is now unreadable.
+    path.write_text(json.dumps({"revoked_chains": None}))
+    monkeypatch.setattr(rt, "_state_singleton", RefreshStateManager(state_path=path))
+
+    valid, _user, reason, _c, _j, _e = rt.validate_refresh_token(token)
+    assert valid is False, "a revoked chain came back to life through a corrupt file"
+    assert reason.startswith("refresh state unavailable")
+
+
+@pytest.mark.asyncio
+async def test_a_wrong_shaped_state_file_refuses_rotation_without_a_500(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """At the endpoint: 401, not 500 (round 1) and not 200 (round 3)."""
+    path = tmp_path / "refresh_chains.json"
+    path.write_text(json.dumps({"chain_peers": None, "consumed_jtis": None}))
+
+    token, _chain, _jti, _exp = generate_refresh_token("alice")
+    monkeypatch.setattr(rt, "_state_singleton", RefreshStateManager(state_path=path))
+
+    response = await h.api_auth_refresh(_refresh_request(token))
+
+    assert response.status == 401
+    assert _body(response)["error"] == "invalid_refresh"
+
+
+def test_a_degraded_store_does_not_overwrite_the_unreadable_file(tmp_path: Path) -> None:
+    """Persisting would destroy the records AND silently self-heal into the bypass.
+
+    An empty write here loses whatever the operator still has on disk, and the
+    NEXT start would load a clean empty store and resume rotating -- converting a
+    refusal into the very bypass it exists to prevent. So the file is left alone.
+    """
+    path = tmp_path / "refresh_chains.json"
+    original = json.dumps({"revoked_chains": None})
+    path.write_text(original)
+
+    mgr = RefreshStateManager(state_path=path)
+    assert mgr.degraded_reason()
+    mgr.revoke_chain("some-chain", 9e12)  # triggers _persist
+
+    assert path.read_text() == original, "the unreadable file was overwritten"
+
+
+def test_a_malformed_chain_binding_does_not_brick_the_store(tmp_path: Path) -> None:
+    """One bad record must not take every refresh with it (mirrors the exp guard)."""
+    path = tmp_path / "refresh_chains.json"
+    path.write_text(
+        json.dumps(
+            {
+                "chain_peers": [
+                    {"chain_id": "bad", "peer_key": LAPTOP_KEY, "exp": "not-a-number"},
+                    {"chain_id": "good", "peer_key": PHONE_KEY, "exp": 9e12},
+                    {"chain_id": "nokey", "exp": 9e12},
+                ]
+            }
+        )
+    )
+    mgr = RefreshStateManager(state_path=path)
+    assert mgr.chain_peer("bad") == ""
+    assert mgr.chain_peer("nokey") == ""
+    assert mgr.chain_peer("good") == PHONE_KEY


### PR DESCRIPTION
## Problem / Motivation

A dashboard refresh cookie stolen from allowed tailnet node A and replayed from allowed node B rotates successfully, and the replacement access token comes back pinned to **B**.

Phase 3 pins ACCESS sessions to a daemon-verified tailnet peer, and #2411 made rotation carry that pin forward. The peer-bound rotation mechanism (`require_peer` / `peer_key`) exists and works — `/api/auth/refresh` verifies the carried key against the daemon-verified peer and refuses with `peer_mismatch` / `peer_unverified` / `peer_binding_missing` before any mint. But it was armed for exactly **one** producer: the persistent QR phone session in `tailnet_mobile.py`. Every ordinary Phase-3 session opened an unbound chain and took the `else` branch into `_rebind_rotated_token_to_peer`, which re-binds the rotated token to whoever presents it next.

Proven on `origin/main` before writing the fix: an ordinary `?token=` exchange with a verified laptop peer mints a chain with `require_peer` **absent**; replaying that cookie with the phone resolving returns `200` and `check_token_peer(new_access, PHONE_KEY)` is `True`.

## Why it matters

The refresh cookie is a 30-day bearer credential, and the chain was the laundering path around the access token's own device pin. Anyone who obtains one — a backup, a shared browser profile, a second machine the user also owns and someone else can reach — converts it into a fresh, fully-pinned session on their own device, and the audit trail attributes it to them as a legitimate peer. `kirocrew logout` is the only thing that ends it, which the remote-and-mobile guide already documents as a known gap.

## What changed (motivation → approach → change)

The existing mechanism is **extended** to ordinary Phase-3 sessions; no second mechanism is introduced.

- **`token_auth`** — an exchange that resolves a daemon-verified, allowlisted peer now opens its chain with `require_peer` + that peer's `peer_key`. Gated on a *resolved peer*, not on the pin key: that key is `ip:<addr>` when nothing resolved, and binding a chain to the tunnel's shared loopback address would read as a pin while excluding nobody.
- **`refresh_tokens`** — `refresh_chains.json` gains a `chain_peers` record (`chain_id` → `peer_key`, `exp`): evicted with its chain, dropped on revocation, and re-stamped inside the *same locked write* as the consumption, so one rotation still costs one state write and can never record a spent jti while losing the binding that decides who may spend its replacement. Malformed records are skipped rather than fatal, mirroring the existing `exp` guard.
- **`auth_refresh`** — the signed claim and the server-side record are two **independent** authorities, and the request must satisfy every key either of them names. The record earns its place because this gap *was* one mint path carrying the claim while the others did not: a rotation path that drops the claim is caught by the record it cannot influence. **It does not cover a future *mint* path that omits both** — such a chain has no claim and no record, which is indistinguishable from a legitimate pre-upgrade chain and so rotates unbound. Making that detectable would need a positive marker on every unbound chain (a schema version, or an explicit `unbound` record) so absence stops meaning "legacy"; that is a wider design move than this PR, and moot while the legacy-chain question below is still open. Credit to Design Review for catching the overclaim.
- **`dashboard.tailscale.bind_refresh_chains`** (default `true`) is the operator's opt-out. Narrowing-only like the two existing tailscale load rules — a non-boolean resolves to `true` — so a typo can only ever leave the binding on.

**Security property now enforced:** a refresh chain opened by a daemon-verified tailnet peer can only be rotated for that same peer key. A different node (node scope) or a different login is refused with `peer_identity_mismatch` and audited. The refusal does **not** revoke the chain: identity resolution fails transiently as often as maliciously, and burning a 30-day credential over a daemon blip would turn a recoverable hiccup into a re-mint.

### The roaming tradeoff @NicholasRBowers raised

`pin_scope` already owns roaming, and the binding respects it rather than overriding it:

- At **`login`** scope the pin key is `ts:login:<login>`, so the same person's other device rotates normally. Roaming works with the binding on. (Test: `test_login_scope_still_roams_between_the_users_own_devices`.)
- At **`node`** scope (the default) the ACCESS token was *already* device-pinned in-memory. So an unbound chain was the only thing making cross-device use appear to work — by laundering a fresh pin on rotation, which is the defect itself, not a feature the guide promised.
- `bind_refresh_chains: false` covers the operator who genuinely needs cross-device roaming at node scope and accepts that a stolen refresh cookie then renews from any allowed node. Documented as that tradeoff in both the guide and the spec.

### Migration

Absence, per the issue's scope note. A chain with neither the signed claim nor a `chain_peers` record is unbound — that is every chain outstanding at upgrade, and every session opened with no verified peer — so the change logs nobody out by itself.

### Unreadable persisted state fails closed, and does not crash

Three review rounds landed on this one function from opposite directions. The
invariant now shipped satisfies all of them:

> **Absence is fine; corruption of a PRESENT security record is not.**

| State of `refresh_chains.json` | Reading | Why |
|---|---|---|
| missing / unparseable | start empty *(unchanged, pinned)* | `atomic_write` makes a torn write impossible, so a file that will not parse is "not our state", not "our records, lost" |
| key absent | no records | a fresh install has revoked nothing; refusing here would deny rotation on every healthy system |
| key present, not a list | **degraded — refuse** | the records existed and cannot be read, so no control can be proven satisfied |
| top-level valid-JSON non-dict | **degraded — refuse** | it parsed, so this is not the unreadable-file case: something replaced our records with a document that cannot hold any |
| one element not a mapping | filtered | junk beside good entries is not evidence the good ones are untrustworthy |

Round 1 (GPT, BLOCKING) was that a malformed container **raised** inside the
`RefreshStateManager` constructor — which runs from `_get_state()` — so one bad
byte-range 500'd **every** `/api/auth/refresh` until the file was hand-repaired.
A `.get(key, [])` default does not cover it: the key exists, so the default is
never consulted.

Round 3 (GPT, upheld by the Opus adjudication) was that reading it as **empty**
is the opposite defect, and the more serious one: `revoked_chains` read as empty
makes `is_chain_revoked` answer `False` for a chain `POST /api/auth/logout`
already killed, so a stolen cookie rotates into fresh credentials. Nothing
self-corrects it — reuse detection only re-fires on a jti replay the attacker
need not cause.

So `_record_list` returns `None` for a present-but-unreadable list, `_load`
records which keys were unreadable, and `validate_refresh_token` refuses with
`"refresh state unavailable"` — placed **before** `is_chain_revoked`, since that
is the check being bypassed. It is the same posture, and the same wording shape,
the function already applies twelve lines down when the revocation counter cannot
be read. `_persist` also refuses while degraded: writing our empty in-memory
state over the operator's file would destroy the records *and* let the next start
load a clean store and resume rotating, converting the refusal into the bypass it
exists to prevent.

Availability cost, stated plainly: **all rotation stops until the file is
repaired or removed.** The ~20h access cookie masks it, `revocation_gen` lives in
a separate file so `kirocrew logout` still works, and the condition is loud
(`logger.error` naming the path and the affected keys).

**The seam this leaves, named rather than shipped quietly.** An unparseable or
*deleted* file still starts empty, so `{"revoked_chains": null}` refuses all
rotation while `rm refresh_chains.json` silently drops the same revocations. That
asymmetry is deliberate and is scoped to **accidental** corruption — a hand-edit,
a foreign or legacy format, a bad restore. It is not a defence against an
adversarial write, and cannot be: this file lives beside `token_signing.key` in
the same `0700` data home, so anyone who can write one can write the other and
mint arbitrary tokens outright. Closing the seam properly would need a positive
"I have no records" marker (a schema version, or a sentinel) so that *absence*
stops being ambiguous with *fresh install* — a wider format change than this PR
should carry, and the reason the unparseable-file branch is left exactly as
`test_tr_i_17_corrupted_state_file_starts_empty` pins it. A regression test now
asserts that boundary so a future round of this argument cannot quietly widen
into it.

### ⚠️ Residual tradeoff, flagged for a maintainer call

The `require_peer` claim is carried onto **both** halves of the rotated pair. Binding only the chain would leave the access cookie with the same laundering shape one credential over: after a restart the in-memory pin map is empty, so a stolen access cookie is re-pinned to whichever allowed node presents it first. Binding both closes that sibling hole for free and keeps the two credentials consistent.

The cost: an access cookie carrying `require_peer` fails closed when no peer resolves, so **a session bound this way needs one re-mint via the `kirocrew token` URL after an operator switches identity trust off.** That is the same fail-closed posture the QR `require_peer` shape already has, but it is new for ordinary sessions, so it is a maintainer decision rather than mine. The narrower alternative — bind the chain only, leave the rotated access token as today — is a two-line change if you prefer it; I did not take it because it leaves the post-restart takeover hole open on the access cookie.

## Tests

`test/test_refresh_peer_binding.py` — 23 tests, red before / green after. The exploit was reproduced against unmodified `main` first (see Manual verification).

| Test | Locks in |
|---|---|
| `test_stolen_refresh_cookie_cannot_rotate_from_another_allowed_node` | the exploit end to end: steal from laptop, replay from phone → `peer_identity_mismatch`, no `Set-Cookie`, jti not consumed, chain not revoked |
| `test_the_original_node_still_rotates_its_own_chain` | the legitimate device keeps its session, and the binding survives onto the rotated pair (so the *second* rotation is not silently unbound) |
| `test_ordinary_phase3_exchange_binds_the_chain_it_opens` | the mint side — the gap was here |
| `test_the_chain_binding_is_persisted_for_the_next_gateway` | the on-disk `chain_peers` shape, and a fresh manager reading it back (the restart case) |
| `test_a_non_tailnet_exchange_still_opens_an_unbound_chain` | ordinary token+IP installs are untouched |
| `test_the_rotated_access_token_carries_the_signed_device` | both halves of the rotated pair carry the binding |
| `test_a_rotated_access_token_is_refused_for_another_node_after_restart` | no first-arrival takeover with an empty pin map, and the original device still authenticates |
| `test_login_scope_still_roams_between_the_users_own_devices` | the roaming resolution above |
| `test_the_opt_out_restores_the_unbound_chain` | `bind_refresh_chains: false` |
| `test_a_pre_upgrade_chain_keeps_todays_unbound_semantics` | the migration rule |
| `test_the_persisted_record_alone_refuses_a_different_peer` | the record as an independent authority, with no claim on the token at all |
| `test_a_bound_chain_cannot_rotate_while_identity_is_unverifiable` | fail closed on an unresolvable peer, **without** revoking |
| `test_revoking_a_chain_drops_its_peer_record` | no binding outliving its chain |
| `test_an_expired_chain_binding_is_evicted` | the state file stays bounded |
| `test_a_malformed_chain_binding_does_not_brick_the_store` | one bad record does not take every refresh with it |
| `test_a_wrong_shaped_state_file_does_not_500_every_refresh` | the round-1 blocker, parametrized over all three record keys and three non-object documents |
| `test_a_wrong_shaped_state_file_still_serves_a_rotation` | the same finding at the endpoint it broke — `/api/auth/refresh` answers `200`, not `500` |

**Regression sweep** — this is exactly the code where a narrow fix breaks a legitimate flow, so the sweep is wider than the new file: **875 passed, 3 skipped, 0 failed** across the auth / refresh / tailnet / token_auth / config-loader / config-baseline / peer-auth / mobile-link selection, including all 50 existing `test_auth_refresh_handlers_cov80.py` tests and the full `test_refresh_tokens.py` and `test_token_auth.py` files. An earlier sweep on the pre-rebase tree ran 4444 tests over a wider selection with the same result.

Gates, all green on the rebased tree: `black` (baselined), `isort`, `flake8`, `mypy` (1288 files, no issues), `docs-lint` (261 files), plus the repo's `check_*` gates for subprocess encoding, agent-SDK boundary, sync-IO-in-async, lockdown-before-publish, loop-bound locks, builtin-skill scope, testpaths coverage, brand name, harness parity, feature map, changelog history, and focus cue. `config-baseline.json` was regenerated for the new config field.

The diff-scoped runner escalates to the full backend suite for this surface; that full run is deferred to CI's sharded `Backend Tests` lanes, which is where it completes in reasonable time.

## Manual verification

The exploit was reproduced as an executable probe against unmodified `origin/main` before any source change — the ordinary `?token=` link exchange minted `require_peer`-absent, the phone's replay returned `200`, and `check_token_peer(new_access, PHONE_KEY)` was `True`. That probe is not committed; its assertions live on as `test_stolen_refresh_cookie_cannot_rotate_from_another_allowed_node` with the outcome inverted.

**One `nosemgrep` added, for a proven false positive.** `python-logger-credential-disclosure`
fired on the two new `logger.warning` calls in `refresh_tokens.py`, and the
"potential hardcoded secret" it names is the **format string itself** — the
literal begins `"refresh_tokens: ..."`, which contains "token". Neither call logs
a credential: one logs a JSON field *name* (`"chain_peers"` / `"consumed_jtis"` /
`"revoked_chains"`) plus a type name, the other a file path plus a type name.
Suppressed in the form this repo already uses for this exact rule
(`sel.py:1388`, `slack/scope_probe.py:65`, `providers/acp.py:1108`,
`mcp_gateway/credwatch.py:206`): a comment naming what *is* logged, then the rule
id inline. The module's four pre-existing `"refresh_tokens: ..."` log calls carry
the same false positive and are simply baselined, since the gate scans diff-only.
Rewording was the alternative, but it would break the six-call prefix convention
this module relies on for log grepping.

Not exercised against a live tailnet: every test fakes `resolve_forwarded_peer`, which is how the existing peer tests in this area work too, so the daemon-facing half (`tailscale whois` behind `tailscale serve`) is unchanged and uncovered here as before.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change — auth handlers, the refresh-token module, config schema, and docs. No frontend file is touched and no rendered surface changes (CI's `Frontend Lint & Type Check` and `Bundle Size Gate` both skip on this diff).

## Related Issues

Follow-up from #2411 (issue #1762, RFC `rfc-tailnet-dashboard-access` Phase 3).

Closes #2417

## Pattern harvest

Rule candidate: review-prompt

Pattern: a security mechanism whose enforcement is complete but whose *arming* has exactly one producer.

The verify side here was correct and well-tested from day one; the defect was that only one of several mint paths set the claim it verifies, so the check was unreachable for every other session shape. Worth asking on review of any new signed claim: *which mint paths can reach this check, and which silently bypass it by omitting the claim?* The same question applies to `boot`, `no_refresh`, and `embed_parent_port` in this file, each of which carries its own "carried, never re-derived" comment for the same reason.

Design Review sharpened this into the form worth keeping: a second authority protects the paths that carry *part* of the state, but **absence is not detectable** — a producer that omits every marker is indistinguishable from a legitimate legacy record. So the durable guard for the next producer is the review question above, not the record.

Also generalizable as a design rule, applied in this PR: when a signed claim gates a security decision, keep a **server-side record the credential cannot influence** as a second authority, so the next mint path that forgets the claim fails closed instead of silently unbound.

## Review dispositions

Every raised concern is answered in its own comment on this PR. Summary:

| Lane | Finding | Disposition |
|---|---|---|
| GPT r1 | malformed `chain_peers` crashes every refresh | **fixed** — shared chokepoint, 7 shapes, 5 pre-existing |
| GPT r2 | tests leak process-global auth state | **fixed** — the isolation fixture `test_token_auth.py` already uses; leak measured (10 bindings + a pinned store) |
| GPT r3 | malformed security lists must not read as empty | **needs-a-decision** — hit #2 on this span, and it asks the opposite of r1; the coherent invariant reverses a pinned test |
| GPT r3 | legacy chains replayable across peers | **needs-a-decision** — the migration ruling #2417 deferred to a named owner |
| Design | access-token binding is a wider change | **needs-a-decision** — escalated, not merged by default |
| Design | record does not cover a forgetful *mint* path | **accepted** — overclaim removed from this body |
| First Principles | `chain_peer()` wrapper has 0 consumers | **fixed** — deleted |
| First Principles | the opt-out serves the case the PR calls the defect | **needs-a-decision** — keep with an explicit yes, or drop it |

Four decisions are with the maintainer; nothing else is outstanding.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff



