### PR TITLE
docs(prepare-pr): write PR bodies at the explain-for Age 10 register

### DIFF
--- a/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
+++ b/src/kiro_crew/builtin_skills/kirocrew-dev/prepare-pr/SKILL.md
@@ -470,13 +470,36 @@ absent. Phase 1.5 checks them against the diff.
 
 1. **Problem / Motivation** — the concrete symptom, or the gap for a feature.
 2. **Why it matters** — impact if left unfixed.
-3. **What changed (motivation → approach → change)** — symptom → root cause → the specific change, so the reader sees *why this is the right fix*.
+3. **What changed (motivation → approach → change)** — symptom → root cause → the specific change, so the reader sees *why this is the right fix*. Three short paragraphs at most — one per arrow. Write it in the register below.
 4. **Tests** — what was added/updated and what each locks in.
 5. **Manual verification** — steps done/needed, or "N/A — unit coverage sufficient" with a one-line why.
 6. **Screenshots / video — MANDATORY for any user-visible UI change.** See below.
 7. **Issue link** — a real closing keyword. See below.
 
 Omit a section only when truly not applicable, and say so.
+
+### Writing register — Age 10
+
+Every prose section above is written at the **Age 10 row of the `explain-for`
+skill**: everyday words, plain cause and effect, one idea per sentence. A reviewer
+must get the point in one pass without decoding it. This sets the *register*, never
+the depth — the facts stay complete and technically exact.
+
+- **One idea per sentence, point first.** Do not chain clauses with `so that`,
+  `which means`, `thereby` or `hence`. Short sentences, in order.
+- **A term stays only when it IS the fact.** Keep identifiers, file paths, error
+  strings, function and flag names verbatim. Cut decorative jargon
+  (`orchestrate`, `surface`, `leverage`, `holistic`, `non-trivial`).
+- **Name the thing, then what it does.** `_reconcile_adopted() re-checks drift
+  every 300s`, not `a reconciliation cadence is introduced at the adoption layer`.
+- **Three paragraphs, not a report.** No nested bullets, no numbered findings, no
+  per-file walkthrough inside a section. Evidence and history belong in the review
+  thread, not the body.
+- **Say the effect in user words.** What a person sees now that they did not see
+  before, or stops seeing. Not "improves robustness".
+
+Rewrite check before opening the PR: read section 3 once, out loud. If any
+sentence needs a second read to find its point, rewrite that sentence.
 
 ### Screenshots
 

