### PR TITLE
style: black-format the AI review workflow tests (#8803)

### DIFF
--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -5246,9 +5246,7 @@ class TestGptRefusalTerminalState:
         # to remove.
         assert "re-run the workflow or inspect" not in proc.stdout
 
-    def test_completed_verdict_quoting_the_marker_is_not_reclassified(
-        self, tmp_path: Path
-    ) -> None:
+    def test_completed_verdict_quoting_the_marker_is_not_reclassified(self, tmp_path: Path) -> None:
         # On the clean path codex-review-output.md is verbatim model prose. A
         # review that QUOTES the refusal marker — say, while reviewing this
         # workflow — must not flip a completed verdict into a refusal: the


### PR DESCRIPTION
## Problem / Motivation

The Main Ratchet Audit's `ratchet-gates` lane is red on main: the whole-tree black gate (`RATCHET_SCOPE_WHOLE_TREE=1 python3 scripts/check_black_formatting.py`) names exactly one new offender, `test/test_ai_review_workflows.py`, which landed unformatted in commit `8c7ad04` and is not in `.github/black-baseline.txt`.

## Why it matters

Because the drift sits on main, it surfaces as an inherited red on every unrelated pull request (a PR builds against merge(branch, main)). Every contributor pays for it until main is fixed.

## What changed (motivation → approach → change)

Symptom: the gate fails naming one file. Root cause: `8c7ad04` landed one function signature in `test/test_ai_review_workflows.py` split across three lines where black (26.3.1, `line-length = 100`) joins it onto one. Change: apply exactly the remedy the gate prints — `black --target-version py310 test/test_ai_review_workflows.py` — and nothing else. One file, +1/−3 lines, formatting only. No baseline edit (the baseline only ever shrinks), no gate/script/workflow change, no ceiling change.

`git diff --ignore-all-space` shows the identical +1/−3 hunk (a line re-join, not a content edit), and both pre-push reviewers confirmed the token stream of the file is byte-identical before/after (comments/NL excluded): no assertion, argument, fixture, or control flow changed.

## Tests

No new tests. The gate script (`scripts/check_black_formatting.py`) is itself the regression test and already runs on every PR and on main's ratchet audit. Verified locally: the gate goes 1 offender → 0 offenders, and `pytest test/test_ai_review_workflows.py` collects and passes the same 378 tests before and after the reformat — formatting did not change collection.

## Manual verification

N/A — formatting-only change to a test file; the gate run and unchanged test collection above are the whole verification.

## Related Issues

Closes #8803

## Pattern harvest

Not generalizable: the black ratchet gate is itself the rule for this class; this PR just applies the remedy the gate already prints for a drift that reached main.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behavior changed
- [x] No secrets, credentials, or internal references in the diff
