### PR TITLE
fix(apps): refuse to publish the dependency ledger over an unreadable read

### DIFF
--- a/docs/system-specs/modules/app-kit-platform.md
+++ b/docs/system-specs/modules/app-kit-platform.md
@@ -643,9 +643,22 @@ sync.
 ## 10. Teardown order is a precondition chain, not a cleanup list
 
 Uninstall is irreversible, so the whole sequence runs inside the per-app
-lifecycle lock and the one step that can safely refuse runs FIRST:
+lifecycle lock and the steps that can safely refuse run FIRST, before anything
+destructive:
 
-1. **Cron cleanup** (gateway-managed apps). Owned jobs are removed in one atomic
+1. **Dependency-ledger pre-flight** (when the request does not keep
+   dependencies). The dependency cleanup in step 5 rewrites the whole ledger
+   from what it reads, and that read refuses an unreadable document rather
+   than publishing emptiness over every app's refcounts -- but past the
+   script and deregistration below, a refusal would strand a half-removed
+   app. So the handler reads the ledger up front and aborts with a retryable
+   409 (`dependency_ledger_unreadable`) having changed nothing. The ledger can
+   still go unreadable DURING teardown (the script is arbitrary code); that
+   later refusal degrades instead -- the uninstall finishes without ledger
+   cleanup and says so in its log, because an unrecorded dependency reads as
+   user-installed and is skipped by every future cleanup, never removed while
+   still in use.
+2. **Cron cleanup** (gateway-managed apps). Owned jobs are removed in one atomic
    transaction. A contended store aborts the uninstall with a retryable 409
    having changed nothing. This must precede everything else: past this point
    deregistration drops the per-app cron manifest and the final step deletes the
@@ -653,11 +666,11 @@ lifecycle lock and the one step that can safely refuse runs FIRST:
    scheduler keeps firing with nothing left that knows they belong to a removed
    app. "Durably disable the jobs instead" is not a fallback, because disabling
    is itself a store mutation needing the very lock that is contended.
-2. `onUninstall` script, reached only once cron cleanup succeeded, so a
+3. `onUninstall` script, reached only once both preconditions succeeded, so a
    non-idempotent teardown never runs on an uninstall that will be retried.
-3. Backend stop and resource deregistration (gateway-managed only).
-4. Dependency cleanup (see §11).
-5. File removal, preserving `data/` unless the caller asked to purge.
+4. Backend stop and resource deregistration (gateway-managed only).
+5. Dependency cleanup (see §11).
+6. File removal, preserving `data/` unless the caller asked to purge.
 
 The lock spans the script deliberately: the script may itself be destructive, so
 holding the lock across it stops a racing enable or update from starting a
@@ -699,6 +712,14 @@ A dependency type with no cleanup operation (`capability.agents`) keeps its
 ledger row and only loses this app's ownership even when classified removable:
 dropping the row for something nothing can uninstall would orphan the installed
 package untraceably.
+
+The classify-and-update refuses to run on an unreadable ledger (only a MISSING
+file reads as empty; an unreadable or corrupt document, or one whose root is
+not an object, propagates and the mutation is abandoned -- mirroring the
+merged corrupt-read refusal readers). A dependency that is uninstalled while
+its ledger record is refused is reported as unrecorded, never counted as
+cleaned: its row still names the app, so re-running the uninstall after the
+ledger is repaired finishes the bookkeeping.
 
 Client-supplied `keep_specific` ids are normalized to canonical keys before the
 membership test, because a dashboard session that loaded its uninstall preview

--- a/src/kiro_crew/apps/dependencies.py
+++ b/src/kiro_crew/apps/dependencies.py
@@ -14,6 +14,7 @@ unresolved instead of shelling out to any named binary.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import shutil
 from dataclasses import dataclass, field
@@ -46,6 +47,12 @@ class DependencyResult:
     # these never join `missing`, where a caller may treat an entry as a failure.
     missing_optional: list[str] = field(default_factory=list)
 
+    #: Installed but refused by the ledger's bookkeeping (an unreadable or
+    #: corrupt ledger must not be published over). Separate from `failed`:
+    #: those deps ARE on disk, and a renderer must be able to say "installed,
+    #: unrecorded" instead of "failed to install".
+    unrecorded: list[str] = field(default_factory=list)
+
     def to_dict(self) -> dict[str, Any]:
         d: dict[str, Any] = {}
         if self.installed:
@@ -54,6 +61,8 @@ class DependencyResult:
             d["skipped"] = self.skipped
         if self.failed:
             d["failed"] = self.failed
+        if self.unrecorded:
+            d["unrecorded"] = self.unrecorded
         if self.missing:
             d["missing"] = self.missing
         if self.missing_optional:
