### PR TITLE
fix: offload knowledge delete and import off the event loop (#8670)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/knowledge.py
+++ b/src/kiro_crew/dashboard/handlers/knowledge.py
@@ -502,13 +502,26 @@ async def delete_item(request: web.Request) -> web.Response:
     item = store.get_item(item_id)
     if not item:
         return web.json_response({"error": "not found"}, status=404)
-    store.delete_item(item_id)
+
+    # BEGIN IMMEDIATE takes the write lock eagerly (busy_timeout 10s, so a
+    # concurrent writer can park this call for that long) and the commit is
+    # followed by _load_graph(), a full scan of entities and entity_relations
+    # that grows linearly with the library -- never on the event loop.
+    # The SEL record rides in the same worker as the commit: a client
+    # disconnect cancels this coroutine at the await, and a cancellation
+    # landing after the worker committed must not skip the audit line. The
+    # worker thread runs to completion regardless, and SEL writes are
+    # lock-guarded, so emitting from it is safe.
+    def _delete_and_audit() -> None:
+        store.delete_item(item_id)
+        _sel_log("item.delete", item_id=item_id)
+
+    await asyncio.to_thread(_delete_and_audit)
     # A now-empty source is reclaimed by the store's own orphan rule on the next
     # open, which checks the document-state tables, in-flight jobs and the location
     # table first. Deleting the row here instead raised on the foreign keys those
     # tables hold -- after the item delete had already committed -- and dropped a
     # source that still held documents by location.
-    _sel_log("item.delete", item_id=item_id)
     return web.json_response({"ok": True})
 
 
@@ -1635,8 +1648,25 @@ async def import_bundle(request: web.Request) -> web.Response:
         redacted_type = _redact(rel.get("relation_type"))
         rel["relation_type"] = redacted_type if redacted_type is not None else ""
         rel["description"] = _redact(rel.get("description"))
+    store = _store(request)
+
+    # BEGIN IMMEDIATE takes the write lock eagerly (busy_timeout 10s) and a
+    # large bundle inserts thousands of rows before the commit rebuilds the
+    # entity graph with a full table scan -- never on the event loop. The
+    # success audit rides in the same worker as the commit: a client
+    # disconnect cancels the awaiting coroutine, and a cancellation landing
+    # after the worker committed must not skip the SEL record (the worker
+    # thread runs to completion regardless; SEL writes are lock-guarded).
+    # The worker re-raises here, so every arm below still catches exactly
+    # what the synchronous call raised; the rejection arms keep their own
+    # audit lines because they are tied to the HTTP response they build.
+    def _import_and_audit() -> dict:
+        result = store.import_bundle(body)
+        _sel_log("import", **result)
+        return result
+
     try:
-        result = _store(request).import_bundle(body)
+        result = await asyncio.to_thread(_import_and_audit)
     except KnowledgeBundleError as exc:
         # The store enforces the JSON-column well-formedness invariant
         # (sources.properties / entities.aliases) at the writer; surface its
@@ -1677,7 +1707,6 @@ async def import_bundle(request: web.Request) -> web.Response:
             {"error": "internal server error", "code": "knowledge_import_failed"},
             status=500,
         )
-    _sel_log("import", **result)
     return web.json_response(result)
 
 

