### PR TITLE
fix(release): put the Windows installer on the GitHub Release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -952,15 +952,88 @@ jobs:
       # softprops/action-gh-release pre-pends `body`/`body_path` to the
       # `generate_release_notes` output rather than replacing it, so the
       # native "New Contributors" block (rendered from this repository's own
-      # commit history, per commit range) still appears after our section --
-      # do not hand-write a contributors list here, see AGENTS.md's changelog
-      # rule for why a hand-written list would duplicate that block.
+      # commit history, per commit range) still appears after our section.
+      #
+      # Two transforms are applied on the way, because the CHANGELOG section is
+      # written for a rendered FILE and the release body is a comment field:
+      #
+      #  - `### Contributors` is DROPPED. The section is required to carry it
+      #    (it ships in the wheel and feeds the dashboard's Releases page, where
+      #    no native block exists), but the release page renders its own
+      #    contributor block from the tag range, so copying ours in duplicates
+      #    the list directly above GitHub's. That duplicated on v0.3.0 and again
+      #    on v0.5.0 -- as a hand-written list was blamed both times, when the
+      #    copy is what actually carries it.
+      #  - Paragraphs and list items are JOINED onto one line. GitHub renders a
+      #    release body with GFM line breaks ON, so the CHANGELOG's ~76-column
+      #    wrapping becomes real <br>s and the page shows a fixed-width column
+      #    with a wide empty gutter (reported on v0.5.0). The same text is
+      #    correct in CHANGELOG.md, where a rendered file does not do this.
       - name: Extract CHANGELOG section for the release body
         run: |
           python3 - "${{ needs.version.outputs.channel }}" "${{ needs.version.outputs.base_version }}" <<'PY_EXTRACT'
+          import re
           import sys
           sys.path.insert(0, "src")
           from kiro_crew.changelog import parse_sections
+
+          FENCE = re.compile(r"^\s*(```|~~~)")
+          HEADING = re.compile(r"^\s{0,3}#{1,6}\s")
+          LIST_ITEM = re.compile(r"^(\s*)([-*+]|\d+[.)])\s+")
+          # Table rows, block quotes and thematic breaks own their line.
+          STANDALONE = re.compile(r"^\s*(\||>|---\s*$|\*\*\*\s*$|___\s*$)")
+
+
+          def drop_contributors(body: str) -> str:
+              """Remove the trailing `### Contributors` subsection, if present."""
+              out, skipping = [], False
+              for line in body.split("\n"):
+                  if HEADING.match(line):
+                      skipping = line.strip().lower().startswith("### contributors")
+                  if not skipping:
+                      out.append(line)
+              return "\n".join(out)
+
+
+          def unwrap(body: str) -> str:
+              """Join each paragraph / list item onto one line, keeping structure."""
+              out, buf, in_fence, marker = [], [], False, ""
+
+              def flush():
+                  if buf:
+                      out.append(" ".join(part.strip() for part in buf))
+                      buf.clear()
+
+              for raw in body.split("\n"):
+                  if in_fence:
+                      out.append(raw)
+                      if FENCE.match(raw) and raw.strip().startswith(marker):
+                          in_fence = False
+                      continue
+                  fence = FENCE.match(raw)
+                  if fence:
+                      flush()
+                      in_fence, marker = True, fence.group(1)
+                      out.append(raw)
+                  elif not raw.strip():
+                      flush()
+                      out.append("")
+                  elif HEADING.match(raw) or STANDALONE.match(raw):
+                      flush()
+                      out.append(raw.rstrip())
+                  elif LIST_ITEM.match(raw):
+                      flush()
+                      buf.append(raw.rstrip())
+                  else:
+                      buf.append(raw.rstrip())
+              flush()
+              collapsed = []
+              for line in out:
+                  if line == "" and collapsed and collapsed[-1] == "":
+                      continue
+                  collapsed.append(line)
+              return "\n".join(collapsed).strip() + "\n"
+
 
           channel, base_version = sys.argv[1], sys.argv[2]
           notes = ""
@@ -972,7 +1045,7 @@ jobs:
                       f"::error::CHANGELOG.md has no '## [{base_version}]' section; "
                       "the stable gate should have caught this earlier."
                   )
-              notes = sections[0] + "\n"
+              notes = unwrap(drop_contributors(sections[0]))
           with open("release-notes.md", "w", encoding="utf-8") as out:
               out.write(notes)
           PY_EXTRACT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -779,9 +779,19 @@ jobs:
   # to Stable with no GitHub Release page and no assets. Naming each dependency
   # explicitly is the documented workaround and the pattern every other lane in
   # this file already uses.
+  #
+  # `build-windows` is in `needs` as a WAIT EDGE and deliberately not in the
+  # `if:` below. Without the edge, `download-artifact` collects whatever exists
+  # the moment it runs, so a Windows build still queued on a slow runner would
+  # be omitted from the page with nothing going red -- the same silent-omission
+  # failure this job's Windows asset exists to end. Without the exemption from
+  # the `if:`, a Windows problem would take the whole release page down with it,
+  # and per-platform independence (soft_fail, an optional bundle role, a
+  # probe-and-skip publish lane) is the one thing every other Windows hop here
+  # already preserves.
   github-release:
     name: Create GitHub Release
