### PR TITLE
fix(agent): narrow the goal conductor's core grant to named verbs

### DIFF
--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -5327,6 +5327,64 @@ _MEMBER_DASHBOARD_GRANTS: tuple[str, ...] = _CONDUCTOR_DASHBOARD_GRANTS + (
 )
 
 
+#: The kirocrew-core verbs the goal conductor may call WITHOUT an approval
+#: prompt. Named one by one rather than as the whole ``@kirocrew-core`` server,
+#: which put 74 registered core tools behind a single auto-approve entry. The
+#: reason is the same one ``_CONDUCTOR_DASHBOARD_GRANTS`` states above and
+#: ``_PIPELINE_CONDUCTOR_CORE_GRANTS`` restates below: this agent ingests
+#: content it does not control (goal text, child-session transcripts, web
+#: reads) on nudge-driven cycles with nobody at the keyboard, and a
+#: server-wide grant let that content reach ``task_run``, ``workflow_run`` and
+#: the ``spawn_*`` family — starting persistent work or a fleet of subagents
+#: with no human in the loop.
+#:
+#: Dropping those three is not a new policy, it is the spec catching up with
+#: the prompt: ``_CONDUCTOR_SYSTEM_PROMPT`` already PROHIBITS them by name ("a
+#: work item never goes to ``spawn_run``, ``spawn_sub_agents``,
+#: ``workflow_run`` or ``task_run``"), so a grant that auto-approved them
+#: contradicted the charter it shipped with.
+#:
+#: DERIVED, not copied. The set is the union of the prompt's own "Your tools:"
+#: inventory and the ``goal-conductor`` skill's real call sites, filtered to
+#: the tools that actually register on ``kirocrew-core`` — the ``session_*``
+#: and ``chat_folder_*`` verbs the charter also names are
+#: ``@kirocrew-dashboard`` and are granted by the tuple above, while
+#: ``list_sessions`` is core (``mcp_tools/sessions.py``) despite sitting in the
+#: prompt's child-session paragraph. Deriving rather than reusing the sibling's
+#: thirteen is load-bearing: ``select_crew`` is absent from that tuple and is
+#: step 1 of this conductor's documented dispatch procedure
+#: (``goal-conductor/SKILL.md``), so copying would have broken dispatch on the
+#: first cycle while looking like a correct patch.
+#:
+#: ``select_crew`` earns its place under the invariant already stated for the
+#: dashboard tuple — a granted verb may CREATE or READ, never MUTATE something
+#: that already exists and is not the agent's own. ``_do_select_crew`` reads
+#: config, resolves the crew's bindings, and appends one routing-decision
+#: record keyed to its OWN session; it binds nothing and starts no work.
+#:
+#: What is granted: reads (``resource_status``, ``list_sessions``, skills), the
+#: patrol loop's own lifecycle (``monitor_*``, ``autonudge_stop``, ``wait``),
+#: the conductor's OWN durable ledger, routing (``select_crew``), and
+#: reporting to the owner (``send_message``, ``send_notification``,
+#: ``ask_question``).
+_CONDUCTOR_CORE_GRANTS: tuple[str, ...] = (
+    "@kirocrew-core/monitor_start",
+    "@kirocrew-core/monitor_update",
+    "@kirocrew-core/autonudge_stop",
+    "@kirocrew-core/wait",
+    "@kirocrew-core/resource_status",
+    "@kirocrew-core/list_sessions",
+    "@kirocrew-core/session_ledger_read",
+    "@kirocrew-core/session_ledger_record",
+    "@kirocrew-core/skill_search",
+    "@kirocrew-core/skill_fetch",
+    "@kirocrew-core/select_crew",
+    "@kirocrew-core/send_message",
+    "@kirocrew-core/send_notification",
+    "@kirocrew-core/ask_question",
+)
+
+
 def _install_conductor_agent() -> None:
     """Generate and install the kirocrew-conductor agent config.
 
@@ -5342,8 +5400,9 @@ def _install_conductor_agent() -> None:
     the explicit per-agent assignment that set requires — it is deliberately
     absent from the default agent's spec.
 
-    ``@kirocrew-dashboard`` is MOUNTED whole but auto-approved only verb by verb,
-    via ``_CONDUCTOR_DASHBOARD_GRANTS`` (see its comment for the per-verb
+    ``@kirocrew-core`` and ``@kirocrew-dashboard`` are both MOUNTED whole but
+    auto-approved only verb by verb, via ``_CONDUCTOR_CORE_GRANTS`` and
+    ``_CONDUCTOR_DASHBOARD_GRANTS`` (see their comments for the per-verb
     reasoning). Both backends honour a per-tool reference, so the narrowing is
     real rather than cosmetic: kiro-cli's ``is_tool_in_allowlist`` checks
     ``@server`` and then ``@server/<tool>``, and ``allowed_tools_to_permissions``
@@ -5425,7 +5484,7 @@ def _install_conductor_agent() -> None:
         "session",
         "report",
         "tool_search",
-        "@kirocrew-core",
+        *_CONDUCTOR_CORE_GRANTS,
         *_CONDUCTOR_DASHBOARD_GRANTS,
     ):
         (granted if _may_auto_approve(ref) else withheld).append(ref)
@@ -5570,8 +5629,10 @@ instruction with `monitor_update` so every later cycle honors it.
 #: extending the dashboard-grants invariant below to the core surface: the
 #: conductor ingests untrusted content (issue text, PR bodies) on unattended
 #: cycles, and a server-wide grant would let that content start persistent
-#: work (``task_run``, ``workflow_run``, ``cron_add``) or spawn arbitrary
-#: subagents with no human in the loop. What is granted is reads
+#: work (``task_run``, ``workflow_run``) or spawn arbitrary
+#: subagents with no human in the loop. (``cron_add`` used to be named here
+#: too; it registers on ``kirocrew-cron``, which neither conductor mounts, so
+#: it was never reachable through this grant either way.) What is granted is reads
 #: (``resource_status``, ``list_sessions``, skills), the conductor's OWN
 #: patrol-loop lifecycle (``monitor_*``, ``autonudge_stop``, ``wait``), its
 #: OWN durable ledger, and reporting to the owner (``send_message``,

--- a/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/goal-conductor/SKILL.md
@@ -352,7 +352,15 @@ watches, and that cost grows with the loop's own history.
   Auto-approved by name: `chat_folder_tree`, `chat_folder_create`,
   `session_create`, `session_read_message` — so a patrol cycle that wakes on a
   nudge with nobody at the keyboard never blocks, and filing rides the create
-  itself (the `folder` argument), so it costs no extra approval. **`session_send`
+  itself (the `folder` argument), so it costs no extra approval. The
+  `@kirocrew-core` verbs are granted by name too, and only these: `monitor_start`,
+  `monitor_update`, `autonudge_stop`, `wait`, `resource_status`, `list_sessions`,
+  `session_ledger_read`, `session_ledger_record`, `skill_search`, `skill_fetch`,
+  `select_crew`, `send_message`, `send_notification`, `ask_question`. That covers
+  every core call this procedure asks you to make; **any other core tool is
+  mounted but prompts**, including `task_run`, `workflow_run` and the `spawn_*`
+  family, which this charter forbids you to route a work item to in the first
+  place. **`session_send`
   and `session_stop` are deliberately NOT auto-approved**, because each writes to
   a session that is not yours: a seed runs as the target's own turn, and a stop
   discards the target's in-flight work. You ingest external content by design, so

--- a/test/test_conductor_agent.py
+++ b/test/test_conductor_agent.py
@@ -94,11 +94,15 @@ class TestConductorInstaller:
     def test_prompt_names_the_tools_it_expects_to_be_used(self, tmp_path, monkeypatch):
         """The charter mounts whole servers, so the prompt must name what it wants.
 
