### PR TITLE
fix(acp): classify a kindless mcp tool call by its transport

### DIFF
--- a/docs/system-specs/modules/acp-client.md
+++ b/docs/system-specs/modules/acp-client.md
@@ -87,12 +87,45 @@ Both the shared runtime and the legacy direct `AcpClient` route permission
 frames through `_dispatch.build_permission_event`, including the same provenance
 flags. A shell-cache hit whose value is `False` sets `shell_classified=True` —
 it is a resolved non-shell call, not a cache miss — and a structured-params
-cache hit sets `raw_params_trusted=True`. The raw-params cache is read without
-consuming it, so a repeated permission frame for the same `toolCallId` keeps the
-original tool-call arguments authoritative instead of falling back to the
-permission frame's agent-authored inline input. A genuine miss may carry inline
-data for display, but both provenance flags remain false and consumers that
-need trusted arguments fail closed.
+cache hit sets `raw_params_trusted=True`.
+
+The shell cache is written **only** from a usable backend `kind` string. A
+`tool_call` frame that omits `kind` writes nothing — even when its
+`_meta.kiro.mcpServerName` proves the call MCP-served — because a cached `False`
+reads back as a RESOLVED non-shell classification (`shell_classified=True`),
+which flips `AcpEvent.child_low_fidelity` to `False` and would un-gate the
+content-matching auto-approve paths (title-keyed `auto_approve_tools`) for a
+call whose title is agent-authored and whose mutating/read nature nothing
+verified. The transport signal instead feeds the identity-only lane: the
+`_meta.kiro` identity caches (below) carry it to the permission event, where
+`AcpEvent.child_mcp_identity_trusted` and the CLI consumer's
+`_unverifiable_shell` escape consume it without ever minting a classification.
+A miss keeps reading as an absent classification, and a frame reporting
+`kind: "execute"` caches `True` whatever its `_meta` says — the transport
+identity never waives a shell check.
+
+For a CHILD event, the identity lane only helps a consumer the handle actually
+delivers to: the session handle fail-closes every low-fidelity child permission
+request whose consumer never set `child_fidelity_aware`
+(`child_low_fidelity_unaware_consumer`). The dashboard runner and `kirocrew
+chat` both opt in — the CLI qualifies because its approval path runs no
+content-matching auto-approve: hook gate, then the `_unverifiable_shell`
+fail-close, then an interactive prompt that shows only non-model-authored
+context (the cached command, the `_meta.kiro` identity, the target path). The
+opt-in admits every low-fidelity child event, not just MCP-served ones, so the
+CLI's own first check re-applies the boundary: a low-fidelity child event is
+rejected (`child_unverified_context`) unless its identity is verified, consumed
+as `not child_unconditional_grant_eligible` — the same hoisted expression the
+other grant-path consumers use, never a re-spelling — the
+trusted transport identity is the one context that survives an empty params
+cache and can be shown to the human, while a child edit with no cached
+parameters would prompt without a Path line, an undisclosed write.
+
+The raw-params cache is read without consuming it, so a repeated permission frame
+for the same `toolCallId` keeps the original tool-call arguments authoritative
+instead of falling back to the permission frame's agent-authored inline input. A
+genuine miss may carry inline data for display, but both provenance flags remain
+false and consumers that need trusted arguments fail closed.
 
 The host always sends one-shot approvals (`always=False`, the default). KiroCrew — not the agent — owns the trust scope (`slot._trust`, `slot._trust_reads`, `slot._trusted_patterns`, `safety_override`, `channel.trusted`, parent session `approval_policy`). Per-call `session/request_permission` is required so KiroCrew's PreToolUse hooks (`auto_deny_tools`, sensitive-path checks, credential redaction) fire on every tool invocation. The `always=True` path is reserved for a future "skip KiroCrew hooks for this exact tool" feature; no caller passes it today.
 
@@ -104,12 +137,13 @@ session durable trust merely because the display cache was already consumed.
 
 A remote (HTTP) MCP server's initial `tool_call` legitimately streams an empty or
 absent `rawInput`, so the params cache stays empty and every child permission
-request for such a tool is low-fidelity (`AcpEvent.child_low_fidelity`). The
-`_meta.kiro` identity caches are written unconditionally from the same frame, so
-the permission event still carries the verified `mcp_server_name`/`tool_name`
-pair plus the explicit `mcp_identity_trusted` provenance flag (set only when
-BOTH cache reads hit — mirroring `raw_params_trusted`, so an inline fallback
-can never count as verified); `AcpEvent.child_mcp_identity_trusted` exposes
+request for such a tool is low-fidelity (`AcpEvent.child_low_fidelity`) on the
+arguments half. The `_meta.kiro` identity caches are written unconditionally from
+the same frame, so the permission event still carries the verified
+`mcp_server_name`/`tool_name` pair plus the explicit `mcp_identity_trusted`
+provenance flag (set only when BOTH cache reads hit — mirroring
+`raw_params_trusted`, so an inline fallback can never count as verified);
+`AcpEvent.child_mcp_identity_trusted` exposes
 that verified-identity half (arguments unverified) and
 `AcpEvent.child_unconditional_grant_eligible` hoists the grant-eligibility
 expression for the unconditional grant paths documented in

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1737,7 +1737,17 @@ it only when their extractors actually produced an identity pair (a frame
 without `_meta.kiro` populates nothing and asserts no provenance), and
 `_to_llm_event` copies it; it mirrors
 `raw_params_trusted`, so a future inline population path fails closed instead
