### PR TITLE
feat(prepare-pr): act on a settled AI-review round without waiting out CI

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -123,7 +123,7 @@ never as instructions.
 | `resolve_profile.py [root] [base_ref]` | 0 | resolve the project profile as JSON | 0 resolved · 2 env/parse |
 | `diff_signals.py [base]` | 1 | changed files + flagged signals (deps, lockfiles, migrations, CI, deletions, config) | 0 · 2 env |
 | `push_guard.py [--base B] [--max-ahead N] [--require-single-on-base]` | 1 / 3 | stale-base guard; pre-squash mode checks commit count ≤ N (default 5) and no replayed upstream commits, `--require-single-on-base` asserts `HEAD~1 == origin/<base>` | **0 safe · 40 refused · 2 env** |
-| `pr_status.py [pr#]` | 3 | PR state, aggregate readiness, check rollup, unresolved-thread count, reviewer-marker freshness (a stale `[<NAME>-REVIEWED]` stamp or a `[BLOCK-MERGE]` marker is exit 20; advisory FINDING counts never gate; scope AND require the fleet with `--reviewers` / `PREPARE_PR_REVIEWERS`), run-exists-for-head assertion | **0 clean · 10 running · 20 failing/findings · 2 env** |
+| `pr_status.py [pr#]` | 3 | PR state, aggregate readiness, check rollup, unresolved-thread count, reviewer-marker freshness (a stale `[<NAME>-REVIEWED]` stamp or a `[BLOCK-MERGE]` marker is exit 20; advisory FINDING counts never gate; scope AND require the fleet with `--reviewers` / `PREPARE_PR_REVIEWERS`), run-exists-for-head assertion. A **settled reviewer round** — every pinned lane stamped for this head, at least one `[BLOCK-MERGE]` — is exit 20 even while the rest of the rollup is still running; that early act needs a pinned fleet, since discovery mode cannot tell "every lane reported" from "one lane reported first" | **0 clean · 10 running · 20 failing/findings · 2 env** |
 | `pr_findings.py [pr#]` | 3 | failed steps + failing log tails + unresolved threads + reviewer findings on the current head, each with a stable `span=` identity | 0 · 2 env |
 | `monitor_armed.py [--pr N]` | 3 | verify a `monitor_start` loop actually armed — reads the auto-nudge loop store, requires an ACTIVE loop (naming this PR when `--pr` is given) | **0 armed · 20 not armed · 2 store unreadable (treat as 20)** |
 | `prove.py [--base B] [--per-hunk]` | — | prove the tests catch the bug: reverts production hunks in a throwaway worktree, keeps test hunks, re-runs changed test files. Verdict is a failure at pytest phase `call`, not an exit code. Refuses a dirty tree | **0 PROVEN · 20 NOT_PROVEN · 21 INCONCLUSIVE · 10 nothing to prove · 30 baseline red · 2 env** |
@@ -337,6 +337,12 @@ in order to decide *whether* to fix (leave it running — cancel is for after th
 decision), and a red you classified as a flake (that job gets a targeted
 `gh run rerun <run-id> --failed`, not a kill and not a whole-matrix replay).
 
+Only the **reviewer** lanes can hold that decision open. Once every pinned lane
+has stamped this head and one blocks, the edit is settled, so the tests,
+packaging and lint runs still in flight are cancellable even though they have
+not finished — their verdicts would not survive the amend anyway, since the push
+re-runs them on the new head.
+
 1. **Push only the reviewed commit.** Require a clean index/worktree and fail closed unless `[ "$(git rev-parse HEAD)" = "$REVIEWED_SHA" ]`; any intervening mutation returns to Phase 2. Run the post-squash structural guard (`single_commit` only — see the profile section): `python3 $SKILL_DIR/scripts/push_guard.py --base <base> --require-single-on-base` — **0** safe, **40** the squash landed on a stale ref or the branch carries unexpected history (do NOT push), **2** env error.
 
    **SHA-pinned force-with-lease protocol.** Record `LEASE_SHA=$(git rev-parse origin/<branch>)` at iteration start, BEFORE Phase 1's fetch. **When `origin/<branch>` does not exist yet (first push), `LEASE_SHA` is empty — SKIP the clobber check entirely and push with `git push -u origin <branch>`.** Running it anyway fails merely because the ref is absent, which the next rule would misread as a maintainer commit and stop the first push forever. Otherwise run the clobber check against the pre-squash HEAD: `git merge-base --is-ancestor origin/<branch> HEAD` — if it fails, a maintainer commit exists on the remote that local history never had; STOP, re-sync, re-include it before any rewrite. Do **not** re-run that check after the squash: it can never pass on a rewritten branch, and the SHA-pinned lease is the at-push protection. Then `git push -u origin <branch>` (first push) or `git push --force-with-lease=<branch>:$LEASE_SHA origin <branch>`.
