### PR TITLE
fix(security): hand the push arity scan raw words, not cut ones

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3486,17 +3486,28 @@ def _protected_name_in_substitution(tokens: "list[str]", start: int) -> str:
     Scans forward until the substitution closes (``shlex`` splits it across tokens
     because it splits on whitespace only) and returns the product name, or a
     by-name kill program, if either appears inside it.  Returns "" when neither does.
+
+    The depth is read from the shared quote-aware walk, with the quote state
+    carried ACROSS tokens because ``shlex`` splits on whitespace and a quoted word
+    can span one. A private ``str.count`` walk closed the substitution at a QUOTED
+    ``)`` and stopped scanning there, so a name hidden after it was never seen --
+    an UNDER-deny for this rule, not the over-deny a previous audit of this line
+    recorded.
     """
     depth = 0
+    state = 0
+    ansi = False
     for token in tokens[start:]:
-        depth += token.count("(") - token.count(")")
+        walk = _shell_quote_walk(token, state=state, ansi=ansi)
+        depth += walk.paren_delta
+        state, ansi = walk.end_state, walk.end_ansi
         m = _SELF_NAME_RE.search(token)
         if m:
             return m.group(0)
         for verb in _KILL_BY_NAME_PROGRAMS:
             if verb in token:
                 return verb
-        if depth <= 0 and token is not tokens[start]:
+        if depth <= 0 and state == 0 and token is not tokens[start]:
             break
     return ""
 
@@ -4655,6 +4666,16 @@ def _substitution_bodies(text: str) -> "list[str]":
     first does not truncate the outer body; backticks are taken pairwise.  Only
     the BODY is returned -- a bare ``kill`` must not be attributed a name that
     merely appears in a LATER, unrelated command of the same line.
+
+    The nesting walk is QUOTE-AWARE, through the same
+    :func:`_matching_close_paren` span the git-publish boundary walk uses. A
+    private, quote-unaware copy of it truncated the body at a QUOTED ``)``, and
+    that lost the nested command entirely rather than merely mis-sizing the span:
+    ``git push origin my-feature > >(X=')' git push origin main)`` extracted the
+    body ``X='``, so the nested publish of a protected branch was never scanned
+    and ``is_denied`` returned None for a command bash executes. An UNPROVEN span
+    yields the whole remainder, which is the fail-closed direction -- scanning
+    text that is not really in the body can only add findings.
     """
     bodies: list[str] = []
     i = 0
@@ -4662,30 +4683,12 @@ def _substitution_bodies(text: str) -> "list[str]":
         # PROCESS substitutions run their body as a command just as a command
         # substitution does -- ``cat <(kirocrew token)`` executes the inner command and
         # feeds its output through a pipe.  Same paren-nesting walk.
-        if text.startswith("<(", i) or text.startswith(">(", i):
-            depth = 1
-            j = i + 2
-            while j < len(text) and depth:
-                if text[j] == "(":
-                    depth += 1
-                elif text[j] == ")":
-                    depth -= 1
-                j += 1
-            bodies.append(text[i + 2 : j - 1 if depth == 0 else len(text)])
-            i = j
+        if text.startswith(("<(", ">(", "$("), i):
+            end, proven = _matching_close_paren(text, i + 2)
+            bodies.append(text[i + 2 : end - 1] if proven else text[i + 2 :])
+            i = end
             continue
-        if text.startswith("$(", i):
-            depth = 1
-            j = i + 2
-            while j < len(text) and depth:
-                if text[j] == "(":
-                    depth += 1
-                elif text[j] == ")":
-                    depth -= 1
-                j += 1
-            bodies.append(text[i + 2 : j - 1 if depth == 0 else len(text)])
-            i = j
-        elif text[i] == "`":
+        if text[i] == "`":
             j = text.find("`", i + 1)
             bodies.append(text[i + 1 : j if j != -1 else len(text)])
             i = len(text) if j == -1 else j + 1
@@ -6069,6 +6072,115 @@ def _is_git_push_via_normalizer(text_lower: str) -> bool:
 _SHELL_OPERATOR_CHARS = "()&;|<>"
 
 
+class _ShellChar(NamedTuple):
+    """One step of the shell's quote/escape state machine."""
+
+    #: Offset in the source text where this step's raw ``text`` begins. Named
+    #: ``offset`` rather than ``index`` because a NamedTuple field cannot shadow
+    #: ``tuple.index``.
+    offset: int
+    #: The raw text consumed -- TWO characters for a backslash escape pair, so a
+    #: consumer that rebuilds a word by appending ``text`` preserves the spelling.
+    text: str
+    #: The SIGNIFICANT character: for an escape pair, the character escaped.
+    char: str
+    #: True only where shell SYNTAX lives: unquoted and unescaped. An operator, a
+    #: separator or whitespace is structure here and data everywhere else.
+    active: bool
+    #: Quote state AFTER this step: 0 normal, 1 single-quoted, 2 double-quoted.
+    state: int
+    #: Whether an open single quote is an ANSI-C ``$'...'``, where a backslash
+    #: escapes rather than standing for itself.
+    ansi: bool
+    #: The text ended on a backslash with nothing to escape -- so whatever split
+    #: this text off was itself escaped, and the word continues past it.
+    trailing_escape: bool
+
+
+def _iter_shell_chars(text: str, state: int = 0, ansi: bool = False) -> "Iterator[_ShellChar]":
+    """THE shell quote/escape state machine. Every push-path reading of shell
+    quoting walks through this one generator.
+
+    Four readings used to keep their own copy, and they did not agree. The word
+    splitter had no ANSI-C awareness while the boundary walk did, so in
+    ``git push origin feature > >(echo $'a\\'b') main`` the splitter read the
+    ESCAPED quote as a real closer, reopened on the next quote, and fused the
+    trailing ``main`` into one unterminated word -- the boundary walk then proved
+    its parenthesis correctly, but the protected refspec was already trapped
+    inside the word it had been handed. That is the same two-scanners defect this
+    module was already cured of twice (two tokenizers, then two paren counters),
+    so the cure is structural: one machine, several consumers, no second opinion
+    to drift from.
+
+    Bash's rules, once: a backslash escapes the next character outside quotes,
+    inside double quotes, and inside ``$'...'``, but is LITERAL inside a plain
+    single quote; an escaped quote is data and closes nothing. The ``$'``
+    lookback is within-text, which is correct because whitespace cannot sit
+    between the ``$`` and its quote. It can misread ``$$'`` (PID expansion) as
+    ANSI-C, and that direction only ever OVER-flags: a plain-single reading
+    closes at every quote the ANSI reading skips, so a walk can end "still open"
+    where bash closed, never the reverse.
+
+    *state* and *ansi* resume a walk, which is what lets a quoted word spanning
+    whitespace be read without desyncing.
+    """
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and (state != 1 or ansi):
+            if i + 1 >= n:
+                yield _ShellChar(i, ch, ch, False, state, ansi, True)
+                return
+            yield _ShellChar(i, text[i : i + 2], text[i + 1], False, state, ansi, False)
+            i += 2
+            continue
+        was_unquoted = state == 0
+        if state == 0:
+            if ch == "'":
+                state = 1
+                ansi = i > 0 and text[i - 1] == "$"
+            elif ch == '"':
+                state = 2
+        elif state == 1:
+            if ch == "'":
+                state = 0
+        elif ch == '"':
+            state = 0
+        yield _ShellChar(i, ch, ch, was_unquoted, state, ansi, False)
+        i += 1
+
+
+def _matching_close_paren(text: str, open_end: int) -> "tuple[int, bool]":
+    """``(index just past the matching ``)``, proven)`` for a paren opened before
+    *open_end*, walked QUOTE-AWARELY through :func:`_iter_shell_chars`.
+
+    THE one span computation for a substitution or subshell body. Both the
+    git-publish boundary walk and the nested-payload EXTRACTOR read it, because a
+    body extracted over a different span than the boundary proved is exactly how a
+    nested command escapes the scan: ``git push origin my-feature > >(X=')' git
+    push origin main)`` truncated the extracted body at the QUOTED ``)``, so the
+    payload came back as ``X='`` and the nested publish of a protected branch was
+    never scanned at all -- ``is_denied`` allowed a command bash runs.
+
+    ``proven`` is False when the parens never balance before the text ends. The
+    caller must fail CLOSED on that: for an extractor the safe reading is the
+    whole remainder (scan more, never less).
+    """
+    depth = 1
+    for step in _iter_shell_chars(text, 0, False):
+        if step.offset < open_end:
+            continue
+        if step.active:
+            if step.char == "(":
+                depth += 1
+            elif step.char == ")":
+                depth -= 1
+                if depth == 0:
+                    return (step.offset + len(step.text), True)
+    return (len(text), False)
+
+
 def _cut_at_operator(token: str) -> str:
     """*token* up to the first GLUED shell operator, with leading ones removed.
 
@@ -6098,26 +6210,22 @@ def _cut_at_operator(token: str) -> str:
 
     Quotes are PRESERVED in the result; both call sites remove them afterwards
     (see ``_dequote_token``), which is what keeps ``'(main)'`` a literal ref.
+
+    Escapes are honoured through the shared walk, so ``ma\\)in`` keeps its
+    literal paren instead of being cut at it -- bash hands git the ref ``ma)in``.
     """
     out: list[str] = []
-    in_single = False
-    in_double = False
-    for char in token:
-        if char == "'" and not in_double:
-            in_single = not in_single
-            out.append(char)
-            continue
-        if char == '"' and not in_single:
-            in_double = not in_double
-            out.append(char)
-            continue
-        if char in _SHELL_OPERATOR_CHARS and not in_single and not in_double:
+    for step in _iter_shell_chars(token):
+        if step.trailing_escape:
+            out.append(step.text)
+            break
+        if step.active and step.char in _SHELL_OPERATOR_CHARS:
             if not out:
                 # Leading operator, e.g. the ``(`` of ``(git push ...``: bash
                 # treats it as punctuation before the word, so drop and continue.
                 continue
             break
-        out.append(char)
+        out.append(step.text)
     return "".join(out)
 
 