-of counting as verified on non-emptiness alone). The grant-eligibility
+of counting as verified on non-emptiness alone). `child_mcp_identity_trusted`
+does NOT require a resolved shell classification: a backend may omit `kind` on
+its MCP `tool_call` frames, leaving the shell cache unwritten, and the trusted
+transport identity is itself proof the call is MCP-served and not a host shell
+command (a host shell or builtin never carries a server name — `acp-client.md`
+§ Tool Permission Protocol). That proof stays confined to the identity-only
+property: minting a resolved `shell_classified` from it would flip
+`child_low_fidelity` to `False` and un-gate the content-matching auto-approve
+paths for a kindless mutating call with a read-looking, agent-authored title.
+A `kind` that resolved to execute still caches `is_shell=True`, which keeps
+the identity split closed for shell calls. The grant-eligibility
 expression is hoisted to one place,
 `AcpEvent.child_unconditional_grant_eligible`
 (`not child_low_fidelity or child_mcp_identity_trusted`), consumed by all

--- a/src/kiro_crew/acp/types.py
+++ b/src/kiro_crew/acp/types.py
@@ -732,22 +732,31 @@ class AcpEvent:
         satisfy them.
 
         Requirements, each fail-closed on its cache: a child origin
-        (``sub_session_id``), a RESOLVED non-shell classification
-        (``shell_classified`` and not ``is_shell`` — an unclassified event
-        defaults to non-shell and must not pass as one; a shell tool's deny
-        gates need the command bytes this event lacks), the canonical
+        (``sub_session_id``), no RESOLVED shell classification to the contrary
+        (``not is_shell`` — a frame whose ``kind`` resolved to execute cached
+        True, and its deny gates need the command bytes this event lacks; the
+        transport identity must never waive that), the canonical
         ``mcp_server_name`` + ``tool_name`` pair recovered from the tool_call
         cache (empty on a miss, and populated only for genuinely MCP-served
         tools — a host shell/builtin can never carry a server name), and the
         explicit ``mcp_identity_trusted`` provenance flag set by the trusted
         population sites — non-emptiness alone is NOT proof of provenance, so
         an identity pair written by any future inline/agent-authored fallback
-        stays untrusted until that site earns the flag. A
-        non-child event returns False: parents never need the split.
+        stays untrusted until that site earns the flag.
+
+        ``shell_classified`` is deliberately NOT required: a backend may omit
+        ``kind`` on its MCP tool_call frames, leaving the shell cache
+        unwritten. The trusted transport identity is itself proof the call is
+        MCP-served and therefore not a host shell command — but that proof
+        stays confined to THIS identity-only property. Minting a resolved
+        ``shell_classified`` from it instead would flip ``child_low_fidelity``
+        to False and un-gate the content-matching auto-approve paths, letting
+        a kindless mutating call with a read-looking, agent-authored title
+        auto-approve without a prompt. A non-child event returns False:
+        parents never need the split.
         """
         return bool(
             self.sub_session_id
-            and self.shell_classified
             and not self.is_shell
             and self.mcp_identity_trusted
             and self.mcp_server_name

--- a/src/kiro_crew/cli_chat.py
+++ b/src/kiro_crew/cli_chat.py
@@ -72,6 +72,12 @@ _USER_DENY_CODE = "user_denied"
 #: command could be recovered to gate on. Distinct from ``hook_deny``: the gate
 #: did not reject it, we refused to ASK about it.
 _UNVERIFIED_SHELL_CODE = "unverified_shell"
+#: A child permission request whose structured security context never reached
+#: the caches AND whose MCP identity is unverified. The prompt would show an
+#: agent-authored title with no trusted line under it — no command, no
+#: ``_meta.kiro`` identity, and (for an edit) no target path — so approval
+#: would consent to a description of the call rather than to the call.
+_CHILD_UNVERIFIED_CODE = "child_unverified_context"
 #: The authorization gate itself could not produce a verdict. A broken gate is
 #: not permission to run, so the request is refused and answered under its own
 #: code rather than being left pending.
@@ -272,6 +278,20 @@ async def _chat(message: str | None, model: str | None, agent: str | None = None
     provider: LLMProvider = build_provider_factory(cfg)(
         _CLI_SESSION_KEY, agent=agent_name, channel_id=channel_id
     )
+    # This consumer implements the low-fidelity child downgrade, so opt in:
+    # without this the handle-level fail-close gate rejects every low-fidelity
+    # child permission request before it reaches `_answer_permission`, audited
+    # as `child_low_fidelity_unaware_consumer` -- the auto-deny this file's
+    # `_unverifiable_shell` escape exists to end. The contract this assertion
+    # makes: no content-matching auto-approve runs here. `_answer_permission`
+    # is child-context fail-close (rejecting a low-fidelity child request
+    # without a verified identity) -> hook gate -> `_unverifiable_shell`
+    # fail-close -> interactive human prompt, and `_prompt_allows` shows the
+    # human only non-model-authored context (the cached command, the
+    # `_meta.kiro` MCP identity, the target path) -- a forged title has nothing
+    # to satisfy. The non-interactive `-m` path stays fail-closed too: it
+    # denies rather than prompts.
+    provider.child_fidelity_aware = True
     # Built once per process, not per request: a permission request must not
     # depend on a config read succeeding while the turn is parked.
     gate = _build_tool_gate(agent_name or "")
@@ -491,6 +511,19 @@ def _unverifiable_shell(event: LLMEvent) -> bool:
     # behind it. An absent classification is not a negative one -- the same
     # distinction ``child_low_fidelity`` already draws on this flag.
     if not event.shell_classified:
+        # One narrow escape: a trusted MCP transport identity. When the
+        # preceding ``tool_call``'s cache write recovered a non-empty
+        # ``_meta.kiro`` server/tool pair (``mcp_identity_trusted`` is set only
+        # by that cache-hit path, never from the permission payload), the call
+        # is proven MCP-served -- and an MCP-served tool is not a host shell
+        # command, so there are no command bytes for this gate to verify. A
+        # backend that omits ``kind`` on its MCP frames would otherwise have
+        # every such tool auto-denied here. This waives nothing shell-shaped:
+        # a frame whose ``kind`` resolved to execute cached ``is_shell`` True
+        # and took the trusted-signal branch above, where the shell gate's own
+        # deny-by-default backstop governs.
+        if event.mcp_identity_trusted and event.mcp_server_name and event.tool_name:
+            return False
         return True
     # Normalised before the shared check so a cosmetic variant still denies --
     # widening a fail-closed test is safe in a way widening an allow is not.
@@ -725,6 +758,33 @@ async def _answer_permission(
     """
     gate = gate or _build_tool_gate()
     title = event.title or "tool call"
