### PR TITLE
fix(sel): warm singleton at startup; drop per-site audit hops (#8608)

### DIFF
--- a/docs/system-specs/modules/sel.md
+++ b/docs/system-specs/modules/sel.md
@@ -67,6 +67,16 @@ computing the HMAC chain in enqueue order and batching up to `_QUEUE_DRAIN_BATCH
 events into one `open()`+write. The writer starts lazily on first `log()` and
 registers an `atexit` flush.
 
+The singleton itself is warmed at gateway startup: both async server start
+paths await `warm_sel_singleton()` (an `asyncio.to_thread(sel)`, best-effort)
+before building the middleware chain, so when the warm succeeds
+`_init_locked` — blocking file I/O — never runs on the event loop as a
+handler's first touch, and non-critical call sites need no per-site thread
+hop (#8608). A failed warm logs a warning and leaves that init retry to the
+first later touch, on its caller's thread. `critical=True` writes are
+synchronous by design and their call sites still offload themselves when
+reached from the loop.
+
 - **Durability**: eventually-durable, not synchronously-durable — a crash/kill
   can lose at most the events still queued. Acceptable for an audit log; the
   hot path (e.g. per-message skill triggering) no longer pays fsync/lock latency.

--- a/src/kiro_crew/dashboard/handlers/_shared.py
+++ b/src/kiro_crew/dashboard/handlers/_shared.py
@@ -1893,17 +1893,15 @@ async def require_owner_dashboard_request(
     """Owner gate shared across dashboard handler modules.
 
     Returns ``None`` when the caller IS the dashboard owner, allowing the
-    request to proceed.  Otherwise audits the denial via SEL (off-thread so a
-    first-process SEL construction cannot stall the event loop), checks for
-    a stale pre-owner bootstrap subject (relabelling the denial to a 401), and
-    falls back to a 403 with the standard ``owner_only`` code.
+    request to proceed.  Otherwise audits the denial via SEL (an enqueue —
+    the singleton is warmed at startup, see ``sel.warm_sel_singleton``),
+    checks for a stale pre-owner bootstrap subject (relabelling the denial
+    to a 401), and falls back to a 403 with the standard ``owner_only`` code.
 
     Imports ``is_owner_dashboard_request`` and ``stale_owner_session_response``
     inside the function body to avoid a circular import: ``source_providers``
     imports chat-state helpers that reach back into sibling handler modules.
     """
-    import asyncio
-
     from kiro_crew.dashboard.handlers.source_providers import (
         is_owner_dashboard_request,
     )
@@ -1911,21 +1909,20 @@ async def require_owner_dashboard_request(
     if is_owner_dashboard_request(request):
         return None
 
-    # Off the loop: the FIRST sel() of a process CONSTRUCTS the log (trust-dir
-    # creation, key validation — blocking file IO), so on a fresh gateway whose
-    # first mutating request is non-owner this would stall every other request.
+    # SEL is warmed at gateway startup (sel.warm_sel_singleton), so this
+    # ``log_api_access`` only enqueues to the writer thread — no thread hop
+    # needed (#8608). Guarded because a FAILED warm leaves construction to
+    # retry here and possibly raise.
     caller = str(request.get("user") or "unknown")
     try:
         from kiro_crew.sel import sel as _sel
 
-        await asyncio.to_thread(
-            lambda: _sel().log_api_access(
-                caller=caller,
-                operation=operation,
-                outcome="denied",
-                source="dashboard",
-                resources="non_owner_block",
-            )
+        _sel().log_api_access(
+            caller=caller,
+            operation=operation,
+            outcome="denied",
+            source="dashboard",
+            resources="non_owner_block",
         )
     except Exception:  # pragma: no cover - audit must never change the outcome
         logger.debug("SEL audit for non-owner %s failed", operation, exc_info=True)

--- a/src/kiro_crew/dashboard/handlers/autonudge.py
+++ b/src/kiro_crew/dashboard/handlers/autonudge.py
@@ -128,22 +128,25 @@ async def _audit_monitor_access(
     *,
     error: str = "",
 ) -> None:
-    """Record a monitor authorization decision off the event-loop thread."""
+    """Record a monitor authorization decision (best-effort).
+
+    A bare enqueue: the SEL singleton is warmed at gateway startup
+    (``sel.warm_sel_singleton``), so no per-site thread hop is needed (#8608).
+    Guarded because a FAILED warm leaves construction to retry here.
+    """
     try:
-        await asyncio.to_thread(
-            lambda: sel().log_api_access(
-                caller=str(
-                    request.get("user")
-                    or request.headers.get("X-Session-Key")
-                    or request.remote
-                    or "unknown"
-                ),
-                operation=operation,
-                outcome=outcome,
-                source="dashboard",
-                resources=request.path,
-                error=error,
-            )
+        sel().log_api_access(
+            caller=str(
+                request.get("user")
+                or request.headers.get("X-Session-Key")
+                or request.remote
+                or "unknown"
+            ),
+            operation=operation,
+            outcome=outcome,
+            source="dashboard",
+            resources=request.path,
+            error=error,
         )
     except Exception:
         logger.debug("Could not audit %s monitor access", operation, exc_info=True)

--- a/src/kiro_crew/dashboard/handlers/connections.py
+++ b/src/kiro_crew/dashboard/handlers/connections.py
@@ -363,14 +363,13 @@ async def api_connections_mint(request: web.Request) -> web.Response:
     if adopted is not None:
         # ONE event, outcome ``ok``: unlike the cold path below, this request both
         # starts and finishes here, so a ``started`` with no completion would leave the
-        # audit trail showing a mint that never ended.
-        await asyncio.to_thread(
-            lambda: sel().log_api_access(
-                caller="dashboard",
-                operation="connections_mint",
-                outcome="ok",
-                resources=f"provider:{slug} reason=adopted_warm_mint",
-            )
+        # audit trail showing a mint that never ended. A bare enqueue — SEL is
+        # warmed at gateway startup (sel.warm_sel_singleton, #8608).
+        sel().log_api_access(
+            caller="dashboard",
+            operation="connections_mint",
+            outcome="ok",
+            resources=f"provider:{slug} reason=adopted_warm_mint",
         )
         # ``waiting`` rather than ``minting``: the URL exists already. The card polls
         # the mint state either way, and that poll now finds it on the first read.
@@ -392,20 +391,15 @@ async def api_connections_mint(request: web.Request) -> web.Response:
     _mint_tasks.add(task)
     task.add_done_callback(_mint_tasks.discard)
 
-    # Off the loop: only the append is queued to SEL's writer thread. The FIRST
-    # sel() of a process CONSTRUCTS the log -- trust-dir creation, key validation,
-    # and on Windows the owner-only DACL on the key file -- and this handler runs
-    # BEFORE the audit
-    # middleware's own call (that one logs the response), so on a fresh gateway
-    # whose first state-changing request is a Connect click it would land here and
-    # stall every other request. Same reasoning as server._audit_denied.
-    await asyncio.to_thread(
-        lambda: sel().log_api_access(
-            caller="dashboard",
-            operation="connections_mint",
-            outcome="started",
-            resources=f"provider:{slug}",
-        )
+    # A bare enqueue (plus the writer thread's one-time start on the process's
+    # first log()): the construction cost this handler used to dodge (the
+    # FIRST sel() of a process) is paid once at gateway startup instead
+    # (sel.warm_sel_singleton, #8608).
+    sel().log_api_access(
+        caller="dashboard",
+        operation="connections_mint",
+        outcome="started",
+        resources=f"provider:{slug}",
     )
     return web.json_response({"ok": True, "slug": slug, "state": "minting", "token": token})
 
@@ -581,17 +575,14 @@ async def api_connections_cancel(request: web.Request) -> web.Response:
 
     dropped = await cancel_mint(slug, token)
 
-    # Off the loop: the FIRST sel() of a process constructs the log (trust-dir
-    # creation, key validation, on Windows the owner-only DACL). Same reasoning
-    # as api_connections_mint above.
-    await asyncio.to_thread(
-        lambda: sel().log_api_access(
-            caller="dashboard",
-            operation="connections_cancel",
-            outcome="ok",
-            source="dashboard",
-            resources=f"provider:{slug} dropped={dropped}",
-        )
+    # A bare enqueue: SEL is warmed at gateway startup (sel.warm_sel_singleton,
+    # #8608), so no per-site thread hop is needed.
+    sel().log_api_access(
+        caller="dashboard",
+        operation="connections_cancel",
+        outcome="ok",
+        source="dashboard",
+        resources=f"provider:{slug} dropped={dropped}",
     )
     return web.json_response({"ok": True, "slug": slug, "dropped": dropped})
 
@@ -689,24 +680,22 @@ async def api_connections_disconnect(request: web.Request) -> web.Response:
             if label not in surviving:
                 surviving.append(label)
 
-    # Off the loop: the FIRST sel() of a process constructs the log. Same
-    # reasoning as api_connections_cancel above.
-    await asyncio.to_thread(
-        lambda: sel().log_api_access(
-            caller="dashboard",
-            operation="connections_disconnect",
-            # No `or grant_shared_with` escape any more: only ATTEMPTED pairs are
-            # re-stat'd, so a survivor is always a failed unlink rather than a
-            # deliberate keep that had to be excused.
-            outcome="partial" if surviving else "ok",
-            source="dashboard",
-            resources=(
-                f"provider:{slug} artifacts_removed={len(removed)} "
-                f"surviving={len(surviving)} entry_removed={scope.entry_removed} "
-                f"grant_shared={len(scope.grant_shared_with)} "
-                f"census_incomplete={scope.census_incomplete}"
-            ),
-        )
+    # A bare enqueue: SEL is warmed at gateway startup (sel.warm_sel_singleton,
+    # #8608).
+    sel().log_api_access(
+        caller="dashboard",
+        operation="connections_disconnect",
+        # No `or grant_shared_with` escape any more: only ATTEMPTED pairs are
+        # re-stat'd, so a survivor is always a failed unlink rather than a
+        # deliberate keep that had to be excused.
+        outcome="partial" if surviving else "ok",
+        source="dashboard",
+        resources=(
+            f"provider:{slug} artifacts_removed={len(removed)} "
+            f"surviving={len(surviving)} entry_removed={scope.entry_removed} "
+            f"grant_shared={len(scope.grant_shared_with)} "
+            f"census_incomplete={scope.census_incomplete}"
+        ),
     )
     return web.json_response(
         {
@@ -793,15 +782,13 @@ async def api_connections_premint(request: web.Request) -> web.Response:
     _premint_tasks.add(task)
     task.add_done_callback(_premint_tasks.discard)
 
-    # Off the loop for the same reason as api_connections_mint: this handler can be
-    # the first state-changing request a fresh gateway serves, and the FIRST sel()
-    # of a process constructs the log.
-    await asyncio.to_thread(
-        lambda: sel().log_api_access(
-            caller="dashboard",
-            operation="connections_premint",
-            outcome="started",
-            resources=f"providers:{len(slugs)}",
-        )
+    # A bare enqueue, same as api_connections_mint: the first-touch construction
+    # this used to dodge is paid once at gateway startup (sel.warm_sel_singleton,
+    # #8608).
+    sel().log_api_access(
+        caller="dashboard",
+        operation="connections_premint",
+        outcome="started",
+        resources=f"providers:{len(slugs)}",
     )
     return web.json_response({"ok": True, "preminting": slugs})

--- a/src/kiro_crew/dashboard/handlers/cron.py
+++ b/src/kiro_crew/dashboard/handlers/cron.py
@@ -1023,15 +1023,15 @@ async def _promote_pending_grant(
         )
     # The commit landed and the promoting write already consumed the pending
     # request, so the grant is fully active with nothing left to clear.
+    # A bare enqueue: SEL is warmed at gateway startup (sel.warm_sel_singleton,
+    # #8608); guarded because a FAILED warm leaves construction to retry here.
     try:
-        await asyncio.to_thread(
-            lambda: _sel().log_api_access(
-                caller="dashboard",
-                operation="cron.secret_request_approved",
-                outcome="allowed",
-                source="dashboard",
-                resources=f"{job_id}:{','.join(sorted(updated.secret_env))}",
-            )
+        _sel().log_api_access(
+            caller="dashboard",
+            operation="cron.secret_request_approved",
+            outcome="allowed",
+            source="dashboard",
+            resources=f"{job_id}:{','.join(sorted(updated.secret_env))}",
         )
     except Exception:
         logger.debug("SEL logging failed for cron secret approve", exc_info=True)
@@ -1068,15 +1068,13 @@ async def api_cron_secret_grant(request: web.Request) -> web.Response:
     # to record.
     if request.get("internal_auth") is True:
         try:
-            await asyncio.to_thread(
-                lambda: _sel().log_api_access(
-                    caller=str(request.get("user") or "internal"),
-                    operation="cron.secret_grant",
-                    outcome="denied",
-                    source="dashboard",
-                    resources=request.match_info.get("job_id", ""),
-                    error="operator_only",
-                )
+            _sel().log_api_access(
+                caller=str(request.get("user") or "internal"),
+                operation="cron.secret_grant",
+                outcome="denied",
+                source="dashboard",
+                resources=request.match_info.get("job_id", ""),
+                error="operator_only",
             )
         except Exception:  # pragma: no cover - audit must never change the outcome
             logger.debug("SEL audit for machine secret-grant denial failed", exc_info=True)

--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -75,24 +75,22 @@ async def _deny_app_caller(request: web.Request, operation: str) -> web.Response
     404 rather than 403, matching the slot-access denials: a distinct status
     would confirm the surface exists to a caller that may not know about it.
 
-    The audit is offloaded with the ``_sel()`` accessor INSIDE the thread: on
-    a fresh gateway the first SEL touch performs synchronous filesystem
-    initialization (HMAC key load/create, chain-head read), which must never
-    run on the event loop. The fast allow path (no app token) stays on-loop
-    with no thread hop.
+    The audit is a bare enqueue: SEL is warmed at gateway startup
+    (``sel.warm_sel_singleton``), so the first-touch filesystem
+    initialization this call site used to offload never runs here (#8608).
+    Guarded because a FAILED warm leaves construction to retry on this
+    thread and possibly raise.
     """
     request_app = request.get("app", "")
     if not request_app:
         return None
     try:
-        await asyncio.to_thread(
-            lambda: _sel().log_api_access(
-                caller=request_app,
-                operation=operation,
-                outcome="denied",
-                source="app_isolation",
-                error="apps cannot access member threads",
-            )
+        _sel().log_api_access(
+            caller=request_app,
+            operation=operation,
+            outcome="denied",
+            source="app_isolation",
+            error="apps cannot access member threads",
         )
     except Exception:  # pragma: no cover - audit must never change the outcome
         logger.debug("SEL audit for %s app denial failed", operation, exc_info=True)
@@ -283,15 +281,13 @@ async def api_member_thread(request: web.Request) -> web.Response:
             # untouched (re-entrant), and let the user resolve it in the
             # crew manager.
             try:
-                await asyncio.to_thread(
-                    lambda: _sel().log_api_access(
-                        caller=request.remote or "",
-                        operation="member_thread_open",
-                        outcome="denied",
-                        source="member_pin",
-                        resources=f"slug={slug}",
-                        error="binding names a crew outside the slug's owners",
-                    )
+                _sel().log_api_access(
+                    caller=request.remote or "",
+                    operation="member_thread_open",
+                    outcome="denied",
+                    source="member_pin",
+                    resources=f"slug={slug}",
+                    error="binding names a crew outside the slug's owners",
                 )
             except Exception:  # pragma: no cover - audit must never change the outcome
                 logger.debug("SEL audit for member_pin denial failed", exc_info=True)
@@ -322,15 +318,13 @@ async def api_member_thread(request: web.Request) -> web.Response:
             _history_exists = await asyncio.to_thread(_log.has_log, _history_key)
             if _history_exists:
                 try:
-                    await asyncio.to_thread(
-                        lambda: _sel().log_api_access(
-                            caller=request.remote or "",
-                            operation="member_thread_open",
-                            outcome="denied",
-                            source="member_pin",
-                            resources=f"slug={slug}",
-                            error="orphan history: binding gone, transcript survives",
-                        )
+                    _sel().log_api_access(
+                        caller=request.remote or "",
+                        operation="member_thread_open",
+                        outcome="denied",
+                        source="member_pin",
+                        resources=f"slug={slug}",
+                        error="orphan history: binding gone, transcript survives",
                     )
                 except Exception:  # pragma: no cover - audit must never change the outcome
                     logger.debug("SEL audit for member_pin denial failed", exc_info=True)
@@ -390,15 +384,13 @@ async def api_member_thread(request: web.Request) -> web.Response:
         # resolves it in the crew manager (restore the name, or delete the
         # thread), and until then the thread refuses to speak as anyone else.
         try:
-            await asyncio.to_thread(
-                lambda: _sel().log_api_access(
-                    caller=request.remote or "",
-                    operation="member_thread_open",
-                    outcome="denied",
-                    source="member_pin",
-                    resources=f"slug={slug}",
-                    error="live slot pinned to a crew the registry no longer names",
-                )
+            _sel().log_api_access(
+                caller=request.remote or "",
+                operation="member_thread_open",
+                outcome="denied",
+                source="member_pin",
+                resources=f"slug={slug}",
+                error="live slot pinned to a crew the registry no longer names",
             )
         except Exception:  # pragma: no cover - audit must never change the outcome
             logger.debug("SEL audit for member_pin denial failed", exc_info=True)

--- a/src/kiro_crew/dashboard/handlers/messaging.py
+++ b/src/kiro_crew/dashboard/handlers/messaging.py
@@ -4748,17 +4748,15 @@ async def api_teams_activity(request: web.Request) -> web.Response:
     source = request.remote or "unknown"
     throttled_source = "" if is_proxied_request(request) else source
     if throttled_source and webhooks.auth_throttle_blocked(throttled_source):
-        # Off the loop: the first ``sel()`` of a process CONSTRUCTS the log
-        # (trust-dir creation, key validation — blocking file IO), and this
-        # route can be the first request a fresh gateway ever serves.
-        await asyncio.to_thread(
-            lambda: _sel().log_api_access(
-                caller=source,
-                operation="teams.activity",
-                outcome="denied",
-                source="teams",
-                error="auth failures throttled",
-            )
+        # A bare enqueue: SEL is warmed at gateway startup
+        # (sel.warm_sel_singleton, #8608), so even when this route is the
+        # first request a fresh gateway serves, no construction runs here.
+        _sel().log_api_access(
+            caller=source,
+            operation="teams.activity",
+            outcome="denied",
+            source="teams",
+            error="auth failures throttled",
         )
         return web.json_response(
             {"error": "too many failed attempts", "code": "auth_throttled"}, status=429

--- a/src/kiro_crew/dashboard/handlers/secrets.py
+++ b/src/kiro_crew/dashboard/handlers/secrets.py
@@ -47,20 +47,17 @@ async def _owner_only(request: web.Request, operation: str) -> web.Response | No
     """
     if is_owner_dashboard_request(request):
         return None
-    # Off the loop: the FIRST sel() of a process CONSTRUCTS the log (trust-dir
-    # creation, key validation — blocking file IO), so on a fresh gateway whose
-    # first secrets request is non-owner this would otherwise stall every other
-    # request. Same reasoning as agents._require_owner.
+    # A bare enqueue: SEL is warmed at gateway startup (sel.warm_sel_singleton,
+    # #8608). Guarded because a FAILED warm leaves construction to retry here
+    # and possibly raise — the audit must never change the outcome.
     caller = str(request.get("user") or "unknown")
     try:
-        await asyncio.to_thread(
-            lambda: _sel().log_api_access(
-                caller=caller,
-                operation=operation,
-                outcome="denied",
-                source="dashboard",
-                resources="non_owner_block",
-            )
+        _sel().log_api_access(
+            caller=caller,
+            operation=operation,
+            outcome="denied",
+            source="dashboard",
+            resources="non_owner_block",
         )
     except Exception:  # pragma: no cover — audit must never change the outcome
         logger.debug("SEL audit for non-owner %s failed", operation, exc_info=True)

--- a/src/kiro_crew/dashboard/handlers/session_control.py
+++ b/src/kiro_crew/dashboard/handlers/session_control.py
@@ -11,7 +11,6 @@ that take a target share one guard.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from aiohttp import web
@@ -43,25 +42,21 @@ async def _require_internal(request: web.Request) -> web.Response | None:
     """
     if request.get("internal_auth") is True:
         return None
-    # Off the loop AND best-effort, the two properties `_audit_denied` exists to
-    # carry for exactly this shape of site: a refusal logged BEFORE the audit
-    # middleware has run. `log_api_access` only enqueues, but the FIRST `sel()` of
-    # a process constructs the log -- trust-dir creation and key validation,
-    # blocking file IO -- so a fresh gateway whose first session-control request
-    # is unauthenticated would run that synchronously on
-    # the event loop. And construction can raise (a trust root too short to sign
-    # the chain), which unguarded would turn this 403 into a 500: losing the
+    # Best-effort, the property `_audit_denied` exists to carry for exactly this
+    # shape of site: a refusal logged BEFORE the audit middleware has run.
+    # `log_api_access` only enqueues — SEL is warmed at gateway startup
+    # (sel.warm_sel_singleton, #8608), so no thread hop is needed. Construction
+    # can still raise on a FAILED warm (a trust root too short to sign the
+    # chain), which unguarded would turn this 403 into a 500: losing the
     # denial in order to report it.
     try:
-        await asyncio.to_thread(
-            lambda: sel().log_api_access(
-                caller="unknown",
-                operation=f"session_control.{request.path.rsplit('/', 1)[-1]}",
-                outcome="denied",
-                source="dashboard",
-                resources=request.path,
-                error="internal secret required",
-            )
+        sel().log_api_access(
+            caller="unknown",
+            operation=f"session_control.{request.path.rsplit('/', 1)[-1]}",
+            outcome="denied",
+            source="dashboard",
+            resources=request.path,
+            error="internal secret required",
         )
     except Exception:
         logger.warning("Failed to log a session-control denial to SEL", exc_info=True)

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -178,7 +178,7 @@ from kiro_crew.safety_override import (
     take_dropped_grant,
 )
 from kiro_crew.security import redact_credentials, redact_exfiltration_urls
-from kiro_crew.sel import sel
+from kiro_crew.sel import sel, warm_sel_singleton
 from kiro_crew.skill_usage import register_skill_read_observer
 from kiro_crew.skills import SkillsLoader, set_pending_consumed_hook, set_pending_staged_hook
 from kiro_crew.tunnel.setup import setup_tunnel
@@ -459,39 +459,39 @@ _PRE_AUDIT_DENY_STATUSES = frozenset({401, 403})
 
 
 async def _audit_denied(caller: str, request: web.Request, error: str) -> None:
-    """Record a middleware refusal in the SEL, off the event loop, best-effort.
+    """Record a middleware refusal in the SEL, best-effort.
 
     Shared by every middleware that denies BEFORE ``sel_audit_middleware`` runs
     (that one is registered inner to them, so a bare raise produces a 403 that
     appears nowhere in the audit log). One helper rather than per-site calls
-    because both properties below are easy to omit at a new deny site and
+    because the property below is easy to omit at a new deny site and
     invisible when omitted:
 
-    * OFF THE LOOP — ``log_api_access`` only enqueues, but the first ``sel()``
-      of a process CONSTRUCTS the log: trust-dir creation, key validation, and
-      on Windows the owner-only DACL on the key file. A fresh
-      dashboard whose first state-changing request is cross-origin would run
-      that synchronously on the event loop and stall every other request.
     * BEST-EFFORT — a trust root too short to sign the chain makes construction
       raise, and an unguarded write would turn the refusal into a 500: losing
       the denial in order to report it.
 
+    No thread hop: the SEL singleton is warmed at startup
+    (:func:`kiro_crew.sel.warm_sel_singleton`, awaited by both start paths
+    before the middleware chain is built), so ``log_api_access`` here only
+    enqueues to the writer thread (after its one-time start on first
+    ``log()``) (#8608). The guard stays because a FAILED
+    warm leaves construction to retry on this thread and possibly raise.
+
     Calling this CLAIMS the request (:func:`origin.mark_audit_claimed`) so the
     deny-audit boundary outer to every barrier does not record the same refusal
     a second time. The claim is set unconditionally, before the write: a write
-    that failed here fails identically in the boundary, so a second doomed
-    thread hop buys nothing.
+    that failed here fails identically in the boundary, so retrying in the
+    boundary buys nothing.
     """
     mark_audit_claimed(request)
     try:
-        await asyncio.to_thread(
-            lambda: sel().log_api_access(
-                caller=caller,
-                operation=f"{request.method} {request.path}",
-                outcome="denied",
-                resources=request.path,
-                error=error,
-            )
+        sel().log_api_access(
+            caller=caller,
+            operation=f"{request.method} {request.path}",
+            outcome="denied",
+            resources=request.path,
+            error=error,
         )
     except Exception:
         logger.warning("Failed to log a middleware denial to SEL", exc_info=True)
@@ -3632,6 +3632,13 @@ async def start_dashboard(
     # I/O lands on the loop on the first auth op.
     await warm_auth_singletons()
 
+    # Warm the SecurityEventLog singleton off the loop before any handler or
+    # middleware can be its first touch, so a first ``log_api_access`` is a
+    # non-blocking enqueue on every path — call sites need no per-site
+    # ``asyncio.to_thread`` hop (#8608). Best-effort inside the helper: a
+    # failed warm never blocks readiness.
+    await warm_sel_singleton()
+
     # Explicit middleware ordering — self-documenting and immune to future insertions
     app.middlewares[:] = [
         # Outermost: privacy-safe per-route latency (rec #1). Times the FULL
@@ -4436,6 +4443,11 @@ async def start_api_server(
     # Warm the auth singletons off the event loop before building the chain
     # (parity with start_dashboard) so no blocking key-file I/O hits the loop.
     await warm_auth_singletons()
+
+    # Warm the SecurityEventLog singleton off the loop (parity with
+    # start_dashboard) so the first audit on this entrypoint is also a
+    # non-blocking enqueue, never an on-loop ``_init_locked`` (#8608).
+    await warm_sel_singleton()
 
     # Explicit ordering mirrors start_dashboard: latency → deny-audit → host →
     # csrf → token → audit.

--- a/src/kiro_crew/sel.py
+++ b/src/kiro_crew/sel.py
@@ -2140,7 +2140,11 @@ class SecurityEventLog:
         The HMAC chain (prev_hash/entry_hash) is computed in the writer thread
         in enqueue order, so callers never pay the hash + file-append cost on
         the hot path. If the writer can't be started (unexpected), fall back to
-        a synchronous write so an event is never silently dropped.
+        a synchronous write off the event loop; ON the loop the non-critical
+        event is dropped with a warning instead, because the inline write's
+        filesystem work would freeze every task the loop serves
+        (no-blocking-call-on-event-loop) — best-effort audit loss is the
+        survivable direction.
 
         When ``critical=True`` the event is written SYNCHRONOUSLY and a
         filesystem failure is re-raised, so a fail-closed caller (e.g. safety
@@ -2179,13 +2183,33 @@ class SecurityEventLog:
                 self.flush()
             self._flush_batch([event], raise_on_error=True)
             return
+        incremented = False
         try:
             self._ensure_writer()
             with self._pending_cond:
                 self._pending += 1
+            incremented = True
             self._queue.put(event)
         except Exception:
-            # Writer unavailable — write synchronously so the audit entry lands.
+            # The event never reached the queue, so return its pending credit —
+            # otherwise flush() waits its full timeout on a count nothing will
+            # ever decrement (the writer only credits batches it dequeues).
+            if incremented:
+                self._decr_pending(1)
+            # Writer unavailable. Off the loop, write synchronously so the
+            # audit entry lands. ON the loop, drop it instead: `_flush_batch`
+            # is redaction + chain lock + open/write/flush on the caller's
+            # thread, and a non-critical audit is best-effort by contract —
+            # losing one event is survivable, freezing every session's turn
+            # and the liveness heartbeat is not (no-blocking-call-on-event-loop).
+            # Critical writes never take this branch; they fail closed above.
+            if _on_event_loop():
+                logger.warning(
+                    "SEL writer enqueue failed on the event loop; "
+                    "dropping non-critical event",
+                    exc_info=True,
+                )
+                return
             logger.warning("SEL writer enqueue failed; writing synchronously", exc_info=True)
             self._flush_batch([event])
 
@@ -3320,6 +3344,44 @@ def audit_sources() -> tuple[str, ...]:
 def sel() -> SecurityEventLog:
     """Module-level accessor for the singleton SEL instance."""
     return SecurityEventLog()
+
+
+async def warm_sel_singleton() -> None:
+    """Prime the SecurityEventLog singleton OFF the event loop at startup.
+
+    The first ``sel()`` of a process runs ``_init_locked`` — blocking file I/O
+    (trust-dir creation, HMAC key load/create, a tail read of the live log) —
+    on whatever thread touches it first. Before this warm existed, every
+    handler that could plausibly be a fresh gateway's first SEL touch carried
+    its own ``asyncio.to_thread`` wrapper (18+ sites), while 250+ other
+    ``log_api_access`` call sites remained candidate first-touch stalls
+    (#8608). Warming once here, before the server accepts traffic, fixes the
+    class: a post-init ``log_api_access`` only enqueues to the writer thread
+    (after the writer's one-time daemon-thread start on first ``log()``), so
+    call sites need no thread hop.
+
+    Both async startup paths (``start_dashboard`` / ``start_api_server``)
+    ``await`` this before building the middleware chain — the same pattern as
+    ``token_auth.warm_auth_singletons``. The cost does not scale with user
+    data: one key-file read (or create), one backward tail read of the live
+    log (a single 4 KiB chunk on a healthy log; worst case a full backward
+    scan of the live log, bounded by rotation's ``_SEGMENT_MAX_BYTES``, when
+    its tail holds no parseable record), and a ``stat``.
+
+    Best-effort by design: construction can raise (e.g. a trust root too
+    short to sign the chain), and an SEL init failure must not keep the
+    gateway from becoming ready — audit degradation is survivable, a boot
+    loop is not. On a failed warm the first later touch retries init on its
+    caller's thread, as every call site did before the per-site hops existed;
+    every ``critical=True`` audit still fails closed at its own site.
+    """
+    try:
+        await asyncio.to_thread(sel)
+    except Exception:
+        logger.warning(
+            "SEL startup warm failed; the first audit write will retry init",
+            exc_info=True,
+        )
 
 
 def _trust_root_key_loads(path: Path) -> bool:

--- a/test/test_api_health.py
+++ b/test/test_api_health.py
@@ -455,11 +455,12 @@ def test_every_middleware_denial_is_audited_off_the_loop() -> None:
     """Wiring pin: every middleware that refuses BEFORE ``sel_audit_middleware``
     must route its audit through the shared ``_audit_denied`` helper.
 
-    That helper owns two properties which are easy to omit at a new deny site
-    and invisible when omitted: the write runs OFF the event loop (the first
-    ``sel()`` of a process constructs the log — trust-dir creation, key
-    validation, an ``icacls`` subprocess on Windows), and it is best-effort (an
-    audit that raises must not turn the 403 into a 500).
+    That helper owns a property which is easy to omit at a new deny site and
+    invisible when omitted: the write is best-effort (an audit that raises
+    must not turn the 403 into a 500). The write itself is a direct enqueue —
+    the SEL singleton is warmed at gateway startup (``sel.warm_sel_singleton``,
+    pinned in test_sel_startup_warm.py), so the per-call thread hop the helper
+    used to carry is gone (#8608) and must not quietly return.
 
     A bare raise with no audit at all is no longer a silent failure — the
     deny-audit boundary records it by position (see the chain tests below) — so
@@ -473,9 +474,10 @@ def test_every_middleware_denial_is_audited_off_the_loop() -> None:
     from kiro_crew.dashboard import server as server_mod
 
     helper = inspect.getsource(server_mod._audit_denied)
-    assert (
-        "asyncio.to_thread" in helper
-    ), "_audit_denied no longer offloads the SEL write off the event loop"
+    assert "asyncio.to_thread" not in helper, (
+        "_audit_denied re-grew a per-call thread hop; SEL is warmed at startup "
+        "(sel.warm_sel_singleton), so log_api_access is a non-blocking enqueue"
+    )
     assert "except Exception" in helper, "_audit_denied is no longer best-effort"
 
     # Both pre-audit barriers are built by a shared factory, so the deny arms live
@@ -490,7 +492,7 @@ def test_every_middleware_denial_is_audited_off_the_loop() -> None:
         ), f"{name} has a deny arm that no longer audits via _audit_denied"
         assert 'outcome="denied"' not in src, (
             f"{name} re-grew a hand-rolled denial audit; route it through "
-            "_audit_denied so the off-loop and best-effort properties hold "
+            "_audit_denied so the best-effort property holds "
             "(sel_audit_middleware's ok/error request audit is unaffected)"
         )
 
@@ -502,7 +504,7 @@ def test_every_middleware_denial_is_audited_off_the_loop() -> None:
     ):
         assert 'outcome="denied"' not in inspect.getsource(func), (
             f"{name} re-grew a hand-rolled denial audit; route it through "
-            "_audit_denied so the off-loop and best-effort properties hold "
+            "_audit_denied so the best-effort property holds "
             "(sel_audit_middleware's ok/error request audit is unaffected)"
         )
 
@@ -617,9 +619,10 @@ async def test_a_forgetful_pre_audit_refusal_is_still_audited_by_position(
     assert denials[0]["operation"] == "GET /api/sessions"
     assert denials[0]["resources"] == "/api/sessions"
     assert "403" in denials[0]["error"]
-    # Off the loop, via the shared helper — not an inline sel() call on the
-    # event loop, which the first sel() of a process would block on.
-    assert spy.threads[0] != "MainThread"
+    # A direct enqueue on the loop thread via the shared helper — the
+    # singleton is warmed at startup (sel.warm_sel_singleton, #8608), so no
+    # per-call thread hop remains to reintroduce.
+    assert spy.threads[0] == "MainThread"
 
 
 @pytest.mark.asyncio

--- a/test/test_members_dm_thread.py
+++ b/test/test_members_dm_thread.py
@@ -1507,15 +1507,17 @@ class TestMemberActivityRoute:
 
 
 class TestDenialAuditOffload:
-    """Deny-path SEL audits must never run on the event loop (issue #8523).
+    """Deny-path SEL audits are direct enqueues since the startup warm (#8608).
 
-    On a fresh gateway the first ``_sel()`` touch performs synchronous
-    filesystem initialization (HMAC key load/create, chain-head read); a
-    denial that audits inline therefore stalls every gateway task. Each test
-    records the thread the audit actually ran on and fails if it is the
-    event-loop thread — reverting any call site to a bare
-    ``_sel().log_api_access(...)`` turns the recorded ident back into the
-    loop's and fails these.
+    The per-site ``asyncio.to_thread`` wrappers existed because a fresh
+    gateway's first ``_sel()`` touch performed synchronous filesystem
+    initialization (HMAC key load/create, chain-head read). That first touch
+    now happens once at gateway startup (``sel.warm_sel_singleton``, awaited
+    by both server start paths — pinned in test_sel_startup_warm.py), so a
+    handler-side ``log_api_access`` is a non-blocking enqueue and the thread
+    hop is gone. Each test records the thread the audit ran on and fails if
+    it is NOT the event-loop thread — re-adding a pointless per-site offload
+    turns the recorded ident back into a worker's and fails these.
     """
 
     @staticmethod
@@ -1528,7 +1530,7 @@ class TestDenialAuditOffload:
         return _RecordingSel()
 
     @pytest.mark.asyncio
-    async def test_app_denial_audit_runs_off_the_event_loop(self, tmp_path, monkeypatch):
+    async def test_app_denial_audit_runs_inline(self, tmp_path, monkeypatch):
         state = _make_state(tmp_path)
         record: dict = {}
         monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: self._recording_sel(record))
@@ -1547,12 +1549,12 @@ class TestDenialAuditOffload:
         assert record["kwargs"]["outcome"] == "denied"
         assert record["kwargs"]["source"] == "app_isolation"
         assert record["kwargs"]["operation"] == "members.list"
-        # The audit — including the ``_sel()`` accessor — ran off-loop.
-        assert record["thread_ident"] != loop_ident
+        # The audit is a direct enqueue on the loop thread — no thread hop.
+        assert record["thread_ident"] == loop_ident
 
     @pytest.mark.asyncio
-    async def test_member_pin_denial_audit_runs_off_the_event_loop(self, tmp_path, monkeypatch):
-        """The pin-mismatch denial (binding names a non-owner) audits off-loop."""
+    async def test_member_pin_denial_audit_runs_inline(self, tmp_path, monkeypatch):
+        """The pin-mismatch denial (binding names a non-owner) audits inline."""
         state = _make_state(tmp_path)
         record: dict = {}
         monkeypatch.setattr("kiro_crew.dashboard.handlers.sel", lambda: self._recording_sel(record))
@@ -1567,76 +1569,18 @@ class TestDenialAuditOffload:
                 assert (await resp.json())["code"] == "member_pin_mismatch"
         assert record["kwargs"]["source"] == "member_pin"
         assert record["kwargs"]["outcome"] == "denied"
-        assert record["thread_ident"] != loop_ident
+        assert record["thread_ident"] == loop_ident
         assert not state._slots
 
-    @pytest.mark.asyncio
-    async def test_first_sel_touch_initializes_off_the_event_loop(self, tmp_path, monkeypatch):
-        """A deny-path audit that is SEL's FIRST touch initializes off-loop.
+    def test_no_members_sel_audit_is_offloaded(self):
+        """AST guard (inverted from #8523 by #8608): no ``log_api_access``
+        call in members.py hides inside an ``asyncio.to_thread`` lambda.
 
-        Uses a real ``SecurityEventLog`` against a fresh directory so the
-        first-touch work (HMAC key create, chain-head read) genuinely runs,
-        and records the thread ``_init_locked`` executes on.
-        """
-        from kiro_crew import sel as sel_mod
-
-        state = _make_state(tmp_path)
-        sel_dir = tmp_path / "sel-home"
-        init_record: dict = {}
-        real_init = sel_mod.SecurityEventLog._init_locked
-
-        def _recording_init(inst, base_dir, sync):
-            init_record["thread_ident"] = threading.get_ident()
-            return real_init(inst, base_dir, sync)
-
-        monkeypatch.setattr(sel_mod.SecurityEventLog, "_init_locked", _recording_init)
-        # sync=True keeps the append inline in the worker thread (no background
-        # writer to leak); the FIRST-TOUCH construction below is still real.
-        monkeypatch.setattr(
-            sel_mod, "sel", lambda: sel_mod.SecurityEventLog(base_dir=sel_dir, sync=True)
-        )
-        # Displace-then-RESTORE the process singleton, the ``sel_private_root``
-        # convention (that fixture itself is unusable here: it pre-builds the
-        # instance, which would consume the very first touch this test needs).
-        # The reset is immediately followed by the try so a failure can never
-        # lose ``prior_instance`` (see conftest's ordering warning).
-        prior_instance = sel_mod.SecurityEventLog._instance
-        sel_mod.SecurityEventLog._instance = None
-        sel_mod.SecurityEventLog._initialized = False
-        try:
-
-            @web.middleware
-            async def _as_app(request: web.Request, handler):
-                request["app"] = "some-app"
-                return await handler(request)
-
-            app = _make_members_app(state)
-            app.middlewares.insert(0, _as_app)
-            loop_ident = threading.get_ident()
-            with _patched_config([CREW]):
-                async with TestClient(TestServer(app)) as client:
-                    assert (await client.get("/api/members")).status == 404
-            # First touch happened HERE (singleton was reset above) …
-            assert init_record["thread_ident"] is not None
-            # … did its filesystem initialization for real …
-            assert (sel_dir / "trust" / "sel_hmac.key").is_file()
-            # … and never on the event loop.
-            assert init_record["thread_ident"] != loop_ident
-        finally:
-            # Restore the PRIOR singleton (not ``None``): leaving ``None`` would
-            # make the next default ``sel()`` mint a SECOND instance — and a
-            # second writer thread — on the worker's session-shared directory.
-            sel_mod.SecurityEventLog._instance = prior_instance
-            sel_mod.SecurityEventLog._initialized = False
-
-    def test_every_members_sel_audit_is_offloaded(self):
-        """AST guard: no ``log_api_access`` call in members.py runs on-loop.
-
-        Every such call — regardless of how the receiver is spelled
-        (``_sel().log_api_access``, a hoisted ``s = _sel()``, a module-level
-        ``sel()``) — must sit inside a lambda handed to ``asyncio.to_thread``,
-        covering the sites the thread-ident tests do not exercise individually
-        (orphan-history, live-slot mismatch) and any site added later.
+        The startup warm makes a post-init ``log_api_access`` a non-blocking
+        enqueue, so a per-site thread hop is pure overhead — an extra
+        suspension point and a worker dispatch per denial. A future site that
+        genuinely needs a synchronous write (``critical=True``) must offload
+        AND adjust this guard with that reasoning.
         """
         import ast
         import inspect
@@ -1665,5 +1609,9 @@ class TestDenialAuditOffload:
             and node.func.attr == "log_api_access"
         ]
         assert audits, "expected log_api_access audit sites in members.py"
-        on_loop = [node.lineno for node in audits if id(node) not in offloaded]
-        assert not on_loop, f"synchronous _sel().log_api_access at lines {on_loop}"
+        wrapped = [node.lineno for node in audits if id(node) in offloaded]
+        assert not wrapped, (
+            f"to_thread-wrapped _sel().log_api_access at lines {wrapped}; SEL is "
+            "warmed at startup (sel.warm_sel_singleton), so a non-critical audit "
+            "is a direct enqueue (#8608)"
+        )

--- a/test/test_sel_startup_warm.py
+++ b/test/test_sel_startup_warm.py
@@ -1,0 +1,196 @@
+"""Startup warm of the SecurityEventLog singleton (#8608).
+
+``SecurityEventLog._init_locked`` runs on whatever thread first calls
+``sel()``; after init, a non-critical ``log_api_access`` only enqueues to the
+writer thread. Before #8608 that first touch was dodged per call site — 18+
+``asyncio.to_thread`` wrappers across the dashboard handlers — while 250+
+other ``log_api_access`` sites remained candidate first-touch stalls. The
+cause-level fix warms the singleton once, off the loop, in BOTH async server
+start paths, before the middleware chain is built and before the socket
+binds.
+
+These tests pin the three halves of that contract:
+
+* the warm helper genuinely initializes the singleton OFF the event loop
+  (real ``SecurityEventLog``, fresh directory, recorded ``_init_locked``
+  thread) — this is the migrated #8523 first-touch property, now asserted at
+  the startup warm instead of at a per-site hop;
+* a failed warm never raises out of the helper (an SEL init error must not
+  keep the gateway from becoming ready);
+* both ``start_dashboard`` and ``start_api_server`` await the warm before
+  publishing readiness (source guard, same convention as
+  ``test_token_auth.test_start_paths_warm_auth_singletons_off_loop``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+from kiro_crew import sel as sel_mod
+
+
+def test_warm_sel_singleton_initializes_off_the_event_loop(tmp_path, monkeypatch):
+    """The warm is SEL's first touch and ``_init_locked`` runs off-loop.
+
+    Uses a real ``SecurityEventLog`` against a fresh directory so the
+    first-touch work (HMAC key create, chain-head read) genuinely runs, and
+    records the thread ``_init_locked`` executes on.
+
+    Mutation guard: replacing ``await asyncio.to_thread(sel)`` with a bare
+    ``sel()`` in the helper turns the recorded ident into the loop's and
+    fails this.
+    """
+    sel_dir = tmp_path / "sel-home"
+    init_record: dict = {}
+    real_init = sel_mod.SecurityEventLog._init_locked
+
+    def _recording_init(inst, base_dir, sync):
+        init_record["thread_ident"] = threading.get_ident()
+        return real_init(inst, base_dir, sync)
+
+    monkeypatch.setattr(sel_mod.SecurityEventLog, "_init_locked", _recording_init)
+    # sync=True keeps appends inline on their caller's thread (no background
+    # writer to leak); the FIRST-TOUCH construction below is still real.
+    monkeypatch.setattr(
+        sel_mod, "sel", lambda: sel_mod.SecurityEventLog(base_dir=sel_dir, sync=True)
+    )
+    # Displace-then-RESTORE the process singleton (the ``sel_private_root``
+    # fixture is unusable here: it pre-builds the instance, which would consume
+    # the very first touch this test needs). The reset is immediately followed
+    # by the try so a failure can never lose ``prior_instance``.
+    prior_instance = sel_mod.SecurityEventLog._instance
+    sel_mod.SecurityEventLog._instance = None
+    sel_mod.SecurityEventLog._initialized = False
+    try:
+
+        async def _drive() -> int:
+            await sel_mod.warm_sel_singleton()
+            return threading.get_ident()
+
+        loop_ident = asyncio.run(_drive())
+
+        # The warm happened HERE (singleton was reset above) …
+        assert init_record.get("thread_ident") is not None, "the warm never initialized SEL"
+        # … did its filesystem initialization for real …
+        assert (sel_dir / "trust" / "sel_hmac.key").is_file()
+        # … and never on the event loop.
+        assert init_record["thread_ident"] != loop_ident
+    finally:
+        # Restore the PRIOR singleton (not ``None``): leaving ``None`` would
+        # make the next default ``sel()`` mint a SECOND instance — and a
+        # second writer thread — on the worker's session-shared directory.
+        sel_mod.SecurityEventLog._instance = prior_instance
+        sel_mod.SecurityEventLog._initialized = False
+
+
+def test_warm_sel_singleton_swallows_init_failure(monkeypatch, caplog):
+    """A failed warm logs and returns — it must never block gateway readiness.
+
+    Both start paths await this helper before ``state.ready = True``; an
+    exception escaping it would turn an SEL init error (e.g. an unwritable
+    trust dir) into a gateway that never comes up. The per-action semantics
+    are unchanged by a failed warm: the first later touch retries init on its
+    caller's thread, and every ``critical=True`` audit still fails closed at
+    its own site.
+
+    Mutation guard: removing the helper's ``except Exception`` fails this.
+    """
+
+    def _boom():
+        raise RuntimeError("trust root too short to sign the chain")
+
+    monkeypatch.setattr(sel_mod, "sel", _boom)
+
+    with caplog.at_level("WARNING", logger=sel_mod.logger.name):
+        asyncio.run(sel_mod.warm_sel_singleton())  # must not raise
+
+    assert any("SEL startup warm failed" in r.message for r in caplog.records)
+
+
+def test_start_paths_warm_sel_singleton_before_ready() -> None:
+    """Source guard: both async server startup paths must await
+    ``warm_sel_singleton()`` BEFORE publishing readiness, so no handler's
+    first ``log_api_access`` can be the singleton's on-loop first touch.
+
+    Position matters, not just presence: a warm awaited after
+    ``state.ready = True`` (or after the middleware chain is serving) would
+    race the very first request. The helper itself must offload via
+    ``asyncio.to_thread`` — a bare ``sel()`` inside an ``async def`` would
+    run the blocking init on the loop.
+    """
+    import inspect
+
+    from kiro_crew.dashboard import server as _srv
+
+    helper_src = inspect.getsource(sel_mod.warm_sel_singleton)
+    assert (
+        "asyncio.to_thread(sel)" in helper_src
+    ), "warm_sel_singleton no longer offloads the first touch off the loop"
+    assert "except Exception" in helper_src, (
+        "warm_sel_singleton is no longer best-effort; a failed warm would "
+        "keep the gateway from becoming ready"
+    )
+
+    for fn in (_srv.start_dashboard, _srv.start_api_server):
+        src = inspect.getsource(fn)
+        warm_at = src.find("await warm_sel_singleton()")
+        assert warm_at != -1, f"{fn.__name__} must await warm_sel_singleton()"
+        ready_at = src.find("state.ready = True")
+        assert ready_at != -1, f"{fn.__name__} lost its readiness publication?"
+        assert warm_at < ready_at, (
+            f"{fn.__name__} warms SEL only after readiness is published; the "
+            "first request can then beat the warm and init on the loop"
+        )
+        chain_at = src.find("app.middlewares[:]")
+        assert chain_at == -1 or warm_at < chain_at, (
+            f"{fn.__name__} builds the middleware chain before the SEL warm; "
+            "a deny-audit middleware's first refusal could then be the "
+            "singleton's on-loop first touch"
+        )
+
+
+def test_writer_unavailable_fallback_never_writes_on_the_event_loop(tmp_path, monkeypatch):
+    """When the writer can't start, the non-critical fallback is loop-aware.
+
+    ``log()``'s enqueue path falls back to a synchronous ``_flush_batch`` when
+    ``_ensure_writer()`` raises (thread/resource exhaustion). With the per-site
+    ``to_thread`` wrappers gone (#8608), that fallback is now reachable ON the
+    event loop — where its redaction + chain lock + open/write would freeze
+    every task the loop serves. So on the loop the event is dropped with a
+    warning; off the loop the synchronous write still lands the entry. Either
+    way the pending credit taken before the failed enqueue is returned, so
+    ``flush()`` cannot wait on a count nothing will decrement.
+
+    Mutation guards: removing the ``_on_event_loop()`` drop branch fails the
+    on-loop half; making the drop unconditional fails the off-loop half.
+    """
+    sel_dir = tmp_path / "sel-home"
+    prior_instance = sel_mod.SecurityEventLog._instance
+    sel_mod.SecurityEventLog._instance = None
+    sel_mod.SecurityEventLog._initialized = False
+    try:
+        inst = sel_mod.SecurityEventLog(base_dir=sel_dir, sync=False)
+        flushed: list[list] = []
+        monkeypatch.setattr(inst, "_flush_batch", lambda batch, **kw: flushed.append(batch))
+
+        def _no_writer(self=None):
+            raise RuntimeError("cannot start sel-writer")
+
+        monkeypatch.setattr(inst, "_ensure_writer", _no_writer)
+
+        # ON the loop: dropped, not written, and no pending credit leaks.
+        async def _on_loop():
+            inst.log_api_access(caller="t", operation="op", outcome="ok")
+
+        asyncio.run(_on_loop())
+        assert flushed == [], "the fallback wrote synchronously on the event loop"
+        assert inst._pending == 0, "a dropped event leaked its pending credit"
+
+        # OFF the loop (plain thread, no running loop): written synchronously.
+        inst.log_api_access(caller="t", operation="op", outcome="ok")
+        assert len(flushed) == 1, "the off-loop fallback no longer lands the entry"
+        assert inst._pending == 0
+    finally:
+        sel_mod.SecurityEventLog._instance = prior_instance
+        sel_mod.SecurityEventLog._initialized = False


### PR DESCRIPTION
## Problem / Motivation

`SecurityEventLog._init_locked` runs on whatever thread first calls `sel()` (blocking file I/O: trust-dir creation, HMAC key load/create, a tail read of the live log). On a fresh gateway, whichever handler audits first paid that init on the event loop — stalling every session's turn and the liveness heartbeat. The per-site fix, `await asyncio.to_thread(lambda: _sel().log_api_access(...))`, was replicated 17 times across the dashboard (four of them added by PR #8604), while 250+ other `log_api_access` call sites in `src/kiro_crew` remained candidate first-touch stalls.

## Why it matters

Every new audit site is a latent loop stall unless its author remembers the wrapper — a class that grows with the codebase. The wrappers themselves add a suspension point and a worker dispatch per audit (some on deny paths where the surrounding code explicitly must not yield), and the members.py AST guard existed only to police the workaround.

## What changed (motivation → approach → change)

Symptom → cause: the per-site hops only dodge the singleton's *first touch*; after init a non-critical `log_api_access` is an enqueue. So pay the first touch once, at startup, off the loop:

- **`sel.warm_sel_singleton()`** (new): `await asyncio.to_thread(sel)`, best-effort. Awaited by BOTH `start_dashboard` and `start_api_server` right after `await warm_auth_singletons()` — before the middleware chain is built and before the socket binds, so no handler or middleware can be the first touch. Same shape and position as the auth-singleton warm precedent.
- **17 non-critical wrappers deleted** (`_shared`, `autonudge`, `connections` ×5, `cron` ×2, `members` ×4, `messaging`, `secrets`, `session_control` handlers, `server._audit_denied`) — replaced with direct calls. Pre-existing per-site `try/except` guards are KEPT: construction can still raise after a FAILED warm (e.g. a trust root too short to sign the chain), and an unguarded audit would turn a 403 denial into a 500.
- **7 `critical=True` sites deliberately keep their `to_thread` wrappers** (`autonudge_authz` ×2, `taskrunner`, `cron` ×3, `md_notebook`): a critical audit writes SYNCHRONOUSLY on its caller's thread by design (audit-or-deny), so their offload carries the write, not just the init. This is the issue's own "verify no site was relying on the wrapper for more than warm-up cost" caveat — the issue's "delete all 18" over-counted.
- **`log()` writer-unavailable fallback made loop-aware** (pre-push GPT review finding): the synchronous `_flush_batch` fallback was reachable ON the loop once the hops were gone. On the loop a non-critical event is now dropped with a warning (best-effort by contract; a frozen loop is not survivable); off the loop it still writes synchronously. Either way the failed enqueue's pending credit is returned so `flush()` cannot wait on a count nothing will decrement.
- Docs: `docs/system-specs/modules/sel.md` gains the startup-warm paragraph (including the failed-warm caveat).

**Boot-path justification** (AUTOSDE `no-new-work-on-gateway-boot-path`): the warm is one awaited `asyncio.to_thread` before readiness — the rule's explicitly allowed shape for init that must precede serving traffic. Worst-case bound on a large profile: one key-file read (or create), one backward tail read of the live log — a single 4 KiB chunk on a healthy log, worst case a full backward scan bounded by rotation's `_SEGMENT_MAX_BYTES` (32 MiB) when the tail holds no parseable record — and a `stat`. No cross-process chain lock is taken at init. A failed warm logs and never blocks readiness; the first later touch then retries init on its caller's thread (as every call site did before the per-site hops existed), and `critical=True` audits still fail closed at their own sites.

**Pre-push review dispositions** (GPT `gpt-5.6-sol` + Opus `claude-opus-5`):
- GPT "unbounded warm can hang boot on an unresponsive filesystem": rebutted — both start paths already await the unguarded, timeout-less `warm_auth_singletons()` (three `to_thread` hops reading `token_signing.key` under the same `config_dir()` data home) *before* this warm, so a hung data-home filesystem wedges boot at the existing precedent first; this warm adds no new failure mode, and the proposed dual-path mitigation would reintroduce the per-site complexity this PR exists to delete.
- GPT "sync fallback reachable on loop": real — fixed at root (loop-aware fallback above), mutation-verified.
- GPT "failed warm restores the first-touch stall": accepted residual, deliberately: it only arises when SEL storage is already broken, the retry cost is one bounded init attempt, and the alternative (warm-state machine gating every call site) is disproportionate. Documented at the helper, the doc, and the guards.
- Opus (PASS, 3 rationale-accuracy findings): all fixed — worst-case bound stated honestly (was healthy-case), `sel.md` absolute softened with the failed-warm caveat, "only enqueues" qualified with the writer's one-time start.

## Tests

- `test/test_sel_startup_warm.py` (new): real `SecurityEventLog` init runs off-loop through the warm (migrated #8523 first-touch property); a failed warm is swallowed and logged; a source guard pins both start paths awaiting the warm before `state.ready = True` and before the middleware chain; the writer-unavailable fallback drops on-loop, writes off-loop, and leaks no pending credit.
- `test/test_members_dm_thread.py`: thread-ident tests flipped to pin the inline enqueue; the members AST guard is inverted (no `log_api_access` may hide inside a `to_thread` lambda).
- `test/test_api_health.py`: `_audit_denied` pins updated (direct call, still best-effort; boundary audit asserted on `MainThread`).
- Mutation-verified — each of these is caught by a distinct test: bare `sel()` in the warm, dropped `except`, warm removed from either start path, warm moved after readiness, a re-added per-site wrapper, the fallback's loop-guard dropped, the fallback made drop-unconditional.

## Manual verification

N/A — unit coverage sufficient: the startup ordering, off-loop init, failure swallow, and fallback semantics are each pinned by an automated test; no UI or external service is involved.

## Related Issues

Closes #8608
Refs #8523, PR #8604 (the four wrappers + AST guard + test this migrates)

## Pattern harvest

Rule candidate: review-prompt
Pattern: "per-call-site thread hop to dodge a singleton's first-touch init — warm the singleton once at startup instead, and check whether any site's offload carries a synchronous write (critical=True) rather than just init cost"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
