### PR TITLE
fix(storage): walk the empty-trash guard by descriptor, not by name

### DIFF
--- a/src/kiro_crew/session_storage.py
+++ b/src/kiro_crew/session_storage.py
@@ -64,6 +64,7 @@ home isolated from the store it reads (see :func:`reclaim_block_reason`).
 
 from __future__ import annotations
 
+import errno
 import hashlib
 import json
 import logging
@@ -1518,19 +1519,70 @@ def _unlisted_files(batch: Path) -> list[Path]:
     listed: set[str] = set(_manifest_rels(batch))
     failures: list[OSError] = []
     unlisted = []
-    for root, _dirs, names in os.walk(batch, onerror=failures.append):
-        for name in names:
-            path = Path(root) / name
-            if name == MANIFEST_NAME:
-                continue
-            try:
-                if not path.is_file():
+    # os.fwalk where the platform has it: this guard must complete on trees
+    # whose component paths exceed the platform PATH_MAX (1024 on macOS, where
+    # a name-based walk dies with ENAMETOOLONG and permanently wedges the batch
+    # as ``unreadable_batch`` — #8724). fwalk traverses and stats via directory
+    # descriptors, so only the MANIFEST-RELATIVE strings below ever use the
+    # textual path, and those are pure string operations with no length limit.
+    # This also matches #7011's descriptor discipline for the approval scan,
+    # chain-open, and removal passes; the guard was the one name-based walk left.
+    #
+    # CPython defines fwalk only where ``{open, stat} <= os.supports_dir_fd``
+    # — on native Windows it does not exist, mirroring this module's
+    # ``_FD_SAFE_DELETE`` coarse path. There the ORIGINAL name-based walk is
+    # kept: Windows never had the macOS 1024-byte wedge, so status quo is
+    # exactly right, and an unconditional fwalk would crash every Empty-Trash
+    # with an AttributeError no caller catches (fork-review finding).
+    fwalk = getattr(os, "fwalk", None)
+    if fwalk is not None:
+        # Unlike os.walk, fwalk RAISES when the top itself cannot be statted or
+        # opened rather than routing that first error through ``onerror`` — catch
+        # it into the same failure list so an unopenable batch stays a refusal
+        # with a reason, never an escaping OSError. RecursionError is belt only:
+        # CPython's fwalk is iterative on every Python this package supports
+        # (>=3.12; verified at depth 5000 under the default 1000-frame limit),
+        # but the guard's contract is that NO traversal failure escapes as a
+        # crash, so the impossible case still lands in the failure list.
+        try:
+            for root, _dirs, names, rootfd in fwalk(batch, onerror=failures.append):
+                for name in names:
+                    if name == MANIFEST_NAME:
+                        continue
+                    try:
+                        # follow_symlinks=True mirrors the Path.is_file() this
+                        # replaces: a symlink to a regular file counts, a broken
+                        # link does not.
+                        st = os.stat(name, dir_fd=rootfd)
+                    except OSError as exc:
+                        if exc.errno in (errno.ENOENT, errno.ENOTDIR, errno.EBADF, errno.ELOOP):
+                            # The same cases Path.is_file() reports as False.
+                            continue
+                        failures.append(exc)
+                        continue
+                    if not stat.S_ISREG(st.st_mode):
+                        continue
+                    path = Path(root) / name
+                    if path.relative_to(batch).as_posix() not in listed:
+                        unlisted.append(path)
+        except OSError as exc:
+            failures.append(exc)
+        except RecursionError as exc:
+            failures.append(OSError(f"traversal exceeded the recursion limit: {exc}"))
+    else:
+        for root, _dirs, names in os.walk(batch, onerror=failures.append):
+            for name in names:
+                path = Path(root) / name
+                if name == MANIFEST_NAME:
                     continue
