### PR TITLE
fix(autonudge): reconcile stranded active loops and log fires (#8636)

### DIFF
--- a/src/kiro_crew/autonudge.py
+++ b/src/kiro_crew/autonudge.py
@@ -124,6 +124,23 @@ _MONITOR_RETRY_MAX_BACKOFF_SECS = 300
 # to cancel the pending fire again if they are still actively conversing.
 _OVERDUE_REARM_SECS = 10
 
+# How often the reconciler walks the store looking for an active loop with no
+# live timer task. A stranded loop (fire delivered but the slot's stop hook
+# never arrived, a dropped deferred re-arm) is rescued after two consecutive
+# eligible passes -- so within two to three intervals of going quiet; the walk
+# itself is an in-memory scan of a small dict, so the interval is chosen for
+# rescue latency, not cost. The two-pass requirement, not this number, is what
+# keeps the reconciler from mistaking short-lived live states (a running user
+# turn, a mutation window) for strandings; see _reconcile_once.
+_RECONCILE_INTERVAL_SECS = 60
+
+
+def _resolve_beat(beat: "asyncio.Future[None]") -> None:
+    """Resolve one reconciler heartbeat future (see ``_reconcile_forever``)."""
+    if not beat.done():
+        beat.set_result(None)
+
+
 # Persisted source category for a deliberate ``autonudge_stop`` directive.
 # The caller's free-form explanation is intentionally not stored: it is
 # model-authored text and the watchdog only needs the deterministic source.
@@ -746,6 +763,15 @@ class AutoNudgeService:
         # its accepted fingerprint. Durable delivery state remains authoritative
         # after the dispatcher returns or the process restarts.
         self._accepted_monitor_turns: dict[str, str] = {}
+        # The periodic reconciler task (see _reconcile_forever). Owned by
+        # start()/stop(); None while the service is not running.
+        self._reconciler: asyncio.Task | None = None
+        # Loop ids the previous reconciler pass found eligible-and-unarmed.
+        # A rescue requires membership here AND a second eligible observation
+        # (see _reconcile_once); notify_user_input clears a slot's candidacy,
+        # so any sign of life restarts the two-pass clock. Not persisted --
+        # after a restart, start() re-arms every active loop anyway.
+        self._reconcile_candidates: set[str] = set()
         self._observers: list[Callable[[str, NudgeLoop | None], None]] = []
         self._lock = asyncio.Lock()
 
@@ -1148,9 +1174,32 @@ class AutoNudgeService:
                     self._arm_from_deadline(loop)
             global _INSTANCE
             _INSTANCE = self
+        # The reconciler is the timer-driven backstop for a loop stranded
+        # active-but-unarmed (see _reconcile_forever). Spawned outside the
+        # maintenance lock: it takes no locks of its own and its first pass is
+        # a full interval away, so nothing it reads can race the load above.
+        # ``done()`` alone is not enough: a task whose event loop closed
+        # without cancellation is not done, yet can never run again -- the
+        # same singleton-outlives-its-loop scenario _cancel_timer documents.
+        # Without the closed-loop clause a start() under a fresh loop would
+        # silently decline to spawn and run with no backstop.
+        if (
+            self._reconciler is None
+            or self._reconciler.done()
+            or self._reconciler.get_loop().is_closed()
+        ):
+            self._reconciler = asyncio.create_task(self._reconcile_forever())
         logger.info("AutoNudge started")
 
     def stop(self) -> None:
+        # Retire the reconciler first so a pass cannot re-arm a timer this
+        # method is about to cancel. Same closed-loop guard as _cancel_timer:
+        # stop() runs from synchronous shutdown paths where the task's loop
+        # may already be gone, and cancelling through a closed loop raises.
+        t = self._reconciler
+        self._reconciler = None
+        if t is not None and not t.done() and not t.get_loop().is_closed():
+            t.cancel()
         # Through _cancel_timer, not a bare t.cancel() loop: shutdown is the likeliest
         # moment for a timer's loop to be closing already, and one cancellation policy
         # means this path inherits both of its guards instead of restating neither.
@@ -1158,6 +1207,7 @@ class AutoNudgeService:
         for loop_id in list(self._timers):
             self._cancel_timer(loop_id)
         self._timers.clear()
+        self._reconcile_candidates.clear()
         self._accepted_monitor_turns.clear()
         self._maintenance_quiescing.clear()
         self._maintenance_quiesce_events.clear()
@@ -2967,6 +3017,12 @@ class AutoNudgeService:
         loop = self._find_by_slot(slot_key)
         if not loop:
             return
+        # A user turn starting is proof the slot is alive: restart the
+        # reconciler's two-pass clock so the stranded-loop backstop never
+        # re-arms a timer this hook is about to cancel on purpose. If this
+        # turn then dies without its stop hook, candidacy simply rebuilds
+        # over the next two passes and the rescue still happens.
+        self._reconcile_candidates.discard(loop.id)
         if loop.id in self._firing:
             self._rearm_pending.discard(loop.id)
             logger.info(
@@ -3132,6 +3188,160 @@ class AutoNudgeService:
                 logger.warning("AutoNudge: deadline persist failed", exc_info=t.exception())
 
         task.add_done_callback(_finish)
+
+    async def _reconcile_forever(self) -> None:
+        """Periodically rescue any active loop left with no live timer.
+
+        A dashboard-bound loop has exactly one re-arm path after a delivered
+        fire: ``notify_turn_complete``, called by the gateway after the slot's
+        stop hook. If that hook never arrives -- the nudge turn errors, times
+        out or is cancelled on a path that skips it, or the deferred re-arm was
+        dropped by ``notify_user_input`` during the fire window -- the loop is
+        left persisted ``active=true`` with a finished (or missing) timer task
+        and nothing on a timer ever revives it. The only rescues used to be a
+        gateway restart or a genuine turn completing in that exact slot. This
+        task is the general backstop: it re-arms toward the loop's own
+        persisted deadline, so a rescue never fires earlier than the schedule
+        the user set (``_arm_from_deadline`` self-heals a cleared deadline into
+        a fresh full countdown).
+
+        The wait is scheduled through ``loop.call_later`` rather than
+        ``asyncio.sleep`` on purpose: this file's own test suite (and any
+        similar consumer) routinely patches module-level ``asyncio.sleep`` to
+        a no-op to fast-forward the per-loop timers, and under that patch a
+        sleep-based periodic task degrades into a busy loop that re-arms and
+        re-fires everything continuously. A watchdog's cadence must stay on
+        the wall clock regardless of how the timers it watches are driven.
+        """
+        ev_loop = asyncio.get_running_loop()
+        while True:
+            beat: asyncio.Future[None] = ev_loop.create_future()
+            handle = ev_loop.call_later(_RECONCILE_INTERVAL_SECS, _resolve_beat, beat)
+            try:
+                await beat
+            finally:
+                handle.cancel()
+            if shutdown_event.is_set():
+                return
+            try:
+                self._reconcile_once()
+            except Exception:  # noqa: BLE001 - one bad pass must not kill the backstop
+                logger.exception("AutoNudge: reconciler pass failed")
+
+    def _reconcile_once(self) -> None:
+        """One reconciler pass: rescue active loops stranded with no live timer.
+
+        "No live timer" means the ``_timers`` entry is absent OR its task has
+        finished. The finished-task form matters: nothing pops a timer task
+        from ``_timers`` when it completes normally, so the stranded states
+        this backstop exists for (a delivered fire whose stop hook never came,
+        a timer task killed by an exception) leave a DONE task behind rather
+        than an empty slot -- a membership test alone would miss every one of
+        them. The absent form covers a loop whose pending timer was cancelled
+        by ``notify_user_input`` and whose ``notify_turn_complete`` then never
+        arrived because the slot's turn died on a hook-skipping path.
+
+        A loop is re-armed only after TWO CONSECUTIVE passes observe it
+        eligible-and-unarmed, because one observation cannot tell "stranded"
+        apart from two live states that look identical for a while:
+
+        * A slot whose user turn is still running. ``notify_user_input``
+          cancelled the timer on purpose, and ``notify_turn_complete`` will
+          re-arm when the turn ends. The turn-start hook also clears this
+          loop's candidacy (see ``notify_user_input``), so a session showing
+          any sign of life defers its rescue by a full two intervals. A turn
+          that outlives BOTH intervals is re-armed anyway -- one observation
+          window has to end somewhere, and the fire path's busy-slot refusal
+          (plus its backoff) keeps a rescue that guessed wrong from ever
+          delivering into the running turn; the wasted attempt is the cost of
+          rescuing the turn that died silently, which looks identical from
+          here.
+        * A loop inside another coroutine's mutation window. ``update()``
+          mutates fields, awaits an offloaded store write, and ROLLS BACK the
+          fields if the write fails -- a single-pass reconciler could arm the
+          transiently-active shape and leave a rolled-back inactive loop with
+          a live timer. Two passes shrink that window, but the write has no
+          timeout, so the guard that CLOSES it is the lock check below: every
+          mutation runs inside ``self._lock``, this pass is synchronous, and
+          a pass that finds the lock held defers entirely.
+
+        Deliberately never touched, whatever the passes observe:
+
+        * A loop mid-fire (``_firing``): its running task must never be
+          cancelled (see ``update``), and ``_arm_timer`` cancels before it
+          creates. The fire window owns its own re-arm bookkeeping.
+        * A loop quiesced by administrative cleanup: cleanup owns it.
+        * A monitor record whose version this gateway does not implement:
+          ``_arm_from_deadline`` refuses those with an INFO line, and letting
+          the reconciler retry it would repeat that line every pass forever.
+        * A monitor whose wake claim is in flight with NO completion-evidence
+          deadline -- EXCEPT a ``BUSY`` retry. The no-deadline shape is a
+          claim that died mid-handoff: ``_load`` retires it on restart, and
+          arming it here would wake a controller that answers ``NO_CHANGE``
+          forever (the probe path is never reached, so no budget or cap can
+          end it) -- an unretirable zombie dressed as a rescue. A ``BUSY``
+          delivery is the one no-deadline shape that is legitimately LIVE:
+          it proves no action turn started, and ``_load`` resumes it at its
+          persisted retry deadline, so this pass must too. A claim WITH a
+          deadline is safe: its ``next_due_ts`` is that deadline, and the
+          armed tick either finds evidence or retires the claim through
+          ``record_monitor_completion_evidence_unavailable``.
+        """
+        if self._lock.locked():
+            # A mutation or persist is mid-flight. ``update()`` mutates loop
+            # fields, awaits an offloaded store write, and ROLLS BACK the
+            # fields if the write fails -- all inside ``self._lock`` -- and
+            # that write has no timeout, so a wedged disk can hold the
+            # transient shape across ANY number of passes; observation counts
+            # alone cannot bound it. This pass is synchronous, so deferring
+            # whenever the lock is held at entry makes overlap with a locked
+            # mutation window impossible rather than merely unlikely.
+            # Candidacies are left untouched: the deferred pass neither
+            # confirms nor refutes them, and dropping them would push every
+            # rescue behind a busy store's persist cadence.
+            return
+        eligible: set[str] = set()
+        for loop in list(self._loops.values()):
+            # Mirror _timer's own re-arm guard, not a stricter one: an
+            # INACTIVE loop still waiting for terminal-completion evidence
+            # owns a finite accepted-turn correlation whose expiry needs a
+            # timer (_waits_for_terminal_completion), and losing that timer
+            # to a user-input cancel with no turn-complete re-arm (the hook
+            # ignores inactive loops) would otherwise strand the claim and
+            # refuse every replacement watch on the slot forever.
+            if not loop.active and not self._waits_for_terminal_completion(loop):
+                continue
+            if loop.id in self._firing or loop.id in self._maintenance_quiescing:
+                continue
+            monitor = loop.monitor
+            if monitor is not None and monitor.version != MONITOR_STATE_VERSION:
+                continue
+            if (
+                monitor is not None
+                and monitor.wake_in_flight
+                and monitor.completion_evidence_deadline <= 0
+                and monitor.wake_delivery is not MonitorDispatchResult.BUSY
+            ):
+                # A BUSY retry is EXEMPT from this skip: it proves no action
+                # turn started, its evidence deadline is intentionally empty,
+                # and _load resumes exactly this shape at its persisted retry
+                # deadline on restart -- so retiring it here would kill a
+                # retry the store's own recovery logic considers live.
+                continue
+            timer = self._timers.get(loop.id)
+            if timer is not None and not timer.done():
+                continue
+            if loop.id not in self._reconcile_candidates:
+                eligible.add(loop.id)
+                continue
+            logger.info(
+                "AutoNudge: reconciler re-arming stranded loop %s on slot %s "
+                "(active with no live timer across two passes)",
+                loop.id,
+                loop.slot_key,
+            )
+            self._arm_from_deadline(loop)
+        self._reconcile_candidates = eligible
 
     async def _monitor_tick_is_quiet(self, loop: NudgeLoop) -> bool:
         """Observe this loop's subject cheaply; say whether to skip the turn.
@@ -3720,7 +3930,32 @@ class AutoNudgeService:
         # bounds, which is what the user pays for. A watch can still sit on a pull
         # request for days inside a small cap, which is the intended reading of the
         # number, and monitor_start's own description says so at the arming surface.
-        if await self._monitor_tick_is_quiet(loop):
+        #
+        # Exception-safe on purpose, and exception-safe in the SPENDING
+        # direction. The gate resolves every uncertainty it can reason about
+        # toward firing, and an exception ESCAPING it means its own failure
+        # handling was bypassed -- so the escape is treated exactly like every
+        # other uncertain observation: not quiet, fall through to the fire.
+        # Letting it escape here instead killed the timer task outright:
+        # ``self._timers`` holds a strong reference, so the dead task was never
+        # garbage-collected, "Task exception was never retrieved" was never
+        # emitted, and the loop sat persisted active with nothing left to wake
+        # it. Skipping the tick would be the other wrong answer: a gate that
+        # raises deterministically would keep the loop alive, re-arming and
+        # delivering nothing forever -- the silent-mute shape this whole gate
+        # is documented to avoid ("every uncertain path resolves toward
+        # spending"). Firing keeps the loop doing its job with the gate's
+        # saving lost for that tick, and the traceback makes the defect loud.
+        try:
+            tick_is_quiet = await self._monitor_tick_is_quiet(loop)
+        except Exception:  # noqa: BLE001 - any escape here used to kill the timer
+            logger.exception(
+                "AutoNudge: probe gate failed for loop %s -- treating the tick "
+                "as not quiet and firing",
+                loop.id,
+            )
+            tick_is_quiet = False
+        if tick_is_quiet:
             # A quiet tick MUST re-arm itself. Nothing else will: the delivered
             # paths re-arm through notify_turn_complete (dashboard slots) or
             # through the fire cycle's own exit (channel keys), and a quiet tick
@@ -4091,6 +4326,18 @@ class AutoNudgeService:
         # cannot be clobbered by a concurrent update()'s snapshot (and so the
         # fsync stays off the event loop).
         await self._persist_locked()
+        # At INFO, deliberately. Delivered fires used to be unlogged entirely,
+        # so a loop that died and a loop with nothing to report were
+        # byte-identical in the journal. One line per DELIVERED turn -- each of
+        # which already spends a model turn, so the log can never outpace the
+        # work -- is what makes both this loop's health and the reconciler's
+        # rescues observable from outside the process.
+        logger.info(
+            "AutoNudge: loop %s fired cycle %d on slot %s (delivered)",
+            loop.id,
+            loop.cycle_count,
+            loop.slot_key,
+        )
         self._emit("fired", loop)
         # POST-DELIVERY budget check: the budget gates when turns START, so a
         # slow in-flight turn can overshoot it (bounded by the transport's

--- a/test/test_autonudge_reconciler.py
+++ b/test/test_autonudge_reconciler.py
@@ -1,0 +1,514 @@
+"""Tests for the AutoNudge stranded-loop rescues (issue #8636).
+
+The defect these pin: a dashboard-bound (``chat-NNN-...``) loop's only re-arm
+path after a delivered fire is ``notify_turn_complete``. If that hook never
+arrives -- the nudge turn dies on a path that skips the stop hook, the probe
+gate raises (the ``_monitor_tick_is_quiet`` await used to sit OUTSIDE
+``_timer``'s try/finally, so an escaping exception killed the timer task), or
+``notify_user_input`` dropped the deferred re-arm -- the loop was left
+persisted ``active=true`` with no live timer and nothing on a timer to revive
+it. Three fixes are covered here:
+
+* the probe gate is exception-safe in the SPENDING direction: an escaping
+  exception is treated as "not quiet" and falls through to the fire, so the
+  timer task neither dies nor silently mutes the loop;
+* a periodic reconciler walks the store and re-arms any active loop observed
+  eligible-and-unarmed on two consecutive passes -- and only those;
+* delivered fires are logged at INFO so a dead loop and a calm loop are no
+  longer byte-identical in the journal.
+
+Two subtleties these tests encode on purpose. First, nothing pops a timer
+task from ``_timers`` when it completes normally, so the stranded states
+leave a DONE task behind rather than an empty slot; the reconciler must treat
+both forms as unarmed, since a membership test alone would miss every
+fire-delivered stranding. Second, a single unarmed observation cannot tell
+"stranded" apart from a running user turn or an ``update()`` mutation window,
+which is why a rescue requires two consecutive passes and why
+``notify_user_input`` resets a slot's candidacy.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+
+import pytest
+
+from kiro_crew.autonudge import AutoNudgeService, NudgeLoop
+from kiro_crew.monitoring.models import (
+    MONITOR_STATE_VERSION,
+    MonitorDispatchResult,
+    MonitorOutcome,
+    MonitorState,
+)
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setenv("KIROCREW_AUTONUDGE", "1")
+
+
+@pytest.fixture
+def svc(tmp_path, event_loop):
+    """Service with GUARANTEED teardown on every exit path.
+
+    Every test here calls ``start()``, which spawns the reconciler task and
+    publishes the module-global ``_INSTANCE``. A trailing ``svc.stop()`` in
+    the test body is skipped by any failing assertion before it, leaking a
+    pending task (and the global) past the test -- so the stop lives here,
+    where pytest runs it on failure too, and the cancelled reconciler is
+    drained on the test's still-open event loop. A SYNC fixture on purpose:
+    the pinned pytest-asyncio (0.20.3) cannot run async-generator fixtures
+    under pytest 9 (``FixtureDef.unittest`` was removed), so the drain goes
+    through the ``event_loop`` fixture, which outlives this one by fixture
+    ordering. ``stop()`` is idempotent, so the lifecycle test that exercises
+    it explicitly stays valid.
+    """
+    service = AutoNudgeService(base_dir=tmp_path)
+    yield service
+    # Snapshot EVERY background task the service may hold, not just the
+    # reconciler: ``stop()`` clears ``_timers`` (cancelling, not draining),
+    # and ``_inflight_adds`` holds detached ``_persist_locked`` writers --
+    # e.g. from a rescue's ``_persist_soon()`` -- that stop() deliberately
+    # leaves running. An undrained writer can recreate ``tmp_path`` AFTER
+    # pytest removes it, which is exactly the stray-directory shape the
+    # no-test-side-effects rule names. Draining here lets the writes finish
+    # while the directory still exists and retires every task in-loop.
+    tasks = [
+        t
+        for t in (service._reconciler, *service._timers.values(), *service._inflight_adds)
+        if t is not None
+    ]
+    service.stop()
+    live = [t for t in tasks if not t.done()]
+    if live and not event_loop.is_closed():
+        with contextlib.suppress(asyncio.TimeoutError):
+            event_loop.run_until_complete(
+                asyncio.wait_for(asyncio.gather(*live, return_exceptions=True), timeout=5)
+            )
+
+
+def _timer_is_live(svc: AutoNudgeService, loop_id: str) -> bool:
+    t = svc._timers.get(loop_id)
+    return t is not None and not t.done()
+
+
+def _reconcile_twice(svc: AutoNudgeService) -> None:
+    """Two consecutive passes -- the minimum that can rescue anything."""
+    svc._reconcile_once()
+    svc._reconcile_once()
+
+
+async def _run_timer_as_production_would(svc: AutoNudgeService, loop: NudgeLoop):
+    """Run one zero-delay timer pass with the running task AS the _timers entry.
+
+    Models the production shape exactly: the running timer task IS the
+    ``_timers`` entry, so when it completes it stays there as a DONE task.
+    ``add()`` armed a real ``idle_secs`` timer; replace it with this one.
+    """
+    svc._cancel_timer(loop.id)
+    t = asyncio.get_running_loop().create_task(svc._timer(loop, delay=0))
+    svc._timers[loop.id] = t
+    await t
+    return t
+
+
+# ── Fire path: a delivered fire with no turn-complete hook ──
+
+
+@pytest.mark.asyncio
+async def test_delivered_fire_without_turn_complete_is_rescued_by_reconciler(svc, caplog):
+    """The stranding the issue observed: fire delivered, stop hook never came.
+
+    The dashboard fire path deliberately does not self-re-arm (the nudge
+    turn's end is supposed to do it via ``notify_turn_complete``), so after
+    the timer coroutine returns the loop is active with no live timer. Two
+    consecutive reconciler passes must arm it again -- toward the loop's own
+    deadline, which the delivered fire cleared, so the rescue starts a fresh
+    full countdown rather than firing immediately.
+    """
+    fired: list[str] = []
+
+    async def on_fire(loop: NudgeLoop) -> bool:
+        fired.append(loop.id)
+        return True
+
+    svc._on_fire = on_fire
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="watch the PR", idle_secs=300)
+    with caplog.at_level(logging.INFO, logger="kiro_crew.autonudge"):
+        await _run_timer_as_production_would(svc, loop)
+    assert fired == [loop.id]
+    # Delivered fires are logged at INFO -- the observability half of the fix.
+    assert any("fired cycle" in r.message for r in caplog.records)
+    # Stranded: active, deadline cleared, timer entry present but finished.
+    assert loop.active
+    assert loop.next_due_ts == 0.0
+    assert loop.id in svc._timers and svc._timers[loop.id].done()
+    assert not _timer_is_live(svc, loop.id)
+
+    # One pass only records candidacy; a second consecutive pass rescues.
+    before = time.time()
+    svc._reconcile_once()
+    assert not _timer_is_live(svc, loop.id)
+    svc._reconcile_once()
+    assert _timer_is_live(svc, loop.id)
+    # Re-armed via _arm_from_deadline's own 0.0 self-heal: fresh full countdown.
+    assert loop.next_due_ts >= before + 300
+
+
+@pytest.mark.asyncio
+async def test_delivered_fire_never_rearms_a_dashboard_loop_by_itself(svc):
+    """Without a reconciler PASS nothing revives it (the running periodic
+    task's first beat is a full wall-clock interval away, far beyond this
+    test), which is exactly the pre-fix stranding."""
+
+    async def on_fire(loop: NudgeLoop) -> bool:
+        return True
+
+    svc._on_fire = on_fire
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    await _run_timer_as_production_would(svc, loop)
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert not _timer_is_live(svc, loop.id)
+    assert loop.active
+
+
+# ── Gate path: an exception escaping the probe gate ──
+
+
+@pytest.mark.asyncio
+async def test_gate_exception_falls_through_to_fire_and_keeps_loop_alive(svc, caplog):
+    """A raising gate must neither kill the timer task nor mute the loop.
+
+    The module's own contract is that every uncertain observation resolves
+    toward spending a turn; an exception escaping the gate is the most
+    uncertain observation there is, so the tick fires exactly as it would
+    have before the gate existed. The timer task must complete without the
+    exception propagating (a strong ref in ``_timers`` means a task killed by
+    an exception is never even reported by asyncio).
+    """
+    fired: list[str] = []
+
+    async def on_fire(loop: NudgeLoop) -> bool:
+        fired.append(loop.id)
+        return True
+
+    async def boom(loop: NudgeLoop) -> bool:
+        raise RuntimeError("probe gate blew up")
+
+    svc._on_fire = on_fire
+    svc._monitor_tick_is_quiet = boom  # type: ignore[method-assign]
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    with caplog.at_level(logging.ERROR, logger="kiro_crew.autonudge"):
+        t = await _run_timer_as_production_would(svc, loop)
+    # The tick SPENT a turn -- fail-toward-firing, not fail-toward-silence.
+    assert fired == [loop.id]
+    # The timer task finished cleanly; the exception did not kill it.
+    assert t.done() and t.exception() is None
+    assert loop.active
+    assert loop.stopped_reason == ""
+    # The defect is loud: the escaping exception is logged with traceback.
+    assert any("probe gate failed" in r.message for r in caplog.records)
+    # Dashboard slot: the delivered fire waits on notify_turn_complete, and
+    # the reconciler is the backstop when that hook never comes.
+    _reconcile_twice(svc)
+    assert _timer_is_live(svc, loop.id)
+
+
+@pytest.mark.asyncio
+async def test_gate_exception_on_channel_loop_leaves_loop_armed_and_active(svc):
+    """Channel-bound loops self-re-arm on the fire path, so a raising gate
+    leaves the loop armed and active with no reconciler involved at all."""
+    fired: list[str] = []
+
+    async def on_fire(loop: NudgeLoop) -> bool:
+        fired.append(loop.id)
+        return True
+
+    async def boom(loop: NudgeLoop) -> bool:
+        raise RuntimeError("probe gate blew up")
+
+    svc._on_fire = on_fire
+    svc._monitor_tick_is_quiet = boom  # type: ignore[method-assign]
+    await svc.start()
+    loop = await svc.add(slot_key="slack:1234567890.123", message="go", idle_secs=300)
+    await _run_timer_as_production_would(svc, loop)
+    assert fired == [loop.id]
+    assert loop.active
+    assert _timer_is_live(svc, loop.id)
+
+
+# ── Reconciler predicate ──
+
+
+@pytest.mark.asyncio
+async def test_reconciler_rearms_active_loop_with_absent_timer_only(svc):
+    """Re-arms active+unarmed (after two passes); leaves inactive and
+    live-timer loops alone."""
+    await svc.start()
+    stranded = await svc.add(slot_key="chat-1-111", message="a", idle_secs=300)
+    inactive = await svc.add(slot_key="chat-2-222", message="b", idle_secs=300)
+    healthy = await svc.add(slot_key="chat-3-333", message="c", idle_secs=300)
+    # Strand one: timer entry absent entirely (the dead-user-turn shape).
+    svc._cancel_timer(stranded.id)
+    assert stranded.id not in svc._timers
+    # Deactivate one and drop its timer: the reconciler must NOT revive it.
+    svc._cancel_timer(inactive.id)
+    inactive.active = False
+    healthy_task = svc._timers[healthy.id]
+
+    _reconcile_twice(svc)
+
+    assert _timer_is_live(svc, stranded.id)
+    assert inactive.id not in svc._timers
+    assert svc._timers[healthy.id] is healthy_task  # untouched, same task
+
+
+@pytest.mark.asyncio
+async def test_reconciler_rearms_active_loop_whose_timer_task_finished(svc):
+    """The DONE-task form of stranded: entry present, task finished."""
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    svc._cancel_timer(loop.id)
+    done = asyncio.get_running_loop().create_task(asyncio.sleep(0))
+    await done
+    svc._timers[loop.id] = done
+    _reconcile_twice(svc)
+    assert _timer_is_live(svc, loop.id)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_mid_fire_and_quiesced_loops(svc):
+    """A loop mid-fire or owned by cleanup must not be touched."""
+    await svc.start()
+    firing = await svc.add(slot_key="chat-1-111", message="a", idle_secs=300)
+    quiesced = await svc.add(slot_key="chat-2-222", message="b", idle_secs=300)
+    svc._cancel_timer(firing.id)
+    svc._cancel_timer(quiesced.id)
+    svc._firing.add(firing.id)
+    svc._maintenance_quiescing.add(quiesced.id)
+    try:
+        _reconcile_twice(svc)
+        assert firing.id not in svc._timers
+        assert quiesced.id not in svc._timers
+    finally:
+        svc._firing.discard(firing.id)
+        svc._maintenance_quiescing.discard(quiesced.id)
+
+
+def _monitor(**overrides) -> MonitorState:
+    state = MonitorState(
+        kind="github_pr",
+        target="owner/repo#1",
+        objective="watch it",
+        created_ts=time.time(),
+    )
+    for name, value in overrides.items():
+        setattr(state, name, value)
+    return state
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_dead_wake_claim_but_rescues_live_one(svc):
+    """A wake claim with no completion-evidence deadline died mid-handoff.
+
+    ``_load`` retires that shape on restart; arming it here would wake a
+    controller that answers NO_CHANGE forever -- no budget or cap could end
+    it. A claim WITH a deadline is the safe half (its ``next_due_ts`` is that
+    deadline) and must still be rescued.
+    """
+    await svc.start()
+    dead = await svc.add(slot_key="chat-1-111", message="a", idle_secs=300)
+    live = await svc.add(slot_key="chat-2-222", message="b", idle_secs=300)
+    dead.monitor = _monitor(wake_in_flight=True, completion_evidence_deadline=0.0)
+    live.monitor = _monitor(wake_in_flight=True, completion_evidence_deadline=time.time() + 120)
+    svc._cancel_timer(dead.id)
+    svc._cancel_timer(live.id)
+    _reconcile_twice(svc)
+    assert dead.id not in svc._timers
+    assert _timer_is_live(svc, live.id)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_rescues_busy_retry_and_inactive_terminal_waiter(svc):
+    """Two structured-monitor recovery states the skip predicates must NOT
+    exclude, both mirrored from the store's own semantics:
+
+    * a ``BUSY`` retry has ``wake_in_flight`` and an intentionally empty
+      evidence deadline, yet ``_load`` resumes it at its persisted retry
+      deadline on restart -- the in-process backstop must treat it as live;
+    * an INACTIVE loop still waiting for terminal-completion evidence owns a
+      finite accepted-turn correlation whose expiry needs a timer
+      (``_timer``'s own re-arm guard includes it), and
+      ``notify_turn_complete`` ignores inactive loops, so a user-input
+      cancel would otherwise strand the claim forever.
+    """
+    await svc.start()
+    busy = await svc.add(slot_key="chat-1-111", message="a", idle_secs=300)
+    waiter = await svc.add(slot_key="chat-2-222", message="b", idle_secs=300)
+    busy.monitor = _monitor(
+        wake_in_flight=True,
+        completion_evidence_deadline=0.0,
+        wake_delivery=MonitorDispatchResult.BUSY,
+    )
+    waiter.monitor = _monitor(
+        outcome=MonitorOutcome.USER_STOP,
+        wake_in_flight=True,
+        completion_evidence_deadline=time.time() + 120,
+    )
+    waiter.active = False
+    waiter.next_due_ts = waiter.monitor.completion_evidence_deadline
+    svc._cancel_timer(busy.id)
+    svc._cancel_timer(waiter.id)
+    _reconcile_twice(svc)
+    assert _timer_is_live(svc, busy.id)
+    assert _timer_is_live(svc, waiter.id)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_monitor_version_this_gateway_does_not_implement(svc, caplog):
+    """The version refusal itself lives in ``_arm_from_deadline``; the
+    reconciler's own guard exists so an unimplementable record is not retried
+    (and its INFO refusal not repeated) on every pass forever. Pin the guard
+    by the silence, not the timer: without it each pass would log both the
+    rescue line and the refusal line."""
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-111", message="a", idle_secs=300)
+    loop.monitor = _monitor(version=MONITOR_STATE_VERSION + 1)
+    svc._cancel_timer(loop.id)
+    with caplog.at_level(logging.INFO, logger="kiro_crew.autonudge"):
+        _reconcile_twice(svc)
+    assert loop.id not in svc._timers
+    assert not any("not arming" in r.message for r in caplog.records)
+    assert not any("re-arming stranded" in r.message for r in caplog.records)
+
+
+# ── Two-pass quiescence ──
+
+
+@pytest.mark.asyncio
+async def test_single_pass_never_rearms(svc):
+    """One unarmed observation is not evidence of stranding: it is also what a
+    running user turn and an update() mutation window look like."""
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    svc._cancel_timer(loop.id)
+    svc._reconcile_once()
+    assert loop.id not in svc._timers
+
+
+@pytest.mark.asyncio
+async def test_user_input_resets_reconcile_candidacy(svc):
+    """A user turn starting between passes proves the slot is alive: the
+    rescue clock restarts, so an actively-conversing session is never armed
+    behind ``notify_user_input``'s deliberate cancel."""
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    svc.notify_user_input("chat-1-123")  # deliberate cancel: user turn begins
+    svc._reconcile_once()  # pass 1: candidate
+    svc.notify_user_input("chat-1-123")  # still conversing
+    svc._reconcile_once()  # pass 2: candidacy was reset -- must NOT arm
+    assert loop.id not in svc._timers
+    svc._reconcile_once()  # pass 3: second consecutive quiet pass -- rescue
+    assert _timer_is_live(svc, loop.id)
+
+
+@pytest.mark.asyncio
+async def test_transiently_active_loop_is_not_armed(svc):
+    """Models update()'s rollback window: a loop that looks active+unarmed on
+    one pass but is inactive again by the next (failed persist rolled it
+    back) must end up with no timer."""
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    svc._cancel_timer(loop.id)
+    loop.active = True
+    svc._reconcile_once()  # observes the transient shape: candidate only
+    assert loop.id not in svc._timers
+    loop.active = False  # rollback landed before the next pass
+    svc._reconcile_once()
+    assert loop.id not in svc._timers
+
+
+@pytest.mark.asyncio
+async def test_pass_defers_while_mutation_lock_held_and_keeps_candidacy(svc):
+    """Every mutation (update/add/persist) runs inside ``svc._lock`` and its
+    store write has no timeout, so a wedged write can hold a transient shape
+    across ANY number of passes. A pass that finds the lock held must defer
+    entirely -- arming nothing, and dropping no candidacy, so the rescue is
+    delayed rather than restarted."""
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    svc._cancel_timer(loop.id)
+    svc._reconcile_once()  # pass 1: candidate recorded
+    assert loop.id in svc._reconcile_candidates
+    async with svc._lock:  # a mutation window is open (e.g. a stalled write)
+        svc._reconcile_once()
+        svc._reconcile_once()
+        assert loop.id not in svc._timers  # deferred: nothing armed
+        assert loop.id in svc._reconcile_candidates  # candidacy preserved
+    svc._reconcile_once()  # lock released: the second real pass rescues
+    assert _timer_is_live(svc, loop.id)
+
+
+# ── Reconciler lifecycle ──
+
+
+@pytest.mark.asyncio
+async def test_periodic_task_rescues_end_to_end(svc, monkeypatch):
+    """The backstop works with nobody calling _reconcile_once by hand: shrink
+    the beat interval, strand a loop, and a live timer appears on its own."""
+    import kiro_crew.autonudge as _an
+
+    monkeypatch.setattr(_an, "_RECONCILE_INTERVAL_SECS", 0.05)
+    await svc.start()
+    loop = await svc.add(slot_key="chat-1-123", message="go", idle_secs=300)
+    svc._cancel_timer(loop.id)
+    deadline = time.time() + 5.0
+    while time.time() < deadline and not _timer_is_live(svc, loop.id):
+        await asyncio.sleep(0.05)
+    assert _timer_is_live(svc, loop.id)
+
+
+@pytest.mark.asyncio
+async def test_reconciler_beat_stays_on_wall_clock_under_patched_sleep(svc, monkeypatch):
+    """This file's sibling suites patch module asyncio.sleep to a no-op to
+    fast-forward the per-loop timers; a sleep-based reconciler would busy-spin
+    under that patch and re-arm everything continuously. The call_later beat
+    must keep the reconciler dormant regardless."""
+    import kiro_crew.autonudge as _an
+
+    real_sleep = asyncio.sleep
+    passes: list[float] = []
+    orig_pass = svc._reconcile_once
+
+    def counting_pass() -> None:
+        passes.append(time.time())
+        orig_pass()
+
+    svc._reconcile_once = counting_pass  # type: ignore[method-assign]
+
+    async def _nosleep(_secs):
+        return None
+
+    monkeypatch.setattr(_an.asyncio, "sleep", _nosleep)
+    await svc.start()
+    await real_sleep(0.3)
+    assert passes == []  # first beat is a full wall-clock interval away
+
+
+@pytest.mark.asyncio
+async def test_start_spawns_reconciler_and_stop_retires_it(svc):
+    await svc.start()
+    task = svc._reconciler
+    assert task is not None and not task.done()
+    svc.stop()
+    assert svc._reconciler is None
+    for _ in range(3):
+        await asyncio.sleep(0)
+    assert task.cancelled()


### PR DESCRIPTION
## What

A dashboard-bound (`chat-NNN-...`) AutoNudge loop's only re-arm path after a delivered fire is `notify_turn_complete`. If that hook never arrives — the nudge turn dies on a hook-skipping path, the probe gate raises (the `_monitor_tick_is_quiet` await sat OUTSIDE `_timer`'s try/finally, so the exception killed the timer task), or `notify_user_input` dropped the deferred re-arm — the loop was stranded persisted `active=true`, `stopped_reason=""`, with no live timer and nothing on a timer to revive it. Fires were also entirely unlogged, so a dead loop and a calm loop were byte-identical in the journal.

Closes #8636

## How

1. **Exception-safe probe gate, in the spending direction.** An exception escaping `_monitor_tick_is_quiet` is treated as "not quiet" and falls through to the fire — the same direction as every other uncertain observation in this file ("every uncertain path resolves toward spending"). The timer task neither dies (the old defect: `self._timers` holds a strong ref, so the dead task never even produced a "Task exception was never retrieved") nor silently mutes the loop (which a skip-the-tick handling would have done under a deterministically-raising gate). The traceback is logged.

2. **Periodic reconciler.** A `start()`-owned task walks `self._loops` every 60s and re-arms any loop observed **eligible-and-unarmed on two consecutive passes**, via `_arm_from_deadline`'s existing `0.0` self-heal (no new scheduling logic). Key details:
   - "Unarmed" = `_timers` entry absent **or a DONE task**. Nothing pops a completed timer task from `_timers`, so every fire-delivered stranding leaves a done task behind — the issue's suggested `loop.id not in self._timers` predicate alone would miss all of them.
   - **Two-pass quiescence** is what makes single observations safe: one unarmed observation is also what a running user turn (`notify_user_input`'s deliberate cancel) and an `update()` mutation window (fields mutated, offloaded write pending, rollback on failure) look like. Two eligibility checks a full interval apart cannot both land inside a mutation window, and a committed activation arms itself. `notify_user_input` additionally resets the slot's candidacy, so an actively-conversing session is never armed behind the hook's deliberate cancel — while a turn that dies silently still gets rescued two passes later.
   - Never touched: mid-fire loops (`_firing` — cancelling that task is forbidden), maintenance-quiesced loops, monitor records of an unimplemented version (arming would repeat `_arm_from_deadline`'s refusal INFO every pass), and a monitor wake claim in flight with **no** completion-evidence deadline — that shape died mid-handoff, `_load` retires it on restart, and arming it would wake a controller answering `NO_CHANGE` forever with no budget or cap able to end it. A claim WITH a deadline is rescued (its `next_due_ts` is that deadline).
   - The beat uses `loop.call_later` + a future rather than `asyncio.sleep`, because the test suite patches module `asyncio.sleep` to a no-op to fast-forward per-loop timers — a sleep-based watchdog degrades into a busy loop under that patch. Pinned by a test.

3. **Observability.** INFO on every delivered fire (one line per delivered turn — each already spends a model turn, so the log can never outpace the work) and INFO on every reconciler rescue; ERROR with traceback on a gate escape.

## Pre-push review

Two model-pinned lanes (GPT 5.6, Opus) reviewed the first draft and forced real changes, all verified on-source before fixing:
- Both lanes: the draft's gate-exception handling (skip the tick and re-arm) inverted the module's fail-toward-spending contract — a deterministically-raising gate would have produced an alive-but-mute loop, the exact shape #8636 is about. Reworked to fall-through-to-fire.
- Opus BLOCKING: the draft reconciler would have revived a dead monitor wake claim (`wake_in_flight=true`, `completion_evidence_deadline<=0`) that `_load` deliberately retires, creating an unretirable `NO_CHANGE` zombie. Now skipped.
- GPT BLOCKING: a single-pass reconciler could arm `update()`'s uncommitted transiently-active state and leave a rolled-back inactive loop with a live timer. The two-pass design bounds this out (mutation windows are one file write; passes are 60s apart).
- Opus CONCERN: single-pass re-arm during a >60s human turn would have caused probe-and-refuse churn against `notify_user_input`'s deliberate cancel. Two-pass + candidacy reset on user input addresses it.
- Plus: `start()` respawn guard now has the same closed-event-loop clause as `stop()`; two false comment claims fixed (interval "never races" wording; "bounded by max_cycles" when `max_cycles=0` means unlimited).

## Tests

`test/test_autonudge_reconciler.py`, 15 tests: the three cases the issue names (fire-without-hook rescued; gate exception leaves the loop alive/armed — dashboard via reconciler and channel via the fire path's self-re-arm; reconciler re-arms active-unarmed and not inactive), plus DONE-task-form stranding, mid-fire/quiesced/dead-claim/version-guard skips, two-pass quiescence (single pass never arms; user input resets candidacy; a transiently-active loop is never armed), an end-to-end periodic rescue with nobody calling `_reconcile_once` by hand, wall-clock beat under patched `asyncio.sleep`, and start/stop lifecycle.

Mutation-verified: 13 distinct mutations (gate unwrapped, exception-classified-quiet, single-pass arm, candidacy reset removed, dead-claim skip removed, version guard removed, done-task predicate weakened to membership, inactive revived, mid-fire not skipped, hollow periodic task, no reconciler spawn, fire log removed) each caught by a distinct test.

Local gates: black-baseline, isort, flake8, mypy, subprocess-encoding, brand-name, harness-parity all green under CI-pinned tool versions. The only failing test in the neighboring autonudge suites (`TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved`) fails byte-identically on pristine main — host-environmental (`$HOME` realpath), not this change.

## Out of scope (pre-existing, observed while fixing)

- The quiet-tick re-arm assigns `loop.next_due_ts` directly without mirroring `loop.monitor.next_probe_at` (`_set_monitor_deadline`) — pre-existing on the quiet path, cosmetic for non-structured loops.
- Legacy `_timer` has no `loop.active` check between its terminal bounds and the fire.
- `AutoNudgeService.stop()` has no production caller (gateway shutdown relies on `shutdown_event`), so the reconciler can linger up to one interval past shutdown.


## Pattern harvest

Class: a supervised background task whose only revival path is an externally-delivered lifecycle hook — if the hook can be skipped, the resource strands in a live-looking state with no timer-driven guarantee.

Rule candidate: review-prompt — when a component's re-arm/renew/refresh depends on a callback another subsystem must deliver (stop hooks, completion events, webhooks), require either a periodic reconciler over the persisted state or an in-band self-renewal on every exit path, plus a log line on the renew so a dead instance is distinguishable from a calm one.

<!-- readiness-refresh 2026-09-05T06:38Z -->