### PR TITLE
fix(models): fold namespaced pins at substitute and picker sites (#8616)

### DIFF
--- a/docs/system-specs/modules/session.md
+++ b/docs/system-specs/modules/session.md
@@ -126,11 +126,15 @@ plus tips generation) express a `"auto"` model preference and pass it to a
 best-effort per-session `set_model`. The wire chokepoint
 (`AcpSessionHandle.set_model` → `resolve_usable_model`) mirrors the interactive
 `_wire_model_id`: it sends a served id, sends `"auto"` only when the backend
-advertises it, and for anything else — `"auto"` where a partition doesn't serve
-it, or an unentitled concrete id — resolves to `""` and **skips the
-send**, inheriting the session's served backend default. So these tasks never
-put an unserved model or a literal unavailable `"auto"` on the wire (which would
-fail with `Invalid model ID`). A reactive retry in `run_bg_oneliner`
+advertises it, folds a concrete pin carrying a stale `<namespace>::` qualifier
+to its advertised bare spelling (issue #8521, via `resolve_pin_spelling` — the
+same fold the wire sites and the display verdict use, so a substitute resolves
+to what a cold start of the same pin would send), and for anything else —
+`"auto"` where a partition doesn't serve it, or a concrete id served under
+neither spelling — resolves to `""` and **skips the send**, inheriting the
+session's served backend default. So these tasks never put an unserved model or
+a literal unavailable `"auto"` on the wire (which would fail with `Invalid model
+ID`). A reactive retry in `run_bg_oneliner`
 (retry once with the first advertised model on a mid-prompt rejection) remains a
 thin backstop for the fail-open case where the advertised set was unknown at
 send time.

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -1840,8 +1840,17 @@ def resolve_usable_model(preferred: str, advertised: Sequence[str] | None) -> st
         else ``""`` — exactly ``_wire_model_id``'s
         ``"auto" if "auto" in advertised else ""``;
       - concrete + usable             -> that id;
-      - concrete + not served         -> ``""`` (inherit the served default rather
-        than substituting a possibly-unavailable ``"auto"``).
+      - concrete carrying a stale ``<namespace>::`` qualifier for a bare id the
+        backend serves -> its ADVERTISED bare spelling (issue #8521's
+        ``openrouter::z-ai/glm-5.3-flash`` against a set advertising the bare
+        ``z-ai/glm-5.3-flash``), so a substitute pin persisted under the
+        qualified catalog spelling still reaches the wire instead of silently
+        inheriting the default. Same fold the wire sites use
+        (``providers.acp``, ``session_allocation``) and the display verdict
+        (``chat_runner._pinned_model_verdict``), so a background substitute
+        resolves to the very id a cold start of the same pin would send;
+      - concrete + served under NEITHER spelling -> ``""`` (inherit the served
+        default rather than substituting a possibly-unavailable ``"auto"``).
 
     The EXPLICIT user-pick paths do NOT use this: they ``raise``
     (``model_is_unusable``) so a user who chose a model sees an error, not a swap.
@@ -1857,7 +1866,12 @@ def resolve_usable_model(preferred: str, advertised: Sequence[str] | None) -> st
         return "auto" if not model_is_unusable("auto", ids) else ""
     if not model_is_unusable(preferred, ids):
         return preferred
-    return ""
+    # A literal miss can be a stale ``<namespace>::`` qualifier on a model the
+    # backend fully serves: fold to the advertised spelling and substitute THAT.
+    # ``resolve_pin_spelling`` returns ``""`` when the pin is absent under both
+    # spellings, which keeps the "" -means-inherit-default contract for a genuine
+    # miss — so an unserved substitute is still never forced onto the wire.
+    return resolve_pin_spelling(preferred, ids)
 
 
 def _format_acp_error(error: object, available_models: Sequence[str] | None = None) -> str:

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -19,7 +19,11 @@ from typing import Any
 from aiohttp import BodyPartReader, web
 
 from kiro_crew import agent_state, model_registry
