### PR TITLE
fix(sandbox): close the PAT exposures md-notebook's carve-out opens

### DIFF
--- a/docs/system-specs/modules/md-notebook.md
+++ b/docs/system-specs/modules/md-notebook.md
@@ -36,14 +36,107 @@ Rooted at `MD_NOTEBOOK_HOME`, defaulting to `~/.kiro/crew/workspace/md-notebook/
 
 | Path | Contents |
 | --- | --- |
-| `vaults.json` | Vault descriptors. No secrets, but `localPath` is what sync runs git against, so it is in `_SENSITIVE_HOME_DIRS`. Written via a temp file + `os.replace`. |
-| `pat` | GitHub token, chmod 0600, never echoed back to the UI (only a boolean is). Also listed in `_SENSITIVE_HOME_DIRS`, so agent file tools cannot read it through the shared gate — 0600 alone does not isolate another process running as the same user. |
+| `vaults.json` | Vault descriptors. No secrets, but `localPath` is what sync runs git against, so it is in `_SENSITIVE_HOME_DIRS`. Published through the staging directory + `os.replace`. |
+| `pat` | GitHub token, chmod 0600, never echoed back to the UI (only a boolean is). Also listed in `_SENSITIVE_HOME_DIRS`, so agent file tools cannot read it through the shared gate — 0600 alone does not isolate another process running as the same user. Cleared by writing an EMPTY file, never by `unlink`: the empty file is the reader's absent-equivalent, and removing the inode would delete the sandbox mask's mount target. |
+| `settings.json` | The `autoSync` authorization bit and the `lastSync` stamp. Published through the staging directory with `fsync`, so a rename from an unflushed page cache cannot discard an acknowledged toggle. |
+| `../../md-notebook-staging/` | Write-staging directory for the three state files above, at the crew data home ROOT. Every state writer opens its temp HERE and renames onto the target, so no temp carrying PAT bytes ever lands at a name the sandbox masks do not cover. Masked as a whole directory. It is top-level rather than a child of this directory because a mask covers the leaf and not its ancestors: under the agent-writable `workspace/md-notebook` it could be renamed out from under its own mask. Same filesystem, so the publish rename stays atomic. |
 | `vaults/<id>/` | Vaults this app cloned itself. Attached vaults stay where the user has them. |
+
+The three state files and the staging directory resolve through the crew data home and
+ignore `MD_NOTEBOOK_HOME`; only clone data under `vaults/` follows it.
 
 A vault descriptor carries `id`, `name`, `repo`, `localPath`, `branch`, `readOnly`, an
 optional `subfolder` scope, plus `knowledge` and `knowledgeSourceId`. The `external` field
 returned by `GET /api/vaults` is COMPUTED on read (`localPath` is outside `vaults/`) and
 never persisted.
+
+## Sandbox
+
+`sandbox._CREW_HIDDEN_LEAVES` bind-masks the three state files and `md-notebook-staging` in every
+sandbox tier, so an agent's spawned subprocesses cannot read the GitHub token or repoint a
+vault. The backend itself is a sandboxed spawn that OWNS those files, so exactly that one
+spawn gets them back: `_APP_BACKEND_OWNED_LEAVES` declares the leaves it owns and
+`apps/backend.py` passes `app_backend_visible_targets()` as `extra_visible_dirs`, gated on
+shipped-builtin provenance. A spelling that sits beneath an independently masked directory
+is refused rather than carved, because carving it would unmask that whole foreign tree.
+
+Two properties keep the mask meaningful now that the backend can create these files:
+
+* **The masks are materialised before launch.** `mount(2)` cannot target an absent path and
+  the launcher's hiding loops guard on existence, so an absent leaf would get no mask at
+  all and a namespace spawned before the first vault attach would read the PAT saved after
+  it. `_materialize_md_notebook_mask_targets()` creates each leaf's absent-equivalent
+  document (`pat` empty, `vaults.json` `[]`, `settings.json` `{}`) before launch. It refuses
+  the spawn for a non-regular file at a leaf or a creation failure, but a link in the chain
+  DEGRADES instead: that leaf is skipped and the spawn proceeds, because refusing would let
+  one optional app's on-disk layout stop every sandboxed process on the host — an operator
+  who symlinks `workspace/` to another disk would find no agent could start, over a Notes
+  file they may never have created. Skipping is safe only because it is keyed off the same
+  predicate that withholds the carve-out (`carveout_chain_has_planted_link`, applied in
+  `app_backend_visible_targets`): while a link is in the chain the backend cannot write this
+  state at all, so an unmaterialised — and therefore unmasked — leaf has nothing to expose.
+  The two are never decided separately, and a test pins them together. The staging directory
+  is a direct child of the data home, so the shared `_materialize_maskable_dirs` covers it
+  under its own rule.
+* **The backend spawn starts isolated.** It launches with `-I` and runs the module through
+  `runpy` with an explicit import root, so interpreter startup hooks (`sitecustomize`,
+  `usercustomize`, user-site `.pth`) from an agent-writable directory do not execute in the
+  one namespace where the PAT is unmasked. The other module builtins keep the bare
+  `python -m` launch.
+* **Pre-upgrade orphans are swept.** Older writers staged beside the target, so a crash in
+  that window could leave a PAT-bearing `*.tmp` at a name no mask covers. Every `*.tmp`
+  direct child of the state directory is such an orphan by construction — the writers now
+  stage in the top-level staging directory, and note temps live beside their note under
+  `vaults/<id>/` — so the sweep removes them. Because it DELETES, its guard is stronger
+  than the materialiser's: the descent from the crew data home is ANCHORED and
+  per-component, each step `open`ed `O_NOFOLLOW | O_DIRECTORY` relative to the descriptor
+  above it, with every `lstat`/`unlink` issued against the pinned final descriptor. Opening
+  the joined path would be unsound however carefully the chain was pre-checked, because
+  `O_NOFOLLOW` constrains only the FINAL component: an intermediate directory swapped
+  between check and open would redirect the whole descent and the sweep would unlink inside
+  a tree the agent chose. A root whose descent fails is skipped, not escalated to a spawn
+  refusal — skipping removes the hazard, while refusing would break every spawn on a host
+  that merely symlinks its legacy home. Regular files only, sparing
+  another spawn's in-flight ceiling temp) and refuses the spawn if one cannot be removed.
+  Unlike materialisation this runs on BOTH launch paths, Linux and macOS: a Seatbelt deny
+  covers the named leaves, never an arbitrary `*.tmp` sibling, so an orphan would otherwise
+  stay readable on macOS forever. A removal is logged as a security event — the token in
+  that file was readable by anything running as this user, so it should be rotated.
+* **A skipped root has its whole state directory masked.** Skipping the sweep leaves the
+  one thing the three leaf masks cannot cover: an orphan whose name is neither `pat` nor a
+  state file. So the same predicate that withholds the carve-out also adds the state
+  DIRECTORY to the hidden set, on both launch paths, and a directory mask covers every name
+  inside it. This is deliberately conditional rather than always-on: the directory also
+  holds the vault clone data agents are MEANT to read, so masking it wholesale on a healthy
+  host would hide the user's notes and defeat the app. It applies only where the chain is
+  linked — where the carve-out is already withheld, the app is already non-functional for
+  that root, and hiding the directory costs nothing that still works. The predicate is
+  asked about a LEAF path, the same shape the carve-out filter passes, because it judges a
+  path's parent chain: asking about the directory would miss a link at the directory itself,
+  which is exactly the case the final-component refusal leaves unswept.
+
+The agent-side file-tool gate (`security.is_sensitive_path`) fences all four paths
+independently of the OS mask, so the agent's own reach through tool calls is unchanged.
+
+### Why the state writers do not go through `atomic_write`
+
+`_write_state_staged_sync` stages its temp in the top-level staging directory and renames
+onto the target, rather than calling `atomic_write`. That is a deliberate fork of the
+secret-write chokepoint, recorded here so it stays a decision:
+
+* `atomic_write` stages in the TARGET's parent (`mkstemp(dir=path.parent)`), and its
+  pinned-parent path opens that temp through a directory descriptor precisely so the
+  location cannot be re-resolved. Staging elsewhere is not a parameter it has; adding
+  `staging_dir=` would have to either bypass that fence or duplicate it for a second
+  directory, on a primitive with many callers and a large contract (ACL preservation,
+  retry, fsync, restrict-on-error policy).
+* The one guard the fork must not shed is the #4381 planted-link refusal that
+  `restrict_to_owner=True` implied. It is not reimplemented: `atomic_write.refuse_linked_parent`
+  is the same private helper made public for exactly this caller class, and tests fail if
+  either call site drops it.
+* The cost is real and accepted: a future guard added inside `atomic_write` does not reach
+  this writer. #8797 would remove the reason for the fork entirely by moving state into one
+  masked directory, so `staging_dir=` is the right follow-up only if #8797 is declined.
 
 ## Routes
 

--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -51,6 +51,7 @@ from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
 from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.sandbox import (
+    MD_NOTEBOOK_APP_NAME,
     RLIMIT_PROFILE_BUILD,
     RLIMIT_PROFILE_TOOL,
     app_backend_visible_targets,
@@ -1695,6 +1696,16 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
         logger.warning("Refusing to spawn third-party app %s backend: %s", app_name, denied)
         return None
 
+    # Whether this spawn executes the SHIPPED md-notebook backend — provenance on the
+    # executed path the admission gate above vetted. Only the isolated-startup branch
+    # below reads it: that is the one spawn whose namespace holds an unmasked PAT, so
+    # interpreter startup hooks must not ride along. The state-file carve-out further
+    # down is keyed off the GENERIC ``is_builtin_app`` check instead, because it applies
+    # to every app that owns hidden leaves.
+    _shipped_md_notebook = app_name == MD_NOTEBOOK_APP_NAME and is_builtin_app(
+        app_name=app_name, app_root=execution_path
+    )
+
     if is_module_entry:
         entry = None  # sentinel; no file path for module-style entries
     else:
@@ -2036,15 +2047,47 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
                     logger.warning("Failed to install npm deps for app %s: %s", app_name, exc)
 
     # --- Module-style Python builtin (e.g. kiro_crew.apps.builtins.<name>) ---
-    # Module-style entries have no file path — invoke via `python -m <module>`.
-    # Run under the gateway's own python interpreter (sys.executable) so the
-    # module path resolves against the gateway's installed packages, with
-    # cwd at the KiroCrew source root so relative imports inside the module
-    # work without venv setup.
+    # Module-style entries have no file path — the module runs under the gateway's own
+    # interpreter (sys.executable) so it resolves against the gateway's installed
+    # packages, with cwd at the kiro_crew source root so relative imports inside the
+    # module work without venv setup.
+    #
+    # The md-notebook spawn ALONE starts isolated (``-I``): a bare ``python -m`` runs the
+    # interpreter's startup hooks — ``sitecustomize`` / ``usercustomize`` / user-site
+    # ``.pth`` — and the default user site is an agent-writable, gateway-independent
+    # injection path a FRESH interpreter honours even though the running gateway never
+    # re-imports it. For md-notebook that startup code would run inside the one namespace
+    # where the PAT is unmasked, so the hooks must not ride along. Scoped to the spawn
+    # that carries the carve-out, not to every module builtin: the others have no
+    # unmasked secret in their namespace, and rewriting their import environment here
+    # would be a rider on a fix scoped to one.
+    #
+    # ``-I`` also drops cwd-on-sys.path, the user site's PACKAGES, and ``PYTHONPATH`` (it
+    # implies ``-E``), so the import universe the module needs is restated EXPLICITLY:
+    # ``runpy`` (the machinery behind ``-m``) runs the module after inserting the root
+    # kiro_crew ITSELF was imported from — backend.py lives in that same package, so its
+    # own tree root IS that root. Correct across a venv install (site-packages, harmless
+    # duplicate), a --user install (the user-site dir re-admitted as a plain path entry
+    # WITHOUT its hooks — a plain sys.path insert never imports usercustomize and never
+    # processes ``.pth``), and a source tree (the repo ``src`` root). ``repr`` keeps both
+    # injected strings inert literals.
     elif entry is None:
         python_bin = sys.executable
-        cmd = [python_bin, "-m", entry_point]
-        cwd = str(Path(__file__).resolve().parent.parent.parent)
+        _import_root = str(Path(__file__).resolve().parent.parent.parent)
+        cwd = _import_root
+        if _shipped_md_notebook:
+            cmd = [
+                python_bin,
+                "-I",
+                "-c",
+                (
+                    "import runpy, sys; "
+                    f"sys.path.insert(0, {_import_root!r}); "
+                    f"runpy.run_module({entry_point!r}, run_name='__main__', alter_sys=True)"
+                ),
+            ]
+        else:
+            cmd = [python_bin, "-m", entry_point]
 
     # --- Exec (shell-launcher) backend ---
     # Explicit `backend.type: "exec"` (exec the entry point file as-is — also

--- a/src/kiro_crew/apps/builtins/md_notebook/server.py
+++ b/src/kiro_crew/apps/builtins/md_notebook/server.py
@@ -28,6 +28,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 import uuid
 from pathlib import Path, PurePosixPath
@@ -39,7 +40,7 @@ from kiro_crew import hooks, platform_compat, security
 from kiro_crew.apps.builtins.md_notebook import git_ops
 from kiro_crew.apps.builtins.md_notebook import notes as notes_mod
 from kiro_crew.apps.proxy_auth import raw_request_target, verify_proxy_request
-from kiro_crew.atomic_write import atomic_write, replace_with_retry
+from kiro_crew.atomic_write import refuse_linked_parent, replace_with_retry
 from kiro_crew.config.paths import config_dir
 from kiro_crew.constants import WINDOWS_DEVICE_STEMS
 from kiro_crew.loop_lock import LoopBoundLock
@@ -50,6 +51,13 @@ logger = logging.getLogger(__name__)
 
 PORT = int(os.environ.get("PORT", 9137))
 APP_NAME = os.environ.get("KIROCREW_APP_NAME", "md-notebook")
+
+#: The state writers' staging directory, a TOP-LEVEL leaf in the crew data home. Must stay
+#: byte-identical to ``sandbox._MD_NOTEBOOK_STAGING_LEAF``, which is what masks it from the
+#: agent and hands it back to this backend's own spawn — a mismatch would silently stage
+#: PAT bytes outside the mask. Spelled here rather than imported so this app backend does
+#: not pull the sandbox module into its own process; a test pins the two together.
+_STAGING_LEAF = "md-notebook-staging"
 
 
 # Data-home paths are resolved LAZILY, never at import time (issue #874): the
@@ -366,9 +374,11 @@ def _discard_staged_sync(tmp: Path) -> None:
 def _atomic_write_text_sync(path: Path, content: str) -> None:
     """Stage, publish, and clean up on failure -- the single-attempt whole.
 
-    Kept for callers that write a file with no freshness contract and no retry
-    (the settings store). The note save drives the two halves itself so it can
-    republish one temp across attempts.
+    Stages BESIDE the target (a note inside the vault, possibly a different
+    filesystem from the crew home). State files (vaults/settings/PAT) use
+    ``_write_state_staged_sync`` instead, which stages in the masked staging
+    dir. The note save drives the two halves itself so it can republish one
+    temp across attempts.
     """
     tmp = _new_staged_note_path(path)
     with git_ops.inflight_temp(tmp):
@@ -380,18 +390,94 @@ def _atomic_write_text_sync(path: Path, content: str) -> None:
             raise
 
 
+def _staging_dir() -> Path:
+    """The masked write-staging directory every STATE writer publishes through.
+
+    Every state writer (vaults/settings/PAT) stages its temp file HERE and renames onto
+    its target. A temp staged beside the target — the previous shape — carries the real PAT
+    bytes under a name the OS sandbox's three leaf masks do not cover, and a SIGKILL
+    between write and rename left that unmasked sibling readable by a same-uid sandboxed
+    agent forever.
+
+    A TOP-LEVEL directory in the crew data home (``sandbox._MD_NOTEBOOK_STAGING_LEAF``),
+    NOT a child of the state directory, for the reason the sibling ``aws-control-staging``
+    leaf records: a mask covers the leaf, not its ancestors, so a staging dir under the
+    agent-writable ``workspace/md-notebook`` could be renamed out from under its own mask
+    and a later PAT write would publish through the replacement, unmasked, into a live
+    agent's view. It stays on the same filesystem as the targets, so the publish rename is
+    still atomic. NOTE saves are deliberately untouched — they stage beside the note inside
+    the vault, which may be a different filesystem, and hold no secret.
+    """
+    # Mirrors ``_crew_data_home``'s resolution, minus the app subdirectory: the staging
+    # directory is a sibling of ``workspace``, not of the state files. Under the ``_HOME``
+    # test hook it sits beside that hook's directory, which keeps it on the same
+    # filesystem as the targets — the only property the rename depends on.
+    if _HOME is not None:
+        return _HOME.parent / _STAGING_LEAF
+    try:
+        base = config_dir()
+    except Exception:
+        override = os.environ.get("KIROCREW_HOME")
+        base = Path(override) if override else Path.home() / ".kiro" / "crew"
+    return base / _STAGING_LEAF
+
+
+def _write_state_staged_sync(target: Path, content: str, *, fsync_file: bool = False) -> None:
+    """Stage *content* in the masked staging dir, then rename onto *target*.
+
+    ``mkstemp`` opens the temp 0600 on POSIX before any payload byte;
+    ``restrict_to_owner`` adds the owner-only DACL on Windows (chmod is a no-op
+    there), warn-not-fail per the original PAT policy — losing the credential
+    write is worse than a permissions warning. On failure the temp is removed;
+    a removal that itself fails leaves the orphan inside the mask, not beside
+    the target.
+    """
+    staging = _staging_dir()
+    # The planted-link refusal atomic_write enforces:
+    # atomic_write(restrict_to_owner=True)
+    # refuses a secret write whose parent chain passes through a planted
+    # symlink/junction — otherwise mkdir(parents=True), mkstemp and the rename
+    # all follow the link and the token lands OUTSIDE the sensitive-path fence
+    # while the caller sees success. Moving the staging off atomic_write must
+    # not shed that guard. Both chains this write walks, checked BEFORE the
+    # mkdirs (mkdir walks THROUGH a planted link and would build the tree
+    # under its target); the probe name is never created, only its chain is
+    # judged.
+    refuse_linked_parent(target)
+    refuse_linked_parent(staging / ".chain-probe")
+    staging.mkdir(parents=True, exist_ok=True)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(staging), suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        try:
+            restrict_to_owner(tmp)
+        except OSError:
+            logger.warning("could not restrict a staged state temp to owner-only", exc_info=True)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fd = -1
+            fh.write(content)
+            if fsync_file:
+                fh.flush()
+                os.fsync(fh.fileno())
+        replace_with_retry(tmp, target)
+    except BaseException:
+        if fd >= 0:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+
+
 def _write_vaults_sync(vaults: list[dict[str, Any]]) -> None:
     """Replace the vault registry, retrying the Windows rename window.
 
     Same reason as the note writer above: this file is read back by every
     later request, so a handle can be open on it when the rename lands.
+    Staged in the masked staging dir — see :func:`_staging_dir`.
     """
-    target = _vaults_json()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    tmp = target.with_name(f"vaults.json.{uuid.uuid4().hex}.tmp")
-    with open(tmp, "w", encoding="utf-8") as fh:
-        json.dump(vaults, fh, indent=2)
-    replace_with_retry(tmp, target)
+    _write_state_staged_sync(_vaults_json(), json.dumps(vaults, indent=2))
 
 
 def _read_pat_sync() -> Optional[str]:
@@ -412,22 +498,15 @@ def _read_pat_sync() -> Optional[str]:
 
 
 def _write_pat_sync(pat: str) -> None:
-    target = _pat_file()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    # Write to an owner-only sibling temp, fsync, then atomically replace. A
-    # direct O_TRUNC open would empty the existing token before the new bytes
-    # land, so a failure partway (a full disk is the realistic one) would lose a
-    # valid credential.
-    #
-    # os.chmod's 0600 is a no-op on Windows (it only toggles read-only), leaving
-    # the token readable by other accounts. restrict_to_owner applies an
-    # owner-only DACL there and chmod 0600 on POSIX, and atomic_write applies it
-    # to the temp BEFORE any payload byte — narrower than the previous
-    # write-then-restrict here, which left the token in a parent-inherited-DACL
-    # file until the lockdown landed. restrict_on_error="warn"
-    # keeps the original policy: a chmod failure warns rather than losing the
-    # credential. Written 0600 and never echoed back (only a boolean).
-    atomic_write(target, pat, fsync=True, restrict_to_owner=True, restrict_on_error="warn")
+    # Stage in the MASKED staging dir, fsync, then atomically replace. A direct
+    # O_TRUNC open would empty the existing token before the new bytes land, so
+    # a failure partway (a full disk is the realistic one) would lose a valid
+    # credential — and a temp staged BESIDE the target would hold the real PAT
+    # bytes at a name the sandbox's leaf masks do not cover (see _staging_dir).
+    # The temp is 0600 from mkstemp on POSIX and owner-only-DACL'd on Windows
+    # before any payload byte, warn-not-fail; written 0600 and never echoed
+    # back (only a boolean).
+    _write_state_staged_sync(_pat_file(), pat, fsync_file=True)
 
 
 async def read_vaults() -> list[dict[str, Any]]:
@@ -522,13 +601,14 @@ def _read_settings_sync() -> dict[str, Any]:
 
 
 def _write_settings_sync(settings: dict[str, Any]) -> None:
-    # Create the settings file's OWN parent, like the PAT write does — since
-    # settings.json now resolves under the crew data home (or the _HOME test
-    # hook), not under _home(), the two dirs diverge and mkdir'ing _home() would
-    # leave the settings dir absent and the write failing with ENOENT.
-    target = _settings_json()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    _atomic_write_text_sync(target, json.dumps(settings, indent=2))
+    # Staged in the masked staging dir like the other state writers (see
+    # _staging_dir); the helper creates both the staging dir and the target's
+    # own parent, which diverges from _home() when the _HOME test hook is unset.
+    # fsync preserved from the previous path (_stage_note_text_sync fsync'd):
+    # settings carry the autoSync authorization bit and the lastSync stamp, and
+    # a rename published from an unflushed page cache can discard an
+    # acknowledged toggle on power loss.
+    _write_state_staged_sync(_settings_json(), json.dumps(settings, indent=2), fsync_file=True)
 
 
 async def read_settings() -> dict[str, Any]:
@@ -1530,13 +1610,14 @@ async def api_pat(request: web.Request) -> web.Response:
     if pat:
         await asyncio.to_thread(_write_pat_sync, str(pat))
     else:
-        def _remove() -> None:
-            try:
-                os.unlink(_pat_file())
-            except FileNotFoundError:
-                pass
-
-        await asyncio.to_thread(_remove)
+        # Clear by atomically REPLACING with an empty file, never by unlink:
+        # the empty file is the reader's absent-equivalent (_read_pat_sync maps
+        # "" to None), while removing the inode deletes the sandbox mask's
+        # mount target — a clear landing between the launcher's materialize and
+        # mount steps would leave that namespace maskless, and a later PAT save
+        # would be readable inside it. Routed through the same staged writer as
+        # the save so the guards match.
+        await asyncio.to_thread(_write_pat_sync, "")
     return web.json_response(
         {"hasPat": bool(await read_pat()), "hasGhAuth": bool(await gh_token())}
     )

--- a/src/kiro_crew/atomic_write.py
+++ b/src/kiro_crew/atomic_write.py
@@ -653,6 +653,21 @@ def _link_trust_anchor(parent: Path) -> tuple[Path, tuple[str, ...]] | None:
     return None
 
 
+def refuse_linked_parent(path: Path | str) -> None:
+    """Public form of the planted-link refusal, for out-of-band stagers.
+
+    ``atomic_write(restrict_to_owner=True)`` applies this automatically, and
+    that chokepoint is where the guard normally lives. A secret writer that
+    must stage its temp OUTSIDE the target's parent (md-notebook's masked
+    top-level staging directory) cannot route through ``atomic_write`` itself, so it
+    calls this on the same paths its ``mkdir``/``mkstemp``/``replace`` will
+    walk — BEFORE the mkdirs, which follow a planted link and would build the
+    tree under its target. Raises ``OSError`` on refusal, like the private
+    form.
+    """
+    _refuse_linked_parent(Path(path))
+
+
 def _refuse_linked_parent(path: Path) -> None:
     """Refuse to write a secret whose parent chain passes through a link.
 

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from kiro_crew import platform_compat
+from kiro_crew.atomic_write import refuse_linked_parent
 from kiro_crew.config.paths import config_dir
 from kiro_crew.constants import KIROCREW_SPAWNED_ENV, KIROCREW_SPAWNED_VALUE
 from kiro_crew.identity_stores import AUTH_SQLITE_DB, AUTH_SQLITE_SIDECAR_SUFFIXES
@@ -188,6 +189,31 @@ _CREW_HOME_PREFIXES: tuple[str, ...] = (".kiro/crew", ".kirocrew")
 # in none of them. Spelled here rather than imported so this low-level module keeps not
 # importing the 7k-line security module (the ``_POLICY_CACHE_LEAF`` convention above).
 
+#: The md-notebook builtin's name, and its own state files under the crew data home.
+#: Named so the mask, the backend carve-out that lifts it, and the materialiser that
+#: gives it a mount target cannot drift apart on a literal.
+MD_NOTEBOOK_APP_NAME: str = "md-notebook"
+_MD_NOTEBOOK_STATE_LEAVES: tuple[str, ...] = (
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/pat",
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/vaults.json",
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/settings.json",
+)
+#: The backend's write-staging directory, masked as a WHOLE DIRECTORY like ``whatsapp``.
+#: Every md-notebook state writer stages its temp file HERE and renames onto its target,
+#: because a temp staged BESIDE the target carries the real PAT bytes under a name the
+#: three leaf masks do not cover — and a SIGKILL between write and rename leaves that
+#: unmasked sibling readable by a same-uid sandboxed agent forever. A directory mask
+#: covers every name inside it, present and future, so the staging window and any crash
+#: orphan both stay masked.
+#:
+#: A TOP-LEVEL leaf, for the same reason ``aws-control-staging`` is one: a mask covers the
+#: leaf, not its ancestors, so a staging dir under the agent-writable
+#: ``workspace/md-notebook`` could be renamed out from under its own mask and a later PAT
+#: write would publish through the replacement, unmasked, into a live agent's view. It
+#: stays on the same filesystem as the state files (both under the crew data home), so the
+#: publish rename is still atomic.
+_MD_NOTEBOOK_STAGING_LEAF: str = f"{MD_NOTEBOOK_APP_NAME}-staging"
+
 #: Crew-home leaves with no legitimate in-sandbox reader — bind-masked in every mode.
 _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     # Channel credentials. Already file-masked in cc/strict via ``_CC_FILES``; listing
@@ -234,9 +260,11 @@ _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     # The backend spawn therefore passes them back as ``extra_visible_dirs`` via
     # :func:`app_backend_visible_targets` — the mask still applies to every OTHER
     # sandboxed process, which is the population it exists to fence.
-    "workspace/md-notebook/pat",
-    "workspace/md-notebook/vaults.json",
-    "workspace/md-notebook/settings.json",
+    *_MD_NOTEBOOK_STATE_LEAVES,
+    # The staging directory those three writers publish through. Masked as a whole
+    # DIRECTORY so the in-flight temp — which holds the same bytes as the leaves above,
+    # PAT included — and any crash orphan are covered at every name, present and future.
+    _MD_NOTEBOOK_STAGING_LEAF,
     # Browser session material. The extension token reaches the CLI through the
     # environment, never by ``open()``, so masking the file costs nothing; the other
     # four are retired leaves with no reader left in the tree. The LIVE browser paths
@@ -395,10 +423,12 @@ _CREW_READONLY_TARGETS: list[str] = _crew_home_entries(_CREW_READONLY_LEAVES)
 #: backend belong here — an in-process builtin (routes/hooks) runs unsandboxed in the
 #: gateway and needs no exemption.
 _APP_BACKEND_OWNED_LEAVES: dict[str, tuple[str, ...]] = {
-    "md-notebook": (
-        "workspace/md-notebook/pat",
-        "workspace/md-notebook/vaults.json",
-        "workspace/md-notebook/settings.json",
+    MD_NOTEBOOK_APP_NAME: (
+        *_MD_NOTEBOOK_STATE_LEAVES,
+        # The writers stage here and rename onto the leaves above, so the backend needs
+        # this directory back too — carving out only the three targets would leave every
+        # state write failing on the masked staging dir instead of the masked leaf.
+        _MD_NOTEBOOK_STAGING_LEAF,
     ),
 }
 
@@ -429,8 +459,48 @@ def app_backend_visible_targets(app_name: str, mode: str = "standard") -> tuple[
     targets = [os.path.join(home, entry) for entry in _crew_home_entries(leaves)]
     targets.extend(_relocated_crew_targets(leaves))
     return tuple(
-        target for target in targets if not carveout_shadowed_by_foreign_mask(target, mode=mode)
+        target
+        for target in targets
+        if not carveout_shadowed_by_foreign_mask(target, mode=mode)
+        and not carveout_chain_has_planted_link(target)
     )
+
+
+def carveout_chain_has_planted_link(path: str) -> bool:
+    """Whether *path*'s parent chain passes through a link, so it must not be carved out.
+
+    The boolean form of :func:`atomic_write.refuse_linked_parent`, for
+    the two producers that must DEGRADE rather than raise. An app's state leaves sit under
+    an agent-writable tree, so a link planted at an intermediate component means this
+    process cannot tell which directory a write to that name will land in — and handing a
+    spawn a carve-out for such a name unmasks whatever the link currently points at.
+
+    Refusing the CARVE-OUT is the proportionate response, not refusing the spawn. Withhold
+    it and the owning backend fails on its own masked state, which is the app's problem;
+    refuse the spawn and one optional app's on-disk layout takes every sandboxed process on
+    the host down with it. The two are safe together because they are keyed off this one
+    predicate: while it holds, the backend cannot write the state, so a leaf left
+    unmaterialised — and therefore unmasked — has nothing to expose.
+
+    Fails toward "unsafe": an unresolvable chain is reported as planted, so the carve-out is
+    withheld rather than granted on a path this process could not verify.
+    """
+    try:
+        refuse_linked_parent(path)
+    except OSError as exc:
+        logger.warning(
+            "SECURITY: not carving %s out of the sandbox masks — a parent component is a "
+            "link (%s), so this process cannot tell which directory a write to that name "
+            "would reach. The owning app backend will fail on its own state until the link "
+            "is replaced with a real directory; every other spawn is unaffected.",
+            path,
+            exc,
+        )
+        return True
+    except Exception:  # pragma: no cover - defensive; a spawn must not fail on this
+        logger.debug("could not check the carve-out chain for %s", path, exc_info=True)
+        return True
+    return False
 
 
 def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool:
@@ -643,12 +713,50 @@ _CREW_PRECREATE_HIDDEN_DIR_LEAVES: tuple[str, ...] = (
     "aws-control-staging",
     "appearance-library",
     "quarantined-clones",
+    # md-notebook's write-staging directory, for the same reason and by the same rule: a
+    # direct child of the data home, so the plain ``mkdir`` above is sound. Left to lazy
+    # creation, a sandbox spawned before the first state write finds it absent, the
+    # ``SENSITIVE_DIRS`` loop skips it, and the directory the backend creates later shows
+    # up INSIDE that running sandbox — with the PAT staging window in it.
+    _MD_NOTEBOOK_STAGING_LEAF,
 )
+
+#: The masked md-notebook leaves materialised before a namespace spawn, and what each
+#: holds. This is the per-leaf argument the sibling-gap note above asks for: ``mount(2)``
+#: cannot mask an absent path and the ``SENSITIVE_FILES`` loop guards on ``isfile``, so an
+#: ABSENT leaf gets NO mask, and a namespace that outlives the leaf's later creation reads
+#: the real bytes — the PAT among them. That was vacuous while nothing could create these
+#: files on a sandboxed host; the backend carve-out
+#: (:func:`app_backend_visible_targets`) makes creation possible, so the mask has to be
+#: made non-vacuous first. Each document is its reader's absent-equivalent, and the
+#: md-notebook backend is the only reader:
+#:
+#:   * ``vaults.json`` — ``_read_vaults_sync`` returns ``[]`` for absent (OSError) and
+#:     for ``[]`` alike;
+#:   * ``settings.json`` — ``_load_settings_sync`` returns the defaults for absent and
+#:     reads ``{}`` as every-field-default;
+#:   * ``pat`` — ``_read_pat_sync`` maps absent (OSError) and empty (``"" or None``) both
+#:     to ``None``.
+#:
+#: The STALE-read criterion that excludes most hidden leaves does not arise: the agent's
+#: view is the pinned empty MASK file either way, never this document, which is exactly
+#: the mask's intent.
+_MD_NOTEBOOK_PRECREATE_CONTENT: dict[str, bytes] = {
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/pat": b"",
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/vaults.json": b"[]\n",
+    f"workspace/{MD_NOTEBOOK_APP_NAME}/settings.json": b"{}\n",
+}
+assert set(_MD_NOTEBOOK_PRECREATE_CONTENT) == set(_MD_NOTEBOOK_STATE_LEAVES)
 
 #: What a materialised ceiling holds — the empty JSON object every reader above
 #: already treats as its absent default. NOT a zero-byte file, which is not valid
 #: JSON and would read as CORRUPT rather than as absent.
 _EMPTY_CEILING_DOCUMENT: bytes = b"{}\n"
+
+#: Prefix of the in-flight temp ``_publish_empty_ceiling`` stages in its target's
+#: parent. Named so a sweep of that directory can tell a gateway-owned temp mid-publish
+#: from an orphan it is meant to remove.
+_CEILING_TEMP_PREFIX: str = ".kirocrew-ceiling-"
 
 
 def _sealable_absent_ceilings() -> tuple[list[str], list[str]]:
@@ -853,8 +961,10 @@ def _require_real_dir_nofollow(target: str) -> None:
         )
 
 
-def _publish_empty_ceiling(target: str, parent: str) -> bool:
-    """Write the empty document to a sibling temp file, then link it into place.
+def _publish_empty_ceiling(
+    target: str, parent: str, content: bytes = _EMPTY_CEILING_DOCUMENT
+) -> bool:
+    """Write *content* (default: the empty document) to a sibling temp, then link it in.
 
     Two steps rather than ``open(target, O_CREAT | O_EXCL)`` followed by a write,
     because the one-step form publishes the NAME before the BYTES: a crash, a full
@@ -880,13 +990,13 @@ def _publish_empty_ceiling(target: str, parent: str) -> bool:
     fd = -1
     tmp = ""
     try:
-        fd, tmp = tempfile.mkstemp(dir=parent, prefix=".kirocrew-ceiling-", suffix=".tmp")
+        fd, tmp = tempfile.mkstemp(dir=parent, prefix=_CEILING_TEMP_PREFIX, suffix=".tmp")
         # ``os.write`` is not obliged to consume the whole buffer, and a short write is
         # not an error — it returns a count. Taking that count for success would link a
         # TRUNCATED document, which reads as corrupt rather than as absent and is the
         # exact outcome the temp-then-link shape exists to prevent. Loop, and treat zero
         # progress as an error so a filesystem that accepts nothing cannot spin here.
-        view = memoryview(_EMPTY_CEILING_DOCUMENT)
+        view = memoryview(content)
         while view:
             written = os.write(fd, view)
             if written <= 0:
@@ -1045,6 +1155,336 @@ def _materialize_maskable_dirs() -> list[str]:
                 f"cannot create the masked directory {target}: {exc}"
             ) from exc
         created.append(target)
+    return created
+
+
+def _md_notebook_degraded_mask_dirs() -> list[str]:
+    """The md-notebook state directories to mask WHOLESALE because the app is degraded.
+
+    Normally only the three secret leaves are masked, and that is deliberate: the same
+    directory holds the vault clone data, which agents are meant to read. Masking it
+    wholesale on a healthy host would hide the user's notes from every agent — the app's
+    whole purpose.
+
+    When a component of the chain is a planted link the calculus inverts. The carve-out is
+    withheld under this same predicate, so the backend cannot write there and the app is
+    already non-functional for that root; hiding the directory costs nothing that still
+    works. What it buys is the one exposure skipping leaves behind: a legacy staging orphan
+    holding real PAT bytes that :func:`_sweep_one_md_notebook_state_dir` cannot delete
+    through a link, and that the three leaf masks do not cover because its name is neither
+    ``pat`` nor a state file. A directory mask covers every name inside it, orphans
+    included.
+
+    Masking is fail-safe in the direction that matters: the launcher binds an empty
+    directory over the resolved path INSIDE the namespace only, so a link pointing
+    somewhere unexpected costs that sandbox visibility of a path it should not have been
+    reading, never anything on the host.
+    """
+    dirs: list[str] = []
+    roots: list[str] = []
+    try:
+        roots.append(str(config_dir()))
+    except Exception:  # pragma: no cover - defensive; a spawn must not fail on this
+        logger.debug("could not resolve the crew data home for the md-notebook mask")
+    try:
+        home = Path.home()
+        roots.extend(str(home / Path(prefix)) for prefix in _CREW_HOME_PREFIXES)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("could not resolve $HOME for the md-notebook mask")
+    for root in dict.fromkeys(roots):
+        state_dir = os.path.join(root, *_MD_NOTEBOOK_STATE_COMPONENTS)
+        # Ask the predicate about a LEAF, exactly as the carve-out filter does, not about
+        # the directory: it judges a path's PARENT chain, so passing the directory would
+        # miss a link at the directory itself — the very case the sweep's final-component
+        # refusal leaves unswept. Sharing the input shape keeps "withheld" and "masked"
+        # literally the same decision rather than two that merely agree today.
+        probe = os.path.join(state_dir, os.path.basename(_MD_NOTEBOOK_STATE_LEAVES[0]))
+        if carveout_chain_has_planted_link(probe):
+            dirs.append(state_dir)
+    return dirs
+
+
+def _sweep_legacy_md_notebook_temps() -> list[str]:
+    """Remove pre-upgrade staging temps left BESIDE md-notebook's state files.
+
+    Before the staging directory existed, all three state writers staged a sibling of
+    their target: ``vaults.json.<hex>.tmp`` and ``settings.json.<hex>.tmp`` from
+    ``git_ops.staged_temp_name``, and ``tmp<random>.tmp`` from ``atomic_write``'s
+    ``mkstemp(dir=path.parent, suffix=".tmp")``. A SIGKILL in that window left a file
+    holding the real PAT bytes at a name NO mask covers — not the three leaves, and not
+    the staging directory. Materialising forward does not help: the exposure is an
+    artefact already on disk, so on an upgraded host the exact bytes this carve-out
+    exists to fence would stay readable by a same-uid agent forever.
+
+    Runs on EVERY sandbox launch path, Linux namespace and macOS Seatbelt alike, and is
+    deliberately NOT part of :func:`_materialize_md_notebook_mask_targets`. Materialising
+    is Linux-only for a good reason — a Seatbelt deny is a path rule that holds for a name
+    that does not exist yet — but that reasoning does not transfer to an orphan that DOES
+    exist at a name no rule names: the Seatbelt profile denies the leaves and the staging
+    directory, never an arbitrary ``*.tmp`` sibling, so skipping macOS would leave the
+    token readable there forever. For the same asymmetry it sweeps EVERY crew-home
+    spelling, live and legacy, while materialising touches only the live one.
+
+    Every ``*.tmp`` DIRECT child of the state directory is such an orphan by
+    construction: the state writers now stage inside the top-level staging directory, and
+    note temps live beside their note inside ``vaults/<id>/``. Directories, links, and
+    special files are left alone — only regular files are removed, judged by ``lstat`` so
+    a link is never followed.
+
+    **Fail-closed like the materialiser.** If an orphan cannot be removed the spawn is
+    refused, naming the path: launching would hand the agent the PAT this whole mechanism
+    is built to hide, and the operator can delete the file. Returns the paths it removed.
+    """
+    removed: list[str] = []
+    # Every crew-home spelling, not just the live one. The mask covers BOTH prefixes
+    # (see ``_crew_home_entries``), so a pre-upgrade orphan under an un-migrated or
+    # rolled-back ``~/.kirocrew`` is exposed exactly as one under the current home. This
+    # is the opposite requirement from MATERIALISING, which is live-home-only because a
+    # stub in a home nothing reads would be a file nobody opens: a token already written
+    # to the legacy home stays readable no matter which home is live now. De-duplicated so
+    # a relocated ``KIROCREW_HOME`` coinciding with a prefix is swept once.
+    roots: list[str] = []
+    try:
+        roots.append(str(config_dir()))
+    except Exception:  # pragma: no cover - defensive; a spawn must not fail on this
+        logger.debug(
+            "could not resolve the crew data home for the md-notebook sweep", exc_info=True
+        )
+    try:
+        home = Path.home()
+        roots.extend(str(home / Path(prefix)) for prefix in _CREW_HOME_PREFIXES)
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("could not resolve $HOME for the md-notebook sweep", exc_info=True)
+    for root in dict.fromkeys(roots):
+        removed.extend(_sweep_one_md_notebook_state_dir(root))
+    return removed
+
+
+#: The components between a crew data home and the md-notebook state directory. The
+#: sweep descends them ONE AT A TIME from the home, so each name is resolved by the
+#: kernel inside a directory this process already holds open.
+_MD_NOTEBOOK_STATE_COMPONENTS: tuple[str, ...] = ("workspace", MD_NOTEBOOK_APP_NAME)
+
+
+def _open_dir_anchored(anchor: str, components: tuple[str, ...]) -> int | None:
+    """Open ``anchor/*components`` by descending one component at a time, or return None.
+
+    Every step uses ``O_NOFOLLOW | O_DIRECTORY`` relative to the descriptor of the step
+    above it, so the kernel refuses a link AT EACH component and resolves each name inside
+    a directory this process is already holding. Opening the joined PATH instead would be
+    unsound however carefully the chain was pre-checked: ``O_NOFOLLOW`` constrains only the
+    FINAL component, so an intermediate directory swapped between the check and the open
+    would silently redirect the whole descent, and the caller would then ``unlink`` inside
+    a tree the agent chose. The descriptor chain closes that window structurally rather
+    than narrowing it.
+
+    ``anchor`` must be a trusted path (a crew data home), and the caller owns the returned
+    descriptor. None means some component is absent, is not a directory, or is a link —
+    all of which are "nothing safe to do here", never an error to escalate.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        fd = os.open(anchor, flags)
+    except OSError:
+        return None
+    for name in components:
+        try:
+            nxt = os.open(name, flags | getattr(os, "O_NOFOLLOW", 0), dir_fd=fd)
+        except OSError:
+            os.close(fd)
+            return None
+        os.close(fd)
+        fd = nxt
+    return fd
+
+
+def _sweep_one_md_notebook_state_dir(root: str) -> list[str]:
+    """Remove the legacy staging orphans in ONE md-notebook state directory.
+
+    The guards here are stricter than the sibling materialiser's for a concrete reason:
+    that function only ever creates, while this one ``unlink``s, and an unlink through an
+    attacker-chosen directory is irreversible.
+
+    The intermediate components (``workspace/``, ``workspace/md-notebook``) are
+    agent-writable, so a RESOLVING link planted at one of them would otherwise make this
+    sweep list and delete ``*.tmp`` files in a tree the agent picked. The descent from
+    *root* is therefore anchored and per-component (:func:`_open_dir_anchored`), and every
+    ``lstat`` and ``unlink`` is issued against the pinned final descriptor.
+
+    A root whose descent fails is SKIPPED, not escalated to a spawn refusal: skipping
+    removes the deletion hazard completely, and refusing would fail every agent spawn on a
+    host whose layout is merely unusual rather than hostile — one that symlinks the legacy
+    ``~/.kirocrew`` at the new home, say. An orphan under such a root survives unswept,
+    which is why the same predicate that degrades the app also masks the whole state
+    directory (:func:`_md_notebook_degraded_mask_dirs`): the orphan is then hidden from the
+    sandbox even though it could not be deleted.
+    """
+    removed: list[str] = []
+    state_dir = os.path.join(root, *_MD_NOTEBOOK_STATE_COMPONENTS)
+    dir_fd = _open_dir_anchored(root, _MD_NOTEBOOK_STATE_COMPONENTS)
+    if dir_fd is None:
+        # Absent, not a directory, or a link at some component. Nothing safe to do here.
+        return removed
+    try:
+        names = os.listdir(dir_fd)
+        protected = {os.path.basename(leaf) for leaf in _MD_NOTEBOOK_STATE_LEAVES}
+        for name in names:
+            if not name.endswith(".tmp") or name in protected:
+                continue
+            # ``_publish_empty_ceiling`` stages ITS temp in the target's parent — this
+            # very directory — under this prefix, and publishes with ``os.link``. Two
+            # concurrent spawns would otherwise let one's sweep unlink the other's
+            # in-flight temp between its ``mkstemp`` and its ``link``, failing that spawn
+            # for no reason. These are gateway-owned and short-lived, never the legacy
+            # orphans this sweep is for.
+            if name.startswith(_CEILING_TEMP_PREFIX):
+                continue
+            candidate = os.path.join(state_dir, name)
+            # Both syscalls go through the pinned descriptor, so the name is resolved
+            # inside the directory this function verified — never through a component
+            # something swapped after the check.
+            try:
+                if not stat.S_ISREG(os.lstat(name, dir_fd=dir_fd).st_mode):
+                    continue
+            except OSError:
+                continue
+            try:
+                os.unlink(name, dir_fd=dir_fd)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                raise SandboxCeilingUnsealable(
+                    f"cannot remove the legacy md-notebook staging temp {candidate}: "
+                    f"{exc}. It was staged beside the state files by a pre-upgrade "
+                    "writer, so it can hold the real PAT bytes at a name no mask covers. "
+                    "Launching anyway would leave it readable inside every agent "
+                    "namespace — delete it and retry."
+                ) from exc
+            logger.warning(
+                "SECURITY: removed a legacy md-notebook staging temp at %s. A pre-upgrade "
+                "writer staged it beside the state files, where no sandbox mask covers "
+                "it, so it may have held the GitHub token in cleartext. Treat that token "
+                "as exposed to anything that ran as this user and rotate it if in doubt.",
+                candidate,
+            )
+            removed.append(candidate)
+    finally:
+        os.close(dir_fd)
+    return removed
+
+
+def _materialize_md_notebook_mask_targets() -> list[str]:
+    """Create md-notebook's absent state files and staging dir so their masks can mount.
+
+    The NESTED counterpart to :func:`_materialize_maskable_dirs`, whose plain ``mkdir``
+    is sound only for a DIRECT child of the data home. These leaves sit under
+    ``workspace/md-notebook/``, and that restriction names exactly why the difference
+    matters: the intermediate components are agent-writable, so a RESOLVING link planted
+    at one of them would land the materialised files under an attacker-chosen tree while
+    the launcher masks the lexical path. Every chain this function walks therefore goes
+    through :func:`atomic_write.refuse_linked_parent` BEFORE any
+    ``mkdir``, because ``mkdir`` itself follows a planted link.
+
+    Closes the sibling gap named at :data:`_CREW_PRECREATE_READONLY_DIR_LEAVES`: the
+    ``SENSITIVE_FILES`` mask loop guards on ``isfile``, so an ABSENT leaf gets no mask at
+    all. :data:`_MD_NOTEBOOK_PRECREATE_CONTENT` carries the per-leaf absent-equivalence
+    argument that gap note requires.
+
+    Runs on the Linux spawn path only, at the same site as
+    :func:`_materialize_sealable_ceilings`; the macOS profile needs nothing here because
+    Seatbelt denies are path rules that hold for names that do not exist yet.
+    **Fail-closed** for the same reason the ceiling materialiser is: launching anyway
+    would run the agent with a mask the launcher silently skipped. Creation happens only
+    under the LIVE data home (``config_dir()``) — a stub in the deprecated spelling would
+    be a file nothing reads — and an absent data home root is left absent, mirroring
+    ``_sealable_absent_ceilings``.
+
+    Never truncates and never removes: an existing regular file is left byte-for-byte
+    alone, and ``EEXIST`` outcomes are the benign race.
+    """
+    created: list[str] = []
+    try:
+        root = str(config_dir())
+    except Exception:  # pragma: no cover - defensive; a spawn must not fail on this
+        logger.debug("could not resolve the crew data home for md-notebook masking", exc_info=True)
+        return created
+    if not os.path.isdir(root):
+        return created
+
+    # The staging DIRECTORY is not created here: it is a direct child of the data home, so
+    # ``_materialize_maskable_dirs`` above already covers it under its own rule. The legacy
+    # sweep is not here either — it must run on the macOS path too, so both launch sites
+    # call it directly.
+    for leaf, content in _MD_NOTEBOOK_PRECREATE_CONTENT.items():
+        target = os.path.join(root, leaf)
+        # A link planted at an intermediate component means this process cannot tell which
+        # directory the write would reach, so the leaf is SKIPPED rather than materialised —
+        # and the spawn proceeds. Refusing here would let one optional app's on-disk layout
+        # take every sandboxed process on the host down with it: an operator who symlinks
+        # ``workspace/`` to another disk would find no agent could start, over a Notes file
+        # they may never have created.
+        #
+        # Skipping is safe only because it is keyed off the SAME predicate that withholds
+        # the carve-out (:func:`carveout_chain_has_planted_link`, applied in
+        # :func:`app_backend_visible_targets`). While the condition holds the backend cannot
+        # write this state at all, so a leaf left unmaterialised — and therefore unmasked —
+        # has nothing to expose. The two must never be decided separately: granting the
+        # carve-out while skipping materialisation is exactly the hole this function exists
+        # to close, which is why a test pins them together.
+        if carveout_chain_has_planted_link(target):
+            continue
+        if os.path.exists(target):
+            # Present is acceptable only as a REGULAR file, and ``lstat`` is what
+            # decides — so this is also the LINK refusal. A mount RESOLVES its target,
+            # so a resolving link here would mask the referent while the lexical name
+            # stayed an agent-replaceable link in a writable parent: swap it after
+            # launch and a later PAT write publishes to an unmasked name inside the
+            # live namespace. (``atomic_write`` deliberately ALLOWS a leaf link,
+            # because ``os.replace`` does not follow the final component; a mount
+            # target has the opposite requirement.) A FIFO, socket, or device node is
+            # refused for a different reason: the launcher's hiding loops classify with
+            # ``isdir``/``isfile`` and a special file matches NEITHER, so its mask
+            # would be silently skipped for the whole sandbox.
+            if not stat.S_ISREG(os.lstat(target).st_mode):
+                raise SandboxCeilingUnsealable(
+                    f"the md-notebook state mask target {target} exists but is not a "
+                    "regular file (a link, or a special file). The mask would bind "
+                    "over a referent, or be skipped by the launcher's isdir/isfile "
+                    "loops. Remove or replace it with a regular file."
+                )
+            continue
+        parent = os.path.dirname(target)
+        try:
+            os.makedirs(parent, exist_ok=True)
+        except OSError as exc:
+            raise SandboxCeilingUnsealable(
+                f"cannot create {parent} to give the md-notebook state mask a mount "
+                f"target: {exc}. Launching anyway would leave {target} maskless in every "
+                "agent namespace once the Notes backend creates it."
+            ) from exc
+        if _publish_empty_ceiling(target, parent, content=content):
+            created.append(target)
+        else:
+            # A lost publish race is benign ONLY when the winner clears the SAME bar an
+            # existing target had to: a regular file. ``lstat`` judges it, so this also
+            # catches a DANGLING leaf link — ``exists()`` is False for one, so it reaches
+            # the publish, where ``os.link`` fails EEXIST on the link's own name. And it
+            # catches an agent racing ``mkfifo``/``symlink`` between the validation and
+            # the publish, which accepting bare existence here would have let through.
+            try:
+                winner = os.lstat(target)
+            except OSError as exc:
+                raise SandboxCeilingUnsealable(
+                    f"cannot re-check the md-notebook state mask target {target} after a "
+                    f"publish race: {exc}"
+                ) from exc
+            if not stat.S_ISREG(winner.st_mode):
+                raise SandboxCeilingUnsealable(
+                    f"the md-notebook state mask target {target} is not a regular file "
+                    "after the publish (a link, or a special file that won the race), so "
+                    "the mask would bind over a referent or be skipped by the launcher's "
+                    "isdir/isfile loops. Remove or replace it with a regular file."
+                )
     return created
 
 
@@ -3373,6 +3813,12 @@ def _build_launcher_script(
     hidden_dirs.extend(_pod_os_home_targets(tuple(dirs)))
     hidden_dirs.extend(_relocated_policy_cache_dirs())
     hidden_dirs.extend(_relocated_crew_targets(_CREW_HIDDEN_LEAVES))
+    # Placed BEFORE the extra_visible_dirs filter on purpose: the predicate that adds
+    # these is the same one that withholds the backend's carve-out, so in practice they
+    # never collide — and if a future change did hand the backend its state paths while
+    # the chain is linked, cancelling this mask is the correct, visible consequence of
+    # that decision rather than a silently retained one.
+    hidden_dirs.extend(_md_notebook_degraded_mask_dirs())
     hidden_dirs.extend(_voice_runtime_sandbox_paths())
     hidden_dirs.extend(os.path.abspath(path) for path in extra_hidden_dirs)
     unhidden = [
@@ -4382,6 +4828,14 @@ def namespace_argv(
     # The mask loop has the same guard (``isdir``), so the on-demand hidden
     # directories get the same treatment for the same reason.
     _materialize_maskable_dirs()
+    # And the ``SENSITIVE_FILES`` loop is guarded on ``isfile``, so md-notebook's state
+    # leaves — creatable on a sandboxed host now that the backend carve-out exists —
+    # need a mount target too.
+    _materialize_md_notebook_mask_targets()
+    # A pre-upgrade orphan already ON disk is a different problem from an absent mask
+    # target, and this one is not Linux-specific: see the sweep's own docstring for why
+    # the macOS path calls it too.
+    _sweep_legacy_md_notebook_temps()
 
     script = _build_launcher_script(
         sandbox_level,
@@ -4564,6 +5018,11 @@ def _build_seatbelt_profile(
         + _pod_os_home_targets(tuple(dirs))
         + _relocated_policy_cache_dirs()
         + _relocated_crew_targets(_CREW_HIDDEN_LEAVES)
+        # Seatbelt needs this for the same reason the Linux launcher does: the sweep
+        # cannot delete an orphan through a linked chain on either platform, so the
+        # directory mask is what keeps that orphan out of the sandbox. Omitting it here
+        # would close the exposure on Linux and leave it open on macOS.
+        + _md_notebook_degraded_mask_dirs()
         + list(_voice_runtime_sandbox_paths())
     )
     for target in masked_targets:
@@ -4920,6 +5379,13 @@ def sandbox_exec_argv(
     resolved_argv = list(argv)
     if resolved_argv:
         resolved_argv[0] = _resolve_agent_executable(resolved_argv[0])
+
+    # A pre-upgrade md-notebook staging temp holding the PAT sits at a name this profile
+    # never denies (it names the state leaves and the staging directory, not an arbitrary
+    # ``*.tmp`` sibling), so removing it is NOT Linux-only work. File materialisation
+    # stays on the namespace path — a Seatbelt deny is a path rule that holds for a name
+    # that does not exist yet — but an orphan already on disk needs sweeping here too.
+    _sweep_legacy_md_notebook_temps()
 
     profile = _build_seatbelt_profile(
         sandbox_level,

--- a/src/kiro_crew/security/paths.py
+++ b/src/kiro_crew/security/paths.py
@@ -245,6 +245,16 @@ _CREW_SECRET_LEAVES: list[str] = [
     # HMAC-gated ``PUT /api/settings``; the app's own backend opens the file
     # directly rather than through this gate, so it keeps working.
     "workspace/md-notebook/settings.json",
+    # The Notes builtin's write-staging directory. Every state writer above stages
+    # its temp file in here before renaming onto its target, so during a write —
+    # and after a crash between write and rename — a file in this directory holds
+    # the same bytes as the leaves above, PAT included. Classified as the whole
+    # DIRECTORY (like ``whatsapp``) so every temp name, present and future, is
+    # covered. A TOP-LEVEL leaf, not one under ``workspace/md-notebook``, so an
+    # agent-writable ancestor cannot be renamed out from under it. The app's own
+    # backend opens it directly rather than through this gate, so writes keep
+    # working.
+    "md-notebook-staging",
     # The AWS Control builtin's app data directory. ``backup.json`` in here holds
     # ``nightly``, the bit that AUTHORIZES the app's startup loop to upload the
     # gateway's memory and workspace to S3 unattended, so a prompt-injected agent

--- a/test/test_app_backend.py
+++ b/test/test_app_backend.py
@@ -1775,6 +1775,118 @@ class TestTheCacheOnlyChildCanSeeTheCacheItMustBootFrom:
         assert seen.get("visible") == ()
 
 
+class TestTheMdNotebookBackendCanSeeItsOwnStateFiles:
+    """The md-notebook spawn's isolated startup, which rides with its mask carve-out.
+
+    The carve-out itself is main's (``app_backend_visible_targets``, pinned in
+    ``test_sandbox_governance_mask.py``). What is pinned HERE is the startup shape that
+    has to accompany it: this is the one spawn whose namespace holds an unmasked PAT, so
+    a bare ``python -m`` — which runs ``sitecustomize`` / ``usercustomize`` and the user
+    site's ``.pth`` files from an agent-writable directory — would execute that injected
+    code right where the token is readable. The spawn therefore starts with ``-I`` and
+    re-states its import root explicitly, and that rewrite is scoped to this spawn alone.
+    """
+
+    @staticmethod
+    def _spy(bmod, monkeypatch):
+        seen: dict = {}
+
+        def _spy_wrap(argv, **kwargs):
+            seen["visible"] = kwargs.get("extra_visible_dirs")
+            seen["argv"] = list(argv)
+            return (list(argv), None)
+
+        monkeypatch.setattr(bmod, "wrap_argv", _spy_wrap)
+        monkeypatch.setattr(
+            bmod.subprocess, "Popen", lambda *a, **k: (_ for _ in ()).throw(OSError("stop"))
+        )
+        return seen
+
+    def test_the_shipped_builtin_spawn_starts_isolated_with_the_carveout(
+        self, app_env, monkeypatch
+    ):
+        import kiro_crew.apps.backend as bmod
+        from kiro_crew.apps.manager import register_builtin_apps
+        from kiro_crew.sandbox import MD_NOTEBOOK_APP_NAME, app_backend_visible_targets
+
+        register_builtin_apps()
+        seen = self._spy(bmod, monkeypatch)
+
+        bmod.start_app_backend("md-notebook")
+
+        assert seen.get("visible"), "the spawn passed no visible dirs at all"
+        for path in app_backend_visible_targets(MD_NOTEBOOK_APP_NAME):
+            assert path in seen["visible"], (
+                "md-notebook's own state stays masked from the one spawn that "
+                f"owns it, so attach/clone still EPERMs (missing {path!r}, "
+                f"saw {seen['visible']!r})"
+            )
+        # Startup isolation rides with the carve-out: a bare `python -m` runs
+        # sitecustomize/usercustomize, and the default user site is an
+        # agent-writable injection path that would execute inside the one
+        # namespace where the PAT is unmasked.
+        argv = seen["argv"]
+        assert "-I" in argv, f"module builtin spawned without isolated startup: {argv!r}"
+        assert "-m" not in argv and any(
+            "runpy" in a and "kiro_crew.apps.builtins.md_notebook" in a for a in argv
+        ), f"the module must run via runpy with an explicit import root: {argv!r}"
+
+    def test_other_module_builtins_keep_the_bare_module_launch(self, app_env, monkeypatch):
+        """The isolated-startup rewrite is scoped to the spawn that carries the
+        carve-out: the other module builtins have no unmasked secret in their
+        namespace, and rewriting their import environment would be a rider on a
+        fix scoped to one (First Principles review)."""
+        import kiro_crew.apps.backend as bmod
+        from kiro_crew.apps.manager import register_builtin_apps
+
+        register_builtin_apps()
+        seen = self._spy(bmod, monkeypatch)
+
+        bmod.start_app_backend("file-explorer")
+
+        argv = seen["argv"]
+        assert "-I" not in argv and "-m" in argv, (
+            f"a non-md-notebook module builtin changed launch shape: {argv!r}"
+        )
+        assert seen.get("visible") == (), (
+            "a non-md-notebook builtin received the state carve-out"
+        )
+
+    def test_a_third_party_app_wearing_the_name_keeps_the_mask(
+        self, app_env, tmp_path, monkeypatch
+    ):
+        """The carve-out is bought with provenance, never with a name: an app
+        NAMED md-notebook that executes from the mutable installed tree (here
+        via the blanket third-party toggle the fixture enables) must not see
+        the GitHub token."""
+        import kiro_crew.apps.backend as bmod
+
+        seen = self._spy(bmod, monkeypatch)
+
+        src = tmp_path / "source" / "md-notebook"
+        src.mkdir(parents=True)
+        (src / APP_MANIFEST_FILENAME).write_text(
+            json.dumps(
+                {
+                    "name": "md-notebook",
+                    "version": "9.9.9",
+                    "displayName": "Impostor",
+                    "description": "wears the builtin's name",
+                    "backend": {"entryPoint": "server.py", "healthCheck": "/health"},
+                }
+            )
+        )
+        (src / "server.py").write_text("import time\ntime.sleep(30)\n")
+        install_app(src)
+
+        bmod.start_app_backend("md-notebook")
+
+        assert seen.get("visible") == (), (
+            "a third-party app bought the md-notebook state carve-out with its "
+            f"name alone (saw {seen.get('visible')!r})"
+        )
+
+
 # =============================================================================
 # Post-startup liveness watch (#5726)
 # =============================================================================

--- a/test/test_ci_surface_tests.py
+++ b/test/test_ci_surface_tests.py
@@ -342,6 +342,7 @@ def test_ignore_list_matches_the_names_conftest_previously_inlined() -> None:
         "test_sandbox_argv.py",
         "test_sandbox_cc_mode.py",
         "test_sandbox_hardlink_scan.py",
+        "test_sandbox_md_notebook_carveout.py",
         "test_sandbox_nested_tier.py",
         "test_pid_lifecycle.py",
         "test_pid_sweep_helpers.py",

--- a/test/test_sandbox_md_notebook_carveout.py
+++ b/test/test_sandbox_md_notebook_carveout.py
@@ -1,0 +1,725 @@
+"""The hardening that rides with the md-notebook backend's mask carve-out.
+
+The carve-out ITSELF is not retested here: ``_APP_BACKEND_OWNED_LEAVES`` names the hidden
+leaves the Notes backend owns, ``app_backend_visible_targets`` resolves them, and
+``apps/backend.py`` passes them as ``extra_visible_dirs`` for exactly that spawn; a spelling
+beneath a foreign mask is refused by ``carveout_shadowed_by_foreign_mask``. Both are pinned
+in ``test_sandbox_governance_mask.py``.
+
+What this file pins is what that carve-out OPENS, and the guards that close it. Making the
+three state files writable on a sandboxed host for the first time exposed two credential
+paths:
+
+* an ABSENT leaf gets no mask at all — ``mount(2)`` cannot target a missing path and the
+  launcher's hiding loops guard on existence — so an agent namespace spawned before the
+  first vault attach reads the PAT saved after it;
+* the state writers staged their temp BESIDE the target, so a file holding the real PAT
+  bytes sat at a name none of the three leaf masks covers, and a SIGKILL between write and
+  rename left it readable by a same-uid agent forever.
+
+The answers are :func:`sandbox._materialize_md_notebook_mask_targets` and the masked
+top-level ``md-notebook-staging`` directory every state writer now publishes through.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+
+import pytest
+
+import kiro_crew.sandbox as sb
+
+_MODES = ("standard", "cc", "strict")
+_CREW_PREFIXES = (".kiro/crew", ".kirocrew")
+
+
+def _crew_path(prefix: str, leaf: str) -> str:
+    from pathlib import Path
+
+    return os.path.join(str(Path.home()), *prefix.split("/"), *leaf.split("/"))
+
+
+def _hidden_dirs(mode: str) -> set[str]:
+    script = sb._build_launcher_script(mode)
+    match = re.search(r"SENSITIVE_DIRS = (\[.*?\])\n", script, re.S)
+    assert match, "SENSITIVE_DIRS not found in the generated launcher script"
+    return set(json.loads(match.group(1)))
+
+
+@pytest.fixture()
+def crew_home(tmp_path, monkeypatch):
+    """An isolated crew data home, shared by every class in this module.
+
+    Module-level so the mask classes and the sweep classes cannot drift onto different
+    isolation: the ``Path.home`` patch below is what keeps this suite from deleting
+    ``*.tmp`` files in the developer's real data home, and a class that quietly lacked it
+    would do exactly that.
+    """
+    home = tmp_path / ".kiro" / "crew"
+    home.mkdir(parents=True)
+    monkeypatch.setattr(sb, "config_dir", lambda: home)
+    # The sweep resolves the LEGACY home spelling from ``Path.home()`` as well, which no
+    # ``KIROCREW_HOME`` pin covers.
+    monkeypatch.setattr(sb.Path, "home", staticmethod(lambda: tmp_path))
+    return home
+
+
+class TestALinkedChainMasksTheWholeStateDirectory:
+    """A degraded root hides its whole state directory, and a healthy one does NOT.
+
+    Skipping the sweep on a linked chain leaves one thing behind that the three leaf masks
+    cannot cover: a legacy staging orphan holding real PAT bytes, whose name is neither
+    ``pat`` nor a state file. A directory mask covers every name inside it.
+
+    The negative half matters just as much. That directory also holds the vault clone data,
+    which agents are MEANT to read, so masking it wholesale on a healthy host would hide
+    the user's notes and defeat the app. The mask is therefore keyed to the same predicate
+    that withholds the carve-out: it appears only where the app is already non-functional.
+    """
+
+    def test_a_healthy_host_does_not_mask_the_state_directory(self, crew_home) -> None:
+        (crew_home / "workspace" / "md-notebook").mkdir(parents=True)
+
+        assert sb._md_notebook_degraded_mask_dirs() == [], (
+            "a healthy host masked the whole state directory, which would hide the vault "
+            "clone data agents are meant to read"
+        )
+
+    def test_a_planted_link_masks_the_state_directory(self, crew_home, tmp_path) -> None:
+        elsewhere = tmp_path / "elsewhere-mask-dir"
+        elsewhere.mkdir()
+        (crew_home / "workspace").mkdir(parents=True)
+        (crew_home / "workspace" / "md-notebook").symlink_to(elsewhere, target_is_directory=True)
+
+        masked = sb._md_notebook_degraded_mask_dirs()
+
+        assert str(crew_home / "workspace" / "md-notebook") in masked
+
+    def test_the_orphan_the_sweep_cannot_delete_is_masked_instead(self, crew_home, tmp_path):
+        """The two halves meet here: the sweep leaves the orphan, the mask hides it.
+
+        A directory the sweep refuses to descend keeps its orphan, so the mask must name
+        that directory — otherwise the PAT bytes in it stay readable in every sandbox.
+        """
+        victim = tmp_path / "victim-orphan"
+        (victim / "md-notebook").mkdir(parents=True)
+        orphan = victim / "md-notebook" / "pat.tmp"
+        orphan.write_text("ghp_realtoken")
+        (crew_home / "workspace").symlink_to(victim, target_is_directory=True)
+
+        removed = sb._sweep_legacy_md_notebook_temps()
+
+        assert orphan.exists(), "the sweep deleted through a planted link"
+        assert removed == []
+        state_dir = str(crew_home / "workspace" / "md-notebook")
+        assert state_dir in sb._md_notebook_degraded_mask_dirs(), (
+            "the sweep could not delete the orphan AND the directory is unmasked, so the "
+            "PAT bytes in it stay readable inside the sandbox"
+        )
+
+    def test_both_launch_paths_carry_the_degraded_mask(self) -> None:
+        """Linux and macOS build their hidden sets separately, so a fix applied to one
+        leaves the other exposed. Pinned by source because the mask list is computed from
+        the live host, which is healthy in CI."""
+        import inspect
+
+        for builder in (sb._build_launcher_script, sb._build_seatbelt_profile):
+            assert "_md_notebook_degraded_mask_dirs()" in inspect.getsource(
+                builder
+            ), f"{builder.__name__} does not carry the degraded state-directory mask"
+
+
+class TestTheStagingDirectoryIsMaskedAndCarvedBack:
+    """The write-staging directory is fenced from agents and returned to the backend.
+
+    The three leaf masks cover exactly three names, so the temp the writers publish
+    through needs its own cover. It is masked as a whole DIRECTORY (every name inside it,
+    present and future) and handed back only to the spawn that owns the leaves — carving
+    out the leaves alone would move the EPERM from the leaf to the staging dir.
+    """
+
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    def test_the_staging_dir_is_masked_in_every_mode(self, mode: str, prefix: str) -> None:
+        assert _crew_path(prefix, sb._MD_NOTEBOOK_STAGING_LEAF) in _hidden_dirs(mode)
+
+    def test_the_backend_gets_the_staging_dir_back(self) -> None:
+        targets = sb.app_backend_visible_targets(sb.MD_NOTEBOOK_APP_NAME)
+
+        for prefix in _CREW_PREFIXES:
+            assert _crew_path(prefix, sb._MD_NOTEBOOK_STAGING_LEAF) in targets
+
+    def test_the_launcher_lifts_the_staging_mask_for_that_spawn(self) -> None:
+        script = sb._build_launcher_script(
+            "standard",
+            extra_visible_dirs=sb.app_backend_visible_targets(sb.MD_NOTEBOOK_APP_NAME),
+        )
+        match = re.search(r"SENSITIVE_DIRS = (\[.*?\])\n", script, re.S)
+        assert match
+        hidden = set(json.loads(match.group(1)))
+
+        for prefix in _CREW_PREFIXES:
+            assert _crew_path(prefix, sb._MD_NOTEBOOK_STAGING_LEAF) not in hidden
+
+    def test_the_precreate_table_covers_exactly_the_state_leaves(self) -> None:
+        """Materialising a leaf needs its own absent-equivalence argument, so the two
+        tables must not drift: a leaf added to the mask without one would be created
+        with no proof that empty means absent to its reader."""
+        assert set(sb._MD_NOTEBOOK_PRECREATE_CONTENT) == set(sb._MD_NOTEBOOK_STATE_LEAVES)
+        assert sb._MD_NOTEBOOK_STAGING_LEAF not in sb._MD_NOTEBOOK_PRECREATE_CONTENT
+
+
+class TestANewOwnedLeavesAppCannotSilentlySkipMaterialization:
+    """A drift gate: `_APP_BACKEND_OWNED_LEAVES` is generic, this hardening is not.
+
+    The materialiser, the precreate table, and the `-I` startup isolation are all keyed to
+    md-notebook by name, while the owned-leaves table any app can join is a plain dict. An
+    app added there would get its leaves unmasked for its own spawn — and would silently
+    reopen BOTH holes this file exists to close: no mount target for an absent leaf, and
+    interpreter startup hooks running in a namespace holding its secret. Neither failure
+    is visible at runtime, so the omission has to be loud HERE instead.
+    """
+
+    def test_every_owned_leaves_app_is_covered_by_materialization(self) -> None:
+        covered = {
+            sb.MD_NOTEBOOK_APP_NAME: set(sb._MD_NOTEBOOK_PRECREATE_CONTENT)
+            | {sb._MD_NOTEBOOK_STAGING_LEAF},
+        }
+        assert set(sb._APP_BACKEND_OWNED_LEAVES) == set(covered), (
+            "an app gained entries in _APP_BACKEND_OWNED_LEAVES without materialisation "
+            "coverage. Its own spawn now sees those leaves, so before shipping it you must "
+            "(a) give every FILE leaf an absent-equivalent document with a written "
+            "per-leaf argument, the way _MD_NOTEBOOK_PRECREATE_CONTENT does, and "
+            "materialise it before launch — otherwise an absent leaf gets NO mask and a "
+            "namespace spawned earlier reads whatever the backend writes later; and "
+            "(b) decide explicitly whether that spawn needs the -I isolated startup "
+            "md-notebook uses, since a bare `python -m` runs agent-writable "
+            "sitecustomize/usercustomize inside the one namespace where its secret is "
+            "unmasked. Then extend this table."
+        )
+        for app, leaves in sb._APP_BACKEND_OWNED_LEAVES.items():
+            assert set(leaves) == covered[app], (
+                f"{app}'s owned leaves and its materialisation coverage have drifted: "
+                f"{set(leaves) ^ covered[app]}"
+            )
+
+
+class TestAbsentStateFilesAreMaterializedSoTheMaskCanMount:
+    """``mount(2)`` cannot target an absent path and the launcher's hiding loops
+    guard on existence, so an absent leaf gets NO mask in the spawned namespace.
+    The carve-out makes these three files creatable on a sandboxed host for the
+    first time, so an agent namespace spawned before the first vault attach
+    would read the PAT saved after it — unless the absent-equivalent documents
+    are materialised before launch."""
+
+    def test_the_fixture_really_isolates_the_real_home(self, crew_home, tmp_path):
+        """Guard the guard: if ``Path.home`` ever stops being patched here, this suite
+        would sweep the developer's own crew home. Fail loudly instead."""
+        assert sb.Path.home() == tmp_path
+
+    def test_every_leaf_is_created_with_its_absent_equivalent_document(self, crew_home):
+        created = sb._materialize_md_notebook_mask_targets()
+        state = crew_home / "workspace" / "md-notebook"
+        assert set(created) == {str(state / n) for n in ("pat", "vaults.json", "settings.json")}
+        assert (state / "vaults.json").read_bytes() == b"[]\n"
+        assert (state / "settings.json").read_bytes() == b"{}\n"
+        assert (state / "pat").read_bytes() == b""
+        # The PAT mount target is a credential path: owner-only from birth.
+        assert os.stat(state / "pat").st_mode & 0o077 == 0
+
+    def test_the_staging_dir_is_materialized_by_the_shared_direct_child_path(self) -> None:
+        """The staging directory is a DIRECT child of the data home, so it belongs to
+        ``_materialize_maskable_dirs`` — whose plain ``mkdir`` is only sound for direct
+        children — rather than to the nested md-notebook materialiser."""
+        assert sb._MD_NOTEBOOK_STAGING_LEAF in sb._CREW_PRECREATE_HIDDEN_DIR_LEAVES
+        assert "/" not in sb._MD_NOTEBOOK_STAGING_LEAF
+
+    def test_the_staging_dir_has_no_agent_writable_ancestor(self) -> None:
+        """A mask covers the leaf, NOT its ancestors. Under ``workspace/md-notebook`` — a
+        tree the agent can write at OS level — the staging dir could be renamed out from
+        under its own mask, and a later PAT write would publish through the replacement,
+        unmasked, into a live agent's view. Top-level, like ``aws-control-staging``."""
+        assert not sb._MD_NOTEBOOK_STAGING_LEAF.startswith("workspace/")
+        for leaf in sb._MD_NOTEBOOK_STATE_LEAVES:
+            assert not sb._MD_NOTEBOOK_STAGING_LEAF.startswith(os.path.dirname(leaf))
+
+    def test_the_backend_and_the_mask_name_the_same_staging_dir(self) -> None:
+        """The writer spells the leaf itself rather than importing the sandbox module into
+        the app backend's process, so the two spellings are pinned here: a mismatch would
+        stage PAT bytes at a name nothing masks."""
+        from kiro_crew.apps.builtins.md_notebook import server
+
+        assert server._STAGING_LEAF == sb._MD_NOTEBOOK_STAGING_LEAF
+
+    def test_the_sweep_runs_on_the_macos_launch_path_too(self) -> None:
+        """Materialising is Linux-only for a real reason — a Seatbelt deny is a path rule
+        that holds for a name that does not exist yet — but that does NOT transfer to an
+        orphan already on disk at a name no rule names. The profile denies the leaves and
+        the staging dir, never an arbitrary ``*.tmp`` sibling, so skipping macOS would
+        leave a pre-upgrade token readable there forever."""
+        import inspect
+
+        for fn in (sb.namespace_argv, sb.sandbox_exec_argv):
+            assert "_sweep_legacy_md_notebook_temps()" in inspect.getsource(
+                fn
+            ), f"{fn.__name__} does not sweep legacy md-notebook staging temps"
+
+    def test_the_documents_read_as_absent_to_the_backend(self, crew_home, monkeypatch):
+        """The whole materialisation argument: an empty document must mean what
+        an absent file means TO THE READER. Pin it against the backend's own
+        read functions rather than restating their behavior here."""
+        from kiro_crew.apps.builtins.md_notebook import server
+
+        sb._materialize_md_notebook_mask_targets()
+        monkeypatch.setattr(server, "_HOME", crew_home / "workspace" / "md-notebook")
+        assert server._read_vaults_sync() == []
+        assert server._read_settings_sync() == server._default_settings()
+        assert server._read_pat_sync() is None
+
+    def test_existing_state_is_left_byte_for_byte_alone(self, crew_home):
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        (state / "vaults.json").write_text('[{"id": "real"}]')
+        assert sb._materialize_md_notebook_mask_targets()  # creates only the other two
+        assert (state / "vaults.json").read_text() == '[{"id": "real"}]'
+
+    def test_a_legacy_sibling_temp_is_swept(self, crew_home):
+        """A pre-upgrade writer staged BESIDE the target, so a SIGKILL in that window
+        left real PAT bytes at a name no mask covers — not the three leaves, not
+        the staging directory. Materialising forward cannot help an artefact on disk, so
+        the orphan is removed."""
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        orphans = [
+            state / "tmpab12cd34.tmp",  # atomic_write's mkstemp(dir=parent)
+            state / "vaults.json.deadbeef.tmp",  # git_ops.staged_temp_name
+            state / "settings.json.cafe1234.tmp",
+        ]
+        for o in orphans:
+            o.write_text("ghp_leaked_token")
+
+        removed = sb._sweep_legacy_md_notebook_temps()
+
+        for o in orphans:
+            assert not o.exists(), f"legacy PAT-bearing temp survived: {o}"
+        # The returned list is the caller-visible record of WHICH credentials were exposed,
+        # which is what the operator needs in order to know what to rotate — assert it
+        # rather than leaving it as bookkeeping nothing reads.
+        assert set(removed) == {str(o) for o in orphans}
+
+    def test_the_sweep_keeps_real_state_and_clone_data(self, crew_home):
+        """Only ``*.tmp`` DIRECT children are orphans by construction. The state files,
+        the staging dir, and the vault clones must all survive."""
+        state = crew_home / "workspace" / "md-notebook"
+        (state / "vaults").mkdir(parents=True)
+        (state / "vaults" / "v1").mkdir()
+        (state / "vaults" / "v1" / "note.md.abcd.tmp").write_text("a note temp, not ours")
+        (state / "pat").write_text("ghp_real")
+        (state / "vaults.json").write_text("[]")
+
+        sb._sweep_legacy_md_notebook_temps()
+        sb._materialize_md_notebook_mask_targets()
+
+        assert (state / "pat").read_text() == "ghp_real"
+        assert (state / "vaults.json").read_text() == "[]"
+        assert (
+            state / "vaults" / "v1" / "note.md.abcd.tmp"
+        ).exists(), "the sweep reached into a vault clone; it must only touch direct children"
+
+    def test_a_legacy_home_orphan_is_swept_too(self, crew_home, tmp_path):
+        """The mask covers BOTH crew-home spellings, so an orphan under an un-migrated or
+        rolled-back ``~/.kirocrew`` is exposed exactly like one under the live home. This
+        is the opposite requirement from materialising, which is live-home-only because a
+        stub in a home nothing reads would be a file nobody opens — a token already written
+        to the legacy home stays readable whichever home is live now."""
+        legacy = tmp_path / ".kirocrew" / "workspace" / "md-notebook"
+        legacy.mkdir(parents=True)
+        orphan = legacy / "tmplegacy1.tmp"
+        orphan.write_text("ghp_leaked_token")
+
+        sb._sweep_legacy_md_notebook_temps()
+
+        assert not orphan.exists(), "a legacy-home PAT temp survived the sweep"
+
+    def test_a_relocated_home_orphan_is_swept_too(self, tmp_path, monkeypatch):
+        """The live home is resolved through ``config_dir()``, which ``KIROCREW_HOME`` can
+        move OUT from under ``$HOME`` entirely — so the two roots are not interchangeable
+        and neither alone is sufficient. Pins the live-home root independently of the
+        ``$HOME``-prefix roots, which the other sweep tests happen to share."""
+        relocated = tmp_path / "srv" / "crew"
+        state = relocated / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        monkeypatch.setattr(sb, "config_dir", lambda: relocated)
+        monkeypatch.setattr(sb.Path, "home", staticmethod(lambda: tmp_path / "elsewhere"))
+        orphan = state / "tmprelocated.tmp"
+        orphan.write_text("ghp_leaked_token")
+
+        sb._sweep_legacy_md_notebook_temps()
+
+        assert not orphan.exists(), "a relocated-home PAT temp survived the sweep"
+
+    def test_the_sweep_refuses_to_delete_through_a_planted_parent_link(self, crew_home, tmp_path):
+        """The sweep UNLINKS, so following a planted link is irreversible deletion in a
+        tree the agent chose — strictly worse than the materialiser's create-only version
+        of the same hazard. The intermediate components are agent-writable, so the chain
+        gets the same planted-link refusal, and the root is skipped rather than swept.
+
+        The planted path resolves COMPLETELY — the victim really does contain an
+        ``md-notebook`` directory holding a ``*.tmp`` file — so the open succeeds and the
+        chain refusal is the only thing standing between the sweep and the deletion.
+        ``O_NOFOLLOW`` cannot help here: it only judges the final component, which is a
+        real directory."""
+        victim_state = tmp_path / "victim" / "md-notebook"
+        victim_state.mkdir(parents=True)
+        bystander = victim_state / "unrelated.tmp"
+        bystander.write_text("someone else's file")
+        # ``workspace`` itself is the planted link, so the state dir resolves inside it.
+        (crew_home / "workspace").symlink_to(tmp_path / "victim", target_is_directory=True)
+
+        sb._sweep_legacy_md_notebook_temps()
+
+        assert bystander.exists(), "the sweep deleted through a planted parent link"
+
+    def test_the_sweep_refuses_to_delete_through_a_linked_state_dir(self, crew_home, tmp_path):
+        """Same hazard one component deeper, where the LEAF is the link. The
+        ``O_NOFOLLOW`` open is what refuses it, and it also pins the directory so a swap
+        between the check and the unlink cannot redirect either syscall."""
+        victim = tmp_path / "victim2"
+        victim.mkdir()
+        bystander = victim / "unrelated.tmp"
+        bystander.write_text("someone else's file")
+        (crew_home / "workspace").mkdir()
+        (crew_home / "workspace" / "md-notebook").symlink_to(victim, target_is_directory=True)
+
+        sb._sweep_legacy_md_notebook_temps()
+
+        assert bystander.exists(), "the sweep deleted through a linked state directory"
+
+    def test_the_descent_refuses_a_link_at_every_component_not_just_the_last(
+        self, crew_home, tmp_path
+    ):
+        """``O_NOFOLLOW`` judges only the FINAL component, so opening the joined path is
+        unsound however carefully the chain was pre-checked: an intermediate directory
+        swapped between the check and the open redirects the whole descent, and the sweep
+        then unlinks inside a tree the agent chose. The descent is therefore per-component
+        from the trusted anchor, which the kernel enforces at each step instead of at one.
+
+        Exercised directly on the helper because the interesting property is per-component
+        refusal, and a chain-level test cannot tell which component did the refusing.
+        """
+        elsewhere = tmp_path / "elsewhere-descent"
+        elsewhere.mkdir()
+
+        # A clean chain opens and is usable.
+        (crew_home / "workspace" / "md-notebook").mkdir(parents=True)
+        fd = sb._open_dir_anchored(str(crew_home), sb._MD_NOTEBOOK_STATE_COMPONENTS)
+        assert fd is not None
+        os.close(fd)
+
+        # A link at the LAST component is refused.
+        (crew_home / "workspace" / "md-notebook").rmdir()
+        (crew_home / "workspace" / "md-notebook").symlink_to(elsewhere, target_is_directory=True)
+        assert sb._open_dir_anchored(str(crew_home), sb._MD_NOTEBOOK_STATE_COMPONENTS) is None
+
+        # And so is a link at an INTERMEDIATE component, which is the case a joined-path
+        # open with O_NOFOLLOW would have accepted.
+        (crew_home / "workspace" / "md-notebook").unlink()
+        (crew_home / "workspace").rmdir()
+        victim = tmp_path / "victim-descent"
+        (victim / "md-notebook").mkdir(parents=True)
+        (crew_home / "workspace").symlink_to(victim, target_is_directory=True)
+        assert sb._open_dir_anchored(str(crew_home), sb._MD_NOTEBOOK_STATE_COMPONENTS) is None
+
+    def test_the_sweep_spares_an_inflight_ceiling_temp(self, crew_home):
+        """``_publish_empty_ceiling`` stages ITS temp in the target's parent — the very
+        directory this sweep scans — and publishes with ``os.link``. Two concurrent spawns
+        would otherwise let one's sweep unlink the other's temp between the ``mkstemp`` and
+        the ``link``, failing that spawn for no reason. Gateway-owned, not an orphan."""
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        inflight = state / f"{sb._CEILING_TEMP_PREFIX}abcd1234.tmp"
+        inflight.write_bytes(b"")
+
+        sb._sweep_legacy_md_notebook_temps()
+
+        assert inflight.exists(), "the sweep unlinked another spawn's in-flight temp"
+
+    def test_a_non_regular_tmp_is_left_alone_by_the_sweep(self, crew_home):
+        """``lstat`` decides, so a link is never followed and a directory is not removed:
+        the sweep deletes files, and anything else at such a name is the operator's."""
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        (state / "a-dir.tmp").mkdir()
+
+        sb._sweep_legacy_md_notebook_temps()
+
+        assert (state / "a-dir.tmp").is_dir()
+
+    def test_an_unremovable_legacy_temp_refuses_the_spawn(self, crew_home, monkeypatch):
+        """Fail-closed like every other branch here: if the orphan cannot be removed,
+        launching would hand the agent the PAT this mechanism exists to hide."""
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        (state / "tmpstuck.tmp").write_text("ghp_leaked_token")
+
+        def _refuse(path, *a, **k):
+            raise OSError(13, "Permission denied")
+
+        monkeypatch.setattr(sb.os, "unlink", _refuse)
+        with pytest.raises(sb.SandboxCeilingUnsealable, match="tmpstuck.tmp"):
+            sb._sweep_legacy_md_notebook_temps()
+
+    def test_an_absent_data_home_is_not_created(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sb, "config_dir", lambda: tmp_path / "never-made")
+        assert sb._materialize_md_notebook_mask_targets() == []
+        assert not (tmp_path / "never-made").exists()
+
+    def test_a_failed_publish_refuses_the_spawn(self, crew_home, monkeypatch):
+        """Fail-closed: launching anyway would run the agent with a mask the
+        launcher silently skips — the exact hole this materialiser closes."""
+        monkeypatch.setattr(sb, "_publish_empty_ceiling", lambda *a, **k: False)
+        with pytest.raises(sb.SandboxCeilingUnsealable):
+            sb._materialize_md_notebook_mask_targets()
+
+    def test_a_planted_intermediate_symlink_degrades_the_app_not_the_host(
+        self, crew_home, tmp_path
+    ):
+        """The planted-link hazard, materialiser edition: ``os.makedirs`` follows a RESOLVING symlink planted
+        at ``workspace/md-notebook`` (an agent-writable tree a spawned subprocess can
+        symlink at OS level), so materialising would land the files at the link's target
+        while the launcher masks the lexical path.
+
+        The response is to SKIP the leaf and let the spawn proceed, not to refuse it.
+        Refusing would let one optional app's on-disk layout take every sandboxed process
+        on the host down with it — an operator who symlinks ``workspace/`` to another disk
+        would find no agent could start, over a Notes file they may never have created.
+        """
+        elsewhere = tmp_path / "elsewhere-mask"
+        elsewhere.mkdir()
+        (crew_home / "workspace").mkdir(parents=True)
+        (crew_home / "workspace" / "md-notebook").symlink_to(elsewhere, target_is_directory=True)
+
+        created = sb._materialize_md_notebook_mask_targets()
+
+        assert created == [], "the materialiser wrote through a planted link"
+        assert list(elsewhere.iterdir()) == [], (
+            "the materialiser followed the planted link and created state at "
+            f"its target: {list(elsewhere.iterdir())!r}"
+        )
+
+    def test_skipping_materialisation_and_withholding_the_carveout_are_one_decision(
+        self, crew_home, tmp_path, monkeypatch
+    ):
+        """THE safety coupling, pinned in one place because separating the two reopens the
+        exact hole this file exists to close.
+
+        Skipping materialisation leaves a leaf unmasked, which is only harmless while
+        nothing can write it. That is guaranteed by the carve-out being withheld under the
+        SAME predicate: if a future change made the materialiser skip while
+        ``app_backend_visible_targets`` still handed the backend its state paths, the
+        backend could publish a PAT to a name no mask covers.
+        """
+        elsewhere = tmp_path / "elsewhere-coupling"
+        elsewhere.mkdir()
+        (crew_home / "workspace").mkdir(parents=True)
+        (crew_home / "workspace" / "md-notebook").symlink_to(elsewhere, target_is_directory=True)
+        # The carve-out resolves against $HOME, so point it at the same planted tree.
+        monkeypatch.setattr(sb.Path, "home", staticmethod(lambda: crew_home.parent.parent))
+
+        skipped = sb._materialize_md_notebook_mask_targets() == []
+        carved = sb.app_backend_visible_targets(sb.MD_NOTEBOOK_APP_NAME)
+        # Scope to the spelling whose chain actually carries the planted link — the one the
+        # materialiser just skipped. The legacy ``.kirocrew`` spelling has no link in its
+        # chain and the backend never writes it (it resolves state through ``config_dir()``),
+        # so carving that one out grants nothing the owner did not already have.
+        planted = str(crew_home / "workspace" / "md-notebook")
+        state_leaf_carved = [t for t in carved if t.startswith(planted)]
+
+        assert skipped, "materialisation did not skip, so this coupling is not under test"
+        assert state_leaf_carved == [], (
+            "materialisation was skipped for a planted chain while the carve-out still "
+            f"handed the backend those same state paths — a PAT could publish unmasked: "
+            f"{state_leaf_carved!r}"
+        )
+
+    def test_a_resolving_leaf_symlink_refuses_the_spawn(self, crew_home, tmp_path):
+        """A RESOLVING link at the leaf is refused too, not only a dangling one:
+        mount(2) resolves its target, so a resolving ``pat`` link would put the
+        mask on the referent while the lexical name stays an agent-replaceable
+        link — swap it after launch and a later PAT write publishes to an
+        unmasked name inside the live namespace."""
+        real = tmp_path / "somewhere-else-pat"
+        real.write_bytes(b"")
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        (state / "pat").symlink_to(real)
+        with pytest.raises(sb.SandboxCeilingUnsealable):
+            sb._materialize_md_notebook_mask_targets()
+
+    def test_a_dangling_leaf_symlink_refuses_the_spawn(self, crew_home, tmp_path):
+        """A DANGLING leaf link takes the other route to the same refusal: ``exists()``
+        is False for one, so it reaches the publish, where ``os.link`` fails EEXIST on
+        the link's own name and the race re-check lstats it as a link."""
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        (state / "pat").symlink_to(tmp_path / "nothing-here")
+        with pytest.raises(sb.SandboxCeilingUnsealable):
+            sb._materialize_md_notebook_mask_targets()
+
+    def test_a_special_file_at_a_leaf_refuses_the_spawn(self, crew_home):
+        """An EXISTING target is acceptable only as a regular file: the
+        launcher's hiding loops classify with isdir/isfile, and a FIFO at
+        ``pat`` matches neither — the mask is silently skipped for the whole
+        sandbox."""
+        state = crew_home / "workspace" / "md-notebook"
+        state.mkdir(parents=True)
+        os.mkfifo(state / "pat")
+        with pytest.raises(sb.SandboxCeilingUnsealable):
+            sb._materialize_md_notebook_mask_targets()
+
+    def test_a_raced_special_file_refuses_the_spawn(self, crew_home, monkeypatch):
+        """A LOST publish race is benign only when the winner clears the same
+        regular-file bar the pre-check enforces: an agent racing mkfifo between
+        validation and publish must not have its non-file accepted on bare
+        existence."""
+
+        real_publish = sb._publish_empty_ceiling
+
+        def _raced(target, parent, content=b"{}\n"):
+            if target.endswith("pat") and not os.path.exists(target):
+                os.mkfifo(target)  # the racing writer wins with a FIFO
+                return False  # our publish loses (os.link EEXIST -> False)
+            return real_publish(target, parent, content=content)
+
+        monkeypatch.setattr(sb, "_publish_empty_ceiling", _raced)
+        with pytest.raises(sb.SandboxCeilingUnsealable):
+            sb._materialize_md_notebook_mask_targets()
+
+    def test_namespace_argv_materializes_before_the_launcher_runs(self, crew_home):
+        """The call site: every Linux spawn gets mount targets before its child
+        mounts, so no agent namespace can predate the mask."""
+        sb.namespace_argv(["/bin/true"])
+        state = crew_home / "workspace" / "md-notebook"
+        for name in ("pat", "vaults.json", "settings.json"):
+            assert (state / name).is_file(), f"{name} absent after namespace_argv"
+
+
+class TestStateWritersStageInsideTheMask:
+    """The three leaf masks cover exactly three names — a temp staged BESIDE the
+    target holds the same bytes (PAT included) at a name no mask covers, and a
+    SIGKILL between write and rename leaves it there forever. Every state writer must stage
+    under the whole-directory top-level staging mask instead."""
+
+    @pytest.fixture()
+    def server(self, tmp_path, monkeypatch):
+        from kiro_crew.apps.builtins.md_notebook import server
+
+        monkeypatch.setattr(server, "_HOME", tmp_path / "state")
+        return server
+
+    def test_a_crashed_publish_leaves_the_temp_inside_the_mask(self, server, monkeypatch):
+        def _boom(tmp, target):
+            raise AssertionError("simulated crash at publish time")
+
+        monkeypatch.setattr(server, "replace_with_retry", _boom)
+        # Suppress the failure-path unlink so the orphan the crash WOULD leave
+        # is observable — this models SIGKILL, which runs no cleanup at all.
+        monkeypatch.setattr(server.Path, "unlink", lambda self, *a, **k: None)
+        with pytest.raises(AssertionError):
+            server._write_pat_sync("ghp_secret")
+
+        state = server._HOME
+        orphans_beside_target = list(state.iterdir())
+        assert (
+            not orphans_beside_target
+        ), f"a PAT temp was staged beside the target, outside the mask: {orphans_beside_target!r}"
+        staged = list(server._staging_dir().iterdir())
+        assert staged, "the temp was not staged under the masked staging dir at all"
+        assert staged[0].read_text() == "ghp_secret"
+        if os.name == "posix":
+            assert os.stat(staged[0]).st_mode & 0o077 == 0
+
+    def test_each_writer_publishes_to_its_target_with_no_residue(self, server):
+        server._write_pat_sync("ghp_token")
+        server._write_vaults_sync([{"id": "v1"}])
+        server._write_settings_sync({"autoSync": True})
+        state = server._HOME
+        assert (state / "pat").read_text() == "ghp_token"
+        assert "v1" in (state / "vaults.json").read_text()
+        assert "autoSync" in (state / "settings.json").read_text()
+        assert list(server._staging_dir().iterdir()) == [], "a successful write left residue"
+        assert {p.name for p in state.iterdir()} == {
+            "pat",
+            "vaults.json",
+            "settings.json",
+        }, "a writer left a temp beside its target"
+
+    def test_a_planted_parent_link_refuses_the_write(self, server, tmp_path):
+        """The planted-link guard atomic_write enforces, which staging here must keep: a
+        secret write whose parent chain passes through a planted link is refused, because
+        mkdir/mkstemp/rename all follow it and the token lands outside the sensitive-path
+        fence."""
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        # server fixture sets _HOME to tmp_path/"state" without creating it;
+        # plant the state dir itself as a link to a foreign directory.
+        server._HOME.symlink_to(elsewhere, target_is_directory=True)
+        with pytest.raises(OSError):
+            server._write_pat_sync("ghp_secret")
+        assert list(elsewhere.iterdir()) == [], (
+            "the PAT write followed a pre-planted parent link and published "
+            f"the token outside the fence: {list(elsewhere.iterdir())!r}"
+        )
+
+    def test_a_planted_staging_link_refuses_the_write(self, server, tmp_path):
+        """Same guard, one component deeper: the staging dir itself must be a real
+        directory, not a link redirecting every temp (PAT bytes included)."""
+        elsewhere = tmp_path / "elsewhere-staging"
+        elsewhere.mkdir()
+        server._HOME.mkdir(parents=True)
+        server._staging_dir().symlink_to(elsewhere, target_is_directory=True)
+        with pytest.raises(OSError):
+            server._write_pat_sync("ghp_secret")
+        assert (
+            list(elsewhere.iterdir()) == []
+        ), "the staged temp followed a pre-planted staging link outside the mask"
+
+    def test_clearing_the_pat_keeps_the_mask_mount_target(self, server):
+        """Clearing must atomically empty the file, never unlink it: the inode
+        is the sandbox mask's mount target, and a clear landing between the
+        launcher's materialize and mount steps would leave that namespace
+        maskless for a later PAT save."""
+        server._write_pat_sync("ghp_token")
+        assert server._read_pat_sync() == "ghp_token"
+        server._write_pat_sync("")  # what api_pat's clear branch calls
+        pat_file = server._HOME / "pat"
+        assert pat_file.is_file(), "the PAT clear removed the mask's mount target"
+        assert pat_file.read_bytes() == b""
+        assert server._read_pat_sync() is None, "empty must read as absent"
+
+    def test_the_clear_ROUTE_keeps_the_mask_mount_target(self, server, monkeypatch):
+        """Pins the ROUTE, not just the writer. The test above proves an empty write is
+        absent-equivalent; this one proves ``api_pat``'s clear branch actually takes it.
+        An ``os.unlink`` there would delete the mask's mount target while every
+        writer-level assertion above still passed."""
+        server._write_pat_sync("ghp_token")
+        pat_file = server._HOME / "pat"
+        assert pat_file.is_file()
+
+        async def _fake_body(_request):
+            return {"pat": ""}
+
+        async def _no_gh():
+            return None
+
+        monkeypatch.setattr(server, "json_body", _fake_body)
+        monkeypatch.setattr(server, "gh_token", _no_gh)
+
+        response = asyncio.run(server.api_pat(object()))
+
+        assert pat_file.is_file(), "the clear route removed the mask's mount target"
+        assert pat_file.read_bytes() == b""
+        assert json.loads(response.text)["hasPat"] is False

--- a/test/windows-collect-ignore.txt
+++ b/test/windows-collect-ignore.txt
@@ -25,6 +25,7 @@ test_harness.py                    # spawns real gateways; PGID + socketpair plu
 test_sandbox_argv.py               # OS sandbox is POSIX-only
 test_sandbox_cc_mode.py            # OS sandbox is POSIX-only
 test_sandbox_hardlink_scan.py      # OS sandbox is POSIX-only (launcher uses getuid)
+test_sandbox_md_notebook_carveout.py  # OS sandbox is POSIX-only (launcher uses getuid)
 test_sandbox_nested_tier.py        # OS sandbox is POSIX-only (launcher uses getuid; env at /usr/bin)
 test_pid_lifecycle.py              # process-group semantics
 test_pid_sweep_helpers.py          # process-group semantics


### PR DESCRIPTION
> **This PR was re-scoped.** It opened as the fix for #8762 (the Notes backend masked
> from its own state files). That issue was fixed and closed by **#8794**, which landed a
> generic carve-out on main. What remains here is the HARDENING that carve-out needs and
> did not ship with — so this PR no longer closes #8762 and no longer carries a carve-out
> of its own. It now builds on main's `_APP_BACKEND_OWNED_LEAVES` /
> `app_backend_visible_targets`, and reuses #8965's foreign-mask refusal rather than
> reimplementing it.

## Problem / Motivation

Giving the md-notebook backend its own hidden state leaves back made
`workspace/md-notebook/{pat,vaults.json,settings.json}` writable on a sandboxed host for
the first time. Two paths then expose the GitHub PAT to a same-uid sandboxed agent. Both
are reachable on `main` today.

**A — an absent leaf gets no mask at all.** `mount(2)` cannot target a path that does not
exist, and the launcher's hiding loops are guarded on existence, so a leaf that has never
been written is silently skipped:

- `sandbox.py:3584` `if os.path.isdir(target):` and `sandbox.py:3674` `if os.path.isfile(target):` — an absent path matches neither loop.
- `_CREW_PRECREATE_HIDDEN_DIR_LEAVES` (`sandbox.py:598`) is the only hidden-leaf materialiser input on main, and it holds `("aws-control-staging",)` — nothing for the md-notebook FILE leaves.
- main's own comment above `_CREW_PRECREATE_READONLY_DIR_LEAVES` already names this: *"The same `mount(2)` limit leaves the `SENSITIVE_DIRS` / `SENSITIVE_FILES` mask loops skipping their own absent targets. That is a real sibling gap … each leaf needs its own argument."*

So on a default install an agent namespace spawned **before** the first vault attach has
no mask at the `pat` name. The namespace outlives that: the backend saves a PAT later, and
the still-running agent reads it at the real path.

**B — the staged temp sits outside the mask.** The mask covers exactly three names
(`sandbox.py:217-219`), while the writers published through `atomic_write`, which stages
next to the target:

- `atomic_write.py:980` `fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")`
- `server.py:429` `atomic_write(target, pat, fsync=True, restrict_to_owner=True, …)`

