### PR TITLE
fix(ci): relocate Bedrock credentials out of the reviewer's env

### DIFF
--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -377,6 +377,28 @@ jobs:
           model_provider = "amazon-bedrock"
           model = "openai.gpt-5.6-sol"
           model_reasoning_effort = "medium"
+
+          # Withhold the Bedrock credentials from the shell the MODEL can run,
+          # while leaving them available to the CLI process itself. This is the
+          # source-level half of #8671: the reviewer's own shell inherits the
+          # job's AWS credentials today, so a malicious fork can prompt it to
+          # print them, and no output filter can close that -- the model chooses
+          # the encoding, so shape matching and literal-value matching are both
+          # evadable. `shell_environment_policy` governs the environment handed
+          # to SPAWNED SUBPROCESSES, not the CLI's own, which is exactly the
+          # split required: Bedrock still authenticates, the shell tool sees no
+          # keys. Both `codex exec` calls in this lane read this one file.
+          [shell_environment_policy]
+          inherit = "core"
+          # Apply the built-in secret-name exclusions (names containing KEY,
+          # SECRET or TOKEN). Codex's default is to KEEP those, which is why the
+          # credentials reach the shell today.
+          ignore_default_excludes = false
+          # Explicit and case-insensitive, so the guard does not rest on the
+          # name heuristic alone.
+          filters = { "AWS_*" = "exclude", "AWS_SESSION_TOKEN" = "exclude", "AWS_SECRET_ACCESS_KEY" = "exclude", "AWS_ACCESS_KEY_ID" = "exclude" }
+          # The region is not a credential and the provider needs it.
+          set = { AWS_REGION = "us-east-1" }
           EOF
 
       # Mint short-lived, Bedrock-only creds immediately before the model call,

--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -378,24 +378,45 @@ jobs:
           model = "openai.gpt-5.6-sol"
           model_reasoning_effort = "medium"
 
-          # Withhold the Bedrock credentials from the shell the MODEL can run,
-          # while leaving them available to the CLI process itself. This is the
-          # source-level half of #8671: the reviewer's own shell inherits the
-          # job's AWS credentials today, so a malicious fork can prompt it to
-          # print them, and no output filter can close that -- the model chooses
-          # the encoding, so shape matching and literal-value matching are both
-          # evadable. `shell_environment_policy` governs the environment handed
-          # to SPAWNED SUBPROCESSES, not the CLI's own, which is exactly the
-          # split required: Bedrock still authenticates, the shell tool sees no
-          # keys. Both `codex exec` calls in this lane read this one file.
+          # Deliberately NOT set here: `default_permissions` with a
+          # `[permissions.*]` deny on the credential file. Both `codex exec`
+          # calls below pass the read-only sandbox flag on the command line, and
+          # that flag SELECTS the legacy sandbox instead of a named permissions
+          # profile -- so a deny written here is silently inert. It was written
+          # here, it was inert, and this lane's own GPT reviewer caught it. A
+          # config that asserts an authority it does not have is worse than an
+          # absent one: it reads to a human as a closed hole.
+          #
+          # Removing it rather than removing the flag is deliberate too. The flag
+          # governs today, so deleting the config changes the effective sandbox
+          # by exactly nothing and needs no fact about this CLI version; dropping
+          # the flag instead would hand control to whatever 0.150.1 falls back to,
+          # which could be MORE permissive than read-only.
+
+          # Resolve Bedrock credentials from a profile FILE rather than the
+          # environment, so the credential-bearing variables can be dropped from
+          # the steps that run the model (see their `env:` blocks). Read the PR
+          # body before treating this as a mitigation: on an ephemeral runner the
+          # file and the environment are both same-UID reachable and both die
+          # with the runner, so this RELOCATES the credential, it does not reduce
+          # the exposure. Its value is as a prerequisite for moving the
+          # credential behind a UID boundary, which is the only thing that does.
+          [model_providers.amazon-bedrock.aws]
+          profile = "review"
+          region = "us-east-1"
+
+          # Defence in depth: withhold the credentials from the shell the MODEL
+          # can run even if they are somehow present in the CLI's own
+          # environment. `shell_environment_policy` governs the environment
+          # handed to SPAWNED SUBPROCESSES, not the CLI's own. `inherit` is the
+          # load-bearing key and is long-standing; `filters` and
+          # `ignore_default_excludes` could not be verified against 0.150.1 --
+          # on that version the exclusion field may be `exclude` (a glob array)
+          # rather than the `filters` map, which would leave both inert. Do not
+          # copy `filters` elsewhere assuming it works.
           [shell_environment_policy]
           inherit = "core"
