### PR TITLE
fix(system): stop the untrusted manifest source open from hanging on a FIFO

### DIFF
--- a/src/kiro_crew/pinned_fs.py
+++ b/src/kiro_crew/pinned_fs.py
@@ -1421,11 +1421,14 @@ def put_back_no_clobber(
     *src_name* is treated as UNTRUSTED, which is the part that is easy to skip. It is a name
     in a directory an actor may be able to write to, and the whole reason this function runs
     is that an earlier step already failed -- so time has passed. The name is opened
-    ``O_NOFOLLOW`` and its inode checked against *expect_ino* before anything is read from
-    it, and the copy reads that DESCRIPTOR rather than re-opening the name. Without that, a
-    name swapped for a symbolic link is followed and whatever it points at -- a credential,
-    say -- is linked or copied into the destination under a name the caller will treat as its
-    own.
+    ``O_NOFOLLOW | O_NONBLOCK``, screened for a regular file, and its inode checked against
+    *expect_ino* before anything is read from it, and the copy reads that DESCRIPTOR rather
+    than re-opening the name. Without ``O_NOFOLLOW``, a name swapped for a symbolic link is
+    followed and whatever it points at -- a credential, say -- is linked or copied into the
+    destination under a name the caller will treat as its own. ``O_NOFOLLOW`` alone is not
+    enough: it does not refuse a FIFO, and opening one for reading blocks until a writer
+    appears, so the hardening itself hangs. Both flags are needed, and neither is what
+    decides -- the screen below is.
 
     First choice is ``os.link``, which cannot clobber, and it is called with
     ``follow_symlinks=False`` so a swap landing after the verification links the link itself
@@ -1455,14 +1458,24 @@ def put_back_no_clobber(
     Returns ``None`` when the name is back, :data:`PUT_BACK_NAME_TAKEN` when something else
     holds it (nothing was overwritten), or :data:`PUT_BACK_FAILED`.
     """
+    # O_NONBLOCK for the same reason `copy_file_pinned` carries it: O_NOFOLLOW refuses a
+    # symbolic link and does NOT refuse a FIFO, so a named pipe at this name blocks the open
+    # until a writer appears -- forever, with no timeout and no message. That is not a wrong
+    # answer, it is NO answer, and it is the one failure an operator cannot read off a log.
+    # The flag has no effect on a regular file; it only guarantees the screen below is reached.
+    src_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
     try:
-        src = os.open(src_name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=src_parent_fd)
+        src = os.open(src_name, src_flags, dir_fd=src_parent_fd)
     except OSError:
         return PUT_BACK_FAILED
     try:
-        if os.fstat(src).st_ino != expect_ino:
+        st = os.fstat(src)
+        if not _stat.S_ISREG(st.st_mode) or st.st_ino != expect_ino:
             # The name no longer holds what was moved aside, so there is nothing here this
             # function may put anywhere. Refusing leaves the caller to report the name.
+            # S_ISREG is checked as well as the inode because an inode number is reusable:
+            # a FIFO created after the entry was unlinked can carry the number this call
+            # recorded, and only the mode tells the two apart.
             return PUT_BACK_FAILED
         linked = False
         try:

--- a/test/test_trash_pinned_sibling_removal.py
+++ b/test/test_trash_pinned_sibling_removal.py
@@ -15,6 +15,7 @@ import errno
 import json
 import logging
 import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -771,6 +772,86 @@ class TestPutBackNoClobber:
 
         assert not (tmp_path / "tree" / "index").exists(), "nothing may be placed from a swap"
         assert secret.read_text() == "a credential this code has never read"
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="planting a FIFO needs mkfifo (POSIX)")
+    def test_a_source_swapped_for_a_fifo_is_refused_rather_than_waited_on(
+        self, tmp_path: Path
+    ) -> None:
+        """``O_NOFOLLOW`` refuses a symbolic link. It does NOT refuse a FIFO.
+
+        Opening a named pipe for reading blocks until a writer appears, so the guard that
+        makes the moved-aside name safe is also the thing that can hang on it -- forever, with
+        no timeout and no message. That failure produces no answer rather than a wrong one,
+        which is why no review lane and no green board can see it: the run simply stops.
+
+        The call is made on a bounded thread so this test REDDENS on the hang instead of
+        joining it. Without ``O_NONBLOCK`` on the source open the thread is still running when
+        the deadline passes; with it, the open returns and the screen below refuses the FIFO.
+        """
+        (tmp_path / "aside").mkdir()
+        (tmp_path / "tree").mkdir()
+        recorded = tmp_path / "aside" / "debris"
+        recorded.write_text("the moved copy")
+        ino = recorded.stat().st_ino
+        # The swap: same name, now a pipe with no writer on the other end.
+        recorded.unlink()
+        os.mkfifo(recorded, 0o600)
+
+        answered: list[str | None] = []
+
+        def _attempt() -> None:
+            src = os.open(str(tmp_path / "aside"), pinned_fs.dir_flags())
+            dst = os.open(str(tmp_path / "tree"), pinned_fs.dir_flags())
+            try:
+                answered.append(
+                    pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=ino)
+                )
+            finally:
+                pinned_fs.close_all((src, dst))
+
+        # daemon: a thread parked in a blocking open cannot be reclaimed from outside, so on
+        # the failing path it is left to the interpreter rather than joined forever here.
+        caller = threading.Thread(target=_attempt, daemon=True)
+        caller.start()
+        caller.join(20)
+        assert not caller.is_alive(), (
+            "the open never returned: a FIFO at the moved-aside name blocked it, "
+            "which is the hang this flag exists to prevent"
+        )
+        assert answered == [pinned_fs.PUT_BACK_FAILED]
+
+        assert not (tmp_path / "tree" / "index").exists(), "nothing may be placed from a pipe"
+
+    @pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="planting a FIFO needs mkfifo (POSIX)")
+    def test_a_fifo_carrying_the_recorded_inode_is_still_refused(self, tmp_path: Path) -> None:
+        """An inode number is REUSABLE, so the inode check alone does not identify a file.
+
+        Once the entry is unlinked its number is free, and a FIFO created afterwards can carry
+        the very number this call recorded -- so the identity check agrees and the mode is the
+        only thing left that can tell them apart. Reaching that state deterministically is
+        simpler than racing for it: the FIFO's own inode is handed in as the recorded one,
+        which is the same input the reuse produces.
+
+        Without the mode screen the pipe is hard-linked to the manifest's name and the landed
+        inode matches, so the call reports SUCCESS and leaves a FIFO where the index belongs --
+        every later reader of that name then blocks on it.
+        """
+        (tmp_path / "aside").mkdir()
+        (tmp_path / "tree").mkdir()
+        os.mkfifo(tmp_path / "aside" / "debris", 0o600)
+        reused = os.stat(tmp_path / "aside" / "debris", follow_symlinks=False).st_ino
+
+        src = os.open(str(tmp_path / "aside"), pinned_fs.dir_flags())
+        dst = os.open(str(tmp_path / "tree"), pinned_fs.dir_flags())
+        try:
+            assert (
+                pinned_fs.put_back_no_clobber(src, dst, "debris", "index", expect_ino=reused)
+                == pinned_fs.PUT_BACK_FAILED
+            )
+        finally:
+            pinned_fs.close_all((src, dst))
+
+        assert not (tmp_path / "tree" / "index").exists(), "a pipe may not take the index name"
 
 
 class TestTheCoarsePlatform:


### PR DESCRIPTION
## What is the problem?

`pinned_fs.put_back_no_clobber` opens the moved-aside manifest name
`O_RDONLY | O_NOFOLLOW` before it reads anything from it, and treats that open as the
thing that makes an untrusted name safe. **`O_NOFOLLOW` refuses a symbolic link. It does
not refuse a FIFO.** Opening a named pipe for reading blocks until a writer appears, so a
pipe planted at that name blocks the open forever, with no timeout and no message.

The hardening can hang. Issue #7566's own comparison table lists this open in the
"after" column as the improvement over base -- the hang is not a residual it accepted, it
is one nobody saw.

Measured in a bounded child, both directions, with the exact flag sets from this file:

```
line 1459 flags (O_RDONLY|O_NOFOLLOW)         : STILL BLOCKED after 5s   <-- no answer
line  492 flags (O_RDONLY|O_NOFOLLOW|NONBLOCK): returned fd, fstat reached, S_ISFIFO=True
```

`#7491` introduced this function and this open, so this is a regression in a merged PR
rather than an inherited residual.

## Why this issue matters to the user

This runs on the recovery path that puts the trash index back when a tree will not go --
after a restore, a rolled-back move, or an `empty_trash` that failed partway. The data it
guards is the user's only copy of their session history.

The failure mode is what makes it worth fixing rather than documenting. It produces **no
answer instead of a wrong one**: no exception, no log line, no red check -- the operation
simply stops, holding its descriptors, and the user sees a restore that never finishes. A
hazard whose symptom is silence is invisible to every review lane and every green board,
which is why four rounds of review on the surrounding lines did not name it.

By the function's own threat model this is reachable: its docstring already states that
`src_name` is "a name in a directory an actor may be able to write to, and the whole reason
this function runs is that an earlier step already failed -- so time has passed."

## How our fix solves it

**The answer was already written 950 lines above the defect.** `copy_file_pinned` carries
`O_NONBLOCK` on its own source open, above a comment recording that omitting it "hangs the
whole snapshot or restore forever with no timeout and no message" -- itself found when a
mutation probe stalled until a watchdog killed it. This applies the same flag to the same
class of open, so the two source opens in this module now agree.

Chaining symptom to root cause:

- **Symptom:** the recovery never returns.
- **Because:** `os.open` on a FIFO with no writer blocks in the kernel.
- **Because:** the flag set omitted `O_NONBLOCK`, so the open could block at all.
- **Root cause:** `O_NOFOLLOW` was treated as sufficient screening for an untrusted name.
  It only refuses one of the two things that name can become.

`O_NONBLOCK` does not decide anything -- it guarantees the screen is *reached*, and has no
effect on a regular file. So the fix also adds the screen that decides: **`S_ISREG`,
mirroring the sibling.** An inode number is reusable, so a FIFO created after the entry was
unlinked can carry the number the caller recorded; the identity check then agrees with
itself and only the mode tells the two apart. Without that screen the pipe is hard-linked
to the manifest's name, the landed inode matches, and the call reports **success** while
leaving a FIFO where the index belongs -- every later reader of that name then blocks too.

Nothing else changed. The by-name `os.link` re-resolution and the by-name unlink remain as
`#7566` records them.

## What tests we did

Two tests next to the existing `put_back_no_clobber` cluster in
`test/test_trash_pinned_sibling_removal.py`, each proven to redden on its own half of the
fix and only its own half:

| Removed | `..._refused_rather_than_waited_on` | `..._carrying_the_recorded_inode_is_still_refused` |
| --- | --- | --- |
| `O_NONBLOCK` | **FAILED** -- "the open never returned" | FAILED (its open blocks too) |
| `S_ISREG` only | passed | **FAILED** -- returned `None`, i.e. reported success |

The mutation output is the evidence, not the assertion text: with `S_ISREG` removed the call
returns `None` -- "the name is back" -- having linked a FIFO to the manifest name.

The hang test runs the call on a **bounded thread** and asserts the thread finished, so a
regression reddens this test in 20 s instead of stalling the suite until a watchdog kills
it. It is `skipif`'d on `mkfifo` so the Windows shards skip it rather than error.

Green on the four files that exercise the changed function or its caller, single-process:
`test_trash_pinned_sibling_removal.py` (37), `test_trash_write_durability.py` and
`test_pinned_staging.py` (130 combined), `test_session_storage.py` (229) -- **359 passed**.
`black`, `isort`, `flake8`, `mypy` clean. I did not run the full suite; these files are the
regression surface for `pinned_fs.py` and its trash caller.

## Any other suggestions on the work

Found by auditing the whole span against one invariant -- *every path is resolved to a
descriptor exactly once, and all subsequent work goes through the descriptor* -- rather than
by patching the sites review named. The invariant is what surfaced it: patch-chasing cannot
find a defect that produces silence.

Two things the audit turned up that belong to `#7566` rather than here, and are posted on
that issue with their measurements:

1. **`copy_file_pinned`'s docstring rejects the `os.link`-publish design as "proven
   exploitable" because the link re-resolves by name -- and `put_back_no_clobber` still uses
   exactly that design.** A second audit reached the same conclusion about this function
   from an unrelated direction. Recorded, not folded in: changing it is a design decision
   about a merged PR's chosen shape, not a flag.
2. **Linux CI cannot reach the coarse Windows branch, but `Backend Tests (Windows)` does** --
   4 shards, and none of the three trash/session files are in `test/windows-collect-ignore.txt`.
   That matters for the larger option on `#7566`, because "we cannot verify a Windows
   behaviour change" turns out not to be true.

## Pattern harvest

Rule candidate: semgrep

Pattern: `os.open` of a caller-influenced name with `O_RDONLY` and without `O_NONBLOCK`.

This is generalizable by direct evidence rather than by guess: this module already fixed
this exact class once, at `copy_file_pinned`, with a comment explaining the consequence --
and then reintroduced it 950 lines later in a new function added by a different PR. One
occurrence is a defect; a second occurrence in the same file, after the first was
understood and documented, is a pattern. `O_NOFOLLOW` next to the open is an aggravating
signal rather than a mitigating one: its presence shows the author was screening the name
for hostility and believed the screening complete, which is exactly the state in which the
FIFO case is missed.

A rule should flag an `O_RDONLY` open whose path is not statically known when `O_NONBLOCK`
is absent, and should not be satisfied by the presence of `O_NOFOLLOW`. The check is cheap
and the failure it prevents is a silent hang, which no test timeout attributes to the right
line and no review lane reports.

Refs #7566
