### PR TITLE
test(chat): ratchet the bounded slot-detail disk-vs-window disagreement

### DIFF
--- a/test/test_slot_detail_disk_window_authority_7526.py
+++ b/test/test_slot_detail_disk_window_authority_7526.py
@@ -1,0 +1,149 @@
+"""POSITIVE CONTROL for issue #7526 — must be RED against unpatched main.
+
+Builds the disk-vs-window disagreement the issue describes and asserts the
+bounded branch returns the WINDOW's answer. Both branches read the SAME corpus
+here, stubbed on BOTH readers (the bounded branch calls
+``read_messages_chained_full``, the unbounded one ``read_messages_chained``), so
+a pass cannot come from one of them silently reading an empty tmp history.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+from kiro_crew.dashboard.state import _ChatSlot
+
+SETTLED = 12
+OLDER = 4  # rows above the live window -> _disk_older_count
+LIMIT = 4
+
+#: These four are RED on current main and stay red until the authority contract for
+#: the bounded branch is ruled on (issue #7526). ``strict`` on purpose: whoever
+#: lands the fix gets a failure here telling them to delete the marker, so the
+#: reproduction cannot rot into a silently-passing test the way the round-1..4
+#: tests preserved in ``c9979c43`` did -- those stub ``read_messages_chained``,
+#: which the bounded branch no longer calls, so they now pass vacuously.
+DISAGREEMENT = pytest.mark.xfail(
+    strict=True,
+    reason="#7526: the bounded branch is disk-authoritative for the window region",
+)
+
+
+@pytest.fixture()
+def state(tmp_path: Any) -> Any:
+    st = _make_state(tmp_path)
+    st.push_slots_update = lambda: None  # type: ignore[method-assign]
+    return st
+
+
+def _row(i: int, content: str) -> dict:
+    return {
+        "role": "user" if i % 2 == 0 else "assistant",
+        "content": content,
+        "cls": "msg msg-u" if i % 2 == 0 else "msg msg-a",
+        "ts": f"2026-09-01T00:00:{i:02d}Z",
+        "meta": {"mid": f"mid-{i}"},
+    }
+
+
+def _bind_corpus(state: Any, on_disk: list[dict]) -> None:
+    """Stub every disk reader the handler can reach with ONE corpus."""
+    state.conversation_log.read_messages_chained = (  # type: ignore[method-assign]
+        lambda _key: [dict(r) for r in on_disk]
+    )
+    state.conversation_log.read_messages_chained_full = (  # type: ignore[method-assign]
+        lambda _key: [dict(r) for r in on_disk]
+    )
+    state.conversation_log.read_rotated_messages_chained = (  # type: ignore[method-assign]
+        lambda _key: []
+    )
+    state.conversation_log.chain_mid_rotation = lambda _key: False  # type: ignore[method-assign]
+
+
+def _slot(state: Any, window: list[dict], on_disk: list[dict], name: str = "chat-1") -> Any:
+    slot = _ChatSlot(key=name)
+    slot.messages = window
+    slot._disk_older_count = OLDER
+    slot._disk_window_len = len(window)
+    state._slots[name] = slot
+    _bind_corpus(state, on_disk)
+    return slot
+
+
+async def _get(state: Any, query: str, name: str = "chat-1") -> dict:
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.get(f"/api/chat/slots/{name}{query}")
+        assert resp.status == 200
+        return await resp.json()
+
+
+def _variant_switch(state: Any) -> None:
+    """A variant switch: the newest assistant row rewritten IN PLACE, same mid.
+
+    ``api_chat_slot_switch_variant`` assigns ``target["content"]`` and
+    ``target["ts"]`` on the existing window dict and never touches ``meta.mid``,
+    so disk holds the previous variant at the SAME id.
+    """
+    on_disk = [_row(i, f"m{i}") for i in range(SETTLED)]
+    window = [dict(r) for r in on_disk[OLDER:]]
+    window[-1] = {**window[-1], "content": "SELECTED VARIANT", "ts": "2026-09-01T00:09:99Z"}
+    _slot(state, window, on_disk)
+
+
+def _regenerate_truncation(state: Any) -> None:
+    """A regenerate whose inline save failed: disk still holds the deleted tail."""
+    on_disk = [_row(i, f"m{i}") for i in range(SETTLED)]
+    # `del slot.messages[u_idx + 1:]` dropped the last two turns.
+    window = [dict(r) for r in on_disk[OLDER : SETTLED - 2]]
+    _slot(state, window, on_disk)
+
+
+class TestContentDisagreement:
+    @DISAGREEMENT
+    @pytest.mark.asyncio
+    async def test_bounded_read_returns_the_selected_variant(self, state: Any) -> None:
+        _variant_switch(state)
+        data = await _get(state, f"?limit={LIMIT}")
+        assert data["messages"][-1]["content"] == "SELECTED VARIANT"
+
+    @DISAGREEMENT
+    @pytest.mark.asyncio
+    async def test_both_branches_agree_on_content(self, state: Any) -> None:
+        _variant_switch(state)
+        bounded = await _get(state, f"?limit={LIMIT}")
+        unbounded = await _get(state, "")
+        assert bounded["messages"][-1]["content"] == unbounded["messages"][-1]["content"]
+
+
+class TestLengthDisagreement:
+    @DISAGREEMENT
+    @pytest.mark.asyncio
+    async def test_bounded_read_does_not_resurrect_the_deleted_tail(self, state: Any) -> None:
+        _regenerate_truncation(state)
+        data = await _get(state, f"?limit={SETTLED}")
+        contents = [m["content"] for m in data["messages"]]
+        assert "m10" not in contents and "m11" not in contents
+
+    @DISAGREEMENT
+    @pytest.mark.asyncio
+    async def test_both_branches_agree_on_length(self, state: Any) -> None:
+        _regenerate_truncation(state)
+        bounded = await _get(state, f"?limit={SETTLED}")
+        unbounded = await _get(state, "")
+        assert [m["content"] for m in bounded["messages"]] == [
+            m["content"] for m in unbounded["messages"]
+        ]
+
+
+class TestTheFrozenPrefixSurvives:
+    @pytest.mark.asyncio
+    async def test_older_session_rows_above_the_window_are_still_served(self, state: Any) -> None:
+        """Window authority must not swallow the prefix the bound exists to page into."""
+        _variant_switch(state)
+        data = await _get(state, f"?limit={SETTLED}")
+        contents = [m["content"] for m in data["messages"]]
+        assert contents[:OLDER] == [f"m{i}" for i in range(OLDER)]


### PR DESCRIPTION
## What is the problem?

The bounded branch of `GET /api/chat/slots/{slot}` and the unbounded branch do not agree on which store decides a row's content inside the live window's region. The unbounded branch returns `older + list(slot.messages)`, so the window decides. The bounded branch reads the chained disk corpus and merges only the rows disk is *missing*, so disk decides -- and a row that was rewritten in place is not missing, it is present at the same `meta.mid` holding stale text.

Two triggers reach it, both ordinary user actions:

- **A variant switch.** `api_chat_slot_switch_variant` assigns `target_dict["content"]` and `target_dict["ts"]` on the existing window dict and never touches `meta.mid`. Its inline save is wrapped in a `try/except` that swallows the failure **without** setting `_pending_rewrite`, so the next periodic flush takes the append path rather than the rewrite path and disk keeps the previous variant indefinitely -- not for one flush interval.
- **A regenerate.** `chat_regenerate` does `del slot.messages[u_idx + 1:]` and only then saves. A failed save leaves the deleted turns on disk.

`Refs #7526` -- **this PR does not resolve that issue.** It carries the reproduction only.

## Why this issue matters to the user

Both are user-visible transcript corruption. Selecting a variant paints the one you switched *away from* straight back over it, because `chat_variant_switch` is broadcast and the client's handler dispatches `refreshSlot` -- which is bounded as of #6947. Regenerating can bring deleted turns back. Neither is hypothetical and neither needs a race to observe.

## How our fix solves it

It does not fix it, deliberately. It **ratchets** it.

The contract decision -- which store is authoritative for the bounded branch's window region -- is not a local change, and that is the finding that kept production code out of this PR. It spans three surfaces:

1. **The bounded handler** itself (`chat_handlers.py`), including the `total` and `next_before` it reports.
2. **`api_chat_fork`.** It resolves a client-supplied `at_message_index` against exactly this corpus and mirrors it on purpose: *"Mirror that corpus here, or every index sent after the reader paged past a rotation boundary resolves short by the archived visible-row count, silently forking the WRONG message."* Change the bounded read's corpus without changing fork in lockstep and a fork lands on a different message.
3. **The client.** `pagingCursorAfterKeptHead` treats `next_before` as a row offset in the server's corpus index space and shifts it by the kept head's own `serverRowCount`. `retainServerTotal` keeps `total` as a warm-read baseline, and its own comment records the cost of a wrong one: a bad baseline "makes the next warm read that ordinary collapse as a truncation and suppress the rescue, dropping a live row."

So the ratchet is the part that is safe to land now: four `xfail(strict=True)` tests that pin today's answer. `strict` is the point -- the day the contract is settled they turn into an `xpass` and force whoever fixed it to delete the marker, so the fix cannot land while leaving prose behind claiming the old behaviour.

It also defuses a live trap. The eleven tests preserved in `c9979c43` **no longer reproduce anything**: they stub `read_messages_chained`, and the bounded branch now reads `read_messages_chained_full`, so the disk side is never consulted and eight of them pass vacuously against an unpatched handler. Anyone who picks the issue up and runs them concludes the bug is gone. These stub *both* readers with one corpus, so a pass cannot come from an empty tmp history.

## What tests we did

`test/test_slot_detail_disk_window_authority_7526.py`, +150/-0, no other file touched.

Red-before was established against the unpatched handler *without* the markers, and each failed for the right reason rather than by construction:

| Test | Unmarked result on main |
|---|---|
| `test_bounded_read_returns_the_selected_variant` | `AssertionError: assert 'm11' == 'SELECTED VARIANT'` |
| `test_both_branches_agree_on_content` | bounded `'m11'` vs unbounded `'SELECTED VARIANT'` |
| `test_bounded_read_does_not_resurrect_the_deleted_tail` | `'m10'` present after truncation |
| `test_both_branches_agree_on_length` | bounded and unbounded row lists differ |

`TestTheFrozenPrefixSurvives` is **not** marked: it passes today and guards the opposite error -- a future fix that swallows the older-session prefix the bound exists to page into. A ratchet that only pins the broken direction lets an over-correction through.

With the markers: `1 passed, 4 xfailed`. `flake8`, `isort` and `mypy` clean on the file. Single-file runs only (`-n0`); the suite was not run, by fleet instruction -- another track on the host was measured at 26G on full-suite runs tonight.

## Any other suggestions on the work

Two things found while establishing the premise that are worth the record but are not this PR's to change:

- The issue's stated obstacle is misdiagnosed. It says `_disk_older_count` "describes the current session's file while the corpus is a chained read". It does not -- both load sites compute it as `len(read_messages_chained(key)) - len(window)` (`chat_persistence.py:1110`, `:1586`), already in chained-corpus units. **The boundary is exact for any session with no rotated archive**, so "cannot reconcile" is stronger than the code supports.
- Where it genuinely is not computable, the reason is different: the bounded branch reads `read_messages_chained_full`, which prepends each chain key's archive block *and* applies `drop_persisted_tail_prefix`, which drops live rows and reports how many to nobody. Rotation needs `_SESSION_MAX_BYTES = 10 * 1024 * 1024`, so that shape needs a real 10MB `rotate` segment in the chain **and** a later member carrying an archive segment. Real, but not the common path -- and I could not measure its production frequency, which is why the fail-closed fallback's blast radius stays unquantified.

Both are recorded in full on the issue.

## Pattern harvest

Rule candidate: a preserved test kept as documentation of intended behaviour rots into a false all-clear the moment the code under it changes which collaborator it calls -- these stubbed `read_messages_chained` and kept passing after the handler moved to `read_messages_chained_full`, reporting green for a bug that was never fixed. A reproduction must stub every reader the path can reach, or assert the stub was actually consulted, so that "passes" cannot mean "never ran".

Refs #7526
