### PR TITLE
fix(design-tweak): stop the preview HTML scan enumerating a junctioned tree

### DIFF
--- a/src/kiro_crew/apps/builtins/design_tweak/backend/preview_files.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/preview_files.py
@@ -269,7 +269,15 @@ def scan_html(runtime: Any, root: Any, limit: int = 40, max_depth: int = 3) -> l
             # Check before ``is_dir()``, which follows links.  Diagnostic names
             # are visible to the preview page, so even listing a linked private
             # directory would disclose information.
-            if entry.is_symlink():
+            #
+            # ``is_link_or_junction``, not ``is_symlink()``: a Windows directory
+            # junction is a reparse point ``is_symlink()`` does NOT report, and a
+            # junction is precisely a DIRECTORY link — so it fell straight through
+            # to the ``is_dir()`` arm below and the walk enumerated the linked tree.
+            # Junctions need no elevation on Windows, while symlinks there do, so
+            # the symlink-only test withheld the listing exactly where a user cannot
+            # plant the link and allowed it where they can.
+            if runtime.is_link_or_junction(entry):
                 continue
             name = entry.name
             if entry.is_dir():

--- a/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
+++ b/src/kiro_crew/apps/builtins/design_tweak/backend/server.py
@@ -44,6 +44,7 @@ from kiro_crew.platform_compat import (
     SIGKILL,
     SIGTERM,
     get_ppid,
+    is_link_or_junction,
     kill_process_tree,
     trusted_system_bin,
 )
