### PR TITLE
fix: verify session pop before warning on agent/effort switch (#8664)

### DIFF
--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -3189,19 +3189,22 @@ async def _reset_slot_session_or_warn(
     connected client rendering the OLD value over a switch that actually
     happened (the acting tab's ``performSlotSwitch`` also keeps its old store
     value on a non-2xx). ``None`` tells the caller to record the degraded
-    teardown and FALL THROUGH — its rebind guard (``effective_session_key``)
-    must still run, so a slot rebound during the raising await keeps answering
-    rollback + 409 — and then answer 200 with
-    :data:`_TEARDOWN_INCOMPLETE_WARNING` after the usual slots push. This is
-    the agent and reasoning-effort handlers' precedent, shared here so the
-    model and workspace handlers' four call sites (first attempt +
-    idle-decline retry each) do not repeat the try block. Only the raise path
-    is new: a normal ``bool`` verdict passes through untouched, so the decline
-    (``False``) ladders keep their semantics.
+    teardown and answer 200 with :data:`_TEARDOWN_INCOMPLETE_WARNING` after
+    the usual slots push; a caller with a rebind guard
+    (``effective_session_key`` — the model and workspace handlers) must still
+    FALL THROUGH and run it, so a slot rebound during the raising await keeps
+    answering rollback + 409. Shared
+    by all four commit-before-reset switch handlers (agent, reasoning effort,
+    model, workspace) so none of them repeats the try block: each calls twice
+    (first attempt + idle-decline retry). Only the raise path is
+    handled here: a normal ``bool`` verdict passes through untouched, so the
+    decline (``False``) ladders keep their semantics.
 
-    ``skip_if_busy`` is fixed at True because every caller is a switch handler
-    whose destructive fallback must decline atomically against a slipped-in
-    turn (their shared invariant); a caller that wants propagation keeps using
+    ``skip_if_busy`` is fixed at True: every caller is a switch handler with
+    a decline ladder (agent, reasoning effort, model, workspace), and
+    :func:`_reset_slot_session` must decline a busy session atomically with
+    the pop rather than tear it down mid-turn — the ladder then disambiguates
+    the decline. A caller that wants every raise to propagate keeps using
     :func:`_reset_slot_session` directly.
     """
     # Captured BEFORE the await: the post-raise probe must compare INSTANCE
@@ -5626,13 +5629,18 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
         # flight creates a fresh session from the slot's CURRENT bindings,
         # so the new agent must already be visible or that session
         # cold-starts on the old binding and stays stale after the switch
-        # reports success. Deliberately NO rollback on a failing reset: the
+        # reports success. NO rollback on a POST-POP teardown failure: the
         # reset pops the session from the map before shutting the process
-        # down, so by the time shutdown can fail the old binding's session
-        # no longer exists — every future send cold-starts on the NEW
-        # binding, and a replacement session created by a concurrent send
-        # mid-reset already runs it. Restoring the old label would advertise
-        # a binding nothing runs (and tear against that replacement).
+        # down, so once the pop has happened the old binding's session no
+        # longer exists — every future send cold-starts on the NEW binding,
+        # and a replacement session created by a concurrent send mid-reset
+        # already runs it. Restoring the old label would advertise a binding
+        # nothing runs (and tear against that replacement). That the pop
+        # happened is VERIFIED, not assumed: the reset below routes through
+        # _reset_slot_session_or_warn, which propagates a pre-pop raise —
+        # and THAT path does roll back (see the except below), because the
+        # probe has proven the opposite premise: the old session survives on
+        # this old binding.
         slot.agent = _CommitToken(agent_name)
         # Ownership token for the rollback paths below: the committed value is
         # a str SUBCLASS instance whose identity only this request holds — it
@@ -5758,22 +5766,42 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
             return children_409
         teardown_incomplete = False
         reset_ok = True
+        # The switch is COMMITTED already (slot.agent above), so a POST-POP
+        # teardown raise is answered as a success with a degraded-teardown
+        # warning — but only once the helper has verified the raise came
+        # AFTER the session pop. A PRE-POP raise means the old session
+        # survives on the old binding, so the helper propagates it and this
+        # request rolls the commit back and answers 500 instead of a false
+        # success. The helper resets with skip_if_busy=True, which keeps this
+        # handler's decline ladder
+        # below: SessionManager.reset evaluates busyness atomically with the
+        # session pop, so a turn that slipped into the microsecond residue
+        # after the re-check above is declined (reset_ok False) instead of
+        # torn down mid-stream. The helper's None verdict marks the degraded
+        # post-pop teardown; a bool verdict is the reset outcome the ladder
+        # reads.
         try:
-            # skip_if_busy: SessionManager.reset evaluates busyness atomically
-            # with the session pop, so a turn that slipped into the microsecond
-            # residue after the re-check above is declined instead of torn
-            # down mid-stream.
-            reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
+            reset_verdict = await _reset_slot_session_or_warn(
+                state, slot, session_key, switch_kind="agent"
+            )
         except Exception:
-            # The switch is COMMITTED regardless: the reset pops the session
-            # before its shutdown can fail, so the new binding is what every
-            # replacement or future session runs. This is a success with a
-            # degraded teardown, and it must be reported as one — a 500 here
-            # would make the acting tab's performSlotSwitch keep the OLD
-            # store value, corrupting the cycle base and the displayed state
-            # for a switch that actually happened.
+            # The identity probe proved the pop never happened: the old
+            # session is still alive on the old binding, so the committed
+            # values describe a switch that did not take — and the acting tab
+            # keeps its OLD store value on the 500, so leaving them would
+            # split server state from every client. Roll back the commit
+            # (identity-scoped, so a concurrent explicit pick that landed
+            # during the raising await keeps its win) and re-push so clients
+            # and persisted state land on the rolled-back truth, then let the
+            # raise escape as a 500.
+            _rollback_switch()
+            slot._dirty = True
+            state.push_slots_update()
+            raise
+        if reset_verdict is None:
             teardown_incomplete = True
-            logger.exception("Slot %s agent switch: old session teardown incomplete", name)
+        else:
+            reset_ok = reset_verdict
         if not reset_ok and not teardown_incomplete:
             # Disambiguate the decline FAIL-CLOSED, the workspace handler's
             # template: a live provider mid-turn → roll back and 409; a live
@@ -5789,21 +5817,25 @@ async def api_chat_slot_agent(request: web.Request) -> web.Response:
                     return web.json_response(
                         {"error": "a turn is in flight", "code": "turn_in_flight"}, status=409
                     )
+                # Retry through the same probing helper: a pre-pop raise on
+                # the retry propagates (roll back + 500) exactly as the first
+                # attempt, and a post-pop raise becomes the committed 200 +
+                # warning. Left as a bare _reset_slot_session the retry would
+                # answer a false success on a pre-pop raise, the divergence
+                # the first-attempt guard prevents.
                 try:
-                    reset_ok = await _reset_slot_session(
-                        state, slot, session_key, skip_if_busy=True
+                    reset_verdict = await _reset_slot_session_or_warn(
+                        state, slot, session_key, switch_kind="agent"
                     )
                 except Exception:
-                    # Same as the first attempt: a post-pop teardown raise is a
-                    # COMMITTED switch with a degraded teardown, not a failure.
-                    # Left unwrapped this raise escapes the handler under
-                    # slot._lock as a 500 while slot.agent stays committed and
-                    # un-rolled-back, so the acting tab's performSlotSwitch keeps
-                    # the OLD store value for a switch that happened — the exact
-                    # divergence the first-attempt guard prevents. Fall through
-                    # to the committed 200 + warning path instead.
+                    _rollback_switch()
+                    slot._dirty = True
+                    state.push_slots_update()
+                    raise
+                if reset_verdict is None:
                     teardown_incomplete = True
-                    logger.exception("Slot %s agent switch: old session teardown incomplete", name)
+                else:
+                    reset_ok = reset_verdict
                 if (
                     not reset_ok
                     and not teardown_incomplete
@@ -7129,18 +7161,42 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
             teardown_incomplete = False
             reset_ok = True
             try:
-                # skip_if_busy: the re-check above is a best-effort fast path
-                # — SessionManager.reset evaluates busyness atomically with
-                # the session pop, so a turn that slipped into the residue
-                # (or holds the semaphore before its prompt is in flight,
-                # which has_active_turn cannot see) is declined here instead
-                # of torn down mid-stream.
-                reset_ok = await _reset_slot_session(state, slot, session_key, skip_if_busy=True)
-            except Exception:
-                logger.exception(
-                    "Slot %s reasoning_effort switch: old session teardown incomplete", name
+                # A POST-POP teardown raise does NOT undo the switch (the
+                # reset pops the session first, so every replacement runs the
+                # new value) and is answered as a success with a warning —
+                # but only once the helper has verified the raise came AFTER
+                # the session pop. A PRE-POP raise means the old session
+                # survives on the old effort, so the helper propagates it and
+                # this request restores the prior effort and answers 500.
+                # The helper resets with skip_if_busy=True, which keeps this
+                # handler's decline ladder below:
+                # SessionManager.reset evaluates busyness atomically with the
+                # session pop, so a turn that slipped into the residue (or
+                # holds the semaphore before its prompt is in flight, which
+                # has_active_turn cannot see) is declined here instead of torn
+                # down mid-stream. The helper's None verdict marks the
+                # degraded post-pop teardown; a bool verdict is the reset
+                # outcome the ladder reads.
+                reset_verdict = await _reset_slot_session_or_warn(
+                    state, slot, session_key, switch_kind="reasoning_effort"
                 )
+            except Exception:
+                # The identity probe proved the pop never happened: the old
+                # session is still alive on the old effort, so the committed
+                # value describes a switch that did not take and the acting
+                # tab keeps its OLD store value on the 500. Restore the prior
+                # effort (only if this request's write still stands) and
+                # re-push so clients and persisted state land on the truth,
+                # then let the raise escape as a 500.
+                if slot.reasoning_effort == effort:
+                    slot.reasoning_effort = prior_effort
+                slot._dirty = True
+                state.push_slots_update()
+                raise
+            if reset_verdict is None:
                 teardown_incomplete = True
+            else:
+                reset_ok = reset_verdict
             if not reset_ok and not teardown_incomplete:
                 # Disambiguate the decline FAIL-CLOSED (the workspace
                 # handler's template): live provider mid-turn → roll back and
@@ -7155,23 +7211,27 @@ async def api_chat_slot_reasoning_effort(request: web.Request) -> web.Response:
                             {"error": "a turn is in flight", "code": "turn_in_flight"},
                             status=409,
                         )
+                    # Retry through the same probing helper: a pre-pop raise on
+                    # the retry propagates (restore + 500) exactly as the first
+                    # attempt, and a post-pop raise becomes the committed 200 +
+                    # warning below.
                     try:
-                        reset_ok = await _reset_slot_session(
-                            state, slot, session_key, skip_if_busy=True
+                        reset_verdict = await _reset_slot_session_or_warn(
+                            state,
+                            slot,
+                            session_key,
+                            switch_kind="reasoning_effort",
                         )
                     except Exception:
-                        # A post-pop teardown raise on the retry is a COMMITTED
-                        # switch with a degraded teardown, not a failure; left
-                        # unwrapped it escapes under slot._lock as a 500 while
-                        # slot.reasoning_effort stays committed, so the acting
-                        # tab keeps the OLD store value. Fall through to the
-                        # committed 200 + warning path (the first attempt's
-                        # guard).
+                        if slot.reasoning_effort == effort:
+                            slot.reasoning_effort = prior_effort
+                        slot._dirty = True
+                        state.push_slots_update()
+                        raise
+                    if reset_verdict is None:
                         teardown_incomplete = True
-                        logger.exception(
-                            "Slot %s reasoning_effort switch: old session teardown incomplete",
-                            name,
-                        )
+                    else:
+                        reset_ok = reset_verdict
                     if (
                         not reset_ok
                         and not teardown_incomplete

--- a/test/test_ask_question_roundtrip.py
+++ b/test/test_ask_question_roundtrip.py
@@ -845,9 +845,12 @@ def test_every_session_reset_goes_through_the_chokepoint() -> None:
         "a switch handler resets the session directly, so a pending "
         "ask_question would outlive the agent it was waiting on"
     )
-    assert body[1].count("await _reset_slot_session(") >= 5, (
+    direct = body[1].count("await _reset_slot_session(")
+    via_warn = body[1].count("await _reset_slot_session_or_warn(")
+    assert direct + via_warn >= 10, (
         "expected the agent, model, bulk-model, reasoning-effort and workspace "
-        "switches to reset through the chokepoint"
+        "switches (plus reload) to reset through the chokepoint — directly or "
+        "via _reset_slot_session_or_warn, which wraps it"
     )
 
 

--- a/test/test_chat_slot_reasoning_effort.py
+++ b/test/test_chat_slot_reasoning_effort.py
@@ -92,6 +92,71 @@ class TestChatSlotReasoningEffort:
             assert slot.reasoning_effort == "low"
 
     @pytest.mark.asyncio
+    async def test_reset_raise_before_pop_propagates(self):
+        # A raise with the session STILL REGISTERED came before the pop: the
+        # old session survives on the old effort, so a 200 + warning would
+        # report a switch that did not take. The helper re-raises instead of
+        # answering a committed-switch success it cannot vouch for, and the
+        # handler restores the prior effort first — the acting tab keeps its
+        # old store value on a non-2xx, and the probe has proven the
+        # surviving session still runs it.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.reasoning_effort = "high"
+        state = _mock_state(slot)
+        alive = MagicMock(spec=LLMProvider)
+        alive.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=alive)
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("pre-pop boom"))
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            )
+            assert resp.status == 500
+            assert slot.reasoning_effort == "high"
+            # The rollback re-pushes so a broadcast that carried the
+            # provisional value mid-await is corrected.
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reset_raise_with_successor_session_still_succeeds(self):
+        # A concurrent send can register a SUCCESSOR session for the same key
+        # after the pop and before the old session's shutdown raises: the
+        # helper's probe compares instance IDENTITY, so a different registered
+        # provider is NOT the unpopped old session — the switch is committed
+        # and the answer is 200 + warning.
+        from kiro_crew.providers.base import LLMProvider
+
+        slot = _ChatSlot("test")
+        slot.reasoning_effort = "high"
+        state = _mock_state(slot)
+        old = MagicMock(spec=LLMProvider)
+        old.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=old)
+
+        async def _pop_register_successor_and_raise(*_a, **_k):
+            successor = MagicMock(spec=LLMProvider)
+            successor.has_active_turn.return_value = False
+            state.sessions.get_provider = MagicMock(return_value=successor)
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_pop_register_successor_and_raise)
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/test/reasoning-effort",
+                json={"reasoning_effort": "low"},
+            )
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["reasoning_effort"] == "low"
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.reasoning_effort == "low"
+            state.push_slots_update.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_failed_reset_spares_concurrent_writes(self):
         # Commit-after-reset: the failure path touches nothing, so a value
         # written by a concurrent actor while the reset was failing survives

--- a/test/test_dashboard_chat.py
+++ b/test/test_dashboard_chat.py
@@ -7579,7 +7579,19 @@ class TestRuntimeWiring:
         slot.agent = "oncall"
         slot.workspace = "oncall-ws"
         slot.project = "/tmp/oncall"
-        state.sessions.reset = AsyncMock(side_effect=RuntimeError("shutdown blew up"))
+        old = MagicMock()
+        old.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=old)
+
+        async def _pop_then_raise(*_a, **_k):
+            # The canonical post-pop shape: the provider is deregistered
+            # before the shutdown raises, so the helper's identity probe
+            # classifies the raise as post-pop and the handler answers the
+            # committed switch.
+            state.sessions.get_provider = MagicMock(return_value=None)
+            raise RuntimeError("shutdown blew up")
+
+        state.sessions.reset = AsyncMock(side_effect=_pop_then_raise)
 
         mock_cfg = MagicMock()
         mock_cfg.agents = {"research": MagicMock(workspace="research-ws", memory_store="default")}
@@ -7634,7 +7646,8 @@ class TestRuntimeWiring:
     ):
         """A failed switch never disturbs values written while it was in flight.
 
-        Commit-after-reset means the failure path touches nothing, so state
+        The handler commits before the reset and its failure path touches
+        nothing further, so state
         written by a concurrent actor during the (failing) reset — e.g. the
         project endpoint, which does not take the slot lock — survives
         untouched. Restoring captured priors here (the old rollback shape)
@@ -7656,6 +7669,10 @@ class TestRuntimeWiring:
             raise RuntimeError("shutdown blew up")
 
         state.sessions.reset = AsyncMock(side_effect=_concurrent_switch_lands_then_reset_fails)
+        # No live session was ever registered for the key, so the helper's
+        # identity probe classifies the raise as post-pop and answers the
+        # committed switch rather than a 500.
+        state.sessions.get_provider = MagicMock(return_value=None)
 
         mock_cfg = MagicMock()
         mock_cfg.agents = {"research": MagicMock(workspace="research-ws", memory_store="default")}
@@ -7697,6 +7714,112 @@ class TestRuntimeWiring:
             assert slot.agent == "writer"
             assert slot.workspace == "writing-ws"
             assert slot.project == "/tmp/writing"
+
+    def _patch_agent_resolution(self, monkeypatch):
+        """Stub config + binding resolution so the agent switch reaches its reset."""
+        mock_cfg = MagicMock()
+        mock_cfg.agents = {"research": MagicMock(workspace="research-ws", memory_store="default")}
+        mock_cfg.workspaces = {"research-ws": MagicMock(dir="/tmp/research")}
+        mock_cfg.default_workspace = "default"
+        mock_cfg.default_memory_store = "default"
+        mock_cfg.memory_stores = {}
+        mock_cfg.memory = MagicMock()
+        mock_bindings = MagicMock()
+        mock_bindings.workspace_dir = Path("/tmp/research")
+        mock_bindings.memory_store_name = "default"
+        mock_bindings.model = ""
+        monkeypatch.setattr("kiro_crew.dashboard.chat.KiroCrewConfig.load", lambda: mock_cfg)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.KiroCrewConfig.load", lambda: mock_cfg
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers.resolve_agent_bindings",
+            lambda cfg, name, project_dir=None: mock_bindings,
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_handlers._workspace_name_for_dir",
+            lambda cfg, ws_dir: "research-ws",
+        )
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_reset_raise_before_pop_propagates(
+        self, tmp_path, monkeypatch
+    ):
+        """A raise with the session STILL REGISTERED propagates as a 500.
+
+        The SAME provider instance registered before and after the raise
+        means the failure came BEFORE the session pop (e.g. in the
+        pending-wait unblock): the old session survives on the old agent, so
+        a 200 + warning would report a switch that did not take. The
+        committed values are rolled back before the raise escapes — the
+        acting tab keeps its old store value on a non-2xx, and the probe has
+        proven the surviving session still runs the old binding.
+        """
+        from kiro_crew.providers.base import LLMProvider
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.agent = "oncall"
+        alive = MagicMock(spec=LLMProvider)
+        alive.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=alive)
+        state.sessions.reset = AsyncMock(side_effect=RuntimeError("pre-pop boom"))
+        self._patch_agent_resolution(monkeypatch)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            assert resp.status == 500
+            assert slot.agent == "oncall"
+
+    @pytest.mark.asyncio
+    async def test_api_chat_slot_agent_reset_raise_with_successor_succeeds(
+        self, tmp_path, monkeypatch
+    ):
+        """A successor registered post-pop is not the unpopped old session.
+
+        A concurrent send can register a SUCCESSOR session for the same key
+        after the pop and before the old session's shutdown raises: the
+        helper's probe compares instance IDENTITY, so a different registered
+        provider still classifies as post-pop — the switch is committed, the
+        successor cold-started from the committed bindings, and the answer is
+        200 + warning.
+        """
+        from kiro_crew.providers.base import LLMProvider
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("s1")
+        slot.agent = "oncall"
+        old = MagicMock(spec=LLMProvider)
+        old.has_active_turn.return_value = False
+        state.sessions.get_provider = MagicMock(return_value=old)
+
+        async def _pop_register_successor_and_raise(*_a, **_k):
+            successor = MagicMock(spec=LLMProvider)
+            successor.has_active_turn.return_value = False
+            state.sessions.get_provider = MagicMock(return_value=successor)
+            raise RuntimeError("shutdown boom")
+
+        state.sessions.reset = AsyncMock(side_effect=_pop_register_successor_and_raise)
+        self._patch_agent_resolution(monkeypatch)
+
+        async with TestClient(TestServer(_make_app_with_agent_routes(state))) as client:
+            resp = await client.post("/api/chat/slots/s1/agent", json={"agent": "research"})
+            data = await resp.json()
+            assert resp.status == 200
+            assert data["ok"] is True
+            assert data["agent"] == "research"
+            assert data["warning"] == "old session teardown incomplete"
+            assert slot.agent == "research"
 
     @pytest.mark.asyncio
     async def test_api_chat_slot_agent_success_commit_spares_concurrent_pick(

--- a/test/test_eager_spawn.py
+++ b/test/test_eager_spawn.py
@@ -517,8 +517,8 @@ class TestProjectSetWiring:
         app.router.add_post("/api/chat/slots/{slot}/agent", api_chat_slot_agent)
         with (
             patch(
-                "kiro_crew.dashboard.chat_handlers._reset_slot_session",
-                new=AsyncMock(),
+                "kiro_crew.dashboard.chat_handlers._reset_slot_session_or_warn",
+                new=AsyncMock(return_value=True),
             ),
             patch("kiro_crew.dashboard.chat_handlers.save_slot_off_loop", new=AsyncMock()),
             patch("kiro_crew.dashboard.chat_handlers.schedule_eager_spawn") as sched,


### PR DESCRIPTION
## What is the problem?

The slot **agent** (`api_chat_slot_agent`) and **reasoning-effort** (`api_chat_slot_reasoning_effort`) switch handlers in `chat_handlers.py` wrapped their session reset in a bare `try/except Exception -> teardown_incomplete = True`, answering `200 + degraded-teardown warning` for ANY exception the reset raised. That is wrong for a raise that happens BEFORE the session is popped from the map (e.g. inside `_reset_slot_session`'s pending-wait unblock): the old session is still alive on the OLD agent/effort, so "switch committed, teardown degraded" is a false success. This is #8664, and #8659's own test `test_reset_raise_before_pop_propagates` demonstrated it on the two precedent handlers.

## Why this issue matters to the user

A user who switches a slot's agent or reasoning effort gets a success response while the live session keeps running the old binding. The acting tab's `performSlotSwitch` treats the 200 as applied and holds the new value in its store, so the UI and the server diverge with no error surfaced -- the switch silently did not take.

## How the fix solves it

`_reset_slot_session_or_warn` (added by #8659) already verifies the "switch committed, teardown degraded" premise by provider INSTANCE IDENTITY: a raise with the same provider instance still registered is a pre-pop failure and is re-raised; a post-pop raise (no provider, or a successor registered by a concurrent send) returns `None` so the caller answers the committed 200 + warning.

Both the agent and reasoning-effort handlers now route both of their reset call sites (first attempt + idle-decline retry) through this helper. On the propagate path (pre-pop raise) the handler rolls its committed value back and re-raises as a 500 instead of answering a false success; a post-pop `None` verdict keeps the committed 200 + warning.

Chain from symptom to root cause: false 200 -> handler swallowed every reset exception as `teardown_incomplete` -> it never distinguished a pre-pop raise (old session survives on old value) from a post-pop raise (new value is what every replacement runs) -> route through the identity-probing helper that makes exactly that distinction.

### Reconciliation note (rebased onto current main)

This PR's branch had gone stale into a merge conflict. Main advanced four commits on `chat_handlers.py` since the branch's base, most relevantly #8998 (session-keyed switch lock via `AsyncExitStack`), which also grew both handlers a two-attempt decline ladder (`reset_ok` first attempt + an idle-decline retry). Main had NOT independently fixed #8664 -- both handlers still used the bare `except -> teardown_incomplete` shape at BOTH reset sites. The reconciliation:

- Kept main's superior identity-token rollback (`_CommitToken` + `_rollback_switch()`) instead of the branch's original value-compare CAS.
- Routed BOTH reset call sites per handler (first attempt + idle-decline retry) through `_reset_slot_session_or_warn`, mapping its `None` verdict to `teardown_incomplete` and its `bool` verdict to the ladder's `reset_ok`.
- Used `session_key` (from `effective_session_key(slot)`) rather than the branch's `_history_key_for(name)`, matching main's deliberate switch to the effective key.
- Did NOT thread a new `skip_if_busy` parameter through the helper. The branch's original design passed `skip_if_busy=False` from the agent/effort handlers (they had no decline ladder then); main's reconciled handlers keep their decline ladder, which needs the busy-decline, so all four callers resolve to `True`. A parameter no caller varies is unjustified surface, so the helper keeps main's fixed `skip_if_busy=True` and this PR adds no new signature -- it only routes the two handlers through the existing helper.

## Pattern harvest

Defect class: **a handler reported the outcome of a state transition before confirming the transition had actually committed.** Both handlers committed the new binding, then treated ANY exception from the teardown as "committed, teardown merely degraded" -- but a raise that fires BEFORE the session pop means the commit did not take effect on the live session at all, so the `200 + warning` described an outcome that had not occurred. The response was keyed on "an exception happened" rather than on "where in the transition it happened."

Generalises well beyond these two handlers: any commit-then-teardown (or commit-then-side-effect) path that maps all failures to one degraded-success answer has this bug latent, because the failure's POSITION relative to the point of no return is exactly what decides whether the commit stands. The fix shape is the reusable part: probe an identity that only exists on one side of the transition (here, the provider instance surviving the pop) and branch the answer on that probe, not on the mere presence of an exception.

What would catch it next time: a test that injects a raise on EACH side of the point of no return and asserts opposite outcomes (pre-commit-point -> propagate/rollback; post-commit-point -> committed success) -- `test_reset_raise_before_pop_propagates` and its successor-succeeds sibling are that pair, and the mutation that neuters the identity probe reddens both, which is the signal that the two sides are genuinely distinguished rather than collapsed. A reviewer heuristic falls out of it too: when a handler answers success-with-warning inside a broad `except`, ask which side of the commit the caught exception can come from -- if it can come from both, the answer is wrong for one of them.

Rule candidate: a handler must not report a state transition's outcome until the transition is confirmed committed -- a pre-commit-point failure propagates (error), a post-commit-point failure degrades (success + warning); branch on a probe of which side the failure occurred, never on the mere presence of an exception.

## What tests we did

- `test/test_chat_slot_reasoning_effort.py` -- 44 passed (incl. `test_reset_raise_before_pop_propagates`, successor-succeeds).
- `test/test_dashboard_chat.py` -- 768 passed (incl. `test_api_chat_slot_agent_reset_raise_before_pop_propagates`, `..._reset_raise_with_successor_succeeds`).
- `test/test_ask_question_roundtrip.py` -- 63 passed. `test/test_eager_spawn.py` -- 64 passed.
- Mutation check: neutering the helper's pre-pop re-raise (return `None` instead of raising) reddened BOTH handlers' `reset_raise_before_pop_propagates` tests on assertion, confirming the fix is load-bearing at both sites (re-verified after removing the parameter).
- `black --check`, `isort --check-only`, `flake8` clean on the changed file; `mypy` reports no errors in `chat_handlers.py` (2 pre-existing errors in the unrelated, untouched `transcribe.py` are main-owned).
- `git merge-tree --write-tree kirocrew/main HEAD` exits 0 against main `f4268fb5665d`.

This is a pure backend change with no rendered UI delta, so there is no screenshot to attach.

## Any other suggestions on the work

The issue's item 4 sketched a deeper fix: report degraded-teardown from `SessionManager.reset`'s own verdict (it pops before teardown), which would delete the outside-in identity probe entirely. That is a larger, cross-module change and is left as follow-up; this PR takes the helper route the issue prescribes as its primary task.

Closes #8664

