### PR TITLE
fix(gateway): preserve the client sendId through the slot queue drain

### DIFF
--- a/src/kiro_crew/dashboard/chat_delivery.py
+++ b/src/kiro_crew/dashboard/chat_delivery.py
@@ -534,18 +534,33 @@ def queue_for_next_turn(
     message: str,
     *,
     directive_user_origin: bool = False,
+    send_id: str | None = None,
 ) -> str:
     """Append *message* to the slot's queue and announce it; return the queue id.
 
     The running turn's teardown drains the queue, so this is how a message
     reaches a busy slot when steering is unavailable or not asked for.
+
+    *send_id* is the client-minted ``meta.sendId`` the plain send path persists
+    on its user row, already passed through ``normalize_send_id`` by the caller.
+    When present it is stamped onto the queue entry's meta: the drain unions
+    every consumed entry's meta onto the row it writes, so this is what gives a
+    QUEUED send's row the same ``meta.sendId`` a dispatched send's row gets --
+    without it the drained row is id-less and a client that sent into a busy
+    slot has no identity to prove its own delivery by (it would have to fall
+    back to text, which a same-text resend or an injection can share). Additive:
+    a send whose POST carried no usable id stores nothing here and the entry
+    meta keeps the exact prior shape.
     """
     # circular import: session_control imports this module at module level.
     from kiro_crew.dashboard.session_control import containment_meta
 
