### PR TITLE
test(members): drive an increasing clock in roster order test (#8499)

### DIFF
--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -241,7 +241,7 @@ class TestMemberRoutes:
         assert "AKIA" not in preview
 
     @pytest.mark.asyncio
-    async def test_roster_orders_by_message_ts_not_file_mtime(self, tmp_path):
+    async def test_roster_orders_by_message_ts_not_file_mtime(self, tmp_path, monkeypatch):
         """last_active_ts is the newest MESSAGE's own timestamp.
 
         Non-message writes (metadata, rehydration) bump the transcript file's
@@ -250,8 +250,30 @@ class TestMemberRoutes:
         newest time must NOT promote it above the thread whose message is
         actually newer.
         """
+        import datetime as _dt
         import os
         import time
+
+        # append stamps each row via monotonic_transcript_ts, whose correction
+        # only consults prior rows of the SAME file — two freshly created files
+        # each get a raw clock read. On a coarse clock (Windows' ~15ms tick)
+        # these back-to-back appends collide, and the strict `<` below fails on
+        # equal timestamps. Drive a strictly-increasing clock so the
+        # chronological order this test asserts is actually encoded in the
+        # timestamps, on every OS. The stand-in must be tz-aware: append calls
+        # .astimezone() on the result.
+        _base = _dt.datetime(2026, 7, 25, 0, 0, 0, tzinfo=_dt.timezone.utc)
+        _tick = {"n": 0}
+
+        # Subclass keeps datetime classmethods (fromisoformat) available while
+        # patched, so _parse_transcript_ts is not silently degraded.
+        class _IncDateTime(_dt.datetime):
+            @classmethod
+            def now(cls, tz=None):
+                _tick["n"] += 1
+                return _base + _dt.timedelta(seconds=_tick["n"])
+
+        monkeypatch.setattr("kiro_crew.history.datetime", _IncDateTime)
 
         state = _make_state(tmp_path)
         write_dm_binding(CREW, member=CREW, slot_key=member_slot_key(CREW))
@@ -263,6 +285,9 @@ class TestMemberRoutes:
         state.conversation_log.append(old_key, "user", "older message")
         state.conversation_log.append(new_key, "user", "newer message")
         # Touch the OLDER thread's file so its mtime is the newest of the two.
+        # Deliberately the REAL clock (2026-09-xx+), far ahead of the fake
+        # message timestamps (fixed 2026-07-25): the mtime-vs-ts contrast is
+        # the point of this test — do not "align" the two clocks.
         old_path = state.conversation_log._path(old_key)
         now = time.time() + 60
         os.utime(old_path, (now, now))


### PR DESCRIPTION
## Summary

`test/test_members_dm_thread.py::TestMembersRoster::test_roster_orders_by_message_ts_not_file_mtime` is flaky on the Windows CI shard. It appends one message to each of two freshly created transcript files back-to-back and asserts strict `<` on their `last_active_ts`. `monotonic_transcript_ts` only corrects against prior rows of the SAME file, so both appends take raw `datetime.now()` reads; on Windows' ~15.6 ms clock tick the reads collide and the assertion fails on equal timestamps. The production code is correct — cross-file ordering is not something it promises; the test assumed clock resolution it does not control.

**Test-only fix:** monkeypatch `kiro_crew.history.datetime` in the test with a strictly increasing, tz-aware clock (mirrors the existing prior art in `test/test_history.py::test_recent_from_source_sorted_by_ts`), so the chronological order the test asserts is encoded in the timestamps on every OS. Two refinements over the prior art, from pre-push review: the stand-in subclasses `datetime.datetime` so `fromisoformat` stays available while patched (keeps `_parse_transcript_ts` undegraded), and a comment marks the deliberate fake-message-clock vs real-`os.utime`-clock contrast so a later reader does not "align" them.

The `os.utime` mtime bump on the OLDER thread's file is unchanged — that is the behaviour under test (mtime must not reorder rows). The assertion stays strict `<`. No changes to `src/kiro_crew/history.py` or roster code.

Closes #8499

## Testing

- `isort --check-only`, `flake8`, `mypy src/kiro_crew/` — all pass locally
- Diff-scoped black gate and brand gate pass post-commit
- Full pytest runs in CI (local test execution is disabled on this host by operator policy)

## Pre-push review

Two model-pinned read-only reviewers on the staged diff:
- GPT lane (gpt-5.6-sol): PASS, no findings
- Opus lane (claude-opus-5): PASS, 3 Low advisories — 2 applied (datetime subclass; two-clocks comment), 1 deferred (shared conftest fixture for the duplicated fake-clock helper, out of this fix's file scope)
