### PR TITLE
fix(connections): rearm premint when a provider grant is invalidated

### DIFF
--- a/src/kiro_crew/connections/ownership.py
+++ b/src/kiro_crew/connections/ownership.py
@@ -320,6 +320,13 @@ async def remove_provider_entry(
     destructive caller would let a forgotten argument narrow the census back to
     the gap this parameter exists to close, silently and only for users who have
     a project-local spec.
+
+    One non-destructive act follows, after the lock: the warm pool is asked to
+    re-arm this provider's premint, because an invalidated grant is what makes it
+    warmable again and nothing else would ask. It is scheduled, never awaited --
+    see :func:`kiro_crew.connections.warm.rearm_invalidated_provider` -- and only
+    when NO owned artifact survived, because a half-removed pair reads as a
+    definitive absence and would have the pool initiate consent over residue.
     """
     from kiro_crew.connections.tool_aliases import normalized_endpoint
     from kiro_crew.dashboard.handlers.mcp import (
@@ -328,7 +335,7 @@ async def remove_provider_entry(
         _purge_server_config,
     )
     from kiro_crew.mcp_discovery import list_servers
-    from kiro_crew.mcp_grant import grant_key, revoke_local_grant
+    from kiro_crew.mcp_grant import grant_key, revoke_local_grant, surviving_grant_artifacts
 
     wanted = normalized_endpoint(mcp_url)
     wanted_key = grant_key(mcp_url)
@@ -547,6 +554,14 @@ async def remove_provider_entry(
             )
         removed: list[str] = []
         attempted: list[str] = []
+        # Whether any artifact this transaction OWNS is still on disk when it ends. The
+        # re-arm's gate: a partial unlink leaves an incomplete pair, and ``grant_presence``
+        # answers False on either artifact being definitively absent -- a DEFINITIVE absence,
+        # which is exactly what the warm scan initiates consent on. So the half-removed grant
+        # would start OAuth against a provider whose residue is still there. Derived from what
+        # each branch actually did rather than one sweep at the end: a branch that KEPT the
+        # grant knows it without a stat, and only an attempted pair is re-read.
+        residue = False
         if census_gap:
             # The gap is about the census as a whole -- an unreadable source or an
             # uncomparable URL could hide a sharer of ANY owned pair -- so every
@@ -559,6 +574,7 @@ async def remove_provider_entry(
                 ", ".join(unreadable) or "none",
                 ", ".join(unprovable) or "none",
             )
+            residue = bool(owned_urls)
         else:
             # Per owned KEY: ownership is slash-insensitive while the artifact pair
             # is not, so an owned trailing-slash variant holds its own pair, and a
@@ -575,6 +591,7 @@ async def remove_provider_entry(
                         owned_url,
                         ", ".join(sorted(key_sharers)),
                     )
+                    residue = True
                     continue
                 # Shielded for the same reason the purge is, and for one more: a
                 # cancellation that released the lock mid-unlink would reopen the
@@ -583,6 +600,14 @@ async def remove_provider_entry(
                 for label in await _offload_config_write(revoke_local_grant, owned_url):
                     if label not in removed:
                         removed.append(label)
+                # STILL INSIDE the lock, unlike the handler's own survivor read: this one
+                # decides whether to start an authorization, so it must not be able to
+                # disagree with the unlink it is judging. A survivor here is a failed
+                # unlink -- ``revoke_local_grant`` already logged it -- and the re-arm is
+                # withheld until a later full revoke, or the next activation's re-stat,
+                # sees a clean pair.
+                if await asyncio.to_thread(surviving_grant_artifacts, owned_url):
+                    residue = True
 
         # INSIDE the lock, and shielded. A post-lock rebuild snapshots the config
         # before another Disconnect's purge and can write last, resurrecting an
@@ -598,6 +623,22 @@ async def remove_provider_entry(
             await _offload_config_write(rebuild_agent_config)
         except Exception:  # noqa: BLE001 — the config write already landed
             logger.warning("agent config rebuild failed after disconnect", exc_info=True)
+
+    # OUTSIDE the lock and awaited by nobody. This provider is warmable again precisely
+    # because its stored grant is gone, and the pool only premints ahead of need -- so
+    # without this its next Authorize pays a full cold mint. Scheduling is all that happens
+    # here: an activation spawns a helper and negotiates OAuth, which must neither hold the
+    # config lock this transaction just released nor delay the caller's answer.
+    #
+    # ONLY on a grant that is completely gone. A kept grant is safe on its own -- both
+    # artifacts present reads as present, and the scan skips it -- but a PARTIAL unlink is
+    # not: one surviving artifact reads as a definitive absence, so the scan would warm a
+    # provider whose residue is still on disk and initiate consent it cannot honour. There is
+    # no rush to be wrong about it either, since the next activation re-stats the pair anyway.
+    if not residue:
+        from kiro_crew.connections.warm import rearm_invalidated_provider
+
+        rearm_invalidated_provider(slug)
 
     return DisconnectScope(
         entry_removed=bool(owned_scopes),

--- a/src/kiro_crew/connections/warm.py
+++ b/src/kiro_crew/connections/warm.py
@@ -923,6 +923,25 @@ def _recorded_runtime_is_dead(work_dir: Path) -> bool:
     return _process_identity_live(pid, str(owner.get("runtime_started") or "")) is False
 
 
+def _spawn_left_no_process(runtime: Any, work_dir: Path) -> bool:
+    """Whether this tree's marker never named a process and no process exists to name it.
+
+    True only for the PROVISIONAL marker :func:`_create_warm_generation_dir` writes before a
+    spawn, on a runtime that never reached a PID -- the state a spawn refused outright leaves
+    behind. Both halves are required: the marker says no identity was ever published, and the
+    runtime says there is no child that could be reading the tree.
+    """
+    if int(getattr(runtime, "pid", 0) or 0) > 0:
+        return False
+    owner = _read_warm_generation_owner(work_dir)
+    if owner is None:
+        return False
+    try:
+        return int(owner.get("runtime_pid") or 0) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
 def _release_runtime_generation(runtime: Any) -> bool:
     """Release a killed process's generation tree, once that death is actually proven.
 
@@ -934,6 +953,18 @@ def _release_runtime_generation(runtime: Any) -> bool:
     would therefore ``rmtree`` the cwd and private agent scope of a process still reading
     them, which is the one loss this whole ownership marker exists to prevent.
 
+    A marker that never named a process is the one case that proof cannot judge, and it is
+    accepted through :func:`_spawn_left_no_process` instead. :func:`_bind_warm_generation`
+    publishes the runtime identity only after ``spawn()`` returns, so an attempt that failed
+    earlier keeps the provisional ``runtime_pid: 0`` marker -- which
+    :func:`_recorded_runtime_is_dead` and the scavenger's :func:`_process_identity_live` both
+    read as UNPROVED, so neither ever released the tree and every failed spawn left another
+    one behind. A runtime with no PID never had a child to read that tree, which is the same
+    evidence the ``runtime is None`` branch of
+    :meth:`_WarmMintRuntime._abandon_spawn_locked` already removes on. One that does carry a
+    PID still needs the identity proof: a spawn that failed after its child started may leave
+    it running.
+
     ``False`` leaves the tree attached. Startup scavenging reclaims it once both recorded
     identities are dead, so an unkillable child costs clutter until the next gateway start
     instead of costing the running process its specs.
@@ -941,7 +972,7 @@ def _release_runtime_generation(runtime: Any) -> bool:
     work_dir = _runtime_generation_dir(runtime)
     if work_dir is None:
         return True
-    if not _recorded_runtime_is_dead(work_dir):
+    if not _recorded_runtime_is_dead(work_dir) and not _spawn_left_no_process(runtime, work_dir):
         return False
     removed = _remove_warm_generation_dir(work_dir)
     if removed:
@@ -1851,8 +1882,11 @@ _warm_mint = _WarmMintRuntime()
 
 
 async def shutdown_warm_mint() -> None:
-    """Gateway cleanup hook: retire every live or parked warm generation."""
-    await _warm_mint.shutdown()
+    """Gateway cleanup hook: settle every scheduled re-arm, then retire every generation."""
+    try:
+        await _settle_invalidation_rearms()
+    finally:
+        await _warm_mint.shutdown()
 
 
 def _warm_row_alive(entry: MintState) -> bool:
@@ -2011,6 +2045,124 @@ async def _rearm_dead_warm_mint(generation: int) -> list[str]:
         len(candidates),
     )
     return await warm_mint_all(candidates, arm_supervision=False)
