### PR TITLE
fix: install playwright-cli into a private prefix when npm's is root-owned

### DIFF
--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -96,7 +96,7 @@ def cli_env() -> dict[str, str]:
     PATH now matches the path the binary was resolved on.
     """
     env = dict(os.environ)
-    env["PATH"] = node_augmented_path(augmented_path(env.get("PATH", "")))
+    env["PATH"] = _search_path(node_augmented_path(augmented_path(env.get("PATH", ""))))
     return env
 
 
@@ -136,8 +136,13 @@ def cli_path() -> str | None:
     inherit it on ``$PATH``. Without this the standalone install would SUCCEED
     and the panel would keep reporting the CLI as absent -- the worst shape of
     failure available here, since nothing errors and the offer never withdraws.
+
+    The private install prefix is appended on top of that (:func:`_search_path`),
+    because no PATH heuristic can guess a directory Kiro Crew itself chose.
     """
-    return find_node_tool(CLI_BIN, base_path=augmented_path(os.environ.get("PATH", "")))
+    return find_node_tool(
+        CLI_BIN, base_path=_search_path(augmented_path(os.environ.get("PATH", "")))
+    )
 
 
 def _first_version(text: str) -> str | None:
@@ -220,12 +225,40 @@ _PLAYWRIGHT_CORE_PKG = "playwright-core"
 _CLI_PKG_SCOPE = "@playwright"
 _CLI_PKG_NAME = "cli"
 
-#: Where the standalone installer puts the package tree. `npm --global --prefix`
+#: Where an unprivileged install puts the package tree. `npm --global --prefix`
 #: writes under ``<prefix>/lib/node_modules`` on POSIX and ``<prefix>/node_modules``
 #: on Windows, so both are probed.
 _STANDALONE_PREFIX_ENV = "KIROCREW_PLAYWRIGHT_CLI_HOME"
 _STANDALONE_PREFIX_DIR = "playwright-cli"
 _NODE_MODULES = "node_modules"
+
+#: Where the standalone installer drops its launcher, and where the private-prefix
+#: retry links its own. On ``$PATH`` for an ordinary login shell, which the private
+#: prefix's own ``bin`` is not -- see :func:`_link_private_launcher`.
+_USER_BIN_DIR = ".local/bin"
+
+
+def standalone_prefix() -> Path:
+    """The install prefix used when the npm global prefix is not writable.
+
+    One definition shared by the package-tree probe, the launcher search and the
+    private-prefix install itself, so a relocated prefix
+    (``KIROCREW_PLAYWRIGHT_CLI_HOME``) cannot move the install away from where
+    detection looks for it. Mirrors ``playwright-cli.sh``, which defaults to the
+    same ``<data home>/playwright-cli``.
+    """
+    override = os.environ.get(_STANDALONE_PREFIX_ENV, "").strip()
+    return Path(override) if override else config_dir() / _STANDALONE_PREFIX_DIR
+
+
+def standalone_bin_dir() -> Path:
+    """Directory the private prefix's launcher lands in.
+
+    ``npm --global --prefix P`` writes ``P/bin/<name>`` on POSIX and ``P/<name>.cmd``
+    on Windows -- npm's own layout, not a choice made here.
+    """
+    prefix = standalone_prefix()
+    return prefix if platform_compat.IS_WINDOWS else prefix / "bin"
 
 
 def _standalone_node_modules() -> list[Path]:
