### PR TITLE
refactor(chat-core): one dashboard row set -- ChatPage spreads createTranscriptRenderers

### DIFF
--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
+import { Fragment, useState, useRef, useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useLocation, useNavigate, useNavigationType, useSearchParams } from 'react-router-dom'
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -13,6 +13,7 @@ import { isTouchDevice } from '../utils/isTouchDevice'
 import { isBrowseCommand } from '../utils/browseCommand'
 import { isHiddenInvisibleAssistantRow } from '../utils/invisibleText'
 import { mergeRenderers, resolveRenderer, type MessageRenderer, type MessageRenderContext } from '../app-sdk/messageRenderers'
+import { createTranscriptRenderers } from './chat/transcriptRenderers'
 // Re-exported so the symbol `ChatPage` exported before this extraction stays
 // importable from here; the implementation lives in `utils/browseCommand` so a
 // pure test need not pull ChatPage's module graph.
@@ -65,7 +66,6 @@ import SnipOverlay from '../components/SnipOverlay'
 import { captureScreen, screenSnipSupported, currentTabCaptureDeps } from '../hooks/useScreenSnip'
 import { useTheme } from '../hooks/useTheme'
 import CollapsibleToolGroup from './chat/CollapsibleToolGroup'
-import ThinkingBlock from './chat/ThinkingBlock'
 import { RowDisclosureProvider } from './chat/rowDisclosure'
 import type { DisplayItem, TurnItem } from './chat/types'
 import { MeasureFarm } from '../hooks/virtualizer/MeasureFarm'
@@ -283,7 +283,7 @@ import SubagentProgressBar from './chat/SubagentProgressBar'
 import TaskProgressBar from './chat/TaskProgressBar'
 import SidePanel, { CHAT_PANE_MIN_W, sidePanelFillWidth } from './chat/SidePanel'
 import { useSidePanelDock } from '../hooks/useSidePanelDock'
-import { createTurnGrouper, applyRunningState, hasReasoningContent, REASONING_ROLES, TURN_OPENER_ROLES } from './chat/groupDisplayItems'
+import { createTurnGrouper, applyRunningState, REASONING_ROLES, TURN_OPENER_ROLES } from './chat/groupDisplayItems'
 // Hold-down for the display-layer running latch: a slots broadcast that
 // catches the agent between tool calls flaps `running` false for well under
 // a second; only a false that persists longer reflects the turn ending.
@@ -332,7 +332,6 @@ import { EdgeFade, JumpToBottomButton } from '../app-sdk/ChatScrollChrome'
 import { PanelLeftSolid, PanelLeftLight, PanelRightSolid } from '../components/icons/panels'
 
 import InfoTip from '../components/InfoTip'
-import { FileCard } from '../components/FileCard'
 import SlotTagPopover from '../components/SlotTagPopover'
 import { TagPopoverProvider } from '../hooks/useTagPopover'
 
@@ -341,23 +340,15 @@ import DetailPanel from '../components/DetailPanel'
 
 import type { ChatMessage, Artifact } from '../types'
 
-import ToolCallLine from './chat/ToolCallLine'
 import { shouldMountSidePanel, isSidePanelHidden, sidePanelDockMotion } from './chat/sidePanelMount'
 import { optsForReplace } from './chat/replaceGuard'
-import WorkflowRunCard, { extractWorkflowRunId } from './chat/WorkflowRunCard'
-import SubagentRunCard, { extractSpawnRunLaunch } from './chat/SubagentRunCard'
-import WorkflowCompletionCard, { isWorkflowCompletionMessage } from './chat/WorkflowCompletionCard'
-import SubagentCompletionCard from './chat/SubagentCompletionCard'
-import { isSubagentCompletionMessage, type ParsedSubagentCompletion } from './chat/subagentCompletion'
+import type { ParsedSubagentCompletion } from './chat/subagentCompletion'
 import { renderMcpOAuthMessage } from './chat/McpOAuthBanner'
 import { useConnectionsUiEnabled } from '../hooks/useConnectionsUi'
 import TurnBlock from './chat/TurnBlock'
 import Clickable from '../components/Clickable'
 import StopEventCard from './chat/StopEventCard'
-import NudgeCard, { nudgeMatchesLoop } from './chat/NudgeCard'
-import RecoveryCard, { resolveInjectCard } from './chat/RecoveryCard'
 import NoticeCard from './chat/NoticeCard'
-import { ErrorCard } from './chat/ErrorCard'
 import WorkflowProgressBar from './chat/WorkflowProgressBar'
 import { tryQuickSend } from '../lib/quickSend'
 import { rewindWithRollback } from '../lib/rewindCall'
@@ -704,24 +695,6 @@ export function messageRowKey(m: ChatMessage, i: number): string {
   return keyTs ? `${role}-${keyTs}` : `${role}-${i}`
 }
 
