### PR TITLE
fix(chat): bubble-vanish probe reports rows hidden in place (#8661)

### DIFF
--- a/website/src/pages/chat/TurnBlock.tsx
+++ b/website/src/pages/chat/TurnBlock.tsx
@@ -484,6 +484,16 @@ function CollapseToggle({ expanded, onToggle, label }: { expanded: boolean; onTo
 function CollapsibleSection({ expanded, children }: { expanded: boolean; children: ReactNode }) {
   return (
     <motion.div
+      // Collapse marker for the bubble-vanish probe (useBubbleVanishProbe):
+      // rows inside stay MOUNTED while the height animates to 0, so without
+      // this attribute a collapse is indistinguishable from a windowing bug.
+      // Present exactly while this section hides its mounted children, i.e.
+      // when the interim / collapseAll folds pass expanded={false}. The
+      // default-mode tool fold is different: it hard-codes expanded={true}
+      // and collapses by UNMOUNTING under AnimatePresence, so it never sets
+      // this marker — and moves no probe counter either, because tool items
+      // carry no [data-display-index] of their own.
+      data-collapsed={expanded ? undefined : 'true'}
       initial={{ height: 0, opacity: 0 }}
       animate={expanded ? { height: 'auto', opacity: 1 } : { height: 0, opacity: 0 }}
       exit={{ height: 0, opacity: 0 }}

--- a/website/src/pages/chat/useBubbleVanishProbe.ts
+++ b/website/src/pages/chat/useBubbleVanishProbe.ts
@@ -6,7 +6,8 @@
 // bug is whether the vanished rows are absent from the store at that moment or
 // present-but-unrendered. This probe captures exactly that: a MutationObserver
 // watches the transcript scroller, and whenever the number of mounted message
-// rows DROPS between frames it logs the DOM count against the store's message
+// rows DROPS between frames — or the number of VISIBLE rows drops while the
+// mounted count holds — it logs the DOM counts against the store's message
 // count and the grouped display-item count at the same instant.
 //
 // Reading the log:
@@ -14,6 +15,12 @@
 //   - `displayItems` fell but `storeMessages` held → grouping collapse
 //     (loose rows folding into one turn — expected while a turn accumulates).
 //   - both held while `mountedRows` fell           → windowing/render path.
+//   - `mountedRows` held while `visibleRows` fell  → a mounted row's content
+//     was hidden in place (turn collapse via CollapsibleSection's height-0
+//     container, marked `data-collapsed="true"`), NOT the windowing path.
+//   - `mountedRows` AND `visibleRows` both fell    → an unmount and a collapse
+//     landed in the same frame — compare the two deltas before blaming either
+//     subsystem for the whole drop.
 import { useEffect, type RefObject } from 'react'
 
 /** Set `localStorage[BUBBLE_PROBE_FLAG] = '1'` and reload to enable. */
@@ -48,7 +55,19 @@ export function useBubbleVanishProbe(
     const el = scrollerRef.current
     if (!el) return
     const mountedRows = () => el.querySelectorAll('[data-display-index]').length
+    // Rows whose content is not hidden inside a collapsed turn container.
+    // `data-display-index` sits on the virtualizer's row wrapper OUTSIDE
+    // TurnBlock, and CollapsibleSection renders INSIDE the row — so the fold
+    // is a DESCENDANT of the row, and the right test is "does this row contain
+    // a collapsed fold", not `closest()` up the ancestor chain. A collapsed
+    // fold keeps its children mounted while animating height to 0, so this
+    // count moves when mountedRows does not.
+    const visibleRows = () =>
+      Array.from(el.querySelectorAll('[data-display-index]')).filter(
+        row => !row.querySelector('[data-collapsed="true"]'),
+      ).length
     let last = mountedRows()
+    let lastVisible = visibleRows()
     let raf = 0
     const mo = new MutationObserver(() => {
       // Coalesce a mutation burst into one per-frame reading — a React commit
@@ -59,21 +78,43 @@ export function useBubbleVanishProbe(
       raf = requestAnimationFrame(() => {
         raf = 0
         const now = mountedRows()
-        if (now < last) {
+        const nowVisible = visibleRows()
+        const mountedDropped = now < last
+        // Fourth bucket: mounted rows held while visible rows fell — a row was
+        // hidden IN PLACE (turn collapse), not unmounted by the windowing path.
+        const hiddenInPlace = !mountedDropped && nowVisible < lastVisible
+        if (mountedDropped || hiddenInPlace) {
           const counts = getCounts()
           // eslint-disable-next-line no-console
-          console.warn('[bubbleProbe] mounted rows dropped', {
-            mountedBefore: last,
-            mountedAfter: now,
-            storeMessages: counts.store,
-            displayItems: counts.display,
-            at: new Date().toISOString(),
-          })
+          console.warn(
+            hiddenInPlace
+              ? '[bubbleProbe] row content hidden in place (mounted held, visible fell)'
+              : '[bubbleProbe] mounted rows dropped',
+            {
+              kind: hiddenInPlace ? 'hidden-in-place' : 'mounted-drop',
+              mountedBefore: last,
+              mountedAfter: now,
+              visibleBefore: lastVisible,
+              visibleAfter: nowVisible,
+              storeMessages: counts.store,
+              displayItems: counts.display,
+              at: new Date().toISOString(),
+            },
+          )
         }
         last = now
+        lastVisible = nowVisible
       })
     })
-    mo.observe(el, { childList: true, subtree: true })
+    // `attributes` + the filter: a turn collapse toggles `data-collapsed` on an
+    // existing container and changes NO children, so without attribute
+    // observation that transition would never produce a reading.
+    mo.observe(el, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-collapsed'],
+    })
     return () => {
       mo.disconnect()
       if (raf) cancelAnimationFrame(raf)

--- a/website/src/test/TurnBlock.test.tsx
+++ b/website/src/test/TurnBlock.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import TurnBlock from '../pages/chat/TurnBlock'
 import type { DisplayItem, TurnItem } from '../pages/chat/types'
 
@@ -47,6 +47,17 @@ describe('TurnBlock — interim fan-out fold', () => {
     const { container } = render(<TurnBlock turn={turn} renderItem={renderItem} />)
     expect(container.querySelector('button')).toBeNull()
     expect(screen.getByTestId('item-0')).toBeInTheDocument()
+  })
+
+  it('marks the fold with data-collapsed while collapsed and clears it on expand', () => {
+    // The bubble-vanish probe keys its hidden-in-place bucket off this
+    // attribute: present exactly while the section hides its mounted rows.
+    const turn = { ...makeTurn(interimItems()), interim: true }
+    const { container } = render(<TurnBlock turn={turn} renderItem={renderItem} />)
+    const fold = collapsed(container) as HTMLElement
+    expect(fold.getAttribute('data-collapsed')).toBe('true')
+    fireEvent.click(container.querySelector('button')!)
+    expect(fold.hasAttribute('data-collapsed')).toBe(false)
   })
 })
 

--- a/website/src/test/useBubbleVanishProbe.test.tsx
+++ b/website/src/test/useBubbleVanishProbe.test.tsx
@@ -24,6 +24,34 @@ function makeScrollerWithRows(n: number) {
   return el
 }
 
+/**
+ * Scroller mirroring the REAL transcript nesting: `data-display-index` sits on
+ * the virtualizer's row wrapper, and the collapsible container (the shape
+ * CollapsibleSection produces) renders INSIDE the row. Toggling
+ * `data-collapsed` on that inner container hides the row's content in place
+ * without removing a single node.
+ */
+function makeScrollerWithCollapsible(nPlainRows: number, nFoldedRows: number) {
+  const el = document.createElement('div')
+  for (let i = 0; i < nPlainRows; i++) {
+    const row = document.createElement('div')
+    row.setAttribute('data-display-index', String(i))
+    el.appendChild(row)
+  }
+  const containers: HTMLElement[] = []
+  for (let i = 0; i < nFoldedRows; i++) {
+    const row = document.createElement('div')
+    row.setAttribute('data-display-index', String(nPlainRows + i))
+    const fold = document.createElement('div') // CollapsibleSection's motion.div
+    fold.appendChild(document.createElement('div')) // the folded turn content
+    row.appendChild(fold)
+    el.appendChild(row)
+    containers.push(fold)
+  }
+  document.body.appendChild(el)
+  return { el, containers }
+}
+
 describe('useBubbleVanishProbe', () => {
   let warnSpy: ReturnType<typeof vi.spyOn>
   let rafSpy: ReturnType<typeof vi.spyOn>
@@ -78,9 +106,52 @@ describe('useBubbleVanishProbe', () => {
     })
     expect(warnSpy).toHaveBeenCalledTimes(1)
     const payload = warnSpy.mock.calls[0][1] as Record<string, unknown>
+    expect(payload.kind).toBe('mounted-drop')
     expect(payload.mountedBefore).toBe(5)
     expect(payload.mountedAfter).toBe(3)
     expect(payload.storeMessages).toBe(10)
     expect(payload.displayItems).toBe(3)
+  })
+
+  it('reports the hidden-in-place bucket when a collapse hides a row\'s content without removing nodes', async () => {
+    localStorage.setItem(BUBBLE_PROBE_FLAG, '1')
+    // Real nesting: 2 plain rows + 3 rows each wrapping a collapsible fold.
+    const { el, containers } = makeScrollerWithCollapsible(2, 3)
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    renderHook(() => useBubbleVanishProbe(ref, () => ({ store: 5, display: 5 })))
+
+    // Collapse one turn: the attribute flips on the fold INSIDE its row,
+    // no node is removed anywhere.
+    await act(async () => {
+      containers[0].setAttribute('data-collapsed', 'true')
+      await Promise.resolve()
+    })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('hidden in place')
+    const payload = warnSpy.mock.calls[0][1] as Record<string, unknown>
+    expect(payload.kind).toBe('hidden-in-place')
+    expect(payload.mountedBefore).toBe(payload.mountedAfter) // mounted held
+    expect(payload.mountedAfter).toBe(5)
+    expect(payload.visibleBefore).toBe(5)
+    expect(payload.visibleAfter).toBe(4) // the collapsed row left the visible count
+  })
+
+  it('re-expanding (attribute removed) produces no reading — only drops are reported', async () => {
+    localStorage.setItem(BUBBLE_PROBE_FLAG, '1')
+    const { el, containers } = makeScrollerWithCollapsible(2, 3)
+    const ref: RefObject<HTMLDivElement | null> = { current: el }
+    renderHook(() => useBubbleVanishProbe(ref, () => ({ store: 5, display: 5 })))
+
+    await act(async () => {
+      containers[0].setAttribute('data-collapsed', 'true')
+      await Promise.resolve()
+    })
+    expect(warnSpy).toHaveBeenCalledTimes(1) // the collapse itself
+
+    await act(async () => {
+      containers[0].removeAttribute('data-collapsed')
+      await Promise.resolve()
+    })
+    expect(warnSpy).toHaveBeenCalledTimes(1) // re-expand added nothing
   })
 })


### PR DESCRIPTION
## Summary

The #7045 bubble-vanish probe (`useBubbleVanishProbe`) could not observe a turn collapsed IN PLACE: `CollapsibleSection` animates its container to height 0 with children still mounted, so none of the probe's counters moved and any coinciding row-count drop was misattributed to the windowing/render path (#8661). The reporter asked for a fourth "hidden in place" reading bucket — the smaller of the two options they proposed.

Instrument-only change; `RUNNING_LATCH_MS`, `syncSlotRunningFromServer` and all orchestration/liveness logic are untouched.

- `TurnBlock.tsx` — `CollapsibleSection` now marks its `motion.div` with `data-collapsed="true"` while collapsed (attribute absent when expanded). No visual or behavioral change. The default-mode tool fold is documented as out of scope: it hard-codes `expanded={true}` and collapses by unmounting under `AnimatePresence`, and its items carry no `[data-display-index]`, so it moves no probe counter.
- `useBubbleVanishProbe.ts` — keeps `mountedRows()` unchanged (existing three buckets keep their meaning); adds `visibleRows()`, which counts `[data-display-index]` rows that do NOT contain a `[data-collapsed="true"]` fold (`data-display-index` sits on the virtualizer's row wrapper OUTSIDE `TurnBlock`, so the fold is a descendant of the row — containment, not `closest()`); observes `attributes` with `attributeFilter: ['data-collapsed']` so a collapse that changes no children still produces a reading; emits one `console.warn` shape with a `kind` tag (`mounted-drop` / `hidden-in-place`) plus `visibleBefore`/`visibleAfter` alongside all existing fields; header reading key gains the fourth bucket and a both-fell disambiguation line.
- Tests — hidden-in-place bucket on the REAL nesting (fold inside the row, attribute flip removes no nodes → exactly one reading, mounted held, visible fell); regression for the existing mounted-drop shape; re-expand produces no reading; `TurnBlock` test asserting the attribute toggles with the collapsed state.

## Testing

- `npx tsc -b` — clean
- `npx eslint` on the four changed files — clean
- `npx vitest` runs in CI (probe + TurnBlock suites extended; this host does not run test suites locally by policy)
- Two model-pinned pre-push review lanes: GPT lane PASS; Opus lane raised two blocking findings, both verified against `ChatPage.tsx` and fixed before this PR — (1) the initial `closest()` ancestor test could never match the real DOM (rows are ancestors of the fold, not descendants) — replaced with row-containment and the fixture rebuilt to the real nesting; (2) the collapse-marker comment overclaimed coverage of the unmount-based tool fold — narrowed, with the no-counter-movement reasoning recorded.

## Screenshots

<!-- no-visual-delta -->
**Why no screenshot:** debug-only console instrument behind the opt-in `kirocrew_debug_bubble_probe` localStorage flag, plus an inert data attribute; nothing user-visible changes.

## Pattern harvest

Rule candidate: when a diagnostic keys off a DOM marker, verify the marker's ancestor/descendant direction against the real host DOM before writing the selector — the identifying attribute (`data-display-index`) lived on a virtualizer wrapper OUTSIDE the component, so the collapsed container is a descendant of the row and `closest()` could never match; and build the test fixture with the production nesting, because an inverted fixture certifies the broken selector green.

No linked issue: not applicable — Closes #8661
