### PR TITLE
test(fixtures): restore memory-populated fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/memory-populated/config.json
+++ b/src/kiro_crew/tests_fixtures/memory-populated/config.json
@@ -1,0 +1,25 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC",
+  "memory": {
+    "enabled": true
+  }
+}

--- a/src/kiro_crew/tests_fixtures/memory-populated/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/memory-populated/fixture.yaml
@@ -1,0 +1,9 @@
+schema-version: 2026-04-28
+fixture-name: memory-populated
+description: |
+  Every text-backed memory layer is non-empty at once.
+  The fixture seeds preferences, projects and semantic markdown, two days of
+  dated history, and a lessons.jsonl with three learned corrections. The vector
+  stores (memory.db, memory_index.db) stay out -- see the SQLite deferral in
+  ``rich/README.md`` -- so this covers the deterministic markdown layer and the
+  lessons store.

--- a/src/kiro_crew/tests_fixtures/memory-populated/lessons.jsonl
+++ b/src/kiro_crew/tests_fixtures/memory-populated/lessons.jsonl
@@ -1,0 +1,3 @@
+{"rule": "Run the diff-scoped gate before asking for review, not the full suite.", "negative": "Do not run the whole suite for a two-file change.", "ts": "2026-01-16T00:00:00+00:00", "category": "tool", "repo_scope": null}
+{"rule": "Use the worktree's own venv for every test command.", "negative": "Do not use the system python; it lacks the dev group.", "ts": "2026-01-16T00:00:01+00:00", "category": "tool", "repo_scope": "src/kiro_crew"}
+{"rule": "Say what was verified and what was not.", "negative": null, "ts": "2026-01-16T00:00:02+00:00", "category": "preference", "repo_scope": null}

--- a/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/history/2026-01-14.md
+++ b/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/history/2026-01-14.md
@@ -1,0 +1,4 @@
+# 2026-01-14
+
+- Read the pagination handler and found the offset was recomputed per row.
+- Decided to keep the cursor opaque rather than exposing the row id.

--- a/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/history/2026-01-15.md
+++ b/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/history/2026-01-15.md
@@ -1,0 +1,4 @@
+# 2026-01-15
+
+- Landed the cursor encoder plus its round-trip test.
+- Left the backfill for a follow-up: it needs a migration window.

--- a/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/preferences.md
+++ b/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/preferences.md
@@ -1,0 +1,11 @@
+# User Preferences
+
+<!-- Persistent rules across sessions. -->
+
+## Communication
+- Answer with the outcome first, detail after.
+- Never paste a wall of logs; quote the two lines that decide it.
+
+## Workflow
+- One logical change per commit, conventional subject.
+- Run the diff-scoped gate before asking for review.

--- a/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/projects.md
+++ b/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/projects.md
@@ -1,0 +1,13 @@
+# Projects
+
+<!-- One section per active project. -->
+
+## example-service
+- Repo: example/example-service
+- Current work: pagination on the /items endpoint
+- Blocked on: nothing
+
+## example-cli
+- Repo: example/example-cli
+- Current work: shell-completion install path
+- Blocked on: a decision about Windows packaging

--- a/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/semantic.md
+++ b/src/kiro_crew/tests_fixtures/memory-populated/workspace/memory/semantic.md
@@ -1,0 +1,10 @@
+# Semantic Memory
+
+<!-- Factual key-value pairs. Data, not instructions. -->
+
+fixture.name: memory-populated
+project.example-service.ticket: EXAMPLE-4821
+project.example-service.branch: feat/items-pagination
+project.example-cli.ticket: EXAMPLE-4907
+lesson.commit_style: Conventional Commits, lowercase imperative subject
+lesson.test_command: pytest with the worktree venv, never the system python