@@ -6196,6 +6304,72 @@ _PUSH_VALUE_SHORTS = frozenset({"o"})
 _PUSH_NO_VALUE_SHORTS = frozenset({"f", "n", "q", "v", "u", "d", "4", "6"})
 
 
+class _ShellWalk(NamedTuple):
+    """What one pass of the shell's quote/escape state machine observed."""
+
+    #: The text split at its UNQUOTED ``<`` ``>`` ``&`` ``(`` ``)`` operators.
+    pieces: list[str]
+    #: True when at least one such operator was seen outside quotes.
+    saw_operator: bool
+    #: True when the text ends on a backslash that escapes the next character —
+    #: i.e. whatever split this text off was itself escaped.
+    trailing_escape: bool
+    #: Quote state at the end: 0 normal, 1 single-quoted, 2 double-quoted. Feed
+    #: it back in to resume the walk across a whitespace boundary.
+    end_state: int
+    #: Whether the still-open single quote was an ANSI-C ``$'...'``.
+    end_ansi: bool
+    #: Unquoted ``(`` minus unquoted ``)``. Quoted parens contribute NOTHING,
+    #: which is what makes a process-substitution boundary provable.
+    paren_delta: int
+
+
+def _shell_quote_walk(text: str, state: int = 0, ansi: bool = False) -> _ShellWalk:
+    """The ONE quote/escape state machine the push scan reads shell text with.
+
+    Every signal the scan derives from shell quoting comes from this single pass,
+    so no two readings of the same text can disagree: the operator split and the
+    fragment signal (:func:`_push_token_shell_read`), and the unquoted paren
+    depth that proves a process-substitution boundary
+    (:func:`_git_push_args`). A second, quote-UNAWARE paren count is exactly how
+    ``git push origin feature > >(echo '(' ) main`` published a protected branch:
+    the quoted ``(`` inflated the depth, so the closing ``)`` never returned it
+    to zero and the trailing ``main`` was swallowed into the substitution.
+
+    Uses the shell's own rules, via :func:`_iter_shell_chars`, which owns the
+    state machine: a backslash escapes the next character outside quotes, inside
+    double quotes, and inside ``$'...'`` ANSI-C strings, but is LITERAL inside
+    plain single quotes; an ESCAPED quote is data, not a delimiter.
+
+    *state* and *ansi* resume a walk across a whitespace boundary, because a
+    quoted word can span one (``>(echo 'a b')``).
+    """
+    pieces: list[str] = []
+    buf: list[str] = []
+    saw_operator = False
+    trailing_escape = False
+    paren_delta = 0
+    for step in _iter_shell_chars(text, state, ansi):
+        state, ansi = step.state, step.ansi
+        if step.trailing_escape:
+            trailing_escape = True
+            break
+        if step.active and step.char in "<>&()":
+            saw_operator = True
+            if step.char == "(":
+                paren_delta += 1
+            elif step.char == ")":
+                paren_delta -= 1
+            if buf:
+                pieces.append("".join(buf))
+                buf = []
+            continue
+        buf.append(step.text)
+    if buf:
+        pieces.append("".join(buf))
+    return _ShellWalk(pieces, saw_operator, trailing_escape, state, ansi, paren_delta)
+
+
 def _push_token_shell_read(token: str) -> "tuple[list[str] | None, bool]":
     """One quote/escape-state walk over a RAW (pre-dequote) token, returning
     ``(operator_pieces, open_state)``.
@@ -6212,78 +6386,19 @@ def _push_token_shell_read(token: str) -> "tuple[list[str] | None, bool]":
     RETURNED TO NORMAL by the token's end: an open quote or a trailing escape
     means the whitespace that split this token was itself quoted or escaped —
     the token is a FRAGMENT of a word fused across the split, the shape that
-    let ``--push-option='ci skip'`` erase the floor tag. The walk uses the
-    shell's own rules: a backslash escapes the next character outside quotes,
-    inside double quotes, and inside ``$'...'`` ANSI-C strings, but is
-    LITERAL inside plain single quotes; an ESCAPED quote is data, not a
-    delimiter. (Counting quote characters — an earlier shape here — was
-    bypassed by ``\\"``: the escaped quote flipped the parity even though it
-    closes nothing. Found by the GPT 5.6 review lane on #7808.) A complete
-    word with escaped quotes therefore keeps its precise reading, both
-    directions. The ``$``-lookback for ANSI-C can misread ``$$'`` (PID
-    expansion) as ANSI-C, but that direction only ever OVER-flags — a
-    plain-single reading closes at every quote the ANSI reading skips, so the
-    walk can end "still open" where bash split normally, never the reverse.
+    let ``--push-option='ci skip'`` erase the floor tag. A complete word with
+    escaped quotes therefore keeps its precise reading, both directions.
 
-    ONE walk serves both signals (a review subtraction: the identical state
-    machine briefly shipped twice); both consequences are protective-only —
-    a hit poisons the positional split, never widens an allow.
+    A thin view over :func:`_shell_quote_walk`, which owns the state machine.
+    ONE walk serves every signal (a review subtraction: the identical state
+    machine briefly shipped twice); both consequences here are protective-only
+    — a hit poisons the positional split, never widens an allow.
     """
-    pieces: list[str] = []
-    buf: list[str] = []
-    found = False
-    trailing_escape = False
-    state = 0  # 0 = normal, 1 = single-quoted, 2 = double-quoted
-    ansi = False  # the open single quote was $'...' (ANSI-C): backslash escapes
-    i = 0
-    n = len(token)
-    while i < n:
-        ch = token[i]
-        if state == 0:
-            if ch == "\\":
-                if i + 1 >= n:
-                    trailing_escape = True  # the escaped char was the separator
-                    break
-                buf.append(token[i : i + 2])
-                i += 2
-                continue
-            if ch in "<>&()":
-                found = True
-                if buf:
-                    pieces.append("".join(buf))
-                    buf = []
-                i += 1
-                continue
-            if ch == "'":
-                state = 1
-                ansi = i > 0 and token[i - 1] == "$"
-            elif ch == '"':
-                state = 2
-        elif state == 1:
-            if ansi and ch == "\\":
-                if i + 1 >= n:
-                    trailing_escape = True  # escapes the separator inside $'...'
-                    break
-                buf.append(token[i : i + 2])
-                i += 2
-                continue
-            if ch == "'":
-                state = 0
-        else:  # state == 2, inside double quotes
-            if ch == "\\":
-                if i + 1 >= n:
-                    trailing_escape = True  # escaped separator / continuation
-                    break
-                buf.append(token[i : i + 2])
-                i += 2
-                continue
-            if ch == '"':
-                state = 0
-        buf.append(ch)
-        i += 1
-    if buf:
-        pieces.append("".join(buf))
-    return (pieces if found else None, state != 0 or trailing_escape)
+    walk = _shell_quote_walk(token)
+    return (
+        walk.pieces if walk.saw_operator else None,
+        walk.end_state != 0 or walk.trailing_escape,
+    )
 
 
 #: A token that BEGINS with a redirection: optional fd number, ``&``, or bash
@@ -6366,28 +6481,109 @@ _AMBIGUOUS_REFSPEC_RE = re.compile(r"@\{")
 
 # TRUE shell command separators (NOT command-substitution boundaries). Used to
 # scan the PRE-SPLIT text for substitution glued into a push target — see
-# ``_is_push_to_protected_branch``.
+# ``_is_push_to_protected_branch``. Applied through
+# ``_split_push_command_segments``, which honours quoting; the pattern itself is
+# retained as the separator vocabulary.
 _CMD_SEPARATOR_RE = re.compile(r"&&|\|\||[;|\n]")
+
+#: The same separators as spellings, longest first so ``&&``/``||`` win over a
+#: single ``|``. A LONE ``&`` is deliberately absent: it is not a segment
+#: separator here, and the argument scan reads it as operator glue that poisons
+#: the positional split.
+_SHELL_SEGMENT_SEPARATORS = ("&&", "||", ";", "|")
+
+
+def _split_push_command_segments(text: str) -> list[str]:
+    """Split *text* into the shell's TRUE command segments, honouring quoting.
+
+    A separator only separates where the SHELL reads one. Inside quotes, or
+    escaped with a backslash, ``;`` / ``|`` / ``&&`` / ``||`` are ordinary
+    characters in the word — ``git push origin 'feature|x'`` publishes a branch
+    literally named ``feature|x`` — and splitting there truncated the word
+    mid-quote. The fragment then arrived with the shell state still open, which
+    ``_push_segment_targets_protected`` reads as a word fused across the
+    boundary, so an ordinary unprotected refname was denied by the protective
+    fallback (and by its ungated sentinel, which no catalog row can switch off).
+
+    A NEWLINE always separates, escaped or not, and the backslash is KEPT in the
+    segment it ends. That is not an inconsistency: a backslash-newline VANISHES
+    in bash, fusing the words on either side into one that neither segment can
+    reconstruct (``origin ma\\`` + newline + ``in`` publishes MAIN), and the
+    retained trailing escape is exactly the signal the cumulative-open-state
+    check ungates on. Every other escaped separator survives as a LITERAL
+    character in the word, so the fused word necessarily contains it and can
+    never equal a protected branch name.
+
+    Distinct from :func:`_split_shell_segments`, which serves the ``cd``-tracking
+    pass: that one wants FEWER segments (a wrong split corrupts the tracked
+    directory), leaves pipes joined because they do not move the directory, and
+    emits an unquoted paren as its own segment. This one needs a pipe to separate
+    — each side is a command whose push must be judged on its own — and needs the
+    parens left inside the word, because the argument scan reads them as the
+    operator glue they are. They are not interchangeable.
+
+    Quote state comes from :func:`_iter_shell_chars`, the module's one shell
+    state machine, so this cannot disagree with the word split or the boundary
+    walk about where a quote ends.
+    """
+    segments: list[str] = []
+    rest = text
+    while True:
+        buf: list[str] = []
+        resume_at: int | None = None
+        for step in _iter_shell_chars(rest):
+            if step.trailing_escape:
+                buf.append(step.text)
+                break
+            if step.char == "\n":
+                # A NEWLINE always separates. When it was ESCAPED the backslash
+                # is kept, because that is the splice signal: bash makes the
+                # backslash-newline vanish, fusing the words on either side into
+                # one that neither segment can reconstruct.
+                if step.text.startswith("\\"):
+                    buf.append("\\")
+                resume_at = step.offset + len(step.text)
+                break
+            if step.active:
+                separator = next(
+                    (s for s in _SHELL_SEGMENT_SEPARATORS if rest.startswith(s, step.offset)),
+                    None,
+                )
+                if separator is not None:
+                    resume_at = step.offset + len(separator)
+                    break
+            buf.append(step.text)
+        segments.append("".join(buf))
+        if resume_at is None:
+            return segments
+        rest = rest[resume_at:]
+
 
 # Shell expansions that fuse text INTO a word, so the literal command hides the
 # real push target. Any of these inside a git-publish command is unverifiable
 # -> deny (fail closed):
 #   - command substitution   $(...)   and backticks  `...`
 #   - parameter expansion     ${...}
