### PR TITLE
fix(snapshot): resolve the notification merge source once

### DIFF
--- a/docs/system-specs/modules/cli.md
+++ b/docs/system-specs/modules/cli.md
@@ -226,6 +226,22 @@ work, not introduced by it.
 A refusal to stage is a permission decision and is written to the SEL audit log —
 `snapshot_rejected` or `state_restore_rejected`, both with `reason=unpinnable_staging`.
 
+The restore's notification merge (`_merge_notifications`) resolves each name **once**:
+where the platform can pin, source and destination are each opened through
+`pinned_fs.open_in_pinned_parent` (the parent chain walked with `O_NOFOLLOW` from a
+caller-resolved root, so an ancestor swap is refused too), the descriptor is judged with
+`fstat` (`S_ISREG`) plus `pinned_fs.refuse_hardlink_alias` — a hardlinked alias is a
+regular file that no link screen can see, only the inode's link count — and the
+validation pass and the copy loop read that same held descriptor — the source rewound
+with `seek(0)`, the destination one `O_RDWR|O_APPEND` handle for both its scan and the
+append. Validating a name and then re-opening it are two resolutions of the same string,
+and the staging tree is agent-writable, so a swap between them used to append the link
+target's bytes into the live `notifications.jsonl` under a validation that had vouched
+for a different file. `O_NONBLOCK` is load-bearing, not hygiene: without it a name that
+became a FIFO blocks the open forever, converting a refused restore into a hung one.
+Where the platform has no `O_NOFOLLOW`, `pinned_fs.is_reparse_point` is the by-name
+floor, the same degradation `_backup_and_copy` applies.
+
 The dashboard's import path (`portability.apply_import_zip`) is the **exception**, and
 deliberately: it has no flag and no consent surface, so refusing there would not mean
 "ask the user", it would mean deleting import on that platform. It therefore proceeds with

--- a/src/kiro_crew/snapshot.py
+++ b/src/kiro_crew/snapshot.py
@@ -2556,6 +2556,86 @@ def _notification_key(record: bytes, path: Path) -> tuple[Any, ...] | None:
     return ("raw", record if record.endswith(_TERMINATORS) else record + b"\n")
 
 
