### PR TITLE
fix(acp): recover a directive marker a backend copied into two envelope fields

### DIFF
--- a/docs/system-specs/features/agent-host-contract.md
+++ b/docs/system-specs/features/agent-host-contract.md
@@ -222,9 +222,12 @@ invented one.
 
 | | kiro-cli | KAS | CC |
 |---|---|---|---|
-| How a tool result arrives | `content[].content.text` blocks, or `rawOutput.items[].Text` / `.Json.stdout` | `content[].content.text` blocks, or a **flat `rawOutput` object with no `items`** (measured: `{output, exitCode, message}`, `{kind, retracted}`) — and an MCP result can arrive as an **already-serialised** JSON envelope under a key this repository does not recognise | `content[]` text blocks |
+| How a tool result arrives | `content[].content.text` blocks, or `rawOutput.items[].Text` / `.Json.stdout` | `content[].content.text` blocks, or a **flat `rawOutput` object with no `items`** (measured: `{output, exitCode, message}`, `{response, imageBase64Urls, message}`, `{kind, retracted}`) — and an MCP result can arrive as an **already-serialised** JSON envelope under a key this repository does not recognise | `content[]` text blocks |
 | Marker survives untouched | yes | **no** — the envelope reaches the consumer through `json.dumps`, which escapes every quote in it | yes |
 | Recovery | not needed | `acp/_dispatch._repair_escaped_marker`, run over the joined output before redaction and the head cut | not needed |
+| Same text in several fields | no | **yes** — `{response, …, message}` carries the result TWICE, so one directive raises the frame's marker count to 2 | no |
+
+Duplication is why the recovery deduplicates by VALUE rather than counting sentinels. The refusal to guess between two markers is real — applying the wrong directive is worse than applying none — but it must fire on two DIFFERENT payloads, not on one payload delivered twice. It fired on the duplicate, so `_repair_escaped_marker` returned nothing, `peek` could name no selector, and the gateway-parked record went unclaimed: every `monitor_start` from a KAS-backed session was acknowledged to the model and armed no loop. The envelope branch now takes the single DISTINCT marker-bearing string, and additionally requires that string to hold exactly one sentinel, because the whole-text refusal it runs ahead of is what used to cover the two-directives-in-one-field case.
 
 `rawOutput` is unstructured passthrough, so `items[]` is one producer's wrapper
 rather than a contract. `_build_tool_result_event` therefore serialises any other

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -1174,11 +1174,27 @@ def _marker_bearing_text(payload: dict[str, Any], _max_nodes: int = 512) -> str 
 
     Keyed on the SENTINEL rather than on any envelope field name, because the
     field differs per backend and the sentinel is a fixed control token this