That temp holds the real PAT bytes at a name no mask covers. A SIGKILL between write and
rename leaves it readable forever. Related, same mechanism: `server.py:1447` cleared the
PAT with `os.unlink(_pat_file())`, deleting the mask's own mount target.

## Why it matters

The exposed value is a live GitHub token with push rights to the user's notes vaults. The
reader is any same-uid process in an agent namespace — which is exactly the population
`_CREW_HIDDEN_LEAVES` exists to fence, so both paths defeat the control rather than
sitting outside it. Path A needs no crash and no race: a fresh install, one long-lived
agent session, then a first vault attach.

## What changed (motivation → approach → change)

Hole A is an absent mount target, so the fix is to stop the target being absent.
`_materialize_md_notebook_mask_targets()` publishes each leaf's absent-equivalent document
before launch, at the same call site as `_materialize_sealable_ceilings()` /
`_materialize_maskable_dirs()`. It is the NESTED counterpart to the latter, which
deliberately handles only direct children of the data home with a plain `mkdir`; these
leaves sit under an agent-writable `workspace/md-notebook/`, so every chain it walks first
goes through the #4381 planted-link refusal, before any `mkdir` (a `mkdir` follows a
planted link). `_MD_NOTEBOOK_PRECREATE_CONTENT` carries the per-leaf absent-equivalence
argument main's gap note asks for: `pat` → empty, `vaults.json` → `[]`, `settings.json` →
`{}`, each already what its reader returns for absent.

