### PR TITLE
fix(test): bind AF_UNIX test sockets under a short temp base

### DIFF
--- a/test/test_dashboard_peer_auth.py
+++ b/test/test_dashboard_peer_auth.py
@@ -23,20 +23,40 @@ from __future__ import annotations
 
 import asyncio
 import json
+import shutil
 import socket
+import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Iterator
 from unittest.mock import MagicMock
 
 import pytest
 from aiohttp import web
+from tmpdir_helpers import short_tmp_base
 
 import kiro_crew.dashboard.token_auth as ta
 from kiro_crew import platform_compat
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.mcp_gateway.socketsec import PeerCredResult
 from kiro_crew.peer_resolve import resolve_peer_identity
+
+
+@pytest.fixture
+def short_sock_dir() -> "Iterator[Path]":
+    """A SHORT base for every AF_UNIX bind/connect path in this module.
+
+    ``sun_path`` caps at 104 bytes on macOS, and a pytest ``tmp_path`` under a
+    deep TMPDIR (or xdist) exceeds it, failing ``bind()`` with ``OSError:
+    AF_UNIX path too long`` (#8610). Same pattern as ``test_socketsec.py``:
+    ``mkdtemp`` under :func:`short_tmp_base`, removed at teardown because
+    ``mkdtemp`` registers no finalizer.
+    """
+    base = Path(tempfile.mkdtemp(dir=short_tmp_base()))
+    yield base
+    shutil.rmtree(base, ignore_errors=True)
+
 
 SECRET = "test-internal-secret"
 INTERNAL = frozenset({"/api/spawn"})
