### PR TITLE
fix(security): quote-aware argv window for the bare-kill scan (#8633)

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -4633,6 +4633,13 @@ def _substitution_depth_delta(token: str) -> int:
 
     Used so a separator INSIDE ``$( … )`` is not mistaken for the end of the argv
     being scanned -- ``<name> $(true; echo <verb>)`` is one command, not two.
+
+    KNOWN LIMIT: this counts characters on tokens ``normalize_shell_command``
+    has already stripped the quotes from, so a QUOTED paren or backtick is
+    indistinguishable from a real one here and a window bounded by this delta
+    under-runs on decoyed input.  The bare-``kill`` window recovers by
+    re-deriving its bodies from the raw text, where the quotes still exist
+    (:func:`_bare_kill_raw_bodies`, #8633).
     """
     return token.count("$(") + token.count("`") // 2 - token.count(")")
 
@@ -5461,6 +5468,349 @@ def _is_mint_verb(token: str) -> bool:
     return _normalize_operand(token) == "token"
 
 
+def _static_substitution_output(body: str) -> str:
+    """The word a command substitution STATICALLY expands to, else a marker.
+
+    ``$(echo kill)`` and ``$(printf kill)`` put the verb in COMMAND position
+    through their output; the undecoyed spelling is already detected by the
+    token walk (``kill)`` strips to a ``kill`` basename), so only the decoyed
+    combination slipped -- the raw window had no anchor for it (server-side
+    GPT review round 6, bash-measured).  Resolution is deliberately narrow:
+    ``echo``/``printf`` with a literal first operand, flags and format words
+    skipped.  Anything dynamic returns ``"\x00"``, a word no program name
+    matches, so an unresolvable generator can only under-anchor (miss goes to
+    the remainder ledger), never conjure one.
+    """
+    tokens = body.split()
+    if tokens and _program_basename(tokens[0]) in {"echo", "printf"}:
+        for arg in tokens[1:]:
+            operand = _normalize_operand(arg)
+            if operand.startswith("-") or "%" in operand:
+                continue
+            return operand
+    return "\x00"
+
+
+# An assignment word (``k=kill``): bash only honours these BEFORE the first
+# non-assignment word of a command, and their value is visible to LATER
+# commands only (expansion happens before the assignment takes effect).
+_RAW_ASSIGNMENT_RE = re.compile(r"([a-z_][a-z0-9_]*)=(.*)\Z")
+
+
+def _kill_prefix_keeps_anchor(words: "list[tuple[str, bool]]", word: "list[str]") -> bool:
+    """True when a glued substitution must NOT cost the word its kill anchor.
+
+    ``kill$(B)`` runs the program ``kill`` whenever B expands to NOTHING at
+    runtime -- ``$(:)``, ``$(true)``, any silent command -- which no static
+    scan can decide, so the anchor decision fails toward detection: a FIRST
+    word whose pre-glue prefix is exactly ``kill`` keeps its anchor (server-
+    side GPT review round 3, bash-measured: ``kill$(:) $(pgrep -f <name>)``
+    kills).  Only the first word, because the program position is what makes
+    the prefix a program: ``echo kill$(printf x) $(pgrep -f <name>)`` hands
+    every ``kill...`` word to echo as data, and eating the anchor there is
+    what keeps that spelling allowed.  The glued word's OWN body sits at the
+    anchor's index, inside the forward bound, so ``kill$(pgrep -f <name>)``
+    -- whose program is ``kill<pids>``, not ``kill`` -- still attributes
+    nothing from its glue.
+    """
+    return not words and _program_basename("".join(word)) == "kill"
+
+
+def _bare_kill_raw_bodies(source: str) -> "list[str]":
+    """Substitution bodies inside a bare ``kill``'s own argv, read from the RAW text.
+
+    The token walk in :func:`_is_self_kill` bounds the same window with
+    :func:`_substitution_depth_delta`, which counts parens on tokens
+    ``normalize_shell_command`` has already stripped the quotes from -- so by the
+    time the counter runs, a QUOTED close-paren is indistinguishable from a real
+    closer and it ends the window early: ``kill $(printf ')' ; pgrep -f
+    kirocrew)`` scored the quoted paren as depth -1, cut the argv at the ``;``,
+    and dropped the ``pgrep`` clause that names the target -- while bash, whose
+    substitution scan is quote-aware, runs that ``pgrep`` (measured).
+
+    The raw text still HAS the quotes, so the window is re-derived here from the
+    same quote-aware machinery the extractor uses (:func:`_iter_shell_chars`
+    for the walk, :func:`_matching_close_paren` for each span): a separator
+    splits a segment only OUTSIDE quotes and OUTSIDE any substitution span, and
+    a body is attributed only when it sits AFTER a top-level word that resolves
+    to ``kill`` in the SAME segment.  Both bounds carry weight: the segment
+    bound keeps ``kill 123; echo $(cat /tmp/kirocrew)`` allowed (the
+    substitution belongs to the ``echo``), and the forward bound keeps
+    ``LOG=$(ls /tmp/kirocrew.log) kill 4242`` allowed (the substitution
+    precedes the kill, so it is an environment word's value, not the kill's
+    operand) -- the exact false positive the token walk's own scoping replaced.
+
+    Three quoting rules are load-bearing, each bash-measured (pre-push review):
+
+    * A substitution body is parsed in its OWN NEUTRAL quote context, because
+      that is how bash reads ``$( )`` -- a ``$(`` inside double quotes closes at
+      an interior ``)`` even though the outer quote is still open.  The walk
+      then RESUMES with the outer quote state it carried into the opener, so
+      ``echo "$(date)" ; kill $(...)`` keeps its ``;`` as a real separator and
+      the kill segment is still scanned.
+    * A backtick closer is found through an escape-skipping scan: within
+      backticks a backslash escapes ``\\``` and the escaped backtick is DATA,
+      so taking it as the closer would truncate the body before the clause
+      that names the target.
+    * ``&>`` / ``&>>`` (and the trailing ``2>&1`` form) are redirects of the
+      SAME simple command, not separators -- splitting there discarded the
+      ``kill`` word before its substitution was attributed.
+
+    A word GLUED to a substitution (``kill$(x)``, ``LOG=$(x)``) is never the
+    bare ``kill`` this scan attributes to: bash joins the expansion into the
+    word, so the program it runs is not the literal word prefix.  Glued words
+    are flagged and excluded from the kill match, which keeps
+    ``echo kill$(printf kirocrew)`` -- where ``kill...`` is an argument of
+    ``echo`` -- out of the deny set.
+
+    Words collect what the shell PASSES, not what the operator typed: a quote
+    character that is quote SYNTAX (an opener or closer -- the state machine's
+    own transitions say which) is dropped, while a quote character that is DATA
+    (inside the other quote type, or escaped) is kept.  Without that,
+    ``k''ill`` reached the comparison spelled with its splice and the kill was
+    missed (server-side GPT review, bash-measured: the spliced spelling runs
+    ``kill``).  A syntax quote still OPENS a word -- ``''#`` is the word ``#``,
+    not a comment -- which the ``open_word`` flag carries.
+
+    An UNPROVEN span (parens that never balance) takes the whole remainder as
+    the body and ends the walk.  That cannot under-detect: bash cannot execute
+    past an unterminated substitution either (the whole line is a syntax
+    error), so there is no later command to lose -- while the remainder still
+    reaches the name search attributed to the CURRENT segment, which is what
+    keeps the decoyed-and-unbalanced spelling detected.
+
+    A top-level ``#`` starting a word begins a comment, which ends at the next
+    newline; the skip lands ON that newline so the segment boundary it carries
+    is still honoured.
+
+    This pass is a UNION with the token walk, never a replacement: the tokens
+    carry resolutions the raw text does not (``p=$(pgrep -f kirocrew); kill $p``
+    resolves ``$p`` at tokenization) and the raw text carries the quoting the
+    tokens lost.  Keeping both is what guarantees no previously-detected
+    spelling is dropped.
+    """
+    bodies: list[str] = []
+    words: list[tuple[str, bool]] = []  # (word, glued-to-a-substitution)
+    tagged: list[tuple[int, str]] = []  # (index of the word the body belongs to, body)
+    word: list[str] = []
+    glued = False
+    open_word = False  # a word has begun, even if only as quote syntax (``''``)
+
+    def end_word() -> None:
+        nonlocal glued, open_word
+        if word:
+            words.append(("".join(word), glued))
+            word.clear()
+        glued = False
+        open_word = False
+
+    aliases: dict[str, str] = {}
+
+    def resolves_to_kill(w: str) -> bool:
+        # The literal spelling, or a variable an EARLIER command assigned the
+        # verb to: ``k=kill; $k $(...)`` reaches this walk spelled ``$k``,
+        # while the token walk sees it resolved -- so the decoyed alias
+        # spelling slipped both union halves (server-side GPT review round 5,
+        # bash-measured).  Both ``$k`` and ``${k}`` count; the value check
+        # goes through the same basename read as the literal.
+        if _program_basename(w) == "kill":
+            return True
+        if not w.startswith("$"):
+            return False
+        name = w[1:]
+        if name.startswith("{") and name.endswith("}"):
+            name = name[1:-1]
+        return _program_basename(aliases.get(name, "")) == "kill"
+
+    def end_segment() -> None:
+        end_word()
+        # Anchor selection BEFORE recording this segment's assignments: bash
+        # expands ``$k`` before the same command's ``k=...`` takes effect, so
+        # ``k=kill $k ...`` must not see its own assignment.
+        kill_at = next(
+            (k for k, (w, g) in enumerate(words) if not g and resolves_to_kill(w)),
+            None,
+        )
+        if kill_at is not None:
+            bodies.extend(body for idx, body in tagged if idx > kill_at)
+        # Only the assignment PREFIX is real: a ``k=kill`` in argument
+        # position (``echo k=kill``) assigns nothing, and recording it would
+        # let a later ``$k`` conjure a kill anchor out of printed text.
+        for w, _g in words:
+            assignment = _RAW_ASSIGNMENT_RE.match(w)
+            if assignment is None:
+                break
+            aliases[assignment.group(1)] = assignment.group(2)
+        words.clear()
+        tagged.clear()
+
+    def record_body(body: str) -> None:
+        # A body glued onto an open word belongs to THAT word's index; a body
+        # starting a word of its own sits at the next index.  Either way the
+        # forward bound above compares against the kill word's index.
+        tagged.append((len(words), body))
+
+    i = 0
+    n = len(source)
+    state = 0
+    ansi = False
+    while i < n:
+        jumped = False
+        for step in _iter_shell_chars(source[i:], state, ansi):
+            off = i + step.offset
+            ch = step.char
+            escaped = len(step.text) == 2
+            in_single = step.state == 1 and not (ch == "'" and step.active)
+            if not escaped and not in_single and ch == "$" and source.startswith("$(", off):
+                # bash parses the body in a fresh context, so the span is
+                # proven from the slice at NEUTRAL state -- and the walk
+                # resumes with the OUTER state carried across the jump.
+                rel, proven = _matching_close_paren(source[off + 2 :], 0)
+                body = source[off + 2 : off + 1 + rel] if proven else source[off + 2 :]
+                # An EMPTY substitution expands to NOTHING, so the word
+                # CONTINUES across it -- ``kill$()`` runs ``kill`` (the same
+                # glue-evasion ``_EMPTY_SUBST_RE`` undoes for the token walk;
+                # server-side GPT review, bash-measured).  Marking it glued
+                # instead handed the evasion a free pass: the glued word was
+                # excluded from the kill match and the segment lost its anchor.
+                if proven and not body.strip():
+                    # The word is OPEN even when the expansion vanishes: a
+                    # ``#`` right after ``$()`` is a word to bash (comments
+                    # are lexed before expansion), not a comment.
+                    open_word = True
+                    i = off + 2 + rel
+                    state, ansi = step.state, step.ansi
+                    jumped = True
+                    break
+                fresh_word = not word and not open_word
+                if not fresh_word and not _kill_prefix_keeps_anchor(words, word):
+                    glued = True
+                record_body(body)
+                if fresh_word:
+                    # A word that IS a substitution stands where its OUTPUT
+                    # stands: ``$(echo kill) $(pgrep -f <name>)`` runs kill.
+                    # The synthetic word keeps positions honest too -- later
+                    # bodies in the segment no longer share this one's index.
+                    words.append((_static_substitution_output(body), False))
+                end_word()
+                if not proven:
+                    i = n
+                    jumped = True
+                    break
+                i = off + 2 + rel
+                state, ansi = step.state, step.ansi
+                jumped = True
+                break
+            if not escaped and not in_single and ch == "`":
+                closer = _backtick_closer(source, off + 1)
+                body = source[off + 1 : closer if closer != -1 else n]
+                # Empty backticks: same word-continuity rule as ``$()``.
+                if closer != -1 and not body.strip():
+                    open_word = True
+                    i = closer + 1
+                    state, ansi = step.state, step.ansi
+                    jumped = True
+                    break
+                fresh_word = not word and not open_word
+                if not fresh_word and not _kill_prefix_keeps_anchor(words, word):
+                    glued = True
+                record_body(body)
+                if fresh_word:
+                    words.append((_static_substitution_output(body), False))
+                end_word()
+                if closer == -1:
+                    i = n
+                    jumped = True
+                    break
+                i = closer + 1
+                state, ansi = step.state, step.ansi
+                jumped = True
+                break
+            if step.active:
+                if ch in "<>" and source.startswith("(", off + 1):
+                    rel, proven = _matching_close_paren(source[off + 2 :], 0)
+                    fresh_word = not word and not open_word
+                    if not fresh_word and not _kill_prefix_keeps_anchor(words, word):
+                        glued = True
+                    record_body(source[off + 2 : off + 1 + rel] if proven else source[off + 2 :])
+                    if fresh_word:
+                        # A process substitution expands to a /dev/fd PATH,
+                        # never to its own stdout -- no static output here.
+                        words.append(("\x00", False))
+                    end_word()
+                    if not proven:
+                        i = n
+                        jumped = True
+                        break
+                    i = off + 2 + rel
+                    state, ansi = step.state, step.ansi
+                    jumped = True
+                    break
+                if ch in "&|" and (
+                    (word and word[-1] in "<>") or (ch == "&" and not word and source.startswith(">", off + 1))
+                ):
+                    # The full redirect grammar audited against the separator
+                    # set (this class produced three review rounds one spelling
+                    # at a time -- ``2>&1``, ``&>``, ``>|``): a ``&`` or ``|``
+                    # riding a trailing ``<``/``>`` is a descriptor duplication
+                    # or the noclobber override, and a leading ``&>``/``&>>``
+                    # redirects both streams -- all redirects of THIS command,
+                    # never separators of it.  ``;`` and newline appear in no
+                    # redirect spelling, which closes the enumeration.
+                    word.append(ch)
+                    continue
+                if ch in ";|&\n":
+                    end_segment()
+                    continue
+                if ch == "#" and not word and not open_word:
+                    newline = source.find("\n", off)
+                    i = n if newline == -1 else newline
+                    state, ansi = 0, False
+                    jumped = True
+                    break
+                if ch in "()" or ch.isspace():
+                    end_word()
+                    continue
+            if not escaped and ch in "'\"" and (step.active or step.state == 0):
+                # Quote SYNTAX: an opener (active) or a closer (back at state
+                # 0).  bash does not pass these on, so the word must not carry
+                # them -- ``k''ill`` is the word ``kill``.  A quote that is
+                # DATA (inside the other quote type, or escaped) falls through
+                # and stays in the word.
+                open_word = True
+                continue
+            word.append(ch)
+            open_word = True
+        if not jumped:
+            break
+    end_segment()
+    return bodies
+
+
+def _backtick_closer(source: str, start: int) -> int:
+    """Index of the backtick that CLOSES a substitution opened before *start*.
+
+    Within backticks bash strips a backslash before ``$``, ``\\``` and ``\\\\``,
+    so an escaped backtick is data and must not be taken as the closer --
+    ``str.find`` did, and it truncated ``kill `printf '\\`' ; pgrep -f <name>```
+    one clause short of the target's name (found in pre-push review, bash-
+    measured: the inner command past the escaped backtick runs).  Quotes do NOT
+    protect a backtick from closing, so this scan honours backslashes only.
+
+    -1 when no unescaped closer exists before the text ends.
+    """
+    j = start
+    n = len(source)
+    while j < n:
+        if source[j] == "\\":
+            j += 2
+            continue
+        if source[j] == "`":
+            return j
+        j += 1
+    return -1
+
+
 def _is_self_kill(text_lower: str) -> bool:
     """True if *text_lower* terminates a KiroCrew process.
 
@@ -5519,7 +5869,7 @@ def _is_self_kill(text_lower: str) -> bool:
     # the ``/`` and misses the path-qualified form), while the substitution BODY is
     # taken from the whole string: segment splitting cuts on ``$(`` and ``)``,
     # which would separate the verb from its own substitution.
-    for frame in _self_token_frames(text_lower):
+    for source, frame in _shell_payload_walk(text_lower):
         for i, token in enumerate(frame):
             if _program_basename(token) != "kill":
                 continue
@@ -5554,6 +5904,16 @@ def _is_self_kill(text_lower: str) -> bool:
                     _resolve_param_defaults(body)
                 ):
                     return True
+        # The window above is bounded by ``_substitution_depth_delta`` on
+        # DE-QUOTED tokens, so a quoted close-paren reads as a real closer and
+        # closes the window early, dropping the clause that names the target
+        # (``kill $(printf ')' ; pgrep -f kirocrew)``).  Re-derive the same
+        # window from the RAW text, where the quotes still exist (#8633).
+        for body in _bare_kill_raw_bodies(source):
+            if _SELF_NAME_RE.search(_debracket(body)) or _SELF_NAME_RE.search(
+                _resolve_param_defaults(body)
+            ):
+                return True
     return False
 
 

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -3625,6 +3625,150 @@ class TestSelfFloorShortCircuit:
         assert security._is_credential_mint(cmd)
 
 
+class TestSelfKillArgvWindowIsQuoteAware:
+    """The bare-``kill`` argv window survives a QUOTED close-paren decoy (#8633).
+
+    ``_substitution_depth_delta`` counts parens on tokens the tokenizer already
+    stripped the quotes from, so ``kill $(printf ')' ; pgrep -f <name>)`` scored
+    the quoted paren as a real closer, ended the window at the ``;``, and
+    dropped the ``pgrep`` clause that names the target -- while bash, whose
+    substitution scan is quote-aware, runs that ``pgrep`` (measured).  The fix
+    re-derives the window's substitution bodies from the RAW text through the
+    same quote-aware span scan the extractor uses, as a UNION with the token
+    walk, so no previously-detected spelling is dropped.
+    """
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the decoy class from the issue: a quoted ')' inside the body
+            "kill $(printf ')' ; pgrep -f {n})",
+            # same decoy through the backtick spelling of the substitution
+            "kill `printf ')' ; pgrep -f {n}`",
+            # the kill matched at any argv position, as the token walk does
+            "sudo kill $(printf ')' ; pgrep -f {n})",
+            # the decoy inside a nested shell payload is the same command
+            'sh -c \'kill $(printf ")" ; pgrep -f {n})\'',
+            # a quoted separator is DATA: bash hands kill the substitution too
+            "kill 123 ';' $(pgrep -f {n})",
+            # ``&>`` is a redirect of the SAME command, not a separator: bash
+            # runs ``kill <substitution output>`` (pre-push review, measured)
+            "kill &>/dev/null $(printf ')' ; pgrep -f {n})",
+            # ``>|`` (noclobber override) is the last separator-charactered
+            # member of the redirect grammar -- same rule, measured
+            # (server-side GPT review round 4)
+            "kill >|/dev/null $(printf ')' ; pgrep -f {n})",
+            # an escaped backtick is DATA inside a backtick body, so it must
+            # not be taken as the closer (pre-push review, measured)
+            "kill `printf '\\`' ; pgrep -f {n}`",
+            # a proven substitution INSIDE double quotes must not swallow the
+            # rest of the line: the ``;`` after it is a real separator and the
+            # kill segment after it is still scanned (pre-push review, measured)
+            'echo "$(date)" ; kill $(printf \')\' ; pgrep -f {n})',
+            # the decoy fully inside double quotes: bash parses the body in a
+            # fresh quote context, so the interior ')' stays data
+            "kill \"$(printf ')' ; pgrep -f {n})\"",
+            # quote-SPLICED kill: bash passes the word ``kill``, so the spliced
+            # spelling with the decoy must not slip both union halves
+            # (server-side GPT review, measured)
+            "k''ill $(printf ')' ; pgrep -f {n})",
+            "k'i'll $(printf ')' ; pgrep -f {n})",
+            '"ki"ll $(printf \')\' ; pgrep -f {n})',
+            # an EMPTY substitution expands to nothing, so ``kill$()`` is the
+            # word ``kill`` -- the glue exclusion must not eat the anchor
+            # (server-side GPT review round 2, measured)
+            "kill$() $(printf ')' ; pgrep -f {n})",
+            "kill$( ) $(pgrep -f {n})",
+            # a NON-empty body can still expand to nothing at runtime
+            # (``$(:)``, ``$(true)``), which no static scan decides -- a FIRST
+            # word whose pre-glue prefix is ``kill`` keeps its anchor
+            # (server-side GPT review round 3, measured)
+            "kill$(:) $(pgrep -f {n})",
+            "kill$(:) $(printf ')' ; pgrep -f {n})",
+            "kill$(true) `pgrep -f {n}`",
+            # a variable an EARLIER command assigned the verb to reaches the
+            # raw walk spelled ``$k`` while the token walk sees it resolved --
+            # so the decoyed alias slipped both union halves (server-side GPT
+            # review round 5, measured)
+            "k=kill; $k $(printf ')' ; pgrep -f {n})",
+            "k=kill; ${{k}} $(printf ')' ; pgrep -f {n})",
+            "x=/usr/bin/kill; $x $(printf ')' ; pgrep -f {n})",
+            # a command-position substitution whose OUTPUT is the verb: the
+            # undecoyed spelling is already token-detected, so only the
+            # decoyed combination needed the raw anchor (server-side GPT
+            # review round 6, measured)
+            "`printf kill` $(printf ')' ; pgrep -f {n})",
+            "$(echo kill) $(printf ')' ; pgrep -f {n})",
+        ],
+    )
+    def test_quoted_paren_decoy_is_still_a_self_kill(self, cmd):
+        assert _denied_by(cmd.format(n=_NAME)) == _RULE_KILL
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the undecorated control the issue names
+            "kill $(pgrep -f {n})",
+            # an unbalanced span is UNPROVEN: fail closed, scan the remainder
+            "kill $(pgrep -f {n}",
+            # decoyed AND unbalanced: only the raw pass sees this one, so it is
+            # what discriminates its fail-closed remainder from an empty body
+            "kill $(printf ')' ; pgrep -f {n}",
+        ],
+    )
+    def test_control_spellings_remain_detected(self, cmd):
+        assert _denied_by(cmd.format(n=_NAME)) == _RULE_KILL
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # the issue's documented intentional non-detections: the name is an
+            # operand of a DIFFERENT command, so the fix must not widen the
+            # window into denying them
+            "kill 8123 && cp /tmp/{n}.json ~/",
+            "kill 123; echo $(cat /tmp/{n})",
+            # a comment is prose, not a command: bash never runs the pgrep
+            "kill 123 # $(pgrep -f {n})",
+            # single quotes make the whole thing data for echo
+            "echo 'kill $(pgrep -f {n})'",
+            # a substitution BEFORE the kill word is an environment word's
+            # value, not the kill's operand -- the exact false positive the
+            # token walk's own scoping replaced (pre-push review)
+            "LOG=$(ls /tmp/{n}.log) kill 4242",
+            "nice -n $(cat /opt/{n}/etc/nice) kill -TERM 4242",
+            # ``kill...`` glued to a substitution is an ARGUMENT of echo, not
+            # a program: bash runs only the echo (pre-push review)
+            "echo kill$(printf {n})",
+            # same glue, with a LATER substitution naming the product: the
+            # glued word must not anchor the forward window either
+            "echo kill$(printf x) $(pgrep -f {n})",
+            # a proven double-quoted substitution must not absorb the rest of
+            # the line into the kill's window (pre-push review)
+            'kill "$(printf 123)"; echo {n}',
+            'kill "$(printf 123)" && cp /tmp/{n}.json ~/',
+        ],
+    )
+    def test_scoped_non_detections_stay_allowed(self, cmd):
+        assert _denied_by(cmd.format(n=_NAME)) is None
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # a REAL pipe or or-list still separates -- only the redirect
+            # spellings (``2>&1``, ``&>``, ``>|``) ride inside a word.
+            # Predicate-level: the raw regex TIER matches these across the
+            # pipe on main too (its ``[^;&#>]`` class admits ``|``), so the
+            # public-gate verdict is owned by that tier, not this walk.
+            "kill 123 | grep $(cat /tmp/{n})",
+            "kill 123 || echo $(cat /tmp/{n})",
+        ],
+    )
+    def test_pipe_still_separates_the_argv_window(self, cmd):
+        from kiro_crew import security
+
+        assert security._is_self_kill(cmd.format(n=_NAME).lower()) is False
+
+
 class TestStdinProgramTextScoping:
     """A stdin-reading interpreter is judged on its PROGRAM, not on its neighbours.
 


### PR DESCRIPTION
## Summary

`_is_self_kill`'s bare-`kill` argv window is bounded by `_substitution_depth_delta`, which counts parens on tokens `normalize_shell_command` has already stripped the quotes from. A QUOTED close-paren is therefore indistinguishable from a real substitution closer by the time it is counted, so `kill $(printf ')' ; pgrep -f kirocrew)` scored the quoted paren as depth -1, ended the window at the `;`, and dropped the `pgrep` clause that names the target — while bash, whose substitution scan is quote-aware, runs that `pgrep` (measured: on 3 live victims, the first PID arrives mangled as `)PID` but bash's `kill` builtin continues past a bad argument and the remaining targets die). The undecorated `kill $(pgrep -f kirocrew)` was already detected; only the decoyed spelling escaped. Same defect class as #8150, in a second location.