-from kiro_crew.acp.client import advertised_model_ids, model_is_unusable
+from kiro_crew.acp.client import (
+    advertised_model_ids,
+    model_is_unusable,
+    resolve_pin_spelling,
+)
 from kiro_crew.acp_backends import selectable_backend_values
 from kiro_crew.agent import (
     AGENT_FILENAME,
@@ -1827,6 +1831,24 @@ def _entitled_kiro_models(request: web.Request, models: list[dict]) -> list[dict
     difference in how the two fold spelling variants shows up as a row the picker
     offers and the wire then withholds.
 
+    A literal miss is retried through :func:`resolve_pin_spelling` before it is
+    dropped (issue #8521): a catalog row carrying a stale ``<namespace>::``
+    qualifier for a bare id the backend serves would never match the advertised
+    row, so it was silently withheld even though the account can run it. On a
+    fold hit the row is KEPT but REWRITTEN to the advertised bare spelling — the
+    wire (``set_model``) accepts advertised ids verbatim, so the picker must
+    offer the id the wire will take, keeping picker and wire in agreement. A row
+    absent under BOTH spellings stays dropped.
+
+    Only the fold REWRITES are de-duplicated: a rewrite is skipped when its
+    advertised id was already produced — by another rewrite, or by a row kept
+    verbatim ahead of it — so two spellings collapsing to the same served id
+    yield one row (first-seen order). Rows the pre-fold literal code kept (the
+    ``auto`` sentinel and literally-usable rows) are NEVER dropped: they may
+    share a canonical key with a sibling row (an alias and its provider-prefixed
+    id both fold under ``_normalize_model_key``), and the catalog listed both on
+    purpose, so the dedup must not reach them.
+
     The ``auto`` sentinel is never filtered: it means "inherit whatever the
     session already resolved", so it stays selectable even on a backend that does
     not advertise it by name.
@@ -1863,12 +1885,30 @@ def _entitled_kiro_models(request: web.Request, models: list[dict]) -> list[dict
     if not advertised:
         return models
     advertises_auto = any(_normalize_model_key(i) == "auto" for i in advertised)
-    kept = [
-        m
-        for m in models
-        if _normalize_model_key(m.get("model_name", "")) == "auto"
-        or not model_is_unusable(m.get("model_name", ""), advertised)
-    ]
+    kept: list[dict] = []
+    # Keys of every row kept so far, so a fold rewrite can tell it has collided
+    # with an id already offered. Populated for verbatim keeps too (they are the
+    # rewrite's collision targets) but only rewrites are ever dropped against it —
+    # a verbatim keep is never removed even if it shares a canonical key with a
+    # sibling row (see the docstring: distinct catalog spellings stay distinct).
+    seen_keys: set[str] = set()
+    for m in models:
+        name = m.get("model_name", "")
+        if _normalize_model_key(name) == "auto" or not model_is_unusable(name, advertised):
+            # `auto` or a literal hit: kept verbatim, exactly as the pre-fold
+            # comprehension did. Record its key so a later fold cannot re-offer
+            # the same served id, but never drop the row itself here.
+            kept.append(m)
+            seen_keys.add(_normalize_model_key(name))
+            continue
+        folded = resolve_pin_spelling(name, advertised)
+        if not folded:
+            continue  # absent under both spellings: stays withheld
+        key = _normalize_model_key(folded)
+        if key in seen_keys:
+            continue  # this fold collapsed onto an id already offered
+        seen_keys.add(key)
+        kept.append({**m, "model_name": folded})
     # Tell "not comparable" apart from "entitled to almost nothing". A backend
     # that advertises `auto` shares a namespace with the catalog by definition, so
     # `auto` alone is a real answer — the most restricted tier there is — and must

--- a/test/test_api_models_entitlement.py
+++ b/test/test_api_models_entitlement.py
@@ -80,8 +80,11 @@ def test_a_spelling_the_wire_rejects_is_not_offered():
     # offered by the picker and then withheld at spawn, which is the lie this
     # narrowing exists to remove. The keep/drop decision therefore delegates to
     # `model_is_unusable` instead of folding spellings.
-    request = _request(_provider([{"modelId": "auto"}, {"modelId": "claude-opus-4-8"},
-                                 {"modelId": "claude-opus-5"}]))
+    request = _request(
+        _provider(
+            [{"modelId": "auto"}, {"modelId": "claude-opus-4-8"}, {"modelId": "claude-opus-5"}]
+        )
+    )
     assert _names(agents._entitled_kiro_models(request, CATALOG)) == ["auto", "claude-opus-5"]
 
 
@@ -204,6 +207,63 @@ def test_malformed_advertised_entries_are_ignored():
     assert agents._entitled_kiro_models(request, CATALOG) == CATALOG
 
 
+# ── Namespace fold (#8521): a stale `<namespace>::` qualifier on a catalog row ──
+# A row spelled `<namespace>::<bare-id>` for a bare id the backend serves would
+# never match the advertised bare row and was silently dropped; the picker now
+# folds it and REWRITES it to the advertised spelling the wire accepts.
+
+# CATALOG carries no namespaced row (its tests assert against it verbatim), so
+# these use a dedicated variant.
+NS_CATALOG = [
+    {"model_name": "auto", "description": "Models chosen by task"},
+    {"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "GLM 5.3 Flash"},
+]
+
+
+def test_namespaced_row_is_kept_and_rewritten_to_the_advertised_spelling():
+    # The backend serves the BARE id; the catalog row is qualified. Under the old
+    # literal-only keep/drop this row was dropped, leaving only `auto`.
+    request = _request(_provider([{"modelId": "auto"}, {"modelId": "z-ai/glm-5.3-flash"}]))
+    rows = agents._entitled_kiro_models(request, NS_CATALOG)
+    assert _names(rows) == ["auto", "z-ai/glm-5.3-flash"]
+
+
+def test_namespaced_row_absent_under_both_spellings_is_dropped():
+    # Served under neither the qualified nor the bare spelling -> withheld. The
+    # advertised set names `auto`, so it is comparable with the catalog (not a
+    # namespace mismatch) and narrows to `auto` alone: the qualified row is NOT
+    # offered as a usable pick, which is the withhold invariant this test pins.
+    request = _request(_provider([{"modelId": "auto"}, {"modelId": "some-other-model"}]))
+    assert _names(agents._entitled_kiro_models(request, NS_CATALOG)) == ["auto"]
+
+
+def test_two_rows_folding_to_the_same_advertised_id_are_deduped():
+    # A catalog offering both the bare and the qualified spelling of the SAME
+    # served id must yield exactly one row (first-seen order), not a duplicate
+    # picker entry.
+    catalog = [
+        {"model_name": "z-ai/glm-5.3-flash", "description": "bare"},
+        {"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "qualified"},
+    ]
+    request = _request(_provider([{"modelId": "z-ai/glm-5.3-flash"}]))
+    assert _names(agents._entitled_kiro_models(request, catalog)) == ["z-ai/glm-5.3-flash"]
+
+
+def test_namespaced_row_folding_onto_an_already_kept_usable_row_is_deduped():
+    # The cross-branch collision the dedup exists for, isolated: a BARE usable row
+    # is kept first (the literal-hit branch, recording its key), then a namespaced
+    # row folds onto that same served id (the rewrite branch) and must be dropped
+    # against the already-kept key. Exactly one row survives, in first-seen order —
+    # the bare row's original spelling, not the folded rewrite.
+    catalog = [
+        {"model_name": "auto", "description": "Models chosen by task"},
+        {"model_name": "z-ai/glm-5.3-flash", "description": "bare, usable"},
+        {"model_name": "openrouter::z-ai/glm-5.3-flash", "description": "qualified, folds on"},
+    ]
+    request = _request(_provider([{"modelId": "auto"}, {"modelId": "z-ai/glm-5.3-flash"}]))
+    assert _names(agents._entitled_kiro_models(request, catalog)) == ["auto", "z-ai/glm-5.3-flash"]
+
+
 # ── End-to-end through the handler ──
 
 
@@ -243,22 +303,21 @@ def test_api_models_returns_only_entitled_rows(tmp_path):
     request = _kiro_request(
         tmp_path, _provider([{"modelId": "auto"}, {"modelId": "claude-sonnet-5"}])
     )
-    with patch.object(
-        agents.KiroCrewConfig, "load", return_value=SimpleNamespace(agent=SimpleNamespace(provider="kiro"))
-    ), patch(
-        "kiro_crew.acp.client._resolve_kiro_bin_for_spawn", return_value="/usr/bin/kiro-cli"
-    ), patch(
-        "kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None
-    ), patch(
-        "kiro_crew.env.augmented_path", lambda p: p
-    ), patch(
-        "kiro_crew.dashboard.handlers.agents.wrap_argv", _stub_wrap_argv
-    ), patch(
-        "kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv
-    ), patch(
-        "kiro_crew.sandbox.resource_limit_preexec", lambda: None
-    ), patch.object(
-        agents.asyncio, "create_subprocess_exec", return_value=_FakeProc(stdout=payload)
+    with (
+        patch.object(
+            agents.KiroCrewConfig,
+            "load",
+            return_value=SimpleNamespace(agent=SimpleNamespace(provider="kiro")),
+        ),
+        patch("kiro_crew.acp.client._resolve_kiro_bin_for_spawn", return_value="/usr/bin/kiro-cli"),
+        patch("kiro_crew.acp.client._resolve_ssh_auth_sock", lambda env: None),
+        patch("kiro_crew.env.augmented_path", lambda p: p),
+        patch("kiro_crew.dashboard.handlers.agents.wrap_argv", _stub_wrap_argv),
+        patch("kiro_crew.dashboard.handlers.agents.cgroup_scope_argv", lambda argv: argv),
+        patch("kiro_crew.sandbox.resource_limit_preexec", lambda: None),
+        patch.object(
+            agents.asyncio, "create_subprocess_exec", return_value=_FakeProc(stdout=payload)
+        ),
     ):
         resp = asyncio.get_event_loop().run_until_complete(agents.api_models(request))
     assert resp.status == 200

--- a/test/test_model_selection_scenarios.py
+++ b/test/test_model_selection_scenarios.py
@@ -33,9 +33,9 @@ from kiro_crew.acp.client import (
 
 # Representative advertised sets for the scenarios below.
 _ENTITLED = ["claude-opus-4.8", "claude-sonnet-4.6", "auto"]  # serves auto
-_FREE_TIER = ["claude-sonnet-4.6"]                            # subset, no auto
-_NO_AUTO_PARTITION = ["gpt-5.6-terra", "gpt-5.6-luna"]        # serves models, not auto
-_UNKNOWN: list = []                                           # no session yet
+_FREE_TIER = ["claude-sonnet-4.6"]  # subset, no auto
+_NO_AUTO_PARTITION = ["gpt-5.6-terra", "gpt-5.6-luna"]  # serves models, not auto
+_UNKNOWN: list = []  # no session yet
 
 
 class TestBackgroundResolution:
@@ -73,6 +73,31 @@ class TestBackgroundResolution:
     def test_blank_advertised_entries_are_ignored(self):
         assert resolve_usable_model("claude-sonnet-4.6", ["", "  ", "claude-sonnet-4.6"]) == (
             "claude-sonnet-4.6"
+        )
+
+    def test_namespaced_pin_resolves_to_the_advertised_bare_spelling(self):
+        # A substitute pin persisted under the qualified catalog spelling
+        # (#8521) must reach the wire, not silently inherit the default: the
+        # literal miss folds to the advertised bare id. Under the old
+        # literal-only code this returned "" (inherit default).
+        assert (
+            resolve_usable_model("openrouter::z-ai/glm-5.3-flash", ["auto", "z-ai/glm-5.3-flash"])
+            == "z-ai/glm-5.3-flash"
+        )
+
+    def test_namespaced_pin_returns_the_advertised_case_not_the_callers(self):
+        # The result is sent on the wire, which accepts the advertised spelling,
+        # so the ADVERTISED case wins over the caller's.
+        assert (
+            resolve_usable_model("openrouter::z-ai/glm-5.3-flash", ["Z-AI/GLM-5.3-Flash"])
+            == "Z-AI/GLM-5.3-Flash"
+        )
+
+    def test_pin_absent_under_both_spellings_inherits_default(self):
+        # Not served bare and not served qualified -> "" (inherit default),
+        # preserving the withhold invariant everywhere.
+        assert (
+            resolve_usable_model("openrouter::no-such-model", ["auto", "z-ai/glm-5.3-flash"]) == ""
         )
 
 


### PR DESCRIPTION
Closes the three sibling comparison sites named in issue #8616 that still compared persisted/inherited model values against advertised sets WITHOUT the #8521 namespace fold (`acp.client.resolve_pin_spelling`). PR #8615 wired the fold into `_pinned_model_verdict`, `_apply_startup_model`, and the kiro runtime path in `providers/acp.py`; this closes the remaining siblings.

## Changes

**SITE 1 — `acp/client.py::resolve_usable_model`**
A concrete literal miss now returns `resolve_pin_spelling(preferred, ids)` instead of falling through to `""`. A namespaced substitute pin (`<namespace>::<bare-id>`) whose bare id the backend advertises now resolves to the advertised bare spelling for the wire; a pin absent under both spellings still returns `""` (inherit the served default). The empty-preferred, empty-advertised, and `auto` branches and the explicit-pick raise path are untouched.

**SITE 2 — `dashboard/handlers/agents.py::_entitled_kiro_models`**
The picker/advertised narrowing retries a literal miss through the fold and KEEPS the row rewritten to the advertised bare spelling, so the picker offers exactly what the literal-comparing selection sinks accept. Absent-under-both rows stay dropped. Dedup is scoped to fold rewrites only — `auto` and literally-usable rows are kept verbatim exactly as the prior comprehension did, so distinct-canonical-key catalog rows are never collapsed. `auto`-always-kept and the fail-open (return full catalog when nothing lines up) behaviors are preserved.

**SITE 3 — `session_allocation.py`**
Verified ALREADY correct and left unmodified: it already folds via `resolve_pin_spelling` under a `model_is_unusable` guard and withholds (leaves the claimed process on `pool_model`) when the fold returns `""`, with an existing comment referencing #8521. This satisfies the adopt-or-document bar as-is.

**Invariant:** a pin absent under BOTH the full and bare spelling is still refused/withheld everywhere.

`docs/system-specs/modules/session.md` updated to name the fold on the background-task resolution path.

## Tests

- `test/test_model_selection_scenarios.py` (+3): namespaced pin resolves to the advertised bare spelling; advertised case/spelling wins over the caller's; absent-under-both returns `""`.
- `test/test_api_models_entitlement.py` (+4): namespaced catalog row kept and rewritten to the advertised spelling; absent-under-both dropped; two rows folding to the same advertised id deduped to one; cross-branch dedup collision (a fold rewrite colliding with an already-kept literal row).

Each new test exercises the changed path and fails if the fold is reverted.

## Verification

- Target suites (`test_model_selection_scenarios.py test_api_models_entitlement.py`): 53 passed (baseline 46).
- Broader caller/regression set (9 files incl. run_bg_oneliner, llm_helpers, session_pool, chat_runner, dashboard_chat, harness_parity): 1391 passed.
- flake8 clean on touched files; `mypy --platform linux src/kiro_crew`: Success (1293 files); `check_harness_parity.py`: pass (positive identity).

Semantic review: two rounds, APPROVED (the dedup-scoped-to-rewrites and collision-test items from the first round were resolved and independently verified in the second).

Note: this is an independent implementation on `main`; the auto-pipeline's PR #8737 for the same issue remains open and untouched.