### PR TITLE
fix(dashboard): mask agent free-text fields in the config endpoint response (#8717)

### DIFF
--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -107,6 +107,77 @@ _SSE_INTERVAL_SECS = 5
 # distinct from "" so the UI can render a "set (hidden)" placeholder.
 _SENSITIVE_MASK = "••••••••"
 
+# Agent-record fields that carry agent- or package-writable FREE TEXT. An agent
+# can edit ``config.json`` directly, and agent sync copies ``description``
+# straight off a discovered agent spec, so a third-party package controls these
+# strings. They are not schema-``sensitive`` (they are not secrets the OWNER
+# stored), so the schema-driven walk in ``_masked_config_dict`` never touches
+# them — this named list is what closes that gap on the config endpoint (#8717).
+#
+# Scope: every ``str`` field of ``KiroCrewAgentConfig`` whose LOAD path does not
+# pin its shape. ``reasoning_effort`` (``coerce_effort`` collapses anything but
+# a known level to ``""``) and ``session_color`` (``_safe_color`` pins to
+# ``#rrggbb``) are excluded because their guards already refuse redactable
+# content; everything else — including fields with only an isinstance-str
+# guard, which constrains type but not content — is in. A test enumerates the
+# dataclass's ``str`` fields against this tuple plus that exception set, so a
+# newly added free-text field fails loudly instead of shipping unmasked.
+#
+# The record KEY (the agent name) is handled separately in the pass below:
+# a suspicious-keyed record is REMOVED from the browser-facing view (masking a
+# key would collide two suspicious records into one entry), and the
+# name-reference fields that could still spell it are masked. PR #8472 refuses
+# a credential-shaped name at creation, which will close that hazard at its
+# source for names arriving through the create route once it lands.
+_AGENT_UNTRUSTED_TEXT_FIELDS = (
+    "description",
+    "triggers",
+    "kiro_agent",
+    "workspace",
+    "memory_store",
+    "model",
+    "source",
+    "telegram_account",
+)
+
+
+def _mask_agent_free_text(value: object) -> object:
+    """Render ONE agent-record free-text value for the config response.
+
+    Same rule PR #8472 proposes for the roster endpoint's rows: a value the
+    redactors would alter — credential- or exfiltration-URL-shaped text — is
+    replaced WHOLESALE by ``_SENSITIVE_MASK``; a non-string is masked too (it
+    is not renderable content, and ``description`` has no load-time type guard,
+    so one can genuinely arrive here). Benign content passes through
+    byte-identical, so an ordinary stored value renders exactly as written.
+    Until #8472 lands, ``GET /api/agents`` still ships these fields verbatim —
+    that half of the class is tracked there, not here.
+
+    A fixed sentinel rather than an in-place scrub: a scrubbed view is a
+    FUNCTION of the stored value, so any future write-side "treat the mask as
+    unchanged" rule would have to recompute the transform and breaks under
+    redaction-chain drift or a stale view; the sentinel is recognizable
+    regardless of either. Named cost: a value containing one credential-shaped
+    token is masked entirely, the same trade ``_masked_config_dict`` already
+    makes for schema-sensitive values.
+
+    Keyed on ``_redact_external`` itself rather than a second detector so this
+    rule and the roster's cannot drift apart. The import is function-local to
+    match this module's handler-import style, not for boot-path weight —
+    ``handlers.agents`` already imports ``discover`` at module level, so it is
+    loaded at handler setup regardless.
+    """
+    from kiro_crew.dashboard.handlers.discover import _redact_external
+
+    if not isinstance(value, str):
+        return _SENSITIVE_MASK
+    # No falsy pre-check on purpose: ``_redact_external`` returns falsy input
+    # unchanged, so ``""`` compares equal and passes through — a ``value and``
+    # guard here would only look like the fail-open bug class without being it.
+    if _redact_external(value) != value:
+        return _SENSITIVE_MASK
+    return value
+
 
 def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
     """Return ``cfg.to_dict()`` with sensitive string values masked.
@@ -118,6 +189,25 @@ def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
     is ever added it MUST treat ``_SENSITIVE_MASK`` as "unchanged" and keep the
     stored value. Sensitivity is schema-driven (``sensitive=True`` field
     metadata), so newly added sensitive fields are masked automatically.
+
+    Two masking passes. The schema walk covers owner-stored secrets
+    (``sensitive=True``). A second pass covers agent-record free text
+    (``_AGENT_UNTRUSTED_TEXT_FIELDS``): those values are agent- and
+    package-writable, so a credential- or exfiltration-URL-shaped one is
+    masked wholesale (``_mask_agent_free_text``) instead of shipping to the
+    browser verbatim. The write-side note above holds for this pass too:
+    neither branch of this endpoint can echo the mask into storage — the
+    PATCH allowlist (``_EDITABLE_CONFIG``) names no ``agents.*`` path, and
+    the PUT branch reads only the singular ``agent`` section against a
+    hardcoded key list. The agents CRUD route is the write path for these
+    fields; its read pair is ``GET /api/agents``, which today still ships
+    them verbatim — that half of the class is PR #8472's, which proposes the
+    same mask plus the mask-means-unchanged write rule this endpoint does not
+    need. Named cost of the wider field set: the overview's config tab renders
+    ``kiro_agent``/``workspace``/``memory_store`` and cross-references the
+    latter two against the workspace and store lists, so a masked value breaks
+    that "used by" row — but only for a record whose value is already
+    credential-shaped, and therefore already meaningless as a reference.
     """
     from kiro_crew.config.schema import JSON_SCHEMA
     from kiro_crew.config.validation import _is_sensitive_path
@@ -150,6 +240,44 @@ def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
                     node[key] = _SENSITIVE_MASK
 
     _walk(masked, "")
+
+    # Second pass: agent-record free text. These fields are absent from the
+    # schema's sensitive set by design (they are not owner secrets), so the walk
+    # above cannot cover them; see _AGENT_UNTRUSTED_TEXT_FIELDS. Both response
+    # sites of this endpoint (the GET body and the PATCH echo) funnel through
+    # this one function, so this pass gives the redaction rule surface coverage
+    # here rather than the point coverage #8717 records.
+    #
+    # The record KEY (the agent name) is handled by REMOVAL, not masking: agent
+    # sync stores a discovered agent's name as this dict's key, so a
+    # credential-shaped package name would ship verbatim as a key — and masking
+    # a key would collide two suspicious records into one entry. Dropping the
+    # record from this browser-facing view (save() still carries it) leaks
+    # nothing and collides nothing; the name-reference fields that could still
+    # spell the removed name (``default_agent``, ``session.pool_agent``) are
+    # masked when they match. Named cost: a suspicious-keyed record is invisible
+    # in the config tab — the same trade the roster's project rows make, and the
+    # name was never renderable content.
+    agents = masked.get("agents")
+    if isinstance(agents, dict):
+        removed: set[object] = set()
+        for name in list(agents.keys()):
+            if not isinstance(name, str) or _mask_agent_free_text(name) != name:
+                agents.pop(name)
+                removed.add(name)
+                continue
+            record = agents[name]
+            if not isinstance(record, dict):
+                continue
+            for field_name in _AGENT_UNTRUSTED_TEXT_FIELDS:
+                if field_name in record:
+                    record[field_name] = _mask_agent_free_text(record[field_name])
+        if removed:
+            if masked.get("default_agent") in removed:
+                masked["default_agent"] = _SENSITIVE_MASK
+            session_section = masked.get("session")
+            if isinstance(session_section, dict) and session_section.get("pool_agent") in removed:
+                session_section["pool_agent"] = _SENSITIVE_MASK
     return masked
 
 

--- a/test/test_config_agent_fields_redaction.py
+++ b/test/test_config_agent_fields_redaction.py
@@ -1,0 +1,278 @@
+"""Agent-record free text must leave GET /api/config/kirocrew masked (#8717).
+
+``description`` and ``triggers`` on an agent record are agent- and
+package-writable: an agent can edit ``config.json`` directly, and agent sync
+copies ``description`` straight off a discovered agent spec. They are not
+schema-``sensitive`` (they are not owner secrets), so ``_masked_config_dict``'s
+schema-driven walk never touched them and a credential- or
+exfiltration-URL-shaped value shipped to the browser verbatim — from BOTH
+response sites of the endpoint (the GET body and the PATCH echo). The roster
+endpoint masks the same class of strings (#8472); these tests pin the config
+endpoint's side of that rule.
+
+The rule under test (``_mask_agent_free_text``): a value ``_redact_external``
+would alter is replaced WHOLESALE by ``_SENSITIVE_MASK``; a non-string is
+masked too; benign content is byte-identical. The save() path is never masked —
+masking there would persist the sentinel over the stored value.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew.config import loader as L
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.sections import KiroCrewAgentConfig
+from kiro_crew.dashboard.handlers.core import (
+    _AGENT_UNTRUSTED_TEXT_FIELDS,
+    _SENSITIVE_MASK,
+    _mask_agent_free_text,
+    _masked_config_dict,
+)
+
+# Shapes _redact_external verifiably alters (probed against the real chain):
+# a credential-shaped token, and a URL with a conventionally-named secret param.
+_CRED_DESCRIPTION = "helper agent AKIAIOSFODNN7EXAMPLE for builds"
+_EXFIL_TRIGGERS = "post results to https://collector.example.com/x?token=abc123"
+# Benign strings the redactors leave byte-identical, including non-ASCII.
+_BENIGN_DESCRIPTION = "Reviews pull requests and summarizes diffs."
+_BENIGN_TRIGGERS = "use for code review, PR summaries, 代码审查"
+
+
+def _cfg_with_agents() -> KiroCrewConfig:
+    cfg = KiroCrewConfig()
+    cfg.agents["shady"] = KiroCrewAgentConfig(
+        description=_CRED_DESCRIPTION, triggers=_EXFIL_TRIGGERS
+    )
+    cfg.agents["plain"] = KiroCrewAgentConfig(
+        description=_BENIGN_DESCRIPTION, triggers=_BENIGN_TRIGGERS
+    )
+    return cfg
+
+
+def test_payload_preconditions_pin_the_redactor():
+    """If a fixture stops tripping/passing ``_redact_external``, fail HERE.
+
+    Localizes a detector regression: without these, a redactor change makes the
+    masking tests fail with no signal whether the rule or the detector moved.
+    """
+    from kiro_crew.dashboard.handlers.discover import _redact_external
+
+    assert _redact_external(_CRED_DESCRIPTION) != _CRED_DESCRIPTION
+    assert _redact_external(_EXFIL_TRIGGERS) != _EXFIL_TRIGGERS
+    assert _redact_external(_BENIGN_DESCRIPTION) == _BENIGN_DESCRIPTION
+    assert _redact_external(_BENIGN_TRIGGERS) == _BENIGN_TRIGGERS
+
+
+def test_every_unguarded_str_field_is_in_the_masked_set():
+    """INVARIANT: the masked tuple plus the shape-guarded exceptions must
+    cover every ``str`` field of ``KiroCrewAgentConfig``.
+
+    This is the ratchet against the class recurring: a newly added free-text
+    record field fails here instead of shipping to the browser unmasked. Each
+    exception names the load-time guard that justifies it — a guard that pins
+    the SHAPE (not just the type) to something the redactors cannot alter.
+    """
+    import dataclasses
+
+    shape_guarded = {
+        "reasoning_effort",  # coerce_effort: unknown level collapses to ""
+        "session_color",  # _safe_color: pinned to #rrggbb or ""
+    }
+    str_fields = {f.name for f in dataclasses.fields(KiroCrewAgentConfig) if f.type in ("str", str)}
+    assert str_fields, "field-type introspection returned nothing — check f.type handling"
+    covered = set(_AGENT_UNTRUSTED_TEXT_FIELDS) | shape_guarded
+    assert str_fields == covered, (
+        f"unmasked free-text field(s): {sorted(str_fields - covered)}; "
+        f"stale tuple entries: {sorted(covered - str_fields)}"
+    )
+
+
+class TestMaskAgentFreeText:
+    def test_credential_shaped_value_is_masked_wholesale(self):
+        assert _mask_agent_free_text(_CRED_DESCRIPTION) == _SENSITIVE_MASK
+
+    def test_url_secret_param_value_is_masked_wholesale(self):
+        assert _mask_agent_free_text(_EXFIL_TRIGGERS) == _SENSITIVE_MASK
+
+    def test_benign_value_is_byte_identical(self):
+        # Byte-identical, not merely equal-after-normalization: the browser must
+        # render exactly what the owner stored.
+        assert _mask_agent_free_text(_BENIGN_DESCRIPTION) is _BENIGN_DESCRIPTION
+
+    def test_empty_string_passes_through(self):
+        assert _mask_agent_free_text("") == ""
+
+    def test_non_string_is_masked(self):
+        # Load-bearing, not defensive: ``description`` is a bare ``entry.get``
+        # on the load path (no type guard, unlike ``model``/``triggers``), so a
+        # non-string genuinely reaches this function. Masking it also pins the
+        # wire shape: the frontend types the field as ``string``, and an object
+        # must not ship where a string is declared.
+        assert _mask_agent_free_text({"k": "v"}) == _SENSITIVE_MASK
+        assert _mask_agent_free_text(None) == _SENSITIVE_MASK
+
+    def test_partial_credential_masks_the_whole_value(self):
+        # Wholesale, not in-place scrub: the benign remainder is lost with the
+        # token. This is the named cost of a view that cannot be mistaken for
+        # content — pin it so an in-place scrub cannot sneak back in.
+        out = _mask_agent_free_text(_CRED_DESCRIPTION)
+        assert "helper agent" not in str(out)
+
+
+class TestMaskedConfigDict:
+    def test_suspicious_agent_fields_leave_masked(self):
+        masked = _masked_config_dict(_cfg_with_agents())
+        assert masked["agents"]["shady"]["description"] == _SENSITIVE_MASK
+        assert masked["agents"]["shady"]["triggers"] == _SENSITIVE_MASK
+        body = json.dumps(masked)
+        assert "AKIAIOSFODNN7EXAMPLE" not in body
+        assert "collector.example.com" not in body
+
+    def test_benign_agent_fields_are_untouched(self):
+        masked = _masked_config_dict(_cfg_with_agents())
+        assert masked["agents"]["plain"]["description"] == _BENIGN_DESCRIPTION
+        assert masked["agents"]["plain"]["triggers"] == _BENIGN_TRIGGERS
+
+    def test_other_record_fields_are_not_masked(self):
+        # The pass is scoped to the named free-text fields; structural fields
+        # (workspace, source, ...) must keep rendering in the Settings UI.
+        masked = _masked_config_dict(_cfg_with_agents())
+        record = masked["agents"]["shady"]
+        for key, val in record.items():
+            if key in _AGENT_UNTRUSTED_TEXT_FIELDS:
+                continue
+            assert val != _SENSITIVE_MASK, f"unexpected mask on agents.*.{key}"
+
+    def test_extended_fields_mask_when_suspicious(self):
+        # The wider field set (#8717 review): every unguarded record string is
+        # covered, not just the two the issue named. A credential-shaped
+        # workspace/kiro_agent must mask; the benign defaults must not.
+        cfg = KiroCrewConfig()
+        cfg.agents["odd"] = KiroCrewAgentConfig(
+            kiro_agent=_CRED_DESCRIPTION, workspace=_EXFIL_TRIGGERS
+        )
+        masked = _masked_config_dict(cfg)
+        record = masked["agents"]["odd"]
+        assert record["kiro_agent"] == _SENSITIVE_MASK
+        assert record["workspace"] == _SENSITIVE_MASK
+        # Untouched benign defaults keep rendering in the Settings UI.
+        assert record["memory_store"] == "default"
+        assert record["source"] == "kirocrew"
+
+    def test_suspicious_record_key_is_removed_not_leaked(self):
+        # Agent sync stores a discovered agent's NAME as the map key, so a
+        # credential-shaped package name would ship verbatim as a key. Removal,
+        # not masking: masking a key would collide two suspicious records.
+        cfg = KiroCrewConfig()
+        cfg.agents[_CRED_DESCRIPTION] = KiroCrewAgentConfig(description="x")
+        cfg.agents["plain"] = KiroCrewAgentConfig(description=_BENIGN_DESCRIPTION)
+        masked = _masked_config_dict(cfg)
+        assert _CRED_DESCRIPTION not in masked["agents"]
+        assert "plain" in masked["agents"]
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(masked)
+        # save() still carries the record — only the browser view drops it.
+        assert _CRED_DESCRIPTION in cfg.to_dict()["agents"]
+
+    def test_name_references_to_removed_record_are_masked(self):
+        # default_agent / session.pool_agent spell an agent name verbatim, so a
+        # removed record's name must not survive through them.
+        cfg = KiroCrewConfig()
+        cfg.agents[_CRED_DESCRIPTION] = KiroCrewAgentConfig()
+        cfg.default_agent = _CRED_DESCRIPTION
+        cfg.session.pool_agent = _CRED_DESCRIPTION
+        masked = _masked_config_dict(cfg)
+        assert masked["default_agent"] == _SENSITIVE_MASK
+        assert masked["session"]["pool_agent"] == _SENSITIVE_MASK
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(masked)
+
+    def test_benign_name_references_are_untouched(self):
+        cfg = KiroCrewConfig()
+        cfg.agents["plain"] = KiroCrewAgentConfig()
+        cfg.default_agent = "plain"
+        cfg.session.pool_agent = "plain"
+        masked = _masked_config_dict(cfg)
+        assert masked["default_agent"] == "plain"
+        assert masked["session"]["pool_agent"] == "plain"
+
+    def test_save_path_is_never_masked(self):
+        # to_dict()/save() must keep the stored value — masking there would
+        # persist the sentinel over the operator's config.
+        cfg = _cfg_with_agents()
+        _masked_config_dict(cfg)
+        stored = cfg.to_dict()["agents"]["shady"]
+        assert stored["description"] == _CRED_DESCRIPTION
+        assert stored["triggers"] == _EXFIL_TRIGGERS
+
+
+def _point_loader_at(tmp_path, monkeypatch, data: dict) -> None:
+    cfgp = tmp_path / "config.json"
+    cfgp.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+
+
+def _seed_config() -> dict:
+    return {
+        "agents": {
+            "kirocrew": {
+                "kiro_agent": "kirocrew",
+                "workspace": "default",
+                "memory_store": "default",
+                "description": _CRED_DESCRIPTION,
+                "triggers": _EXFIL_TRIGGERS,
+            }
+        },
+        "default_agent": "kirocrew",
+        "auto_update": False,
+    }
+
+
+class TestConfigEndpointWire:
+    """Both response sites, over HTTP — the wire is what the browser reads."""
+
+    @pytest.mark.asyncio
+    async def test_get_response_masks_agent_free_text(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.handlers import core as core_mod
+
+        _point_loader_at(tmp_path, monkeypatch, _seed_config())
+        app = web.Application()
+        app.router.add_route("*", "/api/config/kirocrew", core_mod.api_kirocrew_config)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/api/config/kirocrew")
+            assert resp.status == 200
+            body = await resp.json()
+        assert body["agents"]["kirocrew"]["description"] == _SENSITIVE_MASK
+        assert body["agents"]["kirocrew"]["triggers"] == _SENSITIVE_MASK
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(body)
+
+    @pytest.mark.asyncio
+    async def test_patch_echo_masks_agent_free_text(self, tmp_path, monkeypatch):
+        """The PATCH handler's config echo is the second response site."""
+        from kiro_crew.dashboard.handlers import api_kirocrew_config_patch
+
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(_seed_config()), encoding="utf-8")
+        app = web.Application()
+        app.router.add_patch("/api/config/kirocrew", api_kirocrew_config_patch)
+        app["state"] = SimpleNamespace(subagents=MagicMock(spec=["update_completion_keep"]))
+        with patch("kiro_crew.config.loader.config_path", return_value=cfg_path):
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.patch(
+                    "/api/config/kirocrew", json={"path": "auto_update", "value": True}
+                )
+                assert resp.status == 200
+                body = await resp.json()
+        assert body["agents"]["kirocrew"]["description"] == _SENSITIVE_MASK
+        assert body["agents"]["kirocrew"]["triggers"] == _SENSITIVE_MASK
+        assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(body)
+        # The PATCH wrote only its own path; the stored free text is untouched.
+        stored = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert stored["agents"]["kirocrew"]["description"] == _CRED_DESCRIPTION


