### PR TITLE
fix(members): carry the bound gateway port into the dispatch MCP env

### DIFF
--- a/docs/system-specs/modules/session-control.md
+++ b/docs/system-specs/modules/session-control.md
@@ -216,7 +216,11 @@ tool set, mounted **per session** rather than through the on-disk agent
 template: a member DM session's ACP `session/new` **and `session/load`** carry
 the dashboard server as a session-level `mcpServers` entry (built by
 `members.member_dispatch_session_server`, identity via `KIROCREW_SESSION_KEY`
-in the entry's env) — both establishment paths, because `session/load`
+in the entry's env, plus `KIROCREW_BOUND_PORT` — the entry's env is built from
+scratch rather than inherited, and a child left to rediscover the port falls
+through to the run-marker check, which needs an `lsof` view the sandbox's user
+namespace does not have, so a gateway on any non-default port would be dialled
+at the default one) — both establishment paths, because `session/load`
 re-initializes the session's MCP servers, so a resume that skipped the
 injection would strip a member thread of its tools mid-conversation. On the
 KAS backend the wire agent projection additionally grants the server in

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -163,12 +163,28 @@ def member_dispatch_session_server(session_key: str) -> dict[str, object] | None
     applies to the agent-declared ``mcpServers`` block, not to what the host
     itself injects per session).
 