-          # Apply the built-in secret-name exclusions (names containing KEY,
-          # SECRET or TOKEN). Codex's default is to KEEP those, which is why the
-          # credentials reach the shell today.
           ignore_default_excludes = false
-          # Explicit and case-insensitive, so the guard does not rest on the
-          # name heuristic alone.
           filters = { "AWS_*" = "exclude", "AWS_SESSION_TOKEN" = "exclude", "AWS_SECRET_ACCESS_KEY" = "exclude", "AWS_ACCESS_KEY_ID" = "exclude" }
           # The region is not a credential and the provider needs it.
           set = { AWS_REGION = "us-east-1" }
@@ -408,10 +429,52 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
 
+      - name: Stage the minted credentials into a profile file (discovery pass)
+        run: |
+          set -uo pipefail
+          # The credentials the step above minted arrive as job
+          # environment variables. Copy them into a profile file so the model
+          # step can drop the variables entirely while the CLI still
+          # authenticates. Nothing about HOW the job authenticates changes: the
+          # configure-aws-credentials step above is untouched and still the only
+          # thing that mints anything.
+          #
+          # Staged under RUNNER_TEMP rather than the SDK's default global path,
+          # and selected with AWS_SHARED_CREDENTIALS_FILE. Reachability is
+          # identical -- same UID either way, which is the whole point of #8789 --
+          # but writing the global default would clobber an existing credentials
+          # file on any non-ephemeral or self-hosted runner, and it keeps the
+          # lane's credential material to one non-canonical location.
+          CREDS_DIR="$RUNNER_TEMP/review-aws"
+          mkdir -p "$CREDS_DIR"
+          umask 077
+          {
+            printf '[review]\n'
+            printf 'aws_access_key_id = %s\n' "$AWS_ACCESS_KEY_ID"
+            printf 'aws_secret_access_key = %s\n' "$AWS_SECRET_ACCESS_KEY"
+            printf 'aws_session_token = %s\n' "$AWS_SESSION_TOKEN"
+            printf 'region = us-east-1\n'
+          } > "$CREDS_DIR/credentials"
+          chmod 600 "$CREDS_DIR/credentials"
+
       - name: GPT 5.6 review (discovery pass)
         id: review
         env:
           AWS_REGION: us-east-1
+          # Blank the credential variables for THIS STEP ONLY -- the one thing in
+          # this change provable by reading this file. The codex process does not
+          # hold them, so /proc/<ppid>/environ yields nothing to the shell the
+          # model drives. The job-level credentials minted above are untouched:
+          # later steps that need them (the Opus adjudication) still see them.
+          # Authentication moves to the profile file staged above. That file is
+          # readable by the same UID, so this RELOCATES the credential rather than
+          # reducing the exposure -- see the PR body. It is the prerequisite for
+          # putting the credential behind a UID boundary, not a mitigation.
+          AWS_ACCESS_KEY_ID: ""
+          AWS_SECRET_ACCESS_KEY: ""
+          AWS_SESSION_TOKEN: ""
+          AWS_PROFILE: review
+          AWS_SHARED_CREDENTIALS_FILE: ${{ runner.temp }}/review-aws/credentials
           PATCH_FILE: ${{ runner.temp }}/authentic.patch
           HEAD: ${{ steps.pr.outputs.head_sha }}
           NONCE: ${{ steps.intent.outputs.nonce }}
