### PR TITLE
fix(electron): re-resolve backend path after in-place update

### DIFF
--- a/website/electron/gateway-recovery.js
+++ b/website/electron/gateway-recovery.js
@@ -255,10 +255,102 @@ function revealWindowForConnect(win, { reconnect = false } = {}) {
   win.show();
 }
 
+// The gateway's own stale-asset watchdog exits with this status when the
+// install directory it was started from has been replaced or pruned underneath
+// it (EX_TEMPFAIL: "retry later"). Mirrors STALE_ASSET_EXIT_CODE in the
+// backend's dashboard/stale_asset_watchdog.py; keep the two in sync.
+const STALE_ASSET_EXIT_CODE = 75;
+
+/**
+ * Decide how the supervisor reacts to a bundled backend that vanished
+ * underneath it on macOS.
+ *
+ * Two signals mean "the bundle we spawned from is gone": the gateway exited
+ * with STALE_ASSET_EXIT_CODE (its watchdog saw its own assets disappear), or a
+ * spawn of a binary that passed the executable probe moments earlier failed
+ * ENOENT (the file was removed between probe and exec). Both happen when an
+ * update replaces the .app in place while a session is running. Nothing inside
+ * the process can learn where the new bundle is -- every Electron path API is
+ * a launch-time snapshot -- so recovery is a fresh filesystem probe of the same
+ * candidate list: when the bundle was swapped at the same path the new backend
+ * is found there; when it was pruned the probe falls through to a user-level
+ * install or a PATH lookup.
+ *
+ * The budget is one re-resolve per incident. A second stale signal in the same
+ * incident means the probe found nothing usable, so the only remaining move is
+ * to restart the whole app -- and only when the caller has verified there is
+ * still something to restart. A pruned bundle takes this app's own executable
+ * with it, so the caller probes that executable first and passes the result
+ * in; when it is gone the verdict is "none" and the ordinary failure dialog is
+ * shown instead of exiting the app into nothing. (The caller then also
+ * confirms the fresh copy actually started before exiting, which closes the
+ * window between the probe and the restart.)
+ *
+ * @param {object} o
+ * @param {boolean} o.isMac             only macOS swaps bundles under a running
+ *                                      app; Linux is restarted by its service
+ *                                      manager and Windows stops the app first.
+ * @param {boolean} o.bundled           the child that failed was the bundled
+ *                                      backend. A PATH or dev install that is
+ *                                      missing or exits 75 has nothing stale to
+ *                                      re-resolve, and a dev machine with no
+ *                                      kirocrew at all must never relaunch.
+ * @param {number|null} [o.exitCode]    the child's exit status, when it exited.
+ * @param {string} [o.spawnErrorCode]   the spawn error's code, when spawn failed.
+ * @param {number} [o.attempts=0]       re-resolves already spent on this incident.
+ * @param {boolean} [o.quitting=false]  the app is shutting down.
+ * @param {boolean} [o.installingUpdate=false] the updater owns the bundle right
+ *                                      now; respawning would race the swap.
+ * @param {boolean} [o.relaunchTargetExists=false] the caller re-probed its own
+ *                                      executable (the one a restart re-runs)
+ *                                      and found it. Defaults to false so a
+ *                                      caller that never checked can only reach
+ *                                      the dialog, never a blind exit.
+ * @returns {"reresolve" | "relaunch" | "none"}
+ *   "reresolve" — probe the candidate list again and respawn.
+ *   "relaunch"  — the re-resolved child is stale too and the app can still be
+ *                 re-run; restart the app.
+ *   "none"      — not a stale-bundle signal, not ours to act on, or nothing
+ *                 launchable remains; take the ordinary failure path.
+ */
+function shouldReresolveBackend({
+  isMac,
+  bundled,
+  exitCode = null,
+  spawnErrorCode = "",
+  attempts = 0,
+  quitting = false,
+  installingUpdate = false,
+  relaunchTargetExists = false,
+}) {
+  if (!isMac || quitting || installingUpdate) return "none";
+  if (!isStaleBundleSignal({ exitCode, spawnErrorCode })) return "none";
+  // Past the first attempt the child under judgment is whatever the re-probe
+  // found (possibly not bundled), and the incident is already established.
+  if (attempts >= 1) return relaunchTargetExists ? "relaunch" : "none";
+  return bundled ? "reresolve" : "none";
+}
+
+/**
+ * True when a child's fate says the bundle it came from is gone: the gateway
+ * exited with STALE_ASSET_EXIT_CODE, or a binary that passed the executable
+ * probe failed to spawn with ENOENT.
+ *
+ * @param {object} o
+ * @param {number|null} [o.exitCode]
+ * @param {string} [o.spawnErrorCode]
+ */
+function isStaleBundleSignal({ exitCode = null, spawnErrorCode = "" }) {
+  return exitCode === STALE_ASSET_EXIT_CODE || spawnErrorCode === "ENOENT";
+}
+
 module.exports = {
   chooseRecoveryStrategy,
   classifyAdoptedGateway,
   revealWindowForConnect,
+  shouldReresolveBackend,
+  isStaleBundleSignal,
+  STALE_ASSET_EXIT_CODE,
   GATEWAY_OWNERSHIP_STATES,
   waitForServiceRebind,
   waitForProcessExit,

--- a/website/electron/gateway-supervisor.js
+++ b/website/electron/gateway-supervisor.js
@@ -55,6 +55,8 @@ const {
   snapshotPortPids,
   incumbentSnapshotBlocksRespawn,
   unrecoverableGatewayDialog,
+  shouldReresolveBackend,
+  isStaleBundleSignal,
 } = require("./gateway-recovery");
 const { capturePySpyDump } = require("./pyspy-dump");
 const {
@@ -81,8 +83,14 @@ const {
 const DEFAULT_THEME_ACCENT = "#8E48FF";
 const THEME_ACCENT_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 const INSTALLING_STATUS = "Finishing installation…";
+const RESTARTING_STATUS = "Restarting Kiro Crew to finish the update…";
 const POLL_INTERVAL_MS = 500;
 const ADOPTED_RECOVERY_WAIT_MS = 30_000;
+// How long this instance stays alive waiting for a successor copy of the app
+// to prove itself by serving on the gateway port (relaunchViaConfirmedSuccessor):
+// Electron boot plus the successor's own gateway budget, with margin.
+const SUCCESSOR_READY_TIMEOUT_MS = 60_000;
+const SUCCESSOR_POLL_MS = 500;
 const LSOF_CANDIDATES = ["/usr/sbin/lsof", "/usr/bin/lsof"];
 
 /**
@@ -119,6 +127,8 @@ function createGatewaySupervisor({
   spawnFn = defaultSpawn,
   execFileFn = defaultExecFile,
   execFileSyncFn = defaultExecFileSync,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
   processRef = process,
   dirname = __dirname,
 } = {}) {
@@ -169,6 +179,154 @@ function createGatewaySupervisor({
   // Set before updater shutdown begins. It keeps an intentional stop from being
   // read as a wedge and resurrected while the bundle is being replaced.
   let installingUpdate = false;
+  // Re-resolves spent on the current stale-bundle incident (see
+  // shouldReresolveBackend). Reset whenever a fresh gateway is asked for,
+  // whenever one reaches handoff, and whenever a monitored backend answers
+  // again, so each incident gets its own budget.
+  let reresolveAttempts = 0;
+
+  /**
+   * Can app.relaunch() still find something to re-exec? Electron relaunches
+   * this process's own executable (process.execPath; inside the .app bundle on
+   * a packaged macOS build), so the bundle being pruned out from under a
+   * running app is visible as that path no longer existing. A swapped bundle
+   * leaves a new executable at the same path and reads as relaunchable.
+   */
+  function canRelaunchThisApp() {
+    const target = processObj.execPath;
+    if (typeof target !== "string" || !target) return false;
+    try {
+      fs.accessSync(target, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Restart the app by starting a fresh copy of it and exiting only once that
+   * copy is demonstrably alive.
+   *
+   * app.relaunch() is not usable here: it returns nothing and only schedules a
+   * re-exec for exit time, so when the bundle is pruned between the probe
+   * above and that re-exec the app exits into nothing and no code is left to
+   * notice. Spawning the successor ourselves lets this process observe it, but
+   * Node's "spawn" event only proves the exec succeeded: a bundle intact
+   * enough to exec and broken enough to crash during initialization would
+   * still take the app down. The handshake is therefore the successor's own
+   * gateway answering on the port: it was silent when this handoff began (the
+   * child that owned it exited or never started), so an answer there means
+   * the successor booted, ran its supervisor, and started a serving backend.
+   * A 503 "starting" counts too: the successor's gateway is bound and only
+   * still restoring sessions.
+   *
+   * Everything short of that is a failure with this instance still alive:
+   * a spawn error (ENOENT on a pruned bundle), the successor exiting before
+   * its gateway answered, or the bounded wait running out. The failure path
+   * kills a successor that is still running so exactly one instance remains,
+   * takes the single-instance lock back so a later manual launch still routes
+   * here, and runs the caller's ordinary failure bookkeeping.
+   *
+   * The liveness monitor is stopped for the duration: were it to fire during
+   * the handoff it would force-stop the port the successor's gateway is
+   * binding. Mid-session the boot splash is put back first, since only it
+   * renders status and the user would otherwise watch the window vanish
+   * unannounced; a failed mid-session handoff then surfaces the failure
+   * dialog itself, the way the monitor's recovery would have.
+   *
+   * @param {() => void} onFailed  the caller's ordinary failure bookkeeping.
+   */
+  function relaunchViaConfirmedSuccessor(onFailed) {
+    const target = processObj.execPath;
+    const args = Array.isArray(processObj.argv) ? processObj.argv.slice(1) : [];
+    const midSession = livenessMonitor !== null;
+    if (livenessMonitor) {
+      livenessMonitor.stop();
+      livenessMonitor = null;
+    }
+    if (midSession) {
+      // Only the boot splash renders status messages; the dashboard has no
+      // listener. Put the splash back so the announcement lands where the
+      // user is looking, without stealing focus from a hidden window.
+      const window = mainWindow();
+      if (window && !window.isDestroyed()) {
+        try {
+          window.webContents.loadFile(path.join(dirname, "loading.html"), {
+            query: { accent: currentThemeAccent() },
+          });
+        } catch { /* window may be tearing down */ }
+      }
+    }
+    sendStatus(RESTARTING_STATUS);
+    app.releaseSingleInstanceLock();
+    let settled = false;
+    let gone = false;
+    let pollTimer = null;
+    let deadlineTimer = null;
+    const clearTimers = () => {
+      if (pollTimer) { clearTimeoutFn(pollTimer); pollTimer = null; }
+      if (deadlineTimer) { clearTimeoutFn(deadlineTimer); deadlineTimer = null; }
+    };
+    const successor = spawn(target, args, { detached: true, stdio: "ignore" });
+
+    const fail = (reason) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      glog(`successor app ${reason} — cannot relaunch; surfacing the failure instead`);
+      if (!gone) {
+        try { successor.kill(); }
+        catch (killError) { glog(`could not stop the unconfirmed successor: ${killError && killError.message}`); }
+      }
+      try {
+        if (!app.requestSingleInstanceLock()) glog("could not re-take the single-instance lock: another instance holds it");
+      } catch (lockError) {
+        glog(`could not re-take the single-instance lock: ${lockError && lockError.message}`);
+      }
+      onFailed();
+      if (!midSession) return;
+      const window = mainWindow();
+      if (!window || window.isDestroyed() || quitting()) return;
+      showLoadingThenConnect(window, BACKEND_URL, { reconnect: true })
+        .catch((error) => glog(`surfacing the failed relaunch failed: ${error && error.message}`));
+    };
+    const confirm = () => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      successor.unref();
+      glog(`successor app (pid ${successor.pid}) is serving on :${PORT} — exiting this instance`);
+      app.exit(0);
+    };
+    const poll = async () => {
+      pollTimer = null;
+      if (settled) return;
+      // The splash loads asynchronously and may have missed the first send.
+      sendStatus(RESTARTING_STATUS);
+      const readiness = await fetchGatewayReadiness();
+      if (settled) return;
+      if (readiness === "ready" || readiness === "starting") { confirm(); return; }
+      pollTimer = setTimeoutFn(poll, SUCCESSOR_POLL_MS);
+    };
+
+    successor.once("spawn", () => {
+      if (settled) return;
+      glog(`successor app started (pid ${successor.pid}) — waiting for its gateway to answer on :${PORT}`);
+      deadlineTimer = setTimeoutFn(
+        () => fail(`did not answer on :${PORT} within ${SUCCESSOR_READY_TIMEOUT_MS / 1000}s`),
+        SUCCESSOR_READY_TIMEOUT_MS,
+      );
+      void poll();
+    });
+    successor.once("error", (error) => {
+      gone = true;
+      fail(`failed to start (${error.code || error.message}) from ${target}`);
+    });
+    successor.once("exit", (code, signal) => {
+      gone = true;
+      fail(`exited (code=${code} signal=${signal}) before its gateway answered`);
+    });
+  }
 
   function sendStatus(message) {
     mainWindow()?.webContents?.send("status", message);
@@ -411,6 +569,7 @@ function createGatewaySupervisor({
   }
 
   function startGateway() {
+    reresolveAttempts = 0;
     glog(`launch: port=${PORT} home=${KIROCREW_HOME} packaged=${app.isPackaged} resourcesPath=${processObj.resourcesPath || "(none)"} log=${gatewayLogPath()}`);
     sendStatus("Checking if gateway is running…");
     return new Promise((resolve) => {
@@ -482,6 +641,11 @@ function createGatewaySupervisor({
     return path.resolve(dirname, "..");
   }
 
+  // Every call probes the candidate list afresh (findKirocrewBin does live
+  // access() checks), which is what lets a stale-bundle respawn pick up a
+  // backend swapped in at the same path. resourcesPath itself is a launch-time
+  // snapshot and so is every other Electron path API; there is nothing newer to
+  // read.
   function spawnGateway(resolve) {
     // The gateway owns its data root. Create it before deriving the redirected
     // bytecode cache, honoring an explicit KIROCREW_HOME without touching the
@@ -506,7 +670,7 @@ function createGatewaySupervisor({
     let execState = "executable";
     try { fs.accessSync(bin, fs.constants.X_OK); }
     catch (error) { execState = `NOT-EXECUTABLE(${error.code})`; }
-    glog(`no gateway on :${PORT} — spawning bundled backend: bin=${bin} bundled=${bundled} ${execState}`);
+    glog(`no gateway on :${PORT} — spawning bundled backend: bin=${bin} bundled=${bundled} ${execState} staleRetries=${reresolveAttempts}`);
 
     // The Windows installer writes backend-dist incrementally. Refusing an
     // incomplete interpreter is preventive but cannot see package siblings that
@@ -624,12 +788,64 @@ function createGatewaySupervisor({
     // Bind handlers to this child, not the mutable slot. Recovery can replace a
     // child before its late error/exit event arrives; stale events must never
     // orphan the replacement or fabricate a start failure for it.
+    //
+    // Both handlers share one stale-bundle recovery. It returns true when it
+    // took the child's fate over (respawned, or a fresh copy of the app is
+    // being started), so the caller skips its ordinary failure bookkeeping;
+    // `giveUp` is that bookkeeping, for the one case where taking over fails
+    // later (the successor never started). `resolve` may already be settled by
+    // then; a second call is a no-op, which is what a child that dies hours
+    // after boot needs.
+    const recoverStaleBackend = ({ exitCode = null, spawnErrorCode = "", giveUp }) => {
+      // Probe the relaunch target first: when the bundle was swapped in place
+      // the new executable sits at the same path; when it was pruned the path
+      // is gone and exiting would leave the user with no app at all.
+      const relaunchTargetExists = canRelaunchThisApp();
+      const verdict = shouldReresolveBackend({
+        isMac: IS_MAC,
+        bundled,
+        exitCode,
+        spawnErrorCode,
+        attempts: reresolveAttempts,
+        quitting: quitting(),
+        installingUpdate,
+        relaunchTargetExists,
+      });
+      const cause = exitCode === null ? `spawn ${spawnErrorCode}` : `exit ${exitCode}`;
+      if (verdict === "none") {
+        // reresolveAttempts only ever rises on macOS, so a spent budget plus a
+        // stale signal plus a missing executable is exactly the pruned case.
+        if (
+          reresolveAttempts >= 1 && !relaunchTargetExists
+          && isStaleBundleSignal({ exitCode, spawnErrorCode })
+        ) {
+          glog(`stale bundle persists after re-resolve (${cause} on bin=${bin}) but this app's executable is gone (${processObj.execPath || "?"}) — cannot relaunch; surfacing the failure instead`);
+        }
+        return false;
+      }
+      if (verdict === "reresolve") {
+        reresolveAttempts += 1;
+        glog(`stale bundle (${cause} on bin=${bin}) — re-resolving the backend and respawning (attempt ${reresolveAttempts})`);
+        gatewayProcess = null;
+        gatewayStartFailure = null;
+        spawnGateway(resolve);
+        return true;
+      }
+      glog(`stale bundle persists after re-resolve (${cause} on bin=${bin}) — starting a fresh copy of the app from ${processObj.execPath}`);
+      relaunchViaConfirmedSuccessor(giveUp);
+      return true;
+    };
+
     child.on("error", (error) => {
       glog(`spawn ERROR code=${error.code || "?"} msg=${error.message}`);
       if (gatewayProcess !== child) return;
-      gatewayStartFailure = { error: error.message, bundled };
-      sendStatus(`Gateway failed: ${error.message}`);
-      resolve(false);
+      const giveUp = () => {
+        gatewayStartFailure = { error: error.message, bundled };
+        sendStatus(`Gateway failed: ${error.message}`);
+        resolve(false);
+      };
+      if (recoverStaleBackend({ spawnErrorCode: error.code || "", giveUp })) return;
+      giveUp();
     });
     child.on("exit", (code, signal) => {
       glog(`gateway child exited code=${code} signal=${signal}`);
@@ -639,8 +855,12 @@ function createGatewaySupervisor({
         glog("HINT: SIGKILL on a freshly-spawned bundled binary almost always means macOS Gatekeeper blocked an unsigned/quarantined nested executable. On the recipient's Mac run: xattr -cr <path to KiroCrew.app>");
       }
       if (gatewayProcess !== child) return;
-      if (!gatewayStartFailure) gatewayStartFailure = { code, signal, bundled };
-      gatewayProcess = null;
+      const giveUp = () => {
+        if (!gatewayStartFailure) gatewayStartFailure = { code, signal, bundled };
+        gatewayProcess = null;
+      };
+      if (recoverStaleBackend({ exitCode: code, giveUp })) return;
+      giveUp();
     });
     resolve(true);
   }
@@ -1032,6 +1252,9 @@ function createGatewaySupervisor({
 
   /** Start or replace the primary own-port post-handoff liveness monitor. */
   function startLivenessMonitor(window) {
+    // A gateway that reached handoff is healthy; a stale-bundle incident that
+    // hits it later starts with a fresh re-resolve budget.
+    reresolveAttempts = 0;
     if (livenessMonitor) {
       livenessMonitor.stop();
       livenessMonitor = null;
@@ -1048,7 +1271,12 @@ function createGatewaySupervisor({
         recoverWedgedGateway(window)
           .catch((error) => glog(`liveness recovery failed: ${error && error.message}`));
       },
-      onRecovered: () => glog("liveness: backend responsive again (transient blip)"),
+      onRecovered: () => {
+        // A re-resolved backend answering again closes its incident; the next
+        // stale signal is a new one and gets the cheaper in-place re-resolve.
+        reresolveAttempts = 0;
+        glog("liveness: backend responsive again (transient blip)");
+      },
       log: (message) => glog(`liveness: ${message}`),
     });
     livenessMonitor.start();

--- a/website/electron/test/gateway-recovery.test.js
+++ b/website/electron/test/gateway-recovery.test.js
@@ -1,5 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   chooseRecoveryStrategy,
   classifyAdoptedGateway,
@@ -9,6 +11,9 @@ const {
   snapshotPortPids,
   incumbentSnapshotBlocksRespawn,
   unrecoverableGatewayDialog,
+  shouldReresolveBackend,
+  isStaleBundleSignal,
+  STALE_ASSET_EXIT_CODE,
 } = require("../gateway-recovery");
 
 describe("chooseRecoveryStrategy", () => {
@@ -291,5 +296,159 @@ describe("incumbentSnapshotBlocksRespawn", () => {
     for (const isWindows of [true, false]) {
       assert.equal(incumbentSnapshotBlocksRespawn({ pids: [4242], isWindows }), false);
     }
+  });
+});
+
+describe("shouldReresolveBackend", () => {
+  const mac = { isMac: true, bundled: true };
+
+  it("pins the watchdog's exit status so the two sides cannot drift apart", () => {
+    const backend = fs.readFileSync(
+      path.join(__dirname, "..", "..", "..", "src", "kiro_crew", "dashboard", "stale_asset_watchdog.py"),
+      "utf8",
+    );
+    assert.match(backend, new RegExp(`^STALE_ASSET_EXIT_CODE = ${STALE_ASSET_EXIT_CODE}$`, "m"));
+  });
+
+  it("re-resolves once when the bundled gateway exits with the stale-asset status", () => {
+    assert.equal(
+      shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, attempts: 0 }),
+      "reresolve",
+    );
+  });
+
+  it("re-resolves once when the bundled binary vanished between probe and spawn", () => {
+    assert.equal(
+      shouldReresolveBackend({ ...mac, spawnErrorCode: "ENOENT", attempts: 0 }),
+      "reresolve",
+    );
+  });
+
+  it("relaunches the app when the re-resolved child is stale again and the app can still be re-executed", () => {
+    assert.equal(
+      shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, attempts: 1, relaunchTargetExists: true }),
+      "relaunch",
+    );
+    assert.equal(
+      shouldReresolveBackend({ ...mac, spawnErrorCode: "ENOENT", attempts: 1, relaunchTargetExists: true }),
+      "relaunch",
+    );
+  });
+
+  // app.relaunch() returns void and only schedules the re-exec for exit time,
+  // so a pruned bundle can only be caught before the call: when the caller's
+  // probe of its own executable came back empty, exiting would strand the
+  // user with no app and no dialog.
+  it("surfaces the failure instead of relaunching when this app's executable is gone", () => {
+    for (const signal of [{ exitCode: STALE_ASSET_EXIT_CODE }, { spawnErrorCode: "ENOENT" }]) {
+      assert.equal(
+        shouldReresolveBackend({ ...mac, ...signal, attempts: 1, relaunchTargetExists: false }),
+        "none",
+      );
+      assert.equal(
+        shouldReresolveBackend({ isMac: true, bundled: false, ...signal, attempts: 1, relaunchTargetExists: false }),
+        "none",
+      );
+    }
+  });
+
+  it("defaults to not relaunching when the caller never probed the relaunch target", () => {
+    assert.equal(
+      shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, attempts: 1 }),
+      "none",
+    );
+  });
+
+  it("does not need the relaunch target for the first, in-place re-resolve", () => {
+    assert.equal(
+      shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, attempts: 0, relaunchTargetExists: false }),
+      "reresolve",
+    );
+  });
+
+  // After a prune the re-probe falls through to a PATH lookup, so the child
+  // under judgment on the second signal is no longer the bundled one. That is
+  // still the same incident, and the only move left is a relaunch.
+  it("relaunches on the second signal even when the re-probe found no bundled binary", () => {
+    assert.equal(
+      shouldReresolveBackend({
+        isMac: true, bundled: false, spawnErrorCode: "ENOENT", attempts: 1, relaunchTargetExists: true,
+      }),
+      "relaunch",
+    );
+  });
+
+  it("never spends more than the single re-resolve before relaunching", () => {
+    for (const attempts of [2, 5]) {
+      assert.equal(
+        shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, attempts, relaunchTargetExists: true }),
+        "relaunch",
+      );
+    }
+  });
+
+  it("leaves Windows and Linux on their own recovery paths", () => {
+    for (const signal of [{ exitCode: STALE_ASSET_EXIT_CODE }, { spawnErrorCode: "ENOENT" }]) {
+      assert.equal(shouldReresolveBackend({ isMac: false, bundled: true, ...signal }), "none");
+      assert.equal(
+        shouldReresolveBackend({
+          isMac: false, bundled: true, attempts: 1, relaunchTargetExists: true, ...signal,
+        }),
+        "none",
+      );
+    }
+  });
+
+  // A dev checkout with no kirocrew anywhere spawns the bare PATH name and gets
+  // ENOENT on every boot; treating that as stale would relaunch the app forever.
+  it("ignores a first signal from a PATH or source-checkout gateway", () => {
+    assert.equal(
+      shouldReresolveBackend({ isMac: true, bundled: false, spawnErrorCode: "ENOENT" }),
+      "none",
+    );
+    assert.equal(
+      shouldReresolveBackend({ isMac: true, bundled: false, exitCode: STALE_ASSET_EXIT_CODE }),
+      "none",
+    );
+  });
+
+  it("ignores every other exit status and spawn error", () => {
+    for (const exitCode of [0, 1, 2, 74, 76, 127, 137, null]) {
+      assert.equal(shouldReresolveBackend({ ...mac, exitCode }), "none", `exit ${exitCode}`);
+    }
+    for (const spawnErrorCode of ["EACCES", "EPERM", "EMFILE", ""]) {
+      assert.equal(shouldReresolveBackend({ ...mac, spawnErrorCode }), "none", spawnErrorCode);
+    }
+  });
+
+  it("stands down while the app quits or the updater owns the bundle", () => {
+    assert.equal(
+      shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, quitting: true }),
+      "none",
+    );
+    assert.equal(
+      shouldReresolveBackend({ ...mac, exitCode: STALE_ASSET_EXIT_CODE, installingUpdate: true }),
+      "none",
+    );
+    assert.equal(
+      shouldReresolveBackend({
+        ...mac, spawnErrorCode: "ENOENT", attempts: 1, installingUpdate: true, relaunchTargetExists: true,
+      }),
+      "none",
+    );
+  });
+});
+
+describe("isStaleBundleSignal", () => {
+  it("recognises the watchdog status and a vanished binary, nothing else", () => {
+    assert.equal(isStaleBundleSignal({ exitCode: STALE_ASSET_EXIT_CODE }), true);
+    assert.equal(isStaleBundleSignal({ spawnErrorCode: "ENOENT" }), true);
+    for (const exitCode of [0, 1, 74, 76, null]) {
+      assert.equal(isStaleBundleSignal({ exitCode }), false, `exit ${exitCode}`);
+    }
+    for (const spawnErrorCode of ["EACCES", "EPERM", ""]) {
+      assert.equal(isStaleBundleSignal({ spawnErrorCode }), false, spawnErrorCode);
+    }
+    assert.equal(isStaleBundleSignal({}), false);
   });
 });

--- a/website/electron/test/gateway-supervisor.test.js
+++ b/website/electron/test/gateway-supervisor.test.js
@@ -34,6 +34,62 @@ function rejectingHttp(onGet = () => {}) {
   };
 }
 
+// An http fake whose answer can change mid-test: `state.status` null refuses the
+// connection, a number answers with that status and `state.body`. Requests are
+// recorded so a test can prove which endpoint was probed.
+function switchableHttp(state) {
+  const requests = [];
+  return {
+    requests,
+    get(url, _options, callback) {
+      requests.push(url);
+      const request = new EventEmitter();
+      request.destroy = () => {};
+      queueMicrotask(() => {
+        if (state.status === null) {
+          request.emit("error", new Error("connection refused"));
+          return;
+        }
+        const response = new EventEmitter();
+        response.statusCode = state.status;
+        response.resume = () => {};
+        callback(response);
+        response.emit("data", state.body || "");
+        response.emit("end");
+      });
+      return request;
+    },
+  };
+}
+
+// Timers the supervisor schedules, held instead of run so a test can fire the
+// one it means (by delay) or prove none is left armed.
+function fakeTimers() {
+  const pending = [];
+  let nextId = 1;
+  return {
+    pending,
+    setTimeoutFn(fn, ms) {
+      const id = nextId;
+      nextId += 1;
+      pending.push({ id, fn, ms });
+      return id;
+    },
+    clearTimeoutFn(id) {
+      const index = pending.findIndex((timer) => timer.id === id);
+      if (index >= 0) pending.splice(index, 1);
+    },
+    fire(ms) {
+      const index = pending.findIndex((timer) => timer.ms === ms);
+      assert.ok(index >= 0, `a ${ms}ms timer is armed`);
+      const [timer] = pending.splice(index, 1);
+      timer.fn();
+    },
+  };
+}
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
 function harness(overrides = {}) {
   const logs = [];
   const spawnCalls = [];
@@ -67,6 +123,7 @@ function harness(overrides = {}) {
       getVersion: () => "0.6.0",
       quit: () => {},
       focus: () => {},
+      ...(overrides.app || {}),
     },
     store,
     BrowserWindow: class {},
@@ -89,16 +146,22 @@ function harness(overrides = {}) {
     pathMod: path.posix,
     httpMod: overrides.httpMod || rejectingHttp(),
     spawnFn: (...args) => {
-      spawnCalls.push(args);
       const child = new EventEmitter();
       child.pid = 1234;
       child.exitCode = null;
-      child.kill = () => {};
+      child.killed = false;
+      child.kill = () => { child.killed = true; };
+      child.unref = () => { child.unrefed = true; };
+      const call = [...args];
+      call.child = child;
+      spawnCalls.push(call);
       return child;
     },
     execFileFn: overrides.execFileFn
       || (() => { throw new Error("execFile must not run in this harness"); }),
     execFileSyncFn: () => { throw new Error("execFileSync must not run in this harness"); },
+    setTimeoutFn: overrides.timers ? overrides.timers.setTimeoutFn : undefined,
+    clearTimeoutFn: overrides.timers ? overrides.timers.clearTimeoutFn : undefined,
     processRef,
     dirname: "/virtual/electron",
   });
@@ -235,4 +298,315 @@ test("install-failure recovery hook is armed once per dispatch", async () => {
     logs.filter((line) => line.includes("restoring gateway")).length,
     1,
   );
+});
+
+// A macOS app whose bundled backend sits at the usual resourcesPath layout. The
+// `pruned` flag flips the bundle out from under the supervisor mid-test, the
+// way an in-place update does; the fs then reports ENOENT for every bundled
+// candidate and findKirocrewBin falls through to the bare PATH name. Whether
+// the app's own executable survives is separate (`appExecutableGone`): a swap
+// leaves a new one at the same path, a prune takes it too.
+const APP_EXEC_PATH = "/virtual/Applications/KiroCrew.app/Contents/MacOS/KiroCrew";
+const APP_ARGV = [APP_EXEC_PATH, "--some-flag"];
+
+function staleBundleHarness({ platform = "darwin", appExecutableGone = false } = {}) {
+  const state = {
+    pruned: false,
+    exits: [],
+    execProbes: [],
+    lockReleases: 0,
+    lockRequests: 0,
+    statuses: [],
+    // What the gateway port answers: silent until a test brings a successor's
+    // gateway up.
+    http: { status: null, body: "" },
+  };
+  const fsMod = {
+    constants: { X_OK: 1 },
+    mkdirSync() {},
+    accessSync(target) {
+      if (target === APP_EXEC_PATH) {
+        state.execProbes.push(target);
+        if (!appExecutableGone) return;
+      } else if (!state.pruned && target.includes("backend-dist")) {
+        return;
+      }
+      const error = new Error("not found");
+      error.code = "ENOENT";
+      throw error;
+    },
+    existsSync() { return false; },
+    openSync() { return 41; },
+    closeSync() {},
+    readFileSync() { throw new Error("unexpected filesystem read"); },
+  };
+  const timers = fakeTimers();
+  const httpMod = switchableHttp(state.http);
+  const built = harness({
+    fsMod,
+    httpMod,
+    timers,
+    mainWindow: {
+      isDestroyed: () => false,
+      webContents: { send: (channel, message) => state.statuses.push(`${channel}:${message}`) },
+    },
+    processRef: {
+      platform,
+      arch: "x64",
+      execPath: APP_EXEC_PATH,
+      argv: APP_ARGV,
+      env: { KIROCREW_HOME: "/virtual/kirocrew-home" },
+      resourcesPath: "/virtual/resources",
+      kill() { throw new Error("process kill must not run in this harness"); },
+    },
+    app: {
+      // No `relaunch` on purpose: app.relaunch() cannot report a failed re-exec,
+      // so the supervisor must never reach for it on this path.
+      releaseSingleInstanceLock() { state.lockReleases += 1; },
+      requestSingleInstanceLock() { state.lockRequests += 1; return true; },
+      exit(code) { state.exits.push(code); },
+    },
+  });
+  return { ...built, state, timers, requests: httpMod.requests };
+}
+
+// The successor spawn the supervisor issues when it decides to restart the app.
+function successorCall(spawnCalls) {
+  return spawnCalls.find((call) => call[0] === APP_EXEC_PATH);
+}
+
+// Drive a stale-bundle harness to the point where a successor copy of the app
+// has been exec'd and the supervisor is waiting for its gateway.
+async function spawnedSuccessor(built) {
+  const { supervisor, spawnCalls, state } = built;
+  await supervisor.start();
+  spawnCalls[0].child.emit("exit", 75, null);
+  spawnCalls[1].child.emit("exit", 75, null);
+  const successor = successorCall(spawnCalls);
+  assert.ok(successor, "a successor copy of this app is spawned");
+  successor.child.emit("spawn");
+  await flush();
+  assert.deepStrictEqual(state.exits, [], "exec success alone must not exit this instance");
+  return successor;
+}
+
+const SUCCESSOR_READY_TIMEOUT_MS = 60_000;
+const SUCCESSOR_POLL_MS = 500;
+
+const BUNDLED_BIN = "/virtual/resources/backend-dist/kirocrew-backend-x64/bin/kirocrew";
+
+test("a bundled gateway that exits with the stale-asset status is respawned from a fresh probe", async () => {
+  const { supervisor, spawnCalls, logs, state } = staleBundleHarness();
+
+  assert.strictEqual(await supervisor.start(), true);
+  assert.strictEqual(spawnCalls.length, 1);
+  assert.strictEqual(spawnCalls[0][0], BUNDLED_BIN);
+
+  // The update swapped the bundle at the same path: the probe still finds it.
+  const first = spawnCalls[0].child;
+  first.exitCode = 75;
+  first.emit("exit", 75, null);
+
+  assert.strictEqual(spawnCalls.length, 2);
+  assert.strictEqual(spawnCalls[1][0], BUNDLED_BIN);
+  assert.ok(logs.some((line) => line.includes("stale bundle (exit 75") && line.includes("attempt 1")));
+  assert.strictEqual(successorCall(spawnCalls), undefined);
+  assert.deepStrictEqual(state.exits, []);
+});
+
+test("a second stale exit starts a fresh copy of the app and exits only once its gateway is serving", async () => {
+  const built = staleBundleHarness();
+  const { spawnCalls, logs, state, timers, requests } = built;
+
+  await built.supervisor.start();
+  spawnCalls[0].child.emit("exit", 75, null);
+  assert.strictEqual(spawnCalls.length, 2);
+
+  spawnCalls[1].child.emit("exit", 75, null);
+
+  assert.strictEqual(spawnCalls.filter((call) => call[0] !== APP_EXEC_PATH).length, 2,
+    "the budget is one backend re-resolve per incident");
+  assert.ok(state.execProbes.length >= 1, "the app executable is probed before restarting");
+  const successor = successorCall(spawnCalls);
+  assert.ok(successor, "a successor copy of this app is spawned");
+  assert.deepStrictEqual(successor[1], ["--some-flag"], "the successor gets this instance's arguments");
+  assert.deepStrictEqual(successor[2], { detached: true, stdio: "ignore" });
+  assert.strictEqual(state.lockReleases, 1, "the single-instance lock is released so the successor can win it");
+  assert.ok(state.statuses.includes("status:Restarting Kiro Crew to finish the update…"),
+    "the window is told why it is about to go away");
+  assert.deepStrictEqual(state.exits, [], "this instance must not exit before the successor is confirmed running");
+
+  // Exec success is not startup: the port is still silent, so this instance
+  // keeps waiting and keeps running.
+  successor.child.emit("spawn");
+  await flush();
+  assert.deepStrictEqual(state.exits, [], "the spawn event alone must not exit this instance");
+  assert.ok(logs.some((line) => line.includes("waiting for its gateway to answer")));
+  assert.ok(requests.some((url) => url.endsWith("/api/ready")), "readiness is probed on /api/ready");
+  assert.ok(timers.pending.some((timer) => timer.ms === SUCCESSOR_READY_TIMEOUT_MS), "the wait is bounded");
+
+  // The successor's gateway comes up and answers ready.
+  state.http.status = 200;
+  state.http.body = JSON.stringify({ ready: true });
+  timers.fire(SUCCESSOR_POLL_MS);
+  await flush();
+
+  assert.strictEqual(successor.child.unrefed, true);
+  assert.deepStrictEqual(state.exits, [0]);
+  assert.ok(logs.some((line) => line.includes("is serving on :5476") && line.includes("exiting this instance")));
+  assert.deepStrictEqual(timers.pending, [], "the deadline is disarmed once the successor is confirmed");
+  assert.ok(state.statuses.filter((entry) => entry === "status:Restarting Kiro Crew to finish the update…").length >= 2,
+    "the restart announcement is re-sent on every poll so a splash that loaded late still shows it");
+});
+
+test("a successor whose gateway is still booting (503 starting) also counts as alive", async () => {
+  const built = staleBundleHarness();
+  const { state, timers } = built;
+  const successor = await spawnedSuccessor(built);
+
+  state.http.status = 503;
+  state.http.body = JSON.stringify({ ready: false });
+  timers.fire(SUCCESSOR_POLL_MS);
+  await flush();
+
+  assert.deepStrictEqual(state.exits, [0]);
+  assert.strictEqual(successor.child.killed, false);
+});
+
+test("a successor that exits before its gateway answers leaves this instance running with the failure surfaced", async () => {
+  const built = staleBundleHarness();
+  const { spawnCalls, logs, state, timers } = built;
+  const successor = await spawnedSuccessor(built);
+
+  // The bundle exec'd but crashed during initialization.
+  successor.child.emit("exit", 1, null);
+
+  assert.deepStrictEqual(state.exits, [], "a successor that died must not take this instance down");
+  assert.strictEqual(state.lockRequests, 1, "the single-instance lock is taken back");
+  assert.strictEqual(successor.child.killed, false, "nothing is left to kill");
+  assert.ok(logs.some((line) => line.includes("exited (code=1 signal=null) before its gateway answered")));
+  assert.strictEqual(spawnCalls.length, 3, "no further respawn: the ordinary failure path owns the outcome now");
+  assert.deepStrictEqual(timers.pending, [], "no poll or deadline stays armed after the failure");
+
+  // A gateway answering later (any gateway) must not revive the handoff.
+  state.http.status = 200;
+  await flush();
+  assert.deepStrictEqual(state.exits, []);
+});
+
+test("a successor that never serves within the bound is stopped and this instance stays", async () => {
+  const built = staleBundleHarness();
+  const { logs, state, timers } = built;
+  const successor = await spawnedSuccessor(built);
+
+  timers.fire(SUCCESSOR_READY_TIMEOUT_MS);
+
+  assert.deepStrictEqual(state.exits, [], "a timed-out handoff must not exit this instance");
+  assert.strictEqual(successor.child.killed, true, "the unconfirmed successor is stopped so one instance remains");
+  assert.strictEqual(state.lockRequests, 1, "the single-instance lock is taken back");
+  assert.ok(logs.some((line) => line.includes("did not answer on :5476 within 60s")));
+  assert.deepStrictEqual(timers.pending, [], "the poll is disarmed with the deadline");
+
+  // A late readiness answer must not exit either.
+  state.http.status = 200;
+  await flush();
+  assert.deepStrictEqual(state.exits, []);
+});
+
+test("a pruned bundle re-probes once, then surfaces the failure when the app executable is gone too", async () => {
+  const { supervisor, spawnCalls, logs, state } = staleBundleHarness({ appExecutableGone: true });
+
+  await supervisor.start();
+  assert.strictEqual(spawnCalls[0][0], BUNDLED_BIN);
+
+  // The versioned directory is gone: the probed binary vanished before exec.
+  state.pruned = true;
+  const enoent = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+  spawnCalls[0].child.emit("error", enoent);
+
+  // The re-probe found nothing bundled and fell through to the PATH name.
+  assert.strictEqual(spawnCalls.length, 2);
+  assert.strictEqual(spawnCalls[1][0], "kirocrew");
+
+  spawnCalls[1].child.emit("error", enoent);
+
+  assert.strictEqual(spawnCalls.length, 2, "never try to start a copy of an executable that is already gone");
+  assert.strictEqual(state.lockReleases, 0);
+  assert.deepStrictEqual(state.exits, [], "a missing app executable must not exit into nothing");
+  assert.ok(logs.some((line) => line.includes("cannot relaunch; surfacing the failure instead")));
+});
+
+// The probe and the restart are not atomic: an in-place update can prune the
+// bundle between the two. The restart is therefore a real spawn whose exec
+// result is observed before this instance exits, so a prune that lands in
+// that window still ends at the failure dialog with the app alive.
+test("a bundle pruned after the probe fails the successor spawn and falls back to the failure dialog", async () => {
+  const { supervisor, spawnCalls, logs, state, timers } = staleBundleHarness();
+
+  await supervisor.start();
+  spawnCalls[0].child.emit("exit", 75, null);
+  spawnCalls[1].child.emit("exit", 75, null);
+  const successor = successorCall(spawnCalls);
+  assert.ok(successor);
+  assert.deepStrictEqual(state.exits, []);
+
+  successor.child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+  assert.deepStrictEqual(state.exits, [], "a successor that never started must not take this instance down");
+  assert.strictEqual(state.lockRequests, 1, "the single-instance lock is taken back");
+  assert.strictEqual(successor.child.killed, false, "there is no process to stop");
+  assert.ok(logs.some((line) => line.includes("successor app failed to start (ENOENT)")));
+  assert.strictEqual(spawnCalls.length, 3, "no further respawn: the ordinary failure path owns the outcome now");
+
+  // A late "spawn" after the error must not exit either, nor arm a wait.
+  successor.child.emit("spawn");
+  await flush();
+  assert.deepStrictEqual(state.exits, []);
+  assert.deepStrictEqual(timers.pending, []);
+});
+
+test("a pruned bundle whose app executable survived still restarts the app", async () => {
+  const { supervisor, spawnCalls, state, timers } = staleBundleHarness({ appExecutableGone: false });
+
+  await supervisor.start();
+  state.pruned = true;
+  const enoent = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+  spawnCalls[0].child.emit("error", enoent);
+  assert.strictEqual(spawnCalls.length, 2);
+  spawnCalls[1].child.emit("error", enoent);
+
+  const successor = successorCall(spawnCalls);
+  assert.ok(successor);
+  successor.child.emit("spawn");
+  await flush();
+  assert.deepStrictEqual(state.exits, []);
+
+  state.http.status = 200;
+  timers.fire(SUCCESSOR_POLL_MS);
+  await flush();
+  assert.deepStrictEqual(state.exits, [0]);
+});
+
+test("a stale exit while the updater owns the bundle is left alone", async () => {
+  const { supervisor, spawnCalls, state } = staleBundleHarness();
+
+  await supervisor.start();
+  supervisor.onInstallDispatched();
+  spawnCalls[0].child.emit("exit", 75, null);
+
+  assert.strictEqual(spawnCalls.length, 1);
+  assert.deepStrictEqual(state.exits, []);
+});
+
+test("Linux and Windows keep their own stale-asset recovery", async () => {
+  for (const platform of ["linux", "win32"]) {
+    const { supervisor, spawnCalls, state } = staleBundleHarness({ platform });
+
+    await supervisor.start();
+    assert.strictEqual(spawnCalls.length, 1, platform);
+    spawnCalls[0].child.emit("exit", 75, null);
+
+    assert.strictEqual(spawnCalls.length, 1, platform);
+    assert.deepStrictEqual(state.exits, [], platform);
+  }
 });


### PR DESCRIPTION
## Problem / Motivation

On macOS, when an update replaces or prunes the app bundle while a session is running, the gateway's stale-asset watchdog exits with status 75. The Electron supervisor then respawns from the binary path it resolved at launch; when that path is gone every respawn fails with ENOENT, the liveness monitor kills and respawns again with the same result, and the app sits with no backend until the user quits and relaunches by hand. Linux was fixed separately (the service manager restarts the gateway on exit 75); the desktop shell had no equivalent.

## Why it matters

Every macOS desktop user who leaves the app open across an update hits a dead dashboard with a spinner, an error dialog whose Retry cannot succeed, and no hint that quitting and relaunching is the fix.

## What changed (motivation → approach → change)

Root cause. The supervisor treats exit 75 and a spawn ENOENT like any other failure, so nothing re-probes for the backend until the liveness monitor's 30-second threshold, and that path reuses the same failure bookkeeping. The first commit on this branch added a retry that re-read the bundle path via `app.getAppPath()` two directory levels up, which lands on `Contents/` rather than `Contents/Resources/` and so never found the bundled backend; it also assumed that API could observe a newer bundle, but every Electron path API is a launch-time snapshot.

Fix. What actually recovers a bundle swapped in at the same path is `findKirocrewBin` probing the filesystem again, so the retry now simply respawns from the same candidate list. The decision lives in a pure helper, `shouldReresolveBackend` in `website/electron/gateway-recovery.js`, shared by the spawn-error and exit handlers:

- exit 75 or spawn ENOENT from the bundled child on macOS → re-resolve and respawn once;
- a second stale signal in the same incident → restart the app, but only after the supervisor has probed that the app's own executable (`process.execPath`) still exists, and without `app.relaunch()`. `app.relaunch()` returns nothing and only schedules the re-exec for exit time, so a failed re-exec on a pruned bundle can never be observed from inside the process. Instead the supervisor releases the single-instance lock, spawns a detached successor copy of itself, and exits only once that successor is demonstrably alive. Node's `spawn` event is not that proof: it fires when the exec succeeded, and a bundle intact enough to exec yet broken enough to crash during initialization would still take the app down. The handshake is the successor's own gateway answering `/api/ready` on the shared port (200, or a booting 503 that is not draining), which was silent when the handoff began; an answer there means the successor booted, ran its supervisor, and started a serving backend. A spawn `ENOENT` (bundle pruned between the probe and the restart), the successor exiting before its gateway answered, or a 60-second deadline all leave this instance alive: a still-running successor is stopped so exactly one instance remains, the lock is taken back, and this instance falls through to the normal failure dialog. The liveness monitor is stopped for the handoff so it cannot force-stop the port the successor's gateway is binding; a failed mid-session handoff runs the connect path itself to surface the dialog the monitor would have led to. The helper takes the probe result as `relaunchTargetExists`, defaulting to `false`, so a caller that never checked can only reach the dialog;
- any other platform, exit status, or spawn error, or a PATH/source-checkout gateway → the ordinary failure path, so a dev machine with no `kirocrew` cannot relaunch-loop;
- the helper stands down while the app is quitting or the updater owns the bundle, and the per-incident budget resets when a gateway reaches handoff or a monitored backend answers again after a blip (the liveness monitor's `onRecovered`).

Windows and Linux behaviour is unchanged.

## Tests

`website/electron/test/gateway-recovery.test.js`: every `shouldReresolveBackend` branch (first stale signal → reresolve, second with the relaunch target present → relaunch including when the re-probe fell through to a non-bundled binary, second with the relaunch target gone → none, no `relaunchTargetExists` given → none, non-mac → none, non-bundled first signal → none, other exit codes and spawn errors → none, quitting/installing → none), `isStaleBundleSignal`, plus a pin that the exit status matches the backend watchdog's `STALE_ASSET_EXIT_CODE`.

`website/electron/test/gateway-supervisor.test.js`: drives the real supervisor with a fake spawn and a filesystem that can lose its bundle and, independently, the app's own executable mid-test: a swapped bundle is respawned from the same path; a second exit 75 probes `process.execPath`, releases the single-instance lock, spawns a detached successor with this instance's arguments, tells the window it is restarting, keeps running after the successor's `spawn` event while the port is silent, probes `/api/ready`, and exits only once the successor's gateway answers (200, and separately a booting 503); a successor that exits before its gateway answers leaves this instance running with the lock re-taken and no timer armed; a successor that never answers within the 60s bound is stopped, the lock is re-taken, and this instance stays; a pruned bundle re-probes once, gets ENOENT on the PATH fallback, and when the app executable is gone too never spawns a successor, never exits, and surfaces the failure; a bundle pruned after the probe fails the successor spawn with ENOENT, the lock is re-taken, the instance does not exit, and a late `spawn` cannot exit it either; a pruned bundle whose app executable survived still restarts; a stale exit while the updater owns the bundle is ignored; Linux and Windows never enter the path. The fake `app` deliberately has no `relaunch` method, so any return to `app.relaunch()` on this path throws.

Both suites go red when the helper's existence gate is removed (3 failures) or when the supervisor exits before the successor is confirmed (3 failures); with the previous exit-on-`spawn` supervisor swapped back in, the five handshake tests fail (5 failures, 12 pass). `npm test` in `website/electron`: 1687 tests, 1686 pass, 0 fail, 1 skipped.

## Manual verification

Not performed on a live update. The unit tests pin the whole decision path with a fake filesystem and spawn; the remaining runtime assumptions are Electron's documented `releaseSingleInstanceLock()` / `requestSingleInstanceLock()` semantics, Node's `spawn` / `exit` events, and `/api/ready` answering only once the gateway's HTTP server is bound (the same probe the boot path uses to refuse adopting a draining gateway).

The re-resolve budget also resets when the liveness monitor's `onRecovered` fires, so a re-resolved backend that comes up healthy in the background closes its incident and a later independent stale signal gets the cheaper in-place re-resolve rather than a full app restart.

## Related Issues

no linked issue: reported through the macOS desktop update path, no tracked issue.

## Pattern harvest

Rule candidate: review-prompt
Pattern: recovery path re-reads a launch-time snapshot (resourcesPath, getAppPath, execPath) as if it could observe a changed filesystem

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

Backport: please include in release/0.6.0.


