### PR TITLE
fix(dashboard): persist a slot create inside the slots suspension

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -2709,6 +2709,55 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
                 cfg_proj = ""
             slot.project = cfg_proj or default_project_dir(workspace)
         _sync_dashboard_slots(state)
+        # Persist INSIDE the suspension, ahead of the coalesced broadcast, the
+        # same ordering `session_control.py`'s create span uses ("the whole
+        # allocation-to-persist span runs under `suspend_slots_push`", so "a
+        # slot whose birth write fails is never broadcast at all"). Two paths
+        # mint a slot through this context manager and only this one had the
+        # durable write outside it, which is what made the difference below
+        # reachable:
+        #
+        # `suspend_slots_push`'s `__exit__` flushes the owed push, and on the
+        # coalescing window's LEADING edge that flush broadcasts synchronously
+        # (`state.push_slots_update`). An exception there — a non-serializable
+        # value reaching `json.dumps` is the evidenced shape (#6522, #6532) —
+        # escapes `__exit__`, so with the write out here it skipped a metadata
+        # mutation the request had already acknowledged: this `force=True` save
+        # is the ONLY durable record of a recreate's folder filing or pinned
+        # title (see `_save_slot_to_history`'s message-less merge), and the slot
+        # itself survives in memory, so nothing later reconciles the two. Every
+        # client repairs a dropped FRAME on its next read; none of them repairs
+        # a write that never happened.
+        #
+        # The cost this ordering accepts, named by the comment it replaces: the
+        # suspension is process-wide, so other clients' slot updates coalesce
+        # (they defer — no caller blocks) until this off-loop write completes,
+        # and a contended history lock takes the patient acquire. Accepted for
+        # the same reason the twin accepts it, which awaits a cross-process
+        # metadata write inside its own suspension; this span already suspends
+        # on the workspace-conflict probe above, so it was never await-free.
+        #
+        # A pinned title must persist too (not just a folder move): without the
+        # write, a restart rehydrates the previous title with a refreshable
+        # "auto" origin and the background refresh may rewrite the pin.
+        if folder_id or title or remote_slot_key:
+            # The create/recreate request has been authorized against this
+            # transcript.  Do not let a rebind while the off-loop write waits on
+            # the history lock redirect its newly supplied metadata to another
+            # session.
+            #
+            # No slot retraction on failure, unlike the twin: there the write is
+            # the newborn's only record, so an unpersisted slot would vanish on
+            # restart and retracting is the lesser evil. Here the slot already
+            # has a metadata line and `best_effort` (default) logs the failure
+            # and marks the slot dirty so the periodic flush retries it, which
+            # is the retry the metadata mutation routes rely on.
+            await save_slot_off_loop(
+                state,
+                slot,
+                force=True,
+                expected_history_key=slot_history_key(slot),
+            )
         # Guarantee a frame. get_or_create_slot pushes for a NEW slot, but
         # returns an existing named slot without pushing — and this handler is
         # now the only thing that files a slot (the client sends no follow-up
@@ -2718,27 +2767,6 @@ async def api_chat_slot_create(request: web.Request) -> web.Response:
         # placement. Inside the suspension this only marks a push owed, so the
         # new-slot path still emits exactly ONE coalesced frame.
         state.push_slots_update()
-    # Persist OUTSIDE the suspension. save_slot_off_loop deliberately takes the
-    # patient cross-process history lock, which another holder (a workflow or
-    # cron appending to the same session) can hold for a while — and the
-    # suspension is process-wide, so awaiting it inside would stall every
-    # client's slot updates behind one session's file lock. The in-memory slot
-    # is the source of truth and was already broadcast at block exit; a failed
-    # write re-arms the periodic flush (best_effort).
-    # A pinned title must persist too (not just a folder move): without the
-    # write, a restart rehydrates the previous title with a refreshable "auto"
-    # origin and the background refresh may rewrite the pin.
-    if folder_id or title or remote_slot_key:
-        # The create/recreate request has been authorized against this
-        # transcript.  Do not let a rebind while the off-loop write waits on
-        # the history lock redirect its newly supplied metadata to another
-        # session.
-        await save_slot_off_loop(
-            state,
-            slot,
-            force=True,
-            expected_history_key=slot_history_key(slot),
-        )
     # Speculative session creation: overlap the ACP handshake with the user's
     # think-time before their first message. No-op unless session.eager_spawn.
     #