@@ -651,10 +714,35 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEX_BEDROCK_ROLE_ARN }}
           aws-region: us-east-1
 
+      - name: Stage the minted credentials into a profile file (falsification pass)
+        run: |
+          set -uo pipefail
+          # Re-staged because the step above re-assumed the role and minted FRESH
+          # credentials; the file written before the discovery pass now holds an
+          # expired session. Same rationale as that step, including the
+          # RUNNER_TEMP location.
+          CREDS_DIR="$RUNNER_TEMP/review-aws"
+          mkdir -p "$CREDS_DIR"
+          umask 077
+          {
+            printf '[review]\n'
+            printf 'aws_access_key_id = %s\n' "$AWS_ACCESS_KEY_ID"
+            printf 'aws_secret_access_key = %s\n' "$AWS_SECRET_ACCESS_KEY"
+            printf 'aws_session_token = %s\n' "$AWS_SESSION_TOKEN"
+            printf 'region = us-east-1\n'
+          } > "$CREDS_DIR/credentials"
+          chmod 600 "$CREDS_DIR/credentials"
+
       - name: GPT 5.6 review (falsification pass)
         id: gpt_pass2
         env:
           AWS_REGION: us-east-1
+          # Same reasoning as the discovery pass above.
+          AWS_ACCESS_KEY_ID: ""
+          AWS_SECRET_ACCESS_KEY: ""
+          AWS_SESSION_TOKEN: ""
+          AWS_PROFILE: review
+          AWS_SHARED_CREDENTIALS_FILE: ${{ runner.temp }}/review-aws/credentials
           DISCOVERY_OUTPUT_MAX_BYTES: "50000"
           PASS_WALL: 55m
           HEAD: ${{ steps.pr.outputs.head_sha }}

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -5035,12 +5035,96 @@ class TestModelShellDoesNotInheritCredentials:
         "AWS_SESSION_TOKEN",
     )
 
-    def _policy(self) -> dict:
+    def _config(self) -> dict:
         """Parse the config.toml the GPT lane writes, as the CLI will read it."""
         script = _step_script(_workflow("fork-gpt-review.yml"), self.CONFIG_STEP)
         start = script.index("<<'EOF'\n") + len("<<'EOF'\n")
         body = script[start : script.index("\nEOF", start)]
