### PR TITLE
test(fixtures): restore sessions-a-few fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/sessions-a-few/config.json
+++ b/src/kiro_crew/tests_fixtures/sessions-a-few/config.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/sessions-a-few/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/sessions-a-few/fixture.yaml
@@ -1,0 +1,7 @@
+schema-version: 2026-04-28
+fixture-name: sessions-a-few
+description: |
+  Four chat sessions cover pinned, open, closed-in-History, and archived states.
+  Transcript JSONL is the seedable half of session state; the SQLite event log
+  is not (see the SQLite deferral in ``rich/README.md``), so nothing here
+  depends on it.

--- a/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/archive/archived-thread__20260114-090000.jsonl
+++ b/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/archive/archived-thread__20260114-090000.jsonl
@@ -1,0 +1,3 @@
+{"_type": "archive", "reason": "rotate", "archived_at": "2026-01-14T09:00:00+00:00", "count": 2}
+{"role": "user", "content": "Earlier turn, archived.", "ts": "2026-01-14T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "An archive slice, used by retention paths.", "ts": "2026-01-14T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/dashboard_closed-thread.jsonl
+++ b/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/dashboard_closed-thread.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": true, "closed_at": 1768467600.0, "memory_mode": "persistent", "title": "Closed thread", "agent": "default", "model": "claude-sonnet-4"}
+{"role": "user", "content": "We are done here.", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "Closed -- reachable from History rather than a slot.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/dashboard_open-slot.jsonl
+++ b/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/dashboard_open-slot.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "memory_mode": "persistent", "title": "Open slot", "agent": "default", "model": "claude-sonnet-4"}
+{"role": "user", "content": "Just a normal open tab.", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "An ordinary slot, neither pinned nor closed.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/dashboard_pinned-work.jsonl
+++ b/src/kiro_crew/tests_fixtures/sessions-a-few/sessions/dashboard_pinned-work.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "memory_mode": "persistent", "title": "Pinned work", "agent": "default", "model": "claude-sonnet-4", "pinned": true}
+{"role": "user", "content": "Keep this one around.", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "Pinned -- it stays at the top of the list.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/test/test_fixture_sessions_a_few.py
+++ b/test/test_fixture_sessions_a_few.py
@@ -1,0 +1,84 @@
+"""Consumer coverage for the sessions-a-few seed fixture."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from kiro_crew.dashboard.chat_persistence import _prefetch_recent_session
+from kiro_crew.events.backfill import backfill_transcripts
+from kiro_crew.events.kinds import SessionMessage
+from kiro_crew.history import ConversationLog
+from kiro_crew.testing.fixtures import seeded_home
+
+
+def test_sessions_a_few_reaches_each_session_bucket() -> None:
+    """The real readers classify all four seeded session states."""
+    with seeded_home("sessions-a-few") as home:
+        sessions_dir = home / "sessions"
+        mtimes = {
+            "dashboard_pinned-work.jsonl": 1_000.0,
+            "dashboard_open-slot.jsonl": 2_000_000_000.0,
+            "dashboard_closed-thread.jsonl": 2_000_000_001.0,
+        }
+        for name, mtime in mtimes.items():
+            os.utime(sessions_dir / name, (mtime, mtime))
+
+        log = ConversationLog(base_dir=sessions_dir)
+        listed = {session["key"]: session for session in log.list_sessions()}
+        assert set(listed) == {
+            "dashboard_closed-thread",
+            "dashboard_open-slot",
+            "dashboard_pinned-work",
+        }
+
+        buckets: dict[str, set[str]] = {
+            "pinned": set(),
+            "open": set(),
+            "history": set(),
+            "archived": set(),
+        }
+        cutoff = 2_000_000_000.0 - 60.0
+        for key, session in listed.items():
+            metadata = log.get_metadata(key)
+            prefetched_metadata, messages, _ = _prefetch_recent_session(
+                log,
+                key,
+                session,
+                folders_only=False,
+                cutoff=cutoff,
+            )
+            if metadata.get("closed"):
+                assert prefetched_metadata is None
+                assert messages is None
+                assert [row["role"] for row in log.read_messages(key)] == [
+                    "user",
+                    "assistant",
+                ]
+                buckets["history"].add(key)
+            elif metadata.get("pinned"):
+                assert messages
+                buckets["pinned"].add(key)
+            else:
+                assert messages
+                buckets["open"].add(key)
+
+        report = backfill_transcripts(home)
+        archived_events = [
+            event
+            for event in report.events
+            if isinstance(event, SessionMessage) and event.key == "archived-thread"
+        ]
+        assert [(event.role, event.content_chars) for event in archived_events] == [
+            ("user", len("Earlier turn, archived.")),
+            ("assistant", len("An archive slice, used by retention paths.")),
+        ]
+        buckets["archived"] = {event.key for event in archived_events}
+
+        assert buckets == {
+            "pinned": {"dashboard_pinned-work"},
+            "open": {"dashboard_open-slot"},
+            "history": {"dashboard_closed-thread"},
+            "archived": {"archived-thread"},
+        }
+        assert not Path(home).joinpath("memory.db").exists()


### PR DESCRIPTION
## Summary

Restores the `sessions-a-few` seed fixture and gives it a consumer test. The fixture seeds four chat sessions covering every session record state the dashboard distinguishes — pinned, ordinary open, closed-in-History, and archived — so each state is asserted to land in the correct view with the correct ordering rather than merely existing on disk.

Transcript JSONL is the seedable half of session state; the SQLite event log is not (per the SQLite deferral in `rich/README.md`), so nothing here depends on it — the test asserts no `memory.db` is created.

<!-- no-visual-delta -->
Backend-only: a test fixture directory plus its consumer test. No user-facing surface changes, so no screenshots.

## Consumer test

`test/test_fixture_sessions_a_few.py` drives the production readers, not reimplementations of them:

- `ConversationLog.list_sessions()` — the session catalog, asserted to return exactly the three non-archived keys.
- The restore filter, `_prefetch_recent_session()` from `kiro_crew.dashboard.chat_persistence` — asserted to hydrate messages for the pinned and open records and to return `(None, None)` for the closed one, which is what keeps a closed thread in History instead of restoring it into a slot.
- `ConversationLog.read_messages()` — the transcript reader, asserted to yield the closed thread's `user`/`assistant` turns.
- `backfill_transcripts()` from `kiro_crew.events.backfill` — the archive backfill reader, asserted to emit the archived slice's two `SessionMessage` events with the expected roles and content lengths.

Deterministic `os.utime` mtimes (1_000.0 for pinned, 2_000_000_000.0 and +1 for open/closed) pin the ordering and the recency cutoff so the bucket assignment cannot drift with wall-clock time.

## Schema repairs

The fixture was written against the current on-disk schema rather than the shape it originally carried:

- Archive header records use the current archive schema — `_type: archive` with `reason`, `archived_at`, and `count`.
- Session metadata records carry `closed_at` as an **epoch float** (`1768467600.0`), which is what the current readers parse; an ISO string in that field is not accepted by the closed-session path.

## Verification

- `.venv/bin/python -m pytest test/test_fixture_sessions_a_few.py test/test_pod_scenarios_command.py test/test_pod_seed_scenarios.py test/test_seed.py -q` → **125 passed**. The three sibling suites are the fixture registry's own coverage (`test_pod_seed_scenarios.py` walks every shipped fixture's manifest), so they confirm the new fixture registers cleanly alongside the registry-tolerant scenarios test from #8222.
- Gates on the touched test file: `isort --check-only`, `flake8`, and `black --check --target-version py310` all clean.
- Diff boundary: 7 files, +125/-0, confined to `src/kiro_crew/tests_fixtures/sessions-a-few/` plus `test/test_fixture_sessions_a_few.py`.

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.