-/** Disclosure-map identity for a tool row (#8204). messageRowKey is
- *  `${role}-${clientTs ?? ts}` and tool rows are never clientTs-stamped, so a
- *  burst of tool rows appended in one server tick all share `tool-<tick>` —
- *  expanding one expanded them all, because the row key doubled as the
- *  toolDisclosure map key. Fold `meta.tool_call_id` in when present (ACP-issued,
- *  globally unique) so each row owns its disclosure entry.
- *
- *  Deliberately NOT folded into messageRowKey: the React-key role is not at
- *  stake (each renderMessage element is the sole child of a separately keyed
- *  wrapper), and the key-stability suite pins messageRowKey(tool) === 'tool-<ts>'.
- *  Scoped to role 'tool' and identity when the id is absent, so every other
- *  role's in-session disclosure state keeps its existing key shape.
- *  Exported for tests. */
-export function toolDisclosureKey(m: ChatMessage, key: string): string {
-  if (m.role !== 'tool') return key
-  const tcid = m.meta?.tool_call_id
-  return typeof tcid === 'string' && tcid ? `${key}-${tcid}` : key
-}
 
 /** Render user message content with file chips and image markdown. Handles:
  *  - Fresh messages: meta.files present, displayTxt has @relative/path tokens
@@ -6351,13 +6324,9 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       setContinuing(false)
     })
   }, [activeSlot, continuing, continuable, showRefusedPress])
-  // Index of the newest error row. Only that one gets the action: an error
-  // further up the transcript belongs to a turn that has already been
-  // superseded, and offering to "continue" it would resume the wrong thing.
-  const lastErrorIdx = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) if (messages[i].role === 'error') return i
-    return -1
-  }, [messages])
+  // (The newest-error index that gates the Continue button is derived inside
+  // the shared row set from the transcript it is handed -- see
+  // transcriptRenderers.tsx `lastErrorIndex`.)
 
   const [flyingQuote, setFlyingQuote] = useState<{ text: string; from: DOMRect } | null>(null)
   const inputAreaRef = useRef<HTMLDivElement>(null)
@@ -7676,9 +7645,10 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   // card's Loop button, ...) rides as HOST ENTRIES that reuse the default ids
   // they replace, plus a few page-only shape entries. Order inside this array
   // is the page's precedence order, unchanged from the if-chain it replaces:
-  // reasoning, tool, file, nudge, stop_event, inject-recovery, error, notice,
-  // permission, mcp_oauth, workflow completion, sub-agent completion, hidden
-  // invisible assistant, then the conversational bubble. Roles none of these
+  // the shared dashboard set (sub-agent completion, launch cards, tool,
+  // thinking, file, nudge, recovery inject, workflow completion, error), then
+  // stop_event, notice, permission, undrawn, mcp_oauth, hidden invisible
+  // assistant, and the conversational bubble. Roles none of these
   // claim fall to the registry defaults (`undrawn` for queued/system/done and
   // the reasoning roles; `tool_lifecycle` for raw wire shapes the store
   // normalizes away), and a role NOBODY claims renders as the bubble, which is
@@ -7795,117 +7765,46 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
     )
       },
     }
+    // The dashboard's shared row set (pages/chat/transcriptRenderers.tsx --
+    // tool lines and launch cards, thinking block, nudge, recovery inject, the
+    // two completion cards, the error card with Continue), wired with this
+    // page's behaviours through its options; ChatPane calls the same factory
+    // with fewer. Only rows that are genuinely page-specific follow it.
+    const shared = createTranscriptRenderers({
+      slot: activeSlot || undefined,
+      // An unparseable file row has always fallen through to the bubble on
+      // this page (a pane draws nothing for it); P5-b changes no row's output.
+      renderUnparsedFile: (m, ctx) => bubble.render(m, ctx),
+      onFileOpen: handleFileOpen,
+      onFolderOpen: handleFolderOpen,
+      onOpenSubagentPanel: handleSubagentPanelOpen,
+      toolDisclosure,
+      onToolDisclosureChange: setToolDisclosureFor,
+      // Animate tools in the trailing group (after last assistant/streaming text).
+      toolRunning: (_m, ctx) => slotStateRef2.current === 'tool_running' && ctx.index > lastTextIdxRef.current,
+      transcriptHot,
+      appInPanel: mcpAppPanel,
+      onOpenApp: revealAppInPanel,
+      // The Loop button is offered only when this row's own loop is the one
+      // still bound to the slot, so a historical card never opens a successor
+      // loop's controls (the match rule lives in the factory).
+      activeNudgeLoopId: autoNudgeLoop?.id,
+      onOpenNudgeLoop: () => setAutoNudgeOpen(true),
+      continuable,
+      interrupted,
+      continuing,
+      onContinue: handleContinue,
+      onSessionOpen: selectSessionTab,
+      sessions: connected ? sessionTitles : undefined,
+      activeSession: activeSlot || undefined,
+    })
     const renderers = mergeRenderers([
-      {
-        // Shared with the wrap gate and fold -- see hasReasoningContent in
-        // groupDisplayItems.ts for why there is ONE definition of this condition.
-        // (A reasoning ROLE without reasoning content falls to the registry's
-        // `undrawn` default, which is the `isReasoningRole -> null` arm.)
-        id: 'thinking_block',
-        roles: ['*'],
-        match: hasReasoningContent,
-        render: (m, ctx) => <ThinkingBlock key={ctx.key} content={m.content} disclosureKey={ctx.key} />,
-      },
-      {
-        id: 'tool',
-        roles: ['tool'],
-        render: (m, ctx) => {
-          const i = ctx.index
-          const key = ctx.key
-      // Skip ✅/🚫 completion messages — completion shown via CircleCheckBig icon
-      if (!m.content.startsWith('🔧')) return null
-      // A workflow_run launch renders as a persistent, clickable inline card
-      // (live status + open-panel affordance) instead of the generic tool pill.
-      const wfRunId = extractWorkflowRunId(m)
-      if (wfRunId) return <WorkflowRunCard key={key} runId={wfRunId} message={m} />
-      // Likewise a spawn_run launch: the transient chip above the composer
-      // drops when the wave ends and only covers the viewed slot, so without
-      // this the only record of a spawn is a pill folded into "Worked through
-      // N steps".
-      const spawnLaunch = extractSpawnRunLaunch(m)
-      if (spawnLaunch) return <SubagentRunCard key={key} launch={spawnLaunch} slot={activeSlot || ''} />
-      // Animate tools in the trailing group (after last assistant/streaming text)
-      const isInTrailingGroup = slotStateRef2.current === 'tool_running' && i > lastTextIdxRef.current
-      // Disclosure identity folds in tool_call_id (#8204) — same-tick tool rows
-      // share the row key, and keying the disclosure map by it made one row's
-      // expand/collapse hit them all. React key stays the row key on purpose:
-      // sibling uniqueness is owned by the keyed wrapper, and remounting on a
-      // key change here would drop measured heights for nothing.
-      const dKey = toolDisclosureKey(m, key)
-      return <ToolCallLine key={key} message={m} running={isInTrailingGroup} onFileOpen={handleFileOpen} disclosure={toolDisclosure[dKey]} disclosureKey={dKey} onDisclosureChange={setToolDisclosureFor} appInPanel={mcpAppPanel} onOpenApp={revealAppInPanel} transcriptHot={transcriptHot} />
-        },
-      },
-      {
-        id: 'file',
-        roles: ['file'],
-        render: (m, ctx) => {
-          const key = ctx.key
-      try {
-        const f = JSON.parse(m.content)
-        return <FileCard key={key} file={f} />
-      } catch { /* fall through to default */ }
-          // An unparseable file row: the if-chain fell through to the bubble.
-          return bubble.render(m, ctx)
-        },
-      },
-      {
-        // Auto-nudge turns are machine-facing instruction blobs -- collapse them
-        // to a compact chip instead of rendering the whole payload as a chat
-        // bubble. The Loop button is offered only when this row's own loop is
-        // the one still bound to the slot, so a historical card never opens a
-        // successor loop's controls.
-        id: 'nudge',
-        roles: ['nudge'],
-        render: (m, ctx) => {
-          const key = ctx.key
-      const ownLoop = nudgeMatchesLoop(m, autoNudgeLoop?.id)
-      return <NudgeCard key={key} message={m} disclosureKey={key} onOpenLoop={ownLoop ? () => setAutoNudgeOpen(true) : undefined} />
-        },
-      },
+      ...shared,
       {
         id: 'stop_event',
         roles: ['*'],
         match: m => m.kind === 'stop_event' || m.meta?.kind === 'stop_event',
         render: (m, ctx) => <StopEventCard key={m.meta?.id as string ?? ctx.key} message={m} />,
-      },
-      {
-        // A synthetic turn-recovery continuation (tool refusal / stalled turn /
-        // stalled tool) is machine-facing instruction text. It stays in the
-        // transcript for auditability, but as a one-line card that names the
-        // event and the deny pattern rather than a full-width bubble of prompt
-        // prose. An inject row this does not claim is the bubble's.
-        id: 'recovery_inject',
-        roles: ['inject'],
-        match: m => resolveInjectCard(m) != null,
-        render: (m, ctx) => {
-          const key = ctx.key
-      // One shared decision (resolveInjectCard) so this surface and the
-      // transcript-renderer registry cannot disagree about the same row. It
-      // returns null for a cron row, for a replay of the user's own words, and
-      // for a row with no provenance stamp — each of which keeps the renderer
-      // below. Anything positively marked gateway-authored folds into a note
-      // instead of falling through to a full-width bubble, which is the defect
-      // this replaces.
-      const card = resolveInjectCard(m)
-      if (card) return <RecoveryCard key={key} parsed={card} disclosureKey={key} />
-          return null
-        },
-      },
-      {
-        id: 'error',
-        roles: ['error'],
-        render: (m, ctx) => {
-          const i = ctx.index
-          const key = ctx.key
-          return (
-      <ErrorCard
-        key={key}
-        content={m.content}
-        onContinue={continuable && interrupted && i === lastErrorIdx ? handleContinue : undefined}
-        continuing={continuing}
-      />
-          )
-        },
       },
       { id: 'notice', roles: ['notice'], render: (m, ctx) => <NoticeCard key={ctx.key} content={m.content} /> },
       {
@@ -7935,30 +7834,6 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         },
       },
       {
-        // An injected workflow completion event renders as a compact status card
-        // (with the full result folded away) instead of a wall of raw JSON.
-        id: 'workflow_completion',
-        roles: ['*'],
-        match: isWorkflowCompletionMessage,
-        render: (m, ctx) => {
-          const key = ctx.key
-          return <WorkflowCompletionCard key={key} message={m} onFileOpen={handleFileOpen} onFolderOpen={handleFolderOpen} onSessionOpen={selectSessionTab} sessions={connected ? sessionTitles : undefined} activeSession={activeSlot || undefined} disclosureKey={key} />
-        },
-      },
-      {
-        // An injected sub-agent completion event is machine-facing prompt text
-        // (the spawn-discipline instructions are addressed to the model). It
-        // renders as a compact outcome row with the payload folded away, not as
-        // a chat bubble.
-        id: 'subagent_completion',
-        roles: ['*'],
-        match: isSubagentCompletionMessage,
-        render: (m, ctx) => {
-          const key = ctx.key
-          return <SubagentCompletionCard key={key} message={m} onFileOpen={handleFileOpen} onFolderOpen={handleFolderOpen} onSessionOpen={selectSessionTab} sessions={connected ? sessionTitles : undefined} activeSession={activeSlot || undefined} disclosureKey={key} onOpenPanel={handleSubagentPanelOpen} />
-        },
-      },
-      {
         // A quiet monitor-loop cycle replies with a bare zero-width space
         // (U+200B): the content is truthy but renders as nothing, so the row
         // would draw as an empty bubble -- one per quiet cycle, historical
@@ -7972,7 +7847,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       bubble,
     ])
     return { renderers, fallback: bubble }