Hole B is a temp outside the mask, so the fix is to move the temp inside one. All three
state writers now stage in a TOP-LEVEL `md-notebook-staging` directory, masked as a whole DIRECTORY
so every temp name — present, future, and orphaned — is covered, and added to the app's
owned leaves so the backend's own spawn still gets it back.
`atomic_write.refuse_linked_parent` is the existing #4381 guard made public for a stager
that cannot route through `atomic_write` itself; it is not a second implementation.

Four riders, each closing something the above would otherwise open. A leaf is accepted only
as a REGULAR file, judged by `lstat`, both when it already exists and when it wins the
publish race — one check covering a link (a mount resolves its target, so a resolving link
would mask the referent while the lexical name stayed agent-replaceable) and a
FIFO/socket/device node (matches neither `isdir` nor `isfile`, so its mask is skipped in
silence). Clearing the PAT writes an empty file instead of unlinking, keeping the mount
target. And the md-notebook spawn starts with `-I` + `runpy` and an explicit import root, so
`sitecustomize` / `usercustomize` / user-site `.pth` from an agent-writable directory cannot
execute in the one namespace where the PAT is unmasked; that is scoped to this spawn, and the
other module builtins keep the bare `python -m`.

The staging directory is TOP-LEVEL rather than a child of the state dir, for the reason the
sibling `aws-control-staging` leaf already records: a mask covers the leaf, not its ancestors,
so under the agent-writable `workspace/md-notebook` it could be renamed out from under its own
mask. Being a direct child of the data home also means the shared `_materialize_maskable_dirs`
creates it, under its own documented rule.

