### PR TITLE
test(fixtures): restore skills-custom fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/skills-custom/config.json
+++ b/src/kiro_crew/tests_fixtures/skills-custom/config.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/skills-custom/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/skills-custom/fixture.yaml
@@ -1,0 +1,7 @@
+schema-version: 2026-04-28
+fixture-name: skills-custom
+description: |
+  One live user skill plus one crystallized candidate awaiting review under skills/auto/.pending/.
+  The candidate includes the .meta.json consumed by the pending list. This
+  exercises the Skills tab's live-vs-pending split and approve/dismiss paths
+  without touching the builtin skills that ship in the package.

--- a/src/kiro_crew/tests_fixtures/skills-custom/skills/auto/.pending/flaky-triage/.meta.json
+++ b/src/kiro_crew/tests_fixtures/skills-custom/skills/auto/.pending/flaky-triage/.meta.json
@@ -1,0 +1,10 @@
+{
+  "slug": "flaky-triage",
+  "name": "auto/flaky-triage",
+  "source": "crystallize",
+  "created_at": "2026-01-15T09:00:00+00:00",
+  "description": "Classify a red test as a real regression, a flake, or an environment problem before patching.",
+  "triggers": "flaky test, red shard, rerun failed, triage failure",
+  "has_scripts": false,
+  "scripts": []
+}

--- a/src/kiro_crew/tests_fixtures/skills-custom/skills/auto/.pending/flaky-triage/SKILL.md
+++ b/src/kiro_crew/tests_fixtures/skills-custom/skills/auto/.pending/flaky-triage/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: auto/flaky-triage
+description: Classify a red test as a real regression, a flake, or an environment problem before patching.
+triggers: flaky test, red shard, rerun failed, triage failure
+source: auto
+session_key: fixture
+created_at: 2026-01-15T09:00:00+00:00
+---
+
+# flaky-triage (auto-generated)
+
+## When to use
+A shard went red and it is not yet known whether the diff caused it.
+
+## Steps
+1. Check whether the same test fails on the base commit.
+2. Check whether it fails on one platform only.
+3. Only patch once the cause is named.
+
+## Gotchas
+- A fail-closed gate red is often a cascade of one real failure.

--- a/src/kiro_crew/tests_fixtures/skills-custom/skills/release-notes/SKILL.md
+++ b/src/kiro_crew/tests_fixtures/skills-custom/skills/release-notes/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: release-notes
+description: Draft a release note section from a commit range, grouped by what the reader gets.
+triggers: release notes, changelog section, draft release
+source: user
+---
+
+# release-notes
+
+## When to use
+Asked to draft the changelog section for a version bump.
+
+## Steps
+1. Read the commit range and partition it -- account for every commit.
+2. Group by what the reader gets, most interesting first. Never by commit type.
+3. Lead with breaking changes when the release has any.
+
+## Gotchas
+- A list of commit subjects is not a changelog section.
+- Never restate a count of commits.

--- a/test/test_fixture_skills_custom.py
+++ b/test/test_fixture_skills_custom.py
@@ -1,0 +1,55 @@
+"""Consumer coverage for the ``skills-custom`` seeded-home fixture."""
+
+from __future__ import annotations
+
+from kiro_crew.skills import _BUILTIN_SKILLS_DIR, SkillsLoader, _iter_skill_files
+from kiro_crew.testing.fixtures import seeded_home
+
+_DESCRIPTION = (
+    "Classify a red test as a real regression, a flake, or an environment "
+    "problem before patching."
+)
+_TRIGGERS = "flaky test, red shard, rerun failed, triage failure"
+
+
+def test_skills_custom_fixture_drives_live_and_pending_readers() -> None:
+    with seeded_home("skills-custom") as home:
+        pending_dir = home / "skills" / "auto" / ".pending" / "flaky-triage"
+        meta_file = pending_dir / ".meta.json"
+        assert pending_dir.is_dir()
+        assert meta_file.is_file()
+
+        loader = SkillsLoader(skills_path=home / "skills", install_builtins=False)
+        live = {entry["key"]: entry for entry in loader.list_skills()}
+        builtin_names = {name for name, _path in _iter_skill_files(_BUILTIN_SKILLS_DIR)}
+
+        assert set(live) == {"release-notes"}
+        assert live["release-notes"]["name"] == "release-notes"
+        assert "auto/flaky-triage" not in live
+        assert set(live).isdisjoint(builtin_names)
+
+        pending = loader.list_pending_skills()
+        assert [entry["slug"] for entry in pending] == ["flaky-triage"]
+        assert pending[0]["name"] == "auto/flaky-triage"
+        assert pending[0]["description"] == _DESCRIPTION
+        assert pending[0]["triggers"] == _TRIGGERS
+        assert pending[0]["source"] == "crystallize"
+        assert pending[0]["has_scripts"] is False
+
+        detail = loader.get_pending_skill("flaky-triage")
+        assert detail is not None
+        assert detail["scripts"] == []
+        assert detail["meta"]["slug"] == "flaky-triage"
+        assert detail["meta"]["scripts"] == []
+
+        assert loader.approve_pending_skill("flaky-triage") == "auto/flaky-triage"
+        assert loader.list_pending_skills() == []
+        approved = {entry["key"] for entry in loader.list_skills()}
+        assert approved == {"release-notes", "auto/flaky-triage"}
+        assert approved.isdisjoint(builtin_names)
+
+    with seeded_home("skills-custom") as home:
+        loader = SkillsLoader(skills_path=home / "skills", install_builtins=False)
+        assert loader.dismiss_pending_skill("flaky-triage") is True
+        assert loader.list_pending_skills() == []
+        assert {entry["key"] for entry in loader.list_skills()} == {"release-notes"}


