### PR TITLE
ci: tell a GPT reviewer refusal apart from a crash in the review gate (#8685)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -481,6 +481,22 @@ jobs:
           # away dies on a named timeout instead of mid-call on an expired
           # token, which reads as a model failure and buries the real cause.
           PASS_WALL: 55m
+          # The provider's own refusal line, verbatim from the CLI's error
+          # output including its line-leading "ERROR: " prefix. A refusal and
+          # a crash both arrive as rc != 0 or an empty pass file, but they
+          # mean opposite things: a crash is fixed by re-running, while a
+          # refusal is caused by what the diff IS and is empirically sticky
+          # across re-runs. This line is the only way to tell them apart. The
+          # classification below matches it ANCHORED at line start and only
+          # in the TAIL of the captured stream, because the stream also
+          # carries PR-controlled text (the prompt embeds the PR title/body,
+          # and the reviewer echoes the diff -- which, for any PR touching
+          # this file, contains this very string): an unanchored whole-stream
+          # match would let an echoed copy of the signature reclassify an
+          # ordinary crash as a refusal. The text must stay free of regex
+          # metacharacters -- it is interpolated into an anchored grep
+          # pattern.
+          REFUSAL_SIGNATURE: "ERROR: This request has been flagged for potentially high-risk cyber activity"
         # Pass 1 generates candidates; its output is never posted or gated
         # directly -- the falsification pass below emits the only verdict the
         # comment and gate consume.
@@ -501,6 +517,7 @@ jobs:
           # already `rm -f`-ed.
           rm -f codex-failed-passes
           : > codex-failed-passes
+          rm -f "$RUNNER_TEMP/codex-refused-passes"
           PROMPT=$(printf '%s\n\n%s\n' "$(cat /tmp/codex-prompt.md)" \
             "DISCOVERY PASS: inspect the full current diff and report every candidate that meets the FINDING BAR. This is candidate generation, not the final verdict.")
 
@@ -512,13 +529,28 @@ jobs:
           # credentials (zizmor github-env). The path is under RUNNER_TEMP
           # because the manifest that produced it was materialized from the
           # BASE commit, not from this checkout -- see "Install review CLI".
+          #
+          # The CLI's combined stream is tee'd into RUNNER_TEMP (never the
+          # checkout, so a PR cannot plant a symlink at its name) because a
+          # failed pass is classified below by the provider's own words --
+          # only the captured output can tell a refusal from a crash.
           timeout "$PASS_WALL" \
             "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
             --sandbox read-only \
             --output-last-message "codex-pass-1.md" \
-            "$PROMPT" || rc=$?
+            "$PROMPT" 2>&1 | tee "$RUNNER_TEMP/codex-pass-1-log.txt" || rc=$?
           if [ "$rc" -ne 0 ] || [ ! -s codex-pass-1.md ]; then
-            echo "::warning::GPT 5.6 review pass 1 did not complete (exit ${rc}); the verdict will fail closed."
+            # Anchored + tail-scoped on purpose: the provider emits the
+            # refusal line at column 0 as the stream's final act, while an
+            # echoed copy of the signature (a diff hunk, quoted prose) is
+            # neither line-leading nor reliably last. The 4000-byte tail fits
+            # a single pipe buffer, so the grep cannot SIGPIPE the tail.
+            if tail -c 4000 "$RUNNER_TEMP/codex-pass-1-log.txt" | grep -q "^$REFUSAL_SIGNATURE"; then
+              echo "::warning::GPT 5.6 review pass 1 was refused by the provider (exit ${rc}); the verdict will name the refusal instead of advising a re-run."
+              printf ' 1' >> "$RUNNER_TEMP/codex-refused-passes"
+            else
+              echo "::warning::GPT 5.6 review pass 1 did not complete (exit ${rc}); the verdict will fail closed."
+            fi
             printf ' 1' >> codex-failed-passes
           fi
 
@@ -551,6 +583,11 @@ jobs:
           DISCOVERY_OUTPUT_MAX_BYTES: "50000"
           PASS_WALL: 55m
           HEAD: ${{ github.event.pull_request.head.sha }}
+          # Same signature and same anchored/tail-scoped matching as the
+          # discovery pass: a failed pass carrying it was REFUSED, not
+          # crashed, and the verdict assembly below reports that as its own
+          # terminal state.
+          REFUSAL_SIGNATURE: "ERROR: This request has been flagged for potentially high-risk cyber activity"
         # Pass 2 tries to KILL pass 1's candidates and emits the verdict. Both
         # calls are required: if either failed, no verdict is published and the
         # gate fails closed.
@@ -601,25 +638,64 @@ jobs:
 
           rm -f codex-pass-2.md
           rc=0
+          # tee'd into RUNNER_TEMP for the same reason as pass 1: the captured
+          # stream is what classifies a failed pass as refused vs crashed.
           timeout "$PASS_WALL" \
             "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
             --sandbox read-only \
             --output-last-message "codex-pass-2.md" \
-            "$PROMPT" || rc=$?
+            "$PROMPT" 2>&1 | tee "$RUNNER_TEMP/codex-pass-2-log.txt" || rc=$?
           if [ "$rc" -ne 0 ] || [ ! -s codex-pass-2.md ]; then
-            echo "::warning::GPT 5.6 review pass 2 did not complete (exit ${rc}); the verdict will fail closed."
+            if tail -c 4000 "$RUNNER_TEMP/codex-pass-2-log.txt" | grep -q "^$REFUSAL_SIGNATURE"; then
+              echo "::warning::GPT 5.6 review pass 2 was refused by the provider (exit ${rc}); the verdict will name the refusal instead of advising a re-run."
+              printf ' 2' >> "$RUNNER_TEMP/codex-refused-passes"
+            else
+              echo "::warning::GPT 5.6 review pass 2 did not complete (exit ${rc}); the verdict will fail closed."
+            fi
             failed_passes="${failed_passes} 2"
           fi
 
+          refused_passes="$(cat "$RUNNER_TEMP/codex-refused-passes" 2>/dev/null || true)"
+          refused="false"
           if [ -n "$failed_passes" ]; then
-            {
-              echo "> **Incomplete review:** pass(es)${failed_passes} did not complete."
-              echo
-              echo "The pass-2 verdict was not published because both calls are required. Re-run the workflow for a complete review."
-            } > codex-review-output.md
+            if [ -n "$refused_passes" ]; then
+              # A refusal is not a crash: the provider declined because of
+              # what the reviewed content IS, and measured refusals of this
+              # class recur identically across re-runs, so advising a re-run
+              # points the operator at a remedy that has never been observed
+              # to work. Publish a distinct terminal state -- it still carries
+              # no [GPT-REVIEWED] marker, so the gate still fails closed and a
+              # declined review can never read as an approval -- that names
+              # the refusal and routes to human adjudication. The refusal
+              # dominates a mixed failure (one pass refused, the other
+              # crashed) because the adjudication route is the reliable exit
+              # either way, while a re-run only helps if the refusal does not
+              # recur.
+              refused="true"
+              {
+                echo "> **Reviewer refused:** the provider declined to review this diff (pass(es)${refused_passes})."
+                echo
+                echo "The refusal is caused by the reviewed content, not by a transient failure, so a re-run is very unlikely to produce a verdict. A declined review is not an approval: a repository writer must adjudicate with \`/ai-review override gpt $HEAD: <one-sentence reason>\`."
+              } > codex-review-output.md
+            else
+              {
+                echo "> **Incomplete review:** pass(es)${failed_passes} did not complete."
+                echo
+                echo "The pass-2 verdict was not published because both calls are required. Re-run the workflow for a complete review."
+              } > codex-review-output.md
+            fi
           else
             cp codex-pass-2.md codex-review-output.md
           fi
+          # The refusal classification travels as a step OUTPUT, never by
+          # re-grepping codex-review-output.md downstream: on the clean path
+          # that file is verbatim model prose, so a review that merely QUOTED
+          # a refusal phrase (say, while reviewing this workflow) would
+          # otherwise reclassify a completed verdict. There is deliberately
+          # no refusal marker in the body itself — the prose names the
+          # refusal for human readers, and a marker nothing may parse would
+          # only invite a future step to start grepping model prose for it.
+          echo "refused=$refused" >> "$GITHUB_OUTPUT"
 
           # Gate the adjudication pass below on the verdict THIS step produced,
           # so a clean PR never pays for it. `[BLOCK-MERGE] $HEAD` -- the same
@@ -969,6 +1045,7 @@ jobs:
           HUMAN_OVERRIDE: ${{ steps.human_override.outputs.active }}
           OVERRIDE_ACTOR: ${{ steps.human_override.outputs.actor }}
           OVERRIDE_SOURCE: ${{ steps.human_override.outputs.source }}
+          REFUSED: ${{ steps.gpt_pass2.outputs.refused }}
           ADJ_DECISION: ${{ steps.adj.outputs.decision }}
           ADJ_NOTE: ${{ steps.adj.outputs.note }}
         run: |
@@ -981,6 +1058,20 @@ jobs:
             verdict="✅ human override accepted"
             source_url="https://github.com/$REPO/pull/$PR#issuecomment-$OVERRIDE_SOURCE"
             sentence="Human judgment by @$OVERRIDE_ACTOR overrides the GPT 5.6 finding for \`$HEAD\`; [the recorded reason]($source_url) is authoritative for this commit."
+          elif [ "$REFUSED" = "true" ]; then
+            # The provider REFUSED this diff -- a terminal state distinct from
+            # "incomplete": the refusal is caused by the reviewed content, so
+            # advising a re-run would prescribe a remedy that has never been
+            # observed to work for this class. The gate stays red either way;
+            # this comment is what lets a maintainer reaching for /ai-review
+            # override see that the reviewer refused rather than failed.
+            # $REFUSED is the verdict assembly's step output, never a grep of
+            # the review body: on the clean path that body is model prose, and
+            # a review merely QUOTING the refusal marker must not reclassify a
+            # completed verdict.
+            kind="refused"
+            verdict="⛔ reviewer refused this diff"
+            sentence="The provider declined to review \`$HEAD\`; the refusal is caused by the diff's own content, so a re-run is very unlikely to produce a verdict. A declined review is not an approval — a repository writer must adjudicate with \`/ai-review override gpt $HEAD: <one-sentence reason>\`."
           elif [ -s codex-review-output.md ] \
             && grep -Fq "[GPT-REVIEWED] $HEAD" codex-review-output.md; then
             # Blocked IFF the contract marker is present. There is deliberately
@@ -1031,6 +1122,8 @@ jobs:
               echo "</details>"
             elif [ "$kind" = "incomplete" ]; then
               echo "_See the GPT 5.6 Review job logs; this commit has no completed GPT verdict._"
+            elif [ "$kind" = "refused" ]; then
+              echo "_The refusal text is in the GPT 5.6 Review job logs. It is caused by the diff's content: re-runs have not been observed to clear this class of refusal._"
             else
               echo "_The model was not re-run because an authorized human decision supersedes it._"
             fi
@@ -1069,7 +1162,7 @@ jobs:
             || : > "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md"
 
           if [ -n "$existing" ] && [ "$existing" != "null" ]; then
-            if [ "$kind" = "incomplete" ] \
+            if { [ "$kind" = "incomplete" ] || [ "$kind" = "refused" ]; } \
               && grep -Fq "[GPT-REVIEWED]" "${RUNNER_TEMP:-/tmp}/codex-existing-comment.md"; then
               # Visibility invariant (#8292): a verdict that exists never
               # becomes invisible. The REST comments API exposes no edit
@@ -1078,13 +1171,20 @@ jobs:
               # GraphQL userContentEdits where no reader or tool looks. Keep
               # the existing verdict and prepend ONE dated notice, replacing
               # any notice a previous incomplete run left so they never stack.
-              # Scope: ONLY marker-absent (incomplete) bodies are caught here;
-              # override/blocked/clear kinds still replace the comment, and
-              # "Gate on findings" below stays fail-closed for $HEAD.
+              # Scope: ONLY verdict-less bodies (incomplete and refused) are
+              # caught here; override/blocked/clear kinds still replace the
+              # comment, and "Gate on findings" below stays fail-closed for
+              # $HEAD. The refused notice differs in exactly the way the
+              # states differ: it says re-running is futile instead of
+              # advising one.
               {
                 echo "$MARKER"
                 echo "<!-- codex-stale-notice-begin -->"
-                echo "> ⚠️ **Stale verdict notice ($(date -u +'%Y-%m-%d %H:%M UTC')):** a later GPT 5.6 run did not produce a completed verdict for \`$HEAD\`; the verdict below is from an earlier completed run. Inspect the GPT 5.6 Review job logs and re-run the workflow, or have a repository writer comment \`/ai-review override gpt $HEAD: <one-sentence reason>\`."
+                if [ "$kind" = "refused" ]; then
+                  echo "> ⚠️ **Stale verdict notice ($(date -u +'%Y-%m-%d %H:%M UTC')):** the provider REFUSED to review \`$HEAD\` — the refusal is caused by the diff's own content, so a re-run is very unlikely to produce a fresh verdict. The verdict below is from an earlier completed run on an OLDER commit. A repository writer must adjudicate: \`/ai-review override gpt $HEAD: <one-sentence reason>\`."
+                else
+                  echo "> ⚠️ **Stale verdict notice ($(date -u +'%Y-%m-%d %H:%M UTC')):** a later GPT 5.6 run did not produce a completed verdict for \`$HEAD\`; the verdict below is from an earlier completed run. Inspect the GPT 5.6 Review job logs and re-run the workflow, or have a repository writer comment \`/ai-review override gpt $HEAD: <one-sentence reason>\`."
+                fi
                 echo "<!-- codex-stale-notice-end -->"
                 echo ""
                 # Strip the leading marker and any previous notice block. Both
@@ -1102,7 +1202,7 @@ jobs:
               } > "${RUNNER_TEMP:-/tmp}/codex-merged-comment.md"
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
                 --field body="$(cat "${RUNNER_TEMP:-/tmp}/codex-merged-comment.md")" >/dev/null || true
-              echo "Preserved GPT 5.6 verdict in comment #$existing; prepended incomplete-run notice for $HEAD"
+              echo "Preserved GPT 5.6 verdict in comment #$existing; prepended $kind-run notice for $HEAD"
             else
               gh api --method PATCH "repos/$REPO/issues/comments/$existing" \
                 --field body="$(cat "${RUNNER_TEMP:-/tmp}/codex-comment.md")" >/dev/null || true
@@ -1113,13 +1213,25 @@ jobs:
             echo "Created new GPT 5.6 comment"
           fi
 
-      # Fail-CLOSED gate on two SHA-scoped markers:
+      # Fail-CLOSED gate on SHA-scoped markers:
       #   - [GPT-REVIEWED] <sha> — the review ran and produced a verdict for
       #     THIS commit. Absent => fail rather than silently pass.
       #   - [BLOCK-MERGE] <sha>    — it additionally found a CLOSED-BLOCKING-LIST
       #     issue. This is the ONLY thing that blocks the merge, and the ONLY
       #     thing that can relax it is a fully reconciled clearance from the
       #     adjudication stage above (steps.adj.outputs.decision == 'cleared').
+      #
+      # A provider REFUSAL also fails, but as its own terminal state, read
+      # from the verdict assembly's `refused` step OUTPUT: the refusal is
+      # caused by the diff's content, so its failure message must not advise
+      # the re-run a crash message advises — re-runs have not been observed
+      # to clear this class — and must name human adjudication as the
+      # workable remedy. There is deliberately NO refusal marker in the
+      # verdict body: the body on the clean path is model prose, and a
+      # marker would invite exactly the prose-grepping this output exists to
+      # prevent. The assembly only ever emits refused=true on a run whose
+      # body it wrote itself, with no [GPT-REVIEWED] marker, so a refusal
+      # can never read as a completed review.
       #
       # The old "anchored Severity: HIGH without [BLOCK-MERGE]" fail-closed
       # backstop is GONE. Because the prompt required a severity token on every
@@ -1134,6 +1246,7 @@ jobs:
           ACTOR: ${{ github.actor }}
           HUMAN_OVERRIDE: ${{ steps.human_override.outputs.active }}
           OVERRIDE_ACTOR: ${{ steps.human_override.outputs.actor }}
+          REFUSED: ${{ steps.gpt_pass2.outputs.refused }}
           ADJ_DECISION: ${{ steps.adj.outputs.decision }}
           ADJ_NOTE: ${{ steps.adj.outputs.note }}
         run: |
@@ -1151,6 +1264,17 @@ jobs:
           fi
           reviewed="[GPT-REVIEWED] $HEAD"
           blocked="[BLOCK-MERGE] $HEAD"
+          # A refusal is its own terminal state, distinct from a crash. Still
+          # fail CLOSED — a declined review is not an approval, and passing
+          # here would turn the provider's content filter into a bypass of the
+          # repo's own review requirement — but name the true cause and the
+          # remedy that can work. $REFUSED is the verdict assembly's step
+          # output for THIS run, so a marker quoted inside an old or completed
+          # verdict body can never trip this branch.
+          if [ "$REFUSED" = "true" ]; then
+            echo "::error::GPT 5.6 REFUSED to review $HEAD: the provider declined the request because of the diff's own content, and re-runs have not been observed to clear this class of refusal. Failing closed — a declined review is not an approval. This needs human adjudication: a repository writer can comment '/ai-review override gpt $HEAD: <one-sentence reason>'."
+            exit 1
+          fi
           # Positive proof the review ran for THIS commit (fail closed).
           if ! grep -Fq "$reviewed" codex-review-output.md; then
             echo "::error::GPT 5.6 review did not complete for $HEAD (no [GPT-REVIEWED] marker). Failing closed — re-run the workflow or inspect the GPT 5.6 review step logs."

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -565,7 +565,25 @@ The markers are the **only** gate:
   internal structured-output tool is unreliable when other tools are enabled:
   reviews completed with a success result yet returned no structured output,
   failing this gate closed on healthy reviews.
-- GPT 5.6 emits `[GPT-REVIEWED] <sha>` / `[BLOCK-MERGE] <sha>`.
+- GPT 5.6 emits `[GPT-REVIEWED] <sha>` / `[BLOCK-MERGE] <sha>`. When the provider
+  *refuses* the request — declines to review the diff because of what it contains,
+  as opposed to crashing or timing out — the **same-repo lane** publishes a distinct
+  terminal state: the synthetic verdict body names the refusal in prose (no
+  reviewed marker, so the gate still fails closed), and the classification rides
+  the verdict assembly's `refused` step output. There is deliberately no refusal
+  marker in the body — the body on the clean path is model prose, and a marker
+  would invite prose-grepping, so a review that merely quotes the refusal wording
+  cannot be reclassified. The gate's message names human adjudication
+  (`/ai-review override`) instead of advising a re-run: the refusal is caused by
+  the reviewed content and is empirically sticky — 12 consecutive identical
+  refusals across 10 heads were measured on one PR — so a re-run is not a workable
+  remedy. A failed pass is classified as refused only when the provider's own
+  error line appears line-anchored in the tail of that pass's captured stream,
+  because the stream also carries PR-controlled text (the prompt embeds the PR
+  title/body, and the reviewer echoes the diff). Without the distinction, every
+  security fix whose evidence is a working exploit read as a permanently
+  re-runnable crash (#8685). The fork GPT lane (`fork-gpt-review.yml`) still
+  reports only the generic incomplete state and is tracked separately.
 - Design and UX emit `Design-Verdict:` / `UX-Verdict: PASS | CONCERNS | BLOCK`,
   parsed from a header line.
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -4669,3 +4669,296 @@ class TestForkGptVerdictVisibility:
         # published via create -- not silently dropped.
         assert patch_log.read_text(encoding="utf-8") == ""
         assert created_log.read_text(encoding="utf-8") != ""
+
+
+class TestGptRefusalTerminalState:
+    """A reviewer that CRASHED and one that REFUSED both arrive as ``rc != 0``
+    or an empty pass file, but they mean opposite things: a crash is fixed by
+    re-running, while a provider refusal is caused by what the diff IS and is
+    empirically sticky across re-runs. The lane classifies a failed pass
+    against the provider's own refusal line — anchored at line start and only
+    in the tail of the captured stream, because the stream also carries
+    PR-controlled text — and publishes a distinct terminal state that still
+    fails the gate closed (a declined review is not an approval) but names
+    human adjudication instead of prescribing a re-run. The classification
+    travels as a step output; nothing downstream greps it out of model prose.
+    """
+
+    HEAD = "0123456789abcdef0123456789abcdef01234567"
+
+    @staticmethod
+    def _pass_step(name: str) -> dict:
+        doc = yaml.safe_load(_workflow("codex-review.yml"))
+        for step in list(doc["jobs"].values())[0]["steps"]:
+            if step.get("name") == name:
+                return step
+        raise AssertionError(f"step not found: {name}")
+
+    def test_refusal_is_classified_where_rc_is_captured(self) -> None:
+        workflow = _workflow("codex-review.yml")
+        discovery_step = workflow[
+            workflow.index("- name: GPT 5.6 review (discovery pass)") : workflow.index(
+                "- name: GPT 5.6 review (falsification pass)"
+            )
+        ]
+        review_step = workflow[
+            workflow.index("- name: GPT 5.6 review (falsification pass)") : workflow.index(
+                "- name: Redact credential shapes from review output"
+            )
+        ]
+        for step, n in ((discovery_step, 1), (review_step, 2)):
+            # The signature can only be matched against output that was
+            # captured; the CLI's combined stream is tee'd where rc is
+            # captured, into RUNNER_TEMP so a PR cannot plant a symlink at
+            # the log's name. The match is line-anchored and tail-scoped
+            # because the stream also carries PR-controlled text (the prompt
+            # embeds the PR title/body, and the reviewer echoes the diff —
+            # which, for a PR touching the workflow itself, contains the
+            # signature verbatim): an unanchored whole-stream match would let
+            # an echoed copy reclassify an ordinary crash as a refusal.
+            assert f'tee "$RUNNER_TEMP/codex-pass-{n}-log.txt"' in step
+            assert "REFUSAL_SIGNATURE:" in step
+            assert (
+                f'tail -c 4000 "$RUNNER_TEMP/codex-pass-{n}-log.txt" | grep -q "^$REFUSAL_SIGNATURE"'
+                in step
+            )
+            assert f"printf ' {n}' >> \"$RUNNER_TEMP/codex-refused-passes\"" in step
+        # A stale refusal record from an earlier run of the same job must not
+        # classify a fresh failure, so the record is re-initialized with the
+        # crash record.
+        assert 'rm -f "$RUNNER_TEMP/codex-refused-passes"' in discovery_step
+        # The signature is interpolated into an anchored grep pattern, so it
+        # must carry the provider's line-leading prefix and stay free of
+        # basic-regex metacharacters.
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        assert signature.startswith("ERROR: ")
+        assert re.search(r"[.*\[\]^$\\]", signature) is None
+
+    def _classify(self, tmp_path: Path, log: str) -> str:
+        """Run the discovery pass's failure-classification block against a
+        fabricated captured stream and return the refused-passes record."""
+        bash = _bash()
+        if bash is None:
+            pytest.skip("classification requires Bash")
+        step = self._pass_step("GPT 5.6 review (discovery pass)")
+        script = step["run"]
+        snippet = script[script.index('if [ "$rc" -ne 0 ]') :]
+        runner_temp = tmp_path / "rt"
+        runner_temp.mkdir()
+        (runner_temp / "codex-pass-1-log.txt").write_text(log, encoding="utf-8")
+        result = subprocess.run(
+            [bash, "-c", f"set -uo pipefail\nrc=124\n{snippet}"],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "RUNNER_TEMP": str(runner_temp),
+                "REFUSAL_SIGNATURE": step["env"]["REFUSAL_SIGNATURE"],
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        record = runner_temp / "codex-refused-passes"
+        return record.read_text(encoding="utf-8") if record.exists() else ""
+
+    def test_provider_emitted_refusal_line_classifies_as_refused(self, tmp_path: Path) -> None:
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        log = f"some progress output\n{signature}.\nLearn more here: https://example.invalid\n"
+        assert self._classify(tmp_path, log) == " 1"
+
+    def test_echoed_signature_in_pr_controlled_text_stays_a_crash(self, tmp_path: Path) -> None:
+        # The stream carries the diff the reviewer echoed. A PR touching this
+        # workflow contains the signature verbatim — as an indented diff line,
+        # never line-leading — and a crash on such a PR must stay a crash:
+        # mislabeling it as refused points the operator at /ai-review override
+        # when the re-run it forecloses would have worked.
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        log = f'+          REFUSAL_SIGNATURE: "{signature}"\n> quoted: {signature}\n'
+        assert self._classify(tmp_path, log) == ""
+
+    def test_signature_outside_the_stream_tail_stays_a_crash(self, tmp_path: Path) -> None:
+        # The provider emits the refusal as the stream's final act. A copy of
+        # the line early in a long stream (echoed content scrolled past) must
+        # not classify a later, unrelated crash.
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        log = f"{signature}.\n" + ("x" * 80 + "\n") * 100
+        assert self._classify(tmp_path, log) == ""
+
+    def _assemble_verdict(
+        self,
+        tmp_path: Path,
+        *,
+        failed_passes: str,
+        refused_passes: str | None,
+        pass2: str | None,
+    ) -> tuple[str, str]:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("verdict assembly requires Bash")
+        script = _step_script(_workflow("codex-review.yml"), "GPT 5.6 review (falsification pass)")
+        snippet = script[
+            script.index("refused_passes=") : script.index("# Gate the adjudication pass below")
+        ]
+        runner_temp = tmp_path / "rt"
+        runner_temp.mkdir()
+        gh_output = tmp_path / "gh-output"
+        gh_output.write_text("", encoding="utf-8")
+        if refused_passes is not None:
+            (runner_temp / "codex-refused-passes").write_text(refused_passes, encoding="utf-8")
+        if pass2 is not None:
+            (tmp_path / "codex-pass-2.md").write_text(pass2, encoding="utf-8")
+        harness = f"set -uo pipefail\nfailed_passes='{failed_passes}'\n{snippet}\ncat codex-review-output.md\n"
+        result = subprocess.run(
+            [bash, "-c", harness],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "HEAD": self.HEAD,
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_OUTPUT": str(gh_output),
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout, gh_output.read_text(encoding="utf-8")
+
+    def test_refused_pass_publishes_its_own_terminal_state(self, tmp_path: Path) -> None:
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes=" 2", refused_passes=" 2", pass2=None
+        )
+        assert "Reviewer refused" in out
+        # The refusal must not read as a completed review, must not prescribe
+        # the re-run that has never been observed to work, and deliberately
+        # carries NO machine marker: classification rides the step output, and
+        # a marker in the body would invite the prose-grepping that the
+        # output exists to prevent.
+        assert "[GPT-REVIEWED]" not in out
+        assert "[GPT-REFUSED]" not in out
+        assert "Re-run the workflow" not in out
+        assert "/ai-review override gpt" in out
+        # Downstream classification rides this output, never a body grep.
+        assert "refused=true" in gh_output
+
+    def test_crashed_pass_keeps_the_rerunnable_incomplete_state(self, tmp_path: Path) -> None:
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes=" 1", refused_passes=None, pass2=None
+        )
+        assert "Incomplete review" in out
+        assert "Re-run the workflow" in out
+        assert "[GPT-REFUSED]" not in out
+        assert "refused=false" in gh_output
+
+    def test_refusal_dominates_a_mixed_failure(self, tmp_path: Path) -> None:
+        # Pass 1 crashed AND pass 2 was refused: the adjudication route is the
+        # reliable exit either way, while a re-run only helps if the refusal
+        # does not recur, so the refusal is what the operator is told about.
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes=" 1 2", refused_passes=" 2", pass2=None
+        )
+        assert "Reviewer refused" in out
+        assert "Re-run the workflow" not in out
+        assert "refused=true" in gh_output
+
+    def test_clean_run_still_publishes_pass_2_verbatim(self, tmp_path: Path) -> None:
+        verdict = f"all good\n[GPT-REVIEWED] {self.HEAD}\n"
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes="", refused_passes=None, pass2=verdict
+        )
+        assert f"[GPT-REVIEWED] {self.HEAD}" in out
+        assert "[GPT-REFUSED]" not in out
+        assert "refused=false" in gh_output
+
+    def _run_gate(
+        self, tmp_path: Path, review_output: str, *, refused: str = ""
+    ) -> subprocess.CompletedProcess[str]:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("gate script requires Bash")
+        script = _step_script(_workflow("codex-review.yml"), "Gate on findings")
+        (tmp_path / "codex-review-output.md").write_text(review_output, encoding="utf-8")
+        return subprocess.run(
+            [bash, "-c", f"set -e\n{script}"],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "HEAD": self.HEAD,
+                "ACTOR": "someone",
+                "HUMAN_OVERRIDE": "false",
+                "REFUSED": refused,
+                "ADJ_DECISION": "",
+                "ADJ_NOTE": "",
+            },
+        )
+
+    def test_gate_fails_closed_on_refusal_and_names_adjudication_not_rerun(
+        self, tmp_path: Path
+    ) -> None:
+        proc = self._run_gate(
+            tmp_path,
+            "> **Reviewer refused:** the provider declined.\n",
+            refused="true",
+        )
+        assert proc.returncode == 1
+        assert "REFUSED" in proc.stdout
+        assert "/ai-review override gpt" in proc.stdout
+        # The crash branch's advice must not fire for a refusal: prescribing a
+        # re-run for a content-caused refusal is the defect this state exists
+        # to remove.
+        assert "re-run the workflow or inspect" not in proc.stdout
+
+    def test_completed_verdict_quoting_the_marker_is_not_reclassified(
+        self, tmp_path: Path
+    ) -> None:
+        # On the clean path codex-review-output.md is verbatim model prose. A
+        # review that QUOTES the refusal marker — say, while reviewing this
+        # workflow — must not flip a completed verdict into a refusal: the
+        # gate reads the assembly's step output, never the body.
+        quoted = (
+            "quoting the refusal state: '> **Reviewer refused:** the provider "
+            "declined to review this diff' and the phrase ERROR: This request "
+            "has been flagged for potentially high-risk cyber activity\n"
+            f"[GPT-REVIEWED] {self.HEAD}\n"
+        )
+        proc = self._run_gate(tmp_path, quoted, refused="")
+        assert proc.returncode == 0
+
+    def test_gate_without_refusal_keeps_the_rerunnable_crash_advice(self, tmp_path: Path) -> None:
+        proc = self._run_gate(tmp_path, "> **Incomplete review:** pass(es) 1 did not complete.\n")
+        assert proc.returncode == 1
+        assert "did not complete" in proc.stdout
+
+    def test_gate_still_passes_and_blocks_exactly_as_before(self, tmp_path: Path) -> None:
+        clean = self._run_gate(tmp_path, f"fine\n[GPT-REVIEWED] {self.HEAD}\n")
+        assert clean.returncode == 0
+        blocked = self._run_gate(
+            tmp_path, f"bad\n[GPT-REVIEWED] {self.HEAD}\n[BLOCK-MERGE] {self.HEAD}\n"
+        )
+        assert blocked.returncode == 1
+
+    def test_comment_classifies_refusal_and_preserves_prior_verdicts(self) -> None:
+        workflow = _workflow("codex-review.yml")
+        comment_step = workflow[
+            workflow.index("- name: Post/update review comment") : workflow.index(
+                "- name: Gate on findings"
+            )
+        ]
+        # Its own kind, read from the assembly's step output — never a grep of
+        # the model-authored body — so a maintainer sees "refused" from the
+        # lane itself rather than a generic "incomplete, re-run it", and a
+        # verdict that merely quotes the marker is not reclassified.
+        assert "REFUSED: ${{ steps.gpt_pass2.outputs.refused }}" in comment_step
+        assert 'elif [ "$REFUSED" = "true" ]; then' in comment_step
+        assert 'kind="refused"' in comment_step
+        assert "GPT-REFUSED" not in comment_step
+        # Visibility invariant: a refusal has no verdict, so like an
+        # incomplete run it must never bury an existing [GPT-REVIEWED] body —
+        # it prepends a notice instead, and that notice must not advise the
+        # re-run the incomplete notice advises.
+        assert '{ [ "$kind" = "incomplete" ] || [ "$kind" = "refused" ]; }' in comment_step
+        assert "very unlikely to produce a fresh verdict" in comment_step


