### PR TITLE
refactor(apps): collapse the reconciler's two identical drain branches

### DIFF
--- a/src/kiro_crew/apps/hook_reconcile.py
+++ b/src/kiro_crew/apps/hook_reconcile.py
@@ -1,7 +1,7 @@
 """Hook reconciler — reload app backend hooks when the CLI mutates them out-of-process.
 
-The problem this solves (issue #7880)
---------------------------------------
+The problem this solves
+-----------------------
 An app's ``backend.hooks`` (``on_startup``, ``on_shutdown``, ``routes``) run
 *inside the gateway process*. The gateway loads them once — at boot
 (:func:`kiro_crew.apps.hooks_integration.on_gateway_startup`) and on the
@@ -251,9 +251,9 @@ async def _reconcile_app(name: str, snapshot_info: dict[str, Any] | None) -> Non
     ``app_lifecycle_lock(name)`` via ``get_app``, because a dashboard
     enable/disable/uninstall or a trust withdrawal may have run between the
     snapshot and now. Holding the lock is what closes the revive-during-
-    trust-withdrawal race GPT flagged: a concurrent revoke either has not started
-    (we see it next tick) or has taken the lock first and we block until it is
-    done and then observe the withdrawn state.
+    trust-withdrawal race: a concurrent revoke either has not started (we see it
+    next tick) or has taken the lock first and we block until it is done and then
+    observe the withdrawn state.
     """
     async with app_lifecycle_lock(name):
         # Authoritative re-read under the lock. get_app touches disk, so off-loop.
@@ -544,9 +544,12 @@ async def stop_hook_reconciler() -> None:
 
     Drains any in-flight reconcile pass FIRST (a teardown's async ``on_shutdown``
     may be doing worker cleanup / a buffer flush), then cancels the loop and
-    awaits it so the coroutine has unwound before returning — an in-process
-    gateway restart can then start a fresh reconciler without the old one
-    lingering with stale service handles. After cancelling, runs ONE final
+    awaits it so the coroutine has normally unwound before returning — an
+    in-process restart can then start a fresh reconciler without the old one
+    lingering with stale service handles. Every wait here is bounded by the
+    shared drain budget, so that unwind is best-effort rather than guaranteed: a
+    hung teardown is left running and reclaimed by process exit rather than
+    holding up shutdown. After cancelling, runs ONE final
     reconcile pass so a CLI disable/uninstall that landed after the last poll is
     settled before ``on_gateway_shutdown`` (which only tears down what is still
     loaded) — otherwise that app's ``on_shutdown`` flush would be skipped and its
@@ -585,34 +588,28 @@ async def stop_hook_reconciler() -> None:
         # asyncio.shield keeps the pass RUNNING if we stop waiting (never cancelled
         # mid-teardown); process exit reclaims a true hang.
         pass_ = _active_pass
-        drained = True
         if pass_ is not None and not pass_.done():
             try:
                 await asyncio.wait_for(asyncio.shield(pass_), timeout=_remaining())
-            except asyncio.TimeoutError:
-                # The pass is hung. It stays running under the shield, but we must
-                # NOT wait on it again below -- the loop's cancel handler re-awaits
-                # _active_pass, which would block up to the 60s pass watchdog and
-                # blow the shared drain budget before backend cleanup.
-                drained = False
             except Exception:
                 pass
         task.cancel()
-        if drained:
-            # Pass already settled: awaiting the cancelled loop unwinds promptly,
-            # but still bound it to the shared deadline for safety.
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=_remaining())
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                pass
-        else:
-            # Hung pass: bound the unwind by whatever remains of the shared budget,
-            # so cancellation cannot re-await the straggler past it. The shielded
-            # pass keeps running; process exit reclaims a true hang.
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=_remaining())
-            except (asyncio.TimeoutError, asyncio.CancelledError, Exception):
-                pass
+        # Bound the cancel unwind by whatever remains of the shared budget, for the
+        # same reason every other step here is bounded: the drain must not spend
+        # more than SHUTDOWN_DRAIN_BUDGET_SECS in total, or it blows the ~10s
+        # gateway deadline and the backend cleanup after it is skipped. Whatever
+        # holds the unwind up -- the loop's own cancel handler, or a shielded pass
+        # still settling -- only gets what the earlier steps left.
+        #
+        # The bound applies on BOTH paths, and on the settled one it is not merely
+        # belt-and-braces: a pass that settled slowly can leave _remaining() at
+        # ~0, so this wait can expire before the coroutine has unwound. Expiry is
+        # accepted either way -- shutdown proceeds, the shielded work keeps
+        # running, and process exit reclaims a true hang.
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=_remaining())
+        except (asyncio.CancelledError, Exception):
+            pass
 
         # ONE-SHOT terminal drain: a CLI disable/uninstall landing in the window
         # between the last poll and this stop would otherwise never reach the


