### PR TITLE
fix(chat): honour global agent.model default for auto-created slots

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -50,6 +50,7 @@ from kiro_crew.config.loader import (
     normalize_agent_model,
     refresh_materialized_agents,
     resolve_agent_bindings,
+    resolve_effective_model,
 )
 from kiro_crew.connections import get_visible_providers
 from kiro_crew.constants import strip_control_comments
@@ -919,6 +920,59 @@ def _backfill_canonical_model(client: Any, provider: str) -> str:
     if not is_claude_code(provider) and _is_bedrock_profile_id(prov_model):
         return ""
     return model_registry.canonicalize_for_provider(prov_model, provider)
+
+
+def _default_session_model(
+    cfg: "KiroCrewConfig | None", slot: "_ChatSlot", agent_model: str
+) -> str:
+    """The model a slot that pins nothing STARTS a session on, or ``""``.
+
+    Resolved through :func:`resolve_effective_model` — the one resolver the
+    dashboard's model chip already reads (``/api/agents/resolved-model``) — so
+    the model an auto-created slot runs on is the model the chip says it will.
+    Before this the chat-send path only consulted the crew's own pin
+    (``bindings.model``) and left everything below it to ``get_or_create``,
+    which resolves from the session manager's config SNAPSHOT — refreshed only
+    by the settings handlers that call ``refresh_defaults`` — while this turn and
+    the chip both read a fresh load. A global ``agent.model`` written any other
+    way (``kirocrew config set``, a hand edit) was therefore shown by the chip
+    but not run by the first turn of a fresh slot until the gateway restarted.
+
+    The value is deliberately a LOCAL for the ``get_or_create`` call and is
+    NEVER written to ``slot.model``. That field is persisted slot state and is
+    re-sent as a ``set_model`` override on every resume, so an empty value means
+    "inherit": the slot follows a later change to ``agent.model`` or to the
+    agent's pin, the chip renders the inherited value live, and the explicit
+    slot-create endpoint stores ``""`` when nothing is picked. Persisting the
+    resolved default here would silently turn every inheriting slot into a
+    permanent pin on its first message, and would route an inherited default
+    the account cannot run through the "isn't offered right now" pin flow.
+
+    Returns ``""`` when the slot or crew already pins a model (nothing to
+    resolve), when the config could not be loaded, or when every tier defers
+    to the backend — ``get_or_create`` then resolves as before.
+
+    Blocking: ``resolve_effective_model`` reaches ``_resolve_named_agent_model``
+    (a glob + per-file read of the installed agent JSON) and
+    ``_resolve_agent_model`` (another file read), so callers run this through
+    ``asyncio.to_thread`` and never inline on the event loop. That makes the
+    ``except`` below load-bearing beyond logging: ``resolve_agent_bindings``
+    inside the resolver can raise ``StopIteration`` on a malformed config, and a
+    ``StopIteration`` cannot be delivered through a Future (3.12+ substitutes a
+    ``RuntimeError``; older interpreters leave the future PENDING and the await
+    hangs), so awaiting the thread would fail with the wrong error, or not
+    return at all, instead of surfacing the resolver's. ``StopIteration`` is an
+    ``Exception`` subclass, so it is converted to ``""`` HERE, in the worker,
+    before it can reach the Future boundary. Keep the clause at ``Exception``
+    or wider; narrowing it re-opens that hole.
+    """
+    if slot.model or agent_model or cfg is None:
+        return ""
+    try:
+        return resolve_effective_model(cfg, slot.agent or None)
+    except Exception:  # noqa: BLE001 — includes StopIteration; see docstring
+        logger.warning("Failed to resolve the default model for slot %s", slot.key, exc_info=True)
+        return ""
 
 
 def _pinned_model_verdict(client: Any, model: str, provider: str) -> bool | None:
