### PR TITLE
fix: answer committed slot switch with warning when teardown raises (#8598)

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3110,6 +3110,84 @@ async def _reset_slot_session(
     return reloaded
 
 
+# Advisory response field for a committed switch whose old-session teardown
+# raised. One literal shared by every switch handler (agent, reasoning effort,
+# model, workspace) so a frontend that ever starts reading it never has to
+# match per-handler spellings.
+_TEARDOWN_INCOMPLETE_WARNING = "old session teardown incomplete"
+
+
+async def _reset_slot_session_or_warn(
+    state: DashboardState,
+    slot: _ChatSlot,
+    session_key: str,
+    *,
+    switch_kind: str,
+) -> bool | None:
+    """:func:`_reset_slot_session` for the commit-before-reset switch handlers.
+
+    Returns the reset verdict, or ``None`` when the teardown RAISED after the
+    session pop. The model and workspace handlers commit the new setting
+    BEFORE this await, and ``SessionManager.reset`` pops the session before
+    its shutdown can fail, so a post-pop raise is a success with a degraded
+    teardown — the committed value is what every replacement session runs.
+    That premise is VERIFIED, not assumed: a raise with the SAME provider
+    instance still registered (a pre-pop failure, e.g. in the pending-wait
+    unblock) is re-raised, because the old session then survives on the old
+    value and a 200 would be a false success. Identity, not presence: a
+    successor session registered by a concurrent send after the pop must not
+    be misclassified as the unpopped old one. Propagating a post-pop raise
+    instead would answer 500 without ever reaching
+    ``state.push_slots_update()``, leaving every
+    connected client rendering the OLD value over a switch that actually
+    happened (the acting tab's ``performSlotSwitch`` also keeps its old store
+    value on a non-2xx). ``None`` tells the caller to record the degraded
+    teardown and FALL THROUGH — its rebind guard (``effective_session_key``)
+    must still run, so a slot rebound during the raising await keeps answering
+    rollback + 409 — and then answer 200 with
+    :data:`_TEARDOWN_INCOMPLETE_WARNING` after the usual slots push. This is
+    the agent and reasoning-effort handlers' precedent, shared here so the
+    model and workspace handlers' four call sites (first attempt +
+    idle-decline retry each) do not repeat the try block. Only the raise path
+    is new: a normal ``bool`` verdict passes through untouched, so the decline
+    (``False``) ladders keep their semantics.
+
+    ``skip_if_busy`` is fixed at True because every caller is a switch handler
+    whose destructive fallback must decline atomically against a slipped-in
+    turn (their shared invariant); a caller that wants propagation keeps using
+    :func:`_reset_slot_session` directly.
+    """
+    # Captured BEFORE the await: the post-raise probe must compare INSTANCE
+    # IDENTITY, not mere presence. A concurrent send can register a SUCCESSOR
+    # session for the same key after the pop and before the old session's
+    # shutdown raises — a bare "is a provider registered?" probe would
+    # misclassify that successor as the unpopped old session and answer 500
+    # for a committed switch (GPT review finding on 295817e70). The successor
+    # cold-started from the slot's CURRENT (committed) bindings, so the
+    # committed-success answer is truthful for it.
+    prior_provider = state.sessions.get_provider(session_key)
+    try:
+        return await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+    except Exception:
+        if (
+            prior_provider is not None
+            and state.sessions.get_provider(session_key) is prior_provider
+        ):
+            # The SAME instance is still registered: the raise came BEFORE the
+            # session pop (e.g. the pending-wait unblock that
+            # _reset_slot_session runs first), so the old session is still
+            # alive on the old value and a 200 here would be exactly the false
+            # success the switch handlers' decline ladders treat as worse than
+            # any retryable error. Propagate — a pre-pop failure keeps the
+            # pre-#8598 semantics (Opus review finding: the committed-switch
+            # answer is only truthful once the pop has happened).
+            raise
+        logger.exception(
+            "Slot %s %s switch: old session teardown incomplete", slot.key, switch_kind
+        )
+        return None
+
+
 def _resolve_stop_event(slot: _ChatSlot, outcome: str) -> None:
     """Update the in-flight stop_event message in place with final state."""
     stop_id = slot._stop_event_id
@@ -5496,7 +5574,7 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     if teardown_incomplete:
         # Advisory only — the switch itself succeeded and the response
         # carries the committed state the acting tab writes optimistically.
-        resp_body["warning"] = "old session teardown incomplete"
+        resp_body["warning"] = _TEARDOWN_INCOMPLETE_WARNING
     return web.json_response(resp_body)
 
 
@@ -5864,6 +5942,10 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
                 return str(raw or "").strip() == wire
             return False
 
+        # Set on the reset path when the old session's teardown RAISED after
+        # the pop: the switch is committed, the response carries an advisory
+        # warning (agent-handler precedent via _reset_slot_session_or_warn).
+        teardown_incomplete = False
         try:
             went_live = await _try_live_model_switch(name, slot, provider, model_name)
         except AcpModelUnavailable as exc:
@@ -5950,8 +6032,21 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
             # authoritative-backstop split api_chat_slot_reload documents), so
             # a turn that slipped into the window is declined here instead of
             # torn down mid-stream.
-            reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
-            if not reset_ok:
+            reset_ok = await _reset_slot_session_or_warn(
+                state, slot, session_key, switch_kind="model"
+            )
+            if reset_ok is None:
+                # Teardown raised after the session pop: the switch is
+                # COMMITTED (see _reset_slot_session_or_warn), so the answer
+                # is the committed state with an advisory warning — never a
+                # 500 that strands clients on the old value. Deliberately no
+                # _rollback_pick(): rollback is only for the decline/409
+                # paths, where nothing was torn down. NOT an early return:
+                # the rebind guard below must still run (GPT review finding),
+                # so a slot rebound during the raising await answers the same
+                # rollback + 409 as any other rebind.
+                teardown_incomplete = True
+            elif not reset_ok:
                 # Disambiguate the decline FAIL-CLOSED — with one truth-based
                 # exception checked first. Provider identity or registration
                 # time cannot prove which model a live session runs: dispatch
@@ -5994,10 +6089,15 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
                     # (api_chat_slot_reload's template for this exact race); a
                     # second decline means another turn is genuinely racing,
                     # which is the turn-in-flight case again.
-                    reset_ok = await _reset_slot_session(
-                        state, slot, session_key, skip_if_busy=True
+                    reset_ok = await _reset_slot_session_or_warn(
+                        state, slot, session_key, switch_kind="model"
                     )
-                    if not reset_ok:
+                    if reset_ok is None:
+                        # Retry teardown raised: same committed-switch answer
+                        # as the first attempt, and same fall-through to the
+                        # rebind guard below.
+                        teardown_incomplete = True
+                    elif not reset_ok:
                         _rollback_pick()
                         return web.json_response(
                             {"error": "a turn is in flight", "code": "turn_in_flight"},
@@ -6024,7 +6124,12 @@ async def api_chat_slot_model(request: web.Request) -> web.Response:
                 )
             _broadcast_context_reset(state, slot.key, None)
     state.push_slots_update()
-    return web.json_response({"ok": True, "model": model_name})
+    model_resp: dict = {"ok": True, "model": model_name}
+    if teardown_incomplete:
+        # Advisory only — the switch itself succeeded and the response
+        # carries the committed state (agent-handler precedent).
+        model_resp["warning"] = _TEARDOWN_INCOMPLETE_WARNING
+    return web.json_response(model_resp)
 
 
 # Per-slot transaction locks for the autocompact endpoint. The write span
@@ -6599,7 +6704,7 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
                     {
                         "ok": True,
                         "reasoning_effort": effort,
-                        "warning": "old session teardown incomplete",
+                        "warning": _TEARDOWN_INCOMPLETE_WARNING,
                     }
                 )
         # Live-update and deferral paths commit here (the reset path already
@@ -6772,8 +6877,25 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
         # atomically with the session pop (the authoritative backstop
         # api_chat_slot_reload documents), so the slipped-in turn is declined
         # here instead of torn down mid-stream.
-        reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
-        if not reset_ok:
+        # Set when the old session's teardown RAISED after the pop: the
+        # switch is committed, the response carries an advisory warning
+        # (agent-handler precedent via _reset_slot_session_or_warn).
+        teardown_incomplete = False
+        reset_ok = await _reset_slot_session_or_warn(
+            state, slot, session_key, switch_kind="workspace"
+        )
+        if reset_ok is None:
+            # Teardown raised after the session pop: the switch is COMMITTED
+            # (see _reset_slot_session_or_warn), so the answer is the
+            # committed state with an advisory warning — never a 500 that
+            # strands clients on the old bindings. Deliberately no rollback
+            # of slot.workspace/slot.project: rollback is only for the
+            # decline/409 paths, where nothing was torn down. NOT an early
+            # return: the rebind guard below must still run (GPT review
+            # finding), so a slot rebound during the raising await answers
+            # the same rollback + 409 as any other rebind.
+            teardown_incomplete = True
+        elif not reset_ok:
             # Disambiguate FAIL-CLOSED, same as the model handler: dispatch
             # captures the slot bindings at its call site but registers the
             # session only after a multi-second provider.start(), so no
@@ -6812,8 +6934,15 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
                 # session is always safe, so retry once
                 # (api_chat_slot_reload's template); a second decline means
                 # another turn is genuinely racing.
-                reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
-                if not reset_ok:
+                reset_ok = await _reset_slot_session_or_warn(
+                    state, slot, session_key, switch_kind="workspace"
+                )
+                if reset_ok is None:
+                    # Retry teardown raised: same committed-switch answer as
+                    # the first attempt, and same fall-through to the rebind
+                    # guard below.
+                    teardown_incomplete = True
+                elif not reset_ok:
                     slot.workspace = prior_workspace
                     slot.project = prior_project
                     return web.json_response(
@@ -6834,7 +6963,12 @@ async def api_chat_slot_workspace(request: web.Request) -> web.Response:
                 status=409,
             )
     state.push_slots_update()
-    return web.json_response({"ok": True, "workspace": ws_name})
+    ws_resp: dict = {"ok": True, "workspace": ws_name}
+    if teardown_incomplete:
+        # Advisory only — the switch itself succeeded and the response
+        # carries the committed state (agent-handler precedent).
+        ws_resp["warning"] = _TEARDOWN_INCOMPLETE_WARNING
+    return web.json_response(ws_resp)
 
 
 async def api_chat_slot_project(request: web.Request) -> web.Response:

--- a/test/test_chat_slot_switch_atomicity.py
+++ b/test/test_chat_slot_switch_atomicity.py
@@ -330,10 +330,11 @@ class TestSlotModelSwitchAtomicity:
         state = _mock_state(slot)
         newborn = MagicMock(spec=LLMProvider)
         newborn.has_active_turn.return_value = True
-        # Pre-check and the last-instant pre-reset re-check see no provider;
-        # the post-decline re-read sees the session a slipped-in send
-        # registered after the commit.
-        state.sessions.get_provider = MagicMock(side_effect=[None, None, newborn])
+        # Pre-check, the last-instant pre-reset re-check, and the reset
+        # helper's pre-await identity snapshot all see no provider; the
+        # post-decline re-read sees the session a slipped-in send registered
+        # after the commit.
+        state.sessions.get_provider = MagicMock(side_effect=[None, None, None, newborn])
         state.sessions.reset = AsyncMock(return_value=False)
         async with TestClient(TestServer(_make_app(state))) as client:
             resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
@@ -394,6 +395,143 @@ class TestSlotModelSwitchAtomicity:
             assert resp.status == 200
             assert slot.model == _MODEL_B
             state.sessions.reset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_raise_answers_200_with_warning_and_pushes(self):
+        # A teardown that RAISES (#8598): SessionManager.reset pops the
+        # session before its shutdown can fail, so the switch is COMMITTED
+        # regardless — the handler must answer 200 with the committed model
+        # plus an advisory warning and still push the slots update. The old
+        # unwrapped await propagated a 500 that never reached
+        # push_slots_update, stranding every connected client on the OLD
+        # value while the slot already carried the new one.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("shutdown boom"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["model"] == _MODEL_B
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.model == _MODEL_B
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_retry_raise_answers_200_with_warning_and_pushes(self):
+        # The idle-decline RETRY can raise too (#8598): first reset declined
+        # (idle live session), the retry's teardown throws. Same
+        # committed-switch answer as the first attempt — 200 + warning +
+        # slots push, no rollback to the old model.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        stale = MagicMock(spec=LLMProvider)
+        stale.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=stale)
+        calls = {"n": 0}
+
+        async def _decline_then_pop_and_raise(*_a, **_k):
+            if calls["n"] == 0:
+                calls["n"] += 1
+                return False
+            # The retry pops the session BEFORE its shutdown raises, so the
+            # helper's post-pop probe sees no registered provider.
+            state.sessions.get_provider = MagicMock(return_value=None)
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_decline_then_pop_and_raise)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["model"] == _MODEL_B
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.model == _MODEL_B
+            assert state.sessions.reset.await_count == 2
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_raise_before_pop_propagates(self):
+        # A raise with the session STILL REGISTERED came before the pop: the
+        # old session survives on the old model, so a 200 would be the false
+        # success the decline ladders treat as worse than any retryable
+        # error. The helper re-raises (pre-#8598 semantics) instead of
+        # answering a committed-switch success it cannot vouch for.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot)
+        alive = MagicMock(spec=LLMProvider)
+        alive.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=alive)
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("pre-pop boom"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            assert resp.status == 500
+            state.push_slots_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reset_raise_with_successor_session_still_succeeds(self):
+        # A concurrent send can register a SUCCESSOR session for the same key
+        # after the pop and before the old session's shutdown raises (server
+        # GPT lane finding on 295817e70): the probe compares instance
+        # IDENTITY, so a different registered provider is NOT the unpopped
+        # old session — the switch is committed, the successor cold-started
+        # from the committed bindings, and the answer is 200 + warning.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        old = MagicMock(spec=LLMProvider)
+        old.has_active_turn.return_value = False
+        state = _mock_state(slot, provider=old)
+
+        async def _pop_register_successor_and_raise(*_a, **_k):
+            successor = MagicMock(spec=LLMProvider)
+            successor.has_active_turn.return_value = False
+            state.sessions.get_provider = MagicMock(return_value=successor)
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_pop_register_successor_and_raise)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["model"] == _MODEL_B
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.model == _MODEL_B
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_raising_reset_rolls_back_to_409(self):
+        # The teardown-raise path must NOT bypass the rebind guard (GPT
+        # review finding on the #8598 fix): a slot rebound while the raising
+        # reset awaited answers the same rollback + 409 as any other rebind —
+        # never a 200 that advertises the committed model over a newly bound
+        # session that never saw the switch.
+        slot = _ChatSlot("test")
+        slot.model = _MODEL_A
+        state = _mock_state(slot, provider=None)
+
+        async def _rebind_and_raise(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_rebind_and_raise)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/model", json={"model": _MODEL_B})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.model == _MODEL_A
 
     @pytest.mark.asyncio
     async def test_attached_subagents_refuse_the_reset_and_roll_back(self):
