### PR TITLE
fix(cron): tell a caller at creation when it can never manage the job

### DIFF
--- a/src/kiro_crew/cron.py
+++ b/src/kiro_crew/cron.py
@@ -833,6 +833,46 @@ def build_cron_session_context(job: CronJob) -> tuple[str, str]:
     return f"cron:{job.id}:{run_id}", job.message
 
 
+def cron_job_id_from_session_key(session_key: str) -> str:
+    """The job id inside a ``cron:`` session key, or ``""`` for any other key.
+
+    Every shape this repository mints is ``cron:<job_id>`` with an OPTIONAL third
+    segment, and a job id is ``uuid4().hex[:8]`` so it never contains a colon --
+    which is what makes taking the second segment exact rather than a guess.
+    """
+    if not session_key.startswith("cron:"):
+        return ""
+    return session_key.split(":")[1] if len(session_key.split(":")) > 1 else ""
+
+
+def cron_session_key_is_stable(job: CronJob) -> bool:
+    """Whether every run of *job* presents the SAME session key.
+
+    Lives beside :func:`build_cron_session_context` because it is the inverse of
+    that function's branch, and a predicate that can silently disagree with the
+    code that mints the key is worse than no predicate: it fails QUIET, as a
+    warning that stops firing or one that fires on the wrong job.
+
+    Two minting paths feed this, which is the whole reason callers must not infer
+    the answer from the key's shape:
+
+    * :func:`build_cron_session_context` -- ``cron:<job_id>`` when
+      ``persistent_session``, else ``cron:<job_id>:<run_id>`` with a fresh
+      ``uuid4`` per fire, so the three-segment form there is EPHEMERAL.
+    * the sequential-agent path in the Slack gateway -- ``cron:<job_id>:<agent>``
+      whenever ``agent_sequence`` holds more than one agent. It builds the key
+      directly rather than calling the function above, and an agent NAME is
+      stable, so the three-segment form there is DURABLE.
+
+    So the two forms are indistinguishable by separator count, and only the job
+    record separates them. The sequential path ignores ``persistent_session``
+    entirely, which is why it is checked second rather than combined.
+    """
+    if len(job.agent_sequence) > 1:
+        return True
+    return job.persistent_session
+
+
 # ── Cron expression matching (via croniter) ──
 
 