@@ -72,6 +73,7 @@ _RUNTIME_COMPAT_IMPORTS = (
     get_ppid,
     glob,
     http.client,
+    is_link_or_junction,
     is_sensitive_path,
     kill_process_tree,
     parse_qs,

--- a/test/test_design_tweak_backend.py
+++ b/test/test_design_tweak_backend.py
@@ -14,12 +14,16 @@ import io
 import json
 import os
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+if sys.platform == "win32":  # pragma: no cover - platform-gated
+    import _winapi
 
 from conftest import requires_symlinks
 from kiro_crew.apps.builtins.design_tweak.backend import server
@@ -1415,6 +1419,67 @@ class TestHtmlScanDoesNotFollowSymlinks:
         code, _ctype, body = server._static_response(str(root), "/", "/p/")
         assert code == 404
         assert b"private-notes" not in body
+
+    def test_a_junctioned_directory_is_not_enumerated(self, tmp_path, monkeypatch):
+        """A junction is the case that actually reaches a Windows user.
+
+        Every other test in this class is `@requires_symlinks` and therefore skipped
+        on Windows, because a symlink there needs a privilege. A junction needs none
+        — so the one link type a Windows user can plant was the one the guard did not
+        cover. `is_symlink()` does not report a junction and a junction IS a
+        directory, so the walk fell to the `is_dir()` arm and listed the linked tree.
+        """
+        secret = tmp_path / "protected"
+        secret.mkdir()
+        (secret / "private-notes.html").write_text("<h1>secret</h1>")
+        root = tmp_path / "site"
+        root.mkdir()
+        link = root / "docs"
+        link.mkdir()
+        (link / "private-notes.html").write_text("<h1>secret</h1>")
+        (root / "real.html").write_text("<h1>ok</h1>")
+
+        monkeypatch.setattr(server, "is_link_or_junction", lambda p: Path(p) == link)
+        found = server._scan_html(root)
+
+        assert "real.html" in found
+        assert not any("private-notes" in f for f in found), found
+
+    def test_the_scan_consults_the_shared_link_helper(self, tmp_path, monkeypatch):
+        """A junction is only refused if the walk ASKS the shared helper about it —
+        the seam, not the outcome, is what `is_symlink()` got wrong."""
+        root = tmp_path / "site"
+        (root / "public").mkdir(parents=True)
+        (root / "public" / "a.html").write_text("x")
+        seen = []
+
+        def _spy(p):
+            seen.append(Path(p).name)
+            return False
+
+        monkeypatch.setattr(server, "is_link_or_junction", _spy)
+        server._scan_html(root)
+
+        assert "public" in seen
+
+    @pytest.mark.skipif(
+        sys.platform != "win32", reason="junctions are a Windows reparse point"
+    )
+    def test_a_real_windows_junction_is_not_enumerated(self, tmp_path):
+        """No stub and no elevation: the real reparse point, so the stubbed tests
+        above stand in for something rather than for nothing."""
+        secret = tmp_path / "protected"
+        secret.mkdir()
+        (secret / "private-notes.html").write_text("<h1>secret</h1>")
+        root = tmp_path / "site"
+        root.mkdir()
+        (root / "real.html").write_text("<h1>ok</h1>")
+        _winapi.CreateJunction(str(secret), str(root / "docs"))
+
+        found = server._scan_html(root)
+
+        assert "real.html" in found
+        assert not any("private-notes" in f for f in found), found
 
     def test_ordinary_nested_html_is_still_found(self, tmp_path):
         """The refusal must not break the diagnostic page it feeds."""


### PR DESCRIPTION
## Problem / Motivation

`scan_html` builds the list of previewable pages that Design Tweak's diagnostic
404 renders, so **its walk discloses filenames**. It deliberately tests for a
link before calling `is_dir()`, and the comment in the source says exactly why:

> Check before `is_dir()`, which follows links. Diagnostic names are visible to
> the preview page, so even listing a linked private directory would disclose
> information.

The test it used was `entry.is_symlink()`.

On Windows that does not report a **directory junction** — and a junction is
precisely a DIRECTORY link, so it fell straight through to the `is_dir()` arm of
the same loop. A `docs` junction pointing at a protected directory had the walk
enumerate that directory and print its HTML filenames on the 404 page.

## Why it matters

This is the exact disclosure the guard exists to prevent, reachable on Windows.
Contents never leak — the *listing* does, which is what the sensitive-path floor
is there to withhold.

The platform asymmetry is what makes it worth fixing rather than shrugging at: a
symlink on Windows requires a privilege, a **junction requires none**. So the
symlink-only test withheld the listing in the case a Windows user mostly cannot
create, and allowed it in the case they can.

That asymmetry is also why the gap survived review. Every existing test in
`TestHtmlScanDoesNotFollowSymlinks` is marked `@requires_symlinks`, so the entire
class is skipped on Windows. The suite looked thorough and covered this walk on
POSIX only.

## What changed (motivation → approach → change)

**Symptom** — a junctioned directory under a preview root is enumerated by
`scan_html` and its HTML filenames reach the diagnostic 404.

**Root cause** — the walk tested one link type instead of asking the platform
seam that knows about both. Because a junction is a directory, the miss does not
merely skip a check: it routes the entry into the "descend this directory"
branch.

**Change** — `entry.is_symlink()` becomes `runtime.is_link_or_junction(entry)`.

Reached through `runtime` rather than by importing `platform_compat` into
`preview_files`, because that module's docstring makes `server` the boundary:

> `server` is the composition root and security-policy owner. Helpers receive
> that module as `runtime` and resolve mutable state and **compatibility seams**
> at call time.

`preview_files` already reaches `is_sensitive_path`, `_contained` and
`_is_project_secret` that way, so this keeps one convention rather than adding a
second. `server` therefore gains `is_link_or_junction` in its `platform_compat`
import and in the existing `_RUNTIME_COMPAT_IMPORTS` tuple — the module's own
declared mechanism for "names intentionally present on the runtime module …
resolved late through the server-owned network, filesystem, clock, and platform
seams". That is what keeps the import honest to flake8 without a `noqa`.

This is also a documented repository rule, not only a local inference: the
cross-platform table in `AGENTS.md` carries the row

| Detect/remove a dir link | `is_link_or_junction(path)` / `unlink_link_or_junction(path)` | `path.is_symlink()` (misses a Windows junction) |

so the changed call site was on the NOT column of that table.

Two production files, one of them a single name added to an import list.

## Tests

Added to the existing `TestHtmlScanDoesNotFollowSymlinks` class, so the junction
case sits beside the symlink cases it completes:

* `test_a_junctioned_directory_is_not_enumerated` — the linked tree's HTML names
  must not appear, while the real page still does.
* `test_the_scan_consults_the_shared_link_helper` — the walk must ASK the helper;
  the seam, not the outcome, is what `is_symlink()` got wrong.
* `test_a_real_windows_junction_is_not_enumerated` — **no stub, no elevation.**
  Creates a genuine reparse point with `_winapi.CreateJunction` and asserts the
  protected directory's filename never reaches the listing.

The stubbed tests are needed because `os.path.isjunction` is 3.12+ and always
False off Windows; the real-junction test is what anchors them to actual platform
behaviour instead of to a mock of it.

**Red-before** against the unmodified `main` production files (Windows host,
`-p no:randomly`): **2 failed**, and the real-junction one fails with

```
AssertionError: ['real.html', 'docs/private-notes.html']
```

— the disclosure itself, reproduced on a real junction with nothing mocked. (The
helper-spy test also fails there, with `AttributeError`, since `main`'s `server`
has no such name to patch.)

**Green-after**: the whole file, 288 passed / 10 skipped.

**Gates**: repo black gate ✓, isort ✓, flake8 ✓ (including the F401 the import
would otherwise raise — resolved via the module's own compat tuple, not a
suppression), mypy ✓.

One note on evidence, since it nearly went the other way: an early full-file run
on this branch showed two `TestStaticPreviewServer` timeouts that a pristine-main
run did not. Repeating the full run twice more gave 288 passed in ~8s, matching
`main`'s ~8s; the 41s outlier coincided with an unrelated repository-wide scan
competing for I/O on the same machine. Recorded rather than omitted, because a
single differing run is not attribution either way.

## Manual verification

N/A — unit coverage sufficient. The regression creates a real Windows junction
and drives the actual walk, so the platform behaviour is executed rather than
described; a manual repro would be the same three commands with less precision.

## Related Issues

No linked issue. Found by auditing surviving `is_symlink()` guards against
`platform_compat.is_link_or_junction` after #8165 (`fix(diagnostics): reject a
junctioned log dir, not just a symlinked one`) merged.

Scope is this one walk. Other `is_symlink()` sites each need their own threat
analysis before they are worth changing — #8165's review made exactly that point
— so they are not bundled here.

## Pattern harvest

Rule candidate: `semgrep`

Pattern: `is_symlink()` / `os.path.islink()` used as a refusal immediately before
an `is_dir()` branch. On Windows the predicate misses a directory junction, and
because a junction *is* a directory the missed entry does not fall through
harmlessly — it lands in the descend-this-directory arm, so a guard that reads as
fail-safe becomes fail-open on exactly one platform. A rule can flag the
`islink`-then-`isdir` shape in a walk and require the reparse-aware helper.

Secondary review prompt: a test class whose every member is skipped on a platform
is evidence that platform is **unverified**, not that it is covered — worth
reading as a signal when the code under test is platform-sensitive.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the in-source comment now states which link types are covered and why
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
