### PR TITLE
fix(papyrus): refuse a junctioned path in the Compile link scan

### DIFF
--- a/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/latex.py
@@ -573,7 +573,10 @@ def _symlinked_artifacts(project: Path) -> tuple[list[str], bool]:
     than quietly following what the editor refuses to show.
 
     Bounded by ``store.MAX_PROJECT_FILES`` and does not descend INTO links, so a
-    ``a -> ..`` cycle cannot spin it — same walk shape as ``list_files``.
+    ``a -> ..`` cycle cannot spin it — same walk shape as ``list_files``. "Link" here
+    means what ``store.is_reparse_link`` means, symlink OR Windows directory junction:
+    a junction is the one link type a Windows user can create without elevation, so a
+    symlink-only test leaves the cheapest bypass on that platform open.
 
     Returns ``(links, complete)``. **``complete`` is load-bearing and the caller MUST
     refuse when it is False.** The bound makes the walk terminate, but an exhausted
@@ -601,7 +604,17 @@ def _symlinked_artifacts(project: Path) -> tuple[list[str], bool]:
                 # the answer is partial; never let this look like "no links".
                 return found, False
             try:
-                if entry.is_symlink():
+                # `store.is_reparse_link`, not `is_symlink()`: a Windows directory
+                # junction is a reparse point `is_symlink()` does NOT report, and a
+                # junction is precisely a DIRECTORY link — so it fell through to the
+                # `is_dir()` arm below and the walk DESCENDED it, out of the project.
+                # That breaks this guard in both directions at once: the link is
+                # missing from `found`, so Compile proceeds and lets the compiler
+                # write through it, and the walk spends its budget on a tree outside
+                # the project. `store.list_files` already refuses junctions here, so
+                # asking `is_symlink()` also put Compile back into disagreement with
+                # the file list this docstring cites as the stance it matches.
+                if store.is_reparse_link(entry):
                     found.append(entry.relative_to(project).as_posix())
                     continue
                 # `.git` holds the checkout's own machinery, not document sources, and a

--- a/test/test_papyrus_latex.py
+++ b/test/test_papyrus_latex.py
@@ -27,6 +27,9 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+
+if sys.platform == "win32":  # pragma: no cover - platform-gated
+    import _winapi
 from pathlib import Path
 from typing import Iterator
 from unittest import mock
@@ -1285,3 +1288,110 @@ class TestSandboxRefusalIsReportedNotSwallowed:
         assert wrap.call_count == 1
         # `strict`, not a weaker tier chosen to make the spawn succeed.
         assert _spawn_mode(wrap) == "strict"