### PR DESCRIPTION
## Problem / Motivation

`stop_hook_reconciler` in `src/kiro_crew/apps/hook_reconcile.py` carried a
`drained: bool` flag whose only consumer was an `if drained: ... else: ...`
pair — and the two branches ran **byte-identical** code: the same
`await asyncio.wait_for(asyncio.shield(task), timeout=_remaining())` under the
same `except (asyncio.TimeoutError, asyncio.CancelledError, Exception): pass`.

The two comments above them, however, claimed the cases were bounded
differently ("awaiting the cancelled loop unwinds promptly, but still bound it
to the shared deadline for safety" vs. "bound the unwind by whatever remains of
the shared budget"). So the flag distinguished nothing, and a reader had to diff
the two blocks by eye to discover that.

## Why it matters

This is the gateway's graceful-shutdown drain, sitting under a single 5s budget
that must not starve `_hooks_shutdown`'s ~10s deadline. It is exactly the code
someone reads under time pressure while debugging a shutdown that overran. A
flag that appears to select between two shutdown policies, but does not, is the
most expensive kind of misleading code here: the next person to change one
branch will believe the other is unaffected.

## What changed (motivation → approach → change)

Behaviour is unchanged — this is a readability change.

- **Symptom:** an `if`/`else` whose arms are identical, gated on a flag with no
  other reader, documented as if the arms differed.
- **Root cause:** the `drained` flag was introduced to express "do not wait on
  the hung pass again unbounded", but the bound that actually delivers that —
  `timeout=_remaining()` against the one shared deadline — applies on **both**
  paths, so the branch never needed to exist.
- **Change:** collapse the two arms into one unconditional bounded unwind and
  drop `drained`, dead once its only reader is gone.

Equivalence, checked explicitly:

- **AST-identical arms.** The pre-diff `if`/`else` bodies compare equal under
  `ast.dump`, and applying just this edit to the pre-diff AST reproduces the
  post-diff function AST exactly. The `if`/`else` was total, so the second
  bounded wait already ran on every path, including `pass_ is None`.
- **Exception semantics.** The unwind's `except` tuple is unchanged in what it
  catches. `asyncio.CancelledError` derives from `BaseException`, so it is still
  listed explicitly and still not swallowed by `except Exception`;
  `asyncio.TimeoutError` was already an `Exception` subclass on every supported
  interpreter, so folding it in changes nothing it caught. Removing
  `drained = False` left an otherwise-empty handler, so what that clause
  swallowed is unchanged.
- **No truthiness change** (`drained` only ever held `True`/`False`), nothing
  moved into or out of a `try`/`except`/`finally` or across an `await`, and the
  await count per path is 2 before and after.
- **Budget semantics.** `_remaining()` is still called exactly twice, at the same
  positions relative to `task.cancel()`, in the same event-loop tick. The shared
  `_drain_deadline` and the total wall-clock bound are unchanged.
- **No conditionally-assigned local remains**, so there is no mypy
  first-assignment inference to preserve.

The rest of the diff corrects what the surrounding comments *claim*, because a
comment restated in confident present tense has to be true:

- **The old justification for this bound cannot happen.** Both the old and new
  comments said it exists because the loop's cancel handler re-awaits
  `_active_pass` and would block up to the 60s pass watchdog. It cannot:
  `_reconcile_loop`'s `finally: _active_pass = None` runs when the shielded await
  is cancelled, *before* the outer `except asyncio.CancelledError` tests
  `_active_pass is not None`, so that guard only ever sees `None`. The comment
  now justifies the bound by the shared drain budget itself, which is true and
  does not depend on that path being live. **The fail-safe itself stays** — it
  costs nothing when `_active_pass is None`, and retiring a shutdown fail-safe is
  not something a readability PR should do on the strength of one experiment.
- **The bound is not belt-and-braces on the settled path.** A pass that settles
  slowly leaves `_remaining()` near zero, so this wait can expire there too.
  The comment says so, and the function docstring no longer promises the
  coroutine "has unwound before returning" — it is bounded, therefore
  best-effort.
- **Folded the `except asyncio.TimeoutError` clause into the `except Exception`
  that already subsumed it.** Once it stopped setting the flag it distinguished
  nothing, so leaving it would reproduce one clause up the exact shape this PR
  removes.

Also comment hygiene in the same file, per `AGENTS.md` (comments are not a task
log): the module docstring heading loses its `(issue #7880)` citation and
`_reconcile_app`'s docstring loses a review-round attribution. Both keep the
technical reason they carried — what the reconciler solves, and that holding the
lifecycle lock is what closes the revive-during-trust-withdrawal race. Nothing
references the removed heading text (`docs/` has no reference to this module);
seven sibling call sites still cite the issue number.

## Tests

No test changes. `test/test_hook_reconcile.py` +
`test/test_dashboard_server_startup_coverage.py` (the two modules referencing
`stop_hook_reconciler`): **54 passed**. Widened to `test_app_cli.py`,
`test_lifecycle_hooks.py` and `test_module_loader.py`: 137 passed, 2 skipped.

**Being precise about what those tests do and do not pin**, since it would be
easy to overclaim here:

- The **hung** path (the old `else` arm) is pinned by
  `test_stop_does_not_reawait_a_hung_in_flight_pass`, which asserts a wall-clock
  bound: `stop_hook_reconciler()` must return inside 3.0s against a 3600s hang
  with the budget monkeypatched to 0.2s.
- The **settled** path (the old `if` arm) is exercised by
  `test_stop_drains_in_flight_pass_without_cancelling_it`; two more
  (`test_stop_final_drain_is_bounded`, `test_stop_runs_a_final_drain_pass_before_shutdown`)
  use a 100s poll interval, so `_active_pass` is `None` and the first wait is
  skipped entirely.
- **The second bounded wait itself is not pinned.** Mutating it three ways —
  deleting it, giving it a fresh rather than shared budget, and making it
  unbounded — leaves all five `stop_*` tests green. So the equivalence argument
  above rests on the AST proof, not on the suite. That gap is pre-existing and
  this diff does not widen it; see below.

## Manual verification

N/A — unit coverage sufficient for what changed. The diff adds no path to
exercise, and the equivalence claim is established structurally (AST comparison)
rather than by observing behaviour.

<!-- no-visual-delta -->
**Why no screenshot:** backend-only diff in one Python module; the frontend is
untouched, so there is no rendered surface to show.

## Related Issues

no linked issue: found by an AST sweep for identical sibling branches, not
reported as a defect.

**Left out on purpose, and worth someone picking up:** the shared-deadline
semantics of the cancel unwind have no test net (the three mutations above all
survive), and `_reconcile_loop`'s `except asyncio.CancelledError` re-await of
`_active_pass` appears unreachable for the reason given above. Both are
pre-existing, and both are behaviour questions rather than readability ones — a
refactor PR is the wrong place to either add that coverage or retire that
fail-safe. Happy to file them if a maintainer agrees they are worth tracking.

## Pattern harvest

Not required for a `refactor:` PR, but this one generalizes:

Rule candidate: `lint`
Pattern: an `if`/`else` (or `elif` chain) whose branch bodies are AST-identical,
gated on a flag with no other reader — the comments diverge while the code does
not. Found by comparing `ast.dump` of each branch body across
`src/kiro_crew/`; it was the **only** occurrence, which is what makes keeping it
at zero cheap. A sibling detector for a name subsumed by another member of the
same `except` tuple finds ~221 sites, most of which are deliberate
documentation, so that one is not worth a rule.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass; no new functionality, and the coverage limits are stated above rather than glossed
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no documented behaviour changed; `docs/` does not reference this module
- [x] No secrets, credentials, or internal references in the diff
