### PR TITLE
test: record directive publishes instead of POSTing a live gateway (#8652)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import pathlib
 import shutil
@@ -1264,3 +1265,96 @@ def _reset_create_rate_limit_buckets():
     yield
     with create_rate_limit._lock:
         create_rate_limit._buckets.clear()
+
+
+#: Test modules that own direct coverage of ``mcp_core``'s HTTP plumbing itself.
+#: They call the real ``_post`` (or drive a tool through it) with the transport
+#: patched BELOW it (``loopback_urlopen`` / ``_api_urlopen``), so a recorder
+#: stub above ``_post`` would blind exactly the assertions those modules exist
+#: to make. An exemption is NOT permission to reach the network: the fixture
+#: below leaves ``_post`` real for these modules but replaces the transport
+#: with a refuser, so a test here that forgets its own transport patch gets a
+#: deterministic local failure instead of dialling the operator's gateway.
+_REAL_MCP_POST_MODULES = frozenset(
+    {
+        "test_ephemeral_sessions",
+        "test_mcp_api_base_resolution",
+        "test_mcp_core",
+        "test_mcp_core_coverage",
+        "test_mcp_internal_caller",
+    }
+)
+
+
+class _InertGatewayPosts(list):
+    """What an exempt module sees if it requests ``gateway_posts`` by name.
+
+    No recorder ever appends here, so an equality check would pass vacuously
+    (``== []``) or fail for a reason unrelated to the code under test. Refusing
+    the comparison turns that silent vacuity into an immediate, named failure.
+    """
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - failure path
+        raise AssertionError(
+            "gateway_posts is inert in a _REAL_MCP_POST_MODULES module: the"
+            " recorder is not installed there, so nothing is ever appended."
+            " Assert against your own transport patch instead."
+        )
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
+def gateway_posts(request, monkeypatch):
+    """Record ``mcp_core._post`` calls instead of letting them reach a gateway.
+
+    ``mcp_tools.control._emit_directive`` publishes every directive out of band
+    via ``mcp_core._post("/api/session-directive", ...)`` on the resolved API
+    port and swallows every exception — so a test that emits a directive
+    without stubbing ``_post`` makes a REAL request to whatever is listening
+    there, silently. On a developer machine that is the operator's own live
+    gateway, and the request carries a real-looking session key. The suite only
+    avoided a live write because this conftest's ``KIROCREW_HOME`` pin makes
+    the client read a different instance credential, so the gateway refuses the
+    call — an unrelated guard no test is entitled to rely on. Stubbing here
+    makes reaching the network opt-in for the whole suite rather than opt-out.
+
+    A RECORDER rather than a black hole, so the stub also buys coverage: the
+    out-of-band publish is half of the directive contract (marker + parked
+    record), and a test can request this fixture by name and assert on the
+    ``(path, payload)`` records. The payload is round-tripped through JSON so a
+    non-serializable body fails HERE — the point where the real ``_post`` would
+    have failed (and ``_emit_directive`` would have silently swallowed it). The
+    stub returns ``{}``: falsy for ``.get("ok")`` readers and free of
+    ``"error"``, it invents no success shape the real ``_post`` never promised.
+
+    Opting back in stays explicit and layered: a test's own
+    ``monkeypatch.setattr(mcp_core, "_post", ...)`` simply replaces this stub
+    for that test, and a module that owns direct coverage of ``_post``'s own
+    plumbing lists itself in ``_REAL_MCP_POST_MODULES``. For those modules the
+    transport is replaced with a refuser instead (their per-test transport
+    patches override it), so the no-traffic property holds per test rather
+    than resting on every future test remembering its own patch.
+    """
+    from kiro_crew import mcp_core
+
+    if getattr(request.module, "__name__", "") in _REAL_MCP_POST_MODULES:
+
+        def _refuse_network(*args, **kwargs):
+            raise AssertionError(
+                "test reached mcp_core's real transport: patch"
+                " loopback_urlopen/_api_urlopen (or _post) in the test itself"
+            )
+
+        monkeypatch.setattr(mcp_core, "loopback_urlopen", _refuse_network)
+        yield _InertGatewayPosts()
+        return
+
+    posted: list[tuple[str, dict | None]] = []
+
+    def _capture(path: str, body: dict | None = None, **kwargs) -> dict:
+        posted.append((path, json.loads(json.dumps(body)) if body is not None else None))
+        return {}
+
+    monkeypatch.setattr(mcp_core, "_post", _capture)
+    yield posted

--- a/test/test_ask_question_mcp_tool.py
+++ b/test/test_ask_question_mcp_tool.py
@@ -66,12 +66,17 @@ def default_install(monkeypatch):
 # ── Tool contract ─────────────────────────────────────────────────────────────
 
 
-def test_ask_question_returns_directive_with_validated_questions(default_install):
+def test_ask_question_returns_directive_with_validated_questions(default_install, gateway_posts):
     """A valid call on a default install returns a directive that decodes to the
     validated questions payload — no session key, no HTTP round-trip."""
     result = _call_tool_inner("ask_question", {"questions": QUESTIONS})
     args = session_directive.decode(result, "ask_question")
     assert args == {"questions": _validated_questions()}
+    # BOTH halves of the delivery contract: the marker above, and the
+    # out-of-band record parked for a consumer that never sees the marker.
+    assert gateway_posts == [
+        ("/api/session-directive", {"kind": "ask_question", "args": args})
+    ]
 
 
 def test_ask_question_directive_confirmation_tells_the_model_to_end_its_turn(default_install):
@@ -81,7 +86,7 @@ def test_ask_question_directive_confirmation_tells_the_model_to_end_its_turn(def
     assert "end your turn" in result.lower()
 
 
-def test_non_dashboard_session_is_refused_with_options_hint(monkeypatch):
+def test_non_dashboard_session_is_refused_with_options_hint(monkeypatch, gateway_posts):
     """A non-empty, non-dashboard key (Slack/Discord) has no question card, so
     the tool steers to the [OPTIONS:] tag and emits NO directive."""
     monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "slack:C1")
@@ -90,6 +95,8 @@ def test_non_dashboard_session_is_refused_with_options_hint(monkeypatch):
     assert "[OPTIONS:" in result
     # It is a plain message, not a directive.
     assert session_directive.decode(result, "ask_question") is None
+    # A refusal must not publish: no marker, no parked record.
+    assert gateway_posts == []
 
 
 def test_questions_is_required(default_install):

--- a/test/test_autonudge_stop_auth.py
+++ b/test/test_autonudge_stop_auth.py
@@ -63,7 +63,7 @@ def default_install(monkeypatch):
 # ── monitor_start ──
 
 
-def test_monitor_start_returns_directive_with_validated_payload(default_install):
+def test_monitor_start_returns_directive_with_validated_payload(default_install, gateway_posts):
     """A valid call returns a directive decoding to the validated payload with
     interval_secs mapped to idle_secs."""
     result = _call_tool_inner(
@@ -81,6 +81,9 @@ def test_monitor_start_returns_directive_with_validated_payload(default_install)
         # directive reads the same decision the ack reported.
         "gate": True,
     }
+    # BOTH halves of the delivery contract: the marker above, and the
+    # out-of-band record parked for a consumer that never sees the marker.
+    assert gateway_posts == [("/api/session-directive", {"kind": "monitor_start", "args": args})]
 
 
 def test_monitor_start_runtime_budget_passes_through(default_install):
@@ -130,13 +133,15 @@ def test_monitor_start_confirmation_states_idle_semantics_and_stop_duty(default_
     assert "backstop" in result.lower()
 
 
-def test_monitor_start_short_circuits_for_non_nudgeable_session(monkeypatch):
+def test_monitor_start_short_circuits_for_non_nudgeable_session(monkeypatch, gateway_posts):
     """A non-empty but non-nudge-able key (cron/subagent) yields a plain refusal
     and NO directive."""
     monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "cron:job-9")
     result = _call_tool_inner("monitor_start", {"message": "watch"})
     assert "only works" in result.lower()
     assert session_directive.decode(result, "monitor_start") is None
+    # A short-circuit must not publish: no marker, no parked record.
+    assert gateway_posts == []
 
 
 # ── monitor_update ──
@@ -193,19 +198,25 @@ def test_monitor_update_exposes_no_loop_id_parameter(default_install):
         _call_tool_inner("monitor_update", {"message": "x", "loop_id": "someone-elses-loop"})
 
 
-def test_monitor_update_short_circuits_for_non_nudgeable_session(monkeypatch):
+def test_monitor_update_short_circuits_for_non_nudgeable_session(monkeypatch, gateway_posts):
     monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "subagent:abc")
     result = _call_tool_inner("monitor_update", {"message": "x"})
     assert "only works" in result.lower()
     assert session_directive.decode(result, "monitor_update") is None
