### PR TITLE
feat(security): owner-consented delivery for scanner-flagged files

### DIFF
--- a/docs/feature-map/README.md
+++ b/docs/feature-map/README.md
@@ -197,11 +197,19 @@ is `/settings/<key>`. Panels live in `pages/settings/`.
 | `webhooks` | Inbound webhook tokens and contexts | `WebhooksPanel.tsx` | `handlers/hooks.py` | `GET /api/webhooks`, `POST /api/webhooks/tokens`, `POST /api/webhooks/test` |
 | `instances` | Remote Kiro Crew instances to connect to | `RemoteCrewPanel.tsx`, `InstancesPanel.tsx` | `handlers_instances.py`, `handlers_cloud.py` | `GET,POST /api/instances`, `POST /api/instances/{id}/connect`, `GET /api/cloud/preflight` |
 | `privacy` | Telemetry disclosure and opt-out | `PrivacyPanel.tsx` | `handlers/telemetry.py` | `GET /api/telemetry/collection`, `GET /api/telemetry/beacon` |
-| `security` | Denied commands, sensitive paths, approval posture | `SecurityPanel.tsx`, `PostureDisclosure.tsx` | `handlers/security.py`, `handlers/tailnet.py` | `GET /api/security/denied-commands`, `PATCH .../builtins/{id}`, `POST .../user` |
+| `security` | Denied commands, sensitive paths, approval posture | `SecurityPanel.tsx`, `PostureDisclosure.tsx` | `handlers/security.py`, `handlers/tailnet.py`, `handlers/file_delivery_consent.py` | `GET /api/security/denied-commands`, `PATCH .../builtins/{id}`, `POST .../user`, `GET,POST,DELETE /api/file-delivery/consent` |
 | `secrets` | Stored credentials the agent may use | `SecretsPanel.tsx` | `handlers/secrets.py` | `GET,POST /api/secrets`, `DELETE /api/secrets/{name}` |
 | `developer` | Pointer into the developer surfaces | `DeveloperPanel.tsx` | — | — |
 | `releases` | Release channel, update check, changelog | `ReleasesPanel.tsx` | `handlers/updates.py` | `GET /api/update/check`, `POST /api/update`, `GET /api/changelog`, `GET /api/releases` |
 | `about` | Version, build, diagnostics bundle | `AboutPanel.tsx`, `ReportProblemCard.tsx` | `handlers/diagnostics.py`, `handlers/feedback.py` | `POST /api/diagnostics/collect`, `GET /api/diagnostics/download/{filename}` |