--- a/src/kiro_crew/mcp_cron.py
+++ b/src/kiro_crew/mcp_cron.py
@@ -34,6 +34,8 @@ from kiro_crew.cron import (
     CronStoreBusy,
     CronStoreUnreadable,
     compute_next_run_ts,
+    cron_job_id_from_session_key,
+    cron_session_key_is_stable,
     format_schedule,
     get_local_tz,
     is_valid_skip_date,
@@ -1653,8 +1655,31 @@ def _not_found(job_id: str) -> str:
     Shared by all three refusal branches -- no such id, a row owned by another
     session, a row owning no session -- so none of them is an existence oracle for
     the others. The ``Error:`` prefix is the tool contract's failure marker.
+
+    The two sentences after the marker are addressed to the MODEL reading this, and
+    neither narrows the ambiguity above: they hold verbatim in all three branches,
+    so the string stays one string and discloses nothing it did not before.
+
+    They are here because the vague wording has a failure mode of its own. An agent
+    told only "job not found" reasonably concludes the job is gone and reports THAT
+    to whoever asked -- a fluent, plausible answer that happens to be false, and one
+    the caller cannot distinguish from a true one. Saying outright that this answer
+    is not evidence of absence is the only place that inference can be intercepted.
+    The recovery command is named for the same reason: ``cron adopt`` shipped in
+    #4660 precisely to un-strand these rows, and a caller who never sees it named
+    has no way to reach it from inside the product. It is phrased as something to
+    ASK THE USER for, not to run: ``security.py``'s ``self-protection-cron-adopt``
+    rule denies that command to the agent so a session cannot assign itself
+    ownership of a scheduled job, so an instruction to run it would dead-end at
+    that gate and read as a malfunction.
     """
-    return f"Error: job not found: {job_id}"
+    return (
+        f"Error: job not found: {job_id}. This is the same answer whether no such "
+        f"job exists or one exists that this session does not own, so do not report "
+        f"it as proof the job is gone. `kirocrew cron list` shows every job with its "
+        f"owner; if the job should belong to this session, ask the user to run "
+        f"`kirocrew cron adopt {job_id} --session-of <session>`."
+    )
 
 
 def _unowned_row_refusal(job_id: str) -> str:
@@ -1765,13 +1790,132 @@ def _check_cron_job_ownership(svc: "CronService", job_id: str) -> str | None:
 #: because an identified session is not necessarily the operator, and "N jobs
 #: exist that you may not see" discloses the admin surface's volume to exactly
 #: that principal. Naming the two surfaces that CAN reach those rows discloses
-#: nothing further: both already require the operator's own machine.
+#: nothing further: both already require the operator's own machine, and
+#: ``cron adopt`` is a verb on one of them rather than a third surface.
+#:
+#: The "do not report that no cron jobs exist" clause is addressed to the MODEL,
+#: and it is load-bearing for a caller this sentence otherwise misleads. A
+#: sub-agent asked to review the schedule is scoped to its OWN key, so it reaches
+#: this string legitimately and can relay "there are no cron jobs" upward without
+#: any error having occurred -- a wrong answer that is indistinguishable from a
+#: right one, since the parent has no view of what was filtered. Withholding the
+#: count is still right; leaving the caller to infer absence from the silence was
+#: not.
+#:
+#: ``cron adopt`` is named as something to ASK THE USER for. The agent cannot run
+#: it: ``security.py``'s ``self-protection-cron-adopt`` rule denies the command so
+#: a session cannot assign itself ownership of a scheduled job. Coaching the model
+#: to run it would send it into that gate; coaching it to relay the command points
+#: the text and the deny rule the same way.
 _SCOPED_EMPTY = (
-    "No cron jobs owned by this session. Jobs owned by another session, or "
-    "created without one (the CLI and the onboarding importer), are outside "
-    "this session's scope and are not listed here. Manage those with "
-    "`kirocrew cron list` or on the dashboard Schedule page."
+    "No cron jobs owned by this session. This is NOT an empty registry, so do not "
+    "report that no cron jobs exist: jobs owned by another session, or created "
+    "without one (the CLI and the onboarding importer), are outside this session's "
+    "scope and are not listed here. `kirocrew cron list` and the dashboard Schedule "
+    "page show every job with its owner; to bring one into this session's scope for "
+    "good, ask the user to run `kirocrew cron adopt <job_id> --session-of <session>`."
 )
+
+
+def _owner_unusable_caveat(svc: "CronService", session_key: str, job_id: str) -> str:
+    """Why the row just written may already be unmanageable, or ``""``.
+
+    ``cron_add`` stamps the CALLER's key as the owner and every mutating tool then
+    demands an exact match, so a caller whose own key does not outlive the job has
+    just written a row only ``kirocrew cron adopt`` can rescue. Both branches below
+    succeed today and report a bare success, which is the defect: the loss is
+    silent at the one moment the caller still has the id in front of it and could
+    act.
+
+    A WARNING appended to a success, deliberately, not a refusal. A sub-agent
+    scheduling a job nobody ever pauses is a working flow -- only management is
+    lost, never execution -- so refusing would break callers who are getting
+    exactly what they asked for, to protect them from a cost they may not be
+    paying. Naming the consequence costs those callers one sentence and tells the
+    ones who DID intend to manage the job what to do while it is still cheap.
+
+    Every ``cron adopt`` reference here is addressed to the USER, in the same
+    ``Tell the user:`` register the success string already uses. That is not a
+    style choice: ``security.py``'s ``self-protection-cron-adopt`` rule denies the
+    command to the agent outright, precisely so a session cannot assign itself
+    ownership of a scheduled job. An instruction telling the model to RUN it would
+    dead-end at that gate and read as a malfunction, so the model is told to relay
+    it instead -- the human is the only principal who can execute the remedy, and
+    the deny rule and this text now point the same way.
+
+    Neither branch is reachable from the surfaces that already work: a chat tab is
+    ``dashboard:<slot>`` and a durable cron is ``cron:<job_id>``, and both outlive
+    the jobs they create.
+    """
+    if session_key.startswith("subagent:"):
+        return (
+            " Note: the owner recorded is this sub-agent's conversation. The parent "
+            "session cannot present that key, so the parent cannot pause, resume, or "
+            "remove this job -- not eventually, but starting now -- and the key stops "
+            "resolving at all once the conversation is released or reaped. Tell the "
+            "user: either have the parent create the job, or run `kirocrew cron adopt "
+            f"{job_id} --session-of <parent session>` to transfer it."
+        )
+    # Asked of the JOB RECORD, never of the key's shape. Two different minting
+    # paths produce a three-segment ``cron:`` key -- an ephemeral per-fire run id
+    # and a DURABLE per-agent name for an agent_sequence job -- so counting
+    # separators warns the multi-agent case wrongly. See
+    # cron.cron_session_key_is_stable, which lives next to both mint sites.
+    caller_job_id = cron_job_id_from_session_key(session_key)
+    if not caller_job_id:
+        return ""
+    caller_job = svc.get_job(caller_job_id)
+    # No record means no evidence, so say nothing: a warning we cannot substantiate
+    # is the exact failure this branch was rewritten to remove.
+    if caller_job is None or cron_session_key_is_stable(caller_job):
+        return ""
+    return (
+        " Note: the cron creating this job runs with persistent_session disabled, "
+        "so its session key carries a fresh per-run id and will never match again. "
+        "The owner recorded here is already unusable -- this cron will not "
+        "recognise the job on its next run. Tell the user to run `kirocrew cron "
+        f"adopt {job_id} --session-of <session>` if anything should manage it later."
+    )
+
+
+def _ephemeral_authority_caveat(persistent: bool, is_agent_job: bool, sequence_len: int) -> str:
+    """Warn when the job BEING created or updated is the one that loses authority.
+
+    Distinct from :func:`_owner_unusable_caveat`, which is about the caller. Here
+    the caller may be perfectly durable while the job it is writing is not:
+    ``persistent_session=False`` gives each run a fresh ``cron:<id>:<run_id>`` key
+    (``cron.build_cron_session_context``), so that job can never satisfy an
+    ownership check on a later run -- including against jobs it created itself on
+    an earlier one.
+
+    Two exemptions, both because the flag cannot produce the bad state:
+
+    * NOT an agent job. A script cron is launched with
+      ``KIROCREW_SESSION_KEY=cron:<job_id>`` unconditionally and a command cron
+      issues no MCP call at all.
+    * ``agent_sequence`` longer than one. That path mints a stable
+      ``cron:<job_id>:<agent>`` key and ignores ``persistent_session``, so the
+      warning would be false -- the same conflation
+      :func:`cron.cron_session_key_is_stable` exists to prevent.
+
+    Applied at ``cron_update`` as well as ``cron_add``: the flag is writable on
+    both, so warning only at creation would leave the identical state reachable
+    through a bare ``Updated job:``.
+
+    The argument reads as a context-management knob -- whether a run sees the
+    previous run's transcript -- and nothing at the call site suggests it also
+    revokes the job's authority over the scheduler. That gap is why this is worth
+    a sentence rather than a docs line.
+    """
+    if persistent or not is_agent_job or sequence_len > 1:
+        return ""
+    return (
+        " Note: persistent_session is false, so every run of this job gets a fresh "
+        "session key. It will not be able to pause, resume, or remove any cron job, "
+        "including ones it creates itself, because the ownership check needs the "
+        "same key to come back on a later run. Leave persistent_session at its "
+        "default if this job is meant to manage other jobs."
+    )
 
 
 def _owned_by(jobs: list[CronJob], session_key: str) -> list[CronJob]:
@@ -1969,7 +2113,27 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             source="mcp",
             resources=f"job_id={job.id}",
         )
-        return f"Added job: {job.id} ({job.name}) [{sched_str}]. Tell the user: scheduled for {sched_str}."
+        # Appended to the SUCCESS, after the id exists so both caveats can name it.
+        # Not folded into the audit row above: call_tool_with_logging already records
+        # this invocation against the calling session, and a caveat is advice to the
+        # caller rather than a decision with an effect (cf. _audit_list_scope).
+        #
+        # Every input is read from ``args``, the way persistent_session and
+        # command/script above are, so this site depends on the stored row for
+        # nothing but ``job.id`` -- which the success string already used. Reading
+        # ``job.agent_sequence`` back instead bought nothing (this tool has no
+        # agent_sequence argument, so the field is always empty here) and coupled
+        # the caveat to the whole returned object. ``args`` also keeps the answer
+        # correct by construction if the argument is ever added to the schema.
+        caveats = _owner_unusable_caveat(svc, session_key, job.id) + _ephemeral_authority_caveat(
+            persistent_session if isinstance(persistent_session, bool) else True,
+            not (command or script),
+            len(args.get("agent_sequence") or []),
+        )
+        return (
+            f"Added job: {job.id} ({job.name}) [{sched_str}]. "
+            f"Tell the user: scheduled for {sched_str}.{caveats}"
+        )
 
     if name == "cron_update":
         jid = args["job_id"]
@@ -2059,7 +2223,17 @@ def _call_tool_inner(name: str, args: dict[str, Any]) -> str:
             resources=f"job_id={jid}",
         )
         sched_str = format_schedule(updated.schedule)
-        return f"Updated job: {updated.id} ({updated.name}) [{sched_str}]"
+        # Read from the SAVED row, not from ``args``: an update that leaves
+        # persistent_session alone must still warn if the job is already in that
+        # state and this call turned it into an agent job, and the flag is writable
+        # here exactly as it is on cron_add -- warning only at creation would leave
+        # the identical no-authority state reachable through a bare "Updated job:".
+        caveat = _ephemeral_authority_caveat(
+            updated.persistent_session,
+            not (updated.command or updated.script),
+            len(updated.agent_sequence),
+        )
+        return f"Updated job: {updated.id} ({updated.name}) [{sched_str}]{caveat}"
 
     if name == "cron_remove":
         jid = args["job_id"]

--- a/test/test_cron_owner_caveats.py
+++ b/test/test_cron_owner_caveats.py
@@ -1,0 +1,351 @@
+"""A cron whose owner cannot outlive it says so at creation, not weeks later.
+
+``cron_add`` stamps the caller's session key as the owner and every mutating tool
+then demands an exact match, so two callers write a row they can never manage: a
+sub-agent (whose conversation the parent cannot present, and which is reaped) and a
+cron running with ``persistent_session=False`` (whose key carries a fresh per-run
+id). A third case is the job being created rather than the creator: an agent job
+with ``persistent_session=False`` can never satisfy an ownership check on a later
+run, including against jobs it scheduled itself.
+
+All three succeeded silently before this change. These tests pin the warning AND
+the fact that it is only a warning -- execution is untouched and the durable
+callers stay quiet, which is what keeps the noise off the paths that already work.
+
+See issue #8772.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from kiro_crew.cron import CronService, cron_job_id_from_session_key, cron_session_key_is_stable
+from kiro_crew.mcp_cron import (
+    _SCOPED_EMPTY,
+    _call_tool_inner,
+    _ephemeral_authority_caveat,
+    _not_found,
+    _owner_unusable_caveat,
+)
+
+
+def _unique_name() -> str:
+    return f"test-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cron_store(monkeypatch, tmp_path):
+    """Route all CronService() instances to tmp_path for test isolation."""
+    monkeypatch.setattr("kiro_crew.cron._DEFAULT_DIR", tmp_path)
+    monkeypatch.setattr("kiro_crew.mcp_cron.config_dir", lambda: tmp_path)
+
+
+class TestSessionKeyStabilityPredicate:
+    """The two three-segment ``cron:`` keys mean opposite things.
+
+    ``build_cron_session_context`` mints ``cron:<id>:<run_id>`` with a fresh uuid
+    per fire (ephemeral); the sequential-agent path in the Slack gateway mints
+    ``cron:<id>:<agent>`` for an ``agent_sequence`` job (durable, and it ignores
+    ``persistent_session``). Separator counting cannot tell them apart, which is
+    why the caveat asks the job record.
+    """
+
+    def test_a_default_job_is_stable(self):
+        svc = CronService()
+        job = svc.add_job(name=_unique_name(), message="hi", every_secs=120)
+        assert cron_session_key_is_stable(job) is True
+
+    def test_an_ephemeral_single_agent_job_is_not_stable(self):
+        svc = CronService()
+        job = svc.add_job(
+            name=_unique_name(), message="hi", every_secs=120, persistent_session=False
+        )
+        assert cron_session_key_is_stable(job) is False
+
+    def test_a_multi_agent_job_is_stable_even_with_persistence_off(self):
+        """The regression GPT caught: this shape has 2 colons and is DURABLE."""
+        svc = CronService()
+        job = svc.add_job(
+            name=_unique_name(),
+            message="hi",
+            every_secs=120,
+            persistent_session=False,
+            agent_sequence=["alpha", "beta"],
+        )
+        assert cron_session_key_is_stable(job) is True
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            ("cron:abc12345", "abc12345"),
+            ("cron:abc12345:run5678", "abc12345"),
+            ("cron:abc12345:some-agent", "abc12345"),
+            ("dashboard:chat-3-1712793600", ""),
+            ("subagent:conv-7", ""),
+            ("", ""),
+        ],
+    )
+    def test_job_id_extraction(self, key, expected):
+        assert cron_job_id_from_session_key(key) == expected
+
+
+class TestOwnerUnusableCaveat:
+    """Which CALLERS write a row they cannot come back for."""
+
+    def test_a_subagent_caller_is_told_the_parent_cannot_manage_the_job(self):
+        out = _owner_unusable_caveat(CronService(), "subagent:conv-7", "abc12345")
+        assert "sub-agent's conversation" in out
+        # The whole point is that the loss is immediate, not deferred to reaping.
+        assert "starting now" in out
+        assert "kirocrew cron adopt abc12345" in out
+
+    def test_the_subagent_caveat_tells_the_user_rather_than_the_model_to_adopt(self):
+        """``self-protection-cron-adopt`` denies the command to the agent.
+
+        A caveat that told the model to RUN it would dead-end at that gate, so the
+        remedy has to be relayed to the only principal allowed to execute it.
+        """
+        out = _owner_unusable_caveat(CronService(), "subagent:conv-7", "abc12345")
+        assert "Tell the user" in out
+
+    def test_an_ephemeral_cron_caller_is_told_its_key_will_never_match_again(self):
+        svc = CronService()
+        caller = svc.add_job(
+            name=_unique_name(), message="hi", every_secs=120, persistent_session=False
+        )
+        out = _owner_unusable_caveat(svc, f"cron:{caller.id}:run5678", "abc12345")
+        assert "never match again" in out
+        assert "Tell the user" in out
+        assert "kirocrew cron adopt abc12345" in out
+
+    def test_a_multi_agent_cron_caller_is_not_warned(self):
+        """The false positive GPT flagged: 2 colons, but a DURABLE per-agent key."""
+        svc = CronService()
+        caller = svc.add_job(
+            name=_unique_name(),
+            message="hi",
+            every_secs=120,
+            persistent_session=False,
+            agent_sequence=["alpha", "beta"],
+        )
+        assert _owner_unusable_caveat(svc, f"cron:{caller.id}:alpha", "abc12345") == ""
+
+    def test_an_unknown_caller_job_is_not_warned(self):
+        """No record means no evidence; an unsubstantiated warning is the bug."""
+        assert _owner_unusable_caveat(CronService(), "cron:deadbeef:run1", "abc12345") == ""
+
+    @pytest.mark.parametrize(
+        "session_key",
+        [
+            "dashboard:chat-3-1712793600",
+            "slack:C123:1712793600.1",
+            "",
+        ],
+    )
+    def test_a_durable_caller_gets_no_caveat(self, session_key):
+        """The paths that already work must stay silent.
+
+        The empty key never reaches here (``cron_add`` refuses first), and is
+        included so a future refactor that reorders those checks trips this instead
+        of shipping a caveat with no id in it. The Slack key carries its own colons,
+        which an earlier separator-counting implementation would have misread.
+        """
+        assert _owner_unusable_caveat(CronService(), session_key, "abc12345") == ""
+
+    def test_a_durable_cron_caller_gets_no_caveat(self):
+        """Load-bearing: a default cron IS a stable owner.
+
+        Warning here would fire on the single working orchestration pattern -- a
+        cron managing jobs it created on an earlier fire.
+        """
+        svc = CronService()
+        caller = svc.add_job(name=_unique_name(), message="hi", every_secs=120)
+        assert _owner_unusable_caveat(svc, f"cron:{caller.id}", "abc12345") == ""
+
+
+class TestEphemeralAuthorityCaveat:
+    """Whether the job BEING written can manage crons on a later run."""
+
+    def test_an_ephemeral_agent_job_is_warned(self):
+        out = _ephemeral_authority_caveat(persistent=False, is_agent_job=True, sequence_len=0)
+        assert "persistent_session is false" in out
+        assert "including ones it creates itself" in out
+
+    def test_a_persistent_agent_job_is_not_warned(self):
+        assert _ephemeral_authority_caveat(persistent=True, is_agent_job=True, sequence_len=0) == ""
+
+    def test_a_multi_agent_job_is_not_warned(self):
+        """That path mints a stable per-agent key and ignores the flag."""
+        assert (
+            _ephemeral_authority_caveat(persistent=False, is_agent_job=True, sequence_len=2) == ""
+        )
+
+    @pytest.mark.parametrize("persistent", [True, False])
+    def test_a_command_or_script_job_is_never_warned(self, persistent):
+        """The flag cannot produce the bad state for these, so the warning is noise.
+
+        A script cron is launched with ``KIROCREW_SESSION_KEY=cron:<job_id>``
+        unconditionally and a command cron issues no MCP call at all.
+        """
+        assert (
+            _ephemeral_authority_caveat(persistent=persistent, is_agent_job=False, sequence_len=0)
+            == ""
+        )
+
+
+class TestCronAddSurfacesTheCaveat:
+    """End to end through the tool, including that it is NOT a refusal."""
+
+    def test_a_subagent_still_gets_its_job_and_also_gets_told(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:conv-42")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+        name = _unique_name()
+
+        result = _call_tool_inner("cron_add", {"name": name, "message": "hi", "every": 120})
+
+        # Warned, not refused: the job exists and will fire.
+        assert "Added job" in result
+        assert "Error" not in result
+        assert "sub-agent's conversation" in result
+        jobs = [j for j in CronService().list_jobs() if j.name == name]
+        assert len(jobs) == 1
+        assert jobs[0].session_key == "subagent:conv-42"
+        # The caveat names the real id, so the fix is copy-pasteable.
+        assert f"kirocrew cron adopt {jobs[0].id}" in result
+
+    def test_an_ephemeral_agent_job_is_flagged_at_creation(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:chat-9")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+        name = _unique_name()
+
+        result = _call_tool_inner(
+            "cron_add",
+            {"name": name, "message": "hi", "every": 120, "persistent_session": False},
+        )
+
+        assert "Added job" in result
+        assert "persistent_session is false" in result
+
+    def test_the_ordinary_case_stays_exactly_as_it_was(self, monkeypatch):
+        """A chat tab creating a default job gets no extra sentence at all."""
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:chat-9")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+        name = _unique_name()
+
+        result = _call_tool_inner("cron_add", {"name": name, "message": "hi", "every": 120})
+
+        assert "Added job" in result
+        assert "Note:" not in result
+
+    def test_both_caveats_can_appear_together(self, monkeypatch):
+        """A sub-agent scheduling an ephemeral agent job earns both, not one."""
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "subagent:conv-42")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+        name = _unique_name()
+
+        result = _call_tool_inner(
+            "cron_add",
+            {"name": name, "message": "hi", "every": 120, "persistent_session": False},
+        )
+
+        assert "sub-agent's conversation" in result
+        assert "persistent_session is false" in result
+
+
+class TestCronUpdateSurfacesTheCaveat:
+    """The sibling mutation site: the flag is writable here too."""
+
+    def test_flipping_persistence_off_via_update_is_flagged(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:chat-9")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+        name = _unique_name()
+        _call_tool_inner("cron_add", {"name": name, "message": "hi", "every": 120})
+        job_id = [j for j in CronService().list_jobs() if j.name == name][0].id
+
+        result = _call_tool_inner("cron_update", {"job_id": job_id, "persistent_session": False})
+
+        assert "Updated job" in result
+        assert "persistent_session is false" in result
+
+    def test_an_ordinary_update_stays_quiet(self, monkeypatch):
+        monkeypatch.setenv("KIROCREW_SESSION_KEY", "dashboard:chat-9")
+        monkeypatch.delenv("KIROCREW_CHANNEL_ID", raising=False)
+        name = _unique_name()
+        _call_tool_inner("cron_add", {"name": name, "message": "hi", "every": 120})
+        job_id = [j for j in CronService().list_jobs() if j.name == name][0].id
+
+        result = _call_tool_inner("cron_update", {"job_id": job_id, "every": 300})
+
+        assert "Updated job" in result
+        assert "Note:" not in result
+
+
+class TestRefusalsNameTheWayBack:
+    def test_not_found_denies_being_proof_of_absence(self):
+        out = _not_found("abc12345")
+        # Existing callers assert on this substring; keep it.
+        assert "job not found" in out.lower()
+        assert out.startswith("Error:")
+        assert "do not report it as proof the job is gone" in out
+        assert "kirocrew cron adopt abc12345" in out
+
+    def test_not_found_asks_the_user_to_adopt(self):
+        assert "ask the user to run" in _not_found("abc12345")
+
+    def test_not_found_stays_one_string_for_every_branch(self):
+        """No oracle: the message is a pure function of the id it was handed.
+
+        The added sentences hold verbatim whether the id exists, belongs to another
+        session, or names an ownerless row -- so two ids must differ only where the
+        id itself appears.
+        """
+        a = _not_found("aaaaaaaa")
+        b = _not_found("bbbbbbbb")
+        assert a.replace("aaaaaaaa", "X") == b.replace("bbbbbbbb", "X")
+
+    def test_scoped_empty_denies_being_an_empty_registry(self):
+        assert "NOT an empty registry" in _SCOPED_EMPTY
+        assert "do not report that no cron jobs exist" in _SCOPED_EMPTY
+        assert "kirocrew cron adopt" in _SCOPED_EMPTY
+
+    def test_scoped_empty_asks_the_user_to_adopt(self):
+        assert "ask the user to run" in _SCOPED_EMPTY
+
+    def test_scoped_empty_still_withholds_the_count(self):
+        """Naming the recovery path must not turn into disclosing the volume.
+
+        ``_UNOWNED`` exists because an identified session is not necessarily the
+        operator, so "N jobs you may not see" would leak the admin surface's size
+        to exactly that principal.
+        """
+        assert "withheld" not in _SCOPED_EMPTY.lower()
+        assert not any(ch.isdigit() for ch in _SCOPED_EMPTY)
+
+
+class TestAdoptIsNeverAddressedToTheModel:
+    """One rule across every string: the agent cannot run ``cron adopt``.
+
+    ``security.py``'s ``self-protection-cron-adopt`` denies it so a session cannot
+    assign itself ownership of a scheduled job. Every mention must therefore be
+    routed through the user, and this test is what stops a later reword from
+    quietly re-pointing one of them at the model.
+    """
+
+    def _strings(self):
+        svc = CronService()
+        ephemeral = svc.add_job(
+            name=_unique_name(), message="hi", every_secs=120, persistent_session=False
+        )
+        return [
+            _not_found("abc12345"),
+            _SCOPED_EMPTY,
+            _owner_unusable_caveat(svc, "subagent:conv-7", "abc12345"),
+            _owner_unusable_caveat(svc, f"cron:{ephemeral.id}:run1", "abc12345"),
+        ]
+
+    def test_every_adopt_mention_is_user_directed(self):
+        for s in self._strings():
+            assert "cron adopt" in s, s
+            assert ("ask the user" in s.lower()) or ("tell the user" in s.lower()), s


### PR DESCRIPTION
## 1. What is the problem?

`cron_add` stamps the **caller's** session key as the owner, and every mutating cron
tool then requires an exact match. So a caller whose own key does not outlive the job
writes a row that only `kirocrew cron adopt` can ever rescue -- and it was answered
with a bare success.

Two callers are in that state:

- **A sub-agent.** Its key is `subagent:<id>` (`subagent.py:1344`), which the parent
  session cannot present. The parent is locked out **immediately**, not eventually,
  and the key stops resolving at all once the conversation is released or reaped.
  `@kirocrew-cron` is in the default agent's `tools`, and a sub-agent inherits the
  parent's spec, so this is reachable by default.
- **A cron whose runs do not share one key.** `build_cron_session_context` mints
  `cron:<job_id>:<run_id>` with the run id re-randomised every fire (`cron.py:833`)
  when `persistent_session` is off, so the owner it recorded never matches again.

A third case is the job **being written** rather than its creator: an agent job with
`persistent_session=False` can never satisfy an ownership check on a later run,
including against jobs it scheduled itself. The flag is writable on **both**
`cron_add` and `cron_update` (`mcp_cron.py:1114`, `mcp_cron.py:1231`), so the state
was reachable behind a bare `Added job:` and a bare `Updated job:` alike. The
argument reads as a context-management knob and nothing at either call site said it
also revokes the job's authority over the scheduler.

Separately, the two refusal strings invited a wrong answer. `_not_found` is
deliberately identical for "no such id", "another session's row" and "an ownerless
row" so that none is an existence oracle for the others -- correct, but an agent told
only "job not found" concludes the job is gone and reports that upward. `_SCOPED_EMPTY`
has the same shape: a sub-agent asked to review the schedule is scoped to its own key,
reaches that string legitimately, and can relay "there are no cron jobs" with no error
having occurred.

## 2. Why this issue matters to the user

Every failure here is silent and deferred. `cron_add` returns success, and the loss
surfaces later as `job not found` on a job the user is looking at in the Schedule page.
By then the id is gone from the conversation and the one command that recovers the row
has never been named anywhere the user would see it -- `cron adopt` shipped in #4660
for exactly these rows, but neither in-chat message mentions it.

The wrong-answer path is worse than a refusal, because nothing downstream can detect
it. A parent that delegates "review the cron jobs" gets a fluent, plausible "there are
none" that is indistinguishable from a true one, and no error was raised at any point.

This was reported by a user migrating from an earlier build whose cron orchestrator had
been running on the pre-#4632 fail-open path. They read the scoped-empty message as a
new policy forbidding what they were doing, and concluded their architecture was no
longer supported. The rule is fine; the messages did not carry what a stranded caller
needs.

## 3. How our fix solves it

Chaining from the symptom back:

The symptom is a success that later behaves like a failure. The root cause is that
authority is keyed on a principal whose lifetime is shorter than the resource it
guards, with the mismatch detectable **at creation** and reported at neither end. So the
fix reports it at creation, where the caller still holds the id.

- `_owner_unusable_caveat` appends one sentence when the caller is a sub-agent or a
  cron whose runs do not share a key, naming the exact
  `kirocrew cron adopt <real id> --session-of <session>` to run.
- `_ephemeral_authority_caveat` appends one sentence when the job being written is an
  agent job with `persistent_session=False`. Applied at **both** `cron_add` and
  `cron_update`; the update path reads the SAVED row rather than the args, so a call
  that merely turns a job into an agent job is still caught. Exempt: script and
  command jobs (a script cron is launched with
  `KIROCREW_SESSION_KEY=cron:<job_id>` unconditionally and a command cron issues no
  MCP call), and `agent_sequence` longer than one.
- `_not_found` and `_SCOPED_EMPTY` now say outright that they are not evidence of
  absence, and both name `cron adopt`.

**Ephemerality is read from the job RECORD, never from the key's shape.** Two mint
sites produce a three-segment `cron:` key and they mean opposite things:
`build_cron_session_context` mints `cron:<id>:<run_id>` with a fresh uuid per fire,
while the sequential-agent path in the Slack gateway (`slack/gateway.py:4415`) mints
`cron:<id>:<agent>` whenever `agent_sequence` holds more than one agent -- built
directly rather than through that function, ignoring `persistent_session`, and
**durable**, because an agent name is stable. The new `cron.cron_session_key_is_stable`
answers from the record and lives beside both mint sites so it cannot drift from them
silently: drift here fails quiet, as a warning that stops firing or one that fires on
the wrong job. A caller whose job cannot be resolved warns about nothing, since an
unsupportable claim is the same defect in the other direction.

**Every `cron adopt` reference is addressed to the USER**, in the `Tell the user:`
register the success string already used. `security.py`'s
`self-protection-cron-adopt` (`security.py:1599`) denies that command to the agent
precisely so a session cannot assign itself ownership of a scheduled job, so an
instruction to RUN it would dead-end at that gate and read as a malfunction. The human
is the only principal who can execute the remedy, and the deny rule and this text now
point the same way.

**Warnings appended to a success, deliberately, not refusals.** A sub-agent scheduling a
job nobody ever pauses is a working flow -- only management is lost, never execution --
so refusing would break callers who are getting exactly what they asked for, to protect
them from a cost they may not be paying.

**No authorization change.** `_owned_by`, `_check_cron_job_ownership` and
`_authz_session_key` are untouched. The added sentences hold verbatim in every branch,
so `_not_found` remains one string and is still not an oracle (pinned by a test), and
`_SCOPED_EMPTY` still withholds the withheld-row count -- which matters because
`_UNOWNED` exists precisely because an identified session is not necessarily the
operator.

The durable callers stay silent: a chat tab is `dashboard:<slot>` and a default cron is
`cron:<job_id>`, and both outlive the jobs they create, so neither sees a caveat.

## 4. What tests we did

New `test/test_cron_owner_caveats.py`, 36 cases:

- the stability predicate directly: a default job is stable, an ephemeral single-agent
  job is not, and **a multi-agent job is stable even with `persistent_session=False`**
  -- the shape an earlier separator-counting version warned about wrongly. Job-id
  extraction is pinned across all six key shapes;
- each warned caller gets its caveat, with the **real** job id interpolated;
- **the durable callers get nothing** -- `dashboard:`, a durable `cron:<id>`, `slack:`
  (which carries its own colons), a multi-agent `cron:<id>:<agent>`, an unresolvable
  caller job, and the empty key. The durable-cron case is load-bearing: it is the single
  working orchestration pattern, and warning there would fire on it;
- the sub-agent case is **warned, not refused**: the job exists, has the expected owner,
  and the result carries no `Error`;
- both caveats appear together when both apply;
- `cron_update` flipping `persistent_session` off is flagged, and an ordinary update
  stays quiet;
- `persistent_session` on a command/script job is never warned about, both values;
- `_not_found` is a pure function of its id (two ids differ only where the id appears);
- `_SCOPED_EMPTY` still contains no digit and no "withheld";
- **one test sweeps every string that mentions `cron adopt` and asserts each is
  user-directed**, so a later reword cannot quietly re-point one at the model.

Regression: 148 passed across the neighbouring ownership suites
(`test_cron_session_scope`, `test_mcp_cron_caller_identity`, `test_cron_adopt_ownerless`,
`test_cron_ephemeral_session`, `test_cron_script_identity`), and 2555 passed on a full
`-k "cron or mcp_cron"` sweep of the pre-review revision.

Gates: baselined black gate passes in scope, isort/flake8 clean, mypy reports zero
errors in `mcp_cron.py`.

One local failure was investigated and is not from this change:
`test_cli_lazy_imports.py::test_mcp_stdio_server_answers_initialize_and_tools_list`
fails with `No module named kiro_crew` because the worktree has no editable install. Its
`mcp-core` parameterisation -- a module this PR does not touch -- fails identically, and
both fail the same way on an unmodified checkout.

## 5. Any other suggestions on the work

This is the reporting half of #8772 and deliberately does not close it. Still open there:

- release ownership when a session is **permanently deleted**, so a dead owner cannot
  masquerade as a healthy one. The history-delete funnel already has the right trigger
  semantics (tab close deliberately does not reach it) and `adopt_job(job_id, "")`
  already exists. Release rather than delete: the job is the user's work, only its owner
  is gone, and this collapses an invisible state into the documented ownerless one.
- flag a dead owner where the owner is already printed, using the liveness probe
  `cron adopt` already uses -- as a hint, not a verdict, since that call site documents
  that a brand-new tab with no log yet is a legitimate owner.
- `kirocrew cron add --session-of`, so a CLI-created job can be born owned.
- the `persistent_session` schema descriptions (`mcp_cron.py:1114`, `mcp_cron.py:1231`)
  still read as a pure context knob, so a caller learns the authority consequence only
  after choosing the flag. The caveats are the after-the-choice half of that; the
  before-the-choice half is a schema wording change, deliberately left out of a PR whose
  scope is the reporting layer.
- **the cause-level alternative to caveats 2 and 3**, raised by the First Principles lane
  and worth recording properly: have `_check_cron_job_ownership` compare
  `cron_job_id_from_session_key` on both sides when both keys are `cron:`. The two key
  forms name the same job record, and script crons already present a stable
  `cron:<job_id>` unconditionally (`cron_script.py:1680`), so an ephemeral cron would
  regain authority over its own jobs and both warnings could be deleted along with
  `_ephemeral_authority_caveat`. That is a change to WHO MAY MANAGE WHAT, not to what is
  reported, so it belongs to the authorization question this PR deliberately does not
  touch -- it needs a maintainer's call on the #3836 threat model, not a follow-up
  commit from here. Noted rather than done, and the lane agrees it is
  accepted-and-deferred rather than a demand.
- `cron_job_id_from_session_key` is a fourth spelling of an idiom that stays inline at
  three sites (`chat_utils.py:605`, `messaging.py:1325`, `messaging.py:1548`), so they
  can drift from it. Converging them is right but touches messaging and chat paths that
  have nothing to do with cron ownership, which is a wider blast radius than a
  reporting-layer PR should carry.

Worth stating what should **not** be done, since it is the tempting shortcut: do not
widen `_owned_by`, and do not treat a `dashboard:` key as operator-equivalent. A
dashboard slot can be linked to a Slack thread, so the namespace is not a trust tier,
and using it as one would reopen the chain #3836 closed. Any relaxation belongs on the
token-gated dashboard HTTP surface, not on a session key.

## Pattern harvest

Rule candidate: review ruleset
Pattern: an authorization field is written from the CALLER's identity at creation time
while the guarded resource outlives that identity, and no path releases or reassigns the
field when the identity is destroyed. Flag when a stored `session_key` / `owner` field is
the sole authorization input AND the resource has an independent lifecycle -- a schedule,
a subscription, a background job. The review question that would have caught all four
cases in #8772: name the destruction hook for that identity, and say what happens to the
rows still pointing at it. Here the answer was "there is no hook", and three of five
creation paths produced rows that were unmanageable before anyone looked.

Rule candidate: review ruleset
Pattern: a scope-filtered read whose empty case is worded as absolute absence. When a
function applies an ownership or visibility filter and then returns "No <things>", the
filtered-empty and genuinely-empty states are indistinguishable in the only artifact the
caller receives. That is a correctness bug whenever the consumer is a model, because it
relays the sentence as fact and nothing downstream can tell the two apart -- a wrong
answer with no error attached. Applies to `_not_found` here as much as to the list case:
a deliberately ambiguous refusal still needs to say it is ambiguous.

Not generalizable: the specific wording changes. Which sentence goes in which of the two
strings is local to this tool's contract.

Part of #8772