### PR TITLE
fix(dashboard): reset the effective session in slot switches (#8415)

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -5,7 +5,7 @@
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1601,
+  "_compliant": 1628,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -5425,6 +5425,26 @@ async def _apply_remote_pick_locked(
     return web.json_response({"ok": True, control: value, "remote": True})
 
 
+class _CommitToken(str):
+    """A ``str`` whose per-request IDENTITY marks commit ownership.
+
+    ``api_chat_slot_agent`` commits ``slot.agent`` (and the derived
+    ``slot.workspace`` / ``slot.project``) before its awaits and may have to
+    roll those commits back (session rebound, busy decline). Every one of
+    those fields has unlocked writers (openai_compat, members, the in-turn
+    /agent and set_project directives), so the rollback must not fire when
+    one of them wrote during the awaits — including a write of the SAME text,
+    which a value compare-and-set cannot distinguish from this handler's own
+    commit (the in-turn set_project directive can legitimately write the very
+    project this handler derived). A subclass instance compares, hashes,
+    serializes and persists exactly like the plain string, but is a distinct
+    object per commit: ``slot.<field> is <token>`` is therefore a sound
+    "still my write" test with no cooperation needed from the other writers.
+    """
+
+    __slots__ = ()
+
+
 async def api_chat_slot_agent(request: web.Request) -> web.Response:
     """POST /api/chat/slots/{slot}/agent — set agent for a chat slot."""
     state: DashboardState = request.app["state"]
@@ -5469,6 +5489,42 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
     # race against concurrent writers (e.g. the project endpoint, which does
     # not take this lock).
     async with slot._lock:
+        # The session the switch resets — ``effective_session_key``, never
+        # ``_history_key_for`` (see api_chat_slot_model): a channel- or
+        # cron-born slot runs its turns under its linked key, and the
+        # dashboard-prefixed spelling names a session that never existed —
+        # the reset would "succeed" against nothing while the live process
+        # kept the old agent. Resolved INSIDE the lock: the binding can land
+        # while this request waits on it.
+        session_key = effective_session_key(slot)
+        # App isolation on the SESSION, not just the slot (the cancel routes'
+        # policy): slot ownership does not imply ownership of a linked
+        # channel session, so an app caller may not switch the agent a
+        # channel thread runs on. Denied as an indistinguishable 404.
+        denied = _app_cancel_denied(request, slot, "chat.slot_agent", session_key)
+        if denied is not None:
+            return denied
+        # Never reset under an in-flight turn (the model handler's policy,
+        # and the _cancel_target subtlety): a RUNNING turn owns a captured
+        # identity because ``linked_session_key`` is mutable, so the key
+        # resolved above may not be the turn's — tearing it down would kill
+        # the wrong session (or the streaming turn itself). slot.running is
+        # checked first because it is set at dispatch, BEFORE provider.start()
+        # registers a session, so a cold-starting first turn is invisible to
+        # get_provider but not to slot.running. A 409 is retryable once the
+        # turn completes. Checked BEFORE the commit below, so nothing needs
+        # rolling back.
+        busy_provider = state.sessions.get_provider(session_key)
+        if slot.running or (
+            isinstance(busy_provider, LLMProvider) and busy_provider.has_active_turn()
+        ):
+            return web.json_response(
+                {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+            )
+        # Rollback baseline for the session_rebound path below. The commit is
+        # otherwise deliberately not rolled back on a failing reset (see the
+        # teardown_incomplete comment), so this is the ONE case that unwinds.
+        prior_agent = slot.agent
         # Stored verbatim — never rewritten to whatever currently answers. See
         # the same reasoning in api_chat_slot_create.
         new_workspace = slot.workspace
@@ -5494,7 +5550,19 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
         # binding, and a replacement session created by a concurrent send
         # mid-reset already runs it. Restoring the old label would advertise
         # a binding nothing runs (and tear against that replacement).
-        slot.agent = agent_name
+        slot.agent = _CommitToken(agent_name)
+        # Ownership token for the rollback paths below: the committed value is
+        # a str SUBCLASS instance whose identity only this request holds — it
+        # compares, hashes, serializes and persists exactly like the plain
+        # string, but `slot.agent is <token>` proves no other writer has
+        # touched the field since this commit. Any concurrent write — the
+        # unlocked openai_compat / members / in-turn directive writers
+        # included, and a SAME-VALUE write especially — replaces the object,
+        # so the rollback stands down. A value compare-and-set cannot tell
+        # "still my write" from "their equal write", and rolling back over a
+        # concurrent same-agent dispatch would restore the old agent under a
+        # turn already running the new one.
+        committed_agent = slot.agent
 
         # Resolve workspace from agent bindings. The response value is seeded
         # from the slot's CURRENT workspace, not a "default" literal: if
@@ -5544,20 +5612,75 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
         # cold-starts the replacement session from the slot's CURRENT
         # bindings, so the full new binding TRIPLE must already be visible or
         # the new agent's session starts in the OLD project and its tools run
-        # in the wrong repository. The CAS still protects a concurrent
-        # explicit pick that landed during the resolution awaits above.
+        # in the wrong repository. The write-side CAS still protects a
+        # concurrent explicit pick that landed during the resolution awaits
+        # above; the committed values are identity tokens so the ROLLBACK can
+        # prove ownership — a value compare there would erase a concurrent
+        # same-value write (the in-turn set_project directive can write the
+        # very project this handler derived).
+        committed_workspace: str | None = None
+        committed_project: str | None = None
         if slot.workspace == pre_await_workspace:
-            slot.workspace = new_workspace
+            slot.workspace = _CommitToken(new_workspace)
+            committed_workspace = slot.workspace
         if slot.project == pre_await_project:
-            slot.project = new_project
+            slot.project = _CommitToken(new_project)
+            committed_project = slot.project
 
         # Reset session so the next message uses the new agent.
         logger.info(
             "Slot %s agent switched to %r, resetting session", name, agent_name or "kirocrew"
         )
+
+        def _rollback_switch() -> None:
+            """Unwind this request's commit — only the values still OURS.
+
+            EVERY field is unwound on IDENTITY of its commit token, never
+            value equality: unlocked writers (the in-turn /agent and
+            set_project directives in chat_runner, members, openai_compat)
+            can write the SAME text during this handler's awaits — the
+            in-turn set_project directive can legitimately write the very
+            project this handler derived — and a value compare-and-set would
+            erase that successful concurrent write. Any write replaces the
+            token object, so an identity match proves the field is still
+            this commit's; a field this request never committed (the
+            write-side CAS lost) has a None token and is never touched.
+            """
+            if slot.agent is committed_agent:
+                slot.agent = prior_agent
+            if committed_workspace is not None and slot.workspace is committed_workspace:
+                slot.workspace = pre_await_workspace
+            if committed_project is not None and slot.project is committed_project:
+                slot.project = pre_await_project
+
+        # Last-instant re-probe in a NO-AWAIT window before the teardown (the
+        # model template's rule at its own reset site): the pre-commit check
+        # above is separated from this point by the resolution warm-up await,
+        # so a turn — a channel message on the linked session in particular —
+        # may have started since it ran. Message dispatch does not take
+        # slot._lock, so this fast path plus the atomic skip_if_busy decline
+        # below are what keep the teardown off a streaming turn.
+        recheck = state.sessions.get_provider(session_key)
+        if slot.running or (isinstance(recheck, LLMProvider) and recheck.has_active_turn()):
+            _rollback_switch()
+            return web.json_response(
+                {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+            )
+        # Children guard, shared with reload/model: the reset tears down the
+        # runtime attached sub-agents run on, so a parent that is idle but
+        # still has children must refuse rather than discard their work.
+        children_409 = _subagents_attached_response(state, slot, session_key, "slot_agent")
+        if children_409 is not None:
+            _rollback_switch()
+            return children_409
         teardown_incomplete = False
+        reset_ok = True
         try:
-            await _reset_slot_session(state, slot, _history_key_for(name))
+            # skip_if_busy: SessionManager.reset evaluates busyness atomically
+            # with the session pop, so a turn that slipped into the microsecond
+            # residue after the re-check above is declined instead of torn
+            # down mid-stream.
+            reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
         except Exception:
             # The switch is COMMITTED regardless: the reset pops the session
             # before its shutdown can fail, so the new binding is what every
@@ -5568,11 +5691,71 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
             # for a switch that actually happened.
             teardown_incomplete = True
             logger.exception("Slot %s agent switch: old session teardown incomplete", name)
+        if not reset_ok and not teardown_incomplete:
+            # Disambiguate the decline FAIL-CLOSED, the workspace handler's
+            # template: a live provider mid-turn → roll back and 409; a live
+            # IDLE session that declined (its turn ended before this re-read)
+            # is always safe to tear down, so retry once; a second decline
+            # means another turn is genuinely racing. No live provider means
+            # there was nothing to tear down — the next message cold-starts
+            # under the new binding, which is what the reset would arrange.
+            busy_provider = state.sessions.get_provider(session_key)
+            if isinstance(busy_provider, LLMProvider):
+                if busy_provider.has_active_turn():
+                    _rollback_switch()
+                    return web.json_response(
+                        {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+                    )
+                try:
+                    reset_ok = await _reset_slot_session(
+                        state, slot, session_key, skip_if_busy=True
+                    )
+                except Exception:
+                    # Same as the first attempt: a post-pop teardown raise is a
+                    # COMMITTED switch with a degraded teardown, not a failure.
+                    # Left unwrapped this raise escapes the handler under
+                    # slot._lock as a 500 while slot.agent stays committed and
+                    # un-rolled-back, so the acting tab's performSlotSwitch keeps
+                    # the OLD store value for a switch that happened — the exact
+                    # divergence the first-attempt guard prevents. Fall through
+                    # to the committed 200 + warning path instead.
+                    teardown_incomplete = True
+                    logger.exception("Slot %s agent switch: old session teardown incomplete", name)
+                if (
+                    not reset_ok
+                    and not teardown_incomplete
+                    and state.sessions.get_provider(session_key) is not None
+                ):
+                    _rollback_switch()
+                    return web.json_response(
+                        {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+                    )
+
+        if effective_session_key(slot) != session_key:
+            # The slot was bound to a different session while the resolution
+            # warm-up or the reset awaited (a cron/workflow slot gets linked
+            # when its first result is injected): the session this request
+            # tore down is no longer the slot's, so the committed binding
+            # would describe a session that never saw the switch. The
+            # teardown itself was harmless (that session was idle and no
+            # longer bound); roll back the commit and answer the same 409 the
+            # model and workspace handlers use. Checked BEFORE the metadata
+            # write below so a rolled-back agent is never persisted for
+            # restart.
+            _rollback_switch()
+            return web.json_response(
+                {"error": "slot session was rebound during the switch", "code": "session_rebound"},
+                status=409,
+            )
 
         # Persist the new agent so the session resumes under the correct
         # agent after a gateway restart. INSIDE the lock: two racing switches
         # otherwise interleave their metadata writes, and a stalled earlier
         # write finishing last would restore the older agent on restart.
+        # Deliberately ``_history_key_for``, NOT ``session_key``: this names
+        # the slot's TRANSCRIPT (the .jsonl the restart scan reads), not the
+        # live session the reset above addressed — the same history-vs-session
+        # split ``_cancel_target`` documents.
         if state.conversation_log:
             try:
                 # update_metadata enters _locked (flock + os.close); those are
@@ -5586,6 +5769,35 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
                 )
             except Exception:
                 logger.warning("Failed to persist agent for slot %s", name, exc_info=True)
+
+        if effective_session_key(slot) != session_key:
+            # A binding can land during the metadata await too — the rebound
+            # guard above ran BEFORE that await, so it must be re-validated
+            # after the last await inside the lock or a workflow binding
+            # landing there gets a 200 while the linked session keeps the old
+            # agent. Roll back the commit AND the metadata just persisted:
+            # the 409 tells the caller nothing changed, so the transcript
+            # metadata must agree. Restoring ``slot.agent`` (post-rollback)
+            # rather than ``prior_agent`` is deliberate — if a concurrent
+            # writer took ownership during the awaits, its value is the
+            # truthful current one. The metadata is transcript-scoped and
+            # binding-independent, so its restore needs no further re-check.
+            _rollback_switch()
+            if state.conversation_log:
+                try:
+                    await asyncio.to_thread(
+                        state.conversation_log.update_metadata,
+                        _history_key_for(name),
+                        {"agent": str(slot.agent)},
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to restore agent metadata for slot %s", name, exc_info=True
+                    )
+            return web.json_response(
+                {"error": "slot session was rebound during the switch", "code": "session_rebound"},
+                status=409,
+            )
 
         # Snapshot the response's workspace LAST, immediately before leaving
         # the lock: the metadata await above yields the event loop, so a
@@ -6666,11 +6878,25 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
     # effect (live update, deferral, or reset) — a failed request provably
     # changed nothing.
     async with slot._lock:
+        # The session the switch will probe and, on the fallback path, reset —
+        # ``effective_session_key``, never ``_history_key_for`` (see
+        # api_chat_slot_model): a channel- or cron-born slot runs its turns
+        # under its linked key, and the dashboard-prefixed spelling names a
+        # session that never existed — the live-effort probe would see
+        # nothing and the reset would "succeed" against nothing while the
+        # live process kept the old effort. Resolved INSIDE the lock: the
+        # binding can land while this request waits on it.
+        session_key = effective_session_key(slot)
+        # App isolation on the SESSION, not just the slot (the cancel routes'
+        # policy), BEFORE the same-value fast path so the denial is
+        # indistinguishable from a missing slot for every request shape.
+        denied = _app_cancel_denied(request, slot, "chat.slot_reasoning_effort", session_key)
+        if denied is not None:
+            return denied
         if slot.reasoning_effort == effort:
             return web.json_response({"ok": True, "reasoning_effort": effort})
         logger.info("Slot %s reasoning_effort switched to %r", name, effort or "default")
 
-        session_key = _history_key_for(name)
         provider = state.sessions.get_provider(session_key)
         _updated_live = False
         if isinstance(provider, AcpProvider) and provider.supports_effort():
@@ -6709,7 +6935,62 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
             _updated_live = True
             logger.info("Slot %s effort persisted (model not effort-capable)", name)
 
+        if effective_session_key(slot) != session_key and _updated_live:
+            # The slot was bound to a different session while change_effort /
+            # clear_effort awaited its provider RPC. The push landed on the
+            # session the slot WAS bound to, and change_effort already
+            # persisted the per-model override + overlay — that cannot be
+            # unwound, so a 409 here would claim a rollback that did not
+            # happen and leave the slot value contradicting the persisted
+            # override. Commit the slot value (it is what the new binding's
+            # next cold start reads) and report the rebind as a warning.
+            slot.reasoning_effort = effort
+            state.push_slots_update()
+            return web.json_response(
+                {
+                    "ok": True,
+                    "reasoning_effort": effort,
+                    "warning": "slot session was rebound during the switch; "
+                    "the new binding applies on its next cold start",
+                }
+            )
+
         if not _updated_live:
+            if effective_session_key(slot) != session_key:
+                # Rebound while a FAILED live push awaited: the reset fallback
+                # below would tear down the wrong session, and nothing is
+                # committed yet on this path, so there is genuinely nothing
+                # to roll back — answer the same 409 the model/workspace
+                # handlers use so the retry resolves the current binding.
+                return web.json_response(
+                    {
+                        "error": "slot session was rebound during the switch",
+                        "code": "session_rebound",
+                    },
+                    status=409,
+                )
+            # Never tear down an in-flight turn (the model handler's policy,
+            # and the _cancel_target subtlety: a RUNNING turn owns a captured
+            # identity, so the key resolved above may not be the turn's).
+            # Re-probed here because the change_effort awaits above yielded
+            # the event loop; slot.running is checked first because a
+            # cold-starting first turn is invisible to get_provider. The
+            # effort-capable live provider's active turn never reaches this —
+            # the defer branch above already returned for it. A 409 is
+            # retryable once the turn completes; nothing is committed yet.
+            recheck = state.sessions.get_provider(session_key)
+            if slot.running or (isinstance(recheck, LLMProvider) and recheck.has_active_turn()):
+                return web.json_response(
+                    {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
+                )
+            # Children guard, shared with reload/model: the reset tears down
+            # the runtime attached sub-agents run on. Nothing is committed
+            # yet, so a refusal here changes nothing.
+            children_409 = _subagents_attached_response(
+                state, slot, session_key, "slot_reasoning_effort"
+            )
+            if children_409 is not None:
+                return children_409
             # No live session (or live update failed): reset so the next cold
             # start picks up the new effort via the provider factory/overlay.
             # The effort is committed BEFORE the reset: a message send landing
@@ -6720,13 +7001,80 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
             # value) and is reported as a success with a warning — a 500
             # would make the acting tab keep the OLD store value for a
             # switch that actually happened.
+            prior_effort = slot.reasoning_effort
             slot.reasoning_effort = effort
+            teardown_incomplete = False
+            reset_ok = True
             try:
-                await _reset_slot_session(state, slot, session_key)
+                # skip_if_busy: the re-check above is a best-effort fast path
+                # — SessionManager.reset evaluates busyness atomically with
+                # the session pop, so a turn that slipped into the residue
+                # (or holds the semaphore before its prompt is in flight,
+                # which has_active_turn cannot see) is declined here instead
+                # of torn down mid-stream.
+                reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
             except Exception:
                 logger.exception(
                     "Slot %s reasoning_effort switch: old session teardown incomplete", name
                 )
+                teardown_incomplete = True
+            if not reset_ok and not teardown_incomplete:
+                # Disambiguate the decline FAIL-CLOSED (the workspace
+                # handler's template): live provider mid-turn → roll back and
+                # 409; live IDLE provider → retry once; no live provider →
+                # nothing to tear down, the next message cold-starts under
+                # the new effort.
+                busy_provider = state.sessions.get_provider(session_key)
+                if isinstance(busy_provider, LLMProvider):
+                    if busy_provider.has_active_turn():
+                        slot.reasoning_effort = prior_effort
+                        return web.json_response(
+                            {"error": "a turn is in flight", "code": "turn_in_flight"},
+                            status=409,
+                        )
+                    try:
+                        reset_ok = await _reset_slot_session(
+                            state, slot, session_key, skip_if_busy=True
+                        )
+                    except Exception:
+                        # A post-pop teardown raise on the retry is a COMMITTED
+                        # switch with a degraded teardown, not a failure; left
+                        # unwrapped it escapes under slot._lock as a 500 while
+                        # slot.reasoning_effort stays committed, so the acting
+                        # tab keeps the OLD store value. Fall through to the
+                        # committed 200 + warning path (the first attempt's
+                        # guard).
+                        teardown_incomplete = True
+                        logger.exception(
+                            "Slot %s reasoning_effort switch: old session teardown incomplete",
+                            name,
+                        )
+                    if (
+                        not reset_ok
+                        and not teardown_incomplete
+                        and state.sessions.get_provider(session_key) is not None
+                    ):
+                        slot.reasoning_effort = prior_effort
+                        return web.json_response(
+                            {"error": "a turn is in flight", "code": "turn_in_flight"},
+                            status=409,
+                        )
+            if effective_session_key(slot) != session_key:
+                # Same check after the reset await as after the live push:
+                # the session torn down is no longer the slot's, so the
+                # commit would advertise an effort a session that never saw
+                # the switch does not run. The teardown itself was harmless
+                # (that session was idle and no longer bound); roll back and
+                # let the retry resolve the current binding.
+                slot.reasoning_effort = prior_effort
+                return web.json_response(
+                    {
+                        "error": "slot session was rebound during the switch",
+                        "code": "session_rebound",
+                    },
+                    status=409,
+                )
+            if teardown_incomplete:
                 state.push_slots_update()
                 return web.json_response(
                     {
@@ -7017,6 +7365,16 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
     if not isinstance(project, str):
         return web.json_response({"error": "project must be a string"}, status=400)
     project = project.strip()
+    # Session-level app isolation BEFORE any filesystem probing: the
+    # isdir / sensitive-path / voice-runtime checks below answer differently
+    # for existing vs missing paths, so running them ahead of the denial
+    # would hand an app caller that owns a linked slot an unauthorized
+    # filesystem existence oracle. Best-effort read outside the lock — the
+    # locked re-check below stays authoritative for a binding that moves
+    # while this request waits on the lock.
+    denied = _app_cancel_denied(request, slot, "chat.slot_project", effective_session_key(slot))
+    if denied is not None:
+        return denied
     if project:
         project = os.path.realpath(os.path.expanduser(project))
         if not os.path.isdir(project):
@@ -7060,8 +7418,33 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
     # reset is awaited while holding the lock beyond what the other switch
     # handlers already hold.
     async with slot._lock:
+        # The session the deferred reset will address — ``effective_session_key``,
+        # never ``_history_key_for`` (see api_chat_slot_model): a channel- or
+        # cron-born slot runs its turns under its linked key, and the
+        # dashboard-prefixed spelling names a session that never existed, so
+        # the deferred reset would "succeed" against nothing while the live
+        # process kept the old CWD. Resolved INSIDE the lock (a binding can
+        # land while this request waits on it), and the flag below carries
+        # THIS key — the one the app gate authorized — so authorization and
+        # action cannot disagree. session_directive_apply's set_project path
+        # already resolves the flag the same way.
+        session_key = effective_session_key(slot)
+        # App isolation on the SESSION, not just the slot (the cancel routes'
+        # policy): slot ownership does not imply ownership of a linked
+        # channel session, so an app caller may not repoint the project a
+        # channel thread runs under. Denied as an indistinguishable 404.
+        denied = _app_cancel_denied(request, slot, "chat.slot_project", session_key)
+        if denied is not None:
+            return denied
         old_project = slot.project
-        slot.project = project
+        # _CommitToken (identity-gated rollback), the agent handler's pattern:
+        # slot.project has unlocked writers (the in-turn set_project directive
+        # writes this field without the lock, and may legitimately write the
+        # very project this handler sets). A value compare-and-set rollback
+        # cannot tell such a same-text write from this handler's own commit and
+        # would erase it; a per-request identity token can.
+        committed_project = _CommitToken(project)
+        slot.project = committed_project
         logger.info("Slot %s project set to %r", name, project)
         sel().log_api_access(
             caller=request.get("user", "dashboard"),
@@ -7083,7 +7466,29 @@ async def api_chat_slot_project(request: web.Request) -> web.Response:
         # from inside the kiro-cli process group (the set_project MCP tool); an
         # inline reset would killpg() the caller. Consumed in chat_runner.
         if project != old_project:
-            slot._pending_reset_history_key = _history_key_for(name)
+            if effective_session_key(slot) != session_key:
+                # The slot was bound to a different session while the
+                # recent-project save awaited: arming the flag with the key
+                # this request resolved would have the consumer tear down a
+                # session nobody is on while the slot's ACTUAL session keeps
+                # the old CWD — the exact stale-binding class this handler
+                # was converted to remove. Re-resolving here instead is not
+                # an option either: it would arm a key the app gate above
+                # never authorized. Roll back the commit (identity-gated on
+                # the _CommitToken — the in-turn set_project directive writes
+                # this field without the lock, and a same-value write must not
+                # be mistaken for this handler's own commit) and answer the
+                # same 409 the sibling switch handlers use.
+                if slot.project is committed_project:
+                    slot.project = old_project
+                return web.json_response(
+                    {
+                        "error": "slot session was rebound during the switch",
+                        "code": "session_rebound",
+                    },
+                    status=409,
+                )
+            slot._pending_reset_history_key = session_key
             # Speculatively re-create the session rooted at the new project so the
             # cwd change is paid during think-time. The eager task consumes the
             # deferred reset itself, but only when no turn is running — the

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -3525,6 +3525,71 @@ def _should_suppress_requeue(slot) -> bool:
     return False
 
 
+# Retry cadence for a deferred project-change reset whose consume DECLINED
+# (busy channel turn, attached children). A dashboard slot gets its retry for
+# free at the next turn boundary, but a channel-linked slot's turns do not
+# pass through those boundaries — without an owned retry, a decline against a
+# busy channel session would leave the flag armed forever while the live
+# session keeps serving the old CWD. The retry is deliberately COEXTENSIVE
+# with the flag's lifetime: it exits only when the flag clears or the slot is
+# replaced, never on a clock — a channel turn can outlast any fixed budget,
+# and a timed-out retry would strand the old project permanently on a slot
+# with no other consume boundary. One sleep per tick per armed slot is the
+# whole cost; a stuck consume is surfaced by the periodic warning below.
+_PENDING_RESET_RETRY_DELAY_SECS = 5.0
+_PENDING_RESET_RETRY_WARN_EVERY = 120  # one warning per ~10 minutes armed
+# One retry task per slot key, deduped — a decline observed by the retry task
+# itself re-enters _arm_pending_reset_retry and must not stack a second task.
+_pending_reset_retries: dict[str, tuple["_ChatSlot", asyncio.Task]] = {}
+
+
+def _arm_pending_reset_retry(state: "DashboardState", slot: "_ChatSlot") -> None:
+    """Own the retry of a declined deferred reset (channel slots have no
+    turn-boundary consume, so somebody must).
+
+    Deduped by OWNER IDENTITY, not just key: a decline observed by the retry
+    task itself re-enters here and must not stack a second task, while a
+    REPLACEMENT slot under the same key must not be suppressed by a retiring
+    owner's still-live task — that task exits on its own identity check, and
+    its compare-and-pop cleanup cannot remove a successor's registration.
+    """
+    entry = _pending_reset_retries.get(slot.key)
+    if entry is not None and entry[0] is slot and not entry[1].done():
+        return
+
+    async def _retry() -> None:
+        ticks = 0
+        try:
+            while True:
+                await asyncio.sleep(_PENDING_RESET_RETRY_DELAY_SECS)
+                if state.get_slot(slot.key) is not slot:
+                    return  # slot deleted or replaced; nothing owed BY US
+                if not slot._pending_reset_history_key:
+                    return  # consumed by a turn boundary or eager consume
+                await _consume_pending_reset(state, slot)
+                if not slot._pending_reset_history_key:
+                    return
+                ticks += 1
+                if ticks % _PENDING_RESET_RETRY_WARN_EVERY == 0:
+                    logger.warning(
+                        "Pending project-change reset for slot %s still armed "
+                        "after %d retries; the owning session has stayed busy "
+                        "(or kept children attached) the whole time",
+                        slot.key,
+                        ticks,
+                    )
+        finally:
+            # Compare-and-pop: only remove OUR OWN registration — a
+            # replacement slot may have overwritten it while this task was
+            # winding down, and popping unconditionally would orphan the
+            # successor's dedupe entry.
+            current = _pending_reset_retries.get(slot.key)
+            if current is not None and current[1] is asyncio.current_task():
+                _pending_reset_retries.pop(slot.key, None)
+
+    _pending_reset_retries[slot.key] = (slot, asyncio.create_task(_retry()))
+
+
 async def _consume_pending_reset(
     state: DashboardState, slot: _ChatSlot, *, allow_discard: bool = False
 ) -> bool:
@@ -3583,28 +3648,91 @@ async def _consume_pending_reset(
     torn_down = False
     if slot._pending_reset_history_key:
         pending_key = slot._pending_reset_history_key
-        # This reset does not go through `_reset_slot_session`, so it drops the
-        # withhold verdict itself: a project change can resolve a different
-        # agent, and the next session may advertise a different model list. Done
-        # BEFORE the await and regardless of the outcome -- a teardown that
-        # failed leaves the session in a state this slot cannot vouch for, and
-        # "unknown" is the direction that fails open.
-        slot.record_model_withheld(None)
-        try:
-            await state.sessions.reset(pending_key)
-            torn_down = True
-            if slot._pending_reset_history_key == pending_key:
-                slot._pending_reset_history_key = None
-            # Freshness push for open tabs; verdict-driven, so a teardown that
-            # raised above never reaches it and a declined one broadcasts
-            # nothing (see _broadcast_expired_oauth_banners).
-            _broadcast_expired_oauth_banners(state, slot)
-        except Exception:
-            logger.warning(
-                "Failed to consume pending project-change reset for slot %s",
+        current_key = effective_session_key(slot)
+        if pending_key != current_key:
+            # The slot REBOUND after the flag was armed (a cron/workflow slot
+            # gets linked when its first result is injected; a channel link can
+            # land between arming and this consume). Resetting the stale key and
+            # clearing the flag would tear down a session nobody is on and let
+            # the slot's ACTUAL session keep the old CWD forever — the exact
+            # stale-binding class this deferral exists to remove. Re-arm to the
+            # current session so the reset lands where the turns run; the
+            # producer already validated the project change belongs to this
+            # slot, and re-pointing the key needs no re-authorization (it names
+            # the slot's own live session, not a new authority).
+            slot._pending_reset_history_key = current_key
+            _arm_pending_reset_retry(state, slot)
+            return torn_down
+        if subagents_attached(state, slot, pending_key, "consume_pending_reset"):
+            # Left armed on purpose, same as the discard branch below: the
+            # reset releases the shared runtime attached children run on, so
+            # applying it now would discard their work. The retry task owns
+            # the follow-up — children can outlive every turn boundary.
+            logger.debug(
+                "Deferring queued project-change reset for slot %s: sub-agents attached",
                 slot.key,
-                exc_info=True,
             )
+            _arm_pending_reset_retry(state, slot)
+        else:
+            try:
+                # skip_if_busy, for the same reason the discard branch below
+                # gives: the pending key can name a LIVE channel session (a
+                # linked slot's project change arms `slack:<ts>`), and a force
+                # reset here would tear the provider down under a streaming
+                # channel reply. The check and the teardown must be one atomic
+                # step under the session lock.
+                #
+                # The flag is spent ONLY on a real teardown (reset returned
+                # True). A False return cannot distinguish "nothing registered
+                # under the key" from a busy decline or a session that is
+                # COLD-STARTING and not yet registered — clearing on a probe
+                # that answered None would let a concurrent cold start carrying
+                # the old CWD register afterwards and serve the stale project
+                # with the flag already gone. Leaving it armed is always safe:
+                # the next consume lands it, at worst costing one redundant
+                # cold start after the reset tears down an already-correct
+                # idle session.
+                reset_ok = await state.sessions.reset(pending_key, skip_if_busy=True)
+            except Exception:
+                # A teardown that raised leaves the session in a state this
+                # slot cannot vouch for — neither is its withhold verdict, so
+                # drop it ("unknown" fails open), mirroring
+                # `_reset_slot_session`'s BaseException path. This reset does
+                # not go through that helper, so it owns the drop itself.
+                slot.record_model_withheld(None)
+                logger.warning(
+                    "Failed to consume pending project-change reset for slot %s",
+                    slot.key,
+                    exc_info=True,
+                )
+            else:
+                if reset_ok:
+                    # The verdict describes the session that advertised the
+                    # model list, and that session is gone. Dropped only on a
+                    # REAL teardown (or the raise above): a busy decline
+                    # leaves the session — and therefore its verdict — live
+                    # and accurate, and erasing it would let the dashboard
+                    # show a withheld model as available.
+                    slot.record_model_withheld(None)
+                    torn_down = True
+                    if slot._pending_reset_history_key == pending_key:
+                        slot._pending_reset_history_key = None
+                    # Freshness push for open tabs; verdict-driven (see
+                    # _broadcast_expired_oauth_banners).
+                    _broadcast_expired_oauth_banners(state, slot)
+                else:
+                    logger.debug(
+                        "Deferring queued project-change reset for slot %s: "
+                        "no teardown landed (busy, cold-starting, or no session)",
+                        slot.key,
+                    )
+                    # A channel-linked slot's turns never pass a dashboard
+                    # turn boundary, so a decline here would otherwise never
+                    # be retried and the live channel session would keep the
+                    # old CWD indefinitely. The bounded retry task owns the
+                    # follow-up (deduped; a decline observed by the task
+                    # itself does not stack a second one).
+                    _arm_pending_reset_retry(state, slot)
     if allow_discard and slot._pending_discard_conversation_key:
         discard_key = slot._pending_discard_conversation_key
         if subagents_attached(state, slot, discard_key, "consume_pending_discard"):
@@ -3837,6 +3965,15 @@ async def _eager_spawn(
             return
         async with _eager_spawn_sem:
             await _consume_pending_reset(state, slot)
+            if slot._pending_reset_history_key:
+                # The deferred reset could not land (busy channel turn,
+                # attached children, cold-starting session): pre-warming now
+                # would REUSE or register a session under a key whose
+                # teardown is still owed, and the first real turn would run
+                # on the stale bindings the armed flag exists to remove. The
+                # consumer's retry task owns the follow-up; eager spawn
+                # simply stands down.
+                return
             session_key = effective_session_key(slot)
             if allow_resume:
                 # The focus signal only ever adds the RESUME case; fresh eager

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -1453,6 +1453,20 @@ class TestRequeueSuppression:
 
 
 class TestConsumePendingReset:
+    async def _drain_retry(self, slot_key: str) -> None:
+        """Cancel and await the slot's pending-reset retry task, if armed.
+
+        The decline paths arm a real background task; leaving it pending when
+        the test's loop closes emits 'Task was destroyed but it is pending'.
+        """
+        entry = chat_runner._pending_reset_retries.pop(slot_key, None)
+        if entry is not None:
+            entry[1].cancel()
+            try:
+                await entry[1]
+            except asyncio.CancelledError:
+                pass
+
     @pytest.mark.asyncio
     async def test_no_pending_key_is_a_noop(self, tmp_path):
         state, slot = _state(tmp_path), _slot()
@@ -1465,19 +1479,166 @@ class TestConsumePendingReset:
     async def test_successful_reset_clears_the_flag(self, tmp_path):
         state, slot = _state(tmp_path), _slot()
         slot._pending_reset_history_key = "dashboard:chat-cov-1"
+        state.sessions.reset = AsyncMock(return_value=True)
 
         await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
 
-        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1")
+        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1", skip_if_busy=True)
         assert slot._pending_reset_history_key is None
+
+    @pytest.mark.asyncio
+    async def test_busy_decline_leaves_the_flag_armed(self, tmp_path):
+        # The pending key can name a LIVE channel session (a linked slot's
+        # project change arms slack:<ts>): a busy decline must leave the flag
+        # armed for a later consume instead of tearing down the streaming
+        # reply — the discard branch's pattern. The withhold verdict survives
+        # too: it describes the session that advertised the model list, and
+        # that session is still live and accurate after a decline.
+        state, slot = _state(tmp_path), _slot()
+        slot.linked_session_key = "slack:123.456"
+        slot._pending_reset_history_key = "slack:123.456"
+        slot.model = "some-model"
+        slot.record_model_withheld(True)
+        state.sessions.reset = AsyncMock(return_value=False)
+        state.sessions.get_provider = MagicMock(return_value=MagicMock())
+
+        torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
+
+        assert torn_down is False
+        assert slot._pending_reset_history_key == "slack:123.456"
+        assert slot.model_withheld is True
+        await self._drain_retry(slot.key)
+
+    @pytest.mark.asyncio
+    async def test_busy_decline_arms_a_retry_that_lands_the_reset(self, tmp_path, monkeypatch):
+        # A channel-linked slot's turns never pass a dashboard turn boundary,
+        # so a busy decline arms a bounded retry task; once the channel turn
+        # releases the session, the retry lands the teardown and spends the
+        # flag — no eager reuse of the stale provider in between.
+        monkeypatch.setattr(chat_runner, "_PENDING_RESET_RETRY_DELAY_SECS", 0.01)
+        state, slot = _state(tmp_path), _slot()
+        state._slots[slot.key] = slot
+        slot.linked_session_key = "slack:123.456"
+        slot._pending_reset_history_key = "slack:123.456"
+        # First consume declines (turn in flight), the retry's consume lands.
+        state.sessions.reset = AsyncMock(side_effect=[False, True])
+
+        torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=False)
+        assert torn_down is False
+        assert slot._pending_reset_history_key == "slack:123.456"
+
+        task = chat_runner._pending_reset_retries.get(slot.key)
+        assert task is not None
+        assert task[0] is slot
+        await asyncio.wait_for(task[1], timeout=2.0)
+        assert slot._pending_reset_history_key is None
+        assert state.sessions.reset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_replacement_slot_retry_is_not_suppressed(self, tmp_path, monkeypatch):
+        # A retiring owner's still-live retry task must not dedupe away a
+        # REPLACEMENT slot's retry under the same key: the old task exits on
+        # its own identity check and cannot clear the flag the replacement
+        # owns, so suppressing the new registration would strand the
+        # replacement on the stale project forever.
+        monkeypatch.setattr(chat_runner, "_PENDING_RESET_RETRY_DELAY_SECS", 0.01)
+        state = _state(tmp_path)
+        old_owner = _slot()
+
+        async def _sleep_forever() -> None:
+            await asyncio.sleep(30)
+
+        stale_task = asyncio.get_running_loop().create_task(_sleep_forever())
+        chat_runner._pending_reset_retries[old_owner.key] = (old_owner, stale_task)
+
+        replacement = _slot()  # same key, different object
+        replacement.linked_session_key = "slack:123.456"
+        state._slots[replacement.key] = replacement
+        replacement._pending_reset_history_key = "slack:123.456"
+        state.sessions.reset = AsyncMock(side_effect=[False, True])
+
+        await chat_runner._consume_pending_reset(state, replacement, allow_discard=False)
+        entry = chat_runner._pending_reset_retries.get(replacement.key)
+        assert entry is not None
+        assert entry[0] is replacement
+        await asyncio.wait_for(entry[1], timeout=2.0)
+        assert replacement._pending_reset_history_key is None
+
+        stale_task.cancel()
+        try:
+            await stale_task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_no_teardown_leaves_the_flag_armed(self, tmp_path):
+        # reset() returns False for a busy decline, for "nothing registered
+        # under the key", AND for a key whose session is cold-starting and
+        # not yet registered — the three cannot be told apart from here, so
+        # the flag is spent only on a real teardown. Clearing on a None
+        # provider probe would let a concurrent cold start carrying the old
+        # CWD register after the clear and serve the stale project.
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_reset_history_key = "dashboard:chat-cov-1"
+        state.sessions.reset = AsyncMock(return_value=False)
+
+        torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
+
+        assert torn_down is False
+        assert slot._pending_reset_history_key == "dashboard:chat-cov-1"
+        await self._drain_retry(slot.key)
+
+    @pytest.mark.asyncio
+    async def test_a_rebind_re_arms_the_current_key_and_does_not_reset_the_stale_one(
+        self, tmp_path, monkeypatch
+    ):
+        # The flag was armed for session A, then the slot REBOUND to B (a
+        # cron/workflow slot gets linked when its first result is injected, a
+        # channel link can land between arming and consume). Resetting A and
+        # clearing the flag would tear down a session nobody is on and let B
+        # keep the old CWD forever. The consume must re-arm the flag to B and
+        # leave A alone, so a later consume lands the reset where the turns run.
+        monkeypatch.setattr(chat_runner, "_PENDING_RESET_RETRY_DELAY_SECS", 0.01)
+        state, slot = _state(tmp_path), _slot()
+        state._slots[slot.key] = slot
+        slot.linked_session_key = "slack:B.new"  # slot now runs turns on B
+        slot._pending_reset_history_key = "slack:A.old"  # flag armed for A
+
+        torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=False)
+
+        assert torn_down is False
+        # A was never reset; the flag re-points at the slot's current session.
+        state.sessions.reset.assert_not_awaited()
+        assert slot._pending_reset_history_key == "slack:B.new"
+        await self._drain_retry(slot.key)
+
+    @pytest.mark.asyncio
+    async def test_attached_subagents_defer_the_pending_reset(self, tmp_path):
+        # The reset releases the shared runtime attached children run on —
+        # a slot with children leaves the flag armed for a later consume,
+        # the same policy as the discard branch.
+        state, slot = _state(tmp_path), _slot()
+        slot._pending_reset_history_key = "dashboard:chat-cov-1"
+        subs = MagicMock()
+        subs.running_agents_for = MagicMock(return_value=["child-1"])
+        state.subagents = subs
+
+        torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=False)
+
+        assert torn_down is False
+        state.sessions.reset.assert_not_awaited()
+        assert slot._pending_reset_history_key == "dashboard:chat-cov-1"
+        await self._drain_retry(slot.key)
 
     @pytest.mark.asyncio
     async def test_a_key_queued_during_the_await_is_not_clobbered(self, tmp_path):
         state, slot = _state(tmp_path), _slot()
+        slot.linked_session_key = "old-key"
         slot._pending_reset_history_key = "old-key"
 
-        async def _reset(_key):
+        async def _reset(_key, **_kwargs):
             slot._pending_reset_history_key = "newer-key"
+            return True
 
         state.sessions.reset = AsyncMock(side_effect=_reset)
 
@@ -1488,6 +1649,7 @@ class TestConsumePendingReset:
     @pytest.mark.asyncio
     async def test_reset_failure_leaves_the_flag_armed(self, tmp_path):
         state, slot = _state(tmp_path), _slot()
+        slot.linked_session_key = "old-key"
         slot._pending_reset_history_key = "old-key"
         state.sessions.reset = AsyncMock(side_effect=RuntimeError("no session"))
 
@@ -1564,7 +1726,7 @@ class TestConsumePendingReset:
 
         await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
 
-        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1")
+        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1", skip_if_busy=True)
         state.sessions.discard_conversation.assert_awaited_once_with(
             "dashboard:chat-cov-1", replay=False, skip_if_busy=True
         )
@@ -1574,6 +1736,7 @@ class TestConsumePendingReset:
     @pytest.mark.asyncio
     async def test_a_failed_project_reset_does_not_block_the_discard(self, tmp_path):
         state, slot = _state(tmp_path), _slot()
+        slot.linked_session_key = "old-key"
         slot._pending_reset_history_key = "old-key"
         slot._pending_discard_conversation_key = "old-key"
         state.sessions.reset = AsyncMock(side_effect=RuntimeError("no session"))
@@ -1633,7 +1796,7 @@ class TestConsumePendingDiscardBoundary:
 
         torn_down = await chat_runner._consume_pending_reset(state, slot)
 
-        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1")
+        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1", skip_if_busy=True)
         assert torn_down is True
 
     @pytest.mark.asyncio
@@ -1797,23 +1960,33 @@ class TestConsumePendingDiscardWaitsForSubagents:
         )
 
     @pytest.mark.asyncio
-    async def test_the_project_reset_is_not_gated_on_children(self, tmp_path):
-        """Scope pin: the guard covers the conversation discard this change
-        introduced. The pre-existing project-change reset keeps its behaviour."""
+    async def test_the_project_reset_is_deferred_on_children(self, tmp_path):
+        """The project reset releases the shared runtime attached children run
+        on, so a slot with children leaves the flag armed for a later consume
+        (the same policy as the discard branch, and what
+        test_attached_subagents_defer_the_pending_reset pins)."""
         state, slot = _state(tmp_path), _slot()
         state.subagents = _subs([{"id": "a1"}])
         slot._pending_reset_history_key = "dashboard:chat-cov-1"
 
         torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
 
-        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1")
-        assert slot._pending_reset_history_key is None
-        assert torn_down is True
+        state.sessions.reset.assert_not_awaited()
+        assert slot._pending_reset_history_key == "dashboard:chat-cov-1"
+        assert torn_down is False
+        _entry = chat_runner._pending_reset_retries.pop(slot.key, None)
+        if _entry is not None:
+            _entry[1].cancel()
+            try:
+                await _entry[1]
+            except asyncio.CancelledError:
+                pass
 
     @pytest.mark.asyncio
-    async def test_a_deferred_discard_does_not_hide_a_project_reset(self, tmp_path):
-        """Both queued, children attached: the project reset still runs and the
-        discard stays armed, so neither deferral swallows the other."""
+    async def test_both_deferrals_stay_armed_when_children_are_attached(self, tmp_path):
+        """Both queued, children attached: neither the project reset nor the
+        discard runs — both release the shared runtime attached children run
+        on — so both flags stay armed for a later consume."""
         state, slot = _state(tmp_path), _slot()
         state.subagents = _subs([{"id": "a1"}])
         slot._pending_reset_history_key = "dashboard:chat-cov-1"
@@ -1821,11 +1994,18 @@ class TestConsumePendingDiscardWaitsForSubagents:
 
         torn_down = await chat_runner._consume_pending_reset(state, slot, allow_discard=True)
 
-        state.sessions.reset.assert_awaited_once_with("dashboard:chat-cov-1")
+        state.sessions.reset.assert_not_awaited()
         state.sessions.discard_conversation.assert_not_awaited()
-        assert slot._pending_reset_history_key is None
+        assert slot._pending_reset_history_key == "dashboard:chat-cov-1"
         assert slot._pending_discard_conversation_key == "dashboard:chat-cov-1"
-        assert torn_down is True
+        assert torn_down is False
+        _entry = chat_runner._pending_reset_retries.pop(slot.key, None)
+        if _entry is not None:
+            _entry[1].cancel()
+            try:
+                await _entry[1]
+            except asyncio.CancelledError:
+                pass
 
     @pytest.mark.asyncio
     async def test_no_registry_abstains_rather_than_blocking_forever(self, tmp_path):

--- a/test/test_chat_slot_switch_atomicity.py
+++ b/test/test_chat_slot_switch_atomicity.py
@@ -20,7 +20,10 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard.chat import (
+    api_chat_slot_agent,
     api_chat_slot_model,
+    api_chat_slot_project,
+    api_chat_slot_reasoning_effort,
     api_chat_slot_workspace,
     api_chat_slots_model,
 )
@@ -48,6 +51,9 @@ def _make_app(state: DashboardState) -> web.Application:
     app.router.add_post("/api/chat/slots/model", api_chat_slots_model)
     app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
     app.router.add_post("/api/chat/slots/{slot}/workspace", api_chat_slot_workspace)
+    app.router.add_post("/api/chat/slots/{slot}/agent", api_chat_slot_agent)
+    app.router.add_post("/api/chat/slots/{slot}/reasoning-effort", api_chat_slot_reasoning_effort)
+    app.router.add_post("/api/chat/slots/{slot}/project", api_chat_slot_project)
     return app
 
 
@@ -979,6 +985,9 @@ def _make_app_as(state: DashboardState, app_name: str) -> web.Application:
     app.router.add_post("/api/chat/slots/model", api_chat_slots_model)
     app.router.add_post("/api/chat/slots/{slot}/model", api_chat_slot_model)
     app.router.add_post("/api/chat/slots/{slot}/workspace", api_chat_slot_workspace)
+    app.router.add_post("/api/chat/slots/{slot}/agent", api_chat_slot_agent)
+    app.router.add_post("/api/chat/slots/{slot}/reasoning-effort", api_chat_slot_reasoning_effort)
+    app.router.add_post("/api/chat/slots/{slot}/project", api_chat_slot_project)
     return app
 
 
@@ -1206,6 +1215,462 @@ class TestLinkedSlotSessionKey:
             assert resp.status == 409
             assert data["code"] == "session_rebound"
             assert (slot.workspace, slot.project) == (prior_ws, prior_project)
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_resets_the_linked_session(self, monkeypatch):
+        # The reset targets the linked session; the transcript-metadata write
+        # stays HISTORY-keyed — it names the .jsonl the restart scan reads,
+        # not the live session (the _cancel_target history-vs-session split).
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom)
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        state.conversation_log = MagicMock()
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            assert resp.status == 200
+            assert slot.agent == "new-agent"
+            assert state.sessions.reset.await_args.args[0] == "slack:123.456"
+            meta_call = state.conversation_log.update_metadata.call_args
+            assert meta_call.args[0] == "dashboard:test"
+
+    @pytest.mark.asyncio
+    async def test_agent_switch_sees_the_linked_sessions_active_turn(self):
+        # The busy probe lands on the live linked session: an in-flight
+        # channel turn answers 409 instead of tearing the turn (or a
+        # captured-identity session) down.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        slot.linked_session_key = "slack:123.456"
+        provider = MagicMock(spec=AcpProvider)
+        provider.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=None)
+        state.sessions.get_provider = MagicMock(
+            side_effect=lambda key: provider if key == "slack:123.456" else None
+        )
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.agent == "old-agent"
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_app_caller_cannot_switch_a_linked_sessions_agent(self):
+        # Owning the slot is not owning the channel session it is bound to:
+        # denied as an indistinguishable 404, nothing mutated.
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        slot._app = "demo-app"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            assert resp.status == 404
+            assert slot.agent == "old-agent"
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_reset_rolls_back_the_agent_switch(self, monkeypatch):
+        # The session torn down is no longer the slot's: the commit — the one
+        # case the agent handler's no-rollback rule unwinds — is rolled back,
+        # the metadata write never runs, and the caller retries against the
+        # current binding.
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom)
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        state = _mock_state(slot, provider=None)
+        state.conversation_log = MagicMock()
+
+        async def _reset_and_rebind(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.agent == "old-agent"
+            state.conversation_log.update_metadata.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_effort_switch_probes_and_resets_the_linked_session(self):
+        slot = _ChatSlot("test")
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort", json={"reasoning_effort": "high"}
+            )
+            assert resp.status == 200
+            assert slot.reasoning_effort == "high"
+            probed = {c.args[0] for c in state.sessions.get_provider.call_args_list}
+            assert probed == {"slack:123.456"}
+            assert state.sessions.reset.await_args.args[0] == "slack:123.456"
+
+    @pytest.mark.asyncio
+    async def test_effort_switch_defers_on_the_linked_sessions_active_turn(self):
+        # The live-effort probe lands on the linked session, so its active
+        # turn takes the defer branch (commit now, live push next turn)
+        # instead of a reset against a session that never existed.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        slot.linked_session_key = "slack:123.456"
+        provider = MagicMock(spec=AcpProvider)
+        provider.supports_effort.return_value = True
+        provider.has_active_turn.return_value = True
+        state = _mock_state(slot, provider=None)
+        state.sessions.get_provider = MagicMock(
+            side_effect=lambda key: provider if key == "slack:123.456" else None
+        )
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort", json={"reasoning_effort": "high"}
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["deferred"] is True
+            assert slot.reasoning_effort == "high"
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_app_caller_cannot_switch_a_linked_sessions_effort(self):
+        slot = _ChatSlot("test")
+        slot._app = "demo-app"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot, provider=None)
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort", json={"reasoning_effort": "high"}
+            )
+            assert resp.status == 404
+            assert slot.reasoning_effort == ""
+            state.sessions.reset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_reset_rolls_back_the_effort_switch(self):
+        slot = _ChatSlot("test")
+        state = _mock_state(slot, provider=None)
+
+        async def _reset_and_rebind(*_a, **_k):
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort", json={"reasoning_effort": "high"}
+            )
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.reasoning_effort == ""
+
+    @pytest.mark.asyncio
+    async def test_project_set_defers_the_reset_under_the_linked_session_key(self, tmp_path):
+        # The deferred-reset flag carries the linked key (the key the app
+        # gate authorized), so the chat_runner consumer tears down the
+        # session the slot actually runs on — not dashboard:<slot>.
+        import os
+
+        slot = _ChatSlot("test")
+        slot.project = "/workspace/old-ws"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot)
+        new_dir = os.path.realpath(str(tmp_path))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/project", json={"project": new_dir})
+            assert resp.status == 200
+            assert slot.project == new_dir
+            assert slot._pending_reset_history_key == "slack:123.456"
+
+    @pytest.mark.asyncio
+    async def test_app_caller_cannot_set_a_linked_sessions_project(self, tmp_path):
+        import os
+
+        slot = _ChatSlot("test")
+        slot.project = "/workspace/old-ws"
+        slot._app = "demo-app"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot)
+        new_dir = os.path.realpath(str(tmp_path))
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post("/api/chat/slots/test/project", json={"project": new_dir})
+            assert resp.status == 404
+            assert slot.project == "/workspace/old-ws"
+            assert not slot._pending_reset_history_key
+
+    @pytest.mark.asyncio
+    async def test_agent_reset_declined_busy_rolls_back_and_answers_409(self, monkeypatch):
+        # A turn can start after the last-instant re-check (message dispatch
+        # does not take slot._lock): the reset runs with skip_if_busy=True and
+        # its atomic decline is authoritative — the committed agent is rolled
+        # back, the metadata write never runs, and the in-flight turn survives.
+        from kiro_crew.providers.base import LLMProvider
+
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom)
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        state = _mock_state(slot)
+        state.conversation_log = MagicMock()
+        busy = MagicMock(spec=LLMProvider)
+        # Idle at the pre-commit check and the last-instant re-check (so the
+        # handler proceeds into the reset), mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, False, True]
+        state.sessions.get_provider = MagicMock(return_value=busy)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.agent == "old-agent"
+            assert state.sessions.reset.await_args.kwargs == {"skip_if_busy": True}
+            state.conversation_log.update_metadata.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_effort_reset_declined_busy_rolls_back_and_answers_409(self):
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        state = _mock_state(slot)
+        busy = MagicMock(spec=LLMProvider)
+        # Idle at the pre-reset re-check, mid-turn at the post-decline
+        # re-read: the turn slipped into the reset's own entry window.
+        busy.has_active_turn.side_effect = [False, True]
+        state.sessions.get_provider = MagicMock(return_value=busy)
+        state.sessions.reset = AsyncMock(return_value=False)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort", json={"reasoning_effort": "high"}
+            )
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "turn_in_flight"
+            assert slot.reasoning_effort == ""
+            assert state.sessions.reset.await_args.kwargs == {"skip_if_busy": True}
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_metadata_persist_rolls_back_and_answers_409(self, monkeypatch):
+        # The metadata write awaits AFTER the post-reset rebound guard, so a
+        # binding landing there must be caught by a second re-validation —
+        # otherwise the switch answers 200 while the linked session keeps the
+        # old agent. The rollback also restores the transcript metadata the
+        # write just persisted, so the 409's "nothing changed" is true.
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom)
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        state = _mock_state(slot, provider=None)
+        state.sessions.reset = AsyncMock(return_value=True)
+        log = MagicMock()
+
+        def _persist_and_rebind(_key, _meta):
+            if not slot.linked_session_key:
+                slot.linked_session_key = "cron:job-1"
+
+        log.update_metadata = MagicMock(side_effect=_persist_and_rebind)
+        state.conversation_log = log
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.agent == "old-agent"
+            # The restore wrote the rolled-back agent back into the
+            # transcript metadata (last call).
+            assert log.update_metadata.call_args.args[1] == {"agent": "old-agent"}
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_agent_write_survives_the_rollback(self, monkeypatch):
+        # An unlocked writer (openai_compat / members / in-turn directive)
+        # can write the SAME agent name during this handler's reset await and
+        # dispatch on it. The rollback is gated on the write GENERATION, not
+        # the value, so that concurrent write takes ownership and the
+        # rollback stands down — a value compare-and-set would restore the
+        # old agent over a dispatch already running the new one.
+        def _boom():
+            raise RuntimeError("config unreadable")
+
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", _boom)
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        state = _mock_state(slot, provider=None)
+        state.conversation_log = MagicMock()
+
+        async def _reset_concurrent_write_and_rebind(*_a, **_k):
+            # The concurrent same-value write, then the rebind that forces
+            # this request onto its rollback path.
+            slot.agent = "new-agent"
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_concurrent_write_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            # The concurrent writer's value survives; only OUR commit unwinds.
+            assert slot.agent == "new-agent"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_same_project_write_survives_the_rollback(self, monkeypatch):
+        # The in-turn set_project directive can write the VERY project this
+        # handler derived, during the reset await. The rollback is gated on
+        # each field's commit-token identity, so that successful concurrent
+        # write survives — a value compare-and-set would erase it back to the
+        # pre-switch project.
+        mock_cfg = MagicMock()
+        mock_cfg.agents = {}
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.warm_project_agent_names", AsyncMock()
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: MagicMock(workspace_dir="/tmp/ws2"),
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._workspace_name_for_dir",
+            lambda cfg, ws_dir: "ws2",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.default_project_dir",
+            lambda ws: "/workspace/derived",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.cached_project_agent_names",
+            lambda p: frozenset(),
+        )
+        slot = _ChatSlot("test")
+        slot.agent = "old-agent"
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot, provider=None)
+        state.conversation_log = MagicMock()
+
+        async def _reset_concurrent_project_write_and_rebind(*_a, **_k):
+            # The concurrent same-value write (a plain str, new identity),
+            # then the rebind that forces this request onto its rollback.
+            slot.project = "/workspace/derived"
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        state.sessions.reset = AsyncMock(side_effect=_reset_concurrent_project_write_and_rebind)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/agent", json={"agent": "new-agent"})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            # The concurrent writer's project survives (a value CAS would
+            # have restored /workspace/old-ws); our own agent commit unwinds.
+            assert slot.project == "/workspace/derived"
+            assert slot.agent == "old-agent"
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_project_save_rolls_back_and_answers_409(
+        self, tmp_path, monkeypatch
+    ):
+        # A binding that lands while the recent-project save awaits means the
+        # deferred-reset flag would name a session the slot no longer runs on
+        # (and the flag's consumer would tear down a session nobody is on
+        # while the actual session keeps the old CWD): the commit is rolled
+        # back, the flag stays unarmed, and the caller retries against the
+        # current binding.
+        import os
+
+        slot = _ChatSlot("test")
+        slot.project = "/workspace/old-ws"
+        state = _mock_state(slot)
+
+        def _save_and_rebind(_project):
+            slot.linked_session_key = "cron:job-1"
+
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._save_recent_project", _save_and_rebind
+        )
+        new_dir = os.path.realpath(str(tmp_path))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/test/project", json={"project": new_dir})
+            data = await resp.json()
+            assert resp.status == 409
+            assert data["code"] == "session_rebound"
+            assert slot.project == "/workspace/old-ws"
+            assert not slot._pending_reset_history_key
+
+    @pytest.mark.asyncio
+    async def test_app_caller_project_denied_before_path_probing(self):
+        # The isdir/sensitive-path probes answer differently for existing vs
+        # missing paths: an app caller that owns a linked slot must get the
+        # indistinguishable 404 BEFORE any filesystem check, or the endpoint
+        # is a filesystem existence oracle for unauthorized callers (a
+        # missing path would leak as the probe's 400 instead).
+        slot = _ChatSlot("test")
+        slot.project = "/workspace/old-ws"
+        slot._app = "demo-app"
+        slot.linked_session_key = "slack:123.456"
+        state = _mock_state(slot)
+        async with TestClient(TestServer(_make_app_as(state, "demo-app"))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/project",
+                json={"project": "/definitely/not/a/real/dir-8415"},
+            )
+            assert resp.status == 404
+            assert slot.project == "/workspace/old-ws"
+
+    @pytest.mark.asyncio
+    async def test_rebind_during_live_effort_push_commits_with_warning(self):
+        # change_effort persisted the per-model override before the rebind
+        # was observable, so a 409 would claim a rollback that did not
+        # happen: the slot value is committed (it is what the new binding's
+        # next cold start reads) and the rebind is reported as a warning.
+        from kiro_crew.providers.acp import AcpProvider
+
+        slot = _ChatSlot("test")
+        state = _mock_state(slot, provider=None)
+        provider = MagicMock(spec=AcpProvider)
+        provider.supports_effort.return_value = True
+        provider.has_active_turn.return_value = False
+
+        async def _push_and_rebind(_effort):
+            slot.linked_session_key = "cron:job-1"
+            return True
+
+        provider.change_effort = AsyncMock(side_effect=_push_and_rebind)
+        state.sessions.get_provider = MagicMock(return_value=provider)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort", json={"reasoning_effort": "high"}
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert "rebound" in data["warning"]
+            assert slot.reasoning_effort == "high"
+            state.sessions.reset.assert_not_awaited()
 
 
 class TestSlotProjectSwitchAtomicity:

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -1510,7 +1510,7 @@ class TestPendingProjectReset:
         with _patch_stats():
             await _run_chat(state, slot, "hello")
 
