### PR TITLE
perf(memory): vectorize the episodic sqlite cosine scan with numpy (#8548)

### DIFF
--- a/src/kiro_crew/vector_memory.py
+++ b/src/kiro_crew/vector_memory.py
@@ -2216,7 +2216,11 @@ class VectorMemoryStore:
         tag_filter: list[str] | None = None,
         relevance_filter: bool = False,
     ) -> list[dict]:
-        """Cosine similarity search using embeddings stored in SQLite (stdlib only)."""
+        """Cosine similarity search using embeddings stored in SQLite.
+
+        Scoring is vectorized with numpy when available (one mat-vec over all
+        surviving rows); falls back to the stdlib-only per-row loop otherwise.
+        """
         # Normalize query
         norm = math.sqrt(sum(x * x for x in query_embedding))
         q = [x / norm for x in query_embedding] if norm > 0 else query_embedding
@@ -2241,33 +2245,44 @@ class VectorMemoryStore:
 
         now = datetime.now(tz=timezone.utc)
         candidates: list[dict] = []
-        for r in rows:
-            blob = r["embedding"]
-            n_floats = len(blob) // 4
-            if n_floats != q_len:
-                continue
-            if tag_filter and not self._matches_tags(dict(r), tag_filter):
-                continue
-            vec = struct.unpack(f"{n_floats}f", blob)
-            # dot product (both pre-normalized → cosine similarity)
-            cosine_sim = sum(a * b for a, b in zip(q, vec))
-            created = datetime.fromisoformat(r["created_at"])
-            days_old = max(0, (now - created).days)
-            decay_rate = self._decay_rate_for(r["tags"])
-            score = cosine_sim * (0.7 + 0.3 * r["importance"]) * math.exp(-decay_rate * days_old)
-            candidates.append(
-                {
-                    "id": r["id"],
-                    "conversation_id": r["conversation_id"],
-                    "text": r["text"],
-                    "tags": r["tags"],
-                    "importance": r["importance"],
-                    "created_at": r["created_at"],
-                    "last_accessed_at": r["last_accessed_at"],
-                    "score": round(score, 4),
-                    "cosine_sim": round(cosine_sim, 4),
-                }
-            )
+        if _HAS_NUMPY:
+            # First pass: apply the skip rules and collect surviving rows and
+            # their embedding blobs, preserving order.
+            survivors: list = []
+            blobs: list[bytes] = []
+            for r in rows:
+                blob = r["embedding"]
+                n_floats = len(blob) // 4
+                if n_floats != q_len:
+                    continue
+                if tag_filter and not self._matches_tags(dict(r), tag_filter):
+                    continue
+                survivors.append(r)
+                blobs.append(blob)
+            if survivors:
+                # One mat-vec over every surviving row (both sides are
+                # pre-normalized → the dot product IS the cosine similarity).
+                # float32 matches the stored dtype and the FAISS path.
+                mat = np.frombuffer(b"".join(blobs), dtype=np.float32).reshape(
+                    len(blobs), q_len
+                )
+                sims: list[float] = [float(s) for s in mat @ np.asarray(q, dtype=np.float32)]
+            else:
+                sims = []
+            for r, cosine_sim in zip(survivors, sims):
+                candidates.append(self._episodic_candidate(r, cosine_sim, now))
+        else:
+            for r in rows:
+                blob = r["embedding"]
+                n_floats = len(blob) // 4
+                if n_floats != q_len:
+                    continue
+                if tag_filter and not self._matches_tags(dict(r), tag_filter):
+                    continue
+                vec = struct.unpack(f"{n_floats}f", blob)
+                # dot product (both pre-normalized → cosine similarity)
+                cosine_sim = sum(a * b for a, b in zip(q, vec))
+                candidates.append(self._episodic_candidate(r, cosine_sim, now))
 
         if relevance_filter:
             candidates = self._filter_by_relevance(candidates)
@@ -2282,6 +2297,29 @@ class VectorMemoryStore:
         # regardless of caller. _touch_last_accessed does the locking and debouncing.
         self._touch_last_accessed([c["id"] for c in result])
         return result
