### PR TITLE
fix(nav): yield the drawer swipe to an active text selection (#8357)

### DIFF
--- a/website/src/hooks/useDrawerSwipe.ts
+++ b/website/src/hooks/useDrawerSwipe.ts
@@ -769,6 +769,53 @@ function dragOwnedBelow(chain: HTMLElement[], root: HTMLElement, side: Side): bo
   return false
 }
 
+/**
+ * Whether an active TEXT SELECTION owns the touch starting at `target`.
+ *
+ * A long-press selects a word and puts two drag handles on it, and extending
+ * the selection is a HORIZONTAL drag over ordinary chat text — dead center in
+ * this gesture's arming surface. Nothing else here can see it: the handles are
+ * browser chrome, not elements in the chain, so `dragOwnedBelow` finds no claim
+ * and `findHorizontalScroller` no scroller, and the handle drag passed every
+ * guard and locked as an open-drawer gesture — the drawer slid in mid-selection.
+ * The selection itself is the signal: a non-collapsed range means the user is
+ * working WITH the text under the finger, and a horizontal drag during one is
+ * the handle, not the drawer — the hamburger is still there for the exception.
+ *
+ * A focused EDITABLE under the finger is the same situation one step earlier:
+ * the caret's own handle drags before any range exists, so a touch that begins
+ * inside the element being typed in yields too. Focus is required — merely
+ * containing an input must not turn a whole form into a gesture sink, and an
+ * idle input the user is not in carries no handle to defer to.
+ *
+ * Reads the COMPOSED chain, like the two guards above, and for the same reason
+ * (see `touchedChain`): outside a shadow root both `e.target` AND
+ * `document.activeElement` are retargeted to the host, so a walk up
+ * `parentElement` from the retargeted target never meets an editable inside
+ * one. The chain crosses the boundary, and the focus side descends through
+ * `shadowRoot.activeElement` to the element that really holds the caret.
+ *
+ * Fails toward the gesture, like every guard here: no document (SSR, a bare
+ * test environment) means no selection to defer to.
+ */
+function selectionOwnsTouch(chain: HTMLElement[]): boolean {
+  if (typeof document === 'undefined') return false
+  const sel = typeof document.getSelection === 'function' ? document.getSelection() : null
+  if (sel && !sel.isCollapsed) return true
+  // The deepest focused element: `document.activeElement` stops at a shadow
+  // HOST, and each root names its own inner focus.
+  let active: Element | null = document.activeElement
+  while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement
+  if (!active) return false
+  for (const node of chain) {
+    const editable = node instanceof HTMLInputElement
+      || node instanceof HTMLTextAreaElement
+      || node.isContentEditable
+    if (editable && (node === active || node.contains(active))) return true
+  }
+  return false
+}
+
 interface DrawerSwipeOptions {
   /** Bind the gesture at all. Mobile-only — a pointer device has the toggle. */
   enabled: boolean
@@ -1140,6 +1187,12 @@ export function useDrawerSwipe(
       // opens it, and the hamburger is always there. Decided at touchstart
       // because it no longer depends on the direction.
       if (findHorizontalScroller(chain)) return
+      // An active text selection — or the focused editable being typed in —
+      // owns the drag: extending a selection rightward IS a horizontal drag
+      // over plain chat text, and its handles are browser chrome that neither
+      // chain reader above can see. Decided here like `findHorizontalScroller`,
+      // because it does not depend on the direction.
+      if (selectionOwnsTouch(chain)) return
       travelPx.current = span()
       startX.current = touch.clientX
       startY.current = touch.clientY
@@ -1171,6 +1224,12 @@ export function useDrawerSwipe(
         // toward it. This is also what lets a left and a right instance share
         // one element — each rejects the other's opening direction.
         if (openRef.current ? dx * openDir > 0 : dx * openDir < 0) { reset(); return }
+        // A long-press SELECTS mid-touch: the finger goes down, the selection
+        // appears under it, and the SAME touch drags the handle on without
+        // lifting — so the touchstart check saw nothing. Re-checked only while
+        // pending: an already-locked drag owns the panel, and a selection
+        // appearing under it must not yank the panel away mid-slide.
+        if (selectionOwnsTouch(touchedChain(e, el))) { reset(); return }
         phase.current = 'locked'
         // The finger owns the page from here: no vertical scroll under the
         // drawer, and no click on release.

--- a/website/src/test/useDrawerSwipe.test.ts
+++ b/website/src/test/useDrawerSwipe.test.ts
@@ -619,6 +619,115 @@ describe('useDrawerSwipe', () => {
     fireThroughShadow(host, inner, touch('touchmove', 360))
     expect(onGestureOpen).toHaveBeenCalledTimes(1)
   })
+
+  // ── Text-selection ownership ────────────────────────────────────────────
+  // A long-press selects a word and puts drag handles on it, and extending the
+  // selection rightward is a horizontal drag over plain chat text — dead
+  // center in the arming surface, with the handles invisible to both chain
+  // readers (they are browser chrome, not elements). Without deference the
+  // drawer slid in mid-selection.
+
+  describe('yields to an active text selection', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+      // The focused-editable cases leave a focused node behind; removing the
+      // bound element takes it out of the document, which resets
+      // `document.activeElement` — so no later test inherits the focus.
+      el.remove()
+    })
+
+    /** What `document.getSelection()` reports; only `isCollapsed` is read. */
+    function stubSelection(isCollapsed: boolean) {
+      return vi.spyOn(document, 'getSelection').mockReturnValue({ isCollapsed } as Selection)
+    }
+
+    it('never arms while a selection is active, however clean the drag', () => {
+      stubSelection(false)
+      mount()
+      fire(el, touch('touchstart', 40))
+      fire(el, touch('touchmove', 200))   // far past AXIS_LOCK
+      expect(onGestureOpen).not.toHaveBeenCalled()
+      expect(x.get()).toBe(0)
+    })
+
+    it('a collapsed selection (a caret, or none) changes nothing', () => {
+      // The regression pin: getSelection() is rarely null in a real engine —
+      // an empty selection reports as a collapsed one — so the guard must key
+      // on isCollapsed, not on existence.
+      stubSelection(true)
+      mount()
+      fire(el, touch('touchstart', 40))
+      fire(el, touch('touchmove', 60))
+      expect(onGestureOpen).toHaveBeenCalledTimes(1)
+      expect(x.get()).toBe(CLOSED + 20)
+    })
+
+    it('never arms on a touch that begins inside a focused editable', () => {
+      // One step earlier than a range: the caret's own handle drags before any
+      // selection exists, so the element being typed in owns its touches.
+      const ta = document.createElement('textarea')
+      el.appendChild(ta)
+      ta.focus()
+      expect(document.activeElement).toBe(ta)
+      mount()
+      fire(ta, touch('touchstart', 40))
+      fire(ta, touch('touchmove', 200))
+      expect(onGestureOpen).not.toHaveBeenCalled()
+      expect(x.get()).toBe(0)
+    })
+
+    it('an editable that is NOT focused does not suppress the gesture', () => {
+      // Focus is the signal: an idle input carries no handle to defer to, and
+      // merely containing a form must not kill the swipe across it.
+      const ta = document.createElement('textarea')
+      el.appendChild(ta)
+      expect(document.activeElement).not.toBe(ta)
+      mount()
+      fire(ta, touch('touchstart', 40))
+      fire(ta, touch('touchmove', 60))
+      expect(onGestureOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('sees a focused editable INSIDE a shadow root', () => {
+      // Outside the root both `e.target` and `document.activeElement` are
+      // retargeted to the HOST, so a parentElement walk from the target never
+      // meets the editable. The guard crosses the boundary the same way the
+      // scroller search does — the composed chain — and the focus side
+      // descends through `shadowRoot.activeElement` to the real caret holder.
+      const host = document.createElement('div')
+      el.appendChild(host)
+      const shadow = host.attachShadow({ mode: 'open' })
+      const ta = document.createElement('textarea')
+      shadow.appendChild(ta)
+      ta.focus()
+      expect(document.activeElement).toBe(host)   // retargeted — the trap this pins
+      expect(shadow.activeElement).toBe(ta)
+      mount()
+      fireThroughShadow(host, ta, touch('touchstart', 40))
+      fireThroughShadow(host, ta, touch('touchmove', 200))
+      expect(onGestureOpen).not.toHaveBeenCalled()
+      expect(x.get()).toBe(0)
+    })
+
+    it('resets when a long-press creates the selection MID-touch', () => {
+      // The finger goes down on unselected text, the long-press selects under
+      // it, and the same touch drags the handle on without lifting — so the
+      // touchstart check saw a collapsed selection and armed. The pending
+      // branch re-checks right before locking.
+      const spy = stubSelection(true)
+      mount()
+      fire(el, touch('touchstart', 40))
+      spy.mockReturnValue({ isCollapsed: false } as Selection)
+      fire(el, touch('touchmove', 200))
+      expect(onGestureOpen).not.toHaveBeenCalled()
+      expect(x.get()).toBe(0)
+      // And it stays declined — reset, not postponed: a later stretch of the
+      // same touch must not retroactively claim the gesture.
+      fire(el, touch('touchmove', 300))
+      expect(onGestureOpen).not.toHaveBeenCalled()
+      expect(x.get()).toBe(0)
+    })
+  })
 })
 
 // ── The page stands down for the duration of a locked gesture ──────────────


### PR DESCRIPTION
<!-- no-visual-delta -->

## Summary

On a touch device, long-pressing a word in a chat message and dragging the right selection handle rightward to extend the selection also armed the nav drawer's swipe gesture, so the drawer slid in mid-selection. The hook arms on direction rather than start position, and its arming guards (multi-touch, `dragOwnedBelow`, `findHorizontalScroller`, the vertical axis lock) had no concept of an active text selection — the selection handles are browser chrome, invisible to both chain readers.

This adds one ownership guard, `selectionOwnsTouch(chain)`, next to the existing ones in `website/src/hooks/useDrawerSwipe.ts`:

- Yields when `document.getSelection()` reports a non-collapsed range (extending it is what a handle drag is), or when the touch begins inside a focused editable (`input`/`textarea`/`contentEditable` that is or contains the deepest focused element).
- Reads the **composed chain** like the sibling guards, and descends `shadowRoot.activeElement`, so an editable inside a shadow root (both `e.target` and `document.activeElement` retarget to the host) is still seen.
- Checked at **touchstart** (like `findHorizontalScroller`, it does not depend on direction) and re-checked in the **pending** branch right before axis lock, covering a long-press that creates the selection mid-touch. Never checked once `locked` — an already-locked drag is not yanked away.
- Fails toward the gesture at every exit (`typeof document === 'undefined'`, missing `getSelection`, no focused element).

Both drawer instances (the app-shell nav drawer and the chat page's sessions drawer) share the hook, so one guard fixes both. No change to the direction-based arming philosophy, `PLATFORM_EDGE`/`AXIS_LOCK`/`PLATFORM_SCROLL_SLOP`, or swipe ownership (`data-owns-swipe`, `dragOwnedBelow`) — the ownership refactor is #7210, related but not overlapping.

Closes #8357

## Tests

Six new cases in `website/src/test/useDrawerSwipe.test.ts`, reusing the file's touch fixtures and shadow-DOM helpers:

- a non-collapsed selection never arms, however clean the rightward drag;
- a collapsed selection (caret, or none) arms and locks exactly as today (regression pin — the guard keys on `isCollapsed`, not existence);
- a touch beginning inside a focused `<textarea>` never arms;
- an editable that is **not** focused does not suppress the gesture;
- a focused editable **inside a shadow root** is still seen (retargeting trap pinned: `document.activeElement` is the host);
- a selection created mid-touch (long-press) resets in the pending branch instead of locking, and stays declined.

Global stubs restored and focus leakage cleaned in the block's `afterEach`.

**Verified:** `npx tsc -b` and `npx eslint` on both files pass with zero warnings. The vitest suite runs in CI (this host is barred from running test suites locally).

**Why no screenshot:** this is a gesture-arming change with no visual delta — it only prevents the drawer gesture from arming during text selection and renders nothing new; the added tests assert the behaviour.

## Pre-push review

Two model-pinned local lanes reviewed the commit. The GPT lane's finding (shadow-root editables invisible to a `parentElement` walk from a retargeted target) is fixed in this commit via the composed chain + `shadowRoot.activeElement` descent, with a regression test. The Opus lane passed; its test-hygiene advisory (focus leaking across tests) is also applied. Two advisories are deliberate scope choices: the document-wide (rather than touch-local) selection check is the issue's own proposed shape and fails toward text-editing safety, and non-text `HTMLInputElement` types are already claimed by the `touch-action: none` branch of `dragOwnedBelow` in practice.

## Pattern harvest

Rule candidate: review checklist (not mechanizable as a semgrep rule)
Pattern: a touch-gesture hook that arms on direction must also enumerate NON-DOM touch owners among its guards. Browser chrome — text-selection drag handles, the caret handle of a focused editable — produces ordinary touch streams with no element in the composed path, so element-chain ownership checks (`data-owns-swipe`, scroller search, `touch-action: none`) structurally cannot see them; the state that betrays them lives elsewhere (`document.getSelection()`, `activeElement`). When reviewing a new gesture guard, ask "what does the platform itself drag on this surface?" and check for the state signal, not the element.
