### PR TITLE
fix(hooks): keep the tool-approval import chain free of the cryptography wheel

### DIFF
--- a/src/kiro_crew/secrets/vault.py
+++ b/src/kiro_crew/secrets/vault.py
@@ -25,8 +25,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
 from kiro_crew.atomic_write import atomic_write, fsync_dir
 from kiro_crew.platform_compat import file_lock, restrict_to_owner
 
@@ -332,6 +330,13 @@ class SecretVault:
         return b"v1" + self._SCOPE.encode() + b"\x00" + name.encode()
 
     def _encrypt_entry(self, name: str, plaintext: bytes) -> dict[str, str]:
+        # Imported HERE, not at module top. `kiro_crew.secrets` is reached from
+        # the tool-approval hook's import chain (hooks.on_tool_call ->
+        # slack.gateway -> autonudge -> irq -> cron_script -> secrets), so a
+        # top-level import made every tool approval depend on the `cryptography`
+        # native wheel loading. Only touching a vault entry needs AES-GCM.
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         key = self._get_or_create_key()
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -339,6 +344,8 @@ class SecretVault:
         return {"nonce": nonce.hex(), "ct": ct.hex()}
 
     def _decrypt_entry(self, name: str, entry: dict[str, str], key: bytes) -> bytes:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # see _encrypt_entry
+
         aesgcm = AESGCM(key)
         # A corrupt / hand-edited store can make ``entry`` any shape (a string,
         # a list, a dict missing ``nonce``/``ct``, or one whose values are not

--- a/src/kiro_crew/wecom/media.py
+++ b/src/kiro_crew/wecom/media.py
@@ -33,8 +33,6 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import aiohttp
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from kiro_crew import link_unfurl
 
@@ -115,6 +113,17 @@ def decrypt_media(ciphertext: bytes, key: bytes) -> bytes:
     # that the URL is single-use and lives ~5 minutes, and that the key is per
     # object rather than shared.
     # nosemgrep: python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication  # noqa: E501
+    # Imported HERE, not at module top. This module is reached from the
+    # tool-approval hook: hooks.on_tool_call -> slack.gateway._is_read_only_tool
+    # -> channels -> wecom.gateway -> wecom.client -> wecom.attachments -> here.
+    # A top-level import made every tool approval on the platform depend on the
+    # `cryptography` native wheel loading -- and on a host where that wheel is
+    # platform-mismatched (an AL2 x86_64 build on an Apple-silicon Mac) the hook
+    # raised ImportError before it could answer. Only decrypting a WeCom media
+    # file needs AES; only that path pays for it.
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
     decryptor = Cipher(algorithms.AES(key), modes.CBC(key[:_IV_BYTES])).decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     try:

--- a/src/kiro_crew/weixin/media.py
+++ b/src/kiro_crew/weixin/media.py
@@ -25,8 +25,6 @@ from typing import Any
 from urllib.parse import quote
 
 import aiohttp
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +95,12 @@ def decrypt_aes_ecb(ciphertext: bytes, key: bytes) -> bytes:
     # ECB is dictated by the remote protocol (see module docstring): the CDN
     # hands us objects it already encrypted this way, and we never encrypt with
     # it. There is no algorithm choice to make here.
+    # Lazy for the same reason as wecom.media.decrypt_media: this module sits on
+    # the tool-approval hook's import chain, and only decrypting a media file
+    # needs the `cryptography` native wheel.
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
     decryptor = Cipher(  # nosec B305  # lgtm[py/weak-cryptographic-algorithm]
         algorithms.AES(key), modes.ECB()
     ).decryptor()

