### PR TITLE
docs(i18n): correct the stale numbers in the codemod ratchet JSDoc

### DIFF
--- a/website/scripts/i18n-codemod.mjs
+++ b/website/scripts/i18n-codemod.mjs
@@ -90,8 +90,8 @@ const DRY_RUN = CHECK || process.argv.includes('--dry-run')
 const MERGE = process.argv.includes('--merge')
 
 /**
- * Ratchet, mirroring `npx eslint --max-warnings 1116` in `ci.yml`: 76 user-visible
- * strings are unextracted today, so a hard `--check` would fail on arrival and get
+ * Ratchet, mirroring the `--max-warnings` ceiling on `npx eslint` in `ci.yml`: the CI
+ * gate runs `--baseline=3`, and a hard `--check` would fail on arrival and get
  * disabled. `--baseline=N` fails only ABOVE N. Lower it when convenient, never
  * raise it — but a count below N is tolerated rather than failed, because the
  * literal lives in `scripts/lib/i18n-gate-table.mjs` and forcing every improving branch to edit


### PR DESCRIPTION
<!-- no-visual-delta -->
No rendered text changes: the only edit is a JSDoc comment in a build-time
Node script (`website/scripts/i18n-codemod.mjs`), which ships nothing to the UI.

## Problem / Motivation

The JSDoc over `BASELINE` in `website/scripts/i18n-codemod.mjs` stated two numbers,
and both were stale. Line 93 on `main`:

```
 * Ratchet, mirroring `npx eslint --max-warnings 1116` in `ci.yml`: 76 user-visible
 * strings are unextracted today, so a hard `--check` would fail on arrival and get
 * disabled.
```

Measured against the tree at `a540e334b`:

| Claim | Where the real value lives | Real value |
|---|---|---|
| the gate holds `76` unextracted strings | `website/scripts/lib/i18n-gate-table.mjs:29` | `--baseline=3` (ceiling also noted as `3` at line 223) |
| `ci.yml` runs `npx eslint --max-warnings 1116` | `.github/workflows/ci.yml:1320` | `npx eslint src/ --max-warnings 0` |

`76` was not the ceiling and is not the count either -- `node scripts/i18n-codemod.mjs
--check --baseline=3` currently reports `35 unextracted user-visible string(s) across 22
file(s), 32 above the baseline of 3`. So a reader who trusted the comment got a wrong
ceiling, a wrong count, and a wrong cross-reference in one sentence.

The eslint number is stale in a second way: `--max-warnings` has since been ratcheted all
the way to `0`, so citing a four-digit budget describes a state the repo has left behind.

## What changed

One sentence, two lines, comment only:

- The ceiling is now stated as what the gate actually passes, `--baseline=3`, sourced
  from `i18n-gate-table.mjs` rather than remembered.
- The eslint cross-reference keeps the analogy but drops the number, so it cannot go
  stale again as the ratchet keeps descending. The rest of the block -- the
  `--baseline=N` semantics, the merge-conflict rationale, the `#1004` pointer -- is
  untouched.

Deliberately not changed, so this stays a one-sentence diff:
`website/eslint.i18n.config.js:7` carries the same stale `--max-warnings 1116` figure.
It is a different file and a different comment; flagging rather than folding it in.

## Why it matters

This file's own instruction is that the number is measured, not remembered, and the
`ci.yml` lint gate says the same thing directly above the line it guards ("Re-measure
with `cd website && npx eslint src/` when burning down"). A comment that misreports the
ceiling by 73 is worse than no comment: it is specific, confident and wrong, so the next
person to touch the ratchet reasons from `76` instead of opening the gate table. Nothing
in the text marks it as expired.

## Tests

No behaviour changed -- the edit is inside a `/** ... */` block, and no code, literal or
control flow was touched. What was run from the worktree root at `website/`:

```
node --check scripts/i18n-codemod.mjs                     -> exit 0
npm run typecheck   (tsc -b)                              -> exit 0
npm run lint        (eslint src --ext .ts,.tsx)           -> exit 0
node scripts/i18n-codemod.mjs --check --baseline=3        -> exit 0, same REPORT as before
git status --porcelain                                    -> only this one file modified
```

The last one is the behavioural check that matters here: the gate the comment describes
still runs, still reports `35 ... 32 above the baseline of 3`, and still exits 0. No
Python was touched, so the Python gates do not apply. The full pytest suite was not run.

## Pattern harvest

Not generalizable: this is a single stale literal in one comment. The underlying shape --
a hand-written count next to a gate that owns the real number -- is already codified in
this repo, both by `i18n-gate-table.mjs` holding the literal in one place and by
`ci.yml`'s "re-measure, do not remember" instruction. The fix here is to obey those, not
to add a rule. The one transferable habit, and it is already the stated norm: when a
comment must cite a gate, cite the file that holds the value instead of copying the
value.