+    meta: dict[str, Any] = containment_meta(state, slot)
+    if send_id:
+        meta["sendId"] = send_id
     qid = slot.queue_append(
         message,
-        meta=containment_meta(state, slot),
+        meta=meta,
         directive_user_origin=directive_user_origin,
     )
     state.broadcast_ws(

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -43,6 +43,7 @@ from kiro_crew.dashboard.chat_auto_tag import maybe_auto_tag
 from kiro_crew.dashboard.chat_delivery import (
     STEER_REQUEUED,
     STEER_STEERED,
+    normalize_send_id,
     queue_for_next_turn,
     steer_into_running_turn,
 )
@@ -622,11 +623,19 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # pre-send composer state to THIS entry (the dashboard's cancel-queued
         # restore), which no content-based key can do: serialization is not
         # injective and other tabs can queue colliding content.
+        #
+        # The client's `meta.sendId` rides on the entry too (same gate as the
+        # steer path above: `normalize_send_id` treats anything unusable as
+        # absent). The drain unions entry meta onto the row it writes, so the
+        # queued send's row ends up carrying the same id a dispatched send's row
+        # gets from `slot.append(..., meta=user_meta)` below -- the only way a
+        # sender can prove ITS message landed without matching by text.
         qid = queue_for_next_turn(
             state,
             slot,
             message,
             directive_user_origin=not bool(request_app),
+            send_id=normalize_send_id(user_meta.get("sendId")) if user_meta else None,
         )
         return web.json_response({"ok": True, "queued": True, "queue_id": qid})
 
@@ -678,9 +687,15 @@ async def api_chat(request: web.Request) -> web.StreamResponse:
         # circular import: session_control imports this package's modules at module level.
         from kiro_crew.dashboard.session_control import containment_meta
 
+        # Same entry-meta contract as the busy-slot branch: the client's `sendId`
+        # rides on the queue entry so the drained row carries it.
+        _hold_meta: dict = containment_meta(state, slot)
+        _hold_sid = normalize_send_id(user_meta.get("sendId")) if user_meta else None
+        if _hold_sid:
+            _hold_meta["sendId"] = _hold_sid
         qid = slot.queue_append(
             message,
-            meta=containment_meta(state, slot),
+            meta=_hold_meta,
             directive_user_origin=not bool(request_app),
         )
         _c, _ = redact_exfiltration_urls(message)

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -5231,6 +5231,13 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     # completion never merges (it drains alone and breaks any user-message
     # merge), so a merged row cannot carry them in the first place.
     _drained_ids: list[str] = []
+    # Client send-correlation ids accumulate for the same reason: a merged row
+    # stands for every queued send folded into it, and a sender proving its own
+    # delivery by identity must be able to find its id on that row even when it
+    # was not the last writer. The single-entry case (the overwhelmingly common
+    # one) keeps the plain-send shape -- `sendId` alone -- so a client reading
+    # only that key sees exactly what a dispatched send's row carries.
+    _drained_send_ids: list[str] = []
     # circular import: session_control imports this package's modules at module level.
     from kiro_crew.dashboard.session_control import (
         QUEUED_CONTAINMENT_META_KEY,
@@ -5259,6 +5266,9 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
             _many = _item_meta.get("steer_delivery_ids")
             if isinstance(_many, list):
                 _drained_ids.extend(x for x in _many if isinstance(x, str) and x)
+            _sid = _item_meta.get("sendId")
+            if isinstance(_sid, str) and _sid and _sid not in _drained_send_ids:
+                _drained_send_ids.append(_sid)
             # The admission-time containment snapshot (#5911) is queue plumbing,
             # consumed by _drop_stale_admissions above; it says nothing about the
             # ROW, so it must not ride into the persisted transcript meta.
@@ -5268,6 +5278,12 @@ async def _start_next_queued_turn(state: DashboardState, slot: _ChatSlot) -> boo
     if _drained_ids:
         _drained_meta.pop("steer_delivery_id", None)
         _drained_meta["steer_delivery_ids"] = _drained_ids
+    if len(_drained_send_ids) > 1:
+        # A merged row: `sendId` stays as the union left it (last writer) so the
+        # key is never absent when any entry had one, and `sendIds` names every
+        # send the row stands for. Membership in `sendIds` is the proof a client
+        # should read on a merged row; on a plain row `sendId` is the whole story.
+        _drained_meta["sendIds"] = _drained_send_ids
     # Durable provenance for every `inject` row. `cls` is NOT persisted for this
     # role (chat_persistence only keeps it for `role == "system"`), and the
     # frontend's `meta.cronLabel` exists on the wire only because parse_cls_meta

--- a/test/test_queue_drain_preserve_send_id.py
+++ b/test/test_queue_drain_preserve_send_id.py
@@ -1,0 +1,240 @@
+"""A queued send keeps its client ``meta.sendId`` through the drain.
+
+A dispatched send persists the client's ``meta.sendId`` on its user row; a send
+that arrived while the slot was busy went through the queue instead, and the
+queue entry carried only the containment snapshot -- so the row the drain wrote
+was id-less. A client that had to prove ITS message landed (an unconfirmed-send
+notice deciding whether to retire) had nothing to match on but text, which a
+same-text resend or an injection can share.
+
+These pins cover the producer (``/api/chat`` busy-slot and sub-agent-hold
+branches stamp the id onto the entry), the leg the fix relies on (the drain's
+meta union carries it onto the row), and the merged-row shape (``sendIds``
+names every send a merged row stands for).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+from chat_test_helpers import _make_app, _make_state
+
+_TEXT = "queued while busy"
+_SEND_ID = "s-m4k2p1-9x7"
+
+
+async def _post_busy(state, slot_key: str, message: str, meta: dict | None):
+    body: dict = {"message": message, "slot": slot_key}
+    if meta is not None:
+        body["meta"] = meta
+    async with TestClient(TestServer(_make_app(state))) as client:
+        resp = await client.post("/api/chat", json=body)
+        assert resp.status == 200
+        payload = await resp.json()
+        assert payload.get("queued") is True
+        return payload
+
+
+async def _drain_once(state, slot) -> None:
+    from kiro_crew.dashboard import chat_runner
+
+    with (
+        patch.object(chat_runner, "spawn_guarded_turn", return_value=MagicMock()),
+        patch.object(chat_runner, "_run_chat", return_value=MagicMock()),
+    ):
+        assert await chat_runner._start_next_queued_turn(state, slot) is True
+
+
+def _user_rows(slot) -> list[dict]:
+    return [m for m in slot.messages if m.get("role") == "user"]
+
+
+class TestBusySlotQueueEntry:
+    @pytest.mark.asyncio
+    async def test_entry_carries_the_client_send_id(self, tmp_path, monkeypatch):
+        """The producer half: the busy-slot queue branch stamps `sendId` onto the
+        entry, next to the containment snapshot it already carried."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("busy-chat")
+        slot._in_stage_execution = True  # force the busy queue path
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", MagicMock())
+
+        payload = await _post_busy(state, "busy-chat", _TEXT, {"sendId": _SEND_ID})
+
+        entry = next(i for i in slot._queue if i["content"] == _TEXT)
+        assert entry["meta"].get("sendId") == _SEND_ID, (
+            "the drain unions entry meta onto the row it writes, so the entry is the "
+            "only place the id can be put for a send that never persists its own row"
+        )
+        # The receipt contract is unchanged: `queue_id` still names this entry.
+        assert payload.get("queue_id") == entry["id"]
+
+    @pytest.mark.asyncio
+    async def test_a_send_without_an_id_keeps_the_prior_entry_shape(self, tmp_path, monkeypatch):
+        """Additive, not mandatory: an old client's POST carries no id.
+
+        Pinned as an ABSENT KEY rather than a falsy value -- an empty string would
+        travel to the row and give a client an id that matches nothing.
+        """
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("busy-chat")
+        slot._in_stage_execution = True
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", MagicMock())
+
+        await _post_busy(state, "busy-chat", _TEXT, None)
+
+        entry = next(i for i in slot._queue if i["content"] == _TEXT)
+        assert "sendId" not in entry["meta"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "",  # empty
+            "has.dots.like/a.token=",  # outside the id alphabet
+            "x" * 129,  # over SEND_ID_MAX_LEN
+            42,  # not a string
+        ],
+    )
+    async def test_an_unusable_id_is_treated_as_absent(self, tmp_path, monkeypatch, bad_id):
+        """Same deny-by-default gate as the steer path (`normalize_send_id`): raw
+        client input that fails the shape check is dropped, never truncated or
+        rewritten -- a rewritten id would silently mismatch the client's copy."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        slot = state.get_or_create_slot("busy-chat")
+        slot._in_stage_execution = True
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", MagicMock())
+
+        await _post_busy(state, "busy-chat", _TEXT, {"sendId": bad_id})
+
+        entry = next(i for i in slot._queue if i["content"] == _TEXT)
+        assert "sendId" not in entry["meta"]
+
+
+class TestSubagentHoldQueueEntry:
+    @pytest.mark.asyncio
+    async def test_entry_carries_the_client_send_id(self, tmp_path, monkeypatch):
+        """The idle-slot hold (background sub-agents still running) is the other
+        queue producer a composer send can reach; it stamps the id the same way."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.subagents = MagicMock()
+        state.subagents.running_agents_for = MagicMock(return_value=["agent-1"])
+        slot = state.get_or_create_slot("held-chat")
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", MagicMock())
+
+        payload = await _post_busy(state, "held-chat", _TEXT, {"sendId": _SEND_ID})
+
+        entry = next(i for i in slot._queue if i["content"] == _TEXT)
+        assert entry["meta"].get("sendId") == _SEND_ID
+        assert payload.get("queue_id") == entry["id"]
+
+
+class TestDrainedRow:
+    @pytest.mark.asyncio
+    async def test_drained_row_carries_the_send_id(self, tmp_path, monkeypatch):
+        """End to end: the id on the entry is worth nothing on its own -- the row
+        is what a client reads back off the slot detail."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("busy-chat")
+        slot._in_stage_execution = True
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", MagicMock())
+
+        await _post_busy(state, "busy-chat", _TEXT, {"sendId": _SEND_ID})
+
+        state.subagents = None
+        slot._in_stage_execution = False
+        await _drain_once(state, slot)
+
+        rows = _user_rows(slot)
+        assert rows, "the drain must have written a user row for the queued send"
+        meta = rows[-1].get("meta") or {}
+        assert meta.get("sendId") == _SEND_ID
+        # The single-entry case keeps the plain-send shape: one `sendId`, no list.
+        assert "sendIds" not in meta
+        # Queue plumbing must not ride into the persisted row.
+        from kiro_crew.dashboard.session_control import QUEUED_CONTAINMENT_META_KEY
+
+        assert QUEUED_CONTAINMENT_META_KEY not in meta
+
+    @pytest.mark.asyncio
+    async def test_drained_row_without_an_id_has_no_send_id_key(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("busy-chat")
+        slot._in_stage_execution = True
+        monkeypatch.setattr("kiro_crew.dashboard.chat_handlers._run_chat", MagicMock())
+
+        await _post_busy(state, "busy-chat", _TEXT, None)
+
+        state.subagents = None
+        slot._in_stage_execution = False
+        await _drain_once(state, slot)
+
+        rows = _user_rows(slot)
+        assert rows
+        assert "sendId" not in (rows[-1].get("meta") or {})
+        assert "sendIds" not in (rows[-1].get("meta") or {})
+
+    @pytest.mark.asyncio
+    async def test_merged_row_names_every_send_id(self, tmp_path, monkeypatch):
+        """With `merge_queued_messages` on, several queued sends fold into one row.
+        That row stands for all of them, so it has to name all of them: `sendIds`
+        lists each in queue order, and `sendId` is still present (the union's
+        last writer) so the key is never absent when any entry had one."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        state.subagents = None
+        slot = state.get_or_create_slot("busy-chat")
+
+        from kiro_crew.dashboard import chat_runner
+        from kiro_crew.dashboard.chat_delivery import queue_for_next_turn
+
+        queue_for_next_turn(state, slot, "first", directive_user_origin=True, send_id="s-aaa-1")
+        queue_for_next_turn(state, slot, "second", directive_user_origin=True, send_id="s-bbb-2")
+        # A third entry from an old client carries no id and must not poison the list.
+        queue_for_next_turn(state, slot, "third", directive_user_origin=True, send_id=None)
+
+        cfg = MagicMock()
+        cfg.load.return_value.dashboard.merge_queued_messages = True
+        monkeypatch.setattr(chat_runner, "KiroCrewConfig", cfg)
+        await _drain_once(state, slot)
+
+        rows = _user_rows(slot)
+        assert rows
+        meta = rows[-1].get("meta") or {}
+        assert meta.get("sendIds") == ["s-aaa-1", "s-bbb-2"]
+        assert meta.get("sendId") in ("s-aaa-1", "s-bbb-2")
+        assert "3 queued messages merged" in rows[-1].get("content", "")
+
+
+class TestQueueForNextTurnSeam:
+    def test_send_id_is_stamped_only_when_given(self, tmp_path, monkeypatch):
+        """The helper's own contract, independent of the HTTP handler."""
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        state = _make_state(tmp_path)
+        state.broadcast_ws = MagicMock()
+        slot = state.get_or_create_slot("seam")
+
+        from kiro_crew.dashboard.chat_delivery import queue_for_next_turn
+
+        qid_with = queue_for_next_turn(state, slot, "with id", send_id=_SEND_ID)
+        qid_without = queue_for_next_turn(state, slot, "without id")
+
+        by_id = {i["id"]: i for i in slot._queue}
+        assert by_id[qid_with]["meta"].get("sendId") == _SEND_ID
+        assert "sendId" not in by_id[qid_without]["meta"]
+        # The queue_push announce shape is unchanged: no id leaks onto the broadcast.
+        for call in state.broadcast_ws.call_args_list:
+            event, payload = call.args
+            assert event == "queue_push"
+            assert "sendId" not in payload


### PR DESCRIPTION
## Problem / Motivation

A dispatched send persists the client-minted `meta.sendId` on its user row (`chat_handlers.py`, `slot.append("user", …, meta=user_meta)`), and a steer does too — accepted (`steer_into_running_turn`) or requeued (`_requeue_unconsumed_steers`, #6751). A **plain send into a busy slot** did not: the busy-slot branch and the sub-agent-hold branch queued the text with only the containment snapshot in the entry's meta, and the drain (`_start_next_queued_turn`) wrote an id-less user row.

That is the gap the GPT lane blocked #8599 on. ChatEmbed's unconfirmed-send notice needs to prove that *its* message landed before retiring; with no id on the drained row the only available proof was exact-text equality, which a same-text resend or a cron/sub-agent injection can share — so a genuinely undelivered draft could be silently withdrawn. Both frontend-side workarounds were rejected by GPT and Opus; the server has to keep the id.

## What changed

- **`chat_delivery.queue_for_next_turn`** gains a `send_id: str | None = None` keyword. When present it is stamped onto the queue entry's meta next to the containment snapshot. Additive: `None` leaves the entry shape exactly as before.
- **`chat_handlers.api_chat`**: the busy-slot branch passes `normalize_send_id(user_meta.get("sendId"))`; the sub-agent-hold branch stamps the same key onto its own `containment_meta(...)` dict. `normalize_send_id` is the steer path's existing deny-by-default gate (id alphabet, length bound, credential scan) — an unusable value is treated as **absent**, never truncated or rewritten, since a rewritten id would silently mismatch the client's copy.
- **`chat_runner._start_next_queued_turn`**: the drain's existing meta union already carries the key onto the row (it is how a merged row names its `steer_delivery_ids`). One addition for the `merge_queued_messages` case: when several consumed entries carry distinct ids, the merged row also gets `sendIds` (every id, queue order). `sendId` stays present (the union's last writer) so the key is never absent when any entry had one; on the common single-entry row the shape is `sendId` alone — identical to a dispatched send's row.

No change to the `queued: true` receipt, the `queue_push` broadcast, or the `queue_id` contract.

## Tests

`test/test_queue_drain_preserve_send_id.py` (new, 10 cases):

- busy-slot POST with `meta.sendId` → entry meta carries it; receipt `queue_id` still names the entry
- POST without an id → key **absent** on the entry (not a falsy value)
- unusable ids (empty, outside the alphabet, over `SEND_ID_MAX_LEN`, non-string) → absent
- sub-agent-hold branch → entry carries the id
- drained row carries `sendId`, no `sendIds`, and no containment plumbing key
- drained row for an id-less entry has neither key
- merged drain (`merge_queued_messages` on) of two id-bearing entries + one id-less → `sendIds == [a, b]`, `sendId` is one of them
- `queue_for_next_turn` seam: id stamped only when given; `queue_push` payload unchanged

Local: black, isort, flake8, mypy clean on the touched files; the test file is left to CI.

## Related

Unblocks [#8599](https://github.com/kirodotdev/KiroCrew/pull/8599) (chat-core P2: ChatEmbed on `sendTurn`), which will depend on this behaviour for its delivery proof and delete its text-match fallback. no linked issue: surfaced as a review finding on #8599, not filed separately.

## Pattern harvest

Rule candidate: a queue producer that drops request-scoped correlation meta. Pattern: three producers write `slot.queue_append(..., meta=containment_meta(...))` for a composer-originated message, and only the steer requeue carried the client's `sendId` (#6751) — the two plain-send producers built the same meta dict without it. A structural check (semgrep or a unit pin) that every `queue_append` / `queue_insert` call reachable from `api_chat` with a `user_meta` in scope forwards `normalize_send_id(user_meta.get("sendId"))` would have caught this at the second producer; alternatively fold the id into `containment_meta`'s caller contract so a producer cannot build the entry meta without deciding about it.

## Checklist

- [x] One Conventional Commits commit
- [x] New deterministic tests cover the behaviour
- [x] Self-review completed; code follows project style guidelines
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

N/A — repository placeholder only; no OSPO CLA text has been supplied.
