### PR TITLE
perf(chat): measure the composer's auto-size once per keystroke, not twice

### DIFF
--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -320,6 +320,20 @@ function measuredContentHeight(el: HTMLTextAreaElement): number {
   return twin.scrollHeight
 }
 
+/** The inputs that produced each textarea's current auto-sized height, and the
+ *  height they produced. Both call sites below run for every keystroke — the
+ *  input handler, then the auto-size effect once the new `value` commits — so
+ *  without this the second call repeats a measurement whose every input is
+ *  unchanged. A WeakMap rather than an expando keeps the entry's lifetime tied
+ *  to the element's.
+ *
+ *  Only the MEASUREMENT is elided, never the write: `next !== prev` below still
+ *  runs on a memo hit, so a height this function did not write is still
+ *  corrected. That is what makes the drag handle's double-click reset work
+ *  without a measurement — it clears the inline height while the value stays
+ *  put, so the cached height is both still correct and no longer applied. */
+const lastMeasured = new WeakMap<HTMLTextAreaElement, { inputs: string; height: string }>()
+
 /** Auto-size textarea to fit content (only when not manually sized).
  *
  *  The measurement happens on an off-screen twin (see `measuredContentHeight`),
@@ -340,11 +354,32 @@ function applyHeight(
   prefillHint?: boolean,
   parked?: boolean,
 ) {
-  if (parked) return // clipped out of layout — there is nothing valid to measure
+  if (parked) {
+    // Clipped out of layout — there is nothing valid to measure. Drop the memo
+    // too: unparking re-runs the effect at an UNCHANGED value, so a cached
+    // height would be re-applied without measuring, and font metrics may have
+    // changed across the round-trip. One measurement per unpark is not a cost
+    // worth caching against.
+    lastMeasured.delete(el)
+    return
+  }
   if (manualHeight !== null) return // manual height — wrapper controls size
   const cap = prefillHint ? INPUT_PREFILL_MAX_H : INPUT_DEFAULT_MAX_H
   const prev = el.style.height
-  const next = Math.max(INPUT_MIN_H, Math.min(measuredContentHeight(el), cap)) + 'px'
+  // Everything the twin measures against: its width and box come from the live
+  // element, and an EMPTY value is measured as the placeholder (see
+  // `measuredContentHeight`), so a placeholder swap changes the height too.
+  // `value` last — it is user text and may itself contain the delimiter, so no
+  // content can forge a boundary against the fields in front of it.
+  const inputs = [el.clientWidth, cap, el.placeholder, el.value].join('\u0000')
+  const memo = lastMeasured.get(el)
+  let next: string
+  if (memo !== undefined && memo.inputs === inputs) {
+    next = memo.height
+  } else {
+    next = Math.max(INPUT_MIN_H, Math.min(measuredContentHeight(el), cap)) + 'px'
+    lastMeasured.set(el, { inputs, height: next })
+  }
   if (next !== prev) {
     el.style.height = next
     // Attribute the transcript's resulting viewport change to the composer, so the

--- a/website/src/test/ChatInput.autoSizeMemo.test.tsx
+++ b/website/src/test/ChatInput.autoSizeMemo.test.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithProviders } from './helpers'
+import ChatInput from '../components/ChatInput'
+import { stubStripHeights } from './stripHeights'
+
+// Drag-to-resize is pointer-only, and the composer disregards the persisted
+// manual height outright on a touch device — the manual-mode case below needs a
+// pointer for the preference to be honoured at all.
+vi.mock('../hooks/useIsTouchDevice', () => ({ useIsTouchDevice: () => false }))
+vi.mock('../utils/isTouchDevice', () => ({ isTouchDevice: () => false }))
+vi.mock('../hooks/useIsMobile', () => ({ useIsMobile: () => false }))
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  stubStripHeights()
+  localStorage.clear()
+})
+
+/** Count auto-size measurement passes.
+ *
+ *  A measurement copies the live element's computed box onto the off-screen twin
+ *  before reading it, so exactly one `getComputedStyle(el)` happens per pass —
+ *  which makes it the cheapest observable proxy for "did this call measure?".
+ *  Counting the twin's own reads would not distinguish a pass from the
+ *  caret-follow read, which is deliberately outside the memo. */
+function countMeasures(ta: HTMLTextAreaElement) {
+  const state = { measures: 0 }
+  const real = window.getComputedStyle.bind(window)
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(((el: Element, pseudo?: string | null) => {
+    if (el === ta) state.measures++
+    return real(el as Element, pseudo ?? undefined)
+  }) as typeof window.getComputedStyle)
+  return state
+}
+
+/** ChatInput is controlled, and the per-keystroke double call only appears when
+ *  the committed value flows back in: the input handler measures, then the
+ *  auto-size effect runs again once the new `value` lands. */
+function Harness({ initial = '' }: { initial?: string }) {
+  const [value, setValue] = useState(initial)
+  return <ChatInput value={value} onChange={setValue} onSend={vi.fn()} />
+}
+
+describe('composer auto-size measurement memo', () => {
+  it('measures once per keystroke, not once per call site', () => {
+    renderWithProviders(<Harness />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    const state = countMeasures(ta)
+
+    fireEvent.input(ta, { target: { value: 'ab' } })
+
+    // Both call sites ran for this keystroke; only the first found an input
+    // changed, so the second must not have measured again.
+    expect(state.measures).toBe(1)
+  })
+
+  it('re-measures when the content changes', () => {
+    renderWithProviders(<Harness />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    const state = countMeasures(ta)
+
+    fireEvent.input(ta, { target: { value: 'ab' } })
+    fireEvent.input(ta, { target: { value: 'abc' } })
+
+    expect(state.measures).toBe(2)
+  })
+
+  it('re-measures when the box width changes at an unchanged value', () => {
+    renderWithProviders(<Harness initial="wrapped text" />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    Object.defineProperty(ta, 'clientWidth', { configurable: true, get: () => 600 })
+    const state = countMeasures(ta)
+
+    fireEvent.input(ta, { target: { value: 'wrapped text!' } })
+    expect(state.measures).toBe(1)
+
+    // Same text, narrower box: it wraps to more lines, so the cached height is
+    // wrong even though the content did not move.
+    Object.defineProperty(ta, 'clientWidth', { configurable: true, get: () => 200 })
+    fireEvent.input(ta, { target: { value: 'wrapped text!' } })
+    expect(state.measures).toBe(2)
+  })
+
+  it('restores the height after a manual resize is reset, without measuring', () => {
+    // Manual mode drives the textarea off auto-sizing (inline height:100%) and
+    // the double-click reset clears that. The value never changed, so the cached
+    // height is still correct: the write-guard re-applies it and no measurement
+    // is needed. Eliding the WRITE as well as the measurement would leave the
+    // box with no height at all.
+    renderWithProviders(<Harness initial="test" />)
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.input(ta, { target: { value: 'test!' } })
+    const autoSized = ta.style.height
+    expect(autoSized).not.toBe('')
+    const state = countMeasures(ta)
+    const handle = screen.getByTitle(/Drag to resize/)
+
+    fireEvent.pointerDown(handle, { clientX: 100, clientY: 200 })
+    fireEvent.pointerUp(handle, { clientX: 100, clientY: 200 })
+    fireEvent.doubleClick(handle)
+
+    expect(localStorage.getItem('mc-input-height')).toBeNull()
+    expect(ta.style.height).toBe(autoSized)
+    expect(state.measures).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem / Motivation

`applyHeight` runs twice for every keystroke in the composer -- once from the
input handler, then again from the auto-size effect once the new `value` commits.
Both measured, and the second call's inputs were identical to the first's. Each
measurement costs a `getComputedStyle` on the live element, ~30 style writes onto
the off-screen twin, and a `twin.scrollHeight` read that forces the style recalc
those writes dirtied.

## Why it matters

Paid on every keystroke anyone types, for a height the previous call had already
computed.

## What changed (motivation → approach → change)

A `WeakMap` keyed by the textarea holds the inputs that produced its current
auto-sized height and the height they produced; the cached height is reused when
width, cap, placeholder and value all match.

`placeholder` is in the key because `measuredContentHeight` measures an empty
value as `el.placeholder || ''`, so a placeholder swap changes the height.
`value` is last so no user text can forge the delimiter against the fields ahead
of it.

Only the measurement is elided, never the write -- the existing `next !== prev`
guard still runs on a memo hit. That is load-bearing: the drag handle's
double-click reset clears the inline height while the value stays put, so the
cached height is still correct and only needs re-applying. Eliding the write
leaves the box with no height at all. The same guard is why nothing validates the
memo against `el.style.height`.

## Tests

New `website/src/test/ChatInput.autoSizeMemo.test.tsx`, 4 cases, counting
measurement passes through the single `getComputedStyle(el)` each pass makes:

- one measurement per keystroke rather than one per call site
- re-measures when content changes
- re-measures when the box width changes at an unchanged value
- restores the height after a manual-resize reset without measuring

Mutation-checked: with the memo disabled all four fail at 2 measurements per
keystroke; with the memo also skipping the write, the reset case fails with the
box stranded at no height.

## Manual verification

Two builds of this commit differing only by this change, served locally and typed
into an idle composer -- ~70 keystrokes, 3 runs per build, sidebar expanded, empty
transcript, Chrome DevTools performance traces.

| per keystroke                       | without memo      | with memo        |
|-------------------------------------|-------------------|------------------|
| forced style recalculations         | 7.82 (7.78-7.90)  | 4.88 (4.87-4.88) |
| ...attributed to the composer frame | 7.77              | 4.86             |
| Layout count                        | 2.97              | 2.98             |

Layout is unchanged, as expected for a change that elides a style measurement and
not a layout pass. Resolved heights are unchanged. No latency claim is made: each
build's runs were captured as a block, so session drift is not separable from the
variant.

## Screenshots / video

<!-- no-visual-delta -->

**Why no screenshot:** the composer resolves to the same heights as before -- the
change elides a redundant measurement, it does not alter the measured result.
Height equality is pinned by the tests above (the manual-resize-reset case asserts
the exact prior pixel height is restored).

## Related Issues

N/A -- no filed issue; found while profiling composer typing.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no user-facing behaviour change
- [x] No secrets, credentials, or internal references in the diff
