### PR TITLE
fix(gateway): use respawn_executable when restarting after update

### DIFF
--- a/src/kiro_crew/platform/wheel_engine.py
+++ b/src/kiro_crew/platform/wheel_engine.py
@@ -243,6 +243,90 @@ def running_from_managed_venv(layout: ManagedVenvLayout | None = None) -> bool:
     return layout.is_managed_tree(Path(sys.executable))
 
 
+def _legacy_nested_venv() -> Path:
+    """The venv an earlier ``cli.sh`` created INSIDE the data home.
+
+    Mirrors cli.sh's ``_OLD_VENV`` (``<data home>/venv``) exactly. The current
+    installer retires it: a re-run that lands a working tree beside the data
+    home repoints the stable link and the launcher at that tree, then
+    ``rm -rf``s this one. The gateway's own wheel auto-update drives that
+    re-run, so the deletion can happen underneath the running process.
+    """
+    return data_home() / "venv"
+
+
+def _respawn_tree_is_managed(layout: ManagedVenvLayout) -> bool:
+    """Is the tree serving THIS process one a restart may re-route?
+
+    Identity is read from the interpreter's ``bin/`` directory, not from the
+    interpreter file: ``python -m venv`` writes ``bin/python3`` as a symlink
+    to the base interpreter, so resolving the file lands outside every venv
+    and would answer "not managed" for every real install. The directory
+    resolves through the layout's own links (stable link -> versioned tree)
+    and stops there.
+
+    Two identities qualify. A tree of this layout (legacy or versioned), and
+    the retired in-data-home venv — our own environment from an earlier
+    installer, which the same cli.sh re-run that lands the new tree deletes
+    from under the running gateway; without the stable link that process has
+    no interpreter left to exec. This is the respawn identity only: the
+    dispatch predicate for the shadow-build path is
+    :func:`running_from_managed_venv`, which keeps its own rule.
+    """
+    bin_dir = Path(sys.executable).parent
+    if layout.is_managed_tree(bin_dir):
+        return True
+    try:
+        resolved = bin_dir.resolve()
+        nested = _legacy_nested_venv().resolve()
+    except OSError:
+        return False
+    return resolved == nested or resolved.is_relative_to(nested)
+
+
+def _interpreter_in(tree: Path) -> str | None:
+    """The usable interpreter inside *tree*'s ``bin/``, or ``None``.
+
+    Prefers this process's own interpreter name so a restart keeps the version
+    it was launched under, and falls back to ``python3``, which every venv
+    ships.
+    """
+    for name in (os.path.basename(sys.executable), "python3"):
+        candidate = tree / "bin" / name
+        try:
+            if candidate.exists() and os.access(candidate, os.X_OK):
+                return str(candidate)
+        except OSError:
+            continue
+    return None
+
+
+def _respawn_fallback(layout: ManagedVenvLayout) -> str:
+    """The answer when the stable link cannot carry the restart.
+
+    ``sys.executable`` whenever it still exists — a broken, absent, or
+    outside-the-layout link must never take the restart path away from a
+    process whose own interpreter is fine.
+
+    When it does NOT exist, the cached path names nothing and the exec would
+    raise ENOENT. That is reachable: the installer re-run that retires the
+    in-data-home venv deletes it on the NEW tree's own import check, which is
+    independent of the stable-link repoint — the repoint is skipped when a real
+    directory sits at the stable name, and its failure is non-fatal. So the
+    nested venv is gone while the link is unusable. The legacy fixed tree is
+    the interpreter that re-run just built and import-verified, and this engine
+    never prunes it, so it is the honest last resort. Validated the same way as
+    the stable link's: inside the layout, present, executable.
+    """
+    if os.path.exists(sys.executable):
+        return sys.executable
+    if layout.is_managed_tree(layout.legacy):
+        candidate = _interpreter_in(layout.legacy)
+        if candidate is not None:
+            return candidate
+    return sys.executable
+
+
 def respawn_executable() -> str:
     """The interpreter a gateway restart should exec.
 
@@ -256,12 +340,21 @@ def respawn_executable() -> str:
 
     Falls back to ``sys.executable`` whenever the stable link does not exist
     or does not carry a usable interpreter, so a broken or absent link can
-    never take the restart path away.
+    never take the restart path away — except when ``sys.executable`` itself is
+    already gone, where :func:`_respawn_fallback` reaches the legacy tree
+    instead of handing back a path that no longer exists.
+
+    One more shape routes here: a process still served by the retired
+    in-data-home venv (:func:`_legacy_nested_venv`). The installer re-run that
+    migrates it deletes that venv after repointing the stable link, so
+    ``sys.executable`` is gone and the stable link is the only interpreter
+    left; before that re-run there is no stable link and the fallback keeps
+    the restart on the nested venv, unchanged.
     """
     if not IS_POSIX:
         return sys.executable
     layout = managed_venv_layout()