+    # A short-circuit must not publish: no marker, no parked record.
+    assert gateway_posts == []
 
 
 # ── autonudge_stop ──
 
 
-def test_autonudge_stop_returns_directive_with_stripped_reason(default_install):
+def test_autonudge_stop_returns_directive_with_stripped_reason(default_install, gateway_posts):
     result = _call_tool_inner("autonudge_stop", {"reason": "  PR is green  "})
     assert session_directive.decode(result, "autonudge_stop") == {"reason": "PR is green"}
+    # The published record carries the same stripped reason as the marker.
+    assert gateway_posts == [
+        ("/api/session-directive", {"kind": "autonudge_stop", "args": {"reason": "PR is green"}})
+    ]
 
 
 def test_autonudge_stop_empty_reason_yields_empty_string(default_install):
@@ -213,11 +224,13 @@ def test_autonudge_stop_empty_reason_yields_empty_string(default_install):
     assert session_directive.decode(result, "autonudge_stop") == {"reason": ""}
 
 
-def test_autonudge_stop_short_circuits_for_non_nudgeable_session(monkeypatch):
+def test_autonudge_stop_short_circuits_for_non_nudgeable_session(monkeypatch, gateway_posts):
     monkeypatch.setattr(mcp_core, "_resolve_session_key_strict", lambda: "cron:job-1")
     result = _call_tool_inner("autonudge_stop", {"reason": "x"})
     assert "only works" in result.lower()
     assert session_directive.decode(result, "autonudge_stop") is None
