### PR TITLE
fix(models): fold namespaced pins at substitute and picker sites (#8616)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -405,7 +405,6 @@ test/test_api_file_diff.py
 test/test_api_hook_test_stop_payload.py
 test/test_api_input_validation.py
 test/test_api_kiro_hooks.py
-test/test_api_models_entitlement.py
 test/test_api_models_retry.py
 test/test_api_server.py
 test/test_api_shutdown.py
@@ -879,7 +878,6 @@ test/test_mochi_routes.py
 test/test_model_registry.py
 test/test_model_registry_parity.py
 test/test_model_selection.py
-test/test_model_selection_scenarios.py
 test/test_module_loader.py
 test/test_native_subagent_spawn.py
 test/test_no_blocking_call_on_loop.py

--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -125,7 +125,9 @@ when done. See [acp-client.md](acp-client.md) for `AcpRuntime` /
 plus tips generation) express a `"auto"` model preference and pass it to a
 best-effort per-session `set_model`. The wire chokepoint
 (`AcpSessionHandle.set_model` → `resolve_usable_model`) mirrors the interactive
-`_wire_model_id`: it sends a served id, sends `"auto"` only when the backend
+`_wire_model_id`: it sends a served id (a persisted pin carrying a stale
+`<namespace>::` qualifier is folded to the advertised spelling via
+`resolve_pin_spelling`), sends `"auto"` only when the backend
 advertises it, and for anything else — `"auto"` where a partition doesn't serve
 it, or an unentitled concrete id — resolves to `""` and **skips the
 send**, inheriting the session's served backend default. So these tasks never

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1840,8 +1840,16 @@ def resolve_usable_model(preferred: str, advertised: Sequence[str] | None) -> st
         else ``""`` — exactly ``_wire_model_id``'s
         ``"auto" if "auto" in advertised else ""``;
       - concrete + usable             -> that id;
-      - concrete + not served         -> ``""`` (inherit the served default rather
-        than substituting a possibly-unavailable ``"auto"``).
+      - concrete, served only under its peeled spelling -> the ADVERTISED
+        spelling. A persisted pin can carry a stale ``<namespace>::<bare-id>``
+        qualifier while the session advertises the bare id (#8521's mismatch
+        class); the literal miss is retried through
+        :func:`resolve_pin_spelling`, and the fold's answer — not the caller's
+        spelling — goes on the wire, because the qualified spelling is one the
+        backend never advertised;
+      - concrete + not served under either spelling -> ``""`` (inherit the
+        served default rather than substituting a possibly-unavailable
+        ``"auto"``).
 
     The EXPLICIT user-pick paths do NOT use this: they ``raise``
     (``model_is_unusable``) so a user who chose a model sees an error, not a swap.
@@ -1857,7 +1865,11 @@ def resolve_usable_model(preferred: str, advertised: Sequence[str] | None) -> st
         return "auto" if not model_is_unusable("auto", ids) else ""
     if not model_is_unusable(preferred, ids):
         return preferred
-    return ""
+    # Literal miss: the pin may only differ by a stale ``<namespace>::``
+    # qualifier. The fold answers with the advertised spelling on a hit and
+    # ``""`` when the model is absent under both spellings — exactly the
+    # inherit-the-default answer this path wants.
+    return resolve_pin_spelling(preferred, ids)
 
 
 def _format_acp_error(error: object, available_models: Sequence[str] | None = None) -> str:

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -38,6 +38,7 @@ from kiro_crew.agent_discovery import (
     spec_model,
     spec_str,
 )
+from kiro_crew.agent_sdk.drivers.acp import resolve_pin_spelling
 from kiro_crew.agent_sdk.provider_identity import is_claude_code
 from kiro_crew.apps.bridges import _mcp_lock as _agent_file_lock
 from kiro_crew.apps.bridges import _registration_source
