### PR TITLE
feat(work-ledger): store module for conductor/worker work items (phase 1)

### DIFF
--- a/src/kiro_crew/work_ledger.py
+++ b/src/kiro_crew/work_ledger.py
@@ -1,0 +1,1615 @@
+"""The shared work record between a conductor session and the workers it dispatched.
+
+Three ledgers now carry that name, and they are not interchangeable.
+:mod:`kiro_crew.session_ledger` is ONE session's own durable state. Issue Radar's
+``crew_store`` is a per-repository work ledger keyed by a forge issue number. This
+module is the third: a record two parties write and neither owns, so that a
+conductor learns what a worker did as DATA instead of reading its transcript.
+
+Phase 1 of the conductor-work-ledger RFC (pull request #8842) — storage only.
+No MCP tool, no HTTP route, no UI, and deliberately no importer anywhere else in the
+tree, so the phase reverts by deleting this file and its test.
+
+WRITER OWNERSHIP is the whole design, and it is expressed as two entry points rather
+than one update function with a field allowlist:
+
+  * :func:`apply_conductor_action` writes ``title``, ``acceptance``, ``state``,
+    ``verdict``, ``decision``, ``worker_session_key``, ``round`` and ``fails``.
+  * :func:`apply_worker_report` writes ``status``, ``summary``, ``artifacts``,
+    ``pr`` and ``last_report_at``.
+
+The two field sets are disjoint. Phase 2 mounts one tool on each, so a worker cannot
+reach a conductor field because the function it can call takes no parameter that
+names one — an absent parameter outlives an allowlist that must be kept correct as
+fields are added. Phase 1 performs NO identity resolution; that is Phase 2's job at
+the tool layer, and the split shape here is what lets it be done by construction.
+
+LOCK ORDER, for the two paths that hold more than one lock. ``create`` enforces the
+per-conductor item cap, which means reading the items directory, so it holds the
+conductor lock across the whole transaction and takes the new item's lock from
+inside that hold. ``bind`` holds the item lock and takes the worker's binding lock
+from inside it, because "this worker holds no other open item" is a property of
+the binding file, not of the item. So: **conductor -> item -> binding(worker)**.
+No path anywhere takes any two of these in the other relative order, so the order
+is total and two conductors cannot deadlock. Every other write takes exactly one
+lock: the conductor lock for ``goal``, the item lock for ``decide``/``verdict``/
+``close`` and for a worker report. File locks on fresh descriptors do NOT nest, so
+each locked body has a ``_locked`` twin that a holder calls directly rather than
+re-acquiring.
+
+CAPS REFUSE, THEY DO NOT TRUNCATE. Every bound on a STORED field is validated
+before the first write, so a refusal leaves every file byte-identical. A truncated
+summary the worker believes landed whole is a silent loss the worker cannot detect.
+The one bounded projection is the event line's ``text``: it is a 500-char excerpt of
+a field the item record already holds in full, so clipping it loses nothing.
+
+CORRUPTION READS AS ABSENT. A torn, truncated, non-UTF-8 or oversized record returns
+``None`` rather than raising, matching :mod:`kiro_crew.session_ledger`'s treatment of
+an oversized state file. A reader of a two-writer store must not be the thing that
+crashes because the other writer was interrupted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import secrets
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterator
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import data_home
+from kiro_crew.platform_compat import file_lock
+from kiro_crew.session_ledger import _store_name
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+# --------------------------------------------------------------------------- #
+# Vocabularies
+# --------------------------------------------------------------------------- #
+
+#: A work item's disposition, written by the conductor. A DIFFERENT question from
+#: ``verdict``: an item may hold ``verdict: fail`` and stay ``open`` while the
+#: worker retries, which is the state ``ledger_entry.py`` encodes today as "fails
+#: incremented but still running".
+ITEM_STATES: frozenset[str] = frozenset({"open", "accepted", "rejected", "abandoned"})
+
+#: States from which no further write is accepted.
+TERMINAL_ITEM_STATES: frozenset[str] = frozenset({"accepted", "rejected", "abandoned"})
+
+#: ``accept_eval.py``'s own five values, reused rather than paralleled, so a verdict
+#: crosses from that script into this store with no translation.
+VERDICTS: frozenset[str] = frozenset({"pass", "fail", "pending", "refused", "error"})
+
+#: What a worker may say about itself. ``blocked`` and ``question`` are separate
+#: because they differ in WHO must act: an external dependency versus the conductor.
+WORKER_STATUSES: frozenset[str] = frozenset({"progress", "done", "blocked", "question"})
+
+#: Every ITEM write appends exactly one event, so there is no way to move an item
+#: field without a line explaining it (the conductor's own ``goal``/``round``
+#: header is the one eventless write, because it belongs to no item). ``report``
+#: is the only kind a worker can produce.
+EVENT_KINDS: frozenset[str] = frozenset(
+    {"create", "bind", "report", "decision", "verdict", "close"}
+)
+
+#: The conductor's disjoint operations. One action per call, because the field sets
+#: do not overlap and a single flat schema would accept nonsense combinations.
+CONDUCTOR_ACTIONS: frozenset[str] = frozenset(
+    {"create", "bind", "decide", "verdict", "close", "goal"}
+)
+
+# --------------------------------------------------------------------------- #
+# Caps. Each one refuses; none truncates.
+# --------------------------------------------------------------------------- #
+
+MAX_ITEMS_PER_CONDUCTOR = 32
+MAX_EVENTS_PER_ITEM = 200
+MAX_DEPTH = 2
+
+MAX_GOAL_CHARS = 2000
+MAX_TITLE_CHARS = 200
+MAX_DECISION_CHARS = 2000
+MAX_SUMMARY_CHARS = 500
+MAX_EVENT_TEXT_CHARS = 500
+
+MAX_ARTIFACT_KEYS = 16
+MAX_ARTIFACT_KEY_CHARS = 64
+MAX_ARTIFACT_VALUE_CHARS = 512
+
+MIN_PR = 1
+MAX_PR = 1_000_000_000
+
+#: A record over this size reads as absent. The writers cannot approach it — every
+#: field is capped far below — so crossing it means the file was torn, hand-edited,
+#: or written by something that is not this module.
+MAX_RECORD_BYTES = 1_000_000
+
+#: How long an item may go unreported before :func:`is_stale` will consider it, once
+#: its worker is also confirmed not running. A default, not a policy: the caller
+#: passes its own window.
+DEFAULT_STALE_WINDOW_SECS = 900.0
+
+# --------------------------------------------------------------------------- #
+# Error codes. Named for the HTTP-facing vocabulary Phase 2 maps them onto, so the
+# mapping is a lookup rather than a re-classification.
+# --------------------------------------------------------------------------- #
+
+CODE_NO_LEDGER = "no_ledger"
+CODE_UNKNOWN_ITEM = "unknown_item"
+CODE_ALREADY_BOUND = "already_bound"
+CODE_ITEM_CLOSED = "item_closed"
+CODE_ITEM_CAP_EXCEEDED = "item_cap_exceeded"
+CODE_DEPTH_EXCEEDED = "depth_exceeded"
+CODE_FIELD_TOO_LONG = "field_too_long"
+CODE_INVALID_ACTION = "invalid_action"
+CODE_INVALID_STATUS = "invalid_status"
+CODE_INVALID_VALUE = "invalid_value"
+
+
+class WorkLedgerError(Exception):
+    """A store invariant was violated, or a cap refused a write.
+
+    Carries ``code`` — one of the ``CODE_*`` constants — and, for a bound that
+    refused, the ``field`` whose cap it was. Phase 2 maps ``code`` onto a status and
+    quotes ``field`` back, so the caller learns WHICH bound it crossed rather than
+    that something was too long.
+    """
+
+    def __init__(self, message: str, *, code: str, field: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.field = field
+
+
+# --------------------------------------------------------------------------- #
+# Records
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class ConductorRecord:
+    """One conductor session's ledger header. The conductor is the sole writer.
+
+    There is deliberately NO item roster field. The item list is derived by listing
+    the items directory (:func:`list_work_items`), which removes a writer and with
+    it a class of clobber — the same choice Issue Radar's ``list_work_items`` makes.
+    """
+
+    slot_key: str = ""
+    goal: str = ""
+    round: int = 0
+    depth: int = 0
+    parent_item: str | None = None
+    created_at: str = ""
+    schema: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "slot_key": self.slot_key,
+            "goal": self.goal,
+            "round": self.round,
+            "depth": self.depth,
+            "parent_item": self.parent_item,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> ConductorRecord:
+        """Coerce stored JSON into a record. NEVER raises.
+
+        A wrong-typed field resets to its default rather than failing the read: this
+        file is written by one party and read by a probe, a page and the conductor
+        itself, and a single bad field must not take all three down.
+        """
+        if not isinstance(raw, dict):
+            return cls()
+        return cls(
+            slot_key=_as_str(raw.get("slot_key")),
+            goal=_as_str(raw.get("goal")),
+            round=_as_int(raw.get("round"), 0),
+            depth=_as_int(raw.get("depth"), 0),
+            parent_item=_as_opt_str(raw.get("parent_item")),
+            created_at=_as_str(raw.get("created_at")),
+            schema=_as_int(raw.get("schema"), SCHEMA_VERSION),
+        )
+
+
+@dataclass
+class WorkItem:
+    """One dispatched work item. Two writers, one per-item lock, disjoint fields.
+
+    Conductor-owned: ``title``, ``acceptance``, ``state``, ``verdict``, ``decision``,
+    ``worker_session_key``, ``round``, ``fails``.
+    Worker-owned: ``status``, ``summary``, ``artifacts``, ``pr``, ``last_report_at``.
+    Server-owned: ``item_id``, ``created_at``, ``closed_at``.
+
+    ``orphaned`` and ``stale`` are NOT fields. They are derived at read time by
+    :func:`is_orphaned` and :func:`is_stale`, because a stamped flag would need
+    something running at close time to stamp it, a missed stamp would stay wrong
+    forever, and a derived flag self-heals when a session is reopened.
+    """
+
+    item_id: str = ""
+    title: str = ""
+    acceptance: dict[str, Any] = field(default_factory=dict)
+    state: str = "open"
+    verdict: str | None = None
+    decision: str = ""
+    worker_session_key: str | None = None
+    round: int = 0
+    fails: int = 0
+    status: str | None = None
+    summary: str = ""
+    artifacts: dict[str, str] = field(default_factory=dict)
+    pr: int | None = None
+    last_report_at: str | None = None
+    created_at: str = ""
+    closed_at: str | None = None
+    schema: int = SCHEMA_VERSION
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state in TERMINAL_ITEM_STATES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "item_id": self.item_id,
+            "title": self.title,
+            "acceptance": self.acceptance,
+            "state": self.state,
+            "verdict": self.verdict,
+            "decision": self.decision,
+            "worker_session_key": self.worker_session_key,
+            "round": self.round,
+            "fails": self.fails,
+            "status": self.status,
+            "summary": self.summary,
+            "artifacts": self.artifacts,
+            "pr": self.pr,
+            "last_report_at": self.last_report_at,
+            "created_at": self.created_at,
+            "closed_at": self.closed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> WorkItem:
+        """Coerce stored JSON into an item. NEVER raises. See
+        :meth:`ConductorRecord.from_dict` for why a bad field resets rather than
+        failing the read."""
+        if not isinstance(raw, dict):
+            return cls()
+        state = _as_str(raw.get("state"))
+        status = _as_opt_str(raw.get("status"))
+        verdict = _as_opt_str(raw.get("verdict"))
+        artifacts_raw = raw.get("artifacts")
+        artifacts: dict[str, str] = {}
+        if isinstance(artifacts_raw, dict):
+            artifacts = {str(k): v for k, v in artifacts_raw.items() if isinstance(v, str)}
+        return cls(
+            item_id=_as_str(raw.get("item_id")),
+            title=_as_str(raw.get("title")),
+            acceptance=raw["acceptance"] if isinstance(raw.get("acceptance"), dict) else {},
+            state=state if state in ITEM_STATES else "open",
+            verdict=verdict if verdict in VERDICTS else None,
+            decision=_as_str(raw.get("decision")),
+            worker_session_key=_as_opt_str(raw.get("worker_session_key")),
+            round=_as_int(raw.get("round"), 0),
+            fails=_as_int(raw.get("fails"), 0),
+            status=status if status in WORKER_STATUSES else None,
+            summary=_as_str(raw.get("summary")),
+            artifacts=artifacts,
+            pr=_finite_int(raw.get("pr")),
+            last_report_at=_as_opt_str(raw.get("last_report_at")),
+            created_at=_as_str(raw.get("created_at")),
+            closed_at=_as_opt_str(raw.get("closed_at")),
+            schema=_as_int(raw.get("schema"), SCHEMA_VERSION),
+        )
+
+
+@dataclass
+class WorkEvent:
+    """One line in an item's event log.
+
+    ``id`` is content-addressed, so a line written twice — a retry, a restored
+    backup, a rollback that replayed — collapses on read instead of double-counting.
+    """
+
+    id: str = ""
+    ts: str = ""
+    item_id: str = ""
+    kind: str = ""
+    status: str | None = None
+    text: str = ""
+
+    @property
+    def is_progress_report(self) -> bool:
+        """Whether this is the one event kind that coalesces. See
+        :func:`_coalesce_progress`."""
+        return self.kind == "report" and self.status == "progress"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "ts": self.ts,
+            "item_id": self.item_id,
+            "kind": self.kind,
+            "status": self.status,
+            "text": self.text,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> WorkEvent | None:
+        """Parse one stored line, or ``None`` when it is not one.
+
+        ``None`` rather than a defaulted record: an event log is append-only and a
+        torn tail must be SKIPPED, not folded in as an event with empty fields that
+        a reader would then have to distinguish from a real one.
+        """
+        if not isinstance(raw, dict):
+            return None
+        kind = _as_str(raw.get("kind"))
+        if kind not in EVENT_KINDS:
+            return None
+        status = _as_opt_str(raw.get("status"))
+        return cls(
+            id=_as_str(raw.get("id")),
+            ts=_as_str(raw.get("ts")),
+            item_id=_as_str(raw.get("item_id")),
+            kind=kind,
+            status=status if status in WORKER_STATUSES else None,
+            text=_as_str(raw.get("text")),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Coercion helpers. None of these raise.
+# --------------------------------------------------------------------------- #
+
+
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _as_opt_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _as_int(value: Any, default: int) -> int:
+    parsed = _finite_int(value)
+    return default if parsed is None else parsed
+
+
+def _finite_int(value: Any) -> int | None:
+    """*value* as an int, or ``None`` when it is not one.
+
+    ``bool`` is rejected before ``int`` because ``True`` is an ``int`` in Python, so
+    a cap written as ``value <= MAX`` is silently defeated by a boolean. A FRACTIONAL
+    float is rejected too rather than truncated: ``int()`` would store a number the
+    caller never asked for while reporting success.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            return None
+        if not value.is_integer():
+            return None
+    return int(value)
+
+
+def _now_iso() -> str:
+    """Local time with offset, seconds precision — the same stamp
+    :mod:`kiro_crew.session_ledger` writes, so two ledgers read side by side sort
+    against each other."""
+    return datetime.now().astimezone().isoformat(timespec="seconds")
+
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+
+#: Directory naming is :func:`kiro_crew.session_ledger._store_name` -- readable
+#: fold plus ``sha256[:8]`` -- imported rather than copied. ``session_ledger``
+#: imports only the three modules this one already imports, so the leaf-module
+#: argument that justifies ``crew_chat``'s own copy does not apply here.
+
+#: The only shape an item id may have — ``it_`` plus the eight hex chars
+#: :func:`mint_item_id` produces.
+_ITEM_ID_RE = re.compile(r"^it_[0-9a-f]{8}$")
+
+_CONDUCTOR_FILE = "conductor.json"
+_KEY_FILE = "slot_key"
+_LOCK_FILE = ".lock"
+_ITEMS_DIR = "items"
+_BINDINGS_DIR = "bindings"
+
+
+def mint_item_id() -> str:
+    """A fresh server-side item id.
+
+    Minted here and never accepted from a model, which is what keeps a model-supplied
+    string out of a path component. ``secrets`` rather than ``random`` because an id
+    a caller can predict is an id it can name in a request before the item exists.
+    """
+    return f"it_{secrets.token_hex(4)}"
+
+
+def _require_item_id(item_id: str) -> str:
+    """Gate an item id before it can reach a filesystem path.
+
+    ``Path("/store") / item_id`` DISCARDS the base when *item_id* is absolute and
+    honours ``..`` when it is relative, so an unchecked id is an arbitrary-file read
+    on any read path and an arbitrary-file WRITE on any write path. The check lives
+    at this single choke point every path constructor passes through rather than at
+    each caller, because a caller-level check protects only the callers someone
+    remembered.
+    """
+    if not _ITEM_ID_RE.match(item_id or ""):
+        raise WorkLedgerError(f"invalid item id {item_id!r}", code=CODE_INVALID_VALUE)
+    return item_id
+
+
+def _work_ledger_root() -> Path:
+    """Resolved per call, never cached at import: ``data_home()`` is overridable and
+    a module-level constant would freeze the first value a test happened to set."""
+    return data_home() / "work-ledger"
+
+
+def conductor_dir(slot_key: str) -> Path:
+    """The directory holding *slot_key*'s ledger. Does not create it."""
+    if not slot_key or "\0" in slot_key or "/" in slot_key or "\\" in slot_key:
+        raise WorkLedgerError(
+            f"invalid slot key for work ledger: {slot_key!r}", code=CODE_INVALID_VALUE
+        )
+    base = _work_ledger_root()
+    resolved = (base / _store_name(slot_key)).resolve()
+    parent = base.resolve()
+    if resolved == parent or not resolved.is_relative_to(parent):
+        raise WorkLedgerError(
+            f"path traversal blocked for slot key: {slot_key!r}", code=CODE_INVALID_VALUE
+        )
+    return resolved
+
+
+def items_dir(slot_key: str) -> Path:
+    return conductor_dir(slot_key) / _ITEMS_DIR
+
+
+def item_path(slot_key: str, item_id: str) -> Path:
+    return items_dir(slot_key) / f"{_require_item_id(item_id)}.json"
+
+
+def item_events_path(slot_key: str, item_id: str) -> Path:
+    return items_dir(slot_key) / f"{_require_item_id(item_id)}.jsonl"
+
+
+def _item_lock_path(slot_key: str, item_id: str) -> Path:
+    return items_dir(slot_key) / f"{_require_item_id(item_id)}.lock"
+
+
+def bindings_dir() -> Path:
+    return _work_ledger_root() / _BINDINGS_DIR
+
+
+def binding_path(worker_slot_key: str) -> Path:
+    """Where a worker's binding lives, keyed by the worker's own session key.
+
+    Named with the SAME readable-plus-digest fold as a conductor directory rather
+    than the digest alone: the fold is strictly more collision-resistant (a
+    collision needs both the same sanitised prefix and the same digest), and it
+    keeps one naming scheme across the store instead of two.
+    """
+    if not worker_slot_key or "\0" in worker_slot_key:
+        raise WorkLedgerError(
+            f"invalid worker slot key: {worker_slot_key!r}", code=CODE_INVALID_VALUE
+        )
+    base = bindings_dir()
+    resolved = (base / f"{_store_name(worker_slot_key)}.json").resolve()
+    if not resolved.is_relative_to(base.resolve()):
+        raise WorkLedgerError(
+            f"path traversal blocked for worker key: {worker_slot_key!r}",
+            code=CODE_INVALID_VALUE,
+        )
+    return resolved
+
+
+# --------------------------------------------------------------------------- #
+# Locks
+# --------------------------------------------------------------------------- #
+
+
+@contextmanager
+def _open_lock(path: Path) -> Iterator[None]:
+    """Hold an advisory lock on *path*, creating the lock file if absent.
+
+    ``file_lock`` takes an already-open descriptor and fails CLOSED — it raises
+    rather than entering the critical section unserialised — which is why nothing
+    here has a lock-less fallback.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as handle:
+        with file_lock(handle.fileno(), exclusive=True):
+            yield
+
+
+@contextmanager
+def conductor_lock(slot_key: str) -> Iterator[None]:
+    """Hold the conductor lock. FIRST in the lock order; see the module docstring."""
+    with _open_lock(conductor_dir(slot_key) / _LOCK_FILE):
+        yield
+
+
+@contextmanager
+def item_lock(slot_key: str, item_id: str) -> Iterator[None]:
+    """Hold one item's lock. SECOND in the lock order; see the module docstring."""
+    with _open_lock(_item_lock_path(slot_key, item_id)):
+        yield
+
+
+@contextmanager
+def binding_lock(worker_slot_key: str) -> Iterator[None]:
+    """Hold one worker's binding lock. THIRD in the lock order; see the module
+    docstring. Guards the read-then-write on ``bindings/<worker>.json`` so two
+    conductors binding the same worker at once cannot both see it free."""
+    path = binding_path(worker_slot_key)
+    with _open_lock(path.with_suffix(".lock")):
+        yield
+
+
+# --------------------------------------------------------------------------- #
+# Whole-file reads. A corrupt record reads as absent.
+# --------------------------------------------------------------------------- #
+
+
+def _read_json_record(path: Path, *, strict: bool = False) -> Any | None:
+    """Parse a whole-file JSON record, or ``None`` when it cannot be trusted.
+
+    ``strict=True`` keeps the corruption-reads-as-absent contract for CONTENT
+    (torn, oversized, non-UTF-8) but re-raises an I/O error other than
+    ``FileNotFoundError``. A guard that must fail CLOSED uses it: a file that is
+    present but momentarily unreadable -- a Windows rename race, a permission
+    blip -- must not be mistaken for a file that is gone.
+
+    Absent, unreadable, non-UTF-8, unparseable, and OVER the size ceiling all read
+    the same way, because a two-writer store's reader must not be what crashes when
+    the other writer was interrupted mid-write. The ceiling is checked before the
+    read so a hand-grown file cannot be pulled into memory first.
+    """
+    try:
+        if path.stat().st_size > MAX_RECORD_BYTES:
+            logger.warning(
+                "work ledger record over the size ceiling; treating as absent: %s",
+                path.name,
+            )
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except OSError:
+        if strict:
+            raise
+        return None
+    except (ValueError, UnicodeDecodeError):
+        # ``ValueError`` already covers ``json.JSONDecodeError``.
+        return None
+
+
+def _serialize(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _write_record(path: Path, payload: dict[str, Any]) -> None:
+    """Whole-file atomic replace, owner-only.
+
+    ``restrict_to_owner=True`` alongside ``mode=0o600`` — ``atomic_write`` accepts
+    the pair and refuses the flag with any other mode, so the two are effectively
+    one choice. ``session_ledger`` passes only the mode; this store carries a
+    worker's own words into a conductor's context, so it takes the stronger form.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(path, _serialize(payload), mode=0o600, restrict_to_owner=True)
+
+
+def read_conductor(slot_key: str, *, strict: bool = False) -> ConductorRecord | None:
+    """*slot_key*'s conductor record, or ``None`` when there is no readable ledger.
+
+    ``strict`` has :func:`_read_json_record`'s meaning; the two header WRITERS use
+    it so a transient I/O error cannot masquerade as an absent ledger and mint a
+    fresh header over the real one.
+
+    Lock-free: a reader that took the write lock would serialise every probe tick
+    behind every write, and a whole-file atomic replace means a reader sees either
+    the old record or the new one, never a blend.
+    """
+    raw = _read_json_record(conductor_dir(slot_key) / _CONDUCTOR_FILE, strict=strict)
+    if raw is None:
+        return None
+    record = ConductorRecord.from_dict(raw)
+    if not record.slot_key:
+        record.slot_key = slot_key
+    return record
+
+
+def read_work_item(slot_key: str, item_id: str, *, strict: bool = False) -> WorkItem | None:
+    """One item, or ``None`` when it is absent or unreadable. Lock-free.
+
+    A record whose stored ``item_id`` names a DIFFERENT item than the file it sits
+    in reads as absent. The writer always keeps the two equal, so a mismatch is a
+    misnamed or hand-moved file, and honouring its stored id would let a write
+    taken under THIS item's lock land on THAT item's path.
+    """
+    raw = _read_json_record(item_path(slot_key, item_id), strict=strict)
+    if raw is None:
+        return None
+    item = WorkItem.from_dict(raw)
+    if not item.item_id:
+        item.item_id = item_id
+    elif item.item_id != item_id:
+        logger.warning(
+            "work ledger item %s stores id %s; treating as absent", item_id, item.item_id
+        )
+        return None
+    return item
+
+
+def list_work_items(slot_key: str) -> list[WorkItem]:
+    """Every readable item, oldest first.
+
+    DERIVED by listing the items directory rather than read from an index, so there
+    is no third writer over a file both parties care about, and therefore no index
+    to fall out of step with the files it names. An unreadable item is skipped: one
+    torn file must not hide the rest.
+    """
+    try:
+        entries = sorted(items_dir(slot_key).glob("it_*.json"))
+    except OSError:
+        return []
+    items: list[WorkItem] = []
+    for entry in entries:
+        # The glob is a prefix match; only a full ``it_<8 hex>`` stem is an item.
+        # A stray ``it_bad.json`` is corruption in the directory, and corruption
+        # reads as absent here too rather than crashing every listing.
+        if not _ITEM_ID_RE.match(entry.stem):
+            continue
+        item = read_work_item(slot_key, entry.stem)
+        if item is not None:
+            items.append(item)
+    items.sort(key=lambda it: (it.created_at, it.item_id))
+    return items
+
+
+# --------------------------------------------------------------------------- #
+# Events
+# --------------------------------------------------------------------------- #
+
+
+def event_id(ts: str, item_id: str, kind: str, text: str, *, status: str | None = None) -> str:
+    """Content-addressed id for one event line.
+
+    Pipe-separated rather than concatenated, matching Issue Radar's ``_event_id``:
+    bare concatenation lets two different tuples produce one string, so two distinct
+    events could collapse into each other on read.
+
+    ``status`` IS part of the identity. Timestamps are seconds-precision, so a
+    ``progress`` report and a ``blocked`` report with the same summary in the same
+    second would otherwise share an id, and first-seen-wins dedupe would drop the
+    transition — the one line the conductor most needs to see. ``None`` renders as
+    the empty string, so every non-report kind keeps a stable formula.
+    """
+    raw = f"{ts}|{item_id}|{kind}|{status or ''}|{text}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def _read_events_unlocked(path: Path, *, strict: bool = False) -> list[WorkEvent]:
+    """Every parseable line, oldest first, duplicate ids collapsed FIRST-seen-wins.
+
+    A malformed line is skipped rather than failing the read: the log is append-only
+    and a torn tail must not hide the history in front of it. ``strict`` re-raises
+    an I/O error other than ``FileNotFoundError``; the WRITER reads that way, because
+    it rewrites the whole log from what it read and a transient error read as
+    "empty" would replace the entire history with one line.
+    """
+    try:
+        if path.stat().st_size > MAX_RECORD_BYTES:
+            logger.warning("work ledger event log over the size ceiling: %s", path.name)
+            return []
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        return []
+    except OSError:
+        if strict:
+            raise
+        return []
+    seen: set[str] = set()
+    out: list[WorkEvent] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        event = WorkEvent.from_dict(parsed)
+        if event is None:
+            continue
+        if event.id and event.id in seen:
+            continue
+        if event.id:
+            seen.add(event.id)
+        out.append(event)
+    return out
+
+
+def read_events(slot_key: str, item_id: str, *, limit: int | None = None) -> list[WorkEvent]:
+    """One item's events, oldest first, deduplicated. ``limit`` keeps the NEWEST."""
+    events = _read_events_unlocked(item_events_path(slot_key, item_id))
+    if limit is not None and limit >= 0:
+        return events[-limit:] if limit else []
+    return events
+
+
+def _coalesce_progress(events: list[WorkEvent], incoming: WorkEvent) -> list[WorkEvent]:
+    """Drop the trailing ``progress`` report when *incoming* is another one.
+
+    This is the answer to the RFC's open question Q6. A worker in a tight loop can
+    otherwise append 200 ``progress`` lines and roll its own history off the back of
+    the cap before the conductor ever wakes — ``progress`` does not wake it — so the
+    events that DID matter are the ones lost. Collapsing consecutive progress keeps
+    the newest position and spends the cap on transitions instead of on chatter.
+
+    Only CONSECUTIVE progress reports merge, and only with each other. A ``done``,
+    ``blocked`` or ``question`` between two progress lines stops the merge, because
+    a status change is exactly the history worth keeping.
+    """
+    if not incoming.is_progress_report or not events:
+        return events
+    if not events[-1].is_progress_report:
+        return events
+    return events[:-1]
+
+
+def _append_event_locked(
+    slot_key: str, item_id: str, kind: str, text: str, *, status: str | None = None
+) -> WorkEvent:
+    """Append one event to *item_id*'s log. THE CALLER MUST HOLD THE ITEM LOCK.
+
+    Stamps ``ts`` here, under the lock and immediately before the write, so file
+    order and timestamp order agree. A caller that built its entry first and then
+    blocked on the lock would write a line whose timestamp precedes the line already
+    above it, and a reader sorting by ``ts`` would disagree with one walking the file.
+
+    The whole log is REWRITTEN rather than appended to. The RFC specifies an append
+    under the lock, and a plain append cannot implement either the oldest-dropped
+    cap or the progress-coalescing rule, both of which delete a line. One rewrite
+    path does both, and at 200 short lines it costs less than the second code path
+    would. Atomicity is unchanged: the rewrite is an ``atomic_write`` rename held
+    under the same lock, so a reader sees the old log or the new one.
+    """
+    if kind not in EVENT_KINDS:
+        raise WorkLedgerError(f"unknown event kind {kind!r}", code=CODE_INVALID_VALUE)
+    ts = _now_iso()
+    trimmed = text[:MAX_EVENT_TEXT_CHARS]
+    incoming = WorkEvent(
+        id=event_id(ts, item_id, kind, trimmed, status=status),
+        ts=ts,
+        item_id=item_id,
+        kind=kind,
+        status=status,
+        text=trimmed,
+    )
+    path = item_events_path(slot_key, item_id)
+    events = _coalesce_progress(_read_events_unlocked(path, strict=True), incoming)
+    events.append(incoming)
+    if len(events) > MAX_EVENTS_PER_ITEM:
+        events = events[-MAX_EVENTS_PER_ITEM:]
+    body = "".join(json.dumps(event.to_dict(), ensure_ascii=False) + "\n" for event in events)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(path, body, mode=0o600, restrict_to_owner=True, newline="\n")
+    return incoming
+
+
+def _read_text_or_none(path: Path) -> str | None:
+    """A file's text as it stands, or ``None`` when it does not exist. For rollback:
+    ``newline=""`` so what is restored is byte-for-byte what was there."""
+    try:
+        with path.open("r", encoding="utf-8", newline="") as fh:
+            return fh.read()
+    except FileNotFoundError:
+        return None
+
+
+def _restore_text(path: Path, snapshot: str | None) -> None:
+    """Put *path* back as *snapshot* found it; ``None`` means delete. Never raises --
+    the caller already holds the error it must surface."""
+    try:
+        if snapshot is None:
+            path.unlink(missing_ok=True)
+        else:
+            atomic_write(path, snapshot, mode=0o600, restrict_to_owner=True, newline="")
+    except OSError:
+        logger.error(
+            "work ledger: could not restore %s after a failed write", path.name, exc_info=True
+        )
+
+
+def _commit_item_locked(
+    slot_key: str, item: WorkItem, kind: str, text: str, *, status: str | None = None
+) -> WorkEvent:
+    """Persist one item change AND the event that explains it. HOLD THE ITEM LOCK.
+
+    Two files, no atomic two-file rename, so the order and the rollback are what make
+    the pair safe. EVENT FIRST, ITEM SECOND: if the item write then fails, the log is
+    put back exactly as it was, so the two never disagree. The other order would let
+    a disk-full between the writes persist a state change with no line explaining
+    it -- a terminal item with no ``close`` event, forever.
+
+    The serialized item is measured against the read ceiling BEFORE either write.
+    ``_require_acceptance`` bounds the compact form, but the stored form is indented,
+    and an item that writes successfully and then reads as absent is the silent loss
+    this module exists to refuse.
+    """
+    payload = item.to_dict()
+    body = _serialize(payload)
+    if len(body.encode("utf-8")) > MAX_RECORD_BYTES:
+        raise WorkLedgerError(
+            "item record would exceed the read ceiling; shrink acceptance",
+            code=CODE_FIELD_TOO_LONG,
+            field="acceptance",
+        )
+    events_path = item_events_path(slot_key, item.item_id)
+    log_before = _read_text_or_none(events_path)
+    event = _append_event_locked(slot_key, item.item_id, kind, text, status=status)
+    try:
+        _write_record(item_path(slot_key, item.item_id), payload)
+    except BaseException:
+        _restore_text(events_path, log_before)
+        raise
+    return event
+
+
+# --------------------------------------------------------------------------- #
+# Validation. Every bound is checked BEFORE the first write, so a refusal leaves
+# every file byte-identical.
+# --------------------------------------------------------------------------- #
+
+
+def _require_text(value: Any, cap: int, name: str, *, required: bool = True) -> str:
+    if value is None:
+        if required:
+            raise WorkLedgerError(f"{name} is required", code=CODE_INVALID_VALUE, field=name)
+        return ""
+    if not isinstance(value, str):
+        raise WorkLedgerError(f"{name} must be a string", code=CODE_INVALID_VALUE, field=name)
+    if len(value) > cap:
+        raise WorkLedgerError(
+            f"{name} is {len(value)} chars; the cap is {cap}",
+            code=CODE_FIELD_TOO_LONG,
+            field=name,
+        )
+    return value
+
+
+def _require_choice(value: Any, allowed: frozenset[str], name: str, code: str) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        raise WorkLedgerError(
+            f"{name} must be one of {sorted(allowed)}; got {value!r}",
+            code=code,
+            field=name,
+        )
+    return value
+
+
+def _require_acceptance(value: Any) -> dict[str, Any]:
+    """``acceptance`` is stored VERBATIM and never interpreted here.
+
+    ``accept_eval.py`` is the only thing that decides whether an item passed, so
+    this store validates the container and not the contents — a shape check here
+    would be a second, drifting copy of that script's contract.
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise WorkLedgerError(
+            "acceptance must be an object", code=CODE_INVALID_VALUE, field="acceptance"
+        )
+    try:
+        serialized = json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError) as exc:
+        raise WorkLedgerError(
+            f"acceptance must be JSON-serialisable: {exc}",
+            code=CODE_INVALID_VALUE,
+            field="acceptance",
+        ) from exc
+    if len(serialized.encode("utf-8")) > MAX_RECORD_BYTES // 2:
+        raise WorkLedgerError(
+            "acceptance is too large to store",
+            code=CODE_FIELD_TOO_LONG,
+            field="acceptance",
+        )
+    return value
+
+
+def _require_artifacts(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise WorkLedgerError(
+            "artifacts must be an object", code=CODE_INVALID_VALUE, field="artifacts"
+        )
+    if len(value) > MAX_ARTIFACT_KEYS:
+        raise WorkLedgerError(
+            f"artifacts has {len(value)} keys; the cap is {MAX_ARTIFACT_KEYS}",
+            code=CODE_FIELD_TOO_LONG,
+            field="artifacts",
+        )
+    out: dict[str, str] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise WorkLedgerError(
+                "artifacts must map strings to strings",
+                code=CODE_INVALID_VALUE,
+                field="artifacts",
+            )
+        if len(key) > MAX_ARTIFACT_KEY_CHARS:
+            raise WorkLedgerError(
+                f"artifacts key is {len(key)} chars; the cap is " f"{MAX_ARTIFACT_KEY_CHARS}",
+                code=CODE_FIELD_TOO_LONG,
+                field="artifacts",
+            )
+        if len(item) > MAX_ARTIFACT_VALUE_CHARS:
+            raise WorkLedgerError(
+                f"artifacts value is {len(item)} chars; the cap is " f"{MAX_ARTIFACT_VALUE_CHARS}",
+                code=CODE_FIELD_TOO_LONG,
+                field="artifacts",
+            )
+        out[key] = item
+    return out
+
+
+def _require_pr(value: Any) -> int | None:
+    """A worker's CLAIMED pull-request number.
+
+    A claim only, and the docstring says so because the shape nearly leaked here:
+    ``accept_eval.py`` needs an integer ``pr``, the worker is what learns the
+    number, and filling ``acceptance.pr`` from this field would let a worker name
+    any already-green pull request and pass. Promoting a claim into ``acceptance``
+    is a conductor action.
+    """
+    if value is None:
+        return None
+    number = _finite_int(value)
+    if number is None or not (MIN_PR <= number <= MAX_PR):
+        raise WorkLedgerError(
+            f"pr must be an integer in {MIN_PR}..{MAX_PR}; got {value!r}",
+            code=CODE_INVALID_VALUE,
+            field="pr",
+        )
+    return number
+
+
+def _require_count(value: Any, name: str) -> int:
+    number = _finite_int(value)
+    if number is None or number < 0:
+        raise WorkLedgerError(
+            f"{name} must be a non-negative integer; got {value!r}",
+            code=CODE_INVALID_VALUE,
+            field=name,
+        )
+    return number
+
+
+# --------------------------------------------------------------------------- #
+# Depth
+# --------------------------------------------------------------------------- #
+
+
+def child_depth(parent_depth: int) -> int:
+    """The depth a conductor dispatched BY one at *parent_depth* would have.
+
+    Refuses past the cap rather than clamping: a clamped depth would let level three
+    exist while reporting as level two, which is the failure the cap exists to stop.
+    Two levels rather than three because each level multiplies sessions — three
+    levels of three items is twenty-seven — and because a summary of summaries of
+    summaries is not evidence any more. That number is a guess informed by session
+    multiplication, not a measurement (RFC Q5).
+    """
+    depth = _require_count(parent_depth, "depth")
+    if depth + 1 > MAX_DEPTH:
+        raise WorkLedgerError(
+            f"depth {depth} is at the cap of {MAX_DEPTH}; this session may not "
+            "dispatch a conductor",
+            code=CODE_DEPTH_EXCEEDED,
+            field="depth",
+        )
+    return depth + 1
+
+
+# --------------------------------------------------------------------------- #
+# Derived flags. Pure functions — Phase 1 wires no dashboard state.
+# --------------------------------------------------------------------------- #
+
+
+def is_orphaned(item: WorkItem, *, conductor_slot_exists: bool) -> bool:
+    """Whether nothing is left to read *item*'s reports.
+
+    Derived, never stored: nothing is running at session-close time to stamp a flag,
+    a missed stamp would stay wrong forever, and a derived flag self-heals when the
+    session is reopened. The worker keeps writing — its binding is still valid — and
+    the writes simply accumulate unread.
+    """
+    return not conductor_slot_exists and not item.is_terminal
+
+
+def is_stale(
+    item: WorkItem,
+    *,
+    worker_running: bool,
+    now: datetime | None = None,
+    window_secs: float = DEFAULT_STALE_WINDOW_SECS,
+) -> bool:
+    """Whether *item* has gone quiet in a way that is worth waking someone for.
+
+    A CONJUNCTION, and the conjunction is the point: quiet plus not running. A worker
+    in a thirty-minute build is running, so it is never flagged however long it stays
+    silent. The window exists only to cover the gap between binding and the first
+    report, and to catch a session that ended without reporting.
+
+    A terminal item is never stale — there is nothing left to report. An item with no
+    report yet is measured from ``created_at``, which is what makes the bind-to-first-
+    report gap visible. An unparseable timestamp reads as stale, because the
+    alternative is an item that can never be flagged.
+    """
+    if item.is_terminal or worker_running:
+        return False
+    reference = item.last_report_at or item.created_at
+    if not reference:
+        return True
+    stamped = _parse_iso(reference)
+    if stamped is None:
+        return True
+    moment = now or datetime.now().astimezone()
+    if stamped.tzinfo is None:
+        stamped = stamped.astimezone()
+    if moment.tzinfo is None:
+        moment = moment.astimezone()
+    return moment - stamped > timedelta(seconds=max(window_secs, 0.0))
+
+
+def _parse_iso(value: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# Bindings. One file per worker, written only by a conductor's ``bind`` action, and
+# only as a whole-file replacement under that worker's binding lock -- so a
+# worker's binding moves to a new item exactly when its prior item is terminal,
+# and two conductors cannot both believe they bound it.
+# --------------------------------------------------------------------------- #
+
+
+def read_binding(worker_slot_key: str, *, strict: bool = False) -> tuple[str, str] | None:
+    """The ``(conductor_slot_key, item_id)`` *worker_slot_key* is bound to.
+
+    ``None`` when unbound, which is the state Phase 2 answers as ``not_bound``. A
+    binding naming a malformed item id also reads as unbound rather than raising:
+    a worker cannot repair its own binding, so a clean refusal is the only useful
+    answer. ``strict`` has :func:`_read_json_record`'s meaning -- a present but
+    momentarily unreadable file raises instead of reading as unbound -- and is
+    what the bind guard uses so it fails closed.
+    """
+    raw = _read_json_record(binding_path(worker_slot_key), strict=strict)
+    if not isinstance(raw, dict):
+        return None
+    conductor = _as_str(raw.get("conductor_slot_key"))
+    item_id = _as_str(raw.get("item_id"))
+    if not conductor or not _ITEM_ID_RE.match(item_id):
+        return None
+    return conductor, item_id
+
+
+def _refuse_if_worker_holds_open_item(worker_slot_key: str) -> None:
+    """Refuse a bind that would overwrite a binding whose item is still open.
+
+    A worker has exactly ONE binding file, so a second bind silently repoints its
+    only report channel: the first item keeps naming the worker while every report
+    lands on the second, and with no unbind path that is permanent. A binding whose
+    item is terminal, or whose item FILE IS GONE, is stale and may be replaced --
+    that is how a worker session is reused for a new item once its last one closed.
+
+    A binding whose item does NOT name this worker back is stale too. ``bind``
+    writes the binding first and the item second, so a process killed between the
+    two leaves exactly that half-state; the writer never produces it any other way.
+    Treating it as live would make the retry of that very bind refuse forever.
+
+    FAILS CLOSED on a transient read error. The prior item's file is not under this
+    lock -- its own conductor may be mid-rename on it -- so a momentary ``OSError``
+    is propagated rather than read as "absent": the bind refuses and the caller
+    retries, instead of stranding an item that was open all along.
+
+    CALL UNDER THE WORKER'S BINDING LOCK, so the check and the write it guards are
+    one critical section.
+    """
+    existing = read_binding(worker_slot_key, strict=True)
+    if existing is None:
+        return
+    prior_conductor, prior_item_id = existing
+    try:
+        prior = read_work_item(prior_conductor, prior_item_id, strict=True)
+    except WorkLedgerError:
+        return
+    if prior is None or prior.is_terminal:
+        return
+    if prior.worker_session_key != worker_slot_key:
+        logger.warning(
+            "work ledger: binding for a worker names item %s, which does not name the "
+            "worker back; treating the binding as an interrupted bind and replacing it",
+            prior_item_id,
+        )
+        return
+    raise WorkLedgerError(
+        f"worker is already bound to open item {prior_item_id!r}; close that item "
+        "before binding the worker again",
+        code=CODE_ALREADY_BOUND,
+        field="worker_session_key",
+    )
+
+
+def _read_binding_text(worker_slot_key: str) -> str | None:
+    """The binding file's bytes-as-text, or ``None`` if absent. For rollback: text
+    rather than a parsed record, so what is restored is what was there."""
+    try:
+        return _read_text_or_none(binding_path(worker_slot_key))
+    except OSError:
+        return None
+
+
+def _restore_binding_text(worker_slot_key: str, snapshot: str | None) -> None:
+    """Put the binding back as *snapshot* found it. ``None`` means delete. Never
+    raises: the caller already holds the error it must surface."""
+    _restore_text(binding_path(worker_slot_key), snapshot)
+
+
+def _write_binding(worker_slot_key: str, conductor_slot_key: str, item_id: str) -> None:
+    _write_record(
+        binding_path(worker_slot_key),
+        {
+            "schema": SCHEMA_VERSION,
+            "conductor_slot_key": conductor_slot_key,
+            "item_id": item_id,
+            "worker_slot_key": worker_slot_key,
+            "created_at": _now_iso(),
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Conductor writes
+# --------------------------------------------------------------------------- #
+
+
+def ensure_conductor(
+    slot_key: str,
+    *,
+    goal: str = "",
+    depth: int = 0,
+    parent_item: str | None = None,
+) -> ConductorRecord:
+    """Create *slot_key*'s ledger if absent, and return the record either way.
+
+    Idempotent, and it does NOT overwrite an existing goal, round or depth — a
+    conductor that re-enters its own ledger on a later round must not reset it.
+    Use ``apply_conductor_action(slot_key, "goal", ...)`` to change the goal.
+
+    *depth* and *parent_item* are SERVER-owned in Phase 2: the value passed here
+    comes from the creating session's own record via :func:`child_depth`, never from
+    a model. Refuses a depth past the cap so a ledger cannot exist at a level that
+    is not allowed to conduct.
+    """
+    checked_goal = _require_text(goal, MAX_GOAL_CHARS, "goal", required=False)
+    checked_depth = _require_count(depth, "depth")
+    if checked_depth > MAX_DEPTH:
+        raise WorkLedgerError(
+            f"depth {checked_depth} is past the cap of {MAX_DEPTH}",
+            code=CODE_DEPTH_EXCEEDED,
+            field="depth",
+        )
+    if parent_item is not None:
+        _require_item_id(parent_item)
+    directory = conductor_dir(slot_key)
+    with conductor_lock(slot_key):
+        existing = read_conductor(slot_key, strict=True)
+        if existing is not None:
+            return existing
+        record = ConductorRecord(
+            slot_key=slot_key,
+            goal=checked_goal,
+            round=0,
+            depth=checked_depth,
+            parent_item=parent_item,
+            created_at=_now_iso(),
+        )
+        _write_record(directory / _CONDUCTOR_FILE, record.to_dict())
+        try:
+            atomic_write(directory / _KEY_FILE, slot_key + "\n", mode=0o600)
+        except OSError:
+            logger.debug("work ledger: slot_key breadcrumb write failed", exc_info=True)
+        return record
+
+
+def apply_conductor_action(
+    slot_key: str,
+    action: str,
+    *,
+    item_id: str | None = None,
+    title: Any = None,
+    acceptance: Any = None,
+    worker_session_key: Any = None,
+    decision: Any = None,
+    verdict: Any = None,
+    state: Any = None,
+    goal: Any = None,
+    round_number: Any = None,
+    fails: Any = None,
+) -> dict[str, Any]:
+    """Write the fields the CONDUCTOR owns, and append the one event that explains it.
+
+    Never writes ``status``, ``summary``, ``artifacts``, ``pr`` or ``last_report_at``
+    — those are the worker's, and :func:`apply_worker_report` is the only path to
+    them. Phase 2 mounts this behind the conductor's tool and that one behind the
+    worker's, so ownership is enforced by which function a caller can reach rather
+    than by filtering inside a shared one.
+
+    Actions and their fields:
+
+    ``create``  ``title``, ``acceptance``, optional ``round_number`` — mints an id.
+    ``bind``    ``item_id``, ``worker_session_key`` — writes the binding file.
+    ``decide``  ``item_id``, ``decision``, optional ``round_number``.
+    ``verdict`` ``item_id``, ``verdict``, optional ``fails``.
+    ``close``   ``item_id``, ``state``, optional ``decision`` — stamps ``closed_at``.
+    ``goal``    ``goal``, optional ``round_number`` — the conductor record only.
+
+    Returns ``{"conductor", "item", "event"}``; ``item`` and ``event`` are ``None``
+    for ``goal``. Raises :class:`WorkLedgerError` with a ``code`` from the ``CODE_*``
+    constants. Every bound is checked before the first write, so a refused call
+    leaves every file byte-identical.
+    """
+    if action not in CONDUCTOR_ACTIONS:
+        raise WorkLedgerError(
+            f"unknown action {action!r}; expected one of {sorted(CONDUCTOR_ACTIONS)}",
+            code=CODE_INVALID_ACTION,
+            field="action",
+        )
+    record = read_conductor(slot_key)
+    if record is None:
+        raise WorkLedgerError(f"no work ledger for {slot_key!r}", code=CODE_NO_LEDGER)
+
+    if action == "goal":
+        return {
+            "conductor": _write_goal(slot_key, record, goal, round_number),
+            "item": None,
+            "event": None,
+        }
+    if action == "create":
+        return _create_item(slot_key, record, title, acceptance, round_number)
+    return _write_item_action(
+        slot_key,
+        record,
+        action,
+        item_id,
+        worker_session_key=worker_session_key,
+        decision=decision,
+        verdict=verdict,
+        state=state,
+        round_number=round_number,
+        fails=fails,
+    )
+
+
+def _write_goal(
+    slot_key: str, record: ConductorRecord, goal: Any, round_number: Any
+) -> ConductorRecord:
+    """Partial update of the conductor header, merged UNDER the lock.
+
+    Bounds are checked before the lock; the fields a caller omitted are filled from
+    the record re-read inside it, never from the pre-lock snapshot. Otherwise a
+    goal-only call and a round-only call racing each other would each restore the
+    other's field to the stale value it read before waiting.
+    """
+    checked_goal = None if goal is None else _require_text(goal, MAX_GOAL_CHARS, "goal")
+    checked_round = None if round_number is None else _require_count(round_number, "round")
+    with conductor_lock(slot_key):
+        current = read_conductor(slot_key, strict=True) or record
+        if checked_goal is not None:
+            current.goal = checked_goal
+        if checked_round is not None:
+            current.round = checked_round
+        _write_record(conductor_dir(slot_key) / _CONDUCTOR_FILE, current.to_dict())
+        return current
+
+
+def _create_item(
+    slot_key: str,
+    record: ConductorRecord,
+    title: Any,
+    acceptance: Any,
+    round_number: Any,
+) -> dict[str, Any]:
+    """Mint one item under the conductor lock.
+
+    The lock is the conductor's, not the item's, because the cap it enforces is a
+    property of the SET: counting the items and adding one must not interleave with
+    another call doing the same, or two calls each see thirty-one and both write.
+    The new item's own lock is taken from inside that hold, in the documented order.
+
+    Refuses when the conductor is at the depth cap, because an item is a dispatch and
+    a session at the cap may not dispatch.
+    """
+    checked_title = _require_text(title, MAX_TITLE_CHARS, "title")
+    checked_acceptance = _require_acceptance(acceptance)
+    checked_round = None if round_number is None else _require_count(round_number, "round")
+    if record.depth >= MAX_DEPTH:
+        raise WorkLedgerError(
+            f"conductor is at depth {record.depth} and the cap is {MAX_DEPTH}; it may "
+            "not dispatch further work",
+            code=CODE_DEPTH_EXCEEDED,
+            field="depth",
+        )
+    with conductor_lock(slot_key):
+        # The default round comes from the header re-read INSIDE the lock, not
+        # from the pre-lock snapshot, so a concurrent ``goal`` round bump is seen.
+        if checked_round is None:
+            live = read_conductor(slot_key)
+            checked_round = live.round if live is not None else record.round
+        existing = list_work_items(slot_key)
+        if len(existing) >= MAX_ITEMS_PER_CONDUCTOR:
+            raise WorkLedgerError(
+                f"conductor holds {len(existing)} items; the cap is " f"{MAX_ITEMS_PER_CONDUCTOR}",
+                code=CODE_ITEM_CAP_EXCEEDED,
+                field="items",
+            )
+        item_id = mint_item_id()
+        while (items_dir(slot_key) / f"{item_id}.json").exists():
+            item_id = mint_item_id()
+        item = WorkItem(
+            item_id=item_id,
+            title=checked_title,
+            acceptance=checked_acceptance,
+            state="open",
+            round=checked_round,
+            created_at=_now_iso(),
+        )
+        with item_lock(slot_key, item_id):
+            event = _commit_item_locked(slot_key, item, "create", checked_title)
+        return {"conductor": read_conductor(slot_key), "item": item, "event": event}
+
+
+def _write_item_action(
+    slot_key: str,
+    record: ConductorRecord,
+    action: str,
+    item_id: str | None,
+    *,
+    worker_session_key: Any,
+    decision: Any,
+    verdict: Any,
+    state: Any,
+    round_number: Any,
+    fails: Any,
+) -> dict[str, Any]:
+    """``bind``, ``decide``, ``verdict`` and ``close``, each one item lock deep.
+
+    Field validation is complete before the lock is taken, so a cap or shape refusal
+    never creates a lock file for an item it declined to touch. Refusals that need
+    the stored record — unknown item, closed item, already bound — happen under the
+    lock, after that file exists.
+    """
+    checked_id = _require_item_id(item_id or "")
+    checked_worker: str | None = None
+    checked_decision: str | None = None
+    checked_verdict: str | None = None
+    checked_state: str | None = None
+    checked_fails: int | None = None
+    checked_round: int | None = None
+
+    if action == "bind":
+        checked_worker = _require_text(worker_session_key, 512, "worker_session_key")
+        if "\0" in checked_worker:
+            raise WorkLedgerError(
+                "worker_session_key must not contain a null byte",
+                code=CODE_INVALID_VALUE,
+                field="worker_session_key",
+            )
+    elif action == "decide":
+        checked_decision = _require_text(decision, MAX_DECISION_CHARS, "decision")
+    elif action == "verdict":
+        checked_verdict = _require_choice(verdict, VERDICTS, "verdict", CODE_INVALID_VALUE)
+        if fails is not None:
+            checked_fails = _require_count(fails, "fails")
+    else:  # close
+        checked_state = _require_choice(state, ITEM_STATES, "state", CODE_INVALID_VALUE)
+        if checked_state == "open":
+            raise WorkLedgerError(
+                "close needs a terminal state, not 'open'",
+                code=CODE_INVALID_VALUE,
+                field="state",
+            )
+        if decision is not None:
+            checked_decision = _require_text(decision, MAX_DECISION_CHARS, "decision")
+    if round_number is not None:
+        if action != "decide":
+            raise WorkLedgerError(
+                f"round_number is not a field of {action!r}; only decide (and create) " "take it",
+                code=CODE_INVALID_VALUE,
+                field="round_number",
+            )
+        checked_round = _require_count(round_number, "round")
+
+    with item_lock(slot_key, checked_id):
+        item = read_work_item(slot_key, checked_id)
+        if item is None:
+            raise WorkLedgerError(
+                f"unknown item {checked_id!r}", code=CODE_UNKNOWN_ITEM, field="item_id"
+            )
+        if item.is_terminal:
+            raise WorkLedgerError(f"item {checked_id!r} is {item.state}", code=CODE_ITEM_CLOSED)
+        if checked_round is not None:
+            item.round = checked_round
+
+        if action == "bind":
+            if item.worker_session_key:
+                raise WorkLedgerError(
+                    f"item {checked_id!r} is already bound",
+                    code=CODE_ALREADY_BOUND,
+                    field="worker_session_key",
+                )
+            assert checked_worker is not None
+            with binding_lock(checked_worker):
+                prior_binding = _read_binding_text(checked_worker)
+                _refuse_if_worker_holds_open_item(checked_worker)
+                # Binding FIRST, item SECOND, so a failure between the two never
+                # leaves an item that names a worker with no binding behind it --
+                # that item would refuse every retry with ``already_bound`` and the
+                # worker could never report. The other half-state is harmless: a
+                # binding naming an item that does not name the worker is simply
+                # stale and the next bind replaces it. Should the item write fail
+                # anyway, the binding file is put back exactly as it was found.
+                _write_binding(checked_worker, slot_key, checked_id)
+                try:
+                    item.worker_session_key = checked_worker
+                    event = _commit_item_locked(slot_key, item, "bind", _store_name(checked_worker))
+                except BaseException:
+                    _restore_binding_text(checked_worker, prior_binding)
+                    raise
+        elif action == "decide":
+            assert checked_decision is not None
+            item.decision = checked_decision
+            event = _commit_item_locked(slot_key, item, "decision", checked_decision)
+        elif action == "verdict":
+            assert checked_verdict is not None
+            item.verdict = checked_verdict
+            if checked_fails is not None:
+                item.fails = checked_fails
+            event = _commit_item_locked(slot_key, item, "verdict", checked_verdict)
+        else:
+            assert checked_state is not None
+            item.state = checked_state
+            if checked_decision is not None:
+                item.decision = checked_decision
+            item.closed_at = _now_iso()
+            event = _commit_item_locked(slot_key, item, "close", checked_decision or checked_state)
+        return {"conductor": record, "item": item, "event": event}
+
+
+# --------------------------------------------------------------------------- #
+# Worker writes
+# --------------------------------------------------------------------------- #
+
+
+def apply_worker_report(
+    slot_key: str,
+    item_id: str,
+    *,
+    status: Any,
+    summary: Any,
+    artifacts: Any = None,
+    pr: Any = None,
+) -> dict[str, Any]:
+    """Write the fields the WORKER owns: ``status``, ``summary``, ``artifacts``,
+    ``pr`` and ``last_report_at``. Nothing else is reachable from here.
+
+    There is no ``verdict``, ``state``, ``acceptance``, ``decision`` or ``round``
+    parameter, so a worker cannot mark itself accepted or widen its own bar — the
+    strongest thing it can say is ``status: done``, which is the TRIGGER for the
+    conductor to run ``accept_eval.py``, not a substitute for it.
+
+    *slot_key* and *item_id* are the CONDUCTOR's key and the bound item, which
+    Phase 2 resolves from the caller's own binding via :func:`read_binding` rather
+    than accepting either from the worker. Phase 1 takes them as arguments because
+    there is no identity layer yet; that is the whole reason nothing imports this
+    module until Phase 2 puts the resolver in front of it.
+
+    ``status: progress`` twice in a row collapses in the event log — see
+    :func:`_coalesce_progress` — but the item's own fields always hold the newest
+    report.
+    """
+    checked_status = _require_choice(status, WORKER_STATUSES, "status", CODE_INVALID_STATUS)
+    checked_summary = _require_text(summary, MAX_SUMMARY_CHARS, "summary")
+    checked_artifacts = _require_artifacts(artifacts)
+    checked_pr = _require_pr(pr)
+    checked_id = _require_item_id(item_id)
+
+    with item_lock(slot_key, checked_id):
+        item = read_work_item(slot_key, checked_id)
+        if item is None:
+            raise WorkLedgerError(
+                f"unknown item {checked_id!r}", code=CODE_UNKNOWN_ITEM, field="item_id"
+            )
+        if item.is_terminal:
+            raise WorkLedgerError(f"item {checked_id!r} is {item.state}", code=CODE_ITEM_CLOSED)
+        item.status = checked_status
+        item.summary = checked_summary
+        item.artifacts = checked_artifacts
+        if checked_pr is not None:
+            item.pr = checked_pr
+        item.last_report_at = _now_iso()
+        event = _commit_item_locked(
+            slot_key, item, "report", checked_summary, status=checked_status
+        )
+        return {"item": item, "event": event}
+
+
+def read_work_brief(slot_key: str, item_id: str) -> dict[str, Any] | None:
+    """What ONE worker may see about its own item, and nothing more.
+
+    Not the conductor's goal, not its other items, not a sibling's state: a worker
+    has no reason to see its peers and every reason not to be able to. Phase 2's
+    ``work_brief`` tool is this function behind the binding resolver.
+    """
+    item = read_work_item(slot_key, item_id)
+    if item is None:
+        return None
+    return {
+        "item_id": item.item_id,
+        "title": item.title,
+        "acceptance": item.acceptance,
+        "round": item.round,
+        "decision": item.decision,
+        "status": item.status,
+        "summary": item.summary,
+    }
+
+
+def accept_batch(items: list[WorkItem]) -> dict[str, Any]:
+    """The ``{"items": [...]}`` document ``accept_eval.py`` reads on stdin.
+
+    Composed from ``acceptance`` ALONE. The worker's claimed ``pr`` is deliberately
+    absent: filling ``acceptance.pr`` from a worker's report would let a worker name
+    any already-green pull request and pass. The claim is surfaced beside the item
+    for a conductor to promote explicitly, which turns the two-phase acceptance the
+    skill performs by hand into a visible field without moving control of the bar.
+    """
+    return {
+        "items": [
+            # ``id`` / ``accept`` are the keys accept_eval.py reads; ``item_id`` /
+            # ``acceptance`` are this store's field names. The rename happens here,
+            # at the one seam between the two, so neither side learns the other's
+            # vocabulary.
+            {"id": item.item_id, "accept": item.acceptance}
+            for item in items
+            if not item.is_terminal and item.acceptance
+        ]
+    }

--- a/test/test_work_ledger.py
+++ b/test/test_work_ledger.py
@@ -1,0 +1,1394 @@
+"""Conductor work ledger store — Phase 1 exit criteria, one test per criterion.
+
+Pins what the conductor-work-ledger RFC (pull request #8842) §Migration plan
+Phase 1 lists: every enum and cap fails a test if its value changes; two concurrent
+writers against one item leave a parseable record and an uninterleaved event log; a
+torn, truncated or oversized file reads as absent; a refused cap leaves the prior
+bytes untouched; ``depth`` at the cap refuses ``create``; consecutive ``progress``
+reports coalesce; a duplicated event line collapses on read; and nothing in
+``src/kiro_crew`` imports the module, so the phase reverts by deleting two files.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import work_ledger as wl
+
+CONDUCTOR = "chat-1-conductor"
+WORKER = "chat-2-worker"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Every test writes into its own data home, never the live one."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / "home"))
+    yield
+
+
+def _new_item(*, title: str = "port the gate", acceptance: dict | None = None) -> str:
+    wl.ensure_conductor(CONDUCTOR, goal="drive the fleet")
+    result = wl.apply_conductor_action(
+        CONDUCTOR,
+        "create",
+        title=title,
+        acceptance=acceptance if acceptance is not None else {"kind": "human_approval"},
+    )
+    return result["item"].item_id
+
+
+def _bytes_on_disk(item_id: str) -> tuple[bytes, bytes]:
+    item = wl.item_path(CONDUCTOR, item_id).read_bytes()
+    events = wl.item_events_path(CONDUCTOR, item_id).read_bytes()
+    return item, events
+
+
+# ── vocabularies and caps, pinned ─────────────────────────────────────────
+
+
+def test_item_states_are_exactly_the_four_dispositions():
+    assert wl.ITEM_STATES == {"open", "accepted", "rejected", "abandoned"}
+    assert wl.TERMINAL_ITEM_STATES == {"accepted", "rejected", "abandoned"}
+    assert "open" not in wl.TERMINAL_ITEM_STATES
+
+
+def test_verdicts_are_accept_evals_five_values():
+    assert wl.VERDICTS == {"pass", "fail", "pending", "refused", "error"}
+
+
+def test_worker_statuses_are_exactly_four_and_separate_blocked_from_question():
+    assert wl.WORKER_STATUSES == {"progress", "done", "blocked", "question"}
+
+
+def test_event_kinds_are_exactly_six():
+    assert wl.EVENT_KINDS == {
+        "create",
+        "bind",
+        "report",
+        "decision",
+        "verdict",
+        "close",
+    }
+
+
+def test_conductor_actions_are_exactly_six():
+    assert wl.CONDUCTOR_ACTIONS == {
+        "create",
+        "bind",
+        "decide",
+        "verdict",
+        "close",
+        "goal",
+    }
+
+
+def test_caps_hold_their_rfc_values():
+    assert wl.MAX_ITEMS_PER_CONDUCTOR == 32
+    assert wl.MAX_EVENTS_PER_ITEM == 200
+    assert wl.MAX_DEPTH == 2
+    assert wl.MAX_GOAL_CHARS == 2000
+    assert wl.MAX_TITLE_CHARS == 200
+    assert wl.MAX_DECISION_CHARS == 2000
+    assert wl.MAX_SUMMARY_CHARS == 500
+    assert wl.MAX_EVENT_TEXT_CHARS == 500
+    assert wl.MAX_ARTIFACT_KEYS == 16
+    assert wl.MAX_ARTIFACT_KEY_CHARS == 64
+    assert wl.MAX_ARTIFACT_VALUE_CHARS == 512
+    assert (wl.MIN_PR, wl.MAX_PR) == (1, 1_000_000_000)
+    assert wl.SCHEMA_VERSION == 1
+
+
+# ── paths and ids ─────────────────────────────────────────────────────────
+
+
+def test_item_id_is_server_minted_and_shape_checked():
+    minted = wl.mint_item_id()
+    assert wl._ITEM_ID_RE.match(minted)
+    assert wl.mint_item_id() != minted
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["", "it_", "it_XYZ", "it_1a2b3c4", "../etc/passwd", "/abs/it_1a2b3c4d", "it_1a2b3c4d.json"],
+)
+def test_a_model_supplied_string_cannot_reach_a_path_component(bad):
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.item_path(CONDUCTOR, bad)
+    assert caught.value.code == wl.CODE_INVALID_VALUE
+
+
+def test_directory_name_is_session_ledgers_fold_not_a_copy():
+    from kiro_crew import session_ledger
+
+    assert wl._store_name is session_ledger._store_name
+    assert not hasattr(wl, "_STORE_NAME_UNSAFE")
+
+
+def test_directory_name_is_readable_plus_digest_and_distinguishes_case():
+    name = wl._store_name("chat-1-abc")
+    assert name.startswith("chat-1-abc-")
+    assert len(name.rsplit("-", 1)[1]) == 8
+    assert wl._store_name("Chat") != wl._store_name("chat")
+    assert "/" not in wl._store_name("slack:C1/x")
+
+
+@pytest.mark.parametrize("bad", ["", "a/b", "a\\b", "a\0b"])
+def test_conductor_dir_refuses_a_key_that_could_escape_the_root(bad):
+    with pytest.raises(wl.WorkLedgerError):
+        wl.conductor_dir(bad)
+
+
+def test_binding_path_shares_the_conductor_naming_scheme():
+    assert wl.binding_path(WORKER).name == f"{wl._store_name(WORKER)}.json"
+    assert wl.binding_path(WORKER).parent == wl.bindings_dir()
+    with pytest.raises(wl.WorkLedgerError):
+        wl.binding_path("has\0null")
+
+
+# ── conductor record ──────────────────────────────────────────────────────
+
+
+def test_ensure_conductor_is_idempotent_and_never_resets_progress():
+    first = wl.ensure_conductor(CONDUCTOR, goal="ship it")
+    wl.apply_conductor_action(CONDUCTOR, "goal", goal="ship it", round_number=4)
+    again = wl.ensure_conductor(CONDUCTOR, goal="something else")
+    assert again.round == 4
+    assert again.goal == "ship it"
+    assert again.created_at == first.created_at
+    assert (wl.conductor_dir(CONDUCTOR) / "slot_key").read_text().strip() == CONDUCTOR
+
+
+def test_read_conductor_is_none_before_anything_is_written():
+    assert wl.read_conductor(CONDUCTOR) is None
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "create", title="x", acceptance={})
+    assert caught.value.code == wl.CODE_NO_LEDGER
+
+
+def test_conductor_record_has_no_item_roster_field():
+    wl.ensure_conductor(CONDUCTOR)
+    stored = json.loads((wl.conductor_dir(CONDUCTOR) / "conductor.json").read_text())
+    assert "items" not in stored
+    assert "item_roster" not in stored
+
+
+def test_goal_action_leaves_the_goal_alone_when_only_the_round_moves():
+    wl.ensure_conductor(CONDUCTOR, goal="keep me")
+    record = wl.apply_conductor_action(CONDUCTOR, "goal", round_number=2)["conductor"]
+    assert (record.goal, record.round) == ("keep me", 2)
+
+
+def test_goal_and_round_partial_updates_merge_under_the_lock(monkeypatch):
+    """A goal-only write racing a round-only write must not restore the other's
+    stale value: omitted fields come from the record read inside the lock."""
+    wl.ensure_conductor(CONDUCTOR, goal="old")
+    real_lock = wl.conductor_lock
+    interleaved: list[str] = []
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def racing_lock(slot_key):
+        # First entrant: while it waits, another writer moves the round to 9.
+        if not interleaved:
+            interleaved.append("x")
+            monkeypatch.setattr(wl, "conductor_lock", real_lock)
+            wl.apply_conductor_action(CONDUCTOR, "goal", round_number=9)
+        with real_lock(slot_key):
+            yield
+
+    monkeypatch.setattr(wl, "conductor_lock", racing_lock)
+    record = wl.apply_conductor_action(CONDUCTOR, "goal", goal="new")["conductor"]
+    assert (record.goal, record.round) == ("new", 9)
+
+
+def test_ensure_conductor_refuses_a_depth_past_the_cap():
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.ensure_conductor("deep", depth=3)
+    assert caught.value.code == wl.CODE_DEPTH_EXCEEDED
+
+
+def test_ensure_conductor_records_a_parent_item_and_checks_its_shape():
+    parent = wl.mint_item_id()
+    record = wl.ensure_conductor("child", depth=1, parent_item=parent)
+    assert (record.depth, record.parent_item) == (1, parent)
+    with pytest.raises(wl.WorkLedgerError):
+        wl.ensure_conductor("child2", depth=1, parent_item="not-an-id")
+
+
+# ── depth ─────────────────────────────────────────────────────────────────
+
+
+def test_child_depth_advances_one_level_and_refuses_at_the_cap():
+    assert wl.child_depth(0) == 1
+    assert wl.child_depth(1) == 2
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.child_depth(2)
+    assert caught.value.code == wl.CODE_DEPTH_EXCEEDED
+
+
+def test_create_is_refused_when_the_conductor_is_at_the_depth_cap():
+    wl.ensure_conductor("capped", goal="g", depth=wl.MAX_DEPTH)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action("capped", "create", title="t", acceptance={})
+    assert caught.value.code == wl.CODE_DEPTH_EXCEEDED
+    assert wl.list_work_items("capped") == []
+
+
+def test_a_conductor_one_below_the_cap_may_still_dispatch():
+    wl.ensure_conductor("mid", goal="g", depth=1)
+    result = wl.apply_conductor_action("mid", "create", title="t", acceptance={})
+    assert result["item"].item_id.startswith("it_")
+
+
+# ── item lifecycle ────────────────────────────────────────────────────────
+
+
+def test_create_mints_an_item_and_appends_exactly_one_create_event():
+    item_id = _new_item()
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None
+    assert (item.state, item.status, item.verdict) == ("open", None, None)
+    events = wl.read_events(CONDUCTOR, item_id)
+    assert [e.kind for e in events] == ["create"]
+
+
+def test_items_are_derived_from_the_directory_and_sorted_oldest_first():
+    first = _new_item(title="one")
+    second = _new_item(title="two")
+    listed = [item.item_id for item in wl.list_work_items(CONDUCTOR)]
+    assert set(listed) == {first, second}
+    assert wl.list_work_items("never-existed") == []
+
+
+def test_bind_writes_the_binding_and_refuses_a_second_one():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=item_id, worker_session_key=WORKER)
+    assert wl.read_binding(WORKER) == (CONDUCTOR, item_id)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=item_id, worker_session_key="chat-3")
+    assert caught.value.code == wl.CODE_ALREADY_BOUND
+
+
+def test_a_worker_with_an_open_item_cannot_be_bound_to_a_second_one():
+    """GPT F2: a worker holds ONE binding file, so a second bind would silently
+    repoint its only report channel and strand the first item forever."""
+    first = _new_item(title="first")
+    second = _new_item(title="second")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
+    before = (_bytes_on_disk(second), wl.binding_path(WORKER).read_bytes())
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    assert caught.value.code == wl.CODE_ALREADY_BOUND
+    assert first in str(caught.value)
+    # Nothing moved: the binding still names the first item, the second is unbound.
+    assert wl.read_binding(WORKER) == (CONDUCTOR, first)
+    assert (_bytes_on_disk(second), wl.binding_path(WORKER).read_bytes()) == before
+    second_item = wl.read_work_item(CONDUCTOR, second)
+    assert second_item is not None and second_item.worker_session_key is None
+
+
+def test_a_worker_may_be_rebound_once_its_prior_item_is_terminal():
+    first = _new_item(title="first")
+    second = _new_item(title="second")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
+    wl.apply_conductor_action(CONDUCTOR, "close", item_id=first, state="accepted")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    assert wl.read_binding(WORKER) == (CONDUCTOR, second)
+
+
+def test_a_worker_may_be_rebound_when_its_prior_binding_is_stale():
+    """A binding pointing at an item that no longer reads is stale, not open."""
+    first = _new_item(title="first")
+    second = _new_item(title="second")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
+    wl.item_path(CONDUCTOR, first).unlink()
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    assert wl.read_binding(WORKER) == (CONDUCTOR, second)
+
+
+def test_a_worker_bound_by_another_conductor_is_refused_too():
+    other = "chat-9-other-conductor"
+    mine = _new_item(title="mine")
+    wl.ensure_conductor(other, goal="g")
+    theirs = wl.apply_conductor_action(other, "create", title="theirs", acceptance={})[
+        "item"
+    ].item_id
+    wl.apply_conductor_action(other, "bind", item_id=theirs, worker_session_key=WORKER)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=mine, worker_session_key=WORKER)
+    assert caught.value.code == wl.CODE_ALREADY_BOUND
+    assert wl.read_binding(WORKER) == (other, theirs)
+
+
+def test_a_failed_item_write_during_bind_restores_the_prior_binding(monkeypatch):
+    """GPT round 3: a bind that fails between its two writes must leave neither a
+    half-bound item (which would refuse every retry) nor a dangling new binding."""
+    first = _new_item(title="first")
+    second = _new_item(title="second")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
+    wl.apply_conductor_action(CONDUCTOR, "close", item_id=first, state="accepted")
+    binding_before = wl.binding_path(WORKER).read_bytes()
+    item_before = wl.item_path(CONDUCTOR, second).read_bytes()
+    real_write = wl._write_record
+
+    def boom_on_item(path, payload):
+        if path.name == f"{second}.json":
+            raise OSError("disk full")
+        real_write(path, payload)
+
+    monkeypatch.setattr(wl, "_write_record", boom_on_item)
+    with pytest.raises(OSError):
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    monkeypatch.setattr(wl, "_write_record", real_write)
+    assert wl.binding_path(WORKER).read_bytes() == binding_before
+    assert wl.item_path(CONDUCTOR, second).read_bytes() == item_before
+    # And the retry succeeds -- the item was never half-bound.
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    assert wl.read_binding(WORKER) == (CONDUCTOR, second)
+
+
+def test_a_failed_first_bind_leaves_no_binding_file(monkeypatch):
+    item_id = _new_item()
+    real_write = wl._write_record
+
+    def boom_on_item(path, payload):
+        if path.name == f"{item_id}.json":
+            raise OSError("disk full")
+        real_write(path, payload)
+
+    monkeypatch.setattr(wl, "_write_record", boom_on_item)
+    with pytest.raises(OSError):
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=item_id, worker_session_key=WORKER)
+    assert not wl.binding_path(WORKER).exists()
+    assert wl.read_binding(WORKER) is None
+
+
+def test_read_binding_is_none_when_absent_or_malformed():
+    assert wl.read_binding(WORKER) is None
+    path = wl.binding_path(WORKER)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"conductor_slot_key": CONDUCTOR, "item_id": "../x"}))
+    assert wl.read_binding(WORKER) is None
+    path.write_text("not json")
+    assert wl.read_binding(WORKER) is None
+
+
+def test_decide_verdict_and_close_each_move_one_field_and_log_one_event():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="retry once")
+    wl.apply_conductor_action(CONDUCTOR, "verdict", item_id=item_id, verdict="fail", fails=1)
+    mid = wl.read_work_item(CONDUCTOR, item_id)
+    assert mid is not None
+    assert (mid.decision, mid.verdict, mid.fails, mid.state) == ("retry once", "fail", 1, "open")
+    wl.apply_conductor_action(
+        CONDUCTOR, "close", item_id=item_id, state="accepted", decision="landed"
+    )
+    closed = wl.read_work_item(CONDUCTOR, item_id)
+    assert closed is not None
+    assert (closed.state, closed.decision) == ("accepted", "landed")
+    assert closed.closed_at
+    assert [e.kind for e in wl.read_events(CONDUCTOR, item_id)] == [
+        "create",
+        "decision",
+        "verdict",
+        "close",
+    ]
+
+
+def test_a_terminal_item_refuses_every_further_write():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "close", item_id=item_id, state="abandoned")
+    for call in (
+        lambda: wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="again"),
+        lambda: wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="still here"),
+    ):
+        with pytest.raises(wl.WorkLedgerError) as caught:
+            call()
+        assert caught.value.code == wl.CODE_ITEM_CLOSED
+
+
+def test_close_refuses_open_as_a_terminal_state():
+    item_id = _new_item()
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "close", item_id=item_id, state="open")
+    assert caught.value.field == "state"
+
+
+def test_an_unknown_item_and_an_unknown_action_are_named_distinctly():
+    wl.ensure_conductor(CONDUCTOR)
+    with pytest.raises(wl.WorkLedgerError) as unknown:
+        wl.apply_conductor_action(CONDUCTOR, "decide", item_id=wl.mint_item_id(), decision="x")
+    assert unknown.value.code == wl.CODE_UNKNOWN_ITEM
+    with pytest.raises(wl.WorkLedgerError) as action:
+        wl.apply_conductor_action(CONDUCTOR, "teleport")
+    assert action.value.code == wl.CODE_INVALID_ACTION
+
+
+def test_round_rides_along_with_a_conductor_action():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="d", round_number=7)
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.round == 7
+
+
+# ── writer ownership ──────────────────────────────────────────────────────
+
+
+def test_the_worker_path_writes_only_worker_fields():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="conductor said")
+    wl.apply_worker_report(
+        CONDUCTOR,
+        item_id,
+        status="done",
+        summary="tests pass",
+        artifacts={"pr": "8842"},
+        pr=8842,
+    )
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None
+    assert (item.status, item.summary, item.pr) == ("done", "tests pass", 8842)
+    assert item.artifacts == {"pr": "8842"}
+    assert item.last_report_at
+    # Untouched by the worker: the conductor still owns the bar and the disposition.
+    assert (item.decision, item.state, item.verdict) == ("conductor said", "open", None)
+
+
+def test_apply_worker_report_has_no_conductor_field_parameter():
+    import inspect
+
+    names = set(inspect.signature(wl.apply_worker_report).parameters)
+    assert names == {"slot_key", "item_id", "status", "summary", "artifacts", "pr"}
+    assert not names & {"verdict", "state", "acceptance", "decision", "fails", "round_number"}
+
+
+def test_accept_batch_is_built_from_acceptance_and_never_from_a_claimed_pr():
+    item_id = _new_item(acceptance={"kind": "pr_checks", "repo": "owner/name"})
+    wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="s", pr=999)
+    batch = wl.accept_batch(wl.list_work_items(CONDUCTOR))
+    assert batch == {
+        "items": [{"id": item_id, "accept": {"kind": "pr_checks", "repo": "owner/name"}}]
+    }
+    assert "999" not in json.dumps(batch)
+
+
+def test_accept_batch_drops_terminal_items_and_items_with_no_bar():
+    kept = _new_item(acceptance={"kind": "human_approval"})
+    bare = _new_item(acceptance={})
+    closed = _new_item(acceptance={"kind": "human_approval"})
+    wl.apply_conductor_action(CONDUCTOR, "close", item_id=closed, state="accepted")
+    ids = [entry["id"] for entry in wl.accept_batch(wl.list_work_items(CONDUCTOR))["items"]]
+    assert ids == [kept]
+    assert bare not in ids
+
+
+def test_accept_batch_is_what_accept_eval_reads_end_to_end():
+    """The keys are accept_eval.py's, not this store's: pipe the batch through the
+    real script and every item must come back under its own id, not a positional
+    fallback like ``#0``."""
+    import subprocess
+    import sys
+
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "kiro_crew"
+        / "builtin_skills"
+        / "goal-conductor"
+        / "scripts"
+        / "accept_eval.py"
+    )
+    item_id = _new_item(acceptance={"kind": "human_approval"})
+    batch = wl.accept_batch(wl.list_work_items(CONDUCTOR))
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(batch),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    results = json.loads(proc.stdout)["results"]
+    assert [r["id"] for r in results] == [item_id]
+    assert results[0]["verdict"] in wl.VERDICTS
+    assert results[0]["verdict"] != "error"
+
+
+def test_work_brief_shows_the_item_and_not_the_conductors_goal():
+    item_id = _new_item(title="one job")
+    brief = wl.read_work_brief(CONDUCTOR, item_id)
+    assert brief is not None
+    assert brief["title"] == "one job"
+    assert set(brief) == {
+        "item_id",
+        "title",
+        "acceptance",
+        "round",
+        "decision",
+        "status",
+        "summary",
+    }
+    assert "goal" not in brief
+    assert "worker_session_key" not in brief
+    assert wl.read_work_brief(CONDUCTOR, wl.mint_item_id()) is None
+
+
+# ── caps refuse, and a refusal changes no bytes ───────────────────────────
+
+
+def test_the_item_cap_refuses_the_thirty_third_item():
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    for index in range(wl.MAX_ITEMS_PER_CONDUCTOR):
+        wl.apply_conductor_action(CONDUCTOR, "create", title=f"t{index}", acceptance={})
+    before = sorted(p.name for p in wl.items_dir(CONDUCTOR).iterdir())
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "create", title="one too many", acceptance={})
+    assert caught.value.code == wl.CODE_ITEM_CAP_EXCEEDED
+    assert sorted(p.name for p in wl.items_dir(CONDUCTOR).iterdir()) == before
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_field",
+    [
+        ({"status": "progress", "summary": "x" * (wl.MAX_SUMMARY_CHARS + 1)}, "summary"),
+        (
+            {
+                "status": "progress",
+                "summary": "ok",
+                "artifacts": {f"k{i}": "v" for i in range(wl.MAX_ARTIFACT_KEYS + 1)},
+            },
+            "artifacts",
+        ),
+        (
+            {
+                "status": "progress",
+                "summary": "ok",
+                "artifacts": {"k" * (wl.MAX_ARTIFACT_KEY_CHARS + 1): "v"},
+            },
+            "artifacts",
+        ),
+        (
+            {
+                "status": "progress",
+                "summary": "ok",
+                "artifacts": {"k": "v" * (wl.MAX_ARTIFACT_VALUE_CHARS + 1)},
+            },
+            "artifacts",
+        ),
+    ],
+)
+def test_a_refused_worker_cap_leaves_both_files_byte_identical(kwargs, expected_field):
+    item_id = _new_item()
+    wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="baseline")
+    before = _bytes_on_disk(item_id)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_worker_report(CONDUCTOR, item_id, **kwargs)
+    assert caught.value.code == wl.CODE_FIELD_TOO_LONG
+    assert caught.value.field == expected_field
+    assert _bytes_on_disk(item_id) == before
+
+
+def test_a_refused_conductor_cap_leaves_both_files_byte_identical():
+    item_id = _new_item()
+    before = _bytes_on_disk(item_id)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(
+            CONDUCTOR,
+            "decide",
+            item_id=item_id,
+            decision="d" * (wl.MAX_DECISION_CHARS + 1),
+        )
+    assert (caught.value.code, caught.value.field) == (wl.CODE_FIELD_TOO_LONG, "decision")
+    assert _bytes_on_disk(item_id) == before
+
+
+def test_an_oversized_title_and_goal_are_refused_not_truncated():
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    for action, kwargs, name in (
+        ("create", {"title": "t" * (wl.MAX_TITLE_CHARS + 1), "acceptance": {}}, "title"),
+        ("goal", {"goal": "g" * (wl.MAX_GOAL_CHARS + 1)}, "goal"),
+    ):
+        with pytest.raises(wl.WorkLedgerError) as caught:
+            wl.apply_conductor_action(CONDUCTOR, action, **kwargs)
+        assert (caught.value.code, caught.value.field) == (wl.CODE_FIELD_TOO_LONG, name)
+    record = wl.read_conductor(CONDUCTOR)
+    assert record is not None and record.goal == "g"
+
+
+def test_a_boundary_length_value_is_accepted():
+    item_id = _new_item(title="t" * wl.MAX_TITLE_CHARS)
+    wl.apply_worker_report(
+        CONDUCTOR,
+        item_id,
+        status="progress",
+        summary="s" * wl.MAX_SUMMARY_CHARS,
+        artifacts={"k" * wl.MAX_ARTIFACT_KEY_CHARS: "v" * wl.MAX_ARTIFACT_VALUE_CHARS},
+    )
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and len(item.summary) == wl.MAX_SUMMARY_CHARS
+
+
+@pytest.mark.parametrize("bad_pr", [0, -1, wl.MAX_PR + 1, True, 1.5, float("nan"), "12", object()])
+def test_pr_is_bounded_and_a_bool_is_not_an_integer(bad_pr):
+    item_id = _new_item()
+    before = _bytes_on_disk(item_id)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="s", pr=bad_pr)
+    assert caught.value.field == "pr"
+    assert _bytes_on_disk(item_id) == before
+
+
+def test_an_unknown_status_is_refused_with_its_own_code():
+    item_id = _new_item()
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_worker_report(CONDUCTOR, item_id, status="finished", summary="s")
+    assert caught.value.code == wl.CODE_INVALID_STATUS
+
+
+def test_wrong_typed_fields_are_refused_rather_than_coerced():
+    item_id = _new_item()
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary=17)
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="s", artifacts=["x"])
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="s", artifacts={"k": 1})
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_conductor_action(CONDUCTOR, "create", title="t", acceptance=["nope"])
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_conductor_action(CONDUCTOR, "verdict", item_id=item_id, verdict="fail", fails=-1)
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_conductor_action(CONDUCTOR, "verdict", item_id=item_id, verdict="maybe")
+    with pytest.raises(wl.WorkLedgerError):
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=item_id, worker_session_key="a\0b")
+
+
+def test_acceptance_must_be_json_serialisable():
+    wl.ensure_conductor(CONDUCTOR)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "create", title="t", acceptance={"fn": lambda: None})
+    assert caught.value.field == "acceptance"
+
+
+def test_an_oversized_acceptance_is_refused(monkeypatch):
+    wl.ensure_conductor(CONDUCTOR)
+    monkeypatch.setattr(wl, "MAX_RECORD_BYTES", 200)
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "create", title="t", acceptance={"blob": "x" * 400})
+    assert caught.value.code == wl.CODE_FIELD_TOO_LONG
+
+
+def test_acceptance_is_stored_verbatim_and_never_interpreted():
+    payload = {"kind": "pr_checks", "pr": 123, "repo": "owner/name", "extra": [1, {"a": None}]}
+    item_id = _new_item(acceptance=payload)
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.acceptance == payload
+
+
+# ── events ────────────────────────────────────────────────────────────────
+
+
+def test_event_id_is_content_addressed_and_sixteen_hex():
+    first = wl.event_id("2026-01-01T00:00:00+00:00", "it_1a2b3c4d", "report", "hello")
+    assert len(first) == 16
+    assert first == wl.event_id("2026-01-01T00:00:00+00:00", "it_1a2b3c4d", "report", "hello")
+    assert first != wl.event_id("2026-01-01T00:00:00+00:00", "it_1a2b3c4d", "report", "hi")
+
+
+def test_event_id_includes_status_so_a_transition_survives_dedupe():
+    ts = "2026-01-01T00:00:00+00:00"
+    progress = wl.event_id(ts, "it_1a2b3c4d", "report", "same", status="progress")
+    blocked = wl.event_id(ts, "it_1a2b3c4d", "report", "same", status="blocked")
+    assert progress != blocked
+    # No status renders as the empty string, so non-report kinds keep one formula.
+    assert wl.event_id(ts, "it_1a2b3c4d", "create", "t") == wl.event_id(
+        ts, "it_1a2b3c4d", "create", "t", status=None
+    )
+
+
+def test_same_summary_status_change_in_one_second_keeps_both_lines(monkeypatch):
+    """GPT F1: seconds-precision timestamps plus a byte-identical summary must not
+    let a ``blocked`` transition collapse into the ``progress`` line before it."""
+    item_id = _new_item()
+    monkeypatch.setattr(wl, "_now_iso", lambda: "2026-01-01T00:00:00+00:00")
+    wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="same words")
+    wl.apply_worker_report(CONDUCTOR, item_id, status="blocked", summary="same words")
+    reports = [e for e in wl.read_events(CONDUCTOR, item_id) if e.kind == "report"]
+    assert [e.status for e in reports] == ["progress", "blocked"]
+    assert len({e.id for e in reports}) == 2
+
+
+def test_event_id_separators_keep_two_different_tuples_apart():
+    # Bare concatenation would make these two identical.
+    assert wl.event_id("a", "b", "create", "cd") != wl.event_id("a", "bc", "create", "d")
+
+
+def test_a_duplicated_event_line_collapses_on_read():
+    item_id = _new_item()
+    path = wl.item_events_path(CONDUCTOR, item_id)
+    line = path.read_text(encoding="utf-8").strip()
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+        handle.write(line + "\n")
+    assert len(wl.read_events(CONDUCTOR, item_id)) == 1
+
+
+def test_a_torn_event_line_is_skipped_and_the_history_before_it_survives():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="keep me")
+    path = wl.item_events_path(CONDUCTOR, item_id)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"id": "abc", "kind": "rep')
+    kinds = [event.kind for event in wl.read_events(CONDUCTOR, item_id)]
+    assert kinds == ["create", "decision"]
+
+
+def test_a_line_with_an_unknown_kind_or_a_non_object_is_skipped():
+    item_id = _new_item()
+    path = wl.item_events_path(CONDUCTOR, item_id)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"id": "x", "kind": "teleport", "text": ""}) + "\n")
+        handle.write("[1, 2, 3]\n")
+        handle.write("\n")
+    assert [event.kind for event in wl.read_events(CONDUCTOR, item_id)] == ["create"]
+
+
+def test_a_failed_item_write_rolls_the_event_log_back(monkeypatch):
+    """GPT round 4 F1: state and its event must never disagree. Event goes first;
+    if the item write fails the log is restored byte-for-byte, and a retry works."""
+    item_id = _new_item()
+    item_before, log_before = _bytes_on_disk(item_id)
+    real_write = wl._write_record
+
+    def boom_on_item(path, payload):
+        if path.name == f"{item_id}.json":
+            raise OSError("disk full")
+        real_write(path, payload)
+
+    monkeypatch.setattr(wl, "_write_record", boom_on_item)
+    with pytest.raises(OSError):
+        wl.apply_conductor_action(CONDUCTOR, "close", item_id=item_id, state="accepted")
+    with pytest.raises(OSError):
+        wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="x")
+    assert _bytes_on_disk(item_id) == (item_before, log_before)
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.state == "open" and item.status is None
+    monkeypatch.setattr(wl, "_write_record", real_write)
+    wl.apply_conductor_action(CONDUCTOR, "close", item_id=item_id, state="accepted")
+    assert [e.kind for e in wl.read_events(CONDUCTOR, item_id)] == ["create", "close"]
+
+
+def test_a_failed_event_write_leaves_the_item_untouched(monkeypatch):
+    item_id = _new_item()
+    before = _bytes_on_disk(item_id)
+    real_atomic = wl.atomic_write
+
+    def boom_on_log(path, content, **kw):
+        if str(path).endswith(".jsonl"):
+            raise OSError("disk full")
+        real_atomic(path, content, **kw)
+
+    monkeypatch.setattr(wl, "atomic_write", boom_on_log)
+    with pytest.raises(OSError):
+        wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="d")
+    assert _bytes_on_disk(item_id) == before
+
+
+def test_create_default_round_is_read_under_the_lock(monkeypatch):
+    """GPT round 4 F2: a round bump that lands while create waits for the lock must
+    be the round the new item is assigned to."""
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    real_lock = wl.conductor_lock
+    fired: list[str] = []
+    from contextlib import contextmanager
+
+    @contextmanager
+    def racing_lock(slot_key):
+        if not fired:
+            fired.append("x")
+            monkeypatch.setattr(wl, "conductor_lock", real_lock)
+            wl.apply_conductor_action(CONDUCTOR, "goal", round_number=5)
+        with real_lock(slot_key):
+            yield
+
+    monkeypatch.setattr(wl, "conductor_lock", racing_lock)
+    item = wl.apply_conductor_action(CONDUCTOR, "create", title="t", acceptance={})["item"]
+    assert item.round == 5
+
+
+def test_an_acceptance_that_indents_past_the_read_ceiling_is_refused(monkeypatch):
+    """GPT round 4 F3: the compact-form check is not enough; the stored form is
+    indented and must fit the ceiling too, or a successful create reads as absent."""
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    monkeypatch.setattr(wl, "MAX_RECORD_BYTES", 2000)
+    # Compact size ~600 bytes (under 1000 = ceiling // 2); indent=2 nesting blows past 2000.
+    nested: dict = {"k": "v"}
+    for _ in range(60):
+        nested = {"n": nested}
+    assert len(json.dumps(nested).encode()) < 1000
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "create", title="t", acceptance=nested)
+    assert caught.value.code == wl.CODE_FIELD_TOO_LONG
+    assert wl.list_work_items(CONDUCTOR) == []
+
+
+def test_the_event_cap_drops_the_oldest_line():
+    item_id = _new_item()
+    for index in range(wl.MAX_EVENTS_PER_ITEM + 5):
+        wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision=f"round {index}")
+    events = wl.read_events(CONDUCTOR, item_id)
+    assert len(events) == wl.MAX_EVENTS_PER_ITEM
+    assert events[0].kind != "create"
+    assert events[-1].text == f"round {wl.MAX_EVENTS_PER_ITEM + 4}"
+
+
+def test_read_events_limit_keeps_the_newest():
+    item_id = _new_item()
+    for index in range(4):
+        wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision=str(index))
+    assert [e.text for e in wl.read_events(CONDUCTOR, item_id, limit=2)] == ["2", "3"]
+    assert wl.read_events(CONDUCTOR, item_id, limit=0) == []
+
+
+def test_event_text_is_bounded_on_the_line_without_refusing_the_write():
+    item_id = _new_item()
+    wl.apply_conductor_action(
+        CONDUCTOR, "decide", item_id=item_id, decision="d" * wl.MAX_DECISION_CHARS
+    )
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    events = wl.read_events(CONDUCTOR, item_id)
+    assert item is not None and len(item.decision) == wl.MAX_DECISION_CHARS
+    assert len(events[-1].text) == wl.MAX_EVENT_TEXT_CHARS
+
+
+def test_appending_an_unknown_event_kind_is_refused():
+    item_id = _new_item()
+    with wl.item_lock(CONDUCTOR, item_id):
+        with pytest.raises(wl.WorkLedgerError):
+            wl._append_event_locked(CONDUCTOR, item_id, "teleport", "x")
+
+
+def test_read_events_is_empty_for_an_absent_or_oversized_log(monkeypatch):
+    item_id = _new_item()
+    assert wl.read_events(CONDUCTOR, wl.mint_item_id()) == []
+    monkeypatch.setattr(wl, "MAX_RECORD_BYTES", 1)
+    assert wl.read_events(CONDUCTOR, item_id) == []
+
+
+# ── the progress coalescing rule (RFC Q6) ─────────────────────────────────
+
+
+def test_consecutive_progress_reports_collapse_to_the_newest():
+    item_id = _new_item()
+    for step in ("first", "second", "third"):
+        wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary=step)
+    events = wl.read_events(CONDUCTOR, item_id)
+    assert [(e.kind, e.text) for e in events] == [
+        ("create", "port the gate"),
+        ("report", "third"),
+    ]
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.summary == "third"
+
+
+def test_a_status_change_between_two_progress_reports_stops_the_merge():
+    item_id = _new_item()
+    wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="a")
+    wl.apply_worker_report(CONDUCTOR, item_id, status="blocked", summary="b")
+    wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="c")
+    texts = [e.text for e in wl.read_events(CONDUCTOR, item_id) if e.kind == "report"]
+    assert texts == ["a", "b", "c"]
+
+
+def test_a_conductor_event_between_two_progress_reports_stops_the_merge():
+    item_id = _new_item()
+    wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="a")
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="carry on")
+    wl.apply_worker_report(CONDUCTOR, item_id, status="progress", summary="b")
+    assert [e.kind for e in wl.read_events(CONDUCTOR, item_id)] == [
+        "create",
+        "report",
+        "decision",
+        "report",
+    ]
+
+
+def test_only_progress_reports_merge_and_never_done_reports():
+    item_id = _new_item()
+    wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="a")
+    wl.apply_worker_report(CONDUCTOR, item_id, status="done", summary="b")
+    texts = [e.text for e in wl.read_events(CONDUCTOR, item_id) if e.kind == "report"]
+    assert texts == ["a", "b"]
+
+
+# ── corruption reads as absent ────────────────────────────────────────────
+
+
+def test_a_truncated_item_file_reads_as_absent():
+    item_id = _new_item()
+    path = wl.item_path(CONDUCTOR, item_id)
+    raw = path.read_text(encoding="utf-8")
+    path.write_text(raw[: len(raw) // 2], encoding="utf-8")
+    assert wl.read_work_item(CONDUCTOR, item_id) is None
+    assert wl.list_work_items(CONDUCTOR) == []
+
+
+def test_a_non_utf8_item_file_reads_as_absent():
+    item_id = _new_item()
+    wl.item_path(CONDUCTOR, item_id).write_bytes(b"\xff\xfe not utf-8")
+    assert wl.read_work_item(CONDUCTOR, item_id) is None
+
+
+def test_an_oversized_item_file_reads_as_absent(monkeypatch, caplog):
+    item_id = _new_item()
+    monkeypatch.setattr(wl, "MAX_RECORD_BYTES", 4)
+    with caplog.at_level("WARNING"):
+        assert wl.read_work_item(CONDUCTOR, item_id) is None
+    assert "size ceiling" in caplog.text
+
+
+def test_a_corrupt_conductor_file_reads_as_absent():
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    (wl.conductor_dir(CONDUCTOR) / "conductor.json").write_text("{ torn", encoding="utf-8")
+    assert wl.read_conductor(CONDUCTOR) is None
+
+
+def test_a_malformed_item_filename_is_skipped_not_raised():
+    good = _new_item(title="good")
+    (wl.items_dir(CONDUCTOR) / "it_bad.json").write_text("{}", encoding="utf-8")
+    (wl.items_dir(CONDUCTOR) / "it_1a2b3c4d5.json").write_text("{}", encoding="utf-8")
+    assert [item.item_id for item in wl.list_work_items(CONDUCTOR)] == [good]
+    # create walks the same listing for the cap, so it must not crash either.
+    wl.apply_conductor_action(CONDUCTOR, "create", title="next", acceptance={})
+
+
+def test_one_torn_item_does_not_hide_its_siblings():
+    good = _new_item(title="good")
+    bad = _new_item(title="bad")
+    wl.item_path(CONDUCTOR, bad).write_text("{", encoding="utf-8")
+    assert [item.item_id for item in wl.list_work_items(CONDUCTOR)] == [good]
+
+
+def test_a_wrong_typed_stored_field_resets_to_its_default_without_raising():
+    item_id = _new_item()
+    path = wl.item_path(CONDUCTOR, item_id)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    stored.update(
+        {
+            "state": "teleported",
+            "status": 17,
+            "verdict": "maybe",
+            "round": "many",
+            "artifacts": {"keep": "me", "drop": 5},
+            "title": None,
+            "pr": True,
+            "acceptance": "not an object",
+        }
+    )
+    path.write_text(json.dumps(stored), encoding="utf-8")
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None
+    assert (item.state, item.status, item.verdict, item.round) == ("open", None, None, 0)
+    assert item.artifacts == {"keep": "me"}
+    assert (item.title, item.pr, item.acceptance) == ("", None, {})
+
+
+def test_an_item_file_storing_a_different_id_reads_as_absent(caplog):
+    """GPT round 5 F1: honouring a mismatched stored id would let a write taken
+    under this item's lock land on another item's path."""
+    a = _new_item(title="a")
+    b = _new_item(title="b")
+    stored = json.loads(wl.item_path(CONDUCTOR, a).read_text(encoding="utf-8"))
+    stored["item_id"] = b
+    wl.item_path(CONDUCTOR, a).write_text(json.dumps(stored), encoding="utf-8")
+    with caplog.at_level("WARNING"):
+        assert wl.read_work_item(CONDUCTOR, a) is None
+    assert "treating as absent" in caplog.text
+    b_before = wl.item_path(CONDUCTOR, b).read_bytes()
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "decide", item_id=a, decision="x")
+    assert caught.value.code == wl.CODE_UNKNOWN_ITEM
+    assert wl.item_path(CONDUCTOR, b).read_bytes() == b_before
+
+
+def test_the_bind_guard_fails_closed_on_a_transient_read_error(monkeypatch):
+    """GPT round 5 F2: a prior item that is present but momentarily unreadable must
+    NOT read as stale, or the worker is rebound and its open item stranded."""
+    first = _new_item(title="first")
+    second = _new_item(title="second")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
+    real_read_text = Path.read_text
+
+    def flaky(self, *a, **kw):
+        if self.name == f"{first}.json":
+            raise PermissionError("sharing violation")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    with pytest.raises(PermissionError):
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+    assert wl.read_binding(WORKER) == (CONDUCTOR, first)
+    second_item = wl.read_work_item(CONDUCTOR, second)
+    assert second_item is not None and second_item.worker_session_key is None
+
+
+def test_the_bind_guard_fails_closed_when_the_binding_itself_is_unreadable(monkeypatch):
+    """GPT round 6: the same strictness applies to the BINDING read, or a transient
+    error there reads as unbound and the open item is stranded."""
+    first = _new_item(title="first")
+    second = _new_item(title="second")
+    wl.apply_conductor_action(CONDUCTOR, "bind", item_id=first, worker_session_key=WORKER)
+    binding_before = wl.binding_path(WORKER).read_bytes()
+    real_read_text = Path.read_text
+
+    def flaky(self, *a, **kw):
+        if self.parent == wl.bindings_dir():
+            raise PermissionError("sharing violation")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    with pytest.raises(PermissionError):
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=second, worker_session_key=WORKER)
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+    assert wl.binding_path(WORKER).read_bytes() == binding_before
+    assert wl.read_binding(WORKER) == (CONDUCTOR, first)
+    # The lenient reader still answers 'unbound' for a worker tool.
+    monkeypatch.setattr(Path, "read_text", flaky)
+    assert wl.read_binding(WORKER) is None
+
+
+def test_a_transient_read_error_does_not_reset_the_conductor_header(monkeypatch):
+    """GPT round 7 F1: ensure_conductor must not mint a fresh header over one it
+    merely failed to read."""
+    wl.ensure_conductor(CONDUCTOR, goal="keep me", depth=1)
+    wl.apply_conductor_action(CONDUCTOR, "goal", round_number=4)
+    before = (wl.conductor_dir(CONDUCTOR) / "conductor.json").read_bytes()
+    real_read_text = Path.read_text
+
+    def flaky(self, *a, **kw):
+        if self.name == "conductor.json":
+            raise PermissionError("sharing violation")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    with pytest.raises(PermissionError):
+        wl.ensure_conductor(CONDUCTOR, goal="other")
+    # The action entry point's lenient pre-lock read answers ``no_ledger`` first;
+    # either way nothing is written.
+    with pytest.raises((PermissionError, wl.WorkLedgerError)):
+        wl.apply_conductor_action(CONDUCTOR, "goal", goal="other")
+    with pytest.raises(PermissionError):
+        wl._write_goal(CONDUCTOR, wl.ConductorRecord(slot_key=CONDUCTOR), "other", None)
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+    assert (wl.conductor_dir(CONDUCTOR) / "conductor.json").read_bytes() == before
+    record = wl.read_conductor(CONDUCTOR)
+    assert record is not None and (record.goal, record.round, record.depth) == ("keep me", 4, 1)
+
+
+def test_a_transient_read_error_does_not_truncate_the_event_log(monkeypatch):
+    """GPT round 7 F1: the log writer rewrites from what it read, so an unreadable
+    log must fail the write, not be replaced by a one-line log."""
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="one")
+    wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="two")
+    before = _bytes_on_disk(item_id)
+    real_read_text = Path.read_text
+
+    def flaky(self, *a, **kw):
+        if self.suffix == ".jsonl":
+            raise PermissionError("sharing violation")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    with pytest.raises(PermissionError):
+        wl.apply_conductor_action(CONDUCTOR, "decide", item_id=item_id, decision="three")
+    monkeypatch.setattr(Path, "read_text", real_read_text)
+    assert _bytes_on_disk(item_id) == before
+    assert len(wl.read_events(CONDUCTOR, item_id)) == 3
+
+
+def test_an_interrupted_bind_can_be_retried(caplog):
+    """GPT round 7 F2: a binding whose item does not name the worker back is the
+    half-state a kill between bind's two writes leaves; the retry must succeed."""
+    item_id = _new_item()
+    # Simulate the crash: binding written, item never updated.
+    wl._write_binding(WORKER, CONDUCTOR, item_id)
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.worker_session_key is None
+    with caplog.at_level("WARNING"):
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=item_id, worker_session_key=WORKER)
+    assert "interrupted bind" in caplog.text
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.worker_session_key == WORKER
+    assert wl.read_binding(WORKER) == (CONDUCTOR, item_id)
+    # And a genuinely live binding (item names the worker) still refuses.
+    other = _new_item(title="other")
+    with pytest.raises(wl.WorkLedgerError) as caught:
+        wl.apply_conductor_action(CONDUCTOR, "bind", item_id=other, worker_session_key=WORKER)
+    assert caught.value.code == wl.CODE_ALREADY_BOUND
+
+
+def test_lenient_reads_still_treat_a_transient_error_as_absent(monkeypatch):
+    item_id = _new_item()
+    real_read_text = Path.read_text
+
+    def flaky(self, *a, **kw):
+        if self.name == f"{item_id}.json":
+            raise PermissionError("sharing violation")
+        return real_read_text(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_text", flaky)
+    assert wl.read_work_item(CONDUCTOR, item_id) is None
+    assert wl.list_work_items(CONDUCTOR) == []
+
+
+def test_round_number_is_refused_on_actions_that_do_not_take_it():
+    item_id = _new_item()
+    for action, kwargs in (
+        ("bind", {"worker_session_key": WORKER}),
+        ("verdict", {"verdict": "pass"}),
+        ("close", {"state": "accepted"}),
+    ):
+        before = _bytes_on_disk(item_id)
+        with pytest.raises(wl.WorkLedgerError) as caught:
+            wl.apply_conductor_action(CONDUCTOR, action, item_id=item_id, round_number=3, **kwargs)
+        assert caught.value.field == "round_number"
+        assert _bytes_on_disk(item_id) == before
+
+
+def test_records_built_from_a_non_object_are_empty_defaults():
+    assert wl.ConductorRecord.from_dict("nope").goal == ""
+    assert wl.WorkItem.from_dict(None).state == "open"
+    assert wl.WorkEvent.from_dict([1]) is None
+
+
+def test_read_helpers_backfill_an_id_the_stored_record_lost():
+    item_id = _new_item()
+    path = wl.item_path(CONDUCTOR, item_id)
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    del stored["item_id"]
+    path.write_text(json.dumps(stored), encoding="utf-8")
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None and item.item_id == item_id
+
+    conductor_file = wl.conductor_dir(CONDUCTOR) / "conductor.json"
+    header = json.loads(conductor_file.read_text(encoding="utf-8"))
+    del header["slot_key"]
+    conductor_file.write_text(json.dumps(header), encoding="utf-8")
+    record = wl.read_conductor(CONDUCTOR)
+    assert record is not None and record.slot_key == CONDUCTOR
+
+
+# ── derived flags ─────────────────────────────────────────────────────────
+
+
+def test_orphaned_is_derived_and_is_never_a_stored_field():
+    item_id = _new_item()
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None
+    assert "orphaned" not in item.to_dict()
+    assert "stale" not in item.to_dict()
+    assert wl.is_orphaned(item, conductor_slot_exists=False) is True
+    assert wl.is_orphaned(item, conductor_slot_exists=True) is False
+
+
+def test_a_terminal_item_is_neither_orphaned_nor_stale():
+    item_id = _new_item()
+    wl.apply_conductor_action(CONDUCTOR, "close", item_id=item_id, state="accepted")
+    item = wl.read_work_item(CONDUCTOR, item_id)
+    assert item is not None
+    assert wl.is_orphaned(item, conductor_slot_exists=False) is False
+    assert wl.is_stale(item, worker_running=False, window_secs=0) is False
+
+
+def test_stale_needs_both_a_quiet_item_and_a_stopped_worker():
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    quiet = wl.WorkItem(
+        item_id=wl.mint_item_id(),
+        created_at=(now - timedelta(hours=2)).isoformat(),
+        last_report_at=(now - timedelta(hours=1)).isoformat(),
+    )
+    assert wl.is_stale(quiet, worker_running=False, now=now, window_secs=60) is True
+    # Running is the whole point of the conjunction: a long build is never stale.
+    assert wl.is_stale(quiet, worker_running=True, now=now, window_secs=60) is False
+    assert wl.is_stale(quiet, worker_running=False, now=now, window_secs=7200) is False
+
+
+def test_an_item_with_no_report_yet_is_measured_from_creation():
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    fresh = wl.WorkItem(item_id=wl.mint_item_id(), created_at=now.isoformat())
+    assert wl.is_stale(fresh, worker_running=False, now=now, window_secs=60) is False
+    old = wl.WorkItem(item_id=wl.mint_item_id(), created_at=(now - timedelta(hours=1)).isoformat())
+    assert wl.is_stale(old, worker_running=False, now=now, window_secs=60) is True
+
+
+def test_an_unparseable_or_missing_timestamp_reads_as_stale():
+    assert wl.is_stale(wl.WorkItem(), worker_running=False) is True
+    assert wl.is_stale(wl.WorkItem(last_report_at="not a date"), worker_running=False) is True
+
+
+def test_naive_timestamps_are_compared_without_raising():
+    naive_now = datetime(2026, 1, 1, 12, 0)
+    item = wl.WorkItem(last_report_at="2026-01-01T10:00:00")
+    assert wl.is_stale(item, worker_running=False, now=naive_now, window_secs=60) is True
+
+
+def test_stale_uses_a_default_window_when_none_is_given():
+    assert wl.DEFAULT_STALE_WINDOW_SECS > 0
+    recent = wl.WorkItem(last_report_at=datetime.now().astimezone().isoformat())
+    assert wl.is_stale(recent, worker_running=False) is False
+
+
+# ── concurrency ───────────────────────────────────────────────────────────
+
+
+def test_two_concurrent_writers_leave_a_parseable_item_and_a_clean_event_log():
+    """One report loop and one conductor loop against the SAME item.
+
+    Threads rather than processes so the test runs unchanged on Windows: the locks
+    are taken on separate descriptors, which serialise across threads exactly as
+    they do across processes, and nothing here uses a POSIX-only API.
+    """
+    item_id = _new_item()
+    rounds = 25
+    errors: list[BaseException] = []
+
+    def report() -> None:
+        try:
+            for index in range(rounds):
+                wl.apply_worker_report(
+                    CONDUCTOR,
+                    item_id,
+                    status="blocked" if index % 2 else "done",
+                    summary=f"worker {index}",
+                    artifacts={"step": str(index)},
+                )
+        except BaseException as exc:  # pragma: no cover - surfaced by the assert
+            errors.append(exc)
+
+    def decide() -> None:
+        try:
+            for index in range(rounds):
+                wl.apply_conductor_action(
+                    CONDUCTOR, "decide", item_id=item_id, decision=f"conductor {index}"
+                )
+        except BaseException as exc:  # pragma: no cover - surfaced by the assert
+            errors.append(exc)
+
+    threads = [threading.Thread(target=report), threading.Thread(target=decide)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=120)
+    assert not errors, errors
+    assert not any(thread.is_alive() for thread in threads)
+
+    # The item still parses, and holds one writer's field beside the other's.
+    stored = json.loads(wl.item_path(CONDUCTOR, item_id).read_text(encoding="utf-8"))
+    assert stored["item_id"] == item_id
+    assert stored["decision"].startswith("conductor ")
+    assert stored["summary"].startswith("worker ")
+
+    # Every line is a whole JSON object — no interleaving, no partial line.
+    raw = wl.item_events_path(CONDUCTOR, item_id).read_text(encoding="utf-8")
+    lines = [line for line in raw.splitlines() if line.strip()]
+    assert lines
+    for line in lines:
+        parsed = json.loads(line)
+        assert parsed["item_id"] == item_id
+        assert parsed["kind"] in wl.EVENT_KINDS
+    assert len(wl.read_events(CONDUCTOR, item_id)) == len(lines)
+
+
+def test_the_item_cap_holds_under_concurrent_creates():
+    wl.ensure_conductor(CONDUCTOR, goal="g")
+    refused: list[str] = []
+
+    def create() -> None:
+        for _ in range(12):
+            try:
+                wl.apply_conductor_action(CONDUCTOR, "create", title="t", acceptance={})
+            except wl.WorkLedgerError as exc:
+                refused.append(exc.code)
+
+    threads = [threading.Thread(target=create) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=120)
+    assert len(wl.list_work_items(CONDUCTOR)) == wl.MAX_ITEMS_PER_CONDUCTOR
+    assert refused and set(refused) == {wl.CODE_ITEM_CAP_EXCEEDED}
+
+
+def test_the_lock_order_is_conductor_item_binding_and_is_documented():
+    doc = wl.__doc__ or ""
+    assert "conductor -> item -> binding(worker)" in doc
+    assert "conductor" in (wl.conductor_lock.__doc__ or "").lower()
+    assert "FIRST" in (wl.conductor_lock.__doc__ or "")
+    assert "SECOND" in (wl.item_lock.__doc__ or "")
+    assert "THIRD" in (wl.binding_lock.__doc__ or "")
+
+
+def test_two_conductors_binding_one_worker_at_once_yield_exactly_one_binding():
+    conductors = [f"chat-{n}-c" for n in range(4)]
+    items = []
+    for key in conductors:
+        wl.ensure_conductor(key, goal="g")
+        items.append(
+            (
+                key,
+                wl.apply_conductor_action(key, "create", title="t", acceptance={})["item"].item_id,
+            )
+        )
+    outcomes: list[str] = []
+
+    def bind(key: str, item_id: str) -> None:
+        try:
+            wl.apply_conductor_action(key, "bind", item_id=item_id, worker_session_key=WORKER)
+            outcomes.append("bound")
+        except wl.WorkLedgerError as exc:
+            outcomes.append(exc.code)
+
+    threads = [threading.Thread(target=bind, args=pair) for pair in items]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=120)
+    assert outcomes.count("bound") == 1
+    assert outcomes.count(wl.CODE_ALREADY_BOUND) == 3
+    binding = wl.read_binding(WORKER)
+    assert binding is not None
+    bound = [pair for pair in items if pair == binding]
+    assert len(bound) == 1
+    for key, item_id in items:
+        item = wl.read_work_item(key, item_id)
+        assert item is not None
+        assert (item.worker_session_key == WORKER) == ((key, item_id) == binding)
+
+
+# ── revertability ─────────────────────────────────────────────────────────
+
+
+def test_nothing_in_the_package_imports_the_module_yet():
+    """Phase 1 reverts by deleting one module and one test.
+
+    Asserted on IMPORT statements rather than any mention of the name, and the
+    candidate set is asserted non-empty so a moved source tree fails this test
+    instead of hollowing it out.
+    """
+    package = Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+    sources = [path for path in package.rglob("*.py") if path.name != "work_ledger.py"]
+    assert len(sources) > 100, f"expected the package tree, found {len(sources)} files"
+    offenders = []
+    for path in sources:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "import work_ledger" in text or "from kiro_crew.work_ledger" in text:
+            offenders.append(str(path.relative_to(package)))
+    assert offenders == []