### PR DESCRIPTION
## Summary

`GET /api/config/kirocrew`'s `_masked_config_dict` is schema-driven: it masks only values the JSON schema marks `sensitive=True`. Agent-record free-text fields (`description`, `triggers`, and siblings) are agent- and package-writable — an agent can edit `config.json` directly, and agent sync copies `description` straight off a discovered agent spec — but they are not schema-sensitive, so they left BOTH response sites of the endpoint (the GET body and the PATCH echo) unmasked. This is the config-endpoint half of the class whose roster half PR #8472 proposes to close; issue #8717 records the asymmetry.

The fix adds a second pass to `_masked_config_dict`:

- `_AGENT_UNTRUSTED_TEXT_FIELDS` names every `str` field of `KiroCrewAgentConfig` whose load path does not pin its shape (`description`, `triggers`, `kiro_agent`, `workspace`, `memory_store`, `model`, `source`, `telegram_account`). `reasoning_effort` (`coerce_effort`) and `session_color` (`_safe_color`) are excluded because their load guards already refuse redactable content. An invariant test enumerates the dataclass's `str` fields against the tuple plus that exception set, so a newly added free-text field fails loudly instead of shipping unmasked.
- `_mask_agent_free_text` replaces a value `_redact_external` would alter (credential- or exfiltration-URL-shaped) WHOLESALE with the existing `_SENSITIVE_MASK` sentinel; a non-string is masked too (`description` has no load-time type guard, so one genuinely reaches here). Benign content passes through byte-identical. Keyed on `_redact_external` itself so this rule and the roster's cannot drift apart.
- Both response sites funnel through this one function, so the pass gives the redaction rule surface coverage on this endpoint.