--- a/test/test_approval_chain_no_cryptography.py
+++ b/test/test_approval_chain_no_cryptography.py
@@ -1,0 +1,125 @@
+"""The tool-approval hook's import chain must not depend on the `cryptography`
+native wheel.
+
+Background
+----------
+``hooks.on_tool_call`` -- the function every ACP tool call passes through for
+its approve/deny verdict -- lazily imports ``kiro_crew.slack.gateway`` for
+``_is_read_only_tool``. That module imports ``kiro_crew.channels``, which
+imports every channel gateway, and the WeCom and Weixin gateways reach their
+``media`` modules, which used to import ``cryptography.hazmat`` at module top
+for their AES decryptors. So a host whose ``cryptography`` wheel does not load
+(a platform-mismatched build: the AL2 x86_64 wheel on an Apple-silicon Mac)
+made EVERY tool approval raise ImportError -- not just WeCom media downloads.
+
+The fix moved those imports inside the two decrypt functions. These tests pin
+the property in a subprocess with ``cryptography`` made unimportable, so a
+future top-level import anywhere on the chain fails here rather than in a
+security-path traceback on someone's machine.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+# Makes `import cryptography` (and any submodule) raise ImportError, the way a
+# missing or unloadable wheel does. A meta_path finder rather than a sys.modules
+# None entry, so submodule imports fail too.
+_BLOCK_CRYPTOGRAPHY = textwrap.dedent(
+    """
+    import importlib.abc, sys
+
+    class _Block(importlib.abc.MetaPathFinder):
+        def find_spec(self, name, path=None, target=None):
+            if name == "cryptography" or name.startswith("cryptography."):
+                raise ImportError(f"blocked for this test: {name}")
+            return None
+
+    sys.meta_path.insert(0, _Block())
+    """
+)
+
+
+def _run(snippet: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCK_CRYPTOGRAPHY + textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_the_approval_hook_import_chain_loads_without_cryptography() -> None:
+    proc = _run(
+        """
+        # The exact import hooks.on_tool_call performs, then the chain it drags in.
+        from kiro_crew.slack.gateway import _is_read_only_tool
+        import kiro_crew.channels
+        import kiro_crew.wecom.media
+        import kiro_crew.weixin.media
+        import kiro_crew.secrets.vault
+        assert _is_read_only_tool("Read") is True
+        print("chain ok")
+        """
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "chain ok" in proc.stdout
+
+
+def test_only_decrypting_media_needs_cryptography() -> None:
+    # The dependency did not disappear, it moved to the one place that uses it:
+    # decrypting still fails clearly when the wheel is unavailable.
+    proc = _run(
+        """
+        from kiro_crew.wecom import media as wecom_media
+        from kiro_crew.weixin import media as weixin_media
+        from kiro_crew.secrets.vault import SecretVault
+        import tempfile, pathlib
+        vault = SecretVault.__new__(SecretVault)
+        cases = (
+            (lambda: wecom_media.decrypt_media(b"x" * 32, b"k" * 32)),
+            (lambda: weixin_media.decrypt_aes_ecb(b"x" * 32, b"k" * 16)),
+            (lambda: vault._decrypt_entry("n", {"nonce": "00" * 12, "ct": "00" * 16}, b"k" * 32)),
+        )
+        for fn in cases:
+            try:
+                fn()
+            except ImportError as exc:
+                assert "cryptography" in str(exc), exc
+            else:
+                raise SystemExit("decrypt ran without cryptography?!")
+        print("decrypt needs it")
+        """
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "decrypt needs it" in proc.stdout
+
+
+def test_no_module_on_the_channel_chain_imports_cryptography_at_top_level() -> None:
+    """Static complement to the subprocess test: the chain's modules must not
+    grow a top-level `cryptography` import back. Scoped to what the approval
+    hook reaches -- the channel tree AND `secrets/` (slack.gateway -> autonudge
+    -> irq -> cron_script -> secrets.vault was the second way in). auth/store.py
+    is not on the chain and keeps its top-level import."""
+    import ast
+    from pathlib import Path
+
+    import kiro_crew
+
+    root = Path(kiro_crew.__file__).parent
+    offenders = []
+    for sub in ("wecom", "weixin", "slack", "secrets", "channels.py"):
+        paths = [root / sub] if sub.endswith(".py") else sorted((root / sub).rglob("*.py"))
+        for path in paths:
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in tree.body:  # module top level only
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module]
+                if any(n == "cryptography" or n.startswith("cryptography.") for n in names):
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+    assert offenders == [], f"top-level cryptography import on the approval chain: {offenders}"

--- a/test/test_approval_chain_no_cryptography.py
+++ b/test/test_approval_chain_no_cryptography.py
@@ -47,6 +47,7 @@ def _run(snippet: str) -> subprocess.CompletedProcess:
         [sys.executable, "-c", _BLOCK_CRYPTOGRAPHY + textwrap.dedent(snippet)],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
 


### PR DESCRIPTION
## Summary

`hooks.on_tool_call` — the verdict path for every ACP tool call — lazily imports `kiro_crew.slack.gateway` for `_is_read_only_tool`. At import time that module reaches `wecom.media` and `weixin.media` (via `channels`) and `secrets.vault` (via `autonudge → irq → cron_script`), and all three imported `cryptography.hazmat` at module top for their AES routines. On a host whose `cryptography` native wheel does not load (a platform-mismatched build — the AL2 x86_64 wheel on an Apple-silicon Mac, `dlopen: slice is not valid mach-o file`) **every tool approval raised `ImportError`**, not just a WeCom media download. Found because the Amazon edition's end-to-end drafter tests, which run the real approval chain, failed on every Mac dev host.

### Change

The three imports move inside the functions that use them (`wecom.media.decrypt_media`, `weixin.media.decrypt_aes_ecb`, `SecretVault._encrypt_entry` / `_decrypt_entry`). The dependency did not go away; it moved to the only paths that pay for it.

### Tests

`test/test_approval_chain_no_cryptography.py`, in a subprocess with `cryptography` made unimportable via a `meta_path` finder:
- the approval hook's import chain (`slack.gateway`, `channels`, both `media` modules, `secrets.vault`) loads and `_is_read_only_tool("Read")` answers;
- each decrypt path still fails clearly with an `ImportError` naming `cryptography`;
- a static AST check over `wecom/`, `weixin/`, `slack/`, `secrets/` and `channels.py` refuses a top-level import from growing back (`auth/store.py` is not on the chain and keeps its).

Existing `test_wecom_media.py` / `test_secret*.py`: 202 pass. flake8, isort, black gate clean.

## Pattern harvest

- **A lazily-imported module inherits the import-time failure modes of everything IT imports at top level.** `on_tool_call` was careful to import `slack.gateway` lazily, but the transitive top-level imports made the security path depend on a native wheel that had nothing to do with approving a tool. When a hot or security-critical path imports a large module lazily, the property to protect is "that module's import chain has no optional/native dependency at module scope" — and it is cheap to pin with a subprocess that blocks the dependency.
- **Move a heavy import to the function that uses it, not to a try/except at module top.** A guarded top-level import (`try: import cryptography except ImportError: cryptography = None`) makes every caller check for `None`; a function-scope import keeps the failure exactly where the capability is exercised and the error message names the missing piece.

Rule candidate: a module imported lazily on a security-critical or hot path must itself have no optional/native dependency at module scope -- pin it with a subprocess test that blocks the dependency and imports the chain.
Not generalizable: which specific modules sat on this chain (wecom/weixin media, secrets.vault) is repository history, not a rule.