### PR DESCRIPTION
## Problem / Motivation

A conductor session dispatches work to child sessions and today learns what happened by **reading their transcripts**. It infers "done" from wording, and `session_read_message` cannot separate a worker parked on an approval prompt from one whose process died from one mid-build — all three produce "no new assistant message".

The obvious fix is withheld on purpose. `session_send` runs its body as the target's own user-role turn under the target's grants, so granting it downward would make every worker an operator of its parent. What is needed is a channel that **cannot carry an instruction**.

This is Phase 1 of four from the conductor-work-ledger RFC (pull request #8842): the storage module alone. No MCP tool, no HTTP route, no UI, and no importer anywhere in the tree.

## Why it matters

Without a structured record, every conductor patrol cycle costs a model turn to read and interpret prose, a crashed worker is indistinguishable from a working one, and the acceptance decision is made over text a worker authored. Phase 1 does not fix any of that on its own — it is the store the three later phases are built on, and it is separately reviewable and separately abandonable because it has no callers.

## What changed (motivation → approach → change)

**Goal:** a two-party record where each field has exactly one writer, and the ownership is enforced structurally rather than by a filter that must be kept correct as fields are added.

**Approach.** Two entry points instead of one update function:

- `apply_conductor_action()` writes `title`, `acceptance`, `state`, `verdict`, `decision`, `worker_session_key`, `round`, `fails`.
- `apply_worker_report()` writes `status`, `summary`, `artifacts`, `pr`, `last_report_at`.

The field sets are disjoint, so Phase 2 mounts one tool on each and a worker cannot write a conductor field because the function it can reach takes no parameter that names one. An absent parameter outlives an allowlist. Phase 1 performs no identity resolution — that is Phase 2's job at the tool layer — and the split shape is what lets it be done by construction rather than by validation.

**What was built,** in `src/kiro_crew/work_ledger.py`:

- `ConductorRecord`, `WorkItem`, `WorkEvent` dataclasses with the RFC's caps: goal ≤ 2000, title ≤ 200, decision ≤ 2000, summary ≤ 500, artifacts ≤ 16 keys / key ≤ 64 / value ≤ 512, event text ≤ 500, `pr` in 1..1e9.
- Four closed vocabularies: item state, verdict (`accept_eval.py`'s own five values, reused not paralleled), worker status, event kind.
- Caps of 32 items per conductor, 200 events per item oldest-dropped, depth ≤ 2. **Every cap refuses, none truncates** — a truncated summary the worker believes landed whole is a loss the worker cannot detect. Validation completes before the first write, so a refusal leaves every file byte-identical.
- Path resolution rooted at `data_home()`, reusing `session_ledger._store_name` (readable prefix + `sha256[:8]`) by import rather than a third copy, plus the same traversal guard. `item_id` is server-minted `it_<8 hex>` behind a `^it_[0-9a-f]{8}$` choke point every path constructor passes through, so no model-supplied string reaches a path component.
- Whole-file records via `atomic_write(mode=0o600, restrict_to_owner=True)`; event lines under `platform_compat.file_lock`, never relying on POSIX `O_APPEND`, which Windows does not give.
- Fixed lock order **conductor → item → binding(worker)**, stated in the module docstring and in all three lock helpers' docstrings, and pinned by a test.
- Content-addressed event id — first 16 hex of `sha256(ts|item_id|kind|status|text)` — with first-seen-wins dedupe on read. `status` is in the hash because timestamps are seconds-precision: a `progress` and a `blocked` report with the same summary in one second would otherwise collide and dedupe would drop the transition.
- A worker holds exactly one binding file, so `bind` is refused (`already_bound`) while the worker's prior item is still open. Without that, a second bind silently repoints the worker's only report channel and the first item is stranded with no unbind path. A binding whose item is terminal or unreadable is stale and may be replaced.
- Item list **derived** by listing `items/*.json`. No index file, so there is no third writer and no index to fall out of step.
- `is_orphaned()` and `is_stale()` as pure functions taking "does the conductor slot exist", "is the worker running", the current time and the window as arguments. Phase 1 wires no dashboard state.
- A torn, truncated, non-UTF-8 or oversized record reads as **absent**, matching `session_ledger`'s treatment of an oversized state file.
- `accept_batch()` composed from `acceptance` alone, emitting the `{"id", "accept"}` keys `accept_eval.py` actually reads (a test pipes the batch through the real script). The worker's `pr` is a **claim only** — filling `acceptance.pr` from a worker's report would let a worker name any already-green pull request and pass.

## Deviations from the RFC

Six, all recorded in the code's own docstrings:

1. **The RFC says `atomic_write(mode=0o600, restrict_to_owner=True)` "matching `session_ledger`". `session_ledger` passes only the mode.** This module takes the stronger form anyway — it carries a worker's own words into a conductor's context — so the RFC's *instruction* is followed and its *claim about `session_ledger`* is inaccurate.
2. **Event lines are written by rewriting the whole log, not by appending.** The RFC specifies an append under the lock. A plain append cannot implement either the oldest-dropped cap or the progress-coalescing rule below, both of which delete a line. One rewrite path does both; at 200 short lines it costs less than a second code path, and atomicity is unchanged because the rewrite is an `atomic_write` rename held under the same lock.
3. **Binding files are named with the same readable-plus-digest fold as a conductor directory, not the bare `<worker-digest8>.json` the RFC's layout shows.** Eight hex is 32 bits, so a bare-digest name collides at birthday scale and a collision means one worker reads another's item. The fold requires both the same sanitised prefix *and* the same digest, and it keeps one naming scheme across the store.
4. **The event id input is pipe-separated and includes `status`.** The RFC writes `sha256(ts + item_id + kind + text)`; bare concatenation lets two different tuples produce one string, and omitting `status` lets a same-second, same-summary status transition collide with the line before it. Both would collapse distinct events on read.
5. **A per-worker binding lock, third in the lock order.** The RFC's layout has no lock on `bindings/`. Refusing a rebind while the prior item is open is a read-then-write on the binding file, and two conductors binding one worker at once must not both see it free.
6. **Event `text` is a bounded 500-char excerpt, not a refused field.** The RFC caps `text` at 500 as a stored field; here the full `decision`/`summary` lives on the item record (refused above its own cap), and the event line carries a projection of it, so clipping loses nothing.

**Answer to RFC open question Q6** (should `progress` reports be rate-capped): consecutive `progress` reports **coalesce** — appending a new one drops the previous one, and only consecutive progress reports merge with each other. A worker in a tight loop can otherwise append 200 `progress` lines and roll its own history off the back of the cap before the conductor ever wakes, since `progress` does not wake it, so the events that *did* matter are the ones lost. Any other event kind, or any other status, between two progress lines stops the merge. The item's own fields always hold the newest report either way.

**Registration burden: none.** Investigated and confirmed: no gate maps a source file to a `docs/system-specs/modules/` spec (`scripts/docs_lint.py` checks spec→code, never the reverse); `scripts/check_feature_map.py` watches only `website/src/pages/` and `src/kiro_crew/dashboard/handlers/`; `setup.cfg` already collects `test/`; and `AGENTS.md` forbids a feature PR touching `CHANGELOG.md`. The RFC puts the full module spec in Phase 4, where its cited source paths will resolve.

## Tests

`test/test_work_ledger.py` — 122 tests, one per Phase 1 exit criterion plus branch coverage:

- **Every enum and cap** has a pin test that fails if the value changes.
- **Two concurrent writers against one item** — a report loop and a conductor-action loop, 25 rounds each — leave an item that parses and holds one writer's field beside the other's, and an event log where every line is a whole JSON object. Threads on separate descriptors, no POSIX-only API, so it runs unchanged on the Windows job. A second test proves the 32-item cap holds under four concurrent create loops.
- **Torn, truncated, non-UTF-8 and oversized** item, conductor and event files all read as absent; one torn item does not hide its siblings; a wrong-typed stored field resets to its default without raising.
- **Every cap refuses and leaves both files byte-identical** — asserted on the actual bytes before and after, for summary, all three artifact bounds, decision, title, goal, `pr` and the item cap. A boundary-length value is accepted, so the caps are not off by one.
- **`depth` at the cap refuses `create`**; one below the cap still dispatches; `child_depth` refuses rather than clamping.
- **Progress coalescing**, including the three cases that must *not* merge: a status change between two progress lines, a conductor event between them, and two consecutive `done` reports.
- **Event dedupe** on a duplicated line, plus a torn tail, an unknown kind and a non-object line all skipped. A same-summary `progress`→`blocked` transition within one frozen second keeps both lines.
- **Rebind refusal**: a worker with an open item cannot be bound to a second one (bytes unchanged on refusal); may be rebound once the prior item is terminal or its record is gone; refused across conductors too; four conductors binding one worker concurrently yield exactly one binding.
- **`accept_batch` round-trips through the real `accept_eval.py`** and every item comes back under its own id.
- **Bind is crash-safe in both halves**: an injected failure on the item write restores the prior binding byte-for-byte and the retry succeeds; a failed first bind leaves no binding file. Binding is written before the item so a half-state can only ever be a stale binding, never an `already_bound` item with no binding behind it.
- **Partial `goal` updates merge under the lock**: a goal-only write interleaved with a round-only write keeps both.
- **A malformed `it_*.json` filename is skipped**, not raised, in both listing and `create`.
- **Every write path reads strictly**: a transient `OSError` (not `FileNotFoundError`) on the header, the item, the binding or the event log fails the write instead of being read as "absent" — so no header reset, no log truncation, no rebind over a live binding. Pure readers keep the lenient contract.
- **A stored `item_id` that disagrees with its filename reads as absent**, so a write under one item's lock can never land on another's path.
- **An interrupted bind is retryable**: a binding whose item does not name the worker back is the kill-between-two-writes half-state and is replaced, not refused.
- **Stored-form size**: an acceptance that fits the compact bound but exceeds the read ceiling once indented is refused before any write.
- **`round_number` is accepted only on `decide` and `create`**, matching the action table.
- **Writer ownership**, asserted on `apply_worker_report`'s signature: its parameter set is exactly `{slot_key, item_id, status, summary, artifacts, pr}` and intersects none of `{verdict, state, acceptance, decision, fails, round_number}`.
- **`accept_batch` never carries a claimed `pr`** — asserted by searching the serialised batch for the claimed number.
- **Nothing in `src/kiro_crew` imports the module**, asserted on import statements, with the candidate file set asserted non-empty so a moved source tree fails the test instead of hollowing it out.

**Revert-verified load-bearing.** Fourteen mutations, each caught: removing progress coalescing (1 test failed), truncating instead of refusing an oversized field (3), clamping instead of refusing past the depth cap (1), dropping `status` from the event id (2), removing the open-binding refusal (3), removing the bind rollback (1), resolving omitted goal fields from the pre-lock snapshot (1), removing the malformed-stem filter (1), removing the event-log rollback (1), create's default round from the pre-lock snapshot (1), removing the stored-form size check (1), reverting the header strict read (1), reverting the log strict read (1), treating a non-reciprocal binding as live (1). Tree restored from an in-memory snapshot in a `finally`.

## Manual verification

N/A — this is a storage module with no caller, no route and no UI, and every behaviour it has is reachable from a unit test.

## Related Issues

Phase 1 of 4 of the conductor-work-ledger RFC in #8842. Phases 2–4 (the four MCP tools and their routes, the `monitor_start` wake gate, then the Crew page and the skill rewrite) follow as separate pull requests.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — module spec is Phase 4 per the RFC
- [x] No secrets, credentials, or internal references in the diff