+    The env also carries ``KIROCREW_BOUND_PORT`` — the port this gateway is
+    actually serving. Unlike a chat session's MCP child, which inherits the
+    gateway's whole environment, this entry is built from scratch, so without
+    the port the child's resolution chain falls through to the run marker; that
+    check needs :func:`platform_compat.find_listening_pids` (``lsof``), which
+    sees no listener from inside the sandbox's user namespace, and the child
+    then dials the default port. On a gateway bound anywhere else that is a
+    connection refused on every dispatch call. ``KIROCREW_BOUND_PORT`` rather
+    than ``KIROCREW_PORT`` because the latter means "the port an operator
+    asked for" and is persisted, while this is the transient fact of what got
+    bound.
+
     ``None`` when the server command cannot be resolved — the member thread
     then runs as plain chat and the caller logs the degradation.
     """
     # circular import: agent's module graph is heavy and imports config, which
     # sits below this module for the thread-endpoint path.
     from kiro_crew.agent import _kirocrew_mcp_invocation
+
+    # circular import, same shape: port_resolution reaches config.loader, whose
+    # provider-backend path imports this module.
+    from kiro_crew.port_resolution import resolve_serving_port
 
     try:
         command, args = _kirocrew_mcp_invocation("mcp-dashboard")
@@ -177,11 +193,17 @@ def member_dispatch_session_server(session_key: str) -> dict[str, object] | None
         return None
     if not command:
         return None
+    env: list[dict[str, str]] = [{"name": "KIROCREW_SESSION_KEY", "value": session_key}]
+    # resolve_serving_port() reads KIROCREW_BOUND_PORT first and only then falls
+    # through the client order, so one call covers both "the gateway exported the
+    # port it bound" and "derive it" — and a malformed export is ignored rather
+    # than forwarded.
+    env.append({"name": "KIROCREW_BOUND_PORT", "value": str(resolve_serving_port())})
     return {
         "name": MEMBER_DISPATCH_SERVER,
         "command": command,
         "args": list(args),
-        "env": [{"name": "KIROCREW_SESSION_KEY", "value": session_key}],
+        "env": env,
         "type": "stdio",
     }
 

--- a/test/test_member_dispatch_mount.py
+++ b/test/test_member_dispatch_mount.py
@@ -3,7 +3,9 @@
 Pins the four seams the member-dispatch mount rides on:
 
 - ``members.member_dispatch_session_server`` — the session-level ``mcpServers``
-  element, carrying strict identity via ``KIROCREW_SESSION_KEY`` in its env.
+  element, carrying strict identity via ``KIROCREW_SESSION_KEY`` in its env
+  plus the gateway's bound port, which the from-scratch env would otherwise
+  drop.
 - ``kas_agents.to_client_custom_agent(member_dispatch=True)`` — the KAS wire
   projection widening: the server joins ``tools`` and the conductor's
   approval-free dashboard verbs join the ``allowedTools`` input BEFORE the
@@ -68,6 +70,40 @@ class TestMemberDispatchSessionServer:
         entry = member_dispatch_session_server(MEMBER_KEY)
         assert entry is not None
         assert {"name": "KIROCREW_SESSION_KEY", "value": MEMBER_KEY} in entry["env"]
+
+    def test_env_carries_the_exported_bound_port(self, monkeypatch):
+        """A chat session's MCP child inherits the gateway's environment; this
+        entry is built from scratch, so the port has to be handed over
+        explicitly or the child dials the default one."""
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7779")
+        entry = member_dispatch_session_server(MEMBER_KEY)
+        assert entry is not None
+        assert {"name": "KIROCREW_BOUND_PORT", "value": "7779"} in entry["env"]
+
+    def test_env_falls_back_to_the_serving_resolver(self, monkeypatch):
+        """No export (a gateway started outside the normal path) still yields a
+        port: the serving resolver's remaining order — configured, marker,
+        default — decides it, and the member child inherits that answer instead
+        of re-deriving it without lsof."""
+        from kiro_crew import port_resolution
+
+        monkeypatch.delenv("KIROCREW_BOUND_PORT", raising=False)
+        monkeypatch.setattr(port_resolution, "resolve_serving_port", lambda: 6123)
+        entry = member_dispatch_session_server(MEMBER_KEY)
+        assert entry is not None
+        assert {"name": "KIROCREW_BOUND_PORT", "value": "6123"} in entry["env"]
+
+    def test_port_does_not_displace_the_identity_pair(self, monkeypatch):
+        """Both env pairs, and no KIROCREW_PORT: that name means "the port an
+        operator asked for" and is persisted, so exporting it here would let a
+        transient binding outlive this process."""
+        monkeypatch.setenv("KIROCREW_BOUND_PORT", "7779")
+        entry = member_dispatch_session_server(MEMBER_KEY)
+        assert entry is not None
+        names = [pair["name"] for pair in entry["env"]]
+        assert "KIROCREW_SESSION_KEY" in names
+        assert "KIROCREW_BOUND_PORT" in names
+        assert "KIROCREW_PORT" not in names
 
     def test_unresolvable_command_degrades_to_none(self, monkeypatch):
         import kiro_crew.agent as agent_mod


### PR DESCRIPTION
## Problem / Motivation

On the Crew page, a conductor member session could not dispatch at all. Every `session_create` / `session_send` call from the member's `mcp-dashboard` server failed with a connection refused against port 5476, on a gateway that was actually serving 7779. Plain chat sessions on the same gateway were fine.

## Why it matters

Any user whose gateway is not on the default port loses the whole Crew dispatch feature — the conductor cannot open or drive a single worker session. Nothing in the failure names the port, so it reads as "Crew is broken".

## What changed (motivation → approach → change)

Symptom: dispatch calls dial 5476 while the gateway serves 7779.

Root cause: `members.member_dispatch_session_server()` builds the session-level `mcpServers` entry's `env` from scratch — it carried only `KIROCREW_SESSION_KEY`. A plain chat session's MCP child inherits the gateway's whole environment, including the `KIROCREW_BOUND_PORT` the gateway exports in `dashboard/server.py`; this child inherits nothing. With neither `KIROCREW_PORT` nor `KIROCREW_BOUND_PORT` set, the child's `port_resolution.resolve_client_port_src` chain skips the env step and falls through to the run-marker check. That check verifies ownership through `platform_compat.find_listening_pids` (`lsof`), which sees no listener from inside the sandbox's user namespace, so the marker is rejected and the chain ends at the default port.

Change: append `KIROCREW_BOUND_PORT` to that env, sourced from `port_resolution.resolve_serving_port()`. That one call already reads the gateway's own `KIROCREW_BOUND_PORT` export first and only then falls through the client order (`KIROCREW_PORT` → configured → marker → default), so it covers both "the gateway told us what it bound" and "derive it", and it ignores a malformed export rather than forwarding it.

`KIROCREW_PORT` is deliberately *not* exported: per that module's own contract it means "the port an operator asked for" and is persisted, while the bound port is the transient fact of what this process actually holds.

The import is function-local, matching the existing `_kirocrew_mcp_invocation` precedent in the same function — `port_resolution` reaches `config.loader`, whose provider-backend path imports this module.

## Tests

`test/test_member_dispatch_mount.py`, three cases on `member_dispatch_session_server`:

- `test_env_carries_the_exported_bound_port` — with `KIROCREW_BOUND_PORT=7779` exported, the entry's env contains that pair.
- `test_env_falls_back_to_the_serving_resolver` — with the export removed and `resolve_serving_port` monkeypatched, the env carries the resolver's answer.
- `test_port_does_not_displace_the_identity_pair` — both `KIROCREW_SESSION_KEY` and `KIROCREW_BOUND_PORT` are present, and `KIROCREW_PORT` is absent.

Revert-verified: with the one `env.append` line removed, all three fail; with it restored, all pass.

## Manual verification

N/A — the seam is a pure dict builder and the three cases cover both branches plus the negative. The end-to-end symptom (dispatch on a non-default port) is what the fallback branch reconstructs.

## Related Issues

Complementary to and non-overlapping with #8611 (`fix(members): dispatch MCP home override`), which adds `KIROCREW_HOME` to the same env block via `agent._managed_mcp_env()`. This PR is based on `origin/main`, not on that branch. To keep a future rebase cheap, the env is now built as a list and appended to rather than rewritten as a dict literal.

## Pattern harvest

Pattern: an env block constructed from scratch for a child process silently drops the inherited variables its siblings rely on — here the child's own fallback chain masked the omission by resolving to a plausible-but-wrong default instead of failing loudly.

Rule candidate: review-prompt — when a spawn passes an explicit `env` rather than inheriting, enumerate what the inheriting path supplies and state why each omission is safe.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/session-control.md`)
- [x] No secrets, credentials, or internal references in the diff