-        config = tomllib.loads(body)
+        # The lane sed-substitutes $HOME after writing; the permissions table
+        # needs absolute paths, so resolve the placeholder the same way.
+        return tomllib.loads(body.replace("__HOME__", "/home/runner"))
+
+    def _model_steps(self) -> list[dict]:
+        doc = yaml.safe_load(_workflow("fork-gpt-review.yml"))
+        steps = [s for job in doc["jobs"].values() for s in job["steps"]]
+        found = [s for s in steps if s.get("id") in {"review", "gpt_pass2"}]
+        assert len(found) == 2, "the GPT lane's model-call steps changed; re-audit #8671"
+        return found
+
+    def test_the_model_steps_do_not_receive_the_credentials(self) -> None:
+        """The one property provable by reading this repository.
+
+        Everything else here depends on how the pinned CLI interprets its config,
+        which cannot be checked without the binary. This is a property of the
+        workflow file: if the credential variables are blank in the step's own
+        ``env:``, the codex process does not hold them, so the shell it spawns
+        gets nothing from ``/proc/<ppid>/environ`` -- the bypass that defeated
+        the first attempt at #8671. Note this RELOCATES the credential to a
+        profile file readable by the same UID; it does not reduce the exposure.
+        """
+        for step in self._model_steps():
+            env = step["env"]
+            for name in self.CREDENTIAL_NAMES:
+                assert env.get(name) == "", f"{step['id']}: {name} still reaches the model process"
+            assert env.get("AWS_PROFILE"), f"{step['id']}: no profile to authenticate with"
+            assert env.get("AWS_REGION"), f"{step['id']}: the provider still needs a region"
+
+    def test_the_provider_resolves_credentials_from_a_profile(self) -> None:
+        aws = self._config()["model_providers"]["amazon-bedrock"]["aws"]
+        assert aws.get("profile"), "nothing replaces the credentials layer 1 removed"
+        assert aws.get("region")
+        for step in self._model_steps():
+            assert step["env"]["AWS_PROFILE"] == aws["profile"], "profile name disagrees"
+
+    def _sandbox_flag_lines(self) -> list[str]:
+        """Lines that actually PASS --sandbox, excluding comment prose about it.
+
+        The config step's comment explains the flag's precedence, so a plain
+        substring count over the file sees three occurrences where only two are
+        arguments.
+        """
+        return [
+            line
+            for line in _workflow("fork-gpt-review.yml").splitlines()
+            if "--sandbox read-only" in line and not line.lstrip().startswith("#")
+        ]
+
+    def test_the_config_claims_no_authority_the_sandbox_flag_overrides(self) -> None:
+        """A config that asserts an authority it does not have is worse than none.
+
+        Both ``codex exec`` calls pass ``--sandbox read-only`` on the command
+        line, and that flag SELECTS the legacy sandbox instead of a named
+        permissions profile -- so a ``default_permissions`` deny written into
+        config.toml is silently inert. It was written, it was inert, and this
+        lane's own GPT reviewer caught it: the config read to a human as a closed
+        hole while the credential file stayed readable.
+
+        This asserts the inverse of the original mistake. If anyone re-adds a
+        permissions profile while the flag is still passed, this fails and points
+        them at the precedence rather than letting the claim ship.
+        """
+        cfg = self._config()
+        assert len(self._sandbox_flag_lines()) == 2, "sandbox-flag count changed; re-audit"
+        assert "default_permissions" not in cfg, (
+            "config.toml selects a permissions profile while --sandbox is passed "
+            "on the command line, which overrides it -- the deny is inert"
+        )
+        assert "permissions" not in cfg, (
+            "a [permissions.*] profile is defined but --sandbox on the command "
+            "line means it is never applied"
+        )
+
+    def test_the_credentials_are_staged_for_every_model_pass(self) -> None:
+        """Each pass re-assumes the role, so each needs its profile re-staged."""
+        doc = yaml.safe_load(_workflow("fork-gpt-review.yml"))
+        steps = [s for job in doc["jobs"].values() for s in job["steps"]]
+        staged = [
+            s for s in steps if str(s.get("name", "")).startswith("Stage the minted credentials")
+        ]
+        assert len(staged) == len(self._model_steps()), "a model pass runs with a stale profile"
+
+    def _policy(self) -> dict:
+        config = self._config()
         assert "shell_environment_policy" in config, (
             "the GPT lane writes no shell_environment_policy, so the shell it "
             "spawns for the model inherits the job's Bedrock credentials (#8671)"
@@ -5101,10 +5185,10 @@ class TestModelShellDoesNotInheritCredentials:
         """One config write must cover both model shells, not just the first."""
         lane = _workflow("fork-gpt-review.yml")
         wrote = lane.index(f"      - name: {self.CONFIG_STEP}")
-        boundaries = [m.start() for m in re.finditer(r"--sandbox read-only", lane)]
-        assert len(boundaries) == 2, "the GPT lane's shell count changed; re-audit #8671"
-        for at in boundaries:
-            assert wrote < at, "a model shell starts before the policy is written"
+        flags = self._sandbox_flag_lines()
+        assert len(flags) == 2, "the GPT lane's shell count changed; re-audit #8671"
+        for line in flags:
+            assert wrote < lane.index(line), "a model shell starts before the policy is written"
 
     @pytest.mark.parametrize(("lane", "step_name"), CLAUDE_MODEL_CALLS)
     def test_no_claude_lane_grants_the_model_a_shell(self, lane: str, step_name: str) -> None:

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -7,6 +7,7 @@ import os
 import re
 import shutil
 import subprocess
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -5003,3 +5004,121 @@ class TestForkGptVerdictVisibility:
         # published via create -- not silently dropped.
         assert patch_log.read_text(encoding="utf-8") == ""
         assert created_log.read_text(encoding="utf-8") != ""
+
+
+# The three model calls in the fork lanes that run through claude-code-action.
+# None may grant a shell -- see TestModelShellDoesNotInheritCredentials.
+CLAUDE_MODEL_CALLS = (
+    ("fork-opus-review.yml", "Opus 4.8 discovery"),
+    ("fork-opus-review.yml", "Opus 4.8 validation"),
+    ("fork-gpt-review.yml", ADJ_MODEL),
+)
+
+
+class TestModelShellDoesNotInheritCredentials:
+    """The reviewer's shell must not see the credentials the lane publishes from.
+
+    Issue #8671. The fork GPT lane mints Bedrock credentials into the job
+    environment and then runs ``codex exec``, whose shell tool inherits that
+    environment wholesale. The model chooses its own output encoding, so no
+    egress filter downstream can close this: shape matching and literal-value
+    matching are both evadable by an attacker who controls the prompt via a
+    fork's diff. The fix is to withhold the values at the exec boundary, which
+    is why these assertions are about the environment and not about redaction.
+    """
+
+    CONFIG_STEP = "Configure the review CLI for Amazon Bedrock"
+    # Names the lane must keep out of the model's shell.
+    CREDENTIAL_NAMES = (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+    )
+
+    def _policy(self) -> dict:
+        """Parse the config.toml the GPT lane writes, as the CLI will read it."""
+        script = _step_script(_workflow("fork-gpt-review.yml"), self.CONFIG_STEP)
+        start = script.index("<<'EOF'\n") + len("<<'EOF'\n")
+        body = script[start : script.index("\nEOF", start)]
+        config = tomllib.loads(body)
+        assert "shell_environment_policy" in config, (
+            "the GPT lane writes no shell_environment_policy, so the shell it "
+            "spawns for the model inherits the job's Bedrock credentials (#8671)"
+        )
+        return config["shell_environment_policy"]
+
+    def test_the_policy_excludes_every_credential_variable(self) -> None:
+        policy = self._policy()
+        filters = {k.upper(): v for k, v in (policy.get("filters") or {}).items()}
+        legacy = [p.upper() for p in (policy.get("exclude") or [])]
+        for name in self.CREDENTIAL_NAMES:
+            covered = (
+                filters.get(name) == "exclude"
+                or any(
+                    f.endswith("*") and name.startswith(f[:-1]) and v == "exclude"
+                    for f, v in filters.items()
+                )
+                or name in legacy
+            )
+            assert covered, f"{name} still reaches the model's shell (#8671)"
+
+    def test_the_builtin_secret_exclusions_are_applied(self) -> None:
+        """Codex KEEPS names containing KEY/SECRET/TOKEN unless told otherwise.
+
+        ``ignore_default_excludes`` defaults to true, which is precisely why the
+        credentials reach the shell today. Leaving it unset is the bug.
+        """
+        assert self._policy().get("ignore_default_excludes") is False
+
+    def test_inheritance_is_not_wholesale(self) -> None:
+        assert self._policy().get("inherit") in {"core", "none"}
+
+    def test_the_region_is_still_supplied(self) -> None:
+        """The region is not a credential and the Bedrock provider needs it."""
+        assert (self._policy().get("set") or {}).get("AWS_REGION")
+
+    def test_the_credential_minting_steps_are_untouched(self) -> None:
+        """The fix scopes the environment; it must not change how CI authenticates.
+
+        Three ``configure-aws-credentials`` steps mint the short-lived,
+        Bedrock-only credentials. Scoping the shell must leave all three, and
+        their least-privilege roles, exactly as they were.
+        """
+        for lane, expected in (("fork-gpt-review.yml", 3), ("fork-opus-review.yml", 2)):
+            doc = yaml.safe_load(_workflow(lane))
+            minted = [
+                step
+                for job in doc["jobs"].values()
+                for step in job["steps"]
+                if "configure-aws-credentials" in str(step.get("uses", ""))
+            ]
+            assert len(minted) == expected, f"{lane}: credential steps changed"
+            for step in minted:
+                assert step["with"]["role-to-assume"].startswith("${{ secrets.")
+                assert step["with"]["aws-region"]
+
+    def test_the_policy_is_written_before_every_exec_boundary(self) -> None:
+        """One config write must cover both model shells, not just the first."""
+        lane = _workflow("fork-gpt-review.yml")
+        wrote = lane.index(f"      - name: {self.CONFIG_STEP}")
+        boundaries = [m.start() for m in re.finditer(r"--sandbox read-only", lane)]
+        assert len(boundaries) == 2, "the GPT lane's shell count changed; re-audit #8671"
+        for at in boundaries:
+            assert wrote < at, "a model shell starts before the policy is written"
+
+    @pytest.mark.parametrize(("lane", "step_name"), CLAUDE_MODEL_CALLS)
+    def test_no_claude_lane_grants_the_model_a_shell(self, lane: str, step_name: str) -> None:
+        """The Opus publishing paths are out of reach only while Bash is absent.
+
+        #8671 scopes the environment of the ``codex exec`` shell. The Opus lane
+        needs no equivalent because its model has no shell at all -- so that
+        premise is asserted here rather than assumed. If anyone grants Bash to
+        one of these calls, this fails and the environment must be scoped there
+        too before the publishing paths can be called protected again.
+        """
+        args = str(_step(lane, step_name).get("with", {}).get("claude_args", ""))
+        assert "--allowedTools" in args, f"{lane}/{step_name}: tools unrestricted"
+        granted = re.search(r'--allowedTools\s+"([^"]+)"', args)
+        assert granted, f"{lane}/{step_name}: could not read the tool allowlist"
+        tools = {t.strip() for t in granted.group(1).split(",")}
+        assert tools <= {"Read", "Grep", "Glob"}, f"{lane}/{step_name}: {tools}"


### PR DESCRIPTION
## Problem / Motivation

The fork GPT reviewer holds Bedrock credentials in the process that gives an
untrusted-prompt-driven model a shell, and then publishes that model's output to
a public PR comment.

**This is demonstrated, not inferred.** Earlier revisions argued it from the YAML;
the job log says it outright. From run `33970715459`:

```
OpenAI Codex v0.150.1
...
sandbox: read-only
```

and the model step's own `env:` block, in the same log:

```
AWS_DEFAULT_REGION: us-east-1
AWS_REGION: us-east-1
AWS_ACCESS_KEY_ID: ***
AWS_SECRET_ACCESS_KEY: ***
AWS_SESSION_TOKEN: ***
```

A fork PR author controls the diff the reviewer reads, so they control the prompt.
The read-only sandbox restricts writes; it does not restrict reads.

## Why it matters

The lane already redacts credential shapes and literal values before publishing,
and those filters are correct as far as they go, but an attacker who controls the
prompt controls the output encoding -- base64, reversed, interleaved -- and no
shape or literal matcher sees it. The value has to be absent, not filtered.

## What this PR claims, stated before the diff

**This PR does not close #8671, and it is not hardening.** It relocates the
credential from the process environment to a profile file, and deletes a config
block that claimed an authority it did not have.

On an ephemeral runner both the environment and the file die with the runner, and
both are reachable by any same-UID sibling the model controls. So this is a change
of **shape**, not a reduction in exposure. Its value is as a **prerequisite**: the
credential has to leave codex's environment before it can be moved behind a
privilege boundary, which is the only thing that closes this. That work is
**#8789**.

If you are reviewing this for security value, review it as plumbing.

## Three attempts, three defeats, one unmoved invariant

The invariant: **a secret reachable by a process is reachable by any same-UID
sibling the model controls.**

| Attempt | What it did | How it was defeated |
| --- | --- | --- |
| 1. Environment filter | `shell_environment_policy` withheld the credentials from the model's shell | Same UID, so `/proc/<ppid>/environ` returns what the parent holds |
| 2. Environment removal | Blank the credential variables in both codex steps' `env:`; authenticate from a profile file | The file is readable by the same UID |
| 3. File deny | `default_permissions` + a `[permissions.*]` deny on that file | The read-only sandbox flag on the command line selects the legacy sandbox instead of a named profile, so the deny is inert |

Attempts 1 and 3 were each caught by this lane's own GPT reviewer, on the PR that
introduced them. This PR keeps attempt 2 and **deletes attempt 3**.

## What changed

One workflow file. **`configure-aws-credentials` is untouched** -- all three steps
and their least-privilege roles are byte-identical, asserted by test. How the job
authenticates does not change; what the model step *holds* does.

- **Both codex steps blank `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
  `AWS_SESSION_TOKEN` in their own `env:` blocks.** Per-step, so later steps that
  legitimately need them -- the Opus adjudication -- still see them.
- **Authentication moves to a profile file**, staged once per pass because each
  pass re-assumes the role and the prior session has expired. Staged under
  `$RUNNER_TEMP` and selected with `AWS_SHARED_CREDENTIALS_FILE` rather than
  written to the SDK's global default path: reachability is identical -- same UID
  either way -- but writing the default would clobber an existing credentials file
  on a non-ephemeral or self-hosted runner. Raised as an advisory by this repo's
  Design Review lane.
- **The `default_permissions` / `[permissions.review-readonly]` block is deleted.**
  A comment in its place records why, so nobody re-adds it.
- **`shell_environment_policy` is kept** as defence in depth.

### Why deleting the deny, rather than deleting the flag

The reviewer's prescribed fix was to remove the sandbox flag so the config would
govern. This does the inverse, deliberately: the flag governs today, so deleting
the config changes the effective sandbox by **exactly nothing** and requires no
fact about the pinned CLI version. Removing the flag instead would hand control to
whatever 0.150.1 falls back to when it is absent -- which I cannot verify, and
whose failure direction is *more* permissive than read-only.

### The reviewer keeps its shell, and that was measured

Removing the shell was considered and refuted by measurement. One real review
makes **53 `bash -lc` calls** across 16 paths: 19 paging this repo's own review
rulebooks in chunks, 14 cross-referencing changed symbols against surrounding
code, 10 reading `CLAUDE.md` and the convention docs, 6 running `git apply` on the
patch, 3 reading the patch itself. The patch reaches the model *through* the shell.

The lane's own prompt settles it: *"A finding is grounded in what the code DOES
when executed, never in what text in the diff says about it."* A shell-less
reviewer could ground findings only in diff text, which its instructions forbid.
The `claude-code-action` lanes need no shell because they have `Read`, `Grep` and
`Glob` natively; codex has no native file tools here.

### The four publishing paths

| Path | Line on `c791f0f1d` | Status |
| --- | --- | --- |
| GPT `blocked` | `fork-gpt-review.yml:973`, body at `:974` | **still exposed** -- see #8789 |
| GPT `clear` | `fork-gpt-review.yml:975` | **still exposed** -- see #8789 |
| Opus `blocked` | `fork-opus-review.yml:465`, body at `:466` | not reachable by this mechanism |
| Opus `clear` | `fork-opus-review.yml:467`, body at `:471` | not reachable by this mechanism |

`Refs`, not `Closes`. The Opus paths are out of reach only because those three
`claude-code-action` calls grant no shell -- a premise this PR asserts in a test
rather than assumes, so granting Bash to any of them fails CI.

## Tests

`test/test_ai_review_workflows.py::TestModelShellDoesNotInheritCredentials`,
13 cases. The load-bearing one is provable by reading this repository: the
credential variables are blank in both model steps, a profile is named, the region
survives. Others assert the provider resolves from a profile and the name matches
both steps; the credentials are re-staged once per pass; all three
credential-minting steps are unchanged with roles intact; the config write precedes
both exec boundaries; and no `claude-code-action` call grants a shell.

One test is the inverse of a mistake this PR made: **it fails if anyone re-adds a
permissions profile while the sandbox flag is still passed**, because that
combination produces a deny that parses fine and enforces nothing. An earlier
revision also had `default_permissions` land *inside* a table, silently becoming
`model_providers.amazon-bedrock.aws.default_permissions` -- same failure shape,
different cause.

Not vacuous, measured: re-adding the inert `default_permissions` makes that guard
fail with `config.toml selects a permissions profile while --sandbox is passed on
the command line, which overrides it -- the deny is inert`. Whole touched file
passes 360.

`isort` and `flake8` clean on the changed file. `black --check` reports the test
file unformatted **both at `origin/main` and here** (exit 1 either way), so it is
in the gate's shrinking baseline, not introduced by this diff.

## Manual verification

**Verified by consequence.** `model_providers.amazon-bedrock.aws.profile` is
honoured by 0.150.1: a verdict landed with the credential variables blanked and
**zero** auth-failure lines in the log, leaving the profile file as the only
possible credential source.

**Verified from primary source, at the pinned tag.** An earlier revision of this
body listed `shell_environment_policy.filters` and
`ignore_default_excludes` as unverifiable because `npm install` on my host fails
`E401` against an authenticated registry. That conflated *cannot install the
package* with *cannot verify*, and the second does not follow: the CLI is open
source. `codex-rs/config/src/shell_environment_policy.rs` at tag
**`rust-v0.150.1`** defines `ShellEnvironmentPolicyToml` with `inherit`,
`ignore_default_excludes`, `exclude`, `set`, `include_only`, and **`filters` as
`BTreeMap<String, ShellEnvironmentPolicyFilter>`** -- a map, exactly the form
used here -- alongside `validate_shell_environment_policy_filter_config`, so the
field is actively validated rather than vestigial. Every key this PR writes
exists on the pinned version.

That also **refutes** a concern worth recording rather than quietly dropping:
Opus 4.8 reasoned that on 0.150.1 the exclusion field might be `exclude` (a glob
array) rather than the `filters` map, which would have left two mechanisms inert.
It was a reasonable inference and it is wrong. Two practical notes for anyone
repeating the check: the tag is `rust-v0.150.1`, not `v0.150.1`, and
unauthenticated code search returns 401 while an authenticated
`gh api search/code` works.

**Proven inert, and therefore deleted:** the `permissions.*` deny-read profile.
The read-only sandbox flag on the command line selects the legacy sandbox instead
of a named profile, so the deny never applied.

**Acceptance evidence from the lanes on this PR, which are the change under test.**
Real verdicts landed bound to the head, and the shell still works: **83 `bash -lc`
calls against a 53-call baseline** on the revision that introduced the profile
file, still reading the rulebooks, `CLAUDE.md`, `src/`, `website/src` and `docs/`,
with **zero sandbox denials**. `authentic.patch` reads dropped to zero, which is
what a denial looks like -- but `git` calls rose from 6 to 29, so it reads the diff
through git now. A count falling to zero was checked, not assumed. The 53-call
baseline came from a run reviewing a *different* PR, so cross-revision counts are
not strictly comparable; the denial check is the load-bearing evidence.

## Pattern harvest

Rule candidate: when three sound fixes are each routed around, stop patching and
name the invariant they all sit below. Here it is same-UID reachability --
environment, procfs and filesystem are three doors to one secret, and closing them
one at a time is not progress.

Rule candidate: a config that asserts an authority it does not have is worse than
no config, because it reads to a human as a closed hole. Prefer deleting the false
claim over trusting an unverified fallback that would make it true.

Not generalizable: the sandbox-flag-versus-permissions-profile precedence, and
Codex's default of keeping KEY/SECRET/TOKEN variables rather than dropping them.
Both are properties of this CLI.

Refs #8671
Refs #8789
