### PR TITLE
feat(tips): let an edition replace the whole feature-tip pool

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -356,7 +356,6 @@ src/kiro_crew/subagent_scale.py
 src/kiro_crew/suggestions.py
 src/kiro_crew/testing/channel_fixtures.py
 src/kiro_crew/testing/fake_acp_backend.py
-src/kiro_crew/tips.py
 src/kiro_crew/vector_memory.py
 src/kiro_crew/webhooks.py
 src/kiro_crew/weixin/client.py

--- a/.github/coverage-baselines/backend.txt
+++ b/.github/coverage-baselines/backend.txt
@@ -88,6 +88,5 @@ src/kiro_crew/slack/client.py 67.2   # 246/366
 src/kiro_crew/suggestions.py 18.7   # 31/166
 src/kiro_crew/telegram/client.py 61.8   # 306/495
 src/kiro_crew/telegram/gateway.py 15.5   # 11/71
-src/kiro_crew/tips.py 64.9   # 335/516
 src/kiro_crew/webex/client.py 64.1   # 173/270
 src/kiro_crew/weixin/gateway.py 20.4   # 11/54

--- a/docs/system-specs/modules/platform-context.md
+++ b/docs/system-specs/modules/platform-context.md
@@ -49,6 +49,7 @@ interface, the public edition is complete standalone.
 | `agent_catalog` | adapter | `DefaultAgentCatalogProvider` (`builtin_agents()` → `[]`) | edition agent-catalog rows |
 | `prompt_sources` | adapter | `DefaultPromptSourceProvider` (`prompt_source_roots()` → `[]`) | edition prompt/SOP roots |
 | `skill_discovery` | adapter | `DefaultSkillDiscoveryProvider` (`skill_providers()` → `[]`) | edition skill discovery providers for the multi-provider search |
+| `tips` | adapter | `DefaultTipsProvider` (`tips_pool()` → `None`) | the edition's feature-tip pool. The one **REPLACE-capable** seam: a supplied `TipsPool` takes over from the public curated file AND the docs-scan catalog instead of being unioned into them, because a public tip advertises a capability an edition build may not have or may not expose. An empty pool means "this build shows no tips" |
 | `denied_rules` | adapter | `DefaultDeniedRuleProvider` (`denied_rules()` → `[]`) | edition denied-command rules that are default-on but USER-DISABLEABLE (distinct from `security`, the un-weakenable overlay floor) |
 | `import_sources` | adapter | `DefaultImportSourceProvider` (`import_sources()` → `[]`) | edition onboarding-import sources |
 | `capability_manager` | adapter | `DefaultCapabilityManager` (`available()` → `False`) | operations-based external package manager: MCP servers, skills, agent packages, and client plugins |

--- a/src/kiro_crew/platform/bootstrap.py
+++ b/src/kiro_crew/platform/bootstrap.py
@@ -49,6 +49,7 @@ from kiro_crew.platform.defaults import (
     DefaultSkillDiscoveryProvider,
     DefaultSlackEnterpriseGate,
     DefaultTelemetryProvider,
+    DefaultTipsProvider,
     DefaultTunnelProvider,
 )
 from kiro_crew.platform.discovery import discover_companion_context, plugin_entry_points
@@ -143,6 +144,7 @@ def build_default_context(
         agent_catalog=DefaultAgentCatalogProvider(),
         prompt_sources=DefaultPromptSourceProvider(),
         skill_discovery=DefaultSkillDiscoveryProvider(),
+        tips=DefaultTipsProvider(),
         denied_rules=DefaultDeniedRuleProvider(),
         import_sources=DefaultImportSourceProvider(),
         capability_manager=DefaultCapabilityManager(),

--- a/src/kiro_crew/platform/context.py
+++ b/src/kiro_crew/platform/context.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:  # avoid import cycles — config.loader imports heavy modules
         SkillDiscoveryProvider,
         SlackEnterpriseGate,
         TelemetryProvider,
+        TipsProvider,
         TunnelProvider,
     )
     from kiro_crew.platform.security_authority import PolicyAuthority
@@ -295,6 +296,12 @@ class PlatformContext:
     agent_catalog: "AgentCatalogProvider"
     prompt_sources: "PromptSourceProvider"
     skill_discovery: "SkillDiscoveryProvider"
+    # The edition's feature-tip pool. The one REPLACE-capable seam in this
+    # contract: a supplied pool takes over from the public curated file AND the
+    # docs-scan catalog rather than being unioned into them, because a public tip
+    # advertises a capability an edition build may not have. v1 addition (no
+    # CONTRACT_VERSION bump).
+    tips: "TipsProvider"
     # Edition-contributed denied-command rules the OPERATOR can switch off.
     # Distinct from ``security`` (the un-weakenable overlay floor).
     # v1 addition (no CONTRACT_VERSION bump).

--- a/src/kiro_crew/platform/defaults.py
+++ b/src/kiro_crew/platform/defaults.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     )
     from kiro_crew.security import DeniedCommandRule
     from kiro_crew.skill_providers.base import SkillProvider