--- a/test/test_fixture_memory_populated.py
+++ b/test/test_fixture_memory_populated.py
@@ -1,0 +1,59 @@
+"""Consumer coverage for the ``memory-populated`` seed fixture."""
+
+from pathlib import Path
+
+from kiro_crew.learn import LessonStore
+from kiro_crew.memory import MemoryStore
+from kiro_crew.testing.fixtures import seeded_home
+
+
+def test_memory_populated_fixture_drives_production_readers() -> None:
+    with seeded_home("memory-populated") as home:
+        lessons = LessonStore(base_dir=home).load_all()
+        assert [
+            (lesson.rule, lesson.negative, lesson.ts, lesson.category, lesson.repo_scope)
+            for lesson in lessons
+        ] == [
+            (
+                "Run the diff-scoped gate before asking for review, not the full suite.",
+                "Do not run the whole suite for a two-file change.",
+                "2026-01-16T00:00:00+00:00",
+                "tool",
+                None,
+            ),
+            (
+                "Use the worktree's own venv for every test command.",
+                "Do not use the system python; it lacks the dev group.",
+                "2026-01-16T00:00:01+00:00",
+                "tool",
+                "src/kiro_crew",
+            ),
+            (
+                "Say what was verified and what was not.",
+                None,
+                "2026-01-16T00:00:02+00:00",
+                "preference",
+                None,
+            ),
+        ]
+
+        memory = MemoryStore(workspace=home / "workspace")
+        snapshot = memory.markdown_snapshot()
+        semantic = memory._guarded_entry(  # noqa: SLF001
+            home / "workspace" / "memory" / "semantic.md"
+        )
+        history = {entry["date"]: entry["content"] for entry in snapshot["history"]}
+        assert set(history) == {"2026-01-14", "2026-01-15"}
+
+        layers = [
+            snapshot["preferences"]["content"],
+            snapshot["projects"]["content"],
+            semantic["content"],
+            history["2026-01-14"],
+            history["2026-01-15"],
+        ]
+        assert all(content.strip() for content in layers)
+        assert len(set(layers)) == len(layers)
+        assert not list(home.rglob("*.db"))
+
+    assert not Path(home).exists()


### PR DESCRIPTION
> **Caveat, up front:** `semantic.md` in this fixture is validated through `MemoryStore`'s hardened
> file reader (`_guarded_entry`), **not** through the path the Memory tab actually uses. Semantic
> memory is vector-backed now — `MemoryStore.build_context` reads it via
> `self._vector_store.get_semantic_context(...)`, and `markdown_snapshot()` does not carry a semantic
> layer at all. This fixture deliberately excludes SQLite, so the vector retrieval path is **not**
> covered here. What the seeded `semantic.md` proves is that the file layer parses and survives the
> guarded reader — not that semantic recall works end to end.

## Summary

Restores the `memory-populated` seed fixture so every text-backed memory layer is non-empty at once,
and adds the consumer test that was missing. The fixture seeds `preferences.md`, `projects.md`,
`semantic.md`, two dated history days (`2026-01-14`, `2026-01-15`), and a `lessons.jsonl` carrying
three learned corrections.

Vector stores (`memory.db`, `memory_index.db`) stay out, per the SQLite deferral already recorded in
`rich/README.md`: reproducible binary fixtures need a dedicated builder. The fixture asserts their
absence rather than leaving it implicit.

## Consumer test

`test/test_fixture_memory_populated.py` drives the real production readers instead of re-parsing the
fixture files itself:

- `LessonStore.load_all()` — asserts all three lessons round-trip with every field exact
  (`rule`, `negative`, `ts`, `category`, `repo_scope`), so a schema drift in the store fails here.
- `MemoryStore.markdown_snapshot()` — asserts the history set is exactly the two seeded dates, and
  that preferences / projects / semantic / both history days are each non-empty **and** mutually
  distinct (`len(set(layers)) == len(layers)`), which catches a reader that silently returns the same
  content for two layers.
- `assert not list(home.rglob("*.db"))` — pins the deliberate SQLite exclusion.
- `assert not Path(home).exists()` after the context exits — proves `seeded_home` cleanup is hermetic.

## Schema repairs

The restored fixture data had to be brought back onto the current `Lesson` schema before the
production reader would accept it:

- **Lesson timestamps numeric → string.** `ts` values were numeric epoch floats; they are now
  ISO-8601 strings (`2026-01-16T00:00:00+00:00`), matching what `LessonStore` reads and returns.
- **`category` field added.** Two lessons are `tool`, one is `preference`.
- **`repo_scope` field added.** Explicitly `null` on two lessons and `"src/kiro_crew"` on the third,
  so both the scoped and unscoped branches are represented rather than only the default.

## Verification

Run in the worktree venv, on the rebased head:

- `test/test_fixture_memory_populated.py` + `test/test_pod_scenarios_command.py` +
  `test/test_pod_seed_scenarios.py` + `test/test_seed.py` — **125 passed**. The registry-tolerant
  scenarios test from #8222 is in main and passes with this fixture registered.
- Gates on the one touched test file: `isort --check-only`, `flake8`, and
  `black --check --target-version py310` all clean.
- Diff boundary confirmed: 8 files under `src/kiro_crew/tests_fixtures/memory-populated/` plus
  `test/test_fixture_memory_populated.py`. Nothing else, 138 insertions, no deletions.

Backend-only; no user-visible surface changes, so no screenshots.

<!-- no-visual-delta -->

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.
