### PR TITLE
fix(pins): scope query unpin by origin

### DIFF
--- a/src/kiro_crew/dashboard/chat_pins.py
+++ b/src/kiro_crew/dashboard/chat_pins.py
@@ -324,39 +324,39 @@ async def api_chat_pins_delete_by_query(request: web.Request) -> web.Response:
     if denied is not None:
         return denied
     request_app = request.get("app", "")
-    async with state._chat_pins_lock:
-        # Prefer mid-based lookup; fall back to message_ts for legacy pins
+
+    def _matches_identity(pin: dict) -> bool:
+        if pin["slot_key"] != slot_key:
+            return False
         if mid:
-            idx = next(
-                (
-                    i
-                    for i, p in enumerate(state._chat_pins)
-                    if p["slot_key"] == slot_key and p.get("mid") == mid
-                ),
-                None,
-            )
-        else:
-            idx = next(
-                (
-                    i
-                    for i, p in enumerate(state._chat_pins)
-                    if p["slot_key"] == slot_key and p.get("message_ts") == message_ts
-                ),
-                None,
-            )
+            return pin.get("mid") == mid
+        return pin.get("message_ts") == message_ts
+
+    async with state._chat_pins_lock:
+        # App callers select only their own record, so a foreign same-key pin
+        # left by slot reuse cannot mask a later caller-owned pin. Dashboard
+        # callers keep the owner-wide view by leaving request_app empty.
+        idx = next(
+            (
+                i
+                for i, pin in enumerate(state._chat_pins)
+                if _matches_identity(pin)
+                and (not request_app or pin.get("origin_app", "") == request_app)
+            ),
+            None,
+        )
         if idx is None:
-            return web.json_response({"error": "not found", "code": "pin_not_found"}, status=404)
-        pin_record = state._chat_pins[idx]
-        # Record-level ownership: app callers can only delete pins they created.
-        if request_app and pin_record.get("origin_app", "") != request_app:
-            sel().log_api_access(
-                caller=request_app,
-                operation="chat.pins_delete",
-                outcome="denied",
-                source="pin_record_ownership",
-                resources=f"slot={slot_key},mid={mid or message_ts}",
-                error="app does not own this pin record",
-            )
+            # Preserve the record-ownership audit for a foreign-only match. An
+            # ordinary missing identity remains a plain not-found response.
+            if request_app and any(_matches_identity(pin) for pin in state._chat_pins):
+                sel().log_api_access(
+                    caller=request_app,
+                    operation="chat.pins_delete",
+                    outcome="denied",
+                    source="pin_record_ownership",
+                    resources=f"slot={slot_key},mid={mid or message_ts}",
+                    error="app does not own this pin record",
+                )
             return web.json_response({"error": "not found", "code": "pin_not_found"}, status=404)
         removed = state._chat_pins.pop(idx)
         try:

--- a/test/test_dashboard_chat_pins.py
+++ b/test/test_dashboard_chat_pins.py
@@ -1130,6 +1130,34 @@ async def test_delete_by_query_app_isolation(tmp_path):
         assert [pin["id"] for pin in state._chat_pins] == ["pin-other"]
 
 
+@pytest.mark.parametrize("query_field", ["mid", "message_ts"])
+@pytest.mark.asyncio
+async def test_delete_by_query_selects_callers_record_before_foreign_collision(
+    tmp_path, query_field
+):
+    """A stale foreign record must not mask the caller's own matching pin."""
+    state = _make_state(tmp_path)
+    state.get_or_create_slot("slot-reused", app="app-b")
+    foreign = _pin("foreign-pin", "slot-reused", "ts-shared", origin_app="app-a")
+    own = _pin("own-pin", "slot-reused", "ts-shared", origin_app="app-b")
+    if query_field == "mid":
+        foreign["mid"] = own["mid"] = "m-shared"
+        query = "mid=m-shared"
+    else:
+        foreign.pop("mid")
+        own.pop("mid")
+        query = "message_ts=ts-shared"
+    state._chat_pins.extend([foreign, own])
+
+    async with _client(tmp_path, state=state, app_name="app-b") as client:
+        resp = await client.delete(f"/api/chat/pins/by-query?slot=slot-reused&{query}")
+
+    assert resp.status == 200
+    assert [(pin["id"], pin["origin_app"]) for pin in state._chat_pins] == [
+        ("foreign-pin", "app-a")
+    ]
+
+
 # ── Finding 1: Race condition — slot deleted concurrently ──
 
 
@@ -1574,7 +1602,7 @@ async def test_slot_reuse_cross_app_delete_denial(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_slot_reuse_cross_app_delete_by_query_denial(tmp_path):
+async def test_slot_reuse_cross_app_delete_by_query_denial(tmp_path, monkeypatch):
     """After slot recreation, new app cannot delete old app pins by query."""
     state = _make_state(tmp_path)
     state.get_or_create_slot("slot-reuse", app="app-b")
@@ -1590,12 +1618,21 @@ async def test_slot_reuse_cross_app_delete_by_query_denial(tmp_path):
             "origin_app": "app-a",
         }
     )
+    audit = MagicMock()
+    monkeypatch.setattr("kiro_crew.dashboard.chat_pins.sel", lambda: audit)
 
     async with _client(tmp_path, state=state, app_name="app-b") as client:
         resp = await client.delete("/api/chat/pins/by-query?slot=slot-reuse&mid=m-old-app-a-two")
         assert resp.status == 404
         assert (await resp.json())["code"] == "pin_not_found"
         assert len(state._chat_pins) == 1
+    denied = [
+        call.kwargs
+        for call in audit.log_api_access.call_args_list
+        if call.kwargs.get("source") == "pin_record_ownership"
+    ]
+    assert len(denied) == 1
+    assert denied[0]["caller"] == "app-b"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem / Motivation

App callers using query-form unpin can receive `404 pin_not_found` while their own matching pin exists. After slot reuse, a stale foreign record with the same message identity can sort first and mask the caller-owned record.

## Why it matters

The endpoint becomes unable to remove a valid caller-owned pin even though create and list correctly scope records by `origin_app`. API and app consumers are left with a pin that reappears after refresh.

## What changed (motivation → approach → change)

The handler previously selected the first `(slot_key, mid)` or legacy `(slot_key, message_ts)` match and only then checked ownership. It now treats message identity and caller ownership as one lookup predicate for app callers, while an empty dashboard app claim retains the owner-wide view.

Foreign-only matches still return the indistinguishable 404 and emit the existing record-ownership denial audit. A parameterized regression covers both modern `mid` and legacy `message_ts` lookup.

## Tests

- `python -m pytest test/test_dashboard_chat_pins.py -n0 -q` — 89 passed.
- Added `test_delete_by_query_selects_callers_record_before_foreign_collision` for both query identity forms.
- Extended `test_slot_reuse_cross_app_delete_by_query_denial` to pin the retained SEL denial audit.
- `flake8` and `mypy` pass on the changed backend/test files.

## Manual verification

Reproduced the pre-fix sequence on `main`: App B created its own same-mid pin with HTTP 201, query-delete returned 404, and both foreign and owned records remained. The fixed regression deletes App B's record and preserves App A's foreign record.

## Related Issues

Fixes #8783

## Pattern harvest

Rule candidate: review-prompt
Pattern: When resource identity is caller-scoped, include ownership in record selection rather than validating whichever matching record sorts first.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (N/A — the external API shape is unchanged)
- [x] No secrets, credentials, or internal references in the diff
