### PR TITLE
fix(security): a bare opener in a redirect target is not grammar (#8634)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4487,11 +4487,34 @@ def _output_redirect_scan(raw: str, start: int = 0) -> "tuple[str, int] | None":
     which put the stdin program back out of view. The whole substitution is one shell
     WORD, and :func:`_operand_span_end` is what carries it across the tokens it spans.
 
-    Depth counts EVERY ``(`` and ``{``, not only a ``$``-prefixed one, because a subshell
-    nested inside a substitution (``$( (true); printf /dev/null)``) closes with its own
-    ``)`` -- counting the opener but not that one would drop the depth to zero early and
-    reopen exactly the hole this closes. *raw* must therefore reach here with its
-    substitution delimiters intact; see the caller.
+    Depth counts every ``(`` and ``{`` INSIDE a substitution, but at depth zero only a
+    ``$``-prefixed opener starts one. A subshell nested inside a substitution
+    (``$( (true); printf /dev/null)``) closes with its own ``)`` -- counting the opener
+    but not that one would drop the depth to zero early and reopen exactly the hole
+    this closes. A BARE opener at depth zero is different: the tokenizer that feeds
+    this scan strips quotes (``_self_token_frames`` shlex-splits, and the caller also
+    edge-strips), so a quoted ``(`` -- one filename character to bash -- arrived here
+    bare, opened a span that never closed, and the target ran past the ``<<<`` that
+    should have ended it. The here-string was absorbed into the target and the program
+    arriving on stdin went unscanned: measured in bash, ``python 2>'a)(b'<<<'<program>'``
+    runs the program, and so does the unquoted-brace spelling ``python 2>a{b<<<'<program>'``
+    (a bare ``{`` is an ordinary filename character). An UNQUOTED bare ``(`` cannot
+    reach execution at all -- bash rejects ``2>a(b`` as a syntax error -- so at depth
+    zero the only executable meaning of a bare opener is a filename character, and the
+    walk now reads it as one. *raw* must reach here with its substitution delimiters
+    intact; see the caller.
+
+    Quote CHARACTERS in *raw* are data, never grammar. The tokenizer resolved quoting
+    before this scan runs, so a quote character that survives is literal text from a
+    spelling like ``2>"a'b"`` -- and reading it as grammar is the same defect in the
+    opposite direction: a single-quote state opened on that data quote consumed the
+    ``<<<`` to the end of the text and hid the operator (found in review, First
+    Principles lane). The walk therefore steps over quote characters like any other
+    filename character. Residuals, tracked rather than chased: a quoted ``'$('`` or
+    a quoted backtick in a filename de-quotes to the same characters as real grammar
+    and still holds or toggles a span -- indistinguishable without the quoting the
+    tokenizer already destroyed, and closing that class needs quote-preserving
+    tokenization at the frame level, not another rule here.
 
     An INDEX is returned rather than the remaining text so a word holding a chain of
     them (``>a>a>a...``) can be walked once. Re-slicing the word per operator was
@@ -4509,7 +4532,16 @@ def _output_redirect_scan(raw: str, start: int = 0) -> "tuple[str, int] | None":
         if char == "`":
             in_backtick = not in_backtick
         elif char in "({":
-            depth += 1
+            # At depth ZERO an opener counts only when `$` precedes it: `$(`, `${` and
+            # `$((` start substitutions, while a BARE `(` mid-word is never grammar in
+            # a command that runs -- unquoted it is a bash syntax error, so the only
+            # spelling that reaches execution is a quoted one, and the tokenizer that
+            # feeds this scan strips quotes (see above). A bare `{` is an ordinary
+            # filename character (measured: `python 2>a{b<<<'<program>'` runs the
+            # program and writes the file `a{b`). INSIDE a substitution every opener
+            # still counts, because a nested subshell closes with its own `)`.
+            if depth or (cut > match.end() and raw[cut - 1] == "$"):
+                depth += 1
         elif char in ")}" and depth:
             depth -= 1
         elif char in "<>" and not depth and not in_backtick:

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -4499,6 +4499,120 @@ class TestPythonStdinDetectorStepsOverOutputRedirects:
             assert not security._is_credential_mint(cmd.lower()), cmd
 
 
+class TestOutputRedirectScanQuoting:
+    """A bare opener in a redirect target is not grammar (issue #8634).
+
+    ``_output_redirect_scan``'s span walk counted every ``(``/``{`` as a depth
+    opener. The tokenizer that feeds it resolves quoting, so a QUOTED ``(`` --
+    one filename character to bash -- arrived bare, opened a span that never
+    closed, and the target ran past the ``<<<``/``<<`` that should have ended
+    it; a bare ``{`` needs no quoting at all. The stdin program then went
+    unscanned -- the same consequence the scan's own docstring describes for a
+    glued heredoc marker. Third site of the #8150 class. The rule that closes
+    it: at depth zero only a ``$``-prefixed opener starts a substitution span.
+    Quote characters that reach the scan are DATA (the tokenizer already
+    resolved quoting), so the walk must not read them as grammar either --
+    the review-found inverse defect.
+    """
+
+    def test_the_quoted_paren_bypass_is_denied_end_to_end(self):
+        """The public consequence, through the production tokenizer (which strips
+        the quotes; the scan sees ``2>a)(b<<<``). Measured in bash: each spelling
+        runs the here-string program. On the uncorrected walk ``is_denied``
+        returned None for all three."""
+        from kiro_crew import security
+
+        prog = "'from kiro_crew.cli import main; main()'"
+        assert security.is_denied(f"python3 2>'a)(b'<<< {prog}") is not None
+        assert security.is_denied(f"python3 2>a{{b<<<{prog}") is not None
+        assert security.is_denied(f'python3 > "a{{b" <<< {prog}') is not None
+        # The balanced spelling was already denied and must stay denied.
+        assert security.is_denied(f"python3 > ab <<< {prog}") is not None
+
+    def test_a_bare_opener_in_a_dequoted_target_is_not_a_delimiter(self):
+        """The walk's own boundary, on the de-quoted form the production path
+        hands it. An unquoted bare ``(`` cannot reach execution (bash syntax
+        error), and a bare ``{`` is an ordinary filename character (measured:
+        ``python 2>a{b<<<'<program>'`` runs the program), so neither may hold
+        the span open past the operator."""
+        from kiro_crew import security
+
+        assert security._output_redirect_scan("2>a)(b<<<") == ("a)(b", 6)
+        assert security._output_redirect_scan("2>a{b<<<x") == ("a{b", 5)
+        # `$((arith))` still spans: the opener is `$`-prefixed.
+        assert security._output_redirect_scan("2>$((1+2))<<<x") == ("$((1+2))", 10)
+
+    def test_a_quoted_opener_does_not_swallow_the_stdin_operator(self):
+        """Positive controls on quote-bearing text -- the quote characters are
+        DATA the walk steps over, and the parens inside them are bare, so the
+        depth-zero rule ends the target at the operator. Each boundary here
+        reached past the operator on the unfixed walk. Measured in bash:
+        ``python3 > 'a(b' <<< '<program>'`` creates the file ``a(b`` and RUNS
+        the here-string program (and the glued ``2>'a)(b'<<<'<program>'``
+        likewise), so the target must end before the operator, where bash ends
+        it."""
+        from kiro_crew import security
+
+        # The issue's measured case: end was 19 (past the `<<<`), now 8.
+        assert security._output_redirect_scan("> 'a(b' <<< payload") == (" 'a(b' ", 8)
+        assert security._output_redirect_scan('> "a{b" <<< payload') == (' "a{b" ', 8)
+        # Glued heredoc after a quoted opener: end was 12 (marker absorbed), now 7.
+        assert security._output_redirect_scan("2>'a(b'<<EOF") == ("'a(b'", 7)
+        assert security._output_redirect_scan('2>"a{b"<<EOF') == ('"a{b"', 7)
+        # An ESCAPED delimiter is one filename character too (`a\(b` is `a(b`).
+        assert security._output_redirect_scan("2>a\\(b<<<x") == ("a\\(b", 6)
+        # A quoted `)` at depth zero plus a quoted `(`: the unquoted walk opened a
+        # span that never closed and ran the target to the end of the text.
+        assert security._output_redirect_scan("2>'a)(b'<<<x") == ("'a)(b'", 8)
+        # ANSI-C: `$'` is not `$(`/`${`, so nothing opens and the paren is data.
+        assert security._output_redirect_scan("2>$'a(b'<<<x") == ("$'a(b'", 8)
+        assert security._output_redirect_scan("2>$'a\\')'<<<x") == ("$'a\\')'", 9)
+
+    def test_a_data_quote_is_not_read_as_grammar(self):
+        """The inverse direction, found in review (First Principles lane): the
+        tokenizer resolves quoting, so a quote character that SURVIVES it is
+        literal filename text (``2>"a'b"`` tokenizes to ``2>a'b``). A quoting
+        state opened on that data quote consumed the ``<<<`` to the end of the
+        text and hid the operator -- measured in bash, the spelling runs the
+        program, so the boundary must stay at the operator. The same rule keeps
+        the PID-parameter spelling (``$$'`` is not ANSI-C) and a quote inside
+        backticks (bash tolerates it unterminated there) at their pre-fix
+        boundaries."""
+        from kiro_crew import security
+
+        assert security._output_redirect_scan("2>a'b<<<x") == ("a'b", 5)
+        assert security._python_reads_stdin(["2>a'b<<<", "'prog'"]) is True
+        assert security._output_redirect_scan("2>$$'\\'<<<X") == ("$$'\\'", 7)
+        assert security._output_redirect_scan("2>`'`a<<<X") == ("`'`a", 6)
+
+    def test_the_unmoved_boundaries_do_not_move(self):
+        """Inverse controls, byte-identical before and after the fix: a real
+        substitution span still holds the walk open, a real backtick region
+        still toggles, and an unterminated quote or trailing backslash is
+        ordinary data to the end of the text."""
+        from kiro_crew import security
+
+        assert security._output_redirect_scan("2>$( (x)>y )") == ("$( (x)>y )", 12)
+        assert security._output_redirect_scan("2>`echo>x`") == ("`echo>x`", 10)
+        assert security._output_redirect_scan("2>${x:->}") == ("${x:->}", 9)
+        assert security._output_redirect_scan("2>'a(b") == ("'a(b", 6)
+        assert security._output_redirect_scan("2>\\") == ("\\", 3)
+
+    def test_the_stdin_program_is_detected_through_a_quoted_target(self):
+        """The detector-level consequence, on quote-bearing tokens and on the
+        de-quoted tokens the production frame actually carries: with the target
+        absorbing the glued ``<<<``, ``_python_reads_stdin`` answered False and
+        the program on stdin went unscanned."""
+        from kiro_crew import security
+
+        assert security._python_reads_stdin(["2>'a)(b'<<<", "'prog'"]) is True
+        assert security._python_reads_stdin(["2>'a(b'<<<", "'prog'"]) is True
+        assert security._python_reads_stdin(['2>"a{b"<<<', "'prog'"]) is True
+        # De-quoted, as `_self_token_frames` hands them over.
+        assert security._python_reads_stdin(["2>a)(b<<<", "prog"]) is True
+        assert security._python_reads_stdin(["2>a{b<<<", "prog"]) is True
+
+
 class TestNestedPayloadExtractionIsLinear:
     """``_nested_shell_payloads`` must stay LINEAR in token count.
 


### PR DESCRIPTION
## Problem / Motivation

`_output_redirect_scan` finds where an output redirect's target ends so the shell-command security gate can tell a redirect from a script path. Its span walk counted **every** `(`/`{` as a depth opener. The tokenizer that feeds it resolves quoting, so a quoted `(` — one filename character to bash — arrived bare, opened a span that never closed, and the target ran past the `<<<`/`<<` operator that should have ended it. The program arriving on stdin was then never scanned.

Measured in bash — each of these runs the here-string program while the gate returned `is_denied = None`:

```bash
python3 2>'a)(b'<<< '<program>'    # quoted parens
python3 > "a{b" <<< '<program>'    # quoted brace
python3 2>a{b<<<'<program>'        # a bare { needs no quoting at all
```

Third site of the #8150 defect class (a delimiter counted in text where quoting decides whether it is a delimiter at all).

## Why it matters

A program arriving on stdin via a here-string bypasses the deny scan entirely — the exact failure mode the scanner's own docstring describes for a glued heredoc marker, reached through a quoting spelling. The end-to-end consequence is real: `python3 2>'a)(b'<<< 'from kiro_crew.cli import main; main()'` was allowed on main and is denied with this fix.

## What changed (motivation → approach → change)

The issue proposed routing the walk through #8150's shared `_quoting_step` rule. Two review rounds subtracted that to a single, smaller rule:

- Pre-push GPT 5.6 proved quote-tracking alone is **inert end-to-end**: `_self_token_frames` shlex-resolves quoting, so the production tokens arrive de-quoted (`2>'a)(b'<<<` → `2>a)(b<<<`) and there are no quotes left to track.
- The First Principles lane then proved the quote-tracking rider was not merely inert but **harmful on the tokens production actually carries**: a quote character that survives tokenization is literal filename data (`2>"a'b"` → `2>a'b`), and reading it as grammar consumed the `<<<` to end-of-text — reopening the defect in the opposite direction. Its subtraction demand was verified and taken.

What ships is one rule: **at depth zero, only a `$`-prefixed opener (`$(`, `${`, `$((`) starts a substitution span.** A bare `(` mid-word is never grammar in a command that runs — unquoted it is a bash syntax error, so the only executable spelling that reaches the scan bare is a quoted filename character. A bare `{` is an ordinary filename character (measured). Inside a substitution every opener still counts (a nested subshell closes with its own `)`). Quote characters are stepped over as data.

Not changed, per the issue's scope: where a redirect target begins, the unterminated-target fallback, and the sibling scanners (`_substitution_depth_delta`, `_is_self_kill`, `_operand_span_end` — #8633's territory).

**Residuals, documented in the code:** a quoted `'$('` or a quoted backtick in a filename de-quotes to the same characters as real grammar and still holds/toggles a span — indistinguishable without the quoting the tokenizer already destroyed. Closing that class needs quote-preserving tokenization at the frame level (follow-up issue, see comments).

## Tests

`TestOutputRedirectScanQuoting` (6 tests), every assertion measured against real bash; reverting the one-line rule is caught by 4 distinct tests:

- End-to-end positive controls through `is_denied()` with the exact production spellings (all `None` on main).
- De-quoted-domain boundaries (`2>a)(b<<<`, `2>a{b<<<x`, `$((arith))` still spans).
- Quote-bearing boundaries (quote chars as data): quoted/escaped `(`, `{`; ANSI-C `$'a(b'`.
- The review-found inverse defect pinned: a data quote is not grammar (`2>a'b<<<x` keeps its boundary; `$$'`, backtick-interior quote unchanged).
- Inverse controls byte-identical before/after: `2>$( (x)>y )`, ``2>`echo>x` ``, `${x:->}`, unterminated quote, trailing backslash.
- Detector-level `_python_reads_stdin` on both token forms.

By construction the rule only ever opens **fewer** spans than main, so the target can only end earlier-or-equal — an operator main exposed can never be hidden by this change.

## Manual verification

All bash ground-truth probes in the docstrings/tests were executed against real bash (file creation + program execution observed): `> 'a(b' <<<`, glued `2>'a)(b'<<<`, `2>a{b<<<`, `2>"a'b"<<<`, `2>$'a\')'`, and the syntax-error control `2>a(b`.

## Related Issues

Closes #8634
Refs #8150

## Pattern harvest

Rule candidate: review-prompt
Pattern: a fix must be proven at the public verdict level on the tokens production actually carries — the tokenizer between the entry point and the helper can both destroy the information a rule keys on (quotes stripped) and deliver that information as data the rule must not re-interpret as grammar (quotes surviving as filename characters).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: module spec documents the sibling de-quoted path, not this scanner's internals
- [x] No secrets, credentials, or internal references in the diff