Write-back safety: neither branch of the endpoint can echo the sentinel into storage — the PATCH allowlist (`_EDITABLE_CONFIG`) names no `agents.*` path, and the PUT branch reads only the singular `agent` section against a hardcoded key list. The `save()` path is never masked.

Named costs: a value containing one credential-shaped token is masked entirely (the same trade `_masked_config_dict` already makes); the overview config tab renders `kiro_agent`/`workspace`/`memory_store` and cross-references the latter two, so a masked value breaks that "used by" row — but only for a record whose value is already credential-shaped and therefore already meaningless as a reference. The record KEY (the agent name) is handled by REMOVAL: agent sync stores a discovered agent's name as the map key, so a credential-shaped package name would ship verbatim as a key, and masking a key would collide two suspicious records into one entry. A suspicious-keyed record is dropped from the browser view (save() still carries it) and the name-reference fields that could still spell it (`default_agent`, `session.pool_agent`) are masked when they match. Named cost: such a record is invisible in the config tab — its name was never renderable content.

Out of scope: `GET /api/agents` still ships these fields verbatim on main — that half of the class is PR #8472's, which carries the same mask plus the mask-means-unchanged write rule its route needs.

## Tests

- New `test/test_config_agent_fields_redaction.py` (18 tests): credential- and URL-shaped values masked wholesale; benign / empty / CJK strings byte-identical; non-strings masked; partial-credential wholesale-mask pinned; extended field set covered; structural fields untouched; `save()` path untouched; redactor-precondition assertions localizing detector regressions; a dataclass-enumeration invariant ratcheting the field tuple; and both response sites driven over HTTP (real GET route, real PATCH handler).
- Mutation-verified 8 ways: removing the second pass, in-place scrub instead of the sentinel, dropping `triggers` from the tuple, dropping `workspace` from the tuple, non-string passthrough, unconditional masking, keeping a suspicious-keyed record, and skipping the name-reference masking each turn distinct tests red.
- Local gates: black-baseline, isort, flake8, mypy (1294 files), subprocess-encoding, brand-name, harness-parity all green; 282 targeted tests across the config-handler test files pass.
- Pre-push review fleet: GPT lane NO-FINDINGS with evidence; Opus lane raised 2 BLOCKING (docstring accuracy against the unmerged #8472; field-set coverage) + 5 CONCERNS — each verified on source and fixed in this head.

## Pattern harvest

Rule candidate: flag any aiohttp `json_response` handler that serializes a config/record dataclass where some `str` fields lack a load-time shape guard and the response path applies only schema-driven masking — the unguarded fields ship agent-writable free text verbatim (semgrep: `web.json_response($X)` where `$X` flows from `to_dict()`/`asdict()` without a per-field mask pass).
Class: schema-driven redaction gives point coverage; writable free-text fields outside the schema's sensitive set need their own named-field mask pass, ratcheted by a dataclass-enumeration invariant test.

Closes #8717
