### PR TITLE
test(fixtures): restore connections-two fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/connections-two/config.json
+++ b/src/kiro_crew/tests_fixtures/connections-two/config.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/connections-two/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/connections-two/fixture.yaml
@@ -1,0 +1,11 @@
+schema-version: 2026-04-28
+fixture-name: connections-two
+description: |
+  Two KIROCREW_HOME-scoped MCP declarations model one durable stdio no-op and one disabled broken server without real credentials.
+  The nominal server stays alive by reading stdin until its client closes the
+  stream; it is intentionally a no-op and is not spawned by the consumer test.
+  The broken server is disabled, points at a nonexistent command, and carries an
+  obviously-fake placeholder credential where a real one would sit.
+
+  Only the KIROCREW_HOME mcp.json scope is seeded. The kiro-global scope
+  (~/.kiro/settings/mcp.json) is outside a fixture tree by definition.

--- a/src/kiro_crew/tests_fixtures/connections-two/mcp.json
+++ b/src/kiro_crew/tests_fixtures/connections-two/mcp.json
@@ -1,0 +1,21 @@
+{
+  "mcpServers": {
+    "fixture-healthy": {
+      "command": "python3",
+      "args": [
+        "-u",
+        "-c",
+        "import sys; sys.stdin.buffer.read()"
+      ],
+      "env": {}
+    },
+    "fixture-broken": {
+      "command": "kirocrew-fixture-missing-binary",
+      "args": [],
+      "env": {
+        "FIXTURE_API_TOKEN": "fixture-placeholder-not-secret"
+      },
+      "disabled": true
+    }
+  }
+}

--- a/test/test_fixture_connections_two.py
+++ b/test/test_fixture_connections_two.py
@@ -1,0 +1,75 @@
+"""Consumer coverage for the ``connections-two`` seeded-home fixture."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from kiro_crew import mcp_discovery
+from kiro_crew.testing.fixtures import seeded_home
+
+
+@pytest.mark.asyncio
+async def test_connections_two_drives_real_mcp_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discover both data-home entries and enforce the disabled spawn gate."""
+    spawned: list[tuple[object, ...]] = []
+
+    async def _refuse_spawn(*args: object, **_kwargs: object) -> None:
+        spawned.append(args)
+        raise AssertionError("a disabled fixture server must never be spawned")
+
+    with seeded_home("connections-two") as home:
+        kirocrew_source = mcp_discovery._mcp_sources()[0]
+        assert kirocrew_source[0].resolve() == (home / "mcp.json").resolve()
+        assert kirocrew_source[1] == mcp_discovery.SCOPE_KIROCREW
+
+        # A fixture can seed only its data-home scope. Keep discovery on that
+        # production-resolved source so this test never reads a machine-global
+        # MCP config or an edition-contributed provider scope.
+        monkeypatch.setattr(mcp_discovery, "_MCP_SOURCES", (kirocrew_source,))
+        monkeypatch.setattr(mcp_discovery, "_MCP_JSON_PATHS", None)
+        monkeypatch.setattr(mcp_discovery, "_extra_scope_sources", lambda: [])
+        monkeypatch.setattr(
+            mcp_discovery,
+            "kiro_agents_dir",
+            lambda: home / "isolated-kiro-agents",
+        )
+
+        scoped = mcp_discovery._load_mcp_json_by_source()
+        assert set(scoped[mcp_discovery.SCOPE_KIROCREW]) == {
+            "fixture-healthy",
+            "fixture-broken",
+        }
+
+        rows = {row.name: row for row in mcp_discovery.list_servers()}
+        healthy = rows["fixture-healthy"]
+        broken = rows["fixture-broken"]
+
+        assert healthy.source == "mcp.json"
+        assert healthy.presence[mcp_discovery.SCOPE_KIROCREW] is True
+        assert healthy.disabled is False
+        assert healthy.env == {}
+        assert isinstance(healthy.args, list) and healthy.args
+        assert shutil.which(healthy.command), "the nominal stdio command must resolve"
+        assert healthy.args[-1] == "import sys; sys.stdin.buffer.read()"
+
+        assert broken.source == "mcp.json"
+        assert broken.presence[mcp_discovery.SCOPE_KIROCREW] is False
+        assert broken.disabled is True
+        assert shutil.which(broken.command) is None
+        assert broken.env == {
+            "FIXTURE_API_TOKEN": "fixture-placeholder-not-secret",
+        }
+
+        monkeypatch.setattr(
+            mcp_discovery,
+            "create_subprocess_limited",
+            _refuse_spawn,
+        )
+        result = await mcp_discovery.probe_server(broken)
+
+    assert result.status == "disabled"
+    assert spawned == []