-    needs: [version, stable-gate, sign-and-notarize]
+    needs: [version, stable-gate, sign-and-notarize, build-windows]
     if: >-
       ${{ always() && needs.version.result == 'success' &&
           needs.stable-gate.result == 'success' &&
@@ -811,7 +821,28 @@ jobs:
       # only from the exact gated artifact emitted after notarization, stapling,
       # and Gatekeeper verification. The unsigned electron-builder zip/DMG are
       # inter-job inputs only and must never become GitHub Release assets.
+      #
+      # The extension list is an ALLOWLIST, so a platform whose extension is
+      # missing is silently absent from the release page rather than failing
+      # anything. The Windows installer was absent exactly that way from v0.2.0
+      # through v0.5.0: every one of those releases published one to the CDN and
+      # to the update feed while the GitHub Release page offered none, and
+      # nothing went red. `test_release_promotion_contract.py` now pins the
+      # collected set against the publishing lanes so a new platform cannot be
+      # forgotten the same way.
+      #
+      # The extension glob is only sound for a format with exactly ONE producer
+      # in the run. macOS and Windows each have two, so both are selected by an
+      # explicit path instead -- see the Windows block below for why an `*.exe`
+      # entry in this glob would put a never-promoted installer on a stable page.
+      #
+      # Deliberately NOT collected: `*.exe.blockmap` (a differential-update
+      # sidecar the feed consumes, not something a human downloads) and
+      # `latest*.yml` (channel feed pointers, which are published to the CDN by
+      # their own lanes and would be misleading as release assets).
       - name: Assemble release assets (require gated macOS artifacts)
+        env:
+          PROMOTE_MODE: ${{ needs.version.outputs.promote_mode }}
         run: |
           set -euo pipefail
           mkdir -p release
@@ -877,6 +908,39 @@ jobs:
 
           cp "$NOTARIZED_ZIP" "release/KiroCrew-${{ needs.version.outputs.version }}-universal-mac.zip"
           cp "$NOTARIZED_DMG" "release/KiroCrew-${{ needs.version.outputs.version }}-universal.dmg"
+
+          # The Windows installer, selected per MODE rather than by extension.
+          # A promotion run holds TWO installers: the candidate's promoted bytes
+          # inside the gated bundle, and a fresh one from `build-windows`, which
+          # carries no `if:` and so rebuilds even when nothing consumes it.
+          # electron-builder's default name embeds the version, so the two names
+          # differ and an `*.exe` glob attaches BOTH -- putting an installer that
+          # was never soaked or promoted on a stable page, looking the more
+          # official of the pair for carrying the version number.
+          if [ "${PROMOTE_MODE:-}" = "true" ]; then
+            WINDOWS_INSTALLER="${NOTARIZED_DIR}/KiroCrew-Setup.exe"
+            [ -s "$WINDOWS_INSTALLER" ] || WINDOWS_INSTALLER=""
+          else
+            # Scoped to the producing artifact, and two is a bug rather than a
+            # coin flip: this must never guess which installer to publish.
+            # Mirrors record-promotion's at_most_one selector.
+            mapfile -t installers < <(find artifacts -type f -path '*build-windows-x64*' -name '*.exe')
+            if [ "${#installers[@]}" -gt 1 ]; then
+              echo "::error::expected at most one Windows installer, found ${#installers[@]}"
+              printf '%s\n' "${installers[@]}"
+              exit 1
+            fi
+            WINDOWS_INSTALLER="${installers[0]:-}"
+          fi
+          # Absence is a NOTICE, not a failure. build-windows is soft-fail so a
+          # Windows problem cannot hold back mac, Linux and the CLI; the bundle
+          # role is optional for the same reason. Loud in the run summary is the
+          # most this hop may do without reintroducing that coupling.
+          if [ -n "$WINDOWS_INSTALLER" ]; then
+            cp "$WINDOWS_INSTALLER" "release/KiroCrew-${{ needs.version.outputs.version }}-Setup-x64.exe"
+          else
+            echo "::notice::no Windows installer available to this run; the release page will offer none."
+          fi
           ls -la release/
 
       # Only a stable release has a CHANGELOG.md section to show (the stable

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -197,9 +197,10 @@ there is no build step at stable-tag time to add it.
    stamped in, so the shipped wheel is `kirocrew-X.Y.Z-py3-none-any.whl` and
    `kirocrew --version` prints `X.Y.Z`. Expect the full build time, not a
    pointer move. `Create GitHub Release` runs (the `if:` fix) and renders
-   GitHub's own contributor block — **do not hand-write a contributors list in
-   the body** (that duplicated the native block on v0.3.0). Verify: stable feed
-   carries the bare `X.Y.Z`, the wheel filename has no `rc`, About shows
+   GitHub's own contributor block, so the body must not carry a second one —
+   see "What the release body must not contain" below, because the body is
+   ASSEMBLED, not written, and the duplicate arrives on its own. Verify: stable
+   feed carries the bare `X.Y.Z`, the wheel filename has no `rc`, About shows
    `X.Y.Z`, CHANGELOG shows no draft heading.
 
    To ship the candidate's exact bytes instead — the only mode where stable runs
@@ -1080,6 +1081,44 @@ A discrepancy is NOT recoverable in place — published keys are immutable and t
 feed is already advertising the wrong label. The remedy is the next version
 forward, so it is worth spending the five minutes on these three checks while
 the run is still fresh.
+
+### What the release body must not contain
+
+The body is **assembled, not written**, and that is why the same three defects
+keep reaching the page. `github-release` passes the extracted CHANGELOG section
+as `body_path` AND sets `generate_release_notes: true`, and
+`softprops/action-gh-release` **pre-pends** the body to the generated notes
+rather than replacing them — so the published body is always
+`CHANGELOG section + whatever GitHub generates`. Nobody has to write a mistake
+for one to appear.
+
+- **No commit list.** `generate_release_notes: true` appends a
+  `## What's Changed` line per commit since the previous tag. On v0.5.0 that was
+  **746 lines for 922 commits** — 65% of the body, and it pushed the whole thing
+  to 125,219 characters, past GitHub's 125,000-character ceiling, so the body was
+  published TRUNCATED mid-word. The page already links "N commits to main since
+  this release", and the reader-facing summary is the CHANGELOG section. Strip it.
+- **No contributors list.** The page renders GitHub's own contributor block from
+  the tag range, natively, whatever the body says. The CHANGELOG section is
+  *required* to end with `### Contributors` (it ships inside the wheel and feeds
+  the dashboard's Releases page, where no such block exists) — so copying that
+  section into the body duplicates the list immediately above GitHub's own. This
+  duplicated on v0.3.0 and again on v0.5.0; the rule is about the BODY, and it
+  does not relax the CHANGELOG's requirement.
+- **No hard-wrapped paragraphs.** GitHub renders issue / PR / release bodies with
+  GFM line breaks ON, so a newline inside a paragraph becomes a real `<br>`.
+  CHANGELOG prose is wrapped at ~76 columns, and copied in verbatim it renders as
+  a fixed-width column with a wide empty gutter down the right of the page — the
+  "big blank area" reported on v0.5.0. The identical text looks correct in
+  `CHANGELOG.md` because a rendered *file* does not enable that option. Join each
+  paragraph and each list item onto one line and let the browser reflow;
+  headings, list nesting, code fences and tables are unaffected.
+
+Trimming the body after the fact is safe and is the normal remedy: release notes
+are prose on the GitHub page, editable independently of the tag, the CHANGELOG,
+and the published bytes. Editing them changes nothing a client downloads and does
+not touch the immutable CDN keys. What is NOT editable is the CHANGELOG section
+itself once shipped.
 
 ## Recovery: roll forward
 

--- a/docs/build/release.md
+++ b/docs/build/release.md
@@ -1010,6 +1010,77 @@ For the desktop swap itself, `ota-test.yml` is the end-to-end proof; run it on
 demand after a change to the updater. It validates the swap mechanism, not
 Gatekeeper acceptance, since it signs with a throwaway identity.
 
+### After a stable release: check the version the user actually sees
+
+The recipe above proves the bytes are live. It does not prove they are labelled
+correctly, and that is where every stable release so far has gone wrong — each
+time one layer further out than the last:
+
+| Release | Bytes | What was wrong anyway |
+|---|---|---|
+| v0.3.0 | correct | fed the RC's own `0.3.0-insider.13` stamp, so stable clients read as insider |
+| v0.4.0 | correct | source files were re-stamped bare, but the shipped wheel was still `0.4.0rc14` |
+| v0.5.0 | correct | wheel and feeds finally bare — the GitHub Release page had no Windows asset |
+
+So the failure mode is not "the release did not happen". It is "the release
+happened and advertises the wrong thing", which no lane fails on. Check the
+label surfaces explicitly:
+
+```bash
+CH=stable; V=0.5.0            # the version you just tagged
+PTR=https://updates.crew.kiro.dev
+BYTES=https://download.crew.kiro.dev
+
+# 1. Every feed advertises the BARE version -- no rc/insider suffix anywhere.
+for f in latest-cli.json latest-mac.yml latest-linux.yml latest-linux-arm64.yml latest.yml; do
+  printf '%-22s ' "$f"
+  curl -fsS "$PTR/feed/$CH/$f" | grep -oE "\"?version\"?:? *\"?[0-9][^\",]*" | head -1
+done
+
+# 2. The wheel's EMBEDDED version, not just its filename. This is what
+#    `pip show` and `kirocrew --version` print, and a promotion cannot change it.
+curl -fsS "$PTR/feed/$CH/latest-cli.json" > /tmp/feed.json
+python3 - <<'PY'
+import hashlib, io, json, re, urllib.request, zipfile
+d = json.load(open("/tmp/feed.json"))
+raw = urllib.request.urlopen(d["wheel_url"], timeout=120).read()
+assert hashlib.sha256(raw).hexdigest() == d["sha256"], "wheel does not match the feed digest"
+z = zipfile.ZipFile(io.BytesIO(raw))
+meta = next(n for n in z.namelist() if n.endswith(".dist-info/METADATA"))
+print("filename:", d["wheel_url"].rsplit("/", 1)[-1])
+print("METADATA Version:", re.search(r"^Version: (.+)$", z.read(meta).decode(), re.M).group(1))
+PY
+
+# 3. The GitHub Release page carries every platform, with no RC-stamped asset.
+gh api "repos/kirodotdev/KiroCrew/releases/tags/v$V" --jq '.assets[].name' | sort
+gh api "repos/kirodotdev/KiroCrew/releases/tags/v$V" --jq '.assets[].name' \
+  | grep -Ei 'rc[0-9]|insider' && echo 'STALE RC ASSET' || echo 'no rc-stamped asset'
+```
+
+What each check is really for:
+
+- **The feeds** are what a running client reads, so a suffix here is what makes a
+  stable install describe itself as a prerelease. All five must agree.
+- **The embedded wheel version** is the one surface a byte-reuse promotion can
+  never fix, which is why stable rebuilds by default. Verify it from the wheel
+  itself: a clean filename around RC-stamped metadata is exactly the v0.4.0
+  shape.
+- **The release page** is assembled by an extension allowlist, so a platform is
+  omitted silently rather than loudly. Compare the asset list against the
+  publish lanes that ran; `test_release_promotion_contract.py` pins the two
+  together, but a lane added without a matching extension still deserves a look
+  here. macOS and Windows are the two the allowlist does NOT cover: each has two
+  possible producers in a promotion run — the promoted bundle and a fresh
+  build — so each is taken from an explicit path, and exactly one asset per
+  platform should appear. Two Windows installers, or one whose name carries a
+  version other than the tag's, means the page is offering a rebuild the
+  promotion was supposed to replace.
+
+A discrepancy is NOT recoverable in place — published keys are immutable and the
+feed is already advertising the wrong label. The remedy is the next version
+forward, so it is worth spending the five minutes on these three checks while
+the run is still fresh.
+
 ## Recovery: roll forward
 
 **There is no rollback.** The recovery path for a bad release is to cut a new

--- a/test/test_release_macos_fail_closed.py
+++ b/test/test_release_macos_fail_closed.py
@@ -1,9 +1,15 @@
-"""Fail-closed contract tests for macOS assets on GitHub Releases.
+"""Fail-closed contract tests for the GitHub Release assembly step.
 
 The release job has ``contents: write`` and is the final trust-boundary hop
 before files become public.  These tests execute its actual shell step so an
 unsigned fallback, a broad ``find | head`` selector, or a superficial presence
 check cannot silently reappear.
+
+Two platforms need that scrutiny, for the same structural reason: a release run
+can hold more than one candidate file for them.  macOS must take only the gated,
+notarized handoff and never the unsigned electron-builder output.  Windows must
+take only the promoted bundle's installer on a promotion run and never the fresh
+rebuild ``build-windows`` produces beside it.
 """
 
 from __future__ import annotations
@@ -65,7 +71,7 @@ def _write_valid_handoff(root: Path, name: str = ARTIFACT_NAME) -> Path:
     return artifact
 
 
-def _run_assembly(root: Path) -> subprocess.CompletedProcess[str]:
+def _run_assembly(root: Path, *, promote_mode: bool = False) -> subprocess.CompletedProcess[str]:
     (root / "artifacts").mkdir(exist_ok=True)
     return subprocess.run(
         ["bash", "-c", _assembly_script()],
@@ -73,7 +79,22 @@ def _run_assembly(root: Path) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         check=False,
+        env={**os.environ, "PROMOTE_MODE": "true" if promote_mode else "false"},
     )
+
+
+#: The release page's Windows asset name, stamped and arch-suffixed the way the
+#: macOS assets beside it are.
+WINDOWS_ASSET = f"KiroCrew-{VERSION}-Setup-x64.exe"  # brand-ok: artifact filename
+#: electron-builder's default NSIS name, `${productName} Setup ${version}.exe`.
+#: The space and the embedded version are the whole point: that is why a rebuilt
+#: installer never collides with the bundle's `KiroCrew-Setup.exe`, and why an
+#: extension glob would attach both instead of choosing.
+REBUILT_INSTALLER = f"KiroCrew Setup {VERSION}.exe"  # brand-ok: artifact filename
+
+
+def _windows_asset(root: Path) -> Path:
+    return root / "release" / WINDOWS_ASSET
 
 
 def test_missing_exact_gated_artifact_does_not_fall_back_to_unsigned(tmp_path: Path) -> None:
@@ -149,3 +170,80 @@ def test_exact_gated_handoff_is_renamed_for_the_release(tmp_path: Path) -> None:
     assert release_dmg.read_bytes() == (gated / "KiroCrew.dmg").read_bytes()
     assert not (release / "unsigned-mac.zip").exists()
     assert not (release / "unsigned.dmg").exists()
+
+
+def test_promotion_publishes_the_bundled_installer_and_never_the_rebuild(
+    tmp_path: Path,
+) -> None:
+    """`build-windows` rebuilds on a promotion run; that rebuild is not shippable.
+
+    The job carries no ``if:``, so a promotion run produces a fresh installer
+    beside the promoted candidate's bytes. electron-builder names it after the
+    version, so the two filenames differ and a ``*.exe`` glob would attach both
+    -- the rebuild looking the more official for carrying the version number.
+    """
+    gated = _write_valid_handoff(tmp_path)
+    (gated / "KiroCrew-Setup.exe").write_bytes(b"promoted installer")
+    (gated / "KiroCrew-Setup.exe.blockmap").write_bytes(b"promoted blockmap")
+    rebuilt = _artifact_dir(tmp_path, "build-windows-x64")
+    (rebuilt / REBUILT_INSTALLER).write_bytes(b"rebuilt installer")
+
+    result = _run_assembly(tmp_path, promote_mode=True)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert _windows_asset(tmp_path).read_bytes() == b"promoted installer"
+    exes = sorted(path.name for path in (tmp_path / "release").glob("*.exe*"))
+    assert exes == [_windows_asset(tmp_path).name], exes
+
+
+def test_a_rebuild_release_takes_the_installer_from_its_producing_artifact(
+    tmp_path: Path,
+) -> None:
+    """Off the promotion path there is one producer, and its name is normalized.
+
+    The raw electron-builder name carries a space and, on a prerelease, the
+    ``-insider.N`` stamp. Renaming it the way the macOS assets are renamed is
+    what makes the release page's own asset list checkable against the tag.
+    """
+    _write_valid_handoff(tmp_path)
+    rebuilt = _artifact_dir(tmp_path, "build-windows-x64")
+    (rebuilt / REBUILT_INSTALLER).write_bytes(b"rebuilt installer")
+    (rebuilt / f"{REBUILT_INSTALLER}.blockmap").write_bytes(b"sidecar")
+    (rebuilt / "latest.yml").write_bytes(b"feed pointer")
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert _windows_asset(tmp_path).read_bytes() == b"rebuilt installer"
+    # The differential-update sidecar and the feed pointer are not assets.
+    assert not list((tmp_path / "release").glob("*.blockmap"))
+    assert not list((tmp_path / "release").glob("latest*.yml"))
+
+
+def test_two_candidate_installers_fail_rather_than_pick_one(tmp_path: Path) -> None:
+    """Guessing which installer to publish is worse than failing the page."""
+    _write_valid_handoff(tmp_path)
+    rebuilt = _artifact_dir(tmp_path, "build-windows-x64")
+    (rebuilt / REBUILT_INSTALLER).write_bytes(b"one")
+    (rebuilt / REBUILT_INSTALLER.replace(VERSION, "9.9.9")).write_bytes(b"two")
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode != 0
+    assert "expected at most one Windows installer" in result.stderr + result.stdout
+
+
+def test_a_missing_windows_installer_is_a_notice_not_a_failure(tmp_path: Path) -> None:
+    """Windows is soft-fail everywhere else; the release page may not be stricter.
+
+    A hard failure here would let a Windows build problem withhold the macOS,
+    Linux and CLI assets that already built cleanly -- the coupling `soft_fail`
+    and the optional bundle role exist to prevent.
+    """
+    _write_valid_handoff(tmp_path)
+
+    result = _run_assembly(tmp_path)
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert not _windows_asset(tmp_path).exists()
+    assert "no Windows installer available to this run" in result.stdout + result.stderr

--- a/test/test_release_notes_body.py
+++ b/test/test_release_notes_body.py
@@ -1,0 +1,195 @@
+"""The release body is assembled, so its shape needs its own contract.
+
+`github-release` hands the extracted CHANGELOG section to
+softprops/action-gh-release as ``body_path`` while ALSO setting
+``generate_release_notes: true``, and that action PRE-PENDS the body to the
+generated notes rather than replacing them. So the published body is always
+``our section + whatever GitHub generates``, and a defect can appear without
+anyone writing it. Three did, on v0.3.0 and again on v0.5.0:
+
+* the CHANGELOG's required ``### Contributors`` list, copied in verbatim,
+  duplicated the contributor block GitHub renders natively from the tag range;
+* the CHANGELOG's ~76-column hard wrapping became real ``<br>``s, because GitHub
+  renders a release body with GFM line breaks ON, leaving a fixed-width column
+  and a wide empty gutter down the page;
+* the generated commit list ran to 746 lines for 922 commits and pushed the body
+  past GitHub's 125,000-character ceiling, publishing it truncated mid-word.
+
+These tests pin the two transforms the extract step applies, by RUNNING the
+step's own embedded script rather than restating what it should do.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kiro_crew.subprocess_utf8 import UTF8_TEXT
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE = ROOT / ".github" / "workflows" / "release.yml"
+STEP_NAME = "Extract CHANGELOG section for the release body"
+
+
+def _extract_step_script() -> str:
+    """Pull the step's embedded python out of the workflow, verbatim."""
+    workflow = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    step = next(
+        s for s in workflow["jobs"]["github-release"]["steps"] if s.get("name") == STEP_NAME
+    )
+    run = step["run"]
+    body = run.split("<<'PY_EXTRACT'\n", 1)[1].rsplit("PY_EXTRACT", 1)[0]
+    return textwrap.dedent(body)
+
+
+def _run_step(tmp_path: Path, changelog: str, *, channel: str = "stable", version: str = "9.9.9"):
+    """Run the real step against a synthetic CHANGELOG in an isolated cwd."""
+    (tmp_path / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    script = tmp_path / "extract.py"
+    script.write_text(_extract_step_script(), encoding="utf-8")
+    # The environment is INHERITED, with only PYTHONPATH overridden so the child
+    # can import `kiro_crew.changelog` from a cwd that is not the checkout.
+    # Handing it a from-scratch dict instead drops SystemRoot on Windows, and
+    # Winsock cannot initialize without it: `import asyncio` in the child then
+    # raises WinError 10106 before the script under test runs at all.
+    env = {**os.environ, "PYTHONPATH": str(ROOT / "src")}
+    result = subprocess.run(
+        [sys.executable, str(script), channel, version],
+        cwd=tmp_path,
+        capture_output=True,
+        env=env,
+        **UTF8_TEXT,
+    )
+    notes = tmp_path / "release-notes.md"
+    return result, notes.read_text(encoding="utf-8") if notes.exists() else None
+
+
+SECTION = """# Changelog
+
+## [9.9.9] — 2026-01-01
+
+An opening paragraph that the CHANGELOG wraps at a narrow column so it
+reads well in a rendered file, spanning three source lines in total
+before the blank line that ends it.
+
+### A feature heading
+
+- **Something shipped** — a bullet whose prose also wraps across more
+  than one source line, the way every entry in this file does.
+- **Another one** — short.
+
+### Contributors
+
+@alice @bob
+@carol
+
+## [9.9.8] — 2025-12-01
+
+Older section that must not leak into the notes.
+"""
+
+
+def test_contributors_subsection_is_dropped_from_the_release_body(tmp_path: Path) -> None:
+    """The CHANGELOG must keep its list; the release body must not carry it.
+
+    AGENTS.md requires the section to end with `### Contributors` because that
+    copy ships inside the wheel and feeds the dashboard's Releases page, where no
+    native block exists. The release page renders its own from the tag range, so
+    the body carrying ours puts two lists next to each other.
+    """
+    result, notes = _run_step(tmp_path, SECTION)
+    assert result.returncode == 0, result.stderr
+    assert notes is not None
+    assert "### Contributors" not in notes
+    assert "@alice" not in notes and "@carol" not in notes
+    # The rest of the section survives.
+    assert "### A feature heading" in notes
+    assert "Something shipped" in notes
+    # And a neighbouring release never leaks in.
+    assert "9.9.8" not in notes and "must not leak" not in notes
+
+
+def test_paragraphs_and_bullets_are_joined_onto_one_line(tmp_path: Path) -> None:
+    """A hard-wrapped body renders as a narrow column with an empty gutter.
+
+    GitHub renders issue/PR/release bodies with GFM line breaks ON, so each
+    source newline inside a paragraph becomes a <br>. Joining them lets the
+    browser reflow to the container instead.
+    """
+    result, notes = _run_step(tmp_path, SECTION)
+    assert result.returncode == 0, result.stderr
+    assert notes is not None
+
+    lines = notes.split("\n")
+    opening = next(line for line in lines if line.startswith("An opening paragraph"))
+    assert "spanning three source lines" in opening, "paragraph was not joined"
+    assert opening.endswith("that ends it."), opening
+
+    bullet = next(line for line in lines if line.startswith("- **Something shipped**"))
+    assert "the way every entry in this file does." in bullet, "bullet was not joined"
+
+    # Structure survives: headings stay on their own lines, bullets stay bullets.
+    assert "### A feature heading" in lines
+    assert sum(1 for line in lines if line.startswith("- **")) == 2
+
+
+def test_code_fences_keep_their_own_line_breaks(tmp_path: Path) -> None:
+    """Joining must never reflow a fenced block -- that would corrupt commands."""
+    changelog = textwrap.dedent("""\
+        # Changelog
+
+        ## [9.9.9] — 2026-01-01
+
+        Intro prose that wraps
+        across two lines.
+
+        ```bash
+        first --command
+        second --command
+        ```
+
+        Trailing prose that also
+        wraps.
+        """)
+    result, notes = _run_step(tmp_path, changelog)
+    assert result.returncode == 0, result.stderr
+    assert notes is not None
+    assert "first --command\nsecond --command" in notes, "fence contents were joined"
+    assert "Intro prose that wraps across two lines." in notes
+
+
+def test_a_prerelease_gets_an_empty_body_not_a_changelog_section(tmp_path: Path) -> None:
+    """Insider/nightly have no shipped section; body_path must still be a file."""
+    result, notes = _run_step(tmp_path, SECTION, channel="insider")
+    assert result.returncode == 0, result.stderr
+    assert notes == ""
+
+
+def test_a_missing_section_fails_closed(tmp_path: Path) -> None:
+    """The stable gate should have caught it; this refuses rather than shipping empty."""
+    result, _ = _run_step(tmp_path, SECTION, version="7.7.7")
+    assert result.returncode != 0
+    assert "has no '## [7.7.7]' section" in result.stderr + result.stdout
+
+
+@pytest.mark.parametrize("field", ["body_path", "generate_release_notes"])
+def test_the_release_step_still_combines_both_inputs(field: str) -> None:
+    """If either input goes away the transforms above stop being load-bearing.
+
+    Pinned so a future change that drops `generate_release_notes` (and with it the
+    native New Contributors block) or stops passing a body is a deliberate edit
+    here, not a silent one.
+    """
+    workflow = yaml.safe_load(RELEASE.read_text(encoding="utf-8"))
+    step = next(
+        s
+        for s in workflow["jobs"]["github-release"]["steps"]
+        if "action-gh-release" in str(s.get("uses", ""))
+    )
+    assert field in step["with"]

--- a/test/test_release_promotion_contract.py
+++ b/test/test_release_promotion_contract.py
@@ -193,6 +193,105 @@ def test_every_stable_lane_consumes_the_verified_handoff() -> None:
     assert mac_inputs["promote"] == PROMOTE_EXPRESSION
 
 
+def _assemble_run() -> str:
+    """The assembly step's shell, quote-normalized so a match ignores quoting."""
+    run = _step(
+        RELEASE, "github-release", "Assemble release assets (require gated macOS artifacts)"
+    )["run"]
+    return run.replace("'", '"')
+
+
+def test_release_page_offers_every_platform_that_publishes() -> None:
+    """The asset allowlist must cover every platform with a publish lane.
+
+    ``Assemble release assets`` collects by extension, so a platform whose
+    extension is missing is simply absent from the release page -- no job fails,
+    nothing goes red. The Windows installer was missing from v0.2.0 through
+    v0.5.0: each of those releases published one to the CDN and the update feed
+    while the GitHub Release page offered none.
+
+    Derived from the publish lanes rather than restating the list, so adding a
+    lane for a new package format fails here until the release page collects it
+    too.
+    """
+    jobs = _workflow(RELEASE)["jobs"]
+    assemble = _assemble_run()
+
+    #: The extension each publish lane's format lands on. macOS is deliberately
+    #: absent: its assets come only from the gated notarized handoff, never from
+    #: a glob, which is what the sibling test pins.
+    lane_extension = {
+        "publish-cli": (".whl", ".tar.gz"),
+        "publish-linux-appimage-x64": (".AppImage",),
+        "publish-linux-appimage-arm64": (".AppImage",),
+        "publish-linux-deb-x64": (".deb",),
+        "publish-linux-deb-arm64": (".deb",),
+        "publish-linux-rpm-x64": (".rpm",),
+        "publish-linux-rpm-arm64": (".rpm",),
+        "publish-windows-x64": (".exe",),
+    }
+    for lane, extensions in lane_extension.items():
+        assert lane in jobs, f"{lane} is gone; update this mapping deliberately"
+        for extension in extensions:
+            assert f'-name "*{extension}"' in assemble, (
+                f"{lane} publishes {extension} but the release page does not collect it"
+            )
+
+    # Sidecars and feed pointers are NOT downloadable assets. The blockmap is a
+    # differential-update input and latest*.yml are channel pointers published
+    # by their own lanes.
+    assert '-name "*.exe.blockmap"' not in assemble
+    assert '-name "latest' not in assemble
+
+
+def test_the_windows_installer_is_chosen_per_mode_not_by_extension() -> None:
+    """A promotion run holds two installers, and only one of them is promotable.
+
+    ``build-windows`` carries no ``if:``, so a promotion run rebuilds the
+    installer even though nothing consumes it -- while the promoted candidate's
+    own bytes sit in the gated bundle under ``KiroCrew-Setup.exe``.
+    electron-builder's default name embeds the version, so the two names differ
+    and a bare ``-name "*.exe"`` in the collection glob attaches BOTH: a stable
+    page would then offer a never-soaked rebuild beside the promoted installer,
+    the rebuild looking the more official of the two for carrying the version.
+
+    So the extension glob must NOT cover ``.exe``, and the selection must branch
+    on ``promote_mode`` -- the same discriminator every other lane here reads.
+    """
+    assemble = _assemble_run()
+    glob_line = next(line for line in assemble.split("\n") if line.startswith("find artifacts"))
+    assert '-name "*.exe"' not in glob_line, "an .exe glob cannot tell a rebuild from a promotion"
+
+    step = _step(
+        RELEASE, "github-release", "Assemble release assets (require gated macOS artifacts)"
+    )
+    assert step["env"]["PROMOTE_MODE"] == "${{ needs.version.outputs.promote_mode }}"
+    assert '[ "${PROMOTE_MODE:-}" = "true" ]' in assemble
+    # Promotion republishes the bundle's byte-identical installer...
+    assert '"${NOTARIZED_DIR}/KiroCrew-Setup.exe"' in assemble
+    # ...and a rebuild takes the producing artifact, refusing to guess between two.
+    assert '-path "*build-windows-x64*" -name "*.exe"' in assemble
+    assert "expected at most one Windows installer" in assemble
+
+
+def test_the_release_page_waits_for_windows_without_depending_on_it() -> None:
+    """The wait edge closes the race; the missing `if:` clause keeps it optional.
+
+    ``download-artifact`` collects whatever exists when it runs, so without
+    ``build-windows`` in ``needs`` a Windows build still queued on a slow runner
+    is simply omitted from the page -- the same silent omission the Windows asset
+    exists to end. Requiring its RESULT would be the opposite error: a Windows
+    failure would take the whole release page down, when soft_fail, the optional
+    bundle role and the probe-and-skip publish lane all exist to stop exactly
+    that.
+    """
+    job = _workflow(RELEASE)["jobs"]["github-release"]
+    assert "build-windows" in job["needs"]
+    assert "needs.build-windows" not in job["if"]
+    # Only always() lets the job run at all once a dependency may be skipped.
+    assert "always()" in job["if"]
+
+
 def test_github_release_selects_explicit_versioned_macos_handoff() -> None:
     verify = _step(RELEASE, "github-release", "Verify promoted release bytes")["run"]
     assert f'--bundle-dir "artifacts/{PROMOTION_ARTIFACT}"' in verify


### PR DESCRIPTION
## Problem / Motivation

`github-release` assembles its assets with an extension **allowlist**, and `*.exe` was never in it:

```
find artifacts -type f \( -name "*.whl" -o -name "*.tar.gz" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \)
```

So every stable release from v0.2.0 through v0.5.0 published a Windows installer to the CDN and advertised it in `latest.yml`, while the GitHub Release page offered none:

| tag | Windows assets on the release page | total assets |
|---|---|---|
| v0.2.0 | **0** | 5 |
| v0.3.0 | **0** | 6 |
| v0.4.0 | **0** | 10 |
| v0.4.1 | **0** | 10 |
| v0.5.0 | **0** | 10 |

Nothing ever failed, because an allowlist omission is silent by construction — the `find` just matches nothing. The installer itself is fine (`desktop/stable/latest/KiroCrew-Setup.exe` is 200, 252 MB, and `latest.yml` carries its URL + sha512 + size), so auto-update and the README download links work; what is missing is only the "download it from the release page" path.

Found while verifying the v0.5.0 release, which was the first one whose wheel and feeds were finally clean — leaving this as the last labelling gap.

## What changed

- **The installer is now collected — from ONE named producer, not by extension.** The extension glob is only sound for a format with a single producer in the run, and Windows has two (see below). No new failure mode: `build-windows` is `soft_fail: true`, so a failed Windows build means no installer and a `::notice::`, exactly as absent-by-omission behaved before.
- **The list is now pinned**, so the next platform cannot be forgotten the same way. The new test derives what the page must collect **from the publish lanes that run**, rather than restating the list — adding a lane for a new package format fails here until the release page collects it too.
- Sidecars stay excluded, and are now asserted as excluded: `*.exe.blockmap` is a differential-update input the feed consumes, and `latest*.yml` are channel pointers published by their own lanes.

### Why the installer is not collected by extension

Collecting `*.exe` with the same recursive glob as the Linux formats is only sound while a release run holds one installer. A **promotion** run holds two:

| Source | Filename | Should it ship? |
|---|---|---|
| `KiroCrew-notarized-stable-<v>/` (the gated promotion bundle) | `KiroCrew-Setup.exe` | yes — the bytes insiders soaked |
| `build-windows-x64/` (a fresh build; `build-windows` carries no `if:`) | `KiroCrew Setup <v>.exe` | **no** — never soaked, never promoted |

electron-builder's default NSIS name embeds the version, so the two names differ and a glob attaches **both** — the rebuild looking the more official of the pair for carrying the version number, on a stable page whose whole point is byte identity with the validated candidate. macOS already avoids this by taking only the exact gated artifact; Windows now does the same:

- **promoting** → the bundle's `KiroCrew-Setup.exe`
- **otherwise** → the one `.exe` under `build-windows-x64`; two is an error, never a coin flip (mirroring `record-promotion`'s `at_most_one`)
- either way, renamed to `KiroCrew-<version>-Setup-x64.exe`, matching the macOS assets and making the runbook's "no RC-stamped asset" grep meaningful

A glob would also have **raced the build it collects from**: `download-artifact` takes whatever exists when it runs, and nothing made `github-release` wait for `build-windows`. A Windows build still queued on a slow runner would be omitted from the page with nothing going red — the same silent omission this asset exists to end. So `build-windows` is now a **wait edge** in `needs`, and deliberately **not** in the job's `if:`: requiring its result would let a Windows problem withhold the macOS, Linux and CLI assets, which `soft_fail`, the optional bundle role and the probe-and-skip publish lane all exist to prevent. A missing installer is a `::notice::`.

## Runbook: the post-release label checks

Every stable release so far shipped **correct bytes with a wrong label**, each time one layer further out than the last:

| Release | Bytes | Wrong anyway |
|---|---|---|
| v0.3.0 | correct | fed the RC's own `0.3.0-insider.13` stamp, so stable clients read as insider |
| v0.4.0 | correct | source files re-stamped bare, but the shipped wheel was still `0.4.0rc14` |
| v0.5.0 | correct | wheel and feeds finally bare — no Windows asset on the release page |

That class is invisible to the pipeline: no lane fails, because the release did happen — it just advertises the wrong thing. So the new `### After a stable release` section gives it three explicit checks:

1. **Every feed advertises the bare version** (all five must agree — a suffix here is what makes a stable install describe itself as a prerelease).
2. **The wheel's EMBEDDED metadata version**, not just its filename — this is what `pip show` and `kirocrew --version` print, and the one surface a byte-reuse promotion can never fix. A clean filename around RC-stamped metadata is exactly the v0.4.0 shape.
3. **Release-page platform coverage**, plus an explicit grep for any RC-stamped asset.

It also states why this is worth doing while the run is fresh: a discrepancy is not recoverable in place, since published keys are immutable and the feed already advertises the wrong label — the remedy is the next version forward.

## Verification

- **All three runbook commands were run as written against the live v0.5.0 release**, not just eyeballed: five feeds all report `0.5.0`, the wheel downloads and its sha256 matches the feed digest with `METADATA Version: 0.5.0`, and the asset list shows no RC-stamped name.
- **The assembly step is EXECUTED, not restated.** `test_release_macos_fail_closed.py` already runs its real shell under bash; the Windows cases join it there — a promotion run with both installers present publishes only the promoted one, a rebuild run takes the producing artifact and normalizes its name, two candidate installers fail rather than pick, and an absent installer is a notice with the other platforms still assembled.
- **122 passed** across every release / publish / workflow-contract test (`test_release_promotion_contract.py`, `test_release_macos_fail_closed.py`, `test_release_notes_body.py`, `test_stable_release_gate.py`, `test_workflow_permissions.py`, `test_github_workflow_security.py`, `test_workflow_secret_and_cache_scope.py`, `test_workflow_cache_setup_uniqueness.py`, `test_release_promotion.py`).
- `docs-lint.sh` clean over 261 markdown files; `check_black_formatting.py`, `check_subprocess_encoding.py`, `check_brand_name.py`, `check_harness_parity.py`, `check_changelog_history.py`, `flake8 src/kiro_crew test` and `mypy --platform linux src/kiro_crew` all clean.
- Mutation-verified: putting `-o -name "*.exe"` back in the glob turns the promotion test **and** the wiring test red; dropping `build-windows` from `needs` turns the wait-edge test red; collecting the `*.exe.blockmap` sidecar turns the allowlist test red. All restore green when reverted.

## Note on scope

This lands on `main`, so `release/0.6.0` inherits it at cut time. It does not retroactively fix the v0.5.0 release page — published assets are immutable and the installer is already reachable through the CDN and the feed. If a `0.5.1` hot patch is cut, this wants backporting to `release/0.5.0` first so that release page carries the installer.


---

## Second commit: the release body's own three defects

Reported while reviewing the v0.5.0 release page: "big blank area" and "too much Before you upgrade". Diagnosing it found the release body is **assembled, not written** — which is why the runbook's existing rule ("do not hand-write a contributors list in the body") never prevented anything:

```yaml
body_path: release-notes.md      # the extracted CHANGELOG section
generate_release_notes: true     # GitHub's commit list
```

`softprops/action-gh-release` **pre-pends** the body to the generated notes rather than replacing them, so the published body is always `our section + whatever GitHub generates`. Nobody has to write a mistake for one to appear. Three did, on v0.3.0 and again on v0.5.0:

| Defect | Scale on v0.5.0 | Cause |
|---|---|---|
| Duplicate contributor list | 50 handles above GitHub's own block | the CHANGELOG section is *required* to carry `### Contributors`, and it is copied in verbatim |
| Hard-wrapped paragraphs | every line ~76 cols, wide empty gutter | GitHub renders release bodies with **GFM line breaks ON**, so each source newline becomes a real `<br>` |
| Generated commit list | **746 lines / 922 commits**, 65% of the body | `generate_release_notes: true` |

The third one also pushed the body to **125,219 characters**, past GitHub's 125,000 ceiling, so it published **truncated mid-word** (`* fix(skil`).

### What this commit changes

Two transforms on the extracted section, because it is authored for a rendered *file* while the release body is a comment field:

- **`### Contributors` is dropped.** `AGENTS.md` requires the CHANGELOG to carry it — that copy ships inside the wheel and feeds the dashboard's Releases page, where no native block exists. This does not relax that requirement; it stops the *body* carrying a second copy.
- **Paragraphs and list items are joined onto one line**, letting the browser reflow. Headings, list nesting, tables and **code fences** are untouched — reflowing a fence would corrupt the commands inside it, so that case has its own test.

**The commit list is deliberately not changed.** Dropping `generate_release_notes` would also drop the native "New Contributors" block it exists for, so the runbook documents trimming the body instead of trading one regression for another.

### Runbook

New section **"What the release body must not contain"**, stating all three rules *with their mechanism* — a rule that says "don't hand-write X" is useless when X arrives automatically. It also records that trimming a published body is safe and normal: release notes are prose on the GitHub page, editable independently of the tag, the CHANGELOG and the published bytes, touching no immutable CDN key. The promote step's existing contributor sentence is corrected to point here.

### Verification

- The new tests run **the step's own embedded script**, extracted from the workflow, against a synthetic changelog — not a restatement of what it should do. They also pin that **both** action inputs are still combined, so removing either becomes a deliberate edit.
- Run against the **real 0.5.0 section**: 153 lines out, `### Contributors` absent, all 16 feature headings intact, longest line 675 chars (was max 108 hard-wrapped).
- **Mutation-verified**: skipping the Contributors drop, and skipping the unwrap, each turn a test red; both restore green.
- **273 passed** across every release/publish/changelog contract test. flake8, black and isort clean on the new file with the CI pins; `check_black_formatting.py` and `docs-lint.sh` both pass.
- **The child now inherits the environment**, with only `PYTHONPATH` overridden. Handing it a from-scratch dict dropped `SystemRoot` on Windows, Winsock cannot initialize without it, and the child died in `import asyncio` with `WinError 10106` before reaching the script under test — four tests red on the Windows shard only. Its output decoding is pinned to UTF-8 (`UTF8_TEXT`) at the same time, since text mode with no `encoding=` reads the Windows ANSI code page.

### Already applied to the live page

The v0.5.0 release body was rewritten by hand with the same shape (369 → 151 lines, 125,219 → 20,381 chars, `Before you upgrade` 12 → 5 items keeping only what changes something a user already configured). Assets, tag and prerelease flag untouched — verified 10/10 assets still attached.

---

## Pattern harvest

Rule candidate: agents-md
Pattern: a release asset collected by a wildcard glob when more than one job in the run can produce that extension

Three defects in this PR's own subject area share one shape: `find artifacts -name "*.<ext>"` is an *inference* about which job produced a file, and it silently answers wrongly the moment two jobs can. It omits (the extension is not listed), it duplicates (two producers, two names), and it races (the producer has not finished). macOS was already hardened against exactly this — "the sole input is the gated artifact, by exact name" — and Windows re-learned it from scratch. The generalizable rule is: **a published asset names its producing artifact; only a format with exactly one producer may be collected by extension.** The corollary is a wiring rule: **a job that consumes another job's artifact must `needs` it**, since `download-artifact` without a wait edge is a race whose failure mode is a missing file rather than an error.

Also worth carrying: a soft-fail producer must be soft on the *consumer* side too. Adding `build-windows` to `needs` without keeping it out of the `if:` would have converted a deliberately-optional platform into a hard dependency of the whole release page.

Not a semgrep rule — it is a per-workflow judgement about the artifact graph, not a syntactic pattern.