@@ -238,9 +271,25 @@ def _standalone_node_modules() -> list[Path]:
     for that install shape at all, and the check would silently degrade to the
     presence-only answer whose false positives it exists to remove.
     """
-    prefix_override = os.environ.get(_STANDALONE_PREFIX_ENV, "").strip()
-    prefix = Path(prefix_override) if prefix_override else config_dir() / _STANDALONE_PREFIX_DIR
+    prefix = standalone_prefix()
     return [prefix / "lib" / _NODE_MODULES, prefix / _NODE_MODULES]
+
+
+def _search_path(base: str) -> str:
+    """*base* plus the private prefix's bin dir, which no PATH heuristic knows.
+
+    APPENDED, not prepended: a system-wide ``npm install -g`` is the standard
+    shape and stays authoritative when both exist. The private prefix is the
+    fallback for a host whose npm prefix is root-owned, and it is reached by
+    KNOWN PATH because it is a directory Kiro Crew chose -- no version manager
+    puts anything there, so :func:`augmented_path`'s guesses can never include it.
+    Without this the private-prefix install would SUCCEED and the panel would
+    keep reporting the CLI absent: the failure shape :func:`cli_path` documents
+    as the worst available here.
+    """
+    return (
+        os.pathsep.join([base, str(standalone_bin_dir())]) if base else str(standalone_bin_dir())
+    )
 
 
 def _launcher_node_modules(anchor: Path) -> list[Path]:
@@ -702,6 +751,101 @@ def _step(
     }
 
 
+# npm's own error codes for "this user may not write the install prefix". A
+# root-owned global ``node_modules`` (a distribution tarball unpacked into
+# /usr/local, a system package, a container image built as root) is the ordinary
+# shape of this, not an exotic one -- MEASURED on an Amazon Linux host whose
+# prefix ``/usr/local/node-v22.12.0-linux-arm64/lib/node_modules`` is owned by
+# ``nobody``, where the panel's install button could only ever fail.
+#
+# Matched on the CODE rather than on the prose, because npm's advice line ("try
+# running the command again as root/Administrator") is the one thing here that
+# must NOT be followed: the fix is a prefix this user owns, and installing the
+# browsing toolchain as root would leave a root-owned tree the gateway then
+# cannot upgrade.
+_PREFIX_DENIED_CODES = ("EACCES", "EPERM", "EROFS")
+
+
+def _prefix_write_denied(text: str) -> bool:
+    """Whether *text* is npm reporting that it cannot write the install prefix.
+
+    Deliberately narrow: only a permission/read-only failure earns the private
+    prefix retry. A registry rejection, a proxy failure or a missing package is a
+    different problem that retrying elsewhere would merely repeat, and whose real
+    remedy is the standalone installer (:func:`_standalone_install_command`).
+    """
+    return any(code in text for code in _PREFIX_DENIED_CODES)
+
+
+def _link_private_launcher(prefix_bin: Path) -> None:
+    """Best-effort ``~/.local/bin`` launcher for a private-prefix install.
+
+    Not required for correctness -- :func:`cli_path` searches the prefix bin dir
+    directly, so the gateway and the panel work without it. It is required for
+    the AGENT, which is documented to run ``playwright-cli`` as an ordinary shell
+    command: that shell resolves the login ``$PATH``, which holds
+    ``~/.local/bin`` but can never hold a Kiro-Crew-chosen prefix. This is the
+    same convention ``playwright-cli.sh`` follows, so the two install shapes leave
+    the host looking alike.
+
+    Failure is logged, never raised or reported as a failed step: a read-only or
+    absent ``~/.local/bin`` costs the shell shortcut, not the install.
+    """
+    source = prefix_bin / CLI_BIN
+    target = Path.home() / _USER_BIN_DIR / CLI_BIN
+    try:
+        if not source.exists():
+            # Windows (``<prefix>/playwright-cli.cmd``) and any future npm layout
+            # change: nothing to link, and a broken link would be worse than none.
+            return
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Replace only a symlink we would have written. A real file there is
+        # somebody else's launcher (or their own script) and is not ours to remove.
+        if target.is_symlink():
+            target.unlink()
+        elif target.exists():
+            logger.info("%s already exists and is not a symlink; leaving it alone", target)
+            return
+        target.symlink_to(source)
+    except OSError as exc:
+        logger.warning("could not link %s -> %s: %s", target, source, exc)
+
+
+def _install_into_private_prefix(npm: str) -> dict[str, Any]:
+    """Install the CLI into a prefix this user owns, after the global one refused.
+
+    ``--global --prefix`` and not a project-local ``npm install``: the global
+    layout is what puts a launcher in ``<prefix>/bin`` and the package under
+    ``<prefix>/lib/node_modules``, which is exactly what
+    :func:`_standalone_node_modules` already probes and what
+    :func:`_launcher_node_modules` already knows how to read a browser revision
+    out of. Reusing that layout means detection needs no new special case.
+    """
+    prefix = standalone_prefix()
+    try:
+        prefix.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return {
+            "name": "npm-install-private-prefix",
+            "ok": False,
+            "returncode": 1,
+            "stderr": f"cannot create the private install prefix {prefix}: {exc}",
+        }
+    step = _step(
+        "npm-install-private-prefix",
+        [npm, "install", "--global", "--prefix", str(prefix), NPM_SPEC],
+        _NPM_INSTALL_TIMEOUT_S,
+        hint=(
+            "The npm global prefix is not writable by this user, so the CLI was "
+            f"installed into {prefix} instead. If this failed too, run the "
+            "standalone installer shown in the Browser settings panel."
+        ),
+    )
+    if step["ok"]:
+        _link_private_launcher(standalone_bin_dir())
+    return step
+
+
 def _download_browser(path: str, engine: str | None = None) -> list[dict[str, Any]]:
     """Download a browser build, adapting to what this host's OS allows.
 