## Fix

Adds `_bare_kill_raw_bodies`: the bare-kill window's substitution bodies are re-derived from the RAW text — where the quotes still exist — through the same quote-aware machinery the extractor uses (`_iter_shell_chars` for the walk, `_matching_close_paren` for each span). A separator splits a command segment only outside quotes and outside any substitution span; a body is attributed only when it sits AFTER a top-level word resolving to `kill` in the SAME segment.

This is a UNION with the existing token walk, never a replacement: the tokens carry resolutions the raw text does not (`p=$(pgrep -f kirocrew); kill $p` resolves `$p` at tokenization), and the raw text carries the quoting the tokens lost. Union-ness is what guarantees no previously-detected spelling is dropped.

Deviation from the issue's suggested mechanism, with reason: the issue suggests changing what bounds the TOKEN walk's window. Token-space window correction requires token-to-raw alignment, which `_resolve_local_assignments` / `_resolve_function_aliases` rewriting makes unreliable (tokens are substituted and re-shaped before the walk). Re-deriving the window on the raw text through the already-reviewed #8150 span machinery reuses one scanner instead of teaching the counter quoting state — the module's own "one machine, several consumers" cure.

## Pre-push review (two model-pinned lanes) and what it forced

Both lanes reviewed the first draft and found real defects, all bash-verified and fixed at root here:

- **Quote-state desync (both lanes, HIGH/BLOCKING):** the first draft restarted its walk at neutral state after each substitution jump and proved spans from offset 0 of the whole source, so a `$(` inside double quotes never proved, `echo "$(date)" ; kill $(decoy)` lost every later segment (miss), and `kill "$(printf 123)"; echo kirocrew` absorbed the remainder (false positive). Fixed: quote state (`state`/`ansi`) is carried across restarts, and each span is proven from its own slice at NEUTRAL state — which is how bash actually re-parses a `$( )` body.
- **`&>` split (both lanes, HIGH/BLOCKING):** `kill &>/dev/null $(decoy)` treated `&` as a separator and discarded the `kill` word. Fixed: `&>` / `&>>` (alongside the existing `2>&1` form) stay inside their word as redirects.
- **Escaped backtick closer (both lanes, HIGH/BLOCKING):** `` kill `printf '\`' ; pgrep -f kirocrew` `` took the escaped backtick as the closer via `str.find` and truncated the body one clause short of the name. Fixed: `_backtick_closer` skips backslash-escaped backticks (quotes deliberately do NOT protect a backtick — bash's rule).
- **Position-blind attribution (both lanes, MEDIUM/BLOCKING):** the first draft attributed every body in a segment whenever ANY word was `kill`, re-introducing verbatim the false positive the token walk's docstring says it replaced (`LOG=$(ls /tmp/kirocrew.log) kill 4242` newly denied). Fixed: bodies are attributed only FORWARD from the kill word, and a word GLUED to a substitution (`echo kill$(printf …)`) is flagged and excluded from the kill match.
- **Quadratic walk (GPT, HIGH):** the first draft's span proofs re-scanned from offset 0 per substitution: 46s at 32 KiB. The neutral-slice proof makes the helper near-linear: **0.040s at 32 KiB** (1000x). The FULL `_is_self_kill` on that adversarial input is a PRE-EXISTING cost — 45.4s on pristine main vs 35.2s on this head (this PR makes it faster, the remaining cost lives in the token machinery) — filed in the follow-up issue below.
- **Four docstring-accuracy findings (Opus, CONCERNS):** the draft's "restarts land at quote depth zero", "unproven is fail-closed like the extractor", "any-position match", and "each covers the other's blind side" claims were false or overstated; all rewritten to describe the shipped mechanism, including WHY unproven-ends-the-walk cannot under-detect (bash cannot execute past an unterminated substitution either).

## Tests

- 22 regression tests in `TestSelfKillArgvWindowIsQuoteAware`: 11 detect cases (the issue's decoy, backtick/sudo/nested/double-quoted/`&>`/escaped-backtick/later-segment spellings, quoted-separator, unbalanced-decoyed control) and 11 allow cases (the issue's two documented intentional non-detections, comments, single-quoted data, substitution-before-kill environment words, glued-word arguments, double-quoted-substitution remainder scoping).
- Mutation-verified: 6 distinct mutations (unwire the raw pass; blind the `$(` opener; drop the forward bound; count glued words; naive backtick find; drop state carry; fail-open unproven spans) each fail at least one distinct test.
- Full local gates green: isort / flake8 7.1.0 / mypy 1.14.1 / black-baseline / subprocess-encoding / brand / harness parity (CI-pinned versions).
- `test_denied_commands_security.py` + `test_security.py`: 2534 passed. Full-suite failures on this host (84F/18E in file_explorer/design_tweak/autonudge/host_isolation) reproduce byte-identically on pristine main — host-environmental, not this change.
- bash ground truth for every claim marked "measured" was captured during review (live-victim harness; both reviewers reproduced the kill independently).

## Server-side review round 1 (head 420606268)

GPT 5.6 lane BLOCKED head 0583d40de with F1 (adjudication upheld): quote-SPLICED ``k''ill`` reached the raw pass's `== "kill"` comparison with its splice intact, so `k''ill $(printf ')' ; pgrep -f kirocrew)` slipped both union halves. Verified on source and in bash (the spliced spelling runs `kill`; the inner clause executes). Fixed at root: the word walk now drops quote SYNTAX characters (openers/closers per the shared state machine's own transitions) while keeping quote DATA (inside the other quote type, or escaped), with an `open_word` flag so `''#` still reads as a word rather than a comment. Pinned by 3 new splice regression tests (25 total); a mutation restoring the old behavior fails all 3.