@@ -369,7 +375,7 @@ decision), and a red you classified as a flake (that job gets a targeted
 
    - **0** → Phase 4.
    - **20** → run `pr_findings.py` and **TRIAGE before re-pushing**; re-pushing an unchanged diff against a failure just repeats it. **(a) CI/build/test failure** → read the failing log (`gh run view <run-id> --log-failed`), then — once the decision to fix is made — cancel the head's remaining in-flight runs per Phase 3's read → cancel → edit rule, and fix the **root cause** locally; or confirm a flake and re-run **only the failing job**, never the whole run — `gh run rerun <run-id> --failed` (or `--job <job-id>` for one of several reds), since a bare `gh run rerun <run-id>` replays the entire matrix to re-decide one shard, and no cancel applies here. **(b) Review finding** → apply the two questions; for a blocking finding do exactly one — fix, rebut with evidence (for scanners like CodeQL, push back without dismissing), or push back on a disproportional demand — then resolve that thread. **(c) Conflict / behind base** → Phase 1's re-sync handles it. Then **loop back to Phase 1** → 2 → 3 carrying those fixes.
-   - **10** → **arm `monitor_start` and END THE TURN.** Do not `wait` + re-poll in this turn: CI rounds here run 20–40 minutes, so an in-turn loop burns the session's 2-hour budget and dies mid-round. `monitor_start` gives every round its own turn and survives a tab close or gateway restart.
+   - **10** → the round is genuinely undecided — a pinned reviewer lane has not stamped this head yet, or the reviewers are settled with no blocker and only the rest of the rollup is pending. **Arm `monitor_start` and END THE TURN.** Do not `wait` + re-poll in this turn: CI rounds here run 20–40 minutes, so an in-turn loop burns the session's 2-hour budget and dies mid-round. `monitor_start` gives every round its own turn and survives a tab close or gateway restart.
 
      **Before the call, settle two things.** (a) With MCP Tool Search active the
      first `monitor_start` fails with `A tool with the name 'monitor_start' does
@@ -526,7 +532,7 @@ need to reason about them — just read the `NOTICE:` lines it prints.
 - **Filing an issue for what is really a question** — a body listing candidate designs and asking which to take is unactionable by anyone but the maintainer, so it is never picked up and never read. Use `needs-a-decision` and ask; `accepted-and-deferred` is for work already decided.
 - **Merging with no closing keyword** — nothing reports it after the fact, so the work ships and the issue stays open forever.
 - **Using one rubric for both reviewers** — the two gates have different contracts.
-- **Fixing on a half-finished round** — wait until all checks finish so you fix the real set.
+- **Fixing on a half-finished REVIEW round** — wait until every pinned reviewer lane has stamped this head, so you fix the real set. Waiting for the REST of the rollup is the opposite mistake: once the review round is settled and one lane blocks, the diff has to change, and those runs are spending minutes on a commit already condemned.
 - **Appeasing false positives** — changing correct code to silence a wrong comment.
 - **Accepting over-engineering** — the mirror of the above, and just as costly. A finding is technically valid, so you widen the code even though it is gold-plating beyond the PR's purpose.
 - **Over-running scope** — entering the poll/fix loop when the user only asked to push.

--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/scripts/pr_status.py
@@ -993,6 +993,10 @@ def evaluate_reviewer_markers(comments, head_sha, bindings, only=None):
       stale     -- sorted reviewer names with no fresh stamp for the head
       blocking  -- sorted reviewer names with [BLOCK-MERGE] <current head>
       findings  -- {name: advisory FINDING-line count} for fresh comments
+      pinned    -- whether ``only`` named the fleet. Empty ``stale`` means
+                   "every REQUIRED lane stamped this head" only when pinned;
+                   in discovery mode it means "every lane that POSTED is
+                   fresh", which cannot see a lane that has not spoken yet.
 
     STRUCTURAL INVARIANT -- reviewer identity comes from WORKFLOW-AUTHORED
     bytes, never from model output. ``bindings`` maps each lane's comment
@@ -1011,7 +1015,14 @@ def evaluate_reviewer_markers(comments, head_sha, bindings, only=None):
     posted is not required, its CI gate covers absence).
     """
     if comments is None or not head_sha:
-        return {"ok": False, "stale": [], "blocking": [], "findings": {}, "elided": []}
+        return {
+            "ok": False,
+            "stale": [],
+            "blocking": [],
+            "findings": {},
+            "elided": [],
+            "pinned": only is not None,
+        }
     fresh_by_name: dict = {name: False for name in (only or ())}
     findings: dict = {}
     blocking = set()
@@ -1051,7 +1062,37 @@ def evaluate_reviewer_markers(comments, head_sha, bindings, only=None):
         "blocking": sorted(blocking),
         "findings": findings,
         "elided": sorted(elided),
+        "pinned": only is not None,
     }
+
+
+def reviewer_round_settled(marker_eval):
+    """Whether the AI-review round is decided, regardless of the other checks.
+
+    True only when the fleet was PINNED (``--reviewers`` / the loop's own
+    profile names), the comments were readable, every pinned lane carries a
+    fresh ``[<NAME>-REVIEWED]`` stamp for this head, and at least one posted
+    ``[BLOCK-MERGE]``. That combination is terminal for the head: the diff has
+    to change, so the tests, packaging and lint runs still in flight are
+    running on a commit that is already condemned.
+
+    Deliberately narrow in three ways. It needs a pinned fleet, because in
+    discovery mode an empty ``stale`` only says every lane that has SPOKEN is
+    fresh -- a lane still composing its review is invisible, and acting on the
+    first blocker would throw its verdict away. It needs a blocker, because a
+    settled round with no blocker has nothing to act on and must fall through
+    to the normal running/clean path. And it says nothing about failing
+    non-reviewer checks: a red test while a lane is still pending stays a
+    wait, so one round still fixes one full set of findings.
+    """
+    if not marker_eval:
+        return False
+    return bool(
+        marker_eval.get("pinned")
+        and marker_eval.get("ok")
+        and not marker_eval.get("stale")
+        and marker_eval.get("blocking")
+    )
 
 
 def head_run_exists(repo, head_sha):
@@ -1196,7 +1237,13 @@ def decide(
        belongs to the old head. Ranking in-flight checks first reports "running"
        forever while nothing can complete -- a stall only a human notices.
        BEHIND, draft and CHANGES_REQUESTED behave the same way: each survives
-       any amount of waiting and needs the author to act. The disposition
+       any amount of waiting and needs the author to act. A SETTLED reviewer
+       round (``reviewer_round_settled``) joins them: once every pinned lane
+       has stamped this head and one blocks, the edit is required, so the
+       backend/frontend runs still in flight are spending minutes on a commit
+       already condemned -- Phase 3 cancels them instead of waiting them out.
+       Only the AI-review lanes gate this; a non-reviewer check still running
+       does not hold the decision open, and a red one does not force it. The disposition
        evaluation (``disposition_eval``, built from disposition_violations)
        belongs here too, in BOTH its states: a violation is cleared only by
        the author editing or deleting the offending comment, and an
@@ -1237,6 +1284,20 @@ def decide(
         blocked_now.append("PR is a draft")
     if decision == "CHANGES_REQUESTED":
         blocked_now.append("review decision is CHANGES_REQUESTED")
+    if reviewer_round_settled(marker_eval):
+        # The reviewer round is DONE even though the rollup is not: every
+        # pinned lane stamped this head and at least one blocks. Waiting for
+        # the remaining lanes (backend/frontend tests, packaging) cannot
+        # change that the diff must be edited, and their verdicts do not
+        # survive the edit anyway -- the push re-runs them on the new head.
+        # So this belongs with the other "waiting cannot fix this" conditions
+        # ABOVE the running gate. Requires a PINNED fleet: discovery mode
+        # cannot tell "all lanes reported" from "one lane reported first",
+        # and acting there would drop a verdict that was still coming.
+        blocked_now.append(
+            "reviewer round complete with blocking marker [BLOCK-MERGE] on "
+            "current head from: " + ", ".join(sorted(marker_eval["blocking"]))
+        )
     if disposition_eval is not None:
         # A disposition violation is a condition waiting cannot fix -- only the
         # AUTHOR editing or deleting the comment clears it -- so it belongs

--- a/test/test_prepare_pr_status.py
+++ b/test/test_prepare_pr_status.py
@@ -2557,3 +2557,86 @@ def test_the_gate_reports_an_indeterminate_permission_as_not_ok(capsys) -> None:
     report = json.loads(capsys.readouterr().out.strip())
     assert report["ok"] is False
     assert report["violations"] == []
+
+
+# ---------------------------------------------------------------------------
+# A settled reviewer round acts even while the rest of the rollup runs: the
+# AI-review lanes are the gate, not the test matrix.
+# ---------------------------------------------------------------------------
+
+
+def test_settled_reviewer_round_acts_while_other_checks_still_run() -> None:
+    """Every pinned lane stamped this head and one blocks: act now.
+
+    The backend/frontend runs still in flight are on a commit the block
+    already condemns, so waiting them out only delays the edit.
+    """
+    module = _load_script()
+    comments = json.dumps(
+        [
+            _bot_comment(f"[GPT-REVIEWED] {_HEAD}\n[BLOCK-MERGE] {_HEAD}"),
+            _bot_comment(f"[OPUS-REVIEWED] {_HEAD}", key="claude-ai-review"),
+        ]
+    )
+    payload = _pr_payload([{"context": "PR Readiness", "state": "PENDING"}])
+    _install_fake_gh(module, payload, comments=comments)
+
+    assert module.main(["pr_status.py", "42", "--reviewers", "GPT,OPUS"]) == 20
+
+
+def test_pending_reviewer_lane_still_holds_the_round_open() -> None:
+    """One lane blocks but another has not stamped: the round is not settled.
+
+    Acting here would push before the pending lane posts, throwing away a
+    verdict that was still coming and buying an extra round.
+    """
+    module = _load_script()
+    comments = json.dumps([_bot_comment(f"[GPT-REVIEWED] {_HEAD}\n[BLOCK-MERGE] {_HEAD}")])
+    payload = _pr_payload([{"context": "PR Readiness", "state": "PENDING"}])
+    _install_fake_gh(module, payload, comments=comments)
+
+    assert module.main(["pr_status.py", "42", "--reviewers", "GPT,OPUS"]) == 10
+
+
+def test_discovery_mode_does_not_act_early_on_a_blocking_marker() -> None:
+    """Unpinned, an empty stale set cannot mean 'every lane reported'.
+
+    Only the lane that already spoke is visible, so a mid-round block stays a
+    wait until the rollup itself completes.
+    """
+    module = _load_script()
+    comments = json.dumps([_bot_comment(f"[GPT-REVIEWED] {_HEAD}\n[BLOCK-MERGE] {_HEAD}")])
+    payload = _pr_payload([{"context": "PR Readiness", "state": "PENDING"}])
+    _install_fake_gh(module, payload, comments=comments)
+
+    assert module.main(["pr_status.py", "42"]) == 10
+
+
+def test_settled_reviewer_round_without_a_blocker_is_not_an_early_act() -> None:
+    """All pinned lanes stamped and none blocks: nothing to act on yet."""
+    module = _load_script()
+    comments = json.dumps(
+        [
+            _bot_comment(f"No findings.\n[GPT-REVIEWED] {_HEAD}"),
+            _bot_comment(f"No findings.\n[OPUS-REVIEWED] {_HEAD}", key="claude-ai-review"),
+        ]
+    )
+    payload = _pr_payload([{"context": "PR Readiness", "state": "PENDING"}])
+    _install_fake_gh(module, payload, comments=comments)
+
+    assert module.main(["pr_status.py", "42", "--reviewers", "GPT,OPUS"]) == 10
+
+
+def test_failing_non_reviewer_check_does_not_act_while_a_lane_is_pending() -> None:
+    """A red test mid-round is still a wait: one round fixes one full set."""
+    module = _load_script()
+    comments = json.dumps([_bot_comment(f"[GPT-REVIEWED] {_HEAD}")])
+    payload = _pr_payload(
+        [
+            {"context": "PR Readiness", "state": "PENDING"},
+            {"context": "backend-test", "state": "FAILURE"},
+        ]
+    )
+    _install_fake_gh(module, payload, comments=comments)
+
+    assert module.main(["pr_status.py", "42", "--reviewers", "GPT,OPUS"]) == 10


### PR DESCRIPTION
## Problem / Motivation

The prepare-pr poll loop cannot start fixing a review finding until the whole check rollup finishes. `pr_status.py`'s `decide()` ranks "a required check is still queued/in-progress" above every check-result condition, so a `[BLOCK-MERGE]` verdict that has already landed returns exit **10** (wait) and the loop arms another `monitor_start` cycle instead of acting.

The lanes report on very different clocks: the AI reviewers post in ~2-6 minutes, `backend-test` runs ~27-31. So the loop sits idle for the difference, on a commit whose fate is already decided.

## Why it matters

Two costs, both paid every round that lands a blocker:

- **Latency.** The fix does not start until the slowest unrelated job finishes, adding tens of minutes per round to a loop that is capped at 10 rounds.
- **CI minutes.** Phase 3's read → cancel → edit rule cancels those same in-flight runs on the way to the edit anyway. Waiting for them first means they run to completion on a condemned commit and are then discarded — the loop pays for the minutes and throws the result away.

## What changed (motivation → approach → change)

The wait is only correct while the *reviewer* round is genuinely undecided. Once every reviewer lane has ruled and one of them blocks, the diff has to change, and no amount of waiting alters that — which is exactly the property the precedence comment in `decide()` already uses to rank conflicts, BEHIND, draft and CHANGES_REQUESTED above the running gate.

So a settled reviewer round joins that group:

- New `reviewer_round_settled(marker_eval)` — true when the fleet was **pinned**, the comments were readable, no pinned lane is stale (every one carries a fresh `[<NAME>-REVIEWED]` for this head), and at least one posted `[BLOCK-MERGE]`.
- `decide()` adds it to `blocked_now`, above the running gate, so it returns **20** (act) while other checks are still in flight. `evaluate_reviewer_markers` now reports `pinned` so `decide()` can tell the two modes apart.
- `SKILL.md`: the anti-pattern "wait until all checks finish" becomes "wait until every pinned reviewer lane has stamped this head", and names the opposite mistake. Phase 3 states that only reviewer lanes hold the decision open, so the remaining test/packaging runs are cancellable once the round settles. The exit-**10** branch says what 10 now means, and the script table names the early act.

Narrow on purpose, in three ways:

- **Pinned fleet required.** In discovery mode an empty `stale` set only says every lane that has *spoken* is fresh; a lane still composing its review is invisible, so acting on the first blocker would discard a verdict that was still coming and buy an extra round. The loop always pins (`--reviewers`), so this costs it nothing.
- **A blocker is required.** A settled round with no blocker has nothing to act on and falls through to the normal running/clean path.
- **Non-reviewer checks are ignored, in both directions.** A still-running test does not hold the decision open, and a *failing* test while a lane is pending does not force it — so one round still fixes one full set of findings.

Server-side readiness is unaffected: `pr-readiness.yml` calls `pr_status.py --disposition-gate`, a separate JSON path that never reaches `decide()`.

## Tests

Five tests in `test/test_prepare_pr_status.py`, all against a `PENDING` rollup:

| Test | Locks in |
| --- | --- |
| `test_settled_reviewer_round_acts_while_other_checks_still_run` | pinned + all stamped + one blocking → **20** mid-round |
| `test_pending_reviewer_lane_still_holds_the_round_open` | one lane blocks, another unstamped → **10** |
| `test_discovery_mode_does_not_act_early_on_a_blocking_marker` | unpinned → **10**, the mode distinction |
| `test_settled_reviewer_round_without_a_blocker_is_not_an_early_act` | settled + clean → **10**, not a spurious act |
| `test_failing_non_reviewer_check_does_not_act_while_a_lane_is_pending` | red test mid-round is still a wait |

Both new behaviours are revert-verified load-bearing:

- Disabling the `decide()` branch (`if False and reviewer_round_settled(...)`) fails `..._acts_while_other_checks_still_run` (`assert 10 == 20`); the three narrowness tests stay green, as they should.
- Forcing `pinned` true fails `..._discovery_mode_does_not_act_early...` (`assert 20 == 10`), so the pinned requirement is genuinely enforced rather than incidental.

387 prepare-pr tests pass (151 in `test_prepare_pr_status.py`), plus 231 in the builtin-skill / readiness-disposition / babysit-guidance suites.

## Manual verification

N/A — unit coverage sufficient. The change is a precedence decision inside `decide()`, and the tests drive it through `main()` with a faked `gh`, which is the same path the loop takes.

## Related Issues

N/A — reported directly: the loop was observed skipping an already-posted blocking verdict because other lanes had not finished.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