+
+    # Fail-close FIRST for a child event with unverified context: opting into
+    # the child-fidelity contract (``child_fidelity_aware`` in ``_chat``) makes
+    # the session handle deliver EVERY low-fidelity child permission request
+    # here, not just the MCP-served ones this consumer can present honestly. A
+    # child edit whose parameters never reached the cache would render a prompt
+    # with no Path line -- an approval that executes an undisclosed write. The
+    # trusted-transport identity is the one context that survives an empty
+    # params cache (the ``_meta.kiro`` pair is backend-authored and shown to
+    # the human), so it is the admission boundary: everything else keeps the
+    # rejection semantics the handle itself applies to fidelity-unaware
+    # consumers. This is exactly the boundary
+    # ``AcpEvent.child_unconditional_grant_eligible`` hoists for the grant
+    # paths, so consume the property rather than re-spelling it.
+    if not event.child_unconditional_grant_eligible:
+        await _audit_refusal(gate, event, error=_CHILD_UNVERIFIED_CODE)
+        await provider.reject_tool(event.request_id)
+        try:
+            safe_title = _for_consent(title, stream=sys.stderr)
+            _print_permission_notice(
+                f"\nDenied automatically: {safe_title} came from a subagent "
+                "without verifiable security context.\n"
+                "   Ask the agent to retry the tool call."
+            )
+        except Exception:
+            logger.warning("Could not prepare the CLI child-denial notice", exc_info=True)
+        return
 
     # Off-loop: the gate resolves the active governance profile, which stats and
     # reads ``profiles/`` on the way to a verdict. That is a filesystem walk, not

--- a/test/test_acp_runtime.py
+++ b/test/test_acp_runtime.py
@@ -7506,9 +7506,14 @@ def test_child_mcp_identity_trusted_isolates_verified_identity():
     assert ev.child_mcp_identity_trusted is True
     # A parent event never needs the split.
     assert _ev(sub_session_id="").child_mcp_identity_trusted is False
-    # Unresolved shell classification: is_shell=False is only the miss
-    # default, so nothing proves this is not a shell tool.
-    assert _ev(shell_classified=False).child_mcp_identity_trusted is False
+    # An unresolved shell classification is NOT disqualifying: a backend may
+    # omit `kind` on its MCP frames, and the trusted transport identity is
+    # itself proof the call is MCP-served and not a host shell command. The
+    # composite stays low-fidelity, so content-matching auto-approval
+    # (title-keyed auto_approve_tools) remains gated for such an event.
+    kindless = _ev(shell_classified=False)
+    assert kindless.child_mcp_identity_trusted is True
+    assert kindless.child_low_fidelity is True
     # A resolved SHELL tool: its deny gates need the command bytes this
     # event lacks — never identity-eligible.
     assert _ev(is_shell=True).child_mcp_identity_trusted is False
@@ -8054,6 +8059,147 @@ def test_missing_kind_is_not_a_resolved_shell_classification():
     assert shell_cache.get("tc-rk") is False  # resolved non-shell
 
 
