### PR TITLE
fix: verify the downloaded browser can resolve its libraries

### DIFF
--- a/docs/system-specs/modules/browser.md
+++ b/docs/system-specs/modules/browser.md
@@ -131,6 +131,45 @@ once, at install, so registry auth applies at install time only.
    stall inside the first browse. `--with-deps` is appended only on an apt host,
    and a refusal there is retried without it — see
    [OS dependencies](#os-dependencies).
+    A successful download is followed by `verify-browser-libraries-<engine>`: each
+    ELF object on disk is read for its declared dependencies and any soname the
+    host cannot provide is reported as **its own advisory step**. The step NEVER
+    fails the install: it carries `ok: true`, `advisory: true` and `returncode: 0`,
+    and `install-skills` runs behind it. That is deliberate — the probe
+    re-implements the dynamic loader's search, an emulation that cannot be
+    completed across musl, glibc hwcaps and cache-only directories, so it must not
+    be able to withdraw a working browser. It reaches the operator as two fields on
+    `GET /api/browser/install` — `last_notice` and `last_notice_command` — because the
+    Browser settings panel renders each differently: the prose muted rather than as an
+    error banner, and the command in a `<pre>` with a copy button, the same treatment
+    `standalone_install` gets because it must be transcribed exactly. Both strings are
+    composed in English — the sonames and the package list have no translation, so the
+    card stays in one language, as `last_error` does. The notice names NO affordance for
+    re-checking, and it can outlive the fix. It is written only during an install run and
+    `detect` deliberately does not probe (an ELF sweep behind every dashboard poll), so
+    after the operator installs the named packages it persists for the life of the
+    gateway process — clearing on restart, or on a re-download of that engine, which the
+    panel does not offer once the engine reads "Downloaded". That is a known gap, accepted
+    because a confirm loop of its own is more surface than a diagnostic earns. Playwright's own host validation cannot carry
+    this. In `playwright-core` as shipped, `EXECUTABLE_PATHS.chromium["linux-arm64"]`
+    is `["chrome-linux-arm64", "chrome"]` while `_validateHostRequirements` is
+    called with the literal `["chrome-linux"]` for both `chromium` and
+    `chromiumHeadlessShell` — so on linux-arm64 the scan is aimed at a directory
+    the build never creates, finds nothing, and writes a `DEPENDENCIES_VALIDATED`
+    marker that suppresses re-validation for 30 days. A broken host reports clean.
+   One work budget covers the whole probe — every directory walked, every entry
+    visited and every file parsed draw from it — because each of those quantities
+    comes from a cache an agent can write to, including how many directories the
+    engine prefix matches. A budget spent yields "cannot determine", never "clean".
+    **Nothing is executed.** The dependency list is parsed out of each file's own
+   ELF dynamic table and compared against a listing of the host's library
+   directories. `ldd` is deliberately not used: glibc's `ldd` runs the binary it
+   inspects, a crafted `PT_INTERP` makes that arbitrary code, and the engine cache
+   is writable with its subdirectories matched by name prefix — so a planted ELF
+   would be reachable, and the interpreter travels inside the file where no
+   absolute argv or scrubbed environment can intercept it. The build's own bundled
+   libraries are excluded by NAME, and an answer of "unknown" is returned rather
+   than "clean" whenever nothing readable declared a dependency.
 4. `playwright-cli install --skills agents --global` so the command reference is
    discoverable from the skill file rather than occupying the system prompt.
    `--skills` accepts `claude` (default) or `agents`; `--global` targets the home
@@ -153,6 +192,15 @@ launch fails `Browser "chromium" is not installed` — and because the gate read
 ready, the panel never offers the download that would fix it. The prefix form also
 let `chromium_headless_shell-<rev>` satisfy `chromium`, which is a different
 artifact.
+
+**Readiness is presence-and-revision only: the install flow's library probe does
+not feed it.** The probe runs on the `install` path; readiness is on the
+`/api/status` poll path, where a per-poll ELF sweep would run behind every dashboard
+poll. The consequence is deliberate and bounded: a host whose libraries were
+already missing before that check existed, or whose libraries go missing after a
+successful install, still reads ready until the next install attempt. Closing that
+needs the probe's verdict cached against directory mtime so readiness can consult
+it without spawning, which is a separate change.
 
 The required revision comes from `playwright-core/browsers.json`, the file
 `install-browser` itself consults. Reading it is a plain file read, so readiness

--- a/src/kiro_crew/browser_cli/install.py
+++ b/src/kiro_crew/browser_cli/install.py
@@ -1161,6 +1161,115 @@ def _step(
     }
 
 
+def _engine_cache_dirs(engine: str) -> list[Path]:
+    """Cache directories holding builds for *engine*.
+
+    Prefix-matched rather than composed from a revision, so the CHROMIUM entry
+    also picks up ``chromium_headless_shell-<rev>``. That is not a bonus: headless
+    is the default launch mode, so the headless shell is the binary a browse
+    actually starts, and a library check that looked only at ``chromium-<rev>``
+    would clear the build that is not the one being run.
+
+    A symlinked child is REFUSED, not followed. The returned path becomes the
+    anchor of a recursive walk, and this cache is writable, so a prefix-named
+    symlink would point that walk at a tree of the planter's choosing during a
+    privileged install. Playwright's own downloads are real directories, so
+    refusing links costs nothing a supported install needs.
+    """
+    cache = _browsers_cache_dir()
+    if cache is None:
+        return []
+    try:
+        return [
+            child
+            for child in cache.iterdir()
+            if child.name.startswith(engine) and not child.is_symlink() and child.is_dir()
+        ]
+    except OSError:
+        return []
+
+
+def _verify_browser_libraries(engine: str) -> dict[str, Any] | None:
+    """Advisory step reporting libraries *engine*'s build may not resolve.
+
+    ``None`` when there is nothing to report -- no missing library, or the probe
+    could not run (see :func:`os_deps.missing_shared_libraries`).
+
+    ADVISORY, and that is a load-bearing decision rather than caution. The probe
+    answers "will the loader find these" by RE-IMPLEMENTING the loader's search:
+    base-name matching against the loader's default directories and the ones
+    ``/etc/ld.so.conf`` names. That emulation cannot be complete -- musl reads its
+    own path file, glibc has hwcaps subdirectories, the loader cache can name a
+    directory no config file mentions, and ``LD_LIBRARY_PATH`` is deliberately not
+    consulted -- so on some host it WILL name a library the real loader resolves. A heuristic that reproduces a platform component must not
+    be able to fail an install, so this reports and the install proceeds.
+
+    That is also what right-sizes the probe's own attack surface. It reads a
+    directory an agent can write to, so a planted tree can influence what it
+    reports; when the report is advisory, the worst that buys is a misleading
+    warning. Nothing is executed, nothing is written, and no install outcome turns
+    on it.
+
+    Reported as a passing step for that reason. :func:`_download_browser` appends
+    this verdict LAST and :func:`install` stops at the first failed step, so an
+    ``ok: False`` here would both fail the install and skip ``install-skills`` --
+    a diagnostic costing more than the problem it describes.
+    """
+    missing = os_deps.missing_shared_libraries(_engine_cache_dirs(engine))
+    if not missing:
+        return None
+    listed = ", ".join(sorted(missing))
+    # Composed here rather than borrowed from `os_deps.missing_deps_hint()`, which
+    # is written for a FAILED step: it asserts the browser "needs OS libraries" and
+    # says to "retry the install", which contradicts both this step's hedge and the
+    # panel's own green result sitting above it. Only the command is shared.
+    command = os_deps.manual_deps_command() or ""
+    # Agrees with the `librar{y|ies}` branch below: "Install them" alongside a
+    # single soname reads as a copy bug to the operator it is addressed to.
+    them = "it" if len(missing) == 1 else "them"
+    # Names no affordance. The panel has none to name: this notice renders only
+    # AFTER a successful install, where there is no install button for an engine
+    # already downloaded, and a confirm loop of its own is more surface than a
+    # diagnostic earns. The operator's own next install re-runs the probe.
+    closing = (
+        f"Install {them} with the command below."
+        if command
+        else f"Install {them} with your system's package manager."
+    )
+    prose = (
+        f"{engine.capitalize()} downloaded, but {len(missing)} shared "
+        f"librar{'y' if len(missing) == 1 else 'ies'} it needs may be missing from "
+        # One hedge, not two: "may be missing ... may not launch" reads as a guess
+        # about a guess. The uncertainty is whether they are there; the consequence
+        # if they are not is certain.
+        f"this host, and it will not launch without {them}: {listed}. {closing}"
+    )
+    return {
+        "name": f"verify-browser-libraries-{engine}",
+        # Nothing failed: the download succeeded and this step only read what it
+        # produced. Reporting it as a failure is what made a heuristic fatal.
+        "ok": True,
+        "advisory": True,
+        "returncode": 0,
+        # Two strings, both carrying DATA: the sentence naming the sonames, and the
+        # command, which the panel renders in a `<pre>` with a copy button because
+        # it must be transcribed exactly (the treatment `standalone_install` gets).
+        #
+        # The card's fixed heading is NOT one of them -- it is one literal with one
+        # consumer, so it belongs in the panel rather than travelling through a step
+        # field, dashboard state, the API payload and a TS type to arrive unchanged.
+        #
+        # Composed here in English rather than assembled from translated fragments:
+        # the sonames and the package list are data with no translation, so the card
+        # stays in one language, as `last_error` already does. Translating it means
+        # the gateway emitting structured data and the panel composing the sentence
+        # -- which needs a pluralised catalog key in every language, since the
+        # wording agrees with the count.
+        "advisory_prose": prose,
+        "advisory_command": command,
+    }
+
+
 def _download_browser(command: list[str], engine: str | None = None) -> list[dict[str, Any]]:
     """Download a browser build, adapting to what this host's OS allows.
 
@@ -1177,7 +1286,10 @@ def _download_browser(command: list[str], engine: str | None = None) -> list[dic
     tried instead of only the last verdict.
 
     Every attempt is judged on its output as well as its exit code: a build whose
-    libraries are missing downloads "successfully" and cannot launch.
+    libraries are missing downloads "successfully" and cannot launch. That check
+    is not sufficient by itself either -- Playwright's validation false-negatives
+    on linux-arm64 -- so a successful download is FOLLOWED by a real library
+    probe (:func:`_verify_browser_libraries`).
     """
     selected_engine = engine or _DEFAULT_BROWSER_ENGINE
     base = [*command, "install-browser", selected_engine]
@@ -1195,13 +1307,20 @@ def _download_browser(command: list[str], engine: str | None = None) -> list[dic
             failure_signal=os_deps.host_deps_unsatisfied,
         )
 
+    def with_library_check(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Append the library verdict when the download succeeded."""
+        if not steps[-1]["ok"]:
+            return steps
+        verdict = _verify_browser_libraries(selected_engine)
+        return steps if verdict is None else [*steps, verdict]
+
     if not os_deps.with_deps_supported():
-        return [attempt(f"install-browser{suffix}", base, True)]
+        return with_library_check([attempt(f"install-browser{suffix}", base, True)])
 
     first = attempt(f"install-browser{suffix}", base + ["--with-deps"], False)
     if first["ok"]:
-        return [first]
-    return [first, attempt(f"install-browser{suffix}-no-deps", base, True)]
+        return with_library_check([first])
+    return with_library_check([first, attempt(f"install-browser{suffix}-no-deps", base, True)])
 
 
 def install() -> dict[str, Any]:

--- a/src/kiro_crew/browser_cli/os_deps.py
+++ b/src/kiro_crew/browser_cli/os_deps.py
@@ -16,13 +16,22 @@ elevates, and nothing here runs a package manager.
 
 The read blocks (the os-release file), so a caller on the event loop offloads
 them -- the same contract as the rest of this package.
+
+This module also owns the check that the downloaded browser can actually RESOLVE
+its libraries (:func:`missing_shared_libraries`), because Playwright's own host
+validation cannot be relied on to say so -- on linux-arm64 it scans a directory
+that does not exist and concludes the host is fine. See that function.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import platform
+import struct
+from collections.abc import Iterable, Iterator
 from functools import lru_cache
+from pathlib import Path
 
 from kiro_crew import platform_compat
 
@@ -234,6 +243,401 @@ def host_deps_unsatisfied(text: str) -> bool:
 
     Read the exit code AND this, never the exit code alone -- see
     :data:`_HOST_VALIDATION_MARKERS` for the measurement.
+
+    NOT sufficient on its own either: Playwright's validation produces FALSE
+    NEGATIVES on linux-arm64, so a host with libraries missing can emit no
+    marker at all. :func:`missing_shared_libraries` is the check that does not
+    depend on Playwright noticing.
     """
     lowered = (text or "").lower()
     return any(marker in lowered for marker in _HOST_VALIDATION_MARKERS)
+
+
+#: ELF constants for reading a build's declared dependencies. Only what is used.
+_ELF_MAGIC = b"\x7fELF"
+_PT_LOAD = 1
+_PT_DYNAMIC = 2
+_DT_NULL = 0
+_DT_NEEDED = 1
+_DT_STRTAB = 5
+
+#: Ceilings applied to every count read out of the file being parsed. The files
+#: come from a writable cache, so each header field is hostile input until it has
+#: been checked: nothing is allocated or seeked from an unvalidated number.
+_MAX_PHNUM = 4096
+_MAX_DYN_ENTRIES = 100_000
+_MAX_SONAME_LEN = 4096
+
+#: Ceiling on entries VISITED while walking one cache directory. Bounds the walk
+#: itself rather than any field inside a file: the directory is writable, so its
+#: breadth is hostile input too, and a link or a deep tree planted there would
+#: otherwise drive an uncapped recursive scan during a privileged install.
+_MAX_WALK_ENTRIES = 20_000
+
+
+# Bounds the NUMBER of dependency names collected, in one file and in aggregate.
+# Each name comes out of a dynamic table in a writable cache, so the count is as
+# attacker-shaped as the walk's breadth was. MEASURED: chromium's build declares
+# 32 unique sonames across 9 candidates and firefox 50 across 24, so a real build
+# is two orders of magnitude below this. Truncating can only shorten a report --
+# a name never added cannot invent a missing library.
+_MAX_SONAMES = 4_000
+
+
+def _needed_sonames(path: Path) -> set[str]:
+    """Sonames *path* declares as dependencies, read WITHOUT executing it.
+
+    ``ldd`` cannot be used here. glibc's ``ldd`` is documented to execute the
+    binary it inspects, and a crafted ``PT_INTERP`` makes that arbitrary code:
+    the interpreter travels inside the ELF, so neither an absolute argv, nor a
+    scrubbed environment, nor an unexported search path prevents it. These files
+    come from a writable cache whose subdirectories are matched by name prefix,
+    so they must be treated as data, never as something to run.
+
+    So the dynamic table is read directly: ``PT_DYNAMIC`` gives the ``DT_NEEDED``
+    string-table offsets and ``DT_STRTAB`` gives the table's virtual address,
+    which is mapped back to a file offset through the ``PT_LOAD`` segment that
+    contains it.
+
+    An empty set means "declares nothing we can read" -- not a parseable ELF, a
+    static binary with no dynamic section, or a field that failed a bound. Never
+    raises: a file this cannot parse must not be able to fail an install.
+    """
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as fh:
+            ident = fh.read(16)
+            if len(ident) < 16 or ident[:4] != _ELF_MAGIC:
+                return set()
+            if ident[4] not in (1, 2) or ident[5] not in (1, 2):
+                return set()
+            is64 = ident[4] == 2
+            endian = "<" if ident[5] == 1 else ">"
+            ph_entry = 56 if is64 else 32
+
+            fh.seek(32 if is64 else 28)
+            raw = fh.read(8 if is64 else 4)
+            if len(raw) < (8 if is64 else 4):
+                return set()
+            phoff = struct.unpack(endian + ("Q" if is64 else "I"), raw)[0]
+            fh.seek(54 if is64 else 42)
+            raw = fh.read(4)
+            if len(raw) < 4:
+                return set()
+            phentsize, phnum = struct.unpack(endian + "HH", raw)
+
+            if phnum > _MAX_PHNUM or phentsize < ph_entry:
+                return set()
+            if phoff <= 0 or phoff + phnum * phentsize > size:
+                return set()
+
+            loads: list[tuple[int, int, int]] = []
+            dynamic: tuple[int, int] | None = None
+            for index in range(phnum):
+                fh.seek(phoff + index * phentsize)
+                hdr = fh.read(ph_entry)
+                if len(hdr) < ph_entry:
+                    return set()
+                if is64:
+                    p_type, _flags, p_off, p_vaddr, _paddr, p_filesz = struct.unpack(
+                        endian + "IIQQQQ", hdr[:40]
+                    )
+                else:
+                    p_type, p_off, p_vaddr, _paddr, p_filesz = struct.unpack(
+                        endian + "IIIII", hdr[:20]
+                    )
+                if p_type == _PT_LOAD:
+                    loads.append((p_vaddr, p_filesz, p_off))
+                elif p_type == _PT_DYNAMIC:
+                    dynamic = (p_off, p_filesz)
+
+            if dynamic is None:
+                return set()
+            dyn_off, dyn_size = dynamic
+            if dyn_off + dyn_size > size:
+                return set()
+
+            step = 16 if is64 else 8
+            entry_fmt = endian + ("Qq" if is64 else "Ii")
+            count = min(dyn_size // step, _MAX_DYN_ENTRIES)
+            fh.seek(dyn_off)
+            table = fh.read(count * step)
+            offsets: list[int] = []
+            strtab_vaddr: int | None = None
+            for index in range(len(table) // step):
+                tag, value = struct.unpack_from(entry_fmt, table, index * step)
+                if tag == _DT_NULL:
+                    break
+                if tag == _DT_NEEDED:
+                    offsets.append(value)
+                elif tag == _DT_STRTAB:
+                    strtab_vaddr = value
+            if strtab_vaddr is None or not offsets:
+                return set()
+
+            strtab_off: int | None = None
+            for vaddr, filesz, file_off in loads:
+                if vaddr <= strtab_vaddr < vaddr + filesz:
+                    strtab_off = file_off + (strtab_vaddr - vaddr)
+                    break
+            if strtab_off is None or strtab_off >= size:
+                return set()
+
+            names: set[str] = set()
+            for relative in offsets:
+                if len(names) >= _MAX_SONAMES:
+                    # Bounded inside the file too, not only in aggregate: one file's
+                    # dynamic table is as attacker-shaped as a thousand of them, so
+                    # the cap has to hold before the set leaves this function.
+                    break
+                if relative < 0:
+                    continue
+                start = strtab_off + relative
+                if start >= size:
+                    continue
+                fh.seek(start)
+                raw = fh.read(_MAX_SONAME_LEN)
+                end = raw.find(b"\x00")
+                if end <= 0:
+                    continue
+                names.add(raw[:end].decode("ascii", errors="replace"))
+            return names
+    except (OSError, struct.error, ValueError):
+        return set()
+
+
+def _host_provided_sonames() -> set[str]:
+    """File names of shared objects this host provides, by directory listing.
+
+    Answers "can the host satisfy this soname" without asking the loader, which is
+    the whole point: asking the loader means running something.
+
+    Only the loader's own configured directories are listed --
+    :func:`platform_compat.system_library_dirs`. ``LD_LIBRARY_PATH`` is NOT read,
+    even though the loader honours it, because a directory named by process
+    environment is an environment-controlled path and listing one from a
+    privileged install is the security class this repository fences. The cost is a
+    host that supplies a library that way being named in the report; since the
+    report is advisory (see ``install._verify_browser_libraries``), that costs a
+    spurious muted line rather than a blocked install.
+
+    Matched by NAME alone. Architecture is deliberately not compared: a multiarch
+    host can carry one soname for several architectures, so a name match can in
+    principle be satisfied by the wrong one -- but that costs a report this check
+    would otherwise have made, and the report is advisory, so the cost is a missing
+    muted line. Comparing architectures means reading an ELF header for every
+    library the host provides: MEASURED at 962 extra file reads and 6x the runtime
+    on an arm64 host, to move the provided set from 970 names to 962 and change no
+    verdict.
+
+    Listing names rather than resolving them is the deliberate bias. A name that is
+    present but somehow unloadable reads as satisfied, so the check errs towards NOT
+    reporting: a false positive would block an install that works, which is worse
+    than the failure being fixed.
+    """
+    names: set[str] = set()
+    for candidate in platform_compat.system_library_dirs():
+        try:
+            if not candidate.is_dir():
+                continue
+            for child in candidate.iterdir():
+                if ".so" in child.name:
+                    names.add(child.name)
+        except OSError:
+            continue
+    return names
+
+
+def _sonames_shipped_with_build(directories: Iterable[Path], budget: list[int]) -> set[str]:
+    """File names of shared objects the build carries itself.
+
+    The ONLY guard against reporting a bundled library as host-missing, and it is
+    enough because it does not depend on the loader: a library present in the tree
+    is the build's own, so naming it "missing on this host" is wrong regardless of
+    whether ``ldd`` managed to resolve it. That independence is what allowed the
+    ``LD_LIBRARY_PATH`` export to be removed -- it resolved exactly the libraries
+    this set already names, since both are built from the same ``rglob("*.so*")``
+    walk, and exporting it into a shell-script ``ldd`` was a code-execution path.
+
+    It also absorbs the loader quirks the search path never handled: ``$ORIGIN``
+    handling, or a nested layout the search path missed.
+
+    Bounded by :func:`_bounded_walk` like every other walk of a cache directory.
+    Every walk must share the ceiling: one uncapped walk over the same tree makes
+    the others' bound worth nothing, since the unbounded work happens either way.
+    """
+    names: set[str] = set()
+    for directory in directories:
+        for path in _bounded_walk(directory, budget, ".so"):
+            try:
+                if path.is_file():
+                    names.add(path.name)
+            except OSError:
+                continue
+    return names
+
+
+def _bounded_walk(
+    directory: Path, budget: list[int], suffix_match: str | None = None
+) -> Iterator[Path]:
+    """Entries under *directory*, stopping when the walk budget runs out.
+
+    *budget* is a ONE-ELEMENT list holding the work still allowed, shared by every
+    walk AND every parse in one probe, and it is REQUIRED. That sharing is the
+    point: a per-call ceiling is multiplied by however many directories the caller
+    passes, and the caller's list comes from a prefix match over a writable cache
+    (``install._engine_cache_dirs``), so its length is attacker-shaped too. A
+    default would silently hand the next caller the per-call ceiling this replaced,
+    so there is none.
+
+    Always walks ``"*"`` and filters AFTER charging the budget. ``rglob`` with a
+    narrower pattern still descends the entire tree but yields only MATCHES, so
+    charging for yields charges for the wrong thing: a cache of a million
+    non-matching files is traversed in full while the counter barely moves. The
+    bound has to cover the work, not the results.
+
+    The generator is also consumed LAZILY: wrapping ``rglob`` in ``sorted()``
+    materialises and sorts everything before a ceiling check inside the loop can
+    ever fire, which likewise enforces a bound only after doing the unbounded work.
+
+    ``rglob`` yields top-down, so a truncated walk keeps the SHALLOW entries. That
+    is what makes truncating safe for the probe: a browser's main executable sits
+    at the top of its build directory, so it is seen before the satellites, and a
+    cut tail cannot produce a "nothing missing" answer for a build whose main
+    binary was never read.
+
+    MEASURED for scale: chromium ships 14 ELF candidates and firefox 44, against a
+    ceiling of :data:`_MAX_WALK_ENTRIES`. It bounds a hostile tree, not a supported
+    one.
+    """
+    left = budget
+    try:
+        for path in directory.rglob("*"):
+            if left[0] <= 0:
+                logger.warning("walk of %s stopped: entry budget spent", directory)
+                return
+            left[0] -= 1
+            if suffix_match is not None and suffix_match not in path.name:
+                continue
+            yield path
+    except OSError:
+        return
+
+
+def _elf_candidates(directory: Path, budget: list[int]) -> list[Path]:
+    """Executables and shared objects under *directory*, most-important first.
+
+    Bounded by :func:`_bounded_walk`, and symlinks are never descended into.
+
+    A symlink swapped in at the top of the walk can redirect it: this reads a path,
+    and a path is re-resolved on every use. The probe does not try to win that
+    race, because its output is ADVISORY (see
+    ``install._verify_browser_libraries``) -- the worst a won race yields is a
+    misleading warning, and nothing is executed or written either way.
+
+    Deliberately NOT pinned with :func:`platform_compat.pin_directory`: that
+    primitive's contract requires POSIX callers to use the returned descriptor for
+    their own opens, and a walk that goes by path string gets nothing from holding
+    it. A pin here would read as protection without being any, which is worse than
+    no pin at all, because it is believed.
+
+    The order puts an executable before a ``.so`` and a shallow path before a deep
+    one, so the main program is probed first.
+    """
+    found: list[Path] = []
+    for path in _bounded_walk(directory, budget):
+        try:
+            if path.is_symlink() or not path.is_file():
+                continue
+            is_executable = os.access(path, os.X_OK)
+            is_shared_object = ".so" in path.name
+            if is_executable or is_shared_object:
+                found.append(path)
+        except OSError:
+            continue
+    found.sort(key=lambda p: (not os.access(p, os.X_OK), len(p.parts), str(p)))
+    return found
+
+
+def missing_shared_libraries(directories: Iterable[Path]) -> set[str] | None:
+    """Sonames the downloaded browser needs that this host cannot resolve.
+
+    Exists because Playwright's own host validation CANNOT be trusted to notice.
+    MEASURED on Amazon Linux 2023 arm64: its registry declares the directory to
+    scan as ``chrome-linux``, while the arm64 build unpacks into
+    ``chrome-linux-arm64``, so it scans a path that does not exist, finds no
+    dependencies at all, concludes the host is fine and writes its
+    ``DEPENDENCIES_VALIDATED`` marker -- which then suppresses re-validation for
+    30 days. The marker was written 23 minutes BEFORE the libraries were
+    installed on that host. A false negative, not a missing warning: the
+    download reports success, ``browser_ok`` reports true, the panel goes green,
+    and the failure only arrives at the user's first browse as an opaque stack
+    trace.
+
+    So this reads the real files, and never hardcodes a build's subdirectory
+    name -- that assumption is the upstream bug being worked around.
+
+    It reads them as DATA. The dependency list comes from each ELF's own dynamic
+    table (:func:`_needed_sonames`) and the answer from a listing of the host's
+    library directories (:func:`_host_provided_sonames`); nothing is executed.
+    ``ldd`` cannot be used, because glibc's ``ldd`` runs the binary it inspects
+    and a crafted ``PT_INTERP`` turns that into arbitrary code -- and these files
+    live in a writable cache whose subdirectories are matched by name prefix, so a
+    planted ELF is reachable. The interpreter travels inside the file, so no
+    absolute argv, scrubbed environment or withheld search path prevents it.
+
+    Only libraries the HOST must provide are reported; the build's own bundled
+    ones are excluded by name (see :func:`_sonames_shipped_with_build`), because
+    reporting those would block an install that works.
+
+    ``None`` means "cannot determine", NOT "nothing missing": off Linux, when no
+    directory exists, or when nothing readable declared a dependency at all.
+    Callers must not turn an unknown into a failed install -- an absent probe is
+    not evidence of a broken browser.
+    """
+    if not platform_compat.IS_LINUX:
+        return None
+    dirs = [d for d in directories]
+    # ONE budget for the whole probe. A per-directory ceiling is multiplied by the
+    # number of directories, and `dirs` comes from a prefix match over a writable
+    # cache (`install._engine_cache_dirs`), so its length is attacker-shaped as
+    # surely as each tree's depth is.
+    budget = [_MAX_WALK_ENTRIES]
+    candidates: list[Path] = []
+    for directory in dirs:
+        try:
+            if directory.is_dir():
+                candidates.extend(_elf_candidates(directory, budget))
+        except OSError:
+            continue
+    if not candidates:
+        return None
+    shipped = _sonames_shipped_with_build(dirs, budget)
+    declared: set[str] = set()
+    for path in candidates:
+        if budget[0] <= 0:
+            # PARSING is charged to the same budget as walking. Reading a file's
+            # headers, program headers and string table is work, and a cache of
+            # files that each declare NOTHING never trips the name cap while still
+            # being parsed one by one. One budget covers every quantity this probe
+            # takes from the cache.
+            logger.warning("ELF parsing for %s stopped: work budget spent", candidates[0])
+            break
+        budget[0] -= 1
+        declared |= _needed_sonames(path)
+        if len(declared) >= _MAX_SONAMES:
+            # The COUNT of names is bounded, not only each name's length and the
+            # number of files walked. Every dependency name comes out of a dynamic
+            # table in the writable cache, so a build with vast tables -- or many
+            # files each with a large one -- grows this set without a cap here.
+            # Truncating loses reports, never invents them: a name that would have
+            # been added can only have made the answer longer.
+            logger.warning("dependency names for %s truncated at %d", candidates[0], _MAX_SONAMES)
+            break
+    if not declared:
+        # Nothing readable declared a dependency. That is "cannot determine": a
+        # browser build always needs host libraries, so an empty answer here means
+        # the files could not be parsed, not that the host is complete.
+        return None
+    provided = _host_provided_sonames()
+    return {name for name in declared if name not in provided and name not in shipped}

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -3501,6 +3501,49 @@ async def api_browser_command_result(request: web.Request) -> web.Response:
     return web.json_response({"ok": True})
 
 
+def _browser_install_notice(result: dict[str, Any]) -> tuple[str | None, str | None]:
+    """The advisory an install produced as ``(prose, command)``.
+
+    An advisory step reports something the operator should act on while the
+    install itself SUCCEEDED -- currently a downloaded browser whose shared
+    libraries may not resolve (``browser_cli.install._verify_browser_libraries``).
+    It carries ``ok: True``, so the failure path above cannot surface it: that one
+    reads a step only when the install failed, and only the decisive last one.
+    Without this, the probe's whole value -- naming the libraries to install
+    before the operator meets a cryptic launch failure -- is computed and dropped.
+
+    Returned as two values because each is rendered differently: the prose is
+    muted, and the command goes in a `<pre>` with a copy button because it must be
+    transcribed EXACTLY -- the treatment this panel already gives
+    ``standalone_install``. The card's fixed heading is the panel's own string; it
+    carries no data, so routing it through here would ship a constant.
+
+    Keyed on the ``advisory`` flag rather than the step's name, so a second
+    advisory does not need this function edited to be seen.
+    """
+    if not result.get("ok"):
+        return (None, None)
+    for step in result.get("steps") or []:
+        if step.get("advisory"):
+            # The step's own name is deliberately NOT prefixed. Unlike
+            # `last_error`, which names the failing step because an operator needs
+            # to know which command broke, this text is a sentence about their
+            # machine -- prefixing it spends the first words on an internal
+            # identifier. Redacted and capped like `last_error`: it is rendered
+            # verbatim in Settings, and a command composed from a package
+            # manager's own output is exactly the kind of string that carries a
+            # proxy URL.
+            prose = step.get("advisory_prose")
+            if not prose:
+                continue
+            command = step.get("advisory_command") or ""
+            return (
+                _redact(str(prose).strip())[:2000],
+                _redact(str(command).strip())[:2000] or None,
+            )
+    return (None, None)
+
+
 async def api_browser_install_get(request: web.Request) -> web.Response:
     """GET /api/browser/install -- whether browsing is available, and why not.
 
@@ -3514,6 +3557,12 @@ async def api_browser_install_get(request: web.Request) -> web.Response:
     payload["installing"] = bool(task and not task.done())
     payload["token"] = browser_cli_token.has_token()
     payload["last_error"] = getattr(state, "_browser_install_error", None)
+    # Separate from `last_error` on purpose: the install SUCCEEDED, so rendering
+    # this as a failure would tell the operator to retry a download that worked.
+    payload["last_notice"] = getattr(state, "_browser_install_notice", None)
+    # The command lives in its own field so the panel can render it in a `<pre>`
+    # with a copy button; it must be transcribed exactly.
+    payload["last_notice_command"] = getattr(state, "_browser_install_notice_command", None)
     return web.json_response(payload)
 
 
@@ -3536,6 +3585,8 @@ async def api_browser_install_start(request: web.Request) -> web.Response:
 
         async def _run() -> None:
             state._browser_install_error = None
+            state._browser_install_notice = None
+            state._browser_install_notice_command = None
             try:
                 result = await asyncio.to_thread(browser_cli_install.install)
                 # The LAST step, not the first failed one. Two reasons, both of
@@ -3573,6 +3624,10 @@ async def api_browser_install_start(request: web.Request) -> web.Response:
                     state._browser_install_error = _redact(
                         f"{first.get('name', 'install')}: {str(detail).strip()}"
                     )[:2000]
+                (
+                    state._browser_install_notice,
+                    state._browser_install_notice_command,
+                ) = _browser_install_notice(result)
             except Exception as exc:  # noqa: BLE001 - surfaced to the operator
                 state._browser_install_error = _redact(str(exc))[:2000]
 
@@ -3625,6 +3680,8 @@ async def api_browser_engine_install(request: web.Request) -> web.Response:
 
     async def _run() -> None:
         state._browser_install_error = None
+        state._browser_install_notice = None
+        state._browser_install_notice_command = None
         try:
             result = await asyncio.to_thread(browser_cli_install.install_browser, engine)
             # The decisive step, not the first failed one: see the CLI install
@@ -3638,6 +3695,10 @@ async def api_browser_engine_install(request: web.Request) -> web.Response:
                     f"{first.get('name', 'install-browser')}: "
                     f"{first.get('stderr') or first.get('error') or 'failed'}"
                 )[:2000]
+            (
+                state._browser_install_notice,
+                state._browser_install_notice_command,
+            ) = _browser_install_notice(result)
         except Exception as exc:  # noqa: BLE001 - surfaced to the operator
             state._browser_install_error = _redact(str(exc))[:2000]
 

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -5521,6 +5521,12 @@ class DashboardState:
         self._browser_snapshot_pruner: asyncio.Task | None = None  # type: ignore[type-arg]
         self._browser_install_task: asyncio.Task | None = None  # type: ignore[type-arg]
         self._browser_install_error: str | None = None
+        # An advisory the install produced while SUCCEEDING -- a downloaded browser
+        # whose shared libraries may not resolve. Separate from the error so a working
+        # install is not rendered as a failure, and split from its command so the panel
+        # can put that in a `<pre>` with a copy button.
+        self._browser_install_notice: str | None = None
+        self._browser_install_notice_command: str | None = None
         self._terminal_title_poller: asyncio.Task | None = None  # type: ignore[type-arg]
         # Background reconciler that surfaces channel-originated sessions
         # (slack:<ts>, discord:…) as chat slots. Held to prevent GC.

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -1893,6 +1893,73 @@ def env_key_allowed(key: str, allowed: frozenset[str] | tuple[str, ...]) -> bool
 
 _TRUSTED_SYSTEM_BIN_DIRS = ("/usr/bin", "/bin", "/usr/sbin", "/sbin", "/run/current-system/sw/bin")
 
+#: Directories the glibc/musl loader searches for a shared object before it
+#: consults any configuration, plus the file that names the rest.
+#:
+#: POSIX-only literals, which is why they live here: this module is the one place
+#: the cross-platform gate exempts, because platform knowledge has to be written
+#: down somewhere and scattering it through callers is how it goes stale. The
+#: sibling of :data:`_TRUSTED_SYSTEM_BIN_DIRS`, for libraries rather than binaries.
+_TRUSTED_SYSTEM_LIB_DIRS = ("/lib", "/lib64", "/usr/lib", "/usr/lib64", "/usr/local/lib")
+
+#: Loader configuration naming the directories beyond the defaults. Read as a
+#: plain file; nothing here runs ``ldconfig``.
+_LD_SO_CONF = "/etc/ld.so.conf"
+
+#: Bound on ``include`` recursion in that configuration, so a self-referential or
+#: circular config cannot loop.
+_LD_CONF_MAX_DEPTH = 4
+
+
+def _ld_conf_dirs(conf: Path, seen: set[Path], depth: int = 0) -> list[str]:
+    """Library directories named by *conf*, following ``include`` directives."""
+    if depth > _LD_CONF_MAX_DEPTH or conf in seen:
+        return []
+    seen.add(conf)
+    found: list[str] = []
+    try:
+        lines = conf.read_text(errors="replace").splitlines()
+    except OSError:
+        return found
+    for line in lines:
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("include"):
+            pattern = line[len("include") :].strip()
+            if not pattern:
+                continue
+            base = Path(pattern)
+            parent = base.parent if base.is_absolute() else conf.parent / base.parent
+            try:
+                children = sorted(parent.glob(base.name))
+            except OSError:
+                continue
+            for child in children:
+                found.extend(_ld_conf_dirs(child, seen, depth + 1))
+        else:
+            found.append(line)
+    return found
+
+
+def system_library_dirs() -> tuple[Path, ...]:
+    """Directories this host may hold shared libraries in, defaults first.
+
+    The loader's own default set plus whatever ``/etc/ld.so.conf`` adds, which is
+    where a distribution puts its multiarch directories. Empty off Linux: there is
+    no equivalent question to answer on macOS or Windows, and a caller that needs
+    one should ask it separately rather than reinterpret this.
+
+    Directories are returned whether or not they exist, so a caller filters; the
+    order is the loader's, so a caller that stops at the first hit matches it.
+    """
+    if not IS_LINUX:
+        return ()
+    names = list(_TRUSTED_SYSTEM_LIB_DIRS)
+    names.extend(_ld_conf_dirs(Path(_LD_SO_CONF), set()))
+    return tuple(Path(name) for name in dict.fromkeys(names))
+
+
 # Windows argv carries a bare name (``taskkill``) while the file on disk carries
 # an extension (``taskkill.exe``), so a trusted lookup must try the suffixes the
 # loader would rather than requiring callers to spell them.

--- a/test/test_browser_cli_install.py
+++ b/test/test_browser_cli_install.py
@@ -421,6 +421,157 @@ def test_install_falls_back_without_deps_when_the_package_step_is_refused(
     assert ["/n/pw", "install-browser", "chromium"] in calls
 
 
+# --- the browser downloaded but cannot resolve its libraries -------------------
+
+
+def test_a_download_that_cannot_resolve_its_libraries_is_reported_not_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: Playwright's host validation FALSE-NEGATIVES on linux-arm64.
+
+    Its registry declares the scan directory as ``chrome-linux`` while the arm64
+    build unpacks into ``chrome-linux-arm64``, so it scans nothing, calls the
+    host good and writes ``DEPENDENCIES_VALIDATED`` -- MEASURED as written 23
+    minutes before the libraries were actually installed. With no marker in the
+    output, ``host_deps_unsatisfied`` sees nothing, the download reports ok, and
+    the failure only lands at the user's first browse. So a real library probe
+    runs after a successful download.
+
+    It REPORTS rather than fails. The probe re-implements the loader's search, so
+    it will be wrong on some host; a heuristic that reproduces a platform component
+    must not be able to withdraw a working install, and ``install-skills`` must
+    still run.
+    """
+    _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
+    monkeypatch.setattr(
+        mod.os_deps, "missing_shared_libraries", lambda dirs: {"libatk-1.0.so.0", "libgbm.so.1"}
+    )
+    monkeypatch.setattr(mod.os_deps, "manual_deps_command", lambda: "sudo dnf install -y atk")
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "stage-node",
+        "install-browser",
+        "verify-browser-libraries-chromium",
+        "install-skills",
+    ]
+    verdict = next(s for s in result["steps"] if s["name"].startswith("verify-"))
+    # Flagged as advisory and carrying both names, so the operator still learns
+    # exactly what to install.
+    assert verdict["advisory"] is True
+    assert "libatk-1.0.so.0" in verdict["advisory_prose"]
+    assert "libgbm.so.1" in verdict["advisory_prose"]
+    # The download genuinely succeeded and is reported honestly -- sending the
+    # operator to re-download bytes already on disk is not the remedy.
+    # Located by name: a positional index silently re-targets whenever install()
+    # gains a step ahead of the download.
+    download = next(s for s in result["steps"] if s["name"] == "install-browser")
+    assert download["ok"] is True
+    assert verdict["returncode"] == 0
+    # THREE distinct strings, each with exactly one consumer, and no duplication.
+    # A composed `stderr` alongside them would repeat both with no reader: the only
+    # step consumers read `stderr` on a FAILED step.
+    assert verdict["advisory_command"] == "sudo dnf install -y atk"
+    assert "sudo dnf" not in verdict["advisory_prose"]
+    assert "command below" in verdict["advisory_prose"]
+    assert "advisory_lead" not in verdict
+    assert "stderr" not in verdict
+    # Not the failure path's "retry the install" wording: that contradicts the
+    # panel's own green result above it.
+    # Names no affordance: the failure path's "retry the install" contradicts the
+    # panel's green result, and there is no re-check button to point at either.
+    assert "retry the install" not in verdict["advisory_prose"]
+    assert "Re-check" not in verdict["advisory_prose"]
+    # The command is its own field now, so it needs no in-prose line break: the
+    # panel renders it in a `<pre>` with a copy button.
+    assert "\n" not in verdict["advisory_prose"]
+    # The skills reference is independent of browser launchability, so a probe
+    # that only SUSPECTS a missing library must not cost it too.
+    assert any(s["name"] == "install-skills" for s in result["steps"])
+
+
+def test_a_resolvable_download_adds_no_extra_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The common case must stay a three-step install."""
+    _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
+    monkeypatch.setattr(mod.os_deps, "missing_shared_libraries", lambda dirs: set())
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "stage-node",
+        "install-browser",
+        "install-skills",
+    ]
+
+
+def test_an_unprobeable_host_never_fails_the_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "Could not check" must not become "broken".
+
+    The download needs no privilege and may be perfectly good; withdrawing it
+    because ``ldd`` is absent would break hosts that work today.
+    """
+    _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
+    monkeypatch.setattr(mod.os_deps, "missing_shared_libraries", lambda dirs: None)
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert not any("verify-browser-libraries" in s["name"] for s in result["steps"])
+
+
+def test_the_library_check_covers_the_headless_shell_not_just_chromium(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Headless is the default launch mode, so the shell is what a browse starts.
+
+    Checking only ``chromium-<rev>`` would clear the build that is not the one
+    being run.
+    """
+    cache = tmp_path / "ms-playwright"
+    for name in ("chromium-1243", "chromium_headless_shell-1243", "firefox-1542"):
+        (cache / name).mkdir(parents=True)
+    monkeypatch.setattr(mod, "_browsers_cache_dir", lambda: cache)
+
+    names = sorted(p.name for p in mod._engine_cache_dirs("chromium"))
+
+    assert names == ["chromium-1243", "chromium_headless_shell-1243"]
+
+
+def test_a_refused_with_deps_retry_is_still_library_checked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The recovery path must not skip the probe the direct path runs."""
+    monkeypatch.setattr(mod.os_deps, "with_deps_supported", lambda: True)
+    monkeypatch.setattr(mod.os_deps, "missing_deps_hint", lambda: "")
+    monkeypatch.setattr(mod.os_deps, "missing_shared_libraries", lambda dirs: {"libgbm.so.1"})
+    calls = _wire(monkeypatch, {"npm": "/n/npm", "playwright-cli": "/n/pw"})
+
+    def fake_run(argv: list[str], timeout: float) -> tuple[int, str, str]:
+        calls.append(list(argv))
+        if "--with-deps" in argv:
+            return 1, "", "sudo: a password is required"
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    result = mod.install()
+
+    assert result["ok"] is True
+    assert [s["name"] for s in result["steps"]] == [
+        "npm-install-global",
+        "stage-node",
+        "install-browser",
+        "install-browser-no-deps",
+        "verify-browser-libraries-chromium",
+        "install-skills",
+    ]
+
+
 def test_a_zero_exit_carrying_the_host_validation_warning_is_a_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/test/test_browser_cli_journeys.py
+++ b/test/test_browser_cli_journeys.py
@@ -296,6 +296,8 @@ class TestBrowserMutationsAreOwnerOnly:
             # leaking into JSON serialization).
             state._browser_install_task = None
             state._browser_install_error = None
+            state._browser_install_notice = None
+            state._browser_install_notice_command = None
             self.app = {"state": state}
             self.path = path
             self._claims: dict[str, str] = {"app": app_claim, "user": user}
@@ -976,3 +978,101 @@ class TestStopGuardsAgainstUnownedProcesses:
         assert kill_calls == [77777]
         assert view_mod._proc is None
         assert view_mod._info is None
+
+
+class TestTheLibraryAdvisoryReachesTheOperator:
+    """A computed advisory that nothing surfaces has no value.
+
+    The verify step ships `ok: True`, and the failure path reads a step only when
+    the install FAILED (and only the decisive last one). So without a dedicated
+    path the probe's whole point -- naming the libraries to install before the
+    operator meets a cryptic launch failure -- is computed and dropped.
+    """
+
+    @staticmethod
+    def _result(*, ok: bool, steps: list[dict]) -> dict:
+        return {"ok": ok, "steps": steps}
+
+    def test_an_advisory_step_becomes_a_notice(self):
+        from kiro_crew.dashboard.handlers import messaging as mod
+
+        result = self._result(
+            ok=True,
+            steps=[
+                {"name": "install-browser", "ok": True, "returncode": 0},
+                {
+                    "name": "verify-browser-libraries-chromium",
+                    "ok": True,
+                    "advisory": True,
+                    "returncode": 0,
+                    "advisory_prose": (
+                        "Chromium downloaded, but 1 shared library it needs may be "
+                        "missing: libgbm.so.1. Install them with the command below."
+                    ),
+                    "advisory_command": "sudo dnf install -y mesa-libgbm",
+                },
+                {"name": "install-skills", "ok": True, "returncode": 0},
+            ],
+        )
+
+        notice, command = mod._browser_install_notice(result)
+
+        assert notice is not None
+        assert "libgbm.so.1" in notice
+        # The step's internal name is NOT prefixed: this is a sentence about the
+        # operator's machine, not a log line naming a failing command.
+        assert not notice.startswith("verify-browser-libraries")
+        # The command comes back separately, for the `<pre>` + copy button.
+        assert command == "sudo dnf install -y mesa-libgbm"
+        assert "sudo dnf" not in notice
+
+    def test_an_install_with_no_advisory_produces_no_notice(self):
+        from kiro_crew.dashboard.handlers import messaging as mod
+
+        result = self._result(ok=True, steps=[{"name": "install-browser", "ok": True}])
+
+        assert mod._browser_install_notice(result) == (None, None)
+
+    def test_a_failed_install_produces_no_notice(self):
+        """The error path owns that case; two banners for one event is noise."""
+        from kiro_crew.dashboard.handlers import messaging as mod
+
+        result = self._result(
+            ok=False,
+            steps=[
+                {"name": "install-browser", "ok": False, "advisory": True, "advisory_prose": "boom"}
+            ],
+        )
+
+        assert mod._browser_install_notice(result) == (None, None)
+
+    def test_the_notice_is_redacted(self):
+        """Rendered verbatim in Settings, so it goes through the same redaction.
+
+        Asserted with an inline-URL credential, which is what `redact_credentials`
+        actually covers. It does NOT strip a bare `_authToken=<value>`; that gap is
+        pre-existing on this surface (`last_error` uses the same helper) and
+        widening a shared redactor is not this change's business.
+        """
+        from kiro_crew.dashboard.handlers import messaging as mod
+
+        result = self._result(
+            ok=True,
+            steps=[
+                {
+                    "name": "verify-browser-libraries-chromium",
+                    "ok": True,
+                    "advisory": True,
+                    "advisory_prose": (
+                        "fetched via https://user:s3cret@proxy.example.com/ -- install libgbm.so.1"
+                    ),
+                }
+            ],
+        )
+
+        notice, _ = mod._browser_install_notice(result)
+
+        assert notice is not None
+        assert "s3cret" not in notice
+        # The actionable part survives redaction.
+        assert "libgbm.so.1" in notice

--- a/test/test_browser_cli_os_deps.py
+++ b/test/test_browser_cli_os_deps.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import platform
+import struct
+from pathlib import Path
 
 import pytest
 
 from kiro_crew import platform_compat
 from kiro_crew.browser_cli import os_deps as mod
+
+ELF_MAGIC = b"\x7fELF"
 
 
 @pytest.fixture(autouse=True)
@@ -205,3 +209,384 @@ class TestTheHostValidationWarningIsAFailure:
 
     def test_none_is_tolerated(self):
         assert mod.host_deps_unsatisfied(None) is False  # type: ignore[arg-type]
+
+
+class TestMissingSharedLibrariesDoesNotTrustPlaywright:
+    """The probe reads files as DATA. Nothing in this class spawns a process."""
+
+    @staticmethod
+    def _elf(path: Path, needed: list[str]) -> None:
+        """Write a minimal but REAL ELF64 little-endian file declaring *needed*.
+
+        Hand-built rather than mocked: the parser's whole job is to read a real
+        dynamic table, so a fake would test nothing about it.
+        """
+        names = b"\x00" + b"\x00".join(n.encode() for n in needed) + b"\x00"
+        offsets, cursor = [], 1
+        for n in needed:
+            offsets.append(cursor)
+            cursor += len(n) + 1
+
+        ph_off, ph_entry = 64, 56
+        dyn_off = ph_off + 2 * ph_entry
+        entries = [(1, o) for o in offsets] + [(5, 0x1000), (0, 0)]
+        dyn = b"".join(struct.pack("<Qq", t, v) for t, v in entries)
+        str_off = dyn_off + len(dyn)
+
+        header = bytearray(64)
+        header[0:4] = b"\x7fELF"
+        header[4] = 2  # ELF64
+        header[5] = 1  # little endian
+        header[6] = 1  # version
+        header[16:18] = struct.pack("<H", 2)  # e_type ET_EXEC
+        header[18:20] = struct.pack("<H", 183)  # e_machine aarch64
+        header[32:40] = struct.pack("<Q", ph_off)  # e_phoff
+        header[54:56] = struct.pack("<H", ph_entry)  # e_phentsize
+        header[56:58] = struct.pack("<H", 2)  # e_phnum
+
+        # PT_LOAD mapping vaddr 0x1000 onto the string table's file offset.
+        load = struct.pack("<IIQQQQQQ", 1, 4, str_off, 0x1000, 0x1000, len(names), len(names), 8)
+        dynamic = struct.pack("<IIQQQQQQ", 2, 6, dyn_off, 0x2000, 0x2000, len(dyn), len(dyn), 8)
+        path.write_bytes(bytes(header) + load + dynamic + dyn + names)
+        path.chmod(0o755)
+
+    def _browser_dir(self, tmp_path, needed=("libatk-1.0.so.0",), name="chrome-linux-arm64"):
+        """A build laid out under a subdirectory Playwright's constant does NOT name."""
+        d = tmp_path / "chromium-1243" / name
+        d.mkdir(parents=True)
+        self._elf(d / "chrome", list(needed))
+        return tmp_path / "chromium-1243"
+
+    def test_a_host_missing_soname_is_reported(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+        browser = self._browser_dir(tmp_path, needed=["libatk-1.0.so.0", "libgbm.so.1"])
+        monkeypatch.setattr(mod, "_host_provided_sonames", lambda arch=None: {"libc.so.6"})
+
+        assert mod.missing_shared_libraries([browser]) == {
+            "libatk-1.0.so.0",
+            "libgbm.so.1",
+        }
+
+    def test_a_resolvable_build_reports_empty_not_none(self, monkeypatch, tmp_path):
+        """Empty and ``None`` are different answers and callers branch on both."""
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+        browser = self._browser_dir(tmp_path, needed=["libatk-1.0.so.0"])
+        monkeypatch.setattr(mod, "_host_provided_sonames", lambda arch=None: {"libatk-1.0.so.0"})
+
+        assert mod.missing_shared_libraries([browser]) == set()
+
+    def test_a_bundled_soname_is_never_called_host_missing(self, monkeypatch, tmp_path):
+        """A library the build carries is its own, even when the host lacks it."""
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+        root = tmp_path / "chromium-1243"
+        build = root / "chrome-linux-arm64"
+        build.mkdir(parents=True)
+        self._elf(build / "chrome", ["libxul.so", "libatk-1.0.so.0"])
+        (build / "libxul.so").write_bytes(b"\x7fELF")
+        monkeypatch.setattr(mod, "_host_provided_sonames", lambda arch=None: set())
+
+        assert mod.missing_shared_libraries([root]) == {"libatk-1.0.so.0"}
+
+    def test_an_unparseable_build_answers_unknown_rather_than_clean(self, monkeypatch, tmp_path):
+        """Nothing readable declaring a dependency is UNKNOWN, not a clean host."""
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+        root = tmp_path / "chromium-1243"
+        build = root / "chrome-linux-arm64"
+        build.mkdir(parents=True)
+        junk = build / "chrome"
+        junk.write_bytes(b"not an elf at all")
+        junk.chmod(0o755)
+
+        assert mod.missing_shared_libraries([root]) is None
+
+    def test_off_linux_is_unknown(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+        assert mod.missing_shared_libraries([tmp_path]) is None
+
+    def test_an_absent_directory_is_unknown(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+        assert mod.missing_shared_libraries([tmp_path / "nope"]) is None
+
+
+class TestNeededSonamesNeverExecutesAndNeverRaises:
+    """The parser faces files from a writable cache, so malformed is the norm."""
+
+    def test_a_truncated_file_is_empty_not_an_error(self, tmp_path):
+        p = tmp_path / "cut"
+        p.write_bytes(b"\x7fELF\x02\x01\x01")
+        assert mod._needed_sonames(p) == set()
+
+    def test_a_non_elf_is_empty(self, tmp_path):
+        p = tmp_path / "text"
+        p.write_text("#!/bin/sh\necho hi\n")
+        assert mod._needed_sonames(p) == set()
+
+    def test_an_absent_file_is_empty(self, tmp_path):
+        assert mod._needed_sonames(tmp_path / "gone") == set()
+
+    def test_an_absurd_program_header_count_is_refused(self, tmp_path):
+        p = tmp_path / "bogus"
+        header = bytearray(64)
+        header[0:4] = b"\x7fELF"
+        header[4], header[5] = 2, 1
+        header[32:40] = struct.pack("<Q", 64)
+        header[54:56] = struct.pack("<H", 56)
+        header[56:58] = struct.pack("<H", 60000)  # over the ceiling
+        p.write_bytes(bytes(header))
+        assert mod._needed_sonames(p) == set()
+
+    def test_a_real_system_binary_declares_libc(self):
+        """Proves the parser works on a genuine ELF, not only hand-built ones.
+
+        Needs a host whose system binaries ARE ELF: on macOS the same paths exist
+        and hold Mach-O, which this parser correctly reads as "not an ELF" -- so an
+        unguarded version of this test asserts a Linux fact on a Darwin runner.
+        """
+        if not platform_compat.IS_LINUX:
+            pytest.skip("system binaries are only ELF on Linux")
+        for candidate in ("/bin/ls", "/usr/bin/ls", "/bin/sh"):
+            path = Path(candidate)
+            if path.exists() and not path.is_symlink():
+                assert any(n.startswith("libc.so") for n in mod._needed_sonames(path))
+                return
+        pytest.skip("no unlinked system binary available to parse")
+
+
+class TestSystemLibraryDirsIsPlatformScoped:
+    """The POSIX literals live in platform_compat; this pins what it answers."""
+
+    def test_off_linux_it_answers_nothing(self, monkeypatch):
+        monkeypatch.setattr(platform_compat, "IS_LINUX", False)
+        assert platform_compat.system_library_dirs() == ()
+
+    def test_on_linux_it_includes_the_loader_defaults_without_duplicates(self):
+        if not platform_compat.IS_LINUX:
+            pytest.skip("Linux-only question")
+        dirs = platform_compat.system_library_dirs()
+        assert len(dirs) == len(set(dirs))
+        assert Path("/lib64") in dirs or Path("/lib") in dirs
+
+    def test_the_host_soname_scan_finds_libc(self):
+        """Proves the scan answers the real question on a real host."""
+        if not platform_compat.IS_LINUX:
+            pytest.skip("Linux-only question")
+        assert any(n.startswith("libc.so") for n in mod._host_provided_sonames())
+
+
+class TestTheWalkIsBoundedAgainstAHostileCache:
+    """The cache is writable, so its breadth and shape are hostile input."""
+
+    def test_a_symlink_is_not_followed_into(self, tmp_path):
+        """A planted link must not aim the walk at a tree of its own choosing."""
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        planted = outside / "libevil.so"
+        planted.write_bytes(b"\x7fELF")
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        (build / "reach").symlink_to(outside)
+
+        found = mod._elf_candidates(build, [mod._MAX_WALK_ENTRIES])
+
+        assert all("outside" not in str(p) for p in found)
+
+    def test_the_walk_stops_at_the_entry_ceiling(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 5)
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        for index in range(40):
+            member = build / f"lib{index:03d}.so"
+            member.write_bytes(b"\x7fELF")
+
+        assert len(mod._elf_candidates(build, [mod._MAX_WALK_ENTRIES])) <= 5
+
+    def test_the_main_executable_survives_truncation(self, tmp_path, monkeypatch):
+        """The order is what makes the ceiling safe, so it is asserted with it."""
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 3)
+        build = tmp_path / "chromium-1243"
+        nested = build / "deep" / "deeper"
+        nested.mkdir(parents=True)
+        for index in range(10):
+            (nested / f"lib{index:03d}.so").write_bytes(b"\x7fELF")
+        main = build / "chrome"
+        main.write_bytes(b"\x7fELF")
+        main.chmod(0o755)
+
+        found = mod._elf_candidates(build, [mod._MAX_WALK_ENTRIES])
+
+        assert found and found[0] == main
+
+
+class TestHostSonamesIgnoreEnvironmentPaths:
+    """A directory named by process environment is not listed."""
+
+    def test_ld_library_path_is_not_consulted(self, tmp_path, monkeypatch):
+        """The loader honours it, and this deliberately does not: listing a
+        directory chosen by environment during a privileged install is the class
+        this repository fences. The cost is a spurious advisory line."""
+        vendor = tmp_path / "vendor"
+        vendor.mkdir()
+        (vendor / "libcustom-vendor.so.7").write_bytes(ELF_MAGIC)
+        monkeypatch.setattr(platform_compat, "system_library_dirs", lambda: ())
+        monkeypatch.setenv("LD_LIBRARY_PATH", str(vendor))
+
+        assert mod._host_provided_sonames() == set()
+
+
+class TestTheBoundIsAppliedBeforeTheWork:
+    """A ceiling checked after materialising the tree bounds nothing."""
+
+    def test_the_walk_is_not_materialised_before_the_ceiling(self, tmp_path, monkeypatch):
+        """The bug: `sorted(rglob(...))` consumes everything before any break."""
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        for n in range(40):
+            (build / f"pad{n:03d}.so").write_bytes(ELF_MAGIC)
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 5)
+
+        # Exactly the ceiling, and it STOPPED rather than filtered: a
+        # materialising walk would have touched all 40 before any check.
+        assert len(list(mod._bounded_walk(build, [mod._MAX_WALK_ENTRIES]))) == 5
+
+    def test_the_shipped_soname_walk_is_bounded_too(self, tmp_path, monkeypatch):
+        """It shares the ceiling; an uncapped second walk voids the first."""
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        for n in range(40):
+            (build / f"lib{n:03d}.so.1").write_bytes(ELF_MAGIC)
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 5)
+
+        assert len(mod._sonames_shipped_with_build([build], [mod._MAX_WALK_ENTRIES])) == 5
+
+    def test_padding_files_consume_the_ceiling_for_the_soname_walk(self, tmp_path, monkeypatch):
+        """The bug this pins: `rglob("*.so*")` counted only the matches, so a tree
+        padded with non-library files was walked in full for free."""
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        for n in range(30):
+            (build / f"pad{n:03d}.txt").write_text("x")
+        (build / "zz-libgbm.so.1").write_bytes(ELF_MAGIC)
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 5)
+
+        # The padding exhausts the ceiling before the library is reached, so the
+        # walk stops rather than reporting a full result from a bounded look.
+        assert mod._sonames_shipped_with_build([build], [mod._MAX_WALK_ENTRIES]) == set()
+
+    def test_the_shallow_entries_are_the_ones_kept(self, tmp_path, monkeypatch):
+        """rglob is top-down, so truncation keeps the main executable's level."""
+        build = tmp_path / "chromium-1243"
+        deep = build / "swiftshader" / "nested"
+        deep.mkdir(parents=True)
+        main = build / "chrome"
+        main.write_bytes(ELF_MAGIC)
+        main.chmod(0o755)
+        for n in range(30):
+            (deep / f"deep{n:03d}.so").write_bytes(ELF_MAGIC)
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 4)
+
+        assert main in mod._elf_candidates(build, [mod._MAX_WALK_ENTRIES])
+
+
+class TestTheNameCountIsBounded:
+    """Names come out of dynamic tables in a writable cache, so the COUNT is
+    attacker-shaped just as the walk's breadth was."""
+
+    @staticmethod
+    def _elf_with_needed(path, count):
+        """Write an ELF64 whose dynamic table declares *count* DT_NEEDED names."""
+        names = [f"libpad{n:05d}.so.1".encode() for n in range(count)]
+        strtab = b"\x00" + b"\x00".join(names) + b"\x00"
+        offsets, at = [], 1
+        for n in names:
+            offsets.append(at)
+            at += len(n) + 1
+        dyn = b"".join(struct.pack("<qQ", 1, off) for off in offsets)
+        dyn += struct.pack("<qQ", 5, 0) + struct.pack("<qQ", 0, 0)
+        ph_off, dyn_off = 64, 64 + 56 * 2
+        str_off = dyn_off + len(dyn)
+        header = bytearray(64)
+        header[0:4] = b"\x7fELF"
+        header[4], header[5], header[6] = 2, 1, 1
+        header[18:20] = struct.pack("<H", 183)
+        header[32:40] = struct.pack("<Q", ph_off)
+        header[54:56] = struct.pack("<H", 56)
+        header[56:58] = struct.pack("<H", 2)
+        load = struct.pack("<IIQQQQQQ", 1, 5, 0, 0, 0, str_off + len(strtab), 0, 0)
+        dynamic = struct.pack("<IIQQQQQQ", 2, 4, dyn_off, dyn_off, 0, len(dyn), 0, 0)
+        # DT_STRTAB vaddr must land inside the PT_LOAD above.
+        dyn = dyn.replace(struct.pack("<qQ", 5, 0), struct.pack("<qQ", 5, str_off), 1)
+        path.write_bytes(bytes(header) + load + dynamic + dyn + strtab)
+
+    def test_one_file_cannot_exceed_the_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(mod, "_MAX_SONAMES", 10)
+        target = tmp_path / "chrome"
+        self._elf_with_needed(target, 40)
+
+        assert len(mod._needed_sonames(target)) <= 10
+
+    def test_the_aggregate_stops_at_the_cap(self, tmp_path, monkeypatch):
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        for n in range(6):
+            f = build / f"bin{n}"
+            self._elf_with_needed(f, 8)
+            f.chmod(0o755)
+        monkeypatch.setattr(mod, "_MAX_SONAMES", 10)
+        monkeypatch.setattr(mod, "_host_provided_sonames", lambda: set())
+        monkeypatch.setattr(mod, "_sonames_shipped_with_build", lambda dirs, budget: set())
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+
+        result = mod.missing_shared_libraries([build])
+
+        # Truncated, and truncation only ever SHORTENS a report -- a name never
+        # added cannot invent a missing library.
+        assert result is not None
+        assert 0 < len(result) < 48
+
+    def test_the_budget_does_not_scale_with_the_number_of_directories(self, tmp_path, monkeypatch):
+        """`_engine_cache_dirs` prefix-matches a writable cache, so the number of
+        directories handed in is attacker-shaped too -- a per-directory ceiling is
+        just that ceiling times N."""
+        dirs = []
+        for d in range(4):
+            build = tmp_path / f"chromium-{d}"
+            build.mkdir()
+            for n in range(10):
+                (build / f"pad{n}.so").write_bytes(ELF_MAGIC)
+            dirs.append(build)
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 12)
+        monkeypatch.setattr(mod, "_host_provided_sonames", lambda: set())
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+
+        budget = [12]
+        total = sum(len(mod._elf_candidates(d, budget)) for d in dirs)
+
+        # One shared budget: the four walks together cannot exceed it, where four
+        # independent ceilings would have allowed 48.
+        assert total <= 12
+
+    def test_parsing_is_charged_to_the_same_budget(self, tmp_path, monkeypatch):
+        """A cache of files that each declare NOTHING never trips the name cap, so
+        without charging parses the probe still opens and parses every one."""
+        build = tmp_path / "chromium-1243"
+        build.mkdir()
+        for n in range(30):
+            f = build / f"bin{n:03d}"
+            f.write_bytes(ELF_MAGIC + b"\x00" * 60)  # parseable header, no DT_NEEDED
+            f.chmod(0o755)
+        monkeypatch.setattr(platform_compat, "IS_LINUX", True)
+        monkeypatch.setattr(mod, "_host_provided_sonames", lambda: set())
+
+        parsed: list = []
+        real = mod._needed_sonames
+        monkeypatch.setattr(mod, "_needed_sonames", lambda p: (parsed.append(p), real(p))[1])
+        # MEASURED: the two walks over 30 files charge 30 each, so 70 leaves 10 for
+        # parsing and 100 leaves enough for all 30.
+        monkeypatch.setattr(mod, "_MAX_WALK_ENTRIES", 70)
+
+        mod.missing_shared_libraries([build])
+
+        # Parsing stops with the budget, well short of all 30 files -- and a cache
+        # that spends the budget answers "cannot determine" rather than "clean",
+        # which is the safe direction.
+        assert 0 < len(parsed) <= 10

--- a/website/src/api/client.ts
+++ b/website/src/api/client.ts
@@ -325,6 +325,14 @@ export interface BrowserInstallData {
   browser_ok: boolean
   installing: boolean
   last_error: string | null
+  /** An advisory the install produced while SUCCEEDING -- currently a browser
+   *  whose shared libraries may not resolve on this host. Separate from
+   *  `last_error` so a working install is not rendered as a failure. */
+  last_notice?: string | null
+  /** The package-manager command from that advisory, carried apart from the prose
+   *  so the panel can render it in a `<pre>` with a copy button — it has to be
+   *  transcribed exactly. */
+  last_notice_command?: string | null
   token: boolean
   /** Per-engine download state, keyed by engine name (chromium/firefox/webkit).
    *  Optional so an older gateway that predates it degrades to "unknown" rather

--- a/website/src/pages/settings/BrowserPanel.tsx
+++ b/website/src/pages/settings/BrowserPanel.tsx
@@ -113,6 +113,10 @@ export function BrowserPanel() {
   // Separate from `!installCmdCopied`: idle and failed both read as not-copied,
   // but only the failure needs a notice (same split as MobileLoginCard).
   const [installCmdCopyFailed, setInstallCmdCopyFailed] = useState(false)
+  // Separate from the installCmd pair: both blocks can be on screen in
+  // different states, so one shared flag would flip the wrong label.
+  const [depsCmdCopied, setDepsCmdCopied] = useState(false)
+  const [depsCmdCopyFailed, setDepsCmdCopyFailed] = useState(false)
 
   const tokenMut = useMutation({
     mutationFn: (value: string) => api.setBrowserToken(value),
@@ -623,6 +627,84 @@ export function BrowserPanel() {
           from this screen.
         */
         <ErrorNotice message={data.last_error} askAgent />
+      )}
+
+      {/*
+        An ADVISORY notice, deliberately not an ErrorNotice: the install
+        succeeded, and a red failure banner would send the operator to retry a
+        download that worked. It reports a downloaded browser whose shared
+        libraries may not resolve on this host, naming what to install before the
+        first launch fails cryptically instead of after.
+
+        Muted rather than coloured, matching the panel's other explanatory text,
+        because the probe re-implements the loader's search and can be wrong on an
+        unusual host -- a warning colour would overstate a heuristic.
+      */}
+      {data.last_notice && !installing && (
+        <SettingsCard>
+          <div className="flex items-start gap-3">
+            {/* AlertTriangle, not Info: the panel's explainer rows use Info, and
+                sharing that glyph is part of why this reads as chrome. Uncoloured,
+                so it distinguishes without alarming. */}
+            <AlertTriangle size={18} className="text-muted shrink-0 mt-[2px]" />
+            <div className="min-w-0 flex-1">
+              <p className="text-[13px] text-muted mt-0 mb-0 break-words">
+                {data.last_notice}
+              </p>
+              {/*
+                A `<pre>` and a copy button, not selectable prose -- the same
+                treatment this panel gives `standalone_install`, and for the same
+                reason: this is a ~300-character package list that must be
+                transcribed EXACTLY, and a typo in it produces another opaque
+                failure for someone already stuck.
+
+                `copyToClipboard` awaited before the label flips, because the
+                Clipboard API is unavailable on a plain-HTTP remote gateway --
+                a plausible way to be reading this panel -- and a "Copied" that
+                lies is worse than none.
+              */}
+              {data.last_notice_command && (
+                <>
+                  <pre className="mt-1.5 mb-1 whitespace-pre-wrap break-all text-[12px] bg-bg-elevated rounded px-2 py-1.5">
+                    <code>{data.last_notice_command}</code>
+                  </pre>
+                  <Btn
+                    onClick={async () => {
+                      let ok = false
+                      try {
+                        ok = await copyToClipboard(data.last_notice_command as string)
+                      } catch {
+                        ok = false
+                      }
+                      setDepsCmdCopied(ok)
+                      setDepsCmdCopyFailed(!ok)
+                    }}
+                  >
+                    <Copy size={13} className="lucide-inline" />{' '}
+                    {depsCmdCopied
+                      ? i18nT('pages.settings.browserPanel.copied')
+                      : i18nT('pages.settings.browserPanel.copy_command')}
+                  </Btn>
+                  {/*
+                    The SAME treatment `standalone_install`'s copy button gets two
+                    cards up, and for the same reason: a copy that failed is most
+                    likely a plain-HTTP remote gateway with no Clipboard API, which
+                    is exactly the operator who cannot fix it alone. A muted line
+                    here made the identical failure quieter in the identical case.
+                  */}
+                  {depsCmdCopyFailed && (
+                    <ErrorNotice
+                      className="mt-2"
+                      message={i18nT('pages.settings.browserPanel.copy_failed')}
+                      variant="inline"
+                      askAgent
+                    />
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </SettingsCard>
       )}
     </SettingsSection>
   )


### PR DESCRIPTION
## Problem / Motivation

The browser downloads fine, then the first browse crashes.

Playwright checks the host for you. On linux-arm64 that check looks in the wrong folder. Its registry says the build lands in `chrome-linux`. The arm64 build lands in `chrome-linux-arm64`. So it scans a folder that is not there, finds nothing to check, and says the host is fine.

Then it writes a `DEPENDENCIES_VALIDATED` marker. That marker stops it re-checking for 30 days.

Measured on Amazon Linux 2023 arm64: the marker was written **23 minutes before the libraries were actually installed**. The install said ok. `browser_ok` said true. The panel went green. The user found out at their first browse, as a stack trace.

## Why it matters

A green panel that cannot browse is worse than a red one. A red panel tells you to install something. A green one sends you looking for a bug in your own code.

The user needs root and a package manager. Nothing tells them that. Nothing they can do to the panel fixes it, because the panel already believes it succeeded.

## What changed (motivation → approach → change)

The symptom is a false negative: a host with missing libraries emits no marker at all, so `host_deps_unsatisfied` sees nothing to report.

The root cause is that Playwright's check is the only check, and it guesses the folder name from a registry that is wrong for this platform. Any fix that also guesses a folder name inherits the same bug.

So this reads the real files instead — **as data, never by running them**.
`missing_shared_libraries()` parses each ELF object's own dynamic table for its
`DT_NEEDED` sonames and compares them against a listing of the host's library
directories. It never hardcodes a build subdirectory — that assumption *is* the
upstream bug — and it runs no subprocess at all.

`ldd` is deliberately not used. glibc's `ldd` executes the binary it inspects, and a
crafted `PT_INTERP` turns that into arbitrary code at gateway privilege. The
interpreter travels inside the file, so an absolute argv, a scrubbed environment and
a withheld search path all fail to intercept it — and the engine cache is writable
with its subdirectories matched by name prefix, so a planted ELF is reachable. Three
review rounds each closed one channel into `ldd` (PATH, then the exported
`LD_LIBRARY_PATH`, then the file itself); reading the table directly closes all of
them at once and is the smaller system: no subprocess, no timeout, no locale
pinning, no trusted-binary resolution, and no entry in `BENIGN_SPAWNS`.

Every walk of a cache directory goes through one lazy generator, `_bounded_walk`, which stops at `_MAX_WALK_ENTRIES` (20,000; chromium ships 14 ELF candidates and firefox 44). Lazy is the point: wrapping `rglob` in `sorted()` materialises and sorts the whole tree before any ceiling check inside the loop can fire, which enforces a bound only after doing the unbounded work. `rglob` yields top-down, so a truncated walk keeps the shallow entries — where a browser's main executable lives — and a cut tail cannot produce a "nothing missing" answer for a build whose main binary was never read.

A successful download is followed by that probe, and a missing library becomes **its
own failed step** (`verify-browser-libraries-<engine>`) rather than flipping the
download's verdict. The download genuinely succeeded; labelling it failed would send
the operator to re-fetch bytes already on disk when what they need is root and a
package manager.

```mermaid
flowchart LR
  subgraph Before
    A1[download browser]:::ctx --> B1[Playwright host check]:::changed --> C1[panel green]:::ctx --> D1[first browse crashes]:::removed
  end
  subgraph After
    A2[download browser]:::ctx --> B2[Playwright host check]:::changed --> E2[parse DT_NEEDED from the real files]:::added --> F2[panel names the missing libraries]:::added
  end
  classDef added fill:#DCFCE7,stroke:#16A34A,color:#14532D,stroke-width:2px
  classDef changed fill:#FEF3C7,stroke:#D97706,color:#78350F,stroke-width:2px
  classDef removed fill:#FEE2E2,stroke:#DC2626,color:#7F1D1D,stroke-dasharray:4 3
  classDef ctx fill:#E0F2FE,stroke:#0284C7,color:#0C4A6E
  linkStyle 2 stroke:#DC2626,stroke-dasharray:4 3
  linkStyle 4,5 stroke:#16A34A,stroke-width:2px
```

🟩 added · 🟨 changed · 🟥 removed · 🟦 unchanged

*The install now checks the files it just downloaded, so the operator is told which libraries to install instead of meeting a stack trace later.*

Three things it deliberately does not do. It never reports a library the build ships itself, which would block an install that works. It returns `None` — "cannot determine" — rather than "broken" when the host is not Linux, no directory exists, or nothing readable declared a dependency, because turning an unknown into a failure would withdraw a working browser. And it never hardcodes a build subdirectory name, since that assumption is the upstream bug.

**Scope: install-time only. `browser_ok` stays presence-and-revision.** The probe runs on the `install` path and does not feed `detect()`. Readiness is on the `/api/status` poll path, so wiring this fan-out into it would put a full ELF sweep of every cache directory behind every dashboard poll. Two cases therefore stay unfixed here, on purpose: a host whose libraries were already missing before this check existed, and a host whose libraries go missing after a successful install. Both still read green until the next install attempt. Closing them needs the verdict cached against directory mtime so readiness can consult it without spawning — a separate change, and `docs/system-specs/modules/browser.md` now says so in both the install-flow and Readiness sections.

## The verdict is advisory

The probe answers "will the loader find these libraries" by re-implementing the loader's search: default directories, `/etc/ld.so.conf`, `LD_LIBRARY_PATH`, base-name matching. That emulation cannot be completed — musl reads its own path file, glibc has hwcaps subdirectories, and the loader cache can name a directory no config file mentions — so on some host it will name a library the real loader resolves.

A heuristic reproduction of a platform component must not be able to fail an install. `_verify_browser_libraries` returns a step with `ok: True` and `advisory: True`, carrying the soname list and the package-manager hint, and `install-skills` runs behind it. The operator learns exactly what to install through a path that exists end to end: `_browser_install_notice` picks the advisory step out of a succeeded install, `GET /api/browser/install` returns it as `last_notice`, and the Browser settings panel renders it. Both install routes set it. It is a separate field from `last_error` and renders as muted text rather than a red `ErrorNotice`, because the install SUCCEEDED — a failure banner would send the operator to retry a download that worked, and a warning colour would overstate a heuristic. A wrong answer costs a line of muted text instead of a withdrawn browser and a skipped skills reference.

That is also what right-sizes the probe's own attack surface. It reads a directory an agent can write to, so a planted tree can influence what it reports — and when the report is advisory, that buys a misleading warning. Nothing is executed, nothing is written, and no install outcome turns on it.

## The upstream gap, verified

Read out of the shipped bundle — `@playwright/cli 0.1.19` / `playwright-core 1.63.0-alpha-2026-08-31`, on aarch64 Amazon Linux 2023. The download path knows the arm64 layout:

```js
EXECUTABLE_PATHS = { "chromium": {
  "linux-x64":   ["chrome-linux64",     "chrome"],
  "linux-arm64": ["chrome-linux-arm64", "chrome"],
```

The host-validation path does not — a hardcoded literal with no arm64 variant:

```js
_validateHostRequirements: (sdkLanguage) =>
  this._validateHostRequirements(sdkLanguage, chromium.dir, ["chrome-linux"], [], ["chrome-win"]),
```

identically for `chromiumHeadlessShell`. So the binary is launched from `chrome-linux-arm64` while the dependency scan is aimed at `chrome-linux`, which the arm64 build never creates: the scan finds no ELF objects, reports the host good, and writes `DEPENDENCIES_VALIDATED`. Reproducible with `stat` on this host — the marker is written at 02:23:08 and `atk-2.54.0`, a library it covers, is installed at 02:46:31, 23m23s later.

This is one shipped version on one architecture. It establishes the gap is real in what users run today, not that it is permanent: if upstream fixes `_validateHostRequirements`, deleting this probe is the right follow-up, which the advisory verdict and the self-contained surface make cheap.

`LD_LIBRARY_PATH` is deliberately NOT read when listing what the host provides. The loader honours it, so this costs a report on a host that supplies libraries that way — but listing a directory named by process environment during a privileged install is a fenced class here, and with the verdict advisory the cost is one spurious muted line. Measured: the variable is unset in this process and in the gateway's, so it was contributing no names.

The advisory composes its own action rather than borrowing `missing_deps_hint()`, which is written for a FAILED step: its "retry the install" wording contradicts the panel's own green result, and its confident "needs OS libraries" undercuts the same sentence's hedge. Only `manual_deps_command()` is shared, and the notice names NO affordance for re-checking. It is written only during an install run and `detect()` deliberately does not probe, so after the operator installs the named packages it persists for the life of the gateway process — clearing on restart, or on a re-download of that engine, which the panel does not offer once the engine reads "Downloaded". A known gap, accepted because a confirm loop of its own is more surface than a diagnostic earns, which two review lanes ruled twice. Two fields — `last_notice` and `last_notice_command` — because the panel renders each differently: the prose muted, the command in a `<pre>` with a copy button (and an `ErrorNotice` when the copy fails, since that means a gateway with no Clipboard API). All three are composed in English by the gateway: the sonames and the package list have no translation, so one language throughout reads better than a translated headline over English prose. Translating it properly means the gateway emitting structured data and the panel composing the sentence — a separate change.

The card carries an `AlertTriangle` glyph rather than the panel's `Info` explainer glyph, and no heading of its own: a fixed heading carries no data, so it was neither worth routing through the API nor worth a hardcoded literal in a translated panel. Both exist because the muted body alone wore the panel's explainer styling exactly, so a skimming operator passed the one sentence that prevents a cryptic first-browse crash. Still uncoloured: colour would overstate a probe that emulates the loader.

Deleting this probe when upstream fixes `_validateHostRequirements` is tracked at #10407 rather than promised here.

## Evidence

The advisory as the operator sees it, captured from the real `BrowserPanel` rendering a real `GET /api/browser/install` payload on a dev server. It sits in the panel's own card treatment with an `AlertTriangle` glyph, muted rather than coloured, below the install cards it refers to:

![Browser settings panel: a card with an AlertTriangle glyph reading "Chromium downloaded, but 2 shared libraries it needs may be missing from this host, so it may not launch: libatk-1.0.so.0, libgbm.so.1. Install them with the command below.", followed by the sudo dnf command in its own block with a Copy command button](https://raw.githubusercontent.com/RadiumGu/KiroCrew/pr-evidence/8639/browser-panel-library-notice.png)

Linked by raw URL from a branch of this fork rather than as a `user-attachments` upload: `gh pr edit --attach` needs write access to this repository, which a fork author does not have. The branch is separate from the PR branch, so the image is not in the diff. A maintainer who prefers an attachment can re-attach the same file.

The first capture rendered it as a bare paragraph outside every card. It read as more page boilerplate rather than a note about this machine, which is the same failure as computing the notice and never surfacing it, one step later -- so it is now a `SettingsCard`, matching the panel's other rows.

The COUNT of dependency names is bounded, not only each name's length and the number of files walked: every name comes out of a dynamic table in the writable cache, so a build with vast tables — or many files each carrying one — grows the collected set without a cap. `_MAX_SONAMES` (4,000) holds inside one file and across the aggregate. MEASURED: chromium's build declares 32 unique sonames across 9 candidates and firefox 50 across 24, two orders of magnitude below it. Truncating can only shorten a report — a name never added cannot invent a missing library.

## Tests

`test/test_browser_cli_os_deps.py` locks in the probe. Reporting: a host-missing soname is reported, a resolvable build reports the empty set rather than `None`, a soname the build carries is never called host-missing, an unparseable build answers unknown rather than clean, and off Linux or an absent directory both answer unknown. The ELF fixtures are real hand-built ELF64 files, because reading a genuine dynamic table is the thing under test.

Parser hostile-input behaviour: a truncated file, a non-ELF, an absent file and an absurd program-header count all return the empty set and none of them raise. `test_a_real_system_binary_declares_libc` parses an actual system binary, so the parser is not only proved against fixtures it wrote itself.

The bound: `test_the_walk_is_not_materialised_before_the_ceiling` puts 40 entries against a ceiling of 5 and asserts the walk STOPPED at 5 rather than filtered to 5; `test_the_shipped_soname_walk_is_bounded_too` asserts the second walk shares it; `test_padding_files_consume_the_ceiling_for_the_soname_walk` asserts non-matching entries consume the ceiling, so a filtered glob cannot buy free traversal; `test_the_shallow_entries_are_the_ones_kept` asserts a truncated walk still contains the main executable.

Host side: `platform_compat.system_library_dirs()` answers `()` off Linux and carries the loader defaults without duplicates on Linux, the host scan finds `libc.so*` on a real host, a soname present only on `LD_LIBRARY_PATH` is NOT counted as provided, and the host scan is matched by name, architecture deliberately not compared (962 extra file reads and 6x the runtime to change no verdict).

`test/test_browser_cli_install.py` pins the advisory contract: a build with unresolvable libraries yields `ok: True` overall, the verdict step carries `advisory: True` and both soname names, and `install-skills` still runs.

165 passed in the probe's own files, and `test_browser_cli_journeys.py` goes 30 -> 34: an advisory behind a later step becomes a notice, no advisory produces none, a FAILED install produces none, and the notice is redacted while the soname survives.


## Manual verification

Measured end to end on the failing host (Amazon Linux 2023, arm64) before the fix: install reports success, `browser_ok` true, panel green, `DEPENDENCIES_VALIDATED` present, first browse crashes. After the fix the install reports the missing sonames and the `dnf` line that installs them.

Local gates on this head: `pytest test/test_browser_cli_install.py test/test_browser_cli_os_deps.py test/test_spawn_audit.py` → **165 passed**. `check_black_formatting.py`, `check_subprocess_encoding.py`, `check_comment_history.py`, `check_agent_sdk_boundary.py`, `check_sync_io_in_async.py`, `check_lockdown_before_publish.py` all exit 0. `flake8` and `isort` clean on the five changed files.

Two things a reader should not read as caused by this PR. `isort --check-only src/kiro_crew test` fails on `test/test_irq.py` and one other file; it fails the same way on a clean `origin/main` worktree, and neither file is in this diff. `run_scoped_tests.py` reports "full suite: broad-impact change" because of an untracked `.venv.bak-*` directory in my worktree, not because of a tracked file.

## Related Issues

no linked issue: found while verifying a browse on arm64, not from a filed report.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a vendor's own host-validation result is trusted as the only check, and its false negative is cached behind a marker that suppresses re-validation.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