-        state.sessions.reset.assert_any_await("dashboard:chat-1-test")
+        state.sessions.reset.assert_any_await("dashboard:chat-1-test", skip_if_busy=True)
         # reset() must appear before get_or_create() on the parent sessions mock.
         sess_calls = state.sessions.mock_calls
         reset_pos = next(i for i, c in enumerate(sess_calls) if c[0] == "reset")
@@ -1561,7 +1561,7 @@ class TestPendingProjectReset:
         with _patch_stats():
             await _run_chat(state, slot, "hello")
 
-        state.sessions.reset.assert_any_await("dashboard:chat-1-test")
+        state.sessions.reset.assert_any_await("dashboard:chat-1-test", skip_if_busy=True)
         assert slot._pending_reset_history_key is None
 
 

--- a/test/test_eager_spawn.py
+++ b/test/test_eager_spawn.py
@@ -176,7 +176,7 @@ class TestEagerSpawn:
         state = _mock_state(slot)
         with patch.object(chat_runner.KiroCrewConfig, "load", _cfg(True)):
             await _eager_spawn(state, slot)
-        state.sessions.reset.assert_awaited_once_with("dashboard:t1")
+        state.sessions.reset.assert_awaited_once_with("dashboard:t1", skip_if_busy=True)
         assert slot._pending_reset_history_key is None
         state.sessions.get_or_create.assert_awaited_once()
 