## Server-side review round 2 (head e64218c38)

GPT 5.6 lane BLOCKED head 420606268 with a residual of round 1's own fix: marking `kill$()` (EMPTY substitution glue) as glued excluded it from the kill match, losing the segment anchor — while bash expands `$()` to nothing and runs `kill`. Fixed by word-continuity for whitespace-only substitution bodies (the raw-walk analogue of `_EMPTY_SUBST_RE`), with `open_word` set on the skip so `$()#` stays a word exactly as bash lexes it. 2 regression tests added (27 total), mutation-verified; bash-measured in both directions.

## Server-side review round 3 (head ba9583da9)

GPT 5.6 lane BLOCKED head e64218c38 with two fenced findings. F1 (`kill$(:)` — a NON-empty body that expands to nothing at runtime re-broke the kill anchor): fixed by `_kill_prefix_keeps_anchor` — a first word whose pre-glue prefix is exactly `kill` keeps its anchor, failing toward detection since emptiness of `$(B)` output is statically undecidable; position-scoped so the round-1 false-positive contract (`echo kill$(printf x) …` allowed) still holds, 3 tests added (30 total), mutation-verified. F2 (`case x in x)` pattern paren truncating the substitution body): verified real in bash but PRE-EXISTING in the shared `_matching_close_paren` on pristine main (identical truncated body, git-publish consumer included) — rebutted with evidence and filed as #8830 so the one shared machine heals all consumers together.