--- a/test/test_prepare_pr_body_register.py
+++ b/test/test_prepare_pr_body_register.py
@@ -1,0 +1,44 @@
+"""The PR body has to read as plain language, and the rule has to stay anchored.
+
+`prepare-pr` writes the PR description, and its "What changed" section is what a
+reviewer reads first. Left unconstrained it grows into layered clauses and
+decorative jargon that hide the actual change. The skill now pins that prose to
+the Age 10 row of the `explain-for` skill.
+
+Two joints can break silently. The register rule can be dropped from
+`prepare-pr` (bodies drift back to dense prose with no test failing), or the
+`explain-for` row it points at can be renamed away (the reference still reads
+fine but resolves to nothing). One assertion each.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS = ROOT / "src" / "kiro_crew" / "builtin_skills"
+PREPARE_PR = SKILLS / "kirocrew-dev" / "prepare-pr" / "SKILL.md"
+EXPLAIN_FOR = SKILLS / "explain-for" / "SKILL.md"
+
+
+def _flat(path: Path) -> str:
+    """Skill body with runs of whitespace collapsed to single spaces.
+
+    These files are hard-wrapped prose, so an asserted phrase can legitimately
+    straddle a newline. Normalizing first keeps the assertions about content
+    rather than about where the wrap landed.
+    """
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def test_prepare_pr_pins_the_pr_body_to_the_age_10_register() -> None:
+    flat = _flat(PREPARE_PR)
+    # The rule itself, and the skill it borrows the calibration from.
+    assert "Age 10 row of the `explain-for`" in flat
+    # Register, not depth: a plain-language rule that also cut facts would be worse.
+    assert "This sets the *register*, never the depth" in flat
+    # The concrete bound on the section the user could not read.
+    assert "Three short paragraphs at most" in flat
+
+
+def test_explain_for_still_carries_the_age_10_row() -> None:
+    """The row `prepare-pr` points at must exist, or the reference is dead."""
+    assert "| Age 10 |" in _flat(EXPLAIN_FOR)


### PR DESCRIPTION
## Problem / Motivation

The PR body that `prepare-pr` writes is hard to read. The worst section is **What
changed (motivation → approach → change)**. It grows into long chained sentences
and dressed-up words, so a reviewer cannot find the actual change in one pass.

The contract said what to include. It said nothing about how to write it, so any
prose that filled the shape passed the Phase 1.5 check.

## Why it matters

Every KiroCrew PR goes through this skill, so this is the first thing a reviewer
reads. When the body needs decoding, reviewers skip it and read the diff cold.
The body then costs tokens and buys nothing, and the author's intent is lost.

## What changed (motivation → approach → change)

**Motivation.** Section 3 of the PR description contract had no rule about
register. Dense prose was as valid as plain prose.

**Approach.** Point it at a register that already exists instead of inventing
one: the Age 10 row of the `explain-for` skill. Borrow the calibration only. This
sets the register, never the depth, so identifiers, paths and error strings stay
verbatim and the facts stay exact.

**Change.** Section 3 now caps at three short paragraphs, one per arrow. A new
`### Writing register — Age 10` block states five rules: one idea per sentence
with the point first, keep a term only when it *is* the fact, name the thing then
what it does, three paragraphs and no nested findings, and say the effect in user
words. It ends with a read-once-out-loud check before the PR opens.

<details>
<summary>Same PR, old register vs new register (the test the user asked for)</summary>

**Old register** — one sentence, four clauses, three abstractions:

> This change addresses the readability gap in the PR description contract by
> introducing a register directive that leverages the existing `explain-for`
> calibration surface, thereby ensuring generated bodies remain accessible to
> reviewers without sacrificing technical fidelity, which in turn should reduce
> review latency across the repository.

**New register** — same facts, one idea per sentence:

> Section 3 had no rule for *how* to write, only what to include. So it points
> at a rule that already exists: the Age 10 row in `explain-for`. Section 3 is
> now three paragraphs, one per arrow, and five plain rules say what to cut.
> Facts stay exact — identifiers and paths are kept verbatim.

Nothing is dropped between them. The second one can be read once.

</details>

## Tests

`test/test_prepare_pr_body_register.py` — two assertions, both mutation-verified:

1. `prepare-pr` still carries the register rule (the Age 10 reference, the
   "register, never the depth" clause, and the three-paragraph cap). Renaming any
   of them lets bodies drift back to dense prose.
2. `explain-for` still carries the `| Age 10 |` row. Rename that row and the
   reference above still reads fine but resolves to nothing.

Mutation check: changing `Age 10 row` to `plain row` fails assertion 1; changing
`| Age 10 |` to `| Age ten |` fails assertion 2. Both restored, both green.

## Manual verification

N/A — the change is skill prose plus a doc ratchet, and the "Same PR" block above
is the behavior demo: this PR's own body is written under the new rule.

Local gates on the diff: `pytest test/test_prepare_pr_body_register.py
test/test_web_verify_skill.py test/test_prepare_pr_profiles.py -n 2` (56 passed),
`black --check`, `isort --check-only`, `flake8`, `scripts/docs_lint.py` (the two
findings it reports are pre-existing untracked RFC files, not in this diff), and
`scripts/check_builtin_skill_scope.py`.

## Related Issues

N/A — reported directly in a dashboard session.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a contract that lists required sections but not the register they are
written in, so unreadable-but-complete prose passes the check.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