-#   - PROCESS substitution   <(...) / >(...)  -- the shell substitutes a
-#     /dev/fd path WORD, so the construct is a positional the split cannot
-#     model; mis-reading it as a removable redirection shifted a value
-#     option's consumption onto the remote and downgraded a protected push to
-#     the disableable single-arg row (GPT 5.6 round 8 on #7808). The operator
-#     adjacency ``<(``/``>(`` is required, so a parenthesis inside a quoted
-#     refname stays data -- but the match is deliberately CONSERVATIVE about
-#     quoting: a QUOTED ``<(`` spelling (a ref literally named ``feat<(x)``)
-#     also matches and over-denies, the same fail-closed posture this regex
-#     already takes for a quoted ``$(``.
+#   - PROCESS substitution   <(...) / >(...)  is NOT here, deliberately: the
+#     shell substitutes a /dev/fd path WORD, so it is unverifiable only where it
+#     SURVIVES as an argv word. Matching it on the whole segment also denied the
+#     shape where the shell REMOVES it — ``git push origin my-feature >
+#     >(tee log.txt)`` is an ordinary feature push whose output is teed — so the
+#     word-position reading lives in ``_push_segment_targets_protected``, which
+#     sees the tokens that survive redirection removal.
 #   - BRACE expansion         {a,b} / {1..5}  -- bash expands ``ma{i,i}n`` to
 #     ``main`` and ``{main,x}`` to ``main x`` BEFORE git sees the token, so a
 #     brace group containing a comma or ``..`` must be treated as ambiguous.
-_AMBIGUOUS_EXPANSION_RE = re.compile(r"\$\(|\$\{|`|[<>]\(|\{[^{}]*(?:,|\.\.)[^{}]*\}")
+_AMBIGUOUS_EXPANSION_RE = re.compile(r"\$\(|\$\{|`|\{[^{}]*(?:,|\.\.)[^{}]*\}")
+
+#: Process substitution, which the shell replaces with a ``/dev/fd`` path WORD.
+#: Read in a word position it is unverifiable — mis-reading it as a removable
+#: redirection shifted a value option's consumption onto the remote and
+#: downgraded a protected push to the disableable single-arg row (GPT 5.6 round 8
+#: on #7808). The operator adjacency is required, so a parenthesis inside a
+#: refname stays data; a QUOTED spelling still matches and over-denies, the same
+#: fail-closed posture the expansion regex takes for a quoted ``$(``.
+_PROCESS_SUBSTITUTION_OPENERS = ("<(", ">(")
 
 
 def _dequote_token(token: str) -> str:
@@ -6399,19 +6595,60 @@ def _dequote_token(token: str) -> str:
     quote/backslash characters that make the token compare unequal to a
     protected name — an evasion of this gate. Remove ALL single/double quotes
     and backslash escapes so the comparison sees the shell-resolved word.
