### PR TITLE
fix(ci): refuse xdist worker replacement on the POSIX test job too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,6 +580,25 @@ jobs:
         # matrix has a single Python, so there is no --no-cov lane left. Each
         # shard emits a partial data file merged later by the coverage-combine
         # job.
+        #
+        # --max-worker-restart=0 overrides setup.cfg's =2 for THIS job too, for
+        # the destination rather than the trigger. backend-test-windows adopted
+        # it because pytest-timeout has no SIGALRM there and every per-test
+        # timeout kills a whole worker (#5043) -- that trigger is Windows-only,
+        # and this job reports `timeout method: signal`, so a slow test here
+        # fails as one test. The destination is shared: whatever kills a worker,
+        # =2 permits the replacement, and xdist's node-replacement path leaves a
+        # node in assigned_work but absent from registered_collections (#2803),
+        # which either dies with INTERNALERROR or never completes the session.
+        # MEASURED on `Backend Tests (3.12, 4)` of run 33788776072 (2026-09-03):
+        # `[gw2] node down: Not properly terminated` at 19:12:56 with 99.8% of
+        # 21077 items already reported, then 12m20s of zero output, then the
+        # 40-minute cap cancelled the job with no summary -- so the one recorded
+        # failure, the crashed item itself, was never named. Its three sibling
+        # shards passed in 28-32 minutes on the same commit, so the budget was
+        # not the problem. Same trade-off Windows accepted: refusing the
+        # replacement abandons that shard's pending work, and a named red at the
+        # 25-minute mark beats an uninterpretable cancellation at the cap.
         env:
           REDUCED: ${{ steps.scope.outputs.reduced }}
           LEAF: ${{ steps.scope.outputs.leaf }}
@@ -636,24 +655,24 @@ jobs:
             fi
             if [ "${#GATES[@]}" -gt 0 ]; then
               echo "::group::leaf corpus gates (${#GATES[@]} file(s), once)"
-              pytest -q -n auto --timeout=120 --no-cov "${GATES[@]}"
+              pytest -q -n auto --timeout=120 --no-cov --max-worker-restart=0 "${GATES[@]}"
               echo "::endgroup::"
             fi
             for pass in $(seq 1 "$LEAF_REPEAT"); do
               echo "::group::leaf changed files, pass $pass/$LEAF_REPEAT"
-              pytest -q -n auto --timeout=120 --no-cov "${CHANGED[@]}"
+              pytest -q -n auto --timeout=120 --no-cov --max-worker-restart=0 "${CHANGED[@]}"
               echo "::endgroup::"
             done
             exit 0
           fi
           if [ "$REDUCED" = "true" ]; then
-            pytest -q -n auto --timeout=120 \
+            pytest -q -n auto --timeout=120 --max-worker-restart=0 \
               --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
               --no-cov \
               "${TARGETS[@]}"
             exit 0
           fi
-          pytest -q -n auto --timeout=120 \
+          pytest -q -n auto --timeout=120 --max-worker-restart=0 \
             --splits "$SHARD_COUNT" --group ${{ matrix.group }} \
             --cov=kiro_crew --cov=sage_lib
         # Nothing is deselected. The eleven files that used to be -- the two sandbox

--- a/test/test_xdist_worker_restart_contract.py
+++ b/test/test_xdist_worker_restart_contract.py
@@ -1,15 +1,34 @@
-"""A Windows xdist run must refuse to replace a dead worker.
+"""A CI xdist run must refuse to replace a dead worker, on every platform.
 
