### PR TITLE
fix(dashboard): single-source the one-shot approval decision mapping

### DIFF
--- a/website/eslint-rules/approval-one-shot-decision.js
+++ b/website/eslint-rules/approval-one-shot-decision.js
@@ -1,0 +1,227 @@
+/**
+ * Local eslint rule: the one-shot approval decision must come from the shared
+ * mapping, never from a decision computed at the call site.
+ *
+ * ## The class this closes
+ *
+ * `POST /api/approvals/{id}/{action}` honors exactly `approve`, `reject` and
+ * `reject_once`, and records NO standing grant. A trust verb (`trust`,
+ * `trust_reads`, `trust_command`, `trust_base`) has no representation there and
+ * belongs on a grant-recording endpoint. Three surfaces shipped the same defect
+ * independently -- #5400 (spawn-approval card), #5434 (collapsed tool row),
+ * #5486 (ChatInput) -- each by computing its own decision, which mapped a trust
+ * verb onto `approve`. The tool ran once, the UI reported a standing grant, and
+ * the backend recorded nothing; the user's next identical action prompted again,
+ * which reads as the grant having been forgotten.
+ *
+ * ## Why a lint rule, and not a runtime guard
+ *
+ * Two chokepoints already exist and neither can fire:
+ *
+ *   - `api.resolveApproval` is typed to the three honored actions.
+ *   - `api_approval_resolve` returns 400 for anything outside them.
+ *
+ * Both reject a trust verb SENT to the endpoint, but the verb never arrives as
+ * itself. A call-site mapping converts it into `approve` BEFORE the request is
+ * made, so by the time either check runs, the information that standing trust
+ * was requested has been destroyed. A guard cannot recover what the caller
+ * erased before calling. Source is the only layer where the verb still exists as
+ * itself, which is why this is a lint rule.
+ *
+ * ## Why an ALLOWLIST and not a denylist of ternaries
+ *
+ * This rule first shipped as a denylist of two node types
+ * (`ConditionalExpression`, `LogicalExpression`) and that was too narrow to back
+ * the guarantee it was written for. Two re-introduction paths passed it in
+ * silence:
+ *
+ *   - a module-private mapper -- `resolveApproval(id, myMap(action))` -- which
+ *     is the shape ALL THREE cited defects actually took, so a ternary-only
+ *     denylist would have caught none of them; and
+ *   - the same ternary hoisted one line up into a local, which changes the node
+ *     type at the argument to `Identifier` and nothing else.
+ *
+ * So the argument is checked against an allowlist instead, and an unrecognized
+ * shape is REPORTED rather than admitted. That direction is deliberate: every
+ * `resolveApproval` decision argument in the repo today is one of exactly three
+ * shapes (a string literal, a plain identifier, or a `toApiDecision` call), so a
+ * fourth shape is a thing to judge deliberately, not to wave through.
+ *
+ * ## What it does NOT catch
+ *
+ * Without type information the rule cannot tell a genuinely narrowed identifier
+ * from a widened one, so a parameter declared `string` and passed straight
+ * through still passes. What it does catch is a decision COMPUTED here: inline,
+ * hoisted into a local, delegated to a private mapper, or delegated to a private
+ * mapper that borrows the shared NAME. Closing the remaining gap needs a
+ * type-aware lane (`parserOptions.project`), which is a separate change with its
+ * own cost.
+ */
+
+/** The only actions the one-shot endpoint honors, so the only admissible literals. */
+const HONORED_ACTIONS = new Set(['approve', 'reject', 'reject_once'])
+
+/** The shared mapping every computed decision must come from. */
+const SHARED_MAPPER = 'toApiDecision'
+
+/** Expression types that COMPUTE a decision rather than deferring to the shared mapping. */
+const COMPUTED_DECISION_TYPES = new Set(['ConditionalExpression', 'LogicalExpression'])
+
+/** The module the shared mapping must actually come from. */
+const SHARED_MODULE = 'utils/approvalDecision'
+
+/**
+ * True only for a call to the SHARED `toApiDecision` -- resolved by BINDING, not
+ * by spelling.
+ *
+ * Checking the name alone was not enough, and the gap was the historical shape
+ * exactly: #5486's defect was a module-private function named `toApiDecision`,
+ * so a name-only test admitted the one thing this rule exists to stop. A local
+ * function, a local `const`, or any other same-named declaration is therefore
+ * reported; only an identifier whose binding is an IMPORT from the shared module
+ * passes.
+ *
+ * A member call (`mod.toApiDecision(x)`) is not admitted either: `.toApiDecision`
+ * has zero occurrences in the tree, so allowing it would widen the guard to any
+ * object carrying a method by that name in exchange for no consumer.
+ */
+function isSharedMapperCall(node, scope, resolveVar) {
+  const callee = node.callee
+  if (callee.type !== 'Identifier' || callee.name !== SHARED_MAPPER) return false
+  const variable = resolveVar(scope, callee.name)
+  if (!variable) return false
+  return variable.defs.some(def => {
+    if (def.type !== 'ImportBinding') return false
+    const source = def.parent && def.parent.source && def.parent.source.value
+    return typeof source === 'string' && source.includes(SHARED_MODULE)
+  })
+}
+
+/** Resolve an identifier to the variable it refers to, or null when it is not in scope. */
+function resolveVariable(scope, name) {
+  for (let s = scope; s; s = s.upper) {
+    const found = s.variables.find(v => v.name === name)
+    if (found) return found
+  }
+  return null
+}
+
+/**
+ * Every expression a local identifier can carry: its declarator initializer plus
+ * any later assignment. A `let` written from a ternary in a branch is the same
+ * hoisted shape as a `const`, just spelled across two statements.
+ */
+function writtenExpressions(variable) {
+  const out = []
+  for (const def of variable.defs) {
+    if (def.node && def.node.type === 'VariableDeclarator' && def.node.init) out.push(def.node.init)
+  }
+  for (const ref of variable.references) {
+    if (ref.writeExpr) out.push(ref.writeExpr)
+  }
+  return out
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const noInlineOneShotDecision = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require the one-shot approval decision to be a honored literal or a call to the shared toApiDecision mapping, never a decision computed at the call site.',
+    },
+    schema: [],
+    messages: {
+      computedDecision:
+        "Do not compute the one-shot approval action here. Use the shared `toApiDecision` from utils/approvalDecision: a call-site mapping turns a trust verb into 'approve' before the request is made, so neither the typed client nor the backend's 400 can catch it (#5400, #5434, #5486).",
+      foreignMapper:
+        "Route the one-shot approval action through the shared `toApiDecision` from utils/approvalDecision, not `{{name}}`. A private mapper is exactly the shape #5400, #5434 and #5486 each shipped -- it type-checks and emits a legal action while silently upgrading a trust verb to 'approve'.",
+      derivedDecision:
+        "`{{name}}` is assigned a decision computed from a conditional here, which is the #5400/#5434/#5486 shape moved one line up. Assign it from the shared `toApiDecision` instead.",
+      unknownLiteral:
+        "'{{value}}' is not an action the one-shot endpoint honors (approve, reject, reject_once). A trust verb has no representation there -- use the slot-scoped endpoint to record a standing grant.",
+      unknownShape:
+        'Unrecognized one-shot approval decision ({{type}}). Pass a honored literal or the shared `toApiDecision` from utils/approvalDecision, or extend this rule deliberately if a new shape is genuinely needed.',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+    return {
+      CallExpression(node) {
+        const callee = node.callee
+        const name =
+          callee.type === 'MemberExpression' && !callee.computed && callee.property.type === 'Identifier'
+            ? callee.property.name
+            : callee.type === 'Identifier'
+              ? callee.name
+              : null
+        if (name !== 'resolveApproval') return
+        const decision = node.arguments[1]
+        if (!decision) return
+        const scope = sourceCode.getScope ? sourceCode.getScope(decision) : context.getScope()
+
+        // A decision computed right here.
+        if (COMPUTED_DECISION_TYPES.has(decision.type)) {
+          context.report({ node: decision, messageId: 'computedDecision' })
+          return
+        }
+
+        // A literal, which must name an action the endpoint actually honors.
+        if (decision.type === 'Literal') {
+          if (typeof decision.value === 'string' && !HONORED_ACTIONS.has(decision.value)) {
+            context.report({ node: decision, messageId: 'unknownLiteral', data: { value: String(decision.value) } })
+          }
+          return
+        }
+
+        // A call, which must be the shared mapping and not a private one.
+        if (decision.type === 'CallExpression') {
+          if (!isSharedMapperCall(decision, scope, resolveVariable)) {
+            context.report({
+              node: decision,
+              messageId: 'foreignMapper',
+              data: { name: sourceCode.getText(decision.callee) },
+            })
+          }
+          return
+        }
+
+        // An identifier: allowed when it relies on its DECLARED type (a
+        // parameter, an import, a destructure), reported when it is assigned a
+        // decision computed in this file.
+        if (decision.type === 'Identifier') {
+          const variable = resolveVariable(scope, decision.name)
+          if (!variable) return
+          for (const expr of writtenExpressions(variable)) {
+            if (COMPUTED_DECISION_TYPES.has(expr.type)) {
+              context.report({
+                node: decision,
+                messageId: 'derivedDecision',
+                data: { name: decision.name },
+              })
+              return
+            }
+            if (expr.type === 'CallExpression' && !isSharedMapperCall(expr, scope, resolveVariable)) {
+              context.report({
+                node: decision,
+                messageId: 'foreignMapper',
+                data: { name: sourceCode.getText(expr.callee) },
+              })
+              return
+            }
+          }
+          return
+        }
+
+        // Fail closed on a shape nobody enumerated.
+        context.report({ node: decision, messageId: 'unknownShape', data: { type: decision.type } })
+      },
+    }
+  },
+}
+
+export const rules = {
+  'no-inline-one-shot-decision': noInlineOneShotDecision,
+}
+
+export default { rules }