**A link in the state chain degrades the app, not the host.** Materialisation cannot verify
which directory a write to that name would reach, so the leaf is SKIPPED and the spawn
proceeds. Refusing it would let one optional app's on-disk layout stop every sandboxed process
on the host — an operator who symlinks `workspace/` to another disk would find no agent could
start, over a Notes file they may never have created. Skipping is safe only because it is keyed
off the SAME predicate that withholds the carve-out (`carveout_chain_has_planted_link`, applied
in `app_backend_visible_targets` alongside #8965's foreign-mask filter): while a link is in the
chain the backend cannot write this state at all, so an unmaterialised — and therefore unmasked
— leaf has nothing to expose. The two are never decided separately, and a test pins them
together because separating them reopens exactly the hole this PR closes.

Two further items close the same exposures on paths materialising forward cannot reach.
**Pre-upgrade orphans are swept**: an older writer staged beside the target, so a crash in
that window can leave a PAT-bearing `*.tmp` at a name no mask covers, and exposure B would
otherwise be closed for new installs while an upgraded host kept those bytes readable
forever. Every `*.tmp` DIRECT child of the state dir is such an orphan by construction —
the writers now stage in the top-level staging dir, and note temps live beside their note under
`vaults/<id>/` — so the sweep removes them (regular files only, judged by `lstat`, sparing another spawn's
in-flight ceiling temp), refuses the spawn if one cannot be removed, and logs each removal as
a token-exposure event so the operator knows to rotate. It runs on BOTH launch paths and
across BOTH crew-home spellings, unlike materialising, which is Linux- and live-home-only:
a Seatbelt deny and a live-home stub cannot reach an orphan already on disk under a legacy
home. **A drift gate** pins the fact that this hardening
is md-notebook-literal while `_APP_BACKEND_OWNED_LEAVES` is a generic table: an app joining
it would get its leaves unmasked for its own spawn and silently reopen both holes, neither
visible at runtime, so a test fails until that app either ships its own materialisation and
startup-isolation decision or is added to the coverage table.

## Tests

`test/test_sandbox_md_notebook_carveout.py` (new, POSIX-only by collection):

- `TestTheStagingDirectoryIsMaskedAndCarvedBack` — `md-notebook-staging` is masked in all three tiers and both home spellings, is returned to the backend spawn, is lifted from the launcher's hidden list for it, has no agent-writable ancestor, is named identically by the writer and the mask, and is absent from the precreate table (the two tables must not drift). Also that the sweep runs on BOTH launch paths.
- `TestAbsentStateFilesAreMaterializedSoTheMaskCanMount` — every leaf is created with its absent-equivalent document; those documents read as absent to the backend; existing state is left byte-for-byte alone; an absent data home is not created; and the spawn is REFUSED on a failed publish, a planted intermediate symlink, a resolving leaf symlink, a dangling leaf symlink, a special file at a leaf, and one raced in during the publish window. Plus the legacy sweep: pre-upgrade sibling temps in all three shapes are removed; the state files and vault clones survive; a non-regular `*.tmp` is left alone; an unremovable orphan refuses the spawn; and the sweep refuses to delete through a planted parent link or a linked state directory (the chain guard and the `O_NOFOLLOW` open are each mutation-pinned). Plus: `namespace_argv` materialises before the launcher script is built.
- `TestANewOwnedLeavesAppCannotSilentlySkipMaterialization` — the drift gate: an app added to `_APP_BACKEND_OWNED_LEAVES` without materialisation coverage fails, with the message naming both things it must decide.
- `TestStateWritersStageInsideTheMask` — a crashed publish leaves its temp inside the mask; each writer publishes to its target with no residue; a planted parent link and a planted staging link each refuse the write; and the PAT clear keeps the mount target, asserted both at the writer and through `api_pat`'s clear branch.

`test/test_app_backend.py` — the shipped md-notebook spawn starts isolated (`-I`, `runpy`,
explicit root) while other module builtins keep `-m` and get no carve-out, and a
third-party app wearing the name gets neither.

`docs/system-specs/modules/md-notebook.md` records the state layout (including the staging dir
and `settings.json`, both previously undocumented) and a new Sandbox section.

**Mutation-checked:** every guard was reverted in turn and the owning test asserted to go
red — **27 mutations, 27 caught, 0 survivors**, re-run in full AFTER the rebase onto
`cbdd4a569` rather than before, because the staging leaf moving to the data-home root and the
sweep being hoisted onto both launch paths invalidated the earlier run.

Three of those mutants were only caught because the run exposed a weakness and it was fixed
rather than explained away: a dedicated leaf-link helper turned out to be unreachable
(`lstat` already refuses a link at both the existing-target and race-winner checks) so it was
deleted as dead code; the PAT-clear test called the writer directly and so never pinned
`api_pat`'s branch, which now has a route-level test; and the sweep's returned list was
bookkeeping no caller consumed, so it is now asserted as the operator-visible record of which
credentials were exposed. Stated precisely: the `dir_fd` PINNING of `lstat`/`unlink` is
defence-in-depth against a TOCTOU race and is NOT mutation-pinned — in any non-racing test the
chain guard fires first — while both link guards themselves are.

## Manual verification

N/A — unit coverage sufficient. Both holes are on the sandbox launch path, and the tests
drive the real `_materialize_md_notebook_mask_targets()`, the real writers, and the real
`namespace_argv` / launcher-script builders against a temp data home; the refusals are
asserted by planting the actual on-disk shapes (symlinks, FIFOs, a raced `mkfifo`).

## Related Issues

Context, deliberately NOT closing keywords:

- #8762 — the original defect, already closed by #8794. This PR hardens that fix; it does not re-fix it.
- #8965 — the foreign-mask shadow refusal, merged. Reused via `carveout_shadowed_by_foreign_mask`; the staging spelling this PR adds is filtered by it for free.
- #8797 — retiring the leaf-mask apparatus for a single masked `.state/` directory. That would subsume the staging and leaf-link work here; it needs a migration of live user state and is deliberately not attempted in this PR.
- #8796 — integrity-verified provenance for credential-sensitive spawns, the architecture-level ask extracted from an earlier round of this PR.

## Pattern harvest

Rule candidate: `semgrep`
Pattern: a mask/deny entry naming a path that no materialiser list covers, where the
launcher applies that entry under an existence predicate (`isdir` / `isfile` / `exists`).
Both halves are statically visible — the guarded application and the absent target — and
together they are the whole bug class, so detecting it needs no runtime probe.

Rule candidate: `semgrep`
Pattern: a secret writer opening its temp with `mkstemp(dir=…)` /
`NamedTemporaryFile(dir=…)` pointed at the TARGET's parent, while that parent is covered
by leaf-granular rather than directory-granular masking. The temp name is by construction
outside a leaf mask.

Not generalizable: which empty document is absent-equivalent for a given leaf. That is a
per-reader semantic judgement (`b""` vs `b"[]"` vs `b"{}"` here), so the table carries a
written argument per leaf rather than a lint.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
