### PR TITLE
test(fixtures): restore multi-workspace fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/multi-workspace/config.json
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/config.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    },
+    "review": {
+      "dir": "workspace-review"
+    },
+    "research": {
+      "dir": "workspace-research"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/multi-workspace/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/fixture.yaml
@@ -1,0 +1,7 @@
+schema-version: 2026-04-28
+fixture-name: multi-workspace
+description: |
+  Three named workspaces seed distinct memory and agent-pinned sessions.
+  The default, review and research workspaces each carry visibly different
+  memory content, and one session per workspace selects a different agent.
+  Agent identity is stored per session rather than in workspace configuration.

--- a/src/kiro_crew/tests_fixtures/multi-workspace/sessions/dashboard_ws-default.jsonl
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/sessions/dashboard_ws-default.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": false, "title": "Day-to-day", "agent": "default", "workspace": "default", "pinned": true}
+{"role": "user", "content": "What is in this workspace?", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "The default workspace: day-to-day work and its memory.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/multi-workspace/sessions/dashboard_ws-research.jsonl
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/sessions/dashboard_ws-research.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": false, "title": "Research notes", "agent": "orchestrator", "workspace": "research"}
+{"role": "user", "content": "Where did we land on the cursor question?", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "Opaque cursor; the row id stays internal.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/multi-workspace/sessions/dashboard_ws-review.jsonl
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/sessions/dashboard_ws-review.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": false, "title": "Review queue", "agent": "kirocrew", "workspace": "review"}
+{"role": "user", "content": "Anything waiting on me?", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "The review workspace tracks open review threads.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/multi-workspace/workspace-research/memory/preferences.md
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/workspace-research/memory/preferences.md
@@ -1,0 +1,4 @@
+# User Preferences
+
+fixture.memory: research-memory-sentinel
+workspace.purpose: research

--- a/src/kiro_crew/tests_fixtures/multi-workspace/workspace-research/memory/semantic.md
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/workspace-research/memory/semantic.md
@@ -1,0 +1,8 @@
+# Semantic Memory
+
+<!-- Factual key-value pairs. -->
+
+fixture.name: multi-workspace
+fixture.workspace: workspace-research
+fixture.memory: research-memory-sentinel
+workspace.purpose: research

--- a/src/kiro_crew/tests_fixtures/multi-workspace/workspace-review/memory/preferences.md
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/workspace-review/memory/preferences.md
@@ -1,0 +1,4 @@
+# User Preferences
+
+fixture.memory: review-memory-sentinel
+workspace.purpose: code review

--- a/src/kiro_crew/tests_fixtures/multi-workspace/workspace-review/memory/semantic.md
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/workspace-review/memory/semantic.md
@@ -1,0 +1,8 @@
+# Semantic Memory
+
+<!-- Factual key-value pairs. -->
+
+fixture.name: multi-workspace
+fixture.workspace: workspace-review
+fixture.memory: review-memory-sentinel
+workspace.purpose: code review

--- a/src/kiro_crew/tests_fixtures/multi-workspace/workspace/memory/preferences.md
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/workspace/memory/preferences.md
@@ -1,0 +1,4 @@
+# User Preferences
+
+fixture.memory: default-memory-sentinel
+workspace.purpose: day-to-day work

--- a/src/kiro_crew/tests_fixtures/multi-workspace/workspace/memory/semantic.md
+++ b/src/kiro_crew/tests_fixtures/multi-workspace/workspace/memory/semantic.md
@@ -1,0 +1,8 @@
+# Semantic Memory
+
+<!-- Factual key-value pairs. -->
+
+fixture.name: multi-workspace
+fixture.workspace: workspace
+fixture.memory: default-memory-sentinel
+workspace.purpose: day-to-day work

--- a/test/test_fixture_multi_workspace.py
+++ b/test/test_fixture_multi_workspace.py
@@ -1,0 +1,54 @@
+"""Consumer coverage for the shipped multi-workspace seed fixture."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig, workspace_dir_for
+from kiro_crew.history import ConversationLog
+from kiro_crew.memory import MemoryStore
+
+pytest_plugins = ["kiro_crew.testing.fixtures"]
+
+
+@pytest.mark.parametrize("seeded_home_fixture", ["multi-workspace"], indirect=True)
+def test_multi_workspace_fixture_routes_sessions_and_memory(
+    seeded_home_fixture: Path,
+) -> None:
+    config = KiroCrewConfig.load()
+    assert config.default_workspace == "default"
+    assert set(config.workspaces) == {"default", "review", "research"}
+
+    seeded_root = seeded_home_fixture.resolve()
+    expected = {
+        "default": seeded_root / "workspace",
+        "review": seeded_root / "workspace-review",
+        "research": seeded_root / "workspace-research",
+    }
+    resolved = {name: workspace_dir_for(name) for name in expected}
+    assert resolved == expected
+    assert len(set(resolved.values())) == 3
+    assert workspace_dir_for() == expected["default"]
+
+    memories: dict[str, str] = {}
+    for name, workspace in resolved.items():
+        store = MemoryStore(workspace=workspace)
+        store.init()
+        memories[name] = store.read_preferences()
+
+    assert len(set(memories.values())) == 3
+    assert "default-memory-sentinel" in memories["default"]
+    assert "review-memory-sentinel" in memories["review"]
+    assert "research-memory-sentinel" in memories["research"]
+    assert "default-memory-sentinel" not in memories["review"]
+
+    log = ConversationLog(base_dir=seeded_root / "sessions")
+    metadata = [log.get_metadata(row["key"]) for row in log.list_sessions()]
+    assert len(metadata) == 3
+    assert {(item["workspace"], item["agent"]) for item in metadata} == {
+        ("default", "default"),
+        ("review", "kirocrew"),
+        ("research", "orchestrator"),
+    }


### PR DESCRIPTION
## Summary

Restores the `multi-workspace` seed fixture and gives it a consumer test. The fixture seeds three named workspaces — `default`, `review`, `research` — each with visibly distinct memory content, plus one agent-pinned session per workspace. Backend-only; no user-visible surface changes.

## Consumer test

`test/test_fixture_multi_workspace.py` drives the fixture through production readers rather than asserting on file layout:

- `KiroCrewConfig.load()` — asserts `default_workspace == "default"` and that the workspace set is exactly `{default, review, research}`.
- `workspace_dir_for()` — resolves each named workspace to its own directory, asserts all three paths are distinct, and asserts the no-argument call resolves to the default workspace.
- `MemoryStore(workspace=...).read_preferences()` — reads memory per workspace, asserts all three reads differ, asserts each workspace's own sentinel is present, and asserts the default workspace's sentinel does **not** leak into `review`.
- `ConversationLog.get_metadata()` — asserts the three seeded sessions carry the expected `(workspace, agent)` pairs: `(default, default)`, `(review, kirocrew)`, `(research, orchestrator)`.

## Schema repairs

Seed default, review, and research workspaces with distinct memory plus one agent-pinned session per workspace. The consumer test drives production config loading, workspace resolution, transcript metadata, and memory reads to prove default selection and prevent cross-workspace leaks.

## Verification

`.venv/bin/python -m pytest` — **125 passed**:

- `test/test_fixture_multi_workspace.py` — 1
- `test/test_pod_scenarios_command.py` — 18
- `test/test_pod_seed_scenarios.py` — 60
- `test/test_seed.py` — 46

Gates on the touched test file: `isort --check-only`, `flake8`, `black --check --target-version py310` — all clean.

Backend-only diff (12 files, +134). No screenshots.

<!-- no-visual-delta -->
Touched surfaces are the shipped seed-fixture data under `src/kiro_crew/tests_fixtures/multi-workspace/` and one new test file. No frontend, dashboard, gateway endpoint, or MCP tool surface is changed, so there is no visual delta to capture.

## Pattern harvest

One fixture-specific correction, worth recording because it decided whether the isolation assertion had any force:

Today's `MemoryStore` reads `preferences.md`, not `semantic.md`. The preserved copy of this fixture seeded `semantic.md` files that the current reader no longer sees, so a memory-isolation test written against it would have been **vacuously green** — three empty reads compare equal to each other and to nothing. The fixture now seeds a distinct `preferences.md` per workspace, which is what the reader actually loads, so the "all three differ" and "no cross-workspace leak" assertions read real content. Agent identity likewise does not live in workspace configuration; it lives in session metadata under the field `agent`, which is where the test asserts it.

Not generalizable: fixture restoration validated against current production readers; no new rule.