--- a/test/test_chat_slot_create_folder.py
+++ b/test/test_chat_slot_create_folder.py
@@ -29,10 +29,22 @@ from aiohttp.test_utils import TestClient, TestServer
 # resolves to the stdlib `test` and fails with ModuleNotFoundError on CI.
 from chat_test_helpers import _make_ready_kiro_prerequisite
 
+from kiro_crew.dashboard.chat_utils import slot_history_key
 from kiro_crew.dashboard.state import _SLOTS_BROADCAST_INTERVAL_S, DashboardState
 from kiro_crew.history import ConversationLog
 
 FOLDER_ID = "f-design"
+
+
+def _raise_on_slots(payload):
+    """A ``_broadcast`` double that fails the way the evidenced defect does.
+
+    The exception TYPE is incidental — ``json.dumps`` on a non-serializable slot
+    value is the shape #6522 hit — so these tests pin the ordering instead: any
+    raise out of the flush must not unwind past the durable write.
+    """
+    if payload.get("_type") == "slots":
+        raise TypeError("Object of type object is not JSON serializable")
 
 
 def _make_state(tmp_path):
@@ -104,9 +116,7 @@ class TestCreateInFolder:
     async def test_create_with_folder_files_the_slot(self, tmp_path):
         state = _make_state(tmp_path)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID}
-            )
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
             assert resp.status == 200
             assert (await resp.json())["folder_id"] == FOLDER_ID
         assert state._slots["s1"].folder_id == FOLDER_ID
@@ -115,9 +125,7 @@ class TestCreateInFolder:
     async def test_unknown_folder_is_rejected(self, tmp_path):
         state = _make_state(tmp_path)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots", json={"name": "s1", "folder_id": "nope"}
-            )
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": "nope"})
             assert resp.status == 400
             # The client switches on `code`; the prose is advisory and localizable.
             assert (await resp.json())["code"] == "folder_not_found"
@@ -130,9 +138,7 @@ class TestCreateInFolder:
         state = _make_state(tmp_path)
         seen = _record_broadcasts(state)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post(
-                "/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID}
-            )
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
             assert resp.status == 200
 
         # Exactly one coalesced broadcast, not create-then-correct.
@@ -207,9 +213,7 @@ class TestCreateInFolder:
             # Simulate a slot that has already run a turn: the flag is consumed.
             state._slots["s1"]._folder_changed = False
 
-            resp = await client.post(
-                "/api/chat/slots", json={"name": "s1", "folder_id": "f-other"}
-            )
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": "f-other"})
             assert resp.status == 200
         assert state._slots["s1"].folder_id == "f-other"
         assert state._slots["s1"]._folder_changed is True
@@ -222,9 +226,7 @@ class TestCreateInFolder:
             await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
             state._slots["s1"]._folder_changed = False
 
-            resp = await client.post(
-                "/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID}
-            )
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
             assert resp.status == 200
         assert state._slots["s1"]._folder_changed is False
 
@@ -386,9 +388,7 @@ class TestFolderTagInheritance:
         assert state._slots["reused"].tags == []
 
     @pytest.mark.asyncio
-    async def test_moving_an_existing_slot_into_a_tagged_folder_does_not_retro_tag(
-        self, tmp_path
-    ):
+    async def test_moving_an_existing_slot_into_a_tagged_folder_does_not_retro_tag(self, tmp_path):
         """(e) PATCH /slots/{slot}/folder moves without inheriting the folder's tags."""
         state = self._tagged_state(tmp_path, ["t1", "t2"])
         async with TestClient(TestServer(self._app_with_folder_patch(state))) as client:
@@ -453,3 +453,76 @@ class TestFolderTagInheritance:
             assert resp.status == 200
             assert (await resp.json())["tags"] == ["t1"]
         assert state._slots["fresh"].tags == ["t1"]
