### PR TITLE
fix(test): settle the skills dedupe fetch on the test's clock, not a 5ms timer

### DIFF
--- a/website/src/test/SkillPickerMenu.dedupe.test.tsx
+++ b/website/src/test/SkillPickerMenu.dedupe.test.tsx
@@ -29,10 +29,20 @@ function Harness({ client, query = '', open = true, onSelect = vi.fn(), onClose 
   )
 }
 
-/** What the bounded client does to a wedged gateway: reject with TimeoutError. */
-const timesOut = () => () =>
-  new Promise((_resolve, reject) =>
-    setTimeout(() => reject(new DOMException('deadline exceeded', 'TimeoutError')), 5))
+/** What the bounded client does to a wedged gateway: reject with TimeoutError —
+ *  but on the TEST's clock, not a wall-clock timer. A timer-based deadline
+ *  raced the menu's mount: once it fired first the prefetch was already
+ *  settled, nothing was in flight to dedupe onto, and staleTime 0 (see
+ *  skillsCacheStaleTime(undefined)) made the menu fetch again, so the
+ *  one-call assertion failed on a slow runner rather than on a real
+ *  regression. `expire()` fires the same rejection at a chosen point. */
+function wedgedGateway() {
+  let expire = () => {}
+  const impl = () => new Promise((_resolve, reject) => {
+    expire = () => reject(new DOMException('deadline exceeded', 'TimeoutError'))
+  })
+  return { impl, expire: () => expire() }
+}
 
 beforeEach(() => { vi.clearAllMocks() })
 afterEach(() => { vi.restoreAllMocks() })
@@ -50,17 +60,26 @@ describe('SkillPickerMenu — deduping onto ChatInput\'s in-flight prefetch', ()
   it('reuses the in-flight promise — ONE fetch — and still settles, releasing Enter', async () => {
     // Dedupe on the shared key means the menu never runs its own queryFn, which
     // is why the deadline is bound in the client: the winner fetches for both.
-    mockApi.skills.mockImplementation(timesOut())
+    const gateway = wedgedGateway()
+    mockApi.skills.mockImplementation(gateway.impl)
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } })
     void startPrefetch(qc)
     await waitFor(() => expect(mockApi.skills).toHaveBeenCalled())
     const onSelect = vi.fn()
     render(<Harness client={qc} query="grill" onSelect={onSelect} />)
+    // Mounted and subscribed to the SAME key while the prefetch is still in
+    // flight — the only window in which dedupe is even the question. Asserting
+    // it here is what makes the one-call count below a claim about dedupe
+    // instead of a claim about which of two timers won.
+    expect(await screen.findByText(/Loading skills…/)).toBeInTheDocument()
+    expect(mockApi.skills).toHaveBeenCalledTimes(1)
+    // Now let the shared deadline expire: one rejection settles both readers.
+    gateway.expire()
     await waitFor(() => expect(screen.queryByText(/Loading skills…/)).not.toBeInTheDocument())
     await waitFor(() => expect(fireEvent.keyDown(document, { key: 'Enter' })).toBe(true))
     expect(onSelect).not.toHaveBeenCalled()
-    // One call, not two: proof the dedupe happened rather than two independent
-    // fetches that would each have been bounded anyway.
+    // Still one call after settling: the menu rode the prefetch's promise
+    // rather than running its own bounded fetch alongside it.
     expect(mockApi.skills).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
## Summary

`Frontend Tests (2)` failed on an unrelated docs-only PR ([run 33945418592](https://github.com/kirodotdev/KiroCrew/actions/runs/33945418592/job/101250617502)) with `expected "vi.fn()" to be called 1 times, but got 2 times` in `website/src/test/SkillPickerMenu.dedupe.test.tsx`. The test raced its own deadline, so the failure was timing, not a regression.

The shared prefetch rejected on a **5 ms wall-clock timer**. On a loaded runner that fired before the menu mounted, so there was no in-flight promise to dedupe onto, and `skillsCacheStaleTime(undefined) === 0` marked the settled (errored) entry stale — the menu then ran its own fetch, making the count 2.

## Fix

The wedged gateway now returns a promise the **test** rejects, via an `expire()` handle. The test:

1. starts the prefetch, waits for the first call,
2. renders the menu and asserts it is mounted and showing `Loading skills…` on the same key **while the fetch is still in flight** — the only window in which dedupe is even the question — and that the count is still 1,
3. calls `expire()` to fire the same `TimeoutError`,
4. re-checks that Enter is released and the count is still 1 after settling.

Test-only; no product code changed.

## Verification

- Reproduced the exact CI assertion locally by delaying the `render` past the 5 ms timer.
- Rewritten test passes with a **200 ms** pre-render delay (the old one fails at 30 ms).
- Negative control: appending a `'BREAK'` segment to `SkillPickerMenu`'s `queryKey` still makes it fail with `called 1 times, but got 2 times`, so it continues to catch a real dedupe regression.
- `npx vitest run --shard=2/4`: 462 files, 6769 passed, 1 expected fail. `typecheck` and `eslint` clean.

Sibling `SkillPickerMenu.timeout.test.tsx` and `SlashCommandMenu.timeout.test.tsx` use the same `timesOut()` helper but assert a single-mount retry-policy count, so they carry no cross-mount race and are left alone.

## Pattern harvest

Rule candidate: a test that asserts request-deduplication must hold the shared promise pending under test control and assert the second reader is subscribed before settling it; a wall-clock timer makes the assertion a race against mount time.

Rule candidate: when a query's `staleTime` is 0, a settled cache entry is immediately refetched, so any "only one fetch" assertion is only meaningful while the first fetch is still in flight.