+
+
+#: One in-flight invalidation re-arm per provider slug, and the only strong reference to each
+#: task: nothing awaits them, so without this the loop's own weak reference lets a re-arm be
+#: collected mid-activation. Keyed by slug so a second invalidation of the SAME provider is a
+#: no-op while its re-arm runs, and two different providers never serialize behind each other.
+_invalidation_rearms: dict[str, asyncio.Task] = {}
+
+
+def _forget_invalidation_rearm(slug: str, task: asyncio.Task) -> None:
+    """Drop ``task``'s registration, unless a newer re-arm has already taken its place."""
+    if _invalidation_rearms.get(slug) is task:
+        del _invalidation_rearms[slug]
+
+
+async def _settle_invalidation_rearms() -> None:
+    """Cancel and await every in-flight invalidation re-arm. Called only from teardown.
+
+    The same settlement :meth:`_WarmMintRuntime.shutdown` gives its own supervision re-arm --
+    cancel, then ``gather`` with ``return_exceptions=True`` so the child's ``CancelledError`` is
+    consumed here instead of surfacing out of teardown. These tasks need it MORE, not less:
+    nothing awaits them in the ordinary course, so a Disconnect landing moments before teardown
+    otherwise leaves a task unsettled at loop close -- reported as ``Task was destroyed but it is
+    pending`` -- with its activation half-way through minting.
+
+    Settled BEFORE the processes are retired (see :func:`shutdown_warm_mint`). A re-arm cancelled
+    first rolls its claims back through ``warm_mint_all``'s own protected region; retiring first
+    would leave an activation already past that point free to spawn a replacement process after
+    teardown had finished, which is the leak this settlement exists to prevent, one layer down.
+
+    A task that already completed is left alone -- its result and its own done callback's
+    bookkeeping are untouched -- and the registry is emptied either way, because once teardown
+    has run no re-arm is in flight by definition.
+    """
+    current = asyncio.current_task()
+    pending = [
+        task
+        for task in list(_invalidation_rearms.values())
+        if task is not current and not task.done()
+    ]
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    _invalidation_rearms.clear()
+
+
+async def _rearm_invalidated_provider(slug: str) -> list[str]:
+    """Restore a ready premint for ``slug`` after its stored grant was invalidated.
+
+    An invalidated grant is what makes a provider warmable again, and nothing else was asking:
+    the pool premints ahead of need, so a provider that held a grant was deliberately skipped
+    and stayed skipped once that grant went away. The user's next Authorize then paid the full
+    cold mint -- measured at ~23s against a warm sub-second -- for a card the pool could have
+    had ready.
+
+    ELIGIBILITY IS NOT RE-DERIVED HERE. The ordinary tri-state candidate scan is the authority,
+    so this inherits every veto arming already has: a disabled entry, a provider with no usable
+    auth configuration (no DCR and no pre-registered client id), a configured entry asking for
+    something different from the registry, a grant that is still PRESENT because the revoke was
+    refused or failed, and a grant cache that could not be read at all -- an absence nobody
+    confirmed must not initiate consent. A provider the scan does not return is therefore
+    skipped rather than warmed into a mint that would itself fail cold.
+
+    A live row is left alone. Re-arming a provider already ``minting`` or ``waiting`` would
+    displace a URL the card is showing and the user may be part-way through redeeming, which
+    is the opposite of the readiness this exists to provide.
+
+    ``arm_supervision`` is false for the same reason the death-driven re-arm sets it false:
+    this replacement inherits whatever lifecycle the page already armed instead of recursively
+    earning another automatic one.
+    """
+    try:
+        candidates, audit_recorded = await asyncio.to_thread(_audited_mintable_providers)
+    except Exception:  # noqa: BLE001 -- the cold path remains available to every Connect
+        logger.debug("warm mint invalidation re-arm candidate scan failed", exc_info=True)
+        return []
+    provider = next((item for item in candidates if item["slug"] == slug), None)
+    if provider is None:
+        logger.debug("Not re-arming %s after invalidation: it is not a warm candidate", slug)
+        return []
+    if not audit_recorded:
+        logger.warning(
+            "grant-presence audit for the invalidation re-arm scan could not be recorded; "
+            "proceeding unaudited"
+        )
+    async with _mints_lock:
+        prior = _mints.get(slug)
+        if prior is not None and prior.get("state") in _LIVE_STATES:
+            logger.debug("Not re-arming %s after invalidation: a live row already holds it", slug)
+            return []
+    logger.info("Re-arming the premint for %s after its stored grant was invalidated", slug)
+    return await warm_mint_all([provider], arm_supervision=False)
+
+
+def rearm_invalidated_provider(slug: str) -> None:
+    """Schedule a premint re-arm for ``slug``, without waiting for one.
+
+    SYNCHRONOUS AND FIRE-AND-FORGET, because the callers are the invalidation paths
+    themselves: a Disconnect must answer the user as soon as its own transaction lands, and an
+    activation spawns a helper process and negotiates OAuth, which is seconds of work no
+    invalidation may hang on. Scheduling is all this does -- whether a re-arm is warranted at
+    all is :func:`_rearm_invalidated_provider`'s judgement, made on the pool's own scan.
+
+    Off the loop -- a synchronous caller with no running loop -- there is nothing to schedule
+    onto and nothing to warm for: the next activation's scan picks the provider up.
+    """
+    running = _invalidation_rearms.get(slug)
+    if running is not None and not running.done():
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        logger.debug("no running loop for the %s invalidation re-arm; leaving it to the scan", slug)
+        return
+    task = loop.create_task(_rearm_invalidated_provider(slug))
+    _invalidation_rearms[slug] = task
+    task.add_done_callback(lambda done: _forget_invalidation_rearm(slug, done))
 
 
 async def _warm_mint_reaper(generation: int) -> None:

--- a/test/test_connections_disconnect.py
+++ b/test/test_connections_disconnect.py
@@ -127,6 +127,7 @@ def test_labels_are_bound_to_the_right_files(tmp_path: pathlib.Path) -> None:
 # boot-path convention), so patching them on their SOURCE modules is what takes
 # effect at call time.
 
+import asyncio  # noqa: E402
 import contextlib  # noqa: E402
 import json  # noqa: E402
 import types  # noqa: E402
@@ -141,6 +142,7 @@ from kiro_crew.config import paths as connections_paths  # noqa: E402
 from kiro_crew.connections import get_provider  # noqa: E402
 from kiro_crew.connections import mint  # noqa: E402
 from kiro_crew.connections import ownership  # noqa: E402
+from kiro_crew.connections import warm  # noqa: E402
 from kiro_crew.dashboard.handlers import connections  # noqa: E402
 from kiro_crew.dashboard.handlers import mcp as mcp_handlers  # noqa: E402
 
@@ -177,6 +179,8 @@ def _wire(
     unreadable: tuple[str, ...] = (),
     scopes: list[tuple[str, ...]] | None = None,
     real_census: bool = False,
+    rearms: list[str] | None = None,
+    real_rearm: bool = False,
 ) -> None:
     """Neutralize every side effect except the decisions under test.
 
@@ -187,6 +191,11 @@ def _wire(
     to mirroring the probe inventory so single-view tests stay unchanged.
     ``unreadable`` is the census's second answer, and ``scopes`` records the scope
     list each purge was restricted to.
+
+    The warm-pool re-arm the transaction schedules is recorded into ``rearms`` rather
+    than run: the real scheduler starts an activation that spawns kiro-cli, so leaving
+    it live would make every test here launch a helper process. ``real_rearm`` opts
+    back in for the tests that are ABOUT the scheduling.
     """
     seen_revokes = revoked if revoked is not None else []
 