+
+
+class TestDurableWriteOrdering:
+    """The durable write runs INSIDE the suspension, ahead of the broadcast.
+
+    ``suspend_slots_push``'s ``__exit__`` flushes the owed push, and on the
+    coalescing window's LEADING edge that flush broadcasts synchronously — so an
+    exception there escapes ``__exit__`` and unwinds the rest of the handler.
+    With the forced save sitting after the ``with`` block, that unwind skipped a
+    metadata mutation the request had already acknowledged, and this save is the
+    only durable record of a recreate's folder filing or pinned title.
+
+    ``session_control.py``'s create span already keeps its persist inside the
+    suspension for the same reason ("a slot whose birth write fails is never
+    broadcast at all"); these pin the ordering here, not the exception, so any
+    future raise from the flush is covered too.
+    """
+
+    @pytest.mark.asyncio
+    async def test_raising_exit_broadcast_cannot_skip_the_folder_write(self, tmp_path):
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            # A session that has been used, which is the case the forced save is
+            # the only durable record for: re-filing an EXISTING slot. Its
+            # window is non-empty, so the save takes the full-save path.
+            slot = state.get_or_create_slot("s1")
+            slot.append("user", "hello")
+            slot.drain()
+            pinned = slot_history_key(slot)
+
+            # get_or_create_slot above already consumed a leading edge. Wait the
+            # window out, or the flush below is deferred to the trailing timer,
+            # the handler returns 200, and this test proves nothing.
+            await asyncio.sleep(_SLOTS_BROADCAST_INTERVAL_S + 0.05)
+            state._broadcast = _raise_on_slots  # type: ignore[method-assign]
+
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
+
+        # The failure still reaches the caller: this is an ordering fix, not a
+        # swallow. Whether an already-committed create should answer 500 at all
+        # is the half of #6532 that was declined, and folding it in here would
+        # resurrect it.
+        assert resp.status == 500
+        # But the acknowledged mutation is on disk. Outside the suspension, the
+        # escaping exception skipped this write entirely and nothing reconciled
+        # the in-memory slot against it.
+        meta = state.conversation_log._read_metadata(pinned) or {}
+        assert meta.get("folder_id") == FOLDER_ID, (
+            "the folder filing never reached disk — a broadcast failure unwound "
+            "past the durable write, so a restart resurrects the old placement"
+        )
+
+    @pytest.mark.asyncio
+    async def test_raising_exit_broadcast_cannot_skip_the_pinned_title_write(self, tmp_path):
+        """Same ordering, via the other field that reaches disk only here."""
+        state = _make_state(tmp_path)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            slot = state.get_or_create_slot("s1")
+            slot.append("user", "hello")
+            slot.drain()
+            pinned = slot_history_key(slot)
+
+            await asyncio.sleep(_SLOTS_BROADCAST_INTERVAL_S + 0.05)
+            state._broadcast = _raise_on_slots  # type: ignore[method-assign]
+
+            resp = await client.post("/api/chat/slots", json={"name": "s1", "title": "Pinned"})
+
+        assert resp.status == 500
+        meta = state.conversation_log._read_metadata(pinned) or {}
+        assert meta.get("title") == "Pinned", (
+            "the pinned title never reached disk — a restart rehydrates the old "
+            "title with a refreshable 'auto' origin"
+        )

--- a/test/test_chat_slot_create_folder.py
+++ b/test/test_chat_slot_create_folder.py
@@ -116,7 +116,9 @@ class TestCreateInFolder:
     async def test_create_with_folder_files_the_slot(self, tmp_path):
         state = _make_state(tmp_path)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
+            resp = await client.post(
+                "/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID}
+            )
             assert resp.status == 200
             assert (await resp.json())["folder_id"] == FOLDER_ID
         assert state._slots["s1"].folder_id == FOLDER_ID
@@ -125,7 +127,9 @@ class TestCreateInFolder:
     async def test_unknown_folder_is_rejected(self, tmp_path):
         state = _make_state(tmp_path)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": "nope"})