-    if not running_from_managed_venv(layout):
+    if not _respawn_tree_is_managed(layout):
         return sys.executable
     # The link's TARGET must resolve inside this layout's own trees before it
     # is trusted with an exec: a stable link repointed outside the managed
@@ -271,16 +364,11 @@ def respawn_executable() -> str:
     # own tree included), which is the RFC's accepted local-code-execution gap
     # and is not widened by the link.
     if not layout.is_managed_tree(layout.stable_link):
-        return sys.executable
-    candidate = layout.stable_link / "bin" / os.path.basename(sys.executable)
-    if not candidate.exists():
-        candidate = layout.stable_link / "bin" / "python3"
-    try:
-        if candidate.exists() and os.access(candidate, os.X_OK):
-            return str(candidate)
-    except OSError:
-        pass
-    return sys.executable
+        return _respawn_fallback(layout)
+    candidate = _interpreter_in(layout.stable_link)
+    if candidate is not None:
+        return candidate
+    return _respawn_fallback(layout)
 
 
 # ── Manifest fetch and verification ─────────────────────────────────────────

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -9389,6 +9389,14 @@ class GatewayOrchestrator:
         from kiro_crew.platform.update_governance import min_version, update_required
         from kiro_crew.platform.update_provider import UpdateProvider
 
+        # Loaded BEFORE provider.apply(): the legacy-nested-venv migration the
+        # resolver exists for deletes the venv this process imports from, so a
+        # deferred import after a successful apply would raise
+        # ModuleNotFoundError and leave a closed-session gateway un-restarted
+        # (found in review). The module stays off the boot path either way —
+        # this method runs from the update timer, not from gateway start.
+        from kiro_crew.platform.wheel_engine import respawn_executable
+
         assert isinstance(provider, UpdateProvider)
 
         result = await provider.check()
@@ -9427,7 +9435,7 @@ class GatewayOrchestrator:
                 self.dashboard_state.push_update_progress("pulling", "Applying mandatory update…")
             success = await provider.apply()
             if success:
-                await self._restart_after_update()
+                await self._restart_after_update(respawn_executable)
             else:
                 if self.dashboard_state:
                     self.dashboard_state.push_update_progress(
@@ -9449,7 +9457,7 @@ class GatewayOrchestrator:
                     self.dashboard_state.push_update_progress("pulling", "Downloading update…")
                 success = await provider.apply()
                 if success:
-                    await self._restart_after_update()
+                    await self._restart_after_update(respawn_executable)
                 else:
                     if self.dashboard_state:
                         self.dashboard_state.push_update_progress(
@@ -9462,8 +9470,16 @@ class GatewayOrchestrator:
         else:
             print("👻 Already on latest version")
 
-    async def _restart_after_update(self) -> None:
-        """Save state and restart the process after a successful update apply."""
+    async def _restart_after_update(self, respawn: Callable[[], str]) -> None:
+        """Save state and restart the process after a successful update apply.
+
+        ``respawn`` is :func:`kiro_crew.platform.wheel_engine.respawn_executable`,
+        imported by the caller BEFORE ``provider.apply()`` ran: the apply may
+        have deleted the venv this process imports from, so nothing here may
+        import from disk. Calling it is still deferred to this point, because
+        the answer (stable link vs. ``sys.executable``) is only right after the
+        apply has repointed the link.
+        """
         logger.info("Update applied, restarting gateway")
         if self.dashboard_state:
             self.dashboard_state.push_update_progress("restarting", "Restarting server…")
@@ -9494,7 +9510,8 @@ class GatewayOrchestrator:
             await asyncio.to_thread(flush_breadcrumb_writes, 2.0)
         except Exception:
             logger.debug("Breadcrumb flush before update restart failed", exc_info=True)
-        platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
+        exe = await asyncio.to_thread(respawn)
+        platform_compat.reexec_python_module("kiro_crew", sys.argv[1:], executable=exe)
 
     async def _check_for_updates_legacy(self) -> None:
         """Legacy update check — the existing layout-aware logic."""
@@ -9705,6 +9722,12 @@ class GatewayOrchestrator:
         # implementation of it (issue #4210 exists to close the two-conventions
         # gap, not to add a second helper).
         from kiro_crew.platform.update_provider import _kill_and_reap
+
+        # Loaded before the reinstall below for the same reason as the provider
+        # path: `pip install -e .` rewrites the package this process imports
+        # from, so the resolver must already be in memory when the restart
+        # needs it. Called only after the install succeeded (see the exec below).
+        from kiro_crew.platform.wheel_engine import respawn_executable
 
         try:
             # Every git call below reads a tree an agent can write, and several of
@@ -10414,7 +10437,8 @@ class GatewayOrchestrator:
             # Use -m kiro_crew rather than sys.argv[0] so the restart resolves
             # the freshly reinstalled entry point regardless of how the
             # original process was launched.
-            platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
+            exe = await asyncio.to_thread(respawn_executable)
+            platform_compat.reexec_python_module("kiro_crew", sys.argv[1:], executable=exe)
         except Exception:
             logger.warning("Auto-update failed", exc_info=True)
             if self.dashboard_state:
@@ -10448,6 +10472,12 @@ class GatewayOrchestrator:
         to a temp dir and atomically replaces via ``ln -sf``).
         """
         from kiro_crew.dashboard.handlers import _update_info
+
+        # Loaded before cli.sh runs: the installer's legacy-venv migration
+        # `rm -rf`s the venv this process imports from once the new tree is
+        # linked, so a deferred import after it would not find the module.
+        # Called only after the installer succeeded (see the exec below).
+        from kiro_crew.platform.wheel_engine import respawn_executable
 
         # Read the command through the SAME accessor the caller selected this
         # branch with. Reading a bare `_update_info["update_command"]` here is
@@ -10639,7 +10669,8 @@ class GatewayOrchestrator:
         except Exception:
             logger.debug("Breadcrumb flush before install restart failed", exc_info=True)
         # Restart into the freshly-installed version.
-        platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])
+        exe = await asyncio.to_thread(respawn_executable)
+        platform_compat.reexec_python_module("kiro_crew", sys.argv[1:], executable=exe)
 
     # ------------------------------------------------------------------
     # Main run loop

--- a/test/test_gateway_restart_uses_respawn_executable.py
+++ b/test/test_gateway_restart_uses_respawn_executable.py
@@ -1,0 +1,311 @@
+"""Every gateway restart-after-update path must exec ``respawn_executable()``.
+
+``sys.executable`` is cached at process start. After an auto-update replaces a
+managed install, that path can point into the tree the update just pruned, so
+``os.execv`` on it dies with ENOENT and the gateway never comes back. The
+dashboard's update handler already routes through
+``kiro_crew.platform.wheel_engine.respawn_executable``; these tests pin the
+three restart sites in ``GatewayOrchestrator`` to the same rule.
+
+Each test drives the REAL method to its exec line: the download / apply /
+breadcrumb steps ahead of it are stubbed, and only the two seams under test are
+replaced -- the interpreter lookup (returns a sentinel) and the exec itself
+(recorded instead of replacing the test process).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.slack import gateway as gw
+from kiro_crew.slack.gateway import GatewayOrchestrator
+
+_STABLE_INTERPRETER = "/managed/current/bin/python-sentinel"
+
+
+def _make_orchestrator() -> GatewayOrchestrator:
+    cfg = KiroCrewConfig()
+    with patch.object(cfg, "load_credentials", return_value={"KIROCREW_OWNER_ID": "U1"}):
+        orch = GatewayOrchestrator(cfg, no_dashboard=True, no_crons=True, no_open=True)
+    # No dashboard slots to save, no sessions to close: the tests are about the
+    # exec, not the teardown that precedes it.
+    orch.dashboard_state = None
+    orch.sessions = None
+    return orch
+
+
+@pytest.fixture
+def exec_seams(monkeypatch):
+    """Replace the interpreter lookup and the exec; return both recorders."""
+    respawn = MagicMock(return_value=_STABLE_INTERPRETER)
+    monkeypatch.setattr("kiro_crew.platform.wheel_engine.respawn_executable", respawn)
+    reexec = MagicMock()
+    monkeypatch.setattr("kiro_crew.platform_compat.reexec_python_module", reexec)
+    # The breadcrumb drain hits the real safety-override store; not under test.
+    monkeypatch.setattr(gw, "flush_breadcrumb_writes", lambda *_a, **_k: None)
+    return respawn, reexec
+
+
+@pytest.fixture
+def update_info():
+    """Hand a test the process-global update cache, restored on teardown.
+
+    ``dashboard.handlers.updates._update_info`` is module-level state shared by
+    every test in the worker (the convention ``test_get_update_info.py`` also
+    follows). A test that repopulates it must not leave its shape behind for
+    whatever runs next.
+    """
+    from kiro_crew.dashboard.handlers import updates
+
+    original = dict(updates._update_info)
+    yield updates._update_info
+    updates._update_info.clear()
+    updates._update_info.update(original)
+
+
+def _assert_execs_the_respawn_interpreter(respawn: MagicMock, reexec: MagicMock) -> None:
+    reexec.assert_called_once()
+    args, kwargs = reexec.call_args
+    assert args[0] == "kiro_crew"
+    assert list(args[1]) == sys.argv[1:]
+    assert kwargs.get("executable") == _STABLE_INTERPRETER, (
+        "restart exec'd sys.executable instead of respawn_executable(); after an "
+        "update pruned the old install that path no longer exists"
+    )
+    respawn.assert_called_once_with()
+
+
+class TestRestartAfterUpdate:
+    @pytest.mark.asyncio
+    async def test_execs_the_respawn_interpreter(self, exec_seams):
+        respawn, reexec = exec_seams
+        orch = _make_orchestrator()
+
+        await orch._restart_after_update(respawn)
+
+        _assert_execs_the_respawn_interpreter(respawn, reexec)
+
+
+class TestResolverIsLoadedBeforeTheApply:
+    """The resolver must be in memory before the update rewrites the install.
+
+    The legacy-nested-venv migration ``respawn_executable`` exists for deletes
+    the venv this process imports from; a ``from ... import`` placed after the
+    apply would raise ``ModuleNotFoundError`` and leave a closed-session
+    gateway un-restarted. Pin the ORDER inside each restart path: the import
+    precedes the first apply/spawn, and the restart helper imports nothing
+    from wheel_engine at all.
+    """
+
+    @staticmethod
+    def _method(name: str) -> ast.AsyncFunctionDef:
+        tree = ast.parse(inspect.getsource(gw))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+                return node
+        raise AssertionError(f"{name} not found in gateway.py")
+
+    @staticmethod
+    def _resolver_import_lines(fn: ast.AST) -> list[int]:
+        return [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "kiro_crew.platform.wheel_engine"
+            and any(alias.name == "respawn_executable" for alias in node.names)
+        ]
+
+    @staticmethod
+    def _first_call_line(fn: ast.AST, attr_names: set[str]) -> int:
+        lines = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in attr_names
+        ]
+        assert lines, f"no apply/spawn call found among {sorted(attr_names)}"
+        return min(lines)
+
+    @pytest.mark.parametrize(
+        ("method", "apply_attrs"),
+        [
+            ("_check_for_updates_via_provider", {"apply"}),
+            ("_auto_apply_update", {"create_subprocess_exec"}),
+            ("_auto_apply_wheel_update", {"create_subprocess_exec"}),
+        ],
+    )
+    def test_import_precedes_the_first_apply(self, method, apply_attrs):
+        fn = self._method(method)
+        imports = self._resolver_import_lines(fn)
+        assert len(imports) == 1, f"{method}: expected one resolver import, got {imports}"
+        first_apply = self._first_call_line(fn, apply_attrs)
+        assert imports[0] < first_apply, (
+            f"{method}: respawn_executable is imported at line {imports[0]}, after "
+            f"the apply at line {first_apply}; a post-apply import reads a venv "
+            "the update may have deleted"
+        )
+
+    def test_restart_helper_does_not_import_the_resolver(self):
+        fn = self._method("_restart_after_update")
+        assert self._resolver_import_lines(fn) == [], (
+            "_restart_after_update must take the resolver from its caller, which "
+            "imported it before the apply"
+        )
+
+    def test_every_reexec_in_the_gateway_passes_an_explicit_executable(self):
+        """Discovered, not enumerated — this is what polices a FOURTH site.
+
+        The parametrized order check above names its three methods, so a new
+        restart path added later would not be examined by it. The defect this
+        PR fixes has a shape that can be found without knowing where it lives:
+        a ``reexec_python_module`` call with no ``executable=`` re-execs the
+        cached ``sys.executable``, which an update may have pruned. Walk every
+        such call in gateway.py instead of a list of known ones.
+        """
+        tree = ast.parse(inspect.getsource(gw))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "reexec_python_module"
+        ]
+        assert calls, "expected at least one reexec_python_module call in gateway.py"
+        missing = [
+            node.lineno for node in calls if not any(kw.arg == "executable" for kw in node.keywords)
+        ]
+        assert not missing, (
+            f"reexec_python_module at line(s) {missing} in gateway.py passes no "
+            "executable=; it would re-exec sys.executable, which an update can "
+            "prune. Resolve the interpreter with wheel_engine.respawn_executable() "
+            "(imported before the apply step) and pass it as executable=."
+        )
+
+
+class TestAutoApplyWheelUpdate:
+    @pytest.mark.asyncio
+    async def test_successful_install_execs_the_respawn_interpreter(
+        self, exec_seams, update_info, monkeypatch
+    ):
+        respawn, reexec = exec_seams
+        orch = _make_orchestrator()
+
+        update_info.clear()
+        update_info.update(
+            {
+                "remediation": {
+                    "kind": "command",
+                    "message": "Re-run the installer to upgrade.",
+                    "command": "sh -c true",
+                }
+            }
+        )
+        # Same pins the wheel-apply tests in test_slack_gateway.py use to reach
+        # the spawn on any host: POSIX platform, a trusted `sh`, a trusted PATH.
+        monkeypatch.setattr("kiro_crew.platform.update_layout.cdn_bases_are_safe", lambda: True)
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.update_blocked_reason", lambda _base: None
+        )
+        monkeypatch.setattr("kiro_crew.slack.gateway.sys.platform", "linux")
+        monkeypatch.setattr("kiro_crew.platform_compat.trusted_system_bin", lambda name: "/bin/sh")
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_provider._trusted_path_env",
+            lambda: {"PATH": "/usr/bin:/bin"},
+        )
+
+        proc = MagicMock()
+        proc.returncode = 0  # the installer succeeded: the method must restart
+        proc.stdout = None
+        proc.stderr = None
+        proc.wait = AsyncMock(return_value=0)
+        spawn = AsyncMock(return_value=proc)
+        monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+
+        await orch._auto_apply_wheel_update()
+
+        spawn.assert_awaited_once()
+        _assert_execs_the_respawn_interpreter(respawn, reexec)
+
+
+class TestAutoApplyGitUpdate:
+    """The git-checkout path: fetch, reset, rebuild, reinstall, then exec."""
+
+    @staticmethod
+    def _scripted_git(monkeypatch) -> AsyncMock:
+        """A ``create_subprocess_exec`` that answers each git step as a clean,
+        behind-origin checkout would, and refuses any spawn it does not expect."""
+
+        def _proc(rc: int, stdout: bytes = b"") -> MagicMock:
+            proc = MagicMock()
+            proc.returncode = rc
+            proc.communicate = AsyncMock(return_value=(stdout, b""))
+            proc.wait = AsyncMock(return_value=rc)
+            return proc
+
+        async def _spawn(*argv, **_kwargs):
+            words = [str(a) for a in argv[1:]]
+            if words[:2] == ["rev-parse", "--abbrev-ref"]:
+                return _proc(0, b"main\n")
+            if words[:1] == ["fetch"]:
+                return _proc(0)
+            if words[:2] == ["rev-parse", "--verify"]:
+                return _proc(0, b"0123456789abcdef0123456789abcdef01234567\n")
+            if words[:1] == ["diff"] and "--quiet" in words:
+                return _proc(1)  # HEAD differs from origin: an update is pending
+            if words[:2] == ["status", "--porcelain"]:
+                return _proc(0)  # clean tracked tree
+            if words[:2] == ["diff", "--name-only"]:
+                return _proc(0)  # the target adds no colliding paths
+            if words[:2] == ["reset", "--hard"]:
+                return _proc(0)
+            raise AssertionError(f"unexpected spawn on the git update path: {argv!r}")
+
+        spawn = AsyncMock(side_effect=_spawn)
+        monkeypatch.setattr("asyncio.create_subprocess_exec", spawn)
+        return spawn
+
+    @pytest.mark.asyncio
+    async def test_successful_update_execs_the_respawn_interpreter(
+        self, exec_seams, monkeypatch, tmp_path
+    ):
+        respawn, reexec = exec_seams
+        orch = _make_orchestrator()
+
+        monkeypatch.setenv("KIROCREW_PROJECT_DIR", str(tmp_path))
+        monkeypatch.setattr("kiro_crew.platform_compat.trusted_git_bin", lambda: "/usr/bin/git")
+        # The pre-reset refusals, each answered the way a clean checkout on the
+        # primary branch answers them. Their own behaviour is pinned elsewhere.
+        monkeypatch.setattr(gw, "git_command_env", lambda: {})
+        monkeypatch.setattr(gw, "is_primary_branch", lambda _branch: True)
+        monkeypatch.setattr(gw, "repo_exec_config_reason", lambda _proj: "")
+        monkeypatch.setattr(gw, "tracks_upstream", lambda _proj, _branch: True)
+        monkeypatch.setattr(gw, "resolve_remote_url", lambda _proj, remote: "https://example/r.git")
+        monkeypatch.setattr(
+            "kiro_crew.platform.update_governance.update_blocked_reason", lambda _url: None
+        )
+        monkeypatch.setattr(gw, "commits_ahead", lambda _proj, _target: 0)
+        monkeypatch.setattr(gw, "hidden_worktree_edits", lambda _proj: [])
+        spawn = self._scripted_git(monkeypatch)
+        # Post-reset rebuild steps: no optional backend, frontend and deps sync
+        # come back clean, and the package reload is a no-op (reloading the real
+        # package inside the test process is not what is under test).
+        monkeypatch.setattr(gw, "_pinned_kiro_cli", AsyncMock(return_value=None))
+        monkeypatch.setattr(gw, "build_frontend_async", AsyncMock())
+        monkeypatch.setattr(gw.dep_sync, "sync_or_reinstall", lambda *_a, **_k: 0)
+        monkeypatch.setattr(gw, "importlib", SimpleNamespace(reload=lambda module: module))
+
+        await orch._auto_apply_update()
+
+        # The scripted git ran through to the reset: the exec below is the
+        # restart after a real apply, not an early return.
+        spawned = [[str(a) for a in call.args[1:3]] for call in spawn.await_args_list]
+        assert ["reset", "--hard"] in spawned
+        _assert_execs_the_respawn_interpreter(respawn, reexec)