### PR DESCRIPTION
## Summary

Restores the `connections-two` seeded-home fixture and gives it a consumer test that
actually exercises production code.

The fixture seeds two MCP server declarations into the `KIROCREW_HOME`-scoped
`mcp.json`: one healthy stdio no-op and one **disabled** server pointing at a
nonexistent binary. Together they model the two states connections-related code has
to handle — a well-formed reachable declaration, and a declaration that must be
recognised and then deliberately *not* launched.

Only the `KIROCREW_HOME` `mcp.json` scope is seeded. The kiro-global scope
(`~/.kiro/settings/mcp.json`) is outside a fixture tree by definition, and the test
pins discovery to the fixture's own production-resolved source so it can never read
a machine-global MCP config or an edition-contributed provider scope.

Two fixture-specific details worth stating up front so reviewers don't have to
rediscover them:

- **The healthy server is a durable stdio no-op that blocks on stdin.** Its command
  is `python3 -u -c 'import sys; sys.stdin.buffer.read()'`, which replaces the
  preserved copy's immediate-exit `python3 -c print`. A server that exits the moment
  it starts is not a usable stdio server fixture; blocking on stdin keeps the
  declaration durable (it stays alive until its client closes the stream) while
  remaining a genuine no-op. The consumer test never spawns it.
- **The credential is a fixture placeholder, not a secret.** The disabled entry
  carries `FIXTURE_API_TOKEN=fixture-placeholder-not-secret` where a real credential
  would sit. The literal value is self-describing and passes scrub-lint as
  `fixture-placeholder-not-secret`.

## Consumer test

`test/test_fixture_connections_two.py` drives real MCP discovery rather than
asserting on the fixture's own JSON:

- Asserts the fixture's `mcp.json` is what production `mcp_discovery._mcp_sources()`
  resolves as the `SCOPE_KIROCREW` source, then pins discovery to exactly that
  source for the rest of the test.
- `_load_mcp_json_by_source()` must report both `fixture-healthy` and
  `fixture-broken` in the `SCOPE_KIROCREW` scope, and `list_servers()` must
  surface both as rows.
- Well-formedness of the healthy row: `source == "mcp.json"`, present in scope, not
  disabled, empty `env`, non-empty `args`, its command resolves on `PATH` via
  `shutil.which`, and its final arg is the literal stdin-blocking program.
- State of the broken row: `disabled is True`, absent from presence, command does
  **not** resolve on `PATH`, and its `env` is exactly the placeholder token.
- **The no-spawn gate.** `create_subprocess_limited` is monkeypatched to a stub that
  records the call and raises, then `await probe_server(broken)` must return
  `status == "disabled"` with the spawn list empty. This proves the disabled entry
  short-circuits at the gate rather than being launched and failing — the assertion
  that would silently pass if the gate regressed into "try it and see".

## Schema repairs

- Seed one durable stdio no-op and one disabled broken MCP declaration in the
  `KIROCREW_HOME` `mcp.json` scope, using only an obviously-fake placeholder
  credential.
- `fixture.yaml` carries `schema-version: 2026-04-28`, the fixture name, and a
  description that documents the durable-stdin behaviour, the intentional no-op, the
  nonexistent command on the disabled entry, the placeholder credential, and the
  explicit scope boundary.
- The healthy server now blocks on stdin instead of exiting immediately, keeping it
  durable without launching it during the test.

## Verification

`.venv/bin/python -m pytest` on the fixture test plus the three registry/seed
consumers: **125 passed**, 0 failed.

| File | Tests |
| --- | --- |
| `test/test_fixture_connections_two.py` | 1 |
| `test/test_pod_scenarios_command.py` | 18 |
| `test/test_pod_seed_scenarios.py` | 60 |
| `test/test_seed.py` | 46 |

Gates on the touched test file, all clean with no fixups required: `isort
--check-only`, `flake8`, `black --check --target-version py310`.

Backend-only change (fixture data plus one test file); no user-visible surface, so
no screenshots.

<!-- no-visual-delta -->

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.