-        ``@kirocrew-core`` puts ~70 tools in front of this agent. Naming only the
-        session-control ones left the rest unaddressed, which is how a conductor
-        talks itself into running a work item in its own turn. Both directions are
-        pinned: the tools the four jobs need, and the four that would end-run the
-        no-write property by executing the work here.
+        ``@kirocrew-core`` puts 74 registered tools in front of this agent. Naming
+        only the session-control ones left the rest unaddressed, which is how a
+        conductor talks itself into running a work item in its own turn. Both
+        directions are pinned: the tools the four jobs need, and the four that
+        would end-run the no-write property by executing the work here.
+
+        Those four are also the reason the core grant is per-verb rather than
+        server-wide — the prompt PROHIBITS them, so a blanket auto-approve
+        contradicted the charter it shipped with.
         """
         prompt = " ".join(self._install(tmp_path, monkeypatch)["prompt"].split())
         for named in (
@@ -119,16 +123,18 @@ class TestConductorInstaller:
         """The security properties of the spec, in one place.
 
         No ``fs_write``: the conductor cannot do a work item's work itself.
-        ``@kirocrew-dashboard`` is MOUNTED whole but never granted whole — the
-        auto-approve list names verbs, so the destructive ones keep prompting.
-        ``execute_bash`` is mounted and never granted, because ``allowedTools``
-        has no argument matching and trusting the two bundled scripts cannot be
-        told apart from trusting arbitrary shell.
+        ``@kirocrew-core`` and ``@kirocrew-dashboard`` are MOUNTED whole but never
+        granted whole — the auto-approve list names verbs, so the destructive ones
+        keep prompting. ``execute_bash`` is mounted and never granted, because
+        ``allowedTools`` has no argument matching and trusting the two bundled
+        scripts cannot be told apart from trusting arbitrary shell.
         """
         data = self._install(tmp_path, monkeypatch)
         assert "fs_write" not in data["tools"]
         assert "@kirocrew-dashboard" in data["tools"]
         assert "@kirocrew-dashboard" not in data["allowedTools"]
+        assert "@kirocrew-core" in data["tools"]
+        assert "@kirocrew-core" not in data["allowedTools"]
         assert "execute_bash" in data["tools"]
         assert "execute_bash" not in data["allowedTools"]
 
@@ -185,6 +191,85 @@ class TestConductorInstaller:
         # The bare server must never appear: it would grant every verb, including
         # the four the test above withholds.
         assert "@kirocrew-dashboard" not in granted
+
+    def test_core_grants_are_named_verbs_never_the_whole_server(self, tmp_path, monkeypatch):
+        """Both directions of the core narrowing, because only one of them can rot.
+
+        The positive half — the 14 verbs the charter needs are granted — passes
+        just as well against the server-wide ``@kirocrew-core`` this replaced, so
+        on its own it is vacuous on the thing being changed. The negative half is
+        the real assertion: the verbs the charter never names must be DENIED, and
+        it is the half a future edit can silently undo by restoring the bare
+        server or widening the tuple.
+
+        The denied set carries a representative per family rather than one token
+        case, because they reach ``allowed_tools_to_permissions`` as separate
+        patterns and a family could classify differently: persistent work
+        (``task_run``, the ``workflow_*`` group), agent fan-out (the ``spawn_*``
+        group), session and workspace mutation (``set_project``,
+        ``reset_conversation``), egress (``deploy_artifact``, ``browser``,
+        ``ops_mission_control_api``) and the ``artifact_*`` writes.
+
+        Spelled as literals, deliberately: deriving the expectation from
+        ``agent._CONDUCTOR_CORE_GRANTS`` would let the tuple and its test drift
+        together and assert nothing.
+        """
+        granted = self._install(tmp_path, monkeypatch)["allowedTools"]
+        core = {g for g in granted if g.startswith("@kirocrew-core")}
+        assert core == {
+            "@kirocrew-core/monitor_start",
+            "@kirocrew-core/monitor_update",
+            "@kirocrew-core/autonudge_stop",
+            "@kirocrew-core/wait",
+            "@kirocrew-core/resource_status",
+            "@kirocrew-core/list_sessions",
+            "@kirocrew-core/session_ledger_read",
+            "@kirocrew-core/session_ledger_record",
+            "@kirocrew-core/skill_search",
+            "@kirocrew-core/skill_fetch",
+            "@kirocrew-core/select_crew",
+            "@kirocrew-core/send_message",
+            "@kirocrew-core/send_notification",
+            "@kirocrew-core/ask_question",
+        }
+        # The bare server is what this test exists to keep out: it would re-grant
+        # all 74 registered core tools, including every verb named below.
+        assert "@kirocrew-core" not in granted
+        for denied in (
+            # Persistent work — the three the prompt PROHIBITS by name.
+            "task_run",
+            "workflow_run",
+            "workflow_author",
+            "workflow_rerun_subtree",
+            "workflow_cancel",
+            # Agent fan-out with no human in the loop.
+            "spawn_run",
+            "spawn_sub_agents",
+            "spawn_steer",
+            "spawn_continue",
+            # Mutating the caller's own session or project out from under it.
+            "set_project",
+            "reset_conversation",
+            # Egress and machine reach.
+            "deploy_artifact",
+            "browser",
+            "ops_mission_control_api",
+            "file_send",
+            # Artifact and memory writes.
+            "artifact_save",
+            "artifact_update",
+            "artifact_delete",
+            "learn_add",
+            "knowledge_add_document",
+        ):
+            assert f"@kirocrew-core/{denied}" not in granted, denied
+        # And the projected KAS policy must deny them too, not just the kiro-cli
+        # allowlist: a ``kirocrew-core/*`` pattern here would re-grant every one
+        # of them on the KAS backend while the list above still looked narrow.
+        match = self._install(tmp_path, monkeypatch)["permissions"]["rules"][0]["match"]
+        assert "kirocrew-core/*" not in match
+        for denied in ("task_run", "spawn_run", "set_project", "browser", "artifact_save"):
+            assert f"kirocrew-core/{denied}" not in match, denied
 
     def test_template_grants_never_leak_into_the_conductor_list(self, tmp_path, monkeypatch):
         """No-op proof for #7401: the conductor replaces ``allowedTools``