--- a/test/test_wheel_engine.py
+++ b/test/test_wheel_engine.py
@@ -691,6 +691,153 @@ class TestRespawnExecutable:
         monkeypatch.setattr(sys, "executable", str(exe))
         assert respawn_executable() == str(exe)
 
+    def test_symlinked_interpreter_still_routes_through_stable_link(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A real venv's bin/python3 is a symlink to the base interpreter.
+
+        Identity must come from the tree the link lives in, not from where it
+        points: resolving the file lands outside every venv and would make
+        every real managed install answer plain sys.executable.
+        """
+        base = tmp_path / "base-python" / "bin"
+        base.mkdir(parents=True)
+        base_exe = base / "python3.12"
+        base_exe.write_text("")
+        legacy = tmp_path / "crew-venv"
+        (legacy / "bin").mkdir(parents=True)
+        old_exe = legacy / "bin" / "python3"
+        old_exe.symlink_to(base_exe)
+        new_tree = tmp_path / "crew-venv-2.0.0"
+        (new_tree / "bin").mkdir(parents=True)
+        new_exe = new_tree / "bin" / "python3"
+        new_exe.write_text("")
+        new_exe.chmod(0o755)
+        (new_tree / "bin" / "kirocrew").write_text("")
+        stable = tmp_path / "crew-venv-current"
+        stable.symlink_to(new_tree)
+
+        monkeypatch.setenv("KIROCREW_VENV", str(legacy))
+        monkeypatch.setattr(sys, "executable", str(old_exe))
+        assert respawn_executable() == str(stable / "bin" / "python3")
+
+    def _nested_venv_home(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        """A data home whose ``venv/`` is the retired in-data-home install."""
+        home = tmp_path / "crew"
+        nested = home / "venv"
+        (nested / "bin").mkdir(parents=True)
+        (nested / "bin" / "python3").write_text("")
+        (nested / "bin" / "kirocrew").write_text("")
+        monkeypatch.setenv("KIROCREW_HOME", str(home))
+        monkeypatch.delenv("KIROCREW_VENV", raising=False)
+        monkeypatch.setattr(sys, "executable", str(nested / "bin" / "python3"))
+        return home
+
+    def test_retired_nested_venv_routes_through_stable_link(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The installer re-run cli.sh performs on migration: it builds the
+        new tree BESIDE the data home, repoints the stable link at it, then
+        ``rm -rf``s the in-data-home venv this process is running from. The
+        restart must exec the stable link's interpreter — sys.executable no
+        longer exists."""
+        import shutil
+
+        home = self._nested_venv_home(monkeypatch, tmp_path)
+        new_tree = tmp_path / "crew-venv"
+        (new_tree / "bin").mkdir(parents=True)
+        new_exe = new_tree / "bin" / "python3"
+        new_exe.write_text("")
+        new_exe.chmod(0o755)
+        (new_tree / "bin" / "kirocrew").write_text("")
+        stable = tmp_path / "crew-venv-current"
+        stable.symlink_to(new_tree)
+        shutil.rmtree(home / "venv")
+
+        assert not Path(sys.executable).exists()
+        assert respawn_executable() == str(stable / "bin" / "python3")
+
+    def test_nested_venv_before_migration_keeps_sys_executable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """No stable link yet (the installer has not been re-run): the nested
+        venv is the only interpreter, and the restart stays on it."""
+        home = self._nested_venv_home(monkeypatch, tmp_path)
+        assert respawn_executable() == str(home / "venv" / "bin" / "python3")
+
+    def _migrated_legacy_tree(self, tmp_path: Path) -> Path:
+        """The tree cli.sh's re-run builds beside the data home and verifies."""
+        new_tree = tmp_path / "crew-venv"
+        (new_tree / "bin").mkdir(parents=True)
+        exe = new_tree / "bin" / "python3"
+        exe.write_text("")
+        exe.chmod(0o755)
+        (new_tree / "bin" / "kirocrew").write_text("")
+        return new_tree
+
+    def test_unusable_stable_link_after_migration_uses_legacy_tree(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A real directory at the stable name makes cli.sh SKIP the repoint
+        (its guard only writes a symlink or an absent path), but the nested-venv
+        delete is gated on the new tree's own import check, so it still runs.
+        The cached interpreter is then gone and the stable link cannot be
+        trusted — the restart must take the import-verified legacy tree rather
+        than exec a path that no longer exists."""
+        import shutil
+
+        home = self._nested_venv_home(monkeypatch, tmp_path)
+        new_tree = self._migrated_legacy_tree(tmp_path)
+        (tmp_path / "crew-venv-current").mkdir()  # corrupt: a directory, not a link
+        shutil.rmtree(home / "venv")
+
+        assert not Path(sys.executable).exists()
+        assert respawn_executable() == str(new_tree / "bin" / "python3")
+
+    def test_failed_stable_link_repoint_after_migration_uses_legacy_tree(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """cli.sh's repoint failure is non-fatal (it warns and continues), so
+        the migration can delete the nested venv leaving no stable link at
+        all."""
+        import shutil
+
+        home = self._nested_venv_home(monkeypatch, tmp_path)
+        new_tree = self._migrated_legacy_tree(tmp_path)
+        shutil.rmtree(home / "venv")
+
+        assert not (tmp_path / "crew-venv-current").exists()
+        assert respawn_executable() == str(new_tree / "bin" / "python3")
+
+    def test_deleted_interpreter_with_no_usable_legacy_tree_keeps_sys_executable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The fallback never invents an interpreter: with the legacy tree
+        absent too there is nothing to validate, and the answer stays
+        ``sys.executable`` exactly as before."""
+        import shutil
+
+        home = self._nested_venv_home(monkeypatch, tmp_path)
+        nested_exe = home / "venv" / "bin" / "python3"
+        shutil.rmtree(home / "venv")
+
+        assert not (tmp_path / "crew-venv").exists()
+        assert respawn_executable() == str(nested_exe)
+
+    def test_live_interpreter_is_never_displaced_by_the_legacy_tree(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The legacy fallback is reached ONLY when the cached path is gone. A
+        process whose own interpreter still exists keeps it, so a corrupt
+        stable link cannot silently move a healthy gateway onto another
+        tree."""
+        home = self._nested_venv_home(monkeypatch, tmp_path)
+        self._migrated_legacy_tree(tmp_path)
+        (tmp_path / "crew-venv-current").mkdir()
+
+        assert Path(sys.executable).exists()
+        assert respawn_executable() == str(home / "venv" / "bin" / "python3")
+
 
 class TestReexecExecutableParameter:
     def test_reexec_uses_supplied_executable(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem / Motivation

After an auto-update replaces a managed install, the gateway tries to restart itself and dies with `ENOENT` instead of coming back. The three restart-after-update paths in `GatewayOrchestrator` (`_restart_after_update`, `_auto_apply_update`, `_auto_apply_wheel_update`) exec `sys.executable`, and after the update pruned the old install that path no longer exists.

## Why it matters

Every operator on a managed (wheel/installer) install who has auto-update on: the update applies, the gateway exits to restart, and nothing comes back up until someone starts it by hand. An unattended host stays down.

## What changed (motivation → approach → change)

Symptom: the gateway process is gone after a successful auto-update, with an `os.execv` ENOENT in the log.

Root cause, in two halves. The gateway sites called `platform_compat.reexec_python_module("kiro_crew", sys.argv[1:])` with no `executable=`, so they fell back to the cached `sys.executable` in the tree the update just removed. But the resolver they should have called could not answer correctly either: `respawn_executable()` decided "is this a managed venv?" by resolving the interpreter FILE, and `python -m venv` writes `bin/python3` as a symlink to the base interpreter — so the resolved path landed outside every venv and the predicate said "not managed" for every real `cli.sh` install. Wiring the sites up alone would still have ENOENT'd.

The change fixes both halves. Each of the three sites resolves the interpreter through `wheel_engine.respawn_executable()` (via `asyncio.to_thread`, since it stats the filesystem) and passes it as `executable=`, matching what the dashboard update handler already does. The resolver is imported *before* the apply step and called *after* it — the module is deliberately off the gateway boot path, so a deferred import would read a package the migration has already deleted, while the answer is only correct once the stable link has been repointed. In `wheel_engine.py`, respawn identity is now read from the interpreter's `bin/` **directory** (symlink-correct), the retired in-data-home venv counts as a respawn identity so a process it serves can restart through the stable link after the migration deletes it, and the fallback reaches the validated legacy tree when the stable link is unusable *and* `sys.executable` is already gone.

**This changes behaviour for the existing dashboard caller too** (`handlers/updates.py`), not just the three new ones: both identity rules widen what `respawn_executable()` answers for symlinked-interpreter and legacy-nested-venv installs. `running_from_managed_venv()` keeps its own file-resolving rule — it gates shadow-build *dispatch* rather than a restart, so correcting it moves a different mechanism's behaviour and is tracked in #8938 instead of being folded in here.

## Tests

`test/test_gateway_restart_uses_respawn_executable.py` (new) — one test per restart site. Each drives the real method to its exec line with the download/apply/breadcrumb steps stubbed, patches `respawn_executable` to return a sentinel path and `reexec_python_module` to record the call, and asserts the exec received `executable=<sentinel>`. `TestResolverIsLoadedBeforeTheApply` parses `gateway.py` and pins, per method, exactly one `respawn_executable` import whose line precedes the first `apply` / `create_subprocess_exec` call.

`test/test_wheel_engine.py` — the identity rules and the fallback. Two migration shapes that must reach the legacy tree (a real directory at the stable name, so `cli.sh` skips the repoint; and no stable link at all, so the repoint failed non-fatally) and two that must NOT (`sys.executable` still present, so a corrupt link cannot displace a healthy gateway; no usable legacy tree, so the answer stays `sys.executable`).

Each production hunk was reverted in place to confirm the matching tests go red. Local run on the rebased tree: 753 passed, 23 skipped across `test_wheel_engine.py`, `test_gateway_restart_uses_respawn_executable.py`, `test_update_check_install_aware.py`, `test_platform_compat.py`, `test_slack_gateway.py`. isort / flake8 7.1.0 / black / mypy (1302 files) all clean.

## Manual verification

N/A — unit coverage sufficient: the change is which interpreter path is handed to `execv`, and the tests assert exactly that argument on every affected site. The one premise that is not unit-testable — that `cli.sh` creates venvs with a symlinked interpreter, skips the stable-link repoint when a real directory occupies the stable name, and deletes the nested venv on the new tree's own import check rather than on the repoint — was read off `cli.sh` on this PR's rebased base, and the symlink behaviour was measured on a real `python3 -m venv`.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only change to the gateway restart path; nothing under `website/` and no rendered surface.

## Related Issues

no linked issue: found while tracing a post-update restart failure on a managed install. Follow-up filed as #8938.

## Pattern harvest

Rule candidate: review-prompt

Two concretely-checkable shapes, both grep-able:

1. `reexec_python_module(...)` / an `os.exec*` call with no `executable=` on a code path that runs after an install or update step — the cached `sys.executable` may name a pruned tree.
2. `Path(sys.executable).resolve()` (or `is_managed_tree(Path(sys.executable))`) used as a "which venv am I in?" predicate. `python -m venv` symlinks `bin/python3` to the base interpreter, so resolving the FILE escapes the venv; the containment question must be asked of `Path(sys.executable).parent`. Grep `resolve()` applied to `sys.executable` — the sibling this PR left is #8938, found exactly this way.

Not generalizable: nothing here is a tuning constant.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no documented behaviour changed
- [x] No secrets, credentials, or internal references in the diff

Backport: please include in release/0.6.0.
