### PR TITLE
fix(mcp): allocate probe TMPDIR before the sandbox wrap and carve it out (#8653)

### DIFF
--- a/src/kiro_crew/mcp_discovery.py
+++ b/src/kiro_crew/mcp_discovery.py
@@ -1844,16 +1844,6 @@ async def probe_server(
         # start?" probe runs for real instead of fail-closing. Third-party
         # probes (and any customized managed command/args/env) pass False and
         # keep the full fail-close + opt-in behavior.
-        wrapped_argv, env, sandbox_cleanup = await sandboxed_spawn_argv_async(
-            [resolved, *(server.args or [])],
-            mode="standard",
-            env=env,
-            strip_python_env=True,
-            first_party_fixed_argv=_is_first_party_managed_argv(
-                server.name, server.command, server.args or [], server.env or {}
-            ),
-            _prepare=sandboxed_spawn_argv,
-        )
         # Probe temp containment (#5064): each probe gets its OWN private dir
         # under the managed root, cleaned in this function's finally -- unlike
         # a backend, a probe knows exactly when its lifecycle ends, so no
@@ -1862,23 +1852,74 @@ async def probe_server(
         # would cycle), created off-loop, and fail-open: a probe must run even
         # when containment cannot be set up.
         #
+        # Allocated BEFORE the sandbox wrap (#8653): the managed root lives at
+        # ``<data home>/run/mcp-tmp``, inside the runtime parent the sandbox
+        # seals read-only, so the wrap must know the directory to carve its
+        # write access out of that seal. Allocating after the wrap handed the
+        # child a ``TMPDIR`` it could not write -- a Bun-packaged server then
+        # failed the probe with "Cannot find the native Koffi module" because
+        # it could not extract its native module. The allocation failure path
+        # stays fail-open (probe runs with inherited temp, no carve-out), and
+        # the outer ``finally`` sweeps the dir even when the wrap itself
+        # raises.
+        #
         # Mirrors the backend chokepoint: a spec-DECLARED temp wins -- the
         # operator pointed this server at chosen storage, and overriding it
         # would trade litter for ENOSPC on the data-home volume. Checked
         # case-insensitively (Windows env keys are case-insensitive and the
         # sanitized spec preserves the author's spelling).
-        try:
-            _declared_temp_upper = {
-                key.upper()
-                for key in (server.env or {})
-                if key.upper() in ("TMPDIR", "TMP", "TEMP")
-            }
-            if not _declared_temp_upper:
-                from kiro_crew.mcp_gateway.backend_tmp import allocate_probe_tmp, tmp_env
+        _declared_temp_upper = {
+            key.upper()
+            for key in (server.env or {})
+            if key.upper() in ("TMPDIR", "TMP", "TEMP")
+        }
+        probe_scratch: "Path | None" = None
+        if not _declared_temp_upper:
+            try:
+                from kiro_crew.mcp_gateway.backend_tmp import (
+                    allocate_probe_tmp,
+                    probe_child_scratch,
+                )
 
                 probe_tmp = await asyncio.to_thread(allocate_probe_tmp)
-                env = {**env, **tmp_env(probe_tmp)}
-            else:
+                # The child gets a SCRATCH SUBDIR, never the allocation root:
+                # the root holds the ``.owner`` reclamation record, and the
+                # write carve-out below must not put that record inside the
+                # child's writable window (see probe_child_scratch).
+                probe_scratch = await asyncio.to_thread(probe_child_scratch, probe_tmp)
+            except Exception:
+                logger.debug("probe temp containment unavailable", exc_info=True)
+                if probe_tmp is not None and probe_scratch is None:
+                    # The allocation exists but its child-facing half does
+                    # not: reclaim now. Ownerless-or-provisional dirs are
+                    # deliberately never deleted by the sweeps until
+                    # owner-dead+idle, and no probe pid will ever be recorded
+                    # for this one.
+                    from kiro_crew.mcp_gateway.backend_tmp import sweep_backend_tmp
+
+                    await asyncio.to_thread(sweep_backend_tmp, probe_tmp)
+                    probe_tmp = None
+        wrapped_argv, env, sandbox_cleanup = await sandboxed_spawn_argv_async(
+            [resolved, *(server.args or [])],
+            mode="standard",
+            env=env,
+            strip_python_env=True,
+            extra_writable_dirs=(
+                (str(probe_scratch),) if probe_scratch is not None else ()
+            ),
+            first_party_fixed_argv=_is_first_party_managed_argv(
+                server.name, server.command, server.args or [], server.env or {}
+            ),
+            _prepare=sandboxed_spawn_argv,
+        )
+        try:
+            if probe_scratch is not None:
+                from kiro_crew.mcp_gateway.backend_tmp import tmp_env
+
+                # Merged AFTER the wrap so the managed triple lands on the
+                # SCRUBBED env the child actually receives.
+                env = {**env, **tmp_env(probe_scratch)}
+            elif _declared_temp_upper:
                 # Yielding alone is not enough: ambient temp keys are still in
                 # ``env`` and ``tempfile`` consults TMPDIR before TMP, so a
                 # spec declaring only TMP would silently write through the

--- a/src/kiro_crew/mcp_gateway/backend_tmp.py
+++ b/src/kiro_crew/mcp_gateway/backend_tmp.py
@@ -97,6 +97,28 @@ def allocate_probe_tmp() -> Path:
     return allocate_backend_tmp("probe")
 
 
+#: Child-facing scratch subdirectory of a probe allocation (see
+#: :func:`probe_child_scratch`).
+PROBE_SCRATCH_SUBDIR = "tmp"
+
+
+def probe_child_scratch(root: Path) -> Path:
+    """Create and return the child-facing scratch subdir of a probe allocation.
+
+    The allocation ROOT holds the ``.owner`` reclamation record. The probe's
+    sandbox write carve-out and the ``TMPDIR`` triple point at this SUBDIR so
+    that record stays OUTSIDE the child's writable window (#8653): a child
+    that could garble ``.owner`` (or write a live pid into it) would make the
+    directory permanently unreclaimable by the daemon sweep after a gateway
+    crash, since the sweep deletes only owned-and-dead directories. Same
+    permission treatment as the parent allocation.
+    """
+    scratch = root / PROBE_SCRATCH_SUBDIR
+    scratch.mkdir(mode=0o700)
+    platform_compat.restrict_dir_to_owner(scratch)
+    return scratch
+
+
 def tmp_env(path: Path) -> dict[str, str]:
     """The ``TMPDIR``/``TMP``/``TEMP`` triple pointing a child at *path*.
 

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -2756,6 +2756,7 @@ def _build_launcher_script(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
 ) -> str:
     """Build a Python launcher script for the Linux namespace sandbox.
 
@@ -2862,6 +2863,29 @@ def _build_launcher_script(
     # without relying on how subpath treats a non-directory.
     dirs_json = json.dumps(list(dict.fromkeys(hidden_dirs)))
     readonly_json = json.dumps(list(dict.fromkeys(readonly_dirs)))
+    # Write carve-outs (#8653): validated against the same seals this script
+    # embeds. The launcher re-binds each approved directory over itself AFTER
+    # the READONLY seal and remounts that bind read-write, so the carve-out
+    # overrides only the runtime parent's seal — the validator refuses any
+    # candidate that would re-open a hidden tree, a ceiling, or the voice
+    # runtime. ``hidden_dirs`` was already filtered down to the entries that
+    # stay hidden, so ``hidden_dirs + unhidden`` reconstitutes the FULL
+    # pre-``extra_visible_dirs`` candidate set: the ``+ unhidden`` term is
+    # load-bearing, not redundant — dropping it would let a tree a caller
+    # re-exposed read-only grow a writable window through this parameter
+    # (pinned by test_launcher_refuses_carveout_inside_unhidden_tree).
+    runtime_parents = list(_voice_runtime_parent_paths())
+    writable_json = json.dumps(
+        _writable_carveout_spellings(
+            extra_writable_dirs,
+            subtree_guards=hidden_dirs
+            + unhidden
+            + [path for path in readonly_dirs if path not in set(runtime_parents)]
+            + ([os.path.join(home, ".ssh")] if hide_ssh else []),
+            literal_guards=[os.path.join(home, f) for f in files],
+            carveable_parents=runtime_parents,
+        )
+    )
     files_json = json.dumps(
         list(dict.fromkeys([os.path.join(home, f) for f in files] + hidden_dirs))
     )
@@ -2980,6 +3004,31 @@ def _mount_or_die(source, target, flags, what):
             % (what, _err, os.strerror(_err))
         )
 
+def _mount_or_warn(source, target, flags, what):
+    """``mount(2)`` that degrades OPEN with an advisory, for access-WIDENING mounts.
+
+    The write carve-out pair (#8653) is the inverse of every ``_mount_or_die``
+    site: those mounts WITHHOLD access and a silent failure hands the agent a
+    visible credential, so they refuse; these mounts GRANT access inside an
+    already-sealed subtree, so a failure means the path simply stays sealed --
+    the pre-carve-out behavior, in which the one consequence is that a probe's
+    private temp dir is unwritable. Killing the spawn for that would trade a
+    degraded probe for no probe at all.
+
+    Emits the classifier's ADVISORY severity (the prefix
+    ``_SANDBOX_LAUNCHER_WARNING_PREFIX`` in dashboard/handlers/worktree.py
+    matches; the severity set is ratcheted by test_worktree_create.py) and
+    reports success so callers can chain: the carve-out's remount is pointless
+    after its bind already failed.
+    """
+    if _libc.mount(source, target, None, flags, None) != 0:
+        sys.stderr.write(
+            "sandbox: WARNING -- %s failed (errno %d); continuing with the "
+            "path sealed\\n" % (what, ctypes.get_errno())
+        )
+        return False
+    return True
+
 def _locked_mount_flags(target):
     """Mount flags on *target* the kernel may have LOCKED, ready to re-assert.
 
@@ -3020,6 +3069,7 @@ REAL_UID = {uid}
 REAL_GID = {gid}
 SENSITIVE_DIRS = {dirs_json}
 READONLY_DIRS = {readonly_json}
+WRITABLE_DIRS = {writable_json}
 SENSITIVE_FILES = {files_json}
 EXPOSE_FILES = {expose_json}
 ENV_PREFIXES = {env_prefixes_json}
@@ -3202,6 +3252,46 @@ def main():
                               _MS_REMOUNT | _MS_BIND | _MS_RDONLY
                               | _locked_mount_flags(target),
                               "sealing read-only path %s" % d)
+
+        # Writable carve-outs (#8653) — validated by the builder against every
+        # seal this script applies; each approved entry lives INSIDE the sealed
+        # runtime parent and covers no other protected path. MUST run AFTER the
+        # READONLY loop, for two reasons, the second stronger than the first:
+        # (a) the fresh bind inherits that mount's MS_RDONLY, which the remount
+        # then clears while re-asserting the kernel-locked nosuid/nodev/noexec
+        # bits (``_locked_mount_flags`` never returns MS_RDONLY); (b) a
+        # non-recursive MS_BIND does not replicate submounts, so if the parent
+        # self-bind were established AFTER the carve-out, lookups through the
+        # new parent mount would not find the carve-out mount at all and the
+        # writable window would vanish silently — the #8653 failure back with
+        # no error. Clearing MS_RDONLY here is permitted because the seal
+        # being cleared was created inside THIS namespace without
+        # MNT_LOCK_READONLY (a data home on a genuinely read-only underlying
+        # mount could not have produced the carve-out directory at all); the
+        # underlying filesystem's nosuid/nodev/noexec bits remain locked and
+        # are re-asserted, not dropped.
+        #
+        # These two mounts WIDEN access, so unlike every _mount_or_die above
+        # they fail OPEN: a host that refuses the bind or the remount keeps
+        # the seal, degrading to the pre-carve-out behavior (the probe's temp
+        # dir is unwritable, exactly as before this feature) instead of
+        # killing the spawn. A bind that succeeded whose remount then failed
+        # leaves a read-only bind stacked on a read-only parent — the sealed
+        # behavior, not a widening. The ``islink`` refusal mirrors the sweep
+        # hygiene rules: a symlink planted where the carve-out dir should be
+        # must not redirect the writable window elsewhere (the Seatbelt
+        # backend needs no equivalent, since its rules match the kernel's
+        # resolved operation path).
+        for d in WRITABLE_DIRS:
+            target = d.encode()
+            if not os.path.isdir(target) or os.path.islink(target):
+                continue
+            if _mount_or_warn(target, target, _MS_BIND,
+                              "writable carve-out bind for %s" % d):
+                _mount_or_warn(target, target,
+                               _MS_REMOUNT | _MS_BIND
+                               | _locked_mount_flags(target),
+                               "writable carve-out remount for %s" % d)
 
         # Restore selectively exposed files into the now-empty mounts
         for src_path, filename in EXPOSE_FILES:
@@ -3681,6 +3771,7 @@ def namespace_argv(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
 ) -> list[str]:
     """Wrap *argv* via the Python namespace launcher.
 
@@ -3708,6 +3799,7 @@ def namespace_argv(
         strip_python_env=strip_python_env,
         extra_hidden_dirs=extra_hidden_dirs,
         extra_visible_dirs=extra_visible_dirs,
+        extra_writable_dirs=extra_writable_dirs,
     )
     run_dir = _ensure_run_dir()
     fd, path = tempfile.mkstemp(
@@ -3718,6 +3810,108 @@ def namespace_argv(
     platform_compat.chmod_safe(path, 0o700)
 
     return [sys.executable, *_LAUNCHER_INTERPRETER_FLAGS, path, *resolved_argv]
+
+
+def _path_within(path: str, parent: str) -> bool:
+    """Whether *path* equals *parent* or lies inside it (lexical, normalized)."""
+    parent_normalized = os.path.normpath(parent)
+    if path == parent_normalized:
+        return True
+    prefix = parent_normalized.rstrip(os.sep) + os.sep
+    return path.startswith(prefix)
+
+
+def _writable_carveout_spellings(
+    extra_writable_dirs: tuple[str, ...],
+    *,
+    subtree_guards: list[str],
+    literal_guards: list[str],
+    carveable_parents: list[str],
+) -> list[str]:
+    """Validate write carve-outs against the sandbox's own seals (#8653).
+
+    ``extra_writable_dirs`` exists for exactly one purpose: a caller that hands
+    a child its private scratch directory INSIDE the sealed runtime parent
+    (``<data home>/run``, kept read-only via :func:`_voice_runtime_parent_paths`)
+    needs that one directory writable — the MCP probe's ``TMPDIR`` lives at
+    ``run/mcp-tmp/<probe>`` and a Bun-packaged server must extract its native
+    module there before it can answer the handshake. Everything else stays
+    sealed.
+
+    Both sandbox backends apply the carve-out with override semantics (Seatbelt
+    is last-match-wins; the Linux launcher remounts a fresh bind read-write), so
+    an unvalidated path here would re-open whatever it covers. Each candidate is
+    therefore checked, in BOTH its lexical and canonical spelling (the data home
+    may be a supported symlink, and path-based rules see each spelling
+    independently), against every seal the profile emits:
+
+    * it must lie inside a ``carveable_parents`` entry — the runtime parent's
+      write-only seal is the ONLY seal this parameter may punch through;
+    * no guard (``subtree_guards`` — read-hidden trees, read-only ceilings,
+      the voice runtime — or ``literal_guards`` — sealed single files, rename
+      guards) may equal the carve-out or live inside it, since the override
+      would re-open that guard;
+    * it may not sit inside a non-carveable subtree guard, so a read-hidden
+      tree can never grow a writable window.
+
+    A candidate that fails any check is SKIPPED with a security warning rather
+    than raising: the callers treat temp containment as fail-open hygiene, and
+    a refused carve-out degrades to today's sealed behavior instead of blocking
+    the spawn. Returns the deduplicated approved spellings.
+
+    Two scope notes. Comparisons are LEXICAL and case-sensitive: on a
+    case-insensitive filesystem (default APFS) a differently-cased spelling of
+    a guard would not match, so this validator is a backstop for the
+    self-derived paths its callers pass — paths whose case matches the emitted
+    rules by construction — not a boundary for hostile input, which must never
+    reach this parameter. And the ``realpath``/``isdir`` calls here are safe
+    despite the no-filesystem-IO-on-the-event-loop rule the profile builders
+    cite: every async caller reaches those builders through
+    ``shielded_prepare_off_loop``'s worker thread.
+    """
+    carveable = [os.path.normpath(path) for path in carveable_parents]
+    subtree = [os.path.normpath(path) for path in subtree_guards]
+    literals = [os.path.normpath(path) for path in literal_guards]
+    carveable_set = set(carveable)
+    approved: list[str] = []
+    for raw in extra_writable_dirs:
+        if not raw or not os.path.isabs(raw):
+            logger.warning(
+                "SECURITY: refusing sandbox write carve-out %r: not an absolute path",
+                raw,
+            )
+            continue
+        lexical = os.path.normpath(os.path.abspath(raw))
+        canonical = os.path.realpath(lexical)
+        spellings = list(dict.fromkeys((lexical, canonical)))
+        if not os.path.isdir(canonical):
+            logger.warning(
+                "SECURITY: refusing sandbox write carve-out %r: not an existing " "real directory",
+                raw,
+            )
+            continue
+        refusal: str | None = None
+        for spelling in spellings:
+            if not any(_path_within(spelling, parent) for parent in carveable):
+                refusal = f"{spelling!r} is outside every carveable runtime parent"
+                break
+            for guard in subtree + literals:
+                if _path_within(guard, spelling):
+                    refusal = f"sealed path {guard!r} would be re-opened by it"
+                    break
+            if refusal:
+                break
+            for guard in subtree:
+                if guard not in carveable_set and _path_within(spelling, guard):
+                    refusal = f"it lies inside sealed subtree {guard!r}"
+                    break
+            if refusal:
+                break
+        if refusal:
+            logger.warning("SECURITY: refusing sandbox write carve-out %r: %s", raw, refusal)
+            continue
+        approved.extend(spellings)
+    return list(dict.fromkeys(approved))
 
 
 # ── Backend: macOS sandbox-exec ──
@@ -3734,6 +3928,7 @@ def _build_seatbelt_profile(
     *,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
 ) -> str:
     """Build a Seatbelt .sb profile denying reads of sensitive dirs."""
     home = str(Path.home())
@@ -3755,12 +3950,18 @@ def _build_seatbelt_profile(
     expose_abs = {os.path.join(home, f) for f in expose_files}
     crew_hidden = _crew_hidden_sandbox_targets()
     rules: list[str] = []
-    for target in (
+    # Every masked target below doubles as a guard for the write carve-outs
+    # appended at the end: Seatbelt is last-match-wins, so an allow emitted
+    # after these denies re-opens whatever it covers, and the carve-out
+    # validator must therefore see the same target list the rules were built
+    # from (conservatively including entries `extra_visible_dirs` re-exposed).
+    masked_targets = (
         [os.path.join(home, d) for d in dirs]
         + _relocated_policy_cache_dirs()
         + _relocated_crew_targets(_CREW_HIDDEN_LEAVES)
         + list(_voice_runtime_sandbox_paths())
-    ):
+    )
+    for target in masked_targets:
         if _hidden_path_contains_visible_path(
             target, extra_visible_dirs
         ) and not _is_voice_runtime_dir(target):
@@ -3812,12 +4013,14 @@ def _build_seatbelt_profile(
     # sandbox launcher itself is stored there), but deny every write through
     # both lexical and canonical spellings. Literal ancestor rules prevent a
     # same-UID agent from renaming a parent around the path-based subtree deny.
-    for target in _voice_runtime_parent_paths():
+    runtime_parents = list(_voice_runtime_parent_paths())
+    for target in runtime_parents:
         escaped = target.replace('"', '\\"')
         rules.append(f'(deny file-write* (literal "{escaped}"))')
         rules.append(f'(deny file-write* (subpath "{escaped}"))')
         rules.append(f'(deny file-link (subpath "{escaped}"))')
-    for target in _voice_runtime_ancestor_guards():
+    ancestor_guards = list(_voice_runtime_ancestor_guards())
+    for target in ancestor_guards:
         escaped = target.replace('"', '\\"')
         rules.append(f'(deny file-write* (literal "{escaped}"))')
     # The crew data home's ceilings: readable (in-sandbox code resolves them) but never
@@ -3825,9 +4028,10 @@ def _build_seatbelt_profile(
     # READONLY_DIRS on Linux. Both spellings, because a ceiling may be a file
     # (``literal``) or a directory (``subpath``), and ``file-link`` stops the agent
     # minting a writable alias to the same inode.
-    for target in [
+    readonly_targets = [
         os.path.join(home, rel) for rel in _CREW_READONLY_TARGETS
-    ] + _relocated_crew_targets(_CREW_READONLY_LEAVES):
+    ] + _relocated_crew_targets(_CREW_READONLY_LEAVES)
+    for target in readonly_targets:
         escaped = target.replace('"', '\\"')
         rules.append(f'(deny file-write* (literal "{escaped}"))')
         rules.append(f'(deny file-write* (subpath "{escaped}"))')
@@ -3838,7 +4042,8 @@ def _build_seatbelt_profile(
         rules.append(f'(deny file-read* (literal "{escaped}"))')
         # Also deny hardlinking the protected file (see above).
         rules.append(f'(deny file-link (literal "{escaped}"))')
-    for target in dict.fromkeys(os.path.abspath(path) for path in extra_hidden_dirs):
+    extra_hidden_targets = list(dict.fromkeys(os.path.abspath(path) for path in extra_hidden_dirs))
+    for target in extra_hidden_targets:
         if _hidden_path_contains_visible_path(target, extra_visible_dirs):
             continue
         escaped = target.replace('"', '\\"')
@@ -3863,8 +4068,10 @@ def _build_seatbelt_profile(
         rules.append(f'(deny file-link (literal "{escaped}"))')
 
     # .ssh: deny all access except reading known_hosts (strict only)
+    ssh_guards: list[str] = []
     if sandbox_level == "strict":
         ssh_dir = os.path.join(home, ".ssh")
+        ssh_guards.append(ssh_dir)
         ssh_escaped = ssh_dir.replace('"', '\\"')
         ssh_kh = os.path.join(ssh_dir, "known_hosts")
         ssh_kh_escaped = ssh_kh.replace('"', '\\"')
@@ -3877,6 +4084,22 @@ def _build_seatbelt_profile(
         # denied subtree.  Blanket over the whole subpath — no known_hosts
         # exception, since a hardlink to known_hosts has no legitimate use.
         rules.append(f'(deny file-link (subpath "{ssh_escaped}"))')
+
+    # Write carve-outs (#8653), validated against every seal above and emitted
+    # LAST: Seatbelt is last-match-wins, so this allow overrides only the
+    # runtime-parent write seal for exactly the approved directory (both
+    # spellings — Seatbelt rules are path-based). The subtree's ``file-link``
+    # deny deliberately stays in force: a probe scratch dir never needs to mint
+    # hardlinks, and the deny is what stops aliasing a sealed inode into the
+    # writable window.
+    for spelling in _writable_carveout_spellings(
+        extra_writable_dirs,
+        subtree_guards=masked_targets + readonly_targets + extra_hidden_targets + ssh_guards,
+        literal_guards=ancestor_guards + [os.path.join(home, f) for f in files],
+        carveable_parents=runtime_parents,
+    ):
+        escaped = spelling.replace('"', '\\"')
+        rules.append(f'(allow file-write* (subpath "{escaped}"))')
 
     return _SEATBELT_PROFILE.format(deny_rules="\n".join(rules))
 
@@ -4063,6 +4286,7 @@ def sandbox_exec_argv(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
 ) -> tuple[list[str], str | None]:
     """Wrap *argv* with ``sandbox-exec -f <profile>``.
 
@@ -4080,6 +4304,7 @@ def sandbox_exec_argv(
         sandbox_level,
         extra_hidden_dirs=extra_hidden_dirs,
         extra_visible_dirs=extra_visible_dirs,
+        extra_writable_dirs=extra_writable_dirs,
     )
     run_dir = _ensure_run_dir()
     fd, path = tempfile.mkstemp(
@@ -6024,6 +6249,7 @@ def wrap_argv(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
     is_kiro_cli: bool | None = None,
     first_party_fixed_argv: bool = False,
 ) -> tuple[list[str], str | None]:
@@ -6037,6 +6263,13 @@ def wrap_argv(
         extra_hidden_dirs: Additional absolute directory trees to deny.
         extra_visible_dirs: Trusted paths that must remain visible when an
             otherwise-hidden parent contains them.
+        extra_writable_dirs: Self-derived scratch directories INSIDE the sealed
+            runtime parent (``<data home>/run``) that the child must be able to
+            write — e.g. the MCP probe's private ``TMPDIR`` (#8653). Validated
+            by :func:`_writable_carveout_spellings`; a candidate that would
+            re-open any other seal is refused with a security warning. Inert on
+            backends with no path seal to carve (Windows, the no-backend
+            fail-open path): there the directory is already writable.
         is_kiro_cli: Explicit executable classification for descriptor-backed
             Kiro snapshots whose launch path no longer has a ``kiro-cli``
             basename. ``None`` retains basename detection for other callers.
@@ -6310,7 +6543,7 @@ def wrap_argv(
         sys.platform == "darwin" and kiro_spawn and kiro_internal_sandbox_enabled()
     ) or (sys.platform == "win32" and is_kiro_cli is True and kiro_internal_sandbox_enabled())
     if delegate_to_kiro:
-        if extra_hidden_dirs or extra_visible_dirs:
+        if extra_hidden_dirs or extra_visible_dirs or extra_writable_dirs:
             # A delegated sandbox cannot enforce KiroCrew-specific path hides.
             # macOS keeps the outer seatbelt. Windows falls through to its
             # no-backend policy and fail-closes unless explicitly opted in.
@@ -6321,6 +6554,7 @@ def wrap_argv(
                     strip_python_env=strip_python_env,
                     extra_hidden_dirs=extra_hidden_dirs,
                     extra_visible_dirs=extra_visible_dirs,
+                    extra_writable_dirs=extra_writable_dirs,
                 )
         else:
             delegated = _delegate_to_kiro_internal_sandbox(
@@ -6336,13 +6570,14 @@ def wrap_argv(
     backend = detect_backend(config_mode=mode)
 
     if backend == "namespace":
-        if extra_hidden_dirs or extra_visible_dirs:
+        if extra_hidden_dirs or extra_visible_dirs or extra_writable_dirs:
             wrapped = namespace_argv(
                 argv,
                 sandbox_level,
                 strip_python_env=strip_python_env,
                 extra_hidden_dirs=extra_hidden_dirs,
                 extra_visible_dirs=extra_visible_dirs,
+                extra_writable_dirs=extra_writable_dirs,
             )
         else:
             wrapped = namespace_argv(
@@ -6356,13 +6591,14 @@ def wrap_argv(
         # hands the caller a flag to unlink) the moment that list changes.
         return wrapped, _launcher_script_of(wrapped)
     if backend == "sandbox-exec":
-        if extra_hidden_dirs or extra_visible_dirs:
+        if extra_hidden_dirs or extra_visible_dirs or extra_writable_dirs:
             return sandbox_exec_argv(
                 argv,
                 sandbox_level,
                 strip_python_env=strip_python_env,
                 extra_hidden_dirs=extra_hidden_dirs,
                 extra_visible_dirs=extra_visible_dirs,
+                extra_writable_dirs=extra_writable_dirs,
             )
         return sandbox_exec_argv(
             argv,
@@ -6570,6 +6806,7 @@ async def wrap_argv_async(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
     is_kiro_cli: bool | None = None,
     first_party_fixed_argv: bool = False,
     _prepare: Callable[..., tuple[list[str], str | None]] | None = None,
@@ -6591,6 +6828,8 @@ async def wrap_argv_async(
         options["extra_hidden_dirs"] = extra_hidden_dirs
     if extra_visible_dirs:
         options["extra_visible_dirs"] = extra_visible_dirs
+    if extra_writable_dirs:
+        options["extra_writable_dirs"] = extra_writable_dirs
     if is_kiro_cli is not None:
         options["is_kiro_cli"] = is_kiro_cli
     if first_party_fixed_argv:
@@ -6688,6 +6927,7 @@ def sandboxed_spawn_argv(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
     first_party_fixed_argv: bool = False,
 ) -> tuple[list[str], dict[str, str], str | None]:
     """Single chokepoint for agent-influenced subprocess spawns.
@@ -6715,6 +6955,10 @@ def sandboxed_spawn_argv(
             hidden in both the macOS Seatbelt and Linux namespace profiles.
         extra_visible_dirs: Trusted paths that must remain visible when an
             otherwise-hidden parent contains them.
+        extra_writable_dirs: Self-derived scratch directories inside the sealed
+            runtime parent that the child must be able to write (#8653) — see
+            :func:`wrap_argv`. Validated; refused candidates degrade to the
+            sealed behavior rather than blocking the spawn.
         first_party_fixed_argv: Threaded to :func:`wrap_argv`. True ONLY for
             spawns whose full argv is derived inside this package with zero
             agent/repo/user-config influence; every passing site must be
@@ -6726,13 +6970,14 @@ def sandboxed_spawn_argv(
         pass *scrubbed_env* as the subprocess ``env=`` and unlink *cleanup_path*
         (a temp launcher/profile) after the child exits.
     """
-    if extra_hidden_dirs or extra_visible_dirs:
+    if extra_hidden_dirs or extra_visible_dirs or extra_writable_dirs:
         wrapped, cleanup = wrap_argv(
             argv,
             mode=mode,
             strip_python_env=strip_python_env,
             extra_hidden_dirs=extra_hidden_dirs,
             extra_visible_dirs=extra_visible_dirs,
+            extra_writable_dirs=extra_writable_dirs,
             first_party_fixed_argv=first_party_fixed_argv,
         )
     else:
@@ -6877,6 +7122,7 @@ async def sandboxed_spawn_argv_async(
     strip_python_env: bool = False,
     extra_hidden_dirs: tuple[str, ...] = (),
     extra_visible_dirs: tuple[str, ...] = (),
+    extra_writable_dirs: tuple[str, ...] = (),
     first_party_fixed_argv: bool = False,
     executor: ThreadPoolExecutor | None = None,
     _prepare: Callable[..., tuple[list[str], dict[str, str], str | None]] | None = None,
@@ -6898,6 +7144,8 @@ async def sandboxed_spawn_argv_async(
         options["extra_hidden_dirs"] = extra_hidden_dirs
     if extra_visible_dirs:
         options["extra_visible_dirs"] = extra_visible_dirs
+    if extra_writable_dirs:
+        options["extra_writable_dirs"] = extra_writable_dirs
     if first_party_fixed_argv:
         options["first_party_fixed_argv"] = True
     return await shielded_prepare_off_loop(

--- a/test/test_mcp_discovery.py
+++ b/test/test_mcp_discovery.py
@@ -2534,6 +2534,114 @@ class TestProbeTempContainment:
         assert not root.exists() or not any(root.iterdir())
 
     @pytest.mark.asyncio
+    async def test_probe_tmp_allocated_before_wrap_and_carved_out(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """#8653: the probe TMPDIR is allocated BEFORE the sandbox wrap, which
+        receives it as a write carve-out, and the spawn env points at it.
+
+        The managed probe root lives at ``<data home>/run/mcp-tmp``, inside the
+        runtime parent the sandbox seals read-only. A TMPDIR allocated after
+        the wrap is a directory the sandboxed child cannot write -- a
+        Bun-packaged server then fails the probe with "Cannot find the native
+        Koffi module" because it cannot extract its native module. Lock BOTH
+        halves of the fix: the ordering (alloc, then wrap) and the carve-out
+        kwarg naming the allocated dir.
+        """
+        import sys
+        from pathlib import Path
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+
+        calls: list[str] = []
+        real_alloc = bt.allocate_probe_tmp
+
+        def alloc_spy():
+            calls.append("alloc")
+            return real_alloc()
+
+        monkeypatch.setattr(bt, "allocate_probe_tmp", alloc_spy)
+
+        captured_wrap: dict = {}
+
+        def _wrap(argv, *a, env=None, **k):
+            calls.append("wrap")
+            captured_wrap.update(k)
+            return list(argv), dict(env if env is not None else os.environ), None
+
+        monkeypatch.setattr("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _wrap)
+
+        server = McpServerInfo(
+            name="order-lock", command=sys.executable, args=["-c", "pass"]
+        )
+        with patch(
+            "kiro_crew.mcp_discovery.create_subprocess_limited",
+            new_callable=AsyncMock,
+            side_effect=OSError("stop after env capture"),
+        ) as spawn_mock:
+            await probe_server(server)
+
+        assert calls == ["alloc", "wrap"]
+        carve = captured_wrap.get("extra_writable_dirs")
+        assert carve is not None and len(carve) == 1
+        scratch = Path(carve[0])
+        # The carve-out is the child-facing SCRATCH SUBDIR of the allocation,
+        # never the allocation root: the root holds the ``.owner`` reclamation
+        # record, which must stay OUTSIDE the child's writable window (a
+        # garbled ``.owner`` makes the dir unreclaimable by the daemon sweep).
+        assert scratch.name == bt.PROBE_SCRATCH_SUBDIR
+        allocated = scratch.parent
+        assert allocated.parent == home / "run" / "mcp-tmp"
+        owner = allocated / bt.OWNER_FILENAME
+        assert not str(owner).startswith(str(scratch) + os.sep)
+        # The managed triple lands on the env the child actually receives,
+        # pointing at the SAME dir the wrap carved out.
+        captured_env = spawn_mock.call_args.kwargs["env"]
+        assert captured_env["TMPDIR"] == str(scratch)
+
+    @pytest.mark.asyncio
+    async def test_probe_alloc_failure_wraps_without_carveout(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Containment is fail-open hygiene: when allocation fails, the probe
+        # must still run -- wrapped, with inherited temp and no carve-out.
+        import sys
+
+        from kiro_crew.mcp_gateway import backend_tmp as bt
+
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setattr(bt, "config_dir", lambda: home)
+        monkeypatch.setattr(
+            bt,
+            "allocate_probe_tmp",
+            MagicMock(side_effect=OSError("disk full")),
+        )
+
+        captured_wrap: dict = {}
+
+        def _wrap(argv, *a, env=None, **k):
+            captured_wrap.update(k)
+            return list(argv), dict(env if env is not None else os.environ), None
+
+        monkeypatch.setattr("kiro_crew.mcp_discovery.sandboxed_spawn_argv", _wrap)
+
+        server = McpServerInfo(
+            name="alloc-fail", command=sys.executable, args=["-c", "pass"]
+        )
+        result = await probe_server(server)
+
+        # The wrap ran (kwargs captured) and received no carve-out.
+        assert "extra_writable_dirs" not in captured_wrap
+        # And the probe was not diverted into an error about containment --
+        # whatever the handshake outcome, allocation failure is not the error.
+        assert "disk full" not in (result.error or "")
+
+    @pytest.mark.asyncio
     async def test_probe_drops_reserved_kirocrew_namespace_from_spec_env(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/test/test_sandbox_argv.py
+++ b/test/test_sandbox_argv.py
@@ -925,6 +925,196 @@ class TestBuildSeatbeltProfile:
         assert "file-link*" not in profile
 
 
+class TestWritableCarveouts:
+    """#8653: a probe's private TMPDIR must be writable inside the sandbox.
+
+    The MCP probe's TMPDIR lives at ``<data home>/run/mcp-tmp/<probe>``, inside
+    the runtime parent both backends seal read-only, so the wrap must carve
+    exactly that directory back out — a Bun-packaged server extracts its native
+    module into TMPDIR before it can answer the handshake. These tests lock the
+    carve-out's two properties: it OPENS the approved directory (emitted after
+    the seal — Seatbelt is last-match-wins) and it opens NOTHING else (the
+    validator refuses every candidate that would re-open another seal).
+    """
+
+    def _relocated_home(self, monkeypatch, tmp_path):
+        custom_home = tmp_path / "crew-home"
+        custom_home.mkdir()
+        monkeypatch.setattr(sandbox_mod, "config_dir", lambda: custom_home)
+        probe = custom_home / "run" / "mcp-tmp" / "probe-x"
+        probe.mkdir(parents=True)
+        return custom_home, probe
+
+    @staticmethod
+    def _spellings(path) -> list[str]:
+        lexical = os.path.normpath(str(path))
+        return list(dict.fromkeys((lexical, os.path.realpath(lexical))))
+
+    def test_seatbelt_carveout_allow_lands_after_run_seal(self, monkeypatch, tmp_path):
+        home, probe = self._relocated_home(monkeypatch, tmp_path)
+        profile = _build_seatbelt_profile(
+            "standard", extra_writable_dirs=(str(probe),)
+        )
+        deny = f'(deny file-write* (subpath "{home / "run"}"))'
+        assert deny in profile
+        for spelling in self._spellings(probe):
+            allow = f'(allow file-write* (subpath "{spelling}"))'
+            assert allow in profile
+            # Seatbelt is last-match-wins: the allow must come AFTER the seal,
+            # or the seal wins and the child's TMPDIR stays unwritable.
+            assert profile.index(allow) > profile.index(deny)
+        # The subtree's hardlink deny is deliberately NOT re-opened: a scratch
+        # dir never needs to mint hardlinks, and the deny is what stops
+        # aliasing a sealed inode into the writable window.
+        assert "(allow file-link" not in profile
+        assert "(allow file-read" not in profile
+
+    @pytest.mark.parametrize(
+        "candidate",
+        [
+            "run",  # the sealed parent itself: contains the voice runtime
+            os.path.join("run", "voice-runtime"),  # the hidden runtime root
+            "elsewhere",  # outside every carveable parent
+            os.path.join("run", "absent"),  # does not exist
+        ],
+    )
+    def test_seatbelt_refuses_unsafe_carveouts(self, monkeypatch, tmp_path, candidate):
+        home, _probe = self._relocated_home(monkeypatch, tmp_path)
+        (home / "elsewhere").mkdir()
+        profile = _build_seatbelt_profile(
+            "standard", extra_writable_dirs=(str(home / candidate),)
+        )
+        assert "(allow file-write*" not in profile
+
+    def test_seatbelt_refuses_relative_carveout(self, monkeypatch, tmp_path):
+        self._relocated_home(monkeypatch, tmp_path)
+        profile = _build_seatbelt_profile(
+            "standard", extra_writable_dirs=("run/mcp-tmp/probe-x",)
+        )
+        assert "(allow file-write*" not in profile
+
+    @_POSIX_ONLY
+    def test_launcher_embeds_validated_carveout(self, monkeypatch, tmp_path):
+        home, probe = self._relocated_home(monkeypatch, tmp_path)
+        script = _build_launcher_script(
+            "standard", extra_writable_dirs=(str(probe),)
+        )
+        expected = json.dumps(self._spellings(probe))
+        assert f"WRITABLE_DIRS = {expected}" in script
+        # Structural anchor (not prose): the carve-out loop's remount must
+        # clear the seal -- a remount that re-passed MS_RDONLY would silently
+        # keep the carve-out read-only. Scope the check to the loop body.
+        loop = self._writable_loop(script)
+        assert "_MS_REMOUNT | _MS_BIND" in loop
+        assert "_locked_mount_flags(target)" in loop
+        assert "_MS_RDONLY" not in loop
+
+    @staticmethod
+    def _writable_loop(script: str) -> str:
+        """The carve-out loop's body, anchored on structure, not prose.
+
+        ``EXPOSE_FILES`` is looped twice in the script (a pre-read before the
+        seals and the restore after them); anchor on the restore loop, i.e.
+        the first occurrence AFTER the carve-out loop starts.
+        """
+        start = script.index("for d in WRITABLE_DIRS:")
+        end = script.index("for src_path, filename in EXPOSE_FILES:", start)
+        return script[start:end]
+
+    @_POSIX_ONLY
+    def test_launcher_refuses_unsafe_carveout(self, monkeypatch, tmp_path):
+        home, _probe = self._relocated_home(monkeypatch, tmp_path)
+        script = _build_launcher_script(
+            "standard", extra_writable_dirs=(str(home / "run"),)
+        )
+        assert "WRITABLE_DIRS = []" in script
+
+    @_POSIX_ONLY
+    def test_launcher_seals_before_carveout_rebind(self, monkeypatch, tmp_path):
+        """The READONLY seal must precede the carve-out re-bind.
+
+        Load-bearing ordering: a non-recursive MS_BIND does not replicate
+        submounts, so a parent self-bind established AFTER the carve-out would
+        mask the carve-out mount entirely -- the writable window vanishes
+        silently and #8653 is back with no error.
+        """
+        home, probe = self._relocated_home(monkeypatch, tmp_path)
+        script = _build_launcher_script(
+            "standard", extra_writable_dirs=(str(probe),)
+        )
+        assert script.index("for d in READONLY_DIRS:") < script.index(
+            "for d in WRITABLE_DIRS:"
+        )
+
+    @_POSIX_ONLY
+    def test_launcher_carveout_mounts_fail_open(self, monkeypatch, tmp_path):
+        """The two carve-out mounts WIDEN access, so they must not route
+        through ``_mount_or_die``: a host refusing them keeps the seal
+        (pre-carve-out behavior) instead of losing every sandboxed probe."""
+        home, probe = self._relocated_home(monkeypatch, tmp_path)
+        script = _build_launcher_script(
+            "standard", extra_writable_dirs=(str(probe),)
+        )
+        loop = self._writable_loop(script)
+        assert "_mount_or_die" not in loop
+        assert "_mount_or_warn" in loop
+
+    @_POSIX_ONLY
+    def test_launcher_refuses_carveout_inside_unhidden_tree(
+        self, monkeypatch, tmp_path
+    ):
+        """A caller-re-exposed (``extra_visible_dirs``) tree must still refuse
+        a writable window: exposure cancels the hide, not the write seal, so
+        the validator's guard set must include the ``unhidden`` entries (the
+        ``+ unhidden`` term in the builder is load-bearing)."""
+        home, _probe = self._relocated_home(monkeypatch, tmp_path)
+        exposed = home / "run" / "exposed-tree"
+        inside = exposed / "scratch"
+        inside.mkdir(parents=True)
+        script = _build_launcher_script(
+            "standard",
+            extra_hidden_dirs=(str(exposed),),
+            extra_visible_dirs=(str(exposed),),
+            extra_writable_dirs=(str(inside),),
+        )
+        assert "WRITABLE_DIRS = []" in script
+
+    def test_symlinked_data_home_emits_both_spellings(self, monkeypatch, tmp_path):
+        """A symlinked data home (supported) must carve BOTH spellings:
+        Seatbelt rules are path-based and see each spelling independently."""
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        lexical_home = tmp_path / "linked-home"
+        os.symlink(real_home, lexical_home)
+        monkeypatch.setattr(sandbox_mod, "config_dir", lambda: lexical_home)
+        probe = lexical_home / "run" / "mcp-tmp" / "probe-x"
+        probe.mkdir(parents=True)
+        lexical = os.path.normpath(str(probe))
+        canonical = os.path.realpath(lexical)
+        assert lexical != canonical  # the premise of the test
+        profile = _build_seatbelt_profile(
+            "standard", extra_writable_dirs=(str(probe),)
+        )
+        for spelling in (lexical, canonical):
+            assert f'(allow file-write* (subpath "{spelling}"))' in profile
+
+    def test_validator_refuses_dir_inside_hidden_tree(self, monkeypatch, tmp_path):
+        """A carve-out under a read-hidden tree must be refused even when a
+        (buggy or hostile) caller also names that tree as a carveable parent:
+        write access without read access is still a tampering channel."""
+        home, _probe = self._relocated_home(monkeypatch, tmp_path)
+        hidden = home / "run" / "secrets"
+        inside = hidden / "scratch"
+        inside.mkdir(parents=True)
+        approved = sandbox_mod._writable_carveout_spellings(
+            (str(inside),),
+            subtree_guards=[str(hidden)],
+            literal_guards=[],
+            carveable_parents=[str(home / "run")],
+        )
+        assert approved == []
+
+
 class TestBuildLauncherScript:
     @_POSIX_ONLY
     def test_strict_script_contains_dirs(self):

--- a/test/test_sandbox_mount_checked.py
+++ b/test/test_sandbox_mount_checked.py
@@ -72,6 +72,7 @@ _LANDMARKS = (
     "# Private mount propagation",  # the propagation site
     "for d in SENSITIVE_DIRS:",  # the credential-dir loop
     "for d in READONLY_DIRS:",  # the read-only exposure loop
+    "for d in WRITABLE_DIRS:",  # the write carve-out loop (#8653, fail-open)
     "for f in SENSITIVE_FILES:",  # the sensitive-file loop
     "if HIDE_SSH and os.path.isdir(SSH_DIR):",  # the .ssh block
     "sandbox: BLOCKED",  # the refusal
@@ -131,6 +132,7 @@ def _run(
     fail_at: int | None,
     err: int = errno.EPERM,
     script: str | None = None,
+    writable_dirs: list[str] | None = None,
 ) -> tuple[_FakeLibc, str | None]:
     """Run the mount region. Returns ``(fake_libc, refusal_message_or_None)``.
 
@@ -181,6 +183,9 @@ def _run(
         "EXPOSE_FILES": [],
         "SENSITIVE_DIRS": [str(aws)],
         "READONLY_DIRS": [str(cache)],
+        # Empty by default so the six-site call numbering above stays stable;
+        # the carve-out tests inject their own entry (#8653).
+        "WRITABLE_DIRS": list(writable_dirs or []),
         "SENSITIVE_FILES": [str(lone)],
         "SSH_DIR": str(ssh),
         "SSH_KNOWN_HOSTS": str(ssh / "known_hosts"),
@@ -303,6 +308,57 @@ def test_every_tier_routes_all_six_mounts_through_the_guard() -> None:
 
 
 # --------------------------------------------------------------------------
+# Write carve-out (#8653): the ONE access-WIDENING pair, and it fails OPEN
+# --------------------------------------------------------------------------
+
+
+def _carveout_home(tmp_path: Path) -> str:
+    scratch = tmp_path / "home" / "run" / "mcp-tmp" / "probe-x" / "tmp"
+    scratch.mkdir(parents=True)
+    return str(scratch)
+
+
+def test_carveout_mounts_run_and_spawn_proceeds(tmp_path: Path) -> None:
+    """Healthy path: the pair runs (bind + rw remount) and nothing refuses."""
+    scratch = _carveout_home(tmp_path)
+    libc, refusal = _run(tmp_path, fail_at=None, writable_dirs=[scratch])
+    assert refusal is None
+    # six guarded sites + the carve-out bind + its rw remount
+    assert len(libc.calls) == 8
+    bind, remount = libc.calls[4], libc.calls[5]
+    assert bind[1] == scratch.encode() and remount[1] == scratch.encode()
+    # The remount clears the seal: MS_RDONLY must NOT be re-passed.
+    _MS_RDONLY, _MS_REMOUNT = 1, 32
+    assert remount[2] & _MS_REMOUNT
+    assert not remount[2] & _MS_RDONLY
+
+
+@pytest.mark.parametrize("fail_at", [5, 6], ids=["carveout-bind", "carveout-remount"])
+def test_a_failed_carveout_mount_degrades_open(
+    tmp_path: Path, fail_at: int, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The carve-out pair WIDENS access, so its failure must not refuse.
+
+    A refused carve-out means the path stays sealed -- the pre-#8653 behavior,
+    whose one consequence is an unwritable probe temp dir. The spawn must
+    proceed (the remaining hiding mounts still run and still refuse on their
+    own failures), and the operator gets the classifier's ADVISORY severity,
+    not a fatal one.
+    """
+    scratch = _carveout_home(tmp_path)
+    libc, refusal = _run(tmp_path, fail_at=fail_at, writable_dirs=[scratch])
+    assert refusal is None, "an access-widening mount failure must not refuse"
+    # The hiding mounts AFTER the carve-out still ran: sensitive file + ssh,
+    # and on a failed bind the pointless remount is skipped.
+    expected_calls = 7 if fail_at == 5 else 8
+    assert len(libc.calls) == expected_calls
+    advisory = capsys.readouterr().err
+    assert "sandbox: WARNING" in advisory
+    assert "writable carve-out" in advisory
+    assert "sandbox: BLOCKED" not in advisory
+
+
+# --------------------------------------------------------------------------
 # Break-arms: one mutation per assertion above
 # --------------------------------------------------------------------------
 
@@ -343,8 +399,10 @@ _ARMS: dict[str, tuple[str, str]] = {
         "_libc.mount(ssh_tmp, SSH_DIR.encode(), None, _MS_BIND, None)",
     ),
     "happy_path": (
-        "if _libc.mount(source, target, None, flags, None) != 0:",
-        "if _libc.mount(source, target, None, flags, None) == 0:",
+        "if _libc.mount(source, target, None, flags, None) != 0:\n"
+        "        _err = ctypes.get_errno()",
+        "if _libc.mount(source, target, None, flags, None) == 0:\n"
+        "        _err = ctypes.get_errno()",
     ),
     "drop_errno": (
         '"sandbox: BLOCKED -- %s failed: errno %d (%s). The sandbox could not "',


### PR DESCRIPTION
## Summary

Fixes #8653: on macOS the MCP Connections probe handed a Bun-packaged server a `TMPDIR` it could not write, so Bun failed to extract its native Koffi module and the probe reported `Cannot find the native Koffi module` while the same server worked outside the probe.

Root cause (verified on-source): `allocate_probe_tmp()` places the probe's private temp dir at `<data home>/run/mcp-tmp/<probe>` — inside the runtime parent that **both** sandbox backends seal read-only (macOS: `(deny file-write* (subpath <home>/run))` via `_voice_runtime_parent_paths`; Linux: RDONLY bind remount in the launcher's `READONLY_DIRS`). The issue's suggested reorder alone is inert — the profile builder never read `TMPDIR` — so the fix is both halves:

1. **Reorder**: allocate the probe temp dir *before* `sandboxed_spawn_argv_async` (`src/kiro_crew/mcp_discovery.py`), so the wrap can know it.
2. **Validated write carve-out**: new keyword-only `extra_writable_dirs` on the sandboxed-spawn chokepoint, threaded to both backends:
   - Seatbelt emits `(allow file-write* (subpath …))` **after** every deny (last-match-wins), both lexical and canonical spellings; the subtree's `file-link` deny stays in force.
   - The Linux launcher re-binds the dir over itself **after** the READONLY seal (a non-recursive parent self-bind established later would mask the carve-out mount) and remounts the bind read-write, re-asserting kernel-locked `nosuid`/`nodev`/`noexec`. These two access-*widening* mounts fail **open** (path stays sealed, spawn proceeds), unlike the sealing `_mount_or_die` mounts.
   - `_writable_carveout_spellings` refuses any candidate outside the sealed runtime parent, any that would re-open a hidden tree / read-only ceiling / the voice runtime / a sealed file, and any that does not exist. Refusals log a `SECURITY:` warning and degrade to today's sealed behavior.
3. The child receives a **scratch subdir** (`<alloc>/tmp`) rather than the allocation root, keeping the `.owner` reclamation record outside the writable window (a garbled `.owner` would make the dir unreclaimable by the daemon sweep after a gateway crash).

## Ground truth

The dev host denies unprivileged userns, so measurements ran the **real generated launcher** inside a privileged container (results identical in a nested unprivileged userns):

| Check | Result |
|---|---|
| No carve-out: write into probe TMPDIR | **EROFS** (the reported bug's mechanism) |
| With carve-out: write into scratch subdir | **succeeds** |
| With carve-out: write `.owner`, `run/`, `run/voice-runtime` | all **sealed** |
| Validator: candidate = `run`, voice-runtime, outside tree, absent dir, unhidden tree, relative path | all **refused** |

macOS Seatbelt cannot be executed on the dev host; the allow-after-deny ordering is pinned by tests against the generated profile text (Seatbelt is last-match-wins, the same property `(allow default)` + denies already relies on).

## Testing

- 9 mutation directions, each caught by a distinct test: revert the reorder; drop the allow emission; emit the allow before the denies; weaken the guard (parent approved); re-pass `MS_RDONLY` on the unseal remount; drop the `WRITABLE_DIRS` embed; swap the READONLY/WRITABLE loop order; drop the `+ unhidden` guard term; drop the canonical spelling.
- Affected suites green: `test_sandbox_argv.py`, `test_mcp_discovery.py`, `test_backend_tmp.py`, `test_spawn_audit.py`, `test_sandbox_governance_mask.py`, `test_sandbox_cc_mode.py`, `test_papyrus_latex.py`, `test_kiro_prerequisite.py`, `test_governance_distribution.py`, CPP wiring suites (1600+ tests).
- All local gates green with CI-pinned tools: black-baseline, isort, flake8, mypy, subprocess-encoding, brand, harness parity.

## Pre-push AI review

Two model-pinned lanes reviewed the commit; all verified findings addressed:

- **GPT (BLOCKING → extracted)**: a *spec-declared* `TMPDIR` pointing inside the sealed runtime parent remains unwritable. Pre-existing (before this fix, declared *and* managed temps were both unwritable there; this PR changes only the managed path) and needs a design decision (reject vs substitute vs warn) that must not be made by silently carving out untrusted config paths — extracted to a follow-up issue.
- **Opus (CONCERNS, all addressed)**: `.owner` inside the writable window → child now gets a scratch subdir; carve-out mounts failed closed → now fail open; wrong comment about the `+ unhidden` guard term → corrected and pinned by a new test; load-bearing loop ordering untested → pinned by a new test with the stronger (mount-masking) rationale in the comment; overbroad `MNT_LOCK_READONLY` claim → reworded; case-sensitivity and off-loop notes added to the validator docstring; symlinked-data-home dual-spelling now pinned by a test.
- Opus also surfaced a **pre-existing** exposure: the `run` self-bind masks the earlier `run/voice-runtime` empty-dir hide, re-exposing the real directory read-only inside the sandbox. Confirmed in a container with a pristine (no-carve-out) launcher; this PR does not touch either loop — extracted to a follow-up issue.

## Tests section

See Testing above; all evidence measured, none simulated.

## Pattern harvest

Rule candidate: any resource path handed to a sandboxed child (temp dir, socket dir, workdir) must be allocated BEFORE the sandbox profile/launcher is generated and explicitly carved out of whichever seal covers it -- allocate-then-wrap, never wrap-then-allocate, because path-based confinement snapshots the world at build time and a post-snapshot allocation lands inside a seal with no rule that knows it.
Class: resource allocated after the confinement snapshot that governs it. Sibling instances found and extracted: #8747 (spec-declared TMPDIR inside the sealed parent, pre-existing), #8748 (mount-ordering masks an earlier hide, pre-existing).