@@ -742,6 +880,90 @@ class TestSlotWorkspaceSwitchAtomicity:
             resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
             assert resp.status == 200
             assert seen_during_reset == [("new-ws", "/workspace/new-ws")]
+
+    @pytest.mark.asyncio
+    async def test_reset_raise_answers_200_with_warning_and_pushes(self):
+        # A teardown that RAISES (#8598): the workspace/project pair is
+        # committed before the reset and SessionManager.reset pops the
+        # session before its shutdown can fail, so the handler must answer
+        # 200 with the committed workspace plus an advisory warning and still
+        # push the slots update — never a 500 that strands clients on the old
+        # bindings.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("shutdown boom"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["workspace"] == "new-ws"
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_retry_raise_answers_200_with_warning_and_pushes(self):
+        # The idle-decline RETRY can raise too (#8598): first reset declined
+        # (idle live session), the retry's teardown throws. Same
+        # committed-switch answer — 200 + warning + slots push, no rollback
+        # to the old bindings.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        idle = MagicMock(spec=LLMProvider)
+        idle.has_active_turn.return_value = False
+        state = _mock_state(slot, provider=idle)
+        calls = {"n": 0}
+
+        async def _decline_then_pop_and_raise(*_a, **_k):
+            if calls["n"] == 0:
+                calls["n"] += 1
+                return False
+            # The retry pops the session BEFORE its shutdown raises, so the
+            # helper's post-pop probe sees no registered provider.
+            state.sessions.get_provider = MagicMock(return_value=None)
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_decline_then_pop_and_raise)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["workspace"] == "new-ws"
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.workspace == "new-ws"
+            assert slot.project == "/workspace/new-ws"
+            assert state.sessions.reset.await_count == 2
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_raising_reset_rolls_back_to_409(self):
+        # The teardown-raise path must NOT bypass the rebind guard (GPT
+        # review finding on the #8598 fix): a slot rebound while the raising
+        # reset awaited answers the same rollback + 409 as any other rebind.
+        slot = _ChatSlot("test")
+        slot.workspace = "old-ws"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot, provider=None)
+
+        async def _rebind_and_raise(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_rebind_and_raise)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/workspace", json={"workspace": "new-ws"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert (slot.workspace, slot.project) == ("old-ws", "/workspace/old-ws")
 
 
 def _make_app_as(state: DashboardState, app_name: str) -> web.Application:


### PR DESCRIPTION
## Problem / Motivation

`api_chat_slot_model` and `api_chat_slot_workspace` commit the new setting to the slot BEFORE awaiting `_reset_slot_session(...)`, and each handler has two such awaits (first attempt + the idle-decline retry). None was wrapped in a try, so a teardown that raised (e.g. provider shutdown throwing after the session was already popped) propagated a 500 and never reached `state.push_slots_update()` — connected clients kept rendering the OLD value while the slot already carried the NEW one, until an unrelated slots push. Surfaced by the GPT review lane on #5697.

## Why it matters

Every open tab (including the acting one — `performSlotSwitch` keeps its old store value on a non-2xx) shows a model/workspace that is not what the slot will actually run, for a switch that in fact succeeded. The stale display persists until an unrelated slots push.

## What changed (motivation → approach → change)

`SessionManager.reset` pops the session before its shutdown can fail, so a post-pop raise means the switch is committed and only the teardown degraded — the in-tree `api_chat_slot_agent` / `api_chat_slot_reasoning_effort` handlers already answer that case with 200 + a warning. This PR extends the same precedent to the model and workspace handlers, without duplicating four try blocks:

- New shared helper `_reset_slot_session_or_warn`: wraps `_reset_slot_session(..., skip_if_busy=True)` and returns `None` when the teardown raised after the session pop. The four call sites (model first/retry, workspace first/retry) record `teardown_incomplete` and answer 200 with the committed value plus `"warning": "old session teardown incomplete"` after the usual slots push (same literal as the agent/effort precedent, now a shared constant `_TEARDOWN_INCOMPLETE_WARNING`). No rollback on the raise path; the `False`-verdict decline ladders are byte-identical.
- The raise path is a fall-through, not an early return: the existing `effective_session_key(slot) != session_key` rebind guard still runs (rollback + 409 on rebind), and the model handler's `_broadcast_context_reset` still fires.
- The post-pop premise is verified by INSTANCE IDENTITY, not assumed and not presence-probed: the helper captures the provider before the await; a raise with that same instance still registered is a pre-pop failure (old session alive on the old value — a 200 would be a false success) and re-raises, while a successor session registered by a concurrent send after the pop is a different instance and still gets the committed-success answer.