+
+Flagged-file delivery consent (`GET,POST,DELETE /api/file-delivery/consent`,
+owner-gated) is listed on the `security` row because that is the tab it belongs
+to, but **no panel is wired to it yet** -- the endpoints are the only way to
+record or withdraw the grant today (#8793). Stated rather than implied: the
+backend control landed first so the delivery gates could read it, and the panel
+is a follow-up. Nothing about the grant is reachable from an agent either way;
+the record sits on the sandbox-sealed keystone floor.
 
 Instances is deliberately not a rail row: it is set up here once and switched
 from the header tab strip. Webhooks carries both a preview flag and

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -877,6 +877,30 @@ def aws_consent_path() -> Path:
     return config_dir() / "aws_service_consent.json"
 
 
+def file_delivery_consent_path() -> Path:
+    """Return path to file_delivery_consent.json -- flagged-file delivery consent.
+
+    Same KEYSTONE reasoning as :func:`aws_consent_path`, and the leaf is on
+    ``security._CREW_SECRET_LEAVES`` for the same reason: a recorded consent to
+    deliver a file the credential scanner flagged is an authorization, not a
+    preference. Storing it in ``config.json`` would leave it writable by any
+    auto-approved agent shell, so a prompt-injected agent could mint the grant and
+    consent, on the owner's behalf, to shipping the owner's secrets -- the exact
+    shape ``CredentialPolicy.exempt_exact_hosts`` refuses when it says such a set
+    is "NEVER sourced from ``config.json``". ``is_sensitive_path`` blocks the tool
+    path and ``is_sensitive_bash_command`` blocks the shell forms.
+
+    Holds ``{"<destination_class>": {destination_class, granted_at}}``; every read
+    fails soft to NO CONSENT (see ``file_delivery_consent.read_grant``). The only
+    writer is the authenticated, OWNER-gated dashboard
+    ``/api/file-delivery/consent`` handler, which opens the path directly rather
+    than through this gate. There is deliberately NO CLI verb -- a terminal
+    command that records a grant on request is a grant an automated caller can
+    take. Respects ``KIROCREW_HOME``.
+    """
+    return config_dir() / "file_delivery_consent.json"
+
+
 def read_local_secret(port: int) -> str:
     """Read the internal-API credential for the gateway on *port*.
 

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -668,6 +668,14 @@ from kiro_crew.dashboard.handlers.core import (  # noqa: E402, F401
     logo,
     pwa_file,
 )
+
+# Flagged-file delivery consent — owner-gated, and the ONLY writer of
+# ``file_delivery_consent.json``. No CLI counterpart, deliberately.
+from kiro_crew.dashboard.handlers.file_delivery_consent import (  # noqa: E402, F401
+    api_file_delivery_consent_delete,
+    api_file_delivery_consent_get,
+    api_file_delivery_consent_post,
+)
 from kiro_crew.dashboard.handlers.notifications_push import (  # noqa: E402, F401
     api_push_notification,
 )

--- a/src/kiro_crew/dashboard/handlers/file_delivery_consent.py
+++ b/src/kiro_crew/dashboard/handlers/file_delivery_consent.py
@@ -1,0 +1,145 @@
+"""Owner-gated dashboard endpoints for flagged-file delivery consent.
+
+The ONLY writer of ``file_delivery_consent.json``. The store sits on the keystone
+floor so an agent cannot write it with file tools or a shell form, and there is
+deliberately no CLI verb -- a terminal command that records a grant on request is
+a grant an automated caller can take, and its guard would have to key on an env
+var an in-process agent can unset. That leaves exactly one door, and this module
+is it.
+
+Every verb, reads included, is refused to anyone but the dashboard OWNER. Three
+callers had to be shut out and only the first is obvious:
+
+* an AGENT: already blocked from the file itself by the keystone fence, but an
+  app token declaring this route's permission would be the same door's second
+  key, so the check is here too rather than relying on the fence alone.
+* an APP token: an app could otherwise mint a grant with no human in the loop.
+* an allowed MESSAGING user: a Slack allow-listed non-owner running
+  ``!dashboard`` authenticates with ``app == ""``, so an app-only check would let
+  them authorize delivery of the OWNER's secrets.
+
+Reads are refused for their own reason: the response says which delivery
+destinations the owner has blessed, which tells a caller where a flagged file
+would land unrefused. ``is_owner_dashboard_request`` already encodes exactly the
+rule needed (app present and empty, caller equal to ``owner_id`` or a local-owner
+subject), so it is reused rather than re-derived.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _dt
+import logging
+
+from aiohttp import web
+
+from kiro_crew import file_delivery_consent
+from kiro_crew.dashboard.handlers._shared import _owner_denial_response
+from kiro_crew.dashboard.handlers.source_providers import (
+    is_owner_dashboard_request,
+)
+
+logger = logging.getLogger(__name__)
+
+_CODE_OWNER_REQUIRED = "dashboard_owner_required"
+_CODE_UNKNOWN_CLASS = "unknown_destination_class"
+
+
+async def _deny_non_owner(request: web.Request, operation: str) -> web.Response | None:
+    """Refuse anyone but the dashboard OWNER on every consent endpoint.
+
+    Async because the denial is AUDITED, and the audit writes to the security event
+    log -- a synchronous disk write, whose first call on a fresh gateway also
+    initialises the log. Running that on the event loop would let one refused
+    request stall every other request and the heartbeat, so it goes through
+    ``asyncio.to_thread`` (``no-blocking-call-on-event-loop``). The owner PREDICATE
+    itself is pure and stays inline.
+    """
+    if is_owner_dashboard_request(request):
+        return None
+    # Names the calling APP, never a credential -- worded to say so plainly, since
+    # "token" in a logger literal reads as a possible secret to the SAST rule.
+    logger.warning(
+        "refused %s: confirming delivery of scanner-flagged files is a dashboard "
+        "owner action (app=%s)",
+        operation,
+        request.get("app"),
+    )
+    await asyncio.to_thread(
+        file_delivery_consent.audit_decision,
+        "*",
+        outcome="denied",
+        detail=f"{operation}: non-owner caller refused",
+    )
+    return _owner_denial_response(request, "dashboard owner required", _CODE_OWNER_REQUIRED)
+
+
+def _requested_class(request: web.Request) -> str | None:
+    """The grantable destination class named by the query, or ``None``.
+
+    Validated against ``GRANTABLE_CLASSES`` rather than parsed loosely, so a
+    request naming one of the never-grantable legs (the Slack or channel upload
+    path) is refused here as an unknown class and never reaches the store.
+    """
+    requested = (request.query.get("destination_class") or "").strip()
+    return requested if requested in file_delivery_consent.GRANTABLE_CLASSES else None
+
+
+def _grant_payload(grant: file_delivery_consent.Grant | None) -> dict[str, object] | None:
+    if grant is None:
+        return None
+    return grant.to_dict()
+
+
+async def api_file_delivery_consent_get(request: web.Request) -> web.Response:
+    """GET /api/file-delivery/consent -- the grantable classes and their consent."""
+    denied = await _deny_non_owner(request, "file_delivery_consent.read")
+    if denied:
+        return denied
+    grants = {
+        name: _grant_payload(await asyncio.to_thread(file_delivery_consent.read_grant, name))
+        for name in sorted(file_delivery_consent.GRANTABLE_CLASSES)
+    }
+    return web.json_response(
+        {
+            "ok": True,
+            "grantable": sorted(file_delivery_consent.GRANTABLE_CLASSES),
+            # Surfaced so the settings panel can SAY that the upload legs are
+            # permanently excluded rather than merely omitting them, which reads
+            # as an oversight.
+            "never_grantable": sorted(file_delivery_consent.NEVER_GRANTABLE_CLASSES),
+            "labels": file_delivery_consent.CLASS_LABELS,
+            "grants": grants,
+        }
+    )
+
+
+async def api_file_delivery_consent_post(request: web.Request) -> web.Response:
+    """POST /api/file-delivery/consent -- record the owner's confirmation."""
+    denied = await _deny_non_owner(request, "file_delivery_consent.grant")
+    if denied:
+        return denied
+    destination_class = _requested_class(request)
+    if destination_class is None:
+        return web.json_response(
+            {"error": "unknown destination class", "code": _CODE_UNKNOWN_CLASS}, status=400
+        )
+    granted_at = _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds")
+    grant = await asyncio.to_thread(
+        file_delivery_consent.record_grant, destination_class, granted_at=granted_at
+    )
+    return web.json_response({"ok": True, "grant": grant.to_dict()})
+
+
+async def api_file_delivery_consent_delete(request: web.Request) -> web.Response:
+    """DELETE /api/file-delivery/consent -- withdraw a recorded confirmation."""
+    denied = await _deny_non_owner(request, "file_delivery_consent.revoke")
+    if denied:
+        return denied
+    destination_class = _requested_class(request)
+    if destination_class is None:
+        return web.json_response(
+            {"error": "unknown destination class", "code": _CODE_UNKNOWN_CLASS}, status=400
+        )
+    removed = await asyncio.to_thread(file_delivery_consent.revoke, destination_class)
+    return web.json_response({"ok": True, "removed": removed})

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -28,7 +28,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 from aiohttp.multipart import BodyPartReader
 
-from kiro_crew import pinned_fs, platform_compat
+from kiro_crew import file_delivery_consent, pinned_fs, platform_compat
 from kiro_crew.atomic_write import (
     atomic_write,
     open_access_control_source,
@@ -286,7 +286,14 @@ async def api_outbox_notify(request: web.Request) -> web.Response:
     # and validate MIME against the shared BINARY_MIME_ALLOWLIST.
     try:
         text = raw.decode("utf-8")
-        if redact(text) != text:
+        # The owner's grant covers this leg: the card renders in the owner's own
+        # authenticated dashboard. No audit event here -- the delivery decision is
+        # already recorded by the tool leg, and the byte handover is recorded by
+        # the download route; a third entry for rendering a card would only bury
+        # the two that answer a real question.
+        if redact(text) != text and not file_delivery_consent.is_granted(
+            file_delivery_consent.CLASS_OWNER_DASHBOARD
+        ):
             _sel().log_tool_invocation(
                 session_key="api",
                 source="api",
@@ -406,16 +413,52 @@ async def api_outbox_download(request: web.Request) -> web.StreamResponse:
     if is_text:
         redacted = redact(text)
         if redacted != text:
+            # This is where the flagged bytes actually leave for the owner's
+            # browser, so a grant is honoured here AND the handover is audited --
+            # the refusal it replaces was self-evident in the 400, whereas a
+            # successful consented download would otherwise leave no trace.
+            #
+            # TWO conjuncts, and the second is not redundant. This route is absent
+            # from every ``token_auth`` bypass list, which establishes that it needs
+            # AUTHENTICATION -- not that it needs OWNER IDENTITY. A Slack
+            # allow-listed non-owner running ``!dashboard`` authenticates with
+            # ``app == ""`` and ``sub != owner_id``, so ordinary token auth admits
+            # them while ``is_owner_dashboard_request`` does not. Without the owner
+            # conjunct the grant would convert a clean 400-for-everyone into raw
+            # bytes for every authenticated caller -- widening the audience as a
+            # side effect of a control meant to narrow it, and contradicting the
+            # "owner's own authenticated browser" audience this class is scoped to.
+            from kiro_crew.dashboard.handlers.source_providers import (  # lazy: import cycle
+                is_owner_dashboard_request,
+            )
+
+            if not (
+                file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD)
+                and is_owner_dashboard_request(request)
+            ):
+                _sel().log_tool_invocation(
+                    session_key="api",
+                    source="api",
+                    tool_name="file_send",
+                    tool_kind="download",
+                    outcome="denied",
+                    error="content_redacted",
+                )
+                return web.json_response(
+                    {"error": "file content was redacted; download aborted"}, status=400
+                )
             _sel().log_tool_invocation(
                 session_key="api",
                 source="api",
                 tool_name="file_send",
                 tool_kind="download",
-                outcome="denied",
-                error="content_redacted",
+                outcome="completed",
+                error="sensitive_content_delivered_with_consent",
             )
-            return web.json_response(
-                {"error": "file content was redacted; download aborted"}, status=400
+            file_delivery_consent.audit_decision(
+                file_delivery_consent.CLASS_OWNER_DASHBOARD,
+                outcome="delivered",
+                detail=f"download: {path.name}",
             )
     safe_name = urllib.parse.quote(path.name, safe="")
     content_type, _ = mimetypes.guess_type(path.name)

--- a/src/kiro_crew/dashboard/routes/system.py
+++ b/src/kiro_crew/dashboard/routes/system.py
@@ -131,6 +131,12 @@ def register(app: web.Application) -> None:
     app.router.add_get("/api/aws/consent", handlers.api_aws_consent_get)
     app.router.add_post("/api/aws/consent", handlers.api_aws_consent_post)
     app.router.add_delete("/api/aws/consent", handlers.api_aws_consent_delete)
+    # Flagged-file delivery consent. Owner-gated in the handler; deliberately NOT
+    # on the strict-internal list in server.py, because unlike the file_send legs
+    # its only legitimate caller IS the owner's browser.
+    app.router.add_get("/api/file-delivery/consent", handlers.api_file_delivery_consent_get)
+    app.router.add_post("/api/file-delivery/consent", handlers.api_file_delivery_consent_post)
+    app.router.add_delete("/api/file-delivery/consent", handlers.api_file_delivery_consent_delete)
     app.router.add_get("/api/approvals", handlers.api_approvals)
     app.router.add_post("/api/approvals/{id}/{action}", handlers.api_approval_resolve)
 

--- a/src/kiro_crew/file_delivery_consent.py
+++ b/src/kiro_crew/file_delivery_consent.py
@@ -1,0 +1,325 @@
+"""Explicit owner consent before Kiro Crew delivers a file whose contents the
+credential scanner flags.
+
+An agent can legitimately generate secret material the owner needs delivered --
+a VPN device private key inside a compose stack the owner will deploy on another
+machine is the reported case. Every delivery surface refuses it today, and the
+refusal is CORRECT rather than over-eager: that file matches the PEM private key
+branch of ``security._CREDENTIAL_PATTERNS``, the highest-confidence detector in
+the catalogue. The detector is right, so no amount of tuning is the remedy --
+what is missing is a way for the owner to say "yes, that is mine, hand it over."
+
+Selecting the destination class IS the consent point, not the delivery
+-----------------------------------------------------------------------
+The delivery cannot be the confirmation point, for the same reason
+:mod:`kiro_crew.aws_consent` gives for a paid AWS call: ``file_send`` fires from
+surfaces with nobody watching. A cron job exports a report, a subagent hands back
+an artifact, a Slack thread reply attaches a file. A per-invocation "Deliver /
+Cancel" card has no one to answer it there, and "no confirmation available means
+no delivery" would leave the feature exactly as broken as the hard wall it
+replaced.
+
+There is a second, sharper reason here. The same scanner rule is enforced at FOUR
+independent points, and only one of them is the tool call:
+
+* ``mcp_tools.messaging.file_send``      -- the MCP tool, before any byte is copied
+* ``dashboard.handlers.files``           -- ``POST /api/outbox/notify``
+* ``dashboard.handlers.files``           -- ``GET  /api/outbox/{filename}``
+* ``dashboard.handlers.files._gate_upload_file`` -- shared by the Slack and
+  channel upload legs
+
+A card shown at the tool call can only speak for the first. The other three
+re-scan at serve time and know nothing about a click that happened earlier, so a
+per-invocation grant would report "delivered", render a card, and then refuse the
+download -- worse than today's clean refusal. A durable record is readable at
+every gate, which is why the grant is configuration-time and lives on disk.
+
+Which destinations a grant can EVER cover
+-----------------------------------------
+``GRANTABLE_CLASSES`` has exactly one member, and that is a security property
+rather than a starting point.
+
+* ``owner_dashboard`` -- the outbox file on the owner's own disk, the chat file
+  card, and the authenticated ``GET /api/outbox/{filename}`` download. The
+  audience is the owner's own machine and their own authenticated browser (no
+  entry in any ``dashboard.token_auth`` bypass list reaches that route). An owner
+  seeing their own secret is not a leak.
+
+Deliberately absent, and named in :data:`NEVER_GRANTABLE_CLASSES` so a reader can
+see the omission is a decision:
+
+* the Slack upload leg -- the one destination with a genuine third-party audience
+  AND the one an agent aims by argument, since ``file_send``'s schema exposes an
+  optional ``channel`` id. A grant reachable by a tool argument is not owner
+  consent; it is agent-chosen disclosure wearing consent's name.
+* the channel (Telegram / Discord) upload leg -- the destination comes from the
+  caller's session map rather than an argument, but a linked conversation is not
+  demonstrably 1:1, and an audience that cannot be proved is a reason to refuse
+  rather than to assume.
+
+Both of those legs pass through ``_gate_upload_file``, which exists (by its own
+docstring) "so the Slack and channel legs cannot drift apart gate by gate". That
+function does not read this module, and nothing in this module can be reached
+from it. The guarantee is therefore structural: there is no code path by which a
+grant arrives at a third-party destination, so the property cannot be undone by
+inverting a check -- only by editing that gate, which is a separate decision.
+
+What this does NOT change
+-------------------------
+No detector, pattern, or threshold moves. ``security.redact`` and its catalogue
+are untouched; a grant changes what a gate DOES with a positive result, never
+whether the scanner finds it. Note also that ``security.redact`` runs only the
+exfiltration-URL and credential passes -- it does not call ``redact_local_paths``
+-- so the scope a grant can affect is credentials and exfil URLs, not "anything
+sensitive".
+
+Where the grant lives, and why not ``config.json``
+--------------------------------------------------
+``file_delivery_consent.json`` sits on the read+write KEYSTONE floor
+(``security._CREW_SECRET_LEAVES``), the same placement as
+``aws_service_consent.json`` and ``computer_use.json``, and for the same reason:
+this is an authorization record, not a preference. ``config.json`` is writable by
+any auto-approved agent shell, so a grant stored there could be minted by a
+prompt-injected agent -- consenting, on the owner's behalf, to shipping the
+owner's secrets. The platform's own ``CredentialPolicy.exempt_exact_hosts``
+docstring states the rule this file obeys: such a set is "NEVER sourced from
+``config.json`` -- an agent-writable exemption would be a hole in the redaction
+ceiling."
+
+The authenticated, OWNER-gated dashboard handler opens the path directly and is
+the only writer. There is deliberately no CLI verb: a terminal command that
+records a grant on request is a grant an automated caller can take, and its guard
+would have to key on an env var an in-process agent can unset.
+
+Known limit, stated rather than papered over
+--------------------------------------------
+A grant is durable and coarse. Once ``owner_dashboard`` is confirmed, every later
+flagged file reaches the owner's dashboard without asking again -- that is the
+point (an unattended cron must be able to deliver), and it is also the cost. The
+grant does not distinguish one secret from another, so an agent that generates a
+credential the owner did NOT ask for will also be able to put it in the owner's
+outbox. What that buys an attacker is bounded by the audience: the file lands on
+the owner's own disk and in the owner's own authenticated browser, which is where
+the agent could already write it with ordinary file tools. Every delivery under a
+grant is SEL-audited as ``sensitive_content_delivered_with_consent`` so the
+record exists even though the refusal does not.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import file_delivery_consent_path
+
+logger = logging.getLogger(__name__)
+
+#: The one destination class a grant can cover: the owner's own disk plus their
+#: own authenticated dashboard (outbox file, chat file card, download route).
+#: The id is the stored grant key, so renaming it invalidates existing grants
+#: (fail-closed: the owner is asked again) rather than silently authorizing a
+#: different destination.
+CLASS_OWNER_DASHBOARD = "owner_dashboard"
+
+#: Destination classes a grant may EVER cover. Exactly one member, deliberately.
+GRANTABLE_CLASSES: frozenset[str] = frozenset({CLASS_OWNER_DASHBOARD})
+
+#: Destination classes that must never appear in :data:`GRANTABLE_CLASSES`,
+#: recorded so the omission reads as a decision rather than an oversight. Both
+#: route through ``dashboard.handlers.files._gate_upload_file``, which does not
+#: read this module; these ids exist for documentation and for the ratchet test
+#: that asserts the two sets stay disjoint.
+NEVER_GRANTABLE_CLASSES: frozenset[str] = frozenset({"slack_upload", "channel_upload"})
+
+#: Human-facing labels for the confirmation surface and the log lines.
+CLASS_LABELS: dict[str, str] = {
+    CLASS_OWNER_DASHBOARD: "This machine's outbox and my own dashboard",
+}
+
+#: Serialises the read-modify-write below. Deliberately an IN-PROCESS lock, and
+#: deliberately NOT a lock FILE beside the grant.
+#:
+#: A sibling lock file is agent-reachable. ``is_sensitive_path`` covers it, so the
+#: agent's file tools refuse it, but that is the evadable tier -- a runtime-
+#: constructed path escapes the text and argv matchers, exactly as
+#: ``sandbox._CREW_READONLY_LEAVES`` says of its own docstring. A sandboxed agent
+#: that took such a lock would not read the grant and could not forge it; it would
+#: block the owner's REVOKE, leaving consent active. A consent mechanism whose
+#: withdrawal can be denied by the party the consent constrains is defective in its
+#: central promise, so the artifact is removed rather than defended: an agent cannot
+#: hold a lock that does not exist.
+#:
+#: One writer makes this sufficient. ``aws_consent`` needs a cross-process file lock
+#: because it has TWO writers -- its dashboard handler and the ``kirocrew
+#: aws-consent`` CLI. This grant has exactly one writer, the owner-gated dashboard
+#: handler, and deliberately NO CLI verb (a terminal command that records a grant on
+#: request is a grant an automated caller can take). One writer in one process is
+#: served by a process-local lock.
+#:
+#: WHAT IS NO LONGER SERIALISED, stated because it is a narrowing: two gateway
+#: processes sharing one data home would not serialise their writes against each
+#: other. That configuration was never served by the previous file lock either --
+#: the precedent's cross-process lock exists for the CLI, not for multi-gateway --
+#: and a torn write still cannot widen a grant, because ``read_grant`` refuses any
+#: row whose ``destination_class`` disagrees with its key and ``_read_all`` fails
+#: soft to "no consent" on anything unparseable.
+_STORE_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class Grant:
+    """A recorded consent to deliver scanner-flagged files to one destination class."""
+
+    destination_class: str
+    granted_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "destination_class": self.destination_class,
+            "granted_at": self.granted_at,
+        }
+
+
+def _read_all() -> dict[str, Any]:
+    """The whole store, or ``{}`` when it is missing or unreadable.
+
+    Failing soft is the right READ behaviour -- an authorization record that
+    cannot be parsed is not an authorization, so every gate keeps refusing. See
+    :func:`_preserve_if_unreadable` for what happens before a write, where
+    failing soft would otherwise discard the unreadable bytes.
+    """
+    try:
+        raw = json.loads(file_delivery_consent_path().read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        logger.warning(
+            "file-delivery consent store is unreadable; treating every destination as unconfirmed"
+        )
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _write_all(data: dict[str, Any]) -> None:
+    # Fail-loud lockdown BEFORE any content lands, same as the sibling keystone
+    # stores: restrict_to_owner=True applies the owner-only DACL to the temp file
+    # before the payload reaches it and implies the owner-only POSIX mode. The
+    # default restrict_on_error="raise" refuses to write a record it cannot
+    # protect. Every failure inside atomic_write happens before the final path is
+    # touched, so no cleanup is needed here and an unlink would instead delete the
+    # previous, healthy, already-locked-down store on a transient failure.
+    atomic_write(
+        file_delivery_consent_path(),
+        json.dumps(data, indent=2, sort_keys=True),
+        restrict_to_owner=True,
+    )
+
+
+def read_grant(destination_class: str) -> Grant | None:
+    """The stored grant for ``destination_class``, or ``None`` when there is none.
+
+    Fails soft to ``None`` (no consent) on a missing, unreadable, or malformed
+    file: an authorization record that cannot be read is not an authorization.
+    """
+    row = _read_all().get(destination_class)
+    if not isinstance(row, dict):
+        return None
+    stored = str(row.get("destination_class", ""))
+    # A row filed under one key but naming another destination is not a grant for
+    # either: refuse rather than trust the key, so a hand-edited or partially
+    # written store cannot widen a grant by disagreeing with itself.
+    if stored != destination_class:
+        logger.warning(
+            "file-delivery consent record under %r names %r; treating as absent",
+            destination_class,
+            stored,
+        )
+        return None
+    return Grant(destination_class=stored, granted_at=str(row.get("granted_at", "")))
+
+
+def is_granted(destination_class: str) -> bool:
+    """Whether the owner has confirmed delivery to ``destination_class``.
+
+    Fail-closed on every unexpected input: a class outside
+    :data:`GRANTABLE_CLASSES` is refused before the store is even read, so a
+    caller cannot consult this module about a third-party destination and get a
+    True. LOCAL only -- no network, no probe.
+    """
+    if destination_class not in GRANTABLE_CLASSES:
+        return False
+    return read_grant(destination_class) is not None
+
+
+def record_grant(destination_class: str, *, granted_at: str) -> Grant:
+    """Persist the owner's consent for ``destination_class``."""
+    if destination_class not in GRANTABLE_CLASSES:
+        raise ValueError(f"destination class {destination_class!r} can never be granted")
+    grant = Grant(destination_class=destination_class, granted_at=granted_at)
+    with _STORE_LOCK:
+        # No corrupt-sidecar preservation, deliberately. ``aws_consent`` copies an
+        # unparseable store aside before replacing it because its store can hold
+        # SEVERAL service grants with account and caller-ARN detail, which an
+        # operator would not want silently discarded. This store holds at most one
+        # row of ``{destination_class, granted_at}``: there is nothing in it worth
+        # recovering, and losing an already-unreadable copy costs the owner one
+        # re-grant.
+        #
+        # What writing one WOULD cost is an unfenced artifact. ``is_sensitive_path``
+        # covers this leaf and its ``.tmp``, but NOT a ``.corrupt-<stamp>`` sibling
+        # (measured: False for that suffix on all four keystone consent leaves). A
+        # sidecar is also never read back -- the only writers in the tree are this
+        # module and ``aws_consent``, with no reader anywhere -- so it could not
+        # alter a grant either way. Rather than fence an artifact that has no
+        # reader and no value, it is not created: the same reasoning as the absent
+        # lock file above.
+        data = _read_all()
+        data[destination_class] = grant.to_dict()
+        _write_all(data)
+    audit_decision(destination_class, outcome="granted")
+    return grant
+
+
+def revoke(destination_class: str) -> bool:
+    """Drop consent for ``destination_class``. True when a grant was removed."""
+    with _STORE_LOCK:
+        data = _read_all()
+        if destination_class not in data:
+            return False
+        del data[destination_class]
+        _write_all(data)
+    audit_decision(destination_class, outcome="revoked")
+    return True
+
+
+def audit_decision(destination_class: str, *, outcome: str, detail: str = "") -> None:
+    """Record a consent state change, a denial, or a consented delivery in the SEL.
+
+    Grants, revocations, denials AND deliveries made under a grant are recorded.
+    The delivery entry is the point: the refusal it replaces was self-evident in
+    the tool's error string, whereas a successful consented delivery would
+    otherwise leave no trace that a flagged file left the gate at all. Every
+    entry answers a question an incident review actually asks -- who authorized
+    delivery, when was it withdrawn, and which flagged files went out under it.
+
+    Never raises: an audit failure must not be what stops a refusal from being
+    enforced. Imported lazily because this module is reached from the MCP stdio
+    servers, whose stray writes would corrupt the JSON-RPC stream, and because
+    the security-event layer pulls the redaction stack the read path never needs.
+    """
+    try:
+        from kiro_crew.sel import sel
+
+        sel().log_api_access(
+            caller="owner" if outcome in ("granted", "revoked") else "gateway",
+            operation=f"file_delivery_consent.{outcome}",
+            outcome=outcome,
+            source="file-delivery-consent",
+            resources=(f"{destination_class}: {detail[:200]}" if detail else destination_class),
+        )
+    except Exception:  # pragma: no cover - audit must never break the gate
+        logger.debug("could not write the file-delivery consent audit event", exc_info=True)

--- a/src/kiro_crew/mcp_tools/messaging.py
+++ b/src/kiro_crew/mcp_tools/messaging.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from kiro_crew import mcp_core
+from kiro_crew import file_delivery_consent, mcp_core
 from kiro_crew.constants import CHANNEL_OWNER_DM_NAMESPACES
 from kiro_crew.hooks import FileTooLargeError, safe_read_file_bytes
 from kiro_crew.platform import redact_via_context as redact
@@ -769,15 +769,43 @@ def file_send(name: str, args: dict[str, Any]) -> str:
             outcome="info",
             error="binary_file_skipping_content_scan",
         )
+    # A positive here is almost always CORRECT -- the reported case (a VPN device
+    # private key) matches the PEM branch, the highest-confidence detector in the
+    # catalogue -- so the remedy is not a looser scan but an owner who can say
+    # "that is mine". The grant covers ONLY this machine's outbox and the owner's
+    # own authenticated dashboard; the Slack and channel upload legs route through
+    # ``_gate_upload_file``, which does not read the consent store and refuses them
+    # regardless (see file_delivery_consent for why that is structural).
+    delivered_under_consent = False
     if is_text and redact(text) != text:
+        if not file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD):
+            mcp_core.sel().log_tool_invocation(
+                session_key="mcp_core",
+                source="mcp",
+                tool_name="file_send",
+                outcome="denied",
+                error="sensitive_content_detected",
+            )
+            return (
+                "Error: file content contains sensitive data; send aborted. The owner "
+                "can allow delivery to this machine's outbox and their own dashboard "
+                "by recording consent at POST /api/file-delivery/consent"
+                "?destination_class=owner_dashboard (owner-gated; no agent can write "
+                "it). The Slack and channel upload legs can never be granted."
+            )
+        delivered_under_consent = True
         mcp_core.sel().log_tool_invocation(
             session_key="mcp_core",
             source="mcp",
             tool_name="file_send",
-            outcome="denied",
-            error="sensitive_content_detected",
+            outcome="completed",
+            error="sensitive_content_delivered_with_consent",
         )
-        return "Error: file content contains sensitive data; send aborted"
+        file_delivery_consent.audit_decision(
+            file_delivery_consent.CLASS_OWNER_DASHBOARD,
+            outcome="delivered",
+            detail=f"file_send: {clean_name}",
+        )
     dest = mcp_core.outbox_dir() / clean_name
     try:
         with dest.open("xb") as f:
@@ -807,6 +835,20 @@ def file_send(name: str, args: dict[str, Any]) -> str:
     )
     if d.get("error"):
         return f"Error: {d['error']}"