@@ -4134,9 +4188,14 @@ async def _eager_spawn(
             # would be discarded by passing "" here.
             crew_alias = slot.agent or ""
             agent_model = ""
+            # Same default-model resolve as the real turn — the two MUST agree,
+            # or the first message would silently reuse a pre-warmed session
+            # running a different model than the chip promised.
+            loaded_cfg: KiroCrewConfig | None = None
             resolved_ok = False
             try:
                 cfg = KiroCrewConfig.load()
+                loaded_cfg = cfg
                 bindings = resolve_agent_bindings(cfg, slot.agent or None)
                 kiro_agent = bindings.kiro_agent
                 crew_alias = bindings.resolved_alias
@@ -4193,6 +4252,12 @@ async def _eager_spawn(
                     slot.key,
                 )
                 return
+            # Off the loop: the resolve globs and reads agent JSON (see
+            # _default_session_model). It converts every resolver error,
+            # StopIteration included, to "" inside the worker.
+            default_model = await asyncio.to_thread(
+                _default_session_model, loaded_cfg, slot, agent_model
+            )
             _t0 = time.monotonic()
             try:
                 # speculative=True keeps the one-shot first-turn flag armed for
@@ -4210,7 +4275,7 @@ async def _eager_spawn(
                     # cross-namespace name match. "" is authoritative: no
                     # alias applied, so no override applies.
                     crew_agent=crew_alias,
-                    model=slot.model or agent_model or None,
+                    model=slot.model or agent_model or default_model or None,
                     cwd=slot.project or None,
                     speculative=True,
                     speculative_resume=allow_resume,
@@ -6417,9 +6482,12 @@ async def _run_chat(
         memory_store: str | None = None
         # The KiroCrew agent's own default model ("" = inherit). Ranks below the
         # slot's explicit pick and above the bound kiro agent's pin / the global
-        # agent.model fallback, both of which get_or_create resolves when this
-        # and slot.model are empty.
+        # agent.model fallback.
         agent_model = ""
+        # Bound only when the config loaded: `cfg` itself is unbound on a load
+        # failure (see `provider_name`), and the default-model resolve below
+        # needs the loaded object.
+        loaded_cfg: KiroCrewConfig | None = None
         # Read the provider into a local alongside the other bindings. Both model
         # branches below need it, and `cfg` is only bound inside the try — a
         # malformed config raises, the except swallows it, and touching
@@ -6440,6 +6508,7 @@ async def _run_chat(
         _app_agent_unresolved = False
         try:
             cfg = KiroCrewConfig.load()
+            loaded_cfg = cfg
             provider_name = cfg.agent.provider
             # Warm the project agent index OFF the loop, then resolve inline. Only
             # the warm is offloaded: resolve_agent_bindings can raise StopIteration
@@ -6519,6 +6588,14 @@ async def _run_chat(
             "activity_event", {"slot": slot.key, "kind": "status", "text": "Creating session…"}
         )
         slot.model = _normalize_model(slot.model or "") or ""
+        # The model a slot that pins nothing STARTS on, kept OUT of `slot.model`
+        # — see _default_session_model for why persisting it would change what an
+        # empty slot.model means. Off the loop: the resolve globs and reads agent
+        # JSON; the helper converts every resolver error, StopIteration included,
+        # to "" inside the worker, so nothing un-deliverable reaches the Future.
+        default_model = await asyncio.to_thread(
+            _default_session_model, loaded_cfg, slot, agent_model
+        )
         # Consume a deferred project-change reset queued while idle, before
         # get_or_create or we'd reuse the stale session for one turn. Safe here:
         # no session lock is held yet, so reset() can't self-kill.
@@ -6536,7 +6613,7 @@ async def _run_chat(
             # must agree or an eager session and its real first turn would
             # carry different watchdog windows.
             crew_agent=crew_alias,
-            model=slot.model or agent_model or None,
+            model=slot.model or agent_model or default_model or None,
             cwd=slot.project or None,
             reasoning_effort_override=slot.reasoning_effort or None,
         )

--- a/test/test_chat_send_agent_model_default.py
+++ b/test/test_chat_send_agent_model_default.py
@@ -1,0 +1,322 @@
+"""Auto-created chat slots start their session on the global ``agent.model``.
+
+Regression: a slot created implicitly by sending a message (``api_chat`` ->
+``get_or_create_slot`` with no model) carries ``slot.model == ""``. ``_run_chat``
+then passed ``model=slot.model or agent_model or None`` to ``get_or_create``,
+where ``agent_model`` is only the crew's own pin, so a slot on a crew that pins
+nothing handed ``None`` down and left the default to the session manager's
+config snapshot — not to :func:`resolve_effective_model`, the documented
+precedence chain the dashboard's model chip displays. The chip and the session
+could disagree.
+
+These tests drive the REAL ``_run_chat`` and ``_eager_spawn`` bodies with a
+mocked session boundary and assert on the ``model`` kwarg ``get_or_create``
+receives, so they fail if the runner stops resolving the default. They also pin
+the persist-vs-not decision: the resolved default is passed to the session and
+is NOT written into ``slot.model``, whose empty value keeps meaning "inherit".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import unittest.mock
+from pathlib import Path
+
+import pytest
+from test_chat_runner_coverage import _complete, _drive, _runner_state, _set_stream, _slot
+
+from kiro_crew.acp.types import EVENT_TEXT_CHUNK
+from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.dashboard import chat_runner
+from kiro_crew.dashboard.chat_runner import _eager_spawn
+from kiro_crew.providers.base import LLMEvent
+
+GLOBAL_DEFAULT = "claude-opus-5"
+CREW_PIN = "claude-sonnet-5"
+SLOT_PIN = "claude-haiku-5"
+
+
+def _load_config(tmp_path: Path, data: dict) -> KiroCrewConfig:
+    """A real ``KiroCrewConfig`` loaded from *data* (same shape as config.json)."""
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(json.dumps(data))
+    with unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_file):
+        return KiroCrewConfig.load()
+
+
+def _config(tmp_path: Path, *, crew_model: str = "") -> KiroCrewConfig:
+    """Global ``agent.model`` set; the crews pin nothing unless *crew_model*."""
+    return _load_config(
+        tmp_path,
+        {
+            "agent": {"model": GLOBAL_DEFAULT, "provider": "acp"},
+            "agents": {"researcher": {"kiro_agent": "kirocrew", "model": crew_model}},
+            "default_agent": "kirocrew",
+        },
+    )
+
+
+def _turn_state(tmp_path: Path):
+    state, client = _runner_state(tmp_path)
+    _set_stream(client, [LLMEvent(kind=EVENT_TEXT_CHUNK, text="hi"), _complete()])
+    return state, client
+
+
+def _session_model(state) -> str | None:
+    state.sessions.get_or_create.assert_awaited_once()
+    return state.sessions.get_or_create.await_args.kwargs["model"]
+
+
+@pytest.fixture
+def _runner_config(tmp_path):
+    """Serve the real config object to every ``KiroCrewConfig.load()`` in the turn."""
+
+    def _install(cfg: KiroCrewConfig):
+        patcher = unittest.mock.patch.object(
+            chat_runner.KiroCrewConfig, "load", unittest.mock.MagicMock(return_value=cfg)
+        )
+        patcher.start()
+        return patcher
+
+    patchers: list[unittest.mock._patch] = []
+
+    def _use(cfg: KiroCrewConfig) -> None:
+        patchers.append(_install(cfg))
+
+    yield _use
+    for p in patchers:
+        p.stop()
+
+
+class TestRunChatDefaultModel:
+    @pytest.mark.asyncio
+    async def test_fresh_slot_starts_on_the_global_default(self, tmp_path, _runner_config):
+        """slot.model == "" and no crew pin -> the session gets ``agent.model``."""
+        _runner_config(_config(tmp_path))
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+        assert slot.model == "" and slot.agent == ""
+
+        await _drive(state, slot)
+
+        assert _session_model(state) == GLOBAL_DEFAULT
+
+    @pytest.mark.asyncio
+    async def test_resolved_default_is_not_persisted_on_the_slot(self, tmp_path, _runner_config):
+        """The default is a session-creation input, not a pin.
+
+        ``slot.model`` is persisted and re-sent as a ``set_model`` override on
+        every resume, so writing the resolved default there would turn an
+        inheriting slot into a permanent pin: a later change to ``agent.model``
+        would no longer reach it. An empty value must survive the turn.
+        """
+        _runner_config(_config(tmp_path))
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+
+        await _drive(state, slot)
+
+        assert _session_model(state) == GLOBAL_DEFAULT
+        assert slot.model == ""
+
+    @pytest.mark.asyncio
+    async def test_crew_pin_outranks_the_global_default(self, tmp_path, _runner_config):
+        _runner_config(_config(tmp_path, crew_model=CREW_PIN))
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+        slot.agent = "researcher"
+
+        await _drive(state, slot)
+
+        assert _session_model(state) == CREW_PIN
+        assert slot.model == ""
+
+    @pytest.mark.asyncio
+    async def test_explicit_slot_pin_is_untouched(self, tmp_path, _runner_config):
+        _runner_config(_config(tmp_path, crew_model=CREW_PIN))
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+        slot.agent = "researcher"
+        slot.model = SLOT_PIN
+
+        await _drive(state, slot)
+
+        assert _session_model(state) == SLOT_PIN
+        assert slot.model == SLOT_PIN
+
+    @pytest.mark.asyncio
+    async def test_every_tier_deferring_leaves_the_backend_to_choose(
+        self, tmp_path, _runner_config
+    ):
+        """``agent.model`` unset/auto and no installed pin -> ``None``, as before."""
+        cfg = _load_config(
+            tmp_path,
+            {"agent": {"model": "auto", "provider": "acp"}, "default_agent": "kirocrew"},
+        )
+        _runner_config(cfg)
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+
+        with unittest.mock.patch.object(
+            KiroCrewConfig, "_resolve_agent_model", staticmethod(lambda: "")
+        ):
+            await _drive(state, slot)
+
+        assert _session_model(state) is None
+        assert slot.model == ""
+
+    @pytest.mark.asyncio
+    async def test_resolver_failure_falls_back_to_the_old_shape(self, tmp_path, _runner_config):
+        """A resolver error must not kill the turn; the session gets ``None``."""
+        _runner_config(_config(tmp_path))
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+
+        with unittest.mock.patch.object(
+            chat_runner, "resolve_effective_model", side_effect=RuntimeError("boom")
+        ):
+            await _drive(state, slot)
+
+        assert _session_model(state) is None
+        assert slot.model == ""
+
+    @pytest.mark.asyncio
+    async def test_resolver_stop_iteration_does_not_kill_the_turn(self, tmp_path, _runner_config):
+        """``StopIteration`` from the resolver is converted INSIDE the worker.
+
+        The resolve now runs through ``asyncio.to_thread``, and a
+        ``StopIteration`` cannot be delivered through a Future
+        (``set_exception`` rejects it with ``TypeError``). ``resolve_agent_bindings``
+        can raise exactly that on a malformed config, so the helper must turn
+        it into ``""`` before it reaches the thread boundary — otherwise the
+        turn dies with a ``TypeError`` that names neither the config nor the
+        resolver. The turn must complete and hand ``None`` to the session.
+        """
+        _runner_config(_config(tmp_path))
+        state, client = _turn_state(tmp_path)
+        slot = _slot()
+
+        with unittest.mock.patch.object(
+            chat_runner, "resolve_effective_model", side_effect=StopIteration("malformed")
+        ):
+            await _drive(state, slot)
+
+        assert _session_model(state) is None
+        assert slot.model == ""
+        # The turn ran to the provider: the resolver failure was absorbed, not fatal.
+        client.stream.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_default_resolve_runs_off_the_event_loop(self, tmp_path, _runner_config):
+        """The resolver globs and reads agent JSON; it must not run on the loop.
+
+        Pins the ``asyncio.to_thread`` hop by observing the thread the resolver
+        actually runs on: a worker thread has no running loop, and it is not the
+        thread that drives the turn. A future inline call fails both checks.
+        """
+        _runner_config(_config(tmp_path))
+        state, _client = _turn_state(tmp_path)
+        slot = _slot()
+        seen: dict[str, object] = {}
+
+        def _resolver(cfg, agent):
+            seen["thread"] = threading.get_ident()
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                seen["loop_on_thread"] = False
+            else:
+                seen["loop_on_thread"] = True
+            return GLOBAL_DEFAULT
+
+        with unittest.mock.patch.object(chat_runner, "resolve_effective_model", _resolver):
+            await _drive(state, slot)
+
+        assert _session_model(state) == GLOBAL_DEFAULT
+        assert seen["thread"] != threading.get_ident()
+        assert seen["loop_on_thread"] is False
+
+
+class TestDefaultSessionModelThreadBoundary:
+    """The helper's ``except`` is what makes ``asyncio.to_thread`` safe to use."""
+
+    @pytest.mark.asyncio
+    async def test_stop_iteration_is_converted_before_the_future(self, tmp_path):
+        """``StopIteration`` from the resolver comes back as ``""``, not an error.
+
+        Why this matters enough to pin: a ``StopIteration`` cannot be carried
+        by a Future. On 3.12+ asyncio substitutes a ``RuntimeError``
+        ("StopIteration interacts badly with generators") so the resolver's
+        own message is lost; before 3.12 ``set_exception`` raised inside the
+        loop callback and the destination future stayed PENDING, so an await
+        on the hop hung until the test timeout. Either way the failure would
+        name asyncio, not the malformed config. The helper's ``except
+        Exception`` clause is what converts it inside the worker; narrowing
+        that clause (say to ``RuntimeError``) turns this test red. No live
+        negative control here on purpose: an unconverted ``StopIteration``
+        through ``to_thread`` is exactly the hang described above on the
+        older interpreters this repo still targets.
+        """
+        cfg = _config(tmp_path)
+        slot = _slot()
+
+        with unittest.mock.patch.object(
+            chat_runner, "resolve_effective_model", side_effect=StopIteration("malformed")
+        ):
+            result = await asyncio.to_thread(chat_runner._default_session_model, cfg, slot, "")
+
+        assert result == ""
+
+
+class TestEagerSpawnDefaultModel:
+    """The pre-warmed session must run the same model the first real turn would."""
+
+    @pytest.fixture(autouse=True)
+    def _no_debounce(self, monkeypatch):
+        monkeypatch.setattr(chat_runner, "_EAGER_SPAWN_DEBOUNCE_SECS", 0)
+
+    @pytest.mark.asyncio
+    async def test_eager_session_starts_on_the_global_default(self, tmp_path, _runner_config):
+        _runner_config(_config(tmp_path))
+        state, _client = _runner_state(tmp_path)
+        slot = _slot()
+        state._slots[slot.key] = slot
+        state.sessions.release = unittest.mock.MagicMock()
+        state.sessions.remove_if_unclaimed = unittest.mock.AsyncMock(return_value=True)
+
+        await _eager_spawn(state, slot)
+
+        assert _session_model(state) == GLOBAL_DEFAULT
+        assert slot.model == ""
+
+    @pytest.mark.asyncio
+    async def test_eager_resolve_runs_off_the_loop_and_survives_stop_iteration(
+        self, tmp_path, _runner_config
+    ):
+        """Same two guarantees as the real turn, on the pre-warm path.
+
+        The eager spawn is best-effort, so a resolver ``StopIteration`` must
+        neither stall the loop (the resolve is off-loop) nor abort the spawn
+        (converted to ``""`` in the worker, so the session is still created —
+        on ``None``, as before the resolve existed).
+        """
+        _runner_config(_config(tmp_path))
+        state, _client = _runner_state(tmp_path)
+        slot = _slot()
+        state._slots[slot.key] = slot
+        state.sessions.release = unittest.mock.MagicMock()
+        state.sessions.remove_if_unclaimed = unittest.mock.AsyncMock(return_value=True)
+        seen: dict[str, object] = {}
+
+        def _resolver(cfg, agent):
+            seen["thread"] = threading.get_ident()
+            raise StopIteration("malformed")
+
+        with unittest.mock.patch.object(chat_runner, "resolve_effective_model", _resolver):
+            await _eager_spawn(state, slot)
+
+        assert _session_model(state) is None
+        assert slot.model == ""
+        assert seen["thread"] != threading.get_ident()


### PR DESCRIPTION
## Problem / Motivation

A chat session created implicitly by sending a message (the composer's send on a fresh tab goes through `api_chat` → `get_or_create_slot` with no model) can start on a different model than the one the model chip shows for it. The chip resolves the default through `resolve_effective_model` (`/api/agents/resolved-model`); the runner passed `model=slot.model or agent_model or None` to `get_or_create`, where `agent_model` is only the crew's own pin, so a slot on a crew that pins nothing handed `None` down and left the default to the session manager's config snapshot. That snapshot is refreshed only by the settings handlers that call `refresh_defaults`, so a global `agent.model` written any other way (`kirocrew config set agent.model …`, a hand edit of `config.json`) was shown by the chip but not run by the first turn of a fresh slot until the gateway restarted.

## Why it matters

The header promises one model and the session runs another, with nothing in the transcript saying so. Anyone who sets the global default outside the dashboard settings panel hits it on every new chat until they restart.

## What changed (motivation → approach → change)

Symptom → the chat-send path and the model chip resolve the default through two different code paths. Root cause → `_run_chat` (and the eager pre-spawn) only consulted `bindings.model` and deferred the rest to `get_or_create`'s cached-config fallback. Change → resolve the default with `resolve_effective_model(cfg, slot.agent or None)` — the same call and arguments the chip endpoint uses — and pass it into `get_or_create` as `model=slot.model or agent_model or default_model or None`, in both `_run_chat` and `_eager_spawn` (the two must agree, or the first message would reuse a pre-warmed session running a different model than the chip promised).

**Persist-vs-not decision: the resolved default is a session-creation input and is NOT written to `slot.model`.** An earlier revision of this branch backfilled it into `slot.model`; that was reversed (the branch is now one squashed commit). Evidence from the code:

- `slot.model` is persisted slot state and is re-sent as a `set_model` override on every resume (`_backfill_canonical_model`'s docstring, and the fallback guard beside it: "slot.model is PERSISTED — writing the candidate here would … turn a temporary fallback into a permanent pin"). Writing the resolved default there turns every inheriting slot into a permanent pin on its first message: a later change to `agent.model`, or to the agent's own pin, no longer reaches it.
- An empty `slot.model` already means "inherit" everywhere else: `get_or_create(model=None)` re-resolves on every cold start; the dashboard renders inherited slots live through `/api/agents/resolved-model` (`ChatPage.tsx`: `_slotAgentName = currentSlot && !currentSlot.model ? …`) and the "set as agent default" mutation's comment relies on it ("a slot showing an inherited value picks the new pin up without a reload").
- The explicit slot-create endpoint (`api_chat_slot_create`) does not resolve or persist a default either: it stores the caller's `model` verbatim, `""` when nothing was picked. So persisting here would have made the two creation paths *diverge*, not converge.
- Persisting also flipped the post-create branch in `_run_chat`: with `slot.model` non-empty, `_pinned_model_verdict` runs on every fresh/resumed session and an inherited default the account cannot run would emit the "isn't offered right now" notice card and a persisted withheld verdict — a UX change this fix was never meant to make.

The resolve is factored into `_default_session_model(cfg, slot, agent_model)`: returns `""` (so `get_or_create` resolves exactly as before) when the slot or crew already pins a model, when the config could not be loaded, or when every tier defers; a resolver exception is logged and degrades to the old `None` shape instead of killing the turn. The resolver globs and reads the installed agent JSON (`_resolve_named_agent_model`, `_resolve_agent_model`), so both call sites run it through `asyncio.to_thread` rather than inline on the event loop. That makes the helper's `except` load-bearing beyond logging: `resolve_agent_bindings` can raise `StopIteration` on a malformed config, and a `StopIteration` cannot be carried by a Future (asyncio substitutes its own `RuntimeError`), so the helper converts every resolver error — `StopIteration` included, it is an `Exception` subclass — to `""` inside the worker, before it can reach the thread boundary.

**Scope note (design / first-principles review):** this repairs the dashboard's two `get_or_create` callers and deliberately leaves the session manager's snapshot (`owner._cfg`, refreshed only by `refresh_defaults`) untouched, so every other model-less `get_or_create` caller (Slack, Telegram, cron, subagents, task runner) still cold-starts on that snapshot until a restart. The seam-level fix — having `session_allocation.get_or_create` resolve `session_model` from a fresh config load in its existing executor hop, and retiring the caller-side resolve so the ladder has one owner — touches warm-pool and cold-start semantics for every surface and is not a one-line change (`_session_model` and `resolve_effective_model` also differ in their fourth tier, and a fresh load can fail where the snapshot cannot), so it is left for a follow-up rather than folded into this fix — tracked in #8845 (`deferred-finding`, assigned, due 2026-10-03), which also retires `_default_session_model` once the seam resolves the same value.

## Tests

`test/test_chat_send_agent_model_default.py` — replaces the first commit's test, which re-implemented the backfill inline and passed against an unchanged runner. The new module drives the real `_run_chat` and `_eager_spawn` bodies (helpers from `test_chat_runner_coverage`) with a real `KiroCrewConfig` and a mocked session boundary, asserting on the `model` kwarg `get_or_create` receives:

- fresh slot, no crew pin → session gets the global `agent.model`; `slot.model` stays `""` afterwards (locks the not-persisted decision)
- crew pin wins over the global
- explicit `slot.model` pin is untouched
- every tier deferring (`agent.model: auto`, no installed pin) → `None`, as before
- resolver raises → `None`, turn completes
- resolver raises `StopIteration` → `None`, turn still reaches the provider (the conversion happens inside the worker, so nothing un-deliverable reaches the Future)
- the resolve runs on a worker thread with no running loop (pins the `asyncio.to_thread` hop; goes red against an inline call)
- eager pre-spawn passes the same global default and leaves `slot.model` empty; a second eager case covers off-loop + `StopIteration` on the pre-warm path
- `TestDefaultSessionModelThreadBoundary`: the helper returns `""` through `asyncio.to_thread` on `StopIteration`; its docstring records why there is deliberately no live negative control (an unconverted `StopIteration` through `to_thread` leaves the future pending on interpreters before 3.12, which this repo still targets — the test would hang, not fail)

Negative controls run locally: against `origin/main`'s `chat_runner.py` the three global-default cases fail (`assert None == 'claude-opus-5'`); against the first revision's runner the not-persisted and crew-pin cases fail (`assert 'claude-opus-5' == ''`), the resolver-error case kills the turn, and the eager case fails. With the `asyncio.to_thread` hop reverted to an inline call the off-loop test fails; with the helper's `except` narrowed to `RuntimeError` the three `StopIteration` cases fail.

Also green: `test_eager_spawn.py`, `test_agent_default_model.py`, `test_chat_runner_coverage.py`, `test_dashboard_chat.py` and the new module (1177 passed). `isort`, `flake8`, `mypy --platform linux` clean on the touched files; both files black-clean under the pinned `black==26.3.1`.

## Manual verification

N/A — unit coverage sufficient: the assertion is on the `model` argument at the session boundary, which is exactly what the provider factory consumes.

## Related Issues

no linked issue: reported directly, this PR closes nothing. Follow-up (the seam-level fix this PR deliberately defers): #8845.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a "resolved default" written into persisted state changes the meaning of the empty value ("inherit" becomes "pinned") — resolve into a local at the use site instead.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no doc describes this dispatch detail
- [x] No secrets, credentials, or internal references in the diff

Backport: please include in release/0.6.0.