+    # A short-circuit must not publish: no marker, no parked record.
+    assert gateway_posts == []
 
 
 # ── Applier invariants (dashboard.session_directive_apply) ────────────────────

--- a/test/test_monitor_mcp.py
+++ b/test/test_monitor_mcp.py
@@ -9,7 +9,7 @@ from kiro_crew import mcp_core, session_directive
 from kiro_crew.mcp_tools import control
 
 
-def test_monitor_watch_is_stateless_and_canonical():
+def test_monitor_watch_is_stateless_and_canonical(gateway_posts):
     with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value="dashboard:chat-1"):
         result = control.monitor_watch(
             "monitor_watch",
@@ -25,9 +25,13 @@ def test_monitor_watch_is_stateless_and_canonical():
     assert args["target"] == "https://github.com/acme/widgets/pull/7"
     assert "session_key" not in json.dumps(args)
     assert "loop_id" not in json.dumps(args)
+    # BOTH halves of the delivery contract: the marker above, and the
+    # out-of-band record parked for a consumer that never sees the marker —
+    # carrying the same canonicalized payload the marker carries.
+    assert gateway_posts == [("/api/session-directive", {"kind": "monitor_watch", "args": args})]
 
 
-def test_monitor_watch_rejects_native_subagent_binding():
+def test_monitor_watch_rejects_native_subagent_binding(gateway_posts):
     with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value="subagent:child"):
         result = control.monitor_watch(
             "monitor_watch",
@@ -39,9 +43,11 @@ def test_monitor_watch_rejects_native_subagent_binding():
         )
     assert session_directive.decode(result, "monitor_watch") is None
     assert "only works" in result