--- a/test/test_knowledge_mutations_off_loop.py
+++ b/test/test_knowledge_mutations_off_loop.py
@@ -1,0 +1,208 @@
+"""``store.delete_item`` and ``store.import_bundle`` must never run on the event loop.
+
+Both mutations take the write lock with ``BEGIN IMMEDIATE`` (a concurrent writer
+can park them for the connection's 10s busy_timeout) and both end in a full
+rebuild of the entity graph -- ``_load_graph`` scans ``entities`` and
+``entity_relations`` in their entirety, which grows linearly with the library.
+Called straight from a coroutine body, either one freezes every task on the
+gateway's single loop, and on a large profile outlasts the stall watchdog: the
+process is killed and respawned into the same state.
+
+Same two-layer shape as ``test_knowledge_delete_off_loop.py``, whose AST
+helpers this module reuses:
+
+* the ratchet pins every call site at once and fails if a future edit calls
+  either mutation straight from a coroutine body anywhere in the package. It
+  matches on the method NAME alone, so a same-named method on another object
+  (``pack_transfer.import_bundle``, ``appearance_store.import_bundle``) called
+  from a coroutine would also trip it -- a conservative false failure whose
+  message names this store's remedy; read the flagged line before applying it;
+* the behavioural tests drive the real HTTP handlers and assert the THREAD the
+  store call lands on, so a refactor that keeps ``asyncio.to_thread`` in the
+  source but hands it something already-invoked still fails. A third proves an
+  exception raised inside the worker still reaches the handler's except arms as
+  the same typed error the synchronous call raised.
+"""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from test_knowledge_delete_off_loop import _on_loop_call_sites
+
+from kiro_crew.dashboard.handlers import knowledge as kh
+from kiro_crew.knowledge.store import KnowledgeBundleError, KnowledgeStore
+
+
+def test_delete_item_is_never_called_on_the_event_loop():
+    """Ratchet: hand it to a worker, never call it from a coroutine body."""
+    offenders = _on_loop_call_sites("delete_item")
+    assert offenders == [], (
+        "store.delete_item runs on the event loop at:\n  "
+        + "\n  ".join(offenders)
+        + "\nOffload it: await asyncio.to_thread(store.delete_item, item_id). "
+        "It takes the write lock with BEGIN IMMEDIATE and rebuilds the whole "
+        "entity graph before returning, so on a large library it blocks the "
+        "loop past the stall watchdog."
+    )
+
+
+def test_import_bundle_is_never_called_on_the_event_loop():
+    """Ratchet: same rule for the bundle import, which writes even more rows."""
+    offenders = _on_loop_call_sites("import_bundle")
+    assert offenders == [], (
+        "import_bundle runs on the event loop at:\n  "
+        + "\n  ".join(offenders)
+        + "\nOffload it: await asyncio.to_thread(store.import_bundle, body). "
+        "A bundle inserts every item, entity and relation it carries inside "
+        "one BEGIN IMMEDIATE and then rebuilds the entity graph, so the call "
+        "scales with the bundle AND the library."
+    )
+
+
+def _make_app(store: KnowledgeStore) -> web.Application:
+    app = web.Application()
+    state = MagicMock()
+    state.knowledge_store = store
+    app["state"] = state
+    app.router.add_delete("/api/knowledge/items/{id}", kh.delete_item)
+    app.router.add_post("/api/knowledge/import", kh.import_bundle)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_delete_item_handler_runs_the_delete_off_the_loop_thread(tmp_path, monkeypatch):
+    """The offload is real, and the SEL audit travels with the commit.
+
+    The audit must run on the same worker as the mutation: a client disconnect
+    cancels the coroutine at the ``await``, so an audit line placed after it is
+    skippable by the caller -- a committed mutation with no SEL record.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        source_id = store.add_source("src", "local_folder", str(tmp_path))
+        item_id = store.add_item("title", "body", "doc", source_id=source_id)
+
+        seen_threads: list[int] = []
+        real = store.delete_item
+
+        def recording(*args, **kwargs):
+            seen_threads.append(threading.get_ident())
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(store, "delete_item", recording)
+
+        sel_threads: list[int] = []
+        monkeypatch.setattr(
+            kh, "_sel_log", lambda tool, **kw: sel_threads.append(threading.get_ident())
+        )
+
+        async with TestClient(TestServer(_make_app(store))) as client:
+            resp = await client.delete(f"/api/knowledge/items/{item_id}")
+            assert resp.status == 200
+
+        assert seen_threads, (
+            "store.delete_item was never called -- this test no longer "
+            "exercises the delete path and would pass vacuously"
+        )
+        assert threading.get_ident() not in seen_threads, (
+            "store.delete_item ran on the event-loop thread; it must be handed "
+            "to asyncio.to_thread"
+        )
+        assert sel_threads == seen_threads, (
+            "the SEL audit did not run on the worker alongside the commit; an "
+            "audit line after the await is skipped when the client disconnects "
+            "and the cancellation lands post-commit"
+        )
+        assert store.get_item(item_id) is None, "the handler reported ok but the item survived"
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_import_bundle_handler_runs_the_import_off_the_loop_thread(tmp_path, monkeypatch):
+    """The offload is real for the import path, audit riding with the commit."""
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+        seen_threads: list[int] = []
+        real = store.import_bundle
+
+        def recording(*args, **kwargs):
+            seen_threads.append(threading.get_ident())
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(store, "import_bundle", recording)
+
+        sel_threads: list[int] = []
+        monkeypatch.setattr(
+            kh, "_sel_log", lambda tool, **kw: sel_threads.append(threading.get_ident())
+        )
+
+        bundle = {
+            "items": [
+                {
+                    "id": "i1",
+                    "title": "Imported",
+                    "content": "hello",
+                    "summary": "s",
+                    "item_type": "note",
+                }
+            ]
+        }
+        async with TestClient(TestServer(_make_app(store))) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 200
+            assert (await resp.json())["items_imported"] == 1
+
+        assert seen_threads, (
+            "store.import_bundle was never called -- the import path was not "
+            "reached and this test would pass vacuously"
+        )
+        assert threading.get_ident() not in seen_threads, (
+            "store.import_bundle ran on the event-loop thread; it must be "
+            "handed to asyncio.to_thread"
+        )
+        assert sel_threads == seen_threads, (
+            "the success SEL audit did not run on the worker alongside the "
+            "commit; an audit line after the await is skipped when the client "
+            "disconnects and the cancellation lands post-commit"
+        )
+    finally:
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_import_bundle_worker_error_still_reaches_the_typed_400(tmp_path, monkeypatch):
+    """An error raised inside the worker propagates to the handler's arms.
+
+    The handler's whole error contract lives in the ``except`` arms around the
+    store call; moving the call to a worker thread must not change what they
+    catch. ``KnowledgeBundleError`` is the store's own typed rejection, whose
+    message the handler renders verbatim -- the arm most sensitive to the
+    exception arriving as itself rather than wrapped.
+    """
+    store = KnowledgeStore(str(tmp_path / "knowledge.db"))
+    try:
+
+        def rejecting(*args, **kwargs):
+            raise KnowledgeBundleError("'sources.properties' must be a JSON object")
+
+        monkeypatch.setattr(store, "import_bundle", rejecting)
+
+        bundle = {
+            "items": [
+                {"id": "i1", "title": "t", "content": "c", "summary": "s", "item_type": "note"}
+            ]
+        }
+        async with TestClient(TestServer(_make_app(store))) as client:
+            resp = await client.post("/api/knowledge/import", json=bundle)
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["code"] == "malformed_knowledge_bundle"
+        assert "sources.properties" in body["error"]
+    finally:
+        store.close()


### PR DESCRIPTION
## Problem / Motivation

Two knowledge-store mutations run synchronously on the asyncio event loop. In
`src/kiro_crew/dashboard/handlers/knowledge.py`, `async def delete_item` calls
`store.delete_item(item_id)` and `async def import_bundle` calls
`_store(request).import_bundle(body)` directly from the coroutine body. Both
open `BEGIN IMMEDIATE` (taking the write lock eagerly, with a 10s
`busy_timeout` a concurrent writer can consume in full) and both end in
`_load_graph()`, a full scan of `entities` and `entity_relations` that grows
linearly with the library -- measured on the order of seconds at hundreds of
thousands of entities.

## Why it matters

The gateway runs everything on one loop. While either mutation runs there,
every task freezes: the user's chat turn, other dashboard requests, and the
liveness heartbeat. On a large profile the stall outlasts the loop watchdog,
which hard-exits the process; the supervisor respawns into the same state. A
single item delete or bundle import on a big library can therefore present as
a crash loop, not just latency. The module's own on-loop guard already
diagnoses these two call sites.

## What changed (motivation -> approach -> change)

Symptom: loop stalls (and, at scale, watchdog exits) during item delete and
bundle import. Root cause: the two blocking store calls are the last mutation
paths in this module still invoked from a coroutine body. Change: both are
handed to a worker with `await asyncio.to_thread(...)`, the same pattern this
module already uses for `delete_source_cascade` and its other store hops.
`KnowledgeStore` keeps one SQLite connection per thread, created lazily, so a
worker-thread call is the supported access mode.

The success SEL audit line moves into the same worker closure as the commit.
Leaving it after the `await` would have introduced this module's first
suspension point between a committed write and its audit record: a client
disconnect cancels the coroutine at the resume point (`CancelledError` is a
`BaseException` no arm catches), so the mutation would commit with no SEL
record, and the suppression would be caller-controllable. Inside the worker,
the thread runs to completion even when the awaiting task is cancelled, so
commit and audit are inseparable. A cancellation while the work item is still
queued drops both together -- atomic-nothing, no partial state. Error-path
audit lines stay in the `except` arms, tied to the HTTP responses they build;
`asyncio.to_thread` re-raises the worker's exception as itself, so every
existing arm still catches exactly what the synchronous call raised.

Known residual, out of scope here: `_load_graph()` refills the shared graph
in place, so an on-loop graph read can observe a half-built graph while any
offloaded mutation rebuilds it. That window predates this PR (it exists via
the `delete_source` offload on main) and belongs with the store-side graph
work, where the rebuild could publish a fresh graph object atomically.

## Tests

`test/test_knowledge_mutations_off_loop.py` (new):

- Two AST ratchets (reusing the `_on_loop_call_sites` helper from
  `test_knowledge_delete_off_loop.py`) fail if any future edit calls
  `delete_item` or `import_bundle` from a coroutine body anywhere in the
  package, including through a same-module sync helper.
- Two behavioural tests drive the real handlers over HTTP and assert the
  THREAD the store call lands on, so a refactor that keeps `to_thread` in the
  source but hands it something already-invoked still fails. Both also assert
  the SEL audit ran on the same worker as the commit, pinning the
  cancellation-safety property above.
- One error-propagation test raises the store's typed `KnowledgeBundleError`
  inside the worker and asserts the handler still renders its clean 400.

Local gates: isort, flake8 clean; mypy clean on the changed file; the
knowledge-family suite (1000+ tests across `test_knowledge*.py`, handler
coverage, off-loop guards, JSON body guards) passes.

## Manual verification

N/A -- unit coverage sufficient: the behavioural tests exercise the real
aiohttp handlers end-to-end against a real store, and the property under test
(which thread the mutation runs on) is asserted directly.

## Related Issues

Closes #8670

## Pattern harvest

Rule candidate: review-prompt
Pattern: an offload that moves a committed write across an `await` must carry
its audit/finalization into the worker, or a caller-controllable cancellation
splits the commit from its record.