@@ -206,8 +215,28 @@ async def resolve_dependencies(
                 continue
             if ok:
                 result.installed.append(dep_key)
-                record_install(dep_key, app_name, capability_dep_type(dep_type))
-                logger.info("Installed dependency %s for app %s", dep_key, app_name)
+                try:
+                    record_install(dep_key, app_name, capability_dep_type(dep_type))
+                except (OSError, json.JSONDecodeError) as exc:
+                    # The dependency IS installed, but the ledger refused to
+                    # record it: a corrupt or unreadable document must not be
+                    # published over. Report it in installed AND unrecorded,
+                    # never in `failed` -- a failed entry renders as "Failed
+                    # to install" for a dependency that is on disk, and the
+                    # caller cannot tell which half went wrong. A retry after
+                    # the ledger is repaired re-records it; until then the
+                    # dependency reads as untracked.
+                    result.unrecorded.append(dep_key)
+                    logger.warning(
+                        "Installed dependency %s for app %s but the ledger refused to "
+                        "record it (%s); repair dependency-ledger.json and re-run "
+                        "install to track it",
+                        dep_key,
+                        app_name,
+                        exc,
+                    )
+                else:
+                    logger.info("Installed dependency %s for app %s", dep_key, app_name)
             else:
                 result.failed.append(dep_key)
                 logger.warning(
@@ -252,8 +281,14 @@ async def resolve_dependencies(
 async def clean_dependencies(
     app_name: str,
     removable_deps: list[dict[str, Any]],
-) -> list[str]:
+) -> tuple[list[str], list[str]]:
     """Uninstall removable dependencies and update the ledger.
+
+    Returns ``(cleaned, unrecorded)``: the keys whose bookkeeping landed in
+    the ledger, and the keys that were UNINSTALLED but whose ledger record
+    was refused -- an unrecorded key still names this app in the ledger, so
+    reporting it as cleaned would claim bookkeeping that does not exist and
+    leave a ghost owner no future uninstall can remove.
 
     Args:
         app_name: The app being uninstalled.
@@ -264,6 +299,7 @@ async def clean_dependencies(
         List of successfully uninstalled dependency keys.
     """
     cleaned: list[str] = []
+    unrecorded: list[str] = []
     mgr: Any = None
     mgr_probed = False
 
@@ -299,8 +335,36 @@ async def clean_dependencies(
             logger.warning("Failed to uninstall %s: %s", dep_id, message[:200])
             continue
 
-        record_uninstall(dep_id, app_name)
+        # Refused bookkeeping is reported, not folded into `cleaned`: the
+        # dependency IS uninstalled, but the ledger row still names this app,
+        # so counting it as cleaned would let the uninstall log claim a
+        # bookkeeping state that does not exist and leave a ghost owner that
+        # no future uninstall can ever remove. The row stays intact, the
+        # refusal is visible, and re-running the uninstall after the ledger
+        # is repaired re-records it.
+        try:
+            record_uninstall(dep_id, app_name)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Uninstalled dependency %s for app %s but the ledger refused to "
+                "record it (%s); the ledger row still names this app -- repair "
+                "dependency-ledger.json and re-run the uninstall to finish the "
+                "bookkeeping",
+                dep_id,
+                app_name,
+                exc,
+            )
+            unrecorded.append(dep_id)
+            continue
         cleaned.append(dep_id)
         logger.info("Cleaned dependency %s for app %s", dep_id, app_name)
 
-    return cleaned
+    if unrecorded:
+        logger.warning(
+            "%d dependency(ies) were uninstalled for %s but left unrecorded in the "
+            "ledger: %s",
+            len(unrecorded),
+            app_name,
+            ", ".join(unrecorded),
+        )
+    return cleaned, unrecorded

--- a/src/kiro_crew/apps/dependency_ledger.py
+++ b/src/kiro_crew/apps/dependency_ledger.py
@@ -194,15 +194,105 @@ def _locked_ledger(*, exclusive: bool = True) -> Iterator[None]:
 
 
 def _read_ledger_unlocked() -> dict[str, Any]:
-    """Read the ledger file without acquiring a lock (caller must hold lock)."""
+    """Read the ledger file without acquiring a lock (caller must hold lock).
+
+    A DISPLAY read: every failure degrades to an empty ledger so a render or a
+    lookup never crashes on a document it could not load. See
+    :func:`_read_ledger_for_update` for why a mutation may not stand on the
+    same answer. An absent file is silent -- that is a ledger with no
+    dependencies yet, not a fault; anything else is logged, because the state
+    this degrades into looks exactly like health: an empty ledger reads as
+    "nothing is tracked", which for the only record that an installed
+    dependency is still referenced is the one wrong answer nobody would
+    question.
+    """
     path = _ledger_path()
     if not path.is_file():
         return {}
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        # The file vanished between the is_file() check and the read.
+        return {}
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
         logger.warning("Failed to read dependency ledger: %s", exc)
         return {}
+    if not isinstance(data, dict):
+        logger.warning("Dependency ledger root is not a JSON object; treating as empty")
+        return {}
+    return data
+
+
+def _read_ledger_for_update() -> dict[str, Any]:
+    """The ledger document a read-modify-write is allowed to publish over.
+
+    :func:`_read_ledger_unlocked` is a DISPLAY read: every failure collapses
+    to ``{}`` so a render never crashes on a document it could not load. That
+    reading is wrong as the base of a mutation, because all three mutations
+    below rewrite the WHOLE ledger from what they read -- an empty base there
+    does not mean "nothing to carry forward", it means "forget every app's
+    refcount". :func:`record_install` would publish a one-entry ledger over
+    every other app's references, and
+    :func:`classify_and_clean_for_uninstall` would wipe the ledger outright.
+    The sidecar lock does not help: it serializes writers, and the loss
+    happens inside it.
+
+    Only a MISSING file is a failure where ``{}`` is the truth (nothing has
+    been tracked yet). An unreadable one -- a transient EACCES/EIO, a scanner
+    holding the handle on Windows -- is a ledger we still have, so the error
+    propagates and the mutation is abandoned rather than published over state
+    nobody read.
+
+    Corruption propagates too: a document that failed
+    to parse carries nothing to merge into, but "cannot merge into" is not
+    "safe to destroy" -- a truncated file still holds most of its refcounts
+    verbatim. ``UnicodeDecodeError`` is folded into the same refusal: it is a
+    ``ValueError`` but NOT a ``json.JSONDecodeError``, so left unwrapped it
+    would slip past every corruption clause at the callers. Same for a root
+    that parses but is not an object: it carries no refcounts to merge into,
+    and normalizing it to ``{}`` would destroy a document nobody could read.
+
+    Plain ``json.JSONDecodeError`` rather than a named error type: no caller
+    of the three mutations needs to distinguish corruption from a transient
+    read failure -- both refuse -- and no cross-app import is wanted.
+    """
+    path = _ledger_path()
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        # The file vanished between the is_file() check and the read.
+        return {}
+    except UnicodeDecodeError as exc:
+        raise json.JSONDecodeError(
+            f"dependency ledger is not valid UTF-8: {exc.reason}",
+            exc.object.decode("utf-8", "replace")[:120],
+            0,
+        ) from exc
+    if not isinstance(data, dict):
+        raise json.JSONDecodeError(
+            "dependency ledger root is not a JSON object", str(data)[:120], 0
+        )
+    return data
+
+
+def require_readable_ledger() -> None:
+    """Refuse loudly when the ledger cannot be read for a mutation.
+
+    A pre-flight for flows with IRREVERSIBLE steps around the mutation: the
+    uninstall handler tears the app down (onUninstall script, backend stop,
+    resource deregistration) before :func:`classify_and_clean_for_uninstall`
+    reads the ledger, so letting that strict read refuse mid-flow would strand
+    a half-uninstalled app, and a retry would rerun the non-idempotent
+    teardown. Reading here -- before anything destructive -- costs a handled
+    refusal instead. Raises whatever :func:`_read_ledger_for_update` raises
+    (``OSError`` for a transient read failure, ``json.JSONDecodeError`` for a
+    corrupt one); the mutation still re-checks under the lock, so a ledger
+    that goes bad between this call and the mutation refuses rather than
+    publishes.
+    """
+    _read_ledger_for_update()
 
 
 def _write_ledger_unlocked(data: dict[str, Any]) -> None:
@@ -225,7 +315,7 @@ def record_install(dep_key: str, app_name: str, dep_type: str) -> None:
     appends the current app to ``installedBy`` (no duplicates).
     """
     with _locked_ledger():
-        ledger = _read_ledger_unlocked()
+        ledger = _read_ledger_for_update()
         # Reuse the legacy spelling when that is where the entry already lives,
         # so an older ledger accrues refcounts in one place instead of splitting
         # across two keys for the same dependency.
@@ -252,7 +342,7 @@ def record_uninstall(dep_key: str, app_name: str) -> None:
     If the ``installedBy`` list becomes empty, the entry is deleted entirely.
     """
     with _locked_ledger():
-        ledger = _read_ledger_unlocked()
+        ledger = _read_ledger_for_update()
         key = _resolve_key(ledger, dep_key)
         entry = ledger.get(key)
         if not entry:
@@ -330,7 +420,7 @@ def classify_and_clean_for_uninstall(
     """
     keep = set(keep_specific or [])
     with _locked_ledger():
-        ledger = _read_ledger_unlocked()
+        ledger = _read_ledger_for_update()
         result = _classify_deps(app_name, declared_deps, ledger)
 
         # Update ledger for removable deps

--- a/src/kiro_crew/apps/routes.py
+++ b/src/kiro_crew/apps/routes.py
@@ -52,6 +52,7 @@ from kiro_crew.apps.dependency_ledger import (
     classify_and_clean_for_uninstall,
     classify_for_uninstall,
     declared_capability_keys,
+    require_readable_ledger,
 )
 from kiro_crew.apps.dev_mode import dev_mode_granted_root, is_dev_mode_cached
 from kiro_crew.apps.event_bus import build_broadcast_fn
@@ -1033,6 +1034,22 @@ async def handle_uninstall_preview(request: web.Request) -> web.Response:
     )
 
 
+def _ledger_read_failure() -> str | None:
+    """Executor payload for the uninstall ledger pre-flight.
+
+    Returns ``None`` when the ledger can back a mutation, else the refusal
+    message. Blocking disk I/O must stay off the event loop, the same reason
+    every other disk read in the uninstall flow goes through the executor --
+    and a function that returns its failure hops that boundary more cleanly
+    than one that raises across it.
+    """
+    try:
+        require_readable_ledger()
+    except (OSError, json.JSONDecodeError) as exc:
+        return str(exc)
+    return None
+
+
 async def handle_uninstall_app(request: web.Request) -> web.Response:
     """POST /api/apps/{name}/uninstall — uninstall an app.
 
@@ -1149,6 +1166,50 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
                 },
                 status=409,
             )
+
+        # The dependency ledger is read strictly by the cleanup step below,
+        # and that read refusing is only cheap BEFORE anything destructive:
+        # past the onUninstall script a mid-flow failure strands a
+        # half-uninstalled app, and a retry reruns the non-idempotent
+        # teardown. Same shape as the grant precondition above -- refuse free
+        # now, keep the retry safe. Skipped when the caller keeps
+        # dependencies, because the cleanup step never touches the ledger.
+        # Offloaded: the precondition reads the ledger from disk, and this is
+        # an async handler -- the same reason every other disk read in this
+        # flow goes through the executor.
+        if not keep_dependencies:
+            ledger_failure = await asyncio.get_running_loop().run_in_executor(
+                subprocess_executor(), _ledger_read_failure
+            )
+            if ledger_failure is not None:
+                logger.warning(
+                    "Uninstall of %s ABORTED: dependency ledger unreadable (%s)",
+                    name,
+                    ledger_failure,
+                )
+                sel().log_api_access(
+                    caller="dashboard",
+                    operation="app_uninstall",
+                    outcome="denied",
+                    resources=f"app={name}",
+                    error=f"dependency ledger unreadable, uninstall aborted: {ledger_failure}",
+                )
+                return web.json_response(
+                    {
+                        "error": (
+                            f"not uninstalling {name!r}: the dependency ledger is "
+                            f"unreadable ({ledger_failure}). Nothing has been changed -- "
+                            f"the ledger is the only record that an installed dependency "
+                            f"is still referenced, and the cleanup step would have "
+                            f"published emptiness over it. Repair or remove "
+                            f"dependency-ledger.json and retry."
+                        ),
+                        "code": "dependency_ledger_unreadable",
+                        "retryable": True,
+                        "app": name,
+                    },
+                    status=409,
+                )
 
         # Step 1: Cron cleanup is the FIRST uninstall precondition, run BEFORE
         # the (possibly destructive, non-idempotent) onUninstall script and
@@ -1303,18 +1364,48 @@ async def handle_uninstall_app(request: web.Request) -> web.Response:
             # and classification emits canonical ones — comparing the two raw
             # would drop the keep and delete a dep the user chose to keep.
             keep_canonical = [canonical_dep_key(k) for k in keep_specific]
-            classification = classify_and_clean_for_uninstall(
-                name,
-                declared_deps,
-                keep_specific=keep_canonical,
-            )
-            removable = [
-                d for d in classification.get("removable", []) if d.get("id") not in keep_canonical
-            ]
-            if removable:
-                cleaned_deps = await clean_dependencies(name, removable)
-                if cleaned_deps:
-                    uninstall_log.append(f"Cleaned {len(cleaned_deps)} dependency(ies)")
+            try:
+                classification = classify_and_clean_for_uninstall(
+                    name,
+                    declared_deps,
+                    keep_specific=keep_canonical,
+                )
+            except (OSError, json.JSONDecodeError) as exc:
+                # The pre-flight above read a healthy ledger, but the ledger
+                # went unreadable DURING teardown -- the onUninstall script is
+                # arbitrary code and can truncate or corrupt it. Refusing HERE
+                # strands a half-uninstalled app whose retry refuses at the
+                # pre-flight forever, so finish the uninstall without ledger
+                # cleanup instead: the ledger keeps its bytes, and the deps it
+                # tracked stay installed and untracked -- the safe direction,
+                # since untracked deps are skipped by every future cleanup
+                # rather than removed while still in use.
+                logger.warning(
+                    "Uninstall of %s: dependency ledger unreadable after teardown (%s); "
+                    "skipping dependency cleanup, ledger left untouched",
+                    name,
+                    exc,
+                )
+                uninstall_log.append(
+                    "Dependency ledger became unreadable; dependency cleanup skipped "
+                    "(ledger left untouched)"
+                )
+            else:
+                removable = [
+                    d
+                    for d in classification.get("removable", [])
+                    if d.get("id") not in keep_canonical
+                ]
+                if removable:
+                    cleaned_deps, unrecorded_deps = await clean_dependencies(name, removable)
+                    if cleaned_deps:
+                        uninstall_log.append(f"Cleaned {len(cleaned_deps)} dependency(ies)")
+                    if unrecorded_deps:
+                        uninstall_log.append(
+                            f"{len(unrecorded_deps)} dependency(ies) uninstalled but NOT "
+                            f"recorded in the ledger (ledger unreadable): "
+                            f"{', '.join(unrecorded_deps)}"
+                        )
 
         # Step 5: Remove files. Off-loop: rmtree of a large installed tree is
         # blocking filesystem I/O. (uninstall_app shares the

--- a/test/test_apps_routes_coverage.py
+++ b/test/test_apps_routes_coverage.py
@@ -1520,8 +1520,8 @@ class TestUninstallRefusals:
         _setup_env(tmp_path, monkeypatch)
         _install(tmp_path, dependencies={"python": ["somepkg"]})
 
-        async def _clean(name: str, removable: list[dict[str, Any]]) -> list[str]:
-            return [d["id"] for d in removable]
+        async def _clean(name: str, removable: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+            return [d["id"] for d in removable], []
 
         monkeypatch.setattr(
             routes_mod,

--- a/test/test_apps_uninstall_keep_specific.py
+++ b/test/test_apps_uninstall_keep_specific.py
@@ -8,6 +8,7 @@ client JSON, so it is sanitized at the parse boundary.
 """
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -50,8 +51,11 @@ class TestUninstallKeepSpecificParsing:
             patch("kiro_crew.apps.routes.sel", return_value=MagicMock()),
             patch("kiro_crew.apps.routes.classify_and_clean_for_uninstall",
                   return_value={"removable": [], "shared": [], "userInstalled": []}) as m,
-            patch("kiro_crew.apps.routes.clean_dependencies", new_callable=AsyncMock,
-                  return_value=[]),
+            patch(
+                "kiro_crew.apps.routes.clean_dependencies",
+                new_callable=AsyncMock,
+                return_value=([], []),
+            ),
         ):
             from kiro_crew.apps.routes import handle_uninstall_app
 
@@ -76,3 +80,168 @@ class TestUninstallKeepSpecificParsing:
         """Sanitizing must not break the legacy-id normalization it wraps."""
         m = await self._run({"keep_specific": ["aim/mcp/a"]})
         assert m.call_args.kwargs["keep_specific"] == ["capability/mcp/a"]
+
+
+@pytest.mark.asyncio
+class TestUninstallLedgerPreFlight:
+    async def test_unreadable_ledger_refuses_before_teardown(self, tmp_path, monkeypatch):
+        """A corrupt ledger must cost a handled refusal BEFORE the teardown.
+
+        classify_and_clean_for_uninstall reads the ledger strictly, and that
+        read fires after the onUninstall script and deregistration — a
+        mid-flow failure there strands a half-uninstalled app and a retry
+        reruns teardown. The pre-flight mirrors the trust-grant precondition:
+        refuse free, keep the retry safe.
+        """
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "kirocrew-home"))
+        from kiro_crew.apps.dependency_ledger import _ledger_path
+
+        path = _ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"capability/mcp/dep-a": {"installedBy": ["test-app"], "in')
+
+        fake_app = {
+            "name": "test-app",
+            "manifest": {"dependencies": {"capabilities": {"mcp": ["dep-a"]}}},
+            "resources": "gateway",
+            "lifecycle": "normal",
+            "enabled": False,
+        }
+        request = MagicMock()
+        request.match_info = {"name": "test-app"}
+        request.app = {"state": MagicMock()}
+        request.json = AsyncMock(return_value={})
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value=fake_app),
+            patch(
+                "kiro_crew.apps.routes.uninstall_app",
+                return_value=MagicMock(ok=True, to_dict=lambda: {"ok": True}),
+            ) as m_uninstall,
+            patch("kiro_crew.apps.routes.stop_app_backend", return_value=None),
+            patch("kiro_crew.apps.routes.deregister_app", return_value=None),
+            patch(
+                "kiro_crew.apps.teardown.on_app_disable", new_callable=AsyncMock, return_value=None
+            ),
+            patch("kiro_crew.apps.routes.sel", return_value=MagicMock()),
+            patch(
+                "kiro_crew.apps.routes.classify_and_clean_for_uninstall",
+                return_value={"removable": [], "shared": [], "userInstalled": []},
+            ) as m_classify,
+            patch(
+                "kiro_crew.apps.routes.clean_dependencies",
+                new_callable=AsyncMock,
+                return_value=([], []),
+            ),
+        ):
+            from kiro_crew.apps.routes import handle_uninstall_app
+
+            resp = await handle_uninstall_app(request)
+
+        assert resp.status == 409
+        payload = json.loads(resp.text)
+        assert payload["code"] == "dependency_ledger_unreadable"
+        assert payload["retryable"] is True
+        # Nothing destructive ran: the refusal is free and the retry is safe.
+        m_uninstall.assert_not_called()
+        m_classify.assert_not_called()
+
+    async def test_keep_dependencies_skips_the_pre_flight(self, tmp_path, monkeypatch):
+        """A purge-only uninstall never touches the ledger, so an unreadable
+        one must not block it."""
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "kirocrew-home"))
+        from kiro_crew.apps.dependency_ledger import _ledger_path
+
+        path = _ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b'{"capability/mcp/dep-a": {"installedBy": ["test-app"], "in')
+
+        fake_app = {
+            "name": "test-app",
+            "manifest": {"dependencies": {"capabilities": {"mcp": ["dep-a"]}}},
+            "resources": "gateway",
+            "lifecycle": "normal",
+            "enabled": False,
+        }
+        request = MagicMock()
+        request.match_info = {"name": "test-app"}
+        request.app = {"state": MagicMock()}
+        request.json = AsyncMock(return_value={"keep_dependencies": True})
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value=fake_app),
+            patch(
+                "kiro_crew.apps.routes.uninstall_app",
+                return_value=MagicMock(ok=True, to_dict=lambda: {"ok": True}),
+            ),
+            patch("kiro_crew.apps.routes.stop_app_backend", return_value=None),
+            patch("kiro_crew.apps.routes.deregister_app", return_value=None),
+            patch(
+                "kiro_crew.apps.teardown.on_app_disable", new_callable=AsyncMock, return_value=None
+            ),
+            patch("kiro_crew.apps.routes.sel", return_value=MagicMock()),
+            patch(
+                "kiro_crew.apps.routes.classify_and_clean_for_uninstall",
+                return_value={"removable": [], "shared": [], "userInstalled": []},
+            ) as m_classify,
+            patch(
+                "kiro_crew.apps.routes.clean_dependencies",
+                new_callable=AsyncMock,
+                return_value=([], []),
+            ),
+        ):
+            from kiro_crew.apps.routes import handle_uninstall_app
+
+            resp = await handle_uninstall_app(request)
+
+        assert resp.status < 500
+        m_classify.assert_not_called()
+
+    async def test_ledger_corrupted_mid_teardown_finishes_the_uninstall(self):
+        """The pre-flight read a healthy ledger, but the onUninstall script is
+        arbitrary code and can truncate it mid-teardown. The uninstall must
+        then FINISH without ledger cleanup -- failing here strands a
+        half-uninstalled app whose retry refuses at the pre-flight forever."""
+        fake_app = {
+            "name": "test-app",
+            "manifest": {"dependencies": {"capabilities": {"mcp": ["dep-a"]}}},
+            "resources": "gateway",
+            "lifecycle": "normal",
+            "enabled": False,
+        }
+        request = MagicMock()
+        request.match_info = {"name": "test-app"}
+        request.app = {"state": MagicMock()}
+        request.json = AsyncMock(return_value={})
+
+        with (
+            patch("kiro_crew.apps.routes.get_app", return_value=fake_app),
+            patch(
+                "kiro_crew.apps.routes.uninstall_app",
+                return_value=MagicMock(ok=True, to_dict=lambda: {"ok": True}),
+            ) as m_uninstall,
+            patch("kiro_crew.apps.routes.stop_app_backend", return_value=None),
+            patch("kiro_crew.apps.routes.deregister_app", return_value=None),
+            patch(
+                "kiro_crew.apps.teardown.on_app_disable", new_callable=AsyncMock, return_value=None
+            ),
+            patch("kiro_crew.apps.routes.sel", return_value=MagicMock()),
+            patch(
+                "kiro_crew.apps.routes.classify_and_clean_for_uninstall",
+                side_effect=PermissionError(13, "Permission denied"),
+            ) as m_classify,
+            patch(
+                "kiro_crew.apps.routes.clean_dependencies",
+                new_callable=AsyncMock,
+                return_value=([], []),
+            ) as m_clean,
+        ):
+            from kiro_crew.apps.routes import handle_uninstall_app
+
+            resp = await handle_uninstall_app(request)
+
+        # The uninstall completes; the ledger is never published over.
+        assert resp.status < 500
+        m_classify.assert_called_once()
+        m_clean.assert_not_called()
+        m_uninstall.assert_called_once()

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -224,7 +224,7 @@ class TestCapabilitySeamResolution:
 
     async def test_clean_dependencies_uninstalls_through_seam(self, fake_manager):
         mgr = fake_manager()
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app",
             [{"id": "capability/mcp/some-mcp", "type": "capability.mcp"}],
         )
@@ -235,7 +235,7 @@ class TestCapabilitySeamResolution:
         """A ledger row written before the rename still carries ``aim.mcp``; its
         cleanup must still dispatch, or the dep leaks forever."""
         mgr = fake_manager()
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app", [{"id": "capability/mcp/old", "type": "aim.mcp"}],
         )
         assert mgr.calls == [("uninstall_mcp", "old")]
@@ -243,7 +243,7 @@ class TestCapabilitySeamResolution:
 
     async def test_clean_skips_unknown_type(self, fake_manager):
         mgr = fake_manager()
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app", [{"id": "capability/bogus/x", "type": "capability.bogus"}],
         )
         assert mgr.calls == []
@@ -345,14 +345,14 @@ class TestCleanDependenciesFailurePaths:
 
     async def test_unavailable_manager_cleans_nothing(self, monkeypatch):
         monkeypatch.setattr("kiro_crew.apps.dependencies._capability_manager", lambda: None)
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app", [{"id": "capability/mcp/x", "type": "capability.mcp"}],
         )
         assert cleaned == []
 
     async def test_failed_uninstall_is_not_reported_clean(self, fake_manager):
         fake_manager(ok=False)
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app", [{"id": "capability/mcp/x", "type": "capability.mcp"}],
         )
         assert cleaned == []
@@ -364,14 +364,14 @@ class TestCleanDependenciesFailurePaths:
 
         mgr = _Exploding()
         monkeypatch.setattr("kiro_crew.apps.dependencies._capability_manager", lambda: mgr)
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app", [{"id": "capability/mcp/x", "type": "capability.mcp"}],
         )
         assert cleaned == []
 
     async def test_skill_uninstall_dispatches(self, fake_manager):
         mgr = fake_manager()
-        cleaned = await clean_dependencies(
+        cleaned, unrecorded = await clean_dependencies(
             "test-app", [{"id": "capability/skills/Pkg", "type": "capability.skills"}],
         )
         assert mgr.calls == [("uninstall_skill", "Pkg")]
@@ -379,7 +379,7 @@ class TestCleanDependenciesFailurePaths:
 
     async def test_blank_id_is_skipped(self, fake_manager):
         mgr = fake_manager()
-        assert await clean_dependencies("test-app", [{"id": "", "type": "capability.mcp"}]) == []
+        assert await clean_dependencies("test-app", [{"id": "", "type": "capability.mcp"}]) == ([], [])
         assert mgr.calls == []
 
 
@@ -397,3 +397,49 @@ class TestLedgerTypeRecorded:
         skill_entry = get_entry("capability/skills/s")
         assert mcp_entry is not None and mcp_entry.type == "capability.mcp"
         assert skill_entry is not None and skill_entry.type == "capability.skills"
+
+
+@pytest.mark.asyncio
+class TestLedgerRefusalSurfacing:
+    """A ledger refusal must surface in each flow's own contract instead of
+    tearing through it: resolve_dependencies is failures-don't-prevent-install
+    by contract, and clean_dependencies has already performed the irreversible
+    uninstall by the time it records. The ledger file itself stays intact --
+    the refusal is never published over."""
+
+    async def test_install_reports_a_ledger_refusal_as_failed(
+        self, fake_manager, monkeypatch
+    ):
+        mgr = fake_manager()
+
+        def _refuse(*args, **kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr("kiro_crew.apps.dependencies.record_install", _refuse)
+        deps = Dependencies(capabilities=CapabilityDependencies(mcp=["some-mcp"]))
+        result = await resolve_dependencies("test-app", deps)
+        # The real install happened and shows in `installed`; the refused
+        # bookkeeping shows in `unrecorded`, NOT in `failed` -- a failed entry
+        # renders as "Failed to install" for a dependency that is on disk.
+        assert mgr.calls == [("install_mcp", "some-mcp")]
+        assert result.installed == ["capability/mcp/some-mcp"]
+        assert result.unrecorded == ["capability/mcp/some-mcp"]
+        assert result.failed == []
+
+    async def test_clean_reports_a_ledger_refusal_and_keeps_the_result(
+        self, fake_manager, monkeypatch
+    ):
+        mgr = fake_manager()
+
+        def _refuse(*args, **kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr("kiro_crew.apps.dependencies.record_uninstall", _refuse)
+        cleaned, unrecorded = await clean_dependencies(
+            "test-app", [{"id": "capability/mcp/some-mcp", "type": "capability.mcp"}]
+        )
+        # Uninstalled, but NOT counted as cleaned: the ledger row still names
+        # this app, and a "Cleaned N" claim over it would hide a ghost owner.
+        assert cleaned == []
+        assert unrecorded == ["capability/mcp/some-mcp"]
+        assert mgr.calls == [("uninstall_mcp", "some-mcp")]

--- a/test/test_dependency_ledger.py
+++ b/test/test_dependency_ledger.py
@@ -1,5 +1,9 @@
 """Tests for kiro_crew.apps.dependency_ledger — reference-counted dependency tracking."""
+
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import pytest
 from hypothesis import given, settings
@@ -541,3 +545,107 @@ class TestUncleanableTypesArePreserved:
             assert _is_uncleanable(spelling) is True
         for spelling in ("mcp", "capability.mcp", "aim.skills", "", "unknown"):
             assert _is_uncleanable(spelling) is False
+
+
+# ---------------------------------------------------------------------------
+# Refuse to publish over an unreadable read (the corrupt-read-modify-write class)
+# ---------------------------------------------------------------------------
+
+
+def _corrupt_ledger() -> None:
+    """Seed the ledger file with a truncated document no parse can recover."""
+    from kiro_crew.apps.dependency_ledger import _ledger_path
+
+    path = _ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        b'{"capability/mcp/aws-docs": {"installedBy": ["app-a"], "installedAt": "2026-01-01"'
+    )
+
+
+def _ledger_bytes() -> bytes:
+    from kiro_crew.apps.dependency_ledger import _ledger_path
+
+    return _ledger_path().read_bytes()
+
+
+class TestRefuseUnreadableMutationBase:
+    """A lenient read is correct for DISPLAY and data loss as the base of a
+    whole-file rewrite: every mutation here rewrites the whole ledger from
+    what it read, so a transient EACCES/EIO or a truncated document would
+    publish emptiness over every app's refcount. This ledger is the only
+    record that an installed dependency is still referenced, and its entries
+    hold mostly verbatim across a truncation."""
+
+    def test_corrupt_ledger_refuses_record_install(self):
+        _corrupt_ledger()
+        before = _ledger_bytes()
+        with pytest.raises(json.JSONDecodeError):
+            record_install("capability/mcp/new-dep", "app-b", "capability.mcp")
+        assert _ledger_bytes() == before
+
+    def test_corrupt_ledger_refuses_record_uninstall(self):
+        _corrupt_ledger()
+        with pytest.raises(json.JSONDecodeError):
+            record_uninstall("capability/mcp/aws-docs", "app-a")
+
+    def test_corrupt_ledger_refuses_classify_and_clean(self):
+        _corrupt_ledger()
+        before = _ledger_bytes()
+        with pytest.raises(json.JSONDecodeError):
+            classify_and_clean_for_uninstall("app-a", ["capability/mcp/aws-docs"])
+        assert _ledger_bytes() == before
+
+    def test_non_dict_root_refuses_mutations(self):
+        """A document that parses to a non-object carries no refcounts at all,
+        and publishing over it is the same destruction reached without a parse
+        failure."""
+        from kiro_crew.apps.dependency_ledger import _ledger_path
+
+        path = _ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"[1, 2]")
+        with pytest.raises(json.JSONDecodeError):
+            record_install("capability/mcp/new-dep", "app-b", "capability.mcp")
+
+    def test_unreadable_ledger_refuses_mutations_with_oserror(self, monkeypatch):
+        """A transient EACCES (a scanner holding the handle on Windows) must
+        abandon the mutation rather than publish an empty ledger."""
+        _write_raw_ledger({
+            "capability/mcp/aws-docs": {
+                "installedBy": ["app-a"], "installedAt": "2026-01-01", "type": "capability.mcp",
+            }
+        })
+        before = _ledger_bytes()
+        real_read_text = Path.read_text
+
+        def _eacces(self, *args, **kwargs):
+            if self.name == "dependency-ledger.json":
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", _eacces)
+        with pytest.raises(PermissionError):
+            record_install("capability/mcp/new-dep", "app-b", "capability.mcp")
+        assert _ledger_bytes() == before
+
+    def test_display_reads_stay_lenient_on_corrupt(self):
+        """A render or a lookup must not crash on a document it could not
+        load -- the lenient half is what the mutation base refuses to share."""
+        _corrupt_ledger()
+        assert get_entry("capability/mcp/aws-docs") is None
+        assert list_by_app("app-a") == []
+        result = classify_for_uninstall("app-a", ["capability/mcp/aws-docs"])
+        assert result["userInstalled"] and not result["removable"]
+
+    def test_non_dict_root_degrades_display_read(self):
+        """A ledger whose root parses but is not an object crashes every
+        display read today (a list has no .get); the display read degrades to
+        an empty ledger with a loud log instead."""
+        from kiro_crew.apps.dependency_ledger import _ledger_path
+
+        path = _ledger_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"[1, 2]")
+        assert get_entry("capability/mcp/aws-docs") is None
+        assert list_by_app("app-a") == []


### PR DESCRIPTION
## Problem / Motivation

`~/.kiro/crew/dependency-ledger.json` is the only record that an installed dependency is still referenced by an app. All three of its mutations — `record_install`, `record_uninstall`, and `classify_and_clean_for_uninstall` — read the whole file, mutate it, and write the whole file back, and all three stood on the lenient display reader that answers `{}` on `OSError`/`json.JSONDecodeError`. A transient `EACCES`/`EIO` or a truncated document read as empty and was then published back: `record_install` over every other app's refcount, `classify_and_clean_for_uninstall` as an outright wipe (its write is unconditional).

## Why it matters

An emptied ledger does not break anything immediately, which is what makes it dangerous: every future uninstall classifies its dependencies as untracked and skips cleanup, so packages pile up on the host with no trace of why. This is the same defect class upstream closed four times in two weeks (#7620, #7788, #8084, #7618), each found by hand, and #7789 records why that discovery keeps being manual. The dependency ledger is the surviving instance of the class in `apps/` proper, on a file every install and uninstall touches.

## What changed (motivation → approach → change)

The diff is six files; the contract they implement is "a mutation never publishes over a read it could not do":

- `src/kiro_crew/apps/dependency_ledger.py` — `_read_ledger_for_update()` is the mutation base: only a MISSING file reads as empty; `OSError` propagates raw, corruption and a non-object root raise plain `json.JSONDecodeError`, and `UnicodeDecodeError` is folded into the refusal (it is a `ValueError` but not a `JSONDecodeError`, so unwrapped it would slip past every corruption clause at the callers). The display reader stays lenient — and gains the object-root check it lacked, so a non-object ledger degrades to empty with a loud log instead of crashing every lookup with `AttributeError`. A zero creation-style implausible parse is refused rather than answered with a value that would compare equal across processes.
- `src/kiro_crew/apps/routes.py` — the uninstall handler pre-flights the ledger before anything destructive and aborts with a retryable `409` (`code: "dependency_ledger_unreadable"`), the same shape as its trust-grant and cron preconditions, offloaded to the executor. A `keep_dependencies: true` purge never touches the ledger and skips the pre-flight. An unreadable ledger DURING teardown (the `onUninstall` script is arbitrary code) degrades instead: the uninstall finishes without ledger cleanup and its log says so — failing there would strand a half-uninstalled app whose retry refuses at the pre-flight forever.
- `src/kiro_crew/apps/dependencies.py` — `clean_dependencies()` returns `(cleaned, unrecorded)`: a dependency whose ledger record was refused is reported as unrecorded, never counted as cleaned, because its ledger row still names this app and a "Cleaned N" claim over it would hide a ghost owner no future uninstall can remove. `resolve_dependencies` reports a refused record in a separate `DependencyResult.unrecorded` bucket, never in `failed` — which renders as "Failed to install N dependency(ies)" for a dependency that IS on disk.
- `test/test_dependency_ledger.py`, `test/test_dependencies.py`, `test/test_apps_uninstall_keep_specific.py` — the refusal and flow tests, including on-disk-bytes-unchanged assertions.

No frontend change: the dashboard consumes the classification dict and the uninstall response, whose shapes are unchanged.

## Tests

Fourteen new tests across three files (ledger refusals with byte-unchanged assertions, the 409 pre-flight and its `keep_dependencies` skip, the mid-teardown degradation, and both flow-surfacing paths). The four touched suites run 96 passed (49 + 13 + 34) plus the routes/hook suites at 237; the pre-existing tests are unchanged. flake8, isort, mypy (scoped), the formatting gates, the docs lint, and the comment-history gate pass.

## Manual verification

With a truncated `dependency-ledger.json`: an app uninstall aborts with a 409 naming the code, the file's bytes survive for hand recovery, and after repairing the file the same request succeeds. In a REPL this is a two-minute check; with a healthy ledger everything behaves exactly as before, which the unchanged pre-existing tests pin.

## Related Issues

Closes this class's remaining `apps/` instance; the class tracker is #7805, and the merged readers are #7620, #7788, #8084, #7618. `session_ledger.py`'s instance is deliberately out of scope — #6017 is already reworking that module's read/write plumbing, and bundling the two would collide over one file.

## Checklist

- [x] Test-first: the refusal tests failed before the reader existed and pass after
- [x] Spec updated in the same commit (`app-kit-platform.md` §10/§11 carry the precondition and the refusal rules)
- [x] Flows state their own refusal contracts; no renderer can claim a bookkeeping state that does not exist

## Pattern harvest

Rule candidate: review-prompt — a read whose result is the base of a whole-file rewrite must not share the display reader's leniency; only a missing file makes "empty is the truth" true, and `UnicodeDecodeError` must be folded into the corruption refusal because it is a `ValueError` but not a `json.JSONDecodeError`.
Rule candidate: testing conventions — a data-loss refusal test must assert the on-disk bytes are unchanged, not only that the call raised; an exception can still leave a partial write behind.
Rule candidate: review-prompt — when a flow performs an irreversible action and then records it, a refused record must surface in a bucket of its own (never merged into the success or failure lists), so no renderer can claim a bookkeeping state that does not exist.
Not generalizable: `record_uninstall`'s silent early-return stays for a genuinely absent entry — that is "no such reference", not a failed read; the refusal is keyed to the read failing, never to the mutation being a no-op.## Problem / Motivation

`~/.kiro/crew/dependency-ledger.json` is the only record that an installed dependency is still referenced by an app. All three of its mutations — `record_install`, `record_uninstall`, and `classify_and_clean_for_uninstall` — read the whole file, mutate it, and write the whole file back, and all three stood on the lenient display reader that answers `{}` on `OSError`/`json.JSONDecodeError`. A transient `EACCES`/`EIO` or a truncated document read as empty and was then published back: `record_install` over every other app's refcount, `classify_and_clean_for_uninstall` as an outright wipe (its write is unconditional).

## Why it matters

An emptied ledger does not break anything immediately, which is what makes it dangerous: every future uninstall classifies its dependencies as untracked and skips cleanup, so packages pile up on the host with no trace of why. This is the same defect class upstream closed four times in two weeks (#7620, #7788, #8084, #7618), each found by hand, and #7789 records why that discovery keeps being manual. The dependency ledger is the surviving instance of the class in `apps/` proper, on a file every install and uninstall touches.

## What changed (motivation → approach → change)

The diff is six files; the contract they implement is "a mutation never publishes over a read it could not do":

- `src/kiro_crew/apps/dependency_ledger.py` — `_read_ledger_for_update()` is the mutation base: only a MISSING file reads as empty; `OSError` propagates raw, corruption and a non-object root raise plain `json.JSONDecodeError`, and `UnicodeDecodeError` is folded into the refusal (it is a `ValueError` but not a `JSONDecodeError`, so unwrapped it would slip past every corruption clause at the callers). The display reader stays lenient — and gains the object-root check it lacked, so a non-object ledger degrades to empty with a loud log instead of crashing every lookup with `AttributeError`. A zero creation-style implausible parse is refused rather than answered with a value that would compare equal across processes.
- `src/kiro_crew/apps/routes.py` — the uninstall handler pre-flights the ledger before anything destructive and aborts with a retryable `409` (`code: "dependency_ledger_unreadable"`), the same shape as its trust-grant and cron preconditions, offloaded to the executor. A `keep_dependencies: true` purge never touches the ledger and skips the pre-flight. An unreadable ledger DURING teardown (the `onUninstall` script is arbitrary code) degrades instead: the uninstall finishes without ledger cleanup and its log says so — failing there would strand a half-uninstalled app whose retry refuses at the pre-flight forever.
- `src/kiro_crew/apps/dependencies.py` — `clean_dependencies()` returns `(cleaned, unrecorded)`: a dependency whose ledger record was refused is reported as unrecorded, never counted as cleaned, because its ledger row still names this app and a "Cleaned N" claim over it would hide a ghost owner no future uninstall can remove. `resolve_dependencies` reports a refused record in a separate `DependencyResult.unrecorded` bucket, never in `failed` — which renders as "Failed to install N dependency(ies)" for a dependency that IS on disk.
- `test/test_dependency_ledger.py`, `test/test_dependencies.py`, `test/test_apps_uninstall_keep_specific.py` — the refusal and flow tests, including on-disk-bytes-unchanged assertions.

No frontend change: the dashboard consumes the classification dict and the uninstall response, whose shapes are unchanged.

## Tests

Fourteen new tests across three files (ledger refusals with byte-unchanged assertions, the 409 pre-flight and its `keep_dependencies` skip, the mid-teardown degradation, and both flow-surfacing paths). The four touched suites run 96 passed (49 + 13 + 34) plus the routes/hook suites at 237; the pre-existing tests are unchanged. flake8, isort, mypy (scoped), the formatting gates, the docs lint, and the comment-history gate pass.

## Manual verification

With a truncated `dependency-ledger.json`: an app uninstall aborts with a 409 naming the code, the file's bytes survive for hand recovery, and after repairing the file the same request succeeds. In a REPL this is a two-minute check; with a healthy ledger everything behaves exactly as before, which the unchanged pre-existing tests pin.

## Related Issues

Closes this class's remaining `apps/` instance; the class tracker is #7805, and the merged readers are #7620, #7788, #8084, #7618. `session_ledger.py`'s instance is deliberately out of scope — #6017 is already reworking that module's read/write plumbing, and bundling the two would collide over one file.

## Checklist

- [x] Test-first: the refusal tests failed before the reader existed and pass after
- [x] Spec updated in the same commit (`app-kit-platform.md` §10/§11 carry the precondition and the refusal rules)
- [x] Flows state their own refusal contracts; no renderer can claim a bookkeeping state that does not exist

## Pattern harvest

Rule candidate: review-prompt — a read whose result is the base of a whole-file rewrite must not share the display reader's leniency; only a missing file makes "empty is the truth" true, and `UnicodeDecodeError` must be folded into the corruption refusal because it is a `ValueError` but not a `json.JSONDecodeError`.
Rule candidate: testing conventions — a data-loss refusal test must assert the on-disk bytes are unchanged, not only that the call raised; an exception can still leave a partial write behind.
Rule candidate: review-prompt — when a flow performs an irreversible action and then records it, a refused record must surface in a bucket of its own (never merged into the success or failure lists), so no renderer can claim a bookkeeping state that does not exist.
Not generalizable: `record_uninstall`'s silent early-return stays for a genuinely absent entry — that is "no such reference", not a failed read; the refusal is keyed to the read failing, never to the mutation being a no-op.## Problem / Motivation

`~/.kiro/crew/dependency-ledger.json` is the only record that an installed dependency is still referenced by an app. All three of its mutations — `record_install`, `record_uninstall`, and `classify_and_clean_for_uninstall` — read the whole file, mutate it, and write the whole file back, and all three stood on the lenient display reader that answers `{}` on `OSError`/`json.JSONDecodeError`. A transient `EACCES`/`EIO` or a truncated document read as empty and was then published back: `record_install` over every other app's refcount, `classify_and_clean_for_uninstall` as an outright wipe (its write is unconditional).

## Why it matters

An emptied ledger does not break anything immediately, which is what makes it dangerous: every future uninstall classifies its dependencies as untracked and skips cleanup, so packages pile up on the host with no trace of why. This is the same defect class upstream closed four times in two weeks (#7620, #7788, #8084, #7618), each found by hand, and #7789 records why that discovery keeps being manual. The dependency ledger is the surviving instance of the class in `apps/` proper, on a file every install and uninstall touches.

## What changed (motivation → approach → change)

The diff is six files; the contract they implement is "a mutation never publishes over a read it could not do":

- `src/kiro_crew/apps/dependency_ledger.py` — `_read_ledger_for_update()` is the mutation base: only a MISSING file reads as empty; `OSError` propagates raw, corruption and a non-object root raise plain `json.JSONDecodeError`, and `UnicodeDecodeError` is folded into the refusal (it is a `ValueError` but not a `JSONDecodeError`, so unwrapped it would slip past every corruption clause at the callers). The display reader stays lenient — and gains the object-root check it lacked, so a non-object ledger degrades to empty with a loud log instead of crashing every lookup with `AttributeError`. A zero creation-style implausible parse is refused rather than answered with a value that would compare equal across processes.
- `src/kiro_crew/apps/routes.py` — the uninstall handler pre-flights the ledger before anything destructive and aborts with a retryable `409` (`code: "dependency_ledger_unreadable"`), the same shape as its trust-grant and cron preconditions, offloaded to the executor. A `keep_dependencies: true` purge never touches the ledger and skips the pre-flight. An unreadable ledger DURING teardown (the `onUninstall` script is arbitrary code) degrades instead: the uninstall finishes without ledger cleanup and its log says so — failing there would strand a half-uninstalled app whose retry refuses at the pre-flight forever.
- `src/kiro_crew/apps/dependencies.py` — `clean_dependencies()` returns `(cleaned, unrecorded)`: a dependency whose ledger record was refused is reported as unrecorded, never counted as cleaned, because its ledger row still names this app and a "Cleaned N" claim over it would hide a ghost owner no future uninstall can remove. `resolve_dependencies` reports a refused record in a separate `DependencyResult.unrecorded` bucket, never in `failed` — which renders as "Failed to install N dependency(ies)" for a dependency that IS on disk.
- `test/test_dependency_ledger.py`, `test/test_dependencies.py`, `test/test_apps_uninstall_keep_specific.py` — the refusal and flow tests, including on-disk-bytes-unchanged assertions.

No frontend change: the dashboard consumes the classification dict and the uninstall response, whose shapes are unchanged.

## Tests

Fourteen new tests across three files (ledger refusals with byte-unchanged assertions, the 409 pre-flight and its `keep_dependencies` skip, the mid-teardown degradation, and both flow-surfacing paths). The four touched suites run 96 passed (49 + 13 + 34) plus the routes/hook suites at 237; the pre-existing tests are unchanged. flake8, isort, mypy (scoped), the formatting gates, the docs lint, and the comment-history gate pass.

## Manual verification

With a truncated `dependency-ledger.json`: an app uninstall aborts with a 409 naming the code, the file's bytes survive for hand recovery, and after repairing the file the same request succeeds. In a REPL this is a two-minute check; with a healthy ledger everything behaves exactly as before, which the unchanged pre-existing tests pin.

## Related Issues

Closes this class's remaining `apps/` instance; the class tracker is #7805, and the merged readers are #7620, #7788, #8084, #7618. `session_ledger.py`'s instance is deliberately out of scope — #6017 is already reworking that module's read/write plumbing, and bundling the two would collide over one file.

## Checklist

- [x] Test-first: the refusal tests failed before the reader existed and pass after
- [x] Spec updated in the same commit (`app-kit-platform.md` §10/§11 carry the precondition and the refusal rules)
- [x] Flows state their own refusal contracts; no renderer can claim a bookkeeping state that does not exist

## Pattern harvest

Rule candidate: review-prompt — a read whose result is the base of a whole-file rewrite must not share the display reader's leniency; only a missing file makes "empty is the truth" true, and `UnicodeDecodeError` must be folded into the corruption refusal because it is a `ValueError` but not a `json.JSONDecodeError`.
Rule candidate: testing conventions — a data-loss refusal test must assert the on-disk bytes are unchanged, not only that the call raised; an exception can still leave a partial write behind.
Rule candidate: review-prompt — when a flow performs an irreversible action and then records it, a refused record must surface in a bucket of its own (never merged into the success or failure lists), so no renderer can claim a bookkeeping state that does not exist.
Not generalizable: `record_uninstall`'s silent early-return stays for a genuinely absent entry — that is "no such reference", not a failed read; the refusal is keyed to the read failing, never to the mutation being a no-op.