+def _open_notification_file(path: Path, flags: int, *, what: str) -> int:
+    """Open *path* exactly once and judge the DESCRIPTOR, never the name again.
+
+    The merge below used to resolve each name twice -- validate by name, then
+    re-open the same name to copy -- and ``open()`` follows a symlink at the
+    final component, so a swap between the two resolutions redirected the second
+    one (issue #8667). This helper is the single resolution, built from the
+    ``pinned_fs`` primitives rather than re-implementing them (review found the
+    first version carrying a private copy of the hardlink predicate, and two
+    copies of one security predicate drift independently):
+
+    * Where the platform can pin (``supports_pinned_walk``), the open goes
+      through ``pinned_fs.open_in_pinned_parent``: the parent chain is walked
+      component-by-component with ``O_NOFOLLOW`` from a caller-resolved root, so
+      an agent-writable ANCESTOR swapped for a link mid-walk is refused too --
+      the staging tree is exactly such a directory, and guarding only the final
+      component left that gap (``open_dir_pinned``'s own docstring records it).
+    * Elsewhere (Windows: no ``O_NOFOLLOW``, no ``dir_fd``),
+      ``pinned_fs.is_reparse_point`` is the by-name floor, exactly as
+      ``_backup_and_copy`` applies it. An ``lstat`` before the open compared
+      against a later ``fstat`` would NOT be a substitute: that is a
+      check-to-use window, the same mistake as trusting an intermediate name,
+      and ``pinned_fs`` records the identical finding for the pinned walk.
+
+    Flag by flag, because each is load-bearing:
+
+    * ``O_NOFOLLOW`` -- a symlink at the final component fails the open instead
+      of being followed; composed via ``getattr`` because Windows lacks it.
+    * ``O_NONBLOCK`` -- not belt-and-braces: without it, a name that became a
+      FIFO blocks the ``open`` forever with no writer ever coming, converting a
+      refused restore into a HUNG one. With it the open returns at once and the
+      ``fstat`` below refuses the descriptor.
+    * ``O_BINARY`` -- Windows-only; byte-exactness is this merge's contract.
+    * ``O_CLOEXEC`` -- house style, as in ``_dir_flags_nofollow``.
+
+    The judgement is on the descriptor, never a fresh by-name check: ``fstat``
+    + ``S_ISREG`` (FIFOs, devices, directories), then
+    ``pinned_fs.refuse_hardlink_alias`` -- a HARDLINK to a credential passes
+    both link screens (``O_NOFOLLOW`` has nothing to refuse and the alias IS a
+    regular file), so only the inode's link count can see it. That helper
+    CLOSES the descriptor itself before raising, which is why it sits outside
+    this function's own close-on-error arm. Refusals raise ``OSError`` so the
+    merge's abort posture (raise, never skip) is unchanged; the path is
+    embedded ``!r`` because an archive-derived name can carry ANSI controls and
+    the caller prints the exception.
+    """
+    flags = (
+        flags
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_BINARY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    if pinned_fs.supports_pinned_walk():
+        # Resolved by the caller ONCE, as pin_parent requires: resolving inside
+        # the walk would re-follow whatever an ancestor points at by now.
+        fd = pinned_fs.open_in_pinned_parent(
+            os.path.realpath(str(path.parent)),
+            path.name,
+            flags=flags,
+            mode=0o600,
+            what=what,
+            refusal=OSError,
+        )
+    else:
+        if pinned_fs.is_reparse_point(path):
+            raise OSError(f"refusing symlinked {what}: {str(path)!r}")
+        fd = os.open(path, flags)
+    try:
+        if not _stat.S_ISREG(os.fstat(fd).st_mode):
+            raise OSError(f"{what} is not a regular file: {str(path)!r}")
+    except BaseException:
+        os.close(fd)
+        raise
+    # Closes *fd* itself before raising -- deliberately OUTSIDE the
+    # close-on-error arm above, per its documented contract.
+    pinned_fs.refuse_hardlink_alias(fd, what=what, name=str(path), refusal=OSError)
+    return fd
+
+
 def _merge_notifications(src_path: Path, dst_path: Path) -> None:
     """Append the snapshot's notification records to the live file, byte for byte.
 
@@ -2609,78 +2689,153 @@ def _merge_notifications(src_path: Path, dst_path: Path) -> None:
     record already in the destination gains one before anything is appended
     after it. Without that, two records glued into one line that parses as
     neither.
+
+    Each name is resolved exactly ONCE (issue #8667). The predecessor opened
+    ``src_path`` by name for the validation pass and again by name for the copy
+    loop, with nothing carrying identity between the two opens -- so a process
+    able to write the extracted staging tree (which an agent can, on a normal
+    install) could swap the name for a symlink in that window and have the copy
+    append the link TARGET's bytes into the live file that the dashboard serves.
+    The validation pass had vouched for a different file, so "append only
+    records that validated" became silently false. Now each side is opened once
+    through :func:`_open_notification_file` -- the descriptor is judged with
+    ``fstat``, validated, rewound, and reused -- so what was validated is, by
+    construction, what is read. The destination had the identical shape one
+    layer down (scan by name, re-open by name to append) and gets one
+    ``O_RDWR|O_APPEND`` descriptor for the same reason.
+
+    * A destination-scan failure is still a true no-op. The descriptor is opened
+      read-write up front -- that is what makes it one resolution -- but not a
+      byte is written to it until both scans have completed.
+    * The SOURCE is validated whole before anything is appended, so a
+      source-side refusal is also a no-op. Without that pass, a source whose
+      Nth record is undecodable had already appended N-1 records when it
+      aborted, and a retry re-appended every identity-less one of them, since a
+      row with no ``ts`` cannot be deduplicated. The cost is reading the source
+      twice -- through the same descriptor, rewound.
+    * A failure DURING the copy is the residual case, and its prefix stays:
+      rolling it back would be a second unvalidated write. What the held
+      descriptor removes is the NAME swap -- both passes read one pinned inode,
+      so no re-resolution can substitute a different file. It does not freeze
+      the inode's CONTENTS: a writer truncating or rewriting the file in place
+      between the passes can still make the copy see different bytes than the
+      validation did (up to and including zero imports), which lands here or in
+      the count, exactly like any other mid-copy I/O surprise.
     """
     existing: set[tuple[Any, ...]] = set()
     dst_unterminated = False
     try:
-        with open(dst_path, "rb") as f:
-            for record in strict_raw_records(f, dst_path, cap=_NOTIFICATION_RECORD_CAP):
-                key = _notification_key(record, dst_path)
-                if key is not None:
-                    existing.add(key)
-                dst_unterminated = not record.endswith(_TERMINATORS)
-    except (OSError, UnreadableRecord) as exc:
+        # One O_RDWR|O_APPEND descriptor for BOTH the scan and the append: the
+        # scan needs read access and re-opening the name for "ab" later would be
+        # the second resolution this function no longer performs. No O_CREAT --
+        # the caller only routes here when the live file exists, and the old
+        # scan's `open(dst_path, "rb")` aborted on a missing file too.
+        dst_fd = _open_notification_file(
+            dst_path, os.O_RDWR | os.O_APPEND, what="live notification file"
+        )
+    except OSError as exc:
         # No `_safe_name` here, deliberately: this path is the LIVE data home,
         # chosen by the operator, not a name that came out of an archive -- which
         # is the scope `_safe_name`'s own docstring states. The SOURCE prints do
         # wrap it; see the one below.
         print(f"  ⚠️  Could not read {dst_path}: {exc} — merge aborted")
         raise
-    # The ENTIRE source is validated before the destination is opened for append.
-    # Without this pass, a source whose Nth record is undecodable or over-cap has
-    # already appended N-1 records by the time it aborts -- and a retry
-    # re-appends every identity-less one of those, because a row with no ``ts``
-    # cannot be deduplicated by construction. Validating first makes the source
-    # side all-or-nothing in the ordinary case, so there is no prefix to
-    # duplicate.
     try:
-        with open(src_path, "rb") as f:
-            for record in strict_raw_records(f, src_path, cap=_NOTIFICATION_RECORD_CAP):
-                _notification_key(record, src_path)
-    except (OSError, UnreadableRecord) as exc:
-        # The PATH goes through `_safe_name` because a bundle chooses its own inner
-        # root, so an archive-derived path can carry ANSI controls -- and printing
-        # one raw lets a hostile archive move the cursor and overwrite lines right
-        # above the prompt where the operator decides whether to trust the restore.
-        #
-        # The EXCEPTION deliberately does NOT, and the invariant is worth stating
-        # because it is what makes the wrapper unnecessary rather than forgotten:
-        # both types this arm catches already render an embedded path with
-        # repr-style escaping -- `OSError.__str__` does it for its filename, and
-        # `jsonl_util` uses `{path!r}` for the reason its own comment gives.
-        # Measured: a control character in a directory name reaches neither
-        # exception's `str()` raw. Widening this `except` tuple means re-checking
-        # that, because a type formatting a path with `str()` would need the wrapper.
-        print(f"  ⚠️  Could not read {_safe_name(src_path)}: {exc} — merge aborted")
+        out = os.fdopen(dst_fd, "r+b")
+    except Exception:
+        os.close(dst_fd)
         raise
-    imported = 0
-    try:
-        with open(dst_path, "ab") as out, open(src_path, "rb") as f:
-            if dst_unterminated:
-                out.write(b"\n")
-            for record in strict_raw_records(f, src_path, cap=_NOTIFICATION_RECORD_CAP):
-                key = _notification_key(record, src_path)
-                # A `None` key means the record did not PARSE, so it may be a
-                # framing fragment rather than a record -- nothing it could be a
-                # duplicate OF. Both `existing.add` sites refuse `None`, which is
-                # what keeps it out of this membership test; an unconditional
-                # `key is not None` here would be dead, and a mutation proved it
-                # unobservable. A ts-less row that DOES parse is keyed on its raw
-                # bytes and deduplicates normally; see _notification_key for why
-                # raw and not stripped.
-                if key in existing:
-                    continue
-                out.write(record if record.endswith(_TERMINATORS) else record + b"\n")
+    with out:
+        try:
+            for record in strict_raw_records(out, dst_path, cap=_NOTIFICATION_RECORD_CAP):
+                key = _notification_key(record, dst_path)
                 if key is not None:
                     existing.add(key)
-                imported += 1
-    except (OSError, UnreadableRecord) as exc:
-        # Reached only when the source changed BETWEEN the validation pass and
-        # this one, so the prefix already appended stays: rolling it back would
-        # be a second unvalidated write. Names the count so an operator knows a
-        # prefix landed, and identity-less rows in it will re-append on a retry.
-        print(f"  ⚠️  Stopped merging {_safe_name(src_path)} after {imported} record(s): {exc}")
-        raise
+                dst_unterminated = not record.endswith(_TERMINATORS)
+        except (OSError, UnreadableRecord) as exc:
+            # Same no-wrap rationale as the open above: the live path is the
+            # operator's own, not archive-derived.
+            print(f"  ⚠️  Could not read {dst_path}: {exc} — merge aborted")
+            raise
+        # The ENTIRE source is validated before anything is appended. Without this
+        # pass, a source whose Nth record is undecodable or over-cap has already
+        # appended N-1 records by the time it aborts -- and a retry re-appends
+        # every identity-less one of those, because a row with no ``ts`` cannot be
+        # deduplicated by construction. Validating first makes the source side
+        # all-or-nothing in the ordinary case, so there is no prefix to duplicate.
+        try:
+            src_fd = _open_notification_file(
+                src_path, os.O_RDONLY, what="snapshot notification file"
+            )
+        except OSError as exc:
+            # The PATH goes through `_safe_name` because a bundle chooses its own
+            # inner root, so an archive-derived path can carry ANSI controls -- and
+            # printing one raw lets a hostile archive move the cursor and overwrite
+            # lines right above the prompt where the operator decides whether to
+            # trust the restore. The exception is safe to print raw:
+            # `_open_notification_file`'s own refusals embed the path with `!r`,
+            # and an `OSError` raised by the OS renders its filename repr-escaped.
+            print(f"  ⚠️  Could not read {_safe_name(src_path)}: {exc} — merge aborted")
+            raise
+        try:
+            f = os.fdopen(src_fd, "rb")
+        except Exception:
+            os.close(src_fd)
+            raise
+        with f:
+            try:
+                for record in strict_raw_records(f, src_path, cap=_NOTIFICATION_RECORD_CAP):
+                    _notification_key(record, src_path)
+            except (OSError, UnreadableRecord) as exc:
+                # The EXCEPTION deliberately skips `_safe_name`, and the invariant is
+                # worth stating because it is what makes the wrapper unnecessary
+                # rather than forgotten: both types this arm catches already render
+                # an embedded path with repr-style escaping -- `OSError.__str__` does
+                # it for its filename, and `jsonl_util` uses `{path!r}` for the
+                # reason its own comment gives. Measured: a control character in a
+                # directory name reaches neither exception's `str()` raw. Widening
+                # this `except` tuple means re-checking that, because a type
+                # formatting a path with `str()` would need the wrapper.
+                print(f"  ⚠️  Could not read {_safe_name(src_path)}: {exc} — merge aborted")
+                raise
+            imported = 0
+            try:
+                # The SAME descriptor the validation pass just read, rewound -- never
+                # a second `open(src_path)`: re-resolving the name here is the exact
+                # defect this function was rewritten to remove.
+                f.seek(0)
+                out.seek(0, os.SEEK_END)
+                if dst_unterminated:
+                    out.write(b"\n")
+                for record in strict_raw_records(f, src_path, cap=_NOTIFICATION_RECORD_CAP):
+                    key = _notification_key(record, src_path)
+                    # A `None` key means the record did not PARSE, so it may be a
+                    # framing fragment rather than a record -- nothing it could be a
+                    # duplicate OF. Both `existing.add` sites refuse `None`, which is
+                    # what keeps it out of this membership test; an unconditional
+                    # `key is not None` here would be dead, and a mutation proved it
+                    # unobservable. A ts-less row that DOES parse is keyed on its raw
+                    # bytes and deduplicates normally; see _notification_key for why
+                    # raw and not stripped.
+                    if key in existing:
+                        continue
+                    out.write(record if record.endswith(_TERMINATORS) else record + b"\n")
+                    if key is not None:
+                        existing.add(key)
+                    imported += 1
+                # Flushed INSIDE this handler so a delayed-writeback failure is
+                # reported as a stopped merge, exactly as the predecessor's
+                # with-block close was.
+                out.flush()
+            except (OSError, UnreadableRecord) as exc:
+                # The prefix already appended stays: rolling it back would be a
+                # second unvalidated write. Names the count so an operator knows a
+                # prefix landed, and identity-less rows in it will re-append on a
+                # retry.
+                print(
+                    f"  ⚠️  Stopped merging {_safe_name(src_path)} after {imported} record(s): {exc}"
+                )
+                raise
     print(f"  Notifications imported: {imported}")
 
 

--- a/test/test_snapshot.py
+++ b/test/test_snapshot.py
@@ -2741,6 +2741,255 @@ class TestNotificationCopyWhenNoLiveFileExists(_NotificationCopyFixtures):
         assert (home / "notifications.jsonl").is_symlink(), "the operator's link was removed"
 
 
+# ── Issue #8667: the merge must validate and copy the SAME inode, not the same
+# name twice ─────────────────────────────────────────────────────────────────
+
+
+class TestNotificationMergeResolvesEachNameOnce:
+    """One descriptor from validation through copy; a swapped name changes nothing.
+
+    ``_merge_notifications`` used to open ``src_path`` by NAME twice -- once to
+    validate, once to copy -- with nothing carrying identity between the two
+    opens. The staging tree is agent-writable on a normal install, so swapping
+    that name for a symlink in the window made the copy loop append the link
+    TARGET's bytes into the live ``notifications.jsonl`` while the validation
+    pass vouched for a different file. The destination had the identical shape
+    one layer down (scan by name, then re-open by name to append).
+
+    Every fixture here is a real link, FIFO, or rename on a real filesystem --
+    a monkeypatched ``open`` that pretends to be a symlink would route the merge
+    down a path the defect never took.
+    """
+
+    LIVE = b'{"ts":"2026-02-01T00:00:00Z","msg":"local"}\n'
+    GOOD = b'{"ts":"2026-03-01T00:00:00Z","msg":"snap"}\n'
+    # Valid UTF-8, not JSON: exactly the shape of a token/env file, and exactly
+    # what the unfixed copy loop appended UNCONDITIONALLY -- an unparseable
+    # record keeps no dedupe key, so nothing ever refused it.
+    SECRET = b"AWS_SECRET_STAND_IN=hunter2-not-a-notification\n"
+
+    def _files(self, tmp_path):
+        src = tmp_path / "snap-notifications.jsonl"
+        dst = tmp_path / "live-notifications.jsonl"
+        src.write_bytes(self.GOOD)
+        dst.write_bytes(self.LIVE)
+        secret = tmp_path / "secret.env"
+        secret.write_bytes(self.SECRET)
+        return src, dst, secret
+
+    @staticmethod
+    def _merge_in_thread(src, dst, timeout: float = 10.0) -> list[str]:
+        """Run the merge on a daemon thread so a hang FAILS instead of wedging pytest.
+
+        The FIFO cases below are "must not block forever" properties: before the
+        fix (or under a dropped ``O_NONBLOCK``) the open blocks with no writer
+        ever coming, and a test that simply calls the merge would hang the whole
+        suite rather than going red.
+        """
+        import threading
+
+        outcome: list[str] = []
+
+        def run() -> None:
+            try:
+                snapshot_mod._merge_notifications(src, dst)
+                outcome.append("returned")
+            except OSError:
+                outcome.append("raised")
+            except Exception as exc:  # noqa: BLE001 — name any unexpected type
+                outcome.append(f"raised {type(exc).__name__}")
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        t.join(timeout=timeout)
+        if t.is_alive():
+            outcome.append("hung")
+        return outcome
+
+    @requires_symlinks
+    def test_a_source_swapped_for_a_symlink_after_validation_is_not_followed(
+        self, tmp_path, monkeypatch
+    ):
+        """The exact defect: swap the name BETWEEN the two passes.
+
+        The swap is performed the moment the validation pass finishes reading
+        the source -- the third ``strict_raw_records`` call is the copy loop, so
+        completing the second one is the last instant before the window closed.
+        With the name resolved twice, the copy followed the link and the
+        target's bytes landed; with one descriptor, the swap is invisible.
+        """
+        src, dst, secret = self._files(tmp_path)
+        real = snapshot_mod.strict_raw_records
+        calls = {"n": 0}
+
+        def swapping(handle, path, **kwargs):
+            calls["n"] += 1
+            this_call = calls["n"]
+            yield from real(handle, path, **kwargs)
+            if this_call == 2:  # the source validation pass just completed
+                src.unlink()
+                src.symlink_to(secret)
+
+        monkeypatch.setattr(snapshot_mod, "strict_raw_records", swapping)
+        snapshot_mod._merge_notifications(src, dst)
+        after = dst.read_bytes()
+        assert self.SECRET not in after, "the copy loop followed a name swapped after validation"
+        assert after == self.LIVE + self.GOOD, "the archive's own validated bytes must land"
+
+    @requires_symlinks
+    def test_a_source_that_is_already_a_symlink_is_refused_at_the_open(self, tmp_path, capsys):
+        """No window needed: a link sitting at the name must never be followed.
+
+        The unfixed merge read straight through it twice and reported success.
+        A refused open surfaces as a REFUSAL -- raise plus the abort line -- not
+        as a silent skip that installs nothing.
+        """
+        src, dst, secret = self._files(tmp_path)
+        src.unlink()
+        src.symlink_to(secret)
+        before = dst.read_bytes()
+        with pytest.raises(OSError):
+            snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == before, "a refusal must be a no-op on the live file"
+        out = capsys.readouterr().out
+        assert "Notifications imported:" not in out, "reported success on a refused merge"
+        assert "merge aborted" in out
+
+    @requires_symlinks
+    def test_the_reparse_floor_refuses_a_linked_source_where_O_NOFOLLOW_is_absent(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Windows has no ``O_NOFOLLOW``; ``is_reparse_point`` is the floor there.
+
+        Simulated the way this suite already simulates that platform: delete the
+        flag, so ``getattr(os, "O_NOFOLLOW", 0)`` contributes nothing and the
+        by-name screen is the only thing standing between the link and the open.
+        Same floor as ``_backup_and_copy``.
+        """
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+        src, dst, secret = self._files(tmp_path)
+        src.unlink()
+        src.symlink_to(secret)
+        before = dst.read_bytes()
+        with pytest.raises(OSError):
+            snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == before
+        assert self.SECRET not in dst.read_bytes()
+        assert "merge aborted" in capsys.readouterr().out
+
+    @requires_symlinks
+    def test_a_destination_that_is_a_symlink_is_refused_before_anything_is_written(self, tmp_path):
+        """The destination has the same two-resolution shape one layer down.
+
+        A link at the live name redirected the append at whatever it pointed
+        to. Smaller exposure -- the live name is the operator's own file, not an
+        archive-derived one -- but the same fix applies and is pinned the same
+        way.
+        """
+        src, dst, _ = self._files(tmp_path)
+        real_dst = tmp_path / "elsewhere.jsonl"
+        real_dst.write_bytes(self.LIVE)
+        dst.unlink()
+        dst.symlink_to(real_dst)
+        with pytest.raises(OSError):
+            snapshot_mod._merge_notifications(src, dst)
+        assert real_dst.read_bytes() == self.LIVE, "the append was redirected through the link"
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are a POSIX fixture")
+    def test_a_fifo_at_the_source_name_fails_rather_than_hanging(self, tmp_path):
+        """What ``O_NONBLOCK`` buys, pinned so a later cleanup cannot drop it.
+
+        Opening a FIFO for reading with no writer blocks FOREVER without it --
+        converting a refused restore into a hung one. With it the open returns
+        at once and the ``fstat`` regular-file judgement refuses the descriptor.
+        """
+        src, dst, _ = self._files(tmp_path)
+        src.unlink()
+        os.mkfifo(src)
+        before = dst.read_bytes()
+        outcome = self._merge_in_thread(src, dst)
+        assert outcome == ["raised"], f"a FIFO source must refuse, not {outcome}"
+        assert dst.read_bytes() == before
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="FIFOs are a POSIX fixture")
+    def test_the_regular_file_judgement_is_on_the_descriptor_not_the_name(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """``fstat`` judges the inode the merge HOLDS; a name re-check judges whatever
+        the name points at NOW.
+
+        The open pins a FIFO, then the name is swapped to a perfectly ordinary
+        regular file before any by-name re-check could run. The descriptor
+        judgement refuses with the named reason; an ``os.path.isfile(src_path)``
+        check would pass and hand the FIFO descriptor to the record reader.
+        ``pinned_fs.py`` records the identical finding for the pinned walk:
+        an ``lstat``-before-open compared against a later ``fstat`` is the same
+        check-to-use window wearing a different name.
+        """
+        src, dst, _ = self._files(tmp_path)
+        src.unlink()
+        os.mkfifo(src)
+        regular = tmp_path / "regular.jsonl"
+        regular.write_bytes(self.GOOD)
+        real_open = os.open
+
+        def swapping_open(path, flags, *args, **kwargs):
+            fd = real_open(path, flags, *args, **kwargs)
+            try:
+                # Matched on the NAME: under the pinned-parent walk the final
+                # open receives the bare name relative to a dir_fd, not the
+                # full path, and the ancestor components must pass through.
+                if Path(path).name == src.name:
+                    os.replace(regular, src)
+            except TypeError:
+                pass  # non-path first argument; not this seam
+            return fd
+
+        monkeypatch.setattr(snapshot_mod.os, "open", swapping_open)
+        outcome = self._merge_in_thread(src, dst)
+        assert outcome == ["raised"], f"a non-regular descriptor must refuse, not {outcome}"
+        assert "not a regular file" in capsys.readouterr().out
+
+    @pytest.mark.skipif(not hasattr(os, "link"), reason="hardlinks are a POSIX fixture here")
+    def test_a_hardlinked_source_is_refused_on_the_descriptor(self, tmp_path, capsys):
+        """A hardlink defeats every link-shaped screen: ``O_NOFOLLOW`` has nothing to
+        refuse and ``S_ISREG`` is TRUE, because the alias IS the target's inode.
+
+        The descriptor judgement therefore also refuses ``st_nlink != 1`` -- the
+        exact predicate ``pinned_fs.copy_file_pinned`` applies for the same
+        reason (a path guard cannot see an alias; only the inode's link count
+        can). A staged name hardlinked to a credential must refuse, not deliver
+        the credential's bytes into the served feed.
+        """
+        src, dst, secret = self._files(tmp_path)
+        src.unlink()
+        os.link(secret, src)  # a HARDLINK, not a symlink: same inode, nlink == 2
+        before = dst.read_bytes()
+        with pytest.raises(OSError):
+            snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == before, "the hardlinked credential's bytes were delivered"
+        out = capsys.readouterr().out
+        assert "Notifications imported:" not in out
+        assert "merge aborted" in out
+
+    def test_a_valid_unswapped_merge_still_appends_exactly_what_it_validated(
+        self, tmp_path, capsys
+    ):
+        """The happy path is untouched: same records land, dedupe unchanged.
+
+        This is a change to HOW the files are reached, never to what is
+        admitted -- the record cap and the ``_notification_key`` predicate are
+        exactly as they were. A second run of the same import appends nothing.
+        """
+        src, dst, _ = self._files(tmp_path)
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + self.GOOD
+        assert "Notifications imported: 1" in capsys.readouterr().out
+        snapshot_mod._merge_notifications(src, dst)
+        assert dst.read_bytes() == self.LIVE + self.GOOD, "the re-run duplicated a record"
+        assert "Notifications imported: 0" in capsys.readouterr().out
+
+
 # ── Issue #8217: the restore status line must not claim success over a refused
 # cron merge ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem / Motivation

`_merge_notifications` in `src/kiro_crew/snapshot.py` installed an archive's
`notifications.jsonl` into the operator's live one in two passes, and it resolved the
source **name twice**: a validation pass opened `src_path` by name and checked every
record, then the copy loop opened the same name again and appended. Nothing carried
identity between the two opens — no descriptor was held, and `open()` follows a symlink
at the final component. A process able to write the extracted staging tree (which an
agent can, on a normal install — the threat model `jsonl_util`'s readers and `pinned_fs`
are both written against) could replace that name with a symlink after validation and
before the copy. The copy loop followed the link and appended the target's bytes (a token
store, a key file, `.env`) into the live `notifications.jsonl`, which the dashboard then
serves to the bell feed and to SSE clients. The destination path had the identical
double-resolution one layer down (scan by name, then re-open by name to append) — a
smaller exposure, since the live name is the operator's own file rather than an
archive-derived one, but the same shape.

## Why it matters

The validation pass reported success because it validated a *different file*, so the
function's contract — "append only records that validated" — became silently false rather
than loudly broken. A leaked secret then rides a surface the operator trusts (the
notification feed), with the restore reporting success.

## What changed (motivation → approach → change)

Symptom → root cause → fix:

- **Root cause:** validating a name and then re-opening it are two resolutions of the
  same string; the second can land somewhere the first never inspected.
  `pinned_fs.py` records the identical finding for the pinned walk, which is also why an
  `lstat`-before-open compared against a later `fstat` was **not** used — that is a
  check-to-use window, the same mistake wearing a different name.
- **Fix:** each side is now opened exactly **once** through a new
  `_open_notification_file` helper built from the `pinned_fs` primitives (round-2
  review convergence: Design and First Principles both flagged the first version's
  private copy of the hardlink predicate). Where the platform can pin
  (`supports_pinned_walk`), the open goes through `pinned_fs.open_in_pinned_parent` —
  the parent chain walked with `O_NOFOLLOW` from a caller-resolved root, so an
  agent-writable **ancestor** swapped for a link is refused too, not just the final
  component. The descriptor is judged with `fstat` + `S_ISREG` and
  `pinned_fs.refuse_hardlink_alias(refusal=OSError)` — a hardlinked alias is a regular
  file `O_NOFOLLOW` cannot refuse; only the inode's link count can see it (adopted from
  the GPT round-1 finding; the shared primitive replaced the inline predicate in round
  2, minding its close-before-raise contract). Flags carry
  `O_NONBLOCK|O_BINARY|O_CLOEXEC` (each platform-conditional via `getattr`). The
  validation pass runs over that descriptor, then `seek(0)` rewinds it and the copy
  loop reads the **same** descriptor.
  The destination gets one `O_RDWR|O_APPEND` descriptor for both its scan (which needs
  read access) and the append — `O_APPEND`, never `O_TRUNC`, so the `"ab"` semantics are
  preserved.
- **`O_NONBLOCK` is load-bearing, not belt-and-braces** (the code comment says so):
  without it, a name that became a FIFO blocks the open forever, converting a refused
  restore into a hung one. With it the open returns at once and the `fstat` judgement
  refuses the descriptor.
- **Platform floor:** where the platform cannot pin (Windows: no `O_NOFOLLOW`, no
  `dir_fd`), the open is gated behind `pinned_fs.is_reparse_point()` — the same
  degradation `_backup_and_copy` applies and `cli.md` documents as the accepted
  Windows posture. Note the precedent the issue as filed named
  (`_copy_notifications`) does **not exist on main** — it arrives with open PR #8576,
  which deliberately files this span here (`Refs #8667`). The precedents actually used
  are `_backup_and_copy` plus the `pinned_fs` vocabulary (`open_in_pinned_parent`,
  `refuse_hardlink_alias`, the open-first-judge-second order `copy_file_pinned`
  documents).
- **The record cap and the encoding predicate are unchanged.** `_NOTIFICATION_RECORD_CAP`
  and what `_notification_key` accepts stay exactly as they were: this is a change to HOW
  the files are reached, never to what is admitted.
- **The refusal posture is kept.** A refused open raises (plus the existing abort print),
  exactly like a bad record — never a silent skip that installs nothing.
- Doc ripple per AGENTS.md: `docs/system-specs/modules/cli.md`'s "Staging is
  descriptor-pinned" section now states the descriptor-once invariant for this merge, in
  the same commit.

## Tests

New class `TestNotificationMergeResolvesEachNameOnce` in `test/test_snapshot.py`, beside
the existing notification-merge tests. **Red before green: all six defect tests were run
against the unmodified production code first and failed with exactly the predicted
modes** (secret bytes landed; no refusal on links; FIFO reported `hung`), and the
happy-path guard passed both ways by design — a test that only exercises an unswapped
source passes with or without this fix, which was confirmed by that run.

- `test_a_source_swapped_for_a_symlink_after_validation_is_not_followed` — the exact
  defect: swaps `src_path` for a symlink between the validation pass and the copy loop,
  asserts the archive's own bytes landed and the link target's did not.
- `test_a_source_that_is_already_a_symlink_is_refused_at_the_open` — refusal, not
  follow-through; live file untouched; abort line printed, no success line.
- `test_the_reparse_floor_refuses_a_linked_source_where_O_NOFOLLOW_is_absent` — deletes
  `os.O_NOFOLLOW` (the suite's established Windows simulation) and pins the
  `is_reparse_point` floor.
- `test_a_destination_that_is_a_symlink_is_refused_before_anything_is_written` — the
  destination-side sibling of the same shape.
- `test_a_fifo_at_the_source_name_fails_rather_than_hanging` — what `O_NONBLOCK` buys,
  pinned so a later cleanup cannot drop the flag (run on a daemon thread so a hang FAILS
  rather than wedging the suite).
- `test_the_regular_file_judgement_is_on_the_descriptor_not_the_name` — pins `fstat` on
  the held descriptor against the `os.path.isfile` name-check substitute.
- `test_a_hardlinked_source_is_refused_on_the_descriptor` — a hardlink to a credential
  passes `O_NOFOLLOW` and `S_ISREG` (the alias IS the target's inode); the `st_nlink`
  judgement refuses it. Red-first against the pre-adoption head (the credential's bytes
  were delivered), green after.
- `test_a_valid_unswapped_merge_still_appends_exactly_what_it_validated` — happy path +
  dedupe unchanged, re-run appends nothing.

**Mutation checks — six guard mutants, each individually applied, run red, and reverted
to a confirmed green, re-verified on the final (round-2, pinned-parent) shape:**

1. drop `O_NOFOLLOW` from the composed flags → 2 tests red (source-link and
   destination-link refusals);
2. drop `O_NONBLOCK` → 2 tests red (both FIFO tests report `hung`);
3. replace the `seek(0)` descriptor reuse with a second `open(src_path)` — the exact
   defect → the swap test red ("the copy loop followed a name swapped after validation");
4. drop the `is_reparse_point` floor on the no-pin platform branch → floor test red;
5. replace the `fstat` `S_ISREG` judgement with `os.path.isfile(src_path)` → the
   descriptor-vs-name test red (the FIFO descriptor was handed to the record reader);
6. delete the `pinned_fs.refuse_hardlink_alias` call → the hardlink test red, every
   other test green (the predicate is individually load-bearing).

Full `test_snapshot.py` + `test_portability.py` + `test_jsonl_util.py`: 206 passed.
`scripts/local-gate.py --base origin/main` run: backend (full) plus the selector's 210
cross-surface frontend guard specs (212 files, 5784 tests, all green). `black` 26.3.1 /
`isort` / `flake8` / `mypy` clean repo-wide. Backend zero-regression proven by diffing
the sorted failing-test id sets against an `origin/main` worktree **at the same sha
(`6d1b517`), both directions: 243 = 243, byte-identical** — the sets include the 9
inherited #8695 cross-merge reds, which cancel exactly. (One residual pair was a
demonstrated xdist flake in `test_public_repo_chip_status.py`: a different test failed
on each tree's parallel run, and both pass 2/2 standalone on both trees.)

## Manual verification

N/A — unit coverage sufficient: the defect and the fix are both fully observable at the
`_merge_notifications` seam with real files, links, and FIFOs on a real filesystem.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change (snapshot restore internals, tests, module doc); no rendered surface differs.

## Related Issues

Fixes #8667

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a name resolved twice is two different files — validate the descriptor you
read (`open` once, `fstat` the fd including `st_nlink == 1`, rewind and reuse), never
the name again". Knowingly out-of-scope siblings, all disclosed: the `shutil.copy2`
branch of the same restore `if` (`snapshot.py:4033`), owned by open PR #8576 — if that
PR's `_copy_notifications` helper lands first, this merge should reuse it rather than
keep a parallel shape; and six more validate-then-reopen sites in the same restore path
(four `shutil.copy2` component copies, `_merge_crons`' by-name rewrite, `_merge_memory`'s
`ATTACH` re-resolution), tracked in #8725 (deferred-finding, assigned, due 2026-10-05).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
