### PR TITLE
fix(cron): verify the deployed-cron-script source hop (Refs #7093)

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -994,6 +994,62 @@ def _doctor_data_home() -> None:
     )
 
 
+def _doctor_cron_script_sources(issues: list[str]) -> None:
+    """Report deployed cron scripts that no longer agree with their skill-asset source.
+
+    The packaged-to-installed hop is content-verified, ``scripts/`` included. The
+    installed-to-``crons/`` hop is a hand-run ``cp`` documented in the owning
+    skill, and nothing compares its two sides -- so a deploy can run superseded
+    code indefinitely while looking healthy, which is how the shipped PR watch
+    came to re-emit its wake footer once per observation long after the package
+    had split that out.
+
+    Divergence is reported WITHOUT a direction. A cron script body is
+    LLM-writeable by design, so the two sides disagreeing can mean a stale deploy
+    or a deliberate local edit, and nothing on disk distinguishes them. Doctor
+    surfaces the disagreement and leaves the reconciliation to whoever knows
+    which they intended.
+
+    Silent when nothing deployed has a source: a cron script without one is out
+    of scope here, not a finding.
+    """
+    from kiro_crew.skills import (
+        CRON_SOURCE_DIVERGED,
+        CRON_SOURCE_IN_SYNC,
+        deployed_cron_script_sources,
+    )
+
+    states = deployed_cron_script_sources()
+    if not states:
+        return
+
+    print("\nCron Script Sources")
+    for state in states:
+        # Both halves are read off disk and BOTH go through _safe_display. The
+        # crons dir is agent-writeable by design (see cron_script.py), so a
+        # deployed script's name is not merely untrusted in the abstract -- the
+        # design deliberately lets an agent choose it. A diagnostic that reads
+        # those names and prints them raw is exactly the wrong consumer for such
+        # a directory: an OSC/ANSI sequence or a newline in a filename would
+        # drive the terminal or forge the surrounding verdict lines.
+        name = _safe_display(state.name)
+        source = _safe_display(str(state.source))
+        if state.state == CRON_SOURCE_IN_SYNC:
+            print(f"  {name}:  ✅ agrees with {source}")
+        elif state.state == CRON_SOURCE_DIVERGED:
+            print(f"  {name}:  ❌ DIVERGED from {source}")
+        else:
+            print(f"  {name}:  ⏹ could not be compared against {source}")
+
+    if any(state.state == CRON_SOURCE_DIVERGED for state in states):
+        issues.append("deployed cron script diverged from its skill source")
+        print(
+            "               Reconcile using the owning skill's own copy recipe. "
+            "A diverged copy may be a stale deploy OR an intentional local edit "
+            "-- doctor cannot tell which, so it does not overwrite either one."
+        )
+
+
 def _doctor_managed_service_policy(issues: list[str]) -> None:
     """Surface installed service definitions that predate launch-class policy."""
     state = service_controller.installed_service_has_managed_marker()
@@ -2915,6 +2971,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
 
     # ── Data Home (+ leftover legacy home) ──
     _doctor_data_home()
+    _doctor_cron_script_sources(issues)
     _doctor_path_launcher()
     _doctor_trust_root()
     _doctor_strict_identity(cfg)

--- a/src/kiro_crew/skills.py
+++ b/src/kiro_crew/skills.py
@@ -1104,6 +1104,122 @@ def _verified_unchanged_fingerprint(dest_dir: Path, src_dir: Path | None) -> str
     return dest_fingerprint
 
 