-    process emitted itself. Requires EXACTLY ONE match: zero means there is no
-    directive here and the caller should keep dumping the envelope, while two or
-    more means the frame is ambiguous about which string is the directive, and
-    guessing between them could apply the wrong payload. Bounded walk
-    (``_max_nodes``, depth 6) so a pathological envelope cannot spin here.
+    process emitted itself. Requires exactly one DISTINCT match: zero means
+    there is no directive here and the caller should keep dumping the envelope,
+    while two DIFFERENT marker-bearing strings mean the frame is ambiguous about
+    which one is the directive, and guessing between them could apply the wrong
+    payload. Bounded walk (``_max_nodes``, depth 6) so a pathological envelope
+    cannot spin here.
+
+    DISTINCT, not merely one occurrence, because a backend may COPY the whole
+    tool-result text into several envelope fields. KAS does exactly that --
+    ``{"response": <text>, "imageBase64Urls": [], "message": <same text>}`` --
+    so a single ``monitor_start`` directive arrived as two byte-identical hits
+    and this function refused as "ambiguous", which is what left the conductor's
+    patrol loop unarmed: the escaped marker was never repaired, ``peek`` could
+    name no selector, and the gateway-parked record was never claimed. Two
+    copies of one payload pose no choice, so there is nothing to guess: dedupe
+    by value and only refuse when the values genuinely DIFFER.
+
+    The chosen string must also carry exactly one sentinel. The caller's own
+    multi-marker refusal only guards its line-based recovery, so without this a
+    string holding two different directives would resolve here to whichever came
+    first -- the same wrong-payload guess, one level down.
     """
     hits: list[str] = []
     budget = [_max_nodes]
@@ -1188,7 +1204,7 @@ def _marker_bearing_text(payload: dict[str, Any], _max_nodes: int = 512) -> str 
             return
         budget[0] -= 1
         if isinstance(node, str):
-            if session_directive.has_marker(node):
+            if session_directive.has_marker(node) and node not in hits:
                 hits.append(node)
         elif isinstance(node, dict):
             for value in node.values():
@@ -1198,7 +1214,9 @@ def _marker_bearing_text(payload: dict[str, Any], _max_nodes: int = 512) -> str 
                 _walk(value, depth + 1)
 
     _walk(payload, 0)
-    return hits[0] if len(hits) == 1 else None
+    if len(hits) != 1 or hits[0].count(session_directive.SENTINEL) != 1:
+        return None
+    return hits[0]
 
 
 ELIDED_MARKER_VALUE = "[[directive marker emitted on its own line above]]"
@@ -1254,20 +1272,31 @@ def _repair_escaped_marker(text: str) -> str | None:
         return None
     if session_directive.peek(text) is not None:
         return None  # already readable -- nothing to repair
-    if text.count(session_directive.SENTINEL) > 1:
-        # Ambiguous: recovery (2) below reads the FIRST marker line, which would
-        # be a GUESS about which directive the frame meant. Applying the wrong
-        # directive is worse than applying none, and a real frame carries one
-        # marker (a second directive arrives under its own toolCallId), so refuse.
-        return None
 
     # (1) the entire text is a JSON dump.
+    #
+    # Tried BEFORE the multi-marker refusal below, because this recovery does not
+    # guess: it resolves the directive through the envelope's own structure, and
+    # ``_marker_bearing_text`` refuses any envelope whose marker-bearing strings
+    # actually differ. A backend that copies the result text into two fields
+    # therefore raises the whole-text sentinel count to 2 while naming exactly
+    # one payload -- and refusing that as "ambiguous" is what dropped every
+    # directive on KAS (a ``monitor_start`` acknowledged to the model, with no
+    # loop armed and nothing to inspect).
     try:
         outer = json.loads(text)
     except (ValueError, TypeError):
         outer = None
     if isinstance(outer, str):
-        if session_directive.peek(outer) is not None:
+        # One sentinel only, the same bar ``_marker_bearing_text`` holds the dict
+        # branch to. ``peek`` reads the FIRST marker line, so a dumped string
+        # carrying two DIFFERENT directives would resolve to whichever came
+        # first -- and the whole-text refusal that used to cover this branch now
+        # runs after it, guarding recovery (2) alone.
+        if (
+            outer.count(session_directive.SENTINEL) == 1
+            and session_directive.peek(outer) is not None
+        ):
             return outer
     elif isinstance(outer, (dict, list)):
         inner = _marker_bearing_text(outer if isinstance(outer, dict) else {"_": outer})
@@ -1278,6 +1307,15 @@ def _repair_escaped_marker(text: str) -> str | None:
             # marker is dropped from the transcript the user actually reads.
             siblings = json.dumps(_elide_marker_value(outer, inner), default=str)
             return siblings + "\n" + inner
+
+    if text.count(session_directive.SENTINEL) > 1:
+        # Ambiguous for the LINE-BASED recovery only: (2) below reads the FIRST
+        # marker line, which would be a GUESS about which directive the frame
+        # meant. Applying the wrong directive is worse than applying none, and a
+        # real frame carries one marker (a second directive arrives under its own
+        # toolCallId), so refuse rather than pick. Recovery (1) above is exempt
+        # because it makes no such choice -- see its comment.
+        return None
 
     # (2) The escaped dump is only PART of the text -- another output part, or a
     # line of prose, sits beside it -- so (1) cannot parse the whole thing. Undo

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -28,6 +28,7 @@ import ast
 import json
 import types
 
+import pytest
 from source_corpus import parsed_candidates, src_root
 
 from kiro_crew import session_directive as sd
@@ -355,6 +356,155 @@ class TestSurvivesPreSerialisedResultText:
     def test_plain_text_output_is_untouched(self):
         out = _runtime_output(_update(content=[{"content": {"type": "text", "text": "ok"}}]))
         assert out == "ok"
+
+
+class TestSurvivesADuplicatingResultEnvelope:
+    """The backend copies the whole result text into SEVERAL envelope fields.
+
+    KAS returns ``{"response": <text>, "imageBase64Urls": [], "message": <same
+    text>}``, so one directive arrives as two byte-identical marker-bearing
+    strings and the frame's whole-text sentinel count is 2. Both the ambiguity
+    refusal and ``_marker_bearing_text``'s single-match rule then declined, so no
+    selector could be read, the gateway-parked record was never claimed, and a
+    ``monitor_start`` the model had been told was requested armed no loop at all
+    (reproduced from a live ``kirocrew-conductor`` frame). Two copies of ONE
+    payload pose no choice, so there is nothing to guess between.
+    """
+
+    @staticmethod
+    def _kas(text: str) -> str:
+        """The live KAS envelope, pre-serialised as that backend hands it back."""
+        dumped = json.dumps({"response": text, "imageBase64Urls": [], "message": text})
+        assert dumped.count(sd.SENTINEL) == 2, "the duplication is the point"
+        assert sd.peek(dumped) is None, "and the selector does not survive the dump"
+        return dumped
+
+    def test_duplicated_directive_is_recovered(self):
+        repaired = _repair_escaped_marker(self._kas(_monitor()))
+        assert repaired is not None, "a duplicated copy is not an ambiguous frame"
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+
+    def test_duplicated_directive_is_recovered_through_the_runtime(self):
+        # The path the conductor session actually took: the parser must hand the
+        # consumer a frame whose selector reads, or nothing claims the record.
+        for label, update in {
+            "Json.stdout": _update(
+                rawOutput={"items": [{"Json": {"stdout": self._kas(_monitor())}}]}
+            ),
+            "Text": _update(rawOutput={"items": [{"Text": self._kas(_monitor())}]}),
+            "content block": _update(
+                content=[{"content": {"type": "text", "text": self._kas(_monitor())}}]
+            ),
+        }.items():
+            assert sd.peek(_runtime_output(update)) == ("monitor_start", MONITOR_ARGS), label
+
+    def test_two_different_directives_across_fields_are_still_refused(self):
+        # Deduping must key on the VALUE. Two fields carrying DIFFERENT payloads
+        # are a real choice, and picking either applies a directive the tool did
+        # not emit for this frame.
+        other = sd.encode("monitor_start", {**MONITOR_ARGS, "idle_secs": 900}, "Armed: 900s.")
+        frame = json.dumps({"response": _monitor(), "message": other})
+        assert _repair_escaped_marker(frame) is None
+
+    def test_one_field_holding_two_directives_is_refused(self):
+        # The caller's multi-marker refusal guards only its line-based recovery,
+        # so the envelope branch must reject a single string naming two
+        # directives itself -- otherwise it resolves to whichever came first.
+        other = sd.encode("monitor_start", {**MONITOR_ARGS, "idle_secs": 900}, "Armed: 900s.")
+        frame = json.dumps({"response": _monitor() + "\n" + other})
+        assert _repair_escaped_marker(frame) is None
+
+    def test_a_bare_dumped_string_with_two_directives_is_refused(self):
+        # Recovery (1) has TWO branches and both must hold the same bar: the
+        # whole-text refusal that used to cover this one now guards only the
+        # line-based recovery, and ``peek`` reads the FIRST marker line.
+        other = sd.encode("monitor_start", {**MONITOR_ARGS, "idle_secs": 900}, "Armed: 900s.")
+        assert _repair_escaped_marker(json.dumps(_monitor() + "\n" + other)) is None
+
+    def test_a_bare_dumped_string_with_one_directive_is_recovered(self):
+        # The refusal above must not cost the branch its normal case.
+        repaired = _repair_escaped_marker(json.dumps(_monitor()))
+        assert repaired is not None
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+
+    def test_duplicated_frame_keeps_its_sibling_output(self):
+        # Recovery must not trade the rest of the frame for the marker.
+        frame = json.dumps({"response": _monitor(), "message": _monitor(), "note": CANARY})
+        repaired = _repair_escaped_marker(frame)
+        assert repaired is not None
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+        assert CANARY in repaired
+
+
+# One minimal payload per directive tool, in the shape that tool's own
+# ``_emit_directive`` call in ``mcp_tools/control.py`` builds. Keyed by kind so
+# the parametrised test below can assert coverage of every member of
+# ``sd.DIRECTIVE_TOOLS`` rather than of a hand-copied list.
+DIRECTIVE_PAYLOADS: dict[str, dict[str, object]] = {
+    "monitor_start": MONITOR_ARGS,
+    "monitor_watch": {
+        "kind": "github_pull_request",
+        "target": "https://github.com/o/r/pull/1",
+        "objective": "review_ready",
+        "cadence_secs": 300,
+        "max_runtime_secs": 7200,
+        "max_agent_turns": 4,
+        "max_tokens": 200000,
+        "max_provider_errors": 3,
+        "wake_instructions": "report the first red check",
+    },
+    "monitor_update": {"patch": {"message": "poll the PR", "idle_secs": 600}},
+    "monitor_stop": {"reason": "objective met"},
+    "autonudge_stop": {"reason": "done"},
+    "set_project": {"project": "/tmp/example-project", "clear": False},
+    "suggest_followup": {
+        "items": [{"title": "Add a test", "description": "cover the branch", "prompt": "do it"}]
+    },
+    "ask_question": {"questions": [{"question": "pick one", "options": [{"label": "a"}]}]},
+    # The tool emits an empty payload: a caller asking for a clean context always
+    # wants a clean one, so there is nothing to carry.
+    "reset_conversation": {},
+}
+
+
+class TestRecoveryIsKindAgnostic:
+    """The repair keys on the SENTINEL, never on the directive's kind, so every
+    member of ``sd.DIRECTIVE_TOOLS`` must survive the duplicating envelope.
+
+    Parametrised over the CONSTANT rather than a copied list, so a directive tool
+    added later is covered the moment it joins the frozenset — and fails loudly
+    here until someone gives it a payload. The five sibling tests above all carry
+    a ``monitor_start`` payload, which proves the fix for one kind and says
+    nothing about the other eight; this is the property that makes the fix
+    general instead of incidental.
+    """
+
+    @pytest.mark.parametrize("kind", sorted(sd.DIRECTIVE_TOOLS))
+    def test_every_directive_kind_survives_the_duplicating_envelope(self, kind):
+        args = DIRECTIVE_PAYLOADS.get(kind)
+        assert args is not None, (
+            "%s joined sd.DIRECTIVE_TOOLS with no payload in DIRECTIVE_PAYLOADS — "
+            "add its minimal args (the shape its own _emit_directive call builds) "
+            "so this kind is actually covered" % kind
+        )
+        marker = sd.encode(kind, args, "%s requested." % kind)
+        assert sd.peek(marker) == (kind, args), "fixture must start readable"
+        # The live KAS envelope: the result text copied into two fields, then the
+        # whole thing serialised.
+        frame = json.dumps({"response": marker, "imageBase64Urls": [], "message": marker})
+        assert frame.count(sd.SENTINEL) == 2
+        assert sd.peek(frame) is None, "the dump destroys the selector"
+        repaired = _repair_escaped_marker(frame)
+        assert repaired is not None, "%s was not recovered" % kind
+        assert sd.peek(repaired) == (kind, args)
+
+    @pytest.mark.parametrize("kind", sorted(sd.DIRECTIVE_TOOLS))
+    def test_every_directive_kind_survives_the_runtime_parser(self, kind):
+        # Through the real parser, which is the path a session actually takes.
+        marker = sd.encode(kind, DIRECTIVE_PAYLOADS[kind], "%s requested." % kind)
+        frame = json.dumps({"response": marker, "imageBase64Urls": [], "message": marker})
+        out = _runtime_output(_update(rawOutput={"items": [{"Json": {"stdout": frame}}]}))
+        assert sd.peek(out) == (kind, DIRECTIVE_PAYLOADS[kind])
 
 
 class TestSurvivesTheAcpClientParser:


### PR DESCRIPTION
## Problem / Motivation

`monitor_start` looks like it worked and does nothing. A `kirocrew-conductor` session calls `@kirocrew-core/monitor_start`, the tool returns its success line, and then no patrol turn is ever injected — no loop exists to inspect or stop. Observed on two live conductor sessions (`dashboard:chat-83-1788647794`, `dashboard:chat-86-1788648354`), each leaving this in the gateway log:

```
WARNING kiro_crew.acp._dispatch: tool-result carries a session-directive marker whose selector is
  UNREADABLE and could not be repaired: json-unparseable (JSONDecodeError); payload_len=5321 ...
WARNING kiro_crew.dashboard.chat_runner: session-directive NOT APPLIED ... mcp_server_name='',
  tool_name='' ... that session's queue currently holds 1 parked record(s)
```

Queue depth 1 is the tell: the record **was** parked, and the claim failed only because no selector could be read from the frame.

## Why it matters

Every session-bound directive is lost on a KAS-backed session — `monitor_start`, `monitor_watch`, `set_project`, `ask_question`, `suggest_followup`. The failure is silent in the worst direction: the model is told the request was made, so an agent ends its turn expecting to be woken and simply never is. Any long-horizon workflow built on the nudge loop (the conductor's patrol, `babysit`, `prepare-pr`'s CI rounds) stops after one turn with no error to notice.

## What changed (motivation → approach → change)

**Symptom → cause.** KAS hands an MCP tool result back already serialised, and its envelope carries the same text **twice**: `{"response": <text>, "imageBase64Urls": [], "message": <same text>}`. One directive therefore puts two sentinels in the frame, and both halves of the escaped-marker recovery read that as ambiguity — `_repair_escaped_marker` refused on `text.count(SENTINEL) > 1` before trying anything, and `_marker_bearing_text` required exactly one match. Repair returned `None`, `peek` returned `None`, no parked record could be named, no loop was armed.

Confirmed by replaying the captured frame through the real functions: `sentinel count 2`, `peek → None`, `_marker_bearing_text → None`, `_repair_escaped_marker → None`; both marker-bearing strings byte-identical (2696 chars each). With the fix the same frame repairs and `peek` returns `("monitor_start", {...})`.

**Approach.** The refusal to guess between two markers is correct — applying the wrong directive is worse than applying none — but it must fire on two *different* payloads, not on one payload delivered twice. Two copies of one payload pose no choice.

**Change,** all in `acp/_dispatch.py`:

- `_marker_bearing_text` dedupes marker-bearing strings by **value** and returns the single *distinct* one. Genuinely differing values still refuse.
- The whole-text JSON recovery (path 1) now runs **before** the multi-marker refusal. It makes no guess: it resolves the directive through the envelope's own structure, and the deduping helper still rejects a real conflict.
- The multi-marker refusal is kept, scoped to the line-based recovery (path 2), which reads the *first* marker line and therefore does guess.
- Because that whole-text refusal used to cover **both** branches of path 1, each branch now holds the single-sentinel bar itself: the dict branch requires its chosen string to carry exactly one sentinel, and the bare-string branch requires the same of the dumped string. Without the second half, a dumped string holding two different directives would resolve to whichever came first — the guess the reorder is meant to keep fenced.

**Out of scope, tracked separately:** the reviewer surfaced an unbounded recursion in `_elide_marker_value` (the sibling-copy walk) reachable through this same call site, plus a second `json.dumps` C-stack limit behind it. Both are reachable on `main` today via a single-marker deeply nested envelope, so neither is introduced here. Four review rounds in that one span produced mutually contradictory asks — refuse the frame, then keep the directive instead, then keep the siblings too, then the encoder still drops shallow siblings — which is a design question about what an unserialisable frame should degrade to. It is filed with the full analysis as #8886 and this diff no longer touches that code.

`docs/system-specs/features/agent-host-contract.md` §9 gains the measured `{response, imageBase64Urls, message}` shape, a row recording that KAS duplicates the result text, and the paragraph explaining why the recovery dedupes by value.

Not changed: the absent `_meta.kiro` identity (`mcp_server_name=''`). That is the backend's own omission and the out-of-band parked-record path is the designed adaptation to it — it works once the selector is readable, which is what this fixes.

## Tests

`test/test_session_directive_transport.py` — new `TestSurvivesADuplicatingResultEnvelope`, fixtured on the live KAS envelope shape:

- `test_duplicated_directive_is_recovered` — the duplicating envelope repairs and its selector reads.
- `test_duplicated_directive_is_recovered_through_the_runtime` — same through `parse_session_update` for all three output shapes (`Json.stdout`, `Text`, content block), i.e. the path the conductor session took.
- `test_two_different_directives_across_fields_are_still_refused` — deduping keys on the value, so differing payloads still refuse.
- `test_one_field_holding_two_directives_is_refused` — pins the dict branch's per-string single-sentinel rule.
- `test_a_bare_dumped_string_with_two_directives_is_refused` — pins the same rule on the bare-string branch.
- `test_a_bare_dumped_string_with_one_directive_is_recovered` — that refusal does not cost the branch its normal case.
- `test_duplicated_frame_keeps_its_sibling_output` — recovery does not trade the rest of the frame for the marker.

`TestRecoveryIsKindAgnostic` covers the property those seven do not: the repair keys on the **sentinel**, never on the directive's kind, so it is parametrised over `session_directive.DIRECTIVE_TOOLS` **itself** — not a copied list — and asserts each of the nine kinds (`monitor_start`, `monitor_watch`, `monitor_update`, `monitor_stop`, `autonudge_stop`, `set_project`, `suggest_followup`, `ask_question`, `reset_conversation`) round-trips `peek(repaired) == (kind, args)` through the duplicating envelope, once directly and once through `parse_session_update`. Each payload is the shape that kind's own `_emit_directive` call builds. A directive tool added later is covered the moment it joins the frozenset, and fails loudly with a message naming itself until someone gives it a payload — verified by adding a fake kind and watching both tests red.

Revert-verified load-bearing: five separate mutations (drop the dedupe / drop the dict branch's per-string sentinel count / move the refusal back ahead of path 1 / drop the bare-string guard / add a directive kind with no payload) each fail the relevant class, and all pass restored. Dropping the dedupe reds **all 18** parametrised cases, not just `monitor_start`'s — which is the evidence the fix is general rather than incidental.

## Manual verification

Replayed the exact failing frame captured from `dashboard:chat-83-1788647794`'s stored tool output through `_repair_escaped_marker` before and after the change: `None` → repaired, selector readable, args intact including the multi-line CJK `message`. No gateway restart, no live-instance changes.

## Related Issues

no linked issue: diagnosed from live gateway logs, nothing tracked to close.

Related: #8886 — the out-of-scope crash class described above. Deliberately not a closing keyword; this PR does not fix it.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a de-duplication guard implemented as a *count* of occurrences rather than a count of *distinct values*, so an idempotent duplicate is rejected as a conflict. Reachable wherever a transport may copy one payload into several fields. Corollary seen in the same fix: when a shared up-front guard is pushed down past a fork, each branch below the fork has to restate it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
