### PR TITLE
fix(pipeline-conductor): let closure prose downgrade, never close

### DIFF
--- a/docs/design/pipeline-conductor.md
+++ b/docs/design/pipeline-conductor.md
@@ -93,14 +93,19 @@ subprocess-free scripts:
 - `scripts/claim_preflight.py` — one deterministic verdict per candidate item, from five checks in
   one invocation: open PRs (fork PRs included), merged PRs tested for having actually landed on the
   default branch, prose self-claims and closure requests in the body and last comment (a closure
-  request counting only from the reporter or a repository insider, since closing an item is a write
-  driven by ingested text), the named symbol's presence on the default branch, and a
+  request counting only from the reporter or a repository insider, since even a non-writing verdict
+  that withholds work must not be castable by a passer-by), the named symbol's presence on the
+  default branch, and a
   recency/authorship risk flag. The verdict is a pure function of the checks, so every branch is
-  unit-testable, and the exit codes are the interface: `CLAIM` / `SKIP` / `CLOSE` / `UNKNOWN`, where
-  `UNKNOWN` is never reported as `CLAIM`. Two of those checks are deliberately non-vetoing: symbol
+  unit-testable, and the exit codes are the interface: `CLAIM` / `SKIP` / `CLOSE` / `REVIEW` /
+  `UNKNOWN`, where
+  `UNKNOWN` is never reported as `CLAIM`. Three of those checks are deliberately non-vetoing: symbol
   absence downgrades to a high-risk claim unless the item is corroborated as bug-class, because a
   feature request names the symbol it proposes to add, and `risk=high` routes the item out of the
-  batch to its own live recheck rather than merely annotating the line.
+  batch to its own live recheck rather than merely annotating the line. A closure request read in
+  PROSE is the third: it yields `REVIEW`, never a close, because a hand-written sentence is the
+  weakest evidence here and closing is the strongest response — only a merged commit that is an
+  ancestor of the base earns `CLOSE`.
 - `scripts/fleet_probe.py` — one call per cycle: tail-classifies every worker session, emits the
   tail's message index, computes idle age, flags error tails, distinguishes a terminal report from
   an idle one, scans for banned processes scoped to the fleet's own worktrees, and reads host load

--- a/src/kiro_crew/agent.py
+++ b/src/kiro_crew/agent.py
@@ -5519,8 +5519,9 @@ not assumed of the prompt.
 **Scripts are the deterministic half of your loop.** Shell access exists to
 run the scripts the `pipeline-conductor` skill carries:
 `scripts/claim_preflight.py` (ONE verdict per candidate item before you dispatch
-it — CLAIM / SKIP / CLOSE / UNKNOWN, branched on the exit code, and UNKNOWN is
-never permission), `scripts/fleet_probe.py` (the ONE batch probe per patrol
+it — CLAIM / SKIP / CLOSE / REVIEW / UNKNOWN, branched on the exit code; UNKNOWN
+is never permission, and REVIEW is a closure request READ in the item's prose,
+which you confirm yourself because prose never closes an item), `scripts/fleet_probe.py` (the ONE batch probe per patrol
 cycle — worker tails, tail index, idle age, error tails, banned-process scan,
 host load, delivery counters) and `scripts/credit_spend.py` (per-item credit
 rollups and budget verdicts). Read their output; never re-derive what they

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/SKILL.md
@@ -16,7 +16,7 @@ is not assumed: check at first use, and treat an absent script as `UNKNOWN`
 rather than permission.
 
 - `scripts/claim_preflight.py` — one verdict per candidate item before you
-  dispatch it: `CLAIM` / `SKIP` / `CLOSE` / `UNKNOWN`.
+  dispatch it: `CLAIM` / `SKIP` / `CLOSE` / `REVIEW` / `UNKNOWN`.
 - `scripts/fleet_probe.py` — batch worker-tail classification + idle age +
   error tails + banned-process scan + host load + delivery counters, in ONE
   call per cycle.
@@ -285,6 +285,7 @@ python3 scripts/claim_preflight.py --repo <owner/repo> --item <N> \
 | 0 | `CLAIM` | Dispatch it. `risk=high` on the line means self-claim collision risk: that item is NOT batched — it goes to the live recheck on its own, immediately before claiming. |
 | 10 | `SKIP` | Covered, or not workable. Leave it alone; record the reason. |
 | 11 | `CLOSE` | Triage debt, not work. Close the item with the evidence the script printed. |
+| 13 | `REVIEW` | A closure request was READ in the item's prose. **Do not dispatch and do not close.** Open the comment the line names, decide yourself whether the item is really done, and then either close it or dispatch it. This verdict exists because prose is the weakest evidence the preflight collects and closing is the strongest response it had. |
 | 2 | malformed | YOUR arguments or config are wrong. Fix the call — a bad call is not a verdict about the item. |
 | 3 | `UNKNOWN` | A check could not be answered (forge unreachable, rate limited). **Never treat this as permission.** Re-run it later or park the item. |
 