-  }, [slotRunning, handleFileOpen, handleArtifactOpen, selectSessionTab, sessionTitles, connected, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, loadingOlder, cursorIsForActiveSlot, slotOldestIndex, handleLoadEarlier, renderUserContentCb, highlightTs, activeSlotTitle, mode, embedded, popout, handleOpenDiff, handlePlanFromHere, planTaskId, artifactPaths, autoNudgeLoop, toolDisclosure, setToolDisclosureFor, linkPreviewsOn, socialShareOn, handleSubagentPanelOpen, isPinned, handleTogglePinForMessage, connectionsUiOn, showRefusedPress, transcriptHot, revealAppInPanel, continuable, interrupted, continuing, lastErrorIdx, handleContinue, handleFolderOpen, handleSpeak, handleApplyPlan, mcpAppPanel])
+  }, [slotRunning, handleFileOpen, handleArtifactOpen, selectSessionTab, sessionTitles, connected, handleFork, handleQuote, handleAsk, chatConfig, activeSlot, regenerating, handleRegenerate, handleEditResend, slotHasMore, loadingOlder, cursorIsForActiveSlot, slotOldestIndex, handleLoadEarlier, renderUserContentCb, highlightTs, activeSlotTitle, mode, embedded, popout, handleOpenDiff, handlePlanFromHere, planTaskId, artifactPaths, autoNudgeLoop, toolDisclosure, setToolDisclosureFor, linkPreviewsOn, socialShareOn, handleSubagentPanelOpen, isPinned, handleTogglePinForMessage, connectionsUiOn, showRefusedPress, transcriptHot, revealAppInPanel, continuable, interrupted, continuing, handleContinue, handleFolderOpen, handleSpeak, handleApplyPlan, mcpAppPanel])
 
   const renderMessage = useCallback((i: number, m: ChatMessage) => {
     // Key identity rules (clientTs preference + streaming->assistant role
@@ -7986,11 +7861,13 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
       onFileOpen: handleFileOpen,
       hideCardOwnedOAuth: connectionsUiOn,
       autoDeniedIds: NO_AUTO_DENIED,
-      // Only a registry DEFAULT this page does not override reaches these
-      // (raw wire-shape tool rows the store normalizes away); the page's own
-      // entries return keyed elements directly.
-      wrapper: (children) => <div key={key} className="flex flex-col min-w-0">{children}</div>,
-      row: (children) => <div key={key}>{children}</div>,
+      // The shared row set returns `ctx.row(...)`; the row must be a KEYED
+      // passthrough, not an element, so a tool line lands in the DOM exactly as
+      // this page's own entry used to render it (the virtualizer measures the
+      // row's component root). `wrapper` is reached only by a registry default
+      // this page does not override (raw wire-shape tool rows).
+      wrapper: (children) => <Fragment key={key}>{children}</Fragment>,
+      row: (children) => <Fragment key={key}>{children}</Fragment>,
     }
     const entry = resolveRenderer(m, chatPageRenderers)
     // A role nobody claims renders as the conversational bubble -- what the

--- a/website/src/pages/chat/transcriptRenderers.tsx
+++ b/website/src/pages/chat/transcriptRenderers.tsx
@@ -1,12 +1,15 @@
 /**
  * transcriptRenderers — the dashboard's row set for the shared chat transcript.
  *
- * The single-chat surface (ChatPage) dispatches through the same registry with
- * its OWN host list (see `chatPageRenderers` in pages/ChatPage.tsx -- chat-core
- * P5-a); the two dashboard host lists share ids (`tool`, `file`, `nudge`,
- * `recovery_inject`, `thinking_block`, `error`, `workflow_completion`,
- * `subagent_completion`) so they can converge by override, but they are still
- * two lists until a P5 follow-up spreads this factory into ChatPage's.
+ * This is the ONE dashboard row set (chat-core P5-b): the single-chat surface
+ * (ChatPage) spreads this factory into its host list and adds only its
+ * page-only entries (the conversational bubble with fork/pin/footer chrome,
+ * the undrawn/permission rows, the stop-event and OAuth banners); ChatPane
+ * calls it with fewer options. Behaviour a surface cannot supply is an
+ * OPTION with the pane's default -- the tool row's disclosure key, its
+ * "animating" rule, the hot-transcript hint, the completion cards' session
+ * hand-offs -- so the two surfaces differ only in what they wire, never in
+ * how a row is drawn.
  * Every OTHER dashboard surface draws through app-sdk/ChatMessageList, whose
  * default registry is deliberately store-free and therefore renders a WEAKER
  * transcript: a static pill instead of the live tool line, and nothing at all
@@ -24,6 +27,7 @@
  * so an entry reusing a default's `id` REPLACES it, a new `id` ADDS a row type,
  * and a narrow entry must precede the broader one it refines.
  */
+import type React from 'react'
 import ThinkingBlock from './ThinkingBlock'
 import ToolCallLine from './ToolCallLine'
 import NudgeCard, { nudgeMatchesLoop } from './NudgeCard'
@@ -39,9 +43,46 @@ import { FileCard } from '../../components/FileCard'
 import type { MessageRenderer, MessageRenderContext } from '../../app-sdk/messageRenderers'
 import type { ChatMessage } from '../../types'
 
+/** Disclosure-map identity for a tool row (#8204). messageRowKey is
+ *  `${role}-${clientTs ?? ts}` and tool rows are never clientTs-stamped, so a
+ *  burst of tool rows appended in one server tick all share `tool-<tick>` —
+ *  expanding one expanded them all, because the row key doubled as the
+ *  toolDisclosure map key. Fold `meta.tool_call_id` in when present (ACP-issued,
+ *  globally unique) so each row owns its disclosure entry.
+ *
+ *  Deliberately NOT folded into messageRowKey: the React-key role is not at
+ *  stake (each renderMessage element is the sole child of a separately keyed
+ *  wrapper), and the key-stability suite pins messageRowKey(tool) === 'tool-<ts>'.
+ *  Scoped to role 'tool' and identity when the id is absent, so every other
+ *  role's in-session disclosure state keeps its existing key shape.
+ *  Shared by every dashboard surface through this row set (chat-core P5-b);
+ *  exported for tests. */
+export function toolDisclosureKey(m: ChatMessage, key: string): string {
+  if (m.role !== 'tool') return key
+  const tcid = m.meta?.tool_call_id
+  return typeof tcid === 'string' && tcid ? `${key}-${tcid}` : key
+}
+
 export interface TranscriptRendererOptions {
-  /** Slot these rows belong to. The tool line keys its per-slot log off it. */
-  slot: string
+  /** Slot these rows belong to. The tool line keys its per-slot log off it;
+   *  omitted (the single-chat surface) it reads the active slot's. */
+  slot?: string
+  /** Whether a tool row animates as "running". Default: the transcript's
+   *  running flag. ChatPage narrows it to the trailing group -- rows after the
+   *  last assistant text while the slot is in `tool_running`. */
+  toolRunning?: (m: ChatMessage, ctx: MessageRenderContext) => boolean
+  /** The transcript is scrolling / streaming hard; tool rows defer their
+   *  heavier work. */
+  transcriptHot?: boolean
+  /** What to draw for a `file` row whose content is not JSON. Default: nothing
+   *  (a pane); the single-chat surface has always fallen through to its
+   *  conversational bubble for one and passes that. */
+  renderUnparsedFile?: (m: ChatMessage, ctx: MessageRenderContext) => React.ReactNode
+  /** Session hand-offs on the completion cards: open a session chip, and the
+   *  title map + active key the chip resolver needs. */
+  onSessionOpen?: (key: string) => void
+  sessions?: ReadonlyMap<string, string>
+  activeSession?: string
   /** Open a file in the host's side panel. Unwired from a pane until #3300:
    *  the dock is `activeSlot`-keyed while pane focus deliberately is not. */
   onFileOpen?: (path: string, opts?: { line?: number; endLine?: number }) => void
@@ -86,21 +127,24 @@ function lastErrorIndex(messages: ChatMessage[]): number {
 export function createTranscriptRenderers(
   o: TranscriptRendererOptions,
 ): readonly MessageRenderer[] {
-  const toolLine = (m: ChatMessage, ctx: MessageRenderContext) =>
-    ctx.row(
+  const toolLine = (m: ChatMessage, ctx: MessageRenderContext) => {
+    const dKey = toolDisclosureKey(m, ctx.key)
+    return ctx.row(
       <ToolCallLine
         message={m}
-        running={ctx.running}
+        running={o.toolRunning ? o.toolRunning(m, ctx) : ctx.running}
         slot={o.slot}
         onFileOpen={o.onFileOpen}
-        disclosure={o.toolDisclosure?.[ctx.key]}
-        disclosureKey={ctx.key}
+        disclosure={o.toolDisclosure?.[dKey]}
+        disclosureKey={dKey}
         onDisclosureChange={o.onToolDisclosureChange}
         appInPanel={o.appInPanel}
         onOpenApp={o.onOpenApp}
+        transcriptHot={o.transcriptHot}
       />,
       true,
     )
+  }
 
   return [
     // ── Shape-matched rows, ahead of anything keyed only by role ──
@@ -116,6 +160,9 @@ export function createTranscriptRenderers(
           message={m}
           onFileOpen={o.onFileOpen}
           onFolderOpen={o.onFolderOpen}
+          onSessionOpen={o.onSessionOpen}
+          sessions={o.sessions}
+          activeSession={o.activeSession}
           disclosureKey={ctx.key}
           onOpenPanel={o.onOpenSubagentPanel}
         />,
@@ -146,7 +193,7 @@ export function createTranscriptRenderers(
       render: (m, ctx) => {
         const launch = extractSpawnRunLaunch(m)
         if (!launch) return toolLine(m, ctx)
-        return ctx.row(<SubagentRunCard key={ctx.key} launch={launch} slot={o.slot} />, true)
+        return ctx.row(<SubagentRunCard key={ctx.key} launch={launch} slot={o.slot ?? ''} />, true)
       },
     },
     {
@@ -158,6 +205,17 @@ export function createTranscriptRenderers(
       roles: ['tool'],
       match: m => !!m.content?.startsWith('🔧'),
       render: toolLine,
+    },
+    {
+      // The ✅ / 🚫 completion sibling of a tool call carries state, not a row:
+      // completion is drawn by the tool line's own icon, and the 🚫 sibling is
+      // read for the auto-denied flag. Claimed explicitly so it draws nothing on
+      // EVERY surface -- a pane's unclaimed-role fallback already drew nothing,
+      // but the single-chat surface's is the bubble, and "✅ done" as a bubble is
+      // the row this closes.
+      id: 'tool_completion',
+      roles: ['tool'],
+      render: () => null,
     },
 
     // ── Rows the default registry leaves undrawn ──
@@ -185,7 +243,7 @@ export function createTranscriptRenderers(
         try {
           file = JSON.parse(m.content)
         } catch {
-          return null
+          return o.renderUnparsedFile ? o.renderUnparsedFile(m, ctx) : null
         }
         return ctx.row(<FileCard file={file} />)
       },
@@ -235,6 +293,9 @@ export function createTranscriptRenderers(
           message={m}
           onFileOpen={o.onFileOpen}
           onFolderOpen={o.onFolderOpen}
+          onSessionOpen={o.onSessionOpen}
+          sessions={o.sessions}
+          activeSession={o.activeSession}
           disclosureKey={ctx.key}
         />,
         true,

--- a/website/src/test/RecoveryCard.test.tsx
+++ b/website/src/test/RecoveryCard.test.tsx
@@ -339,29 +339,35 @@ describe('ChatPage – recovery card wiring', () => {
   const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../pages/ChatPage.tsx'), 'utf8')
 
   it('imports the card and its shared resolver', () => {
-    expect(src).toMatch(
-      /import\s+RecoveryCard\s*,\s*\{\s*resolveInjectCard\s*\}\s*from\s*['"][^'"]*RecoveryCard['"]/,
-    )
+    // Since chat-core P5-b the recovery row is a shared dashboard entry
+    // (pages/chat/transcriptRenderers.tsx) that ChatPage spreads into its host
+    // list, so the imports live in the factory and the page imports the factory.
+    const factory = readFileSync(resolve(__dirname, '../pages/chat/transcriptRenderers.tsx'), 'utf8')
+    expect(factory).toMatch(/import\s+RecoveryCard\s*,\s*\{\s*resolveInjectCard\s*\}\s*from\s*['"]\.\/RecoveryCard['"]/)
+    expect(src).toMatch(/import \{ createTranscriptRenderers \} from '\.\/chat\/transcriptRenderers'/)
   })
 
   it('routes inject rows through the shared resolver to the card', () => {
-    expect(src).toMatch(/resolveInjectCard\s*\(\s*m\s*\)/)
-    expect(src).toMatch(/<RecoveryCard\s/)
+    const factory = readFileSync(resolve(__dirname, '../pages/chat/transcriptRenderers.tsx'), 'utf8')
+    expect(factory).toMatch(/resolveInjectCard\s*\(\s*m\s*\)/)
+    expect(factory).toMatch(/<RecoveryCard\s/)
   })
 
   it('checks for a card BEFORE the generic inject bubble renders', () => {
-    // Since chat-core P5-a the page dispatches through the app-sdk registry
-    // and precedence is the order of its host entries. The generic bubble
-    // entry (which paints any injected text as a full-width warning bubble)
-    // is the LAST entry; the `inject_recovery` shape entry must sit before it,
-    // or the card is dead code and the raw prompt reappears.
+    // Since chat-core P5-b the page spreads the dashboard's shared row set
+    // (pages/chat/transcriptRenderers.tsx) into its host list, and precedence
+    // is list order. The generic bubble entry (which paints any injected text
+    // as a full-width warning bubble) is the LAST entry; the shared set --
+    // which carries the `recovery_inject` shape entry -- must be spread before
+    // it, or the card is dead code and the raw prompt reappears.
     const list = src.indexOf('const renderers = mergeRenderers([')
-    const card = src.indexOf("id: 'recovery_inject'", list)
+    const shared = src.indexOf('...shared,', list)
     const generic = src.indexOf('\n      bubble,\n    ])', list)
     expect(list).toBeGreaterThanOrEqual(0)
-    expect(card).toBeGreaterThan(list)
-    expect(generic).toBeGreaterThan(card)
-    expect(src).toMatch(/id: 'recovery_inject',\s*\n\s*roles: \['inject'\],\s*\n\s*match: m => resolveInjectCard\(m\) != null/)
+    expect(shared).toBeGreaterThan(list)
+    expect(generic).toBeGreaterThan(shared)
+    const factory = readFileSync(resolve(__dirname, '../pages/chat/transcriptRenderers.tsx'), 'utf8')
+    expect(factory).toMatch(/id: 'recovery_inject',\s*\n\s*roles: \['inject'\],\s*\n\s*match: m => resolveInjectCard\(m\) !== null/)
   })
 })
 

--- a/website/src/test/chatRolesParity.contract.test.ts
+++ b/website/src/test/chatRolesParity.contract.test.ts
@@ -38,15 +38,22 @@ const CHROME_ONLY_ROLES: Record<string, string> = {
 }
 
 /**
- * ChatPage host entries that do not override a default. Each is a SHAPE entry
- * (`roles: ['*']` + `match`) or a deliberately undrawn role, with the reason
- * it is page-only rather than a registry default.
+ * Host entries that do not override a default. ChatPage's host list is the
+ * dashboard's shared row set (`createTranscriptRenderers`, which ChatPane
+ * also uses) plus the page-only entries, so both are listed: each is a SHAPE
+ * entry (`roles: ['*']` + `match`), a role the SDK has no row for, or a
+ * deliberately undrawn role, with the reason it is not a registry default.
  */
 const PAGE_ONLY_ENTRY_IDS: Record<string, string> = {
-  thinking_block: 'ThinkingBlock with page disclosure state; the registry folds reasoning into the group summary (same id as transcriptRenderers)',
-  recovery_inject: 'RecoveryCard for gateway-authored inject rows; the registry renders inject as prose (resolveInjectCard decides, shared; same id as transcriptRenderers)',
+  // -- shared dashboard set (pages/chat/transcriptRenderers.tsx) --
+  thinking_block: 'ThinkingBlock with disclosure state; the registry folds reasoning into the group summary',
+  recovery_inject: 'RecoveryCard for gateway-authored inject rows; the registry renders inject as prose (resolveInjectCard decides, shared)',
+  workflow_completion: 'WorkflowCompletionCard needs session/folder/panel hand-offs the SDK has no seam for',
+  workflow_run_tool: 'launch card refining the tool line; store-connected',
+  subagent_run_tool: 'launch card refining the tool line; store-connected',
+  tool_completion: 'the ✅/🚫 completion sibling draws nothing, claimed so no surface\'s unclaimed-role fallback prints it',
+  // -- page-only --
   permission: 'undrawn here; the registry leaves it to GROUPED_ROLES',
-  workflow_completion: 'WorkflowCompletionCard needs page-only session/folder/panel hand-offs',
   hidden_invisible_assistant: 'zero-width-space quiet-cycle rows; the registry applies the same skip inside its assistant entry',
   bubble: 'the page\'s user / inject / assistant row, with fork, pin, footer, regenerate and search-scope chrome',
 }
@@ -77,8 +84,15 @@ function registryClaimedRoles(): Set<string> {
   return roles
 }
 
+const factorySrc = readFileSync(resolve(__dirname, '../pages/chat/transcriptRenderers.tsx'), 'utf8')
+
 function hostEntryIds(): string[] {
-  return [...rendererBlock().matchAll(/^\s+id: '([a-z_]+)',?$/gm)].map(m => m[1])
+  const page = [...rendererBlock().matchAll(/^\s+id: '([a-z_]+)',?$/gm)].map(m => m[1])
+  // The page spreads the shared dashboard set into its list; its entries are
+  // host entries here too.
+  const spreads = /\.\.\.shared,/.test(rendererBlock()) && /const shared = createTranscriptRenderers\(/.test(rendererBlock())
+  const shared = spreads ? [...factorySrc.matchAll(/^\s+id: '([a-z_]+)',?$/gm)].map(m => m[1]) : []
+  return [...page, ...shared]
 }
 
 describe('chat role parity (ChatPage consumes the app-sdk registry)', () => {
@@ -92,6 +106,18 @@ describe('chat role parity (ChatPage consumes the app-sdk registry)', () => {
     // come back as a `switch`.
     expect(rendererBlock()).not.toMatch(/if \(m\.role\s*[!=]==\s*'[a-z_]+'\)/)
     expect(rendererBlock()).not.toMatch(/switch \(m\.role\)/)
+  })
+
+  it('the SDK defaults that render through ctx.wrapper are unreachable on this page', () => {
+    // `ctx.wrapper` is the SDK's conversational-row layout; the page passes a
+    // keyed Fragment for it, which is only sound if no row reaches those
+    // defaults. Host entries resolve first, so it holds iff the page's bubble
+    // claims every role the wrapper-using defaults claim.
+    const wrapperUsers = defaultMessageRenderers.filter(r => /ctx\.wrapper\(/.test(r.render.toString()))
+    expect(wrapperUsers.map(r => r.id).sort()).toEqual(['assistant', 'inject', 'user'])
+    const bubbleRoles = rendererBlock().match(/id: 'bubble',\s*\n\s*roles: \[([^\]]*)\]/)
+    expect(bubbleRoles).not.toBeNull()
+    for (const r of wrapperUsers) for (const role of r.roles) expect(bubbleRoles![1]).toContain(`'${role}'`)
   })
 
   it('a role nobody claims falls back to the BUBBLE by reference, never to an SDK default by position', () => {

--- a/website/src/test/toolDisclosureKey.collision.test.ts
+++ b/website/src/test/toolDisclosureKey.collision.test.ts
@@ -16,7 +16,8 @@
  */
 import { describe, it, expect } from 'vitest'
 import reducer, { refreshSlot } from '../store/chatSlice'
-import { messageRowKey, toolDisclosureKey } from '../pages/ChatPage'
+import { messageRowKey } from '../pages/ChatPage'
+import { toolDisclosureKey } from '../pages/chat/transcriptRenderers'
 import type { ChatMessage } from '../types'
 
 const SLOT = 'disclosure-key-slot'

--- a/website/src/test/transcriptRenderers.test.tsx
+++ b/website/src/test/transcriptRenderers.test.tsx
@@ -23,7 +23,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { ReactElement } from 'react'
 import type { ChatMessage } from '../types'
-import { GROUPED_ROLES, mergeRenderers, resolveRenderer, type MessageRenderContext } from '../app-sdk/messageRenderers'
+import { mergeRenderers, resolveRenderer, type MessageRenderContext } from '../app-sdk/messageRenderers'
 import { createTranscriptRenderers } from '../pages/chat/transcriptRenderers'
 import { isWorkflowRunTool } from '../pages/chat/WorkflowRunCard'
 import { isSpawnRunTool } from '../pages/chat/SubagentRunCard'
@@ -151,16 +151,20 @@ describe('narrow rows win over the broad row they refine', () => {
 })
 
 describe('the tool row keeps the deny-sibling guard', () => {
-  it('claims only the visible 🔧 message', () => {
-    // The hidden 🚫 sibling shares the role and is read for the auto-denied
-    // flag — drawing it would double the row.
-    expect(idFor(msg('tool', { content: '🚫 denied by policy' }))).toBeUndefined()
-    expect(idFor(msg('tool', { content: 'plain text' }))).toBeUndefined()
+  it('draws only the visible 🔧 message; the completion sibling resolves to a row that draws nothing', () => {
+    // The hidden 🚫 / ✅ sibling shares the role and is read for the auto-denied
+    // flag -- drawing it would double the row. It is CLAIMED (by
+    // `tool_completion`) rather than left unclaimed, so no surface's
+    // unclaimed-role fallback can print it.
+    expect(idFor(msg('tool', { content: '🚫 denied by policy' }))).toBe('tool_completion')
+    expect(idFor(msg('tool', { content: 'plain text' }))).toBe('tool_completion')
+    const entry = resolveRenderer(msg('tool', { content: '✅ done' }), registry())!
+    expect(entry.render(msg('tool', { content: '✅ done' }), ctx())).toBeNull()
   })
 
   it('does not treat a launch-shaped output as a launch without the 🔧 prefix', () => {
     const denied = msg('tool', { content: '🚫 denied', meta: { output: 'Started workflow run `wf_abc123`' } })
-    expect(idFor(denied)).toBeUndefined()
+    expect(idFor(denied)).toBe('tool_completion')
   })
 })
 
@@ -226,56 +230,38 @@ describe('rows the defaults already draw correctly are left to them', () => {
   })
 })
 
-describe('drift guard against the single-chat row chain', () => {
-  // The single-chat surface still renders from its own inline role chain, so
-  // this module is a SECOND row set that has to agree with it. Nothing in the
-  // type system notices when they diverge: a branch added to ChatPage lands
-  // only there, and panes quietly regress to a reduced transcript again — the
-  // exact failure mode this PR exists to fix.
-  //
-  // So pin the agreement mechanically. Every role ChatPage dispatches on must
-  // be CLAIMED by some entry in the registry a pane renders through. This is
-  // deliberately a claim check, not a render check: several rows resolve only
-  // with a content guard (a tool row needs its 🔧 prefix), and what drift
-  // breaks is coverage, not the guard.
-  //
-  // This guard is PERMANENT. Converging the two row sets by moving ChatPage
-  // onto this registry was considered and rejected (#3332, closed not-planned):
-  // the single-chat surface has no problem to fix, so migrating it is risk
-  // without payoff. The asymmetry is what makes the guard sufficient — ChatPage
-  // owns the policy, so drift can only ever degrade a DOWNSTREAM surface, never
-  // that one. If a row both sides draw ever diverges in component or props,
-  // strengthen this into a static comparison of what each side passes rather
-  // than migrating.
+describe('the single-chat surface renders from THIS row set', () => {
+  // Until chat-core P5-b the single-chat surface rendered from its own inline
+  // role chain, so this module was a SECOND row set that had to agree with it,
+  // and the guard here pinned that agreement role by role. ChatPage now
+  // dispatches through the app-sdk registry and SPREADS this factory into its
+  // host list (RFC chat-core extraction, P5), so agreement is by construction:
+  // a row added here reaches the page and every pane at once, and a page-only
+  // row is an explicit entry AFTER the spread. What can still drift is the
+  // spread itself -- so pin that, not the roles.
   const chatPageSrc = readFileSync(join(__dirname, '..', 'pages', 'ChatPage.tsx'), 'utf8')
 
-  const rolesInChatPage = [...new Set(
-    [...chatPageSrc.matchAll(/\.role === '([a-z_]+)'/g)].map(m => m[1]),
-  )].sort()
-
-  it('finds the role chain it is guarding (a rename must fail loudly, not silently pass)', () => {
-    // If ChatPage stops matching this shape the extraction returns nothing and
-    // every assertion below becomes vacuous, so assert the corpus itself.
-    expect(rolesInChatPage.length).toBeGreaterThan(8)
-    expect(rolesInChatPage).toContain('assistant')
-    expect(rolesInChatPage).toContain('user')
-    expect(rolesInChatPage).toContain('tool')
+  it('ChatPage spreads createTranscriptRenderers into its host list, ahead of its page-only rows', () => {
+    expect(chatPageSrc).toMatch(/import \{ createTranscriptRenderers \} from '\.\/chat\/transcriptRenderers'/)
+    const list = chatPageSrc.indexOf('const renderers = mergeRenderers([')
+    const spread = chatPageSrc.indexOf('...shared,', list)
+    const bubble = chatPageSrc.indexOf('\n      bubble,\n    ])', list)
+    expect(list).toBeGreaterThanOrEqual(0)
+    expect(spread).toBeGreaterThan(list)
+    expect(bubble).toBeGreaterThan(spread)
+    expect(chatPageSrc).toMatch(/const shared = createTranscriptRenderers\(\{/)
   })
 
-  it('claims every role the single-chat chain dispatches on', () => {
-    const active = registry()
-    // A `'*'` entry carrying a `match` is SHAPE-matched (a stop event, a
-    // sub-agent completion) and claims no role — counting it would make this
-    // guard vacuous, since every role would look covered by it.
-    const claims = (role: string) =>
-      active.some(r => r.roles.includes(role) || (r.roles.includes('*') && !r.match))
-    // A grouped role is assembled into the collapsible group BEFORE per-row
-    // resolution, so no row entry is expected to claim it — the group owns its
-    // display. Read from the SDK's own export rather than hardcoded, so a
-    // change to what gets grouped moves this exclusion with it.
-    const unclaimed = rolesInChatPage
-      .filter(role => !GROUPED_ROLES.includes(role))
-      .filter(role => !claims(role))
-    expect(unclaimed).toEqual([])
+  it('ChatPage keeps no private copy of a row this set draws', () => {
+    // A page entry reusing one of this set's ids would shadow the shared row
+    // on the page only -- the fork the spread exists to end. Zero exceptions:
+    // the page's one behavioural difference (an unparseable file row falls to
+    // its bubble) is a factory OPTION, not a shadowing entry.
+    const list = chatPageSrc.indexOf('const renderers = mergeRenderers([')
+    const end = chatPageSrc.indexOf('return { renderers, fallback: bubble }', list)
+    const pageIds = [...chatPageSrc.slice(list, end).matchAll(/^\s+id: '([a-z_]+)',?$/gm)].map(m => m[1])
+    const shared = createTranscriptRenderers({ slot: 's1' }).map(r => r.id)
+    const duplicated = pageIds.filter(id => shared.includes(id))
+    expect(duplicated).toEqual([])
   })
 })


### PR DESCRIPTION
## Problem / Motivation

After P5-a (#8713) ChatPage dispatches rows through the app-sdk registry — but the dashboard's *rich* rows (tool line + launch cards, thinking block, nudge, recovery inject, the two completion cards, the error card with Continue) still lived in **two** hand-kept host lists: ChatPage's own, and `pages/chat/transcriptRenderers.tsx`'s `createTranscriptRenderers`, which ChatPane consumes. #8713's review named this precisely: the mechanism was unified, the row set was not, and the `mcp_oauth` defect class survived between the two lists. The factory was also the *weaker* variant — tool disclosure keyed by row key rather than `tool_call_id` (#8204), "running" animation off the transcript flag rather than the page's trailing-group rule, no `transcriptHot`, no session hand-offs on the completion cards — so a pane drew a reduced transcript by construction.

## Why it matters

RFC chat-core extraction **P5-b**. One dashboard row set: a row added or fixed once reaches the page and every pane, and a pane stops being the surface that silently gets less. Stacked on #8713 because it rewrites the host list that PR introduced.

## What changed (motivation → approach → change)

**The factory learns the page's behaviours** (`TranscriptRendererOptions`). Two are unconditional because they are pure and no surface wanted the old default: the tool row's disclosure identity is now the #8204 `tool_call_id` fold for every surface (`toolDisclosureKey` moves out of `ChatPage.tsx` into the factory and is exported from there — a pane's row keys already embed the index, so its output does not change), and an unparseable `file` row draws whatever `renderUnparsedFile(m, ctx)` returns (default nothing, the pane's behaviour; ChatPage passes its bubble, the if-chain's fall-through). The rest are options with the pane's defaults: `toolRunning(m, ctx)` (default: `ctx.running`; ChatPage passes the trailing-group rule `slotState === 'tool_running' && index > lastTextIdx`), `transcriptHot`, and `onSessionOpen` / `sessions` / `activeSession` for the two completion cards. `slot` becomes optional — omitted, the tool line and launch cards read the active slot, which is what the page did. ChatPane's call is unchanged and every default reproduces what it drew before.

**ChatPage's host list is the factory spread plus page-only rows**, in this order: `...createTranscriptRenderers({...})` — which now includes `tool_completion` (the ✅/🚫 sibling draws nothing on every surface; a pane's fallback already drew nothing, the page's is the bubble, so claiming it in the factory closes "✅ done as a bubble" for both) — `stop_event`, `notice`, `permission`, the narrow `undrawn`, `mcp_oauth`, `hidden_invisible_assistant`, and the `bubble`. Nine page entries are deleted (`file` included — its one difference is the `renderUnparsedFile` option) (`thinking_block`, `tool`, `nudge`, `recovery_inject`, `error`, `workflow_completion`, `subagent_completion`), along with nine now-unused imports and the page's `lastErrorIdx` memo (the factory derives the newest-error index from the transcript it is handed).

**`ctx.row` / `ctx.wrapper` are keyed `Fragment`s**, not elements: the factory returns `ctx.row(<ToolCallLine …/>)`, and the row has to land in the DOM exactly as the page's own entry rendered it (the virtualizer measures the row's component root). `ctx.wrapper` is reached by no row on this page — the SDK defaults that use it (`user`, `assistant`, `inject`) claim roles the page's `bubble` entry claims first — and the parity test now **pins** that (it enumerates the wrapper-using defaults from the registry and checks the bubble's role list covers them), so the "no pixel to show" claim is asserted, not assumed.

**No row's output changes** on the page: every option ChatPage passes reproduces the prop set its deleted entry passed (checked entry by entry — tool line, launch cards, thinking block, nudge Loop gating, recovery card, completion cards' hand-offs, error Continue gating on `continuable && interrupted && index === lastErrorIndex`). ChatPane's output is unchanged because every new option defaults to the old behaviour.

**A recorded decision this supersedes.** `transcriptRenderers.test.tsx`'s old drift guard carried a comment that converging the two row sets by moving ChatPage onto the registry "was considered and rejected (#3332, closed not-planned): the single-chat surface has no problem to fix". The RFC's §2.2 names the problem (`mcp_oauth` shipped registered-but-raw in the main chat because there were two lists), P1 introduced the registry and its parity test for exactly that, and P5 is the phase that removes the second list; the guard's comment is rewritten to say so. Flagging it here so the reversal is explicit, not silent.

## Tests

- `transcriptRenderers.test.tsx`: the role-by-role "drift guard against the single-chat row chain" (which parsed ChatPage's `.role ===` literals) becomes a structural guard — ChatPage imports and spreads `createTranscriptRenderers` ahead of its page-only rows, and keeps no private copy of a row the factory draws (zero exceptions). `toolDisclosureKey.collision.test.ts` imports the helper from its new home; `toolDisclosureKey.renderSite.test.tsx` (the #8204 render-site pin) passes unchanged.
- `chatRolesParity.contract.test.ts`: host-entry ids now include the factory's when the page spreads it; the documented non-default ids gain the factory's (`workflow_run_tool`, `subagent_run_tool`, `tool_completion`); a new assertion pins that every SDK default rendering through `ctx.wrapper` is shadowed by the bubble.
- `transcriptRenderers.test.tsx`: the deny-sibling guard now asserts the sibling resolves to `tool_completion` and renders `null` (it used to assert "unclaimed").
- `RecoveryCard.test.tsx`: the card wiring is asserted in the factory and the spread asserted in the page.
- **Compatibility evidence — unmodified:** all 63 `ChatPage*` suites and all `ChatPane*` suites, `transcriptRenderersRenderCov80`, `TranscriptRowGeometry`, `TurnBlock.rowMemo`, `ChatPageCoverage` (the `✅ done` tool-completion row still draws nothing) — 890 tests across 89 files.

Local gates: `tsc -b`, eslint on changed files, `check-i18n-strings` (0 added). The full vitest suite runs in CI.

## Manual verification

N/A — a dispatch/ownership refactor with prop-set-equivalent entries and deterministic coverage; no rendered output changes on either surface.

<!-- no-visual-delta -->
**Why no screenshot:** every option ChatPage passes reproduces the prop set of the entry it replaces, and every new factory option defaults to ChatPane's previous behaviour; there is no pixel to show on either surface.

## Related Issues

- RFC chat-core extraction (#8690), P5-b; stacked on #8713 (P5-a). Supersedes the not-planned outcome of #3332 (see above).
- Later P5 cuts: turn grouping, composer band; #8651 (store-free `ChatInput` seam).

## Checklist

- [x] Single commit, conventional title
- [x] Drift guard replaced by a structural guard, not deleted; parity contract extended
- [x] No user-visible strings added
- [x] Render dispatch / row ownership only

## Contribution License Agreement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