+    from kiro_crew.tips_pool import TipsPool
 
 from kiro_crew import security, sso_status
 from kiro_crew.platform.interfaces import (
@@ -309,6 +310,17 @@ class DefaultSkillDiscoveryProvider:
 
     def skill_providers(self) -> List["SkillProvider"]:
         return []
+
+
+class DefaultTipsProvider:
+    """No edition tip pool — the public curated file + docs-scan catalog.
+
+    ``None`` is the "public pool unchanged" answer, so the standalone edition is
+    behaviorally identical to before the seam existed.
+    """
+
+    def tips_pool(self) -> "Optional[TipsPool]":
+        return None
 
 
 class DefaultDeniedRuleProvider:

--- a/src/kiro_crew/platform/interfaces.py
+++ b/src/kiro_crew/platform/interfaces.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from kiro_crew.config.loader import KiroCrewConfig, TelemetryConfig
     from kiro_crew.security import DeniedCommandRule
     from kiro_crew.skill_providers.base import SkillProvider
+    from kiro_crew.tips_pool import TipsPool
 
 
 class InterceptDecision(enum.Enum):
@@ -632,6 +633,68 @@ class SkillDiscoveryProvider(Protocol):
         site (fallback ``[]``). The public Default returns ``[]`` (discovery
         offers the built-in catalog only). v1 addition (no ``CONTRACT_VERSION``
         bump).
+        """
+        ...
+
+
+class TipsProvider(Protocol):
+    """The edition's feature-tip pool — the one REPLACE-capable edition seam.
+
+    Every other edition hook in this contract is ADD-only: an edition UNIONS its
+    contribution into the public set (``McpToolingProvider.extra_mcp_servers``,
+    ``SkillDiscoveryProvider.skill_providers``, ``DeniedRuleProvider``…).  Tips
+    cannot work that way.  A tip asserts that a feature exists and is worth
+    using, so a public tip shown on an edition build advertises a capability that
+    build may not have or may deliberately not expose — and the failure is
+    silent, because a tip is an unprompted suggestion nobody asked to verify.
+
+    Subtraction is not an alternative: a deny-list has to enumerate the public
+    pool to subtract from it, so every tip added to the public pool afterwards
+    would surface on the edition build until someone remembered to deny it — the
+    default would be leak, not withhold.  Hence full replacement: when an edition
+    supplies a pool, the public curated file and the public docs-scan catalog are
+    not consulted at all.
+    """
+
+    def tips_pool(self) -> "Optional[TipsPool]":
+        """The edition's COMPLETE tip pool, or ``None`` to keep the public one.
+
+        WIRED: ``tips.get_tips_cache`` calls this once per process when it builds
+        the tips cache.  ``None`` (the public Default) leaves today's behavior
+        byte-for-byte — bundled catalog, docs-scan fallback, bundled curated
+        file.  A :class:`TipsPool` REPLACES both the curated pool and the feature
+        catalog, so neither the public curated file nor ``docs/*.md`` is read and
+        no public feature is offered to the tip generator.  An empty pool is legal
+        and means this build shows no tips.
+
+        Scope of that guarantee: the prompt is built from the pool's catalog
+        alone, so a public feature is never put in front of the model, and a
+        generated tip whose ``doc`` is outside that catalog is dropped at parse
+        time (``tips._parse_tips``).  What remains is narrow: a tip could cite a
+        valid pool doc while its prose names something absent, because generated
+        text is checked for shape and provenance, not for subject.  Constrain the
+        pool; treat a generated tip's wording as unverified.
+
+        Pool entries are re-validated on the way into the cache through the same
+        checks the public pool's entries pass (``tips._sanitize_pool``); a
+        malformed entry is dropped and logged rather than served.
+
+        The pool's ``pool_id`` is persisted and compared on load: when it differs
+        from the stamp in ``tips_state.json``, tips generated against the previous
+        pool are discarded rather than re-served, which is what closes the leak on
+        a host that gains (or loses) the companion after tips were already
+        generated.  User dismissals and snoozes are deliberately NOT discarded —
+        they are keyed by tip id and doc, so an entry from another pool simply
+        never matches, and dropping them would silently un-dismiss tips the user
+        already refused.
+
+        Read fail-closed through ``safe_context_call`` at the call site, and the
+        degrade is profile-dependent: on ``standalone`` a failure falls back to the
+        public pool, because there is no other pool to prefer; on a non-standalone
+        build it WITHHOLDS tips (an empty pool stamped ``edition-unavailable``),
+        because falling back to public there would serve exactly the tips this
+        seam exists to keep off that build. A ``PlatformCompositionError`` is
+        re-raised on both. v1 addition (no ``CONTRACT_VERSION`` bump).
         """
         ...
 

--- a/src/kiro_crew/tips.py
+++ b/src/kiro_crew/tips.py
@@ -25,8 +25,19 @@ from kiro_crew.config.paths import config_dir
 from kiro_crew.context import ContextBuilder
 from kiro_crew.llm_helpers import run_bg_oneliner
 from kiro_crew.loop_lock import LoopBoundLock
+from kiro_crew.platform import PROFILE_STANDALONE, current_context, safe_context_call
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
 from kiro_crew.tips_allowlist import TIP_DOC_ALLOWLIST
+
+# Re-exported: ``tips.CatalogEntry`` is the historical import path, and the
+# dataclass moved to the import-light ``tips_pool`` so an edition composition
+# root can build a pool without importing this aiohttp-bearing module.
+from kiro_crew.tips_pool import (
+    PUBLIC_POOL_ID,
+    WITHHELD_POOL_ID,
+    CatalogEntry,
+    TipsPool,
+)
 from kiro_crew.tips_text import truncate_summary
 
 if TYPE_CHECKING:
@@ -109,16 +120,6 @@ Respond with ONLY a JSON array. No explanation, no markdown fences.
 # ── Catalog ──
 
 
-@dataclass
-class CatalogEntry:
-    """A feature discovered from docs/*.md."""
-
-    feature: str  # H1 title (without #)
-    summary: str  # first paragraph
-    doc: str  # filename (e.g. 'cron-and-scheduling.md')
-    mtime: float = 0.0  # file mtime for recency ordering
-
-
 def _scan_docs_catalog() -> list[CatalogEntry]:
     """Scan kiro_crew/docs/*.md for H1 + first paragraph."""
     docs_dir = Path(__file__).parent / "docs"
@@ -139,7 +140,7 @@ def _scan_docs_catalog() -> list[CatalogEntry]:
             continue
         title = m.group(1).strip()
         # First non-empty paragraph after H1
-        rest = text[m.end():].lstrip("\n")
+        rest = text[m.end() :].lstrip("\n")
         para = ""
         for block in rest.split("\n\n"):
             stripped = block.strip()
@@ -148,7 +149,9 @@ def _scan_docs_catalog() -> list[CatalogEntry]:
                 break
         if not para:
             continue
-        entries.append(CatalogEntry(feature=title, summary=truncate_summary(para), doc=md.name, mtime=mtime))
+        entries.append(
+            CatalogEntry(feature=title, summary=truncate_summary(para), doc=md.name, mtime=mtime)
+        )
     return entries
 
 
@@ -179,6 +182,12 @@ class TipsState:
     # loads as False and gets the repair. Without this, a new install's first
     # curated+generated dismissal pair would be lifted on the next load.
     relink_migrated: bool = True
+    # Provenance of the pool the cached ``tips``/``offered`` were produced from
+    # (see kiro_crew.tips_pool.TipsPool). A host that gains or loses an edition
+    # pool must not keep serving tips generated against the previous one — those
+    # describe features this build may not have. Defaults to the public pool
+    # because that is what every pre-stamp state file was generated from.
+    pool_id: str = PUBLIC_POOL_ID
     last_generated: float = 0.0
     last_shown_ts: float = 0.0  # cadence gate timestamp (set on feedback, not on serve)
     tips: list[dict] = field(default_factory=list)  # type: ignore[type-arg]
@@ -236,22 +245,26 @@ def _load_state() -> TipsState:
         # _is_eligible with a 500 on every request until repaired by hand.
         shown_raw = _typed("shown", dict, {})
         shown = {
-            k: v for k, v in shown_raw.items()
+            k: v
+            for k, v in shown_raw.items()
             if isinstance(k, str) and isinstance(v, int) and not isinstance(v, bool)
         }
         snoozed_raw = _typed("snoozed", dict, {})
         snoozed = {
-            k: f for k, v in snoozed_raw.items()
+            k: f
+            for k, v in snoozed_raw.items()
             if isinstance(k, str) and (f := _finite(v)) is not None
         }
         dismissed = [d for d in _typed("dismissed", list, []) if isinstance(d, str)]
         dismissed_docs = [d for d in _typed("dismissed_docs", list, []) if isinstance(d, str)]
         shown_docs = {
-            k: v for k, v in _typed("shown_docs", dict, {}).items()
+            k: v
+            for k, v in _typed("shown_docs", dict, {}).items()
             if isinstance(k, str) and isinstance(v, str)
         }
         snoozed_docs = {
-            k: fv for k, v in _typed("snoozed_docs", dict, {}).items()
+            k: fv
+            for k, v in _typed("snoozed_docs", dict, {}).items()
             if isinstance(k, str) and (fv := _finite(v)) is not None
         }
 
@@ -264,10 +277,12 @@ def _load_state() -> TipsState:
             snoozed=snoozed,
             opted_out=_typed("opted_out", bool, False),
             relink_migrated=_typed("relink_migrated", bool, False),
+            pool_id=_typed("pool_id", str, PUBLIC_POOL_ID) or PUBLIC_POOL_ID,
             last_generated=_finite(data.get("last_generated")) or 0.0,
             last_shown_ts=_finite(data.get("last_shown_ts")) or 0.0,
             tips=[
-                st_t for t in _typed("tips", list, [])
+                st_t
+                for t in _typed("tips", list, [])
                 if (st_t := _sanitize_persisted_tip(t)) is not None
             ],
             offered=_sanitize_persisted_tip(data.get("offered")),
@@ -346,6 +361,7 @@ def _save_state(st: TipsState) -> None:
                 "snoozed": st.snoozed,
                 "opted_out": st.opted_out,
                 "relink_migrated": st.relink_migrated,
+                "pool_id": st.pool_id,
                 "last_generated": st.last_generated,
                 "last_shown_ts": st.last_shown_ts,
                 "tips": st.tips,
@@ -397,6 +413,34 @@ _tips_init_lock = LoopBoundLock()
 _BUNDLED_CATALOG_FILE = Path(__file__).resolve().parent / "data" / "tips_catalog.json"
 
 
+def _clean_catalog_entry(
+    feature: object, summary: object, doc: object, mtime: object
+) -> CatalogEntry | None:
+    """Validate one catalog entry's fields; None if it cannot be trusted.
+
+    Shared by every catalog SOURCE — the bundled JSON and an edition-supplied
+    pool — because a catalog entry reaches the same places regardless of where it
+    came from: the generator prompt, the non-personalized fallback tip bodies,
+    and the mtime arithmetic in ``_select_tip``. A non-string field or a
+    non-finite mtime would surface there as a 500, so the check belongs with the
+    type, not with one loader.
+    """
+    if not (isinstance(feature, str) and isinstance(summary, str) and isinstance(doc, str)):
+        return None
+    if not (feature and summary and doc):
+        return None
+    if isinstance(mtime, bool) or not isinstance(mtime, (int, float)):
+        m = 0.0
+    else:
+        try:
+            m = float(mtime)
+        except (TypeError, ValueError, OverflowError):
+            m = 0.0
+    if not math.isfinite(m):
+        m = 0.0
+    return CatalogEntry(feature=feature, summary=truncate_summary(summary), doc=doc, mtime=m)
+
+
 def _load_bundled_catalog() -> list[CatalogEntry] | None:
     """Load the pre-generated tips catalog shipped with the package.
 
@@ -418,17 +462,11 @@ def _load_bundled_catalog() -> list[CatalogEntry] | None:
         for e in entries_raw:
             if not isinstance(e, dict):
                 continue
-            feature = e.get("feature", "")
-            summary = e.get("summary", "")
-            doc = e.get("doc", "")
-            if feature and summary and doc:
-                try:
-                    mtime = float(e.get("mtime", 0.0))
-                except (TypeError, ValueError, OverflowError):
-                    mtime = 0.0
-                if not math.isfinite(mtime):
-                    mtime = 0.0
-                entries.append(CatalogEntry(feature=feature, summary=truncate_summary(summary), doc=doc, mtime=mtime))
+            entry = _clean_catalog_entry(
+                e.get("feature", ""), e.get("summary", ""), e.get("doc", ""), e.get("mtime", 0.0)
+            )
+            if entry is not None:
+                entries.append(entry)
         return entries if entries else None
     except (OSError, ValueError, TypeError, AttributeError, OverflowError):
         # ValueError covers json.JSONDecodeError; the rest are defense-in-depth
@@ -470,21 +508,190 @@ def _load_curated_tips() -> list[dict]:  # type: ignore[type-arg]
     return out
 
 
+def _degraded_pool() -> TipsPool | None:
+    """What to serve when the edition adapter could not answer.
+
+    Invoked only on the degrade path. The answer differs by profile, and getting
+    it wrong reintroduces the leak: on a NON-standalone build, falling back to
+    the public pool would serve exactly the tips this seam withholds, so a merely
+    broken adapter would advertise public features on an edition host. Withhold
+    instead — an empty pool is already a legal state.
+
+    On standalone there is no other pool to withhold in favour of, so ``None``
+    (the public pool) is both the correct and the only answer.
+    """
+    if current_context().profile == PROFILE_STANDALONE:
+        return None
+    return TipsPool(pool_id=WITHHELD_POOL_ID)
+
+
+def _resolve_pool() -> TipsPool | None:
+    """The edition's tip pool, or ``None`` for the public one.
+
+    Fail-closed per the CPP contract: a ``PlatformCompositionError`` (a
+    non-standalone host whose companion did not compose) propagates rather than
+    silently handing an internal build the public pool — which is precisely the
+    leak this seam exists to close. Any other adapter error degrades through
+    :func:`_degraded_pool`, so tips never take the endpoints down and an edition
+    host withholds rather than falling back to public tips.
+
+    A non-``TipsPool`` return degrades the same way: an adapter that answers with
+    the wrong type must not reach the cache as a half-applied override.
+    """
+    pool = safe_context_call(
+        lambda: current_context().tips.tips_pool(),
+        fallback_factory=_degraded_pool,
+        log_message="edition tips pool unavailable; degrading",
+    )
+    if pool is not None and not isinstance(pool, TipsPool):
+        logger.warning(
+            "TipsProvider.tips_pool() returned %s, expected TipsPool; degrading",
+            type(pool).__name__,
+        )
+        return _degraded_pool()
+    return pool
+
+
+def _sanitize_pool(pool: TipsPool) -> tuple[list[dict], list[CatalogEntry]]:  # type: ignore[type-arg]
+    """Validate an edition pool's entries through the SAME checks as public ones.
+
+    An edition adapter is in-process and trusted for INTENT, but not for shape:
+    it may load its pool from a packaged JSON file or build it in a composition
+    root, so it can carry the same malformed entries a bundled file can. The
+    public paths already gate that (``_load_curated_tips`` runs every entry
+    through ``_sanitize_persisted_tip``; the bundled loader validates catalog
+    fields), and skipping it here would mean a curated entry with a non-string
+    ``id`` reaching ``_is_eligible``, where the unhashable value raises inside the
+    snooze lookup and turns every ``/api/tips/*`` request into a 500. A bad entry
+    must be dropped, exactly as it is on the public path.
+
+    Drops are logged with counts: silently serving 3 of 5 tips would otherwise
+    look to an edition author like their pool loaded fine.
+    """
+    curated: list[dict] = []  # type: ignore[type-arg]
+    for t in pool.curated:
+        sanitized = _sanitize_persisted_tip(t)
+        if sanitized is not None:
+            curated.append(sanitized)
+    catalog: list[CatalogEntry] = []
+    for e in pool.catalog:
+        entry = _clean_catalog_entry(
+            getattr(e, "feature", None),
+            getattr(e, "summary", None),
+            getattr(e, "doc", None),
+            getattr(e, "mtime", 0.0),
+        )
+        if entry is not None:
+            catalog.append(entry)
+    dropped_curated = len(pool.curated) - len(curated)
+    dropped_catalog = len(pool.catalog) - len(catalog)
+    if dropped_curated or dropped_catalog:
+        logger.warning(
+            "tips pool %r: dropped %d malformed curated tip(s) and %d malformed "
+            "catalog entry/entries",
+            pool.pool_id,
+            dropped_curated,
+            dropped_catalog,
+        )
+    return curated, catalog
+
+
+def _reconcile_pool(st: TipsState, pool_id: str) -> bool:
+    """Drop cached tips that were generated against a DIFFERENT pool.
+
+    Returns True when state changed (caller persists). The generated pool,
+    the outstanding offered tip, and the generation timestamp go; a fresh
+    generation runs against the active catalog on the next refresh check.
+
+    The split here is between USER INTENT and CACHE, not between "old" and "new".
+
+    Dismissals and snoozes are intent, and they SURVIVE — but they are read
+    through :func:`_scoped`, so one pool's dismissal cannot suppress another
+    pool's same-named tip. Both halves are needed: clearing them would silently
+    un-dismiss tips the user already refused (and would refuse again if the host
+    switches back), while keeping them in one flat namespace would let a
+    dismissed public ``cron-tip`` suppress an unrelated edition ``cron-tip`` the
+    user never saw. Surviving is correct; being globally visible was not.
+
+    ``shown_docs`` is cache, and it is CLEARED. It maps a tip id to the doc it was
+    shown with, purely so a dismissal arriving after a regeneration can still
+    resolve its stable doc identity. Every entry in it necessarily describes a tip
+    from the pool being discarded, and tip ids are author-chosen slugs, so two
+    pools can name the same id. Keeping the map lets a docless tip in the NEW pool
+    resolve through a colliding id to the OLD pool's doc, and
+    ``api_tips_feedback`` then records that doc in ``dismissed_docs`` — a
+    permanent dismissal of an unrelated feature the user never refused. Nothing is
+    lost by dropping it: the offered slot is cleared in the same breath, so no tip
+    from the old pool can still be acted on.
+    """
+    if st.pool_id == pool_id:
+        return False
+    logger.info(
+        "tips pool changed (%s -> %s); discarding tips generated against the previous pool",
+        st.pool_id,
+        pool_id,
+    )
+    st.pool_id = pool_id
+    st.tips = []
+    st.offered = None
+    st.shown_docs = {}
+    st.last_generated = 0.0
+    return True
+
+
 async def get_tips_cache(state: DashboardState) -> TipsCache:
     """Get or create the tips cache on the state object (async: offloads IO)."""
     if not hasattr(state, "_tips_cache"):
         async with _tips_init_lock:
             if not hasattr(state, "_tips_cache"):
                 loop = asyncio.get_running_loop()
-                # Prefer bundled catalog; fall back to live docs scan if missing/corrupt
-                catalog = await loop.run_in_executor(None, _load_bundled_catalog)
-                if catalog is not None:
-                    logger.debug("Tips catalog loaded from bundled data (%d entries)", len(catalog))
+                pool = await loop.run_in_executor(None, _resolve_pool)
+                catalog: list[CatalogEntry]
+                if pool is not None:
+                    # Full replacement: neither the bundled/scanned public
+                    # catalog nor the bundled curated file is consulted, so no
+                    # public feature can be advertised on this build. Entries go
+                    # through the same validation as the public pool's.
+                    curated, catalog = await loop.run_in_executor(None, _sanitize_pool, pool)
+                    pool_id = pool.pool_id
+                    logger.debug(
+                        "Tips pool %r composed by the edition (%d curated, %d catalog)",
+                        pool_id,
+                        len(curated),
+                        len(catalog),
+                    )
                 else:
-                    logger.debug("Bundled tips catalog unavailable; falling back to live docs scan")
-                    catalog = await loop.run_in_executor(None, _scan_docs_catalog)
+                    pool_id = PUBLIC_POOL_ID
+                    # Prefer bundled catalog; fall back to live docs scan if missing/corrupt
+                    bundled = await loop.run_in_executor(None, _load_bundled_catalog)
+                    if bundled is not None:
+                        catalog = bundled
+                        logger.debug(
+                            "Tips catalog loaded from bundled data (%d entries)", len(catalog)
+                        )
+                    else:
+                        logger.debug(
+                            "Bundled tips catalog unavailable; falling back to live docs scan"
+                        )
+                        catalog = await loop.run_in_executor(None, _scan_docs_catalog)
+                    curated = await loop.run_in_executor(None, _load_curated_tips)
                 st = await loop.run_in_executor(None, _load_state)
-                curated = await loop.run_in_executor(None, _load_curated_tips)
+                if _reconcile_pool(st, pool_id):
+                    # The reconciliation that matters already happened IN MEMORY,
+                    # so a failed write costs only re-running it next boot. Before
+                    # this seam, get_tips_cache wrote nothing at all; letting the
+                    # write raise here would make an unwritable data home turn
+                    # every /api/tips/* request into a 500, which is strictly
+                    # worse than an unpersisted stamp.
+                    try:
+                        await loop.run_in_executor(None, _save_state, st)
+                    except Exception:
+                        logger.warning(
+                            "could not persist the tips pool stamp; continuing with "
+                            "the reconciled in-memory state (it will be redone next "
+                            "boot)",
+                            exc_info=True,
+                        )
                 cache = TipsCache()
                 cache.catalog = catalog
                 cache.curated = curated
@@ -537,9 +744,7 @@ def _select_tip(
     mtimes = {id(t): _tip_mtime(t, i) for i, t in enumerate(candidates)}
 
     # Sort candidates newest-first by mtime
-    sorted_candidates = sorted(
-        candidates, key=lambda t: mtimes[id(t)], reverse=True
-    )
+    sorted_candidates = sorted(candidates, key=lambda t: mtimes[id(t)], reverse=True)
 
     # Compute weights: recency_decay ** tier, where the tier is the rank of the
     # candidate's mtime among the DISTINCT mtimes (tier 0 = newest).
@@ -610,8 +815,28 @@ _TIP_ALLOWED_FIELDS = ("id", "feature", "title", "body", "why", "doc", "doc_link
 _TIP_OPTIONAL_FIELDS = ("doc_link",)
 
 
-def _parse_tips(text: str) -> list[dict]:  # type: ignore[type-arg]
-    """Parse LLM response into a list of tip dicts."""
+def _parse_tips(
+    text: str, allowed_docs: "set[str] | None" = None
+) -> list[dict]:  # type: ignore[type-arg]
+    """Parse LLM response into a list of tip dicts.
+
+    ``allowed_docs`` anchors a generated tip to the catalog it was generated
+    from: a tip whose ``doc`` is not one of these is dropped. Restricting the
+    catalog handed to the generator is what stops a public feature being OFFERED
+    to the model, but it does not constrain what the model writes — so without
+    this a hallucinated public feature comes back as a shape-valid tip and is
+    served, which on an edition build is the unreachable-feature card the pool
+    replacement exists to remove. The catalog is already in hand at the call
+    site, so the check is free.
+
+    A tip with no ``doc`` is dropped under this rule too: it carries no
+    verifiable provenance, and the prompt asks for a catalog filename.
+
+    ``None`` (the default) disables the check, which keeps the function usable
+    for callers that have no catalog to anchor against. This closes MOST of the
+    channel, not all of it — a tip's prose could still name something absent
+    while citing a valid doc.
+    """
     text = text.strip()
     if text.startswith("```"):
         lines = text.split("\n")
@@ -621,6 +846,7 @@ def _parse_tips(text: str) -> list[dict]:  # type: ignore[type-arg]
         result = json.loads(text)
         if isinstance(result, list):
             valid = []
+            unanchored = 0
             for t in result:
                 if not isinstance(t, dict):
                     continue
@@ -632,7 +858,17 @@ def _parse_tips(text: str) -> list[dict]:  # type: ignore[type-arg]
                 # string-only redaction and reach persistence + the dashboard.
                 t = {k: t[k] for k in _TIP_ALLOWED_FIELDS}
                 _sanitize_tip_links(t)
+                # Applied AFTER link sanitization, so a doc this rejects cannot
+                # be smuggled past in a shape the sanitizer would have blanked.
+                if allowed_docs is not None and t.get("doc", "") not in allowed_docs:
+                    unanchored += 1
+                    continue
                 valid.append(t)
+            if unanchored:
+                logger.info(
+                    "dropped %d generated tip(s) naming a doc outside the active catalog",
+                    unanchored,
+                )
             return valid[:_MAX_GENERATED_TIPS]
     except (json.JSONDecodeError, TypeError):
         pass
@@ -663,8 +899,10 @@ def _sanitize_tip_links(t: dict) -> None:  # type: ignore[type-arg]
     """
     for link_field in ("doc", "doc_link"):
         val = t.get(link_field, "")
-        if isinstance(val, str) and val and not (
-            re.match(r"^https?://", val) or re.match(r"^[\w./-]+\.md$", val)
+        if (
+            isinstance(val, str)
+            and val
+            and not (re.match(r"^https?://", val) or re.match(r"^[\w./-]+\.md$", val))
         ):
             t[link_field] = ""
 
@@ -734,11 +972,7 @@ def _sanitize_tip_action(obj: object) -> dict | None:  # type: ignore[type-arg]
     if obj.get("kind") not in _TIP_ACTION_KINDS:
         return None
     label = obj.get("label")
-    if (
-        not isinstance(label, str)
-        or not label.strip()
-        or len(label) > _TIP_ACTION_LABEL_MAX
-    ):
+    if not isinstance(label, str) or not label.strip() or len(label) > _TIP_ACTION_LABEL_MAX:
         return None
     route = obj.get("route")
     if (
@@ -771,7 +1005,7 @@ def _fallback_tips(catalog: list[CatalogEntry], st: TipsState) -> list[dict]:  #
     tips = []
     for entry in catalog:
         tid = entry.doc.replace(".md", "-tip")
-        if tid in st.dismissed:
+        if _scoped(st, tid) in st.dismissed:
             continue
         tips.append(
             {
@@ -788,17 +1022,52 @@ def _fallback_tips(catalog: list[CatalogEntry], st: TipsState) -> list[dict]:  #
     return tips
 
 
+# Separator between a pool stamp and a dismissal key. A unit separator cannot
+# occur in a tip id (author-chosen slug) or a doc filename, so it cannot be
+# forged from either half.
+_SCOPE_SEP = "\x1f"
+
+
+def _scoped(st: TipsState, key: str) -> str:
+    """Namespace a dismissal/snooze key to the pool whose tip it identifies.
+
+    Dismissal state is persistent and GLOBAL, while a tip id is an author-chosen
+    slug and a doc is a filename — so two pools can independently name
+    ``cron-tip`` or ``channels.md``. Without scoping, dismissing one pool's tip
+    permanently suppresses the other pool's unrelated tip of the same name, which
+    the user never saw and never refused. That is why dismissals can survive a
+    pool switch (they are the user's intent, and must be honoured again if the
+    host switches back) yet must not be read across pools.
+
+    Public keys stay BARE. That keeps the public build byte-identical and makes
+    migration free: every state file written before this existed was the public
+    pool's, so its unprefixed entries are already correctly scoped.
+
+    ``shown`` is deliberately left unscoped — it is a display counter feeding the
+    generator prompt, gates nothing, and a collision there merely merges two
+    counts. Only the fields that decide ELIGIBILITY are namespaced.
+    """
+    if st.pool_id == PUBLIC_POOL_ID:
+        return key
+    return f"{st.pool_id}{_SCOPE_SEP}{key}"
+
+
 def _is_eligible(
     tip: dict, st: TipsState, now: float, snooze_hours: float  # type: ignore[type-arg]
 ) -> bool:
-    """Check if a tip is eligible (not dismissed, not actively snoozed)."""
-    tid = tip.get("id", "")
+    """Check if a tip is eligible (not dismissed, not actively snoozed).
+
+    Every lookup is scoped to the active pool (see :func:`_scoped`), so one
+    pool's dismissal cannot suppress another pool's same-named tip.
+    """
+    tid = _scoped(st, tip.get("id", ""))
     if tid in st.dismissed:
         return False
     # Doc-level dismissal: stable across LLM regenerations that invent new ids.
     # Keys on "doc" ONLY — "doc_link" is a rendering hint and never suppresses,
     # so a curated tip linking a catalog doc cannot take that doc's tip down.
-    doc = tip.get("doc", "")
+    raw_doc = tip.get("doc", "")
+    doc = _scoped(st, raw_doc) if raw_doc else ""
     if doc and doc in st.dismissed_docs:
         return False
     if tid in st.snoozed:
@@ -808,6 +1077,24 @@ def _is_eligible(
     if doc and doc in st.snoozed_docs and now - st.snoozed_docs[doc] < snooze_hours * 3600:
         return False
     return True
+
+
+def _active_pool_dismissals(st: TipsState) -> list[str]:
+    """The active pool's dismissed tip ids, with the pool scope stripped.
+
+    For the generator prompt only. Another pool's dismissals are irrelevant to
+    this pool's catalog, and handing the model raw scoped keys would put a
+    separator-joined internal string in the prompt.
+    """
+    prefix = "" if st.pool_id == PUBLIC_POOL_ID else f"{st.pool_id}{_SCOPE_SEP}"
+    out: list[str] = []
+    for key in st.dismissed:
+        if prefix:
+            if key.startswith(prefix):
+                out.append(key[len(prefix) :])
+        elif _SCOPE_SEP not in key:
+            out.append(key)
+    return out
 
 
 async def generate_tips(state: DashboardState) -> list[dict]:  # type: ignore[type-arg]
@@ -825,7 +1112,7 @@ async def generate_tips(state: DashboardState) -> list[dict]:  # type: ignore[ty
         catalog=catalog_text,
         context=context or "(no user context available)",
         shown_ids=", ".join(st.shown.keys()) or "none",
-        dismissed_ids=", ".join(st.dismissed) or "none",
+        dismissed_ids=", ".join(_active_pool_dismissals(st)) or "none",
     )
 
     loop2 = asyncio.get_running_loop()
@@ -844,7 +1131,7 @@ async def generate_tips(state: DashboardState) -> list[dict]:  # type: ignore[ty
         logger.warning("Tips generation failed; using catalog fallback", exc_info=True)
         return _fallback_tips(cache.catalog, st)
 
-    tips = _parse_tips(text)
+    tips = _parse_tips(text, allowed_docs={e.doc for e in cache.catalog})
     if tips:
         tips = _redact_tips(tips)
         logger.info("Generated %d personalized tips", len(tips))
@@ -943,19 +1230,19 @@ async def api_tips_next(request: web.Request) -> web.Response:
         # Gather eligible candidates. Curated actionable tips (hand-authored,
         # action-first, for features with no docs entry) are the primary pool;
         # LLM-generated tips augment them. Dedupe by id — curated wins.
-        curated_candidates = [
-            t for t in cache.curated if _is_eligible(t, st, now, snooze_hours)
-        ]
+        curated_candidates = [t for t in cache.curated if _is_eligible(t, st, now, snooze_hours)]
         curated_ids = {t.get("id", "") for t in curated_candidates}
         generated_candidates = [
-            t for t in st.tips
+            t
+            for t in st.tips
             if _is_eligible(t, st, now, snooze_hours) and t.get("id", "") not in curated_ids
         ]
         candidates = curated_candidates + generated_candidates
         if not candidates:
             # Last resort: doc-scan catalog fallback (descriptive, not action-first)
             candidates = [
-                t for t in _fallback_tips(cache.catalog, st)
+                t
+                for t in _fallback_tips(cache.catalog, st)
                 if _is_eligible(t, st, now, snooze_hours)
             ]
 
@@ -971,7 +1258,8 @@ async def api_tips_next(request: web.Request) -> web.Response:
         tip: dict | None = None  # type: ignore[type-arg]
         if rng.random() < explore_ratio:
             explore_pool = curated_candidates or [
-                t for t in _fallback_tips(cache.catalog, st)
+                t
+                for t in _fallback_tips(cache.catalog, st)
                 if _is_eligible(t, st, now, snooze_hours)
             ]
             if explore_pool:
@@ -1053,9 +1341,7 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
     try:
         body = await request.json()
     except ValueError:
-        return web.json_response(
-            {"error": "invalid JSON", "code": "invalid_json"}, status=400
-        )
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
 
     if not isinstance(body, dict):
         return web.json_response(
@@ -1085,9 +1371,7 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
 
     valid_actions = ("shown", "ack", "dismiss", "snooze", "helpful", "optout", "optin")
     if action not in valid_actions:
-        return web.json_response(
-            {"error": "invalid action", "code": "invalid_action"}, status=400
-        )
+        return web.json_response({"error": "invalid action", "code": "invalid_action"}, status=400)
 
     now = time.time()
 
@@ -1106,8 +1390,8 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
             st.last_shown_ts = now
             st.offered = None
         elif action in ("ack", "dismiss"):
-            if tip_id and tip_id not in st.dismissed:
-                st.dismissed.append(tip_id)
+            if tip_id and _scoped(st, tip_id) not in st.dismissed:
+                st.dismissed.append(_scoped(st, tip_id))
             # Also record the catalog doc (stable feature identity): LLM
             # regeneration invents fresh ids, so id-only dismissal would let
             # the same feature resurface.
@@ -1131,13 +1415,13 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
                         if entry.doc.replace(".md", "-tip") == tip_id:
                             doc = entry.doc
                             break
-                if doc and doc not in st.dismissed_docs:
-                    st.dismissed_docs.append(doc)
+                if doc and _scoped(st, doc) not in st.dismissed_docs:
+                    st.dismissed_docs.append(_scoped(st, doc))
             st.last_shown_ts = now
             st.offered = None
         elif action == "snooze":
             if tip_id:
-                st.snoozed[tip_id] = now
+                st.snoozed[_scoped(st, tip_id)] = now
                 doc = ""
                 if isinstance(st.offered, dict) and st.offered.get("id") == tip_id:
                     doc = st.offered.get("doc", "")
@@ -1154,7 +1438,7 @@ async def api_tips_feedback(request: web.Request) -> web.Response:
                             doc = entry.doc
                             break
                 if isinstance(doc, str) and doc:
-                    st.snoozed_docs[doc] = now
+                    st.snoozed_docs[_scoped(st, doc)] = now
             st.last_shown_ts = now
             st.offered = None
         elif action == "helpful":

--- a/src/kiro_crew/tips_pool.py
+++ b/src/kiro_crew/tips_pool.py
@@ -1,0 +1,127 @@
+"""The tip-pool payload carried across the tips platform seam.
+
+Kept in its own import-light module (no aiohttp, no dashboard state) so an
+edition's composition root can build a :class:`TipsPool` without importing the
+tips runtime, and so ``kiro_crew.platform.interfaces`` can name the type under
+``TYPE_CHECKING`` without pulling the runtime into the platform package.
+
+``kiro_crew.tips`` re-exports both names, so ``tips.CatalogEntry`` keeps
+resolving for existing callers and tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Tuple
+
+# Provenance stamp of the public/open-source pool: the bundled
+# ``data/tips_curated.json`` plus the ``docs/*.md`` scan catalog.  Persisted in
+# ``tips_state.json`` so a host that later composes an edition pool can tell its
+# cached generated tips came from a DIFFERENT pool and drop them (see
+# ``tips._reconcile_pool``).  An edition pool may not reuse this id.
+PUBLIC_POOL_ID = "public"
+
+# Stamp of the empty pool served when an edition build's adapter could not
+# answer.  The degrade for a non-standalone build has to be "no tips", not "the
+# public tips": falling back to the public pool there would serve exactly the
+# tips this seam exists to withhold, so a broken adapter would reintroduce the
+# leak.  A distinct id (not PUBLIC_POOL_ID) keeps the provenance stamp honest, so
+# tips generated under a real pool are not re-served under this one.
+WITHHELD_POOL_ID = "edition-unavailable"
+
+
+@dataclass
+class CatalogEntry:
+    """A feature the tips engine may talk about.
+
+    The public build derives these from ``kiro_crew/docs/*.md`` (H1 + first
+    paragraph, allowlisted); an edition supplies its own through
+    :class:`TipsPool`.  Mutable (not frozen) because the doc scan and the
+    bundled-catalog loader both build entries incrementally.
+    """
+
+    feature: str  # H1 title (without #)
+    summary: str  # first paragraph
+    doc: str  # filename (e.g. 'cron-and-scheduling.md')
+    mtime: float = 0.0  # file mtime for recency ordering
+
+
+@dataclass(frozen=True)
+class TipsPool:
+    """A COMPLETE tip pool that REPLACES the public one — never merges with it.
+
+    This is the one thing that makes the tips seam different from every ADD-only
+    edition seam in the contract (``McpToolingProvider.extra_mcp_servers``,
+    ``SkillDiscoveryProvider.skill_providers``, …).  Those UNION an edition's
+    contribution into the public set, which is the wrong shape here: a tip is a
+    claim that a feature EXISTS and is worth using, so a public tip surfacing on
+    an edition build advertises a capability that build may not have, or may
+    deliberately not expose.  Suppression-by-subtraction cannot fix that either —
+    it needs the public list enumerated to subtract from, so every new public tip
+    would leak until someone remembered to deny it.  So the edition hands over a
+    whole pool and the public one is not consulted at all.
+
+    A pool with empty ``curated`` AND empty ``catalog`` is legal and means "this
+    build shows no tips": the engine has nothing eligible and serves none, rather
+    than falling back to the public pool.
+
+    ``pool_id`` is the pool's PROVENANCE, not a display name.  It is persisted
+    into ``tips_state.json`` and compared on every load; when it changes, tips
+    that were generated against the previous pool are discarded instead of being
+    re-served (the switch-over leak).  Give a stable, edition-specific value —
+    the same string across restarts, a different string from any other pool.
+    """
+
+    pool_id: str
+    # Hand-authored, action-first tips.  Same dict shape as the public
+    # ``data/tips_curated.json`` entries; each one is re-validated by the tips
+    # runtime through the SAME field checks as a generated tip, so a malformed
+    # entry is dropped rather than served.
+    curated: Tuple[Dict[str, Any], ...] = field(default_factory=tuple)
+    # Feature catalog handed to the tip generator and used by the last-resort
+    # non-personalized fallback.  Replaces the public docs scan entirely, so no
+    # public feature is put in front of the generator, and a generated tip citing
+    # a doc outside this catalog is dropped at parse time.  It does not police the
+    # model's PROSE: a tip could cite a doc here while naming something absent.
+    catalog: Tuple[CatalogEntry, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate the pool's shape at CONSTRUCTION, in the composition root.
+
+        Checked here rather than at the consumption site because this is where
+        the author can still fix it: an edition typically builds its pool from a
+        packaged JSON file, so ``curated`` can arrive as ``None`` from a
+        ``"curated": null`` key, and a bad ``pool_id`` degrades silently (stale
+        tips survive a pool switch). Both would otherwise surface far away — the
+        first as a ``TypeError`` during cache init that turns every
+        ``/api/tips/*`` request into a 500.
+
+        A ``list`` is accepted and frozen into a tuple, because that is what a
+        JSON loader hands back and rejecting it would make the common correct
+        case a trap. Anything else is refused rather than coerced: silently
+        reading ``None`` as "no tips" would ship an empty pool that looks
+        deliberate, and "this build shows no tips" must be a choice, not a typo.
+        """
+        if not isinstance(self.pool_id, str) or not self.pool_id.strip():
+            raise ValueError("TipsPool.pool_id must be a non-empty string")
+        if self.pool_id.strip() == PUBLIC_POOL_ID:
+            raise ValueError(
+                f"TipsPool.pool_id must not be {PUBLIC_POOL_ID!r} — that id marks "
+                "the public pool, and reusing it would make a pool switch "
+                "undetectable, leaving publicly-generated tips in place."
+            )
+        # Frozen dataclass: normal assignment is refused, so freeze the coerced
+        # containers in via object.__setattr__ (the documented pattern, same as
+        # PlatformContext.__post_init__).
+        for name in ("curated", "catalog"):
+            value = getattr(self, name)
+            if isinstance(value, tuple):
+                continue
+            if isinstance(value, list):
+                object.__setattr__(self, name, tuple(value))
+                continue
+            raise TypeError(
+                f"TipsPool.{name} must be a tuple or list, got "
+                f"{type(value).__name__}. An absent section in a packaged pool "
+                "file must be spelled as an empty list, not null."
+            )

--- a/test/test_tips_edition_pool.py
+++ b/test/test_tips_edition_pool.py
@@ -1,0 +1,726 @@
+"""Tests for the edition tip-pool seam (``PlatformContext.tips``).
+
+The seam exists because a tip is an unprompted claim that a feature exists and
+is worth using. On a build that does not have (or deliberately does not expose)
+that feature, a public tip advertises a capability the user cannot reach — the
+"WeChat integration" class of leak. So the seam REPLACES the pool instead of
+unioning into it, and these tests pin the three ways a public tip could still
+get out: through the curated file, through the docs-scan catalog, and through
+generated tips cached in state from BEFORE the pool was composed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import os
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew.platform import (
+    PROFILE_ENTERPRISE,
+    PROFILE_STANDALONE,
+    PlatformCompositionError,
+    build_default_context,
+    reset_context,
+    set_context,
+)
+from kiro_crew.platform.defaults import DefaultTipsProvider
+from kiro_crew.tips import (
+    TipsState,
+    _reconcile_pool,
+    _resolve_pool,
+    _save_state,
+    get_tips_cache,
+)
+from kiro_crew.tips_pool import (
+    PUBLIC_POOL_ID,
+    WITHHELD_POOL_ID,
+    CatalogEntry,
+    TipsPool,
+)
+
+_EDITION_TIP = {
+    "id": "edition-only-tip",
+    "feature": "Edition Feature",
+    "title": "An edition-only feature",
+    "body": "Only this build has it.",
+    "why": "",
+    "doc": "",
+    "doc_link": "",
+    "cta_prompt": "",
+}
+
+
+def _pool(pool_id: str = "edition-v1", **kw: object) -> TipsPool:
+    return TipsPool(
+        pool_id=pool_id,
+        curated=kw.get("curated", (dict(_EDITION_TIP),)),  # type: ignore[arg-type]
+        catalog=kw.get(  # type: ignore[arg-type]
+            "catalog",
+            (CatalogEntry(feature="Edition Feature", summary="s", doc="edition.md", mtime=9.0),),
+        ),
+    )
+
+
+class _PoolProvider:
+    """Minimal edition adapter — the shape a companion composition root supplies."""
+
+    def __init__(self, pool: TipsPool | None) -> None:
+        self._pool = pool
+
+    def tips_pool(self) -> TipsPool | None:
+        return self._pool
+
+
+def _install(provider: object, *, profile: str = PROFILE_STANDALONE) -> None:
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    ctx = build_default_context(KiroCrewConfig.load(), profile=profile)
+    set_context(dataclasses.replace(ctx, tips=provider))
+
+
+class TestPoolIdentity:
+    def test_public_default_supplies_no_pool(self) -> None:
+        assert DefaultTipsProvider().tips_pool() is None
+
+    def test_default_context_composes_the_default_provider(self) -> None:
+        from kiro_crew.config.loader import KiroCrewConfig
+
+        ctx = build_default_context(KiroCrewConfig.load())
+        assert isinstance(ctx.tips, DefaultTipsProvider)
+        assert ctx.tips.tips_pool() is None
+
+    @pytest.mark.parametrize("bad", ["", "   "])
+    def test_empty_pool_id_is_refused(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            TipsPool(pool_id=bad)
+
+    def test_pool_may_not_impersonate_the_public_pool(self) -> None:
+        # Reusing the public id would make a switch undetectable, so publicly
+        # generated tips would survive into the edition build.
+        with pytest.raises(ValueError, match="undetectable"):
+            TipsPool(pool_id=PUBLIC_POOL_ID)
+
+    def test_empty_pool_is_legal(self) -> None:
+        pool = TipsPool(pool_id="edition-empty")
+        assert pool.curated == ()
+        assert pool.catalog == ()
+
+    @pytest.mark.parametrize("bad", [None, 17, "tips", {"a": 1}])
+    @pytest.mark.parametrize("field_name", ["curated", "catalog"])
+    def test_non_sequence_container_is_refused(self, field_name: str, bad: object) -> None:
+        # A packaged pool file with `"curated": null` would otherwise reach
+        # iteration in _sanitize_pool and 500 every tips endpoint.
+        with pytest.raises(TypeError, match=f"TipsPool.{field_name}"):
+            TipsPool(pool_id="edition-v1", **{field_name: bad})  # type: ignore[arg-type]
+
+    def test_list_container_is_frozen_to_a_tuple(self) -> None:
+        # A JSON loader hands back lists; rejecting them would make the common
+        # correct case a trap.
+        pool = TipsPool(
+            pool_id="edition-v1",
+            curated=[dict(_EDITION_TIP)],  # type: ignore[arg-type]
+            catalog=[CatalogEntry(feature="F", summary="s", doc="d.md")],  # type: ignore[arg-type]
+        )
+        assert isinstance(pool.curated, tuple)
+        assert isinstance(pool.catalog, tuple)
+
+
+class TestResolution:
+    def test_no_context_resolves_to_the_public_pool(self) -> None:
+        reset_context()
+        assert _resolve_pool() is None
+
+    def test_edition_pool_is_resolved(self) -> None:
+        pool = _pool()
+        _install(_PoolProvider(pool))
+        assert _resolve_pool() is pool
+
+    def test_composition_error_is_fail_closed(self) -> None:
+        class _Broken:
+            def tips_pool(self) -> TipsPool | None:
+                raise PlatformCompositionError("companion did not compose")
+
+        _install(_Broken())
+        # Must NOT degrade to the public pool: that is the leak this seam closes.
+        with pytest.raises(PlatformCompositionError):
+            _resolve_pool()
+
+    def test_transient_adapter_error_degrades_to_public_on_standalone(self) -> None:
+        class _Flaky:
+            def tips_pool(self) -> TipsPool | None:
+                raise RuntimeError("transient")
+
+        _install(_Flaky())
+        assert _resolve_pool() is None
+
+    def test_transient_adapter_error_withholds_on_an_edition_build(self) -> None:
+        """A broken adapter on an edition host must not fall back to public tips.
+
+        That fallback would serve exactly the tips the seam withholds, so a merely
+        flaky adapter would reintroduce the leak. Withhold instead.
+        """
+
+        class _Flaky:
+            def tips_pool(self) -> TipsPool | None:
+                raise RuntimeError("transient")
+
+        _install(_Flaky(), profile=PROFILE_ENTERPRISE)
+        pool = _resolve_pool()
+        assert pool is not None
+        assert pool.pool_id == WITHHELD_POOL_ID
+        assert pool.curated == () and pool.catalog == ()
+
+    def test_wrong_return_type_degrades_to_public_on_standalone(self) -> None:
+        _install(_PoolProvider("not-a-pool"))  # type: ignore[arg-type]
+        assert _resolve_pool() is None
+
+    def test_wrong_return_type_withholds_on_an_edition_build(self) -> None:
+        _install(_PoolProvider("not-a-pool"), profile=PROFILE_ENTERPRISE)  # type: ignore[arg-type]
+        pool = _resolve_pool()
+        assert pool is not None
+        assert pool.pool_id == WITHHELD_POOL_ID
+
+    @pytest.mark.asyncio
+    async def test_withheld_pool_serves_no_tips(self, tmp_path: Path) -> None:
+        class _Flaky:
+            def tips_pool(self) -> TipsPool | None:
+                raise RuntimeError("transient")
+
+        _install(_Flaky(), profile=PROFILE_ENTERPRISE)
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        assert cache.curated == []
+        assert cache.catalog == []
+        assert cache.state.pool_id == WITHHELD_POOL_ID
+
+
+class TestCacheReplacement:
+    @pytest.mark.asyncio
+    async def test_edition_pool_replaces_curated_and_catalog(self, tmp_path: Path) -> None:
+        _install(_PoolProvider(_pool()))
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        assert [t["id"] for t in cache.curated] == ["edition-only-tip"]
+        assert [e.doc for e in cache.catalog] == ["edition.md"]
+        assert cache.state.pool_id == "edition-v1"
+
+    @pytest.mark.asyncio
+    async def test_no_public_tip_survives_the_override(self, tmp_path: Path) -> None:
+        # The concrete leak: a public curated tip (e.g. the WeChat integration
+        # one) must not be reachable through ANY of the three pool sources.
+        from kiro_crew.tips import _load_curated_tips
+
+        public_ids = {t["id"] for t in _load_curated_tips()}
+        assert public_ids, "public curated pool is empty; test would pass vacuously"
+
+        _install(_PoolProvider(_pool()))
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+
+        reachable = (
+            {t.get("id", "") for t in cache.curated}
+            | {t.get("id", "") for t in cache.state.tips}
+            | {e.doc.replace(".md", "-tip") for e in cache.catalog}
+        )
+        assert not (reachable & public_ids)
+
+    @pytest.mark.asyncio
+    async def test_empty_edition_pool_does_not_fall_back_to_public(self, tmp_path: Path) -> None:
+        _install(_PoolProvider(TipsPool(pool_id="edition-empty")))
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        assert cache.curated == []
+        assert cache.catalog == []
+
+    @pytest.mark.asyncio
+    async def test_public_build_is_unchanged(self, tmp_path: Path) -> None:
+        _install(DefaultTipsProvider())
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        assert cache.curated, "public build must still load the bundled curated tips"
+        assert cache.catalog, "public build must still load the docs catalog"
+        assert cache.state.pool_id == PUBLIC_POOL_ID
+
+
+class TestCrossPoolReconciliation:
+    def test_same_pool_keeps_cached_tips(self) -> None:
+        st = TipsState(pool_id="edition-v1", tips=[dict(_EDITION_TIP)], last_generated=123.0)
+        assert _reconcile_pool(st, "edition-v1") is False
+        assert st.tips and st.last_generated == 123.0
+
+    def test_switch_discards_generated_tips_and_offer(self) -> None:
+        public_tip = {
+            "id": "wechat-tip",
+            "feature": "WeChat",
+            "title": "WeChat integration",
+            "body": "b",
+            "why": "",
+            "doc": "",
+            "doc_link": "",
+            "cta_prompt": "",
+        }
+        st = TipsState(
+            pool_id=PUBLIC_POOL_ID,
+            tips=[public_tip],
+            offered=dict(public_tip),
+            last_generated=123.0,
+        )
+        assert _reconcile_pool(st, "edition-v1") is True
+        assert st.tips == []
+        assert st.offered is None
+        assert st.last_generated == 0.0
+        assert st.pool_id == "edition-v1"
+
+    def test_switch_preserves_user_dismissals(self) -> None:
+        st = TipsState(
+            pool_id=PUBLIC_POOL_ID,
+            dismissed=["wechat-tip"],
+            dismissed_docs=["channels.md"],
+            snoozed={"x-tip": 5.0},
+            snoozed_docs={"cron-and-scheduling.md": 5.0},
+            opted_out=True,
+        )
+        _reconcile_pool(st, "edition-v1")
+        assert st.dismissed == ["wechat-tip"]
+        assert st.dismissed_docs == ["channels.md"]
+        assert st.snoozed == {"x-tip": 5.0}
+        assert st.snoozed_docs == {"cron-and-scheduling.md": 5.0}
+        assert st.opted_out is True
+
+    def test_switch_clears_shown_docs(self) -> None:
+        """shown_docs is CACHE, not intent, and carrying it across corrupts.
+
+        It maps tip id -> doc, and tip ids are author-chosen slugs, so two pools
+        can name the same id. A stale entry lets a docless tip in the NEW pool
+        resolve through a colliding id to the OLD pool's doc.
+        """
+        st = TipsState(pool_id=PUBLIC_POOL_ID, shown_docs={"shared-id": "channels.md"})
+        _reconcile_pool(st, "edition-v1")
+        assert st.shown_docs == {}
+
+    @pytest.mark.asyncio
+    async def test_colliding_id_cannot_dismiss_the_previous_pools_doc(self, tmp_path: Path) -> None:
+        """Dismissing an edition tip must not suppress a public doc.
+
+        The corruption path: a public tip is shown (recording id -> doc), the pool
+        switches, the edition pool reuses that id for a DOCLESS tip, and dismissing
+        it resolves the doc through the stale map and writes a permanent
+        dismissal for a feature the user never refused.
+        """
+        from unittest.mock import MagicMock, Mock
+        from unittest.mock import patch as mpatch
+
+        from aiohttp import streams
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.tips import api_tips_feedback
+
+        shared_id = "shared-id"
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            # State as the public pool left it: id -> public doc.
+            _save_state(TipsState(pool_id=PUBLIC_POOL_ID, shown_docs={shared_id: "channels.md"}))
+            # The edition pool reuses the id for a tip with NO doc of its own.
+            _install(
+                _PoolProvider(
+                    TipsPool(
+                        pool_id="edition-v1",
+                        curated=({**_EDITION_TIP, "id": shared_id, "doc": ""},),
+                    )
+                )
+            )
+            cfg = MagicMock()
+            cfg.dashboard.tips_enabled = True
+            cfg.dashboard.tips_cadence_hours = 0.0
+            cfg.dashboard.tips_snooze_hours = 48.0
+            cfg.dashboard.tips_recency_decay = 0.6
+            cfg.dashboard.tips_explore_ratio = 0.0
+
+            state = types.SimpleNamespace()
+            with mpatch("kiro_crew.tips.KiroCrewConfig") as mock_cfg:
+                mock_cfg.load.return_value = cfg
+                cache = await get_tips_cache(state)
+                payload = streams.StreamReader(
+                    Mock(_reading_paused=False), 2**16, loop=asyncio.get_event_loop()
+                )
+                payload.feed_data(json.dumps({"id": shared_id, "action": "dismiss"}).encode())
+                payload.feed_eof()
+                req = make_mocked_request("POST", "/api/tips/feedback", payload=payload)
+                req.app["state"] = state
+                resp = await api_tips_feedback(req)
+
+        assert resp.status == 200
+        # The id is dismissed; the previous pool's doc is NOT dragged in with it.
+        from kiro_crew.tips import _scoped
+
+        assert cache.state.dismissed == [_scoped(cache.state, shared_id)]
+        assert cache.state.dismissed_docs == []
+
+    @pytest.mark.asyncio
+    async def test_stale_public_tips_are_dropped_on_first_load(self, tmp_path: Path) -> None:
+        """A host that gains the companion must not re-serve public tips."""
+        stale = {
+            "id": "wechat-tip",
+            "feature": "WeChat",
+            "title": "WeChat integration",
+            "body": "b",
+            "why": "",
+            "doc": "",
+            "doc_link": "",
+            "cta_prompt": "",
+        }
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            _save_state(TipsState(pool_id=PUBLIC_POOL_ID, tips=[stale], offered=dict(stale)))
+            _install(_PoolProvider(_pool()))
+            cache = await get_tips_cache(types.SimpleNamespace())
+            assert cache.state.tips == []
+            assert cache.state.offered is None
+            # ...and the new stamp is persisted, so a restart does not re-run it.
+            from kiro_crew.tips import _state_path
+
+            on_disk = json.loads(_state_path().read_text(encoding="utf-8"))
+            assert on_disk["pool_id"] == "edition-v1"
+
+    def test_pool_id_round_trips_through_disk(self, tmp_path: Path) -> None:
+        from kiro_crew.tips import _load_state
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            _save_state(TipsState(pool_id="edition-v1"))
+            assert _load_state().pool_id == "edition-v1"
+
+    def test_missing_or_bad_pool_id_loads_as_public(self, tmp_path: Path) -> None:
+        from kiro_crew.tips import _load_state, _state_path
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            _save_state(TipsState())
+            path = _state_path()
+            data = json.loads(path.read_text(encoding="utf-8"))
+            del data["pool_id"]
+            path.write_text(json.dumps(data), encoding="utf-8")
+            assert _load_state().pool_id == PUBLIC_POOL_ID
+
+            data["pool_id"] = 17
+            path.write_text(json.dumps(data), encoding="utf-8")
+            assert _load_state().pool_id == PUBLIC_POOL_ID
+
+    @pytest.mark.asyncio
+    async def test_unwritable_state_does_not_break_the_endpoints(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pool switch on a read-only data home must not 500 every tips call.
+
+        The in-memory reconciliation is the part that matters; a failed write only
+        costs re-running it next boot. Before this seam get_tips_cache wrote
+        nothing, so a raising write would be a NEW way to take the feature down.
+        """
+        import kiro_crew.tips as tips_mod
+
+        def _boom(_st: TipsState) -> None:
+            raise OSError("read-only file system")
+
+        monkeypatch.setattr(tips_mod, "_save_state", _boom)
+        _install(_PoolProvider(_pool()))
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        # Reconciled in memory despite the failed persist.
+        assert cache.state.pool_id == "edition-v1"
+        assert cache.state.tips == []
+        assert [t["id"] for t in cache.curated] == ["edition-only-tip"]
+
+
+class TestGeneratedTipContainment:
+    """A restricted catalog stops a public feature being OFFERED to the model.
+
+    It does not constrain what the model writes back, so a hallucinated public
+    feature would return as a shape-valid tip and be served — on an edition build
+    that is the unreachable-feature card this whole PR removes. Parse-time
+    anchoring closes it.
+    """
+
+    @staticmethod
+    def _payload(*docs: str) -> str:
+        return json.dumps(
+            [
+                {
+                    "id": f"tip-{i}",
+                    "feature": f"F{i}",
+                    "title": f"T{i}",
+                    "body": "b",
+                    "why": "w",
+                    "doc": d,
+                    "cta_prompt": "",
+                }
+                for i, d in enumerate(docs)
+            ]
+        )
+
+    def test_no_catalog_means_no_anchoring(self) -> None:
+        from kiro_crew.tips import _parse_tips
+
+        # Backwards-compatible default: callers with no catalog keep every tip.
+        tips = _parse_tips(self._payload("edition.md", "channels.md"))
+        assert [t["doc"] for t in tips] == ["edition.md", "channels.md"]
+
+    def test_tip_outside_the_active_catalog_is_dropped(self) -> None:
+        from kiro_crew.tips import _parse_tips
+
+        tips = _parse_tips(self._payload("edition.md", "channels.md"), allowed_docs={"edition.md"})
+        assert [t["doc"] for t in tips] == ["edition.md"]
+
+    def test_docless_generated_tip_is_dropped(self) -> None:
+        from kiro_crew.tips import _parse_tips
+
+        # No doc means no verifiable provenance, and the prompt asks for one.
+        assert _parse_tips(self._payload(""), allowed_docs={"edition.md"}) == []
+
+    def test_anchoring_runs_after_link_sanitization(self) -> None:
+        from kiro_crew.tips import _clean_catalog_entry, _parse_tips
+
+        # A doc the link sanitizer blanks is anchored as "" and so cannot match a
+        # real catalog: _clean_catalog_entry refuses an empty doc, so "" is never
+        # in allowed_docs. Order matters — anchoring before sanitization would
+        # judge the pre-blanked value instead.
+        assert _clean_catalog_entry("F", "s", "", 1.0) is None
+        assert _parse_tips(self._payload("javascript:alert(1)"), allowed_docs={"edition.md"}) == []
+
+    @pytest.mark.asyncio
+    async def test_generation_anchors_against_the_edition_catalog(self, tmp_path: Path) -> None:
+        """End to end: a hallucinated public doc does not survive generation."""
+        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import patch as mpatch
+
+        from kiro_crew.tips import generate_tips
+
+        _install(_PoolProvider(_pool()))  # catalog = edition.md only
+        payload = self._payload("edition.md", "channels.md")
+
+        cfg = MagicMock()
+        cfg.dashboard.tips_model = "auto"
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            state = types.SimpleNamespace(sessions=MagicMock())
+            with (
+                mpatch("kiro_crew.tips.KiroCrewConfig") as mock_cfg,
+                mpatch("kiro_crew.tips.run_bg_oneliner", AsyncMock(return_value=payload)),
+                mpatch("kiro_crew.tips._build_context", return_value=""),
+            ):
+                mock_cfg.load.return_value = cfg
+                tips = await generate_tips(state)
+
+        assert [t["doc"] for t in tips] == ["edition.md"]
+
+
+class TestScopedDismissalIdentity:
+    """Dismissal state is global and persistent; tip ids and docs are not unique.
+
+    Two pools can independently name `cron-tip` or `channels.md`, so a flat
+    namespace lets one pool's dismissal suppress the other's unrelated tip --
+    which the user never saw and never refused. Dismissals must SURVIVE a switch
+    (intent, honoured again on switching back) but must not be READ across pools.
+    """
+
+    def test_public_keys_stay_bare(self) -> None:
+        from kiro_crew.tips import _scoped
+
+        # Free migration: every pre-existing state file was the public pool's, so
+        # its unprefixed entries are already correctly scoped.
+        st = TipsState(pool_id=PUBLIC_POOL_ID)
+        assert _scoped(st, "cron-tip") == "cron-tip"
+
+    def test_edition_keys_are_namespaced(self) -> None:
+        from kiro_crew.tips import _scoped
+
+        st = TipsState(pool_id="edition-v1")
+        assert _scoped(st, "cron-tip") != "cron-tip"
+        assert "cron-tip" in _scoped(st, "cron-tip")
+
+    def test_public_dismissal_does_not_suppress_an_edition_tip(self) -> None:
+        from kiro_crew.tips import _is_eligible
+
+        st = TipsState(
+            pool_id="edition-v1",
+            dismissed=["cron-tip"],
+            dismissed_docs=["channels.md"],
+            snoozed={"cron-tip": 0.0},
+            snoozed_docs={"channels.md": 0.0},
+        )
+        # Same id as the dismissed public tip, but a different pool's tip.
+        assert _is_eligible({"id": "cron-tip", "doc": ""}, st, 0.0, 48.0)
+        # Same doc filename as the dismissed public doc.
+        assert _is_eligible({"id": "other", "doc": "channels.md"}, st, 0.0, 48.0)
+
+    def test_edition_dismissal_still_suppresses_its_own_tip(self) -> None:
+        from kiro_crew.tips import _is_eligible, _scoped
+
+        st = TipsState(pool_id="edition-v1")
+        st.dismissed.append(_scoped(st, "cron-tip"))
+        st.dismissed_docs.append(_scoped(st, "internal.md"))
+        assert not _is_eligible({"id": "cron-tip", "doc": ""}, st, 0.0, 48.0)
+        assert not _is_eligible({"id": "other", "doc": "internal.md"}, st, 0.0, 48.0)
+
+    def test_public_dismissal_still_suppresses_its_own_tip(self) -> None:
+        from kiro_crew.tips import _is_eligible
+
+        st = TipsState(pool_id=PUBLIC_POOL_ID, dismissed=["cron-tip"])
+        assert not _is_eligible({"id": "cron-tip", "doc": ""}, st, 0.0, 48.0)
+
+    def test_dismissal_is_honoured_again_after_switching_back(self) -> None:
+        from kiro_crew.tips import _is_eligible, _reconcile_pool
+
+        st = TipsState(pool_id=PUBLIC_POOL_ID, dismissed=["cron-tip"])
+        tip = {"id": "cron-tip", "doc": ""}
+        _reconcile_pool(st, "edition-v1")
+        assert _is_eligible(tip, st, 0.0, 48.0)  # invisible to the edition pool
+        _reconcile_pool(st, PUBLIC_POOL_ID)
+        assert not _is_eligible(tip, st, 0.0, 48.0)  # intent survived the round trip
+
+    def test_prompt_sees_only_the_active_pools_dismissals_unscoped(self) -> None:
+        from kiro_crew.tips import _active_pool_dismissals, _scoped
+
+        st = TipsState(pool_id="edition-v1", dismissed=["public-tip"])
+        st.dismissed.append(_scoped(st, "edition-tip"))
+        assert _active_pool_dismissals(st) == ["edition-tip"]
+        st.pool_id = PUBLIC_POOL_ID
+        assert _active_pool_dismissals(st) == ["public-tip"]
+
+    @pytest.mark.asyncio
+    async def test_dismissing_an_edition_tip_scopes_what_it_writes(self, tmp_path: Path) -> None:
+        """End to end: the recorded key must not collide with the public pool."""
+        from unittest.mock import MagicMock, Mock
+        from unittest.mock import patch as mpatch
+
+        from aiohttp import streams
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.tips import _is_eligible, api_tips_feedback
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            _install(_PoolProvider(_pool(curated=({**_EDITION_TIP, "id": "cron-tip"},))))
+            cfg = MagicMock()
+            cfg.dashboard.tips_enabled = True
+            cfg.dashboard.tips_cadence_hours = 0.0
+            cfg.dashboard.tips_snooze_hours = 48.0
+            cfg.dashboard.tips_recency_decay = 0.6
+            cfg.dashboard.tips_explore_ratio = 0.0
+
+            state = types.SimpleNamespace()
+            with mpatch("kiro_crew.tips.KiroCrewConfig") as mock_cfg:
+                mock_cfg.load.return_value = cfg
+                cache = await get_tips_cache(state)
+                payload = streams.StreamReader(
+                    Mock(_reading_paused=False), 2**16, loop=asyncio.get_event_loop()
+                )
+                payload.feed_data(json.dumps({"id": "cron-tip", "action": "dismiss"}).encode())
+                payload.feed_eof()
+                req = make_mocked_request("POST", "/api/tips/feedback", payload=payload)
+                req.app["state"] = state
+                assert (await api_tips_feedback(req)).status == 200
+
+        # Recorded, but not as the bare id a public tip would match.
+        assert cache.state.dismissed != ["cron-tip"]
+        assert len(cache.state.dismissed) == 1
+        # The edition tip is suppressed; a public tip of the same name is not.
+        assert not _is_eligible({"id": "cron-tip", "doc": ""}, cache.state, 0.0, 48.0)
+        public_st = TipsState(pool_id=PUBLIC_POOL_ID, dismissed=list(cache.state.dismissed))
+        assert _is_eligible({"id": "cron-tip", "doc": ""}, public_st, 0.0, 48.0)
+
+
+class TestPoolEntryValidation:
+    """A pool is trusted for intent, not for shape.
+
+    An edition may load its pool from a packaged file, so it can carry the same
+    malformed entries a bundled file can. An unhashable ``id`` reaching
+    ``_is_eligible`` raises inside the snooze lookup and 500s every tips call.
+    """
+
+    def test_unhashable_id_would_crash_eligibility(self) -> None:
+        # Pins the mechanism the sanitizer protects, so this class cannot pass
+        # vacuously if _is_eligible later tolerates the bad value.
+        from kiro_crew.tips import _is_eligible
+
+        with pytest.raises(TypeError):
+            _is_eligible({"id": []}, TipsState(snoozed={"x": 1.0}), 0.0, 48.0)
+
+    @pytest.mark.asyncio
+    async def test_malformed_curated_entries_are_dropped(self, tmp_path: Path) -> None:
+        good = dict(_EDITION_TIP)
+        pool = TipsPool(
+            pool_id="edition-v1",
+            curated=(
+                good,
+                {**_EDITION_TIP, "id": []},  # unhashable id
+                {**_EDITION_TIP, "id": "no-body", "body": ""},  # empty required field
+                {"id": "incomplete"},  # missing required fields
+                "not-a-dict",  # type: ignore[arg-type]
+            ),
+        )
+        _install(_PoolProvider(pool))
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        assert [t["id"] for t in cache.curated] == ["edition-only-tip"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_catalog_entries_are_dropped(self, tmp_path: Path) -> None:
+        pool = TipsPool(
+            pool_id="edition-v1",
+            curated=(),
+            catalog=(
+                CatalogEntry(feature="Good", summary="s", doc="good.md", mtime=1.0),
+                CatalogEntry(feature="", summary="s", doc="empty.md", mtime=1.0),
+                CatalogEntry(feature="NoDoc", summary="s", doc="", mtime=1.0),
+                CatalogEntry(feature="BadMtime", summary="s", doc="nan.md", mtime=float("nan")),
+                CatalogEntry(feature=17, summary="s", doc="x.md"),  # type: ignore[arg-type]
+            ),
+        )
+        _install(_PoolProvider(pool))
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            cache = await get_tips_cache(types.SimpleNamespace())
+        assert [e.doc for e in cache.catalog] == ["good.md", "nan.md"]
+        # A non-finite mtime is coerced, not carried into _select_tip's arithmetic.
+        nan_entry = next(e for e in cache.catalog if e.doc == "nan.md")
+        assert nan_entry.mtime == 0.0
+
+    @pytest.mark.asyncio
+    async def test_sanitized_pool_serves_without_error(self, tmp_path: Path) -> None:
+        """End to end: a pool carrying a poisoned entry still serves a tip."""
+        from unittest.mock import MagicMock
+        from unittest.mock import patch as mpatch
+
+        from aiohttp.test_utils import make_mocked_request
+
+        from kiro_crew.tips import api_tips_next
+
+        _install(
+            _PoolProvider(
+                TipsPool(
+                    pool_id="edition-v1",
+                    curated=(dict(_EDITION_TIP), {**_EDITION_TIP, "id": []}),
+                )
+            )
+        )
+        cfg = MagicMock()
+        cfg.dashboard.tips_enabled = True
+        cfg.dashboard.tips_cadence_hours = 0.0
+        cfg.dashboard.tips_snooze_hours = 48.0
+        cfg.dashboard.tips_recency_decay = 0.6
+        cfg.dashboard.tips_explore_ratio = 0.0
+
+        async def _noop(*a: object, **k: object) -> None:
+            return None
+
+        with patch.dict(os.environ, {"KIROCREW_HOME": str(tmp_path)}):
+            state = types.SimpleNamespace()
+            with (
+                mpatch("kiro_crew.tips.KiroCrewConfig") as mock_cfg,
+                mpatch("kiro_crew.tips.maybe_refresh", _noop),
+            ):
+                mock_cfg.load.return_value = cfg
+                req = make_mocked_request("GET", "/api/tips/next")
+                req.app["state"] = state
+                resp = await api_tips_next(req)
+        assert resp.status == 200
+        assert json.loads(resp.body)["tip"]["id"] == "edition-only-tip"


### PR DESCRIPTION
## What is the problem?

The feature-tips engine has exactly one pool of tips, and it is the public one: `data/tips_curated.json` plus a scan of `kiro_crew/docs/*.md`. Every build serves from it, and there is no seam an edition can use to change that.

So a build that does not ship a feature, or deliberately does not expose it, still advertises it. The tip card offers "WeChat (Weixin) integration - connect Kiro Crew to personal WeChat through Tencent's iLink bot API", with a Learn more link, on a build where that channel is not available. There is also no way for such a build to offer tips for the features it *does* have.

## Why this issue matters to the user

A tip is unprompted. The user did not ask a question, so nothing frames the answer as possibly-inapplicable: the card reads as this build telling them about this build. Following it costs them a detour into a Settings page or a doc for a capability they cannot reach, and it makes the rest of the tips less trustworthy, because a suggestion the reader has to sanity-check first is worth less than no suggestion.

## How our fix solves it

`PlatformContext` gains a `tips` slot (`TipsProvider.tips_pool()`), and it is the first REPLACE-capable seam in the contract.

Every existing edition hook is ADD-only: `McpToolingProvider.extra_mcp_servers`, `SkillDiscoveryProvider.skill_providers` and `DeniedRuleProvider.denied_rules` all union an edition's contribution into the public set. That shape cannot express this requirement. Union keeps every public tip. Subtraction, i.e. a deny-list of public tip ids, has to enumerate the public pool to subtract from it, so every tip added to the public pool afterwards would surface until someone remembered to deny it; the default would be leak, not withhold.

So the seam hands over a whole pool:

- `TipsPool(pool_id, curated, catalog)` lives in the import-light `kiro_crew/tips_pool.py`, so a composition root can build one without importing the aiohttp-bearing tips runtime. `CatalogEntry` moved there and is re-exported from `kiro_crew.tips`.
- When a pool is present, `get_tips_cache` uses only it. The bundled catalog, the `docs/*.md` scan, and the bundled curated file are not read.
- An empty pool is legal and means "this build shows no tips". The engine finds nothing eligible and serves none; it does not fall back to the public pool.
- `DefaultTipsProvider.tips_pool()` returns `None`, so a standalone build is byte-for-byte unchanged.
- Pool entries are re-validated on the way in through the same checks public entries pass, and drops are logged. A pool is trusted for intent, not for shape: an edition may load one from a packaged file, so it can carry the same malformed entries a bundled file can, and an unhashable `id` reaching `_is_eligible` would 500 every `/api/tips/*` request. `TipsPool.__post_init__` also refuses a non-sequence container, because a `"curated": null` key must not become a silent empty pool.

Two places the leak could still escape, both closed:

**Persisted tips.** Replacing the pool is not enough, because generated tips are persisted. A host that gains a companion after tips were already generated would keep serving the public tips cached in `tips_state.json`, so the card would still show WeChat. `TipsPool.pool_id` is therefore provenance: stamped into the state file, compared on every load, and on a mismatch the cached `tips`, the outstanding `offered` tip and `last_generated` are dropped so the next refresh regenerates against the active catalog. It may not reuse the public `"public"` id, which would make a switch undetectable.

The switch splits state by USER INTENT vs CACHE. Dismissals and snoozes are intent and survive, because the user would refuse those tips again if the host switched back -- but surviving is not the same as being globally visible. Dismissal state is persistent and global while a tip id is an author-chosen slug and a doc is a filename, so two pools can independently name `cron-tip` or `channels.md`; in one flat namespace a dismissed public `cron-tip` would suppress an unrelated edition `cron-tip` the user never saw. Every eligibility lookup and write is therefore scoped to the active pool (`_scoped`). Public keys stay bare, which keeps the public build byte-identical and makes migration free: every state file written before this was the public pool's, so its unprefixed entries are already correctly scoped. `shown` stays unscoped deliberately -- it is a prompt display counter, gates nothing, and a collision there merely merges two counts. `shown_docs` is cache and is cleared: it maps tip id to doc purely so a dismissal arriving after a regeneration can resolve its stable identity, every entry describes a tip from the pool being discarded, and tip ids are author-chosen slugs -- so keeping it lets a docless tip in the NEW pool resolve through a colliding id to the OLD pool's doc, which `api_tips_feedback` then writes into `dismissed_docs` as a permanent dismissal of a feature the user never refused.

**Generated tips.** Restricting the catalog stops a public feature being OFFERED to the model, but it does not constrain what the model writes back, so a hallucinated public feature would return as a shape-valid tip and be served. `_parse_tips` now takes the active catalog's docs and drops a generated tip whose `doc` is not one of them (a tip with no `doc` too -- no verifiable provenance, and the prompt asks for a filename). The check runs after link sanitization, so a blanked doc cannot pass as an allowed empty string. This closes most of the channel, not all of it: a tip could still cite a valid pool doc while its prose names something absent. Generated text is checked for shape and provenance, never for subject.

**Degrade behaviour is profile-dependent, and deliberately stricter than "fall back to public".** A `PlatformCompositionError` propagates on every profile, per the CPP fail-closed contract. For any other adapter error, or an adapter returning the wrong type, a `standalone` build falls back to the public pool because there is no other pool to prefer -- but a non-standalone build WITHHOLDS tips, serving an empty pool stamped `edition-unavailable`. Falling back to public there would serve exactly the tips this seam exists to keep off that build, so a merely flaky adapter would reintroduce the leak. The cost is that a broken adapter shows an edition user no tips at all; that is the intended trade and worth a maintainer's confirmation.

## What tests we did

New `test/test_tips_edition_pool.py` (50 tests):

- pool identity: empty `pool_id` refused, `"public"` refused, empty pool legal, non-sequence `curated`/`catalog` refused, `list` frozen to tuple;
- resolution: `PlatformCompositionError` propagates; transient error and wrong return type fall back to public on standalone and WITHHOLD on an edition build;
- replacement: no id from the real public curated pool is reachable through `curated`, `state.tips` or `catalog` -- and the assertion fails loudly if the public pool is empty, so it cannot pass vacuously; an empty pool does not fall back; a public build still loads both public sources;
- entry validation: malformed curated and catalog entries dropped, with a test that pins the `TypeError` in `_is_eligible` so the sanitizer tests cannot pass vacuously; a poisoned pool still serves a tip end-to-end;
- containment: a generated tip outside the active catalog is dropped, a docless one is dropped, anchoring runs after link sanitization, and generation end-to-end keeps only the edition doc;
- scoped identity: a public dismissal does not suppress an edition tip of the same id or doc; each pool's own dismissal still suppresses its own tip; a dismissal is honoured again after switching back; the generator prompt sees only the active pool's dismissals, unscoped; and dismissing an edition tip end-to-end records a key a public tip cannot match;
- reconciliation: same pool keeps cached tips; a switch drops tips/offer/timestamp and `shown_docs` but preserves dismissals, snoozes and opt-out; a colliding id cannot dismiss the previous pool's doc (end-to-end through `api_tips_feedback`); a stale public tip in a pre-existing state file is dropped on first load and the stamp persisted; an unwritable state file does not break the endpoints; `pool_id` round-trips and a missing or mistyped value loads as public.

Both one-line fixes were mutation-checked: reverting `st.shown_docs = {}` reproduces `dismissed_docs == ['channels.md']`, removing the catalog anchor fails 4 of the 5 containment tests (the fifth is the no-catalog default, correctly unaffected), and unscoping `_scoped` fails 5 of the 8 scoped-identity tests (the 3 that pass are the public-pool cases, which scoping leaves alone by design).

`test_tips.py` (existing, unchanged), `test_platform_cpp_seam_coverage.py` and `test_cpp_seam_failclosed.py` all pass -- 338 together. The seam-coverage gate is the meaningful one: it proves the new field has a real non-platform consumption site rather than joining the reserved/inert slots. All four gates the CI lint job runs are green locally: `scripts/check_black_formatting.py`, `isort --check-only`, `flake8`, and `mypy src/kiro_crew/` over 1290 files.

## Any other suggestions on the work

Reviewing note: `tips.py` is now fully black-formatted and its `.github/black-baseline.txt` entry pruned, so roughly half its hunks are whitespace. Diff it whitespace-blind.

Two things this PR deliberately does not do. There is no dashboard surface showing which pool is active, so an operator cannot see from the UI whether tips are public, edition-supplied, or withheld; the evidence today is a log line. And the pool is resolved once per process at cache construction, so composing a different pool needs a restart -- that matches how the rest of the context is boot-frozen, but it means the reconcile path only ever runs at startup.