@@ -307,11 +308,18 @@ precedence list:
    `open-pr`.
 3. `prose_claim` — a closure request in the body or the last comment ("this is
    resolved", "please close") **from the item's own reporter or a repository
-   insider** → **CLOSE** `reporter-asked-close`. The authorization condition is
-   load-bearing, not decoration: anyone can comment on a public item, closing one
-   is a WRITE, and this verdict would otherwise let ingested untrusted text drive
-   that write on an unattended cycle. A closure phrase from anybody else is not a
-   closure request — it falls through to the remaining checks.
+   insider** → **REVIEW** `reporter-asked-close` at `risk=high`. **Prose never
+   closes anything.** It is the weakest evidence this script collects — nine
+   separate false-CLOSE paths reached review in one change, and a ratchet that
+   stops a new unguarded PATTERN cannot stop the next unguarded PHRASING of a
+   pattern already guarded, because the space of English that accidentally means
+   "close this" has no edge. So the detection stays and the response is withheld:
+   you read the comment the line names and you decide. The authorization
+   condition stays too, for a different reason than it had — `REVIEW` writes
+   nothing, but it does withhold a dispatch, and a suppression any passer-by can
+   cast is the same denial-of-work channel rule 4 refuses to open. A closure
+   phrase from anybody else is not a closure request — it falls through to the
+   remaining checks.
 4. `prose_claim` — a self-claim ("I'm claiming this", "working on this") **from
    the item's reporter or a repository insider** → **SKIP** `prose-claim`. A claim
    written in prose is invisible to every label and field query that exists, which
@@ -335,8 +343,10 @@ precedence list:
 
 **`risk=high` is a decision, not a note.** A high-risk `CLAIM` is NOT batched:
 it goes to the live per-item recheck immediately before the atomic claim, on its
-own. An annotation nothing acts on is the same defect as a prose predicate — it
-reads as caution and changes nothing.
+own. A `REVIEW` is always high-risk and is not a dispatch at all: it goes on your
+own list, and it clears only when you have read the named comment and either
+closed the item or dispatched it. An annotation nothing acts on is the same
+defect as a prose predicate — it reads as caution and changes nothing.
 
 **A batch snapshot is never the authority.** Preflighting a batch is how you
 order a queue; a per-item live recheck immediately before the atomic claim stays
@@ -348,6 +358,9 @@ item.** Its verdict is CLOSE with the landing-commit evidence, and closing it IS
 the work. Dispatching a worker to rediscover that the work does not exist spends
 a whole session — create, seed, preflight, stand down, unclaim — to learn
 nothing, and leaves claim churn on a repository other operators are reading.
+**An item that merely READS as already fixed is not the same item.** A merged
+commit that is an ancestor of the base is evidence; a sentence saying so is a
+reading, and it comes back as `REVIEW` for you to confirm.
 
 ### Dispatch mechanics
 

--- a/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/claim_preflight.py
+++ b/src/kiro_crew/builtin_skills/pipeline-conductor/scripts/claim_preflight.py
@@ -50,7 +50,11 @@ Exit codes (the conductor branches on these):
 
     0   CLAIM    — dispatch it
    10   SKIP     — covered or not workable; do not dispatch
-   11   CLOSE    — triage debt: already fixed, or the reporter asked to close
+   11   CLOSE    — triage debt: a merged PR already landed the fix
+   13   REVIEW   — a standing closure request was READ in the item's prose. Do
+                   not dispatch and do not close: hand it to a human, or to the
+                   conductor, with the reason. Prose noticing that something
+                   might be resolved is not prose deciding it.
     2            — malformed arguments or config
     3   UNKNOWN  — a check could not be answered (forge unreachable, rate
                    limited, no clone for a question only git can answer)
@@ -75,9 +79,10 @@ The five checks, all of them, every call:
                        the author SAYS, with code fences, backtick spans,
                        blockquotes and quoted spans removed first, because a
                        phrase inside them is being cited. BOTH phrase sets need
-                       standing (the reporter, or a repository insider), for
-                       opposite reasons: CLOSE acts on live work, and a SKIP any
-                       commenter can cast is a denial-of-work channel.
+                       standing (the reporter, or a repository insider), and for
+                       the SAME reason now that neither one closes anything:
+                       each suppresses a dispatch, and a suppression any passer-by
+                       can cast is a denial-of-work channel.
   4. ``symbol_on_base``every symbol the item names, by ``git grep`` on the
                        default branch. Absent means the target code may live
                        only on an unmerged branch — but that reading holds only
@@ -101,7 +106,8 @@ the checks dict so every branch is unit-testable with no forge access):
                                                ``untrusted-fork`` at
                                                ``risk=high`` when the PR is an
                                                unvouched fork
-  3. ``prose_claim.closure_requested``       → CLOSE ``reporter-asked-close``
+  3. ``prose_claim.closure_requested``       → REVIEW ``reporter-asked-close``
+                                               at ``risk=high``
   4. ``prose_claim.claimed_by_other``        → SKIP  ``prose-claim``
   5. ``symbol_on_base.missing`` AND bug-class→ SKIP  ``symbol-absent``
   6. any check errored                       → UNKNOWN
@@ -110,7 +116,22 @@ the checks dict so every branch is unit-testable with no forge access):
                                                symbol or an UNAUTHORIZED claim
                                                forces to ``high``
 
-Rules 2 and 4 both suppress work on evidence anybody can manufacture, and both
+Rule 3 is the one verdict here that is read out of HAND-WRITTEN ENGLISH, and it
+used to be CLOSE — the strongest response this script has, aimed at somebody
+else's live work, on the weakest evidence it collects. Nine separate false-CLOSE
+paths reached review in one change: a quotation bound truncated at a fixed
+offset, closure verbs with no object, bare pronouns resolving to a socket rather
+than the item, a means-versus-state confusion between two prepositions. Each was
+fixed on the merits and a ratchet now stops a new PATTERN shipping unguarded.
+What the ratchet cannot stop is the next unguarded PHRASING of a pattern that is
+already guarded, and the space of English that accidentally resembles "close
+this" has no edge to reach. So the pairing was wrong rather than the patterns:
+detection keeps its job, which is noticing that an item might be resolved, and
+loses the job it should never have had, which is deciding it. Rule 1 still
+CLOSES, because a merged commit that is an ancestor of the base is evidence, not
+prose.
+
+Rules 2, 3 and 4 all suppress work on evidence anybody can manufacture, and all
 answer it the same way rather than by refusing to look: the finding stands, and
 the doubt is published alongside it. A verdict that acts while doubting has to
 say so, or the doubt is only in this docstring.
