### PR TITLE
fix(autopilot): enforce the round cap, bound the plan, refuse dead plans

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -185,7 +185,6 @@ src/kiro_crew/connections/l0_probe.py
 src/kiro_crew/connections/l0_record.py
 src/kiro_crew/connections/registry.py
 src/kiro_crew/connections/tool_aliases.py
-src/kiro_crew/context_management.py
 src/kiro_crew/crew_chat.py
 src/kiro_crew/cron_history.py
 src/kiro_crew/dashboard/cautious_boot.py
@@ -525,7 +524,6 @@ test/test_cloud_ec2.py
 test/test_cloud_handlers.py
 test/test_cloud_launch_job.py
 test/test_collection_status_endpoint.py
-test/test_completion_result_read_off_loop.py
 test/test_computer_use_apps.py
 test/test_computer_use_overlay.py
 test/test_computer_use_skylight.py

--- a/config-baseline.json
+++ b/config-baseline.json
@@ -1224,7 +1224,8 @@
       "hasChildren": true,
       "enumValues": null,
       "defaultValue": {
-        "stage_timeout_seconds": 1800
+        "stage_timeout_seconds": 1800,
+        "max_plan_duration_seconds": 7200
       }
     },
     {
@@ -1240,6 +1241,20 @@
       "hasChildren": false,
       "enumValues": null,
       "defaultValue": 1800
+    },
+    {
+      "path": "orchestrator.max_plan_duration_seconds",
+      "kind": "core",
+      "type": "integer",
+      "required": false,
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "label": "Max Plan Duration",
+      "help": "Ceiling for a WHOLE auto-run plan in seconds, checked at each stage boundary, with one warning at 75% of the budget. The per-stage timeout above multiplies by stage count, so without this a long plan can run unattended for hours. 0 disables. Default 2 h.",
+      "hasChildren": false,
+      "enumValues": null,
+      "defaultValue": 7200
     },
     {
       "path": "messaging",

--- a/docs/system-specs/modules/autopilot.md
+++ b/docs/system-specs/modules/autopilot.md
@@ -29,7 +29,7 @@ is Autopilot") so the model recognizes user references to *autopilot* /
 
 | File | Role |
 |------|------|
-| `dashboard/chat_orchestrator.py` | `_stage_loop` (the stage driver), `_build_stage_context`, `_capture_stage_result`, `api_chat_plan_action` |
+| `dashboard/chat_orchestrator.py` | `_stage_loop` (the stage driver), `_build_stage_context`, `_collect_stage_result_parts` + `_write_stage_result`, `api_chat_plan_action` |
 | `context_management.py` | `OrchestrationTracker`, plan-format validation (`validate_plan_format`, `looks_like_plan`, `ensure_go_all_option`, `strip_plan_markers`, `rephrase_plan`, `extract_plan_metadata`), and all size caps |
 | `dashboard/chat_runner.py` | `_run_chat` (one LLM turn) plus the end-of-turn plan detector that arms the gate |
 | `dashboard/chat_title.py` | `_reset_auto_run_for_new_plan`, `_extract_and_redact_plan_metadata`, `_rephrase_plan_lite` |
@@ -191,27 +191,69 @@ approvals live on separate endpoints an iframe cannot reach.
 ## Execution: the stage loop
 
 `_stage_loop` (`dashboard/chat_orchestrator.py`) owns stage boundaries in Python, not
-in the prompt. It creates the tracker if absent (timeout from
-`orchestrator.stage_timeout_seconds`), resumes at `tracker.current_stage` when
-rounds already exist, and for each stage index:
+in the prompt. It creates the tracker if absent, loads the budgets
+(`orchestrator.stage_timeout_seconds` and `orchestrator.max_plan_duration_seconds`)
+whenever `tracker.budgets_unset` says this tracker has never had them applied,
+resumes at `tracker.current_stage` when rounds already exist, and for each stage
+index:
+
+**A plan whose stages are gone is refused, before anything else.** If
+`slot._plan_stage_count` is 0 the loop posts `⚠️ This plan is no longer active …`,
+logs `auto_run_plan_expired` / `plan_shape_absent`, closes the turn out
+(`chat_done`, `slot.task = None`) and returns — no tracker, no config load, no
+turn. `mode` is persisted and the transcript keeps the plan turn's
+`[OPTION: Go | Go All | Cancel]` row, so a restored slot renders buttons over a
+plan that no longer exists; pressing one used to run zero stages and return in
+total silence (`range(start_idx, 0)` is empty and the completion message is gated
+on `start_idx < total`), which is indistinguishable from a hang. The same gate
+covers a planning turn that parsed no stages, so the message names the state
+rather than a cause. See [Limitations](#limitations) for why the plan is not
+persisted instead.
+
+The budget load is gated on the TRACKER, not on whether this loop created it.
+Gating on `tracker is None` meant a tracker the loop did not build — one created
+lazily by `slack/gateway.py` when a subagent result landed — ran the whole plan on
+constructor defaults, with the plan watchdog sitting at `0` (disabled). A tracker
+constructed WITH an explicit budget answers `budgets_unset == False`, so a paused
+plan's later Go still pays for no load, and `mark_budgets_loaded()` is recorded
+even when the load raised so one bad config read cannot become one per stage-loop
+entry.
 
 1. Break if `_orchestration_stopped(slot, tracker)` — see
    [Stop and Cancel](#stop-and-cancel) for why both flags are read.
 2. **Clamp**: break if `stage_idx >= slot._plan_stage_count`. `total` is
    captured once when the range is built, so a plan that shrank mid-run would
    otherwise emit a phantom "Stage N of M" with N > M.
-3. Check `tracker.is_stage_timed_out()` **before** recording the round, because
-   `record_round` restarts the stage clock. On timeout: clear `_auto_run`, post
+3. **Whole-plan watchdog.** Break if `tracker.is_plan_timed_out()`
+   (`orchestrator.max_plan_duration_seconds`, default 2 h), clearing `_auto_run`
+   and logging `auto_run_timeout` / `plan_duration_exceeded`. Checked at the
+   boundary rather than mid-turn: the running stage has its own ceiling, and
+   cutting between stages leaves every finished stage captured and resumable.
+   `tracker.plan_warning_due()` posts one notice — latched in the tracker — once
+   the run passes `PLAN_WARN_FRACTION` (75%) of that budget. **Enforced under
+   `auto_run` only**: a stage-gated plan spends its wall-clock at approval
+   prompts, and the user clicking each stage is the ceiling. The clock is not
+   re-armed when a plan that was stepped through attended is later switched to
+   Go All, so attended time does count in that one mixed case. Deliberate: the
+   budget is a property of the plan, not of the mode, and a re-arm would let
+   Go/Go All alternation refresh the ceiling indefinitely.
+4. Check `tracker.is_stage_timed_out()` **before** entering the stage, because
+   `start_stage` restarts the stage clock. On timeout: clear `_auto_run`, post
    the elapsed notice, log `auto_run_timeout`, break.
-4. `tracker.record_round(stage_num)` and append a `───── Stage N: Title ─────`
-   separator (class `stage-sep`).
-5. `_build_stage_context` composes the goal, a `status_summary` checklist
+5. `tracker.start_stage(stage_num)` and append a `───── Stage N: Title ─────`
+   separator (class `stage-sep`). `start_stage` registers the stage at **zero
+   rounds** and restarts the stage clock; it deliberately spends no round, because
+   a round is one spawn wave and entering a stage is not one. The loop used to
+   enter through `record_round` — inert while nothing here read the cap, but once
+   the cap is enforced that tick left only 2 waves before the cut on this path
+   while the Slack path still got 3.
+6. `_build_stage_context` composes the goal, a `status_summary` checklist
    (completed / execute-now / pending), previous stage results, the current
    stage's title and bullets, and an explicit "execute Stage N of M now"
    instruction. It is appended as a hidden user message (`auto-go` class) and
    passed to `_run_chat`. An exception from `_run_chat` clears `_auto_run`,
    posts a stage-error notice, logs `auto_run_stage_error`, and breaks.
-6. **Wait for the stage's sub-agents.** Polls
+7. **Wait for the stage's sub-agents.** Polls
    `state.subagents.running_agents_for("dashboard:<slot>")` every 2s, up to 150
    rounds (5 minutes), broadcasting a `chat_status` count every 10 polls. This
    is **fail-closed**: a missing manager, or `running_agents_for` returning
@@ -219,13 +261,27 @@ rounds already exist, and for each stage index:
    `auto_run_subagent_check_failed` SEL event rather than silently skipping
    verification. Exhausting the 150 rounds stops auto-run with
    `auto_run_subagent_timeout`.
-7. `_capture_stage_result` concatenates the assistant messages back to this
-   stage's separator and writes
-   `~/.kiro/crew/sessions/<slot>/stage_<n>_result.md`; the path is recorded on
-   the tracker. Redaction is re-applied here even though both upstream sources
-   are already clean, because this writes a NEW file outside the history log's
-   own redaction pass (redaction is idempotent, so the common case is a no-op).
-8. If not `auto_run` and another stage remains: post
+8. **Capture the stage result**, split across the thread boundary.
+   `_collect_stage_result_parts` walks the assistant messages back to this
+   stage's separator **on the loop**, because `slot.messages` is live state the
+   loop mutates; it returns an immutable tuple of raw strings, which
+   `_write_stage_result` then redacts and writes to
+   `~/.kiro/crew/sessions/<slot>/stage_<n>_result.md` **on a worker**. The path
+   is recorded on the tracker. Redaction is re-applied here even though both
+   upstream sources are already clean, because
+   this writes a NEW file outside the history log's own redaction pass
+   (redaction is idempotent, so the common case is a no-op).
+9. **Round cap after the wave — auto-run only.** Break if the stage has spent
+   `MAX_STAGE_ROUNDS`, clearing `_auto_run` and logging `auto_run_round_cap` /
+   `stage_round_cap` — a request for guidance, not a terminal verdict. Gated on
+   `auto_run` like the watchdog: an attended stage that spent exactly its
+   allowed waves and finished falls through to the normal Go prompt rather than
+   being told "Auto-run stopped" with no Go row. Every
+   round is recorded in one place, `_subagent_done` against
+   `tracker.current_stage` as each spawn wave finishes, which is why this gate is
+   placed after the wave rather than on entry. Placed **after** the capture too,
+   so a stage that genuinely finished keeps its result on disk.
+10. If not `auto_run` and another stage remains: post
    `✅ Stage N complete. Click **Go** to proceed to …` plus a fresh
    `[OPTION: Go | Go All | Cancel]`, mark the loop paused, and return. The
    user's next Go re-enters `_stage_loop`.
@@ -259,8 +315,15 @@ cannot talk its way past.
 | Limit | Value | Scope | Effect |
 |-------|-------|-------|--------|
 | `MAX_TASK_FAILURES` | 3 | per `task_key` (first 80 chars of the task) | System text: must ask the user for guidance before retrying |
-| `MAX_STAGE_ROUNDS` | 3 | per stage | System text: must ask the user for guidance before spawning more |
-| `MAX_STAGE_ESCALATIONS` | 2 | per stage | `is_force_failed()` becomes true: must stop and report, no retry |
+| `MAX_STAGE_ROUNDS` | 3 | per stage | Slack: system text to ask for guidance. Dashboard: `_stage_loop` halts the plan after the stage's wave (`auto_run_round_cap`). All 3 belong to spawn waves — stage entry spends none |
+| `MAX_STAGE_ESCALATIONS` | 2 | per stage | `is_force_failed()` becomes true: must stop and report, no retry. Enforced in `_subagent_done` only |
+
+`MAX_STAGE_ESCALATIONS` is deliberately **not** checked by `_stage_loop`, and that
+is a reachability fact rather than a preference. Escalations are only recorded by
+`reset_after_guidance`, which zeroes the capped stage's rounds while KEEPING its
+key — so `current_stage` (the highest key) does not move, the loop's next entry
+starts at the stage after it, and an escalated stage is never re-entered. Nothing
+on that path can observe `is_force_failed`, so a check there would be dead code.
 
 Sub-agent outcomes feed the tracker from `slack/gateway.py`'s `_subagent_done`
 (`_subagent_done` in `slack/gateway.py`), which resolves the tracker from the parent's **dashboard
@@ -323,6 +386,7 @@ the wrong trade.
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `orchestrator.stage_timeout_seconds` | `1800` | Wall-clock budget per stage before auto-run stops. `0` disables the check. |
+| `orchestrator.max_plan_duration_seconds` | `7200` | Wall-clock budget for the WHOLE plan, checked at each stage boundary, with one warning at 75%. `0` disables the check. |
 | `agent.conductor_skill` | `false` | Emits the always-on delegation skill. Independent of Autopilot: it changes routing knowledge, not the prompt. |
 
 Frontend-side, `defaultAutopilot` in the browser-local chat config
@@ -379,12 +443,24 @@ however long the plan runs.
 
 ## Limitations
 
-- **Plan progress is not persisted.** `_orch_tracker`, `_stage_titles`,
-  `_plan_goal`, `_stage_descriptions`, and `_auto_run` are in-memory `_ChatSlot`
-  attributes and are absent from both `to_dict()` and the persisted history meta
-  line (only `mode` is written, by `_save_slot_to_history`), so a gateway
-  restart or crash loses stage position and the plan must be re-approved. The
-  `stage_*_result.md` files on disk survive, but nothing reloads them.
+- **Plan progress is not persisted, and a restart ends the plan.**
+  `_orch_tracker`, `_stage_titles`, `_plan_goal`, `_stage_descriptions` and
+  `_auto_run` are in-memory `_ChatSlot` attributes, absent from both `to_dict()`
+  and the persisted history meta line (only `mode` is written, by
+  `_save_slot_to_history`), so a gateway restart or crash loses the plan. The
+  `stage_*_result.md` files on disk survive; nothing reloads them.
+
+  This is a choice, not an omission. Autopilot is a lightweight executor of a plan
+  the user is watching, not a task runner that owns work across process lifetimes:
+  resuming means restoring an execution ledger (which stage ran, how many rounds it
+  spent, which results are real), and every one of those restored facts is a way to
+  re-run a completed stage's side effects or to skip a stage that never ran. A
+  plan is cheap to re-ask for; a mis-resumed plan is not.
+
+  What the module owes the user is therefore honesty rather than continuity: the
+  restored slot's `[OPTION: …]` row still renders, and pressing Go gets
+  `⚠️ This plan is no longer active …` (`auto_run_plan_expired`) instead of the
+  silence it used to get. See [the stage loop](#execution-the-stage-loop).
 - Mode cannot be switched while the slot is running: `api_chat_slot_mode`
   returns `409`.
 - Sub-agent wait is capped at 5 minutes per stage; a longer fan-out stops
@@ -395,6 +471,10 @@ however long the plan runs.
 | Area | Location |
 |------|----------|
 | Tracker limits, timeout, `timeout_human`, caps, stale-session cleanup | `test/test_context_management.py` |
+| Round cap enforced on the dashboard path; stage entry spends no round | `test/test_stage_round_cap_enforced.py` |
+| Whole-plan watchdog, the 75% notice, budget loading for a tracker the loop did not build | `test/test_plan_duration_watchdog.py` |
+| Config load off the loop thread, and the cancel/stop windows it opens | `test/test_orchestrator_config_load_off_loop.py` |
+| A plan with no stages is refused out loud rather than silently skipped | `test/test_expired_plan_is_refused.py` |
 | Stage loop guard lifetime, shrink clamp, plan-action routing, plan detection scoped to planning turns, widget-origin `go all` refusal | `test/test_dashboard_chat.py` |
 | Prompt binds the "Autopilot" name | `test/test_prompt_autopilot_binding_rule.py` |
 | `parseOptions` marker/plan parsing | `website/src/test/AssistantMessage.test.tsx` |

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2845,6 +2845,18 @@ class KiroCrewConfig:
                 stage_timeout_seconds=_safe_int(
                     orchestrator_data.get("stage_timeout_seconds", 1800), 1800
                 ),
+                # Default read off the dataclass rather than imported: the loader's
+                # re-export list from config.sections is a frozen boundary snapshot
+                # (test_config_module_boundaries), and this keeps
+                # DEFAULT_MAX_PLAN_DURATION as the single source of truth without
+                # adding an alias to it.
+                max_plan_duration_seconds=_safe_int(
+                    orchestrator_data.get(
+                        "max_plan_duration_seconds",
+                        OrchestratorConfig.max_plan_duration_seconds,
+                    ),
+                    OrchestratorConfig.max_plan_duration_seconds,
+                ),
             ),
             watchdog=WatchdogConfig(
                 check_after_secs=_safe_float(watchdog_data.get("check_after_secs", 60.0), 60.0),

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -61,6 +61,9 @@ logger = logging.getLogger("kiro_crew.config.loader")
 
 DEFAULT_MODEL = "auto"
 DEFAULT_SESSION_TIMEOUT = 3600  # 60 min
+# Ceiling for a WHOLE orchestrator plan. The per-stage timeout multiplies by
+# stage count, so this is the only bound on total unattended runtime.
+DEFAULT_MAX_PLAN_DURATION = 7200  # 2 h
 # Auto-compaction threshold, as a percentage of the context window. Named
 # because two code paths need it — the dataclass field default (used only when
 # there is no config file) and the dict-load fallback in ``load()`` (used when
@@ -1361,6 +1364,16 @@ class OrchestratorConfig:
         default=1800,
         metadata=_meta(
             "Stage Timeout", "Max seconds per stage before auto-run stops. Default 30 min."
+        ),
+    )
+    max_plan_duration_seconds: int = field(
+        default=DEFAULT_MAX_PLAN_DURATION,
+        metadata=_meta(
+            "Max Plan Duration",
+            "Ceiling for a WHOLE auto-run plan in seconds, checked at each stage "
+            "boundary, with one warning at 75% of the budget. The per-stage "
+            "timeout above multiplies by stage count, so without this a long "
+            "plan can run unattended for hours. 0 disables. Default 2 h.",
         ),
     )
 

--- a/src/kiro_crew/context_management.py
+++ b/src/kiro_crew/context_management.py
@@ -61,6 +61,30 @@ MAX_TASK_FAILURES = 3
 MAX_STAGE_ROUNDS = 3
 MAX_STAGE_ESCALATIONS = 2  # after 2 escalations (= 9 rounds), force-fail
 
+# Whole-plan watchdog. ``stage_timeout_seconds`` bounds one stage; a plan with
+# many stages multiplies it, so a 10-stage plan at the 30-minute default can run
+# for hours unattended. This is the ceiling for the WHOLE run, checked at each
+# stage boundary, with a single warning once the run passes
+# ``PLAN_WARN_FRACTION`` of it so the user can intervene before the cut.
+PLAN_WARN_FRACTION = 0.75
+
+# Fallback per-stage budget for a tracker built without one. The authoritative
+# value is ``orchestrator.stage_timeout_seconds``; this is only what the tracker
+# runs on between construction and the config load.
+DEFAULT_STAGE_TIMEOUT = 1800
+
+
+def _human_secs(seconds: int) -> str:
+    """Render a second count as ``30m`` / ``1m30s`` / ``45s``."""
+    if seconds >= 3600:
+        h, rem = divmod(seconds, 3600)
+        m = rem // 60
+        return f"{h}h{m}m" if m else f"{h}h"
+    if seconds >= 60:
+        m, rem = divmod(seconds, 60)
+        return f"{m}m{rem}s" if rem else f"{m}m"
+    return f"{seconds}s"
+
 
 class OrchestrationTracker:
     """Track failures and rounds per orchestrated session.
@@ -68,14 +92,30 @@ class OrchestrationTracker:
     Enforces hard limits that the LLM prompt cannot override.
     """
 
-    def __init__(self, stage_timeout_seconds: int = 1800) -> None:
+    def __init__(self, stage_timeout_seconds: int | None = None) -> None:
+        # ``None`` means "not provided -- load it from config", which is a
+        # different state from an explicit value that happens to equal the
+        # default. The stage loop reads ``budgets_unset`` to decide whether it
+        # owes this tracker a config load, so a tracker built without budgets
+        # (the Slack gateway creates one lazily when a subagent result lands) gets
+        # one, while a caller that passed a budget keeps exactly what it passed.
+        self._budgets_unset: bool = stage_timeout_seconds is None
         self._task_failures: dict[str, int] = {}  # task_key → failure count
         self._stage_rounds: dict[int, int] = {}  # stage_num → round count
         self._stage_escalations: dict[int, int] = {}  # stage_num → escalation count
         self._stage_results: dict[int, str] = {}  # stage_num → result file path
         self.stopped: bool = False
-        self._stage_timeout: int = stage_timeout_seconds
+        self._stage_timeout: int = (
+            DEFAULT_STAGE_TIMEOUT if stage_timeout_seconds is None else stage_timeout_seconds
+        )
         self._stage_start: float = 0.0  # set when stage begins
+        # Whole-plan watchdog. Monotonic deliberately: it measures how long THIS
+        # process has been running the plan, which is all it ever has to measure --
+        # a plan does not outlive its process (nothing persists the plan shape, so
+        # a restart ends the plan; see the module spec's Limitations).
+        self._plan_timeout: int = 0  # 0 = disabled
+        self._plan_start: float = 0.0  # set when the plan's first stage is entered
+        self._plan_warned: bool = False  # the 75% notice fires once per plan
 
     def stop(self) -> None:
         """User requested stop after escalation."""
@@ -84,9 +124,8 @@ class OrchestrationTracker:
     @property
     def has_escalated(self) -> bool:
         """True if any task hit failure limit or any stage hit round limit."""
-        return (
-            any(v >= MAX_TASK_FAILURES for v in self._task_failures.values())
-            or any(v >= MAX_STAGE_ROUNDS for v in self._stage_rounds.values())
+        return any(v >= MAX_TASK_FAILURES for v in self._task_failures.values()) or any(
+            v >= MAX_STAGE_ROUNDS for v in self._stage_rounds.values()
         )
 
     def reset_after_guidance(self) -> None:
@@ -118,9 +157,65 @@ class OrchestrationTracker:
     def record_round(self, stage: int) -> bool:
         """Record a spawn round for a stage. Returns True if limit reached."""
         self._stage_rounds[stage] = self._stage_rounds.get(stage, 0) + 1
-        if self._stage_rounds[stage] == 1 or not self._stage_start:
+        # Only ever STARTS the stage clock, never restarts it: the clock belongs
+        # to the stage, and `start_stage` owns the reset. The old `rounds == 1`
+        # arm was that reset, from when entering a stage and recording a round
+        # were the same call; it is unreachable now, because the only caller that
+        # introduces a new stage key is the loop, which enters through
+        # `start_stage`. The Slack handler records against `current_stage`, an
+        # existing key. Left as a floor for a tracker whose first round arrives
+        # with no stage entry at all (the lazily created Slack-only tracker) and
+        # after `reset_after_guidance` zeroes it.
+        if not self._stage_start:
             self._stage_start = time.monotonic()
+        # The whole-plan clock starts with the plan's first round and is never
+        # restarted by a later one: it is the budget for the RUN, not for a
+        # stage, so re-arming it here would make every stage boundary refresh
+        # the ceiling the watchdog is supposed to enforce.
+        if not self._plan_start:
+            self._plan_start = time.monotonic()
         return self._stage_rounds[stage] >= MAX_STAGE_ROUNDS
+
+    def start_stage(self, stage: int) -> None:
+        """Mark *stage* as the one now executing, without spending a round.
+
+        A round is one SPAWN WAVE -- the unit the subagent-completion handler
+        records, and the unit ``MAX_STAGE_ROUNDS`` budgets, because that is what
+        the orchestrator prompt promises the model ("max 3 rounds per stage").
+        Entering a stage is not a wave.
+
+        The stage loop used to enter through :meth:`record_round`, called for its
+        side effects rather than its count -- harmless while nothing on that path
+        consulted the cap. Once the cap IS consulted there (issue #1783), that
+        tick spent a third of the stage's budget before any subagent had run: a
+        dashboard stage was cut after two waves, while the same stage driven from
+        the Slack handler -- which has no stage loop and so no entry tick -- got
+        three. Stricter than the prompt promises AND inconsistent between paths.
+
+        So the side effects live here and the counting stays in
+        :meth:`record_round`. Registering the stage at zero rounds is what makes
+        :attr:`current_stage` (the highest key) point at it, which is what the
+        Slack handler then records against and what the loop resumes from.
+        """
+        self._stage_rounds.setdefault(stage, 0)
+        # Unconditional: this is the per-STAGE clock, so entering stage 2 must not
+        # inherit stage 1's elapsed time.
+        self._stage_start = time.monotonic()
+        # The whole-plan clock starts with the plan's first stage and is never
+        # restarted: it is the budget for the RUN, so re-arming it here would let
+        # every stage boundary refresh the ceiling the watchdog enforces.
+        if not self._plan_start:
+            self._plan_start = time.monotonic()
+
+    def round_limit_reached(self, stage: int) -> bool:
+        """True when *stage* has spent its whole round budget.
+
+        The same reading ``record_round`` returns, available without recording
+        another round -- the stage loop needs it again after a stage's subagent
+        wave finishes, because the rounds those waves consume are recorded by the
+        subagent-completion handler on this same tracker, not by the loop.
+        """
+        return self._stage_rounds.get(stage, 0) >= MAX_STAGE_ROUNDS
 
     def is_stage_timed_out(self) -> bool:
         """True if current stage has exceeded the timeout."""
@@ -159,11 +254,87 @@ class OrchestrationTracker:
     @property
     def timeout_human(self) -> str:
         """Human-friendly timeout string, e.g. '30m' or '1m30s'."""
-        s = self._stage_timeout
-        if s >= 60:
-            m, rem = divmod(s, 60)
-            return f"{m}m{rem}s" if rem else f"{m}m"
-        return f"{s}s"
+        return _human_secs(self._stage_timeout)
+
+    # ── Whole-plan watchdog ──
+
+    @property
+    def budgets_unset(self) -> bool:
+        """True while this tracker has never had its configured budgets applied.
+
+        The stage loop used to gate its config load on "did I just create this
+        tracker", which meant a tracker it did NOT create -- the one the Slack
+        gateway creates lazily when a subagent result lands on a slot the loop has
+        not reached -- ran the whole plan on constructor defaults: the plan
+        watchdog disabled at 0 and the stage budget at
+        :data:`DEFAULT_STAGE_TIMEOUT` regardless of config. Asking the tracker
+        instead makes the answer independent of how the loop obtained it.
+        """
+        return self._budgets_unset
+
+    def mark_budgets_loaded(self) -> None:
+        """Record that a config load has been attempted for this tracker.
+
+        Called even when the load RAISED: the fallback is the documented
+        behaviour of a failed load, and re-attempting it at every later Go would
+        turn one bad config read into one per stage gate.
+        """
+        self._budgets_unset = False
+
+    @property
+    def max_plan_duration_seconds(self) -> int:
+        """Configured ceiling for the whole plan in seconds (0 = disabled)."""
+        return self._plan_timeout
+
+    @max_plan_duration_seconds.setter
+    def max_plan_duration_seconds(self, seconds: int) -> None:
+        """Set the whole-plan budget after construction.
+
+        Same seam, and same reason, as ``stage_timeout_seconds``: the tracker is
+        published before the orchestrator config load returns, so the configured
+        value is applied here once it is known. Safe only before the first round
+        is recorded -- ``_plan_start`` is 0 until then, so no deadline the run is
+        already being measured against can move.
+        """
+        self._plan_timeout = seconds
+
+    @property
+    def plan_elapsed_seconds(self) -> int:
+        """Seconds since the plan's first round, or 0 before it started."""
+        if not self._plan_start:
+            return 0
+        return int(time.monotonic() - self._plan_start)
+
+    def is_plan_timed_out(self) -> bool:
+        """True once the whole plan has outrun ``max_plan_duration_seconds``."""
+        if not self._plan_start or not self._plan_timeout:
+            return False
+        return (time.monotonic() - self._plan_start) > self._plan_timeout
+
+    def plan_warning_due(self) -> bool:
+        """True exactly once, at the first check past ``PLAN_WARN_FRACTION``.
+
+        Latches on read: the caller emits the notice, and a plan whose remaining
+        stages each re-check must not re-announce it at every boundary.
+        """
+        if self._plan_warned or not self._plan_start or not self._plan_timeout:
+            return False
+        if (time.monotonic() - self._plan_start) < self._plan_timeout * PLAN_WARN_FRACTION:
+            return False
+        self._plan_warned = True
+        return True
+
+    @property
+    def plan_timeout_human(self) -> str:
+        """Human-friendly whole-plan budget, e.g. '2h'."""
+        return _human_secs(self._plan_timeout)
+
+    @property
+    def plan_elapsed_human(self) -> str:
+        """Human-friendly elapsed plan time, e.g. '1h30m'."""
+        return _human_secs(self.plan_elapsed_seconds)
+
+    # ── Stage ledger reads ──
 
     def round_count(self, stage: int) -> int:
         return self._stage_rounds.get(stage, 0)
@@ -257,8 +428,7 @@ Stage N: Verification
 # Loose pre-filter: catches plan-like text cheaply. False positives are
 # handled by rephrase_plan(might_not_be_plan=True) which asks the LLM.
 _PLAN_LIKE_RE = re.compile(
-    r"(?:^|\n)\s*(?:Phase|Step|Stage|Part)\s+\d+\s*[:\-—]"
-    r"|(?:^|\n)\s*\d+\.\s+\*\*[A-Z]",
+    r"(?:^|\n)\s*(?:Phase|Step|Stage|Part)\s+\d+\s*[:\-—]" r"|(?:^|\n)\s*\d+\.\s+\*\*[A-Z]",
     re.IGNORECASE,
 )
 
@@ -300,7 +470,9 @@ def validate_plan_format(text: str) -> tuple[bool, bool, list[str]]:
     return True, len(issues) == 0, issues
 
 
-async def rephrase_plan(text: str, issues: list[str], client: Any, *, might_not_be_plan: bool = False) -> str | None:
+async def rephrase_plan(
+    text: str, issues: list[str], client: Any, *, might_not_be_plan: bool = False
+) -> str | None:
     """Ask the LLM to reformat a malformed plan. Returns fixed text or None.
 
     When *might_not_be_plan* is True, the LLM is instructed to return the

--- a/src/kiro_crew/dashboard/chat.py
+++ b/src/kiro_crew/dashboard/chat.py
@@ -87,7 +87,6 @@ from kiro_crew.dashboard.chat_nav import (  # noqa: F401
 )
 from kiro_crew.dashboard.chat_orchestrator import (  # noqa: F401
     _build_stage_context,
-    _capture_stage_result,
     _previous_result_paths,
     _stage_loop,
     api_chat_plan_action,

--- a/src/kiro_crew/dashboard/chat_orchestrator.py
+++ b/src/kiro_crew/dashboard/chat_orchestrator.py
@@ -11,7 +11,8 @@ from pathlib import Path
 from aiohttp import web
 
 from kiro_crew.config.loader import KiroCrewConfig, config_dir
-from kiro_crew.context_management import OrchestrationTracker
+from kiro_crew.config.sections import OrchestratorConfig
+from kiro_crew.context_management import MAX_STAGE_ROUNDS, OrchestrationTracker
 from kiro_crew.dashboard.chat_runner import _run_chat, _start_next_queued_turn
 from kiro_crew.dashboard.state import DashboardState, _ChatSlot, append_and_surface
 from kiro_crew.dashboard.turn_dispatch import _bounded_turn
@@ -126,15 +127,14 @@ async def _previous_result_paths(
     return await asyncio.to_thread(_read_previous_results, recorded)
 
 
-def _capture_stage_result(
-    slot: "_ChatSlot",
-    stage_num: int,
-) -> str:
-    """Extract assistant messages since stage start and write to disk.
+def _collect_stage_result_parts(slot: "_ChatSlot") -> tuple[str, ...]:
+    """Snapshot the assistant text this stage produced, newest separator backwards.
 
-    Returns the path to the result file.
+    Runs on the event loop because it walks ``slot.messages``, which the loop
+    mutates. Returns an immutable tuple of RAW text so the write half can be
+    handed to a worker without any live slot state crossing the boundary -- the
+    same split as ``_previous_result_paths`` / ``_read_previous_results``.
     """
-    # Collect assistant text from the most recent messages (since last stage separator)
     result_parts: list[str] = []
     for m in reversed(slot.messages):
         role = m.get("role", "")
@@ -142,19 +142,35 @@ def _capture_stage_result(
         if isinstance(cls, str) and "stage-sep" in cls:
             break  # hit the separator for this stage
         if role == "assistant":
-            # Defence in depth before this reaches disk. Both upstream sources are
-            # already clean — live turns via chat_runner._flush_segment, restored
-            # turns via the load-time content pass — but this writes a NEW file
-            # outside the history log's own redaction, so it does not depend on
-            # that. Redaction is idempotent, so the common case is a no-op.
-            text = m.get("content", "")
-            text, _ = redact_exfiltration_urls(text)
-            text, _ = redact_credentials(text)
-            result_parts.append(text)
+            result_parts.append(m.get("content", ""))
     result_parts.reverse()
-    result_text = "\n\n".join(result_parts)
+    return tuple(result_parts)
 
-    session_dir = config_dir() / "sessions" / slot.key
+
+def _write_stage_result(
+    slot_key: str,
+    stage_num: int,
+    raw_parts: tuple[str, ...],
+) -> str:
+    """Redact *raw_parts* and write the stage result file. Returns its path.
+
+    Blocking: ``mkdir`` plus a file write, which is why the caller hands this to
+    a worker. It takes only strings, so nothing the event loop mutates is
+    reachable from that worker.
+    """
+    parts: list[str] = []
+    for text in raw_parts:
+        # Defence in depth before this reaches disk. Both upstream sources are
+        # already clean — live turns via chat_runner._flush_segment, restored
+        # turns via the load-time content pass — but this writes a NEW file
+        # outside the history log's own redaction, so it does not depend on
+        # that. Redaction is idempotent, so the common case is a no-op.
+        text, _ = redact_exfiltration_urls(text)
+        text, _ = redact_credentials(text)
+        parts.append(text)
+    result_text = "\n\n".join(parts)
+
+    session_dir = config_dir() / "sessions" / slot_key
     session_dir.mkdir(parents=True, exist_ok=True)
     path = session_dir / f"stage_{stage_num}_result.md"
     path.write_text(result_text, encoding="utf-8")
@@ -182,6 +198,74 @@ def _completion_excerpts(result_paths: tuple[tuple[int, str], ...]) -> dict[int,
                 excerpts[stage_num] = line[:120]
                 break
     return excerpts
+
+
+def _halt_plan(
+    state: "DashboardState",
+    slot: "_ChatSlot",
+    message: str,
+    *,
+    event_type: str,
+    operation: str,
+    stage_num: int,
+) -> None:
+    """Stop auto-run, tell the user why, and audit it.
+
+    Not redacted: every caller builds *message* from a stage number and a
+    humanized duration, never from model-authored text, which is the same
+    footing as the pre-existing stage-timeout notice beside it.
+    """
+    slot._auto_run = False
+    slot.append("assistant", message, "msg msg-a")
+    state.broadcast_ws(
+        "chat_append",
+        {"slot": slot.key, "html": message, "cls": "msg msg-a"},
+    )
+    sel().log(
+        SecurityEvent(
+            event_id=uuid.uuid4().hex,
+            timestamp=datetime.now(tz=timezone.utc).isoformat(),
+            event_type=event_type,
+            caller_identity=f"dashboard:{slot.key}",
+            agent=getattr(slot, "agent", ""),
+            source="dashboard",
+            operation=operation,
+            outcome="stopped",
+            resources=f"slot={slot.key},stage={stage_num}",
+        )
+    )
+
+
+def _round_cap_message(
+    tracker: OrchestrationTracker,
+    stage_num: int,
+) -> str | None:
+    """The halt notice when *stage_num* has spent its round budget, else ``None``.
+
+    ``MAX_STAGE_ROUNDS`` was recorded but never consulted on the dashboard path, so
+    the "max 3 rounds per stage" the orchestrator prompt promises was unenforced
+    here (issue #1783). Rounds are recorded in ONE place -- the
+    subagent-completion handler in the Slack gateway, once per completed wave on
+    this same tracker -- which is how a dashboard stage reaches the cap at all.
+    The loop itself enters a stage through ``start_stage``, which spends no round,
+    so all three the prompt promises are available to actual spawn waves.
+
+    ``MAX_STAGE_ESCALATIONS`` is deliberately NOT checked here, and that is a
+    reachability fact rather than a preference. An escalation is only recorded by
+    ``reset_after_guidance``, which zeroes that stage's rounds while KEEPING its
+    key -- so ``current_stage`` (the highest key) does not move, the loop's next
+    entry starts at the stage after it, and an escalated stage is never re-entered.
+    Nothing on this path can therefore observe ``is_force_failed``. It stays
+    enforced in the Slack gateway, where the tracker is not driven by a stage loop
+    and the check IS reachable.
+    """
+    if not tracker.round_limit_reached(stage_num):
+        return None
+    rounds = tracker.round_count(stage_num)
+    return (
+        f"⚠️ Stage {stage_num} has used all {MAX_STAGE_ROUNDS} of its spawn rounds "
+        f"({rounds}). Auto-run stopped — send guidance to continue."
+    )
 
 
 def _orchestration_stopped(slot: "_ChatSlot", tracker: OrchestrationTracker) -> bool:
@@ -281,8 +365,8 @@ async def _exit_cancelled_plan(state: "DashboardState", slot: "_ChatSlot") -> No
     state.push_slots_update()
 
 
-async def _load_stage_budget(slot: "_ChatSlot", tracker: OrchestrationTracker) -> bool:
-    """Apply the configured stage timeout to *tracker*. False to abandon the plan.
+async def _load_plan_budgets(slot: "_ChatSlot", tracker: OrchestrationTracker) -> bool:
+    """Apply the configured stage and whole-plan budgets. False to abandon the plan.
 
     The load stats and reads ``config.json`` plus any ``config.local.json``
     overlay, deep-merges them and runs the full schema validation, so it runs on
@@ -313,12 +397,26 @@ async def _load_stage_budget(slot: "_ChatSlot", tracker: OrchestrationTracker) -
     try:
         cfg = await asyncio.to_thread(KiroCrewConfig.load)
         tracker.stage_timeout_seconds = cfg.orchestrator.stage_timeout_seconds
+        tracker.max_plan_duration_seconds = cfg.orchestrator.max_plan_duration_seconds
     except Exception:
+        # Both budgets are set to the dataclass defaults, not left as they are.
+        # The tracker constructs with ``_plan_timeout = 0``, and 0 means DISABLED
+        # everywhere it is read -- so an unreadable or invalid config.json used to
+        # remove the whole-plan ceiling entirely while the stage budget quietly
+        # fell back to its own default. A failed load now lands on exactly the
+        # budgets a default config would have produced (Opus finding).
+        tracker.stage_timeout_seconds = OrchestratorConfig.stage_timeout_seconds
+        tracker.max_plan_duration_seconds = OrchestratorConfig.max_plan_duration_seconds
         logger.debug(
-            "Orchestrator config load failed for slot %s; keeping the default " "stage budget",
+            "Orchestrator config load failed for slot %s; falling back to the "
+            "default stage and plan budgets",
             slot.key,
             exc_info=True,
         )
+    # Recorded whether or not the load raised: the fallback budgets ARE the
+    # documented outcome of a failed load, and leaving the tracker asking for one
+    # would re-attempt a bad config read at every later stage-loop entry.
+    tracker.mark_budgets_loaded()
     if slot._stop_generation != _stop_generation or _orchestration_stopped(slot, tracker):
         logger.info(
             "Stage loop for slot %s abandoned: a stop or plan cancel landed "
@@ -355,6 +453,43 @@ async def _stage_loop(
         await _exit_cancelled_plan(state, slot)
         return
 
+    # A restart erased the plan. `_stage_titles` (and so `_plan_stage_count`) live
+    # only in memory: nothing persists them, deliberately -- the autopilot is a
+    # lightweight executor, not a task runner, and a plan nobody was watching is
+    # not resumed across a restart. But `mode` IS persisted and the transcript
+    # keeps its `[OPTION: Go | Go All | Cancel]` row, so a restored slot offers
+    # buttons with no plan behind them. Clicking one used to run zero stages and
+    # return in silence -- the loop's range is empty, and the completion message is
+    # gated on `start_idx < total`, so the user got no response at all.
+    #
+    # Say so instead. Also covers a plan turn that parsed no stages, which reaches
+    # this the same way, so the wording names the state rather than a cause.
+    if not slot._plan_stage_count:
+        _dead_msg = (
+            "⚠️ This plan is no longer active — its stages are not in memory, "
+            "usually because the gateway restarted since it was created. Nothing "
+            "was run. Send the request again to plan it afresh; any stage results "
+            "that did complete are still on disk under this session's directory."
+        )
+        append_and_surface(state, slot, "assistant", _dead_msg, "msg msg-a")
+        sel().log(
+            SecurityEvent(
+                event_id=uuid.uuid4().hex,
+                timestamp=datetime.now(tz=timezone.utc).isoformat(),
+                event_type="auto_run_plan_expired",
+                caller_identity=f"dashboard:{slot.key}",
+                agent=getattr(slot, "agent", ""),
+                source="dashboard",
+                operation="plan_shape_absent",
+                outcome="refused",
+                resources=f"slot={slot.key}",
+            )
+        )
+        state.broadcast_ws("chat_done", {"slot": slot.key})
+        slot.task = None
+        state.push_slots_update()
+        return
+
     tracker = slot._orch_tracker
     # Publish the tracker BEFORE the config load suspends below. That load is
     # this loop's first await, ahead of every stage gate, and a plan Cancel
@@ -371,7 +506,6 @@ async def _stage_loop(
     # this loop fell back to when the load raised, and takes the configured
     # value below once that is known. Nothing reads the budget until a stage
     # records its first round, which cannot happen before the load returns.
-    _bootstrapping = tracker is None
     if tracker is None:
         tracker = OrchestrationTracker()
         slot._orch_tracker = tracker
@@ -413,7 +547,14 @@ async def _stage_loop(
         # while this was loading is handed off, and the slot is closed out. A
         # bare `return` from the bootstrap would skip all of it and strand that
         # message behind a guard nothing clears.
-        if _bootstrapping and not await _load_stage_budget(slot, tracker):
+        # Asked of the TRACKER, not of whether this loop created it. A slot the
+        # Slack gateway touched first arrives with a tracker it created lazily
+        # when a subagent result landed; that tracker has never seen the config,
+        # and gating on "did I just build this" left it running the whole plan
+        # on constructor defaults -- the plan watchdog disabled at 0 and the
+        # stage budget ignoring config. A tracker that already has its budgets
+        # answers False, so a paused plan's later Go still pays for nothing.
+        if tracker.budgets_unset and not await _load_plan_budgets(slot, tracker):
             return
         for stage_idx in range(start_idx, total):
             if _orchestration_stopped(slot, tracker):
@@ -434,7 +575,51 @@ async def _stage_loop(
                 )
                 break
 
-            # Check timeout BEFORE recording new round (record_round resets timer)
+            # Whole-plan watchdog. The per-stage timeout below bounds ONE stage;
+            # multiplied by stage count it bounds nothing useful, so a long plan
+            # could run unattended for hours (issue #1783). Checked at the stage
+            # boundary rather than mid-turn: the stage that is already running has
+            # its own ceiling, and cutting a plan between stages leaves the work
+            # so far captured on disk and resumable.
+            #
+            # AUTO-RUN ONLY. The budget bounds UNATTENDED runtime, and the clock is
+            # wall-clock from the plan's first round, so a stage-gated plan spends
+            # most of it sitting at an approval prompt: enforcing it there cut a
+            # plan the user was actively stepping through, having counted their own
+            # review time between Go clicks against them. A plan that advances only
+            # when the user asks it to needs no ceiling, because the user is the
+            # ceiling (Opus finding).
+            if auto_run and tracker.is_plan_timed_out():
+                _halt_plan(
+                    state,
+                    slot,
+                    f"⏱️ Plan exceeded its total budget of "
+                    f"{tracker.plan_timeout_human} (elapsed "
+                    f"{tracker.plan_elapsed_human}) before Stage {stage_num}. "
+                    "Auto-run stopped.",
+                    event_type="auto_run_timeout",
+                    operation="plan_duration_exceeded",
+                    stage_num=stage_num,
+                )
+                break
+            # One warning per plan, latched inside the tracker, so the user can
+            # intervene before the cut rather than only learning of it after.
+            # Gated with the cut it warns about: an attended plan is never cut, so
+            # a notice there would announce a ceiling that does not apply.
+            if auto_run and tracker.plan_warning_due():
+                _warn_msg = (
+                    f"⏳ Plan has used {tracker.plan_elapsed_human} of its "
+                    f"{tracker.plan_timeout_human} total budget. It will stop at "
+                    "the first stage boundary past the budget."
+                )
+                slot.append("assistant", _warn_msg, "msg msg-a")
+                state.broadcast_ws(
+                    "chat_append",
+                    {"slot": slot.key, "html": _warn_msg, "cls": "msg msg-a"},
+                )
+
+            # Check the timeout BEFORE entering the stage: `start_stage` restarts
+            # the per-stage clock, so reading it afterwards would always be 0.
             if tracker.is_stage_timed_out():
                 slot._auto_run = False
                 _timeout_msg = (
@@ -461,8 +646,10 @@ async def _stage_loop(
                 )
                 break
 
-            # Record round and emit separator (after timeout check)
-            tracker.record_round(stage_num)
+            # Enter the stage and emit the separator (after the timeout check).
+            # NOT `record_round`: a round is a spawn wave, and the cap this PR
+            # makes real is the wave budget -- see `OrchestrationTracker.start_stage`.
+            tracker.start_stage(stage_num)
             title = titles[stage_idx] if stage_idx < len(titles) else ""
             label = f"Stage {stage_num}: {title}" if title else f"Stage {stage_num}"
             sep = f"\n\n───── {label} ─────\n"
@@ -778,14 +965,44 @@ async def _stage_loop(
             if _orchestration_stopped(slot, tracker):
                 break
 
-            # Capture result to disk
+            # Capture result to disk, split in two: the message walk stays on
+            # the loop (it reads live slot state), and the mkdir + write go to a
+            # worker. This was one synchronous call on the loop.
             try:
-                result_path = _capture_stage_result(slot, stage_num)
+                _raw_parts = _collect_stage_result_parts(slot)
+                result_path = await asyncio.to_thread(
+                    _write_stage_result, slot.key, stage_num, _raw_parts
+                )
                 tracker.record_stage_result(stage_num, result_path)
             except OSError:
                 logger.warning(
                     "Failed to capture stage %d result to disk", stage_num, exc_info=True
                 )
+
+            # Re-check the round cap AFTER the stage's subagent wave: those
+            # completions are what push a dashboard stage to its round limit, and
+            # they land on this tracker while the stage runs. Placed after the
+            # capture above so the completed stage's work is on disk (and its
+            # result recorded) before the plan halts.
+            #
+            # AUTO-RUN ONLY, like the plan watchdog above and for the same reason.
+            # The cap exists to stop an UNATTENDED plan from spinning; an attended
+            # stage that spent exactly its 3 allowed waves and then finished has
+            # done nothing wrong, and the user is about to be asked for Go anyway.
+            # Halting it here read "Auto-run stopped" on a plan that was never in
+            # auto-run and, worse, skipped the Go row below, stranding the
+            # step-through (Opus finding).
+            _cap = _round_cap_message(tracker, stage_num) if auto_run else None
+            if _cap:
+                _halt_plan(
+                    state,
+                    slot,
+                    _cap,
+                    event_type="auto_run_round_cap",
+                    operation="stage_round_cap",
+                    stage_num=stage_num,
+                )
+                break
 
             # Gate: if not auto_run, wait for user approval
             if not auto_run:

--- a/test/test_completion_result_read_off_loop.py
+++ b/test/test_completion_result_read_off_loop.py
@@ -56,9 +56,9 @@ def _make_slot(titles):
 def _stage_texts(monkeypatch, texts):
     """Make each stage's captured result file hold ``texts[stage_num - 1]``.
 
-    The real ``_capture_stage_result`` harvests assistant messages appended by
-    ``_run_chat``, which is mocked here; giving the mock a per-stage body is what
-    puts distinguishable content on disk for the completion read to find.
+    The real capture harvests assistant messages appended by ``_run_chat``, which
+    is mocked here; giving the mock a per-stage body is what puts distinguishable
+    content on disk for the completion read to find.
     """
     stage_box = {"n": 0}
 
@@ -74,9 +74,7 @@ def _stage_texts(monkeypatch, texts):
 def _completion_message(slot):
     """The single '✅ All N stages complete.' summary the loop emits."""
     matches = [
-        m.get("content", "")
-        for m in slot.messages
-        if m.get("content", "").startswith("✅ All ")
+        m.get("content", "") for m in slot.messages if m.get("content", "").startswith("✅ All ")
     ]
     assert len(matches) == 1, f"expected exactly one completion summary, got {len(matches)}"
     return matches[0]
@@ -126,10 +124,12 @@ async def test_completion_result_read_runs_off_the_loop_thread(monkeypatch):
 
     assert paths_read, (
         "no stage result was read at plan completion -- this test no longer "
-        "exercises the completion read and would pass vacuously")
+        "exercises the completion read and would pass vacuously"
+    )
     assert threading.get_ident() not in seen_threads, (
         "a completed stage result was read on the event-loop thread; the "
-        "filesystem work must be handed to asyncio.to_thread")
+        "filesystem work must be handed to asyncio.to_thread"
+    )
     # The summary really is built from what was read off disk, so the assertion
     # above covers the read that produces the user-visible text.
     assert "alpha done" in _completion_message(slot)
@@ -211,18 +211,20 @@ async def test_completion_summary_survives_a_deleted_result_file(monkeypatch, tm
     slot = _make_slot(["First", "Second"])
     _stage_texts(monkeypatch, ["alpha done", "beta done"])
 
-    real_capture = None
+    real_write = None
 
-    def _capture_then_delete_stage_1(s, stage_num):
-        path = real_capture(s, stage_num)
+    # Wraps the WRITE half of the capture (the loop hands it to a worker); the
+    # message walk stays on the loop and is a separate function.
+    def _write_then_delete_stage_1(slot_key, stage_num, raw_parts):
+        path = real_write(slot_key, stage_num, raw_parts)
         if stage_num == 1:
-            (tmp_path / "sessions" / s.key / "stage_1_result.md").unlink()
+            (tmp_path / "sessions" / slot_key / "stage_1_result.md").unlink()
         return path
 
     from kiro_crew.dashboard import chat_orchestrator
 
-    real_capture = chat_orchestrator._capture_stage_result
-    monkeypatch.setattr(chat_orchestrator, "_capture_stage_result", _capture_then_delete_stage_1)
+    real_write = chat_orchestrator._write_stage_result
+    monkeypatch.setattr(chat_orchestrator, "_write_stage_result", _write_then_delete_stage_1)
 
     await _stage_loop(state, slot, auto_run=True)
 
@@ -248,10 +250,10 @@ async def test_no_worker_hop_when_no_stage_results_were_captured(monkeypatch):
     from kiro_crew.dashboard import chat_orchestrator
     from kiro_crew.dashboard.chat import _stage_loop
 
-    def _capture_fails(s, stage_num):
+    def _write_fails(slot_key, stage_num, raw_parts):
         raise OSError("disk full")
 
-    monkeypatch.setattr(chat_orchestrator, "_capture_stage_result", _capture_fails)
+    monkeypatch.setattr(chat_orchestrator, "_write_stage_result", _write_fails)
 
     hops: list[object] = []
     real_to_thread = asyncio.to_thread

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -10486,7 +10486,7 @@ class TestPythonStageLoop:
     def _isolate_config_dir(self, tmp_path, monkeypatch):
         """Redirect every config_dir used by the stage loop to a per-test tmp dir.
 
-        ``_capture_stage_result`` (in ``chat_orchestrator``) writes stage results
+        ``_write_stage_result`` (in ``chat_orchestrator``) writes stage results
         under ``config_dir() / "sessions" / slot.key``. The orchestrator imports
         ``config_dir`` into its own namespace, so patching only the ``chat`` /
         ``state`` namespaces leaves results writing to the live

--- a/test/test_display_time_redaction.py
+++ b/test/test_display_time_redaction.py
@@ -165,20 +165,27 @@ def test_side_chat_parent_snapshot_keeps_user_text() -> None:
 
 
 def test_stage_result_capture_redacts_before_writing_to_disk(tmp_path, monkeypatch) -> None:
-    """_capture_stage_result writes assistant text to a NEW file on disk.
+    """The stage-result capture writes assistant text to a NEW file on disk.
 
     A gateway restart mid-orchestration leaves restored (now unredacted) turns in
     the window, so without redaction here those bytes would be written out.
+
+    Composed from the two halves the stage loop itself calls: the message walk
+    runs on the caller (it reads live slot state) and the redact-plus-write half
+    takes only strings, which is what makes it safe to hand to a worker thread.
     """
     monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
     monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
-    from kiro_crew.dashboard.chat_orchestrator import _capture_stage_result
+    from kiro_crew.dashboard.chat_orchestrator import (
+        _collect_stage_result_parts,
+        _write_stage_result,
+    )
     from kiro_crew.dashboard.state import _ChatSlot
 
     slot = _ChatSlot("chat-1-stage")
     slot.append("assistant", f"result with {SECRET}", "msg msg-a", broadcast=False)
 
-    path = _capture_stage_result(slot, 1)
+    path = _write_stage_result(slot.key, 1, _collect_stage_result_parts(slot))
     written = pathlib.Path(path).read_text()
     assert SECRET not in written, "stage result persisted an unredacted credential"
 

--- a/test/test_expired_plan_is_refused.py
+++ b/test/test_expired_plan_is_refused.py
@@ -1,0 +1,157 @@
+"""A plan whose stages are gone must say so, not return in silence.
+
+The autopilot's plan SHAPE (``_stage_titles``, and so ``_plan_stage_count``) lives
+only in a slot's memory. Nothing persists it, and that is deliberate: the
+autopilot is a lightweight executor, not a task runner, so a plan nobody was
+watching is not resumed across a gateway restart.
+
+What IS persisted is ``mode``, and the transcript keeps the plan turn's
+``[OPTION: Go | Go All | Cancel]`` row. So a restored orchestrator slot renders
+those buttons over a plan that no longer exists. Pressing one used to do nothing
+at all -- ``range(start_idx, 0)`` is empty, and the completion message is gated on
+``start_idx < total`` -- so the user pressed Go and got no response whatsoever, and
+no way to tell a dead plan from a hung one.
+
+The fix is a refusal the user can read, not a resume. These tests pin the refusal
+and pin that it costs nothing: no tracker, no config load, no model turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+def _state() -> MagicMock:
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    return state
+
+
+def _restored_slot(key: str = "expired-plan-slot") -> _ChatSlot:
+    """The shape a restart leaves behind: orchestrator mode, no plan.
+
+    ``mode`` survives because it is persisted with the slot; the stage titles do
+    not. No test sets ``_stage_titles`` here on purpose -- the absence IS the
+    fixture.
+    """
+    slot = _ChatSlot(key, mode="orchestrator")
+    slot._orch_tracker = None
+    return slot
+
+
+def _stub_turn(monkeypatch: Any) -> list[str]:
+    """Record any model turn the loop attempts. It must attempt none."""
+    turns: list[str] = []
+
+    async def _fake_run_chat(_state: Any, _slot: Any, context: str, **_kwargs: Any) -> None:
+        turns.append(context)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _fake_run_chat)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
+    return turns
+
+
+@pytest.mark.asyncio
+async def test_a_plan_with_no_stages_tells_the_user(monkeypatch: Any) -> None:
+    """Go on a restored plan gets an answer, not silence."""
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    turns = _stub_turn(monkeypatch)
+    slot = _restored_slot()
+    state = _state()
+
+    await _stage_loop(state, slot, auto_run=False)
+
+    assistant_rows = [m for m in slot.messages if m.get("role") == "assistant"]
+    assert assistant_rows, (
+        "the user pressed Go and the slot said nothing: a plan whose stages are "
+        "gone must be refused out loud, not silently skipped"
+    )
+    body = " ".join(str(m.get("content", "")) for m in assistant_rows)
+    assert "no longer active" in body, f"the refusal does not name the state: {body!r}"
+    assert turns == [], "a plan with no stages must not run a model turn"
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_closes_the_turn_out(monkeypatch: Any) -> None:
+    """The frontend spinner has to stop, or the slot looks like it is working.
+
+    ``chat_done`` is what clears it, and ``slot.task`` is what the next press
+    checks, so an early return that skips either leaves the slot wedged in a way
+    the user cannot see the cause of.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    _stub_turn(monkeypatch)
+    slot = _restored_slot("expired-plan-closeout")
+    state = _state()
+
+    await _stage_loop(state, slot, auto_run=False)
+
+    events = [call.args[0] for call in state.broadcast_ws.call_args_list]
+    assert "chat_done" in events, f"the turn was never closed out: {events}"
+    assert slot.task is None, "the slot still holds a task nothing will finish"
+    assert state.push_slots_update.called, "the slot list was left stale"
+
+
+@pytest.mark.asyncio
+async def test_the_refusal_costs_nothing(monkeypatch: Any) -> None:
+    """Refused before the tracker is built, so before the config is read.
+
+    Placement matters: the config load is the loop's first await and it exists to
+    give a RUNNING plan its budgets. Refusing after it would stat, read, merge and
+    schema-validate ``config.json`` on a worker thread to serve a plan that is
+    about to be turned away.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    _stub_turn(monkeypatch)
+    loads: list[int] = []
+
+    def _loader() -> Any:  # pragma: no cover - must never run
+        loads.append(1)
+        raise AssertionError("the config was loaded for a plan that cannot run")
+
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.chat_orchestrator.KiroCrewConfig",
+        MagicMock(load=_loader),
+    )
+
+    slot = _restored_slot("expired-plan-cost")
+    await _stage_loop(_state(), slot, auto_run=False)
+
+    assert loads == []
+    assert (
+        slot._orch_tracker is None
+    ), "a tracker was built for a plan with no stages; the refusal must come first"
+
+
+@pytest.mark.asyncio
+async def test_go_all_is_refused_the_same_way(monkeypatch: Any) -> None:
+    """Auto-run is not a different door.
+
+    Go All reaches the same loop with ``auto_run=True``; if the gate sat behind an
+    ``auto_run`` check, the unattended path -- the one nobody is watching -- would
+    be the one that failed silently.
+    """
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    turns = _stub_turn(monkeypatch)
+    slot = _restored_slot("expired-plan-go-all")
+    slot._auto_run = True
+
+    await _stage_loop(_state(), slot, auto_run=True)
+
+    body = " ".join(
+        str(m.get("content", "")) for m in slot.messages if m.get("role") == "assistant"
+    )
+    assert "no longer active" in body, f"Go All was refused in silence: {body!r}"
+    assert turns == []

--- a/test/test_orchestrator_config_load_off_loop.py
+++ b/test/test_orchestrator_config_load_off_loop.py
@@ -57,10 +57,13 @@ def _state() -> MagicMock:
 def _slot(key: str = "cfg-load-slot") -> _ChatSlot:
     slot = _ChatSlot(key, mode="orchestrator")
     slot._auto_run = False
-    # `_plan_stage_count` is derived from the titles, not settable. An empty plan
-    # drives tracker initialisation — the branch under test — and then leaves the
-    # stage loop with nothing to execute, so no model turn is involved.
-    slot._stage_titles = []
+    # `_plan_stage_count` is derived from the titles, not settable. ONE stage is
+    # the cheapest plan that still reaches tracker initialisation — the branch
+    # under test. An empty plan no longer does: the loop refuses a plan whose
+    # stages are not in memory (a restart erased them) before it builds anything,
+    # so an empty-plan fixture would leave every assertion here vacuous. The
+    # single stage's model turn is stubbed out in `_init_tracker`.
+    slot._stage_titles = ["Collect the evidence"]
     slot._orch_tracker = None
     return slot
 
@@ -131,9 +134,21 @@ async def _wait_for_config_gate(task: asyncio.Task[Any], entered: asyncio.Event)
     await entry_task
 
 
-async def _init_tracker(slot: _ChatSlot) -> None:
+async def _init_tracker(slot: _ChatSlot, monkeypatch: Any) -> None:
+    """One real stage-loop entry with only the model turn stubbed out.
+
+    Everything these tests are about — the plan-shape gate, the tracker
+    construction, the config load and the value it lands on the tracker — is the
+    production code path. Replacing ``_run_chat`` stops the single stage the
+    fixture carries from wanting a provider, and nothing else.
+    """
     from kiro_crew.dashboard.chat import _stage_loop
 
+    async def _no_turn(_state: Any, _slot: Any, _context: str, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _no_turn)
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.sel", MagicMock())
     await _stage_loop(_state(), slot, auto_run=False)
 
 
@@ -144,7 +159,7 @@ async def test_config_load_runs_off_the_loop_thread(monkeypatch: Any) -> None:
     _record_config_loads(monkeypatch, threads)
 
     slot = _slot()
-    await _init_tracker(slot)
+    await _init_tracker(slot, monkeypatch)
 
     assert threads, (
         "the orchestrator never loaded config -- this test no longer exercises "
@@ -164,7 +179,7 @@ async def test_configured_timeout_reaches_the_tracker(monkeypatch: Any) -> None:
     _record_config_loads(monkeypatch, threads)
 
     slot = _slot()
-    await _init_tracker(slot)
+    await _init_tracker(slot, monkeypatch)
 
     assert slot._orch_tracker is not None
     assert slot._orch_tracker.stage_timeout_seconds == 42
@@ -183,7 +198,7 @@ async def test_zero_timeout_is_preserved_rather_than_defaulted(monkeypatch: Any)
     _record_config_loads(monkeypatch, threads)
 
     slot = _slot()
-    await _init_tracker(slot)
+    await _init_tracker(slot, monkeypatch)
 
     assert slot._orch_tracker is not None
     assert slot._orch_tracker.stage_timeout_seconds == 0
@@ -196,7 +211,7 @@ async def test_loader_failure_falls_back_to_the_default_timeout(monkeypatch: Any
     _record_config_loads(monkeypatch, threads, raises=True)
 
     slot = _slot()
-    await _init_tracker(slot)
+    await _init_tracker(slot, monkeypatch)
 
     assert threads, "the failing loader was never reached"
     assert slot._orch_tracker is not None
@@ -214,7 +229,7 @@ async def test_existing_tracker_does_not_reload_config(monkeypatch: Any) -> None
     slot = _slot()
     existing = OrchestrationTracker(stage_timeout_seconds=77)
     slot._orch_tracker = existing
-    await _init_tracker(slot)
+    await _init_tracker(slot, monkeypatch)
 
     assert threads == [], "a slot that already has a tracker must not load config"
     assert slot._orch_tracker is existing
@@ -632,9 +647,10 @@ async def test_a_round_recorded_before_loop_entry_does_skip_a_stage(
 
     A tracker that already carries a round at loop ENTRY makes ``start_idx``
     non-zero and stage 1 is skipped. That is the resume path: ``_orch_tracker``
-    is already set, so nothing is published, ``_bootstrapping`` is False and no
-    config load runs at all. Keeping this here is what stops the test above from
-    reading as "record_round does nothing".
+    is already set, so nothing is published, and because that tracker already
+    carries its budgets (``budgets_unset`` is False) no config load runs at all.
+    Keeping this here is what stops the test above from reading as "record_round
+    does nothing".
     """
     threads: list[int] = []
     _record_config_loads(monkeypatch, threads)
@@ -654,7 +670,12 @@ async def test_a_round_recorded_before_loop_entry_does_skip_a_stage(
     slot._auto_run = True
     state = _stop_capable_state(slot)
 
-    resumed = OrchestrationTracker()
+    # Budgets passed explicitly, because that is what an in-process resume
+    # actually holds: the FIRST loop entry loaded them onto this same object, so
+    # entry two owes nothing. A tracker built with no budgets at all is the
+    # restart-resume shape instead, and it does owe one load -- see
+    # test_plan_duration_watchdog's restored-tracker case.
+    resumed = OrchestrationTracker(stage_timeout_seconds=1800)
     resumed.record_round(resumed.current_stage)
     slot._orch_tracker = resumed
 

--- a/test/test_plan_duration_watchdog.py
+++ b/test/test_plan_duration_watchdog.py
@@ -1,0 +1,425 @@
+"""A whole plan needs a duration ceiling, not just a per-stage one.
+
+``OrchestratorConfig`` carried only ``stage_timeout_seconds``. That bounds ONE
+stage, and a plan multiplies it: ten stages at the 30-minute default is a five-hour
+unattended run with nothing to stop it (issue #1783). ``max_plan_duration_seconds``
+is the ceiling for the run, checked at each stage boundary — not mid-turn, because
+the running stage already has its own ceiling and cutting between stages leaves
+every finished stage captured on disk and resumable.
+
+One warning fires at ``PLAN_WARN_FRACTION`` of the budget so the user can
+intervene before the cut rather than only learning of it afterwards, and it is
+latched in the tracker so a long plan does not re-announce it at every boundary.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.sections import DEFAULT_MAX_PLAN_DURATION
+from kiro_crew.context_management import PLAN_WARN_FRACTION, OrchestrationTracker
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path, monkeypatch):
+    for module in ("state", "chat", "chat_orchestrator"):
+        monkeypatch.setattr(f"kiro_crew.dashboard.{module}.config_dir", lambda: tmp_path)
+
+
+def _make_state():
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    return state
+
+
+def _make_slot(titles=("First", "Second", "Third"), *, plan_budget=0):
+    slot = _ChatSlot("plan-watchdog-slot", mode="orchestrator")
+    slot._auto_run = True
+    slot._stage_titles = list(titles)
+    slot._plan_goal = "Test goal"
+    tracker = OrchestrationTracker(stage_timeout_seconds=1800)
+    tracker.max_plan_duration_seconds = plan_budget
+    slot._orch_tracker = tracker
+    return slot
+
+
+def _stage_turns(monkeypatch, *, age_plan_by=0.0):
+    """Mock the stage turn; optionally age the plan clock by *age_plan_by* seconds.
+
+    Ageing is done by rewinding ``_plan_start`` rather than sleeping, so the test
+    exercises the real ``time.monotonic()`` comparison without the wall clock.
+    """
+    box = {"n": 0}
+
+    async def _mock_run_chat(state, slot, message, **kwargs):
+        box["n"] += 1
+        slot.append("assistant", f"stage {box['n']} output", "msg msg-a")
+        if age_plan_by:
+            slot._orch_tracker._plan_start -= age_plan_by
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+    return box
+
+
+def _assistant_text(slot):
+    return "\n".join(m.get("content", "") for m in slot.messages if m.get("role") == "assistant")
+
+
+# ── The tracker's clock ──────────────────────────────────────────────────────
+
+
+class TestPlanClock:
+    def test_config_default_is_two_hours(self):
+        from kiro_crew.config.sections import OrchestratorConfig
+
+        assert OrchestratorConfig().max_plan_duration_seconds == DEFAULT_MAX_PLAN_DURATION
+        assert DEFAULT_MAX_PLAN_DURATION == 7200
+
+    def test_clock_starts_with_the_plan_not_with_each_stage(self):
+        """RED BEFORE: there was no whole-plan clock at all.
+
+        Re-arming it per stage would make every boundary refresh the ceiling the
+        watchdog exists to enforce, so a later round must not move it.
+        """
+        tracker = OrchestrationTracker()
+        tracker.record_round(1)
+        started = tracker._plan_start
+        time.sleep(0.01)
+        tracker.record_round(2)
+
+        assert tracker._plan_start == started
+
+    def test_not_timed_out_before_the_plan_starts(self):
+        tracker = OrchestrationTracker()
+        tracker.max_plan_duration_seconds = 1
+
+        assert tracker.is_plan_timed_out() is False
+
+    def test_timed_out_once_past_the_budget(self):
+        tracker = OrchestrationTracker()
+        tracker.max_plan_duration_seconds = 100
+        tracker.record_round(1)
+        tracker._plan_start -= 101
+
+        assert tracker.is_plan_timed_out() is True
+
+    def test_zero_budget_disables_the_watchdog(self):
+        """Falsy means disabled everywhere else in the tracker; same here."""
+        tracker = OrchestrationTracker()
+        tracker.max_plan_duration_seconds = 0
+        tracker.record_round(1)
+        tracker._plan_start -= 10_000
+
+        assert tracker.is_plan_timed_out() is False
+
+    def test_warning_latches_after_one_read(self):
+        tracker = OrchestrationTracker()
+        tracker.max_plan_duration_seconds = 100
+        tracker.record_round(1)
+        tracker._plan_start -= int(100 * PLAN_WARN_FRACTION) + 1
+
+        assert tracker.plan_warning_due() is True
+        assert tracker.plan_warning_due() is False
+
+    def test_no_warning_below_the_fraction(self):
+        tracker = OrchestrationTracker()
+        tracker.max_plan_duration_seconds = 100
+        tracker.record_round(1)
+        tracker._plan_start -= 10
+
+        assert tracker.plan_warning_due() is False
+
+    def test_human_renderings(self):
+        tracker = OrchestrationTracker()
+        tracker.max_plan_duration_seconds = 7200
+
+        assert tracker.plan_timeout_human == "2h"
+        assert tracker.plan_elapsed_human == "0s"
+
+
+# ── The loop's boundary check ────────────────────────────────────────────────
+
+
+class TestPlanWatchdogStopsTheLoop:
+    @pytest.mark.asyncio
+    async def test_plan_halts_at_the_stage_boundary_past_the_budget(self, monkeypatch):
+        """RED BEFORE: only the per-stage timeout existed, so this ran to the end."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=100)
+        box = _stage_turns(monkeypatch, age_plan_by=200)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert box["n"] == 1, "the plan advanced past its total budget"
+        text = _assistant_text(slot)
+        assert "exceeded its total budget" in text
+        assert "✅ All 3 stages complete." not in text
+        assert slot._auto_run is False
+
+    @pytest.mark.asyncio
+    async def test_halt_names_the_budget_and_the_elapsed_time(self, monkeypatch):
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=100)
+        _stage_turns(monkeypatch, age_plan_by=200)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        text = _assistant_text(slot)
+        assert "1m40s" in text  # the 100s budget
+        assert "before Stage 2" in text
+
+    @pytest.mark.asyncio
+    async def test_finished_stages_keep_their_results(self, monkeypatch, tmp_path):
+        """The cut is at a boundary, so completed work stays on disk and resumable."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=100)
+        _stage_turns(monkeypatch, age_plan_by=200)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert (tmp_path / "sessions" / slot.key / "stage_1_result.md").exists()
+        assert slot._orch_tracker._stage_results.get(1)
+
+    @pytest.mark.asyncio
+    async def test_warning_is_emitted_once_and_the_plan_continues(self, monkeypatch):
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=100)
+        # 80s of a 100s budget after stage 1: past 75%, under the ceiling.
+        box = _stage_turns(monkeypatch, age_plan_by=40)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        text = _assistant_text(slot)
+        warnings = [line for line in text.splitlines() if "total budget. It will stop" in line]
+        assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
+        # It warns, it does not halt: the plan keeps going until the ceiling.
+        assert box["n"] >= 2
+
+    @pytest.mark.asyncio
+    async def test_a_stage_gated_plan_is_never_cut_by_the_plan_budget(self, monkeypatch):
+        """RED BEFORE: an attended plan was cut, counting the user's own think time.
+
+        The clock is wall-clock from the plan's first round, and a stage-gated plan
+        spends most of it parked at an approval prompt — so enforcing the ceiling
+        there refused a plan the user was actively stepping through. The budget
+        exists to bound UNATTENDED runtime; when the user clicks each stage they
+        are the ceiling.
+
+        Driven through a SECOND Go, because that is where the cut landed: one
+        `_stage_loop` call runs a stage and returns to wait for approval, so it
+        never reaches a second stage boundary — and the boundary is the only place
+        the ceiling is evaluated.
+        """
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        state = _make_state()
+        slot = _make_slot(titles=("One", "Two"), plan_budget=100)
+        box = _stage_turns(monkeypatch, age_plan_by=200)
+
+        # First Go: stage 1 runs, the plan clock ages past the budget while the
+        # user reads the result, and the loop pauses for approval.
+        await _stage_loop(state, slot, auto_run=False)
+        assert box["n"] == 1, "stage 1 did not run"
+        assert "Click **Go**" in _assistant_text(slot), "the loop did not pause for approval"
+
+        # Second Go: enters at stage 2 and evaluates the ceiling at its top.
+        await _stage_loop(state, slot, auto_run=False)
+
+        text = _assistant_text(slot)
+        assert box["n"] == 2, "the second Go was refused by the plan budget"
+        assert "exceeded its total budget" not in text
+        assert "total budget. It will stop" not in text
+
+    @pytest.mark.asyncio
+    async def test_an_auto_run_plan_is_still_cut(self, monkeypatch):
+        """Preservation: the ceiling still applies where it was meant to."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=100)
+        box = _stage_turns(monkeypatch, age_plan_by=200)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert box["n"] == 1
+        assert "exceeded its total budget" in _assistant_text(slot)
+
+    @pytest.mark.asyncio
+    async def test_plan_under_its_budget_is_unaffected(self, monkeypatch):
+        """Preservation: a normal plan sees neither the warning nor the halt."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=DEFAULT_MAX_PLAN_DURATION)
+        box = _stage_turns(monkeypatch)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        text = _assistant_text(slot)
+        assert box["n"] == 3
+        assert "✅ All 3 stages complete." in text
+        assert "total budget" not in text
+
+    @pytest.mark.asyncio
+    async def test_disabled_budget_never_halts(self, monkeypatch):
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot(plan_budget=0)
+        box = _stage_turns(monkeypatch, age_plan_by=100_000)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert box["n"] == 3
+        assert "total budget" not in _assistant_text(slot)
+
+    @pytest.mark.asyncio
+    async def test_a_gateway_created_tracker_loads_its_budgets(self, monkeypatch, tmp_path):
+        """RED BEFORE: a tracker the loop did not create ran on constructor defaults.
+
+        The load was gated on ``tracker is None`` -- "did this loop create the
+        tracker" -- which is not the same question as "does this tracker have its
+        budgets". The Slack gateway creates one lazily when a subagent result lands
+        on an orchestrator slot, and the plan then ran with ``_plan_timeout`` at 0,
+        which means DISABLED.
+        """
+        import json
+
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps(
+                {"orchestrator": {"stage_timeout_seconds": 55, "max_plan_duration_seconds": 66}}
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+
+        slot = _make_slot(titles=("One", "Two"))
+        # The shape the gateway leaves behind: a tracker with no budgets, which the
+        # loop did not build and therefore used to skip the load for.
+        slot._orch_tracker = OrchestrationTracker()
+        assert slot._orch_tracker.budgets_unset is True
+        _stage_turns(monkeypatch)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert slot._orch_tracker.max_plan_duration_seconds == 66
+        assert slot._orch_tracker.stage_timeout_seconds == 55
+
+    @pytest.mark.asyncio
+    async def test_a_tracker_that_already_has_budgets_does_not_reload(self, monkeypatch, tmp_path):
+        """Preservation: a paused plan's later Go still pays for no config load."""
+        import json
+
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps({"orchestrator": {"max_plan_duration_seconds": 66}}), encoding="utf-8"
+        )
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+
+        loads: list[int] = []
+        real_load = KiroCrewConfig.load
+
+        def counting_load(*args, **kwargs):
+            loads.append(1)
+            return real_load(*args, **kwargs)
+
+        monkeypatch.setattr(KiroCrewConfig, "load", counting_load)
+
+        slot = _make_slot(titles=("Only",), plan_budget=999)
+        assert slot._orch_tracker.budgets_unset is False
+        _stage_turns(monkeypatch)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert loads == [], "a tracker that already carries its budgets must not reload"
+        assert slot._orch_tracker.max_plan_duration_seconds == 999
+
+    @pytest.mark.asyncio
+    async def test_a_failed_load_still_arms_the_plan_watchdog(self, monkeypatch, tmp_path):
+        """RED BEFORE: an unreadable config silently removed the plan ceiling.
+
+        The tracker constructs with ``_plan_timeout = 0`` and 0 means DISABLED, so
+        the ``except`` branch skipping the assignment left the whole-plan watchdog
+        off while the stage budget fell back to its own default -- an asymmetry
+        with no reading under which it is correct.
+        """
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        def raising_load(*args, **kwargs):
+            raise RuntimeError("config is unreadable")
+
+        monkeypatch.setattr(KiroCrewConfig, "load", raising_load)
+
+        slot = _make_slot(titles=("One",))
+        slot._orch_tracker = None
+        _stage_turns(monkeypatch)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert slot._orch_tracker.max_plan_duration_seconds == DEFAULT_MAX_PLAN_DURATION
+        assert slot._orch_tracker.stage_timeout_seconds == 1800
+
+    @pytest.mark.asyncio
+    async def test_a_failed_load_is_not_retried_on_the_next_entry(self, monkeypatch, tmp_path):
+        """One bad config read must not become one per stage-loop entry."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        loads: list[int] = []
+
+        def raising_load(*args, **kwargs):
+            loads.append(1)
+            raise RuntimeError("config is unreadable")
+
+        monkeypatch.setattr(KiroCrewConfig, "load", raising_load)
+
+        slot = _make_slot(titles=("One",))
+        slot._orch_tracker = None
+        _stage_turns(monkeypatch)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+        assert loads == [1]
+        assert slot._orch_tracker.budgets_unset is False
+
+        # A second entry (the user's next Go) re-uses the same tracker.
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert loads == [1], "the failed load was re-attempted on a later entry"
+
+    @pytest.mark.asyncio
+    async def test_configured_budget_reaches_the_tracker(self, monkeypatch, tmp_path):
+        """The loop's bootstrap load must apply BOTH budgets, not just the stage one."""
+        import json
+
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text(
+            json.dumps(
+                {"orchestrator": {"stage_timeout_seconds": 55, "max_plan_duration_seconds": 66}}
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("kiro_crew.config.loader.config_dir", lambda: tmp_path)
+
+        slot = _make_slot(titles=("Only",))
+        slot._orch_tracker = None  # force the bootstrap path that loads config
+        _stage_turns(monkeypatch)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert slot._orch_tracker.stage_timeout_seconds == 55
+        assert slot._orch_tracker.max_plan_duration_seconds == 66

--- a/test/test_stage_result_write_off_loop.py
+++ b/test/test_stage_result_write_off_loop.py
@@ -1,0 +1,212 @@
+"""Writing a stage result must not run on the gateway event loop.
+
+``_stage_loop`` captures each finished stage to disk. That capture used to be one
+synchronous call on the loop: it walked ``slot.messages``, redacted every
+assistant segment, created the session directory and wrote the file — so a slow
+disk or a large stage blocked every other session on the gateway (issue #1783).
+
+Only the parts that CAN cross a thread boundary do. The message walk stays on the
+loop because ``slot.messages`` is live state the loop mutates; the redaction and
+the filesystem work take an immutable tuple of strings, which is what makes them
+safe to hand to a worker. Same split as ``_previous_result_paths`` /
+``_read_previous_results``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path, monkeypatch):
+    for module in ("state", "chat", "chat_orchestrator"):
+        monkeypatch.setattr(f"kiro_crew.dashboard.{module}.config_dir", lambda: tmp_path)
+
+
+def _make_state():
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    return state
+
+
+def _make_slot(titles=("First",)):
+    slot = _ChatSlot("stage-write-slot", mode="orchestrator")
+    slot._auto_run = True
+    slot._stage_titles = list(titles)
+    slot._plan_goal = "Test goal"
+    slot._orch_tracker = None
+    return slot
+
+
+def _stage_texts(monkeypatch, texts):
+    box = {"n": 0}
+
+    async def _mock_run_chat(state, slot, message, **kwargs):
+        idx = box["n"]
+        box["n"] += 1
+        if idx < len(texts):
+            slot.append("assistant", texts[idx], "msg msg-a")
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+
+
+async def _run_plan(monkeypatch, titles, texts):
+    from kiro_crew.dashboard.chat import _stage_loop
+
+    slot = _make_slot(titles)
+    _stage_texts(monkeypatch, texts)
+    await _stage_loop(_make_state(), slot, auto_run=True)
+    return slot
+
+
+@pytest.mark.asyncio
+async def test_stage_result_write_runs_off_the_loop_thread(monkeypatch, tmp_path):
+    """RED BEFORE: the write was a bare synchronous call in the stage loop."""
+    seen_threads: list[int] = []
+    real_write = pathlib.Path.write_text
+    target = tmp_path / "sessions" / "stage-write-slot" / "stage_1_result.md"
+
+    def recording_write(self, *args, **kwargs):
+        # Scoped to this stage's result file: history and metadata writes on the
+        # loop are legitimate and must not decide this assertion.
+        if self == target:
+            seen_threads.append(threading.get_ident())
+        return real_write(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", recording_write)
+
+    await _run_plan(monkeypatch, ["First"], ["alpha done"])
+
+    assert seen_threads, (
+        "the stage result was never written -- this test no longer exercises the "
+        "capture and would pass vacuously"
+    )
+    assert threading.get_ident() not in seen_threads, (
+        "the stage result was written on the event-loop thread; the filesystem "
+        "work must be handed to asyncio.to_thread"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_directory_is_created_off_the_loop_thread(monkeypatch, tmp_path):
+    """``mkdir`` is its own syscall and travels with the write."""
+    seen_threads: list[int] = []
+    real_mkdir = pathlib.Path.mkdir
+    target = tmp_path / "sessions" / "stage-write-slot"
+
+    def recording_mkdir(self, *args, **kwargs):
+        if self == target:
+            seen_threads.append(threading.get_ident())
+        return real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "mkdir", recording_mkdir)
+
+    await _run_plan(monkeypatch, ["First"], ["alpha done"])
+
+    assert seen_threads, "the session directory was never created"
+    assert threading.get_ident() not in seen_threads
+
+
+@pytest.mark.asyncio
+async def test_redaction_runs_off_the_loop_thread(monkeypatch):
+    """The regex pass over a whole stage's output is CPU work, and it moves too."""
+    from kiro_crew.dashboard import chat_orchestrator
+
+    seen_threads: list[int] = []
+    real = chat_orchestrator.redact_credentials
+    stage_body = "alpha done"
+
+    def recording(text):
+        # Scoped to the stage body: the loop also redacts the separator, the
+        # injected context and the completion summary, and those calls belong on
+        # the loop.
+        if text == stage_body:
+            seen_threads.append(threading.get_ident())
+        return real(text)
+
+    monkeypatch.setattr(chat_orchestrator, "redact_credentials", recording)
+
+    await _run_plan(monkeypatch, ["First"], [stage_body])
+
+    assert seen_threads, (
+        "the stage body was never redacted -- this test no longer exercises the "
+        "capture's redaction pass and would pass vacuously"
+    )
+    assert (
+        threading.get_ident() not in seen_threads
+    ), "stage-result redaction ran on the event-loop thread"
+
+
+@pytest.mark.asyncio
+async def test_the_message_walk_stays_on_the_loop(monkeypatch):
+    """Live slot state must NOT be reachable from the worker.
+
+    ``_collect_stage_result_parts`` reads ``slot.messages``, which the loop
+    mutates, so it is the half that must stay put -- handing the slot itself to a
+    thread is the bug this split exists to avoid.
+    """
+    from kiro_crew.dashboard import chat_orchestrator
+
+    seen_threads: list[int] = []
+    real = chat_orchestrator._collect_stage_result_parts
+
+    def recording(slot):
+        seen_threads.append(threading.get_ident())
+        return real(slot)
+
+    monkeypatch.setattr(chat_orchestrator, "_collect_stage_result_parts", recording)
+
+    await _run_plan(monkeypatch, ["First"], ["alpha done"])
+
+    assert seen_threads == [threading.get_ident()]
+
+
+# ── Preservation ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_result_file_content_is_unchanged(monkeypatch, tmp_path):
+    slot = await _run_plan(monkeypatch, ["First", "Second"], ["alpha done", "beta done"])
+
+    body = (tmp_path / "sessions" / slot.key / "stage_2_result.md").read_text(encoding="utf-8")
+    assert "beta done" in body
+    # Only this stage's output: the walk stops at the stage separator.
+    assert "alpha done" not in body
+
+
+@pytest.mark.asyncio
+async def test_credentials_are_still_redacted_before_disk(monkeypatch, tmp_path):
+    """Preservation: this writes a NEW file outside the history log's redaction."""
+    slot = await _run_plan(monkeypatch, ["First"], ["key AKIAIOSFODNN7EXAMPLE here"])
+
+    body = (tmp_path / "sessions" / slot.key / "stage_1_result.md").read_text(encoding="utf-8")
+    assert "AKIAIOSFODNN7EXAMPLE" not in body
+
+
+def test_the_two_halves_compose_to_the_same_result(tmp_path, monkeypatch):
+    """Preservation: walking then writing off-loop still produces the same file.
+
+    The split is only sound if the halves compose, so this drives them in sequence
+    the way ``_stage_loop`` does and checks the bytes that land.
+    """
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator.config_dir", lambda: tmp_path)
+    from kiro_crew.dashboard.chat_orchestrator import (
+        _collect_stage_result_parts,
+        _write_stage_result,
+    )
+
+    slot = _ChatSlot("sync-capture-slot", mode="orchestrator")
+    slot.append("assistant", "written synchronously", "msg msg-a")
+
+    path = _write_stage_result(slot.key, 1, _collect_stage_result_parts(slot))
+
+    assert pathlib.Path(path).read_text(encoding="utf-8") == "written synchronously"

--- a/test/test_stage_round_cap_enforced.py
+++ b/test/test_stage_round_cap_enforced.py
@@ -1,0 +1,255 @@
+"""``MAX_STAGE_ROUNDS`` must stop a dashboard plan.
+
+``OrchestrationTracker.record_round()`` returns whether the stage has spent its
+round budget, and the dashboard's ``_stage_loop`` recorded the round and threw the
+answer away — so the "max 3 rounds per stage" the orchestrator prompt promises
+enforced nothing on the dashboard path (issue #1783).
+
+Where the rounds come from matters for what has to be tested. Every round is
+recorded by the subagent-completion handler, against ``tracker.current_stage`` as
+each spawn wave finishes — i.e. while the stage is still running. So the enforcing
+gate is the one AFTER a stage's subagent wave, and the mocked stage turn below
+records those rounds the same way the gateway does.
+
+The loop does NOT record one. It enters a stage through ``start_stage``, which
+registers the stage and starts its clock but spends no round, so all three the
+prompt promises are available to actual waves. Entering through ``record_round``
+(which is what the loop used to do, for the side effects rather than the count)
+made the enforced cap 2 waves on this path and 3 on the Slack path — stricter than
+the promise, and inconsistent between the two. That is what
+``test_two_waves_per_stage_is_still_under_the_cap`` guards.
+
+``MAX_STAGE_ESCALATIONS`` is deliberately NOT enforced on this path, and there is
+nothing here to test for it. An escalation is only recorded by
+``reset_after_guidance``, which zeroes that stage's rounds while KEEPING its key —
+so ``current_stage`` does not move, the loop's next entry starts at the stage after
+it, and an escalated stage is never re-entered. It stays enforced in the Slack
+gateway, where the tracker is not driven by a stage loop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from kiro_crew.context_management import MAX_STAGE_ROUNDS, OrchestrationTracker
+from kiro_crew.dashboard.state import _ChatSlot
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(tmp_path, monkeypatch):
+    """Stage results are written under ``config_dir()`` — keep them per-test."""
+    for module in ("state", "chat", "chat_orchestrator"):
+        monkeypatch.setattr(f"kiro_crew.dashboard.{module}.config_dir", lambda: tmp_path)
+
+
+def _make_state():
+    state = MagicMock()
+    state.broadcast_ws = MagicMock()
+    state.push_slots_update = MagicMock()
+    state.subagents = MagicMock()
+    state.subagents.running_agents_for = MagicMock(return_value=[])
+    return state
+
+
+def _make_slot(titles=("First", "Second", "Third")):
+    slot = _ChatSlot("round-cap-slot", mode="orchestrator")
+    slot._auto_run = True
+    slot._stage_titles = list(titles)
+    slot._plan_goal = "Test goal"
+    # A pre-built tracker keeps the loop off its bootstrap path, so no config
+    # load runs and the seeded ledger is the one under test.
+    slot._orch_tracker = OrchestrationTracker(stage_timeout_seconds=1800)
+    return slot
+
+
+def _stage_turns(monkeypatch, *, extra_rounds_per_stage=0, texts=None):
+    """Mock the stage turn, optionally recording subagent-wave rounds.
+
+    ``extra_rounds_per_stage`` mimics the Slack gateway's subagent-completion
+    handler, which records a round against ``tracker.current_stage`` each time a
+    spawn wave for the running stage finishes.
+    """
+    box = {"n": 0}
+
+    async def _mock_run_chat(state, slot, message, **kwargs):
+        idx = box["n"]
+        box["n"] += 1
+        body = (texts or [])[idx] if texts and idx < len(texts) else f"stage {idx + 1} output"
+        slot.append("assistant", body, "msg msg-a")
+        tracker = slot._orch_tracker
+        for _ in range(extra_rounds_per_stage):
+            tracker.record_round(tracker.current_stage)
+
+    monkeypatch.setattr("kiro_crew.dashboard.chat_orchestrator._run_chat", _mock_run_chat)
+    return box
+
+
+def _assistant_text(slot):
+    return "\n".join(m.get("content", "") for m in slot.messages if m.get("role") == "assistant")
+
+
+def _stages_run(box):
+    return box["n"]
+
+
+# ── The enforcing gate: rounds spent during a stage ──────────────────────────
+
+
+class TestRoundCapStopsThePlan:
+    @pytest.mark.asyncio
+    async def test_round_cap_halts_before_the_next_stage(self, monkeypatch):
+        """RED BEFORE: the loop advanced through every stage regardless."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot()
+        # Entry spends nothing, so the cap takes a full MAX_STAGE_ROUNDS waves.
+        box = _stage_turns(monkeypatch, extra_rounds_per_stage=MAX_STAGE_ROUNDS)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert _stages_run(box) == 1, "the plan advanced past a round-capped stage"
+        assert "all 3 of its spawn rounds" in _assistant_text(slot)
+        assert "✅ All 3 stages complete." not in _assistant_text(slot)
+
+    @pytest.mark.asyncio
+    async def test_round_cap_stops_auto_run(self, monkeypatch):
+        """A later Go must not silently keep an auto-run plan going."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot()
+        box = _stage_turns(monkeypatch, extra_rounds_per_stage=MAX_STAGE_ROUNDS)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert slot._auto_run is False
+        # Paired with the halt: a plan that ran to completion also clears the
+        # flag, so the flag alone would assert nothing about the cap.
+        assert box["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_capped_stage_keeps_its_result_on_disk(self, monkeypatch, tmp_path):
+        """The halt is placed AFTER the capture, so the finished stage is not lost.
+
+        Ordering, not mere existence: the cap could have been enforced before the
+        capture, which would throw away a stage that had genuinely finished. The
+        halt assertion is what makes this test about that ordering.
+        """
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot()
+        box = _stage_turns(monkeypatch, extra_rounds_per_stage=MAX_STAGE_ROUNDS)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert box["n"] == 1, "the plan did not halt, so this proves nothing"
+        result = tmp_path / "sessions" / slot.key / "stage_1_result.md"
+        assert result.exists()
+        assert slot._orch_tracker._stage_results.get(1) == str(result)
+
+    @pytest.mark.asyncio
+    async def test_round_cap_is_audited(self, monkeypatch):
+        """The stop is a security-relevant guard, so it is logged like the others."""
+        from kiro_crew.dashboard import chat_orchestrator
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        events: list[str] = []
+        sink = MagicMock()
+        sink.log = MagicMock(side_effect=lambda ev: events.append(ev.operation))
+        monkeypatch.setattr(chat_orchestrator, "sel", lambda: sink)
+
+        slot = _make_slot()
+        _stage_turns(monkeypatch, extra_rounds_per_stage=MAX_STAGE_ROUNDS)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert "stage_round_cap" in events
+
+    @pytest.mark.asyncio
+    async def test_a_plan_under_its_budget_is_unaffected(self, monkeypatch):
+        """Preservation: one round per stage is the normal case and must run through."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot()
+        box = _stage_turns(monkeypatch, extra_rounds_per_stage=0)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert _stages_run(box) == 3
+        assert "✅ All 3 stages complete." in _assistant_text(slot)
+
+    @pytest.mark.asyncio
+    async def test_two_waves_per_stage_is_still_under_the_cap(self, monkeypatch):
+        """The budget belongs to the WAVES, and all 3 of it must be spendable.
+
+        This is the off-by-one guard. Entering a stage through ``record_round``
+        would leave only two waves before the cut, so a plan the prompt says has
+        three rounds per stage would be halted on its second — and the identical
+        stage driven from the Slack handler, which has no stage loop, would get
+        its third. This fails the moment stage entry starts spending a round
+        again.
+        """
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot()
+        box = _stage_turns(monkeypatch, extra_rounds_per_stage=MAX_STAGE_ROUNDS - 1)
+
+        await _stage_loop(_make_state(), slot, auto_run=True)
+
+        assert _stages_run(box) == 3, (
+            "a stage was cut one wave early: something is spending a round that "
+            "is not a spawn wave"
+        )
+        assert "spawn rounds" not in _assistant_text(slot)
+
+
+class TestAttendedPlansAreNotHalted:
+    """The cap bounds UNATTENDED runs; an attended stage at its budget gets Go."""
+
+    @pytest.mark.asyncio
+    async def test_attended_stage_at_the_cap_still_offers_go(self, monkeypatch):
+        """RED BEFORE: `_halt_plan` fired, said "Auto-run stopped", and skipped the Go row."""
+        from kiro_crew.dashboard.chat import _stage_loop
+
+        slot = _make_slot()
+        slot._auto_run = False
+        box = _stage_turns(monkeypatch, extra_rounds_per_stage=MAX_STAGE_ROUNDS)
+
+        await _stage_loop(_make_state(), slot, auto_run=False)
+
+        assert _stages_run(box) == 1, "an attended Go runs exactly one stage"
+        text = _assistant_text(slot)
+        assert "[OPTION: Go | Go All | Cancel]" in text, (
+            "the step-through was stranded: no Go row after a stage that finished "
+            "within its allowed budget"
+        )
+        assert "Auto-run stopped" not in text, "a plan never in auto-run was told it stopped"
+
+
+class TestEntryDoesNotSpendARound:
+    """The tracker-level contract the loop depends on."""
+
+    def test_start_stage_registers_the_stage_at_zero_rounds(self):
+        tracker = OrchestrationTracker(stage_timeout_seconds=1800)
+        tracker.start_stage(1)
+
+        assert tracker.round_count(1) == 0, "entering a stage spent a spawn round"
+        assert tracker.current_stage == 1, (
+            "the stage was not registered, so the Slack handler would record its "
+            "waves against the wrong stage and the loop would resume at the wrong one"
+        )
+        assert tracker.round_limit_reached(1) is False
+
+    def test_the_full_budget_is_available_after_entry(self):
+        tracker = OrchestrationTracker(stage_timeout_seconds=1800)
+        tracker.start_stage(1)
+
+        for _ in range(MAX_STAGE_ROUNDS - 1):
+            assert tracker.round_limit_reached(1) is False
+            tracker.record_round(1)
+
+        assert (
+            tracker.round_limit_reached(1) is False
+        ), f"capped after {MAX_STAGE_ROUNDS - 1} waves; the promise is {MAX_STAGE_ROUNDS}"
+        assert tracker.record_round(1) is True


### PR DESCRIPTION
## Problem / Motivation

Three items from the autopilot hardening tracker (#1783), all the same shape: the
orchestrator advertises a guarantee that nothing implements.

- **`MAX_STAGE_ROUNDS` was dead code on the dashboard.** `record_round()` returns
  whether the stage has spent its round budget and `_stage_loop` discarded the
  return value. The "max 3 rounds per stage" the orchestrator prompt promises
  enforced nothing here.
- **No whole-plan duration ceiling.** `OrchestratorConfig` carried only
  `stage_timeout_seconds`, which bounds ONE stage. Ten stages at the 30-minute
  default is a five-hour unattended run with nothing to stop it.
- **`_capture_stage_result` did blocking disk I/O on the event loop** — the
  message walk, the redaction of every segment, the `mkdir` and the write.

And one defect found while working on a fourth item, which is fixed here instead
of that item:

- **A restored plan's Go did nothing, silently.** `mode` is persisted and the
  transcript keeps the plan turn's `[OPTION: Go | Go All | Cancel]` row, but the
  plan shape is in-memory only — so a restored slot renders buttons over a plan
  that no longer exists, and pressing one ran zero stages and returned no
  response at all. Indistinguishable from a hang.

## Why it matters

A user who clicks Go All is handing over unattended execution on the strength of
two promises: that a stage cannot spin forever, and that the run as a whole is
bounded. Neither held on the dashboard path. The inert round cap means a stage
keeps spawning waves past its budget; the missing duration ceiling means the
worst case is unbounded once you multiply stages.

The silent Go is smaller but worse to sit in front of: the one thing a user
cannot do with it is tell whether anything is happening.

## What changed (motivation → approach → change)

**The round cap stops a dashboard plan.** Where the rounds come from decides
where the gate belongs: `_subagent_done` records one round per completed spawn
wave against `tracker.current_stage`, i.e. while the stage is still running. So
the enforcing gate is the one **after** a stage's subagent wave, and it is placed
after the result capture so a stage that genuinely finished keeps its result on
disk.

**Stage entry no longer spends a round** (`OrchestrationTracker.start_stage`).
This is an off-by-one that only became reachable by enforcing the cap. The loop
entered a stage through `record_round`, called for its side effects rather than
its count — inert while nothing on this path read the cap, but once the cap IS
read that tick spends a third of the budget before any subagent runs: a dashboard
stage would be cut after **two** waves while the identical stage driven from
`_subagent_done` (no stage loop, so no entry tick) got three. Stricter than the
prompt promises *and* inconsistent between the two paths. `start_stage` registers
the stage at zero rounds and restarts the stage clock; counting stays in
`record_round`, so all three rounds belong to actual waves.

**The cap halts auto-run only**, like the watchdog and for the same reason: it
bounds an *unattended* plan. An attended stage that spent exactly its 3 allowed
waves and finished has done nothing wrong and is about to be offered Go anyway;
halting it said "Auto-run stopped" on a plan never in auto-run and skipped the Go
row, stranding the step-through (Opus round 8, `chat_orchestrator.py:988`).

**The cap is a stage-boundary halt, not a per-spawn denial — deliberately.**
Rounds are recorded when a wave *completes*, so within one stage turn the model
can issue a further wave before the boundary check runs (GPT round 7,
`chat_orchestrator.py:995`). Closing that would mean a hard gate inside the spawn
tool that reads the orchestration tracker: a new control layer in the spawn path,
which #1783 does not ask for, and which every spawned agent's own governance gate
already bounds. The boundary halt is the guarantee the prompt actually promises
("auto-run stops"), it is user-visible, and it is exactly what the Slack path has
always had. Overridden rather than built, for the same reason the persistence
item was withdrawn: the finding is real and the fix is out of proportion to it.

**`MAX_STAGE_ESCALATIONS` is deliberately not checked here**, and that is a
reachability fact rather than a preference. Escalations are only recorded by
`reset_after_guidance`, which zeroes the capped stage's rounds while KEEPING its
key — so `current_stage` (the highest key) does not move, the loop's next entry
starts at the stage after it, and an escalated stage is never re-entered. Nothing
on this path can observe `is_force_failed`, so a check here would be dead code:
the very defect this PR is fixing. It stays enforced in `slack/gateway.py`, where
the tracker is not driven by a stage loop.

**Whole-plan watchdog.** `orchestrator.max_plan_duration_seconds` (default 2 h,
`0` disables) is checked at each stage boundary, with one warning at 75% latched
inside the tracker. At the boundary rather than mid-turn: the running stage
already has its own ceiling, and cutting between stages leaves every finished
stage captured on disk.

**Auto-run only.** The clock is wall-clock from the plan's first stage, and a
stage-gated plan spends most of it parked at an approval prompt — so the ceiling
cut a plan the user was actively stepping through, counting their own review time
between Go clicks against them. The budget exists to bound *unattended* runtime;
when the user clicks each stage they are the ceiling. Gated on the loop's
`auto_run` parameter rather than `slot._auto_run`, because the slot flag is
cleared by every halt path and would make the gate depend on whether something
had already gone wrong.

**The budget load is a question about the tracker, not about the loop.** It was
gated on `tracker is None` — "did this loop create the object" — so a tracker the
loop did not build ran the whole plan on constructor defaults, with the new plan
watchdog sitting at `0`, which means DISABLED. That tracker is real: the Slack
gateway creates one lazily when a subagent result lands on a slot the loop has
not reached. The tracker now answers `budgets_unset`, and `mark_budgets_loaded()`
is recorded even when the load *raised*, so one bad config read cannot become one
per stage-loop entry. A failed load lands both budgets on `OrchestratorConfig`'s
dataclass defaults rather than leaving the ceiling at 0.

*Two things ride along.* `context_management.py` and
`test_completion_result_read_off_loop.py` leave `.github/black-baseline.txt`:
both became black-clean as a side effect of formatting the code this change
touches, and the gate requires a file that has become clean to be pruned. Not
split into its own commit because the readiness guard asserts a single commit on
base.

*One user-visible rendering change rides along.* `timeout_human` inlined
minute/second formatting; extracting `_human_secs` so an hour-scale plan budget
can render `2h` added an hours branch that the **existing** per-stage timeout
text now goes through too — a stage timeout configured at 3600s used to print
`60m` and now prints `1h`. Nothing else about that message changed and no caller
parses the string. Kept rather than reverted, because without the hours branch
the 2 h plan budget would render `120m`.

**Capture off the loop, split at the boundary the repo already uses.**
`_collect_stage_result_parts` walks the assistant messages on the loop, because
`slot.messages` is live state the loop mutates, and hands an immutable tuple of
raw strings to `_write_stage_result` on a worker, which redacts and writes. So
the redaction pass moves off the loop too, and nothing mutable is reachable from
that thread — the same split as `_previous_result_paths` / `_read_previous_results`.
`_capture_stage_result` is **deleted**: it was retained "for callers that are not
on the event loop" and there were none (one `# noqa: F401` re-export plus test
files), so the retention rationale was fiction.

**A plan whose stages are gone is refused out loud.** `_stage_loop` posts
`⚠️ This plan is no longer active …`, logs `auto_run_plan_expired` /
`plan_shape_absent`, closes the turn out (`chat_done`, `slot.task = None`) and
returns — before the tracker is built, so before the config is read. Not gated on
`auto_run`, so Go All is refused the same way. The same gate covers a planning
turn that parsed no stages, which arrives in the identical state, so the message
names the state rather than a cause.

## Scope change: cross-restart plan persistence is withdrawn

This PR opened with a fourth item — persisting plan state so a restart resumes.
That was implemented, reviewed over five rounds, and has been **removed** rather
than landed. It is worth stating why in the open, because the item is on #1783
and stays open there.

**The review record.** Nine of the eleven findings raised on this PR came from
that one item, and every one of them was the same class: a persisted record is
untrusted input and the design kept treating it as data it had written itself —
`str()`-coerced result values that let a hand-edited record skip a stage that
never ran, an unconfined result path that inlined any readable file into the next
stage's prompt, a `snapshot()` that iterated live ledger dicts from a worker
thread, `bool("false")` reading as started. Each was fixable and each was fixed.
The last one was not: a crash between recording a stage result in memory and the
next slot save leaves a record that says a stage finished when its work is gone,
or the reverse, and there is no answer to that *inside* the persistence design —
only a durability contract the module does not have.

**The boundary that actually resolves it.** Autopilot is a lightweight executor
of a plan the user is watching, not a task runner that owns work across process
lifetimes. Resuming means restoring an execution ledger — which stage ran, how
many rounds it spent, which results are real — and every restored fact is a way
to re-run a completed stage's side effects or to skip a stage that never ran. A
plan is cheap to re-ask for; a mis-resumed plan is not.

**What the module owes the user is therefore honesty, not continuity.** That is
the refusal above: the plan shape stays in memory, a restart ends the plan, and
the button says so instead of doing nothing. `stage_*_result.md` files still
survive on disk and the message says so.

Removed with it, because it becomes unreachable: the escalation-cap entry gate
(it could only be reached by a restored tracker) and the `plan` metadata field,
`snapshot()`, `from_snapshot()`, `resume_stage()`, `_plan_state_for_save` and
`_restore_plan_state`. `chat_persistence.py` and `history.py` are back to
`origin/main` byte-for-byte.

Kept from that work, because it fixes a pre-existing hole unrelated to
persistence: `budgets_unset` / `mark_budgets_loaded`, which is what stops the
gateway's lazily created tracker from running a plan on constructor defaults.

## Tests

41 tests across four new files, each proven red on this tree before the fix.

- `test/test_stage_round_cap_enforced.py` (9) — a stage whose waves spend its
  round budget halts the plan, stops auto-run, keeps its result on disk (the
  ordering assertion, paired with the halt so it cannot pass vacuously), and is
  audited. Plus the **off-by-one guard**: two waves per stage must run the plan
  through, which fails the moment stage entry starts spending a round again, and
  the tracker-level pair — `start_stage` registers at zero rounds, and the full
  `MAX_STAGE_ROUNDS` is spendable after entry. And an attended stage at exactly
  the cap still gets its Go row rather than a halt.
- `test/test_plan_duration_watchdog.py` (21) — the clock starts with the plan and
  is not re-armed per stage; timeout, disabled (`0`), and the latched 75% warning;
  the loop halts at the boundary naming the budget and elapsed time; finished
  stages stay on disk; a stage-gated plan driven through a **second** Go with the
  clock already past the budget is not cut, while the auto-run cut still fires;
  the config default is 2 h; a tracker the loop did not create loads both budgets,
  one that already carries them does not reload, and a failed load is not
  re-attempted.
- `test/test_stage_result_write_off_loop.py` (7) — the write, the `mkdir` and the
  redaction all run off the loop thread; the message walk stays ON it (live slot
  state must not be reachable from the worker); plus preservation of file content,
  the stage-separator boundary, and redaction before disk.
- `test/test_expired_plan_is_refused.py` (4) — the refusal is audible rather than
  silent, closes the turn out (`chat_done`, `slot.task`, slot list), costs no
  tracker and no config load, and applies to Go All identically.

Two existing files move with the code. `test_completion_result_read_off_loop.py`
moves its intercept from `_capture_stage_result` to `_write_stage_result` —
against the split its substitute would never run and it would pass vacuously.
`test_orchestrator_config_load_off_loop.py`'s fixture now carries one stage
title: it used an EMPTY plan to reach tracker initialisation, and the new refusal
turns an empty plan away before anything is built, so every assertion in that
file would have passed vacuously. Its subjects are unchanged.

## Manual verification

N/A — unit coverage sufficient. Every path is exercised through the real
`_stage_loop` rather than mocked seams; the off-loop assertions wrap the actual
syscalls (`Path.write_text`, `Path.mkdir`) so they record the thread that
genuinely performed the I/O.

Gates run locally on the rebased head: `black` (the repo's baselined gate),
`isort`, `flake8` (`src/` + `test/`), `mypy src/kiro_crew/` (1296 files clean),
`docs_lint`, and 885 tests across the orchestrator / tracker / dashboard-chat
families.

## Related Issues

Related: #1783

no linked issue: #1783 is an umbrella tracker with items this PR deliberately
leaves open, so a closing keyword would close it while most of its checklist is
still unchecked.

This PR covers two P1 items (the dead round cap, the missing total-plan watchdog)
and one P2 item (the blocking capture). Cross-restart plan persistence — also P1 —
is **withdrawn by design** (see the scope-change section); #1783's checklist entry
for it stays unchecked, and the reasoning above is the argument for closing it as
won't-do rather than for keeping it open.

**#8798** is now moot and should be re-scoped or closed: it proposed deriving the
stage loop's start index from `resume_stage()`, which no longer exists.

Also left for follow-up, unchecked on #1783 rather than silently dropped:

- P1: the recovery-retrigger cap never resetting at stage boundaries
  (`gateway.py` `_retrigger_recovery`); stage-1 timeout initialisation.
- P2: an empty stage counting as done; the 2 s subagent busy-wait; linear growth
  of previous-result injection; `_pending_synthesis` armed but never consumed in
  orchestrator mode; one-member-per-sweep stuck-wave reconciliation.
- All of P3.

## Pattern harvest

Rule candidate: review-prompt

Pattern: **a limit is only as real as the unit it counts, and wiring up an
ignored limit re-opens the definition of that unit.** Enforcing
`MAX_STAGE_ROUNDS` was a two-line change; the defect it created was that the loop
had been calling `record_round` for its *side effects* for as long as the counter
was ignored, so switching the counter on silently repurposed a bookkeeping call
as a budget spend — and made one path stricter than both the prompt and the other
path. The proposed rule: when you make a previously-ignored counter load-bearing,
enumerate every existing call site and say, for each, whether it is an instance
of the thing being counted. Its companion, from the same change: state a gate as
a property of the object being gated (`does this tracker have its budgets`) rather
than of the code path that reached it (`did I create this tracker`) — the two
agree everywhere except the path you are adding.

Second, on scope rather than code: **nine of eleven findings landing on one item
of a four-item PR is a design signal, not a run of bad luck.** Every individual
finding on the persistence item was legitimate and fixable, and fixing them one at
a time is what kept the item alive for five rounds; the count was the thing worth
reading. The rule: when findings concentrate that heavily on one item, stop fixing
and ask whether that item's contract is the problem — and prefer withdrawing it
from the PR over converging it, since the other items are then reviewable on their
own merits.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/autopilot.md`: the stage
      loop's new gates and the plan-shape refusal, `start_stage`, the split
      capture, the limits table with the escalation-cap reachability note, and
      the restored "plan progress is not persisted" limitation)
- [x] No secrets, credentials, or internal references in the diff

### Round 8 — advisory residue taken, one blocking finding overridden

Design Review and First Principles both PASS/CONCERNS; their notes are taken:
two stale persistence comments deleted (`chat_orchestrator.py` budget-load gate,
the orphaned `Persistence across a gateway restart` header), `_round_cap_verdict`
→ `_round_cap_message` returning just the string (its `operation` was a constant
with one consumer), redaction dropped from `_halt_plan` / `_dead_msg` /
`_warn_msg` (every input is an integer, a humanized duration or a literal — the
"model-authored" rationale was false), the baseline prune declared above, and the
attended→Go All clock asymmetry recorded in the spec as deliberate.

GPT's blocking finding (per-spawn cap enforcement) is overridden with the
reasoning in the round-cap section above.

### Round 9 — Opus advisory taken; the remaining red is inherited from `main`

The round-cap halt is now gated on `auto_run` (see the round-cap section).

### Round 10 — review lanes all green; one inherited red on `main`

On `5f1613d3d` (rebased past #8844, which closed the `members.py` red from
#8846) all four review lanes pass: Design Review PASS, First Principles PASS,
Opus "No findings", GPT human override accepted. The only failing check is
`Backend Tests (3.12, 4)`, one test — `test_snapshot.py::TestNotificationCopyWhenNoLiveFileExists::test_a_FRESH_gateway_still_orders_the_copy_against_a_delivery`
— which this PR does not touch (its diff is confined to `context_management.py`,
`chat_orchestrator.py`, `config/*` and their tests), which passes locally 3/3,
and which is red on `main` itself at `002081169` (already in this branch's base).
Tracked as #8915 (closed as a duplicate of #8893); it was introduced by #8576.

### Round 11 — rebased past the `main` fix

#8893 is fixed on `main` (#8992, #9047). Rebased onto that `main` (62 commits
ahead of the previous base); one conflict in `docs/system-specs/modules/autopilot.md`,
where `main` had replaced hard-coded line references (`chat_orchestrator.py:140`,
`chat_persistence.py:1398`) with symbol names — resolved by keeping this PR's text
in `main`'s reference style. No code conflicts. The previously-failing
`TestNotificationCopyWhenNoLiveFileExists` class passes on the new base locally
alongside this PR's own tests (913 total), and every local gate is green.