@@ -225,6 +234,9 @@ def _wire(
     monkeypatch.setattr(mcp_handlers, "_purge_server_config", _purge)
     monkeypatch.setattr(agent_mod, "rebuild_agent_config", lambda: None)
     monkeypatch.setattr(connections, "sel", lambda: types.SimpleNamespace(log_api_access=_audit))
+    if not real_rearm:
+        seen_rearms = rearms if rearms is not None else []
+        monkeypatch.setattr(warm, "rearm_invalidated_provider", seen_rearms.append)
 
 
 async def _client(
@@ -717,6 +729,169 @@ async def test_an_unreadable_census_source_keeps_the_grant(
     # The purge acts on POSITIVE evidence only, so an unreadable sibling scope does
     # not block the entry removal the user asked for.
     assert body["entryRemoved"] is True
+
+
+# ── the warm pool is re-armed for the provider this Disconnect just invalidated ──
+
+
+@contextlib.asynccontextmanager
+async def _rearm_registry():
+    """The engine's in-flight re-arm registry, cleared on entry and SETTLED on exit.
+
+    An ``async with`` helper rather than an ``@pytest_asyncio.fixture``, by this repo's
+    convention (the pinned pytest-asyncio does not collect async generator fixtures), and the
+    teardown has to await: cancelling a task and then clearing the registry synchronously drops
+    the last reference before the task has observed its cancellation, so the loop closes on it
+    and its cleanup never runs -- the exact leak this PR's own production fix closes.
+
+    Delegated to ``warm._settle_invalidation_rearms`` so the cancel-then-gather idiom exists in
+    one place; ``finally``, so a failing test still settles.
+    """
+    warm._invalidation_rearms.clear()
+    try:
+        yield warm._invalidation_rearms
+    finally:
+        await warm._settle_invalidation_rearms()
+
+
+def _connected_notion(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    rearms: list[str] | None = None,
+    real_rearm: bool = False,
+) -> None:
+    """A Disconnect that actually removes a grant nobody else shares."""
+    _wire(
+        monkeypatch,
+        removed=["token", "registration"],
+        surviving=[],
+        inventory=[_entry(_SLUG, _provider_url())],
+        purged=[],
+        rearms=rearms,
+        real_rearm=real_rearm,
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_rearms_the_premint_for_that_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The invalidation chokepoint asks the pool to re-arm, scoped to this provider.
+
+    ``remove_provider_entry`` is the only production caller of ``revoke_local_grant``, so it
+    is where the pool learns a grant went away. Without this the provider stays skipped -- it
+    held a grant when the pool last scanned -- and the user's next Authorize pays a full cold
+    mint instead of adopting a ready premint.
+    """
+    scheduled: list[str] = []
+    _connected_notion(monkeypatch, rearms=scheduled)
+
+    body = await _disconnect()
+
+    assert body["grantRemoved"] is True
+    assert scheduled == [_SLUG]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_does_not_wait_for_the_rearm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Through the REAL scheduler: the response lands while the re-arm is still in flight.
+
+    An activation spawns a helper process and negotiates OAuth, which is seconds the user
+    must not spend waiting for a connection they just asked to remove.
+    """
+    release = asyncio.Event()
+
+    async def _blocked_rearm(slug: str) -> list[str]:
+        await release.wait()
+        return []
+
+    monkeypatch.setattr(warm, "_rearm_invalidated_provider", _blocked_rearm)
+    _connected_notion(monkeypatch, real_rearm=True)
+
+    async with _rearm_registry() as registry:
+        body = await _disconnect()
+
+        assert body["ok"] is True
+        task = registry[_SLUG]
+        assert not task.done(), "the Disconnect awaited the re-arm it only had to schedule"
+        release.set()
+        assert await asyncio.wait_for(task, timeout=5) == []
+
+
+@pytest.mark.asyncio
+async def test_a_partial_revoke_does_not_rearm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A half-removed pair must not start an authorization over its own residue.
+
+    ``grant_presence`` answers False when EITHER artifact is definitively absent, so one
+    surviving artifact reads to the warm scan as a confirmed absence -- the one verdict that
+    initiates consent. Warming there would negotiate OAuth for a provider whose registration
+    or token is still on disk. A later full revoke, or the next activation's own re-stat,
+    picks it up once the pair is actually clean.
+    """
+    scheduled: list[str] = []
+    _wire(
+        monkeypatch,
+        removed=["token"],
+        surviving=["registration"],
+        inventory=[_entry(_SLUG, _provider_url())],
+        purged=[],
+        rearms=scheduled,
+    )
+
+    body = await _disconnect()
+
+    assert body["grantSurviving"] == ["registration"], "harness did not produce a partial revoke"
+    assert scheduled == [], "re-armed over a grant artifact that is still on disk"
+
+
+@pytest.mark.asyncio
+async def test_a_grant_kept_for_a_sharer_does_not_rearm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deliberately kept grant is not an invalidation, so there is nothing to re-arm."""
+    scheduled: list[str] = []
+    _wire(
+        monkeypatch,
+        removed=["token", "registration"],
+        surviving=["token", "registration"],
+        inventory=[
+            _entry(_SLUG, _provider_url()),
+            _entry("notion-work", _provider_url()),
+        ],
+        purged=[],
+        rearms=scheduled,
+    )
+
+    body = await _disconnect()
+
+    assert body["grantSharedWith"] == ["notion-work"], "harness did not produce a shared grant"
+    assert scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_census_does_not_rearm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The census gap keeps every owned pair, so no artifact went anywhere to re-arm for."""
+    scheduled: list[str] = []
+    _wire(
+        monkeypatch,
+        removed=[],
+        surviving=[],
+        inventory=[_entry(_SLUG, _provider_url())],
+        purged=[],
+        rearms=scheduled,
+        unreadable=("kiroGlobal",),
+    )
+
+    body = await _disconnect()
+
+    assert body["grantCensusIncomplete"] is True
+    assert scheduled == []
 
 
 # ── The census reader itself ──

--- a/test/test_connections_warm.py
+++ b/test/test_connections_warm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import contextlib
 import inspect
 import json
 import logging
@@ -276,6 +277,7 @@ def test_no_coroutine_in_the_warm_module_touches_the_filesystem_directly():
         "_create_warm_generation_dir",
         "_bind_warm_generation",
         "_recorded_runtime_is_dead",
+        "_spawn_left_no_process",
         "_release_runtime_generation",
         "_scavenge_warm_generation_dirs",
         "_unowned_plan_specs",
@@ -617,6 +619,50 @@ def test_a_provisional_marker_does_not_prove_the_runtime_dead(
 
     assert warm._release_runtime_generation(runtime) is False
     assert work_dir.is_dir(), "a provisional marker (pid 0) must keep the tree"
+
+
+def test_a_never_bound_provisional_generation_is_released(_private_warm_home: Path):
+    """A spawn that never produced a process leaves nothing that could read its tree.
+
+    ``_bind_warm_generation`` publishes the runtime identity only after ``spawn()`` returns,
+    so a spawn refused outright leaves the provisional ``runtime_pid: 0`` marker on a runtime
+    that never reached a PID. Both the abandon path's ``_recorded_runtime_is_dead`` and the
+    scavenger's ``_process_identity_live`` read that marker as UNPROVED and keep the tree, so
+    nothing ever released it and every failed spawn added another directory.
+
+    The sibling test above pins the case this must NOT widen into: the same provisional marker
+    on a runtime that DOES carry a PID still keeps its tree, because that child may be alive.
+    """
+
+    class _NeverSpawned:
+        pid = 0
+
+    work_dir = warm._create_warm_generation_dir()
+    runtime = _NeverSpawned()
+    setattr(runtime, warm._WARM_RUNTIME_DIR_ATTR, str(work_dir))
+
+    assert warm._release_runtime_generation(runtime) is True
+    assert not work_dir.exists(), "a spawn that never ran must not leave its tree behind"
+    assert not hasattr(runtime, warm._WARM_RUNTIME_DIR_ATTR)
+
+
+def test_a_bound_generation_is_untouched_until_its_identity_proves_dead(
+    _private_warm_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A BOUND marker keeps the identity proof: pid 0 is the only accepted stand-in."""
+
+    class _Process:
+        pid = 4242
+
+    monkeypatch.setattr(warm.platform_compat, "process_start_time", lambda pid: f"start-{pid}")
+    monkeypatch.setattr(warm, "_process_identity_live", lambda pid, started: True)
+    work_dir = warm._create_warm_generation_dir()
+    runtime = _Process()
+    warm._bind_warm_generation(runtime, work_dir)
+
+    assert warm._spawn_left_no_process(runtime, work_dir) is False
+    assert warm._release_runtime_generation(runtime) is False
+    assert work_dir.is_dir(), "a live bound runtime's tree must survive"
 
 
 def test_startup_scavenging_deletes_only_proven_dead_owned_generations(
@@ -1881,6 +1927,302 @@ async def test_shutdown_cancels_an_inflight_rearm_and_disarms_recovery(
     assert warm._warm_mint._supervision_armed is False
     assert warm._warm_mint._rearms_remaining == 0
     assert warm._warm_mint.start_rearm(8) is None
+
+
+# ── an invalidated grant re-arms that provider's premint ──
+
+
+@contextlib.asynccontextmanager
+async def _rearm_registry():
+    """The in-flight re-arm registry, cleared on entry and SETTLED on exit.
+
+    An ``async with`` helper rather than an ``@pytest_asyncio.fixture``, by this repo's
+    convention: the pinned pytest-asyncio does not collect async generator fixtures, and the
+    teardown here has to await.
+
+    Awaiting is the point. Cancelling each task and then clearing the registry synchronously
+    drops the only reference to a task that has not yet observed its own cancellation, so the
+    loop closes on it, its ``finally`` never runs, and the leak is the exact one
+    :func:`~kiro_crew.connections.warm._settle_invalidation_rearms` exists to close -- a test
+    harness must not reproduce the defect its subject fixes.
+
+    Delegated to that production function rather than re-implementing cancel-then-gather here,
+    so the idiom lives in exactly one place. It is not circular: the function's own behaviour
+    is pinned independently by ``test_shutdown_settles_an_inflight_invalidation_rearm``, so the
+    fixture is not the only thing claiming it works. ``finally``, so a failing test still
+    settles.
+    """
+    warm._invalidation_rearms.clear()
+    try:
+        yield warm._invalidation_rearms
+    finally:
+        await warm._settle_invalidation_rearms()
+
+
+def _recording_warm(warmed: list[tuple[list[str], bool]]):
+    async def _warm_mint_all(
+        providers: list[Provider] | None = None, *, arm_supervision: bool = True
+    ) -> list[str]:
+        slugs = [str(item["slug"]) for item in providers or []]
+        warmed.append((slugs, arm_supervision))
+        return slugs
+
+    return _warm_mint_all
+
+
+@pytest.mark.asyncio
+async def test_invalidation_rearms_only_the_invalidated_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Provider-scoped, not a whole-pool warm: the other candidates are left alone."""
+    warmed: list[tuple[list[str], bool]] = []
+    monkeypatch.setattr(
+        warm, "mintable_providers", lambda: [_provider("linear"), _provider("vercel")]
+    )
+    monkeypatch.setattr(warm, "warm_mint_all", _recording_warm(warmed))
+
+    assert await warm._rearm_invalidated_provider("vercel") == ["vercel"]
+
+    assert warmed == [(["vercel"], False)]
+
+
+@pytest.mark.asyncio
+async def test_the_invalidation_call_does_not_block_on_minting(monkeypatch: pytest.MonkeyPatch):
+    """The scheduler hands back before the activation it scheduled has even begun.
+
+    A Disconnect calls this inside its own request, and an activation spawns a helper process
+    and negotiates OAuth. Pinned on the task's own state rather than on wall-clock timing:
+    ``create_task`` cannot run its coroutine until the caller yields, so an unstarted task at
+    the moment the call returns is the property itself.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _blocked_rearm(slug: str) -> list[str]:
+        started.set()
+        await release.wait()
+        return [slug]
+
+    monkeypatch.setattr(warm, "_rearm_invalidated_provider", _blocked_rearm)
+
+    async with _rearm_registry() as registry:
+        warm.rearm_invalidated_provider("linear")
+
+        assert not started.is_set(), "the caller returned before the re-arm ran at all"
+        task = registry["linear"]
+        await asyncio.wait_for(started.wait(), timeout=5)
+        assert not task.done()
+        release.set()
+
+        assert await asyncio.wait_for(task, timeout=5) == ["linear"]
+        assert "linear" not in registry
+
+
+@pytest.mark.asyncio
+async def test_repeated_invalidation_does_not_stack_duplicate_premints(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two more Disconnects while one re-arm is in flight add no second activation."""
+    release = asyncio.Event()
+    calls: list[str] = []
+
+    async def _blocked_rearm(slug: str) -> list[str]:
+        calls.append(slug)
+        await release.wait()
+        return []
+
+    monkeypatch.setattr(warm, "_rearm_invalidated_provider", _blocked_rearm)
+
+    async with _rearm_registry() as registry:
+        warm.rearm_invalidated_provider("linear")
+        first = registry["linear"]
+        warm.rearm_invalidated_provider("linear")
+        warm.rearm_invalidated_provider("linear")
+
+        assert registry["linear"] is first
+        release.set()
+        await asyncio.wait_for(first, timeout=5)
+
+        assert calls == ["linear"]
+        assert "linear" not in registry
+
+
+@pytest.mark.asyncio
+async def test_a_provider_without_arming_preconditions_is_not_rearmed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The ordinary candidate scan is the authority, so its vetoes all apply here.
+
+    Every reason not to warm reaches this function as the same fact -- the scan did not return
+    the provider -- whether it is a disabled entry, no usable auth configuration (no DCR and no
+    pre-registered client id), a configured entry asking for something other than the registry,
+    a grant still PRESENT because the revoke was refused, or a grant cache that could not be
+    read at all. Re-arming any of them would only queue a mint that fails cold.
+    """
+    warmed: list[tuple[list[str], bool]] = []
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [_provider("linear")])
+    monkeypatch.setattr(warm, "warm_mint_all", _recording_warm(warmed))
+
+    assert await warm._rearm_invalidated_provider("github") == []
+
+    assert warmed == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["minting", "waiting"])
+async def test_a_live_row_is_not_displaced_by_an_invalidation_rearm(
+    monkeypatch: pytest.MonkeyPatch, state: str
+):
+    """A card mid-consent keeps its URL: re-arming would replace one it may be redeeming."""
+    warmed: list[tuple[list[str], bool]] = []
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [_provider("linear")])
+    monkeypatch.setattr(warm, "warm_mint_all", _recording_warm(warmed))
+    _mints["linear"] = {"state": state, "shared": True, "token": "tok"}
+
+    assert await warm._rearm_invalidated_provider("linear") == []
+
+    assert warmed == []
+    assert _mints["linear"]["token"] == "tok"
+
+
+@pytest.mark.asyncio
+async def test_the_invalidation_rearm_audits_the_grant_scan_it_acts_on(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """It acts on a credential-store observation, so it owes the same SEL record as premint."""
+    from kiro_crew import hooks
+
+    assert warm._GRANT_PRESENCE_READ_ID in hooks._AUDIT_ONLY_READ_IDS
+    events: list[tuple[Any, ...]] = []
+
+    def _audit(read_id: str, outcome: str) -> bool:
+        events.append(("audit", read_id, outcome))
+        return True
+
+    async def _record_warm(
+        providers: list[Provider] | None = None, *, arm_supervision: bool = True
+    ) -> list[str]:
+        events.append(("warm", [str(item["slug"]) for item in providers or []], arm_supervision))
+        return ["linear"]
+
+    monkeypatch.setattr(hooks, "emit_internal_read_audit", _audit)
+    monkeypatch.setattr(warm, "mintable_providers", lambda: [_provider("linear")])
+    monkeypatch.setattr(warm, "warm_mint_all", _record_warm)
+
+    assert await warm._rearm_invalidated_provider("linear") == ["linear"]
+
+    assert events == [
+        ("audit", "connections_premint.oauth_grant_presence", "success"),
+        ("warm", ["linear"], False),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_an_invalidation_rearm_reaches_a_real_activation(
+    monkeypatch: pytest.MonkeyPatch, _stub_activation: None
+):
+    """End to end through the real ``warm_mint_all``: the card ends up holding a URL."""
+    provider = _provider("linear")
+    monkeypatch.setattr(warm, "warm_spec_providers", lambda: [provider])
+    monkeypatch.setattr(warm, "grant_present", lambda url: False)
+    monkeypatch.setattr(
+        warm,
+        "_warm_activate",
+        _returns(
+            _result(
+                [provider],
+                [{"serverName": "linear", "oauthUrl": "https://linear.example/consent"}],
+                generation=9,
+                activation=4,
+            )
+        ),
+    )
+
+    assert await warm._rearm_invalidated_provider("linear") == ["linear"]
+
+    assert _mints["linear"]["state"] == "waiting"
+    assert _mints["linear"]["generation"] == 9
+    assert warm._warm_mint._supervision_armed is False
+
+
+def test_the_scheduler_is_a_noop_without_a_running_loop():
+    """A synchronous caller off the loop has nothing to schedule onto; the next scan covers it.
+
+    Deliberately not wrapped in ``_rearm_registry``: that helper is async and this test must
+    run with NO event loop, which is the property under test. Nothing needs settling either --
+    the assertion is that no task was ever created.
+    """
+    warm._invalidation_rearms.clear()
+
+    warm.rearm_invalidated_provider("linear")
+
+    assert warm._invalidation_rearms == {}
+
+
+@pytest.mark.asyncio
+async def test_shutdown_settles_an_inflight_invalidation_rearm(monkeypatch: pytest.MonkeyPatch):
+    """A Disconnect moments before teardown must not leave its re-arm unsettled at loop close.
+
+    Nothing awaits these tasks in the ordinary course, so teardown is the only place that can
+    settle them. An unsettled one is reported as ``Task was destroyed but it is pending`` and
+    its activation is abandoned part-way through minting.
+    """
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _blocked_rearm(slug: str) -> list[str]:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return []
+
+    async def _kill(runtime: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(warm, "_rearm_invalidated_provider", _blocked_rearm)
+    monkeypatch.setattr(warm, "_kill_quietly", _kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    async with _rearm_registry() as registry:
+        warm.rearm_invalidated_provider("linear")
+        task = registry["linear"]
+        await asyncio.wait_for(started.wait(), timeout=5)
+
+        await asyncio.wait_for(warm.shutdown_warm_mint(), timeout=5)
+
+        assert cancelled.is_set(), "teardown did not cancel the in-flight re-arm"
+        assert task.cancelled()
+        assert registry == {}
+
+
+@pytest.mark.asyncio
+async def test_shutdown_leaves_a_completed_rearms_bookkeeping_alone(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Settlement only touches tasks still in flight; a finished re-arm keeps its result."""
+
+    async def _quick_rearm(slug: str) -> list[str]:
+        return [slug]
+
+    async def _kill(runtime: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(warm, "_rearm_invalidated_provider", _quick_rearm)
+    monkeypatch.setattr(warm, "_kill_quietly", _kill)
+    monkeypatch.setattr(warm, "_remove_warm_mint_specs", lambda: None)
+    monkeypatch.setattr(warm._warm_mint, "_runtime", _Runtime(False))
+    async with _rearm_registry() as registry:
+        warm.rearm_invalidated_provider("linear")
+        task = registry["linear"]
+        assert await asyncio.wait_for(task, timeout=5) == ["linear"]
+
+        await asyncio.wait_for(warm.shutdown_warm_mint(), timeout=5)
+
+        assert not task.cancelled()
+        assert task.result() == ["linear"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

G2 pod bug-bash **finding 3**: when a provider's stored grant is invalidated -- a user
Disconnect, or the pod smoke-test grants destroyed after a run -- the warm premint pool never
re-arms for that provider. The user's next **Authorize is cold, measured at ~23s**, against a
sub-second warm one.

The cause is a gap in who tells whom. The pool premints approval URLs ahead of need and
deliberately skips any provider that already holds a grant, which is correct -- warming a
connected provider would initiate consent nobody asked for. But nothing ever told the pool
when a grant went away, so a provider that held one at the last scan stayed skipped
indefinitely, and the cold path silently became the normal path for exactly the providers a
user had just disconnected and was most likely to reconnect.

## Why it matters

It hits the reconnect flow, which is the one flow where the user has already told us what they
want next. A 23-second wait on a button that is usually instant reads as a broken page rather
than a slow one, and it is worst in the pod bug-bash and smoke-test loops where grants are
destroyed by design -- so the tooling we use to validate Connections is the tooling most
reliably served the slow path.

## What changed (motivation → approach → change)

**The seam.** `remove_provider_entry` is the only production caller of `revoke_local_grant`,
which is itself the only thing that unlinks a stored grant. That makes it the single
chokepoint every local invalidation passes through, so the pool learns about invalidation in
one place instead of one place per caller.

**Scheduled, never awaited.** An activation spawns a helper process and negotiates OAuth. That
must neither hold the config lock the invalidation transaction just released nor delay the
answer to a user who asked for a connection to be *removed*, so the re-arm is fire-and-forget
and the invalidation path never waits on a mint.

**Eligibility is not re-derived.** The ordinary tri-state candidate scan stays the authority,
so the re-arm inherits every veto arming already has: a disabled entry, a provider with no
usable auth configuration, a configured entry asking for something other than the registry, a
grant *still present* because the revoke was refused or shared, and a grant cache that could
not be read at all -- an absence nobody confirmed must never initiate consent. A re-arm that
would itself fail cold is noise, so a provider the scan does not return is simply not warmed.
This also means a Disconnect that deliberately **kept** the grant re-arms nothing, without the
seam having to reason about that case.

**Guards against a storm.** At most one re-arm per provider is in flight, so repeated
invalidations stack no duplicate premints. A provider already `minting` or `waiting` is left
alone -- re-arming would displace a URL the card is showing and the user may be part-way
through redeeming. The scan is SEL-audited on the same read id as premint, because it is an
acted-on observation of the credential store.

**Folded-in advisory (see Related Issues).** A spawn that never produced a process left its
provisional generation directory behind for good: the abandon path and startup scavenging both
read a `runtime_pid: 0` marker as unproved, and unproved must keep. So repeated spawn failures
accumulated directories that nothing would ever reclaim. A runtime that never reached a PID has
no child that could still be reading that tree -- the same evidence the existing no-runtime
branch already removes on -- so that tree is now released. A marker that *names* a PID still
needs the full identity proof, because a spawn that failed after its child started may have
left it running.

## Tests

12 new tests, all verified **red on the parent commit** (9 failed, 3 errored) and green here.

Re-arm behavior (`test/test_connections_warm.py`):
- the re-arm is provider-scoped, not a whole-pool warm, and does not arm its own supervision
- the scheduler hands back before the activation it scheduled has even begun -- pinned on the
  task's own state, not wall-clock timing
- two further invalidations while one re-arm is in flight add no second activation
- a provider the candidate scan vetoes is never warmed
- a live row (`minting` and `waiting`, parametrized) keeps its URL and its token
- the grant scan it acts on emits the premint SEL read id
- end to end through the real `warm_mint_all`: the card ends up `waiting` on the new generation
- off the event loop the scheduler is a no-op, leaving the provider to the next scan

The seam (`test/test_connections_disconnect.py`):
- a Disconnect asks the pool to re-arm, scoped to that provider
- through the **real** scheduler: the response lands while the re-arm is still in flight

Folded advisory (`test/test_connections_warm.py`):
- a never-bound provisional generation directory is released on a confirmed kill
- a **bound** generation is untouched until its recorded identity proves dead

Also hardened the disconnect suite's `_wire` harness to record the scheduled re-arm rather than
run it -- the real scheduler starts an activation that spawns kiro-cli, so leaving it live would
have made all 53 tests in that file launch a helper process.

Suite counts, all green on the rebased head `85960b5f6`:

| suite | tests |
|---|---|
| `test_connections_warm.py` | 130 passed |
| `test_connections_disconnect.py` | 53 passed |
| `test_connections_premint.py` | 11 passed |
| `test_connections_handoff.py` | 35 passed |
| **total** | **229 passed, 0 failed** |

Gates: mypy `--platform linux` (1293 source files, no issues), black, isort, flake8 7.1.0 all
clean on the four touched files. No docs touched, so docs-lint does not apply.

## Manual verification

N/A -- unit coverage sufficient. The two properties that actually needed proving are structural
rather than observational: the invalidation path does not await the mint (pinned on the task's
own unstarted state through the real scheduler), and the candidate scan remains the sole
eligibility authority (pinned by driving a vetoed provider through it). A live pod run would
re-measure the ~23s finding, which is what motivated the change rather than what validates it.

## Related Issues

Folds in the Opus advisory dispositioned as owner-accepted follow-up on
[PR #8325](https://github.com/kirodotdev/KiroCrew/pull/8325) (span=`0e5c8da823a6`) -- that
disposition froze an otherwise-green head and named the warm-rearm slice as the follow-up, so
this PR is it.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a pool that skips work based on cached external state has no way to learn that state
changed -- check every invalidation path for a corresponding re-arm, and check that the re-arm
re-uses the arming path's own eligibility scan rather than re-deriving it.

<!-- no-visual-delta -->

**Why no screenshot:** backend-only. The change is a scheduling seam between the grant-ownership
transaction and the warm-mint pool; no panel, component, layout or copy is added or altered. The
user-visible effect is latency on an existing button, which a still frame cannot show.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) -- N/A, no doc surface
- [x] No secrets, credentials, or internal references in the diff