+def test_trusted_mcp_transport_earns_identity_trust_without_a_classification():
+    """A kind-less frame whose `_meta.kiro.mcpServerName` is populated earns the
+    IDENTITY-trusted half only: the transport discriminator is backend-authored,
+    and an MCP-served tool is not a host shell command, so unconditional grant
+    paths (parent_policy=auto, session trust-all) may honor the call. It must
+    NOT mint a resolved shell classification: shell_classified stays False and
+    child_low_fidelity stays True, keeping every content-matching auto-approve
+    path (title-keyed auto_approve_tools) gated against the agent-authored
+    title."""
+    from kiro_crew.acp._dispatch import _build_tool_call_event, build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    shell_cache: dict[str, bool] = {}
+    raw_cache: dict[str, dict] = {}
+    server_cache: dict[str, str] = {}
+    name_cache: dict[str, str] = {}
+    ev = _build_tool_call_event(
+        {
+            "title": "Asking the knowledge service",
+            "toolCallId": "tc-mcp",
+            "rawInput": {"question": "why"},
+            "_meta": {"kiro": {"mcpServerName": "kb", "toolName": "ask"}},
+        },
+        None,
+        shell_cache=shell_cache,
+        raw_params_cache=raw_cache,
+        mcp_server_name_cache=server_cache,
+        tool_name_cache=name_cache,
+    )
+    assert ev.is_shell is False
+    assert "tc-mcp" not in shell_cache  # no kind -> no classification minted
+
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 11,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {
+                "sessionId": "child-a",
+                "toolCall": {"toolCallId": "tc-mcp", "title": "Asking the knowledge service"},
+                "options": [],
+            },
+        }
+    )
+    event, _ = build_permission_event(
+        msg,
+        shell_cache=shell_cache,
+        raw_params_cache=raw_cache,
+        mcp_server_name_cache=server_cache,
+        tool_name_cache=name_cache,
+    )
+    event.sub_session_id = "child-a"
+    assert event.shell_classified is False
+    assert event.is_shell is False
+    assert event.mcp_identity_trusted is True
+    # The split: identity trusted (unconditional grants may honor it) ...
+    assert event.child_mcp_identity_trusted is True
+    assert event.child_unconditional_grant_eligible is True
+    # ... while the composite stays low-fidelity (title matching stays gated).
+    assert event.child_low_fidelity is True
+
+
+def test_trusted_mcp_transport_never_waives_a_reported_shell_kind():
+    """The transport identity may only ever vouch for a non-shell call, never
+    waive a shell check: an execute-kind frame still caches True even with a
+    server name, so the command-bytes gates keep firing -- and the identity
+    split stays closed for it."""
+    from kiro_crew.acp._dispatch import _build_tool_call_event, build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    shell_cache: dict[str, bool] = {}
+    server_cache: dict[str, str] = {}
+    name_cache: dict[str, str] = {}
+    _build_tool_call_event(
+        {
+            "title": "Running: ls",
+            "kind": "execute",
+            "toolCallId": "tc-both",
+            "_meta": {"kiro": {"mcpServerName": "kb", "toolName": "ask"}},
+        },
+        None,
+        shell_cache=shell_cache,
+        mcp_server_name_cache=server_cache,
+        tool_name_cache=name_cache,
+    )
+    assert shell_cache.get("tc-both") is True
+
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 13,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {
+                "sessionId": "child-a",
+                "toolCall": {"toolCallId": "tc-both", "title": "Running: ls"},
+                "options": [],
+            },
+        }
+    )
+    event, _ = build_permission_event(
+        msg,
+        shell_cache=shell_cache,
+        mcp_server_name_cache=server_cache,
+        tool_name_cache=name_cache,
+    )
+    event.sub_session_id = "child-a"
+    assert event.is_shell is True
+    assert event.child_mcp_identity_trusted is False
+
+
+def test_inline_mcp_server_name_on_a_permission_frame_earns_no_classification():
+    """The agent-reachable permission payload is not a provenance channel: an
+    inline `_meta`/`mcpServerName` there cannot manufacture the identity trust
+    that only the preceding tool_call's cache write can grant."""
+    from kiro_crew.acp._dispatch import build_permission_event
+    from kiro_crew.acp.types import METHOD_REQUEST_PERMISSION
+
+    shell_cache: dict[str, bool] = {}
+    msg = JsonRpcMessage.from_dict(
+        {
+            "id": 12,
+            "method": METHOD_REQUEST_PERMISSION,
+            "params": {
+                "sessionId": "child-a",
+                "toolCall": {
+                    "toolCallId": "tc-forged",
+                    "title": "Asking the knowledge service",
+                    "_meta": {"kiro": {"mcpServerName": "kb", "toolName": "ask"}},
+                },
+                "options": [],
+            },
+        }
+    )
+    event, _ = build_permission_event(msg, shell_cache=shell_cache)
+    event.sub_session_id = "child-a"
+    assert "tc-forged" not in shell_cache
+    assert event.shell_classified is False
+    assert event.mcp_identity_trusted is False
+    assert event.child_mcp_identity_trusted is False
+    assert event.child_unconditional_grant_eligible is False
+    assert event.child_low_fidelity is True
+
+
 def test_shared_permission_event_carries_redaction_provenance_without_secret():
     """The shared-runtime cache must remember that its display input changed.
 
@@ -8238,6 +8384,102 @@ async def test_fidelity_unaware_consumer_gate_rejects_and_audits():
                 answer = frame
         assert answer is not None
         assert answer["result"]["outcome"]["outcome"] in ("selected", "cancelled")
+    finally:
+        await _drain_audits(rt)
+        await _stop_reader(task)
+
+
+@pytest.mark.asyncio
+async def test_aware_consumer_receives_kindless_mcp_child_permission():
+    """The end of the auto-deny, driven through the handle's own dispatch
+    loop: a consumer that opted into the child-fidelity contract (as
+    `kirocrew chat` now does) receives the low-fidelity permission event for
+    a kindless MCP child call -- yielded with the trusted transport identity
+    attached -- instead of the handle rejecting it as
+    `child_low_fidelity_unaware_consumer`."""
+    from kiro_crew.acp.types import (
+        EVENT_PERMISSION_REQUEST,
+        METHOD_REQUEST_PERMISSION,
+        METHOD_SESSION_UPDATE,
+    )
+
+    rt, reader, proc = _make_runtime()
+    q = _register(rt, "sA")
+    handle = AcpSessionHandle("sA", q["sA"], rt)
+    handle.child_fidelity_aware = True
+
+    audited: list[tuple[object, str, str]] = []
+    handle._audit_handle_reject = (  # type: ignore[method-assign]
+        lambda request_id, title, error, sub_session_id="": audited.append(
+            (request_id, title, error)
+        )
+    )
+
+    task = await _start_reader(rt)
+    try:
+        events = []
+
+        async def drive():
+            async for ev in handle.prompt("hi", timeout=3.0):
+                events.append(ev)
+                if ev.kind == EVENT_PERMISSION_REQUEST:
+                    # Answer it so the turn can end.
+                    await handle.reject_tool(ev.request_id)
+
+        driver = asyncio.ensure_future(drive())
+        req_id = (await _await_routed(rt, "sA"))["sA"]
+        _feed(
+            reader,
+            {
+                "method": "_kiro.dev/subagent/list_update",
+                "params": {"subagents": [{"sessionId": "child-a"}]},
+            },
+        )
+        # The child's tool_call: NO kind, backend `_meta.kiro` identity only.
+        _feed(
+            reader,
+            {
+                "method": METHOD_SESSION_UPDATE,
+                "params": {
+                    "sessionId": "child-a",
+                    "update": {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc-88",
+                        "title": "Asking the knowledge service",
+                        "rawInput": {"question": "why"},
+                        "_meta": {"kiro": {"mcpServerName": "kb", "toolName": "ask"}},
+                    },
+                },
+            },
+        )
+        _feed(
+            reader,
+            {
+                "jsonrpc": "2.0",
+                "id": 88,
+                "method": METHOD_REQUEST_PERMISSION,
+                "params": {
+                    "sessionId": "child-a",
+                    "toolCall": {"toolCallId": "tc-88", "title": "Asking the knowledge service"},
+                    "options": [
+                        {"optionId": "reject_once", "name": "Reject", "kind": "reject_once"}
+                    ],
+                },
+            },
+        )
+        _feed(reader, {"jsonrpc": "2.0", "id": req_id, "result": {"stopReason": "end_turn"}})
+        await asyncio.wait_for(driver, timeout=5.0)
+
+        perm = [ev for ev in events if ev.kind == EVENT_PERMISSION_REQUEST]
+        assert perm, "the permission event never reached the aware consumer"
+        ev = perm[0]
+        # Low fidelity is preserved (title matching stays gated elsewhere) --
+        # the aware consumer receives it rather than the handle rejecting it.
+        assert ev.child_low_fidelity is True
+        assert ev.mcp_identity_trusted is True
+        assert ev.mcp_server_name == "kb"
+        assert ev.tool_name == "ask"
+        assert not audited  # the fail-close gate never fired
     finally:
         await _drain_audits(rt)
         await _stop_reader(task)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7509,6 +7509,129 @@ class TestChatPermissionRequest:
         assert sels[0]["error"] == "unverified_shell"
 
     @pytest.mark.asyncio
+    async def test_kindless_mcp_tool_reaches_the_prompt_instead_of_auto_denying(self, monkeypatch):
+        """A backend that omits `kind` on an MCP tool_call must not cost the user
+        the tool. The frame's `_meta.kiro` transport identity earns the
+        _unverifiable_shell escape -- WITHOUT minting a shell classification, so
+        the low-fidelity gates elsewhere keep treating the title as unverified --
+        and the request reaches the normal approval prompt.
+
+        Drives the shared-runtime parser rather than hand-building the event: the
+        auto-deny came from the cache write being skipped, which an event built
+        with trusted identity fields would hide.
+        """
+        from kiro_crew.acp._dispatch import _build_tool_call_event, build_permission_event
+        from kiro_crew.acp.types import JsonRpcMessage
+
+        shell_cache: dict[str, bool] = {}
+        raw_cache: dict[str, dict] = {}
+        server_cache: dict[str, str] = {}
+        name_cache: dict[str, str] = {}
+        _build_tool_call_event(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc-kindless",
+                "title": "Asking the knowledge service",
+                "rawInput": {"question": "why"},
+                "_meta": {"kiro": {"mcpServerName": "kb", "toolName": "ask"}},
+            },
+            None,
+            shell_cache=shell_cache,
+            raw_params_cache=raw_cache,
+            mcp_server_name_cache=server_cache,
+            tool_name_cache=name_cache,
+        )
+        event, _ = build_permission_event(
+            JsonRpcMessage(
+                id="req-kindless",
+                method="session/request_permission",
+                params={
+                    "toolCall": {
+                        "toolCallId": "tc-kindless",
+                        "title": "Asking the knowledge service",
+                    },
+                    "options": [
+                        {"optionId": "allow", "name": "Allow once", "kind": "allow_once"},
+                        {"optionId": "reject", "name": "Deny", "kind": "reject_once"},
+                    ],
+                },
+            ),
+            shell_cache=shell_cache,
+            raw_params_cache=raw_cache,
+            mcp_server_name_cache=server_cache,
+            tool_name_cache=name_cache,
+        )
+
+        assert event.shell_classified is False  # no classification was minted
+        assert event.is_shell is False
+        assert event.mcp_identity_trusted is True  # the escape's actual carrier
+        provider, sels, reads = await self._drive(monkeypatch, event=event, answer="a")
+        assert provider.calls == [("approve", "req-kindless", False)]
+        assert reads["n"] == 1
+        assert [s["outcome"] for s in sels] == ["allowed"]
+
+    @pytest.mark.asyncio
+    async def test_low_fidelity_child_without_identity_is_rejected_not_prompted(
+        self, monkeypatch, capsys
+    ):
+        """The admission boundary of the child-fidelity opt-in: a child event
+        whose params never reached the cache AND whose MCP identity is
+        unverified must be rejected before any prompt. The prompt for such an
+        event would carry only the agent-authored title -- for an edit, no Path
+        line -- so approval would consent to an undisclosed write."""
+        from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+        event = AcpEvent(
+            kind=EVENT_PERMISSION_REQUEST,
+            request_id=9,
+            title="Tidying up the notes file",
+            sub_session_id="child-a",
+            tool_kind="edit",
+            is_shell=False,
+            shell_classified=False,
+            raw_params_trusted=False,
+            options=[{"id": "allow", "label": "Allow Once"}],
+        )
+        assert event.child_low_fidelity is True
+        assert event.child_mcp_identity_trusted is False
+        provider, sels, reads = await self._drive(monkeypatch, event=event, answer="a")
+        assert provider.calls == [("reject", 9, False)]
+        assert reads["n"] == 0  # the human was never asked
+        assert sels[0]["error"] == "child_unverified_context"
+        assert "without verifiable security context" in capsys.readouterr().err
+
+    @pytest.mark.asyncio
+    async def test_identity_trusted_low_fidelity_child_still_reaches_the_prompt(
+        self, monkeypatch, capsys
+    ):
+        """The one admission through that boundary: a child MCP call whose
+        `_meta.kiro` identity survived the cache is presented -- the prompt
+        shows the non-forgeable server/tool pair, the same args-blind consent
+        contract the dashboard's interactive card provides."""
+        from kiro_crew.acp.types import EVENT_PERMISSION_REQUEST, AcpEvent
+
+        event = AcpEvent(
+            kind=EVENT_PERMISSION_REQUEST,
+            request_id=10,
+            title="Asking the knowledge service",
+            sub_session_id="child-a",
+            tool_kind="fetch",
+            is_shell=False,
+            shell_classified=False,
+            raw_params_trusted=False,
+            mcp_server_name="kb",
+            tool_name="ask",
+            mcp_identity_trusted=True,
+            options=[{"id": "allow", "label": "Allow Once"}],
+        )
+        assert event.child_low_fidelity is True
+        assert event.child_mcp_identity_trusted is True
+        provider, sels, reads = await self._drive(monkeypatch, event=event, answer="a")
+        assert provider.calls == [("approve", 10, False)]
+        assert reads["n"] == 1
+        assert "MCP tool: kb / ask" in capsys.readouterr().out
+
+    @pytest.mark.asyncio
     async def test_ordinary_title_and_command_display_unchanged(self, monkeypatch, capsys):
         # The control-stripping must not disturb ordinary text: this is the
         # control for the three cases above.