+            resp = await client.post(
+                "/api/chat/slots", json={"name": "s1", "folder_id": "nope"}
+            )
             assert resp.status == 400
             # The client switches on `code`; the prose is advisory and localizable.
             assert (await resp.json())["code"] == "folder_not_found"
@@ -138,7 +142,9 @@ class TestCreateInFolder:
         state = _make_state(tmp_path)
         seen = _record_broadcasts(state)
         async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
+            resp = await client.post(
+                "/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID}
+            )
             assert resp.status == 200
 
         # Exactly one coalesced broadcast, not create-then-correct.
@@ -213,7 +219,9 @@ class TestCreateInFolder:
             # Simulate a slot that has already run a turn: the flag is consumed.
             state._slots["s1"]._folder_changed = False
 
-            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": "f-other"})
+            resp = await client.post(
+                "/api/chat/slots", json={"name": "s1", "folder_id": "f-other"}
+            )
             assert resp.status == 200
         assert state._slots["s1"].folder_id == "f-other"
         assert state._slots["s1"]._folder_changed is True
@@ -226,7 +234,9 @@ class TestCreateInFolder:
             await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
             state._slots["s1"]._folder_changed = False
 
-            resp = await client.post("/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID})
+            resp = await client.post(
+                "/api/chat/slots", json={"name": "s1", "folder_id": FOLDER_ID}
+            )
             assert resp.status == 200
         assert state._slots["s1"]._folder_changed is False
 
@@ -388,7 +398,9 @@ class TestFolderTagInheritance:
         assert state._slots["reused"].tags == []
 
     @pytest.mark.asyncio
-    async def test_moving_an_existing_slot_into_a_tagged_folder_does_not_retro_tag(self, tmp_path):
+    async def test_moving_an_existing_slot_into_a_tagged_folder_does_not_retro_tag(
+        self, tmp_path
+    ):
         """(e) PATCH /slots/{slot}/folder moves without inheriting the folder's tags."""
         state = self._tagged_state(tmp_path, ["t1", "t2"])
         async with TestClient(TestServer(self._app_with_folder_patch(state))) as client:


### PR DESCRIPTION
## 1. What is the problem?

`api_chat_slot_create` wraps its whole set-up in `state.suspend_slots_push()`. That context manager's `__exit__` flushes the owed push, and on the coalescing window's **leading** edge `push_slots_update` broadcasts *synchronously*. An exception raised there escapes `__exit__` and unwinds the remainder of the handler — which, before this change, included the `await save_slot_off_loop(..., force=True)` that persists the create's folder filing and pinned title, plus `schedule_eager_spawn` and the `200`.

That write is not a duplicate of anything. For a message-less or freshly re-filed slot, `_save_slot_to_history`'s forced merge is the **only** durable record of `folder_id` / a pinned `title` — its own comment names "the recreate PATCH (folder or pinned title)" among the routes that "persist ONLY through this save, so a folder-only merge would silently drop their acknowledged writes on restart".

**Reachability, stated plainly: this is latent, not live.** A `json.dumps` `TypeError` cannot originate in caller data — a value parsed from a JSON body is JSON-serializable by construction — so it needs a server-constructed object reaching slot state. In #6522 that was a test fixture, and #6522's actual root cause (bare `StopIteration` from `resolve_agent_bindings` on an empty `config.agents`) already landed as #6517 / `e48ea4266`. No production path is demonstrated here, and this PR does not claim one.

## 2. Why this issue matters to the user

The two timing branches disagree about what the user is told, and the disagreement falls the wrong way.

- **Leading edge** (`elapsed >= _SLOTS_BROADCAST_INTERVAL_S`, i.e. 0.2 s since the last slots push): the flush broadcasts inline, the exception reaches aiohttp, the caller gets a **500** and the durable write never runs.
- **Inside the window**: the flush is deferred through `loop.call_later(_trailing_slots_flush)`, the handler returns **200**, and the same exception surfaces later as a log line through `crash_guard._asyncio_exception_handler`.

So a **busy** dashboard gets 200 plus a log, and an **idle** one — a person doing a single deliberate new-chat, with no other slot activity in the preceding 200 ms — gets the 500. The failure lands on the least-loaded, most deliberate case, which is the worst possible distribution for a phantom error: the create *did* commit in memory, so the user is told their action failed while the session exists.

And the lost write is the half nothing repairs. A dropped slots **frame** is cosmetic — four independent readers reconcile it (mount `fetchSlots()`, reconnect `fetchSlots()` in `useWebSocket.ts`, the WS-connect snapshot built from `serialize_slots`, and the 5 s poll in `WorldsPopout`). Four independent repair paths is what makes the frame cosmetic; one would not have been enough. None of them repairs a write that never happened: memory holds the new folder, disk holds the old one, and the divergence surfaces on the next restart.

## 3. How our fix solves it

Move the durable write **inside** the suspension, ahead of the broadcast. Nothing else.

This is an ordering change with an in-repo precedent, not a new design. `session_control.py:1131-1139` — the other path that mints a slot through this same context manager — already does exactly this, with the reason written down: "The whole allocation-to-persist span runs under `suspend_slots_push` … It also covers the persist and its failure retraction, so a slot whose birth write fails is never broadcast at all." Two create paths, one context manager, and only this one had its persist outside. The fix makes the broken branch agree with the branch that already ships.

Chain from symptom to cause:

- **Symptom**: `POST /api/chat/slots` answers 500 and the folder/title the user just chose is absent after a restart.
- **Proximate cause**: the exception escapes `__exit__`, so every statement after the `with` block is skipped.
- **Root cause**: the durable write was sequenced *after* a best-effort UI broadcast, so a failure in the optimisation could veto the commit.
- **Fix**: sequence the write before the broadcast, so the broadcast can only ever cost the frame it owns.

Two deliberate non-changes, both scoped out on purpose:

- **The 500 stays.** Whether an already-committed create should answer 500 because a best-effort broadcast failed is a failure-semantics decision, and it was **declined** on this pass with reasons — the broadcast-content half of #6532 is not addressed here, and folding it in would resurrect it. `Closes #6532` therefore covers the ordering defect that is real; the declined half is recorded in the issue, not silently absorbed by this merge.
- **No slot retraction**, unlike the twin. There the write is the newborn's only record, so an unpersisted slot would vanish on restart and retracting is the lesser evil. Here the slot already has a metadata line and `best_effort` (the default) logs the failure and marks the slot dirty so the periodic flush retries it — the retry the metadata mutation routes already rely on.

`_SLOTS_BROADCAST_INTERVAL_S` is untouched, the coalescing is untouched, and what the broadcast contains is untouched.

The comment being replaced argued the write belonged outside because the process-wide suspension would make other clients' slot updates wait behind one session's history lock. That cost is real and the new comment keeps it on the record — it is accepted for the same reason the twin accepts it (which awaits a cross-process metadata write inside its own suspension), and because this span was never await-free anyway: it already suspends on the workspace-conflict probe a few lines above. Coalescing defers other pushes; it does not block their callers.

## 4. What tests we did

Two tests in `test/test_chat_slot_create_folder.py`, a file whose docstring already says "The fix is ordering, so the tests assert ordering".

They pin the **ordering, not the exception**: `_broadcast` is stubbed to raise on a `slots` frame, so any future raise out of the flush is covered rather than just today's `TypeError`. Each waits out `_SLOTS_BROADCAST_INTERVAL_S` first — without that the flush lands on the deferred trailing timer, the handler answers 200, and the test would prove nothing.

- `test_raising_exit_broadcast_cannot_skip_the_folder_write`
- `test_raising_exit_broadcast_cannot_skip_the_pinned_title_write`

Both assert the on-disk metadata line via `conversation_log._read_metadata`, and both assert the response is still 500 — so the tests also pin that this PR does *not* swallow the error.

**Mutation-verified, with the mutation proven to apply.** The handler was reverted with `git checkout origin/main -- src/kiro_crew/dashboard/chat_handlers.py`, and the revert was confirmed by `git diff --stat origin/main` on that path returning zero lines before the run. Against that pre-fix tree both tests fail on the disk assertion — `assert None == 'f-design'` and `assert None == 'Pinned'` — while the `status == 500` assertion passes in both states, which is the evidence that the change moves durability and not the response. The fix patch was then re-applied (`git apply --check` clean) and both pass.

Suites run (targeted, never the full suite):

- `test/test_chat_slot_create_folder.py` — 20 passed
- `test/test_chat_slot_create_folder.py` + `test/test_forced_save_history_key_pin.py` + `test/test_slots_broadcast_coalesce.py` — 38 passed
- `test/test_open_slots_persistence.py -k "suspend or push_slots"` — 4 passed
- `test/test_dashboard_chat.py -k "slot_create or create_slot or folder"` — 76 passed

Gates on the touched files: black, isort, flake8 clean. mypy reports 2 pre-existing errors in `src/kiro_crew/transcribe.py`, reproduced identically on an unmodified main checkout — baseline, not from this change.

## 5. Any other suggestions on the work

- **The 500 is still there and still undecided.** The declined half needs an owner ruling: catch and log at the flush (making both timing branches converge on what the trailing branch already does), or keep fail-loud. Until then the caller-visible outcome of a broadcast failure remains a function of a 0.2 s timer, which no client can be written against.
- **The exit flush can mask the exception that caused it.** `test_suspend_slots_push_unwinds_and_flushes_on_exception` correctly pins that the owed push fires even when the body raises — but it stubs `_broadcast`, so a *failing* flush during unwind is unpinned. When both raise, `@contextmanager` propagates the flush's exception and the body's becomes `__context__`. That is why #6522 read as a broadcast bug: the 500's top line named `json.dumps` while the real cause was chained underneath. A diagnostic that names the offending slot key, field and type before re-raising would be semantics-neutral and cheap.
- **The other publish-then-await birth sites** (18 across 8 files, tracked as #4333) are the same class one layer out; this PR does not widen to them.
- **Adjacent prior art, checked and found not to apply:** [PR #6526](https://github.com/kirodotdev/KiroCrew/pull/6526) names the same symptom (a 500 out of slot create) but approached it through the test's mock config. It was closed by its own author 38 minutes in as "duplicate of #6533 which applies the same fix with full local verification" — a process closure, not a merits ruling, and all three review lanes had passed it. #6533 then also closed unmerged, and #6517 is what landed. So the area was never ruled not-a-defect, the handler unwind was never touched by any of them, and there is no precedent here for or against this change.

## Pattern harvest

Rule candidate: an in-repo sibling already doing the thing correctly is the strongest available authority for a fix's shape — prefer copying a live twin's ordering over reasoning from first principles, and cite the twin by file and line. Here the twin is `session_control.py:1131-1139`, and those numbers were re-resolved at branch point rather than carried over from where the review had named them, because main had moved in between: a citation that was true when written and false when used is worse than no citation, since it still looks verified.

- **When one context manager is used by two paths, the ordering difference between them is the bug report.** The evidence that settled this was not the traceback — it was `session_control.py` doing the same thing correctly, with its reason in a comment. An in-repo sibling that already does it right is the strongest authority a fix's shape can have: it is not one reviewer's judgment against another's, it is the repo's own decision applied consistently.
- **"A dropped update is cosmetic" is a claim about the number of independent repair paths, and it should be counted.** Here there are four, which is why the frame is genuinely cosmetic. The same sentence with one repair path would have been a correctness bug.
- **Separate the messenger from the fault.** The failing `json.dumps` is also what every *read* path goes through (`GET /api/chat/slots`, the WS snapshot), so had the poison been real, nothing at the broadcast could have fixed it. Retrying or swallowing the broadcast would have addressed the messenger; the divergence lived at the unwind boundary.
- **A negative needs its positive run first.** "No production path produces this" was checked against a live gateway journal (2026-09-01T22:54Z → 2026-09-04T16:20Z, 46,794 lines): zero frames through `_do_slots_broadcast`. That is only worth stating because the same grep *does* surface real traceback frames from `dashboard/state.py` — a probe that cannot produce a positive is indistinguishable from an absent signal.
- **A mutation that is not proven to apply proves nothing.** The revert here was verified by `git diff --stat origin/main` returning empty on the path *before* the red run, not by assuming the checkout worked.

Closes #6532