+    # A refusal must not publish: no marker, no parked record.
+    assert gateway_posts == []
 
 
-def test_monitor_watch_rejects_webex_while_finite_legacy_loop_remains_available():
+def test_monitor_watch_rejects_webex_while_finite_legacy_loop_remains_available(gateway_posts):
     audit = MagicMock()
     with (
         patch(
@@ -79,6 +85,10 @@ def test_monitor_watch_rejects_webex_while_finite_legacy_loop_remains_available(
     assert legacy_args is not None
     assert legacy_args["max_cycles"] == 24
     assert legacy_args["max_runtime_secs"] == 14_400
+    # Only the accepted legacy loop publishes; the three refusals park nothing.
+    assert gateway_posts == [
+        ("/api/session-directive", {"kind": "monitor_start", "args": legacy_args})
+    ]
 
 
 @pytest.mark.parametrize(
@@ -143,7 +153,7 @@ def test_structured_monitor_mutations_require_strict_session_identity(tool_name,
     assert audit.log_tool_invocation.call_args.kwargs["outcome"] == "denied"
 
 
-def test_structured_update_and_stop_reject_native_subagent_binding():
+def test_structured_update_and_stop_reject_native_subagent_binding(gateway_posts):
     with patch("kiro_crew.mcp_core._resolve_session_key_strict", return_value="subagent:child"):
         update = control.monitor_update(
             "monitor_update",
@@ -155,6 +165,8 @@ def test_structured_update_and_stop_reject_native_subagent_binding():
     assert session_directive.decode(stop, "monitor_stop") is None
     assert "only works" in update
     assert "only works" in stop
+    # A refusal must not publish: no marker, no parked record.
+    assert gateway_posts == []
 
 
 def test_monitor_inspect_passes_strict_identity_without_fallback():


### PR DESCRIPTION
## Problem / Motivation

Session-directive tool tests reach `mcp_tools.control._emit_directive`, which publishes every directive out of band via `mcp_core._post("/api/session-directive", ...)` on the resolved API port and swallows every exception. `test/conftest.py` stubbed neither `_post` nor the transport under it, so 17 tests across `test_autonudge_stop_auth.py`, `test_monitor_mcp.py`, and `test_ask_question_mcp_tool.py` made real outbound POSTs on every run. On a developer machine the resolved port is the operator's own live gateway, and the request carries a real-looking session key.

## Why it matters

The only reason those POSTs did not park real directive records on the operator's live gateway is that the conftest `KIROCREW_HOME` pin makes the client read a different instance credential, so the gateway refuses the call ("this client authenticated against the wrong Kiro Crew instance"). That is an unrelated guard the tests are not entitled to rely on: any change to credential resolution, or running the suite under the gateway's own home, silently turns test runs into live control-plane writes. This is the `no-test-side-effects` anchor rule (blocking) in `AUTOSDE.yaml`.

## What changed (motivation -> approach -> change)

Symptom: unstubbed network POSTs from directive-tool tests. Root cause: `_emit_directive`'s out-of-band publish path has no default test seam, so reaching the network was opt-out rather than opt-in.

The change adds an autouse `gateway_posts` fixture in `test/conftest.py` that stubs `mcp_core._post` for the whole suite:

- The stub is a RECORDER, not a black hole: it appends `(path, payload)` tuples a test can assert on by requesting the fixture, so the out-of-band publish half of the directive contract (marker + parked record) becomes assertable coverage. This mirrors the recorder shape PR #8640 established in its own per-file fixture (that PR touches only its two test files, not `conftest.py`, so the two changes are disjoint).
- The recorded payload is round-tripped through JSON, so a non-serializable body fails at the point the real `_post` would have failed (and `_emit_directive` would have silently swallowed).
- The stub returns `{}` -- falsy for `.get("ok")` readers and free of `"error"` -- inventing no success shape the real `_post` never promised.
- Five modules that own direct coverage of `_post`'s own plumbing (they patch `loopback_urlopen` / `_api_urlopen` below it) are exempted by name in `_REAL_MCP_POST_MODULES`, following this conftest's existing module-exemption precedent. For those modules the fixture replaces the transport with a refuser instead, so a future test there that forgets its own transport patch fails loudly rather than dialling the gateway; their per-test transport patches override the refuser, so existing coverage is unchanged. An exempt module requesting `gateway_posts` gets an inert sentinel whose comparison raises, so a no-publish assertion there cannot pass vacuously.
- A test that needs its own `_post` behavior keeps working unchanged: its own `monkeypatch.setattr(mcp_core, "_post", ...)` simply replaces the stub.

Directive semantics are untouched; the change is test-only.

## Tests

- `test_monitor_mcp.py`: the canonical `monitor_watch` contract test now asserts the published record carries the same canonicalized payload as the marker; the subagent-binding and structured update/stop refusal tests assert no record is published; the webex-rejection test asserts exactly one record (the accepted legacy loop) and none for the three refusals.
- `test_autonudge_stop_auth.py`: `monitor_start` and `autonudge_stop` contract tests assert the publish half (including that the published reason is the stripped one); all three short-circuit tests assert no publish.
- `test_ask_question_mcp_tool.py`: the directive contract test asserts the publish half; the non-dashboard refusal asserts no publish.
- The fixture itself is exercised by every test in the suite; a targeted run of all 116 mcp-touching test files passes (7619 passed, 0 failed).

## Manual verification

N/A -- unit coverage sufficient: the change is a test seam plus assertions, fully exercised by the suite itself.

## Related Issues

Closes #8652

## Pattern harvest

Rule candidate: review-prompt
Pattern: test fixture layer leaves a fail-soft outbound network call unstubbed, relying on an unrelated auth guard to reject the traffic

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