@@ -287,22 +372,42 @@ class TestConductorInstaller:
     def test_grants_pass_through_the_governance_ceiling(self, tmp_path, monkeypatch):
         """``allowedTools`` never reaches the PreToolUse gate, so it is filtered.
 
-        A ceiling with an opinion about ``@kirocrew-core`` must not be silently
-        bypassed by a static grant list: the ref stays MOUNTED (still in
-        ``tools``) but loses its blanket auto-approve, so its calls prompt and
-        the gate applies the real per-tool rule.
+        A ceiling with an opinion about a granted ref must not be silently
+        bypassed by a static grant list: the server stays MOUNTED (still in
+        ``tools``) but the governed VERB loses its auto-approve, so its calls
+        prompt and the gate applies the real per-tool rule.
+
+        Governs one core verb rather than the whole server, which is what the
+        ceiling now has to be able to reach: after the per-verb narrowing there is
+        no bare ``@kirocrew-core`` entry left for it to have an opinion about.
         """
         data = self._install(
             tmp_path,
             monkeypatch,
-            may_auto_approve=lambda ref: ref != "@kirocrew-core",
+            may_auto_approve=lambda ref: ref != "@kirocrew-core/monitor_start",
         )
         assert "@kirocrew-core" in data["tools"]
         assert "@kirocrew-core" not in data["allowedTools"]
