### PR TITLE
fix(sandbox): unmask an app backend's own state leaves for its spawn

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -27,6 +27,7 @@ from kiro_crew import platform_compat
 from kiro_crew.apps.admission import app_admission_denied
 from kiro_crew.apps.execution import (
     app_execution_denied,
+    is_builtin_app,
     shipped_builtin_app_root,
     shipped_builtin_module_path,
 )
@@ -39,6 +40,7 @@ from kiro_crew.loopback_http import loopback_urlopen
 from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
     RLIMIT_PROFILE_TOOL,
+    app_backend_visible_targets,
     cgroup_scope_argv,
     popen_limited,
     run_limited,
@@ -1133,11 +1135,26 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     # control available. What still bounds a forged cache there is provenance rather than
     # permissions: with ``require_policy_signature`` set in the admission policy, a document
     # nobody trusted is refused however it got onto disk.
+    # The app's OWN hidden state leaves (e.g. md-notebook's vault registry, PAT, and
+    # sync settings) are unmasked for exactly this spawn: the mask fences agent
+    # subprocesses, but this backend is each leaf's only legitimate reader/writer, and
+    # leaving the mask on breaks the app outright (#8762). Unlike the governance cache
+    # these are the app's own read-write state, so the blanket "visible" meaning is the
+    # correct one. Empty for every app without declared owned leaves.
+    #
+    # Gated on IMMUTABLE PACKAGE PROVENANCE of the code this spawn executes, not on the
+    # app name alone: a trusted third-party app that claimed the name could otherwise
+    # spawn with the builtin's credential leaves (the Notes PAT) unmasked. The same
+    # ``execution_path`` the admission gate above vetted is what the provenance check
+    # binds to, so a file-entry install under the builtin's name gets no exemption.
+    _cache_visible = bool(_platform_extra.get(POLICY_CACHE_ONLY_ENV))
     _visible: tuple[str, ...] = ()
-    if _platform_extra.get(POLICY_CACHE_ONLY_ENV):
-        _visible = (str(policy_cache_dir()),)
+    if is_builtin_app(app_root=execution_path, app_name=app_name):
+        _visible = app_backend_visible_targets(app_name)
+    if _cache_visible:
+        _visible = _visible + (str(policy_cache_dir()),)
     sandboxed_cmd, cleanup_path = wrap_argv(cmd, mode="standard", extra_visible_dirs=_visible)
