### PR TITLE
docs(readme): say what happens with Stable and Insider installed side by side

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,18 @@ the installer with `--channel`, and a container switches by pulling a different
 tag. Either way, the other lane's current version then arrives as an ordinary
 update.
 
+Because they are one app, keeping a Stable *and* an Insider copy side by side
+does not give you two independent installs. Both read the same desktop settings
+store, so the channel is a single value and whichever copy wrote it last wins —
+switch to Insider in one and the other follows. They share one update download
+cache as well. `KIROCREW_HOME` does not separate them either: it moves the data
+home, not the desktop settings.
+
 Nightly is a separate app with its own name and icon, so it installs *alongside*
-a Stable or Insider one rather than replacing it. It is not a sandbox, though: it
-reads the same `~/.kiro/crew` data home unless you point it elsewhere with
-`KIROCREW_HOME`.
+a Stable or Insider one rather than replacing it. That also makes it the one copy
+that keeps its own channel and its own settings store. It is not a sandbox,
+though: it reads the same `~/.kiro/crew` data home unless you point it elsewhere
+with `KIROCREW_HOME`.
 
 Running Insider or Nightly is a real contribution. When something looks wrong,
 please [open an issue](https://github.com/kirodotdev/KiroCrew/issues) so it gets


### PR DESCRIPTION
## What

The **Release channels** section already says Stable and Insider are two update
lanes of the same app, and that Nightly installs alongside them. It does not say
what follows for someone who keeps a copy of Stable *and* a copy of Insider,
which is a reasonable thing to try and produces a confusing result: change the
channel in one and the other appears to change on its own.

## Why it reads as a bug

Both copies are the same app identity, so they resolve to the same desktop
settings store. The Settings → About channel preference is therefore one value
with two writers, and the last write wins. They share one update download cache
as well. Someone reaching for `KIROCREW_HOME` to separate them finds it does not
help, because it moves the data home and not the desktop settings — a detail the
existing text does not rule out.

None of this is a defect; it is what "two lanes of the same app" means. It just
was not written down anywhere a user would look, and the switcher makes the
shared value easy to hit by accident.

## How

One paragraph in the same section, after the existing two-lanes paragraph, plus
one sentence on the Nightly paragraph noting that Nightly — already documented as
side-by-side — is consequently the copy that keeps its own channel and settings
store.

Documentation only; no code or behavior change.
