### PR TITLE
fix(config): mask agent description/triggers in config endpoint

### DIFF
--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -2517,6 +2517,15 @@ class KiroCrewConfig:
                     # Same guard as model: a non-string triggers (e.g. `1`) must
                     # not survive load — select_crew's roster calls .strip() on it.
                     raw_triggers = entry.get("triggers", "")
+                    # Same guard, and the last free-text field on this record to
+                    # lack one. The schema validator logs the type mismatch but
+                    # keeps the value ("validated by its consumer"), and this
+                    # loader IS that consumer: an object-valued description
+                    # otherwise reaches every reader that is declared a ``str``,
+                    # including the browser-facing config view, whose redaction
+                    # recognizes only ``str`` — so credential-shaped bytes nested
+                    # inside the object would render there verbatim.
+                    raw_description = entry.get("description", "")
                     agents[name] = KiroCrewAgentConfig(
                         kiro_agent=entry.get("kiro_agent", ""),
                         workspace=entry.get("workspace", "default"),
@@ -2526,7 +2535,7 @@ class KiroCrewConfig:
                         # collapse to "" (inherit) rather than travel to the
                         # provider, where kiro-cli rejects the whole overlay.
                         reasoning_effort=coerce_effort(entry.get("reasoning_effort", "")),
-                        description=entry.get("description", ""),
+                        description=raw_description if isinstance(raw_description, str) else "",
                         triggers=raw_triggers if isinstance(raw_triggers, str) else "",
                         source=entry.get("source", "kirocrew"),
                         # Same guard family as model/triggers: config.json is

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -118,6 +118,16 @@ def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
     is ever added it MUST treat ``_SENSITIVE_MASK`` as "unchanged" and keep the
     stored value. Sensitivity is schema-driven (``sensitive=True`` field
     metadata), so newly added sensitive fields are masked automatically.
+
+    In addition to the schema-``sensitive`` values, the agent-writable free-text
+    fields ``description`` and ``triggers`` on every agent record are redacted in
+    this browser-facing view. Both are writable by the agent itself and by an
+    installed package, and neither is schema-sensitive, so the schema-driven
+    ``_walk`` below leaves them untouched. The roster route (GET /api/agents)
+    still returns the same two fields verbatim: each route owns its own response,
+    so closing this one neither repairs that gap nor waits on it. As with
+    everything else in this function, the redaction lives only in the returned
+    copy and never feeds to_dict()/save().
     """
     from kiro_crew.config.schema import JSON_SCHEMA
     from kiro_crew.config.validation import _is_sensitive_path
@@ -150,6 +160,25 @@ def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
                     node[key] = _SENSITIVE_MASK
 
     _walk(masked, "")
+
+    # Redact the agent-writable free-text fields that are not schema-sensitive
+    # and so slip past the schema-driven walk above. Deliberately NOT the walk's
+    # ``isinstance(val, str) and val`` guard: these two fields are declared
+    # ``str`` but arrive from a hand- and agent-writable config.json, so a value
+    # that is not a string is exactly the untrusted case. Skipping it would be a
+    # redaction bypass — credential-shaped bytes nested in an object or a list
+    # would render verbatim — so anything other than an empty string is masked
+    # here, and the load path coerces the same shapes away upstream. "" alone is
+    # left as-is so the UI shows no "set (hidden)" placeholder for a field nobody
+    # set, and an absent key is not conjured into one. Operates on the
+    # deep-copied `masked` dict, so the real cfg (to_dict()/save()) is untouched.
+    for _agent in masked.get("agents", {}).values():
+        if not isinstance(_agent, dict):
+            continue
+        for _field in ("description", "triggers"):
+            if _field in _agent and _agent[_field] != "":
+                _agent[_field] = _SENSITIVE_MASK
+
     return masked
 
 

--- a/test/test_config_agent_string_masking.py
+++ b/test/test_config_agent_string_masking.py
@@ -1,0 +1,139 @@
+"""Masking of agent-writable free-text values in the config API response.
+
+Agent ``description`` and ``triggers`` are writable by the agent itself and by an
+installed package, and neither is schema-sensitive, so the schema-driven walk in
+``_masked_config_dict`` does not reach them. GET /api/config/kirocrew masks them
+instead. Two properties matter and both are pinned below: the masking applies
+ONLY to the browser-facing view and NEVER to ``to_dict()``/``save()``, and it
+covers a value that is not a ``str`` — a config.json is hand- and agent-writable,
+so an object or a list in one of these fields is the untrusted case, not an
+impossible one, and skipping it would let nested credential-shaped bytes through.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest.mock
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.sections import KiroCrewAgentConfig
+from kiro_crew.dashboard.handlers.core import _SENSITIVE_MASK, _masked_config_dict
+
+
+def _cfg_with_agent(**agent_kwargs) -> tuple[KiroCrewConfig, str]:
+    cfg = KiroCrewConfig()
+    name = "researcher"
+    cfg.agents[name] = KiroCrewAgentConfig(**agent_kwargs)
+    return cfg, name
+
+
+def test_description_and_triggers_masked_in_view():
+    """Both non-empty free-text fields are masked and their raw values vanish."""
+    cfg, name = _cfg_with_agent(
+        description="SECRET-DESCRIPTION-should-not-leak",
+        triggers="SECRET-TRIGGERS-should-not-leak",
+    )
+
+    masked = _masked_config_dict(cfg)
+    agent = masked["agents"][name]
+    assert agent["description"] == _SENSITIVE_MASK
+    assert agent["triggers"] == _SENSITIVE_MASK
+
+    dumped = json.dumps(masked)
+    assert "SECRET-DESCRIPTION-should-not-leak" not in dumped
+    assert "SECRET-TRIGGERS-should-not-leak" not in dumped
+
+
+def test_mask_does_not_leak_into_write_path():
+    """to_dict()/save() must still carry the real values after masking."""
+    cfg, name = _cfg_with_agent(
+        description="real description",
+        triggers="real triggers",
+    )
+
+    # Build the masked view (which must not mutate the underlying cfg).
+    _masked_config_dict(cfg)
+
+    persisted = cfg.to_dict()["agents"][name]
+    assert persisted["description"] == "real description"
+    assert persisted["triggers"] == "real triggers"
+
+
+def test_empty_strings_left_as_empty():
+    """Empty description/triggers stay empty, not replaced by the sentinel."""
+    cfg, name = _cfg_with_agent(description="", triggers="")
+
+    masked = _masked_config_dict(cfg)
+    agent = masked["agents"][name]
+    assert agent["description"] == ""
+    assert agent["triggers"] == ""
+
+
+def test_other_agent_fields_unchanged():
+    """Non-sensitive structural fields survive the masked view verbatim."""
+    cfg, name = _cfg_with_agent(
+        description="hide me",
+        triggers="hide me too",
+        model="claude-sonnet",
+        workspace="research-ws",
+        source="some-package",
+    )
+
+    agent = _masked_config_dict(cfg)["agents"][name]
+    assert agent["model"] == "claude-sonnet"
+    assert agent["workspace"] == "research-ws"
+    assert agent["source"] == "some-package"
+
+
+def test_non_string_values_are_masked_not_skipped():
+    """A value that is not a ``str`` is masked, so nested bytes cannot escape.
+
+    Built directly on the dataclass rather than through the loader on purpose:
+    the view must hold on its own, without depending on an upstream coercion
+    having run. A guard that only recognizes ``str`` would skip every shape here
+    and pass the nested credential straight to the browser.
+    """
+    for _value in (
+        {"k": "AKIAIOSFODNN7EXAMPLE"},
+        ["AKIAIOSFODNN7EXAMPLE"],
+        [{"nested": "AKIAIOSFODNN7EXAMPLE"}],
+    ):
+        cfg, name = _cfg_with_agent(description=_value, triggers=_value)
+
+        masked = _masked_config_dict(cfg)
+        agent = masked["agents"][name]
+        assert agent["description"] == _SENSITIVE_MASK, _value
+        assert agent["triggers"] == _SENSITIVE_MASK, _value
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(masked), _value
+
+
+def test_non_string_scalars_are_masked():
+    """A number/bool in a free-text field is masked too — only "" renders as-is."""
+    cfg, name = _cfg_with_agent(description=7, triggers=False)
+
+    agent = _masked_config_dict(cfg)["agents"][name]
+    assert agent["description"] == _SENSITIVE_MASK
+    assert agent["triggers"] == _SENSITIVE_MASK
+
+
+def test_absent_field_is_not_conjured_into_a_placeholder():
+    """A record missing the key entirely does not gain a "set (hidden)" value.
+
+    ``to_dict()`` emits every dataclass field, so this guards the rule rather
+    than a live shape: masking must key off a key that is present, never write
+    a sentinel where the operator set nothing.
+    """
+    cfg, name = _cfg_with_agent(description="hide me")
+    real_to_dict = cfg.to_dict
+
+    def _to_dict_without_free_text() -> dict:
+        data = real_to_dict()
+        data["agents"][name].pop("description", None)
+        data["agents"][name].pop("triggers", None)
+        return data
+
+    with unittest.mock.patch.object(cfg, "to_dict", _to_dict_without_free_text):
+        agent = _masked_config_dict(cfg)["agents"][name]
+
+    assert "description" not in agent
+    assert "triggers" not in agent

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -5227,6 +5227,34 @@ def test_agent_triggers_load() -> None:
     assert cfg.agents["weird"].triggers == ""
 
 
+def test_agent_description_non_string_normalized_on_load() -> None:
+    """A non-string `description` collapses to "" instead of surviving the load.
+
+    The field is declared ``str`` and the schema validator keeps a mismatched
+    value for its consumer to handle; this loader is that consumer. Letting an
+    object through hands every reader something it is not typed for — including
+    the dashboard's config view, whose redaction only recognizes ``str``, so
+    credential-shaped bytes nested in the object would reach the browser.
+    """
+    cfg = _load_from_dict(
+        {
+            "agents": {
+                "ok": {"kiro_agent": "kirocrew", "description": "deep research crew"},
+                "obj": {"kiro_agent": "kirocrew", "description": {"k": "AKIAIOSFODNN7EXAMPLE"}},
+                "num": {"kiro_agent": "kirocrew", "description": 7},
+                "lst": {"kiro_agent": "kirocrew", "description": ["a", "b"]},
+            },
+            "workspaces": {"default": {"dir": "workspace"}},
+        }
+    )
+    assert cfg.agents["ok"].description == "deep research crew"
+    for _name in ("obj", "num", "lst"):
+        assert cfg.agents[_name].description == "", _name
+    # The credential the object carried is gone from the loaded config entirely,
+    # so no downstream consumer can echo it.
+    assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(cfg.to_dict())
+
+
 # ---------------------------------------------------------------------------
 # Tests for update_config_locked
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #8717.

## Problem

`GET /api/config/kirocrew` returned every agent's `description` and `triggers` verbatim. `_masked_config_dict` (`src/kiro_crew/dashboard/handlers/core.py`) masks only values the schema marks `sensitive`; those two are writable by the agent itself and by an installed package and are **not** schema-sensitive, so the schema-driven walk never reached them.

Underneath that sat a second, sharper defect. `description` was the last free-text field on an agent record without the `isinstance(..., str)` guard its siblings `model` and `triggers` already carry in `KiroCrewConfig.load()`. The schema validator *notices* a type mismatch there, logs it, and keeps the value on the stated grounds that its consumer validates it — and for this field no consumer did. So a `config.json` holding

```json
{"agents": {"x": {"description": {"k": "AKIAIOSFODNN7EXAMPLE"}}}}
```

loaded with `description` as a `dict` on a field declared `str`, and any redaction guarding on `isinstance(val, str)` skipped it and passed the nested credential straight to the browser. `config.json` is hand- **and agent-**writable, so that input is reachable rather than hypothetical. Reproduced before the fix (`CREDENTIAL LEAKS TO BROWSER? True`) and after (`False`).

## Fix

Two layers, one per commit.

**At the load boundary** (`config/loader.py`) — coerce a non-`str` `description` to `""`, exactly as `model` and `triggers` already are. This closes the hole for *every* reader at once rather than once per endpoint, and it is the layer no other open PR on #8717 touches.

**At the view boundary** (`handlers/core.py`) — mask `description`/`triggers` on every `agents.<name>` record of the `copy.deepcopy(cfg.to_dict())` view, deny-by-default:

- The guard is **not** `isinstance(val, str) and val`. That is the fail-open shape the `backend-security-controls` rule names outright ("never write `if x and y and z` guards where a falsy value silently skips the check"), and here it would defeat the redaction it performs — a value that is *not* a string is precisely the untrusted one. Everything but an empty string is masked.
- `""` alone renders unchanged, so the UI shows no "set (hidden)" placeholder for a field nobody set, and an absent key is no longer conjured into one.
- The view must hold on its own rather than inherit the loader's guarantee from a distance, so its tests build the record on the dataclass directly, bypassing the coercion.

**Mask cannot be persisted — verified, not assumed.** `PUT /api/config/kirocrew` accepts only `body["agent"]` (the singular `agent` section); `PATCH` is a strict `_EDITABLE_CONFIG` allowlist that contains no `agents.*` path at all. So there is no route by which the sentinel is read back and written over the real value. Agent descriptions are still edited through `PATCH /api/agents/<name>`, which reads its value from the roster route, so editing is unaffected.

## Scope, stated honestly

An earlier revision of this description claimed #8472 "already masks this same class of strings on the roster path". **That was false** and is retracted here and in the code comments it had reached: #8472 is open and unmerged, and `handlers/agents.py` still ships `{"name": ..., **dataclasses.asdict(agent_cfg)}`, so `GET /api/agents` returns both fields verbatim today. This PR does not close that route and does not depend on it being closed — each route owns its own response. Unifying both behind one rule, and settling whether that rule should be an unconditional mask or a `redact_credentials`-style scrub that preserves benign text, is #8717's remaining work, not something this PR decides.

The issue's final paragraph (agent-sync credential-shaped-name surfacing / gateway logging / install-refusal surface) is labeled "NOT part of this issue" and is untouched.

## Pattern harvest

Rule candidate: semgrep
Pattern: a redaction, masking, or scrub step whose guard is `isinstance(x, str)` (or `and`-chained with a truthiness test) and whose false branch *omits* the value instead of redacting it.

This is one instance of a two-part class, and both parts recurred here:

1. **A type-narrowing guard inside a security control fails open.** `isinstance` in a validator is a check; inside a redactor it is a *bypass*, because the untrusted input is exactly the one that fails the narrowing. The rule should flag a masking assignment reachable only from the `isinstance(..., str)` true-branch, which is mechanically detectable — the enclosing function names a mask/redact sentinel and the else-branch has no write.
2. **A "kept for its consumer to validate" value with no consumer.** The schema validator's own message promises downstream validation; `model` and `triggers` honor it, `description` did not. Not semgrep-shaped, but it is checkable: every field the validator type-warns about should have a coercion at the load site. Worth an `AGENTS.md` line so the next field added to a record inherits the guard by convention rather than by whoever remembers.

The near-miss is what makes it worth a rule: `triggers` was guarded only because `select_crew` calls `.strip()` on it, i.e. because a *crash* forced the issue. `description` had no crashing consumer, so the same missing guard stayed silent and became a redaction bypass instead. A class of bug that only surfaces when something happens to crash is one a linter should be finding.

## Testing

- `pytest test/test_config_agent_string_masking.py test/test_config_extra_sections.py` → 12 passed (7 + 5).
- `pytest test/test_config_loader.py` → 492 passed.
- `pytest test/test_config_api.py test/test_config_patch.py test/test_config_roundtrip.py test/test_config_schema.py test/test_config.py test/test_config_rmw_preserves_settings.py test/test_config_module_boundaries.py test/test_agent_config_merge_on_write.py` → 240 passed, 1 skipped.
- Every module referencing `_masked_config_dict` (`test_connections_ui_flag.py`, `test_telegram.py`) plus `test_dashboard_handlers_core_coverage.py` → 481 passed.
- `-k "select_crew or crew_select or agents_api or agent_roster or conductor"` → 655 passed, 1 skipped (the loader change reaches crew selection).
- Gates clean: black gate, subprocess-encoding gate, `flake8`, `isort`, `mypy --platform linux src/kiro_crew` (1294 files), brand, harness-parity, changelog-history.
- New coverage pins both layers: a `dict`/`list`/nested-`dict` and a scalar (`7`, `False`) in either field mask rather than pass through, the credential bytes are absent from the serialized response, an absent key stays absent, and at the loader an object/number/list `description` collapses to `""` with the credential gone from `to_dict()` entirely.

## Files changed

- `src/kiro_crew/config/loader.py` — `isinstance(..., str)` coercion for `description`.
- `src/kiro_crew/dashboard/handlers/core.py` — deny-by-default masking loop; docstring rationale corrected.
- `test/test_config_loader.py` — loader coercion test beside the sibling `triggers` one.
- `test/test_config_agent_string_masking.py` — 7 tests across both layers.