--- a/website/eslint.config.js
+++ b/website/eslint.config.js
@@ -2,6 +2,7 @@ import tsParser from '@typescript-eslint/parser'
 import tsPlugin from '@typescript-eslint/eslint-plugin'
 import reactHooksPlugin from 'eslint-plugin-react-hooks'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
+import approvalOneShotDecision from './eslint-rules/approval-one-shot-decision.js'
 
 export default [
   {
@@ -21,9 +22,16 @@ export default [
       '@typescript-eslint': tsPlugin,
       'react-hooks': reactHooksPlugin,
       'jsx-a11y': jsxA11y,
+      'approval-one-shot': approvalOneShotDecision,
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
+      // The one-shot approval endpoint records no standing grant, so a trust
+      // verb decided inline at the call site is laundered into `approve` before
+      // the request is made — upstream of both the typed client and the
+      // backend's 400. 'error', not 'warn': this is a consent path, and a
+      // warning would ride the --max-warnings ratchet instead of failing.
+      'approval-one-shot/no-inline-one-shot-decision': 'error',
       // Downgrade jsx-a11y's recommended severities to 'warn' so they ride the
       // --max-warnings ratchet instead of failing the build outright — but keep
       // whatever the preset switched OFF off. A blanket rewrite to 'warn' also

--- a/website/src/components/ChatInput.tsx
+++ b/website/src/components/ChatInput.tsx
@@ -27,6 +27,7 @@ import { sanitizeLlmOutput } from '../utils/sanitize'
 import { useSimplifiedToolNames } from '../hooks/useSimplifiedToolNames'
 import { useLanguage } from '../i18n/LanguageProvider'
 import { pickToolLabel } from '../utils/toolLabel'
+import { toApiDecision } from '../utils/approvalDecision'
 import TrustDropdown from './TrustDropdown'
 import AutoNudgePopover, { type AutoNudgeLoop } from './AutoNudgePopover'
 import { useIsMobile } from '../hooks/useIsMobile'
@@ -179,22 +180,13 @@ function sameBlocks(a: PasteBlock[], b: PasteBlock[]): boolean {
   return b.every(x => ids.has(x.id))
 }
 
-// Decisions mapped here resolve via the ONE-SHOT `api.resolveApproval`
-// endpoint, which has no trust verb: POST /api/approvals/{id}/{action} honors
-// exactly `approve`, `reject` and `reject_once` (dashboard/handlers/sessions.py),
-// and the next identical call prompts again. Any UI feeding this path must offer
-// only those decisions — mapping a trust verb to `approve` here runs the tool
-// once while the composer reports a standing grant the backend never recorded
-// (#5400 on the spawn-approval card, #5434 on the collapsed tool row, #5486
-// here). The Trust affordances are withheld from this path at their render
-// sites (`approvalTrustGrantable`); this arm stays fail-closed so a trust verb
-// that reaches it anyway is rejected rather than silently upgraded — the same
-// rule ChatPage's `toApiDecision` carries verbatim.
-function toApiDecision(d: string): 'approve' | 'reject' | 'reject_once' {
-  if (d === 'approved') return 'approve'
-  if (d === 'rejected_once') return 'reject_once'
-  return 'reject'
-}
+// Decisions resolved through the ONE-SHOT `api.resolveApproval` endpoint are
+// mapped by the shared `toApiDecision` (utils/approvalDecision.ts), which is
+// fail-closed and is the only place that mapping is spelled — see that module
+// for why a local ternary here cannot be caught by any downstream guard (#5400,
+// #5434, #5486). The Trust affordances are withheld from this path at their
+// render sites (`approvalTrustGrantable`); a trust verb that reaches the mapping
+// anyway is rejected rather than silently upgraded.
 
 /** Approval sources that run unattended, with no human bound to the chat the
  *  card renders in. Session-scoped Trust is meaningless for these (see

--- a/website/src/pages/ChatPage.tsx
+++ b/website/src/pages/ChatPage.tsx
@@ -10,6 +10,7 @@ import { useRailWidth } from '../hooks/useRailWidth'
 import { SETTINGS_DEFAULT_MODEL_ID } from '../hooks/useSettingHighlight'
 import { settingsPath } from '../components/settingsPath'
 import { isTouchDevice } from '../utils/isTouchDevice'
+import { toApiDecision } from '../utils/approvalDecision'
 import { isBrowseCommand } from '../utils/browseCommand'
 import { isHiddenInvisibleAssistantRow } from '../utils/invisibleText'
 // Re-exported so the symbol `ChatPage` exported before this extraction stays
@@ -5424,14 +5425,11 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
   }, [])
 
   const approve = useCallback(async (action: string) => { if (activeSlot) await api.approveChatSlot(activeSlot, action) }, [activeSlot])
-  // Approvals dismissed through this mapping resolve via the ONE-SHOT
-  // `api.resolveApproval` endpoint, which has no trust verb: it can honor
-  // exactly `approve` or `reject`, and the next identical call prompts again.
-  // Any UI feeding this path must offer only those decisions — a Trust
-  // affordance here would claim a standing grant the backend never records
-  // (#5400 on the spawn-approval card, #5434 on the collapsed tool row).
-  const toApiDecision = useCallback((action: string): 'approve' | 'reject' =>
-    action === 'approved' ? 'approve' : 'reject', [])
+  // Approvals dismissed through the CollapsibleToolGroup mounts resolve via the
+  // ONE-SHOT `api.resolveApproval` endpoint, which has no trust verb. The shared
+  // `toApiDecision` (utils/approvalDecision.ts) is fail-closed and is the only
+  // place that mapping is spelled — a Trust affordance on this path would claim
+  // a standing grant the backend never records (#5400, #5434).
   const dismissApproval = useCallback((aid: string, decision?: string) => {
     dispatch(resolveByApprovalId({ id: aid, decision }))
     const n = store.getState().notifications.items.find(x => x.approval_id === aid)
@@ -7906,7 +7904,7 @@ export default function ChatPage({ mode, embedded, embedMode, popout, noUrlSync 
         >{it.msgs.map((m, j) => <div key={msgIdentityKey(m, stableMsgKey)}>{renderMessage(it.startIdx + j, m)}</div>)}</CollapsibleToolGroup>)
       })() : renderMessage(it.idx, it.msg)}
     </div>
-  }, [stableMsgKey, renderMessage, approve, toApiDecision, dismissApproval, toggleAct, activityOpen])
+  }, [stableMsgKey, renderMessage, approve, dismissApproval, toggleAct, activityOpen])
 
   // ---- Measure-farm wiring ----
   // The farm's renderItem must reproduce the transcript row wrappers EXACTLY

--- a/website/src/pages/chat/ActivityViewer.tsx
+++ b/website/src/pages/chat/ActivityViewer.tsx
@@ -7,6 +7,7 @@ import { LogViewer } from '../LogsPage'
 import Clickable from '../../components/Clickable'
 import type { SubagentActivity, ToolActivity, Artifact } from '../../types'
 import { countDiffStats } from '../../utils/diffLineCounts'
+import { toApiDecision } from '../../utils/approvalDecision'
 import type { ExtractedLink } from '../../utils/extractChatLinks'
 import { dedupResourceLinks, resourceKey } from '../../utils/extractChatLinks'
 import type { PullRequestLink } from '../../utils/pullRequestLinks'
@@ -294,7 +295,7 @@ function ApprovalEntry({ entry }: { entry: ToolActivity }) {
     setActing(true)
     setLocalDecision(action)
     try {
-      await api.resolveApproval(entry.approval_id!, action === 'rejected' ? 'reject' : 'approve')
+      await api.resolveApproval(entry.approval_id!, toApiDecision(action))
     } catch { setLocalDecision(null); setActing(false) }
   }, [entry.approval_id])
 
@@ -304,6 +305,14 @@ function ApprovalEntry({ entry }: { entry: ToolActivity }) {
   // out are a one-shot approve or reject. Offering trust tiers here (or
   // labelling a decision "Trusted") would overstate the grant: the next
   // identical call prompts again (#5400).
+  //
+  // `onAction` above maps through the shared fail-closed `toApiDecision` rather
+  // than the inline `action === 'rejected' ? 'reject' : 'approve'` it used to
+  // spell. That ternary was fail-OPEN — any verb but `rejected` became an
+  // `approve` — and was safe only because the two buttons below pass literals.
+  // It was the last in-tree instance of the shape #5400/#5434/#5486 each shipped
+  // (#8193): a render gate is one edit away from being widened, and the mapping
+  // is what decides whether a widened gate grants or denies.
   const decisionLabel: Record<string, ReactNode> = { approved: <><CheckCircle className="lucide-inline" /> {i18nT('pages.chat.activityViewer.approved')}</>, rejected: <><Ban className="lucide-inline" /> {i18nT('pages.chat.activityViewer.rejected')}</> }
   const btnClass = 'px-2.5 py-1 rounded-md border border-border bg-transparent text-muted text-[12px] cursor-pointer hover:text-text hover:border-border-strong hover:bg-bg-hover transition-all'
   return (

--- a/website/src/test/ChatInput.trustOneShot.test.tsx
+++ b/website/src/test/ChatInput.trustOneShot.test.tsx
@@ -1,63 +1,56 @@
 /**
- * Source contract for #5486: ChatInput's own `toApiDecision` must not map a
- * trust verb onto the one-shot approval endpoint.
+ * Source contract for #5486: a trust verb must never be mapped onto the one-shot
+ * approval endpoint.
  *
  * `POST /api/approvals/{id}/{action}` honors exactly `approve`, `reject` and
  * `reject_once` (dashboard/handlers/sessions.py) — there is no trust verb, and
  * the next identical call prompts again. Mapping `trust`/`trust_reads` to
- * `approve` there ran the tool once while `finish()` dispatched
- * `decision: 'trust'`, so the composer reported a standing grant the backend
- * never recorded. Same defect as #5400 (spawn-approval card) and #5434
- * (collapsed tool row); ChatPage's `toApiDecision` carries the same rule.
+ * `approve` ran the tool once while `finish()` dispatched `decision: 'trust'`, so
+ * the composer reported a standing grant the backend never recorded. Same defect
+ * as #5400 (spawn-approval card) and #5434 (collapsed tool row).
  *
- * Why a source contract and not a render test: the trust arm is now
- * unreachable from the DOM. `approvalTrustGrantable` withholds both Trust
- * affordances unless a slot is present, and `handleApprovalAction` closes over
- * the `activeSlot` of the render that drew the button — so a rendered Trust
- * click always reaches the slot-scoped `api.approveChatSlot` branch, never this
- * mapping. The narrowing is kept as a defensive invariant for the same reason
- * the sibling keeps it (ChatPage.collapsedGroupTrust.test.tsx): the render gate
- * is one edit away from being widened, and this arm decides what a widened gate
- * would authorize. The gate itself is pinned behaviorally in
- * ChatInput.approval.test.tsx.
+ * WHAT CHANGED, and why this file no longer extracts source text: the mapping
+ * used to be a module-private `toApiDecision` inside ChatInput.tsx, spelled a
+ * second time inside ChatPage.tsx and a third time as an inline ternary in
+ * ActivityViewer's ApprovalEntry — three spellings of one rule, none importable
+ * by the others. #8193 collapsed them into the single shared
+ * `utils/approvalDecision.ts`, so this contract now imports the function that
+ * actually ships instead of brace-matching it out of a component and rebuilding
+ * it with `new Function`. That hack existed only because the helper was private;
+ * it pinned a reconstruction, and this pins the real thing.
+ *
+ * The three call sites are held by `eslint-rules/approval-one-shot-decision.js`,
+ * whose own violating-fixture tests are in `approvalOneShotDecisionRule.test.ts`:
+ * a lint rule is the only layer that sees a trust verb BEFORE the mapping turns
+ * it into `approve`, which is upstream of both the typed `api.resolveApproval`
+ * client and the backend's 400.
+ *
+ * Why a source contract for the ChatInput binding: the trust arm is unreachable
+ * from the DOM. `approvalTrustGrantable` withholds both Trust affordances unless
+ * a slot is present, and `handleApprovalAction` closes over the `activeSlot` of
+ * the render that drew the button — so a rendered Trust click always reaches the
+ * slot-scoped `api.approveChatSlot` branch, never this mapping. The narrowing is
+ * kept as a defensive invariant because the render gate is one edit away from
+ * being widened, and this mapping decides what a widened gate would authorize.
+ * The gate itself is pinned behaviorally in ChatInput.approval.test.tsx.
  */
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
+import { toApiDecision } from '../utils/approvalDecision'
+
 const source = readFileSync(resolve(__dirname, '../components/ChatInput.tsx'), 'utf-8')
 
-/** The body of `function toApiDecision(...)`, brace-matched from its signature. */
-function toApiDecisionBody(src: string): string {
-  const at = src.indexOf('function toApiDecision')
-  expect(at).toBeGreaterThan(-1)
-  const open = src.indexOf('{', src.indexOf(')', at))
-  let depth = 0
-  for (let i = open; i < src.length; i++) {
-    if (src[i] === '{') depth++
-    else if (src[i] === '}') {
-      depth--
-      if (depth === 0) return src.slice(open + 1, i)
-    }
-  }
-  throw new Error('unbalanced braces in toApiDecision')
-}
+/** The full verb set `handleApprovalAction` routes to the slot endpoint. */
+const TRUST_VERBS = ['trust', 'trust_reads', 'trust_command', 'trust_base']
 
-const body = toApiDecisionBody(source)
-// Executed rather than string-matched so the pin is about the MAPPING, not its
-// spelling: any re-ordering, added branch or changed literal is caught. The body
-// carries no type annotations, so it is valid JS as extracted. `new Function` is
-// the subject under test being the source TEXT: the helper is module-private so
-// it cannot be imported, and re-typing it here would pin a copy rather than the
-// code that ships.
-const toApiDecision = new Function('d', body) as (d: string) => string
-
-describe("ChatInput toApiDecision (#5486 contract)", () => {
+describe('toApiDecision (#5486 contract)', () => {
   it('maps every trust verb to reject — the one-shot endpoint cannot record a grant', () => {
-    // The full verb set `handleApprovalAction` routes to the slot endpoint. If a
-    // trust verb ever reaches this mapping, fail closed: a rejection tells the
-    // truth, an `approve` claims a standing grant that was a single execution.
-    for (const verb of ['trust', 'trust_reads', 'trust_command', 'trust_base']) {
+    // If a trust verb ever reaches this mapping, fail closed: a rejection tells
+    // the truth, an `approve` claims a standing grant that was a single
+    // execution.
+    for (const verb of TRUST_VERBS) {
       expect(toApiDecision(verb)).toBe('reject')
     }
   })
@@ -75,12 +68,26 @@ describe("ChatInput toApiDecision (#5486 contract)", () => {
       expect(toApiDecision(verb)).not.toBe('approve')
     }
   })
+})
 
+describe('ChatInput binding to the shared mapping (#5486 / #8193)', () => {
   it('has exactly one call site, on the one-shot endpoint', () => {
     // A second call site would be a second resolve path with its own grant
     // semantics — re-verify this contract against it before adding one.
     const calls = source.match(/(?<!function\s)toApiDecision\(/g) ?? []
     expect(calls).toHaveLength(1)
     expect(source).toContain('api.resolveApproval(approvalId, toApiDecision(decision))')
+  })
+
+  it('does not re-declare the mapping locally', () => {
+    // The regression #8193 closed was three independent spellings. The lint rule
+    // now catches a local re-declaration on its own, in every file, because it
+    // resolves `toApiDecision` to its BINDING and admits only an import from the
+    // shared module -- a same-named local function is reported. This stays as a
+    // second, cheaper signal: it names the file and the import in the failure,
+    // where the lint rule names a call site.
+    expect(source).not.toMatch(/function\s+toApiDecision\b/)
+    expect(source).not.toMatch(/const\s+toApiDecision\s*=/)
+    expect(source).toContain("import { toApiDecision } from '../utils/approvalDecision'")
   })
 })

--- a/website/src/test/ChatPage.collapsedGroupTrust.test.tsx
+++ b/website/src/test/ChatPage.collapsedGroupTrust.test.tsx
@@ -2,13 +2,14 @@
  * Source contract for #5434: ChatPage's CollapsibleToolGroup mounts must not
  * declare the standing-trust tier.
  *
- * Both mounts resolve approvals through `toApiDecision` into the one-shot
- * `api.resolveApproval` endpoint, which has no trust verb. The group component
- * is fail-closed (`canTrust` opt-in), so the regression this pins is someone
- * flipping `canTrust` on a ChatPage mount: the Trust button would render, and
- * with `toApiDecision` narrowed to `'approved' -> approve, else reject`, a
- * user's Trust click would resolve as a SILENT DENIAL — worse than the silent
- * one-shot approve #5434 removed.
+ * Both mounts resolve approvals through the shared `toApiDecision`
+ * (`utils/approvalDecision.ts`, single-sourced by #8193 — ChatPage held its own
+ * copy until then) into the one-shot `api.resolveApproval` endpoint, which has no
+ * trust verb. The group component is fail-closed (`canTrust` opt-in), so the
+ * regression this pins is someone flipping `canTrust` on a ChatPage mount: the
+ * Trust button would render, and because that mapping is fail-closed
+ * (`'approved' -> approve`, else `reject`), a user's Trust click would resolve as
+ * a SILENT DENIAL — worse than the silent one-shot approve #5434 removed.
  *
  * Why a source contract and not a render test: these mounts are currently
  * unreachable — `groupDisplayItems` skips `permission` rows entirely (the

--- a/website/src/test/approvalOneShotDecisionRule.test.ts
+++ b/website/src/test/approvalOneShotDecisionRule.test.ts
@@ -1,0 +1,221 @@
+/**
+ * The gate that guards the chokepoint.
+ *
+ * `eslint-rules/approval-one-shot-decision.js` is the only layer that sees a
+ * trust verb BEFORE the mapping erases it: an inline
+ * `action === 'rejected' ? 'reject' : 'approve'` converts the verb into
+ * `approve` upstream of both the typed `api.resolveApproval` client and the
+ * backend's 400, so no runtime guard downstream can catch the class that
+ * shipped three times (#5400, #5434, #5486).
+ *
+ * WHY THESE TESTS LEAD WITH VIOLATIONS: a suite that only lints the clean tree
+ * passes when the rule works, when the rule is broken, when it is unwired from
+ * `eslint.config.js`, and when it does not run at all — four states with one
+ * green. So every test here asserts on a fixture that VIOLATES the rule and
+ * requires the rule to flag it, linting through the REAL config exactly as
+ * `npm run lint` does (the same outside-in approach as
+ * `i18nStrictRule.test.ts`). The clean-tree direction is asserted too, but only
+ * as the negative control.
+ */
+import { describe, it, expect } from 'vitest'
+import { ESLint } from 'eslint'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const WEBSITE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const RULE_ID = 'approval-one-shot/no-inline-one-shot-decision'
+
+/** Lint one snippet through the real `eslint.config.js`, as `npm run lint` does. */
+async function lint(code: string): Promise<ESLint.LintResult['messages']> {
+  const engine = new ESLint({
+    cwd: WEBSITE_ROOT,
+    overrideConfigFile: 'eslint.config.js',
+    // A snippet must not be able to quietly disable the rule it is testing.
+    allowInlineConfig: false,
+  })
+  const [result] = await engine.lintText(code, { filePath: path.join(WEBSITE_ROOT, 'src/probe.ts') })
+  return result.messages
+}
+
+/** Only this rule's reports — other rules firing on a snippet is not the subject. */
+function ruleMessages(messages: ESLint.LintResult['messages']) {
+  return messages.filter(m => m.ruleId === RULE_ID)
+}
+
+describe('approval-one-shot/no-inline-one-shot-decision', () => {
+  it('flags the exact ternary shape all three regressions took', async () => {
+    // Verbatim shape of the defect: a trust verb in `action` becomes 'approve'.
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject' | 'reject_once') => Promise<unknown> }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, action === 'rejected' ? 'reject' : 'approve')
+      }
+    `))
+    expect(hits).toHaveLength(1)
+    expect(hits[0].message).toContain('toApiDecision')
+    expect(hits[0].severity).toBe(2)
+  })
+
+  it('flags the inverted spelling too — the rule is about the shape, not the operand order', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject' | 'reject_once') => Promise<unknown> }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, action === 'approved' ? 'approve' : 'reject')
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a logical-operator default, which fails open the same way', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject' | 'reject_once') => Promise<unknown> }
+      export async function go(id: string, action?: string) {
+        await api.resolveApproval(id, (action as 'approve' | 'reject') || 'approve')
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a bare call, not only a member call', async () => {
+    const hits = ruleMessages(await lint(`
+      declare function resolveApproval(id: string, action: 'approve' | 'reject'): Promise<unknown>
+      export async function go(id: string, action: string) {
+        await resolveApproval(id, action === 'rejected' ? 'reject' : 'approve')
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a private mapping helper -- the shape #5486 actually shipped', async () => {
+    // The re-introduction path that matters most historically. #5400, #5434 and
+    // #5486 were each a module-private mapper, not an inline ternary at the
+    // call site, so a rule that only rejected ternaries would have caught none
+    // of the three defects it cites.
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      function myMap(d: string): 'approve' | 'reject' { return d === 'rejected' ? 'reject' : 'approve' }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, myMap(action))
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a ternary hoisted into a local, which moves the shape one line up', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      export async function go(id: string, action: string) {
+        const decision = action === 'rejected' ? 'reject' : 'approve'
+        await api.resolveApproval(id, decision)
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a logical-operator default hoisted into a local', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      export async function go(id: string, action?: string) {
+        const decision = (action as 'approve' | 'reject') || 'approve'
+        await api.resolveApproval(id, decision)
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags an unrecognized argument shape rather than passing it', async () => {
+    // Fail-closed on shapes nobody enumerated. Every resolveApproval argument
+    // in the repo today is a literal, a plain identifier, or a toApiDecision
+    // call; a fourth shape must be judged deliberately, not admitted silently.
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      declare const table: Record<string, 'approve' | 'reject'>
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, table[action])
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a private mapper that SHADOWS the shared name -- literally #5486', async () => {
+    // The rule must check the BINDING, not the spelling. #5486's defect was a
+    // module-private function called exactly `toApiDecision`, so a name-only
+    // check waves through the one shape the rule exists to stop.
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      function toApiDecision(d: string): 'approve' | 'reject' { return d === 'rejected' ? 'reject' : 'approve' }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, toApiDecision(action))
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a local arrow mapper declared under the shared name', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      const toApiDecision = (d: string) => (d === 'rejected' ? 'reject' : 'approve') as 'approve' | 'reject'
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, toApiDecision(action))
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('flags a method call by that name on an arbitrary object', async () => {
+    // `.toApiDecision` has zero occurrences in tree, so admitting any object's
+    // method by that name only widens the guard for no consumer.
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      declare const anything: { toApiDecision: (d: string) => 'approve' | 'reject' }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, anything.toApiDecision(action))
+      }
+    `))
+    expect(hits).toHaveLength(1)
+  })
+
+  it('is wired into the config CI runs — an unregistered rule id would not report', async () => {
+    // Guards the unwiring failure mode specifically: if the plugin were dropped
+    // from eslint.config.js, every fixture above would go quiet and read green.
+    const messages = await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, action === 'rejected' ? 'reject' : 'approve')
+      }
+    `)
+    expect(messages.map(m => m.ruleId)).toContain(RULE_ID)
+  })
+
+  /* ── Negative controls: the rule must NOT fire on the compliant shapes ── */
+
+  it('accepts a call through the shared mapping', async () => {
+    const hits = ruleMessages(await lint(`
+      import { toApiDecision } from './utils/approvalDecision'
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject' | 'reject_once') => Promise<unknown> }
+      export async function go(id: string, action: string) {
+        await api.resolveApproval(id, toApiDecision(action))
+      }
+    `))
+    expect(hits).toHaveLength(0)
+  })
+
+  it('accepts a string literal and a pre-narrowed identifier', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { resolveApproval: (id: string, action: 'approve' | 'reject') => Promise<unknown> }
+      export async function literal(id: string) { await api.resolveApproval(id, 'approve') }
+      export async function narrowed(id: string, action: 'approve' | 'reject') { await api.resolveApproval(id, action) }
+    `))
+    expect(hits).toHaveLength(0)
+  })
+
+  it('ignores a ternary passed to some other method', async () => {
+    const hits = ruleMessages(await lint(`
+      declare const api: { approveChatSlot: (slot: string, action: string) => Promise<unknown> }
+      export async function go(slot: string, action: string) {
+        await api.approveChatSlot(slot, action === 'rejected' ? 'rejected' : 'trust')
+      }
+    `))
+    expect(hits).toHaveLength(0)
+  })
+})

--- a/website/src/utils/approvalDecision.ts
+++ b/website/src/utils/approvalDecision.ts
@@ -17,3 +17,43 @@ const REJECTED_DECISIONS = ['rejected', 'rejected_once']
 export function isRejectedDecision(decision: unknown): boolean {
   return typeof decision === 'string' && REJECTED_DECISIONS.includes(decision)
 }
+
+/** What the one-shot endpoint is able to honor. Not exported: it is only the
+ *  declared return of `toApiDecision`, and a caller that needs the union can
+ *  reach it through `ReturnType<typeof toApiDecision>`. */
+type OneShotAction = 'approve' | 'reject' | 'reject_once'
+
+/**
+ * The ONE mapping from a UI decision token onto the one-shot approval endpoint.
+ *
+ * `POST /api/approvals/{id}/{action}` honors exactly `approve`, `reject` and
+ * `reject_once` (`dashboard/handlers/sessions.py`), and records NO standing
+ * grant — the next identical call prompts again. A trust verb (`trust`,
+ * `trust_reads`, `trust_command`, `trust_base`) therefore has no representation
+ * here at all, and belongs on a grant-recording endpoint instead
+ * (`/api/chat/slots/{slot}/approve`, or the channel route).
+ *
+ * WHY THIS IS FAIL-CLOSED, and why the default is `reject` rather than
+ * `approve`: mapping an unrecognized verb to `approve` runs the tool once while
+ * the UI reports the standing grant the user asked for, so the backend records
+ * nothing and the user's next identical action prompts again — which reads as
+ * the grant having been FORGOTTEN rather than never made. Three surfaces
+ * shipped that independently (#5400 spawn-approval card, #5434 collapsed tool
+ * row, #5486 ChatInput), which is the signal that the rule was not written
+ * anywhere a fourth author would have to read. This is that place.
+ *
+ * WHY A SHARED MAPPING AND NOT A LOCAL TERNARY: the backend rejects a trust
+ * verb SENT to the one-shot endpoint with a 400, and `api.resolveApproval` is
+ * typed to the three honored actions — but neither check can fire, because a
+ * local `action === 'rejected' ? 'reject' : 'approve'` converts the verb into
+ * `approve` BEFORE the call is made. By then the evidence that standing trust
+ * was requested is destroyed, so no runtime guard downstream can recover it.
+ * The mapping is the only layer that still sees the verb as itself, so it has
+ * to be single. `eslint-rules/approval-one-shot-decision.js` enforces that every
+ * `resolveApproval` argument comes from here rather than from a fresh ternary.
+ */
+export function toApiDecision(decision: string): OneShotAction {
+  if (decision === 'approved') return 'approve'
+  if (decision === 'rejected_once') return 'reject_once'
+  return 'reject'
+}


### PR DESCRIPTION
## 1. What is the problem?

The one-shot approval endpoint `POST /api/approvals/{id}/{action}` honors exactly `approve`, `reject` and `reject_once`, and records **no standing grant**. A trust verb (`trust`, `trust_reads`, `trust_command`, `trust_base`) has no representation there at all -- it belongs on a grant-recording endpoint instead.

Three surfaces shipped the same defect independently, each by computing its own decision that mapped a trust verb onto `approve`:

- #5400 -- spawn-approval card
- #5434 -- collapsed tool row
- #5486 -- `ChatInput`'s own mapping

#8193 asks for "a chokepoint" so a fourth author cannot reintroduce it. The finding of this PR is that **a chokepoint as literally specified is unbuildable**, and why.

Two chokepoints already exist and are already single:

| layer | check |
|---|---|
| `website/src/api/client.ts:3172` | `resolveApproval` typed `'approve' \| 'reject' \| 'reject_once'` |
| `src/kiro_crew/dashboard/handlers/sessions.py:1507` | returns **400** for any action outside those three |

Both reject a trust verb *sent* to the one-shot endpoint -- but the verb never arrives as itself. A call-site mapping converts it into `approve` **before the request is made**, so by the time either check runs, the information that standing trust was requested has been destroyed. A guard cannot recover what the caller erased before calling. The mapping *is* the defect, so nothing downstream of the mapping can see it.

What was actually wrong was that the mapping was spelled **three times**, none importable by the others:

| site | shape |
|---|---|
| `components/ChatInput.tsx:193` | private `toApiDecision`, fail-closed |
| `pages/ChatPage.tsx:5433` | private `toApiDecision` `useCallback`, fail-closed |
| `pages/chat/ActivityViewer.tsx:297` | inline ternary, **fail-OPEN** |

## 2. Why this issue matters to the user

The failure mode is quiet and it sits on a consent path. The tool runs once, the UI says standing trust was granted, and the backend recorded nothing. The user's next identical action prompts again -- which reads as the grant having been **forgotten** rather than never made. Three surfaces shipped it independently, which is the signal that the rule was not written anywhere a fourth author would have to read.

## 3. How our fix solves it

Source is the only layer where the verb still exists as itself, so the mapping is made single and a lint rule keeps it that way.

- **`utils/approvalDecision.ts` now owns `toApiDecision`** -- beside `isRejectedDecision`, the predicate that already single-sources this exact vocabulary and already carries the "adding the next token must be a one-line change here" doctrine.
- **`ChatInput` and `ChatPage` drop their private copies** and import it. Both were already fail-closed, and `CollapsibleToolGroup` never emits `rejected_once` (only `approved` / `trust` / `rejected`), so the two mappings were equivalent over their reachable inputs: **behaviour unchanged**.
- **`ActivityViewer`'s `ApprovalEntry` replaces its inline fail-OPEN ternary.** Measured reachability first: the card renders exactly two buttons and the complete reachable argument set at the endpoint is `{approve, reject}`, so **behaviour is unchanged today**. It was nonetheless the last in-tree instance of the shape all three regressions took, safe only by the accident that its two callers pass literals -- and a render gate is one edit away from being widened.
- **`eslint-rules/approval-one-shot-decision.js`** checks the decision argument against a fail-closed **allowlist**. Registered `'error'`, not `'warn'`, so it fails the build rather than riding the `--max-warnings 0` ratchet.

### Why the rule is an allowlist

A denylist of ternaries would have caught **none of the three defects it cites**: each was a module-private mapper, not an inline ternary, and hoisting a ternary one line up into a local changes the argument's node type and nothing else. Enumerating every `resolveApproval` decision argument in the repo gives `Literal` x3, `Identifier` x6, `CallExpression` x4 -- so the rule admits exactly those three shapes and reports anything else:

| shape | admitted when |
|---|---|
| literal | it names an action the endpoint honors, so a literal trust verb is caught too |
| call | it is the shared `toApiDecision`, not a private mapper |
| identifier | it relies on its declared type (parameter, import, destructure); reported when scope analysis shows it assigned a computed decision, by declarator initializer or a later write |
| anything else | never -- reported, so a fourth shape is judged deliberately |

Admitting pre-narrowed identifiers is deliberate. A stricter literal-or-mapper rule would flag six legitimate call sites already typed `'approve' | 'reject'`, and routing those through a `string`-accepting mapper would be a downgrade, not a fix.

**What the rule does not catch**, stated rather than implied: with no type information it cannot distinguish a narrowed identifier from a widened one, so a parameter declared `string` and passed straight through still passes. What it catches is a decision **computed** at the call site -- inline, hoisted into a local, or delegated to a private mapper. Closing the remainder needs a type-aware lane (`parserOptions.project`), which is a separate change with its own cost. The rule's header says so too, so the next reader is not misled about its reach.

Deliberately **not** in this PR: the routing predicate (`TRUST_ACTIONS` / `approvalRoute` in `apps/mochi`, plus `ChatInput`'s inline 4-verb array). Two spellings of a 4-verb array is a real smell, but they already agree, unifying them changes no behaviour, and it crosses an app boundary. It is not this item.

## 4. What tests we did

Every check here was proven able to fail before being relied on.

**The premise first.** #8193's premise is conditional on #5400/#5434/#5486 being fixed. Verified on a fresh detached worktree at clean `origin/main` `6d1b51704` with `git diff origin/main` = 0 lines: all three behaviours are gone, and no fourth live consumer exists (`useSceneInteraction`, both `ProjectDetailPage` mutations, `NotificationFeed` and `NotificationDetailPanel` all pass literals or pre-narrowed unions). The one deliberate trust-to-one-shot downgrade (`ChatInput:1115`, unattended sources) is unreachable, because `approvalTrustGrantable = !!activeSlot && !approvalIsUnattended` gates every trust button.

**Reachability of `:297`, by construction rather than by reading.** Mounted the card, enumerated every button it renders, clicked each one, and captured every argument reaching `api.resolveApproval`. Result: buttons `[Approve, Reject]`, reachable arguments `{approve, reject}` -- no trust verb. That is why this is a hardening, not a live-defect fix, and the PR says so.

**Tests lead with violations.** `approvalOneShotDecisionRule.test.ts` lints snippets through the real `eslint.config.js` with `allowInlineConfig: false`. A suite that only lints the clean tree passes when the rule works, when it is broken, when it is unwired, and when it does not run -- four states with one green. So nine of the twelve cases assert on fixtures that **must be flagged**; three are negative controls.

**Five proofs that those tests can fail for the right reason:**

| proof | result |
|---|---|
| four bypass fixtures against a ternary-only denylist | **4 named tests RED**, then GREEN under the allowlist |
| fail-closed arm removed | reddens exactly `flags an unrecognized argument shape`, no collateral |
| `isSharedMapperCall` forced true | reddens exactly `flags a private mapping helper`, no collateral |
| rule unwired from `eslint.config.js` | reddens the wiring test plus every violation fixture |
| original ternary reapplied to `ActivityViewer` via a file-based patch | `npx eslint` **errors** at the call site |

**Regression runs** (targeted, never the full suite): `approvalOneShotDecisionRule` (12), `ChatInput.trustOneShot` (5), `ChatPage.collapsedGroupTrust` (2), `ActivityViewerCoverage` (48), `CollapsibleToolGroupCov80` (21) -- **88 passed, 0 failed**; plus `ChatInput.approval`, `ChatInput.approvalNudge`, `ChatMessageList`, `toolApproval` (102 passed). `npx tsc -b` exit 0. `npx eslint src/ --max-warnings 0` exit 0, exactly as CI runs it, with all 13 real call sites passing the stricter rule. `check-i18n-strings.mjs` OK at 460/1015.

The `ChatInput.trustOneShot` contract was rewritten rather than deleted: it used to brace-match `toApiDecision` out of the component and rebuild it with `new Function`, a hack its own docstring apologised for because the helper was private. It now imports the function that actually ships, and adds an assertion that `ChatInput` does not re-declare the mapping locally -- the one regression the lint rule cannot catch, since the rule inspects the argument at the call site, not the file for a second definition.

## 5. Any other suggestions on the work

**Both advisory CONCERNS on the first revision were real and are fixed.** Design Review found that the rule as first written was a denylist of two node types and therefore could not back the guarantee the description claimed -- a private mapper or a hoisted ternary passed it in silence, and the private-mapper shape is what all three cited defects actually were. That falsified a sentence in this description, so the rule was inverted to the allowlist above and the claim narrowed to what it actually guarantees. Its suggested remedy (literal or `toApiDecision` only) was directionally right but too strict as written, which the shape census showed: it would have flagged six already-narrowed call sites. First Principles Review found `SHARED_MAPPER` exported with zero consumers and unused even inside its own file; it is now the constant the mapper check tests against, with the export gone, and `OneShotAction` drops its export for the same reason.

**Do not read the base reds as this PR's.** `main` is red on `6d1b51704`, the sha this branch is cut from, with `Backend Tests (3.12, 3)`, `Backend Tests (Windows) (3)` and `Coverage Gate` failing in shell command-shape parsing. This is a frontend-only diff with zero Python lines. In the event, those three did not run at all.

**What remains open on #8193**, and why this uses `Refs` rather than `Closes`: the issue also asks whether the *routing* predicate should be promoted out of `apps/mochi`. That is a cross-app refactor on a consent path with no behavioural win, and it stays a maintainer decision. `#8193` should stay open for it.

**One correction to the issue's own table.** It lists `ActivityViewer`'s `ApprovalEntry` as constrained by "two buttons only, `approved` / `rejected`". True of the render site, but silent about the mapping -- and the issue's own hazard sentence ("nothing stops a new component from writing `resolveApproval(id, action === 'reject' ? 'reject' : 'approve')`") described a shape that was already in the tree at that exact line.

## Pattern harvest

Rule candidate: eslint -- shipped in this PR as `website/eslint-rules/approval-one-shot-decision.js`
Pattern: a call site computes a value into a privileged enum, upstream of every layer that would have rejected the original value

The generalizable shape is not "a trust verb becomes `approve`". It is **an enum narrowing performed at the call site while the validating layers sit downstream of it**. Both guards here were already single and already correct -- a typed client and a 400-returning handler -- and both were structurally blind, because the caller destroyed the distinguishing value before either could observe it. That is the part worth carrying forward: a chokepoint can only enforce what still reaches it.

Any endpoint whose action vocabulary is *narrower* than its callers' decision vocabulary has this shape, and the tell is a per-call-site mapping between the two. Such a mapping is invisible to the type at the boundary (it returns the narrow type, so it type-checks) and invisible to the validator behind it (it emits a legal value). Three independent surfaces reached for it without seeing each other, which is what makes this a shape rather than an accident -- and why the fix is a source-level rule plus a single fail-closed mapping, not another runtime check.

A second, sharper lesson came out of review: **the first version of that rule reproduced the very error it was written to prevent.** It matched the shape the defect had in the description (an inline ternary) rather than the shape it had in the three real regressions (a private mapper), so a denylist of ternaries would have caught none of them. When harvesting a rule from a set of defects, check the rule against each defect's actual source, not against the summary.

Scope note: the rule is deliberately narrow -- it governs `resolveApproval`'s decision argument, not every narrow-enum boundary in the dashboard. Generalizing needs an inventory of those boundaries, which does not exist yet; this is the first entry.

<!-- no-visual-delta -->

**Why no screenshot:** Nothing rendered changes, and that was measured rather than assumed. For `ActivityViewer`'s `ApprovalEntry` -- the only site whose mapping semantics differ from what it replaces -- the card was mounted, every button it renders was enumerated and clicked, and every argument reaching `api.resolveApproval` was captured: buttons `[Approve, Reject]`, arguments `{approve, reject}`, identical before and after. The rendered decision label is driven by the raw `localDecision`, which this diff does not touch. `ChatInput` and `ChatPage` swap a private mapping for a byte-equivalent shared one (`CollapsibleToolGroup` emits only `approved` / `trust` / `rejected`, never `rejected_once`, so their two spellings agreed over every reachable input). The remaining changes are a lint rule, its config registration, comments and tests, none of which render. The behavioural delta is confined to what a *future* widened caller would receive: `reject` instead of `approve`.

Refs #8193
