### PR TITLE
refactor(probes): flatten the watch collapse and correct its comments

### DIFF
--- a/src/kiro_crew/probes/gh_pr.py
+++ b/src/kiro_crew/probes/gh_pr.py
@@ -106,12 +106,12 @@ _PINNABLE_HOST = "github.com"
 #: MUST stay below the kernel's ``realert_secs``: the kernel drops sticky dedupe
 #: keys once they pass that window, and what stops a dropped key from being
 #: re-reported is this filter having aged the signal out first. Asserted below
-#: rather than merely documented -- three doc comments claiming an invariant that
-#: nothing checked is what let it drift this far.
+#: rather than merely documented, because a doc comment claiming an invariant
+#: nothing checks does not hold it.
 #:
-#: A constant rather than a cron parameter: as a parameter it had no caller, and
-#: its only distinct capability was misconfiguring the watch into re-waking for
-#: the same comment every re-alert window.
+#: A constant rather than a cron parameter: as a parameter it has no caller, and
+#: its only distinct capability would be misconfiguring the watch into re-waking
+#: for the same comment every re-alert window.
 DEFAULT_COMMENT_HORIZON_SECS = 5 * 3600.0
 
 assert DEFAULT_COMMENT_HORIZON_SECS < DEFAULT_REALERT_SECS, (
@@ -125,11 +125,15 @@ _FAILING = {"FAILURE", "ERROR", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE
 _PASSING = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 #: Noise, not signal (see module docstring).
 _NOISE = {"CANCELLED", "STALE"}
+#: Not settled yet; the empty string is a row carrying neither a conclusion nor a
+#: state.
+_PENDING = {"PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", ""}
 
 #: Wake-a-brain conservativeness order, used ONLY when timestamps cannot
-#: arbitrate duplicate rows (a queued rerun has no startedAt yet): a row that
-#: says "something may be wrong or unfinished" must not lose to an older
-#: "all good" row just because it has no clock value.
+#: arbitrate duplicate rows (a queued rerun has no startedAt yet, and a
+#: StatusContext never has one): a row that says "something may be wrong or
+#: unfinished" must not lose to an "all good" row just because that row has a
+#: clock value and this one does not.
 _CONSERVATIVE = {"failing": 3, "pending": 2, "passing": 1, "noise": 0}
 
 _WAKE_TAIL = (
@@ -159,7 +163,7 @@ def _bucket(item: dict) -> tuple[str, str]:
         return name, "passing"
     if conclusion in _NOISE:
         return name, "noise"
-    if conclusion in ("PENDING", "EXPECTED", "QUEUED", "IN_PROGRESS", ""):
+    if conclusion in _PENDING:
         return name, "pending"
     # Unknown vocabulary: err on the side of waking a brain to look at it.
     return name, "failing"
@@ -183,7 +187,13 @@ def _collapse(rollup: list) -> list[tuple[str, str, str]]:
     ``(workflowName, name)`` and keep the NEWEST row by ``startedAt`` --
     recency is the correct arbiter in both directions, since a rerun-green
     supersedes a stale red and a rerun-red supersedes a stale green.
-    ISO-8601 timestamps order lexically; a missing ``startedAt`` sorts oldest.
+    ISO-8601 timestamps order lexically, so a plain string compare picks the
+    newer row. When EITHER row has no ``startedAt`` recency cannot arbitrate at
+    all, and the more conservative bucket wins instead -- see ``_CONSERVATIVE``.
+    A dateless failing row therefore beats a dated passing one, which is the
+    point: a row may be undated because it is a just-queued rerun or because it
+    is a StatusContext, which carries ``createdAt`` and no start time at all --
+    so silence about when it began is never evidence that it is stale.
     """
     per_key: dict[tuple[str, str], tuple[str, str]] = {}
     for item in rollup:
@@ -202,7 +212,8 @@ def _collapse(rollup: list) -> list[tuple[str, str, str]]:
             details = str(item.get("detailsUrl") or "")
             if details:
                 parsed = urlparse(details)
-                segment = parsed.path.strip("/").split("/", 1)[0] if parsed.path.strip("/") else ""
+                path = parsed.path.strip("/")
+                segment = path.split("/", 1)[0] if path else ""
                 workflow = sanitize_label(
                     f"{parsed.netloc}/{segment}" if segment else parsed.netloc
                 )
@@ -211,10 +222,12 @@ def _collapse(rollup: list) -> list[tuple[str, str, str]]:
         prev = per_key.get(key)
         if prev is None:
             per_key[key] = (started, bucket)
-        elif started and prev[0]:
-            if started >= prev[0]:
+            continue
+        prev_started, prev_bucket = prev
+        if started and prev_started:
+            if started >= prev_started:
                 per_key[key] = (started, bucket)
-        elif _CONSERVATIVE[bucket] > _CONSERVATIVE[prev[1]]:
+        elif _CONSERVATIVE[bucket] > _CONSERVATIVE[prev_bucket]:
             per_key[key] = (started, bucket)
 
     # Workflow-qualified display identity: "workflow / name" when the two
@@ -291,6 +304,7 @@ class PrWatchProbe(Probe):
 
     repo: str
     pr: int
+    host: str
     known_reds: set[str]
     wake_on_green: bool
     note: str
@@ -351,10 +365,6 @@ class PrWatchProbe(Probe):
         # against bool explicitly and refuse everything else -- a nonsense flag
         # is a permanently-invalid config, terminal (ValueError -> Done) like
         # every other malformed field here.
-        #
-        # This arrived on main as #7665 while this branch was moving the probe
-        # out of the skill script; it is ported here rather than dropped,
-        # because this module now owns the parsing it was written against.
         raw_wake = params.get("wake_on_green", True)
         if not isinstance(raw_wake, bool):
             raise ValueError("pr_watch wake_on_green must be true or false")
@@ -611,9 +621,9 @@ class PrWatchProbe(Probe):
 
         Both describe the delivery, not any one signal: the note is what this
         watch was armed for, and the tail tells the woken agent what to do with
-        a wake in general. Emitting them per observation is what made a
-        well-coalesced wake expensive -- six observations meant six copies, 56%
-        of the delivered bytes on a measured real wake.
+        a wake in general. Emitting them per observation instead costs one copy
+        per observation, which on a well-coalesced wake of half a dozen is most
+        of the delivered bytes.
         """
         lines = []
         if self.note:
@@ -627,8 +637,9 @@ class PrWatchProbe(Probe):
         # than rendered empty.
         #
         # This describes ONE observation and nothing else. The note and the
-        # standing instructions moved to wake_suffix(), because the kernel joins
-        # N of these into one body and anything per-observation is paid N times.
+        # standing instructions live in wake_suffix() instead, because the kernel
+        # joins N of these into one body and anything per-observation is paid N
+        # times.
         subject = f"{self.repo}#{self.pr}"
         if head:
             subject += f" (head {head[:9]})"

--- a/src/kiro_crew/probes/targets.py
+++ b/src/kiro_crew/probes/targets.py
@@ -3,10 +3,9 @@
 The point of this module is that nothing new has to be passed in. A babysit
 instruction already names its subject -- "Babysit PR #7491
 (kirodotdev/KiroCrew, branch ...)" -- so asking the caller to also supply a
-target parameter would add an opt-in, and an opt-in is what the previous
-attempts at this saving died of: the parameter existed, nobody passed it, and
-the measured adoption was zero. Inference has no adoption problem because there
-is nothing to adopt.
+target parameter would add an opt-in, and an opt-in only pays off for the
+callers that remember to pass it. Inference has no adoption problem because
+there is nothing to adopt.
 
 The whole design leans on one asymmetry. Failing to infer costs a loop that
 keeps its existing timer -- today's behaviour, no regression. Inferring the
@@ -43,18 +42,16 @@ _PR_URL = re.compile(
 #: ``owner/name#123``. NOT a gating source -- see :func:`infer` for why a shorthand
 #: cannot decide a subject -- but still needed to notice that the text names ANOTHER
 #: pull request besides the URL, which is what makes the URL ambiguous rather than
-#: authoritative. Round 23 deleted this pattern outright and that went too far: with
-#: only URLs scanned, "drive owner/name#42; blocked on <URL for #7>" silently gated
-#: on the BLOCKER, so #7 merging retired a loop whose own work was #42.
+#: authoritative. Scanning URLs alone is not enough: with no shorthand scan, "drive
+#: owner/name#42; blocked on <URL for #7>" gates on the BLOCKER, so #7 merging
+#: retires a loop whose own work is #42.
 #:
 #: The lookbehind refuses a PATH fragment. A babysit instruction routinely cites
 #: source locations, and ``src/kiro_crew/autonudge.py#1751`` would otherwise read as
 #: owner ``kiro_crew`` / repo ``autonudge.py`` / PR 1751 -- so it would manufacture
 #: an ambiguity out of a line reference and refuse to gate anything.
 #:
-#: Quantifiers bounded for the same reason as the URL pattern's, and this is the one
-#: CodeQL flagged: it scans arbitrary prose looking for a SECOND reference, so it
-#: reads the whole instruction rather than stopping at a match.
+#: Quantifiers bounded for the same reason as the URL pattern's.
 _PR_SHORTHAND = re.compile(
     r"(?<![A-Za-z0-9._/#-])"
     r"(?P<owner>[A-Za-z0-9._-]{1,39})/(?P<repo>[A-Za-z0-9._-]{1,100})#(?P<pr>\d+)\b"
@@ -74,7 +71,7 @@ _PR_SHORTHAND = re.compile(
 #: -- it stops at the first token that is neither -- so a later unrelated ``#7511``
 #: elsewhere in the instruction is not swept in.
 _PR_BARE = re.compile(
-    r"\b(?:PRs?|pull requests?)\s*" r"(?P<chain>#\d{1,12}(?:\s*(?:,|and|&)\s*#\d{1,12})*)",
+    r"\b(?:PRs?|pull requests?)\s*(?P<chain>#\d{1,12}(?:\s*(?:,|and|&)\s*#\d{1,12})*)",
     re.IGNORECASE,
 )
 
@@ -115,16 +112,14 @@ def infer(text: str) -> Target | None:
 
     found: set[tuple[str, str, int]] = set()
     # ONLY an explicit public pull-request URL gates a loop. A bare
-    # ``owner/name#123`` was accepted here for several rounds and it proves
-    # neither of the two things this decision needs:
+    # ``owner/name#123`` proves neither of the two things this decision needs:
     #
     # * not that the subject is a PULL REQUEST -- ``#123`` is equally an issue
     #   reference, and a same-numbered pull request may exist and be merged, which
     #   would retire a loop that was watching the issue;
     # * not WHICH SERVER it lives on -- a shorthand resolves through the operator's
     #   ambient gh configuration, so on an enterprise host the same slug names a
-    #   different repository. That ambiguity produced three separate review
-    #   findings on its own.
+    #   different repository.
     #
     # Requiring the full URL also narrows what an agent-written message can cause:
     # a credentialed (audited, read-only, fixed-argv) gh call now happens only for
@@ -168,25 +163,29 @@ def infer(text: str) -> Target | None:
         if (other.group("owner"), other.group("repo"), other_number) != (owner, repo, number):
             return None
     # The same argument for the BARE form, which is how a person actually writes it:
-    # "Babysit PR #42; blocked on <URL for #7>" gated on #7, so #7 merging retired a
-    # loop whose real work on #42 was unfinished. Only a DIFFERENT number refuses --
-    # "watch PR #42 <URL for #42>" is one subject named twice, which is the ordinary
-    # phrasing and must keep gating. Over-refusing costs tokens; under-refusing stops
-    # work, so this resolves the way the rest of the design does.
+    # "Babysit PR #42; blocked on <URL for #7>" would otherwise gate on #7, so #7
+    # merging retires a loop whose real work on #42 is unfinished. Only a DIFFERENT
+    # number refuses -- "watch PR #42 <URL for #42>" is one subject named twice, which
+    # is the ordinary phrasing and must keep gating. Over-refusing costs tokens;
+    # under-refusing stops work, so this resolves the way the rest of the design does.
     for bare in _PR_BARE.finditer(text):
         for found_number in _PR_BARE_NUMBER.findall(bare.group("chain")):
             try:
-                if int(found_number) != number:
-                    return None
+                bare_number = int(found_number)
             except ValueError:
                 continue
+            if bare_number != number:
+                return None
     slug = f"{owner}/{repo}"
-    config: dict[str, object] = {"repo": slug, "pr": number}
-    # Always pinned, because the only spelling that reaches here NAMED the host.
-    # The pin stops an ambient ``GH_HOST`` from re-pointing the slug at a
-    # different server, where a same-numbered pull request could be merged and
-    # retire a watch on a live one.
-    config["host"] = _PUBLIC_HOST
+    config: dict[str, object] = {
+        "repo": slug,
+        "pr": number,
+        # Always pinned, because the only spelling that reaches here NAMED the
+        # host. The pin stops an ambient ``GH_HOST`` from re-pointing the slug at
+        # a different server, where a same-numbered pull request could be merged
+        # and retire a watch on a live one.
+        "host": _PUBLIC_HOST,
+    }
     return Target(
         kind=GH_PR,
         subject=f"{slug}#{number}",


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/probes/` had never been through the module-simplification sweep, and it
had accumulated the two things that sweep exists to remove.

**Comments written as a review log.** `gh_pr.py` and `targets.py` explained their own
rules with a PR number (`#7665`), a review-round marker (`Round 23 deleted this pattern
outright`), a scanner attribution (`this is the one CodeQL flagged`), a finding count
(`produced three separate review findings`), and past-tense narration about how each
rule reached its current shape. `AGENTS.md` § Code style forbids all of these: a comment
states current behavior and its reason, and that history lives in git.

**Two comments that were simply false** — found by checking every rewritten claim against
the adjacent code rather than trusting the prose, which is the part of this work that is
not cosmetic:

1. `_collapse`'s docstring ended *"a missing `startedAt` sorts oldest"*. A row with no
   timestamp is not sorted at all: when **either** row is undated the recency compare is
   skipped and the more conservative bucket wins, so an undated `failing` row **beats** a
   dated `passing` one — verified against a `2099` timestamp. The docstring pointed the
   wrong way on the one axis that matters for a watch probe (whether a possibly-broken
   row can be swallowed by a green one) and contradicted `_CONSERVATIVE`'s own note 50
   lines above. `_CONSERVATIVE`'s *"must not lose to an **older** all-good row"* is
   corrected the same way: that branch reads no dates, so `older` was aspirational.
2. `_PR_SHORTHAND`'s quantifier bound was justified because the pattern *"reads the whole
   instruction rather than stopping at a match"*. It is the **URL** loop that runs to
   completion (it cannot know whether a second subject exists without seeing them all);
   the shorthand loop `return None`s on the first differing match.

## Why it matters

A stale comment flipped to confident present tense misleads the next reader worse than
the stale one did, so a comment sweep that does not verify its claims makes things worse.
Both false comments are about how a red check can be suppressed — exactly the reasoning a
maintainer would lean on when changing this arbitration, and exactly where being wrong is
expensive. `AUTOSDE.yaml`'s `recurring-defect-patterns` names "a docstring or comment that
CONTRADICTS the code below it" as a class that has shipped as a bug here before.

## What changed (motivation → approach → change)

Backend-only, two files, **no behavior change anywhere**.

**Comment hygiene** — six task-log citations dropped, the surviving rationale restated in
present tense, and the two false claims above corrected. For each removal I checked
whether a *constraint a future editor needs* went with the provenance; none did (e.g. the
`#7665` paragraph's load-bearing part — do not coerce `wake_on_green` from a string,
because `bool("false")` is `True` — survives verbatim beside the validator).

**Three structural simplifications:**

- `_collapse` unpacks the stored `(started, bucket)` pair into `prev_started` /
  `prev_bucket` instead of reading `prev[0]` / `prev[1]`, and returns early on the
  first-row case, so the recency-versus-conservativeness arbitration reads as one flat
  chain. `parsed.path.strip("/")` is computed once instead of twice.
- `_bucket`'s pending vocabulary becomes the module constant `_PENDING`, matching
  `_FAILING` / `_PASSING` / `_NOISE` rather than an inline tuple literal.
- `infer` parses a bare chain number the way its two sibling int parses already do —
  assign inside the `try`, compare after it — dropping one nesting level. `int()` is the
  only `ValueError` source there, so the guarded region is unchanged.

Plus two accuracy fixes: `PrWatchProbe` now declares `host`, which `identity()` assigns
and `_fetch()` reads but the attribute block omitted; and `infer` builds its probe config
as one dict literal instead of a literal followed by `config["host"] = …` (which also
removes the window where the config exists without its host pin).

**Deliberately not done**, so a reviewer can see they were considered:

- **The three chained ternaries the detector still reports repo-wide** are all in
  `acp/client.py`, a different module. One module per PR.
- **Documenting `host` in the module docstring's "Message format" block.** It is a real
  validated message key, but the code comment at its parse site says it is expressly *not
  a configuration point* — only `targets.infer` sets it, to one constant. Listing it in an
  operator-facing format block would contradict that.
- **`Target.host_key`'s `"default"` value** is currently unreachable (`infer` is the only
  constructor and always passes the public host). Removing the default changes a
  constructor contract, which is a design call for the second probe kind, not a comment
  sweep.
- **`test/test_probe_targets.py`'s own docstring** still carries the CodeQL attribution
  and first-person narration this PR removed from the code. Real, but it is a different
  file this PR does not otherwise touch — a "while I'm here" fix belongs in its own PR.
- **`_PR_URL`'s ReDoS rationale** (`targets.py:32-36`) claims an unbounded `+` there is a
  polynomial shape; measurement did not reproduce that as quadratic, because the literal
  `http` prefix search rejects most start positions first. Unchanged by this PR and left
  alone: correcting it means re-deciding why those bounds exist, which is wider than this
  diff.

## Tests

No test changes — this PR adds no behavior to lock in, and a test asserting a comment's
text would be the wrong instrument. Existing coverage already pins what the corrected
docstring now describes: `test_babysit_pr_watch.py::test_queued_rerun_without_timestamp_blocks_false_ready`
asserts that an undated rerun row must not lose to an older green row and produce a false
all-green wake — i.e. the behavior the old docstring described backwards.

167 tests across `test_babysit_pr_watch.py`, `test_probe_targets.py`,
`test_babysit_guidance_gates.py` and `test_irq.py` pass, plus the 824 in the wider
`test_irq` / `test_autonudge*` / `test_monitor_*` / `test_github_pull_request_monitor` set.

## Manual verification

N/A — unit coverage sufficient, and equivalence was established mechanically rather than
by inspection:

- **`_collapse`**: exhaustive differential over all 1,884 possible 1–3-row input sequences
  (3 timestamp values × 4 buckets), pre-diff vs post-diff — **0 divergences**. Independently
  reproduced by a reviewer at 40,000 and 60,000 randomized rollups (mixed workflow-less
  rows, 15 `detailsUrl` shapes, non-dict rows, missing `startedAt`), compared as **ordered**
  lists to catch dict-insertion-order drift — 0 diffs.
- **`_bucket`**: exhaustive over 1,080 and 3,174 `conclusion × state × status` combinations
  including `None` / `""` / `0` / `False` / lowercase / unknown vocabulary — 0 diffs, and
  nothing moved between `pending` and `failing` in either direction.
- **`infer`**: 200,000 and 60,000 randomized instruction texts built from adversarial
  fragments (bare chains, `&`/`and`/comma separators, path fragments, enterprise hosts, a
  4,400-digit number that trips CPython's int-conversion limit, `#0`, `#007`), comparing
  `(kind, subject, host_key, message)` with `message` byte-wise — 0 diffs. `"host"` present
  on every one of 6,685 non-`None` results, and the set of host values ever written is
  exactly `{'github.com'}`.
- **All four regexes**: `.pattern` and `.flags` compared at runtime — byte-identical,
  including `_PR_BARE`, whose two adjacent string literals were already concatenated at
  parse time.
- **`host: str`**: `Probe` is a plain class (no `@dataclass`, no `__slots__`, no metaclass,
  no `__init_subclass__`), so a bare annotation creates no class attribute —
  `hasattr(PrWatchProbe, "host")` is `False` both before and after, and nothing in the repo
  reflects over these annotations.

Gates, all exit 0 on the rebased head: `flake8`, `isort --check-only`,
`mypy --platform linux`, `black --check` (both touched files), `check_brand_name.py`,
`check_harness_parity.py`, `check_black_formatting.py`, `check_changelog_history.py`,
`check_per_file_coverage.py --test`, `docs_lint.py --test`, `docs-lint.sh`,
`verify_vendor_manifest.py`, `scrub-lint.sh --no-history`, and the deterministic
`code-review.yml` grep rules (sensitive-path reads, hardcoded model literals, inclusive
language on added lines) — no matches.

## Blocked by a red `main`, not by this diff

`Backend Tests (3.12, 3)`, `Backend Tests (Windows) (3)` and `Coverage Gate` are red on
this PR and **cannot be made green from here**. They are inherited from `main`:

- The 9 failures are all in `test/test_push_branch_gate.py` and `test/test_security.py`
  (`TestGitPublishSubshellGluing`, `TestUnrecognisedOptionsReadProtectively`) — the
  git-publish shell-word gate. This PR touches only two modules under
  `src/kiro_crew/probes/` and no security file.
- **Attributed, not assumed.** A pristine detached worktree at `origin/main`
  (`6d1b51704`) fails the *identical 9 tests* — the failure sets `diff` clean against this
  branch's. Bisected to `eaa8a45bb` *"fix(security): model publish option arity so the
  floor tag holds (#7808)"*: its parent passes 1936 tests, the commit itself fails 9.
- `Coverage Gate` is the same single failure, not a second one — shard 3 aborted, so it
  produced no coverage data to gate on.
- Already reported twice, so nothing is added by a third: **#8695** and **#8706**, both
  naming `#7808` as cascading to every PR.

The two shard-3 jobs on this PR's head report the *same nine test ids* that pristine
`origin/main` does — the sets `diff` clean, so **zero failures are attributable to this PR**.

I did not touch it. `security.py` is a keystone security file that the simplification
campaign forbids reshaping, and folding an unrelated security-gate repair into a
comment-and-readability PR is precisely the "undocumented bug fix riding in a cleanup PR"
this work exists to avoid. **This PR is otherwise green** — 52 of the 55 non-skipped checks
pass, including all five review lanes with zero findings between them — and it will go
green on its own once `#7808` is fixed or reverted on `main` and this branch is rebased.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff — two Python modules under `src/kiro_crew/probes/`,
nothing under `website/`, so no rendered surface changes and CI reports `only_backend`.

## Related Issues

no linked issue: routine module-simplification sweep, not a tracked defect.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality (none needed — no new behavior)
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the corrected comments *are* the documentation; no spec covers this module's internals
- [x] No secrets, credentials, or internal references in the diff