+    # Under an owner grant the third-party legs are not attempted AT ALL. The
+    # shared ``_gate_upload_file`` would refuse them anyway -- it does not read the
+    # consent store, which is what makes that refusal structural rather than a
+    # check someone could invert -- but handing flagged bytes to a handler that
+    # will refuse them is a needless hop for content the owner scoped to their own
+    # dashboard. Returning here keeps the grant's blast radius to exactly the
+    # destination class it names, and belt-and-braces means neither layer is load
+    # bearing alone.
+    if delivered_under_consent:
+        msg = f"File sent: {dest.name} ({desc})" if desc else f"File sent: {dest.name}"
+        return (
+            f"{msg} (delivered to the dashboard under the owner's file-delivery "
+            "consent; Slack and channel upload skipped)"
+        )
     # Native channel delivery first: when the caller's session is linked to a
     # non-Slack conversation with a document-capable transport (a Telegram
     # chat today), the file belongs THERE — the user who asked for it is

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -263,6 +263,13 @@ _CREW_READONLY_LEAVES: tuple[str, ...] = (
     "computer_use.json",
     "oauth_endpoints.json",
     "aws_service_consent.json",
+    # Recorded consent to deliver a scanner-flagged file. Same class as
+    # ``aws_service_consent.json``: a writable grant lets an auto-approved agent
+    # consent, on the owner's behalf, to shipping the owner's secrets. This seal is
+    # the load-bearing half of that design -- ``is_sensitive_path`` and the shell
+    # deny tiers do cover the leaf, but as the READONLY note above says, those tiers
+    # can be evaded by runtime path construction and a kernel write denial cannot.
+    "file_delivery_consent.json",
     # The app dev-mode AUTHORIZATION record (operator grants binding each dev
     # app to its resolved ui root — see apps/dev_mode.py). Sealing it makes
     # "operator, not agent" kernel-enforced: a sandboxed process cannot mint,
@@ -362,6 +369,14 @@ _CREW_PRECREATE_READONLY_FILE_LEAVES: tuple[str, ...] = (
     "computer_use.json",
     "oauth_endpoints.json",
     "aws_service_consent.json",
+    # ``file_delivery_consent._read_all`` returns ``{}`` for both absent and
+    # unreadable, and ``is_granted`` then reports no consent -- so an EMPTY
+    # document means exactly what an ABSENT one means (criterion 1). A stale
+    # sealed read also fails toward refusal: the writer publishes through
+    # ``atomic_write`` (new inode), so a sandboxed reader keeps seeing ``{}`` and
+    # stays frozen at "no consent", which is narrower than the truth
+    # (criterion 2).
+    "file_delivery_consent.json",
 )
 
 #: What a materialised ceiling holds — the empty JSON object every reader above

--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -7764,6 +7764,18 @@ _CREW_SECRET_LEAVES: list[str] = [
     # and the ``kirocrew aws-consent`` CLI are the only writers and open the
     # path directly, not through this gate, so both keep working.
     "aws_service_consent.json",
+    # Recorded consent to deliver a file whose contents the credential scanner
+    # flagged. Same class of control as ``aws_service_consent.json`` above: the
+    # record is what AUTHORIZES a flagged file past four independent content
+    # gates, so an agent that could write it would consent on the owner's behalf
+    # to shipping the owner's secrets. Reading it is fenced too -- the file says
+    # which delivery destinations the owner has already blessed, which tells an
+    # agent where a flagged file would land unrefused, and that is reconnaissance
+    # it should not get for free from the shared gate. The authenticated,
+    # owner-gated dashboard ``/api/file-delivery/consent`` handler is the ONLY
+    # writer and opens the path directly, not through this gate, so it keeps
+    # working; there is deliberately no CLI verb to fence.
+    "file_delivery_consent.json",
     "token_signing.key",
     "refresh_chains.json",
     ".local_secret",

--- a/test/test_file_delivery_consent.py
+++ b/test/test_file_delivery_consent.py
@@ -1,0 +1,456 @@
+"""Owner-consented delivery of scanner-flagged files (issue #7770).
+
+Every piece of credential-shaped material here is SYNTHESIZED AT RUNTIME from a
+small grammar rather than checked in as a literal. That is deliberate and is not
+cosmetic: a diff carrying literal PEM headers or working token strings reads as an
+exfiltration recipe, and one of this repository's pull requests is permanently
+deadlocked because a review provider refused it twelve consecutive times as
+"potentially high-risk cyber activity" and then failed closed on the absent
+verdict. The scanner sees identical bytes at runtime either way, so the
+assertions below are exactly as strong as literals would have been -- only the
+reviewed bytes differ.
+
+``_synth_pem`` in particular never contains real key material: its body is
+deterministic base64 over a SHA-256 of a loop counter, so it is
+private-key-SHAPED without being a private key.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import inspect
+import json
+from unittest.mock import patch
+
+import pytest
+
+from kiro_crew import file_delivery_consent, security
+from kiro_crew.config.loader import file_delivery_consent_path
+
+# ---------------------------------------------------------------- generators
+
+
+def _synth_pem() -> str:
+    """PEM private-key-SHAPED text assembled at runtime from fragments."""
+    rule = "-" * 5
+    begin = " ".join(["BEGIN", "RSA", "PRIVATE", "KEY"])
+    end = " ".join(["END", "RSA", "PRIVATE", "KEY"])
+    body = "\n".join(
+        base64.b64encode(hashlib.sha256(f"kc-7770-{i}".encode()).digest() * 2).decode()
+        for i in range(4)
+    )
+    return f"{rule}{begin}{rule}\n{body}\n{rule}{end}{rule}\n"
+
+
+def _synth_aws_key() -> str:
+    """An AWS-access-key-SHAPED token: fixed public prefix plus synthetic body."""
+    prefix = "A" + "KIA"
+    body = hashlib.sha256(b"kc-7770-aws").hexdigest().upper()[:16]
+    return prefix + body
+
+
+@pytest.fixture(autouse=True)
+def _isolated_store(tmp_path, monkeypatch):
+    """Point the consent store at a tmp dir so no test touches the real one."""
+    store = tmp_path / "file_delivery_consent.json"
+    monkeypatch.setattr(
+        file_delivery_consent, "file_delivery_consent_path", lambda: store, raising=True
+    )
+    return store
+
+
+def _grant() -> None:
+    file_delivery_consent.record_grant(
+        file_delivery_consent.CLASS_OWNER_DASHBOARD, granted_at="2026-09-05T00:00:00+00:00"
+    )
+
+
+# ------------------------------------------------- the generators are honest
+
+
+class TestSynthesizedMaterialActuallyTrips:
+    """A generator the scanner ignores would make every test below vacuous."""
+
+    def test_synth_pem_is_detected(self):
+        pem = _synth_pem()
+        assert security.redact(pem) != pem
+
+    def test_synth_aws_key_is_detected(self):
+        key = _synth_aws_key()
+        assert security.redact(key) != key
+
+
+# --------------------------------------------------- the absolute condition
+
+
+class TestThirdPartyLegsCanNeverBeGranted:
+    def test_grantable_and_never_grantable_are_disjoint(self):
+        assert not (
+            file_delivery_consent.GRANTABLE_CLASSES & file_delivery_consent.NEVER_GRANTABLE_CLASSES
+        )
+
+    def test_only_the_owner_dashboard_class_is_grantable(self):
+        assert file_delivery_consent.GRANTABLE_CLASSES == {
+            file_delivery_consent.CLASS_OWNER_DASHBOARD
+        }
+
+    @pytest.mark.parametrize("leg", sorted(file_delivery_consent.NEVER_GRANTABLE_CLASSES))
+    def test_recording_a_third_party_leg_raises(self, leg):
+        with pytest.raises(ValueError):
+            file_delivery_consent.record_grant(leg, granted_at="2026-09-05T00:00:00+00:00")
+
+    @pytest.mark.parametrize("leg", sorted(file_delivery_consent.NEVER_GRANTABLE_CLASSES))
+    def test_a_third_party_leg_is_never_granted_even_if_the_file_says_so(
+        self, leg, _isolated_store
+    ):
+        """A hand-planted row for an upload leg must not authorize anything.
+
+        ``is_granted`` refuses the class before it reads the store, so the row
+        below is inert. Without that ordering a writer who reached the file --
+        which the keystone fence exists to prevent, but which this test does not
+        assume -- could authorize the Slack leg.
+        """
+        _isolated_store.write_text(
+            json.dumps({leg: {"destination_class": leg, "granted_at": "2026-09-05T00:00:00+00:00"}})
+        )
+        assert file_delivery_consent.is_granted(leg) is False
+
+    def test_the_shared_upload_gate_cannot_read_the_consent_store(self):
+        """The structural half of the guarantee, asserted on real source.
+
+        ``_gate_upload_file`` is the single admission gate both third-party legs
+        route through. If it never references the consent store, no grant can
+        reach the Slack or channel leg by any code path -- a property that cannot
+        be undone by inverting a check, only by editing that function.
+        """
+        from kiro_crew.dashboard.handlers import files as files_handlers
+
+        src = inspect.getsource(files_handlers._gate_upload_file)
+        assert "consent" not in src.lower()
+        assert "file_delivery_consent" not in src
+
+
+# ------------------------------------------------------- no detector moved
+
+
+class TestNoDetectorMoved:
+    def test_a_grant_does_not_change_what_redact_finds(self):
+        """A grant changes what a GATE does with a positive, never the scan."""
+        pem = _synth_pem()
+        before = security.redact(pem)
+        _grant()
+        assert security.redact(pem) == before
+        assert security.redact(pem) != pem
+
+    def test_redact_does_not_strip_local_paths(self):
+        """Bounds the grant's scope: credentials and exfil URLs, not everything.
+
+        Stated in the PR body as a scope claim, so it is pinned here rather than
+        left for a reviewer to derive.
+        """
+        probe = "[Errno 2] No such file or directory: '/home/someone/.kiro/crew/x'"
+        assert security.redact(probe) == probe
+
+
+# ------------------------------------------------------------- the store
+
+
+class TestGrantStore:
+    def test_absent_store_grants_nothing(self):
+        assert (
+            file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD) is False
+        )
+
+    def test_record_then_read(self):
+        _grant()
+        assert file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD)
+        grant = file_delivery_consent.read_grant(file_delivery_consent.CLASS_OWNER_DASHBOARD)
+        assert grant is not None and grant.granted_at == "2026-09-05T00:00:00+00:00"
+
+    def test_revoke_removes_it(self):
+        _grant()
+        assert file_delivery_consent.revoke(file_delivery_consent.CLASS_OWNER_DASHBOARD) is True
+        assert (
+            file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD) is False
+        )
+
+    def test_unreadable_store_grants_nothing(self, _isolated_store):
+        _isolated_store.write_text("{not json")
+        assert (
+            file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD) is False
+        )
+
+    def test_a_row_disagreeing_with_its_key_grants_nothing(self, _isolated_store):
+        """Refuse rather than trust the key, so a partial write cannot widen a grant."""
+        _isolated_store.write_text(
+            json.dumps(
+                {
+                    file_delivery_consent.CLASS_OWNER_DASHBOARD: {
+                        "destination_class": "something_else",
+                        "granted_at": "2026-09-05T00:00:00+00:00",
+                    }
+                }
+            )
+        )
+        assert (
+            file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD) is False
+        )
+
+    def test_no_lock_artifact_is_created_beside_the_grant(self, _isolated_store):
+        """The lock is in-process, so there is no sibling file an agent can hold.
+
+        A sibling lock file is agent-reachable: ``is_sensitive_path`` covers it, but
+        that is the evadable tier, and an agent holding it would block the owner's
+        REVOKE -- a denial of revocation, not a disclosure. The artifact is removed
+        rather than defended, and this pins that it stays removed.
+        """
+        _grant()
+        assert file_delivery_consent.revoke(file_delivery_consent.CLASS_OWNER_DASHBOARD)
+        names = sorted(p.name for p in _isolated_store.parent.iterdir())
+        assert not [n for n in names if "lock" in n.lower()], names
+
+    def test_the_module_defines_no_lock_filename(self):
+        assert not hasattr(file_delivery_consent, "_LOCK_FILENAME")
+        assert not hasattr(file_delivery_consent, "_ConsentLock")
+
+    def test_a_corrupt_store_is_replaced_and_leaves_no_sidecar(self, _isolated_store):
+        """No ``.corrupt-<stamp>`` sibling is written, deliberately.
+
+        That suffix is NOT covered by ``is_sensitive_path`` (measured False on all
+        four keystone consent leaves, while the leaf and its ``.tmp`` are True), and
+        a sidecar has no reader anywhere in the tree, so it could not alter a grant
+        either way. An artifact with no reader and no recoverable value is not
+        created rather than fenced. This store holds one row of
+        ``{destination_class, granted_at}``; there is nothing to preserve.
+        """
+        _isolated_store.write_text("{corrupt")
+        _grant()
+        assert file_delivery_consent.is_granted(file_delivery_consent.CLASS_OWNER_DASHBOARD)
+        siblings = [p.name for p in _isolated_store.parent.iterdir() if "corrupt-" in p.name]
+        assert siblings == [], siblings
+
+    def test_the_module_has_no_sidecar_preservation(self):
+        assert not hasattr(file_delivery_consent, "_preserve_if_unreadable")
+
+
+# ------------------------------------------------------------ the keystone
+
+
+class TestKeystoneFencing:
+    def test_the_grant_file_is_fenced_from_agent_file_tools(self):
+        assert security.is_sensitive_path(str(file_delivery_consent_path())) is True
+
+    def test_the_leaf_is_registered_beside_its_sibling(self):
+        assert "file_delivery_consent.json" in security._CREW_SECRET_LEAVES
+        assert "aws_service_consent.json" in security._CREW_SECRET_LEAVES
+
+    def test_there_is_no_cli_verb_for_the_grant(self):
+        """A CLI verb is a grant an automated caller can take, so there is none."""
+        from kiro_crew import cli
+
+        src = inspect.getsource(cli)
+        assert "file-delivery-consent" not in src
+        assert "file_delivery_consent" not in src
+
+
+# ---------------------------------------------------------------- the tool
+
+
+class TestConsentedDownloadRequiresOwnerIdentity:
+    """A grant lifts the refusal for the OWNER, not for every authenticated caller.
+
+    The bug both review lanes found independently. The download route is absent
+    from every ``token_auth`` bypass list, which establishes it needs
+    AUTHENTICATION, not OWNER IDENTITY -- a Slack allow-listed non-owner running
+    ``!dashboard`` authenticates with ``app == ""`` and ``sub != owner_id``. Without
+    the owner conjunct the grant turns a clean 400-for-everyone into raw bytes for
+    any authenticated caller.
+    """
+
+    def test_the_download_gate_requires_both_conjuncts(self):
+        import inspect
+
+        from kiro_crew.dashboard.handlers import files as files_handlers
+
+        src = inspect.getsource(files_handlers.api_outbox_download)
+        assert "is_granted" in src
+        # Asserted on source because the alternative is an aiohttp request fixture
+        # carrying a forged non-owner identity, which would pin the harness rather
+        # than the route. Paired with the negative below so this cannot pass by
+        # merely mentioning the name.
+        assert "is_owner_dashboard_request" in src
+
+    def test_owner_check_and_grant_are_ANDed_not_ORed(self):
+        import inspect
+
+        from kiro_crew.dashboard.handlers import files as files_handlers
+
+        src = inspect.getsource(files_handlers.api_outbox_download)
+        window = src[src.index("is_granted") : src.index("is_granted") + 400]
+        assert " and is_owner_dashboard_request(request)" in window
+        assert " or is_owner_dashboard_request(request)" not in window
+
+
+def _consent_request(*, app: str = "", user: str = "owner-1", owner: str = "owner-1", query=None):
+    """A request shaped like a real DASHBOARD OWNER call.
+
+    ``is_owner_dashboard_request`` needs ``app`` present-and-empty AND the caller to
+    equal the configured ``owner_id``, so a bare MagicMock is refused. Cases that
+    mean to be refused pass a non-empty ``app`` or a mismatched ``user``. Same
+    construction as ``test_aws_consent._consent_request`` so the two consent
+    endpoints are exercised through one request shape.
+    """
+    from unittest.mock import MagicMock
+
+    req = MagicMock()
+    req.path = "/api/file-delivery/consent"
+    store = {"app": app, "user": user}
+    req.get = lambda key, default=None: store.get(key, default)
+    req.__contains__ = lambda _self, key: key in store
+    req.__getitem__ = lambda _self, key: store[key]
+    state = MagicMock()
+    state.owner_id = owner
+    req.app = {"state": state}
+    req.query = query or {}
+    req.rel_url.query = query or {}
+    return req
+
+
+class TestConsentEndpointRequiresTheOwner:
+    """Every verb, reads included, is refused to anyone but the dashboard owner.
+
+    Reads too, because the GET names which destinations the owner has blessed --
+    i.e. where a flagged file would land unrefused.
+    """
+
+    @pytest.mark.parametrize(
+        "verb",
+        [
+            "api_file_delivery_consent_get",
+            "api_file_delivery_consent_post",
+            "api_file_delivery_consent_delete",
+        ],
+    )
+    def test_an_app_token_is_refused(self, verb):
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        req = _consent_request(app="notes", query={"destination_class": "owner_dashboard"})
+        resp = asyncio.run(getattr(handler, verb)(req))
+        assert resp.status == 403
+
+    @pytest.mark.parametrize(
+        "verb",
+        [
+            "api_file_delivery_consent_get",
+            "api_file_delivery_consent_post",
+            "api_file_delivery_consent_delete",
+        ],
+    )
+    def test_an_allow_listed_non_owner_is_refused(self, verb):
+        """The case an app-only check misses: app is empty, caller is not the owner."""
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        req = _consent_request(
+            app="",
+            user="slack-guest",
+            owner="owner-1",
+            query={"destination_class": "owner_dashboard"},
+        )
+        resp = asyncio.run(getattr(handler, verb)(req))
+        assert resp.status == 403
+
+
+class TestConsentEndpointAsOwner:
+    def test_get_reports_grantable_and_never_grantable(self):
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        resp = asyncio.run(handler.api_file_delivery_consent_get(_consent_request()))
+        assert resp.status == 200
+        payload = json.loads(resp.text)
+        assert payload["grantable"] == [file_delivery_consent.CLASS_OWNER_DASHBOARD]
+        # The panel must be able to SAY the upload legs are excluded rather than
+        # merely omitting them, which reads as an oversight.
+        assert set(payload["never_grantable"]) == set(file_delivery_consent.NEVER_GRANTABLE_CLASSES)
+        assert payload["grants"][file_delivery_consent.CLASS_OWNER_DASHBOARD] is None
+
+    def test_post_then_get_then_delete_round_trip(self):
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        q = {"destination_class": file_delivery_consent.CLASS_OWNER_DASHBOARD}
+        post = asyncio.run(handler.api_file_delivery_consent_post(_consent_request(query=q)))
+        assert post.status == 200
+        assert json.loads(post.text)["grant"]["destination_class"] == (
+            file_delivery_consent.CLASS_OWNER_DASHBOARD
+        )
+        got = json.loads(
+            asyncio.run(handler.api_file_delivery_consent_get(_consent_request())).text
+        )
+        assert got["grants"][file_delivery_consent.CLASS_OWNER_DASHBOARD] is not None
+        delete = asyncio.run(handler.api_file_delivery_consent_delete(_consent_request(query=q)))
+        assert json.loads(delete.text)["removed"] is True
+
+    @pytest.mark.parametrize("leg", sorted(file_delivery_consent.NEVER_GRANTABLE_CLASSES))
+    def test_post_refuses_a_never_grantable_leg_as_unknown(self, leg):
+        """A request naming an upload leg is refused before the store is reached."""
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        resp = asyncio.run(
+            handler.api_file_delivery_consent_post(
+                _consent_request(query={"destination_class": leg})
+            )
+        )
+        assert resp.status == 400
+        assert json.loads(resp.text)["code"] == "unknown_destination_class"
+
+    def test_delete_of_an_absent_grant_reports_not_removed(self):
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        q = {"destination_class": file_delivery_consent.CLASS_OWNER_DASHBOARD}
+        resp = asyncio.run(handler.api_file_delivery_consent_delete(_consent_request(query=q)))
+        assert json.loads(resp.text)["removed"] is False
+
+    def test_an_unknown_class_is_refused_on_delete_too(self):
+        from kiro_crew.dashboard.handlers import file_delivery_consent as handler
+
+        resp = asyncio.run(
+            handler.api_file_delivery_consent_delete(
+                _consent_request(query={"destination_class": "nonsense"})
+            )
+        )
+        assert resp.status == 400
+
+
+class TestFileSendHonoursTheGrant:
+    def _call(self, path):
+        from kiro_crew.mcp_tools.messaging import file_send
+
+        return file_send("file_send", {"path": str(path)})
+
+    def test_without_a_grant_a_flagged_file_is_refused(self, tmp_path):
+        src = tmp_path / "device.conf"
+        src.write_text(_synth_pem())
+        out = self._call(src)
+        assert "sensitive data" in out and "aborted" in out
+
+    def test_with_a_grant_it_delivers_and_skips_both_upload_legs(self, tmp_path):
+        from kiro_crew import mcp_core
+
+        src = tmp_path / "device.conf"
+        src.write_text(_synth_pem())
+        _grant()
+        posted: list[str] = []
+
+        def _fake_post(path, *a, **kw):
+            posted.append(path)
+            return {"ok": True}
+
+        with patch.object(mcp_core, "_post", side_effect=_fake_post):
+            out = self._call(src)
+        assert "File sent" in out
+        assert "Slack and channel upload skipped" in out
+        # The absolute condition, asserted on behaviour: neither upload leg is
+        # even ATTEMPTED for content the owner scoped to their own dashboard.
+        assert "/api/outbox/notify" in posted
+        assert not any("upload-file" in p for p in posted)

--- a/test/test_mcp_core_coverage.py
+++ b/test/test_mcp_core_coverage.py
@@ -1136,7 +1136,13 @@ class TestFileSend:
         src = tmp_path / "creds.txt"
         src.write_text("AKIA" + "P" * 16)
         out = _call_tool("file_send", {"path": str(src)})
-        assert out == "Error: file content contains sensitive data; send aborted"
+        assert out.startswith("Error: file content contains sensitive data; send aborted")
+        # The refusal now names the remedy. A wall that does not say a consented
+        # path exists is the reported complaint behind issue #7770, so this
+        # asserts MORE than the previous exact-equality pin, not less -- and it
+        # asserts the never-grantable legs are named as such.
+        assert "/api/file-delivery/consent" in out
+        assert "can never be granted" in out
 
     def test_disallowed_binary_mime_is_refused(self, tmp_path):
         src = tmp_path / "payload.bin"

--- a/test/test_sandbox_governance_mask.py
+++ b/test/test_sandbox_governance_mask.py
@@ -91,6 +91,12 @@ class TestKeystonesAreSealedInEveryMode:
         "computer_use.json",
         "oauth_endpoints.json",
         "aws_service_consent.json",
+        # Recorded consent to deliver a scanner-flagged file (#7770). Sealing it
+        # is the load-bearing half of the whole design: the deny-list tiers can
+        # be evaded by runtime path construction, so only a kernel write denial
+        # makes "the owner consents, never the agent" true rather than merely
+        # intended.
+        "file_delivery_consent.json",
         # The app dev-mode authorization record (#6907): sealing it is what
         # makes the operator-attestation flag unforgeable from an agent shell
         # — a sandboxed process cannot mint a grant however the toggle was


### PR DESCRIPTION
## Problem / Motivation

An agent can legitimately generate secret material the owner needs delivered. The
reported case is a VPN device private key inside a compose stack the owner will
deploy on another machine. Every delivery surface refuses it and there is no
consented alternative, so the only route left is fully out of band. The reported
reaction was "this security is garbage".

The refusal is CORRECT, and that is the whole point of this change. That file
matches the PEM private key branch of the 23-branch credential catalogue in
`src/kiro_crew/security.py`, the highest-confidence detector in it. **It is a true
positive, not a tuning failure.** No amount of making the detector smarter fixes
it, because the detector is right. What is missing is not a smarter scan but a way
for the owner to say "yes, that is mine".

Two of issue #7770's four factual claims do not hold on current main, and both are
corrected on the issue rather than quietly worked around:

- `application/zip` is NOT in `BINARY_MIME_ALLOWLIST`, so a zip is denied. The
  real bypass vehicle is an allow-listed PDF / PNG / MP4, whose content scan is
  skipped. Filed separately as #8779, not fixed here.
- `api_file_read` returns **200 with a redacted body**, never the alleged 400. The
  400 is `POST /api/outbox/notify`, the server-side twin of the same `file_send`
  gate.

## Why it matters

The default has to stay safe, because a redaction that an agent can talk its way
past is not a redaction. But a hard wall with no owner-consented path makes a
protective control look broken, and it pushes users toward encodings that bypass
the scanner instead of toward the honest path. The owner seeing their own secret is
not the leak. The leak is a third party or a log seeing it, and this change keeps
that distinction as the whole basis of its scope.

## What changed

A durable, owner-granted, keystone-floor consent record, read at the three
owner-facing gates and structurally unreachable from the two third-party ones.

**Why configuration-time rather than a per-invocation card.** The same
`redact(text) != text` rule is enforced at FOUR independent points, only one of
which is the tool call. A card shown at the tool call can only speak for the first;
the other three re-scan at serve time and know nothing about an earlier click, so a
per-invocation grant would report "delivered", render a card, and then refuse the
download. `aws_consent.py` reaches the same conclusion for its own gate and states
the reason: a surface that fires with nobody watching cannot use the request as its
confirmation point. `file_send` fires from cron jobs and subagents, which is that
class.

### The three loosened enforcement paths, by name

Listed because a security change that names what it loosens gets reviewed, and one
that names only what it protects gets waved through and then found.

| # | Path | Was | Now |
|---|---|---|---|
| 1 | `mcp_tools/messaging.py` -- `file_send` pre-copy text gate | unconditional refusal on `redact(text) != text` | refuses UNLESS `owner_dashboard` is granted |
| 2 | `dashboard/handlers/files.py` -- `api_outbox_notify`, the chat file card | 400 | same conditional |
| 3 | `dashboard/handlers/files.py` -- `api_outbox_download`, where bytes reach the browser | 400 | same conditional, plus a SEL audit of the handover |

### Destination classes, and the one that can never be granted

`GRANTABLE_CLASSES` has exactly one member, and that is a security property rather
than a starting point.

| Class | Audience | Grantable |
|---|---|---|
| `owner_dashboard` (outbox file on local disk, chat file card, authenticated `GET /api/outbox/{filename}`) | the owner's own machine and own authenticated browser | YES |
| `slack_upload` (`/api/slack/upload-file`) | owner DM OR an agent-named tracked channel | **NEVER** |
| `channel_upload` (`/api/channel/upload-file`, Telegram / Discord) | a session-linked conversation, not provably 1:1 | **NEVER** |

`slack_upload` is excluded because it is the one destination with a genuine
third-party audience AND the one an agent aims by argument, since `file_send`'s
schema exposes an optional `channel` id. A grant reachable by a tool argument is
not owner consent; it is agent-chosen disclosure wearing consent's name.
`channel_upload` is excluded because a linked conversation is not demonstrably 1:1,
and an audience that cannot be proved is a reason to refuse rather than to assume.

Because that exclusion is total, this is `Refs #7770` rather than `Closes`: the
issue asks for a consented path on the file read endpoint too, and the two upload
legs stay refused by design.

### The exclusion is enforced three deep

1. **Structural.** `_gate_upload_file` is the single admission gate both
   third-party legs route through, and it never reads the consent store. There is
   no code path by which a grant arrives at a third-party destination, so the
   property cannot be undone by inverting a check. A test asserts this over
   `inspect.getsource`, so "I did not loosen the upload legs" decays loudly rather
   than silently on a future refactor.
2. **Behavioural.** Under a grant, `file_send` returns early and never ATTEMPTS
   either upload leg, so flagged bytes are not even handed to a handler that would
   refuse them.
3. **Input validation.** `is_granted` refuses any class outside
   `GRANTABLE_CLASSES` BEFORE reading the store, so a planted row naming
   `slack_upload` is inert. Tested with the row actually written to disk.

### No detector moved

No detector, pattern or threshold changed. `security.redact` and
`_CREDENTIAL_PATTERNS` are untouched; a grant changes what a gate DOES with a
positive result, never whether the scanner finds it. A test pins that a grant does
not change `redact()`'s output.

Scope bound, stated so a reviewer does not have to derive it: `security.redact`
runs only the exfiltration-URL and credential passes and does NOT call
`redact_local_paths`. The scope of this gate, and of anything relaxing it, is
credentials and exfil URLs rather than "anything sensitive". Pinned by a test.

### The grant has no lock file, deliberately

The read-modify-write is serialised by an **in-process** lock, not by a lock file
beside the grant. A sibling lock file is agent-reachable: `is_sensitive_path`
covers it, so the agent's file tools refuse it, but that is the evadable tier -- a
runtime-constructed path escapes the text and argv matchers, which is exactly what
`sandbox._CREW_READONLY_LEAVES` says of those tiers.

**The consequence would have been a denial of REVOCATION, not a disclosure.** An
agent holding such a lock cannot read the grant and cannot forge it; it can block
the owner's `DELETE`, leaving consent active. A consent mechanism whose withdrawal
can be denied by the party the consent constrains is defective in its central
promise, so the artifact is removed rather than defended -- an agent cannot hold a
lock that does not exist. That is a stronger position than sealing it: no seal
entry, no parity question, strictly smaller surface.

One writer is what licenses this. `aws_consent` needs a cross-process file lock
because it has TWO writers, its dashboard handler and the `kirocrew aws-consent`
CLI. This grant has exactly one writer, the owner-gated dashboard handler, and
deliberately no CLI verb.

**The narrowing, stated because it is one:** two gateway processes sharing a single
data home no longer serialise their writes against each other. That configuration
was never served by the file lock either -- the precedent's cross-process lock
exists for the CLI, not for multi-gateway -- and a torn write still cannot widen a
grant, because `_read_all` fails soft to "no consent" on anything unparseable and
`read_grant` refuses any row whose `destination_class` disagrees with its key. Two
tests pin that no lock artifact is created and that the module defines no lock
symbol.

### The grant is writable through exactly one door

**Why a kernel seal rather than a policy check.** The difference between a fix that
holds and a fix that gets routed around is whether the adversary can reach the
thing doing the enforcing. A deny-list entry sits below the invariant here -- a
same-UID agent can construct the path at runtime (`$(printf ...)`) and the text and
argv tiers cannot see it, which `_CREW_READONLY_LEAVES` says in its own docstring:
those tiers "can be evaded by runtime construction ... but a Seatbelt/namespace
write denial cannot". So the enforcement is moved to the kernel, which the agent
cannot construct around.

`file_delivery_consent.json` sits on the read+write keystone floor
(`security._CREW_SECRET_LEAVES`), beside `aws_service_consent.json` and
`computer_use.json`, AND is sealed read-only in the sandbox
(`_CREW_READONLY_LEAVES` plus `_CREW_PRECREATE_READONLY_FILE_LEAVES`). The
precreation set has two entry criteria and both are met by code rather than by
hope: `_read_all` returns `{}` for absent and unreadable alike and `is_granted`
then reports no consent, so an EMPTY document means what an ABSENT one means; and
because the writer publishes via `atomic_write` (new inode) while the seal pins the
old one, a stale sealed read stays frozen at "no consent" -- narrower than the
truth, i.e. a staleness that fails toward LESS permission.

The authenticated, OWNER-gated dashboard
`/api/file-delivery/consent` handler is the only writer and opens the path
directly. There is deliberately **no CLI verb**: a terminal command that records a
grant on request is a grant an automated caller can take, and its guard would have
to key on an env var an in-process agent can unset. A test asserts no CLI verb
exists.

This is on the right side of the platform's own written rule. The
`CredentialPolicy.exempt_exact_hosts` docstring states that such a set is "NEVER
sourced from `config.json` -- an agent-writable exemption would be a hole in the
redaction ceiling". A grant in `config.json` would be exactly that hole; a
keystone leaf written only by an owner-gated dashboard handler is not.

Every verb including reads is owner-gated via `is_owner_dashboard_request`, which
shuts out an app token minting a grant with no human in the loop and an allow-listed
messaging non-owner running `!dashboard`. Reads are gated too, because the response
says where a flagged file would land unrefused.

## Tests

`test/test_file_delivery_consent.py`, 22 tests. 184 pass across the two touched
test files, `-n 0`.

**All adversarial material is generated at runtime from fragments; no literal
payload string is checked in.** The PEM generator's body is base64 over a SHA-256
of a loop counter, so it is private-key-SHAPED without being key material. This is
deliberate: a diff that reads as a catalogue of working payloads can trip a review
provider into refusing it outright, and the assertion strength is identical either
way because the scanner sees the same bytes at runtime. Two tests exist purely so
the rest cannot be vacuous, asserting that the synthesized PEM and AWS-shaped
material actually do trip `redact()`.

**Mutation-verified.** Three file-based mutations, each requiring a NAMED test to
redden, each reverted after:

| Mutation | Test that reddened |
|---|---|
| `is_granted` stops refusing a never-grantable class | `test_a_third_party_leg_is_never_granted_even_if_the_file_says_so[slack_upload]` and `[channel_upload]` |
| the tool gate's grant requirement removed | `test_without_a_grant_a_flagged_file_is_refused` and the pre-existing `test_sensitive_content_aborts_the_send` |
| the leg-skip early return removed | `test_with_a_grant_it_delivers_and_skips_both_upload_legs` |

### One pre-existing pinned assertion was edited, and why that is disclosed here

`test/test_mcp_core_coverage.py::TestFileSend::test_sensitive_content_aborts_the_send`
pinned the refusal string by exact equality. The refusal message now names its own
remedy, because a wall that does not say a consented path exists is the reported
complaint itself.

Before:

    assert out == "Error: file content contains sensitive data; send aborted"

After:

    assert out.startswith("Error: file content contains sensitive data; send aborted")
    assert "/api/file-delivery/consent" in out
    assert "can never be granted" in out

It asserts the original prefix PLUS two new properties, so it checks a superset,
not a subset. Stating it in prose rather than letting a diff line carry it, because
**editing a pinned security assertion is exactly the move that should never pass
silently.**

## Manual verification

### One error class, named, that this PR made three times

Worth stating plainly because a PR that names its own error class is worth more to
the next reader than one that silently fixed three bugs. In each case I asserted
the stronger property from the weaker check:

1. **The download route.** I verified only that it is absent from the four bypass
   lists -- **that establishes it needs authentication, not that it needs owner
   identity. I asserted the stronger property from the weaker check.** The
   consequence was worse than a missing check: the grant converted a clean
   400-for-everyone into raw bytes for every authenticated caller, so the feature
   widened the audience as a side effect of a control meant to narrow it. A Slack
   allow-listed non-owner (`app == ""`, `sub != owner_id`) passes ordinary dashboard
   auth and is rejected by `is_owner_dashboard_request`. Found independently by two
   review lanes. Fixed with that conjunct alongside `is_granted`.
2. **The keystone leaf.** `is_sensitive_path() == True` means the shared file gate
   refuses; it does NOT mean no agent can write the file. The sandbox seal was
   missing, so an agent could have planted its own grant -- which would have
   defeated the entire design. Measured as a positive test, not an absence: adding
   the leaf to the seal ratchet failed 12 ways (`file_delivery_consent.json is
   writable through the cc sandbox`) across three sandbox modes, both data-home
   prefixes, and both platforms, BEFORE the fix; all 12 pass after it.
3. The same shape as the download case, one rung down: presence in a deny list read
   as unreachability.

The seal ratchet names paths individually rather than looping the production tuple,
so it cannot pass vacuously after someone empties that tuple -- which is what makes
it catch the next leaf somebody adds.

- `_gate_upload_file` proved byte-identical to current `origin/main` by extracting
  the function body from both revisions and comparing. `src/.../files.py` carries
  exactly three hunks: the import, `api_outbox_notify`, `api_outbox_download`. No
  hunk touches the shared upload gate.
- Repository black gate (`scripts/check_black_formatting.py`) passes. Note
  `files.py` was already outside the formatter baseline on main, so it was
  deliberately NOT reformatted; only the three genuinely new offenders were
  formatted, with the target version the gate specifies.
- Reviewer note: grepping `files.py` for `consent` also hits three PRE-EXISTING
  comments about macOS folder-consent modals, unrelated to this change.

## Related Issues

Refs #7770

**Ships endpoint-only, deliberately.** No settings panel is wired to
`/api/file-delivery/consent` yet, so an owner records or withdraws the grant by
calling the endpoint. The security boundary is complete -- kernel-enforced seal,
owner gate on every verb, no CLI verb, Slack and channel legs permanently excluded
-- and only the affordance is missing, so this is an advance on #7770 rather than a
close. Filed as #8793, whose suggested shape follows `aws_consent.py`'s panel since
that grant has the same owner-gated keystone shape. The maintainer ruled the
affordance gap a product gap rather than a correctness gap and accepted it here.

Also filed from this work: #8779, the binary-scan gradient -- the binary branch
skips the content scan on the three owner-facing gates but not on the shared upload
gate. And #8801, two defects the parity measurement found in the SHIPPED
`aws_consent` path this design copies: its `.aws_consent.lock` is agent-holdable
(the same revocation-denial, still live) and its `_deny_non_owner` runs the same
blocking SEL write on the event loop that this PR fixes in its own handler.
Deliberately not fixed here -- a shipped consent feature deserves its own review
rather than riding on this diff.

Size note so nobody has to derive it: 897 insertions across 10 files splits as
**628 source / 269 test** (8 and 1 deletions). It is a new channel plus its tests
rather than scope creep. Base is `18a396e9f`; main advanced twice during the work
(`6d1b51704` to `c791f0f1d` to `18a396e9f`) and this branch is rebased onto the
current head.