+        assert "@kirocrew-core/monitor_start" not in data["allowedTools"]
+        # Every sibling grant survives — the ceiling removed one verb, not the set.
+        assert "@kirocrew-core/monitor_update" in data["allowedTools"]
         assert data["allowedTools"] == [
             "session",
             "report",
             "tool_search",
+            "@kirocrew-core/monitor_update",
+            "@kirocrew-core/autonudge_stop",
+            "@kirocrew-core/wait",
+            "@kirocrew-core/resource_status",
+            "@kirocrew-core/list_sessions",
+            "@kirocrew-core/session_ledger_read",
+            "@kirocrew-core/session_ledger_record",
+            "@kirocrew-core/skill_search",
+            "@kirocrew-core/skill_fetch",
+            "@kirocrew-core/select_crew",
+            "@kirocrew-core/send_message",
+            "@kirocrew-core/send_notification",
+            "@kirocrew-core/ask_question",
             "@kirocrew-dashboard/chat_folder_tree",
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",
@@ -312,14 +417,31 @@ class TestConductorInstaller:
     def test_kas_permissions_are_derived_from_the_filtered_grants(self, tmp_path, monkeypatch):
         """The KAS block is derived, not restated — so the ceiling reaches it too.
 
-        Ungoverned: the per-tool dashboard grants project to EXACT ``server/tool``
-        resources rather than a ``kirocrew-dashboard/*`` wildcard, which is what
-        makes the narrowing real on the KAS backend as well as on kiro-cli — a
-        wildcard here would re-grant the ``session_stop`` / ``session_send`` that
-        ``allowedTools`` deliberately withholds. Governed against
-        ``@kirocrew-core``: that pattern is gone while the dashboard ones survive,
-        which is the property a rule list restated as a literal would have lost.
+        Ungoverned: the per-tool grants project to EXACT ``server/tool`` resources
+        rather than ``kirocrew-core/*`` / ``kirocrew-dashboard/*`` wildcards, which
+        is what makes the narrowing real on the KAS backend as well as on kiro-cli
+        — a wildcard here would re-grant the ``task_run`` / ``spawn_run`` and the
+        ``session_stop`` / ``session_send`` that ``allowedTools`` deliberately
+        withholds. Governed against one core verb: that pattern is gone while
+        every sibling survives, which is the property a rule list restated as a
+        literal would have lost.
         """
+        core_resources = [
+            "kirocrew-core/ask_question",
+            "kirocrew-core/autonudge_stop",
+            "kirocrew-core/list_sessions",
+            "kirocrew-core/monitor_start",
+            "kirocrew-core/monitor_update",
+            "kirocrew-core/resource_status",
+            "kirocrew-core/select_crew",
+            "kirocrew-core/send_message",
+            "kirocrew-core/send_notification",
+            "kirocrew-core/session_ledger_read",
+            "kirocrew-core/session_ledger_record",
+            "kirocrew-core/skill_fetch",
+            "kirocrew-core/skill_search",
+            "kirocrew-core/wait",
+        ]
         dashboard_resources = [
             "kirocrew-dashboard/chat_folder_create",
             "kirocrew-dashboard/chat_folder_tree",
@@ -331,28 +453,38 @@ class TestConductorInstaller:
             "rules": [
                 {
                     "capability": "mcp",
-                    "match": ["kirocrew-core/*", *dashboard_resources],
+                    "match": [*core_resources, *dashboard_resources],
                     "effect": "allow",
                 }
             ]
         }
+        assert "kirocrew-core/*" not in data["permissions"]["rules"][0]["match"]
         assert "kirocrew-dashboard/*" not in data["permissions"]["rules"][0]["match"]
 
         governed = self._install(
             tmp_path,
             monkeypatch,
-            may_auto_approve=lambda ref: ref != "@kirocrew-core",
+            may_auto_approve=lambda ref: ref != "@kirocrew-core/monitor_start",
         )
         assert governed["permissions"] == {
-            "rules": [{"capability": "mcp", "match": dashboard_resources, "effect": "allow"}]
+            "rules": [
+                {
+                    "capability": "mcp",
+                    "match": [
+                        *(r for r in core_resources if r != "kirocrew-core/monitor_start"),
+                        *dashboard_resources,
+                    ],
+                    "effect": "allow",
+                }
+            ]
         }
 
     def test_a_fully_governed_host_still_emits_the_permissions_key(self, tmp_path, monkeypatch):
         """``{"rules": []}`` when nothing qualifies — the key's PRESENCE loads the spec.
 
-        Split from the test above once the dashboard grant meant a ceiling on
-        ``@kirocrew-core`` alone no longer empties the rule list: without this,
-        the empty-policy branch would have silently lost its coverage.
+        Split from the test above once the dashboard grant meant a ceiling on one
+        ref alone no longer empties the rule list: without this, the empty-policy
+        branch would have silently lost its coverage.
         """
         data = self._install(tmp_path, monkeypatch, may_auto_approve=lambda ref: False)
         assert data["permissions"] == {"rules": []}
@@ -365,6 +497,10 @@ class TestConductorInstaller:
         ``strip_ungoverned_auto_approve`` names a silent pop as the one withhold
         path with no audit trail. Filtering silently here would make this
         installer exactly that path.
+
+        The withheld ref must be named in the record, which after the per-verb
+        narrowing means the VERB and not just the server — an operator reading
+        "@kirocrew-core was withheld" could not tell which of 14 grants he lost.
         """
         calls: list[dict] = []
 
@@ -373,10 +509,12 @@ class TestConductorInstaller:
                 calls.append(kw)
 
         monkeypatch.setattr(agent, "sel", lambda: _Recorder())
-        self._install(tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core")
+        self._install(
+            tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core/select_crew"
+        )
         withheld = [c for c in calls if c.get("operation") == "mcp_auto_approve_withheld"]
         assert len(withheld) == 1
-        assert "@kirocrew-core" in withheld[0]["resources"]
+        assert "@kirocrew-core/select_crew" in withheld[0]["resources"]
         assert withheld[0]["source"] == "_install_conductor_agent"
 
     def test_no_audit_event_when_nothing_is_withheld(self, tmp_path, monkeypatch):
@@ -400,12 +538,26 @@ class TestConductorInstaller:
 
         monkeypatch.setattr(agent, "sel", lambda: _Broken())
         data = self._install(
-            tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core"
+            tmp_path, monkeypatch, may_auto_approve=lambda ref: ref != "@kirocrew-core/select_crew"
         )
+        assert "@kirocrew-core/select_crew" not in data["allowedTools"]
         assert data["allowedTools"] == [
             "session",
             "report",
             "tool_search",
+            "@kirocrew-core/monitor_start",
+            "@kirocrew-core/monitor_update",
+            "@kirocrew-core/autonudge_stop",
+            "@kirocrew-core/wait",
+            "@kirocrew-core/resource_status",
+            "@kirocrew-core/list_sessions",
+            "@kirocrew-core/session_ledger_read",
+            "@kirocrew-core/session_ledger_record",
+            "@kirocrew-core/skill_search",
+            "@kirocrew-core/skill_fetch",
+            "@kirocrew-core/send_message",
+            "@kirocrew-core/send_notification",
+            "@kirocrew-core/ask_question",
             "@kirocrew-dashboard/chat_folder_tree",
             "@kirocrew-dashboard/chat_folder_create",
             "@kirocrew-dashboard/session_create",


### PR DESCRIPTION
## Problem / Motivation

Two sibling conductor agents shipped with different trust in the same MCP server, and the narrower one carried the written argument for why the wider one is unsafe.

`_install_pipeline_conductor_agent` auto-approves `@kirocrew-core` verb by verb via `_PIPELINE_CONDUCTOR_CORE_GRANTS`, and its comment states the reason: a server-wide grant "would let that content start persistent work (`task_run`, `workflow_run`) or spawn arbitrary subagents with no human in the loop."

`_install_conductor_agent` -- the goal conductor -- still listed a bare `"@kirocrew-core"` in its grant loop. I enumerated the server's real registrations (`src/kiro_crew/mcp_tools/*.py` plus `mcp_core.py`, counting `"name": "<tool>"` entries) rather than trusting the old comment's "~70": **74 tools** were auto-approved behind that one entry.

## Why it matters

The goal conductor ingests content it does not control -- the goal text, child-session transcripts it reads back, and `web_fetch` results -- on nudge-driven cycles with nobody at the keyboard. A server-wide auto-approve meant that content could reach `task_run`, `workflow_run` and the seven `spawn_*` verbs without a human seeing a prompt: the difference between a prompt-injection attempt producing a bad *sentence* and producing a scheduled job or a fleet of subagents.

The asymmetry also made the file argue with itself. A reader comparing the two installers found a documented rationale for narrowing sitting next to an un-narrowed sibling, and could not tell whether the wide grant was a considered exception or an oversight.

Worth being precise about what this is *not*: it is not a new policy. `_CONDUCTOR_SYSTEM_PROMPT` already **prohibits** those verbs by name -- "a work item never goes to `spawn_run`, `spawn_sub_agents`, `workflow_run` or `task_run`". The spec was auto-approving verbs its own charter forbade. This change makes the two agree.

## What changed (motivation, approach, change)

**Symptom to cause.** The grant loop passed a bare server ref where its sibling passes a tuple of verbs. The cause is only that the goal conductor predates the narrowing invariant; nothing depends on the wide form.

**Approach: derive the verb set, do not copy the sibling's.** This is the part worth reading, because the obvious implementation is wrong in a way that looks correct.

I took the union of the prompt's own "Your tools:" inventory and the `goal-conductor` skill's real call sites, then filtered to the tools that actually register on `kirocrew-core`. That yields **14**, not the sibling's 13. The extra verb is **`select_crew`**, and it is load-bearing: `goal-conductor/SKILL.md` step 1 of dispatch says "Call `select_crew` first and pass the agent it names", and it is **absent from `_PIPELINE_CONDUCTOR_CORE_GRANTS`**. Copying the 13 that already ship would have broken the conductor's documented dispatch procedure on its first cycle -- while producing a diff that looked like a correct patch and passing every existing test.

`select_crew` earns its grant under the invariant the dashboard tuple already states -- *a granted verb may CREATE or READ, never MUTATE something that already exists and is not the agent's own*. Applying that existing contract rather than inventing a new justification: `_do_select_crew` loads config, resolves the named crew's bindings, and appends one routing-decision record keyed to **its own** session. It binds nothing, starts no work, and touches no other session's state.

Two more measurements corrected names I could otherwise have read off wrongly:

- **`list_sessions` is core**, not dashboard (`mcp_tools/sessions.py`), despite sitting in the prompt's child-session paragraph next to four dashboard verbs. It belongs in this tuple.
- **`cron_add` was never reachable through either grant.** It registers on `kirocrew-cron` (`mcp_cron.py`), which neither conductor mounts -- `tools` is `execute_bash, fs_read, web_fetch, session, report, tool_search, @kirocrew-core, @kirocrew-dashboard` and `mcpServers` is narrowed to core + dashboard. The sibling's comment named it as a consequence of the wide grant, so that comment **overstated its own case by one verb**. Corrected in place, with the reason, since this PR's new comment mirrors it and a silent disagreement between the two would be worse than the original error.

**Change.** Net effect on the goal conductor's core surface: **74 to 14**. Dropped: all 8 `workflow_*`, all 7 `spawn_*`, `task_run`, `set_project`, `reset_conversation`, `deploy_artifact`, `browser`, `ops_mission_control_api`, `file_send`, 18 `artifact_*`, the `learn_*` and knowledge writes, and the rest.

The narrowing is real on both backends, not cosmetic: kiro-cli's `is_tool_in_allowlist` checks `@server` then `@server/<tool>`, and `allowed_tools_to_permissions` maps each entry to an exact KAS `server/tool` resource. The projected KAS policy changes from a `kirocrew-core/*` wildcard to 14 exact resources, which is asserted below.

`goal-conductor/SKILL.md`'s approval-cost note moves with the code: it now names the granted core verbs and says plainly that any other core tool is mounted but prompts. Leaving that note describing only the dashboard verbs would have made the skill promise a cost the spec no longer charges.

## Tests

`test/test_conductor_agent.py`. The new test is `test_core_grants_are_named_verbs_never_the_whole_server`, and it asserts **both directions** deliberately, because only one of them can rot:

- **Positive** -- the 14 verbs are granted. On its own this is vacuous on the thing being changed: it passes just as well against the server-wide grant it replaces.
- **Negative** -- 20 verbs the charter never names are **denied**, carrying a representative per family rather than one token case, since each reaches `allowed_tools_to_permissions` as its own pattern and a family could classify differently: persistent work (`task_run`, `workflow_run`/`author`/`rerun_subtree`/`cancel`), agent fan-out (`spawn_run`, `spawn_sub_agents`, `spawn_steer`, `spawn_continue`), caller-state mutation (`set_project`, `reset_conversation`), egress and machine reach (`deploy_artifact`, `browser`, `ops_mission_control_api`, `file_send`), and writes (`artifact_save`/`update`/`delete`, `learn_add`, `knowledge_add_document`).
- The same test checks the **projected KAS policy** denies them too -- `kirocrew-core/*` must be absent -- so a wildcard could not re-grant on the KAS backend while the allowlist still looked narrow.

The expectations are spelled as literals rather than derived from `agent._CONDUCTOR_CORE_GRANTS`, so the tuple and its test cannot drift together and assert nothing.

Four existing tests governed the bare server ref and now govern a **verb**, which is what a ceiling has to be able to reach once no bare entry exists: `test_grants_pass_through_the_governance_ceiling`, `test_kas_permissions_are_derived_from_the_filtered_grants`, `test_withholding_a_grant_is_audit_logged` (the audit record must name the withheld verb -- "`@kirocrew-core` was withheld" would not tell an operator which of 14 grants he lost), and `test_audit_failure_does_not_break_the_install`.

**Mutation-verified in both directions, from file-based patches, with the payload proven present before trusting the result** -- a mutation that does not apply proves nothing and looks identical to a passing one:

| Mutation | Payload proof | Result |
|---|---|---|
| Restore the bare `"@kirocrew-core"` in the grant loop | `grep` confirmed the loop line and the tuple both present | **6 named tests failed** (`test_core_grants_are_named_verbs_never_the_whole_server`, `test_no_write_tool_and_shell_not_preapproved`, `test_grants_pass_through_the_governance_ceiling`, `test_kas_permissions_are_derived_from_the_filtered_grants`, `test_withholding_a_grant_is_audit_logged`, `test_audit_failure_does_not_break_the_install`), 28 passed |
| Widen the tuple by one forbidden verb (`@kirocrew-core/task_run`) | `grep` confirmed the added grant at its line; the patch contains the `+` line | **4 named tests failed**, 30 passed |

Failing test names were read from a JUnit XML rather than from a summary line, so the count could not be a formatting artefact. Reverted, re-run, 255 passed across `test_conductor_agent.py`, `test_pipeline_conductor_agent.py`, `test_agent_roster_shared.py`, `test_spawn_agent_roster.py`, `test_kas_permissions.py`, `test_conductor_skill.py`.

Gates run locally: `ruff check` clean, `isort --check-only` clean, `flake8` clean, `scripts/check_black_formatting.py` passed. `mypy src/kiro_crew/agent.py` reports 2 errors, both in `src/kiro_crew/transcribe.py`, present on the base and untouched here.

## Manual verification

N/A -- the installer's whole output is the JSON spec, and the tests assert on the real written file.

**The residual risk is sufficiency, not over-narrowing, and it will not appear in CI.** This is a tightening, so the failure mode is a goal-conductor session that hits an approval prompt on some later cycle where it previously ran. Stating the sources exactly, so a reader knows what was and was not checked:

- **Enumerated:** `_CONDUCTOR_SYSTEM_PROMPT`'s "Your tools:" inventory; every core-tool identifier appearing in `goal-conductor/SKILL.md`; the real `kirocrew-core` registration list, so no verb was assumed onto the wrong server.
- **Not checked, and not checkable this way:** a verb a conductor reaches only in a rare branch -- an error path, an operator's ad-hoc instruction mid-goal, or a future skill revision -- is exactly what an enumeration of documented call sites misses. There is no telemetry of real conductor sessions here to prove the negative.

I have deliberately **not** padded the tuple to cover that gap. A verb added "to be safe" is surface nobody decided on, which is the condition this PR exists to remove. If a prompt shows up in practice, the fix is one named entry with a reason, and `test_core_grants_are_named_verbs_never_the_whole_server` will require that entry to be a deliberate edit.

## Related Issues

Closes #7514

## Pattern harvest

Rule candidate: `review-prompt`

Pattern: when a PR narrows a trust grant for a NEW principal and leaves an existing principal of the same class wide, the diff itself is evidence that the wide grant is now considered unsafe -- so the wide one should become a tracked exception rather than remaining an unremarked default.

Mechanical catch, offered as a follow-up rather than folded in here: a source ratchet listing every bare `@<server>` whole-server auto-approve grant, so keeping or adding one requires an explicit entry with a justification comment and the list can only shrink. Deliberately out of scope for this PR -- it is a new gate with its own baseline and failure modes, and bundling it would hide this security change inside a tooling change.

Second, narrower pattern from doing the work: **deriving a per-verb grant from the agent's own charter rather than copying a sibling's tuple.** The two conductors' sets differ by `select_crew`, and copying would have shipped a broken dispatch step that no existing test could catch. Any future third conductor should derive too.