### PR DESCRIPTION
## Summary

Restores the `skills-custom` seeded-home fixture and gives it a consumer test, so the fixture is
validated against the production skills readers instead of sitting unexercised on disk.

The fixture seeds one live user skill (`release-notes`) plus one crystallized candidate awaiting
review (`flaky-triage`) under `skills/auto/.pending/`, including the `.meta.json` the pending list
consumes. That is the smallest home that exercises the Skills tab's live-vs-pending split and both
of its terminal actions.

## Consumer test

`test/test_fixture_skills_custom.py` drives the real `SkillsLoader` against the seeded home — no
mocks, no reimplemented parsing:

- **Layout survives the seeded-home copy.** First assertions prove the nested `.pending/flaky-triage`
  directory and its `.meta.json` both exist in the materialized home.
- **Live/pending split.** `list_skills()` returns exactly `{release-notes}`; `auto/flaky-triage` is
  absent from the live set, and `list_pending_skills()` returns exactly `[flaky-triage]`.
- **Pending metadata round-trips.** `name`, `description`, `triggers`, `source` (`crystallize`) and
  `has_scripts` are asserted against literals, and `get_pending_skill()` is checked for the same
  `slug`/`scripts` values, so a silent key rename in the reader fails the test.
- **`approve_pending_skill()`** returns `auto/flaky-triage`, empties the pending list, and moves the
  candidate into the live set — asserted as the exact set `{release-notes, auto/flaky-triage}`.
- **`dismiss_pending_skill()`** is exercised in a second, independent seeded home (approve and
  dismiss are mutually exclusive on one candidate): it returns `True`, empties the pending list, and
  leaves the live set unchanged.
- **No builtin collision.** Both the live set and the post-approve set are asserted disjoint from
  the names discovered by `_iter_skill_files(_BUILTIN_SKILLS_DIR)`, so the fixture cannot pass by
  accidentally shadowing a skill that ships in the package, and adding a builtin later cannot break
  it.

## Schema repairs

The fixture is aligned to what the current production readers actually parse, not to an older
fixture's shape:

- `fixture.yaml` carries the current `schema-version: 2026-04-28` and the `fixture-name:` key that
  `pod/runtime.py` scans for.
- `config.json` uses the current workspace key `workspaces.default.dir`, matching
  `WorkspaceConfig.dir` and the loader's `raw_value.get("dir", "workspace")`, rather than the legacy
  `path` spelling still present in older fixtures.
- `.meta.json` carries exactly the key set the pending reader consumes — `slug`, `name`, `source`,
  `created_at`, `description`, `triggers`, `has_scripts`, `scripts` — so the pending list renders
  fully populated instead of falling back to empty-string defaults.

## Packaging: the dot-directory risk is settled empirically

The obvious objection to this fixture is that its payload lives behind two dot paths
(`skills/auto/.pending/flaky-triage/.meta.json`), and packaging tooling routinely drops
dot-prefixed entries — which would make the fixture pass from a source checkout and fail from an
installed distribution. That was not left to inspection of `MANIFEST.in`: both artifacts were built
and their archives listed. `skills/auto/.pending/flaky-triage/.meta.json` is present in **both** the
built sdist (`kirocrew-0.7.0.tar.gz`) and the built wheel (`kirocrew-0.7.0-py3-none-any.whl`),
alongside the candidate's `SKILL.md` and the live `release-notes/SKILL.md`. The
`recursive-include src/kiro_crew/tests_fixtures *` line plus `include_package_data = True` do cover
dot paths in practice.

## Verification

`.venv/bin/python -m pytest -q` over the new test plus every suite that reads the fixture registry:

| Suite | Tests |
| --- | --- |
| `test/test_fixture_skills_custom.py` | 1 |
| `test/test_pod_scenarios_command.py` | 18 |
| `test/test_pod_seed_scenarios.py` | 60 |
| `test/test_seed.py` | 46 |
| **Total** | **125 passed, 0 failed** |

`test_pod_seed_scenarios.py` and `test_pod_scenarios_command.py` are the registry-tolerant scenarios
tests from #8222, so adding a fixture does not have to touch them.

Style gates on the one touched Python file (`test/test_fixture_skills_custom.py`), all clean:
`isort --check-only`, `flake8`, `black --check --target-version py310`.

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.

<!-- no-visual-delta -->
Backend-only: a test fixture directory (JSON/YAML/markdown data) plus one pytest module. No
dashboard, API, or CLI-output surface changes, so there is nothing to screenshot.