@@ -1825,7 +1826,14 @@ def _entitled_kiro_models(request: web.Request, models: list[dict]) -> list[dict
     "this account can run" means. A local comparison would be a second spelling
     of that question — the exact drift that predicate exists to prevent — and any
     difference in how the two fold spelling variants shows up as a row the picker
-    offers and the wire then withholds.
+    offers and the wire then withholds. A literal miss is retried through
+    ``resolve_pin_spelling``, the same namespace fold the wire sites apply
+    before withholding — but the row is REWRITTEN to the advertised spelling
+    the fold answers with (and dropped when another row already offers that
+    spelling): the selection sinks (the agent/crew pin validator and
+    ``set_model``'s pre-flight) compare the picked value literally, so a row
+    must carry an id they accept verbatim, not the catalog's stale
+    ``<namespace>::<bare-id>`` qualifier it resolved from.
 
     The ``auto`` sentinel is never filtered: it means "inherit whatever the
     session already resolved", so it stays selectable even on a backend that does
@@ -1863,19 +1871,39 @@ def _entitled_kiro_models(request: web.Request, models: list[dict]) -> list[dict
     if not advertised:
         return models
     advertises_auto = any(_normalize_model_key(i) == "auto" for i in advertised)
-    kept = [
-        m
+    offered: set[str] = {
+        _normalize_model_key(m.get("model_name", ""))
         for m in models
         if _normalize_model_key(m.get("model_name", "")) == "auto"
         or not model_is_unusable(m.get("model_name", ""), advertised)
-    ]
+    }
+    kept: list[dict] = []
+    for m in models:
+        name = m.get("model_name", "")
+        if _normalize_model_key(name) == "auto" or not model_is_unusable(name, advertised):
+            kept.append(m)
+            continue
+        resolved = resolve_pin_spelling(name, advertised)
+        if not resolved:
+            continue
+        key = _normalize_model_key(resolved)
+        # Another row (literal or already-rewritten) offers this advertised
+        # spelling: emitting a second one would show duplicate rows for one
+        # model, so the qualified duplicate drops.
+        if key in offered:
+            continue
+        offered.add(key)
+        kept.append({**m, "model_name": resolved})
     # Tell "not comparable" apart from "entitled to almost nothing". A backend
     # that advertises `auto` shares a namespace with the catalog by definition, so
     # `auto` alone is a real answer — the most restricted tier there is — and must
     # narrow the picker to it. Only when nothing at all lines up, `auto` included,
     # is this a namespace mismatch (bare vs prefixed provider ids) where showing
     # the whole catalog beats emptying the picker. `auto` is always kept, so it can
-    # never serve as the evidence that the two sides are comparable.
+    # never serve as the evidence that the two sides are comparable. A row
+    # rewritten through the ``resolve_pin_spelling`` retry IS such evidence: a
+    # peeled match proves the two vocabularies line up once the qualifier is
+    # removed.
     if not advertises_auto and not any(
         _normalize_model_key(m.get("model_name", "")) != "auto" for m in kept
     ):

--- a/test/test_api_models_entitlement.py
+++ b/test/test_api_models_entitlement.py
@@ -20,7 +20,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from kiro_crew.acp.client import model_is_unusable
+from kiro_crew.acp.client import model_is_unusable, resolve_pin_spelling
 from kiro_crew.dashboard.handlers import agents
 from kiro_crew.kiro_prerequisite import KiroPrerequisiteService
 
@@ -78,27 +78,51 @@ def test_a_spelling_the_wire_rejects_is_not_offered():
     # `set_model` pre-flights the id exactly as given, and the pin validator in
     # handlers/core applies the same raw predicate — so a dotted row here would be
     # offered by the picker and then withheld at spawn, which is the lie this
-    # narrowing exists to remove. The keep/drop decision therefore delegates to
-    # `model_is_unusable` instead of folding spellings.
-    request = _request(_provider([{"modelId": "auto"}, {"modelId": "claude-opus-4-8"},
-                                 {"modelId": "claude-opus-5"}]))
+    # narrowing exists to remove. The only fold the keep/drop applies is the same
+    # `<namespace>::` peel the wire applies (`resolve_pin_spelling`); it never
+    # translates dotted to dashed, so this row still drops.
+    request = _request(
+        _provider(
+            [{"modelId": "auto"}, {"modelId": "claude-opus-4-8"}, {"modelId": "claude-opus-5"}]
+        )
+    )
     assert _names(agents._entitled_kiro_models(request, CATALOG)) == ["auto", "claude-opus-5"]
 
 
 def test_picker_and_wire_never_disagree_row_by_row():
     # The invariant behind the above, asserted directly against the shared
-    # predicate rather than a hardcoded expectation.
-    advertised = ["auto", "claude-opus-4-8", "claude-sonnet-5"]
+    # predicates rather than a hardcoded expectation, in both directions:
+    # every non-auto row the picker offers must pass the RAW predicate (the
+    # agent/crew pin validator and set_model's pre-flight compare the picked
+    # value literally, so a kept row's spelling must survive them verbatim),
+    # and every dropped catalog row must be one the wire withholds under BOTH
+    # spellings (raw miss AND fold miss).
+    advertised = ["auto", "claude-opus-4-8", "claude-sonnet-5", "z-ai/glm-5.3-flash"]
+    catalog = CATALOG + [{"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "GLM"}]
     request = _request(_provider([{"modelId": m} for m in advertised]))
-    kept = set(_names(agents._entitled_kiro_models(request, CATALOG)))
-    for row in CATALOG:
-        name = row["model_name"]
+    kept = set(_names(agents._entitled_kiro_models(request, catalog)))
+    for name in kept:
         if name == "auto":
             continue
-        assert (name in kept) is not model_is_unusable(name, advertised), (
-            f"{name}: picker kept={name in kept}, wire withholds="
-            f"{model_is_unusable(name, advertised)}"
-        )
+        assert not model_is_unusable(
+            name, advertised
+        ), f"{name}: offered by the picker but rejected by the raw wire predicate"
+    for row in catalog:
+        name = row["model_name"]
+        if name == "auto" or name in kept:
+            continue
+        resolved = resolve_pin_spelling(name, advertised)
+        if resolved:
+            # Dropped as spelled, but the MODEL is offered — under the
+            # advertised spelling the fold answers with.
+            assert resolved in kept, f"{name}: resolvable but its advertised spelling not offered"
+        else:
+            assert model_is_unusable(
+                name, advertised
+            ), f"{name}: dropped by the picker but usable on the wire"
+    # The fold-recovered model is offered — under its advertised spelling.
+    assert "z-ai/glm-5.3-flash" in kept
+    assert "openrouter::z-ai/glm-5.3-flash" not in kept
 
 
 def test_auto_survives_a_backend_that_does_not_advertise_it():
@@ -174,6 +198,75 @@ def test_backend_that_advertises_nothing_leaves_the_catalog_alone():
     assert agents._entitled_kiro_models(request, CATALOG) == CATALOG
 
 
+def test_namespaced_row_is_rewritten_to_the_advertised_spelling():
+    # A catalog row can carry a `<namespace>::<bare-id>` qualifier from the
+    # catalog that named it, while the live session advertises the BARE id. The
+    # picker must offer the model — but under the ADVERTISED spelling, because
+    # the selection sinks (the agent/crew pin validator and set_model's
+    # pre-flight) compare the picked value literally and would refuse the
+    # qualified one. The rest of the row (description) is preserved.
+    catalog = CATALOG + [{"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "GLM"}]
+    request = _request(
+        _provider(
+            [
+                {"modelId": "auto"},
+                {"modelId": "claude-sonnet-5"},
+                {"modelId": "z-ai/glm-5.3-flash"},
+            ]
+        )
+    )
+    rows = agents._entitled_kiro_models(request, catalog)
+    assert _names(rows) == ["auto", "claude-sonnet-5", "z-ai/glm-5.3-flash"]
+    assert rows[-1]["description"] == "GLM"
+
+
+def test_namespaced_row_absent_under_both_spellings_still_drops():
+    # The fold clears false drops only: a model served under neither spelling
+    # stays hidden, exactly as the wire would withhold it.
+    catalog = CATALOG + [{"model_name": "openrouter::not-served", "description": "x"}]
+    request = _request(_provider([{"modelId": "auto"}, {"modelId": "claude-sonnet-5"}]))
+    assert _names(agents._entitled_kiro_models(request, catalog)) == ["auto", "claude-sonnet-5"]
+
+
+def test_namespaced_row_duplicating_a_literal_row_is_dropped():
+    # When the catalog lists BOTH the bare id and a qualified variant of the
+    # same model, rewriting the qualified row would duplicate the bare one —
+    # so it drops instead.
+    catalog = CATALOG + [
+        {"model_name": "z-ai/glm-5.3-flash", "description": "bare"},
+        {"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "qualified"},
+    ]
+    request = _request(_provider([{"modelId": "auto"}, {"modelId": "z-ai/glm-5.3-flash"}]))
+    rows = agents._entitled_kiro_models(request, catalog)
+    assert _names(rows) == ["auto", "z-ai/glm-5.3-flash"]
+    assert rows[-1]["description"] == "bare"
+
+
+def test_two_qualifiers_over_one_bare_id_produce_one_row():
+    # Two catalog rows whose qualifiers peel to the same advertised id must not
+    # become two visually distinct rows for one model.
+    catalog = CATALOG + [
+        {"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "first"},
+        {"model_name": "azure::z-ai/glm-5.3-flash", "description": "second"},
+    ]
+    request = _request(_provider([{"modelId": "auto"}, {"modelId": "z-ai/glm-5.3-flash"}]))
+    rows = agents._entitled_kiro_models(request, catalog)
+    assert _names(rows) == ["auto", "z-ai/glm-5.3-flash"]
+    assert rows[-1]["description"] == "first"
+
+
+def test_fold_kept_row_counts_as_comparability_evidence():
+    # A namespaced row resolving against a bare advertised set proves the two
+    # vocabularies line up once the qualifier is peeled — a real narrowing, not
+    # the sentinel-only namespace mismatch that fails open to the full catalog.
+    catalog = CATALOG + [{"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "GLM"}]
+    request = _request(_provider([{"modelId": "z-ai/glm-5.3-flash"}]))
+    assert _names(agents._entitled_kiro_models(request, catalog)) == [
+        "auto",
+        "z-ai/glm-5.3-flash",
+    ]
+
+
 def test_provider_without_getter_is_skipped_not_fatal():
     # First provider has no getter; the second one's list still applies.
     request = _request(
@@ -243,22 +336,21 @@ def test_api_models_returns_only_entitled_rows(tmp_path):
     request = _kiro_request(
         tmp_path, _provider([{"modelId": "auto"}, {"modelId": "claude-sonnet-5"}])
     )
-    with patch.object(
-        agents.KiroCrewConfig, "load", return_value=SimpleNamespace(agent=SimpleNamespace(provider="kiro"))
-    ), patch(
-        "kiro_crew.acp.client._resolve_kiro_bin_for_spawn", return_value="/usr/bin/kiro-cli"
-    ), patch(
-        "kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None
-    ), patch(
-        "kiro_crew.env.augmented_path", lambda p: p
-    ), patch(
-        "kiro_crew.dashboard.handlers.agents.wrap_argv", _stub_wrap_argv
-    ), patch(
-        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
-    ), patch(
-        "kiro_crew.sandbox.resource_limit_preexec", lambda: None
-    ), patch.object(
-        agents.asyncio, "create_subprocess_exec", return_value=_FakeProc(stdout=payload)
+    with (
+        patch.object(
+            agents.KiroCrewConfig,
+            "load",
+            return_value=SimpleNamespace(agent=SimpleNamespace(provider="kiro")),
+        ),
+        patch("kiro_crew.acp.client._resolve_kiro_bin_for_spawn", return_value="/usr/bin/kiro-cli"),
+        patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None),
+        patch("kiro_crew.env.augmented_path", lambda p: p),
+        patch("kiro_crew.dashboard.handlers.agents.wrap_argv", _stub_wrap_argv),
+        patch("kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv),
+        patch("kiro_crew.sandbox.resource_limit_preexec", lambda: None),
+        patch.object(
+            agents.asyncio, "create_subprocess_exec", return_value=_FakeProc(stdout=payload)
+        ),
     ):
         resp = asyncio.get_event_loop().run_until_complete(agents.api_models(request))
     assert resp.status == 200

--- a/test/test_model_selection_scenarios.py
+++ b/test/test_model_selection_scenarios.py
@@ -33,9 +33,9 @@ from kiro_crew.acp.client import (
 
 # Representative advertised sets for the scenarios below.
 _ENTITLED = ["claude-opus-4.8", "claude-sonnet-4.6", "auto"]  # serves auto
-_FREE_TIER = ["claude-sonnet-4.6"]                            # subset, no auto
-_NO_AUTO_PARTITION = ["gpt-5.6-terra", "gpt-5.6-luna"]        # serves models, not auto
-_UNKNOWN: list = []                                           # no session yet
+_FREE_TIER = ["claude-sonnet-4.6"]  # subset, no auto
+_NO_AUTO_PARTITION = ["gpt-5.6-terra", "gpt-5.6-luna"]  # serves models, not auto
+_UNKNOWN: list = []  # no session yet
 
 
 class TestBackgroundResolution:
@@ -73,6 +73,31 @@ class TestBackgroundResolution:
     def test_blank_advertised_entries_are_ignored(self):
         assert resolve_usable_model("claude-sonnet-4.6", ["", "  ", "claude-sonnet-4.6"]) == (
             "claude-sonnet-4.6"
+        )
+
+    def test_namespaced_pin_resolves_to_the_advertised_spelling(self):
+        # A persisted pin can carry a stale `<namespace>::<bare-id>` qualifier
+        # from the catalog that named it, while the session advertises the BARE
+        # id. The substitute path must resolve it — returning the ADVERTISED
+        # spelling for the wire — not silently inherit the backend default.
+        assert (
+            resolve_usable_model("openrouter::z-ai/glm-5.3-flash", ["z-ai/glm-5.3-flash"])
+            == "z-ai/glm-5.3-flash"
+        )
+
+    def test_namespaced_pin_absent_under_both_spellings_inherits_default(self):
+        # The fold can only clear a false withhold, never create entitlement: a
+        # model the backend serves under neither spelling still resolves to "".
+        assert resolve_usable_model("openrouter::not-served", ["z-ai/glm-5.3-flash"]) == ""
+
+    def test_verbatim_advertised_qualified_id_is_not_peeled(self):
+        # An id advertised WITH its qualifier matches literally and is returned
+        # as given — the peel only runs on a literal miss.
+        assert (
+            resolve_usable_model(
+                "openrouter::z-ai/glm-5.3-flash", ["openrouter::z-ai/glm-5.3-flash"]
+            )
+            == "openrouter::z-ai/glm-5.3-flash"
         )
 
 


### PR DESCRIPTION
Closes #8616

## Summary

Remainder-ledger follow-up to #8615, which added `acp.client.resolve_pin_spelling` — the fold that recovers a persisted model pin carrying a stale `<namespace>::<bare-id>` qualifier (e.g. `openrouter::z-ai/glm-5.3-flash`) when the session advertises the BARE id. #8615 wired it into the three sites where the false withhold was observed; this PR covers the two sibling sites the issue's closed enumeration left open (the third, `session_allocation.py`, was folded into #8615 itself):

- **`acp/client.py::resolve_usable_model`** (background/substitute model resolution): a namespaced `preferred` used to fall through to `""` — silently inheriting the backend default. A literal miss is now retried through the fold, and the fold's answer (the ADVERTISED spelling) is returned for the wire, because the qualified spelling is one the backend never advertised. A pin absent under both spellings still resolves to `""`; `preferred == "auto"`, empty-`preferred`, and unknown-`advertised` behavior are unchanged.
- **`dashboard/handlers/agents.py::_entitled_kiro_models`** (kiro picker narrowing): a qualified catalog row never matched a bare advertised row and was hidden even though the backend serves the model. A fold-resolved row is now kept — **rewritten to the advertised spelling** (and dropped when another row already offers that spelling), because the selection sinks (`_validate_role_model` in `handlers/core.py`, `AcpClient.set_model`'s pre-flight) compare the picked value literally and would refuse the qualified one. A row rewritten through the fold also counts as namespace-comparability evidence for the fail-open check, so the "not comparable vs entitled to almost nothing" contract is preserved and pinned by test.

`docs/system-specs/modules/session.md` gets a one-clause sync; the two touched test files graduated from `.github/black-baseline.txt`.

Pre-push review (two model-pinned lanes, GPT + Opus) converged on one real defect in the first draft — the picker kept the row under its qualified spelling, which every selection sink rejects (offer-then-refuse). Fixed by the rewrite+dedup above; the row-level invariant test now asserts both directions: every non-auto offered row passes the raw wire predicate verbatim, and every dropped row is withheld under both spellings.

## Tests

- `test/test_model_selection_scenarios.py`: namespaced pin resolves to the advertised spelling; absent-under-both-spellings still inherits the default; a verbatim-advertised qualified id is not peeled.
- `test/test_api_models_entitlement.py`: qualified row rewritten to the advertised spelling (description preserved); absent-under-both still drops; qualified duplicate of a literal row drops; two qualifiers over one bare id produce one row; fold-kept row counts as comparability evidence; two-direction picker/wire invariant.
- Mutation-verified: 7 distinct mutations (fold revert, caller-spelling return, entitlement-creating fallback, picker fold-clause removal, fail-open evidence exclusion, keep-verbatim instead of rewrite, dedup removal) each caught by a distinct test.
- Local gates all green with CI-pinned tools: black (baseline pruned), isort, flake8, mypy, subprocess-encoding, docs-lint, brand, harness-parity; targeted suites (model selection, entitlement picker, bg oneliner, acp client, session pool, chat handlers) 399+ passed.

## Pattern harvest

Rule candidate: a semgrep rule flagging direct `model_is_unusable(<persisted-or-catalog-value>, ...)` membership checks that are not accompanied by a `resolve_pin_spelling` retry (or a comment ruling literal comparison correct at that site), scoped to values that arrive from storage/catalog rather than the live picker.
Class: a shared spelling-fold introduced for one comparison site leaves sibling literal-comparison consumers behind; each remaining site either adopts the fold or documents why literal comparison is correct — and a DISPLAY-side adoption must emit the spelling the SELECTION sinks accept, or it converts a false withhold into an offer-then-refuse.