@@ -405,7 +425,7 @@ def _unix_http_request(
 @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
 @pytest.mark.asyncio
 async def test_unix_site_end_to_end_peer_verification(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, short_sock_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Real UnixSite + real AF_UNIX connect: the kernel reports OUR pid/uid,
     so with a session_pid file for an ancestor of this test process the
@@ -442,7 +462,7 @@ async def test_unix_site_end_to_end_peer_verification(
     app.router.add_get("/api/spawn", handler)
     runner = web.AppRunner(app)
     await runner.setup()
-    sock_path = str(tmp_path / "dash-test.sock")
+    sock_path = str(short_sock_dir / "dash-test.sock")
     site = web.UnixSite(runner, sock_path)
     await site.start()
     try:
@@ -501,17 +521,17 @@ def test_check_origin_still_rejects_plain_remote_without_origin() -> None:
 @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
 @pytest.mark.asyncio
 async def test_start_unix_site_binds_and_removes_stale(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    short_sock_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from kiro_crew.dashboard import server as srv
 
     monkeypatch.setattr(
         "kiro_crew.dashboard.server.dashboard_socket_path",
-        lambda port: tmp_path / f"dashboard-{port}.sock",
+        lambda port: short_sock_dir / f"dashboard-{port}.sock",
     )
     # Plant a stale socket file (bound then abandoned) to prove self-healing.
     stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    stale.bind(str(tmp_path / "dashboard-5999.sock"))
+    stale.bind(str(short_sock_dir / "dashboard-5999.sock"))
     stale.close()
 
     app = web.Application()
@@ -539,13 +559,13 @@ async def test_start_unix_site_skipped_on_windows(monkeypatch: pytest.MonkeyPatc
 @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
 @pytest.mark.asyncio
 async def test_start_unix_site_bind_failure_degrades(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    short_sock_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A non-socket file squatting the path makes the bind fail; startup must
     degrade to TCP-only (return None), never raise."""
     from kiro_crew.dashboard import server as srv
 
-    squatter = tmp_path / "dashboard-6001.sock"
+    squatter = short_sock_dir / "dashboard-6001.sock"
     squatter.write_text("not a socket", encoding="utf-8")
     monkeypatch.setattr("kiro_crew.dashboard.server.dashboard_socket_path", lambda port: squatter)
     app = web.Application()
@@ -564,7 +584,7 @@ async def test_start_unix_site_bind_failure_degrades(
 
 
 @pytest.fixture()
-def unix_http_server(tmp_path: Path):
+def unix_http_server(short_sock_dir: Path):
     """A minimal threaded HTTP server on an AF_UNIX socket."""
     import http.server
     import socketserver
@@ -591,7 +611,7 @@ def unix_http_server(tmp_path: Path):
             request, _ = super().get_request()
             return request, ("unix", 0)
 
-    sock_path = str(tmp_path / "client-test.sock")
+    sock_path = str(short_sock_dir / "client-test.sock")
     server = _UnixServer(sock_path, _Handler)
     t = threading.Thread(target=server.serve_forever, daemon=True)
     t.start()
@@ -607,15 +627,15 @@ def test_loopback_urlopen_uses_unix_socket(unix_http_server: str) -> None:
         assert json.loads(resp.read()) == {"via": "unix"}
 
 
-def test_loopback_urlopen_absent_socket_falls_back_to_tcp(tmp_path: Path) -> None:
+def test_loopback_urlopen_absent_socket_falls_back_to_tcp(short_sock_dir: Path) -> None:
     """Socket file missing → straight to TCP (refused on a dead port)."""
     req = urllib.request.Request("http://127.0.0.1:1/api/x")
     with pytest.raises(urllib.error.URLError):
-        loopback_urlopen(req, timeout=2, unix_socket_path=str(tmp_path / "nope.sock"))
+        loopback_urlopen(req, timeout=2, unix_socket_path=str(short_sock_dir / "nope.sock"))
 
 
 @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
-def test_loopback_urlopen_stale_socket_falls_back_to_tcp(tmp_path: Path) -> None:
+def test_loopback_urlopen_stale_socket_falls_back_to_tcp(short_sock_dir: Path) -> None:
     """Socket file exists but nobody listens → connect refused → TCP fallback.
 
     The TCP side serves a real response, proving the fallback actually runs
@@ -623,7 +643,7 @@ def test_loopback_urlopen_stale_socket_falls_back_to_tcp(tmp_path: Path) -> None
     import http.server
     import threading
 
-    stale_path = tmp_path / "stale.sock"
+    stale_path = short_sock_dir / "stale.sock"
     s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     s.bind(str(stale_path))
     s.close()  # bound but never listened/accepting → ECONNREFUSED
@@ -653,7 +673,7 @@ def test_loopback_urlopen_stale_socket_falls_back_to_tcp(tmp_path: Path) -> None
 
 
 @pytest.mark.skipif(platform_compat.IS_WINDOWS, reason="AF_UNIX transport is POSIX-only")
-def test_loopback_urlopen_http_error_propagates_no_fallback(tmp_path: Path) -> None:
+def test_loopback_urlopen_http_error_propagates_no_fallback(short_sock_dir: Path) -> None:
     """A 4xx over the unix socket is a REAL response — it must propagate as
     HTTPError, never trigger a duplicate TCP send."""
     import http.server
@@ -676,7 +696,7 @@ def test_loopback_urlopen_http_error_propagates_no_fallback(tmp_path: Path) -> N
             request, _ = super().get_request()
             return request, ("unix", 0)
 
-    sock_path = str(tmp_path / "err.sock")
+    sock_path = str(short_sock_dir / "err.sock")
     server = _UnixServer(sock_path, _Handler)
     t = threading.Thread(target=server.serve_forever, daemon=True)
     t.start()
@@ -709,12 +729,12 @@ def test_mcp_core_post_prefers_unix_socket(
 
 
 def test_mcp_core_post_falls_back_to_tcp_when_socket_absent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    short_sock_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Error shape of _get is unchanged when neither transport answers."""
     import kiro_crew.mcp_core as mcp_core
 
-    monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", str(tmp_path / "absent.sock"))
+    monkeypatch.setattr(mcp_core, "_API_UNIX_SOCKET", str(short_sock_dir / "absent.sock"))
     monkeypatch.setattr(mcp_core, "_API", "http://127.0.0.1:1")
     monkeypatch.setattr(mcp_core, "_internal_secret", lambda: "s")
     monkeypatch.setattr(mcp_core, "_resolve_session_key", lambda: "dashboard:chat-1")


### PR DESCRIPTION
## Problem / Motivation

`test/test_dashboard_peer_auth.py` binds its AF_UNIX test sockets at pytest's `tmp_path`, whose length depends on the runner's TMPDIR depth and the xdist worker suffix. `sun_path` is capped at 104 bytes on macOS, so a deep basetemp fails the `bind()` with `OSError: AF_UNIX path too long` — the flake reported in #8610. Reproduced deterministically at a basetemp length of 111 characters; at default lengths the same tests pass, which is exactly the reported flake shape.

## Why it matters

The failure is environmental, not behavioural: a contributor on macOS (or any runner with a deep temp root) gets red tests in a suite whose code under test is fine, which erodes trust in the suite and burns triage time on a known platform limit the repo already has a pattern for.

## What changed (motivation → approach → change)

The repo already solves this class in `test/tmpdir_helpers.py` (`short_tmp_base()`, used by `test_socketsec.py`): create socket directories via `mkdtemp` under `/tmp` on POSIX, platform default on Windows. This PR applies that established pattern to the peer-auth suite: a module-level `short_sock_dir` fixture (mkdtemp under `short_tmp_base()`, removed at teardown since `mkdtemp` registers no finalizer), and every AF_UNIX bind/connect path in the module now derives from it — the two tests named in the issue plus the sibling sites that carry the same latent failure (`unix_http_server`, the three `loopback_urlopen` tests, and the `mcp_core` fallback test). `tmp_path` remains for non-socket uses.

## Tests

- Full suite (`test/test_dashboard_peer_auth.py`, 29 tests) passes at default basetemp.
- The same suite passes under a 111-character `--basetemp` — the configuration that reproduced `AF_UNIX path too long` on the unfixed tree (both named tests failed there before this change).
- black gate, isort, flake8, mypy, subprocess-encoding and feature-map gates all green.

## Manual verification

Reproduced the failure on macOS (Apple Silicon) at the unfixed tree with `--basetemp` of length 111 (`OSError: AF_UNIX path too long` from both `test_start_unix_site_binds_and_removes_stale` and `test_start_unix_site_bind_failure_degrades`), then confirmed the identical invocation passes on this branch.

## Screenshots / video

N/A — test-only change.

## Related Issues

Fixes #8610

## Pattern harvest

Rule candidate: an AF_UNIX socket bound in a test must never derive its path from `tmp_path` — always allocate it under `tmpdir_helpers.short_tmp_base()`, because `sun_path` caps at 104 bytes on macOS and pytest's basetemp length is environment-controlled.

## Checklist

- [x] Tests added/updated and passing
- [x] Lint/format gates green
- [x] Docs updated where behaviour changed (N/A — test-only)

## Contribution License Agreement

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