+
+    Shell OPERATORS glued to the word are NOT cut here. ``_cut_at_operator`` is
+    applied where an operator would hide a PROGRAM name (the ``git`` anchor in
+    ``_git_push_args``); for an ARGUMENT, cutting destroyed the very evidence the
+    argument scan reads. ``_push_token_shell_read`` splits a token at its
+    unquoted operators and ``_push_segment_targets_protected`` scans every piece
+    as a refspec candidate, so ``mainline)>log`` still resolves to the protected
+    ``mainline`` — while an uncut token keeps the shape the scan classifies by:
+    ``@(main)`` is extglob pathname expansion, ``origin>/dev/null`` is a
+    remote-only push, and a lone ``&`` is a command boundary. Cutting first
+    reduced all three to bare words and erased their tags.
     """
-    # ``(``/``)`` are shell OPERATORS, never part of the word: in
-    # ``(cd /tmp; git push origin main)`` git receives the ref ``main``, not
-    # ``main)``. Leaving them in made the protected-name compare unequal, so a
-    # protected-branch push inside a subshell was allowed AND audited as a
-    # feature-branch push.
-    #
-    # Stripped BEFORE the quotes come off, matching ``_git_push_args``: an
-    # operator sits OUTSIDE any quoting, so stripping first sees only those.
-    # Doing it last would also eat a paren the user QUOTED as part of the ref
-    # name -- ``git push origin '(main)'`` targets a branch literally named
-    # ``(main)``, which is not a protected branch, and must stay allowed.
-    return _cut_at_operator(token).replace("'", "").replace('"', "").replace("\\", "")
+    return token.replace("'", "").replace('"', "").replace("\\", "")
+
+
+def _split_shell_words(segment: str) -> list[str]:
+    """Split *segment* into words at UNQUOTED, unescaped whitespace.
+
+    ``str.split`` splits inside quotes too, which tears one shell word into
+    fragments the scan then reads as separate arguments. Two consequences, both
+    seen in practice: a wrapper's quoted payload (``bash -c '(cd /tmp && git push
+    origin my-feature)'``) yielded a bare ``git`` token, so the OUTER line — which
+    is not itself a push — was parsed as one and its fragmented ref denied an
+    ordinary feature push; and a legitimately quoted refname arrived with the
+    shell state open, which the fragment rule reads as a word fused across the
+    split. Splitting the way the shell does removes the class: a quoted payload is
+    ONE word, so it is left to the nested-payload reading that judges it properly.
+
+    Quotes and escapes are PRESERVED in the words; the callers strip them
+    (``_dequote_token``) and walk them (``_push_token_shell_read``) themselves.
+
+    Quote state comes from :func:`_iter_shell_chars`, so ANSI-C ``$'...'`` reads
+    the same here as everywhere else. A private copy of the state machine WITHOUT
+    that awareness is what let ``git push origin feature > >(echo $'a\\'b') main``
+    publish a protected branch: the escaped quote closed its state, the next quote
+    reopened it, and the trailing ``main`` fused into one unterminated word --
+    which the boundary walk, reading the same text correctly, could no longer
+    rescue because the refspec was already inside the word it was handed.
+    """
+    words: list[str] = []
+    buf: list[str] = []
+    for step in _iter_shell_chars(segment):
+        if step.trailing_escape:
+            buf.append(step.text)  # trailing escape: the fragment signal
+            break
+        if step.active and step.char.isspace():
+            if buf:
+                words.append("".join(buf))
+                buf = []
+            continue
+        buf.append(step.text)
+    if buf:
+        words.append("".join(buf))
+    return words
 
 
 def _git_push_args(segment: str) -> list[str] | None:
@@ -6426,7 +6663,7 @@ def _git_push_args(segment: str) -> list[str] | None:
     """
     # Strip glued shell operators for the same reason as ``_dequote_token``:
     # ``(git`` IS the git program to bash, and ``main)&`` IS the ref ``main``.
-    raw_tokens = segment.split()
+    raw_tokens = _split_shell_words(segment)
     tokens = [_cut_at_operator(t) for t in raw_tokens]
     # Anchoring compares against a DEQUOTED view, because a quoted ``"git"`` is
     # still the git program to bash. Matching the raw token missed it and
@@ -6487,36 +6724,84 @@ def _git_push_args(segment: str) -> list[str] | None:
         # (``2>/dev/null``) or spaced (``> out``); a PROCESS SUBSTITUTION target
         # is a whole command line, so it is skipped to its matching ``)`` rather
         # than by one word.
+        #
+        # A token that OPENS with ``<(`` / ``>(`` is process substitution, which
+        # bash reads as a WORD, not a redirection -- so it is returned rather than
+        # skipped. Skipping it consumed an option's value (``-o <(echo)``) and
+        # shifted the positional split onto the remote, downgrading a push of a
+        # protected branch to the disableable single-arg row.
+        #
+        # Redirection arity comes from ``_push_token_redirection``, the model the
+        # argument scan itself uses, rather than a second reading of the same
+        # grammar here. The local reading treated the ``-`` of ``<<-`` as an
+        # ATTACHED target, so the tab-stripping heredoc's separated delimiter word
+        # survived as a phantom refspec and erased the tag -- the shape #7808 had
+        # already closed one layer down. One model, one place.
+        #
+        # The tokens are returned in their RAW spelling. The caller's scan is
+        # defined over raw words -- it splits each one at its own unquoted
+        # operators and models redirection arity itself -- so handing it
+        # operator-CUT words erased the shapes it classifies by (``origin>`` read
+        # as a plain remote, ``@(main)`` as the ambiguous ref ``@``, a lone ``&``
+        # as an empty token).
         args: list[str] = []
         raw_args = raw_tokens[i + 1 :]
-        cut_args = tokens[i + 1 :]
         k = 0
         while k < len(raw_args):
-            match = _REDIRECT_START_RE.match(raw_args[k])
-            if match is None:
-                args.append(cut_args[k])
+            if raw_args[k].startswith(_PROCESS_SUBSTITUTION_OPENERS):
+                args.append(raw_args[k])
                 k += 1
                 continue
-            target = raw_args[k][match.end() :]
-            if not target:
-                # Bare operator: its target is the NEXT word, which may itself be
-                # a redirect-prefixed process substitution (``> >(cmd)``).
+            is_redirection, consumes_next = _push_token_redirection(raw_args[k])
+            if not is_redirection:
+                args.append(raw_args[k])
                 k += 1
-                if k >= len(raw_args):
-                    break
-                following = _REDIRECT_START_RE.match(raw_args[k])
-                target = (
-                    raw_args[k][following.end() :] if following else raw_args[k]
-                ) or raw_args[k]
+                continue
+            k += 1
+            if not consumes_next or k >= len(raw_args):
+                continue
+            following = _REDIRECT_START_RE.match(raw_args[k])
+            target = (raw_args[k][following.end() :] if following else raw_args[k]) or raw_args[k]
             if not target.startswith("("):
                 k += 1  # ordinary file target -- one word
                 continue
+            # PROCESS-SUBSTITUTION BOUNDARY, walked QUOTE-AWARELY and proven.
+            #
+            # The target is a whole command line, so it ends at its matching
+            # unquoted ``)``. Counting the parens per word with str.count was
+            # quote-UNAWARE, and that was a live bypass: in
+            # ``git push origin feature > >(echo '(' ) main`` the QUOTED ``(``
+            # inflated the depth to 2, the real ``)`` only returned it to 1, and
+            # the trailing ``main`` was swallowed into the substitution -- so a
+            # protected-branch push came back with the remaining words alone and
+            # was allowed. ``> >(printf "(") main`` is the same shape with double
+            # quotes. Both traced independently by the GPT 5.6 and Opus lanes on
+            # #8712. The shared state machine ignores quoted parens, so the
+            # boundary lands where bash puts it.
+            #
+            # FAIL CLOSED when the boundary cannot be PROVEN complete -- the
+            # words ran out with the substitution still open (``>(echo main``),
+            # or a quote is still open at the end. Silently swallowing the rest
+            # of the segment is precisely how an unterminated construct hid a
+            # refspec. Returning None routes the segment to the caller's
+            # unparseable branch, which emits the non-opt-out-able ambiguity
+            # sentinel: the same posture the whole-segment expansion regex gave
+            # process substitution before it moved to this walk. A PROVEN
+            # boundary is a word; an UNPROVABLE one is ambiguous.
             depth = 0
+            state = 0
+            ansi = False
+            proven = False
             while k < len(raw_args):
-                depth += raw_args[k].count("(") - raw_args[k].count(")")
+                walk = _shell_quote_walk(raw_args[k], state=state, ansi=ansi)
+                depth += walk.paren_delta
+                state, ansi = walk.end_state, walk.end_ansi
                 k += 1
-                if depth <= 0:
+                if state == 0 and depth <= 0:
+                    proven = True
                     break
+            if not proven:
+                return None
         return args
     return None
 
@@ -6630,6 +6915,68 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
     # the state machine).
     if arg_tokens and _push_token_shell_read(" ".join(arg_tokens))[1]:
         tags.add(_GIT_PUBLISH_UNGATED)
+
+    def _classify_word(word: str) -> None:
+        """Read ONE argv word exactly as git's option parser would.
+
+        The single place a word becomes either an option (with its arity) or a
+        positional. Stripping shell punctuation off a word changes WHERE the
+        word came from, never WHAT it is, so every branch that recovers a word
+        from operator glue routes it through here instead of appending it to
+        ``non_flags`` directly. Appending unconditionally is how ``(git push
+        --repo=origin -f)`` erased the floor: the ``)`` was stripped, ``-f`` was
+        filed as a refspec, it matched no protected name, and the segment came
+        back with NO tags at all — a force push to a possibly-protected current
+        branch, admitted by adding one parenthesis (GPT 5.6 security finding on
+        #8712). The same spelling without parens is correctly bare.
+        """
+        nonlocal skip_next, positional_only, repo_in_flag, unrecognised_option
+        if skip_next:
+            # The separated value of a value-taking option: consumed, so it is
+            # never read as a remote or a refspec.
+            skip_next = False
+            return
+        if not word:
+            return
+        if positional_only or word == "-" or not word.startswith("-"):
+            # A lone ``-`` is an OPERAND to git's option parser (a repository
+            # spelled ``./-`` is addressable) — skipping it as a flag shifted
+            # the real refspec into the remote slot and downgraded the row
+            # (GPT 5.6 round 13 on #7808).
+            non_flags.append(word)
+            return
+        if word == "--":
+            positional_only = True
+            return
+        if _push_option_matches(word, _PUSH_REPO_OPTS):
+            repo_in_flag = True
+            skip_next = "=" not in word
+            return
+        if "=" in word:
+            # An attached value binds inside the token — whatever the option is,
+            # it cannot disturb the positional split.
+            return
+        if word.startswith("--"):
+            if _push_option_matches(word, _PUSH_VALUE_OPTS):
+                skip_next = True
+            elif not (
+                word.startswith("--no-")
+                or _push_option_matches(word, _PUSH_NO_VALUE_OPTS)
+                or _push_option_matches(word, _PUSH_ALL_BRANCHES_OPTS)
+            ):
+                unrecognised_option = True
+            return
+        # Short-option token: resolve the bundle char by char like git does.
+        for i, ch in enumerate(word[1:]):
+            if ch in _PUSH_VALUE_SHORTS:
+                # Rest of the token is the attached value; consume the NEXT
+                # token only when there is no rest.
+                skip_next = i == len(word) - 2
+                break
+            if ch not in _PUSH_NO_VALUE_SHORTS:
+                unrecognised_option = True
+                break
+
     pending_redirection_target = False
     for raw, tok, (operator_pieces, _open) in zip(arg_tokens, tokens, shell_reads):
         if tok:
@@ -6667,6 +7014,14 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
             # named ``main`` expands to a push of main with no tag at all).
             if any(ch in tok for ch in "*?[") or any(op in tok for op in ("@(", "+(", "!(")):
                 tags.add("git-publish-push-wildcard-refspec")
+            # Process substitution that SURVIVED redirection removal is an argv
+            # word the shell replaces with a ``/dev/fd`` path, so the split
+            # cannot model it — the ungated posture, like ``ma$in``. Tested here
+            # rather than on the whole segment because a process substitution the
+            # shell REMOVES (the target of ``> >(tee log.txt)``) never reaches
+            # git's argv and must keep the precise reading.
+            if any(op in tok for op in _PROCESS_SUBSTITUTION_OPENERS):
+                tags.add(_GIT_PUBLISH_UNGATED)
         # Shell operators are consumed by the SHELL, so they are handled
         # before every argv-level reading — including after ``--``, which is
         # git's end-of-options, not the shell's (GPT 5.6 round 4 on #7808).
@@ -6725,12 +7080,33 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
                 # pending option value first (GPT 5.6 round 13 — appending it
                 # as a positional while ``skip_next`` stayed armed let the
                 # NEXT real word be eaten as the "value" and erased the
-                # tags), else a positional.
-                if skip_next:
-                    skip_next = False
-                else:
-                    non_flags.append(dequoted_prefix)
+                # tags), else through the ordinary option-vs-positional
+                # reading. The guard above already keeps a flag-shaped prefix
+                # off this branch; classifying rather than appending means a
+                # future loosening of that guard cannot turn a flag into a
+                # refspec behind the gate's back.
+                _classify_word(dequoted_prefix)
                 pending_redirection_target = _push_token_redirection(rest)[1]
+                continue
+            # A word carrying only SUBSHELL PUNCTUATION: ``(cd /tmp; git push
+            # origin my-feature)`` hands the ref token ``my-feature)``, whose
+            # ``)`` merely closes the subshell. It removes nothing from argv and
+            # adds nothing to the word, so the word keeps its exact identity and
+            # the split stays trusted — routing it to the fallback below denied
+            # every legitimate refname pushed inside a subshell. The word itself
+            # is still read as a refspec candidate, so a protected name inside the
+            # parens is caught exactly as it is without them. A leading paren
+            # leaves no prefix and keeps the protective fallback.
+            #
+            # Read through the SAME classifier a bare word takes: stripping the
+            # paren must not change what the word IS. Appending it as a
+            # positional turned ``(git push --repo=origin -f)`` into a push of a
+            # refspec named ``-f`` — no tags at all, so a force push to a
+            # possibly-protected current branch was admitted by one parenthesis,
+            # while ``(git push -f)`` reported the wrong row (remote-only instead
+            # of bare).
+            if rest and dequoted_prefix and all(ch in "()" for ch in rest):
+                _classify_word(dequoted_prefix)
                 continue
             # A bare control operator (``&`` — a single ampersand is NOT a
             # segment separator upstream, only ``&&`` is) or operator glue
@@ -6738,52 +7114,16 @@ def _push_segment_targets_protected(arg_tokens: list[str]) -> frozenset[str]:
             # it pushes main). The split is untrusted, and the operator-
             # delimited pieces are scanned as refspec candidates so a
             # protected name cannot hide behind the glue.
+            #
+            # This branch appends the pieces DIRECTLY, deliberately: it has
+            # already set ``unrecognised_option``, so the fallback below reads
+            # the whole segment protectively (both no-refspec rows fire) and
+            # treats every positional as a refspec candidate. A flag landing in
+            # that candidate list can only ADD a tag, never remove one.
             unrecognised_option = True
             non_flags.extend(p for p in (_dequote_token(pc) for pc in operator_pieces) if p)
             continue
-        if skip_next:
-            skip_next = False
-            continue
-        if not tok:
-            continue
-        if positional_only or tok == "-" or not tok.startswith("-"):
-            # A lone ``-`` is an OPERAND to git's option parser (a repository
-            # spelled ``./-`` is addressable) — skipping it as a flag shifted
-            # the real refspec into the remote slot and downgraded the row
-            # (GPT 5.6 round 13 on #7808).
-            non_flags.append(tok)
-            continue
-        if tok == "--":
-            positional_only = True
-            continue
-        if _push_option_matches(tok, _PUSH_REPO_OPTS):
-            repo_in_flag = True
-            skip_next = "=" not in tok
-            continue
-        if "=" in tok:
-            # An attached value binds inside the token — whatever the option
-            # is, it cannot disturb the positional split.
-            continue
-        if tok.startswith("--"):
-            if _push_option_matches(tok, _PUSH_VALUE_OPTS):
-                skip_next = True
-            elif not (
-                tok.startswith("--no-")
-                or _push_option_matches(tok, _PUSH_NO_VALUE_OPTS)
-                or _push_option_matches(tok, _PUSH_ALL_BRANCHES_OPTS)
-            ):
-                unrecognised_option = True
-            continue
-        # Short-option token: resolve the bundle char by char like git does.
-        for i, ch in enumerate(tok[1:]):
-            if ch in _PUSH_VALUE_SHORTS:
-                # Rest of the token is the attached value; consume the NEXT
-                # token only when there is no rest.
-                skip_next = i == len(tok) - 2
-                break
-            if ch not in _PUSH_NO_VALUE_SHORTS:
-                unrecognised_option = True
-                break
+        _classify_word(tok)
     if unrecognised_option:
         # Fail-protective invariant (#7796, shape C): an option this scan does
         # not model might take a separated value, so the positional split
@@ -6888,7 +7228,7 @@ def _git_publish_floor_tags(text_lower: str) -> frozenset[str]:
     """
     tags: set[str] = set()
     saw_push = False
-    for command in _CMD_SEPARATOR_RE.split(text_lower):
+    for command in _split_push_command_segments(text_lower):
         # ``_is_git_publish`` (not ``_git_push_args``) gates the checks so that
         # glue-evasion forms — which do NOT tokenize to a clean ``git`` token —
         # are still recognized as pushes and cannot slip past the ambiguity /

--- a/test/test_push_branch_gate.py
+++ b/test/test_push_branch_gate.py
@@ -1229,15 +1229,17 @@ class TestUnrecognisedOptionsReadProtectively:
                 f"disableable rules: {set(tags)}"
             )
 
-    def test_a_mid_segment_fused_value_stays_on_the_disableable_fallback(self):
-        # Deliberately narrower than ungating any open token: a quoted value
-        # whose quote CLOSES before segment end cannot splice into the next
-        # line, in-segment joining can only fuse whitespace into the word
-        # (never a valid refname), and the pieces stay visible to the
-        # superset scan — so the operator-facing bare row keeps covering it.
+    def test_a_quoted_whitespace_value_cannot_erase_a_refspec(self):
+        # A quoted value spanning whitespace is ONE shell word, and the word
+        # split now reads it as one, so it never becomes a pair of fragments
+        # whose tail was trusted as the only refspec (the shape that erased the
+        # floor tag). Nothing splices into the next line either, so the ungated
+        # sentinel — reserved for a word this segment cannot reconstruct — must
+        # stay out of it: with no positionals the push is bare, and with
+        # positionals they are read exactly, protected name included.
         for cmd in (
             "git push --repo=origin --push-option='ci skip'",
-            "git push --repo=origin --push-option='ci skip' origin feature-x",
+            "git push --repo=origin -o 'a b'",
         ):
             tags = security._git_publish_floor_tags(cmd)
             assert security._GIT_PUBLISH_UNGATED not in tags, (
@@ -1245,6 +1247,20 @@ class TestUnrecognisedOptionsReadProtectively:
                 f"ungated sentinel: {set(tags)}"
             )
             assert "git-publish-push-bare" in tags
+        # The half that must not be lost: a protected refspec BEHIND such a
+        # value is still seen, whether the remote is positional or in a flag.
+        for cmd in (
+            "git push --repo=origin --push-option='ci skip' origin main",
+            "git push --push-option='ci skip' origin main",
+            "git push --repo=origin -o 'a b' main",
+        ):
+            assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+                cmd
+            ), f"{cmd!r}: a quoted whitespace value erased the protected refspec"
+        # And an unprotected one stays pushable — the value is not a refspec.
+        assert not security._git_publish_floor_tags(
+            "git push --repo=origin --push-option='ci skip' origin feature-x"
+        )
 
     def test_every_bash_metacharacter_is_accounted_for(self):
         """The shell-syntax inventory, as a checked property (Design review).
@@ -1287,9 +1303,17 @@ class TestUnrecognisedOptionsReadProtectively:
         assert "git-publish-push-bare" in floor("git push origin & echo x")
         # Quoting and escapes — the shared walk: fragments poison the split.
         assert "git-publish-push-bare" in floor("git push --repo=origin -o 'a b'")
-        # Subshell parens glue onto the verb token, so no clean ``git`` token
-        # survives and the unparseable fallback ungates the segment.
-        assert floor("(git push origin main)") == {UNGATED}
+        # Subshell parens are punctuation around the command, not part of the
+        # word: the anchor resolves ``(git`` to the git program and the closing
+        # paren is stripped from the ref, so the push is read PRECISELY rather
+        # than through the unparseable fallback. The row must be the same one the
+        # unparenthesised spelling gets — a spelling-specific row would be an
+        # escape hatch — and it is still a denial.
+        assert floor("(git push origin main)") == floor("git push origin main")
+        assert floor("(git push origin main)") == {"git-publish-push-protected-branch-name"}
+        # The spaced spelling leaves a bare ``)`` token, which is operator glue
+        # with no word in front of it, so that one keeps the protective fallback.
+        assert "git-publish-push-protected-branch-name" in floor("( git push origin main )")
         # Benign by bash semantics, deliberately NOT flagged: a comma-free
         # brace passes through LITERALLY (a ref named ``{main}`` is not
         # ``main``); ``!`` history expansion does not run in non-interactive
@@ -1422,3 +1446,572 @@ class TestParserBranchTable:
         # anti-obfuscation branches are upstream of this parser and unaffected.
         got = security._git_publish_floor_tags("git push origin $(echo main)")
         assert got == frozenset({security._GIT_PUBLISH_UNGATED})
+
+
+class TestTokenizerContractBetweenTheLayers:
+    """The seam that broke: what the argument scan is handed, and by whom.
+
+    Two changes to this gate landed independently and crossed. One taught the
+    parse to resolve a git program hidden behind glued operators and to step over
+    redirections; the other added the option-arity and shell-syntax model, which
+    is defined over RAW words — it splits each word at its own unquoted operators
+    and models redirection arity itself. Because neither textually conflicted, the
+    outer parse silently pre-chewed the words the inner model reads, and six
+    shapes lost the identity they are classified by. These pin the contract in
+    both directions so the seam cannot drift apart again.
+    """
+
+    def test_the_argument_scan_is_handed_raw_words(self):
+        # The shapes whose identity lives in the operator: cutting them here
+        # turned each into a plain word and erased its tag.
+        from kiro_crew.security import _git_push_args
+
+        assert _git_push_args("git push origin>/dev/null") == ["origin>/dev/null"]
+        assert _git_push_args("git push origin @(main)") == ["origin", "@(main)"]
+        assert _git_push_args("git push origin & echo x") == ["origin", "&", "echo", "x"]
+        assert _git_push_args("git push --all>/dev/null") == ["--all>/dev/null"]
+
+    def test_redirection_arity_comes_from_one_model(self):
+        # ``<<-`` is a complete operator, so its delimiter is a SEPARATED word.
+        # A second reading of the grammar here read the ``-`` as an attached
+        # target and left ``EOF`` behind as a phantom refspec.
+        from kiro_crew.security import _git_push_args
+
+        assert _git_push_args("git push origin <<- EOF") == ["origin"]
+        # Still stepped over with the shell's arity, and the words behind a
+        # redirection still survive as refspecs.
+        assert _git_push_args("git push origin feature 2>/dev/null main") == [
+            "origin",
+            "feature",
+            "main",
+        ]
+        assert _git_push_args("git push origin feature > out main") == [
+            "origin",
+            "feature",
+            "main",
+        ]
+        assert _git_push_args("git push > >(git push origin my-feature)") == []
+
+    def test_process_substitution_is_a_word_not_a_redirection(self):
+        # ``<(`` / ``>(`` at the start of a word is process substitution, which
+        # bash substitutes as a /dev/fd path WORD. Consuming it as a redirection
+        # ate an option's value and shifted the positional split onto the remote.
+        from kiro_crew.security import _git_push_args
+
+        assert _git_push_args("git push -o <(echo) origin main") == [
+            "-o",
+            "<(echo)",
+            "origin",
+            "main",
+        ]
+        # In a word position it is unverifiable; as a redirection TARGET the shell
+        # removes it, so an ordinary feature push whose output is teed stays
+        # allowed. Both readings, from one place.
+        assert security._GIT_PUBLISH_UNGATED in security._git_publish_floor_tags(
+            "git push -o <(echo) origin main"
+        )
+        assert not security._git_publish_floor_tags("git push origin my-feature > >(tee log.txt)")
+        assert security._git_publish_floor_tags("git push > >(git push origin my-feature)") == {
+            "git-publish-push-bare"
+        }
+
+    def test_a_quoted_separator_does_not_split_the_segment(self):
+        # Splitting on a quoted separator truncated the word mid-quote, and the
+        # fragment then arrived with the shell state open — which the fragment
+        # rule reads as a word fused across the boundary. Legal, unprotected
+        # branch names were denied by the protective fallback.
+        from kiro_crew.security import _split_push_command_segments
+
+        assert _split_push_command_segments("git push origin 'feature|x'") == [
+            "git push origin 'feature|x'"
+        ]
+        for cmd in (
+            "git push origin 'feature|x'",
+            "git push origin 'a;b'",
+            "git push origin 'a&&b'",
+            'git push origin "a||b"',
+        ):
+            assert not security._git_publish_floor_tags(cmd), cmd
+        # An UNQUOTED separator still separates, and each side is judged alone.
+        assert _split_push_command_segments("git push origin | cat") == [
+            "git push origin ",
+            " cat",
+        ]
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "echo x | git push origin main"
+        )
+        # A quoted separator cannot smuggle a protected name past the scan: it
+        # stays inside the word, so the refspec contains it and is not the name.
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "git push origin 'x' ; git push origin main"
+        )
+
+    def test_a_backslash_newline_still_splices_unreconstructably(self):
+        # The one separator that VANISHES, so the words on either side fuse into
+        # one this segment cannot reconstruct. It must keep splitting, and the
+        # trailing escape must survive into the segment it ends — that escape is
+        # the signal the ungated sentinel is drawn from.
+        from kiro_crew.security import _split_push_command_segments
+
+        assert _split_push_command_segments("git push origin ma\\\nin") == [
+            "git push origin ma\\",
+            "in",
+        ]
+        for cmd in ("git push origin ma\\\nin", 'git push origin "ma\\\nin"'):
+            assert security._GIT_PUBLISH_UNGATED in security._git_publish_floor_tags(cmd), cmd
+
+    def test_a_wrapped_payload_is_one_word_not_a_bare_git_token(self):
+        # ``str.split`` tore a wrapper's quoted payload into fragments, so the
+        # OUTER line — which is not itself a push — parsed as one and its
+        # fragmented ref denied ordinary work. The payload is one word; the
+        # caller judges it on its own, which is where the denial still comes from.
+        from kiro_crew.security import _git_push_args, _split_shell_words, is_denied
+
+        assert _split_shell_words("bash -c '(cd /tmp && git push origin my-feature)'") == [
+            "bash",
+            "-c",
+            "'(cd /tmp && git push origin my-feature)'",
+        ]
+        assert _git_push_args("bash -c '(cd /tmp && git push origin my-feature)'") is None
+        assert is_denied("bash -c '(cd /tmp && git push origin my-feature)'") is None
+        assert is_denied("bash -c '(cd /tmp && git push origin main)'") is not None
+
+    def test_stripping_punctuation_never_reclassifies_the_word(self):
+        """A punctuation strip changes WHERE a word came from, not WHAT it is.
+
+        The subshell-punctuation branch recovered the word in front of a ``)``
+        and appended it to the positional list directly, skipping the
+        option-vs-positional classifier every bare word goes through. So
+        ``(git push --repo=origin -f)`` filed ``-f`` as the only refspec, it
+        matched no protected name, and the segment came back with NO tags — a
+        force push to a possibly-protected current branch, admitted by adding
+        one parenthesis. ``(git push -f)`` reported the remote-only row instead
+        of bare, the wrong-identity hazard three earlier rounds each turned into
+        a bypass. Every glue branch that recovers a word now routes it through
+        the one classifier, so the paired spellings agree by construction.
+        """
+        floor = security._git_publish_floor_tags
+        for parenthesised, bare in (
+            # The reported bypass, and its wrong-row sibling.
+            ("(git push --repo=origin -f)", "git push --repo=origin -f"),
+            ("(git push -f)", "git push -f"),
+            ("(git push --repo=origin --force)", "git push --repo=origin --force"),
+            ("(git push -qf)", "git push -qf"),
+            # A value-taking option must still consume its separated value.
+            ("(git push -o ci.skip origin main)", "git push -o ci.skip origin main"),
+            (
+                "(git push --push-option ci.skip origin main)",
+                "git push --push-option ci.skip origin main",
+            ),
+            # End-of-options, all-branches, and an unmodelled option.
+            ("(git push -- origin main)", "git push -- origin main"),
+            ("(git push --all)", "git push --all"),
+            ("(git push --frobnicate origin main)", "git push --frobnicate origin main"),
+            # A GENUINE positional keeps being read as one, protected or not.
+            ("(git push origin main)", "git push origin main"),
+            ("(git push origin refs/heads/main)", "git push origin refs/heads/main"),
+            ("(git push -f origin main)", "git push -f origin main"),
+            ("(git push origin my-feature)", "git push origin my-feature"),
+            ("(git push origin 'release/x')", "git push origin 'release/x'"),
+        ):
+            assert floor(parenthesised) == floor(bare), (
+                f"{parenthesised!r}: the paren strip changed the reading — "
+                f"{set(floor(parenthesised))} vs {set(floor(bare))}"
+            )
+        # Stated absolutely, not only as a pair: a force push with no refspec
+        # names no branch, so the bare row must fire whatever the punctuation.
+        for cmd in (
+            "(git push --repo=origin -f)",
+            "(git push -f)",
+            "(git push --repo=origin -f --quiet)",
+        ):
+            assert "git-publish-push-bare" in security._git_publish_floor_tags(cmd), cmd
+
+    def test_the_other_glue_branches_do_not_reclassify_either(self):
+        # The sibling shapes that recover a word from glue: a glued redirection
+        # keeps its own guard against a flag-shaped prefix, and the bare-operator
+        # fallback marks the split untrusted before it scans the pieces, so a
+        # flag landing among the candidates can only ADD a tag. Pinned so a
+        # future edit cannot quietly turn one of them into an allow.
+        for cmd in (
+            "git push --repo=origin -f>/dev/null",
+            "git push --repo=origin -f&",
+            "git push --repo=origin -f <<- EOF",
+            "git push --repo=origin -f 2>&1",
+            "git push --repo=origin -f)",
+            "git push -f)",
+        ):
+            assert "git-publish-push-bare" in security._git_publish_floor_tags(cmd), (
+                f"{cmd!r}: a force push naming no refspec lost the bare row: "
+                f"{set(security._git_publish_floor_tags(cmd))}"
+            )
+
+
+class TestProcessSubstitutionBoundaryIsProven:
+    """The boundary rule: a PROVEN-complete substitution is a word, an
+    UNPROVABLE one is ambiguous.
+
+    Round 1 moved process substitution off the whole-segment expansion regex's
+    fail-closed ``[<>]\\(`` and onto a paren-depth walk, so that a substitution
+    the shell REMOVES (the target of ``> >(tee log)``) could keep the precise
+    reading instead of denying an ordinary teed push. That walk counted parens
+    with ``str.count``, which is quote-UNAWARE -- and a quoted paren inflates the
+    depth, so the real closer never returns it to zero and every following word
+    is swallowed into the substitution. Both review lanes traced it to a
+    protected-branch push being allowed. The walk now shares the module's one
+    quote/escape state machine and fails closed when the boundary cannot be
+    proven, which restores the old regex's posture for exactly the unprovable
+    cases while keeping round 1's win for the provable ones.
+    """
+
+    def test_a_quoted_paren_cannot_swallow_the_refspec(self):
+        # Both lanes' traces, verbatim. The quoted '(' contributes NOTHING to the
+        # depth, so the substitution ends at its real ')' and 'main' survives as
+        # the refspec it is.
+        for cmd in (
+            "git push origin feature > >(echo '(' ) main",
+            'git push origin feature > >(printf "(") main',
+            "git push origin feature > >(echo '((((' ) main",
+            'git push origin feature > >(cat "((") main',
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert "git-publish-push-protected-branch-name" in tags, (
+                f"{cmd!r}: a quoted paren inflated the substitution boundary and "
+                f"swallowed the protected refspec: {set(tags)}"
+            )
+            assert tags, f"{cmd!r}: publishes main and was ALLOWED"
+        # The words really are recovered, not merely tagged by a fallback.
+        assert security._git_push_args("git push origin feature > >(echo '(' ) main") == [
+            "origin",
+            "feature",
+            "main",
+        ]
+
+    def test_an_unprovable_boundary_fails_closed(self):
+        # The words ran out with the substitution still open, so the boundary
+        # cannot be proven and the rest of the segment cannot be read. Silently
+        # swallowing it is what hid a refspec; this is the ambiguity sentinel,
+        # which no catalog row can switch off -- the posture the whole-segment
+        # regex gave process substitution before the walk existed.
+        for cmd in (
+            "git push origin feature > >(echo main",
+            "git push origin feature > >(echo '('",
+            "git push origin main > >(tee log",
+            "git push origin feature > >(echo 'unterminated",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert (
+                security._GIT_PUBLISH_UNGATED in tags
+            ), f"{cmd!r}: an unclosed process substitution did not fail closed: {set(tags)}"
+            assert security._git_push_args(cmd) is None, cmd
+
+    def test_the_teed_push_round_one_unblocked_stays_unblocked(self):
+        # The round-1 win: a process substitution the shell REMOVES as a
+        # redirection target never reaches git's argv, so the push keeps its
+        # precise reading. A feature push stays allowed; a protected one is still
+        # reported by its own row, and a bare one still fails closed.
+        assert not security._git_publish_floor_tags(
+            "git push origin my-feature > >(tee log.txt)"
+        ), "the teed feature push regressed to a denial"
+        assert security._git_publish_floor_tags("git push origin main > >(tee log)") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+        assert security._git_publish_floor_tags("git push > >(git push origin my-feature)") == {
+            "git-publish-push-bare"
+        }
+        assert security._git_push_args("git push --force origin 2> >(cmd)") == [
+            "--force",
+            "origin",
+        ]
+        # In a WORD position it is still unverifiable -- that half is unchanged.
+        assert security._GIT_PUBLISH_UNGATED in security._git_publish_floor_tags(
+            "git push -o <(echo) origin main"
+        )
+
+    def test_quoted_parens_outside_a_substitution_stay_data(self):
+        # git allows ( and ) in a refname, and a quoted paren is an ordinary
+        # character. The walk must not read one as shell structure in either
+        # direction: these are legal unprotected names and stay pushable, while
+        # a protected name inside a subshell is still reported.
+        for cmd in (
+            "git push origin '('",
+            'git push origin ")"',
+            "git push origin 'feat(x)'",
+            "(git push origin ')')",
+            "(cd /tmp; git push origin my-feature)",
+        ):
+            assert not security._git_publish_floor_tags(cmd), cmd
+        assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+            "(git push origin main)"
+        )
+        # An ANSI-C quoted paren carries a '$', which the per-token pre-check
+        # already ungates -- over-protective, and deliberately so.
+        assert security._GIT_PUBLISH_UNGATED in security._git_publish_floor_tags(
+            "git push origin $'('"
+        )
+
+    def test_the_state_machine_ignores_quoted_parens(self):
+        # The property the boundary rests on, stated directly on the walk.
+        walk = security._shell_quote_walk
+        for text, delta in (
+            ("(", 1),
+            (")", -1),
+            ("'('", 0),
+            ('"("', 0),
+            ("$'('", 0),
+            ("\\(", 0),
+            (">(echo", 1),
+            ("log)", -1),
+            ('"(")', -1),
+            ("'()'", 0),
+        ):
+            assert walk(text).paren_delta == delta, f"{text!r}: delta {walk(text).paren_delta}"
+        # Quote state resumes across a whitespace boundary, which is why a
+        # quoted word spanning one cannot desync the depth.
+        assert walk("'a").end_state == 1
+        assert walk("b'", state=1).end_state == 0
+        assert walk("(", state=1).paren_delta == 0
+
+    def test_the_subshell_punctuation_branch_cannot_be_inflated(self):
+        # Round 2's branch also looks at parens, so it was audited for the same
+        # shape. It is a character-MEMBERSHIP test over the operator tail, not a
+        # depth count, and it is structurally immune: a quoted paren needs a
+        # quote character in that tail, and a quote is not in "()", so the tail
+        # stops qualifying as punctuation and the protective fallback takes it.
+        # A quoted paren also produces no operator split at all, so such a token
+        # never reaches the branch.
+        assert security._push_token_shell_read("main')'") == (None, False)
+        # With no split, it reads as the literal refname `main)` -- a different,
+        # unprotected branch, so allowing it is the correct precise reading.
+        assert not security._git_publish_floor_tags("git push origin main')'")
+        # When a quoted paren DOES sit in the operator tail, the tail stops
+        # qualifying as punctuation and the protective fallback takes the token.
+        for cmd in (
+            "git push origin main)'('",
+            "git push origin main)'x'",
+        ):
+            assert security._git_publish_floor_tags(cmd), f"{cmd!r} was allowed"
+        # And the branch's own case still reads precisely.
+        assert security._git_publish_floor_tags("(git push origin main)") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+
+
+class TestOneQuoteModelOnThePushPath:
+    """Every push-path reading of shell quoting walks ONE state machine.
+
+    This module has now been cured of the same defect three times: two
+    tokenizers with different word models (#7808 vs #7356), two paren counters
+    with different quote models, and finally two QUOTE models -- the word
+    splitter had no ANSI-C (``$'...'``) awareness while the boundary walk did.
+    In ``git push origin feature > >(echo $'a\\'b') main`` the splitter read the
+    ESCAPED quote as a real closer, reopened on the next quote, and fused the
+    trailing ``main`` into one unterminated word; the boundary walk then proved
+    its parenthesis correctly but could no longer rescue a refspec that was
+    already inside the word it had been handed. The cure is structural rather
+    than another flag: :func:`_iter_shell_chars` owns the machine and every
+    consumer drives it, so there is no second opinion left to drift from.
+    """
+
+    def test_an_ansi_c_escaped_quote_cannot_fuse_the_refspec(self):
+        # The trace verbatim. A backslash inside $'...' ESCAPES, so the word ends
+        # at its real closing quote and `main` stays the separate word it is.
+        for cmd in (
+            "git push origin feature > >(echo $'a\\'b') main",
+            "git push origin feature > >(echo $'a\\'b') main extra",
+            "git push origin feature > >(printf $'\\'') main",
+            "git push origin feature > >(echo $'a\\'b\\'c') main",
+        ):
+            tags = security._git_publish_floor_tags(cmd)
+            assert "git-publish-push-protected-branch-name" in tags, (
+                f"{cmd!r}: an ANSI-C escaped quote desynced the word split and "
+                f"fused the protected refspec: {set(tags)}"
+            )
+            assert tags, f"{cmd!r}: publishes main and was ALLOWED"
+        assert security._git_push_args("git push origin feature > >(echo $'a\\'b') main") == [
+            "origin",
+            "feature",
+            "main",
+        ]
+
+    def test_the_word_split_and_the_boundary_walk_agree_on_ansi_c(self):
+        # The property that makes the class impossible: both readings come from
+        # one machine, so they cannot disagree about where a quote ends.
+        for token in (
+            "$'a\\'b'",
+            "$'\\''",
+            "$'('",
+            "$')'",
+            "$'a\\'b'$'c\\'d'",  # adjacent ANSI-C words concatenate into one
+            "$'a\\'b'\"x\"",  # ANSI-C followed by ordinary quoting
+            "$'\\\\'",
+        ):
+            walk = security._shell_quote_walk(token)
+            assert walk.end_state == 0, f"{token!r}: walk left the quote open"
+            # The splitter must agree: a closed word does not swallow its neighbour.
+            assert security._split_shell_words(f"x {token} y") == ["x", token, "y"], token
+        # The CONTRAST that proves the ANSI-C branch is what differs: in a PLAIN
+        # single quote a backslash is literal, so the quote really does close and
+        # the next one really does reopen -- and both readings say so together.
+        plain = "'a\\'b'"
+        assert security._shell_quote_walk(plain).end_state == 1
+        assert security._split_shell_words(f"x {plain} y") == ["x", f"{plain} y"]
+
+    def test_ansi_c_parens_do_not_move_a_substitution_boundary(self):
+        # An ANSI-C quoted paren is data, exactly like a plainly quoted one, so it
+        # contributes nothing to the depth in either direction.
+        for token in ("$'('", "$')'", "$'(('", "$'()'"):
+            assert security._shell_quote_walk(token).paren_delta == 0, token
+        for cmd in (
+            "git push origin feature > >(echo $'(' ) main",
+            "git push origin feature > >(echo $')' ) main",
+            "git push origin feature > >(echo $'((((' ) main",
+        ):
+            assert "git-publish-push-protected-branch-name" in security._git_publish_floor_tags(
+                cmd
+            ), cmd
+        # Outside a substitution the '$' pre-check already ungates it, which is
+        # over-protective and deliberately so.
+        assert security._GIT_PUBLISH_UNGATED in security._git_publish_floor_tags(
+            "git push origin $'('"
+        )
+
+    def test_the_operator_cut_honours_escapes_through_the_same_machine(self):
+        # _cut_at_operator was the fourth walker: it tracked quotes but not
+        # escapes at all. Its pinned readings are unchanged, and an ESCAPED
+        # operator now stays in the word -- bash hands git the ref `ma)in`.
+        cut = security._cut_at_operator
+        assert cut("(git") == "git"
+        assert cut("main)&") == "main"
+        assert cut("mainline)>log") == "mainline"
+        assert cut("my-feature") == "my-feature"
+        assert cut("'(main)'") == "'(main)'"
+        assert cut('"(main)"') == '"(main)"'
+        assert cut("ma\\)in") == "ma\\)in"
+        assert security._dequote_token("ma\\)in") == "ma)in"
+
+    def test_every_earlier_round_still_holds_under_the_shared_machine(self):
+        # The unification must not cost any win the earlier rounds bought.
+        floor = security._git_publish_floor_tags
+        assert not floor("git push origin my-feature > >(tee log.txt)")  # round 1/3
+        assert floor("git push origin main > >(tee log)") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+        assert floor("(git push --repo=origin -f)") == floor("git push --repo=origin -f")  # round 2
+        assert floor("(git push origin main)") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+        assert not floor("git push origin 'feature|x'")  # round 1
+        assert not floor("git push origin 'a;b'")
+        assert floor("git push origin <<- EOF") == frozenset({"git-publish-push-single-arg"})
+        assert "git-publish-push-wildcard-refspec" in floor("git push origin @(main)")
+        assert security._GIT_PUBLISH_UNGATED in floor("git push origin ma\\\nin")  # round 1
+        assert security._git_push_args("bash -c '(cd /tmp && git push origin my-feature)'") is None
+
+
+class TestNestedPayloadExtractionSpansTheProvenBoundary:
+    """The body extracted for nested scanning must span the boundary the walk PROVES.
+
+    Rounds 3 and 4 gave the git-publish boundary walk and the word splitter one
+    quote-aware machine. The nested-payload EXTRACTOR still walked parens on its
+    own, and a quote-unaware span there does not merely mis-size the body -- it
+    loses the nested command outright: ``git push origin my-feature > >(X=')' git
+    push origin main)`` extracted ``X='``, so the publish of a protected branch
+    inside the substitution was never scanned and ``is_denied`` returned None for
+    a command bash executes. Extraction and boundary now read the same span, which
+    is the only arrangement in which they cannot disagree.
+    """
+
+    def test_a_quoted_paren_cannot_hide_a_nested_push(self):
+        # The trace verbatim, plus the quoting variants and nesting.
+        for cmd in (
+            "git push origin my-feature > >(X=')' git push origin main)",
+            'git push origin my-feature > >(X=")" git push origin main)',
+            "git push origin my-feature > >(X=$')' git push origin main)",
+            "git push origin my-feature > >(X=')' Y=')' git push origin main)",
+            "git push origin my-feature > >(X=')' git push origin main Y=')')",
+            "git push origin my-feature > >(echo >(git push origin main))",
+            "git push origin my-feature > >(echo >(X=')' git push origin main))",
+            "cat <(X=')' git push origin main)",
+        ):
+            assert security.is_denied(cmd) is not None, (
+                f"{cmd!r}: a quoted paren truncated the extracted body and the "
+                f"nested protected push was never scanned"
+            )
+        # The control: the same shape WITHOUT the quoted paren was always denied,
+        # so the quoting is what the fix restores rather than a new denial.
+        assert (
+            security.is_denied("git push origin my-feature > >(git push origin main)") is not None
+        )
+
+    def test_the_extracted_body_is_the_whole_body(self):
+        from kiro_crew.security import _substitution_bodies
+
+        assert _substitution_bodies(">(X=')' git push origin main)") == [
+            "X=')' git push origin main"
+        ]
+        assert _substitution_bodies("$(X=')' echo hi)") == ["X=')' echo hi"]
+        assert _substitution_bodies("<(a)<(b)") == ["a", "b"]
+        # Nested substitutions: the outer body keeps the inner one whole. The
+        # extractor returns ONE body per top-level opener; the payload walk is what
+        # descends, so the inner command is reached from the outer body.
+        assert _substitution_bodies(">(echo >(git push origin main))") == [
+            "echo >(git push origin main)"
+        ]
+        assert "git push origin main" in security._shell_payload_sources(
+            "cat >(echo >(git push origin main))"
+        )
+        # UNPROVEN span -> the whole remainder, the fail-closed direction.
+        assert _substitution_bodies(">(git push origin main") == ["git push origin main"]
+        assert _substitution_bodies(">(X=')' git push origin main") == [
+            "X=')' git push origin main"
+        ]
+
+    def test_the_span_helper_is_quote_aware_and_reports_proof(self):
+        from kiro_crew.security import _matching_close_paren
+
+        # offset 2 is just past a ">(" / "$(" opener.
+        assert _matching_close_paren(">(a)", 2) == (4, True)
+        assert _matching_close_paren(">(a(b))", 2) == (7, True)
+        # A quoted closer is data and must not end the span.
+        assert _matching_close_paren(">(X=')' a)", 2) == (10, True)
+        assert _matching_close_paren('>(X=")" a)', 2) == (10, True)
+        assert _matching_close_paren(">(X=$')' a)", 2) == (11, True)
+        # A quoted OPENER must not deepen it either.
+        assert _matching_close_paren(">(X='(' a)", 2) == (10, True)
+        # Never balanced -> not proven, and the span runs to the end.
+        assert _matching_close_paren(">(a", 2) == (3, False)
+        assert _matching_close_paren(">(X=')' a", 2) == (9, False)
+
+    def test_the_self_protection_substitution_scan_is_quote_aware_too(self):
+        # Same class at the self-protection rule: its private str.count walk
+        # stopped at a quoted ')', so a name after it was never seen. That is an
+        # UNDER-deny for this rule -- correcting an earlier audit note on this
+        # line, which had recorded the truncation as over-deny-only.
+        from kiro_crew.security import _protected_name_in_substitution
+
+        # The quoted ')' must sit in a LATER token to reach the close test: a
+        # private str.count walk drove depth to 0 there and BROKE, so the name
+        # after it was never seen.
+        tokens = ["$(true", "X=')'", "kirocrew", "token)"]
+        assert _protected_name_in_substitution(tokens, 0) == "kirocrew"
+        # Still stops at the REAL closer rather than reading a later command.
+        assert _protected_name_in_substitution(["$(true)", ";", "kirocrew"], 0) == ""
+
+    def test_every_earlier_round_still_holds(self):
+        floor = security._git_publish_floor_tags
+        assert not floor("git push origin my-feature > >(tee log.txt)")
+        assert floor("git push origin main > >(tee log)") == frozenset(
+            {"git-publish-push-protected-branch-name"}
+        )
+        assert security.is_denied("git push origin my-feature > >(tee log.txt)") is None
+        assert floor("(git push --repo=origin -f)") == floor("git push --repo=origin -f")
+        assert not floor("git push origin 'feature|x'")
+        assert "git-publish-push-protected-branch-name" in floor(
+            "git push origin feature > >(echo '(' ) main"
+        )
+        assert "git-publish-push-protected-branch-name" in floor(
+            "git push origin feature > >(echo $'a\\'b') main"
+        )
+        assert security._GIT_PUBLISH_UNGATED in floor("git push origin feature > >(echo main")
+        assert security._git_push_args("bash -c '(cd /tmp && git push origin my-feature)'") is None


### PR DESCRIPTION
## Root cause

`eaa8a45bb` (#7808, *model publish option arity so the floor tag holds*) landed **unrebased over** `d402acdf8` (#7356, *close four enforcement bypasses in the bash command gates*). Both rewrote the same `git push` argument tokenizer, in incompatible directions, with **no textual conflict** — so main went red the moment the second one merged.

This is **not** a Windows-only failure. The Windows shard was simply the first lane to finish; the six `test_push_branch_gate.py` failures reproduce on Linux with a plain `pytest test/test_push_branch_gate.py`, and #8697's Linux `Backend Tests (3.12, 3)` job showed the identical six. Linux shards 2–4 on main's own run `33953620339` never completed, which is why the first read looked platform-specific.

## The mechanism

#7808's option-arity and shell-syntax model is defined over **RAW words**. It splits each word at its own unquoted operators (`_push_token_shell_read`), models redirection arity itself (`_push_token_redirection`), truncates at a word-initial `#`, and classifies extglob/glob shapes.

#7356 had meanwhile taught the outer parse (`_git_push_args`) to **cut** a word at its glued operators and to step over redirections with a second, coarser reading of the same grammar. The outer parse therefore pre-chewed the words the inner model reads, and every shape whose identity lives in the operator lost it:

| command | read as | should be |
|---|---|---|
| `git push origin>/dev/null` | plain remote `origin` | remote-only push (single-arg) |
| `git push origin @(main)` | ambiguous ref `@` | extglob wildcard refspec |
| `git push origin & echo x` | empty token | `&` is a command boundary → bare |
| `git push origin <<- EOF` | `EOF` as a refspec | `<<-` consumes its delimiter |
| `git push origin> log` | two positionals | remote-only push (single-arg) |
| `git push --force>/dev/null origin feature-x` | *(no tag at all)* | protective fallback |

Four of those returned **no tag at all** — an allow — and `git push origin & git push origin2 main` lost its bare row. In the other direction, #7808's new whole-segment `[<>]\(` alternative denied `git push origin my-feature > >(tee log.txt)`, an ordinary feature push whose output is teed, which #7356 explicitly pinned as *allowed*.

## The fix — one decision, one place

- **`_git_push_args` returns the RAW spelling** of the words it keeps, and takes its redirection arity from `_push_token_redirection` instead of reading the grammar a second time. That alone fixes `<<-`, whose `-` the local reading took for an attached target.
- **Process substitution is a WORD, not a redirection.** A token opening with `<(` / `>(` is returned rather than skipped, so `-o <(echo)` keeps its value and cannot shift the positional split onto the remote. The word-position ungate moves out of `_AMBIGUOUS_EXPANSION_RE` (which fired on the whole segment) into the scan that sees the tokens surviving redirection removal — so a process substitution the shell *removes* keeps the precise reading, and one that *survives* as an argv word is still ungated.
- **`_dequote_token` no longer cuts at operators.** `_cut_at_operator` stays where an operator can hide a **program** name (the `git` anchor); for an **argument** it destroyed the evidence the scan reads. `mainline)>log` still resolves to protected `mainline` through the piece scan.
- **Segment and word splitting are quote/escape aware** (`_split_push_command_segments`, `_split_shell_words`). Splitting inside quotes truncated a word mid-quote, and the fragment then arrived with the shell state open — which the fragment rule reads as a splice across the boundary. That denied legal refnames (`'feature|x'`, `'a;b'`) and made a wrapper's quoted payload yield a bare `git` token, so the **outer** line parsed as a push and its fragmented ref denied ordinary work (`bash -c '(cd /tmp && git push origin my-feature)'`). A backslash-newline still splits and still keeps its trailing escape: it is the one separator that *vanishes*, and that escape is the signal the ungated sentinel is drawn from.
- **A word whose operator tail is only subshell punctuation keeps its exact identity**, so a refname pushed inside `( ... )` is read precisely. The word is still scanned as a refspec candidate, so a protected name inside the parens is caught exactly as it is without them.

## Nothing is weakened

Every protective assertion holds. Two readings become **more** precise, and both are pinned in the metacharacter inventory:

- `(git push origin main)` now reports the `protected-branch-name` row instead of the unparseable-fallback sentinel. The test asserts it equals the row its *unparenthesised* spelling gets — a spelling-specific row would itself be an escape hatch — and it is still a denial.
- A quoted whitespace-spanning option value no longer needs the protective fallback, because it is no longer torn into two fragments. The regression that matters is kept explicit: a protected refspec **behind** such a value is still seen (`--push-option='ci skip' origin main` → `protected-branch-name`).

## What was tested

- `test/test_push_branch_gate.py` — **109 passed** (103 pre-existing + 6 new).
- **2,663 passed / 1 skipped** across `test_push_branch_gate.py`, `test_security.py`, `test_denied_commands_security.py`, `test_denied_commands_api.py` — the two suites that pin #7356's and #7808's opposing constraints, so both PRs' intents are held simultaneously.
- `test_security_posture.py` and `test_security_regex_linearity.py` included in the same run (repo-wide drift and ReDoS guards, required because this adds functions under `src/kiro_crew`).
- **Red-first proof** for every new assertion by restoring the pre-fix helper in-memory: reverting the word split, the segment split, or the operator cut each reproduces the exact failure the assertion now catches.
- Gates: isort clean, flake8 clean, `mypy --platform linux src/kiro_crew` — *Success: no issues found in 1293 source files*. `black --check` is clean on `test/test_push_branch_gate.py` and on every line this PR adds to `security.py`; that file is listed in `.github/black-baseline.txt`, so it is exempt from the gate and was deliberately **not** wholesale-reformatted (doing so adds ~594 lines of unrelated churn to an urgent fix).

## New test class

`TestTokenizerContractBetweenTheLayers` pins the seam in both directions — what the argument scan is handed and by whom — so the two layers cannot silently drift apart again.

<!-- no-visual-delta -->

**Why no screenshot:** backend-only change. The touched surfaces are the `git push` deny-gate matcher in `src/kiro_crew/security.py` (`_git_push_args`, `_dequote_token`, `_push_segment_targets_protected`, `_git_publish_floor_tags`) and its unit tests. No dashboard, renderer, CLI output or user-visible UI is involved.

## Pattern harvest

Rule candidate: When two PRs edit the same parser and the second merges without rebasing onto the first, a *semantic* merge conflict lands with no textual conflict — before triaging a red as platform-specific, reproduce it locally on the other platform and check whether that platform's shards actually COMPLETED, because an incomplete shard reads as green in the lane.

Rule candidate: A test whose comment explains WHY a value is expected is the place to detect a layer-contract change — when a rationale ("no clean `git` token survives", "fragments poison the split") has become false because another PR fixed that layer, the fix is to re-derive the expected value and say which layer now accounts for it, not to restore the old behaviour.

Not generalizable: The specific arity table entries (`<<-` consuming its delimiter, `<(`/`>(` being words rather than redirections, `>&-` keeping its self-contained reading) are bash grammar facts particular to this matcher and carry no lesson beyond it.