@@ -242,9 +263,12 @@ WITHDRAWAL_RES: tuple[str, ...] = (
 )
 
 #: Closure requests, from the item whose reporter had already said it was done.
-#: Every pattern that can produce CLOSE carries a continuation guard, because
-#: CLOSE is the one verdict that writes to somebody else's live work and this
-#: list has now produced four separate false positives without one.
+#: Every pattern here still carries a continuation guard even though the verdict
+#: no longer closes anything: REVIEW does not write, but it does take the item
+#: out of the dispatch queue and put it in front of a human, so a phrase that
+#: fires on "please close the connection" still spends attention and still
+#: withholds work. This list produced four separate false positives before the
+#: guards, and losing them would restore that whether or not the verdict writes.
 CLOSURE_RES: tuple[str, ...] = (
     rf"\bthis\s+(?:is|was)\s+(?:already\s+)?(?:resolved|fixed)\b{_STATE_END}",
     rf"\bhappy\s+to\s+have\s+(?:{_ISSUE_OBJECT})\s+closed\b",
@@ -279,8 +303,11 @@ ACTIVE_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR
 
 #: Standing to ask for closure on somebody else's item. Narrower than
 #: ACTIVE_ASSOCIATIONS on purpose: CONTRIBUTOR means "has had a PR merged here
-#: once", which is not authority to close another person's report, while CLOSE
-#: is the one verdict that acts on live work.
+#: once", which is not standing to declare another person's report finished. The
+#: set is unchanged now that a closure request produces REVIEW rather than CLOSE
+#: — only the reason is. It is no longer "this verdict writes"; it is that REVIEW
+#: withholds a dispatch, and a suppression any passer-by can cast is the same
+#: denial-of-work channel the self-claim path already refuses to open.
 INSIDER_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 
 #: GitHub's closing keywords. A merged PR is coverage only if it CLAIMS to close
@@ -326,7 +353,13 @@ CHECK_NAMES = (
     "recency",
 )
 
-EXIT_CODES = {"CLAIM": 0, "SKIP": 10, "CLOSE": 11, "UNKNOWN": 3}
+#: One integer per verdict, and a verdict never borrows another's number: the
+#: caller branches on the number alone, so a number that means two things is a
+#: wrong branch rather than a confusing message. Numbers are assigned, never
+#: recycled -- 12 is unallocated here and a later verdict should take the next
+#: free integer rather than fill the gap, because a reader cannot tell a gap
+#: that is free from one that is retired.
+EXIT_CODES = {"CLAIM": 0, "SKIP": 10, "CLOSE": 11, "REVIEW": 13, "UNKNOWN": 3}
 
 #: ``gh`` shapes this script is allowed to run. Everything else — including
 #: every write verb — is refused before the subprocess starts.
@@ -664,10 +697,11 @@ _FENCE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
 _INLINE_CODE_RE = re.compile(r"(`+)[^`]*?\1")
 _BLOCKQUOTE_RE = re.compile(r"^[ \t]*>.*$", re.MULTILINE)
 #: Deliberately UNBOUNDED between the delimiters. A length cap here is a
-#: false-CLOSE channel: a reporter who quotes "please close" inside a quotation
-#: longer than the cap has the phrase read as their OWN prose, and this verdict
-#: performs a write on live work. Linear despite the ``*`` because the class is
-#: negated -- there is no nested quantifier to backtrack through.
+#: false-reading channel: a reporter who quotes "please close" inside a quotation
+#: longer than the cap has the phrase read as their OWN prose, and the item is
+#: then withheld from dispatch over a sentence they were citing. Linear despite
+#: the ``*`` because the class is negated -- there is no nested quantifier to
+#: backtrack through.
 _QUOTED_RE = re.compile('["\u201c\u201d][^"\u201c\u201d\n]*["\u201c\u201d]')
 #: An UNMATCHED opening delimiter is the same channel by the other door: a
 #: citation whose closing quote the author forgot (or that a smart-quote pair
@@ -675,7 +709,7 @@ _QUOTED_RE = re.compile('["\u201c\u201d][^"\u201c\u201d\n]*["\u201c\u201d]')
 #: words. Everything from a leftover delimiter to the end is therefore dropped
 #: too. This is the deliberately lossy direction -- prose after an unbalanced
 #: quote can hide a REAL closure request, which costs one dispatch, where the
-#: other reading closes somebody's live work.
+#: other reading withholds one and asks a human to read a citation.
 _UNCLOSED_QUOTE_RE = re.compile('["\u201c\u201d].*$', re.DOTALL)
 
 
@@ -685,9 +719,11 @@ def plain_prose(text: str) -> str:
     Measured on the item that specified this script: its body quotes the very
     closure phrases the check looks for ("this is resolved / happy to have it
     closed", as a description of what to detect), and scanning it raw produced
-    CLOSE on a live item. A false CLOSE closes work in flight; a missed one only
-    costs the dispatch that discovers the work is done — so citations come out
-    before matching, and the asymmetry runs the cheap way.
+    CLOSE on a live item. That verdict is now REVIEW, so a false reading no
+    longer closes work in flight — but it still withholds the item from dispatch
+    and spends a human read, while a missed one only costs the dispatch that
+    discovers the work is done. The asymmetry narrowed and did not invert, so
+    citations still come out before matching.
 
     Line structure first, then whitespace, then spans. Fences and blockquotes
     are line-shaped, so they have to go while the newlines are still there.
@@ -703,7 +739,7 @@ def plain_prose(text: str) -> str:
     author's own words and returned CLOSE on a live item. Every span rule here
     is therefore allowed to strip too MUCH, never too little -- over-stripping
     can hide a real closure request and cost one dispatch, while under-stripping
-    closes somebody's work in flight.
+    withholds one on a sentence the author was only citing.
     """
     text = _HTML_COMMENT_RE.sub(" ", text)
     text = _FENCE_RE.sub(" ", text)
@@ -878,14 +914,19 @@ def scan_prose(
     as somebody else's — the fail-safe direction is SKIP, never CLAIM.
 
     BOTH phrase sets need STANDING (the item's own author, always true of the
-    body, or a repository insider by ``author_association``) but for opposite
-    reasons, and the asymmetry is the point:
+    body, or a repository insider by ``author_association``). That used to be
+    two rules with opposite reasons; it is now one reason, because neither
+    reading closes anything any more:
 
-    * a closure request produces CLOSE, which acts on live work, so "please
-      close" from a passer-by must not fire it;
+    * a closure request produces REVIEW, which withholds a dispatch and asks a
+      human, so "please close" from a passer-by must not fire it;
     * a self-claim produces SKIP, and a veto anyone can cast is a
       denial-of-work channel -- one comment would suppress a queued item
       indefinitely with nothing downstream reporting the suppression.
+
+    This function is the DETECTOR and knows nothing about either verdict. What
+    it reports and what is done about it are deliberately separate concerns, and
+    that separation is what let the response change without the patterns moving.
 
     So an unauthorized claim is not discarded and not obeyed: it sets
     ``claim_without_standing``, which annotates ``risk=high`` and sends the item
@@ -1188,13 +1229,29 @@ def untrusted_fork_skip(checks: dict) -> int | None:
     return None
 
 
+def closure_request(checks: dict) -> bool:
+    """Whether a STANDING closure request was read out of the item's prose.
+
+    The third member of the family with :func:`unauthorized_claim` and
+    :func:`untrusted_fork_skip`, and the one whose evidence is weakest: those two
+    read a forge field, this one reads hand-written English. So it is also the
+    only one whose verdict declines to act at all — see rule 3 in
+    :func:`verdict` — and the ``risk=high`` it forces is the whole point of the
+    verdict rather than a footnote on it.
+    """
+    prose = checks.get("prose_claim")
+    if not isinstance(prose, dict) or errored(prose):
+        return False
+    return bool(prose.get("closure_requested"))
+
+
 def risk_of(checks: dict) -> str:
     """``low`` or ``high``, from check 5, from an uncorroborated absent symbol,
-    from an unauthorized self-claim, and from an untrusted-fork suppression,
-    defaulting to the cautious side."""
+    from an unauthorized self-claim, from an untrusted-fork suppression, and from
+    a prose closure request, defaulting to the cautious side."""
     if uncorroborated_absent_symbols(checks) or unauthorized_claim(checks):
         return "high"
-    if untrusted_fork_skip(checks) is not None:
+    if untrusted_fork_skip(checks) is not None or closure_request(checks):
         return "high"
     recency = checks.get("recency")
     if not isinstance(recency, dict) or errored(recency):
@@ -1237,8 +1294,16 @@ def verdict(checks: dict) -> tuple[str, str, dict]:
     prose = checks.get("prose_claim")
     if isinstance(prose, dict) and not errored(prose):
         if prose.get("closure_requested"):
+            # NOT CLOSE. A prose reading is the weakest evidence this script
+            # collects and closing is the strongest thing it could do with it,
+            # aimed at work somebody else may still be doing. Nine false-CLOSE
+            # paths in one review made the case that the pairing was the defect
+            # rather than the patterns, so the reading survives and the response
+            # is withheld: the item leaves the dispatch queue, nothing is
+            # written, and a human or the conductor decides. Rule 1 above still
+            # closes, on a merge commit that is an ancestor of the base.
             return (
-                "CLOSE",
+                "REVIEW",
                 "reporter-asked-close",
                 {"comment_id": prose.get("comment_id"), "where": prose.get("where")},
             )
@@ -1311,7 +1376,10 @@ def human_line(item: int, name: str, reason: str, evidence: dict, risk: str) -> 
     if reason == "reporter-asked-close":
         ident = evidence.get("comment_id")
         tail = f"comment-id={ident}" if ident is not None else f"where={evidence.get('where')}"
-        return f"CLOSE {item} reporter-asked-close {tail}"
+        # The comment id is the whole point of the line: this verdict asks a
+        # human to read the sentence the scanner matched, and it never prints
+        # that sentence, so it has to say where to find it.
+        return f"REVIEW {item} reporter-asked-close {tail} risk={risk}"
     if reason == "prose-claim":
         return (
             f"SKIP {item} prose-claim claimed-by={evidence.get('claimed_by')} "

--- a/test/test_pipeline_conductor_claim_preflight.py
+++ b/test/test_pipeline_conductor_claim_preflight.py
@@ -216,8 +216,10 @@ class TestVerdictPrecedence:
         )
 
     def test_closure_request_outranks_a_prose_claim(self, mod):
-        """Precedence 3 before 4: if the reporter says it is done, it is triage
-        debt even when somebody also said they were working on it."""
+        """Precedence 3 before 4: if the reporter says it is done, that reading
+        is the one worth surfacing even when somebody also said they were
+        working on it. It surfaces as REVIEW, not CLOSE -- see
+        :class:`TestClosureProseNeverCloses`."""
         checks = clean_checks(
             prose_claim={
                 "closure_requested": True,
@@ -230,19 +232,23 @@ class TestVerdictPrecedence:
         )
         assert naive_claim(checks) is True
         name, reason, evidence = mod.verdict(checks)
-        assert (name, reason) == ("CLOSE", "reporter-asked-close")
+        assert (name, reason) == ("REVIEW", "reporter-asked-close")
         assert evidence == {"comment_id": 123456, "where": "comment"}
-        assert mod.EXIT_CODES[name] == 11
+        assert mod.EXIT_CODES[name] == 13
+        # The risk is not the caller's to choose here: risk_of() derives it from
+        # the same checks the verdict came from, so the line cannot claim a
+        # REVIEW is low-risk.
+        assert mod.risk_of(checks) == "high"
         assert (
-            mod.human_line(ITEM, name, reason, evidence, "low")
-            == f"CLOSE {ITEM} reporter-asked-close comment-id=123456"
+            mod.human_line(ITEM, name, reason, evidence, mod.risk_of(checks))
+            == f"REVIEW {ITEM} reporter-asked-close comment-id=123456 risk=high"
         )
 
     def test_closure_request_in_the_body_reports_where_instead_of_an_id(self, mod):
         evidence = {"comment_id": None, "where": "body"}
         assert (
-            mod.human_line(ITEM, "CLOSE", "reporter-asked-close", evidence, "low")
-            == f"CLOSE {ITEM} reporter-asked-close where=body"
+            mod.human_line(ITEM, "REVIEW", "reporter-asked-close", evidence, "high")
+            == f"REVIEW {ITEM} reporter-asked-close where=body risk=high"
         )
 
     def test_absent_symbol_skips_only_for_a_corroborated_bug_item(self, mod):
@@ -1902,6 +1908,131 @@ def run_main(mod, monkeypatch, forge: Forge, extra: list[str] | None = None) -> 
     return mod.main(["--repo", REPO, "--item", str(ITEM), *(extra or [])])
 
 
+class TestClosureProseNeverCloses:
+    """Rule 3 reads HAND-WRITTEN ENGLISH, and it used to answer with the
+    strongest thing this script can say about somebody else's live work.
+
+    Nine false-CLOSE paths reached review in one change and each was fixed on the
+    merits, but the space of English that accidentally means "close this" has no
+    edge, so the next unguarded phrasing was always going to arrive. These tests
+    pin the structural answer instead: the reading survives, the response does
+    not. They are deliberately split -- one pins the CONSEQUENCE (no dispatch),
+    one pins the INTEGER -- because those two can drift apart in a refactor and a
+    caller that branches on the number would then break while a
+    consequence-only test stayed green.
+    """
+
+    def closure_checks(self) -> dict:
+        return clean_checks(
+            prose_claim={
+                "closure_requested": True,
+                "claimed_by_other": False,
+                "claim_without_standing": False,
+                "claimed_by": None,
+                "closure_by": "reporter",
+                "where": "comment",
+                "comment_id": 777,
+                "pattern": "x",
+            }
+        )
+
+    def closure_forge(self) -> Forge:
+        return Forge(comments=[a_comment("happy to have this closed", ident=777)])
+
+    def test_a_standing_closure_request_is_never_dispatched(self, mod, monkeypatch):
+        """The consequence that matters. A sentence is not permission to spend a
+        worker session, and it never was -- this is the half of the old behaviour
+        that was right."""
+        checks = self.closure_checks()
+        assert naive_claim(checks) is True
+        name, _, _ = mod.verdict(checks)
+        assert name != "CLAIM"
+        assert mod.EXIT_CODES[name] != mod.EXIT_CODES["CLAIM"]
+        # End to end as well: verdict() is not the only code between the comment
+        # and the dispatch, and a test of the pure function alone would not
+        # notice collect() or main() losing the reading on the way.
+        assert run_main(mod, monkeypatch, self.closure_forge()) != 0
+
+    def test_a_standing_closure_request_is_never_closed_either(self, mod, monkeypatch):
+        """The half that was wrong, and the whole point of the change: the item
+        must not be CLOSED on prose. Asserting the absence of CLOSE is what
+        distinguishes this from the old behaviour, which also refused to
+        dispatch."""
+        name, _, _ = mod.verdict(self.closure_checks())
+        assert name != "CLOSE"
+        assert mod.EXIT_CODES[name] != mod.EXIT_CODES["CLOSE"]
+        assert run_main(mod, monkeypatch, self.closure_forge()) != mod.EXIT_CODES["CLOSE"]
+
+    def test_a_standing_closure_request_exits_thirteen(self, mod, monkeypatch, capsys):
+        """The integer, asserted on its own. The caller branches on this number
+        and nothing else, so it is part of the contract rather than an
+        implementation detail of the verdict name."""
+        name, reason, _ = mod.verdict(self.closure_checks())
+        assert (name, reason) == ("REVIEW", "reporter-asked-close")
+        assert mod.EXIT_CODES["REVIEW"] == 13
+        assert run_main(mod, monkeypatch, self.closure_forge()) == 13
+        assert capsys.readouterr().out.strip().startswith("REVIEW")
+
+    def test_a_review_verdict_is_always_high_risk(self, mod):
+        """``risk`` is computed by risk_of() from the same checks the verdict came
+        from, so the two cannot disagree. Without this, a REVIEW line could print
+        ``risk=low`` -- a verdict that exists BECAUSE the evidence is weak,
+        reporting that the evidence is fine."""
+        checks = self.closure_checks()
+        assert mod.verdict(checks)[0] == "REVIEW"
+        assert mod.risk_of(checks) == "high"
+        assert mod.closure_request(checks) is True
+
+    def test_the_review_line_names_the_comment_to_read(self, mod):
+        """This verdict delegates to a human, and it never prints the matched
+        sentence, so the identifier that lets them find it is the payload."""
+        _, reason, evidence = mod.verdict(self.closure_checks())
+        line = mod.human_line(ITEM, "REVIEW", reason, evidence, "high")
+        assert "comment-id=777" in line
+        assert "risk=high" in line
+
+    def test_a_merged_landed_pr_still_closes(self, mod):
+        """The scope boundary. Rule 1 is EVIDENCE -- a merge commit that is an
+        ancestor of the base -- not a reading of prose, so it keeps CLOSE.
+        Downgrading it too would leave exit 11 with no producers at all."""
+        checks = clean_checks(
+            merged_prs=[
+                {
+                    "number": 8712,
+                    "landed": True,
+                    "closes_item": True,
+                    "merge_commit_sha": "c791f0f1",
+                }
+            ]
+        )
+        name, reason, _ = mod.verdict(checks)
+        assert (name, reason) == ("CLOSE", "already-fixed")
+        assert mod.EXIT_CODES[name] == 11
+
+    def test_an_auto_pipeline_stand_down_is_not_read_as_closure_prose(self, mod):
+        """A pipeline's own stand-down note is the phrasing that most looks like
+        closure without being a reporter's verdict, and it is measurably INERT
+        here: it fires no closure pattern and no self-claim pattern.
+
+        Pinned because that is a property somebody could remove by accident. If
+        a future change teaches this scanner to read "standing down", this test
+        reds and forces the question of whether a pipeline's own note should
+        route through REVIEW at all -- rather than the phrase quietly acquiring a
+        verdict. It does NOT claim such an item is otherwise protected: this
+        script has no check for "my own pipeline already dispositioned this".
+        """
+        stand_down = (
+            "Kiro Crew Auto-Pipeline [operator: redacted] - standing down and "
+            "handing back to `needs-human`. No longer being worked by the fleet; "
+            "the investigation notes are below for whoever picks it up."
+        )
+        assert mod._first_match(mod.CLOSURE_RES, mod.plain_prose(stand_down)) is None
+        assert mod._first_match(mod.SELF_CLAIM_RES, mod.plain_prose(stand_down)) is None
+        # Control: the harness really can match, so the two Nones above are
+        # findings and not a silently broken instrument.
+        assert mod._first_match(mod.CLOSURE_RES, mod.plain_prose("This is resolved.")) is not None
+
+
 class TestEndToEnd:
     def test_clean_item_exits_zero_and_prints_the_claim_line(self, mod, monkeypatch, capsys):
         fresh = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -2083,16 +2214,19 @@ class TestEndToEnd:
         out = capsys.readouterr().out.strip()
         assert out == f"SKIP {ITEM} prose-claim claimed-by=otherdev where=body"
 
-    def test_reporter_asked_close_in_the_last_comment_exits_eleven(self, mod, monkeypatch, capsys):
+    def test_reporter_asked_close_in_the_last_comment_exits_thirteen(
+        self, mod, monkeypatch, capsys
+    ):
         forge = Forge(
             comments=[
                 a_comment("automated triage summary", login="github-actions[bot]", kind="Bot"),
                 a_comment("happy to have this closed", ident=777),
             ]
         )
-        assert run_main(mod, monkeypatch, forge) == 11
+        assert run_main(mod, monkeypatch, forge) == 13
         assert (
-            capsys.readouterr().out.strip() == f"CLOSE {ITEM} reporter-asked-close comment-id=777"
+            capsys.readouterr().out.strip()
+            == f"REVIEW {ITEM} reporter-asked-close comment-id=777 risk=high"
         )
 
     def test_an_absent_symbol_on_a_labelled_bug_exits_ten(self, mod, monkeypatch, capsys):
@@ -2283,7 +2417,21 @@ class TestArgumentHandling:
         assert excinfo.value.code == 2
 
     def test_exit_codes_are_the_documented_ones(self, mod):
-        assert mod.EXIT_CODES == {"CLAIM": 0, "SKIP": 10, "CLOSE": 11, "UNKNOWN": 3}
+        assert mod.EXIT_CODES == {
+            "CLAIM": 0,
+            "SKIP": 10,
+            "CLOSE": 11,
+            "REVIEW": 13,
+            "UNKNOWN": 3,
+        }
+
+    def test_no_two_verdicts_share_an_exit_code(self, mod):
+        """The caller branches on the integer alone, so a shared number is a
+        wrong branch rather than a confusing message. This is the invariant that
+        matters; which particular integers are unallocated is not one, so it is
+        deliberately not asserted here."""
+        codes = list(mod.EXIT_CODES.values())
+        assert len(codes) == len(set(codes))
 
 
 class TestForgeHelpers:

--- a/test/test_pipeline_conductor_skill_contract.py
+++ b/test/test_pipeline_conductor_skill_contract.py
@@ -94,7 +94,7 @@ class TestAgentPromptNamesEveryScript:
 
     def test_prompt_states_the_verdicts_the_conductor_branches_on(self):
         prompt = agent._PIPELINE_CONDUCTOR_SYSTEM_PROMPT
-        for verdict in ("CLAIM", "SKIP", "CLOSE", "UNKNOWN"):
+        for verdict in ("CLAIM", "SKIP", "CLOSE", "REVIEW", "UNKNOWN"):
             assert verdict in prompt, verdict
 
     def test_prompt_carries_the_absent_script_rule(self):
@@ -145,12 +145,12 @@ class TestClaimPreflightIsDocumented:
             for row in _skill_section(self.HEADING).splitlines()
             if row.startswith("|") and row.count("|") >= 3
         }
-        for code in ("0", "10", "11", "2", "3"):
+        for code in ("0", "10", "11", "13", "2", "3"):
             assert code in rows, f"exit code {code} has no row in the branch table"
 
-    def test_all_four_verdicts_are_named(self):
+    def test_all_five_verdicts_are_named(self):
         preflight = _skill_section(self.HEADING)
-        for verdict in ("CLAIM", "SKIP", "CLOSE", "UNKNOWN"):
+        for verdict in ("CLAIM", "SKIP", "CLOSE", "REVIEW", "UNKNOWN"):
             assert verdict in preflight, verdict
 
     def test_unknown_is_never_permission(self):
@@ -160,14 +160,25 @@ class TestClaimPreflightIsDocumented:
         assert "never treat this as permission" in preflight
 
     def test_a_prose_closure_request_requires_author_authorization(self):
-        """CLOSE is a WRITE driven by ingested text on an unattended cycle, and
-        anyone can comment on a public item. Without an authorization condition
-        this verdict lets an untrusted commenter close a live issue."""
+        """Anyone can comment on a public item. The verdict no longer writes --
+        it is REVIEW, not CLOSE -- but it still withholds the item from dispatch,
+        so without an authorization condition an untrusted commenter could park
+        live work by typing one sentence."""
         preflight = _flat(_skill_section(self.HEADING))
         assert "reporter or a repository insider" in preflight
         # An unauthorized phrase must not silently become a weaker verdict
         # either: it is simply not a closure request.
         assert "falls through to the remaining checks" in preflight
+
+    def test_prose_never_closes_an_item(self):
+        """The structural answer to nine false-CLOSE paths in one change: a
+        ratchet stops a new unguarded PATTERN, and cannot stop the next unguarded
+        PHRASING of one already guarded. So the skill has to say that a prose
+        reading is never the authority to close -- otherwise the next reader
+        reinstates the terminal verdict as an obvious simplification."""
+        preflight = _flat(_skill_section(self.HEADING))
+        assert "prose never closes anything" in preflight
+        assert "do not dispatch and do not close" in preflight
 
     def test_a_prose_self_claim_from_anyone_else_is_not_a_veto(self):
         """A veto anyone can cast is a denial-of-work channel: one comment would


### PR DESCRIPTION
## Problem / Motivation

`claim_preflight.py` decides whether a candidate item is dispatched, skipped, or
closed, and one of those verdicts was read out of hand-written English. A closure
request in the item's body or last comment ("this is resolved", "please close")
returned `CLOSE`, exit 11 -- and the conductor's documented action for exit 11 is
to close the item.

That pairs the weakest evidence the script collects with the strongest response
it has, aimed at work somebody else may still be doing. It has failed
repeatedly, and the failures were not independent bugs. Nine separate
false-CLOSE paths reached review during one change:

- a quotation bound truncated at a fixed offset, so a reporter quoting a closure
  phrase past that offset had it read as their own prose;
- closure verbs with no object: "Please close the file after reading it" read as
  a request to close the item;
- bare pronouns: "The connection leaks. Please close it." -- in a bug report a
  bare pronoun resolves to a socket or a handle, not to the item;
- a means-versus-state confusion between two prepositions: "resolved by
  upgrading in your own fork" hands over a workaround and leaves the item open,
  while "fixed in the 0.7 release" really is closure.

Each was fixed on the merits, and a ratchet now stops a new *pattern* shipping
without a guard. What the ratchet cannot stop is the next unguarded *phrasing*
of a pattern that is already guarded. The space of English that means "close
this" is open, the space that accidentally resembles it is larger, and neither
has an edge to reach.

## Why it matters

The failure is silent and it destroys work rather than wasting it. A false
`CLOSE` closes a live issue somebody may be mid-way through, on a public
repository where other operators are reading the queue, during an unattended
cycle with nobody watching. The reporter finds out when they come back to a
closed item.

The opposite error is cheap and self-announcing: a missed closure request costs
one worker dispatch, which discovers the work is already done and stands down.
So the two directions were never symmetric, and the verdict was pointed the
expensive way.

## What changed

Observed symptom: closure prose keeps producing false `CLOSE` verdicts, one
phrasing at a time. Underlying cause: not the patterns -- the pairing. Detection
and response were welded together, so prose had both the job it should have
(noticing that an item might be resolved) and the job it should never have had
(deciding it).

So the detection stays and the response is withheld. `verdict()` rule 3 now
returns a new `REVIEW` verdict at **exit 13**, carrying `risk=high` and the
comment id: the item leaves the dispatch queue, nothing is written, and a human
or the conductor confirms. That makes all nine findings impossible rather than
caught.

Two deliberate boundaries:

- **Rule 1 still closes.** A merged PR whose merge commit is an ancestor of the
  base, carrying a closing keyword for this item, is evidence and not prose. It
  keeps `CLOSE`/11 -- downgrading it too would leave exit 11 with no producers
  and turn a targeted fix into a contract deletion.
- **The detector is unchanged.** Not one pattern, guard, negation window or
  stripping rule moved. A prose detector that changes behaviour in the same diff
  as a verdict change is unreviewable: a later regression could not be
  attributed to either half.

`REVIEW` ships with its consumer in the same commit, so it is not an annotation
nothing reads: `SKILL.md` gains the exit-13 row and states the action (open the
named comment, then close it or dispatch it yourself), and `risk_of()` returns
`high` for the same checks that produce the verdict, so the line cannot report
that a `REVIEW`'s evidence is fine.

Prose that described the old consequence was corrected in the same commit --
`plain_prose()`, the quote-stripping regexes, `INSIDER_ASSOCIATIONS`,
`CLOSURE_RES` and the module docstring all justified themselves by "this verdict
writes to live work". The guards and the standing requirement survive on a
different reason, stated where they live: `REVIEW` writes nothing, but it does
withhold a dispatch, and a suppression any passer-by can cast is the same
denial-of-work channel the self-claim path already refuses to open.

`REVIEW` takes the next free integer after `CLOSE`'s 11, leaving 12
unallocated. The exit table's own comment says numbers are assigned and never
recycled, which is the part a reader of this repo can check; an earlier revision
of this PR justified the gap with a specific out-of-tree caller of 12, which
First Principles correctly flagged as a claim nobody could verify here. That
sentence and the test line that pinned it are gone. The uniqueness assertion
stayed, because that is the invariant that actually carries the contract.

## Tests

Green baseline first, so "any red after this change is mine" is checkable rather
than hoped for: `test_pipeline_conductor_claim_preflight.py` was **318 passed**
on clean `369bb6d0b`, single process, 5.32s. Both files together are now 409
passed.

New, in `TestClosureProseNeverCloses`:

- `test_a_standing_closure_request_is_never_dispatched` -- the consequence that
  matters. Asserts the verdict is not `CLAIM` and its exit code is not `CLAIM`'s,
  at the pure-function level AND end to end through `main()`.
- `test_a_standing_closure_request_exits_thirteen` -- the integer, asserted
  separately on purpose. The number and the no-dispatch behaviour can drift apart
  in a refactor, and a caller branching on the number would then break while a
  consequence-only test stayed green.
- `test_a_standing_closure_request_is_never_closed_either` -- the half that was
  wrong. Asserting the ABSENCE of `CLOSE` is what distinguishes the new behaviour
  from the old, which also refused to dispatch.
- `test_a_review_verdict_is_always_high_risk` -- `verdict()` and `risk_of()`
  cannot disagree, so a verdict that exists because the evidence is weak can
  never print `risk=low`.
- `test_a_merged_landed_pr_still_closes` -- pins the scope boundary above.
- `test_an_auto_pipeline_stand_down_is_not_read_as_closure_prose` -- an automated
  stand-down note is the phrasing that most looks like closure without being a
  reporter's verdict, and it is measurably inert here (no closure pattern, no
  self-claim pattern). Carries a positive control in the same test, so the two
  negative assertions are findings rather than a silently broken instrument.
- `test_no_two_verdicts_share_an_exit_code` -- one integer per verdict.

Both mutants were applied from a file that refuses to run unless it matches
exactly one site, so a mutation that did not land cannot report agreement:

- **M1**, rule 3 returns `CLAIM risk=high` (the "softer verdict that still
  dispatches" alternative): reddens
  `test_a_standing_closure_request_is_never_dispatched` and
  `test_a_standing_closure_request_exits_thirteen`.
- **M2**, `scan_prose` never reports a closure request (the detector stops
  working entirely): reddens the same two, at their end-to-end assertion. The
  pure-function halves pass under M2 because fabricated `checks` bypass the
  detector -- which is why each of those tests carries both halves.

Contract ratchets updated rather than worked around: the exit table, the verdict
enumeration, and the conductor system prompt in `agent.py` are pinned by
`test_pipeline_conductor_skill_contract.py`, and a new
`test_prose_never_closes_an_item` requires the skill to keep saying so, since the
terminal verdict would otherwise read to a future editor as an obvious
simplification.

## Manual verification

N/A -- unit coverage sufficient. The verdict is a pure function of the checks
dict and every branch is exercised without forge access; the end-to-end tests
drive `main()` through a faked `gh`.

## Related Issues

Closes #8191
Refs #8029

## Pattern harvest

Pattern: a detector's finding wired directly to the strongest available
response, where the finding is a reading of natural language and the response is
destructive and irreversible.

The generalization is already visible in this subsystem: three independent
decisions converged on the same answer -- a banned-operation report is always
emitted but enforced for one ownership class only; a suppressed item covered by
an untrusted fork PR keeps its verdict but carries `risk=high` and a marker; and
now a closure reading downgrades instead of closing. Keep the detection, weaken
the response, make the doubt visible. Worth stating once as a review-prompt rule
rather than rediscovered per case.

Rule candidate: review-prompt

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (SKILL.md, the design doc, and the embedded prompt)
- [x] No secrets, credentials, or internal references in the diff