-    if _visible and list(sandboxed_cmd) == list(cmd):
+    if _cache_visible and list(sandboxed_cmd) == list(cmd):
         # The wrap was a no-op, so this host has no OS confinement at all: no sandbox backend,
         # or agent.sandbox='off' with the sandbox_allow_no_isolation opt-in. Said once,
         # because the combination is worth naming — a centrally governed host running app code

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -199,6 +199,12 @@ _CREW_HIDDEN_LEAVES: tuple[str, ...] = (
     "apps/aws-control/data",
     "apps/meetings/data/edits",
     "whatsapp",
+    # The Notes state files below are OWNED by the md-notebook backend, which is itself
+    # a sandboxed spawn (`apps/backend.py`), so the mask alone would break the app: the
+    # registry write's final rename gets EPERM and attach/clone always fails (#8762).
+    # The backend spawn therefore passes them back as ``extra_visible_dirs`` via
+    # :func:`app_backend_visible_targets` — the mask still applies to every OTHER
+    # sandboxed process, which is the population it exists to fence.
     "workspace/md-notebook/pat",
     "workspace/md-notebook/vaults.json",
     "workspace/md-notebook/settings.json",
@@ -308,6 +314,46 @@ def _crew_home_entries(leaves: tuple[str, ...]) -> list[str]:
 _CREW_HIDDEN_DIRS: list[str] = _crew_home_entries(_CREW_HIDDEN_LEAVES)
 #: Exposed read-only in every mode.
 _CREW_READONLY_TARGETS: list[str] = _crew_home_entries(_CREW_READONLY_LEAVES)
+
+#: Hidden crew-home leaves one app's OWN backend must read and write.
+#:
+#: These leaves sit in ``_CREW_HIDDEN_LEAVES`` to fence AGENT subprocesses (a
+#: prompt-injected shell must not repoint a vault's push target or lift the PAT), but
+#: the named app's backend is each leaf's only legitimate reader/writer — and that
+#: backend is itself a sandboxed spawn, so the blanket mask breaks the app (#8762).
+#: ``apps/backend.py`` passes the resolved paths back as ``extra_visible_dirs`` when
+#: spawning exactly that app's backend; every other sandboxed process keeps the mask.
+#:
+#: Keyed by app name as ``apps/backend.py`` spawns it. Only apps with a SPAWNED
+#: backend belong here — an in-process builtin (routes/hooks) runs unsandboxed in the
+#: gateway and needs no exemption.
+_APP_BACKEND_OWNED_LEAVES: dict[str, tuple[str, ...]] = {
+    "md-notebook": (
+        "workspace/md-notebook/pat",
+        "workspace/md-notebook/vaults.json",
+        "workspace/md-notebook/settings.json",
+    ),
+}
+
+
+def app_backend_visible_targets(app_name: str) -> tuple[str, ...]:
+    """Absolute paths of the hidden leaves *app_name*'s own backend owns.
+
+    Resolved the same way the launcher and seatbelt builders spell their hidden
+    targets — ``$HOME``-joined across both data-home spellings, plus the relocated
+    paths when ``KIROCREW_HOME`` moves the data home — so each returned path matches
+    its mask entry exactly and ``_hidden_path_contains_visible_path`` lifts it.
+
+    Returns ``()`` for an app with no owned leaves, leaving its spawn unchanged.
+    """
+    leaves = _APP_BACKEND_OWNED_LEAVES.get(app_name)
+    if not leaves:
+        return ()
+    home = str(Path.home())
+    targets = [os.path.join(home, entry) for entry in _crew_home_entries(leaves)]
+    targets.extend(_relocated_crew_targets(leaves))
+    return tuple(targets)
+
 
 #: The subset of ``_CREW_READONLY_LEAVES`` the launcher may CREATE in order to seal.
 #:

--- a/test/test_sandbox_governance_mask.py
+++ b/test/test_sandbox_governance_mask.py
@@ -397,3 +397,87 @@ class TestThirdPartyCredentialsKeepTheirExistingTiering:
         for listing in (sandbox._STRICT_DIRS, sandbox._CC_DIRS, sandbox._STANDARD_DIRS):
             assert ".local/share/kiro-cli" not in listing
             assert ".local/share/amazon-q" not in listing
+
+
+class TestAppBackendOwnedLeaves:
+    """An app's OWN backend gets its state leaves back; nothing else changes (#8762).
+
+    The md-notebook leaves are masked to fence agent subprocesses, but the Notes
+    backend is itself a sandboxed spawn and is those files' only legitimate
+    reader/writer. Masking it from itself made every attach/clone fail on the
+    registry's final atomic rename. The spawn passes the resolved leaf paths as
+    ``extra_visible_dirs``; these tests pin that the exemption lifts exactly those
+    targets, on both platform builders, and that a default build keeps the mask.
+    """
+
+    LEAVES = (
+        "workspace/md-notebook/pat",
+        "workspace/md-notebook/vaults.json",
+        "workspace/md-notebook/settings.json",
+    )
+
+    def test_the_helper_resolves_both_home_spellings(self) -> None:
+        targets = sandbox.app_backend_visible_targets("md-notebook")
+
+        for prefix in _CREW_PREFIXES:
+            for leaf in self.LEAVES:
+                assert _crew_path(prefix, leaf) in targets
+
+    def test_an_app_with_no_owned_leaves_gets_no_exemption(self) -> None:
+        assert sandbox.app_backend_visible_targets("meetings") == ()
+        assert sandbox.app_backend_visible_targets("no-such-app") == ()
+
+    @_POSIX_ONLY
+    def test_linux_unhides_the_owned_leaves_for_this_spawn(self) -> None:
+        script = sandbox._build_launcher_script(
+            "standard", extra_visible_dirs=sandbox.app_backend_visible_targets("md-notebook")
+        )
+        match = re.search(r"SENSITIVE_DIRS = (\[.*?\])\n", script, re.S)
+        assert match
+        hidden = set(json.loads(match.group(1)))
+
+        for prefix in _CREW_PREFIXES:
+            for leaf in self.LEAVES:
+                assert _crew_path(prefix, leaf) not in hidden, f"{leaf} still masked"
+
+    def test_macos_drops_every_rule_for_the_owned_leaves(self) -> None:
+        profile = sandbox._build_seatbelt_profile(
+            "standard", extra_visible_dirs=sandbox.app_backend_visible_targets("md-notebook")
+        )
+
+        for prefix in _CREW_PREFIXES:
+            for leaf in self.LEAVES:
+                target = _crew_path(prefix, leaf)
+                # Read AND write, because the EPERM the issue reports is the write
+                # side: the staged sibling temp is written fine and the rename onto
+                # the masked literal is what Seatbelt refuses.
+                assert f'"{target}"' not in profile, f"{leaf} still carries a deny rule"
+
+    @_POSIX_ONLY
+    @pytest.mark.parametrize("mode", _MODES)
+    @pytest.mark.parametrize("prefix", _CREW_PREFIXES)
+    @pytest.mark.parametrize("leaf", LEAVES)
+    def test_a_default_build_keeps_the_mask(self, mode: str, prefix: str, leaf: str) -> None:
+        """No exemption without the spawn asking: agent subprocesses stay fenced."""
+        hidden, _readonly, files = _launcher_sets(mode)
+        target = _crew_path(prefix, leaf)
+
+        assert target in hidden
+        assert target in files
+
+    def test_the_backend_spawn_passes_the_owned_leaves(self) -> None:
+        """`apps/backend.py` must thread the helper's result into ``wrap_argv``.
+
+        Asserted structurally rather than by a full spawn, which needs a manifest, a
+        reserved port, and a live interpreter: the call site must derive its visible
+        set from the helper, keyed by the app being spawned — and only behind the
+        immutable-provenance gate, so a third-party install that claimed the builtin's
+        name cannot spawn with the builtin's credential leaves unmasked.
+        """
+        import inspect
+
+        from kiro_crew.apps import backend as backend_mod
+
+        src = inspect.getsource(backend_mod._start_app_backend_body)
+        assert "app_backend_visible_targets(app_name)" in src
+        assert "is_builtin_app(app_root=execution_path, app_name=app_name)" in src


### PR DESCRIPTION
## Problem / Motivation

Attaching a vault in the Notes (md-notebook) app fails on every attempt with

```
[Errno 1] Operation not permitted: '…/vaults.json.<hex>.tmp' -> '…/vaults.json'
```

and leaves an orphan `.tmp` file behind. Registry reads swallow the `OSError` and return `[]`, so the read side fails silently too. PAT and `settings.json` writes hit the same wall.

## Why it matters

The Notes app's core flow — attaching a vault — is completely broken on any build since #7439. Nothing in the UI explains why; the user just sees the attach fail and, on the read path, an empty vault list.

## What changed (motivation → approach → change)

**Root cause:** #7439 added the Notes state files (`pat`, `vaults.json`, `settings.json`) to `_CREW_HIDDEN_LEAVES`, masking them in every sandbox mode. The intent was to fence *agent* subprocesses, and the matching `security.py` entries say "the app's own backend opens it directly rather than through this gate, so it keeps working" — true for the tool-hook gate, false for the OS gate, because app backends are themselves spawned via `wrap_argv(mode="standard")`. The Notes backend was masked from its own registry: the staged sibling temp writes fine, but the rename onto the masked literal is denied by the sandbox's `deny file-write*` rule.

**Approach:** exempt an app's *own* backend spawn — and only that spawn — from the mask entries it owns, instead of removing the entries (which would re-expose the PAT to agent subprocesses) or special-casing paths in the sandbox profiles.

**Change:**

- `sandbox.py`: declare the hidden leaves one app's own backend owns (`_APP_BACKEND_OWNED_LEAVES`, currently just md-notebook — meetings and aws-control run in-process and need no entry) and expose `app_backend_visible_targets(app_name)`, which resolves them across both data-home spellings plus the `KIROCREW_HOME`-relocated paths, matching the mask entries exactly so `_hidden_path_contains_visible_path` lifts them.
- `apps/backend.py`: pass those targets as `extra_visible_dirs` when spawning that app's backend, gated on `is_builtin_app(app_root=execution_path, app_name=app_name)` so the exemption keys on immutable builtin provenance of the code being executed, not on the app *name* — a third-party app claiming the name `md-notebook` still gets the full mask. (This gate closes a blocking finding from the pre-PR AI review; the second reviewer lane passed clean.)

Security posture is unchanged for everything else: agent spawns get no `extra_visible_dirs`, so the mask still fences them; the governance cache keeps its read-only special case, which `extra_visible_dirs` cannot re-open by design.

## Tests

- `app_backend_visible_targets` resolves both home spellings; unknown/in-process apps get `()`.
- Linux launcher drops the three targets from `SENSITIVE_DIRS` when the exemption is passed; the Seatbelt profile carries **no** rule for them (read or write — the write deny is the one that produced the EPERM).
- A default build (no exemption) still masks all three, in every mode, both prefixes.
- The spawn site derives its visible set from the helper *and* gates it on `is_builtin_app` (structural assertions, so neither can silently regress).

`test/test_sandbox_governance_mask.py`, `test/test_apps_backend_coverage.py`, and the md-notebook app suite pass locally (708 tests); flake8, black, isort, and mypy clean.

## Manual verification

Root cause reproduced on an installed build where every vault attach fails with the EPERM above and leaves the orphan `.tmp`. The launcher/Seatbelt tests assert the exact deny rule that produced that EPERM is absent for the app's own spawn and still present for agent spawns; an end-to-end attach on a packaged build is left to CI.

## Related Issues

Fixes #8762

## Pattern harvest

Rule candidate: review-prompt
Pattern: adding a path to a sandbox deny/mask list without auditing every spawn context that legitimately owns that path (comments claiming "the owner bypasses this gate" must name *which* gate).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