+
+
+class TestTheCompileLinkScanRefusesJunctionsToo:
+    """The Compile guard must refuse a link through ``store.is_reparse_link``.
+
+    That helper's own contract says it: "every place this module refuses a link at a
+    name Kiro Crew owns has to refuse a junction too, or the refusal is POSIX-only".
+    ``store.list_files`` honours it. ``_symlinked_artifacts`` asked ``is_symlink()``,
+    which does NOT report a Windows directory junction — and a junction is precisely
+    a DIRECTORY link, so it reached the ``is_dir()`` arm of the same loop and broke
+    the guard in both directions at once:
+
+    * the junction was absent from the refusal list, so Compile proceeded and
+      ``pdflatex`` was free to write through it to whatever it points at — the exact
+      outcome ``_symlinked_artifacts`` exists to prevent; and
+    * the walk DESCENDED it, contradicting the docstring's "does not descend INTO
+      links" and spending ``MAX_PROJECT_FILES`` budget on a tree outside the project,
+      which pushes ``complete`` toward False for reasons the project does not contain.
+
+    Junctions are the link type a Windows user can create WITHOUT elevation, so this
+    is the platform's cheapest bypass — and note every symlink test above is skipped
+    on win32 precisely because symlinks there need a privilege junctions do not.
+
+    Asserted through the shared helper rather than by creating a real junction,
+    because ``os.path.isjunction`` is 3.12+ and always ``False`` off Windows — the
+    same technique ``test_papyrus_store.py`` uses. One real-junction test runs on
+    Windows so the stub is anchored to the platform behaviour it stands in for.
+    """
+
+    def test_a_junction_is_reported_as_a_link(self, project: Path) -> None:
+        junction = project / "linked"
+        junction.mkdir()
+        with mock.patch.object(store, "is_reparse_link", lambda p: Path(p) == junction):
+            links, complete = latex._symlinked_artifacts(project)
+        assert complete is True
+        assert "linked" in links
+
+    def test_the_walk_does_not_descend_a_junction(self, project: Path) -> None:
+        """Descent is the half that survives even once the name is reported, and it
+        cannot be observed through the return value: this scan only ever appends
+        LINKS, so a walk that descended a junction full of ordinary files still
+        returns the same list. Assert it against what the walk LOOKED at instead."""
+        junction = project / "linked"
+        junction.mkdir()
+        (junction / "inside.tex").write_text("x", encoding="utf-8")
+        seen: list[str] = []
+
+        def _spy(p: Path) -> bool:
+            seen.append(Path(p).name)
+            return Path(p) == junction
+
+        with mock.patch.object(store, "is_reparse_link", _spy):
+            links, _complete = latex._symlinked_artifacts(project)
+
+        assert "linked" in links
+        assert "inside.tex" not in seen, "the walk descended into the junction"
+
+    def test_the_scan_consults_the_shared_helper(self, project: Path) -> None:
+        """A junction is only refused if the scan ASKS the helper about it."""
+        (project / "sections").mkdir(exist_ok=True)
+        seen: list[str] = []
+
+        def _spy(p: Path) -> bool:
+            seen.append(Path(p).name)
+            return False
+
+        with mock.patch.object(store, "is_reparse_link", _spy):
+            latex._symlinked_artifacts(project)
+
+        assert "sections" in seen
+
+    @pytest.mark.asyncio
+    async def test_compile_refuses_when_a_junction_is_present(self, project: Path) -> None:
+        """End-to-end: the compiler must not run. Without this the spawn happens and
+        `pdflatex` writes by name through the link."""
+        junction = project / "linked"
+        junction.mkdir()
+        with mock.patch.object(store, "is_reparse_link", lambda p: Path(p) == junction), (
+            mock.patch.object(
+                latex, "find_compiler", mock.AsyncMock(return_value="/usr/bin/pdflatex")
+            )
+        ), mock.patch.object(latex, "_run", mock.AsyncMock()) as run:
+            result = await latex.compile_project(project, "main.tex")
+        assert result.ok is False
+        assert "linked" in result.log
+        assert not run.called, "the compiler ran despite a junctioned directory"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="junctions are a Windows reparse point")
+    def test_a_real_windows_junction_is_refused(self, project: Path) -> None:
+        """No stub and no elevation: the real reparse point, which is what makes the
+        stubbed tests above a stand-in for something rather than for nothing."""
+        outside = project.parent / "outside"
+        outside.mkdir()
+        (outside / "secret.tex").write_text("secret", encoding="utf-8")
+        junction = project / "linked"
+        _winapi.CreateJunction(str(outside), str(junction))
+
+        # A budget of 2 is enough for `main.tex` + `linked`, and NOT enough to also
+        # walk the junction's contents — so `complete` staying True is what proves
+        # the walk stopped at the link rather than following it out of the project.
+        for i in range(4):
+            (outside / f"pad{i}.tex").write_text("", encoding="utf-8")
+        with mock.patch.object(store, "MAX_PROJECT_FILES", 2):
+            links, complete = latex._symlinked_artifacts(project)
+
+        assert "linked" in links, "a real junction was not reported as a link"
+        assert complete is True, "the walk followed a real junction and blew the budget"


### PR DESCRIPTION
## Problem / Motivation

Papyrus refuses to compile a project when anything beneath it is a link. The
reason is in `_symlinked_artifacts`' own docstring: pdflatex **writes files by
name**, and the document chooses those names (`\openout\ch=chapter1`, a
redirected `\jobname`, `.bbl`/`.idx` toolchains), so compiling through a link
overwrites whatever it points at. The guard's stated stance is absolute —
"nothing beneath the project is a link at all".

The walk asked `entry.is_symlink()`.

On Windows that misses a **directory junction**, and a junction is precisely a
DIRECTORY link — so it reached the `is_dir()` arm of the very same loop.

## Why it matters

The guard fails in both directions at once for a junctioned path:

1. **The link is never reported.** `blocked` comes back empty, `compile_project`
   proceeds, and pdflatex is free to write through the junction to whatever it
   points at. That is exactly the outcome this function exists to prevent.
2. **The walk descends into it.** That contradicts the docstring's "does not
   descend INTO links, so a `a -> ..` cycle cannot spin it", and it spends the
   `MAX_PROJECT_FILES` budget on a tree outside the project — which can push
   `complete` to False and produce a "this project has more than N files" refusal
   the user cannot act on, because the files are not in their project.

Junctions are the link type a Windows user can create **without elevation**,
while symlinks there require a privilege. So the symlink-only test covered the
case a Windows user mostly cannot create and missed the one they can.

That asymmetry is also why the gap survived review: every existing link test in
`test_papyrus_latex.py` carries
`@pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")`.
The suite could not have caught this.