The bulk handler `api_chat_slots_model` already isolates per-slot reset exceptions and is untouched. No frontend change: the fix is that the response is a 2xx and the slots push happens.

## Tests

8 new tests in `test/test_chat_slot_switch_atomicity.py`:
- model + workspace: first-attempt teardown raise → 200 + warning, slot carries the NEW value, `push_slots_update` called exactly once
- model + workspace: idle-decline retry teardown raise → same committed-switch answer
- model + workspace: rebind during the raising reset → rollback + 409 `session_rebound` (the raise path must not bypass the rebind guard)
- model: raise with the SAME provider instance still registered (pre-pop) → propagates (500), no slots push, no false success
- model: raise with a SUCCESSOR instance registered (concurrent send won the race) → 200 + warning, not misclassified as pre-pop

Existing 409 decline tests are unchanged.

## Manual verification

N/A — unit coverage sufficient: the raise paths are exercised end-to-end through the aiohttp handlers with mocked session teardown, and the change is backend-only.

## Related Issues

Closes #8598

## Pattern harvest

Rule candidate: review-prompt
Pattern: handler commits state then awaits a teardown/reset without a try — the raise path skips the state broadcast (`push_slots_update`) and answers 5xx for a change that already happened; check EVERY await of the same reset (first attempt AND retry) and that the exception path still runs the post-await guards.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
