### PR TITLE
docs: spec the auto-nudge reconciler and the gate's failure direction

### DIFF
--- a/docs/system-specs/common/injected-messages.md
+++ b/docs/system-specs/common/injected-messages.md
@@ -346,6 +346,39 @@ next turn into the same slot:
 - Loops persist to `autonudge.json` under the data home and are re-armed on gateway
   restart. A slot that is unreachable (no history, deleted, or closed) has its loop
   removed.
+- **A loop stranded with no live timer is rescued by a periodic reconciler.** A
+  dashboard-bound loop's only re-arm path after a delivered fire is the slot's
+  `HOOK_EVENT_STOP`; if that never arrives (the nudge turn errors, times out, or is
+  cancelled on a hook-skipping path) or a deferred re-arm is dropped mid-fire, the
+  loop stays persisted `active` with a finished-or-absent timer and nothing on a
+  timer revives it. A finished timer task counts as "no live timer": nothing pops a
+  timer from the registry when it completes, so that is the shape the strandings
+  actually leave behind. The rescue requires **two consecutive** eligible passes,
+  because one observation cannot tell a stranded loop from a slot whose user turn is
+  still running or a loop inside another coroutine's mutation window; a user turn
+  starting clears the loop's candidacy, so any sign of life restarts the clock. A
+  pass that finds the service lock held defers entirely rather than arm a
+  mid-rollback shape. Re-arming targets the loop's **own persisted deadline**, so a
+  rescue never fires earlier than the schedule the user set. Deliberately skipped
+  whatever the passes observe: a loop mid-fire, one quiesced by administrative
+  cleanup, a monitor record whose version this gateway does not implement, and an
+  in-flight wake claim with no completion-evidence deadline — except a `BUSY` retry,
+  the one no-deadline shape that is legitimately live. An **inactive** loop still
+  awaiting terminal-completion evidence is deliberately **included**: its accepted-turn
+  correlation needs a timer to expire, and stranding it would refuse every replacement
+  watch on the slot forever.
+- **Delivered fires and reconciler rescues are both logged at INFO.** Fires were
+  otherwise unlogged, so a loop that had died and one with nothing to report were
+  byte-identical in the journal. One line per delivered turn — each of which already
+  spends a model turn — is what makes loop health observable from outside the process.
+- **The observation gate fails toward SPENDING.** An exception escaping the
+  pre-fire probe gate is treated as "not quiet" and the tick **fires**, matching the
+  service-wide invariant that every uncertain path resolves toward spending. Letting
+  it escape instead killed the timer task while the registry still held a strong
+  reference, so no "task exception was never retrieved" warning was ever emitted and
+  the loop went silent. Skipping the tick is the other wrong answer: a gate that
+  raises deterministically would keep the loop alive, re-arming and delivering
+  nothing forever — the silent mute the gate exists to prevent.
 - Structured monitor action accounting is a separate internal completion
   callback, not a new injected-message envelope. Until the probe dispatcher is
   attached, structured records remain fail-closed. The dormant adapters do not


### PR DESCRIPTION
Docs-only. Specs the stranded-loop reconciler, the fire logging, and the probe
gate's failure direction that landed in `b6716378a` (#8662) with no spec change.

Context: #8636 (already closed as completed by `b6716378a` — this PR does not
claim to fix it, and carries no closing keyword).

## What changed

One paragraph set in `docs/system-specs/common/injected-messages.md`, under
"Auto-nudge cycle". No code, no tests, no behaviour change.

`b6716378a` changed three user-visible behaviours of the auto-nudge cycle and
shipped no documentation for any of them (`git show --name-only b6716378a` is
`src/kiro_crew/autonudge.py` + `test/test_autonudge_reconciler.py`). The spec
therefore still described a service whose only rescue for a loop left
active-but-unarmed was a gateway restart. Three added bullets close that:

1. **The reconciler.** That a stranded loop is rescued at all; that a *finished*
   timer task — not an absent one — is the shape the strandings actually leave
   behind; that a rescue needs **two consecutive** eligible passes and that a
   user turn starting clears candidacy, so any sign of life restarts the clock;
   that a pass defers entirely while the service lock is held; that re-arming
   targets the loop's **own persisted deadline**, so a rescue never fires ahead
   of the schedule the user set; and the full skip list, including the `BUSY`
   exemption and the deliberate *inclusion* of an inactive loop still awaiting
   terminal-completion evidence.
2. **INFO logging** of delivered fires and rescues — the thing that makes a
   silent loop visible from outside the process.
3. **The gate fails toward SPENDING.** An exception escaping the pre-fire probe
   gate is treated as "not quiet" and the tick fires, per the service-wide
   invariant that every uncertain path resolves toward spending.

Every claim was checked against `origin/main`'s code, not against this branch's
earlier proposal — see the note below, which is the reason the paragraph is not
simply the one this branch originally carried.

## Why this branch is now docs-only

