### PR TITLE
test(settings): point the RemoteCrewPanel diagnosis helper at the ErrorNotice

### DIFF
--- a/website/src/test/RemoteCrewPanel.test.tsx
+++ b/website/src/test/RemoteCrewPanel.test.tsx
@@ -621,8 +621,11 @@ describe('RemoteCrewPanel', () => {
      *  "Ask the agent" link next to `status.error` (StatusBadge renders it through
      *  ErrorNotice), so the note's button must be picked by its container — the
      *  row's link would send the bare message without the ladder. */
+    // The diagnosis note is the shared ErrorNotice (role="alert") since #8749;
+    // this helper still looked for the role="status" box #8729 was written
+    // against, so `closest` returned null and every hand-off case failed.
     const noteAgentButton = () =>
-      within(screen.getByText(/c1: Remote dashboard down/i).closest('[role="status"]') as HTMLElement)
+      within(screen.getByTestId('remote-crew-diagnosis'))
         .getByRole('button', { name: /agent/i })
 
     it('hands the diagnosis to the agent with the ladder code and probe chain', async () => {


### PR DESCRIPTION
## Problem / Motivation

Main is red on four `RemoteCrewPanel.test.tsx` cases (`agent hand-off from the diagnosis note`): every open PR's merge ref fails them (seen on #8816). Two settings batches crossed: #8749 (settings-2) moved the diagnosis note to the shared `ErrorNotice` (`role="alert"`, `testId="remote-crew-diagnosis"`), then #8729 (settings-1) landed a test helper written against the old `role="status"` box, so `closest('[role="status"]')` returns `null` and `within(null)` throws.

## What changed

One helper in the test: select the note by its `remote-crew-diagnosis` testId instead of walking up to a `role="status"` ancestor that no longer exists. No product code touched.

## Tests

Per the owner's standing instruction no suite was run locally; CI verifies. Unblocker for #8816 and any other PR whose merge ref includes both #8729 and #8749.

## Related Issues

Cross-merge of #8729 and #8749. Unblocks #8816.

## Checklist
- [x] One commit, Conventional Commits title
- [x] Existing tests pass (CI)