## Server-side review round 4 (head c892bed05)

GPT 5.6 lane BLOCKED head ba9583da9 on `>|` (noclobber-override redirect read as a separator). Third member of the redirect-spelling class, so the fix closes the CLASS: audited every redirect spelling against the separator set — only `&` and `|` intersect it, `;`/newline never do — and folded both into one guard with the closure argument in the comment. bash-measured in both directions (`>|` decoy detected; a real pipe still separates). 2 tests added, pipe separation pinned at predicate level (33 total), mutation-verified.

## Server-side review round 5 (head 7492a02b2)

GPT 5.6 lane BLOCKED head c892bed05 on the alias+decoy combination `K=kill; $K $(printf ')' ; pgrep -f <name>)`: the token walk resolves `$K` but its window is quote-blind (the original #8633 defect), and the raw walk had the quote-aware window but only a literal `kill` anchor — each union half missing the other's strength on the same input. Fixed by a segment-ordered alias map in the raw walk (assignment-prefix words only, anchor selection before the segment's own assignments record, matching bash's expansion-before-assignment order). 3 tests added (36 total), mutation-verified.

## Server-side review round 6 (head 87a1942c3)

GPT 5.6 lane BLOCKED head 7492a02b2 on `` `printf kill` $(decoy) `` — a command-position substitution producing the verb. The undecoyed twin was already detected on main (token side), so the gap was once more the decoy combination on the raw side. Fixed by `_static_substitution_output`: a pure-substitution word anchors as its statically-resolved output for `echo`/`printf` literal bodies, and as an unmatchable marker for anything dynamic (fail direction: under-anchor to the ledger, never conjure). 2 tests (38 total), mutation-verified, bash-measured.

## Pattern harvest

Rule candidate: a scan window bounded by counting delimiter characters on de-quoted tokens under-runs on quoted delimiters; bound windows on the raw text through the shared quote-aware walk instead.
Class: sibling `_substitution_depth_delta` windows remain in `_is_credential_mint` (mint-verb window), `_operands_lead_with` feeding the self-subcommand floor, and `_is_self_kill`'s pkill loop (low reachability: the exploiting spelling errors at runtime) — tracked with the pre-existing quadratic token-walk cost in the follow-up issue.

Closes #8633







<!-- readiness-refresh 2026-09-06T00:05Z -->