This branch previously carried its own reconciler, gate wrapper and fire log.
`b6716378a` landed the same three changes on `main` first and more completely,
so the code half was dropped in this push rather than rebased forward. Both the
redundancy and one genuine regression are load-bearing:

| This branch (dropped) | `main` after #8662 |
|---|---|
| Re-arms on a **single** observation, holding `self._lock` for the pass | Requires **two consecutive** eligible passes, and **defers entirely** when `self._lock` is held, so a mid-rollback `update()` window can never be armed |
| Skips only `_firing`, and all inactive loops | Also skips `_maintenance_quiescing`, an unimplemented `monitor.version`, and an in-flight wake claim with no evidence deadline (exempting `BUSY`); and deliberately **includes** an inactive loop still in `_waits_for_terminal_completion` |
| `start()`/`stop()` guard on `is None or done()` | Adds the `get_loop().is_closed()` clause, so `start()` under a fresh event loop still spawns a backstop |
| Periodic wait via `asyncio.wait_for(shutdown_event.wait(), …)` | `loop.call_later`, because this suite patches module-level `asyncio.sleep` to a no-op and a sleep-based watchdog degrades into a busy loop under that patch |
| No interlock on user activity | `notify_user_input` clears candidacy, restarting the two-pass clock on any sign of life |
| Gate exception → re-arm and **return**, i.e. the fire is **skipped** | Gate exception → `tick_is_quiet = False`, i.e. **fall through and fire** |

The last row is a regression, not a style difference, and on its own is enough
reason not to rebase the code forward. `autonudge.py` documents that failure
resolves toward *spending*; under this branch's resolution a gate that raises
deterministically re-arms and delivers nothing, forever — the silent mute the
gate exists to prevent. #8662's own comment names that outcome "the other wrong
answer" and fires instead.

The tests could not be carried forward either: they `await _reconcile_loops()`,
while `main`'s pass is the synchronous `_reconcile_once()`, and
`test_reconciler_rearms_active_and_skips_inactive` asserts an inactive loop is
always skipped — the contract `main` deliberately reverses.

`git merge-tree origin/main` confirmed the shape: the only conflicting paths were
`src/kiro_crew/autonudge.py` and `test/test_autonudge_reconciler.py` — exactly
the two redundant ones. The spec file merged clean. Dropping the conflicting
hunks is the resolution, and it is also what cleared the merge conflict that had
frozen `refs/pull/8666/merge` and with it every `pull_request` check on this PR.

**Maintainers:** if you would rather take this as a fresh docs PR, close this one
— the commit is self-contained and cherry-picks onto `main` cleanly. It is left
open and green here rather than abandoned red so the choice is made against a
mergeable artifact.

## Verification

- `docs-lint.sh` passed (261 markdown files); the doc's entry in
  `docs/system-specs/common/README.md` is unchanged and still accurate, since the
  file was modified in place, not moved.
- black gate, subprocess-encoding gate, brand gate, harness-parity gate and
  `check_changelog_history.py` (with `CHANGELOG_BASE_REF=origin/main`, 8 shipped
  sections intact) all pass.
- `flake8 src/kiro_crew test` clean; `mypy --platform linux src/kiro_crew` clean
  (1296 files).
- No tests run: the diff is one markdown file, and nothing under `test/` or
  `src/kiro_crew/` reads it.
- `scrub-lint.sh --no-history` reports a pre-existing failure in
  `test/test_atomic_write_named_duplicates.py` (`/home/tést`, lines 155/157).
  Reproduced on a pristine `origin/main` worktree, so it is main's and outside
  this PR's one-file scope.

## Pattern harvest

Rule candidate: agents-md
Pattern: a recovery path added around a *skippable* gate must state which
direction its failure resolves. This branch and #8662 wrapped the same `await` in
the same `try` and picked opposite recoveries — skip-and-re-arm versus fire — with
only a prose invariant ("failure resolves toward spending", stated ~30 lines away
at an unrelated guard) to distinguish right from wrong. The class is broader than
this module: wherever a gate can *decline* work, an exception handler silently
inherits the decline, which is the one outcome invisible at runtime. Worth an
`AGENTS.md` line requiring a fail-open/fail-closed direction to be named at each
such handler, so the choice is reviewable rather than incidental.

Rule candidate: review-prompt
Pattern: a spec-bearing behaviour change that ships without its spec update is
invisible to every later reader, and the follow-up PR inherits a stale paragraph
describing the *proposal* rather than what shipped. AGENTS.md already requires the
spec in the same commit; #8662 shows the gate does not catch it when the change is
code-only. Worth asking reviewers of an `autonudge`/`hooks`/`session` diff whether
a `docs/system-specs/` paragraph moved with it.

Not generalizable: the duplicate-implementation half. Two PRs racing one issue
number is a process artifact, not a defect class — #8636 drew two independent
fixes because both were authored before either landed.