@@ -773,6 +917,13 @@ def install() -> dict[str, Any]:
     steps.append(
         _step("npm-install-global", [npm, "install", "-g", NPM_SPEC], _NPM_INSTALL_TIMEOUT_S)
     )
+    # A root-owned npm prefix is a host property, not an operator mistake, and it
+    # made the panel's install button unable to succeed at all: the only exit was
+    # the standalone installer, which the operator had to notice, copy and run in
+    # their own terminal. Retrying into a prefix this user owns keeps the failure
+    # visible in the step list while letting the install finish by itself.
+    if not steps[-1]["ok"] and _prefix_write_denied(steps[-1]["stderr"]):
+        steps.append(_install_into_private_prefix(npm))
     if not steps[-1]["ok"]:
         return {"ok": False, "steps": steps}
 

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -284,6 +284,186 @@ def test_install_falls_back_without_deps_when_the_package_step_is_refused(
     assert ["/n/pw", "install-browser", "chromium"] in calls
 
 
+# --- unwritable npm prefix ----------------------------------------------------
+
+# The head of the real npm failure, MEASURED on an Amazon Linux host whose global
+# node_modules is owned by ``nobody``. Kept verbatim because the retry is gated on
+# recognising it, and a paraphrase would not prove that.
+_EACCES_STDERR = (
+    "npm error code EACCES\n"
+    "npm error syscall mkdir\n"
+    "npm error path /usr/local/node-v22.12.0-linux-arm64/lib/node_modules/@playwright\n"
+    "npm error errno -13\n"
+    "npm error Error: EACCES: permission denied, mkdir "
+    "'/usr/local/node-v22.12.0-linux-arm64/lib/node_modules/@playwright'\n"
+    "npm error The operation was rejected by your operating system.\n"
+    "npm error It is likely you do not have the permissions to access this file "
+    "as the current user\n"
+)
+
+
+@pytest.fixture
+def private_prefix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the private install prefix at a scratch dir, and $HOME with it.
+
+    Both, not just the prefix: the successful retry links a launcher into
+    ``~/.local/bin``, and a test must not write into the developer's real one.
+    """
+    prefix = tmp_path / "playwright-cli"
+    monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(prefix))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    return prefix
+
+
+def test_install_retries_into_a_private_prefix_when_the_npm_prefix_is_root_owned(
+    private_prefix: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: a root-owned npm prefix made the install button unwinnable.
+
+    ``npm install -g`` cannot succeed on such a host at all, so before the retry
+    the panel's only exit was the standalone installer -- which the operator had
+    to notice, copy and run in their own terminal. npm's own advice ("run as
+    root") is the one remedy that must not be taken.
+    """
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        mod, "find_node_tool", lambda name, base_path=None: {"npm": "/n/npm"}.get(name)
+    )
+    # Resolves only AFTER the retry has installed something, which is what makes
+    # the ordering assertion below meaningful.
+    monkeypatch.setattr(
+        mod,
+        "cli_path",
+        lambda: "/n/pw" if any("--prefix" in c for c in calls) else None,
+    )
+
+    def fake_run(argv: list[str], timeout: float) -> tuple[int, str, str]:
+        calls.append(list(argv))
+        if argv[0] == "/n/npm" and "--prefix" not in argv:
+            return 243, "", _EACCES_STDERR
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "npm-install-private-prefix",
+        "install-browser",
+        "install-skills",
+    ]
+    # The refused attempt stays visible rather than being swallowed...
+    assert result["steps"][0]["ok"] is False
+    assert "EACCES" in result["steps"][0]["stderr"]
+    # ...but it must not veto an install the retry completed.
+    assert result["steps"][1]["ok"] is True
+    assert calls[0] == ["/n/npm", "install", "-g", "@playwright/cli@latest"]
+    assert calls[1] == [
+        "/n/npm",
+        "install",
+        "--global",
+        "--prefix",
+        str(private_prefix),
+        "@playwright/cli@latest",
+    ]
+    # Never as root: that would leave a tree the gateway cannot later upgrade.
+    assert all("sudo" not in argv for argv in calls)
+
+
+def test_install_does_not_retry_a_failure_a_different_prefix_cannot_fix(
+    private_prefix: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A registry rejection is not a permissions problem.
+
+    Retrying it elsewhere would repeat the same failure, hide the real error
+    behind a second one, and cost the operator a full registry round-trip.
+    """
+    calls = _wire(
+        monkeypatch,
+        {"npm": "/n/npm"},
+        {"/n/npm": (1, "", "npm error code E403\nnpm error 403 Forbidden - GET ...")},
+    )
+
+    result = mod.install()
+
+    assert result["ok"] is False
+    assert [s["name"] for s in result["steps"]] == ["npm-install-global"]
+    assert len(calls) == 1
+
+
+def test_a_private_prefix_install_is_discoverable_and_linked_onto_path(
+    private_prefix: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The two ways the private launcher has to be reachable.
+
+    ``cli_path`` covers the gateway (it searches the prefix bin dir by known
+    path); the ``~/.local/bin`` symlink covers the AGENT, which runs
+    ``playwright-cli`` as a plain shell command and so resolves the login PATH.
+    Without the first, a SUCCESSFUL install would still read as absent in the
+    panel -- failure with no error, and the offer never withdraws.
+
+    ``augmented_path`` is stubbed to contribute nothing, so the assertion is
+    about the prefix dir alone. Not tidiness: this suite runs on hosts that DO
+    have a real ``playwright-cli`` (including one installed by the very fallback
+    under test), and that launcher would otherwise satisfy ``cli_path`` and make
+    the test pass without the search-path change it exists to prove.
+    """
+    monkeypatch.setattr(mod, "augmented_path", lambda base: "")
+    bin_dir = mod.standalone_bin_dir()
+    assert bin_dir == private_prefix / "bin"
+    bin_dir.mkdir(parents=True)
+    launcher = bin_dir / "playwright-cli"
+    launcher.write_text("#!/bin/sh\n")
+    launcher.chmod(0o755)
+
+    assert mod.cli_path() == str(launcher)
+    assert str(bin_dir) in mod.cli_env()["PATH"]
+
+    mod._link_private_launcher(bin_dir)
+    linked = Path.home() / ".local" / "bin" / "playwright-cli"
+    assert linked.is_symlink()
+    assert linked.resolve() == launcher
+
+    # Idempotent: re-running the installer must not fail on its own leftover link.
+    mod._link_private_launcher(bin_dir)
+    assert linked.resolve() == launcher
+
+
+def test_the_private_launcher_link_never_clobbers_a_real_file(private_prefix: Path) -> None:
+    """A non-symlink at the target is somebody else's and is not ours to remove."""
+    bin_dir = mod.standalone_bin_dir()
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "playwright-cli").write_text("#!/bin/sh\n")
+    target = Path.home() / ".local" / "bin" / "playwright-cli"
+    target.parent.mkdir(parents=True)
+    target.write_text("their own wrapper")
+
+    mod._link_private_launcher(bin_dir)
+
+    assert target.read_text() == "their own wrapper"
+
+
+def test_an_unwritable_private_prefix_fails_the_step_rather_than_raising(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The last fallback can itself be refused, and that must stay a step."""
+    monkeypatch.setenv("KIROCREW_PLAYWRIGHT_CLI_HOME", str(tmp_path / "nope"))
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError(13, "permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+
+    step = mod._install_into_private_prefix("/n/npm")
+
+    assert step["ok"] is False
+    assert step["name"] == "npm-install-private-prefix"
+    assert "private install prefix" in step["stderr"]
+
+
 def test_a_zero_exit_carrying_the_host_validation_warning_is_a_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -506,12 +686,17 @@ def test_cli_env_layers_node_dirs_over_the_broad_path(monkeypatch: pytest.Monkey
     (node layer, outermost). The broad layer under it carries ``~/.local/bin`` /
     Homebrew's bin so a mise-managed npm's post-install ``mise reshim`` hook can
     find the ``mise`` binary instead of dying ``mise: command not found``.
+
+    The private install prefix comes LAST, so a system-wide ``npm install -g``
+    still wins whenever one exists -- it is a fallback for a host whose npm
+    prefix is root-owned, not a new preference.
     """
     monkeypatch.setattr(mod, "augmented_path", lambda base: f"/home/.local/bin:{base}")
     monkeypatch.setattr(mod, "node_augmented_path", lambda base: f"/node/bin:{base}")
+    monkeypatch.setattr(mod, "standalone_bin_dir", lambda: Path("/private/pw/bin"))
     monkeypatch.setenv("PATH", "/usr/bin")
 
-    assert mod.cli_env()["PATH"] == "/node/bin:/home/.local/bin:/usr/bin"
+    assert mod.cli_env()["PATH"] == "/node/bin:/home/.local/bin:/usr/bin:/private/pw/bin"
 
 
 @pytest.mark.skipif(
@@ -835,11 +1020,12 @@ class TestCliEnvIsPublic:
     ) -> None:
         monkeypatch.setattr(mod, "augmented_path", lambda base: base)
         monkeypatch.setattr(mod, "node_augmented_path", lambda base: f"/nvm/bin:{base}")
+        monkeypatch.setattr(mod, "standalone_bin_dir", lambda: Path("/private/pw/bin"))
         monkeypatch.setenv("PATH", "/usr/local/bin")
 
         env = mod.cli_env()
 
-        assert env["PATH"] == "/nvm/bin:/usr/local/bin"
+        assert env["PATH"] == "/nvm/bin:/usr/local/bin:/private/pw/bin"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Problem

On a host whose npm global prefix is not writable by the running user, the Browser settings panel's install button **could never succeed**. `install()` ran a bare `npm install -g @playwright/cli@latest` and returned on the first failure:

```
npm error code EACCES
npm error syscall mkdir
npm error path /usr/local/node-v22.12.0-linux-arm64/lib/node_modules/@playwright
npm error Error: EACCES: permission denied, mkdir '.../node_modules/@playwright'
```

Measured on Amazon Linux 2023 (arm64) where that prefix's `lib/node_modules` is owned by `nobody:nobody` mode `0755`. A root-owned npm prefix is an ordinary host property — a distribution tarball unpacked into `/usr/local`, a system package, a container image built as root — not an operator mistake. The only exit was the standalone installer, which the operator had to notice, copy and run in their own terminal.

The module already had every piece needed to avoid this: `KIROCREW_PLAYWRIGHT_CLI_HOME`, `_standalone_node_modules()` probing an unprivileged prefix, and `playwright-cli.sh` performing exactly this install. `install()` just never used them.

## Change

On an `EACCES`/`EPERM`/`EROFS` failure **only**, retry into a prefix the user owns (`<config dir>/playwright-cli`), reusing npm's `--global --prefix` layout so `_standalone_node_modules()` and `_launcher_node_modules()` need no new special case.

Matched on npm's error **code**, not its prose. npm's own advice — *"try running the command again as root/Administrator"* — is the one remedy that must not be taken: it would leave a root-owned tree the gateway then cannot upgrade. A registry rejection or 403 is deliberately **not** retried: a different prefix cannot fix it, and retrying would repeat the failure while hiding the real error behind a second one.

Three supporting changes:

- `cli_path()` and `cli_env()` also search the private prefix bin dir, **appended** so a system-wide `npm install -g` still wins whenever one exists. Without this the retry would SUCCEED while the panel kept reporting the CLI absent — the failure shape `cli_path()`'s own docstring calls the worst available here.
- A best-effort `~/.local/bin` symlink covers the agent, which is documented to run `playwright-cli` as a plain shell command and so resolves the login `$PATH`, which can never hold a KiroCrew-chosen prefix. Same convention `playwright-cli.sh` follows. It never replaces a non-symlink already there, and failure is logged rather than failing the step.
- The refused global attempt stays in the `steps` list so the operator sees what happened, but no longer vetoes an install the retry completed — the same pattern `_download_browser()` already uses for a refused `--with-deps`.

## Verification

End to end on the failing host:

| step | before | after |
|---|---|---|
| `npm-install-global` | EACCES rc=243, install aborts | EACCES rc=243, classified, retried |
| `npm-install-private-prefix` | — | ok |
| `install-browser` | never reached | ok |
| `install-skills` | never reached | ok |

`detect()` afterwards: `installed: True`, `cli_version: 0.1.19`, `browser_ok: True`. `bash -lc 'playwright-cli --version'` resolves through the symlink, and the browser-revision gate reads `chromium-1243` through the package tree, confirming attribution survives the symlink chain.

10 new tests; 277 passed / 3 skipped across `test_browser_cli_install.py`, `test_browser_cli_launch.py`, `test_browser_cli_os_deps.py`, `test_playwright_cli_installer.py`, `test_spawn_audit.py`. Two existing `cli_env` PATH-composition assertions were updated for the appended layer.

## Not fixed here

One adjacent defect found while verifying, in `os_deps.py` rather than `install.py`, and now fixed separately in #8639: `install-browser` reports ok on a host missing browser libraries. `os_deps.host_deps_unsatisfied` keys on Playwright's *"Host system is missing dependencies"* warning, which Playwright never emits here — its registry scans `chrome-linux` while the arm64 build unpacks into `chrome-linux-arm64`, so validation finds nothing, calls the host good and writes a 30-day `DEPENDENCIES_VALIDATED` marker. A false negative, not a missing warning.

**Correction to an earlier revision of this description:** it also claimed `manual_deps_command()` omits `mesa-libgbm`. That was wrong — the package has always been in `_RPM_CHROMIUM_PACKAGES` (35 packages, `mesa-libgbm` included). The claim came from reading a truncated `repr(...)[:400]` of the generated command, which cuts off mid-token at `libxs`, hiding the last four packages. No such defect exists.
