### PR TITLE
fix(dev-fleet): cache disk aggregation behind a TTL instead of rescanning per poll (#8787)

### DIFF
--- a/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/fleet_state.py
@@ -1313,23 +1313,70 @@ _PROVISION_LOCK = LoopBoundLock()
 
 
 # --- disk aggregation ---
+# One aggregation runs `du -sm` sequentially over every worktree (60s
+# per-worktree timeout), so it is far too expensive to run per poll: the
+# dashboard polls /api/disk every 30 seconds, while worktree sizes change only
+# when a checkout is created, removed, or pruned. A completed result is
+# therefore served from ``_DISK`` until it is older than ``_DISK_TTL``; a
+# stale result is refreshed by exactly ONE coalesced background aggregation
+# while every concurrent poll keeps reading the previous numbers
+# (stale-while-revalidate), so an open dashboard never sustains back-to-back
+# scans.
+_DISK_TTL = 300.0  # seconds a completed aggregation stays fresh
 _DISK: dict = {"status": "idle", "total_mb": None, "per": {}}
 _DISK_COMPUTING = False
+# ``time.monotonic()`` when the last aggregation stored its result. 0.0 means
+# no trustworthy completed result exists -- never measured, or invalidated by
+# a worktree mutation -- so the next read must launch a fresh aggregation.
+_DISK_COMPUTED_AT = 0.0
+# Bumped by ``_disk_invalidate``. An aggregation that started BEFORE an
+# invalidation measured the tree the mutation just changed, so stamping its
+# result fresh would serve pre-mutation numbers for a full TTL; the epoch
+# comparison in ``work`` leaves such a result stale instead.
+_DISK_EPOCH = 0
+
+
+def _disk_invalidate() -> None:
+    """Force the next ``_disk`` read to launch a fresh aggregation.
+
+    Called from the worktree-removal chokepoint (which the single-worktree
+    handler, the parallel prune workers, and the auto-prune reaper all route
+    through), because a removal is the in-app mutation that materially changes
+    worktree disk use. Only the freshness stamp is dropped -- the cached
+    numbers keep serving (stale-while-revalidate) -- so the poll after a
+    removal starts one refresh instead of the UI showing pre-removal totals
+    for the rest of the TTL.
+    """
+    global _DISK_COMPUTED_AT, _DISK_EPOCH
+    _DISK_EPOCH += 1
+    _DISK_COMPUTED_AT = 0.0
 
 
 async def _disk() -> dict:
     global _DISK_COMPUTING
-    if _DISK["status"] == "computing":
+    if _DISK_COMPUTING or _DISK["status"] == "computing":
         return dict(_DISK)
-    if _DISK["status"] == "done":
-        snap = dict(_DISK)
-        _DISK["status"] = "idle"
-        return snap
-    _DISK["status"] = "computing"
+    if (
+        _DISK["status"] == "done"
+        and _DISK_COMPUTED_AT > 0.0
+        and time.monotonic() - _DISK_COMPUTED_AT < _DISK_TTL
+    ):
+        return dict(_DISK)
+    # First read, or the completed result went stale: start exactly one
+    # coalesced background refresh. No await separates the in-flight check
+    # above from the flag set below, so on asyncio's single event loop
+    # concurrent polls cannot both reach this point.
+    started_epoch = _DISK_EPOCH
     _DISK_COMPUTING = True
+    if _DISK["status"] != "done":
+        # Only the very first aggregation surfaces as "computing": once a
+        # completed result exists, refreshes run behind it and pollers keep
+        # seeing the previous numbers.
+        _DISK["status"] = "computing"
 
     async def work() -> None:
-        global _DISK_COMPUTING
+        global _DISK_COMPUTING, _DISK_COMPUTED_AT
+        fresh = False
         try:
             per: dict = {}
             total = 0
@@ -1344,13 +1391,25 @@ async def _disk() -> dict:
                 except (ValueError, IndexError):
                     pass
             _DISK.update({"status": "done", "total_mb": total, "per": per})
+            fresh = True
         except Exception:  # noqa: BLE001
-            _DISK.update({"status": "done", "total_mb": None, "per": {}})
+            # A transient discovery failure (a git timeout while a concurrent
+            # prune holds the repo, for example) must not clobber good numbers
+            # or be cached as a fresh measurement. Discovery raises before any
+            # `du` runs, so the next poll's retry is cheap. Only a first run
+            # with nothing to fall back on reports unknown.
+            if _DISK["status"] != "done":
+                _DISK.update({"status": "done", "total_mb": None, "per": {}})
         finally:
+            # Stamp fresh only for a successful measurement no mutation
+            # overlapped (a mid-flight invalidation makes it pre-mutation);
+            # anything else leaves the stamp at 0.0 so the next read starts a
+            # fresh aggregation while the kept numbers serve in the meantime.
+            _DISK_COMPUTED_AT = time.monotonic() if fresh and _DISK_EPOCH == started_epoch else 0.0
             _DISK_COMPUTING = False
 
     asyncio.create_task(work())
-    return {"status": "computing", "total_mb": None, "per": {}}
+    return dict(_DISK)
 
 
 __all__ = (
@@ -1359,7 +1418,10 @@ __all__ = (
     "_CTX_MAX_TICKETS",
     "_CTX_TTL",
     "_DISK",
+    "_DISK_COMPUTED_AT",
     "_DISK_COMPUTING",
+    "_DISK_EPOCH",
+    "_DISK_TTL",
     "_FLEET_CACHE",
     "_FLEET_EPOCH",
     "_FLEET_INFLIGHT",
@@ -1388,6 +1450,7 @@ __all__ = (
     "_context_cached",
     "_cpu_percent",
     "_disk",
+    "_disk_invalidate",
     "_drop_worktrees",
     "_extract_issue_refs",
     "_extract_ticket_ids",

--- a/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/runtime.py
@@ -13,7 +13,7 @@ import sys
 import time
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.dev_fleet import npm_preflight, sync_runner
@@ -698,11 +698,18 @@ async def _start_run(
     cwd: str | None = None,
     env: dict | None = None,
     cleanup_paths: list[str] | None = None,
+    on_finish: Callable[[], None] | None = None,
 ) -> str:
     """Start a background subprocess with output streaming and watchdog.
 
     ``cleanup_paths``: sandbox launcher/profile temp files from
     ``sandboxed_spawn_argv`` — deleted when the run finishes.
+
+    ``on_finish``: invoked once when the run reaches ANY terminal state
+    (done, timeout, spawn failure, shutdown abort, cancellation) — a killed
+    run may still have mutated disk, so terminal means finished, not
+    succeeded. Must be a cheap synchronous callable; exceptions are logged
+    and never propagate into the worker's own cleanup.
     """
     rid = uuid.uuid4().hex[:12]
     # The run KIND, captured before the output loop can touch it. `label` is
@@ -906,6 +913,11 @@ async def _start_run(
                 _RUNS[rid]["exit_code"] = -1
                 _RUNS[rid]["output"].append("[error] " + str(exc))
         finally:
+            if on_finish is not None:
+                try:
+                    on_finish()
+                except Exception:  # noqa: BLE001
+                    logger.exception("run %s on_finish callback failed", rid)
             for cp in cleanup_paths or []:
                 # A caller may register a temp FILE, or a temp directory it
                 # created for one (the dependency-only sync stages a snapshot

--- a/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
+++ b/src/kiro_crew/apps/builtins/dev_fleet/worktree_ops.py
@@ -415,6 +415,12 @@ async def _pod_provision(name: str) -> dict:
             cwd=repository._repo(),
             env=p_env,
             cleanup_paths=[p_cleanup] if p_cleanup else None,
+            # Provisioning builds .venv and the SPA dist INSIDE the worktree
+            # that `du -sm` measures, so a completed (or killed-partway) run
+            # materially changes disk use: drop the disk cache's freshness
+            # stamp at every terminal state so the next /disk poll
+            # re-aggregates instead of serving pre-provision totals.
+            on_finish=fleet_state._disk_invalidate,
         )
         fleet_state._PROVISION_INFLIGHT[name] = rid
     return {"ok": True, "run_id": rid}
@@ -1337,6 +1343,11 @@ async def _worktree_remove_locked(
             (verdict_oid or "").strip()[:12] if verdict_oid else "none",
         )
         fleet_state._fleet_forget(name)
+        # A removed checkout materially changes worktree disk use, and this is
+        # the chokepoint every removal path already routes through: drop the
+        # disk cache's freshness stamp so the next /disk poll re-aggregates
+        # instead of serving pre-removal totals for the rest of the TTL.
+        fleet_state._disk_invalidate()
         return {
             "ok": True,
             "removed": True,
@@ -1932,7 +1943,15 @@ async def _sync_start_locked() -> dict:
         steps_sha256,
     ]
     rid = await runtime._start_run(
-        runtime._SYNC_RUN_LABEL, cmd, env=runtime._build_env(), cleanup_paths=cleanups
+        runtime._SYNC_RUN_LABEL,
+        cmd,
+        env=runtime._build_env(),
+        cleanup_paths=cleanups,
+        # A dependency sync writes pip installs into the repo .venv and
+        # `npm ci` into website/node_modules — both inside trees `du -sm`
+        # measures — so it invalidates the disk cache the same way a
+        # provision run does.
+        on_finish=fleet_state._disk_invalidate,
     )
     _SYNC_RID = rid
     return {"ok": True, "run_id": rid}

--- a/test/test_dev_fleet_app.py
+++ b/test/test_dev_fleet_app.py
@@ -6058,6 +6058,7 @@ async def test_sync_pip_uses_target_repo_venv(monkeypatch, tmp_path):
 
     async def fake_start_run(label, cmd, **kw):
         captured["cmd"] = cmd
+        captured["start_run_kw"] = kw
         return "rid-1"
 
     monkeypatch.setattr(runtime_mod, "_start_run", fake_start_run)
@@ -6067,6 +6068,9 @@ async def test_sync_pip_uses_target_repo_venv(monkeypatch, tmp_path):
     assert pip_argvs, captured.get("argvs")
     assert pip_argvs[0][0] == str(repo / ".venv" / "bin" / "python")
     assert pip_argvs[0][0] != _sys.executable
+    # A dependency sync writes into the measured repo (.venv, node_modules),
+    # so the run must carry the disk-cache invalidation hook (#8787).
+    assert captured["start_run_kw"].get("on_finish") is fleet_state_mod._disk_invalidate
 
 
 @pytest.mark.asyncio
@@ -8432,6 +8436,99 @@ async def test_removal_audit_log_emitted(caplog):
     assert "caller=handler" in msg
     assert "action=removed" in msg
     assert "pr_state=MERGED" in msg
+
+
+@pytest.mark.asyncio
+async def test_removal_invalidates_disk_cache():
+    """Successful removal drops the disk cache's freshness stamp (#8787).
+
+    The chokepoint that every removal path routes through (single-worktree
+    handler, prune workers, auto-prune reaper) must invalidate the /disk TTL
+    cache alongside evicting the fleet row, so the next poll re-aggregates
+    instead of serving pre-removal totals for the rest of the TTL.
+    """
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    with (
+        patch.object(
+            repository_mod,
+            "_find_worktree",
+            new_callable=AsyncMock,
+            return_value=({"path": "/fake/wt", "branch": "feat-x", "is_main": False}, None),
+        ),
+        patch.object(live_mod, "_live_worktree_path", new_callable=AsyncMock, return_value=None),
+        patch.object(live_mod, "_own_checkout_path", return_value=None),
+        patch.object(repository_mod, "_real_dirty", new_callable=AsyncMock, return_value=False),
+        patch.object(
+            fleet_state_mod,
+            "_pr_status_cached",
+            new_callable=AsyncMock,
+            return_value={"state": "MERGED"},
+        ),
+        patch.object(repository_mod, "_own_commits_count", new_callable=AsyncMock, return_value=0),
+        patch.object(repository_mod, "_git", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(fleet_state_mod, "_fetch_pr_head_oid", new_callable=AsyncMock, return_value="aaa1111"),
+        patch.object(fleet_state_mod, "_head_contained_in_pr", new_callable=AsyncMock, return_value=True),
+        patch.object(runtime_mod, "_load_cfg", return_value=None),
+        patch.object(runtime_mod, "_POD_AVAILABLE", False),
+        patch.object(runtime_mod, "_run_cmd", new_callable=AsyncMock, return_value=(0, "", "")),
+        patch.object(repository_mod, "_upstream_remote", new_callable=AsyncMock, return_value="origin"),
+        patch.object(fleet_state_mod, "_disk_invalidate") as invalidate,
+    ):
+        result = await mod._worktree_remove("feat-x", force=False)
+
+    assert result["ok"] is True
+    invalidate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_start_run_invokes_on_finish_at_terminal_state():
+    """_start_run's on_finish fires once when the run finishes (#8787)."""
+    import kiro_crew.apps.builtins.dev_fleet.server as mod
+
+    calls: list[int] = []
+    rid = await mod._start_run("finish-test", ["true"], on_finish=lambda: calls.append(1))
+    for _ in range(50):
+        async with mod._RUNS_LOCK:
+            if mod._RUNS[rid]["status"] != "running":
+                break
+        await asyncio.sleep(0.05)
+    # The callback runs in the worker's finally, after the status stamp.
+    for _ in range(50):
+        if calls:
+            break
+        await asyncio.sleep(0.05)
+    assert calls == [1]
+
+
+@pytest.mark.asyncio
+async def test_pod_provision_registers_disk_invalidation(monkeypatch):
+    """Provisioning builds .venv/dist inside the measured worktree, so the
+    provision run must carry the disk-cache invalidation hook (#8787)."""
+    import kiro_crew.apps.builtins.dev_fleet.worktree_ops as wt_ops
+
+    captured: dict = {}
+
+    async def fake_start_run(label, cmd, **kw):
+        captured.update(kw, label=label)
+        return "rid-1"
+
+    monkeypatch.setattr(wt_ops, "_pod_checkout_guard", AsyncMock(return_value=None))
+    monkeypatch.setattr(fleet_state_mod, "_PROVISION_INFLIGHT", {})
+    monkeypatch.setattr(runtime_mod, "_warm_build_path", AsyncMock())
+    monkeypatch.setattr(runtime_mod, "_start_run", fake_start_run)
+    monkeypatch.setattr(runtime_mod, "_find_cli", lambda: ["kirocrew"])
+    monkeypatch.setattr(repository_mod, "_repo", lambda: "/fake/repo")
+    monkeypatch.setattr(wt_ops, "_pod_env", lambda: {})
+    monkeypatch.setattr(
+        wt_ops,
+        "shielded_prepare_off_loop",
+        AsyncMock(return_value=(["kirocrew", "pod", "provision", "feat-x"], {}, None)),
+    )
+
+    result = await wt_ops._pod_provision("feat-x")
+    assert result == {"ok": True, "run_id": "rid-1"}
+    assert captured.get("on_finish") is fleet_state_mod._disk_invalidate
 
 
 @pytest.mark.asyncio

--- a/test/test_dev_fleet_server_coverage.py
+++ b/test/test_dev_fleet_server_coverage.py
@@ -1079,16 +1079,153 @@ async def test_disk_in_progress_returns_snapshot(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_disk_done_snapshot_resets_to_idle(monkeypatch):
+async def test_disk_fresh_result_served_without_rescan(monkeypatch):
+    """A completed result inside the TTL is a cache, not a one-read handoff."""
     monkeypatch.setattr(fleet_state, "_DISK", {"status": "done", "total_mb": 42, "per": {"a": 42}})
-    snap = await fleet_state._disk()
-    assert snap["total_mb"] == 42
-    assert fleet_state._DISK["status"] == "idle"
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTED_AT", time.monotonic())
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
+    monkeypatch.setattr(
+        repository, "_discover_worktrees", AsyncMock(side_effect=AssertionError("must not scan"))
+    )
+    for _ in range(2):
+        snap = await fleet_state._disk()
+        assert snap == {"status": "done", "total_mb": 42, "per": {"a": 42}}
+    assert fleet_state._DISK["status"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_disk_six_sequential_polls_run_one_aggregation(monkeypatch):
+    """Regression for #8787: an open dashboard polling /disk must not re-scan.
+
+    Six sequential endpoint reads on main ran three full aggregations because
+    the done branch reset the state machine to idle on every snapshot. With
+    the TTL cache the same six reads run exactly one.
+    """
+    monkeypatch.setattr(fleet_state, "_DISK", {"status": "idle", "total_mb": None, "per": {}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTED_AT", 0.0)
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
+    discoveries = 0
+    du_calls: list = []
+
+    async def fake_discover():
+        nonlocal discoveries
+        discoveries += 1
+        return [{"path": "/repo/wt-a"}]
+
+    async def fake_run(cmd, **kw):
+        du_calls.append(cmd)
+        return (0, "12\t/repo/wt-a", "")
+
+    monkeypatch.setattr(repository, "_discover_worktrees", fake_discover)
+    monkeypatch.setattr(runtime, "_run_cmd", fake_run)
+
+    assert (await fleet_state._disk())["status"] == "computing"
+    for _ in range(50):
+        if fleet_state._DISK["status"] == "done":
+            break
+        await asyncio.sleep(0.01)
+    for _ in range(5):
+        snap = await fleet_state._disk()
+        assert snap == {"status": "done", "total_mb": 12, "per": {"wt-a": 12}}
+        await asyncio.sleep(0)  # give any wrongly-spawned refresh a chance to run
+    assert discoveries == 1
+    assert len(du_calls) == 1
+    assert fleet_state._DISK["status"] == "done"  # never reset back to idle
+
+
+@pytest.mark.asyncio
+async def test_disk_stale_cache_coalesces_one_refresh(monkeypatch):
+    """Concurrent polls past the TTL start exactly one background refresh."""
+    monkeypatch.setattr(fleet_state, "_DISK", {"status": "done", "total_mb": 42, "per": {"a": 42}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(
+        fleet_state, "_DISK_COMPUTED_AT", time.monotonic() - fleet_state._DISK_TTL - 1
+    )
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
+    started = 0
+    release = asyncio.Event()
+
+    async def fake_discover():
+        nonlocal started
+        started += 1
+        await release.wait()
+        return [{"path": "/repo/wt-a"}]
+
+    monkeypatch.setattr(repository, "_discover_worktrees", fake_discover)
+    monkeypatch.setattr(runtime, "_run_cmd", AsyncMock(return_value=(0, "7\t/repo/wt-a", "")))
+
+    snaps = await asyncio.gather(*(fleet_state._disk() for _ in range(6)))
+    # Every concurrent poll keeps observing the stale numbers, never a reset.
+    assert all(s == {"status": "done", "total_mb": 42, "per": {"a": 42}} for s in snaps)
+    await asyncio.sleep(0)  # let the refresh task reach the discovery await
+    assert started == 1
+    release.set()
+    for _ in range(50):
+        if fleet_state._DISK["total_mb"] == 7:
+            break
+        await asyncio.sleep(0.01)
+    assert fleet_state._DISK == {"status": "done", "total_mb": 7, "per": {"wt-a": 7}}
+    assert started == 1
+
+
+@pytest.mark.asyncio
+async def test_disk_invalidate_forces_refresh_on_next_read(monkeypatch):
+    """A worktree mutation drops the freshness stamp; the next read re-scans."""
+    monkeypatch.setattr(fleet_state, "_DISK", {"status": "done", "total_mb": 42, "per": {"a": 42}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTED_AT", time.monotonic())
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
+    monkeypatch.setattr(
+        repository, "_discover_worktrees", AsyncMock(return_value=[{"path": "/repo/wt-b"}])
+    )
+    monkeypatch.setattr(runtime, "_run_cmd", AsyncMock(return_value=(0, "9\t/repo/wt-b", "")))
+
+    fleet_state._disk_invalidate()
+    # The stale numbers keep serving while the refresh runs behind them.
+    assert await fleet_state._disk() == {"status": "done", "total_mb": 42, "per": {"a": 42}}
+    for _ in range(50):
+        if fleet_state._DISK["total_mb"] == 9:
+            break
+        await asyncio.sleep(0.01)
+    assert fleet_state._DISK == {"status": "done", "total_mb": 9, "per": {"wt-b": 9}}
+
+
+@pytest.mark.asyncio
+async def test_disk_mid_flight_invalidation_leaves_result_stale(monkeypatch):
+    """An aggregation overlapped by a mutation must not be stamped fresh."""
+    monkeypatch.setattr(fleet_state, "_DISK", {"status": "idle", "total_mb": None, "per": {}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTED_AT", 0.0)
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
+    release = asyncio.Event()
+
+    async def fake_discover():
+        await release.wait()
+        return [{"path": "/repo/wt-a"}]
+
+    monkeypatch.setattr(repository, "_discover_worktrees", fake_discover)
+    monkeypatch.setattr(runtime, "_run_cmd", AsyncMock(return_value=(0, "5\t/repo/wt-a", "")))
+
+    await fleet_state._disk()  # starts the aggregation
+    fleet_state._disk_invalidate()  # a mutation lands mid-flight
+    release.set()
+    for _ in range(50):
+        if fleet_state._DISK["status"] == "done":
+            break
+        await asyncio.sleep(0.01)
+    # The measurement is kept for display but left stale: the next read starts
+    # a fresh aggregation instead of serving pre-mutation numbers for a TTL.
+    assert fleet_state._DISK_COMPUTED_AT == 0.0
 
 
 @pytest.mark.asyncio
 async def test_disk_idle_starts_background_aggregation(monkeypatch):
     monkeypatch.setattr(fleet_state, "_DISK", {"status": "idle", "total_mb": None, "per": {}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTED_AT", 0.0)
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
     monkeypatch.setattr(
         repository,
         "_discover_worktrees",
@@ -1112,6 +1249,9 @@ async def test_disk_idle_starts_background_aggregation(monkeypatch):
 @pytest.mark.asyncio
 async def test_disk_aggregation_failure_reports_unknown(monkeypatch):
     monkeypatch.setattr(fleet_state, "_DISK", {"status": "idle", "total_mb": None, "per": {}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTED_AT", 0.0)
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
     monkeypatch.setattr(
         repository, "_discover_worktrees", AsyncMock(side_effect=RuntimeError("git"))
     )
@@ -1122,6 +1262,31 @@ async def test_disk_aggregation_failure_reports_unknown(monkeypatch):
             break
         await asyncio.sleep(0.01)
     assert fleet_state._DISK == {"status": "done", "total_mb": None, "per": {}}
+
+
+@pytest.mark.asyncio
+async def test_disk_transient_failure_preserves_numbers_and_retries(monkeypatch):
+    """A failed refresh keeps the previous result and is never cached fresh."""
+    monkeypatch.setattr(fleet_state, "_DISK", {"status": "done", "total_mb": 42, "per": {"a": 42}})
+    monkeypatch.setattr(fleet_state, "_DISK_COMPUTING", False)
+    monkeypatch.setattr(
+        fleet_state, "_DISK_COMPUTED_AT", time.monotonic() - fleet_state._DISK_TTL - 1
+    )
+    monkeypatch.setattr(fleet_state, "_DISK_EPOCH", 0)
+    monkeypatch.setattr(
+        repository, "_discover_worktrees", AsyncMock(side_effect=RuntimeError("git timeout"))
+    )
+
+    # Stale read starts the refresh, which fails behind the scenes.
+    assert await fleet_state._disk() == {"status": "done", "total_mb": 42, "per": {"a": 42}}
+    for _ in range(50):
+        if not fleet_state._DISK_COMPUTING:
+            break
+        await asyncio.sleep(0.01)
+    # Good numbers survive the failure, and the stamp stays 0.0 so the next
+    # read retries instead of serving the failure for a full TTL.
+    assert fleet_state._DISK == {"status": "done", "total_mb": 42, "per": {"a": 42}}
+    assert fleet_state._DISK_COMPUTED_AT == 0.0
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Problem / Motivation

Keeping the Dev Fleet dashboard page open drives a perpetual disk-scan loop. The frontend polls `/apps/dev-fleet/api/disk` every 30 seconds, and the backend's `_disk()` state machine treats a completed aggregation as a one-read handoff: the `done` branch snapshots the result and immediately resets status to `idle`, so the very next poll starts another full aggregation. Six sequential endpoint calls on main ran three worktree discoveries and three `du -sm` passes per worktree. Each aggregation runs `du -sm` sequentially over every worktree (60s per-worktree timeout); worktrees hold large `.venv`/`node_modules`/build trees, so an open dashboard sustains heavy disk I/O forever for a slowly-changing summary statistic.

## Why it matters

Anyone who leaves the Dev Fleet page open pays continuous background `du` scans across every checkout — sustained disk I/O and CPU competing with builds, syncs, and the gateway itself, for a number that changes only when a worktree is created, removed, provisioned, or pruned.

## What changed (motivation → approach → change)

Symptom: back-to-back full rescans on every poll. Root cause: the `done → idle` reset at the read site made the state machine a one-read handoff instead of a cache. Change, in `fleet_state.py`:

- A completed result now carries a monotonic freshness stamp (`_DISK_COMPUTED_AT`) and is served from `_DISK` while younger than `_DISK_TTL` (300s, module-level constant) — no state reset, no `du`.
- When stale, exactly one caller starts a coalesced background refresh (guarded by the existing `_DISK_COMPUTING` flag, with no `await` between check and set on the single event loop); concurrent polls keep observing the previous numbers (stale-while-revalidate). Only the very first aggregation surfaces as `status: "computing"`.
- A transient aggregation failure no longer clobbers good numbers and is never stamped fresh: the previous result keeps serving and the next poll retries (discovery raises before any `du` runs, so the retry is cheap). Only a first run with nothing to fall back on reports the unknown shape.
- Worktree mutations invalidate the cache via a new `_disk_invalidate()` (epoch-guarded so an aggregation overlapped by a mutation is stored but left stale): called at the single removal chokepoint every removal path routes through (handler, prune workers, auto-prune reaper), and wired to provision and dependency-sync runs via a new optional `on_finish` terminal callback on `runtime._start_run` — both write `.venv`/`node_modules`/dist inside the trees `du -sm` measures.
- Response shape is unchanged (`status`/`total_mb`/`per`); the frontend consumer reads only `total_mb` and needed no change.

## Tests

- `test_disk_six_sequential_polls_run_one_aggregation` — mirrors the issue's six-sequential-call instrumentation: exactly one discovery and one `du` set, state never resets to idle.
- `test_disk_fresh_result_served_without_rescan` — a fresh result is a cache, not a one-read handoff (scan mock raises if touched).
- `test_disk_stale_cache_coalesces_one_refresh` — six concurrent stale polls start exactly one refresh while all observe the old numbers.
- `test_disk_invalidate_forces_refresh_on_next_read` — invalidation drops freshness; old numbers keep serving while the refresh replaces them.
- `test_disk_mid_flight_invalidation_leaves_result_stale` — an aggregation overlapped by a mutation is stored but not stamped fresh.
- `test_disk_transient_failure_preserves_numbers_and_retries` — a failed refresh keeps the previous result and leaves the stamp at 0.0.
- `test_removal_invalidates_disk_cache`, `test_pod_provision_registers_disk_invalidation`, sync-run hook assertion in `test_sync_pip_uses_target_repo_venv`, and `test_start_run_invokes_on_finish_at_terminal_state` — pin every invalidation wiring point and the new callback's terminal-state contract.

All nine new/changed tests were verified red against main's production code before the fix.

## Manual verification

N/A — unit coverage sufficient: the six-poll regression test reproduces the issue's exact instrumentation against the real state machine, and the endpoint is a pass-through (`api_dev_fleet_disk` → `_disk()`), already covered by the existing handler test.

## Related Issues

Closes #8787

## Pattern harvest

Rule candidate: review-prompt
Pattern: "async result-cache state machines: a `done` branch that resets to `idle` on read is a one-read handoff — poll loops turn it into a hot loop; cache with a TTL + coalesced refresh instead"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