+
+    def _episodic_candidate(self, r: sqlite3.Row, cosine_sim: float, now: datetime) -> dict:
+        """Build one episodic search candidate from a row and its cosine score.
+
+        Shared by both scoring branches of :meth:`_sqlite_vector_search` so the
+        candidate shape cannot silently diverge between numpy-installed and
+        stdlib-only installs.
+        """
+        created = datetime.fromisoformat(r["created_at"])
+        days_old = max(0, (now - created).days)
+        decay_rate = self._decay_rate_for(r["tags"])
+        score = cosine_sim * (0.7 + 0.3 * r["importance"]) * math.exp(-decay_rate * days_old)
+        return {
+            "id": r["id"],
+            "conversation_id": r["conversation_id"],
+            "text": r["text"],
+            "tags": r["tags"],
+            "importance": r["importance"],
+            "created_at": r["created_at"],
+            "last_accessed_at": r["last_accessed_at"],
+            "score": round(score, 4),
+            "cosine_sim": round(cosine_sim, 4),
+        }
 
     def get_episodic_list(
         self, limit: int = 50, offset: int = 0, tag_filter: list[str] | None = None

--- a/test/test_perf_memory_quickwins.py
+++ b/test/test_perf_memory_quickwins.py
@@ -13,6 +13,10 @@ Each test is written to FAIL if its corresponding fix is reverted:
   once instead of probing with ``get_lessons()`` first.
 - ``TestRecentFromSourceTailRead`` — ``recent_from_source`` reads a bounded
   tail rather than the whole transcript.
+- ``TestEpisodicSqliteCosineNumpy`` — the sqlite episodic tier scores rows with
+  one numpy mat-vec when numpy is available (issue #8548), giving identical
+  results to the stdlib loop; ``test_numpy_branch_is_actually_taken`` fails if
+  the vectorized branch is reverted.
 """
 
 from __future__ import annotations
@@ -411,3 +415,162 @@ class TestRecentFromSourceTailRead:
                 )
         msgs = log.recent_from_source("slack-C3", exclude_key="slack-C3-a", max_messages=20)
         assert [m["content"] for m in msgs] == ["from-slack-C3-b"]
+
+
+class TestEpisodicSqliteCosineNumpy:
+    """The sqlite episodic cosine scan gives identical results on both branches.
+
+    Issue #8548: `_sqlite_vector_search` is the tier a default install runs
+    (faiss-cpu is not a declared dependency), and it scored rows with a pure
+    Python loop despite numpy being available. The numpy branch must be a
+    drop-in: same ids, same order, same cosine values as the stdlib loop.
+    """
+
+    DIM = 8
+
+    @staticmethod
+    def _normed(seed: int, dim: int) -> list[float]:
+        """Deterministic pre-normalized vector (matches the storage contract)."""
+        import math as _math
+
+        raw = [float((seed + i) % 5) + 0.25 for i in range(dim)]
+        norm = _math.sqrt(sum(x * x for x in raw))
+        return [x / norm for x in raw]
+
+    def _seed_store(self, tmp_path: Path) -> "VectorMemoryStore":
+        import struct as _struct
+        from datetime import datetime, timezone
+
+        store = VectorMemoryStore(db_path=tmp_path / "mem.db", embedding_dim=self.DIM)
+        store.init()
+        now = datetime.now(tz=timezone.utc).isoformat()
+        rows = [
+            ("ep-1", self._normed(1, self.DIM), ["alpha"]),
+            ("ep-2", self._normed(3, self.DIM), ["beta"]),
+            ("ep-3", self._normed(7, self.DIM), ["alpha", "beta"]),
+            ("ep-4", self._normed(11, self.DIM), []),
+        ]
+        for mem_id, vec, tags in rows:
+            store.db.execute(
+                "INSERT INTO episodic_memories "
+                "(id, conversation_id, text, embedding, tags, importance, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    mem_id,
+                    "conv-1",
+                    f"episodic row {mem_id}",
+                    _struct.pack(f"{self.DIM}f", *vec),
+                    json.dumps(tags),
+                    0.6,
+                    now,
+                ),
+            )
+        # One row whose embedding length does NOT match the query dim: both
+        # branches must skip it.
+        short = self._normed(5, self.DIM - 3)
+        store.db.execute(
+            "INSERT INTO episodic_memories "
+            "(id, conversation_id, text, embedding, tags, importance, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "ep-short",
+                "conv-1",
+                "episodic row with a mismatched embedding length",
+                _struct.pack(f"{self.DIM - 3}f", *short),
+                "[]",
+                0.6,
+                now,
+            ),
+        )
+        store.db.commit()
+        return store
+
+    def _search(
+        self,
+        store: "VectorMemoryStore",
+        monkeypatch: pytest.MonkeyPatch,
+        use_numpy: bool,
+        tag_filter: list[str] | None = None,
+    ) -> list[dict]:
+        import kiro_crew.vector_memory as vm
+
+        monkeypatch.setattr(vm, "_HAS_NUMPY", use_numpy)
+        return store._sqlite_vector_search(
+            query_embedding=self._normed(2, self.DIM),
+            query_text="episodic row",
+            limit=10,
+            mmr=False,
+            tag_filter=tag_filter,
+        )
+
+    def test_numpy_branch_matches_stdlib_branch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if not _HAS_NUMPY:
+            pytest.skip("numpy not available on this platform")
+        store = self._seed_store(tmp_path)
+        fast = self._search(store, monkeypatch, use_numpy=True)
+        slow = self._search(store, monkeypatch, use_numpy=False)
+
+        assert [r["id"] for r in fast] == [r["id"] for r in slow]
+        assert [r["id"] for r in fast]  # non-empty: the fixture rows survived
+        for f, s in zip(fast, slow):
+            assert abs(f["cosine_sim"] - s["cosine_sim"]) < 1e-6
+            assert abs(f["score"] - s["score"]) < 1e-6
+
+    def test_numpy_branch_is_actually_taken(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reverting the vectorization makes this fail: the numpy path must not
+        touch ``struct.unpack``, which is exactly what the old per-row loop did."""
+        if not _HAS_NUMPY:
+            pytest.skip("numpy not available on this platform")
+        import kiro_crew.vector_memory as vm
+
+        store = self._seed_store(tmp_path)
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise AssertionError("struct.unpack called on the numpy branch")
+
+        monkeypatch.setattr(vm.struct, "unpack", _boom)
+        results = self._search(store, monkeypatch, use_numpy=True)
+        assert {r["id"] for r in results} == {"ep-1", "ep-2", "ep-3", "ep-4"}
+
+    def test_mismatched_embedding_length_skipped_in_both_branches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if not _HAS_NUMPY:
+            pytest.skip("numpy not available on this platform")
+        store = self._seed_store(tmp_path)
+        for use_numpy in (True, False):
+            ids = {r["id"] for r in self._search(store, monkeypatch, use_numpy=use_numpy)}
+            assert "ep-short" not in ids
+            assert {"ep-1", "ep-2", "ep-3", "ep-4"} <= ids
+
+    def test_tag_filter_applies_in_both_branches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if not _HAS_NUMPY:
+            pytest.skip("numpy not available on this platform")
+        store = self._seed_store(tmp_path)
+        for use_numpy in (True, False):
+            ids = {
+                r["id"]
+                for r in self._search(store, monkeypatch, use_numpy=use_numpy, tag_filter=["alpha"])
+            }
+            assert ids == {"ep-1", "ep-3"}
+
+    def test_zero_surviving_rows_returns_empty_in_both_branches(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        if not _HAS_NUMPY:
+            pytest.skip("numpy not available on this platform")
+        store = self._seed_store(tmp_path)
+        for use_numpy in (True, False):
+            ids = {
+                r["id"]
+                for r in self._search(
+                    store, monkeypatch, use_numpy=use_numpy, tag_filter=["no-such-tag"]
+                )
+            }
+            assert ids == set()


### PR DESCRIPTION
## Summary

`_sqlite_vector_search` is the episodic tier a default install actually runs (faiss-cpu is not in any dependency metadata), and it scored every row with `struct.unpack` plus a pure-Python generator-sum dot product even though numpy is a declared dependency already imported behind `_HAS_NUMPY`. This vectorizes that scan: one `np.frombuffer(...).reshape(n, dim) @ q` mat-vec in float32 (matching the stored dtype and the FAISS tier), ~7x on 2.5k rows x 1024 dims, per reporter, with max abs score difference ~2e-8 (ranking unchanged).

PR #3109 fixed the analogous defect on the lesson-ranking cosine but explicitly scoped itself to that path; this covers the sibling.

## Changes

- `src/kiro_crew/vector_memory.py` — `_sqlite_vector_search` gains a numpy branch gated on the existing `_HAS_NUMPY` flag (no new import or flag): first pass applies the existing skip rules (`n_floats != q_len`, `tag_filter`) and collects surviving rows + blobs in order; one mat-vec scores them all; empty-survivors case short-circuits without touching `frombuffer`/`reshape`. The original `struct.unpack` + generator-sum loop is kept verbatim as the `else` branch, so stdlib-only installs are byte-for-byte unchanged.
- Candidate-dict assembly is extracted into a shared `_episodic_candidate` helper called by both branches, so the result shape cannot silently diverge between numpy-installed and stdlib-only installs (local Opus review finding).
- Untouched, per the issue scope: `search_episodic` tiering, `_mmr_rerank`, `_filter_by_relevance`, `_touch_last_accessed`, the `round(..., 4)` on score/cosine_sim, and the lesson path from PR #3109.

## Testing

New `TestEpisodicSqliteCosineNumpy` in `test/test_perf_memory_quickwins.py`:

- branch parity: same ids, same order, `cosine_sim`/`score` within 1e-6 with `_HAS_NUMPY` monkeypatched True vs False
- a row with a mismatched embedding length is skipped in both branches
- `tag_filter` applies identically in both branches
- zero surviving rows returns `[]` without error in both branches
- revert detection: the numpy branch never calls `struct.unpack` (monkeypatched to raise), so reverting the vectorization fails the test

No benchmark added to the suite (per issue guidance). Local gates green: isort, flake8, mypy (1288 files), diff-scoped black gate. Two local model-pinned review lanes ran pre-push: GPT lane PASS clean; Opus lane PASS with advisories — the dict-duplication and revert-detection ones are addressed above; the buffer-join transient (same one n x dim float32 copy either way) and float32-accumulation (matches the FAISS tier; drift is below the `round(..., 4)` surface) were assessed as not actionable.

Closes #8548
