### PR TITLE
test(fixtures): restore apps-installed fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/apps-installed/apps/fixture-notes/app.json
+++ b/src/kiro_crew/tests_fixtures/apps-installed/apps/fixture-notes/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-notes",
+  "displayName": "Fixture Notes",
+  "version": "1.0.0",
+  "description": "A tiny installed app used by the apps-installed seed fixture.",
+  "author": "kirocrew-fixture"
+}

--- a/src/kiro_crew/tests_fixtures/apps-installed/apps/fixture-notes/data/notes.md
+++ b/src/kiro_crew/tests_fixtures/apps-installed/apps/fixture-notes/data/notes.md
@@ -1,0 +1,3 @@
+# Fixture notes
+
+App-scoped data, so the app's data dir is not empty.

--- a/src/kiro_crew/tests_fixtures/apps-installed/apps/fixture-notes/installed.json
+++ b/src/kiro_crew/tests_fixtures/apps-installed/apps/fixture-notes/installed.json
@@ -1,0 +1,13 @@
+{
+  "name": "fixture-notes",
+  "version": "1.0.0",
+  "displayName": "Fixture Notes",
+  "enabled": true,
+  "installedAt": "2026-01-15T09:00:00Z",
+  "origin": "local",
+  "resources": "gateway",
+  "lifecycle": "gateway",
+  "schemaVersion": 2,
+  "dev": false,
+  "defaultOnBackfilled": false
+}

--- a/src/kiro_crew/tests_fixtures/apps-installed/config.json
+++ b/src/kiro_crew/tests_fixtures/apps-installed/config.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/apps-installed/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/apps-installed/fixture.yaml
@@ -1,0 +1,6 @@
+schema-version: 2026-04-28
+fixture-name: apps-installed
+description: |
+  One locally installed app with a manifest, persisted metadata, and app-scoped data.
+  The fixture-notes record is enabled with origin=local, resources=gateway, and
+  lifecycle=gateway so app-manager consumers have a non-builtin subject.

--- a/test/test_fixture_apps_installed.py
+++ b/test/test_fixture_apps_installed.py
@@ -1,0 +1,19 @@
+"""Consumer coverage for the apps-installed seed fixture."""
+
+from kiro_crew.apps import manager
+from kiro_crew.testing.fixtures import seeded_home
+
+
+def test_apps_installed_fixture_is_read_by_app_manager() -> None:
+    with seeded_home("apps-installed"):
+        installed = {app["name"]: app for app in manager.list_apps()}
+
+        fixture_notes = installed["fixture-notes"]
+        assert fixture_notes["enabled"] is True
+        assert fixture_notes["origin"] == "local"
+        assert fixture_notes["resources"] == "gateway"
+        assert fixture_notes["lifecycle"] == "gateway"
+        assert fixture_notes["manifest"]["name"] == "fixture-notes"
+
+        data_file = manager.app_data_dir("fixture-notes") / "notes.md"
+        assert data_file.is_file()


### PR DESCRIPTION
## Summary

Restores the `apps-installed` seed fixture, which seeds a `KIROCREW_HOME` containing one
locally installed app rather than a bare home:

- `config.json` — an onboarded home (default workspace `default` -> `workspace`, dark theme,
  host `127.0.0.1`, UTC).
- `apps/fixture-notes/installed.json` — the persisted install record: `enabled: true`,
  `origin: local`, `resources: gateway`, `lifecycle: gateway`.
- `apps/fixture-notes/app.json` — a valid app manifest (name, displayName, version,
  description, author).
- `apps/fixture-notes/data/notes.md` — app-scoped data, so the data-dir resolver has a real
  file to find.
- `fixture.yaml` — fixture metadata at `schema-version: 2026-04-28`.

The point of the fixture is to give app-manager consumers a **non-builtin** subject: an
enabled local app with gateway-managed resources and gateway lifecycle metadata.

## Consumer test

`test/test_fixture_apps_installed.py` drives the production readers only — it never re-reads
the fixture files it seeded, so the fixture is validated through the code path real callers
use:

- `kiro_crew.apps.manager.list_apps()` — asserts `fixture-notes` is listed with
  `enabled is True`, `origin == "local"`, `resources == "gateway"`,
  `lifecycle == "gateway"`, and a parsed `manifest["name"] == "fixture-notes"`.
- `kiro_crew.apps.manager.app_data_dir("fixture-notes")` — asserts the resolver locates the
  seeded `notes.md`.

Both run inside `kiro_crew.testing.fixtures.seeded_home("apps-installed")`, so a schema the
production reader rejects fails the test instead of passing silently.

## Schema repairs

The install record drifted from what the app manager now persists. Repaired against the
preserved pre-split copy:

- `installed_at` renamed to `installedAt` (camelCase, matching the persisted key).
- Four newer persisted fields added: `displayName`, `schemaVersion`, `dev`,
  `defaultOnBackfilled`.

Everything else in the pre-split copy is preserved as-is.

## Verification

`.venv/bin/python -m pytest test/test_fixture_apps_installed.py test/test_pod_scenarios_command.py test/test_pod_seed_scenarios.py test/test_seed.py -q`

**125 passed**, 0 failed.

The acceptance criterion is that this passes *with the fixture present*: `main` already
carries the registry-tolerant scenarios test from #8222, and the scenario/seed suites
enumerate the fixture registry, so a malformed or unregistered fixture would surface there
rather than only in its own test.

Style gates on the touched test file, all clean: `isort --check-only`, `flake8`,
`black --check --target-version py310`.

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.

<!-- no-visual-delta -->
Backend-only change, no screenshots: the diff adds test fixture data under
`src/kiro_crew/tests_fixtures/apps-installed/` plus one test file under `test/`. No dashboard,
CLI-output, or other user-visible surface is touched.
