### PR TITLE
test(fixtures): restore incognito-mix fixture with assertions

### DIFF
--- a/docs/guides/worktree-verification-recipes.md
+++ b/docs/guides/worktree-verification-recipes.md
@@ -30,13 +30,18 @@ kirocrew pod --help | grep -qw api || {
 and `DELETE` require `--allow-write`. It mints the selected pod's dashboard token
 internally, so do not add a `token` query parameter.
 
-Only three packaged scenarios exist: `empty`, `minimal`, and `rich`.
-`kirocrew pod scenarios` prints each name plus its description. Use the smallest
-one that establishes the state under test. The fixture job names asserted below
-are owned by [`minimal/crons.json`](../../src/kiro_crew/tests_fixtures/minimal/crons.json).
-Ten specialized payloads remain deferred until a verification recipe
-demonstrates that one is needed; do not invent a fourth scenario in a feature
-branch.
+The packaged scenarios are the agent's **native seeding vocabulary**:
+`kirocrew pod scenarios` prints each name plus its description, and that listing
+— not this guide — is the authoritative inventory. Use the smallest scenario
+that establishes the state under test. The fixture job names asserted below are
+owned by [`minimal/crons.json`](../../src/kiro_crew/tests_fixtures/minimal/crons.json).
+
+A new scenario earns its place with two things in one PR: a **named debugging or
+verification use case** in its `fixture.yaml` description (the state it pins and
+why an agent would seed it), and a **proving test** that pins the fixture's
+design point so drift turns a build red. A checked-in recipe is not a
+precondition: scenarios exist precisely so agents can seed known states natively
+at debug time instead of designing fixtures on the spot.
 
 ## Find the verification surface without searching the repository
 

--- a/src/kiro_crew/tests_fixtures/incognito-mix/config.json
+++ b/src/kiro_crew/tests_fixtures/incognito-mix/config.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/incognito-mix/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/incognito-mix/fixture.yaml
@@ -1,0 +1,11 @@
+schema-version: 2026-04-28
+fixture-name: incognito-mix
+description: |
+  Three sessions differ only in memory_mode: persistent, incognito, and temporary.
+  The production privacy classifier treats incognito and temporary as private,
+  making this fixture suitable for exclusion tests without hand-built records.
+  Because the three transcripts are byte-identical except for memory_mode, a
+  passing privacy assertion cannot be explained by incidental differences.
+  Use case: verify incognito/temporary behavior natively against a known mix --
+  e.g. a default-open-incognito toggle, where an agent seeds this scenario and
+  checks which of the three sessions surface in history, memory, and search.

--- a/src/kiro_crew/tests_fixtures/incognito-mix/sessions/dashboard_incognito.jsonl
+++ b/src/kiro_crew/tests_fixtures/incognito-mix/sessions/dashboard_incognito.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": false, "title": "Privacy classifier fixture", "agent": "default", "memory_mode": "incognito"}
+{"role": "user", "content": "Classify this session.", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "Classification complete.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/incognito-mix/sessions/dashboard_normal.jsonl
+++ b/src/kiro_crew/tests_fixtures/incognito-mix/sessions/dashboard_normal.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": false, "title": "Privacy classifier fixture", "agent": "default", "memory_mode": "persistent"}
+{"role": "user", "content": "Classify this session.", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "Classification complete.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/src/kiro_crew/tests_fixtures/incognito-mix/sessions/dashboard_temporary.jsonl
+++ b/src/kiro_crew/tests_fixtures/incognito-mix/sessions/dashboard_temporary.jsonl
@@ -1,0 +1,3 @@
+{"_type": "metadata", "created_at": "2026-01-15T09:00:00+00:00", "last_consolidated": 0, "closed": false, "title": "Privacy classifier fixture", "agent": "default", "memory_mode": "temporary"}
+{"role": "user", "content": "Classify this session.", "ts": "2026-01-15T09:00:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}
+{"role": "assistant", "content": "Classification complete.", "ts": "2026-01-15T09:01:00+00:00", "source_thread": "dashboard", "source_user": "dashboard"}

--- a/test/test_fixture_incognito_mix.py
+++ b/test/test_fixture_incognito_mix.py
@@ -1,0 +1,35 @@
+"""Consumer assertions for the ``incognito-mix`` seed fixture."""
+
+from pathlib import Path
+
+from kiro_crew.history import ConversationLog, is_incognito_transcript
+from kiro_crew.testing.fixtures import seeded_home
+
+
+def _memory_mode(home: Path, session_key: str) -> object:
+    metadata = ConversationLog(base_dir=home / "sessions").get_metadata(session_key)
+    return metadata["memory_mode"]
+
+
+def test_normal_session_is_included() -> None:
+    with seeded_home("incognito-mix") as home:
+        memory_mode = _memory_mode(home, "dashboard_normal")
+
+    assert memory_mode == "persistent"
+    assert not is_incognito_transcript(memory_mode)
+
+
+def test_incognito_session_is_private() -> None:
+    with seeded_home("incognito-mix") as home:
+        memory_mode = _memory_mode(home, "dashboard_incognito")
+
+    assert memory_mode == "incognito"
+    assert is_incognito_transcript(memory_mode)
+
+
+def test_temporary_session_is_private() -> None:
+    with seeded_home("incognito-mix") as home:
+        memory_mode = _memory_mode(home, "dashboard_temporary")
+
+    assert memory_mode == "temporary"
+    assert is_incognito_transcript(memory_mode)


### PR DESCRIPTION
## Summary

Restores the `incognito-mix` seed fixture and ships a consumer test that proves it.

The fixture seeds three dashboard sessions — `dashboard_normal`, `dashboard_incognito`, `dashboard_temporary` — whose transcripts are **byte-identical except for the `memory_mode` field**. That is the fixture's design point, not an incidental property: because title, agent, timestamps, and both message records are the same across all three files, a passing privacy assertion cannot be explained by title or message differences. The only variable the classifier can be reacting to is `memory_mode`.

Verified mechanically on this branch: with `memory_mode` normalized away, `dashboard_normal.jsonl` diffs clean against both `dashboard_incognito.jsonl` and `dashboard_temporary.jsonl`.

## Consumer test

`test/test_fixture_incognito_mix.py` drives the real production reader chain rather than hand-building records:

- seeds a throwaway home with `seeded_home("incognito-mix")`
- reads each session header through `ConversationLog(base_dir=home / "sessions").get_metadata(session_key)`
- passes the resulting `memory_mode` to `kiro_crew.history.is_incognito_transcript`

Three cases, one per mode:

| session | `memory_mode` | `is_incognito_transcript` |
|---|---|---|
| `dashboard_normal` | `persistent` | excluded (falsy) |
| `dashboard_incognito` | `incognito` | private (truthy) |
| `dashboard_temporary` | `temporary` | private (truthy) |

Each test asserts the literal mode value *and* the classifier verdict, so a fixture that silently loses its `memory_mode` field fails loudly instead of trivially passing.

## Schema repairs

The restored fixture conforms to the schema the current shipped fixtures and production readers use:

- `fixture.yaml` pinned to `schema-version: 2026-04-28`, matching all three sibling fixtures (`empty`, `minimal`, `rich`), plus the `fixture-name` and `description` keys the manifest parser requires.
- Each `.jsonl` transcript leads with a `{"_type": "metadata", ...}` header record — the line `ConversationLog.get_metadata()` actually reads — carrying `created_at`, `last_consolidated`, `closed`, `title`, `agent`, and `memory_mode`.
- Message records carry the full current record shape: `role`, `content`, `ts`, `source_thread`, `source_user`.
- `config.json` uses the current envelope: `meta.version: 1`, `workspaces` + `default_workspace`, and the `dashboard` block with `onboarded: true` so seeding lands in a usable state.

## Verification

`.venv/bin/python -m pytest` over the fixture test plus the three seed/scenario suites that consume shipped fixtures — **127 passed, 0 failed** (15.9s):

- `test/test_fixture_incognito_mix.py` — 3
- `test/test_pod_scenarios_command.py` — 18
- `test/test_pod_seed_scenarios.py` — 60
- `test/test_seed.py` — 46

`test_pod_seed_scenarios.py` parametrizes its shipped-fixture contract over every fixture, so `incognito-mix` is now covered by `test_manifest_parses_with_a_description`, `test_seeds_into_a_fresh_home`, `test_ships_no_credential_shaped_text`, and `test_stays_small_enough_to_ship` in addition to the consumer test above.

Style gates on the touched test file, all clean: `isort --check-only`, `flake8`, `black --check --target-version py310`.

Diff is 6 added files, 72 insertions, confined to `src/kiro_crew/tests_fixtures/incognito-mix/` and `test/test_fixture_incognito_mix.py`.

Backend-only — test fixtures and a pytest module, no UI surface. <!-- no-visual-delta -->

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.


## Owner ruling (2026-09-05)

This fixture is one of the payloads deferred by the earlier "recipe demonstrates need first" gate. The owner reversed that gate: packaged scenarios are the agent's **native seeding vocabulary** — the named use case here is verifying incognito/temporary behavior against a known mix (e.g. a planned default-open-incognito toggle: seed this scenario, then check which of the three byte-identical-but-for-`memory_mode` sessions surface in history, memory, and search). This PR updates `docs/guides/worktree-verification-recipes.md`'s scenario paragraph accordingly (byte-identical hunk also carried by #8679, so either may merge first).