### PR DESCRIPTION
## Summary

Fixes #8685.

The GPT 5.6 Review gate failed closed identically whether the reviewer **crashed** (fixable by re-running) or the provider **refused** the request (caused by what the diff is; measured 12 consecutive identical refusals across 10 heads on one PR), and prescribed a re-run in both cases. That made every security fix whose evidence is a working exploit read as a permanently re-runnable crash, with `/ai-review override` reachable only by operators who guessed the true cause from raw job logs.

`codex-review.yml` now:

- **Captures each pass's stream** (`tee` into `$RUNNER_TEMP`, outside the PR-writable checkout) and, when a pass fails, classifies it against the provider's own refusal line — **anchored at line start and matched only in the 4000-byte tail** of the stream. The stream also carries PR-controlled text (the prompt embeds the PR title/body, and the reviewer echoes the diff — which, for any PR touching this workflow, now contains the signature verbatim), so an unanchored whole-stream match would let an echoed copy reclassify an ordinary crash as a refusal.
- **Publishes a refusal as its own terminal state.** The synthetic verdict body names the refusal in prose (no `[GPT-REVIEWED]` marker, so the gate still fails closed), and the classification travels as the assembly step's `refused` output. There is deliberately **no refusal marker in the body**: on the clean path that body is model prose, and a marker would invite exactly the prose-grepping the step output exists to prevent — a review that merely quotes the refusal wording cannot be reclassified.
- **Still fails closed.** A declined review is not an approval; auto-passing on refusal would turn the provider's content filter into a bypass of the repo's review requirement. Only the message changes: the gate error and the upserted PR comment name the refusal and route to `/ai-review override gpt <sha>` instead of advising a re-run, and the comment preserves any prior completed verdict under a refusal-specific stale notice (same #8292 visibility invariant as the incomplete path).

Docs: the marker-contract section of `docs/ci/ci-and-reviews.md` documents the new state, scoped to the same-repo lane. Sibling lanes (`fork-gpt-review.yml`, `claude-review.yml`) still collapse the two states; tracked in #8739.

## Tests

13 new tests in `test/test_ai_review_workflows.py` (`TestGptRefusalTerminalState`), mostly behavioral bash-harness runs of the workflow's own script blocks:

- classification: a provider-emitted line-leading refusal in the stream tail classifies as refused; the same text as an echoed diff line (`+          REFUSAL_SIGNATURE: ...`) or outside the tail window stays a crash
- verdict assembly: refused / crashed / mixed / clean paths, including the `refused=true|false` step output, the absence of `[GPT-REVIEWED]` from the refusal body, and the absence of any refusal marker
- gate: refusal fails closed naming adjudication without the crash branch's re-run advice; a completed verdict that quotes the refusal wording is not reclassified; clean-pass and `[BLOCK-MERGE]` behavior unchanged
- comment step: refused kind rides the step output; the incomplete/refused preservation branch and notice wording are pinned

Mutation-verified: 9 distinct mutations (drop refusal branch, wrong marker, gate exit dropped, scoping dropped, wrong log file, anchor dropped, tail window dropped, gate reverted to body grep, output write dropped) each caught by a distinct test. Full file: 360 passed. Local gates: targeted pytest (858), isort, flake8, mypy, black-baseline, subprocess-encoding, docs-lint, brand, harness-parity — all green.

## Pattern harvest

Rule candidate: a classifier that greps a stream carrying untrusted/PR-controlled text must anchor to the emitter's own line shape and scope to where the emitter writes (the tail), or an echoed copy of the signature reclassifies the state.
Rule candidate: a state signal consumed across workflow steps should travel as a step output from the step that computed it, never by re-parsing a marker out of a file that can contain model-authored or untrusted prose — and a body marker with zero consumers should not exist at all, because it invites exactly that parsing.
Class: CI/review gate cannot see the thing it claims to check (crash-vs-refusal collapse; sibling sites: fork-gpt-review.yml, claude-review.yml — tracked in #8739).