-            except OSError as exc:
-                failures.append(exc)
-                continue
-            if path.relative_to(batch).as_posix() not in listed:
-                unlisted.append(path)
+                try:
+                    if not path.is_file():
+                        continue
+                except OSError as exc:
+                    failures.append(exc)
+                    continue
+                if path.relative_to(batch).as_posix() not in listed:
+                    unlisted.append(path)
     if failures:
         raise SessionStorageError(
             f"could not read all of {batch.name!r}, so it is not known whether it "

--- a/test/test_session_storage.py
+++ b/test/test_session_storage.py
@@ -1674,19 +1674,27 @@ class TestUntrustedNamesAreLogSafeOutsideListTrash:
         planted = OSError(13, "Permission denied", str(forged / self._FORGED_NAME))
 
         # ``session_storage.os`` is the global module, so this patch is also seen
-        # by ``shutil.rmtree`` during fixture teardown (which passes ``topdown=``
-        # on Windows).  Accept the real signature and divert only the walk of the
-        # forged batch, delegating every other call to the genuine ``os.walk``.
+        # by other walk users during teardown. Accept the real signature and
+        # divert only the walk of the forged batch, delegating every other call
+        # to the genuine function. Both mechanisms are patched because
+        # ``_unlisted_files`` picks fwalk-vs-walk at call time by availability
+        # (fwalk does not exist on Windows).
+        real_fwalk = getattr(os, "fwalk", None)
         real_walk = os.walk
 
-        def _walk(top, *args, onerror=None, **kwargs):  # type: ignore[no-untyped-def]
-            if Path(top) == forged:
-                assert callable(onerror)
-                onerror(planted)
-                return iter(())
-            return real_walk(top, *args, onerror=onerror, **kwargs)
+        def _divert(real):  # type: ignore[no-untyped-def]
+            def inner(top, *args, onerror=None, **kwargs):  # type: ignore[no-untyped-def]
+                if Path(top) == forged:
+                    assert callable(onerror)
+                    onerror(planted)
+                    return iter(())
+                return real(top, *args, onerror=onerror, **kwargs)
 
-        monkeypatch.setattr(session_storage.os, "walk", _walk)
+            return inner
+
+        monkeypatch.setattr(session_storage.os, "walk", _divert(real_walk))
+        if real_fwalk is not None:
+            monkeypatch.setattr(session_storage.os, "fwalk", _divert(real_fwalk))
         monkeypatch.setattr(session_storage, "_manifest_rels", lambda batch: [])
 
         with pytest.raises(SessionStorageError) as raised:
@@ -2307,7 +2315,10 @@ class TestSharedStoreRefusal:
                 onerror(OSError(5, "simulated read failure"))
             return iter(())
 
+        # Both mechanisms: ``_unlisted_files`` picks fwalk-vs-walk at call time
+        # by availability (fwalk does not exist on Windows).
         monkeypatch.setattr(session_storage.os, "walk", failing_walk)
+        monkeypatch.setattr(session_storage.os, "fwalk", failing_walk, raising=False)
 
         assert session_storage.empty_trash([batch.batch_id]) == 0
         # The batch survives, so nothing was destroyed on an unverifiable scan.


### PR DESCRIPTION
## Problem / Motivation

Fixes #8724. On macOS, a Trash batch whose nested tree pushes component paths past `PATH_MAX` (1024) becomes **permanently un-emptyable**: `_unlisted_files()` — the guard that decides whether an Empty-Trash delete may proceed — still walked by name with `os.walk` after #7011 descriptor-hardened the approval scan, chain-open, and removal passes. The walk dies with `ENAMETOOLONG`, which the guard's fail-closed contract converts into the `SessionStorageError` the caller maps to `SKIP_UNREADABLE` — so the batch silently survives every Empty-Trash attempt, with only a warning log as a trace.

## Why it matters

The failure is silent and permanent: the batch shows in Trash, Empty-Trash reports success, and the data is never reclaimed. It also inverts #7011's intent — the passes that *act* were descriptor-hardened, but the gate that *authorizes* them remained the one name-based walk, so the platform path limit wedges the whole batch. The #7011 deep-nesting regression test only passes on Linux CI because Linux's `PATH_MAX` is 4096; on macOS it fails on main today.

## What changed

`_unlisted_files` now walks with `os.fwalk`: traversal and the per-entry stat run via directory descriptors (`dir_fd`), so only manifest-relative strings ever use the textual path — pure string operations with no length limit. Two semantics deliberately preserved:

- The per-entry check mirrors `Path.is_file()` exactly: `os.stat(name, dir_fd=rootfd)` follows symlinks, and the errno set `Path.is_file()` reports as `False` (`ENOENT`/`ENOTDIR`/`EBADF`/`ELOOP`) is skipped rather than treated as a scan failure; any other `OSError` still joins the failure list and blocks the delete.
- Unlike `os.walk`, `fwalk` RAISES when the top itself cannot be opened instead of routing that error through `onerror` — the new wrapper catches it into the same failure list, so an unopenable batch remains a reason'd refusal, never an escaping `OSError`.

Two test doubles that monkeypatched `session_storage.os.walk` are repointed at `fwalk` with matching signatures; they assert the guard's contract (hostile-name escaping, unreadable-scan refusal), not the walk mechanism.

## Tests

- On macOS 15 (arm64), the #7011 deep-nesting test (`test_a_deeply_nested_batch_does_not_break_the_walk`) **fails on main** with `assert ['unreadable_batch'] == []` and **passes with this change** — the exact fail→pass across the fix for the reported mechanism. (It passes on Linux CI either way because Linux's `PATH_MAX` is 4096.)
- Full `test/test_session_storage.py`: 229 passed.
- black gate, isort, flake8, mypy: green on both changed files.

## Pattern harvest

Rule candidate: guards that gate destructive operations must not walk by name — a platform path-length limit converts a traversal error into a permanently wedged state. Use `os.fwalk` where the platform defines it (CPython: only where `{open, stat} <= os.supports_dir_fd`, so never on native Windows) and keep the name-based walk as the fallback; note `fwalk` raises the top-level open error instead of calling `onerror`, so wrappers must catch it to keep fail-closed semantics.
