### PR TITLE
perf(dev-fleet): reuse active pod snapshot

### DIFF
--- a/docs/system-specs/modules/dev-fleet.md
+++ b/docs/system-specs/modules/dev-fleet.md
@@ -256,7 +256,8 @@ it as hung clicks again or reloads mid-scan.
 
 Relies on `kiro_crew.pod` subpackage (optional import — degrades gracefully if unavailable):
 
-- `runtime.active_names(cfg)` — systemctl list (blocking, offloaded via `run_in_executor`)
+- `runtime.active_names(cfg)` — one point-in-time systemctl/launchctl listing per fleet build
+  (blocking, offloaded via `run_in_executor`), shared by every worktree row
 - `runtime.derive_port(cfg, name)` — cksum-based port derivation (blocking, offloaded)
 - `runtime.health(cfg, name, port, timeout)` — identity-gated HTTP probe (blocking,
   offloaded). Takes the pod's NAME, not just its port, because a derived port is

--- a/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
@@ -947,6 +947,17 @@ async def _build_fleet() -> dict:
     staged_path = live._staged_target()
     worktrees = await repository._discover_worktrees()
     cfg = runtime._load_cfg()
+    loop = asyncio.get_running_loop()
+    active_pod_names: set[str] = set()
+    if runtime._POD_AVAILABLE and cfg and any(not wt.get("is_main", False) for wt in worktrees):
+        try:
+            # One point-in-time service-manager snapshot keeps every row
+            # consistent and avoids repeating the same subprocess per worktree.
+            active_pod_names = await loop.run_in_executor(
+                subprocess_executor(), runtime.rt.active_names, cfg
+            )
+        except Exception:  # noqa: BLE001
+            pass
     legacy_prefixes = tuple(
         f"{r.split('/')[-1].lower()}-wt-" for r in (repository._FALLBACK_REPOS or [])
     )
@@ -965,7 +976,6 @@ async def _build_fleet() -> dict:
         health = None
         has_venv = False
         has_dist = False
-        loop = asyncio.get_running_loop()
         # Build state is a plain filesystem check (``.venv`` binary present /
         # ``static/dist`` directory present) and is therefore knowable on EVERY
         # platform — report it even where pods cannot run, so the Fleet view
@@ -986,12 +996,9 @@ async def _build_fleet() -> dict:
                 pass
         # Pod state, by contrast, only exists where pods can run.
         if runtime._POD_AVAILABLE and cfg and not is_main:
-            try:
-                active = await loop.run_in_executor(
-                    subprocess_executor(), runtime.rt.active_names, cfg
-                )
-                running = name in active
-                if running:
+            running = name in active_pod_names
+            if running:
+                try:
                     port = await loop.run_in_executor(
                         subprocess_executor(), runtime.rt.derive_port, cfg, name
                     )
@@ -1005,8 +1012,8 @@ async def _build_fleet() -> dict:
                     health = await loop.run_in_executor(
                         subprocess_executor(), runtime.rt.health, cfg, name, port, 2
                     )
-            except Exception:  # noqa: BLE001
-                pass
+                except Exception:  # noqa: BLE001
+                    pass
 
         ahead = await repository._git_ahead(path)
         # "shipped" drives the UI's "safe to remove" affordance — require a

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -6454,6 +6454,30 @@ async def test_fleet_pod_health_is_identity_gated_not_a_bare_port_probe():
 
 
 @pytest.mark.asyncio
+async def test_fleet_enumerates_active_pods_once_for_all_worktrees():
+    """Fleet polling must not run one full service-manager query per row."""
+    active_names = MagicMock(return_value=set())
+    fake_cfg = SimpleNamespace()
+    worktrees = [
+        {"path": "/repo", "branch": "main", "is_main": True},
+        *[
+            {"path": f"/repo-wt-{idx}", "branch": f"feat/{idx}", "is_main": False}
+            for idx in range(4)
+        ],
+    ]
+    with patch.object(runtime_mod.rt, "active_names", active_names):
+        fleet = await _fleet_with(
+            worktrees,
+            _POD_AVAILABLE=True,
+            _POD_IMPORTED=True,
+            _load_cfg=lambda: fake_cfg,
+        )
+
+    active_names.assert_called_once_with(fake_cfg)
+    assert all(not row["running"] for row in fleet["worktrees"])
+
+
+@pytest.mark.asyncio
 async def test_fleet_payload_marks_an_inferred_main_checkout():
     with patch.object(repository_mod, "MAIN_REPO_INFERRED", True):
         fleet = await _fleet_with(


### PR DESCRIPTION
## Problem / Motivation

Every Dev Fleet fleet rebuild enumerates the fleet-wide active-pod set once per non-main worktree. Five worktrees produce five complete service-manager queries even though every row asks the same question.

## Why it matters

The dashboard polls every 12 seconds while the backend cache expires after 10 seconds. On Linux each repeated lookup runs `systemctl list-units`; on macOS it runs `launchctl print` and per-label liveness checks. Large fleets therefore multiply subprocess work on nearly every visible poll, and rows in one response can observe different pod snapshots.

## What changed (motivation → approach → change)

`_build_fleet()` now captures one point-in-time active-pod set before projecting worktree rows. Each row performs an in-memory membership check against that shared set, while running pods retain their existing per-row port and identity-gated health probes.

Enumeration remains best-effort: a service-manager failure degrades to no active rows rather than failing the fleet response. Main checkout pod semantics are unchanged. The Dev Fleet system specification now records the one-snapshot-per-build contract.

## Tests

- Added `test_fleet_enumerates_active_pods_once_for_all_worktrees`, which uses four feature worktrees plus main and asserts exactly one `active_names(cfg)` call.
- Re-ran the adjacent identity-gated health projection test.
- Focused result: 2 passed, 419 deselected.
- `flake8`, `mypy`, brand-name checks, and `docs-lint` pass.

## Manual verification

Instrumented the pre-fix path on `main`: five non-main worktrees caused five active-pod enumerations. The fixed regression proves enumeration count remains one as row count grows.

## Related Issues

Fixes #8782

## Pattern harvest

Rule candidate: review-prompt
Pattern: Hoist fleet-wide subprocess queries out of per-row projection loops and reuse one point-in-time snapshot.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated where the behavior contract changed
- [x] No secrets, credentials, or internal references in the diff