-`pytest-timeout` has no SIGALRM on Windows, so it falls back to its thread
-method, and that method cannot fail a single test -- it terminates the whole
-xdist worker. Every per-test timeout on a Windows runner therefore surfaces as
-`node down: Not properly terminated` and pushes xdist into its node-replacement
-path, where the node is left in `assigned_work` but absent from
-`registered_collections` (#2803). That path either dies with INTERNALERROR or
-never completes the session at all, which is how #4227 burned the full
-40-minute job cap without ever naming the test at fault.
+Losing a worker sends the session into xdist's node-replacement path, where the
+node is left in `assigned_work` but absent from `registered_collections`
+(#2803). That path either dies with INTERNALERROR or never completes the session
+at all, which is how #4227 burned the full 40-minute job cap without ever naming
+the test at fault. `--max-worker-restart=0` is what keeps us out of it: the
+first dead worker ends the run promptly with the victim named.
 
-Measured on the pins this job installs (pytest 9.0.3, pytest-xdist 3.5.0,
+This started as a Windows-only guard, because the TRIGGER that was understood
+first is Windows-only: `pytest-timeout` has no SIGALRM there, so it falls back
+to its thread method, and that method cannot fail a single test -- it terminates
+the whole worker, so every per-test timeout surfaces as `node down: Not properly
+terminated`.
+
+The DESTINATION is not platform-specific, and a POSIX shard reached it. On
+`Backend Tests (3.12, 4)` of run 33788776072 (2026-09-03), with the session
+reporting `timeout method: signal` -- so a slow test there fails as one test,
+and this was not the Windows trigger -- a worker died anyway:
+
+    19:12:56  [gw2] node down: Not properly terminated
+    19:12:56  F
+    19:12:56  replacing crashed worker gw2
+    19:16:12  <last progress output; 99.8% of 21077 items reported>
+    19:28:32  ##[error]The operation was canceled.     <- the 40-minute cap
+
+12m20s of zero output, no summary, and so the one recorded failure -- the
+crashed item itself -- was never named. The three sibling shards passed in 28 to
+32 minutes on the same commit, so wall-time capacity (#7516) was not the cause.
+
+Measured on the pins these jobs install (pytest 9.0.3, pytest-xdist 3.5.0,
 pytest-timeout 2.2.0) with one test forced past `--timeout`:
 
     --max-worker-restart=2   run never finishes; one attempt was still live
@@ -17,15 +36,18 @@ pytest-timeout 2.2.0) with one test forced past `--timeout`:
     --max-worker-restart=0   exits 1 in 12.4s and names the crashed test
 
 Upgrading the pin is not an option: 3.8.0, the current release, has the same
-defect shape, so there is no fixed version to move to. Refusing the replacement
-is what keeps us out of the bad path, and nothing else in the repository
-enforces it -- deleting the flag, or "tidying" the Windows invocations to match
-the POSIX job, silently restores a hang that surfaces weeks later as a
-cancelled job on an unrelated PR.
+defect shape, so there is no fixed version to move to.
 
-Deliberately one-directional. It does NOT assert that the POSIX job lacks the
-flag: adopting it there may well be right (a worker can die on Linux too, e.g.
-under OOM), and a test forbidding that would turn a good change red.
+The trade-off is deliberate: refusing the replacement abandons the work still
+pending on that shard, so a killed shard reports fewer tests than it collected.
+That is the right trade for CI -- the job is red either way, and a named red
+beats an uninterpretable cancellation at the cap.
+
+`setup.cfg` keeps `--max-worker-restart=2` deliberately, to absorb a one-off
+memory-pressure crash on a developer machine, so this has to be overridden per
+job -- and nothing else in the repository enforces it. Deleting the flag, or
+"tidying" one invocation to match another, silently restores a hang that
+surfaces weeks later as a cancelled job on an unrelated PR.
 """
 
 from __future__ import annotations
@@ -40,70 +62,129 @@ CI = ROOT / ".github" / "workflows" / "ci.yml"
 
 FLAG = "--max-worker-restart=0"
 
+#: The worker count, however it is spelled. `-n0` / `--numprocesses=0` runs
+#: IN-PROCESS with no workers at all, so there is nothing to lose and nothing to
+#: replace; requiring the flag there would red a job for a hazard it cannot have.
+_WORKERS_RE = re.compile(r"(?:\s-n\s*|\s--numprocesses[= ])(\S+)")
+
 
 def _logical_lines(run: str) -> list[str]:
     """Join shell backslash continuations so one command is one string.
 
-    A per-line scan is the wrong tool here: the invocation this guards already
-    spans three physical lines, and the flag could legitimately move onto a
+    A per-line scan is the wrong tool here: the invocations this guards already
+    span three physical lines, and the flag could legitimately move onto a
     continuation line. A scan that missed it would report a fact about itself,
     not about the workflow.
     """
     return re.sub(r"\\\s*\n\s*", " ", run).splitlines()
 
 
-def _windows_xdist_invocations() -> list[tuple[str, str]]:
-    """Every (job name, command) that runs pytest under xdist on Windows."""
+def _ci_xdist_invocations() -> list[tuple[str, str]]:
+    """Every (job name, command) that runs pytest under xdist, any platform.
+
+    No `runs-on` filter: the node-replacement path is reached by whatever kills
+    a worker, and only the frequency of the kill is platform-specific.
+    """
     workflow = yaml.safe_load(CI.read_text(encoding="utf-8"))
     found: list[tuple[str, str]] = []
     for job_name, job in workflow["jobs"].items():
-        if "windows" not in str(job.get("runs-on", "")).lower():
-            continue
         for step in job.get("steps") or []:
             if not isinstance(step, dict):
                 continue
             for line in _logical_lines(str(step.get("run", ""))):
-                # `-n` is what makes a replacement possible at all; without
-                # xdist there is no worker to lose.
-                if "pytest" in line and re.search(r"\s-n\s", line):
-                    found.append((job_name, line.strip()))
+                if "pytest" not in line:
+                    continue
+                workers = _WORKERS_RE.search(line)
+                if workers is None or workers.group(1) == "0":
+                    continue
+                found.append((job_name, line.strip()))
     return found
 
 
-def test_ci_has_a_windows_xdist_job_to_guard() -> None:
+def test_ci_has_xdist_jobs_to_guard() -> None:
     # Anti-vacuity. Every other assertion here iterates this list, so an empty
     # list would make the whole file pass while guarding nothing -- exactly what
     # a job rename or a shard removal would do.
-    invocations = _windows_xdist_invocations()
+    invocations = _ci_xdist_invocations()
     assert invocations, (
-        "ci.yml has no Windows job running pytest under xdist. If that is "
-        "deliberate, delete this file; if it is a rename, update the discovery "
-        "in _windows_xdist_invocations so the guard keeps applying."
+        "ci.yml has no job running pytest under xdist. If that is deliberate, "
+        "delete this file; if it is a rename or a respelling of -n, update the "
+        "discovery in _ci_xdist_invocations so the guard keeps applying."
     )
 
 
-def test_every_windows_xdist_invocation_refuses_worker_replacement() -> None:
+def test_both_platforms_are_covered() -> None:
+    """The guard used to be Windows-only; #4227 recurred on a POSIX shard.
+
+    Pinning that BOTH families are discovered is what stops the coverage gap
+    from reopening quietly: a platform filter reintroduced in the discovery
+    above would still leave every assertion below passing.
+    """
+    workflow = yaml.safe_load(CI.read_text(encoding="utf-8"))
+    runs_on = {
+        job_name: str(workflow["jobs"][job_name].get("runs-on", "")).lower()
+        for job_name, _ in _ci_xdist_invocations()
+    }
+    assert any("windows" in target for target in runs_on.values()), (
+        f"no Windows xdist job discovered, only {sorted(runs_on)}"
+    )
+    assert any("windows" not in target for target in runs_on.values()), (
+        f"no non-Windows xdist job discovered, only {sorted(runs_on)}"
+    )
+
+
+def test_every_xdist_invocation_refuses_worker_replacement() -> None:
     # The regression this exists for: one invocation losing the flag is enough,
-    # because a shard hangs on the first timeout it happens to hit.
-    for job_name, command in _windows_xdist_invocations():
+    # because a shard hangs on the first worker it happens to lose.
+    for job_name, command in _ci_xdist_invocations():
         assert FLAG in command, (
-            f"{job_name} runs pytest under xdist on Windows without {FLAG}: "
-            f"{command!r}. Without it a timeout-killed worker sends the session "
-            f"into xdist's node-replacement path, which hangs until the job cap "
-            f"(#4227). setup.cfg's --max-worker-restart=2 is a deliberate "
-            f"developer-machine setting, so this has to be overridden per job."
+            f"{job_name} runs pytest under xdist without {FLAG}: {command!r}. "
+            f"Without it a dead worker sends the session into xdist's "
+            f"node-replacement path, which hangs until the job cap (#4227, and "
+            f"again on a POSIX shard in run 33788776072). setup.cfg's "
+            f"--max-worker-restart=2 is a deliberate developer-machine setting, "
+            f"so this has to be overridden per job."
         )
 
 
 def test_the_flag_is_not_weakened_to_allow_a_replacement() -> None:
     # `--max-worker-restart=1` reads like a compromise and is not one: a single
-    # replacement is the case #4227 actually observed, so any nonzero value
-    # re-enters the same path. Catch the plausible near-miss edit explicitly
-    # rather than only the outright deletion.
-    for job_name, command in _windows_xdist_invocations():
+    # replacement is the case #4227 actually observed, on both platforms, so any
+    # nonzero value re-enters the same path. Catch the plausible near-miss edit
+    # explicitly rather than only the outright deletion.
+    for job_name, command in _ci_xdist_invocations():
         for value in re.findall(r"--max-worker-restart[= ](\S+)", command):
             assert value == "0", (
-                f"{job_name} sets --max-worker-restart={value} on Windows. Any "
-                f"nonzero value allows the node replacement that hangs the "
-                f"session; the first replacement is the one #4227 hit."
+                f"{job_name} sets --max-worker-restart={value}. Any nonzero "
+                f"value allows the node replacement that hangs the session; the "
+                f"first replacement is the one #4227 hit."
             )
+
+
+def test_a_serial_invocation_is_not_required_to_carry_the_flag() -> None:
+    """`-n0` means no workers, so the guard must not demand the flag there.
+
+    This pins the DISCOVERY boundary, not the flag: it fails if a broadened scan
+    starts scooping up in-process invocations, which would make
+    `backend-test-macos` red for a hazard it cannot have -- it runs one socket
+    test with no workers to lose. It deliberately does not forbid the flag on a
+    `-n0` line; passing it there is an inert no-op, and a test that rejected it
+    would red a harmless change for no gain.
+    """
+    serial = [
+        line.strip()
+        for job in yaml.safe_load(CI.read_text(encoding="utf-8"))["jobs"].values()
+        for step in (job.get("steps") or [])
+        if isinstance(step, dict)
+        for line in _logical_lines(str(step.get("run", "")))
+        if "pytest" in line and _declares_no_workers(line)
+    ]
+    assert serial, "no -n0 pytest invocation left in ci.yml; drop this test if that is intended"
+    guarded = {command for _, command in _ci_xdist_invocations()}
+    for line in serial:
+        assert line not in guarded, f"a -n0 invocation was discovered as xdist: {line!r}"
+
+
+def _declares_no_workers(line: str) -> bool:
+    workers = _WORKERS_RE.search(line)
+    return workers is not None and workers.group(1) == "0"


### PR DESCRIPTION
Refs #4227 (recurrence evidence in [this comment](https://github.com/kirodotdev/KiroCrew/issues/4227#issuecomment-5550292581)).

## Problem / Motivation

`--max-worker-restart=0` is set on `backend-test-windows` only. Enumerating every xdist invocation in `ci.yml`, 4 of 5 lack it, and all four are the POSIX job.

That scoping was reasonable, because the *trigger* understood at the time is Windows-only: `pytest-timeout` has no SIGALRM there, so it falls back to its thread method, which cannot fail a single test — it terminates the whole worker, and every per-test timeout surfaces as `node down: Not properly terminated`.

The *destination* is not platform-specific. Whatever kills a worker, `setup.cfg`'s `=2` permits the replacement, and xdist's node-replacement path leaves a node in `assigned_work` but absent from `registered_collections` (#2803) — which either dies with INTERNALERROR or never completes the session.

A POSIX shard reached it. `Backend Tests (3.12, 4)` of run [`33788776072`](https://github.com/kirodotdev/KiroCrew/actions/runs/33788776072) (2026-09-03, ubuntu-latest), with `timeout method: signal` in its header, so this was **not** the Windows trigger:

```
19:12:56  [gw2] node down: Not properly terminated
19:12:56  F
19:12:56  replacing crashed worker gw2
19:16:12  last progress output -- 99.8% of 21077 items reported
19:28:32  ##[error]The operation was canceled.        <- the 40-minute cap
```

12m20s of zero output, then `Terminate orphan process: pid (2405) (pytest)` plus four `(python)` in post-job cleanup.

## Why it matters

**The victim's name is destroyed by the hang.** The run recorded exactly one `F` — the crashed item — and the session never reached its summary, so nothing names it. That is #4227's problem 2, and it is what makes this class of red uninterpretable: a maintainer sees a cancellation on a diff that cannot account for it.

**It is not a capacity problem, and the same run proves that.** The three sibling shards passed in 28m44s, 30m49s and 31m56s — inside the band #7516 measured across 44 main-head shards (median 28.30 min, peak 30.62 min). Same commit, same runner pool, same coverage settings. Only shard 4 reached the wall, and it reached it producing nothing for the last 12 minutes. #7516's timeout half stays closed; this shard did not run out of budget doing work.

**The cost is measurable.** The crash was already known at 19:12:56, 24m39s into the job. @chenmingwei23's local measurement on these exact pins puts `=0` at 12.4s to exit with the test named, so the run would have ended around the 25-minute mark instead of being cancelled at 40m18s.

**What this evidence does not establish:** why `gw2` died. The log records no OOM, `MemoryError` or kill message. This change is deliberately root-cause-independent — it is #4227's "one root-cause-independent, cheap fix", applied to the job that still lacks it.

## What changed (motivation → approach → change)

**The flag goes on all four POSIX invocations, not just the sharded one.** The guard's own reasoning applies: one invocation losing the flag is enough, because a shard hangs on the first worker it happens to lose. The leaf and reduced-scope paths run under `-n auto` too.

**The `ci.yml` comment states the trigger/destination split** so the next reader does not have to rediscover why a Windows rationale ended up on a POSIX job, and cites the measured run.

**The guard test generalises rather than being duplicated.** `test_xdist_worker_restart_contract.py` already anticipated this exact change:

> Deliberately one-directional. It does NOT assert that the POSIX job lacks the flag: adopting it there may well be right (a worker can die on Linux too, e.g. under OOM), and a test forbidding that would turn a good change red.

The direction is now decided, so the platform filter is gone and the discovery covers every xdist invocation in `ci.yml`.

**Worker-count detection is explicit about `-n0`.** The old scan keyed on `\s-n\s`, which excluded `-n0` only by accident of spacing and would have missed `-n4` or `--numprocesses=auto`. It now parses the value and skips `0`: an in-process run has no worker to lose, so requiring the flag on `backend-test-macos` would red a job for a hazard it cannot have.

## Tests

`test_both_platforms_are_covered` is the new guard against the gap this PR closes reopening quietly — a platform filter reintroduced in the discovery would otherwise leave every other assertion in the file passing. `test_a_serial_invocation_is_not_required_to_carry_the_flag` pins the `-n0` exclusion, which is a boundary no call site makes visible.

5 passed. Mutation-tested on the EC2 dev box, five mutations:

| mutation | reds |
|---|---|
| drop the flag from one POSIX invocation | 1 — `test_every_xdist_invocation_refuses_worker_replacement` names `backend-test` |
| weaken one to `--max-worker-restart=1` | 2 |
| reintroduce the `"windows" not in runs-on` filter | 1 — `test_both_platforms_are_covered` |
| add the flag to the `-n0` macOS invocation | **0, by design** |
| let the discovery treat `-n0` as xdist | 2 |

The fourth is disclosed rather than hidden, because 0 reds normally reads as a coverage gap. Passing the flag to a `-n0` run is an inert no-op, and a test rejecting it would red a harmless change for no gain — the same trap the original docstring warned about in the other direction. What is actually load-bearing there is the *discovery* boundary, and the fifth mutation confirms that boundary bites.

## Manual verification

`python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses. `scripts/scrub-lint.sh` reports nothing against either file. No line exceeds the 100-column limit. `ruff` is not installed on that box, so formatting was checked by hand against `line-length = 100` rather than by the tool — worth a reviewer's eye.

I cannot demonstrate the fix end to end, because that needs a worker to die in CI, which is exactly the unpredictable event being guarded. What is demonstrable is the pre-state: `=2` is what this job runs today, and the run above is what happened under it.

## Related Issues

Refs #2803, #4227, #5043, #5044, #5267, #7516.
