### PR TITLE
fix(md-notebook): let the Notes backend write its own state under the OS sandbox (#8762)

### DIFF
--- a/docs/system-specs/modules/md-notebook.md
+++ b/docs/system-specs/modules/md-notebook.md
@@ -45,6 +45,43 @@ optional `subfolder` scope, plus `knowledge` and `knowledgeSourceId`. The `exter
 returned by `GET /api/vaults` is COMPUTED on read (`localPath` is outside `vaults/`) and
 never persisted.
 
+### These three leaves and the OS sandbox
+
+`pat`, `vaults.json`, and `settings.json` are named once, as
+`sandbox._MD_NOTEBOOK_OWN_STATE_LEAVES`, and spliced into `sandbox._CREW_HIDDEN_LEAVES`,
+so the OS sandbox bind-masks them for every sandboxed process; they are also on the
+agent-file-tool gate (`_SENSITIVE_HOME_DIRS`), so an agent cannot reach them through a
+file tool either. The one process that legitimately reads AND writes them is this backend,
+which is itself spawned inside the sandbox. Its registry write stages a sibling temp file
+and atomically renames it onto `vaults.json`, and the mask denies that rename with
+`EPERM`, so attach and clone would always fail and reads would silently return `[]`. To
+fix that, the app-backend spawn in `apps/backend.py` passes
+`sandbox.md_notebook_backend_visible_paths()` (the same leaves under both crew-home
+spellings and the relocated data home) as `extra_visible_dirs` for the md-notebook backend
+only. That cancels the mask for these three leaves for that one process, read+write.
+Unlike the policy cache, they are NOT sealed read-only, because the rename target has to
+be writable. Every other sandboxed process keeps the mask, and the agent-file-tool gate is
+untouched.
+
+The carve-out is the first `extra_visible_dirs` caller to grant WRITE, so the name alone
+does not earn it. `md-notebook` is not a reserved app id, so a user could install an app
+under it; if that install lands before builtin registration, registration stands down and
+the user's app becomes what `start_app_backend("md-notebook")` spawns, and handing that
+process write access to the real PAT and vault registry would leak a live GitHub token.
+The carve-out therefore requires
+`execution.is_builtin_app(app_name="md-notebook", app_root=execution_path)` — the same
+immutable package proof the third-party execution gate already ran on this argv: the
+shipped `app.json` must declare this exact name, and the path this spawn will execute must
+resolve inside that package. Nothing reachable from inside the sandbox can forge either
+half, and an unresolvable path denies.
+
+`installed.json` is deliberately NOT what the gate reads. Its fields are mutable, it is
+absent from `_CREW_HIDDEN_LEAVES`, and it lives in the app's own tree — so a sandboxed app
+backend can rewrite its own record. A predicate over `source`/`origin` (for example
+`manager.builtin_owns_installed`) would let a shadow app declare itself builtin-owned and
+collect the PAT on the operator's next enable, which is why `is_builtin_app`'s contract
+states outright that mutable `installed.json` fields are never provenance.
+
 ## Routes
 
 The gateway proxy preserves the `/api/` prefix, so the backend sees exactly the paths the

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -27,6 +27,7 @@ from kiro_crew import platform_compat
 from kiro_crew.apps.admission import app_admission_denied
 from kiro_crew.apps.execution import (
     app_execution_denied,
+    is_builtin_app,
     shipped_builtin_app_root,
     shipped_builtin_module_path,
 )
@@ -37,9 +38,11 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.sandbox import (
+    MD_NOTEBOOK_APP_NAME,
     RLIMIT_PROFILE_BUILD,
     RLIMIT_PROFILE_TOOL,
     cgroup_scope_argv,
+    md_notebook_backend_visible_paths,
     popen_limited,
     run_limited,
     wrap_argv,
@@ -1134,10 +1137,40 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     # permissions: with ``require_policy_signature`` set in the admission policy, a document
     # nobody trusted is refused however it got onto disk.
     _visible: tuple[str, ...] = ()
-    if _platform_extra.get(POLICY_CACHE_ONLY_ENV):
+    _cache_visible = bool(_platform_extra.get(POLICY_CACHE_ONLY_ENV))
+    if _cache_visible:
         _visible = (str(policy_cache_dir()),)
+    # The md-notebook (Notes) backend is the only legitimate reader AND writer of its own
+    # three state leaves (``workspace/md-notebook/{pat,vaults.json,settings.json}``), yet
+    # those leaves are bind-masked in every sandbox mode so no OTHER sandboxed process can
+    # touch them. This backend is itself spawned inside that sandbox, so it inherits the
+    # mask over its own registry and its atomic rename onto ``vaults.json`` fails with
+    # EPERM. Passing the leaves as ``extra_visible_dirs`` cancels the mask for THIS spawn
+    # only, mirroring the policy-cache carve-out just above -- except these must be
+    # read+write (``sandbox`` seals only the policy cache read-only), because the rename
+    # target has to be writable. The agent-file-tool gate and every other process are
+    # unaffected: this widens nothing beyond this one child.
+    #
+    # The name alone is NOT a sufficient gate: "md-notebook" is not a reserved app name, so
+    # a user could install an app under it. When that install lands before builtin
+    # registration, ``register_builtin_apps()`` stands down and leaves the user's record in
+    # place, and ``start_app_backend("md-notebook")`` would then spawn the user's app. Since
+    # this is the first ``extra_visible_dirs`` caller to grant WRITE (to the real Notes PAT
+    # and vault registry), the gate has to prove the code this spawn is about to execute is
+    # first-party -- so it is ``is_builtin_app`` over ``execution_path``, the SAME immutable
+    # package proof the third-party execution gate above already ran on this argv, and not
+    # any property of ``installed.json``. Those fields are mutable and are NOT masked by
+    # the sandbox, so the app backend can rewrite its own installed record: a predicate
+    # reading them would let a shadow app declare itself builtin-owned and collect the PAT
+    # on the next enable. ``is_builtin_app`` instead requires the shipped ``app.json`` to
+    # claim this exact name and the executed path to resolve inside that package, which
+    # nothing inside the sandbox can forge; a missing or unresolvable path denies.
+    if app_name == MD_NOTEBOOK_APP_NAME and is_builtin_app(
+        app_name=app_name, app_root=execution_path
+    ):
+        _visible = _visible + md_notebook_backend_visible_paths()
     sandboxed_cmd, cleanup_path = wrap_argv(cmd, mode="standard", extra_visible_dirs=_visible)
-    if _visible and list(sandboxed_cmd) == list(cmd):
+    if _cache_visible and list(sandboxed_cmd) == list(cmd):
         # The wrap was a no-op, so this host has no OS confinement at all: no sandbox backend,
         # or agent.sandbox='off' with the sandbox_allow_no_isolation opt-in. Said once,
         # because the combination is worth naming — a centrally governed host running app code

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -188,6 +188,36 @@ _CREW_HOME_PREFIXES: tuple[str, ...] = (".kiro/crew", ".kirocrew")
 # in none of them. Spelled here rather than imported so this low-level module keeps not
 # importing the 7k-line security module (the ``_POLICY_CACHE_LEAF`` convention above).
 
+#: App id of the Notes app, from ``apps/builtins/md_notebook/app.json``.
+#:
+#: Owned here because this module owns the carve-out the name selects: the three leaves
+#: below embed it, and :func:`md_notebook_backend_visible_paths` is scoped to exactly the
+#: backend spawned for this app. ``apps/backend.py`` imports it rather than restating the
+#: literal, so the gate and the paths it opens cannot come to name different apps.
+MD_NOTEBOOK_APP_NAME = "md-notebook"
+
+#: The md-notebook (Notes) app backend's OWN three state leaves.
+#:
+#: Unpacked into ``_CREW_HIDDEN_LEAVES`` below, so every OTHER sandboxed process has them
+#: bind-masked, and they are on ``security``'s agent-file-tool gate, so an agent cannot
+#: reach them through a file_read/file_write call either. The one process that
+#: legitimately reads AND writes them is the md-notebook backend itself: it is spawned
+#: inside the OS sandbox (``apps/backend.py``), and its registry write stages a sibling
+#: temp then atomically renames it onto ``vaults.json`` -- a rename the mask denies with
+#: EPERM. So the backend's own spawn passes these leaves as ``extra_visible_dirs`` (see
+#: :func:`md_notebook_backend_visible_paths`), which cancels the mask for THAT process
+#: only. Unlike the policy cache, they are NOT sealed read-only: the rename target must
+#: be writable.
+#:
+#: Named, and spliced into the hidden list rather than restated beside it, so the visible
+#: set the backend opens and the hidden set every other process sees have one source of
+#: truth and cannot drift apart in a later edit.
+_MD_NOTEBOOK_OWN_STATE_LEAVES: tuple[str, ...] = (
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/pat",
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/vaults.json",
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/settings.json",
+)
+
 #: Crew-home leaves with no legitimate in-sandbox reader — bind-masked in every mode.
 _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     # Channel credentials. Already file-masked in cc/strict via ``_CC_FILES``; listing
@@ -199,9 +229,9 @@ _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     "apps/aws-control/data",
     "apps/meetings/data/edits",
     "whatsapp",
-    "workspace/md-notebook/pat",
-    "workspace/md-notebook/vaults.json",
-    "workspace/md-notebook/settings.json",
+    # ``workspace/md-notebook/{pat,vaults.json,settings.json}``: hidden here like the
+    # rest, and additionally re-opened for the Notes backend's own spawn alone.
+    *_MD_NOTEBOOK_OWN_STATE_LEAVES,
     # Browser session material. The extension token reaches the CLI through the
     # environment, never by ``open()``, so masking the file costs nothing; the other
     # four are retired leaves with no reader left in the tree. The LIVE browser paths
@@ -302,6 +332,28 @@ _CREW_SANDBOX_VISIBLE_LEAVES: tuple[str, ...] = (
 def _crew_home_entries(leaves: tuple[str, ...]) -> list[str]:
     """Expand *leaves* across both data-home spellings."""
     return [f"{prefix}/{leaf}" for prefix in _CREW_HOME_PREFIXES for leaf in leaves]
+
+
+def md_notebook_backend_visible_paths() -> tuple[str, ...]:
+    """Absolute paths of the md-notebook backend's own state leaves, every spelling.
+
+    Resolved the same way the hidden set is: joined under both ``_CREW_HOME_PREFIXES``
+    over ``$HOME``, plus :func:`_relocated_crew_targets` for a data home moved out from
+    under ``$HOME`` by ``KIROCREW_HOME``. ``apps/backend.py`` passes the result into
+    ``wrap_argv`` as ``extra_visible_dirs`` for the md-notebook spawn, so
+    ``_hidden_path_contains_visible_path`` cancels the bind mask for exactly these leaves
+    and only for that process. Deriving them from the same
+    ``_MD_NOTEBOOK_OWN_STATE_LEAVES`` the hidden list is spliced from is what keeps the
+    two sets matched, and keeps ``backend.py`` from restating the path logic.
+    """
+    home = str(Path.home())
+    paths = [
+        os.path.join(home, f"{prefix}/{leaf}")
+        for prefix in _CREW_HOME_PREFIXES
+        for leaf in _MD_NOTEBOOK_OWN_STATE_LEAVES
+    ]
+    paths.extend(_relocated_crew_targets(_MD_NOTEBOOK_OWN_STATE_LEAVES))
+    return tuple(dict.fromkeys(paths))
 
 
 #: Bind-masked in every mode.

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -65,6 +65,19 @@ _needs_sandbox_spawn = pytest.mark.skipif(
     "runners deny unshare(NEWNS)); start_app_backend() correctly fail-closes to None",
 )
 
+# Guards the tests that assert on the generated Linux namespace launcher.
+# ``sandbox._build_launcher_script`` reads POSIX-only ``os.getuid``, which raises
+# AttributeError on native Windows before any assertion runs. Guarded per test rather
+# than listed in windows-expected-failures.txt (a burn-down backlog) or
+# windows-collect-ignore.txt (this module's other ~90 tests must keep collecting there):
+# an OS sandbox Windows does not implement is a permanent boundary, not a gap to close.
+# Same route as test_governance_distribution.py's TestAnExposedCacheIsStillReadOnly.
+_needs_posix_launcher = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="sandbox._build_launcher_script calls POSIX-only os.getuid; the Linux "
+    "namespace launcher has no Windows counterpart to assert on",
+)
+
 
 def _make_app_with_backend(tmp_path, name="backend-app"):
     src = tmp_path / "source" / name
@@ -1753,6 +1766,274 @@ class TestTheCacheOnlyChildCanSeeTheCacheItMustBootFrom:
         bmod.start_app_backend("plain-app")
 
         assert seen.get("visible") == ()
+
+
+class TestTheMdNotebookBackendSeesItsOwnStateLeaves:
+    """The Notes backend is the only legitimate reader AND writer of its own three
+    state leaves (``workspace/md-notebook/{pat,vaults.json,settings.json}``).
+
+    Those leaves are bind-masked in every sandbox tier so no OTHER sandboxed process can
+    touch them, and they stay on the agent-file-tool gate. But this backend is itself
+    spawned inside that sandbox, so without a carve-out it inherits the mask over its own
+    registry and its atomic rename onto ``vaults.json`` fails with EPERM -- attach and
+    clone break, reads silently return ``[]``. The spawn passes these leaves as
+    ``extra_visible_dirs`` so the mask is cancelled for THAT process only, read+write
+    (unlike the policy cache, which is sealed read-only) because the rename target must
+    be writable.
+    """
+
+    @staticmethod
+    def _md_notebook_leaves():
+        from kiro_crew import sandbox
+
+        return set(sandbox.md_notebook_backend_visible_paths())
+
+    @staticmethod
+    def _shipped_module_entry_point(app_name):
+        """The dotted ``python -m`` target the app's SHIPPED ``app.json`` declares.
+
+        Read off the immutable package instead of restated here, so the positive case
+        exercises the very provenance the gate proves rather than a literal that could
+        drift from the manifest."""
+        from kiro_crew.apps.execution import shipped_builtin_app_root
+
+        root = shipped_builtin_app_root(app_name)
+        assert root is not None, f"{app_name} ships no builtin app.json"
+        entry = json.loads((root / "app.json").read_text(encoding="utf-8"))
+        entry_point = entry.get("backend", {}).get("entryPoint")
+        assert entry_point, f"{app_name}'s shipped app.json declares no backend entryPoint"
+        return entry_point
+
+    @staticmethod
+    def _forge_builtin_owned_install(app_name):
+        """Rewrite the installed record to CLAIM first-party ownership.
+
+        ``installed.json`` lives in the app's own mutable tree and is absent from
+        ``sandbox._CREW_HIDDEN_LEAVES``, so a sandboxed app backend can write exactly
+        this file. Reproducing the ``source``/``origin`` fields ``register_builtin_apps``
+        writes is therefore something an attacker-controlled backend can do to ITSELF --
+        which is why the carve-out must not read them, and what the shadow-app test
+        below asserts is powerless."""
+        from dataclasses import replace
+
+        from kiro_crew.apps import manager
+
+        existing = manager._read_installed(app_name)
+        assert existing is not None, f"{app_name} was not installed"
+        manager._write_installed(app_name, replace(existing, source="builtin", origin="builtin"))
+
+    def _spawn_and_capture_visible(
+        self,
+        bmod,
+        tmp_path,
+        monkeypatch,
+        app_name,
+        *,
+        module_entry_point=None,
+        forge_builtin_install=False,
+    ):
+        """Run the spawn body far enough to capture ``extra_visible_dirs``, then stop.
+
+        ``module_entry_point`` writes a module-style manifest straight into the installed
+        tree the way ``register_builtin_apps`` does, so ``execution_path`` resolves inside
+        an immutable package; without it the app is installed from *tmp_path* with a FILE
+        entry point, which is the mutable third-party shape. ``Popen`` always raises, so
+        nothing is ever executed either way."""
+        seen: dict = {}
+
+        def _spy_wrap(argv, **kwargs):
+            seen["visible"] = kwargs.get("extra_visible_dirs")
+            return (list(argv), None)
+
+        monkeypatch.setattr(bmod, "wrap_argv", _spy_wrap)
+        monkeypatch.setattr(
+            bmod.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(OSError("stop"))
+        )
+        if module_entry_point is not None:
+            from kiro_crew.apps.manager import InstalledApp, _write_installed, app_dir
+
+            root = app_dir(app_name)
+            root.mkdir(parents=True, exist_ok=True)
+            (root / APP_MANIFEST_FILENAME).write_text(
+                json.dumps(
+                    {
+                        "name": app_name,
+                        "version": "1.0.0",
+                        "displayName": app_name,
+                        "description": "md-notebook state-leaf visibility",
+                        "backend": {"entryPoint": module_entry_point, "port": "auto"},
+                    }
+                )
+            )
+            _write_installed(
+                app_name, InstalledApp(name=app_name, origin="builtin", enabled=True)
+            )
+        else:
+            src = tmp_path / "source" / app_name
+            src.mkdir(parents=True)
+            (src / APP_MANIFEST_FILENAME).write_text(
+                json.dumps(
+                    {
+                        "name": app_name,
+                        "version": "1.0.0",
+                        "displayName": app_name,
+                        "description": "md-notebook state-leaf visibility",
+                        "backend": {"entryPoint": "server.py", "healthCheck": "/health"},
+                    }
+                )
+            )
+            (src / "server.py").write_text("import time\ntime.sleep(30)\n")
+            install_app(src)
+        if forge_builtin_install:
+            self._forge_builtin_owned_install(app_name)
+        bmod.start_app_backend(app_name)
+        return seen
+
+    def test_the_spawn_passes_all_three_leaves_as_visible_dirs(
+        self, app_env, tmp_path, monkeypatch
+    ):
+        import kiro_crew.apps.backend as bmod
+
+        seen = self._spawn_and_capture_visible(
+            bmod,
+            tmp_path,
+            monkeypatch,
+            "md-notebook",
+            module_entry_point=self._shipped_module_entry_point("md-notebook"),
+        )
+
+        visible = set(seen.get("visible") or ())
+        missing = self._md_notebook_leaves() - visible
+        assert not missing, (
+            "the md-notebook backend spawn did not expose its own state leaves, so the "
+            f"atomic rename onto vaults.json stays EPERM-denied (missing {missing!r})"
+        )
+
+    def test_a_shadowing_user_app_gets_none_of_the_leaves(self, app_env, tmp_path, monkeypatch):
+        """Fail-closed boundary: "md-notebook" is NOT a reserved name, so a user could
+        install an app under it. When that install lands before builtin registration,
+        registration stands down and the user's app becomes what start_app_backend
+        spawns. That process must NOT inherit read+write to the real Notes PAT and vault
+        registry -- and it must not be able to TALK ITSELF INTO them either: this shadow
+        app also forges the builtin-owned ``installed.json`` its own backend can write,
+        which is why the carve-out proves immutable package provenance over the executed
+        path instead of reading that record."""
+        import kiro_crew.apps.backend as bmod
+
+        seen = self._spawn_and_capture_visible(
+            bmod, tmp_path, monkeypatch, "md-notebook", forge_builtin_install=True
+        )
+
+        visible = set(seen.get("visible") or ())
+        leaked = self._md_notebook_leaves() & visible
+        assert not leaked, (
+            "a user-installed app shadowing the md-notebook name was handed the real "
+            f"Notes state leaves (including the GitHub PAT): {leaked!r}"
+        )
+
+    def test_borrowing_another_builtins_module_gets_none_of_the_leaves(
+        self, app_env, tmp_path, monkeypatch
+    ):
+        """The other half of the proof: the name matching is not enough, the EXECUTED
+        path must resolve inside md-notebook's own package. A shadow record under the
+        name "md-notebook" whose ``python -m`` target is a DIFFERENT builtin's module
+        runs genuine first-party code, so a "does this execute shipped code?" test would
+        pass it -- and it would then hold the Notes PAT while running something that is
+        not the Notes backend."""
+        import kiro_crew.apps.backend as bmod
+
+        seen = self._spawn_and_capture_visible(
+            bmod,
+            tmp_path,
+            monkeypatch,
+            "md-notebook",
+            module_entry_point=self._shipped_module_entry_point("file-explorer"),
+        )
+
+        visible = set(seen.get("visible") or ())
+        leaked = self._md_notebook_leaves() & visible
+        assert not leaked, (
+            "a spawn executing another builtin's module under the md-notebook name was "
+            f"handed the Notes state leaves: {leaked!r}"
+        )
+
+    def test_another_app_gets_none_of_the_leaves(self, app_env, tmp_path, monkeypatch):
+        """The carve-out is scoped to md-notebook alone: any other backend keeps the mask."""
+        import kiro_crew.apps.backend as bmod
+
+        seen = self._spawn_and_capture_visible(bmod, tmp_path, monkeypatch, "other-app")
+
+        visible = set(seen.get("visible") or ())
+        leaked = self._md_notebook_leaves() & visible
+        assert not leaked, (
+            f"a non-md-notebook backend was handed the Notes state leaves: {leaked!r}"
+        )
+
+    @_needs_posix_launcher
+    def test_the_leaves_are_exposed_read_write_not_hidden_on_linux(self):
+        """When the leaves are supplied, the launcher DROPS them from the hidden set and
+        does NOT seal them read-only -- contrast the policy cache, which stays read-only.
+        The rename target must be writable for attach/clone to succeed."""
+        from kiro_crew import sandbox
+
+        leaves = sandbox.md_notebook_backend_visible_paths()
+
+        hidden_default = json.loads(
+            sandbox._build_launcher_script("standard").split("SENSITIVE_DIRS = ", 1)[1].split(
+                "\n", 1
+            )[0]
+        )
+        script = sandbox._build_launcher_script("standard", extra_visible_dirs=leaves)
+        hidden = json.loads(script.split("SENSITIVE_DIRS = ", 1)[1].split("\n", 1)[0])
+        readonly = json.loads(script.split("READONLY_DIRS = ", 1)[1].split("\n", 1)[0])
+
+        for leaf in leaves:
+            assert leaf in hidden_default, (
+                f"{leaf} must be masked for every OTHER process by default"
+            )
+            assert leaf not in hidden, f"{leaf} must be un-hidden for the md-notebook spawn"
+            assert leaf not in readonly, (
+                f"{leaf} must be READ+WRITE, not sealed read-only like the policy cache"
+            )
+
+    def test_macos_drops_the_denies_for_the_leaves_when_supplied(self):
+        from kiro_crew import sandbox
+
+        leaves = sandbox.md_notebook_backend_visible_paths()
+
+        default = sandbox._build_seatbelt_profile("standard")
+        exposed = sandbox._build_seatbelt_profile("standard", extra_visible_dirs=leaves)
+        for leaf in leaves:
+            assert f'(deny file-read* (subpath "{leaf}"))' in default, (
+                f"{leaf} must be deny-listed for every other process by default"
+            )
+            assert f'(deny file-read* (subpath "{leaf}"))' not in exposed
+            assert f'(deny file-write* (subpath "{leaf}"))' not in exposed
+            assert f'(deny file-write* (literal "{leaf}"))' not in exposed
+
+    @_needs_posix_launcher
+    def test_an_unexposed_leaf_stays_hidden_and_denied(self):
+        """The negative: with no md-notebook visible paths, the leaves stay masked."""
+        from kiro_crew import sandbox
+
+        leaves = sandbox.md_notebook_backend_visible_paths()
+
+        script = sandbox._build_launcher_script("standard")
+        hidden = json.loads(script.split("SENSITIVE_DIRS = ", 1)[1].split("\n", 1)[0])
+        profile = sandbox._build_seatbelt_profile("standard")
+        for leaf in leaves:
+            assert leaf in hidden, f"{leaf} must stay hidden for a spawn that does not name it"
+            assert f'(deny file-read* (subpath "{leaf}"))' in profile
+
+    def test_the_agent_file_tool_gate_still_fences_all_three_leaves(self):
+        """The OS carve-out does not touch the SEPARATE agent-file-tool gate: an agent
+        still cannot read or write these paths through a file tool, under either prefix."""
+        from kiro_crew.security import is_sensitive_path
+
+        for prefix in (".kiro/crew", ".kirocrew"):
+            for leaf in ("pat", "vaults.json", "settings.json"):
+                path = f"~/{prefix}/workspace/md-notebook/{leaf}"
+                assert is_sensitive_path(path) is True, f"{path} must stay behind the tool gate"
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #8762.

## Problem
The Notes (md-notebook) builtin could not attach or clone any vault: every `POST /api/vaults/attach` (and the clone path) failed with `[Errno 1] Operation not permitted` on the final atomic rename of its registry (`vaults.json.<hex>.tmp` -> `vaults.json`). The PAT and `settings.json` writes hit the same wall, and reads silently returned an empty vault list.

## Root cause
PR #7439 added `workspace/md-notebook/{pat,vaults.json,settings.json}` to `_CREW_HIDDEN_LEAVES` in `src/kiro_crew/sandbox.py`, bind-masking them in every OS sandbox mode. That correctly fences them from the agent file-tool gate and every other sandboxed process, but the md-notebook backend is itself spawned inside the sandbox (`apps/backend.py::_start_app_backend_body` calls `wrap_argv(cmd, mode="standard", extra_visible_dirs=_visible)`), so it inherits the mask over its own registry. The staged sibling `.tmp` succeeds (the parent dir was never masked), then the rename onto the masked leaf is denied with EPERM.

## Fix
Carve out only these three md-notebook state leaves from the OS-level bind mask, and only for the md-notebook app backend's own sandboxed process (fix direction #1 from the issue):

- `src/kiro_crew/sandbox.py`: names the three leaves once as `_MD_NOTEBOOK_OWN_STATE_LEAVES` and **splices that tuple into `_CREW_HIDDEN_LEAVES`** rather than restating the literals beside it, so the visible set the backend opens and the hidden set every other process sees have one source of truth. `md_notebook_backend_visible_paths()` resolves them to absolute paths across both crew-home spellings and a relocated data home. The resulting hidden leaf list is byte-identical to `main`'s.
- `src/kiro_crew/apps/backend.py`: for the md-notebook backend spawn only, appends those paths to `extra_visible_dirs` (read+write, not sealed read-only — the rename target has to be writable), cancelling the OS mask for that one process. Mirrors the existing `policy_cache` carve-out. Re-gates the unconfined-cache warning so it no longer misfires.
- The agent-file-tool gate (`security.is_sensitive_path`) is untouched and still fences all three leaves from agents.

## Security: what the carve-out is gated on
This is the first `extra_visible_dirs` caller to grant **WRITE**, and the grant lands on a live GitHub PAT, so the bare app name does not earn it: `md-notebook` is not a reserved app id, and a user app installed under it before builtin registration makes `register_builtin_apps()` stand down and becomes what `start_app_backend("md-notebook")` spawns.

The gate is `execution.is_builtin_app(app_name=app_name, app_root=execution_path)` — the same immutable package proof the third-party execution gate a few hundred lines above already ran on this argv. The shipped `app.json` must claim this exact name **and** the path this spawn will execute must resolve inside that package; an unresolvable path denies.

It is deliberately **not** any property of `installed.json`. An earlier revision of this PR gated on `manager.builtin_owns_installed()`, which reads that record's `source`/`origin` fields — and `installed.json` is mutable, is absent from `_CREW_HIDDEN_LEAVES`, and lives in the app's own tree, so a sandboxed app backend can rewrite its own record, declare itself builtin-owned, and collect the PAT on the operator's next disable/enable. `is_builtin_app` states the rule in its own contract: *mutable `installed.json` fields are never provenance*. Thanks to the GPT 5.6 review lane for catching this; the fix is in the pushed head.

## Testing
Three cases pin the boundary from different sides, and each is load-bearing against a specific weakening:

| Test | Fails when the gate is… |
|---|---|
| `test_the_spawn_passes_all_three_leaves_as_visible_dirs` | absent (reverting the `backend.py` carve-out) |
| `test_a_shadowing_user_app_gets_none_of_the_leaves` — the shadow app also **forges** the builtin-owned `installed.json` its own backend can write | the bare name, **or** `builtin_owns_installed` |
| `test_borrowing_another_builtins_module_gets_none_of_the_leaves` — a shadow record under the md-notebook name whose `python -m` target is a *different* builtin's module | the bare name, **or** any "does this execute shipped code?" test that ignores which package |

Verified by mutation: replacing the gate with `app_name == MD_NOTEBOOK_APP_NAME` reds the last two; replacing it with `builtin_owns_installed(...)` reds the last two as well. The positive case reads its module entry point off the shipped `app.json` instead of restating the dotted path, so it cannot drift from the manifest.

- Targeted: `test/test_app_backend.py test/test_sandbox_governance_mask.py test/test_md_notebook.py test/test_app_execution.py test/test_trusted_apps_api.py` — 995 passed, 0 failed.
- The two tests that assert on the generated Linux namespace launcher now carry a `skipif(sys.platform == "win32")` marker: `sandbox._build_launcher_script` reads POSIX-only `os.getuid`, so both raised `AttributeError` on native Windows. Guarded per test rather than added to `windows-expected-failures.txt` (a burn-down backlog) or `windows-collect-ignore.txt` (this module's other ~90 tests must keep collecting there) — an OS sandbox Windows does not implement is a permanent boundary. Same route as `test_governance_distribution.py`'s `TestAnExposedCacheIsStillReadOnly`.
- Gates: `check_black_formatting.py`, `check_subprocess_encoding.py`, `isort`, `flake8 src/kiro_crew test`, `mypy --platform linux src/kiro_crew` (1294 files), `check_brand_name.py`, `check_harness_parity.py`, `check_changelog_history.py` (with `CHANGELOG_BASE_REF`), `docs-lint.sh` — all clean.

## Pattern harvest
Rule candidate: review-prompt, plus a semgrep rule (both shapes spelled out below)

Pattern: a trust decision gated on a field the subject of the decision can write. The defect class is not "md-notebook" — it is that `installed.json` is app-writable metadata being read as provenance. The tree already has the correct predicate (`execution.is_builtin_app`) and already documents the rule in its docstring, so the failure was a call-site choosing the convenient predicate over the authoritative one.

Two concrete, checkable shapes:

1. **`extra_visible_dirs` / sandbox-carve-out call sites.** Any new argument to `sandbox.wrap_argv(extra_visible_dirs=...)` must state which immutable proof gates it. Before this PR there was exactly one such caller (the read-only `policy_cache`), so the invariant "a carve-out is gated on immutable provenance" had never had to be written down; this PR is the second caller and the first to grant write. The rule belongs in the review prompt for `sandbox.py` / `apps/backend.py`, and the widened invariant is now recorded in `docs/system-specs/modules/md-notebook.md`.
2. **`builtin_owns_installed` as a security gate.** It is a legitimate function — it can only *remove* trust from a name that already has shipped-manifest provenance, which is how `builtin_app_names()` uses it. It becomes a defect only when used *alone* to grant. A semgrep rule can flag `builtin_owns_installed(...)` appearing in a boolean guard that is not also conjoined with `is_builtin_app(...)`; that is a precise, low-false-positive shape over two named functions.

Not a one-off: the same "mutable installed metadata read as provenance" shape is already the subject of three existing regression tests (`test_forged_builtin_origin_fake_name_cannot_claim_shipped_module`, `test_forged_builtin_origin_real_name_cannot_claim_installed_file`, `test_forged_builtin_origin_does_not_exempt_mutable_open_command`), which is direct evidence the class recurs at new call sites rather than being fixed once.

## Files changed
- `src/kiro_crew/sandbox.py`
- `src/kiro_crew/apps/backend.py`
- `test/test_app_backend.py` (new test class)
- `docs/system-specs/modules/md-notebook.md`