+# A cron script body is one file, not a tree, so its ceiling sits far below the
+# whole-tree budget above. A body over this size reads as unverifiable rather
+# than being compared -- the same fail-safe direction an unprovable tree takes.
+_CRON_SOURCE_MAX_BYTES = 2 * 1024 * 1024
+
+CRON_SOURCE_IN_SYNC = "in-sync"
+CRON_SOURCE_DIVERGED = "diverged"
+CRON_SOURCE_UNVERIFIABLE = "unverifiable"
+
+
+@dataclass(frozen=True)
+class CronScriptSource:
+    """One deployed cron script judged against the installed skill asset it came from."""
+
+    name: str
+    source: Path
+    state: str
+
+
+def _skill_script_index(base: Path) -> dict[str, list[Path]]:
+    """Map each ``*.py`` script asset name to the installed skills shipping it.
+
+    A name can be shipped by more than one skill, so the value is a list and the
+    caller decides -- guessing an owner would invent provenance the copy never
+    recorded.
+    """
+    index: dict[str, list[Path]] = {}
+    for _name, skill_file in _iter_skill_files(base):
+        scripts = skill_file.parent / "scripts"
+        if not scripts.is_dir():
+            continue
+        for entry in sorted(scripts.glob("*.py")):
+            index.setdefault(entry.name, []).append(entry)
+    return index
+
+
+def _read_for_comparison(path: Path, root: Path) -> bytes | None:
+    """Read *path* under *root* containment, or None when it cannot be proven."""
+    try:
+        return safe_read_file_bytes_nolink(
+            str(path), within_root=str(root), max_bytes=_CRON_SOURCE_MAX_BYTES
+        )
+    except FileTooLargeError:
+        return None
+    except OSError:
+        return None
+
+
+def deployed_cron_script_sources() -> list[CronScriptSource]:
+    """Judge each deployed cron script that has an installed skill asset of its name.
+
+    This is the second hop of the journey :func:`_verified_unchanged_fingerprint`
+    already guards. The first hop -- packaged ``builtin_skills/`` into the
+    installed skills dir -- is verified by CONTENT, the ``scripts/`` subtree
+    included, precisely because a release that changes only a script leaves
+    ``SKILL.md`` byte-identical, so a manifest-only comparison reports "up to
+    date" while the install keeps running superseded code. The second hop --
+    installed skill asset into ``<config_dir>/crons/`` -- is a hand-run ``cp``
+    documented in the owning skill, and nothing has ever compared its two sides.
+    The same silent staleness the first hop was taught to catch is therefore
+    unobserved one step later.
+
+    Scope is deliberately narrow. A deployed script with NO installed skill asset
+    of that name is ABSENT from the result rather than reported: cron script
+    bodies are LLM-writeable by design (see :mod:`kiro_crew.cron_script`) and
+    most are authored in place with no source anywhere, so whether they ought to
+    have one is a product question this function does not raise. Only a script
+    that DOES have a source can be out of step with it.
+
+    Reads go through the containment-checked reader the fingerprint helpers use,
+    so a symlink, a hardlinked inode, a non-regular file, a path escaping its
+    root, or an oversized body yields ``CRON_SOURCE_UNVERIFIABLE`` instead of a
+    comparison. Unverifiable never reads as agreement -- an instrument whose read
+    failed must not report the two sides equal.
+
+    When several skills ship the same script name, agreement with ANY of them is
+    ``CRON_SOURCE_IN_SYNC``: the copy records no owner, so a mismatch against an
+    arbitrarily chosen candidate would be a fabricated finding.
+    """
+    crons_root = config_dir() / "crons"
+    skills_root = skills_dir()
+    if not crons_root.is_dir() or not skills_root.is_dir():
+        return []
+    index = _skill_script_index(skills_root)
+    if not index:
+        return []
+
+    results: list[CronScriptSource] = []
+    for deployed in sorted(crons_root.glob("*.py")):
+        candidates = index.get(deployed.name)
+        if not candidates:
+            # No source to be out of step with -- out of scope by design.
+            continue
+        body = _read_for_comparison(deployed, crons_root)
+        state = CRON_SOURCE_UNVERIFIABLE
+        matched = candidates[0]
+        if body is not None:
+            unreadable = 0
+            for candidate in candidates:
+                source_body = _read_for_comparison(candidate, skills_root)
+                if source_body is None:
+                    unreadable += 1
+                    continue
+                if source_body == body:
+                    matched = candidate
+                    state = CRON_SOURCE_IN_SYNC
+                    break
+            else:
+                # Every candidate was read and none matched, or some could not
+                # be read at all. Only the fully-read case is a real divergence;
+                # an unread candidate might have been the matching one.
+                state = CRON_SOURCE_UNVERIFIABLE if unreadable else CRON_SOURCE_DIVERGED
+        results.append(CronScriptSource(name=deployed.name, source=matched, state=state))
+    return results
+
+
 def _claim_dir_for_replacement(dest_dir: Path) -> Path | None:
     """Atomically move *dest_dir* to a dot-prefixed sibling before verifying.
 

--- a/test/test_cron_script_source_drift.py
+++ b/test/test_cron_script_source_drift.py
@@ -1,0 +1,275 @@
+"""Second-hop cron script source verification (Refs #7093).
+
+The packaged ``builtin_skills/`` to installed-skills hop is content-verified,
+``scripts/`` included -- ``test_builtin_skill_sync_safety.py`` pins that with
+``test_script_only_package_update_reaches_the_install``. The next hop, installed
+skill asset to ``<config_dir>/crons/``, is a hand-run ``cp`` that nothing ever
+compared, so a deployed cron script could run superseded code indefinitely while
+looking healthy.
+
+These tests pin the hop-2 comparison. The load-bearing one is
+``test_diverged_deploy_is_detected``: an identical-copy test alone stays green
+even if the comparison is deleted outright, so agreement is not evidence the
+instrument works. The scope guard matters just as much -- a deployed script with
+no source at all must NOT be reported, because cron script bodies are
+LLM-writeable by design and whether they ought to have sources is a product
+question this check does not raise.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import skills as skills_mod
+from kiro_crew.skills import (
+    CRON_SOURCE_DIVERGED,
+    CRON_SOURCE_IN_SYNC,
+    CRON_SOURCE_UNVERIFIABLE,
+    deployed_cron_script_sources,
+)
+
+
+@pytest.fixture
+def data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A temp data home with the two directories the comparison spans."""
+    home = tmp_path / "crew"
+    (home / "crons").mkdir(parents=True)
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setattr(skills_mod, "config_dir", lambda: home)
+    monkeypatch.setattr(skills_mod, "skills_dir", lambda: home / "skills")
+    return home
+
+
+def _ship_skill_script(home: Path, skill: str, script: str, body: str) -> Path:
+    """Install a skill under *skill* shipping ``scripts/<script>`` with *body*."""
+    skill_dir = home / "skills" / skill
+    (skill_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill.replace('/', '-')}\ndescription: fixture skill\n---\nbody\n",
+        encoding="utf-8",
+    )
+    target = skill_dir / "scripts" / script
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _deploy(home: Path, script: str, body: str) -> Path:
+    """Write *body* to ``crons/<script>`` the way a hand-run ``cp`` would."""
+    target = home / "crons" / script
+    target.write_text(body, encoding="utf-8")
+    return target
+
+
+def _state_for(name: str) -> str:
+    states = {entry.name: entry.state for entry in deployed_cron_script_sources()}
+    assert name in states, f"{name} absent from {states}"
+    return states[name]
+
+
+class TestHopTwoVerification:
+    def test_diverged_deploy_is_detected(self, data_home: Path) -> None:
+        """A deployed copy whose source moved on reads as diverged.
+
+        This is the assertion the whole check exists for. The source gains a
+        line the deployed copy has never seen -- exactly the shape of the real
+        drift, where a package split a helper out and the deploy kept the old
+        inline body.
+        """
+        _ship_skill_script(
+            data_home, "kirocrew-dev/babysit", "pr_watch.py", "def watch(ctx):\n    pass\n"
+        )
+        _deploy(data_home, "pr_watch.py", "def watch(ctx):\n    return None\n")
+
+        assert _state_for("pr_watch.py") == CRON_SOURCE_DIVERGED
+
+    def test_identical_deploy_agrees(self, data_home: Path) -> None:
+        body = "def watch(ctx):\n    pass\n"
+        _ship_skill_script(data_home, "kirocrew-dev/babysit", "pr_watch.py", body)
+        _deploy(data_home, "pr_watch.py", body)
+
+        assert _state_for("pr_watch.py") == CRON_SOURCE_IN_SYNC
+
+    def test_whitespace_only_difference_still_diverges(self, data_home: Path) -> None:
+        """Comparison is on bytes, so a trailing-newline drift is not waved through."""
+        _ship_skill_script(data_home, "pack/skill", "poller.py", "def run(ctx):\n    pass\n")
+        _deploy(data_home, "poller.py", "def run(ctx):\n    pass")
+
+        assert _state_for("poller.py") == CRON_SOURCE_DIVERGED
+
+    def test_deployed_script_without_a_source_is_not_reported(self, data_home: Path) -> None:
+        """Scope guard: the sourceless majority is out of scope, not a finding.
+
+        Reporting these would re-raise the Tier 0 product question -- whether
+        operational cron scripts ought to ship from the repo at all -- which a
+        maintainer has ruled is not this check's call.
+        """
+        _ship_skill_script(data_home, "pack/skill", "poller.py", "def run(ctx):\n    pass\n")
+        _deploy(data_home, "poller.py", "def run(ctx):\n    pass\n")
+        _deploy(data_home, "gh_cleanup.py", "def cleanup(ctx):\n    pass\n")
+
+        reported = {entry.name for entry in deployed_cron_script_sources()}
+        assert reported == {"poller.py"}
+        assert "gh_cleanup.py" not in reported
+
+    def test_agreement_with_any_candidate_source_is_in_sync(self, data_home: Path) -> None:
+        """Two skills shipping one name: matching either is agreement.
+
+        The copy records no owner, so reporting a mismatch against an
+        arbitrarily chosen candidate would be a fabricated finding.
+        """
+        shared = "def run(ctx):\n    return 2\n"
+        _ship_skill_script(data_home, "pack/first", "shared.py", "def run(ctx):\n    return 1\n")
+        _ship_skill_script(data_home, "pack/second", "shared.py", shared)
+        _deploy(data_home, "shared.py", shared)
+
+        assert _state_for("shared.py") == CRON_SOURCE_IN_SYNC
+
+    def test_divergence_from_every_candidate_is_still_diverged(self, data_home: Path) -> None:
+        _ship_skill_script(data_home, "pack/first", "shared.py", "def run(ctx):\n    return 1\n")
+        _ship_skill_script(data_home, "pack/second", "shared.py", "def run(ctx):\n    return 2\n")
+        _deploy(data_home, "shared.py", "def run(ctx):\n    return 3\n")
+
+        assert _state_for("shared.py") == CRON_SOURCE_DIVERGED
+
+    def test_unreadable_side_is_unverifiable_not_agreement(
+        self, data_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An instrument whose read failed must not report the two sides equal.
+
+        A body over the ceiling is the cheapest way to make the read fail; the
+        verdict must be ``unverifiable``, never ``in-sync``.
+        """
+        body = "def run(ctx):\n    pass\n"
+        _ship_skill_script(data_home, "pack/skill", "poller.py", body)
+        _deploy(data_home, "poller.py", body)
+        monkeypatch.setattr(skills_mod, "_CRON_SOURCE_MAX_BYTES", 4)
+
+        state = _state_for("poller.py")
+        assert state == CRON_SOURCE_UNVERIFIABLE
+        assert state != CRON_SOURCE_IN_SYNC
+
+    def test_no_skills_dir_yields_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "crew"
+        (home / "crons").mkdir(parents=True)
+        monkeypatch.setattr(skills_mod, "config_dir", lambda: home)
+        monkeypatch.setattr(skills_mod, "skills_dir", lambda: home / "skills")
+
+        assert deployed_cron_script_sources() == []
+
+
+class TestDoctorRendersNamesInert:
+    """A deployed script's NAME is chosen by an agent, so doctor must not print it raw.
+
+    ``cron_script.py`` states that bodies under ``<config_dir>/crons/`` are
+    LLM-writeable by design and enumerates the mitigations that make that
+    acceptable. So the filename is not merely untrusted in the abstract -- the
+    design deliberately lets an agent pick it, which makes a diagnostic that
+    echoes it the wrong consumer for that directory. An OSC/ANSI sequence would
+    drive the operator's terminal, and a newline would let a name forge the
+    surrounding verdict lines.
+
+    The contract under test is what doctor PRINTS, so these inject the state
+    rather than staging a file. That is deliberate and not a convenience: a
+    control character is legal in a POSIX filename and rejected by Win32, so an
+    on-disk fixture would test the filesystem's rules instead of the renderer's,
+    and would fail on Windows with ``EINVAL`` before reaching the code under
+    test. Injecting covers the renderer identically on every platform.
+
+    Each test asserts the RAW escape is absent and the escaped form present.
+    Asserting that an ordinary name renders correctly would pass with or without
+    ``_safe_display``, so it would prove nothing.
+    """
+
+    ESC_NAME = "pr_watch\x1b[31m\n_forged.py"
+
+    def _render(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        state: str,
+    ) -> str:
+        from kiro_crew import cli_doctor
+
+        entry = skills_mod.CronScriptSource(
+            name=self.ESC_NAME,
+            source=Path("/skills/pack/skill/scripts") / self.ESC_NAME,
+            state=state,
+        )
+        monkeypatch.setattr(skills_mod, "deployed_cron_script_sources", lambda: [entry])
+        issues: list[str] = []
+        cli_doctor._doctor_cron_script_sources(issues)
+        return capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        ("state", "marker"),
+        [
+            (CRON_SOURCE_IN_SYNC, "agrees with"),
+            (CRON_SOURCE_DIVERGED, "DIVERGED"),
+            (CRON_SOURCE_UNVERIFIABLE, "could not be compared"),
+        ],
+    )
+    def test_every_branch_renders_a_control_sequence_inert(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        state: str,
+        marker: str,
+    ) -> None:
+        """All three verdict branches print a name, so all three must escape it.
+
+        Parametrised rather than written once against the diverged branch: fixing
+        only the branch a reviewer pointed at is half a fix that reads as
+        complete.
+        """
+        out = self._render(monkeypatch, capsys, state)
+
+        assert marker in out
+        assert "\x1b" not in out
+        assert "\\x1b" in out
+
+    def test_source_path_is_also_rendered_inert(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The source half is read off disk too, so it gets the same treatment."""
+        out = self._render(monkeypatch, capsys, CRON_SOURCE_DIVERGED)
+
+        # The escaped name appears twice: once as the deployed name, once inside
+        # the source path. Neither may carry a live escape.
+        assert out.count("\\x1b") >= 2
+        assert "\x1b" not in out
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="Win32 rejects control characters in filenames (EINVAL), so a "
+    "control-character cron script name cannot exist on that platform. The "
+    "renderer itself is covered on every platform by "
+    "TestDoctorRendersNamesInert, which injects the name instead.",
+)
+def test_control_character_name_on_disk_is_enumerated_and_escaped(
+    data_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """End-to-end on POSIX, where such a filename is legal and the vector is live.
+
+    Proves the premise the injected tests assume: a control-character name is
+    accepted by the filesystem, survives enumeration, and still reaches the
+    operator inert.
+    """
+    from kiro_crew import cli_doctor
+
+    name = "poller\x1b[31m.py"
+    _ship_skill_script(data_home, "pack/skill", name, "def run(ctx):\n    pass\n")
+    _deploy(data_home, name, "def run(ctx):\n    return 1\n")
+
+    issues: list[str] = []
+    cli_doctor._doctor_cron_script_sources(issues)
+    out = capsys.readouterr().out
+
+    assert "DIVERGED" in out
+    assert "\x1b" not in out
+    assert "\\x1b" in out


### PR DESCRIPTION
## What is the problem?

Sixteen script crons run from the operator data home. The journey a repo-shipped cron script takes has two hops, and only the first is verified:

- Hop 1, packaged `builtin_skills/` into the installed skills dir, is verified by CONTENT, the `scripts/` subtree included (`skills.py` `_verified_unchanged_fingerprint`). It is content-based on purpose: a release that changes only a script leaves `SKILL.md` byte-identical, so a manifest-only check would report "up to date" while the install kept running superseded code.
- Hop 2, installed skill asset into `<config_dir>/crons/`, is a hand-run `cp` documented in the owning skill (`builtin_skills/kirocrew-dev/babysit/SKILL.md`). Nothing has ever compared its two sides.

So the exact silent staleness hop 1 was taught to catch is unobserved one step later.

## Why this issue matters to the user

It has already happened. The one cron script that has an in-repo source, `pr_watch.py`, is running a stale deploy: the package split its wake-footer emission into a `wake_suffix()` on the probe (`irq.py`, `probes/gh_pr.py`), and the deployed copy predates that split, so it re-emits the footer once per observation instead of once per wake. Nothing flagged that the deploy had fallen behind its own source, because nothing compares them.

## How our fix solves it (chain from symptom to root cause)

Symptom: a deployed cron script silently runs code its source has moved past.
Direct cause: the installed-to-`crons/` copy is unverified.
Why unverified: the verification that exists stops at hop 1.
Fix: extend the same content comparison to hop 2 and surface any divergence in `kirocrew doctor`.

`deployed_cron_script_sources()` (`skills.py`) judges each deployed `crons/*.py` that has an installed skill asset of its name (in-sync, diverged, or unverifiable), reusing the containment-checked reader the fingerprint helpers use. `_doctor_cron_script_sources()` (`cli_doctor.py`) prints a `Cron Script Sources` section and records an issue only on a genuine divergence.

Three deliberate limits:
- Report-only, no direction. A cron body is LLM-writeable by design (`cron_script.py`), so a mismatch may be a stale deploy or an intentional local edit, and nothing on disk distinguishes them. Doctor surfaces the disagreement and overwrites neither side.
- Scoped to scripts that HAVE a source. A deployed script with no skill asset of its name is absent from the result, not reported. Whether operational cron scripts should ship from the repo at all is the Tier 0 product question (see below), and this check does not raise it.
- No new mechanism, no posture change. No in-repo sources added, `resolve_script_path` untouched, the LLM-writeable design untouched.

### Printed names go through the existing `_safe_display` helper

Every name and source path doctor prints is routed through `_safe_display`, in all three branches, not only the one flagged in review. The justification is stronger than generic output escaping: this PR's own investigation established that `cron_script.py:1-6` declares `<config_dir>/crons/` **LLM-writeable by design** and enumerates the mitigations that make that acceptable. The filename is therefore not merely untrusted in the abstract -- the design deliberately lets an agent choose it. A diagnostic that reads those names and prints them raw is exactly the wrong consumer for a deliberately agent-writable directory: an OSC/ANSI sequence would drive the operator's terminal, and a newline would let a filename forge the surrounding verdict lines.

### On the maintainer ruling

@bolichen97 routed #7093 to `needs-human` because Tier 0, how operational code is shipped and reviewed, is a product decision a pipeline cannot grant. This PR does not touch that decision: it closes a verification gap on a hop that already has a verification pattern one step earlier, and leaves the shipping question open.

## What tests we did

`test/test_cron_script_source_drift.py`, 12 cases, run `-n 0` and scoped to that one file. No repo-wide test, format, lint or type scan was run.

Every assertion is one that can only pass with the fix, proven by mutation rather than asserted:

1. **Drift detection.** Blinding the divergence verdict to `in-sync` reddened the three divergence tests (`assert 'in-sync' == 'diverged'`) while the identical-copy tests stayed green -- which is the point: an identical-copy test alone survives deleting the comparison outright, so agreement is not evidence the instrument works.
2. **Output escaping.** Replacing `_safe_display(...)` with the raw values reddened all four escaping tests -- one per branch (in-sync, diverged, unverifiable) plus the source path -- with `assert '\x1b' not in ...`. Each branch failing separately is the evidence the fix covers all of them.

Both mutations were applied from a file-based patch, confirmed present in the file before running, and reverted; all 12 pass on the current head.

Also covered: byte-level whitespace divergence, the sourceless-script scope guard, and multi-source agreement/divergence.

`black --check` is clean on the changed files. **`ruff` is not installed in this environment, so I could not run it locally** -- CI covers that lane; I am not claiming local lint coverage I do not have.

## Pattern harvest

Rule candidate: an issue of the form "N of M things lack X" is an INVENTORY, and an inventory fix can be stale before it ships. Verify the count first; if it has moved, the deliverable must be a mechanism rather than a list.

This item is the evidence. The issue said 15 of 16 script crons had no in-repo source. Measured on clean `origin/main` in a detached worktree it was **17 of 18**, and the baseline reconciles to the byte: two files dated 2026-08-31, the day after filing, at 24 and 28 lines, so 7,780 + 52 = 7,832. The count decayed within 24 hours of being written down.

That single measurement eliminated both candidate shapes at once -- writing the fifteen missing sources, and splitting the issue into fifteen items -- because each of them fixes a snapshot that was already out of date. What survives is a mechanism that keeps holding as the count moves. It is why this PR is 3 files instead of 15.

Two supporting rules from the same item:

- **A "no X exists" claim is worth one more grep before it becomes a fix.** The issue's headline was that script crons have no shipping pattern. One exists, is documented as intentional (`babysit-pr-watch.md`: "a source asset, not a gateway import"), and is used by exactly one script -- so the real gap was narrower and much cheaper: the verification covers hop 1 and not hop 2.
- **Deliberate, unjudged and overlooked are three different states, and only the third licenses deciding it yourself.** I first reported the missing sources as deliberate design. `scripts/check_builtin_skill_scope.py` says verbatim that its gate "does NOT judge whether that family should ship to every install at all" -- explicitly unjudged, which is why the Tier 0 question is left open here rather than answered.

## Any other suggestions on the work

Two findings from the survey belong in their own issue rather than here, filed honestly:

1. `gh_merge_watch.py` writes to the pre-sharding legacy queue path (hardcoded stem, bypassing `queue_file()`/`queue_lock()`/the migration guard); no reader opens that file. Real defect, but the script is registered in no job, so the branch never fires. LATENT, not live. A latent finding reported as live gets the whole issue discounted.
2. The issue's own `pr_watch.py` remedy is misdirected: `wake_suffix()` is in `irq.py` and `probes/gh_pr.py`, in NEITHER copy of `pr_watch.py` (the in-repo file is now a thin driver, the deployed one its larger ancestor). Following the issue's instruction would redeploy the wrong file and conclude the fix did nothing. The correct action is an operator redeploy, and this PR's doctor check is what would tell you it is needed.

Base: `b6716378a`.

Refs #7093

