### PR TITLE
test(security): drop absolute wall-clock caps from 3 linearity tests (#8374)

### DIFF
--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -4571,8 +4571,8 @@ class TestNestedPayloadExtractionIsLinear:
         # (3x for a 2x input) so scheduler noise on a shared runner cannot red it,
         # while a quadratic scan's 4x cannot pass.
         assert large < small * 3, f"{small:.4f}s -> {large:.4f}s looks super-linear"
-        # ...and the absolute floor: the quadratic took ~13 s at this size.
-        assert large < 1.0, f"16k tokens took {large:.3f}s"
+        # No absolute cap: coverage tracing on the backend jobs prices line
+        # events, not algorithmic cost (#8630 precedent); the ratio is the guard.
 
     def test_a_long_double_dash_run_is_also_linear(self):
         """The ``--`` skip after a command flag was a THIRD forward walk, and fixing
@@ -4592,7 +4592,8 @@ class TestNestedPayloadExtractionIsLinear:
         elapsed(500)
         small, large = elapsed(4000), elapsed(8000)
         assert large < small * 3, f"{small:.4f}s -> {large:.4f}s looks super-linear"
-        assert large < 1.0, f"8k+8k tokens took {large:.3f}s"
+        # No absolute cap: coverage tracing on the backend jobs prices line
+        # events, not algorithmic cost (#8630 precedent); the ratio is the guard.
 
     def test_the_stop_predicates_match_the_handling(self):
         """The precomputed index and the branch taken at that index are two places

--- a/test/test_security.py
+++ b/test/test_security.py
@@ -9391,7 +9391,11 @@ class TestPublishFloorNestedPayloads:
         elapsed(500)
         small, large = best(2000), best(16000)
         assert large < small * 20, f"{small:.4f}s -> {large:.4f}s looks super-linear"
-        assert large < 2.0, f"48k tokens took {large:.3f}s"
+        # No absolute wall-clock cap: under the backend jobs' coverage tracing the
+        # same linear implementation costs whatever its LINE-EVENT count is, not
+        # its algorithmic cost, so an absolute bound reds on tracing overhead a
+        # same-runner uninstrumented A/B measures at parity (branch/main 0.94).
+        # The same-run ratio above is the regression guard (see #8630 precedent).
 
     def test_only_one_joined_payload_is_produced_per_walk(self) -> None:
         """The bound above is what keeps it linear, so pin the bound itself."""


### PR DESCRIPTION
## What

Drops the absolute wall-clock caps (2.0s / 1.0s / 1.0s) from the three payload-extraction linearity tests, keeping their same-run ratio guards (which pass everywhere) as the regression teeth:

- `test/test_security.py::TestPublishFloorNestedPayloads::test_the_eval_join_stays_linear`
- `test/test_denied_commands_security.py::TestNestedPayloadExtractionIsLinear::test_the_scan_is_linear_not_quadratic`
- `test/test_denied_commands_security.py::TestNestedPayloadExtractionIsLinear::test_a_long_double_dash_run_is_also_linear`

Continues the #8630 precedent (same-run ratio guards for regex linearity) into the extractor tests.

## Why: the caps price coverage line events, not algorithmic cost

Root-caused on PR #8491 (unblocker for it), where these caps red at a stable ~1.6-1.8x across five consecutive samples while the identical shapes measure at or below merge-base locally. A same-runner interleaved A/B (`main/src` vs the PR's `src`, 10 alternating rounds per arm, fresh subprocess per sample) resolves the contradiction:

| shape | uninstrumented branch/main | under `coverage run` |
|---|---|---|
| eval-join@16000 | **0.94** | 2.41 |
| interp-run@16000 | 1.03 | 2.77 |
| dash-run@8000 | 1.02 | 2.46 |

(runs 33941190551 and 33941626496 on `debug/timing-ab-8197`, since deleted)

The backend test jobs run under pytest-cov line tracing, so a pure-Python hot loop's wall time is proportional to its **line-event count**, not its wall-clock cost. Any refactor that changes line geometry (e.g. #8491 splitting one stop-scan into sparse bisect tables) moves the traced time by 2-3x while uninstrumented time stays at parity — the absolute caps therefore red on tracing overhead, not on regressions. The ratio guards are immune (both sides of the ratio are equally traced) and are the assertions that actually failed the historical quadratic implementations.

## Testing

- Diff-scoped flake8 + isort green.
- The three tests' ratio guards are untouched; test suite runs in CI (per repo policy, no local test runs).
- Evidence runs linked above executed the exact failing shapes on the CI runner class.

no linked issue: methodology defect found during #8491 babysit; unblocks https://github.com/kirodotdev/KiroCrew/pull/8491

🤖 Kiro Crew Auto-Pipeline [operator: CrysisDeu#0c98c3a2]