@@ -496,6 +496,12 @@ class TestProjectSetWiring:
         state._slots = {slot.key: slot}
         state.push_slots_update = MagicMock()
         state.conversation_log = None  # instance attr; spec= does not provide it
+        # The switch handler re-probes the live session in a no-await window
+        # before the teardown (state.sessions.get_provider); sessions is an
+        # instance attr spec= does not synthesize. None = no live session, so
+        # the re-probe passes and the committed switch proceeds.
+        state.sessions = MagicMock()
+        state.sessions.get_provider = MagicMock(return_value=None)
         app = web.Application()
         app["state"] = state
         app.router.add_post("/api/chat/slots/{slot}/agent", api_chat_slot_agent)


### PR DESCRIPTION
## Summary

Item 2 of #8415: three slot-switch handlers still addressed the slot's session as `_history_key_for(name)` (`dashboard:<slot>`). For a channel-/cron-linked slot that key names a session that never existed, so the live probe saw nothing, the reset "succeeded" against nothing, and an IDLE linked session kept serving the old agent/effort/project while the handler reported success. #5697 converted the model, bulk-model and workspace handlers; this applies the same template to the three that remained.

- **`api_chat_slot_agent`** — `session_key = effective_session_key(slot)` resolved inside the slot lock; session-level app isolation via `_app_cancel_denied("chat.slot_agent", ...)`; 409 `turn_in_flight` before the commit and again in a no-await window before the teardown; `_reset_slot_session(..., skip_if_busy=True)` with the workspace handler's fail-closed decline disambiguation (mid-turn → CAS rollback + 409, idle decline → one retry); sub-agent children guard; 409 `session_rebound` rollback when the binding moves during the awaits. The `update_metadata` write deliberately stays history-keyed — it names the transcript, not the live session.
- **`api_chat_slot_reasoning_effort`** — the live-effort probe and the reset both address the effective key; app gate before the same-value fast path; defer-if-active-turn semantics unchanged; the reset fallback gets the same busy discipline (no-await re-probe, `skip_if_busy=True`, decline disambiguation, children guard). A rebind after a **successful** live push commits with a warning instead of a 409 — `change_effort` already persisted the per-model override, so claiming a rollback would be false; a rebind on the failed-push path answers 409 with nothing committed.
- **`api_chat_slot_project`** — the deferred-reset flag carries the key the app gate (`"chat.slot_project"`) authorized, so authorization and action cannot disagree (mirrors `session_directive_apply`); a rebind during the recent-project save rolls back and answers 409 `session_rebound` instead of arming a stale key.
- **`_consume_pending_reset` (chat_runner)** — the pending key can now name a live channel session, so the consumer resets with `skip_if_busy=True`: a busy decline leaves the flag armed for a later consume (the discard branch's pattern) instead of tearing down a streaming channel reply; a no-session `False` spends the flag since the next cold start already picks up the new bindings.

`schedule_eager_spawn`/`_eager_spawn` already key on `effective_session_key` — verified, no change needed.

## Testing

- Local gates: `isort`, `flake8`, `mypy` (clean, 1289 files), diff-scoped black/brand/error-code gates green; error-code baseline regenerated (all new responses carry a `code`).
- `test/test_chat_slot_switch_atomicity.py`: `TestLinkedSlotSessionKey` extended so all six switch handlers are pinned together — per handler the linked-session targeting, the app-token 404 denial, and the rebound 409 rollback; plus the agent/effort busy-decline rollbacks (`skip_if_busy` call shape asserted), the effort defer-on-linked-turn branch, the live-push rebind warning, the project rebind rollback, and the history-keyed metadata write.
- `test/test_chat_runner_coverage.py`: consumer busy-decline leaves the flag armed; no-session decline spends the flag without teardown; existing call-shape assertions updated (`test_eager_spawn.py`, `test_dashboard_approval.py`).
- Full pytest/vitest run left to CI per this host's policy.

## Pre-push review

Two model-pinned read-only lanes (GPT `gpt-5.6-sol` mirroring codex-review, Opus `claude-opus-5` mirroring claude-review + BASE AUTOSDE). Both returned BLOCK on the first round — the resets becoming newly destructive against real linked sessions (missing `skip_if_busy` discipline in agent/effort, the project flag armed after an await without a rebind re-check, the consumer force-killing a live channel reply, non-CAS agent rollback, missing children guards, and the effort live-push rebound claiming a rollback that could not happen). All findings fixed and gates re-run green; no findings rebutted.

CI round 1 (GPT lane, 3 security-class blockers, all fixed at `946e5f15c`): the project handler's session-level app gate now runs **before** any filesystem probing (the isdir/sensitive-path probes answered differently for existing vs missing paths — an existence oracle for an app caller on a linked slot); the deferred-reset consumer defers under attached sub-agent children; and the consumer spends the flag only on a real teardown, since a `False` reset cannot distinguish "no session" from a cold-starting session that has not registered yet.

## Pattern harvest

Rule candidate: grep/semgrep — flag `_history_key_for(` used to address a live SESSION (`sessions.get_provider(_history_key_for(...))`, `sessions.reset(_history_key_for(...))`, `_reset_slot_session(..., _history_key_for(...))`, `_pending_reset_history_key = _history_key_for(...)`) outside `chat_utils`. For any slot that can carry `linked_session_key`, the dashboard-prefixed spelling names a session that never existed; live-session addressing must go through `effective_session_key(slot)` (or `_cancel_target` for cancels). This is the third sweep of the same class (#5697 converted model/bulk/workspace, this PR converts agent/effort/project, and one read-only sibling remains in the effort-levels probe at `handlers/agents.py`), so the class is demonstrably recurring and mechanically greppable. Secondary candidate from the review rounds: a reset that switched from a phantom key to a real key must inherit the full busy discipline (`skip_if_busy=True` + no-await re-probe + children guard) — the destructive-teardown findings in both review lanes were all instances of that one rule.

Closes #8415