@@ -7781,9 +7904,14 @@ class TestChatProviderShutdown:
         def __init__(self):
             self.started = 0
             self.shutdowns = 0
+            self.child_fidelity_aware = False
+            self.fidelity_aware_at_start: bool | None = None
 
         async def start(self):
             self.started += 1
+            # Record the flag as start() sees it: the opt-in must precede the
+            # backend spawn, or an early child permission frame races the gate.
+            self.fidelity_aware_at_start = self.child_fidelity_aware
 
         async def shutdown(self):
             self.shutdowns += 1
@@ -7833,6 +7961,25 @@ class TestChatProviderShutdown:
         with pytest.raises(RuntimeError, match="backend died"):
             await cli_chat._chat("hello", None)
         assert provider.shutdowns == 1
+
+    @pytest.mark.asyncio
+    async def test_chat_opts_into_the_child_fidelity_contract_before_start(self, monkeypatch):
+        """The CLI implements the low-fidelity child downgrade (hook gate ->
+        _unverifiable_shell fail-close -> trusted-fields-only human prompt), so
+        _chat must opt in -- and BEFORE start(), or an early child permission
+        frame races the handle's fail-close gate and is rejected as
+        `child_low_fidelity_unaware_consumer`, the auto-deny this fix ends."""
+        import kiro_crew.cli_chat as cli_chat
+
+        provider = self._FakeProvider()
+        self._patch(monkeypatch, provider)
+
+        async def done(*a, **k):
+            return None
+
+        monkeypatch.setattr(cli_chat, "_send_and_print", done)
+        await cli_chat._chat("hello", None)
+        assert provider.fidelity_aware_at_start is True
 
     @pytest.mark.asyncio
     async def test_shutdown_runs_exactly_once_on_the_normal_path(self, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

An MCP tool invoked from a backend-routed child sub-session is auto-denied
before the user ever sees a prompt. The observed symptom in `kirocrew chat` is a
tool that never ran a command being refused outright, reported as
`⛔ permission auto-rejected (missing security context)` or silently denied by
the CLI's fail-closed shell backstop.

The refusal is not reproducible from a top-level session, which is what makes it
look intermittent: a crew-spawned subagent gets its own ACP session and is
top-level there, so the child gates never apply and the same tool succeeds. Only
a child sub-session — one with `sub_session_id` set — hits the gates.

## Why it matters

Any MCP server a user has configured is unreachable from a child sub-session
whenever the backend omits `kind` on the `tool_call` frame, and there is no way
to opt out. `child_mcp_identity_trusted` is the designed escape hatch for
exactly this case, but it *itself* requires a resolved classification, so
`child_unconditional_grant_eligible` is false and no session grant, global
grant, or parent policy can rescue the call. The user's only recourse is to
disable permission checks wholesale, which trades a false deny for a real loss
of protection.

## What changed (motivation → approach → change)

**Symptom.** A `permission_request` for an MCP tool is refused with no prompt.

**Root cause.** In `_build_tool_call_event`, the shell-classification cache
write was guarded by a resolved `kind` alone:

```python
_kind_resolved = isinstance(update.get("kind"), str) and bool(update.get("kind"))
if tool_call_id and shell_cache is not None and _kind_resolved:
    shell_cache[_ck] = is_shell
```

A `tool_call` frame carrying no `kind` therefore wrote nothing. The following
`permission_request` — which carries no `kind` of its own and depends on the
cache — read `shell_classified=False`. Three independent consumers turn that
into a refusal:

- `cli_chat.py::_unverifiable_shell` — the fail-closed backstop — denies it.
- the low-fidelity-unaware consumer in `session_handle.py` auto-rejects it,
  audited as `child_low_fidelity_unaware_consumer`.
- `types.py::child_mcp_identity_trusted`, the escape hatch, requires
  `shell_classified`, so it cannot fire either.

Declining to cache an unresolved classification is correct — caching `False`
would let a later event read a *resolved* non-shell verdict that no
classification ever produced. The defect is that a kindless frame is treated as
carrying no classification signal at all, when an MCP frame carries a second,
stronger one.

**Approach.** Confine the transport proof to the identity-only lane, and mint no
classification. An earlier revision of this change wrote the shell cache from
the transport signal; review surfaced that a cached `False` reads back as a
RESOLVED non-shell classification (`shell_classified=True`), which flips
`child_low_fidelity` to `False` and un-gates the title-keyed
`auto_approve_tools` content matching — a kindless *mutating* call with a
read-looking, agent-authored title could then auto-approve without a prompt.
The reworked change leaves `_dispatch.py` untouched and instead lets the two
refusing consumers honor the identity proof directly:

- `types.py::child_mcp_identity_trusted` no longer requires
  `shell_classified`. The cache-provenance `_meta.kiro` server/tool pair is
  itself proof the call is MCP-served and therefore not a host shell command —
  a host shell or builtin can never carry a server name. The property already
  feeds only UNCONDITIONAL grant paths (session trust-all, global YOLO,
  `parent_policy=auto`), whose approve decision reads no agent-authored event
  data, so honoring identity without a classification widens nothing that
  matches on content.
- `cli_chat.py::_unverifiable_shell` gains the same narrow escape: an event
  whose trusted identity fields were populated by the tool_call cache hit is
  proven MCP-served, so there are no command bytes for the backstop to demand,
  and the request proceeds to the normal interactive prompt. The escape is not
  child-gated, so a *top-level* kindless MCP frame also moves from auto-deny to
  a prompt -- a deliberate widening in the safe direction (a human decides
  instead of a silent refusal).
- `cli_chat.py::_chat` opts the CLI into the child-fidelity contract
  (`provider.child_fidelity_aware = True`). Without this the third refusing
  consumer -- the session handle's fail-close gate
  (`child_low_fidelity_unaware_consumer`) -- rejects every low-fidelity child
  permission request before the CLI's escape can run. The CLI qualifies for
  the contract because its approval path runs no content-matching
  auto-approve: the child-context fail-close first, then the hook gate, then
  the `_unverifiable_shell` fail-close, then an interactive prompt that shows
  only non-model-authored context (the cached command, the `_meta.kiro` MCP
  identity, the target path); the
  non-interactive `-m` path stays fail-closed and denies rather than prompts.
  Because the opt-in admits every low-fidelity child event -- not just
  MCP-served ones -- the CLI's own first check re-applies the boundary: a
  low-fidelity child event is rejected (`child_unverified_context`) unless
  its identity is verified -- consumed as `not
  event.child_unconditional_grant_eligible`, the same hoisted boundary the
  dashboard runner, Slack gateway, and subagent manager already use, rather
  than a fourth hand-spelling of it. A child edit whose params never reached the
  cache would otherwise prompt without a Path line, and approving it would
  execute an undisclosed write; the trusted transport identity is the one
  context that survives an empty params cache and is shown to the human --
  the same args-blind consent contract the dashboard's interactive card
  provides.

The split is safe in both directions by construction:

- `child_low_fidelity` stays `True` for a kindless frame, so every
  content-matching auto-approve path (trusted patterns, trust-reads, title-keyed
  `auto_approve_tools`) stays gated. Interactive approvers still receive the
  `⚠️ UNVERIFIED child request` annotation.
- A frame whose `kind` resolved to execute caches `is_shell=True`, which keeps
  both the identity property and the CLI escape closed for shell calls — the
  transport identity never waives a shell check.
- The identity fields are populated only from the backend's own `_meta.kiro` on
  the tool_call frame, guarded by the explicit `mcp_identity_trusted`
  provenance flag; inline `_meta` on the agent-reachable permission payload
  earns nothing.
- A frame carrying neither signal still resolves nothing: no classification, no
  identity trust, and deny-by-default everywhere it applied before.

**Scope.** `client.py::_extract_tool_event` writes the shell cache
*unconditionally*, which is a hole in the opposite direction (a wrong
classification rather than a false deny). It is deliberately left alone here and
is worth its own issue.

## Tests

`test/test_acp_runtime.py` — four tests around the split:

- `test_trusted_mcp_transport_earns_identity_trust_without_a_classification` —
  drives `_build_tool_call_event` with a kindless frame carrying
  `_meta.kiro.mcpServerName`, then `build_permission_event`, and asserts both
  halves of the split: no shell-cache write, `shell_classified` `False`,
  `child_mcp_identity_trusted` `True`, `child_unconditional_grant_eligible`
  `True`, and — the security lock — `child_low_fidelity` still `True`, so
  title matching stays gated.
- `test_trusted_mcp_transport_never_waives_a_reported_shell_kind` — a frame
  with `kind: "execute"` *and* a server name still caches `True`, and the
  resulting permission event's `child_mcp_identity_trusted` is `False`. Locks
  the never-waive direction.
- `test_inline_mcp_server_name_on_a_permission_frame_earns_no_classification` —
  inline `_meta` on the agent-reachable permission payload manufactures
  nothing: no cache write, no identity trust, no grant eligibility. Locks
  non-forgeability.
- `test_child_mcp_identity_trusted_isolates_verified_identity` (existing) —
  updated: an unresolved classification with trusted identity now reads
  identity-trusted while the composite stays low-fidelity.

`test/test_acp_runtime.py` —
`test_aware_consumer_receives_kindless_mcp_child_permission` drives the
handle's dispatch loop end-to-end (subagent registration, kindless
`_meta`-carrying tool_call, permission frame) and asserts the opted-in
consumer receives the event -- still low-fidelity, identity trusted -- and
the `child_low_fidelity_unaware_consumer` fail-close never fires.

