### PR TITLE
fix(dashboard): keep steers pending on an empty consumed echo (#8481)

### DIFF
--- a/src/kiro_crew/dashboard/chat_delivery.py
+++ b/src/kiro_crew/dashboard/chat_delivery.py
@@ -456,15 +456,14 @@ async def steer_into_running_turn(
     # RPC: delivered and live, with no consumption echo yet, so `written`.
     #
     # Gone means SOME remover took it during the await, and absence alone does not
-    # say which -- that is the whole difficulty. AT LEAST TWO can: the settle path
-    # promoting an entry a non-empty echo accounted for, and the
-    # `settle_all_on_empty` sweep clearing the pending list on an EMPTY echo, which
-    # is no evidence of consumption at all. After the fact the two removals are
-    # indistinguishable here, so inferring `consumed` from absence persisted a
-    # success badge on a frame that proved nothing -- terminal and never corrected,
-    # which is the exact claim this change exists to stop. An earlier version of
-    # this comment asserted that every other remover had returned above; it had not,
-    # and that sentence is why the bug read as correct.
+    # say which -- that is the whole difficulty. The settle path promotes an entry
+    # a non-empty echo accounted for, and a remover that takes entries WITHOUT
+    # such evidence (an empty-echo sweep, should any caller ever select one) looks
+    # identical here after the fact. So inferring `consumed` from absence persisted
+    # a success badge on a frame that proved nothing -- terminal and never
+    # corrected, which is the exact claim this change exists to stop. An earlier
+    # version of this comment asserted that every other remover had returned
+    # above; it had not, and that sentence is why the bug read as correct.
     #
     # So the state comes from POSITIVE evidence: the settle path records the delivery
     # ids a non-empty echo accounted for, and only a recorded id yields `consumed`.

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -4436,13 +4436,20 @@ def _settle_consumed_steers(
     """
     if not slot._pending_steers:
         return
-    # settle_all_on_empty preserves this path's long-standing behaviour on an
-    # empty echo. The /side sidecar deliberately chose the opposite (an empty
-    # echo is no evidence, so keep entries pending and let the requeue show a
-    # cancellable card); whether the main chat should follow is a separate
-    # change, because its requeue is not exercised here.
+    # An empty echo is no evidence of consumption (``steer_settle`` says so in
+    # as many words), so nothing settles and every entry stays pending. ``_requeue_unconsumed_steers`` -- wired into
+    # ``_run_chat``'s outer finally, so it runs on every turn-exit path --
+    # degrades a pending entry to a queue card at the head of the queue. The
+    # cost is a duplicate: on a backend that injected the steer but echoed no
+    # text, the steer runs again -- usually immediately, since the turn-exit
+    # drain starts the next queued turn -- but it runs VISIBLY, as its own turn
+    # in the transcript (and holds as a cancellable card when the drain is
+    # withheld, e.g. sign-in required), unlike the silent loss that sweeping
+    # the list on no evidence produces. Every sibling call site (the
+    # ``_refusal_notices`` settle in the same event branch, and the ``/side``
+    # sidecar) settles nothing on an empty echo too.
     previous = list(slot._pending_steers)
-    remaining = settle_consumed_steers(previous, snapshot, settle_all_on_empty=True)
+    remaining = settle_consumed_steers(previous, snapshot)
     settled_count = len(previous) - len(remaining)
     logger.debug(
         "Steer consumed for slot %s (%d settled, %d still pending)",
@@ -4451,14 +4458,12 @@ def _settle_consumed_steers(
         len(remaining),
     )
     if state is not None and snapshot.strip():
-        # Promote ONLY on an echo that carried evidence. `settle_all_on_empty=True`
-        # makes an EMPTY echo clear the pending list -- this path's long-standing
-        # behaviour, which suppresses the requeue -- but an empty echo is no
-        # evidence of consumption at all (``steer_settle`` says so in as many
-        # words). Writing `consumed` on it would put the PR's own defect back:
-        # the row, the transcript and the history would all assert an injection
-        # nothing confirmed. Left `written`, which is what is actually known.
-        #
+        # Promote ONLY on an echo that carried evidence. An empty echo settles
+        # nothing, so the multiset difference below is empty and promotes
+        # nothing even without this guard -- it stays as an explicit
+        # fail-closed gate, mirroring ``chat_delivery``'s positive-evidence
+        # discipline, so a future change to the settle rules cannot make an
+        # evidence-free frame promote a row.
         # Promote exactly the entries this echo accounted for. Computed as a
         # multiset difference against `remaining` so a duplicate identical steer
         # that stayed pending does not get its row promoted by its twin's echo.
@@ -9072,11 +9077,11 @@ async def _run_chat(
             elif event.kind == EVENT_STEER_CONSUMED:
                 _settle_consumed_steers(slot, event.text or "", state)
                 if _refusal_notices:
-                    # Same echo, same parser as the user-steer ledger, but
-                    # settle_all_on_empty stays False here: an empty echo is no
-                    # evidence, and treating it as delivery would drop the
-                    # fallback continuation and leave the model holding
-                    # kiro-cli's "User denied tool execution" uncorrected.
+                    # Same echo, same parser as the user-steer ledger: an
+                    # empty echo is no evidence, and treating it as delivery
+                    # would drop the fallback continuation and leave the model
+                    # holding kiro-cli's "User denied tool execution"
+                    # uncorrected.
                     _still_pending = settle_consumed_steers(_refusal_notices, event.text or "")
                     _refusal_notices_settled += len(_refusal_notices) - len(_still_pending)
                     _refusal_notices[:] = _still_pending

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -3918,14 +3918,14 @@ class _ChatSlot:
         # live and terminal state on the slot so reconnects can hydrate cards.
         self._native_subagent_tracker: dict[str, dict[str, Any]] = {}
         self._native_subagent_output: dict[str, list[str]] = {}
-        # Delivery ids whose steer a NON-EMPTY echo actually accounted for. The
-        # settle path can remove an entry from `_pending_steers` for two reasons
-        # that look identical afterwards: a matched echo (evidence), or the
-        # `settle_all_on_empty` sweep on an EMPTY echo (no evidence at all).
-        # `chat_delivery` infers `consumed` from the entry being gone, so without
-        # this it reads an empty frame as a confirmed injection and persists a
-        # success badge nothing proved. Keyed on the delivery id, not the text, so
-        # a later identical steer cannot inherit an earlier one's evidence.
+        # Delivery ids whose steer a NON-EMPTY echo actually accounted for. An
+        # entry can leave `_pending_steers` for reasons that look identical
+        # afterwards, and only a matched, non-empty echo is evidence of
+        # consumption. `chat_delivery` therefore infers `consumed` from
+        # positive evidence rather than from the entry being gone, so no
+        # remover -- present or added later -- can turn an evidence-free frame
+        # into a confirmed injection. Keyed on the delivery id, not the text,
+        # so a later identical steer cannot inherit an earlier one's evidence.
         self._steer_confirmed: set[str] = set()
         # Mid-turn steers handed to the backend but not yet confirmed consumed
         # (no steering_consumed / EVENT_STEER_CONSUMED echo yet). Appended by

--- a/src/kiro_crew/dashboard/steer_settle.py
+++ b/src/kiro_crew/dashboard/steer_settle.py
@@ -19,8 +19,6 @@ _BLOCK_RE = re.compile(r"<user_message>\n(.*?)\n</user_message>", re.DOTALL)
 def settle_consumed_steers(
     pending: list[str],
     snapshot: str,
-    *,
-    settle_all_on_empty: bool = False,
 ) -> list[str]:
     """Return the entries of *pending* that ``snapshot`` did NOT account for.
 
@@ -45,14 +43,9 @@ def settle_consumed_steers(
     A NON-empty echo carrying no envelope is treated as one bare block rather than
     as no evidence, so it settles only the entry it EQUALS -- unrelated prose still
     matches nothing and still settles nothing.
-
-    ``settle_all_on_empty=True`` selects the opposite, and exists only because the
-    main chat has long behaved that way; this argument keeps that path byte-identical
-    rather than changing a behaviour whose requeue this change does not exercise.
-    New callers should leave it False.
     """
     if not snapshot.strip():
-        return [] if settle_all_on_empty else list(pending)
+        return list(pending)
     counts: dict[str, int] = {}
     blocks = _BLOCK_RE.findall(snapshot)
     if not blocks:

--- a/test/test_chat_runner_coverage.py
+++ b/test/test_chat_runner_coverage.py
@@ -1996,7 +1996,9 @@ class TestSteerLifecycle:
             chat_runner._settle_consumed_steers(slot, "a")
 
         assert slot._pending_steers == ["b"]
-        assert settle.call_args.kwargs["settle_all_on_empty"] is True
+        # No opt-out kwarg: the shared rules settle nothing on an empty echo,
+        # and this call site must not select anything else.
+        assert settle.call_args.kwargs == {}
 
     def test_requeue_is_a_noop_without_pending_steers(self, tmp_path):
         state, slot = _state(tmp_path), _slot()

--- a/test/test_steer_requeue.py
+++ b/test/test_steer_requeue.py
@@ -245,15 +245,16 @@ class TestSteerConsumedClears:
         )
         assert slot._pending_steers == []
 
-    def test_empty_snapshot_falls_back_to_settling_all(self, tmp_path, monkeypatch):
-        # Older backend / redacted echo: no usable text -> pre-review behavior
-        # (settle all; duplicate is visible+cancellable, loss is not).
+    def test_empty_snapshot_settles_nothing(self, tmp_path, monkeypatch):
+        # Older backend / redacted echo: no usable text is no evidence of
+        # consumption, so everything stays pending for the turn-end requeue.
+        # A duplicate card is visible and cancellable; a silent loss is not.
         from kiro_crew.dashboard.chat_runner import _settle_consumed_steers
 
         slot = self._slot(tmp_path, monkeypatch)
         slot._pending_steers = ["a", "b"]
         _settle_consumed_steers(slot, "   ")
-        assert slot._pending_steers == []
+        assert slot._pending_steers == ["a", "b"]
 
     def test_substring_steer_not_falsely_settled(self, tmp_path, monkeypatch):
         # review-bot regression: "fix" is a SUBSTRING of the consumed block
@@ -738,8 +739,8 @@ class TestSteerLifecycleState:
 
         async def _consume_during_rpc(_msg):
             # Drive the REAL settle with a REAL echo rather than hand-clearing the
-            # list. A bare `_pending_steers.clear()` reproduces the EVIDENCE-FREE
-            # `settle_all_on_empty` sweep, not a matched echo -- an injection
+            # list. A bare `_pending_steers.clear()` would reproduce an
+            # EVIDENCE-FREE sweep, not a matched echo -- an injection
             # narrower than the fault this test names, which let it pass while
             # `chat_delivery` was inferring `consumed` from absence alone.
             from kiro_crew.dashboard.chat_runner import _settle_consumed_steers
@@ -770,12 +771,12 @@ class TestSteerLifecycleState:
     ):
         """An EMPTY echo is no evidence, so the row must not claim consumption.
 
-        `_settle_consumed_steers` passes `settle_all_on_empty=True`, so an empty
-        frame clears the pending list without matching anything. `chat_delivery`
-        used to infer `consumed` from the entry being gone, which turned a frame
-        that proved nothing into a success badge -- and a row persisted as
-        `consumed` is terminal, so nothing ever corrected it. That is the #7246
-        defect this change exists to remove, reached by a different route.
+        An empty frame settles nothing, so the entry stays registered -- the
+        still-registered path, which yields `written`. `chat_delivery` used to
+        infer `consumed` from the entry being gone, which turned a frame that
+        proved nothing into a success badge -- and a row persisted as `consumed`
+        is terminal, so nothing ever corrected it. That is the #7246 defect this
+        change exists to remove, reached by a different route.
         """
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         state = _make_state(tmp_path)
@@ -800,8 +801,9 @@ class TestSteerLifecycleState:
         outcome = await steer_into_running_turn(state, slot, "go north")
 
         assert outcome == STEER_STEERED
-        # The sweep really did clear it, so this is the absence-inferring path.
-        assert slot._pending_steers == []
+        # The empty echo settled nothing, so the entry is still registered when
+        # the RPC resumes -- the still-registered path, which yields `written`.
+        assert slot._pending_steers == ["go north"]
         row = next(m for m in slot.messages if m.get("meta", {}).get("steer"))
         assert (
             row["meta"].get("steerState") == "written"
@@ -1167,14 +1169,15 @@ class TestSteerLifecycleState:
 
     @pytest.mark.asyncio
     async def test_an_empty_echo_never_claims_consumption(self, tmp_path, monkeypatch, _patch_sel):
-        """An empty echo clears the pending list but must not promote any row.
+        """An empty echo leaves the pending list untouched and promotes no row.
 
-        `settle_all_on_empty=True` is this path's long-standing behaviour and it
-        stays, so an empty echo still suppresses the requeue. But an empty echo is
-        no evidence of consumption -- `steer_settle` says exactly that -- so writing
-        `consumed` off it would reinstate the defect this change exists to remove:
-        the row, the transcript and the history all asserting an injection nothing
-        confirmed.
+        The #8481 regression: an empty EVENT_STEER_CONSUMED echo used to clear
+        the whole pending list with no evidence, which suppressed
+        `_requeue_unconsumed_steers` -- the user's correction was silently
+        lost while its row claimed delivery. An empty
+        echo is no evidence of consumption (`steer_settle` says exactly that),
+        so the entry must stay pending, nothing may be promoted, and the
+        turn-end requeue must render a visible, cancellable queue card.
         """
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
         state = _make_state(tmp_path)
@@ -1186,7 +1189,10 @@ class TestSteerLifecycleState:
         slot._acp_client = client_mock
 
         from kiro_crew.dashboard.chat_delivery import steer_into_running_turn
-        from kiro_crew.dashboard.chat_runner import _settle_consumed_steers
+        from kiro_crew.dashboard.chat_runner import (
+            _requeue_unconsumed_steers,
+            _settle_consumed_steers,
+        )
 
         await steer_into_running_turn(state, slot, "go north")
         row = next(m for m in slot.messages if m.get("meta", {}).get("steer"))
@@ -1194,13 +1200,22 @@ class TestSteerLifecycleState:
 
         _settle_consumed_steers(slot, "   ", state)
 
-        # pending-list behaviour unchanged: the empty echo still settles it
-        assert slot._pending_steers == []
-        # but nothing was CLAIMED about the row
+        # the empty echo settled NOTHING: the entry is still pending
+        assert slot._pending_steers == ["go north"]
+        # and nothing was CLAIMED about the row
         assert row["meta"].get("steerState") == "written"
         assert not any(
             c.args[0] == "chat_message_update" for c in state.broadcast_ws.call_args_list
         )
+
+        # the turn ends with the entry still pending, so the teardown requeue
+        # (wired into _run_chat's outer finally) renders a cancellable card
+        # instead of the correction being silently dropped
+        _requeue_unconsumed_steers(state, slot)
+
+        assert [entry["content"] for entry in slot._queue] == ["go north"]
+        assert slot._pending_steers == []
+        assert row["meta"].get("steerState") == "requeued"
 
     @pytest.mark.asyncio
     async def test_a_duplicate_pending_steer_settles_one_entry_only(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem / Motivation

A mid-turn steer (the user's correction typed while a turn is running) could be silently lost. When the ACP backend sends an `EVENT_STEER_CONSUMED` echo with **empty text** — a legitimate case per `session_handle.py`'s emitter and `steer_settle`'s own docstring (older backend, dropped echo) — the main chat's `_settle_consumed_steers` called `settle_consumed_steers(..., settle_all_on_empty=True)`, which cleared **all** pending steers with no evidence. That suppressed `_requeue_unconsumed_steers`, so the correction ran nowhere while its transcript row claimed delivery.

## Why it matters

The user's correction is exactly the message they care most about mid-turn. Losing it silently — with the UI asserting it was delivered — is the worst failure shape: unrecoverable and invisible. Every sibling call site (the `_refusal_notices` settle in the same event branch, and the `/side` sidecar) already settles nothing on an empty echo for this precise reason; the main chat was the sole holdout.

## What changed (motivation → approach → change)

- Symptom: an empty consumed echo makes a mid-turn steer vanish while its row reads as delivered.
- Root cause: `settle_all_on_empty=True` at the main chat's `_settle_consumed_steers` call treats an evidence-free frame as proof of consumption. The stated reason for deferring the flip ("the requeue mechanism does not exercise this path") is stale: `_requeue_unconsumed_steers` is wired into `_run_chat`'s outer `finally` and runs on every turn-exit path (normal return, exception, cancellation).
- Change: delete the `settle_all_on_empty` opt-in outright — after the flip it had zero production selectors of `True` (both review lanes converged on this), so the empty-echo rule is now unconditional in `settle_consumed_steers`: an empty echo settles nothing, entries stay pending, and the turn-end requeue degrades them to queue cards. The accepted cost, named at the call site: on a backend that injected the steer but echoed no text, the steer runs again — usually immediately via the turn-exit drain, but visibly as its own turn (and holds as a cancellable card when the drain is withheld, e.g. sign-in required), unlike a silent loss.
- Comments/docstrings in `chat_runner.py`, `steer_settle.py`, `state.py`, and `chat_delivery.py` that described the sweep as live behaviour were restated as present-tense invariants.

## Tests

- `test_empty_snapshot_settles_nothing` (rewritten from `test_empty_snapshot_falls_back_to_settling_all`, which pinned the bug): an empty echo leaves `_pending_steers` untouched.
- `test_an_empty_echo_never_claims_consumption` (rewritten as the regression test): empty echo → entry stays pending → no row promoted → `_requeue_unconsumed_steers` emits a `requeued` card carrying the steer.
- `test_an_empty_echo_during_the_rpc_persists_as_written`: updated — the entry now survives the empty echo, exercising the still-registered → `written` path.
- `test_settle_delegates_to_the_shared_rules`: the delegation assert flipped to `settle_all_on_empty is False` (load-bearing).
- Mutation-verified: flipping the empty-echo branch back to settle-everything fails 4 distinct tests.

## Manual verification

N/A — unit coverage sufficient: the settle and requeue paths are exercised end-to-end through `steer_into_running_turn` + `_settle_consumed_steers` + `_requeue_unconsumed_steers` in the tests above, and the full backend suite's failure set is byte-identical to pristine `main` on this host (environmental only).

## Related Issues

Closes #8481. Context: #7997 (merged prerequisite; this flip was deliberately held until it landed), #7998 (distinct no-echo-arrives case, already requeues correctly — not changed here).

## Pattern harvest

Rule candidate: review-prompt
Pattern: a boolean escape-hatch parameter whose only selector is "long-standing behaviour" — the deferral rationale goes stale when the blocking mechanism lands; audit such flags when their named prerequisite merges.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff



<!-- readiness-refresh 2 -->