## What changed (motivation → approach → change)

**Symptom** — a junctioned directory inside a Papyrus project is neither
reported nor skipped by the Compile link scan.

**Root cause** — the scan tests for one link type instead of asking the module's
shared link predicate. `store.is_reparse_link` already exists and its docstring
states the rule this violated:

> every place this module refuses a link at a name Kiro Crew owns has to refuse
> a junction too, or the refusal is POSIX-only

**Change** — one line in `_symlinked_artifacts`: `entry.is_symlink()` becomes
`store.is_reparse_link(entry)`. `latex.py` already imports `store`, so nothing
new is wired in.

This is the same move #7881 made for `store.list_files`, in the sibling module
that PR did not touch. It matters that they agree: this function's docstring
cites `list_files`' stance as the one it is matching ("a link is not a file the
editor should follow"), and since #7881 they had silently diverged on Windows —
the editor refused to show a junctioned file while Compile followed it.

This is also a documented repository rule, not only a local inference: the
cross-platform table in `AGENTS.md` carries the row

| Detect/remove a dir link | `is_link_or_junction(path)` / `unlink_link_or_junction(path)` | `path.is_symlink()` (misses a Windows junction) |

so the changed call site was on the NOT column of that table.

`store.is_reparse_link` detects junctions without depending on
`os.path.isjunction` (3.12+, and this project supports 3.10), so the guard is
present on every supported interpreter.

## Tests

Added `TestTheCompileLinkScanRefusesJunctionsToo` to `test/test_papyrus_latex.py`,
following the pattern #7881 established in `test_papyrus_store.py` — stub the
shared helper, because `os.path.isjunction` is 3.12+ and always False off Windows:

* `test_a_junction_is_reported_as_a_link` — the junction appears in the refusal
  list.
* `test_the_walk_does_not_descend_a_junction` — asserts against what the walk
  **looked at**, via a spy, not against the return value. This scan only ever
  appends *links*, so a walk that descended a junction full of ordinary files
  returns an identical list; checking `found` would pass vacuously and prove
  nothing. (It did: an earlier draft of this test passed on unpatched `main`.)
* `test_the_scan_consults_the_shared_helper` — a junction is only refused if the
  scan asks the helper at all.
* `test_compile_refuses_when_a_junction_is_present` — end-to-end: `compile_project`
  returns `ok=False` and the compiler never runs.
* `test_a_real_windows_junction_is_refused` — **no stub and no elevation.** Creates
  an actual reparse point with `_winapi.CreateJunction` and asserts both halves:
  the junction is reported, and `complete` stays True under a budget of 2, which
  is only possible if the walk stopped at the link instead of following it into a
  padded outside directory. This anchors the stubbed tests to real platform
  behaviour rather than to a mock of it.

**Red-before**, new tests against the unmodified `main` production file
(Windows host, `-p no:randomly`): **5 failed**. The real-junction test fails with
`AssertionError: a real junction was not reported as a link` — the bypass
demonstrated on a genuine reparse point, no mocking involved.

**Green-after**: whole file, 87 passed / 15 skipped.

**Gates**: repo black gate ✓ (nothing in scope unformatted outside the
baseline), isort ✓, flake8 ✓, mypy ✓ (no issues), brand gate ✓.

## Manual verification

N/A — unit coverage sufficient, and stronger than a manual check would be: the
suite creates a real Windows junction and exercises the actual walk, so the
platform behaviour is executed rather than described.

## Related Issues

No linked issue. Found by auditing the surviving `is_symlink()` sites against
`store.is_reparse_link`'s stated contract after #7881 (`fix(papyrus): papyrus
walks refuse a Windows junction`) merged, which fixed `store.py` and left this
sibling in `latex.py`.

Scope is deliberately this one call site. Other `is_symlink()` sites elsewhere in
the tree each need their own threat analysis — as #8165's review put it, per-site
reasoning rather than a sweep — so they are not bundled here.

## Pattern harvest

Rule candidate: `semgrep`

Pattern: `is_symlink()` / `os.path.islink()` used as a *security* refusal on a
path the product owns. On Windows it silently misses a directory junction, which
is both the link type that needs no elevation and a link that `is_dir()` reports
as a directory — so the miss does not merely skip the check, it routes the entry
into the "descend this directory" branch. A lint rule can flag the predicate
inside a refusal or walk and require the project's reparse-aware helper.

Secondary review prompt: when a test suite skips a whole class of tests on one
platform (`skipif(sys.platform == "win32")`), treat that platform as *unverified*
for the behaviour under test rather than as covered.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the function's docstring now defines what "link" means here
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