`test/test_cli.py` —
`test_chat_opts_into_the_child_fidelity_contract_before_start` pins the
CLI's opt-in, and that it happens before `start()` so an early child frame
cannot race the gate.
`test_low_fidelity_child_without_identity_is_rejected_not_prompted` pins the
admission boundary (a param-less child edit is rejected with
`child_unverified_context`, the human never asked), and
`test_identity_trusted_low_fidelity_child_still_reaches_the_prompt` pins the
one admission through it (the prompt shows the non-forgeable server/tool
pair).
`test_kindless_mcp_tool_reaches_the_prompt_instead_of_auto_denying` drives the
shared-runtime parser end-to-end and asserts the user-visible outcome: the
prompt is shown (one read), the tool is approved, the audited outcome is
`allowed` rather than a silent deny — and `shell_classified` stays `False`
throughout, so the escape demonstrably rides the identity fields alone.

## Manual verification

The child-path claim is verified by driving the handle's own dispatch loop
rather than by hand-built events:
`test_aware_consumer_receives_kindless_mcp_child_permission` feeds the raw
subagent registration, the kindless `_meta`-carrying `tool_call`, and the
permission frame through `AcpSessionHandle` and asserts the event is yielded
to an opted-in consumer with the trusted identity attached (and the
fail-close audit never fires). The originally reported symptom was observed
in `kirocrew chat` against a live backend that omits `kind` on MCP frames;
the non-reproducing sibling path is explained by the `sub_session_id`
discriminator (a crew-spawned subagent is top-level in its own ACP session,
so the child gates never apply to it).

Reverting the production hunks with the tests kept (the prove-the-test check)
fails the new assertions, confirming they lock the fix. The touched surfaces
run clean; `flake8`, `mypy`, `isort`, `black`, the docs-lint and spec-index
checks pass. The `website/` lanes are not exercised — this diff touches no
frontend file.

## Related Issues

Adjacent to the provenance-conflation problem described in #6228 (closed) and
#6938. This PR does not restructure the fidelity split; it fixes the narrower
defect that a kindless MCP frame never earns a classification in the first
place.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a security decision cached under one provenance signal, read later by a
consumer that cannot recompute it, where a legitimate frame carrying a
*different* trustworthy signal falls through to the fail-closed branch. The
guard was written as "did we see the signal I expected" rather than "did any
non-agent-authored signal resolve this," so the absence of one signal was
conflated with the absence of all of them. Worth asking of any write to a
cache that a fail-closed gate later reads: is every trustworthy provenance for
this value enumerated here, and does each one only ever resolve in the safe
direction?

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
