### PR TITLE
feat(desktop): backport the baked EXTERNALLY-MANAGED marker to release/0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ test_plan_atomic_writes_subagent_progress.md
 website/electron/backend-dist/
 website/electron/dist/
 website/electron/node_modules
+# Placed by packaging/build-desktop.sh from KIROCREW_MANAGED_INSTALL_MARKER so
+# electron-builder packs it into app.asar; a per-edition build input, not source.
+website/electron/EXTERNALLY-MANAGED
 # Generated launcher icon (created from icon.png when making the desktop shortcut)
 website/electron/KiroCrew.ico
 tui/

--- a/docs/build/desktop-app.md
+++ b/docs/build/desktop-app.md
@@ -864,11 +864,55 @@ commands honored must install the resources directory root-owned.
 
 The commands run with a **constructed environment**, not the app's own. Only an explicit pass-through set reaches them — `USER`, `LOGNAME`, `TZ`, `TMPDIR`, the `LANG`/`LC_*` locale vars, and the proxy vars — plus a narrowed system-only `PATH` and `cwd=/`. `HOME` is deliberately excluded: Python derives its user-site directory from it, so passing it through would let a planted `sitecustomize.py` run on every `python` start. Everything else is absent by construction, because `shell: true` means a shell interprets the command and a shell reads its environment as code: the loader family (`LD_*`/`DYLD_*`), the interpreter family (`PYTHON*`, `NODE_OPTIONS`), the startup files (`BASH_ENV`, `ENV`), the tracing pair (`SHELLOPTS` plus a command-substituting `PS4`), word splitting (`IFS`), and exported shell functions (`BASH_FUNC_*`, which shadow a command name outright). A packager whose updater needs any other variable must set it inside its own command rather than relying on inheritance.
 
-**On Windows the marker's commands are never honored.** There is no POSIX owner
-to read and `access(W_OK)` does not model ACLs, so no honest provenance verdict
-exists; the check fails closed by declaration and every Windows marker is
-treated as bare (managed, updater off). A Windows packager drives updates with
-its own installer, not through this marker.
+**On Windows a loose marker's commands are never honored.** There is no POSIX
+owner to read and `access(W_OK)` does not model ACLs, so no honest provenance
+verdict exists; the check fails closed by declaration and every loose Windows
+marker is treated as bare (managed, updater off). A Windows packager either
+drives updates with its own installer or bakes the marker in (next).
+
+### Baking the marker into the app (editions)
+
+The provenance rule above refuses every install the app's own user owns, which
+is every per-user package manager (a Toolbox, Homebrew, `~/Applications`), and
+can never pass on Windows. An **edition** — a build that IS produced by the
+package manager's owner — does not need to drop a file beside the app after the
+fact; it declares the marker at build time:
+
+```bash
+KIROCREW_MANAGED_INSTALL_MARKER=/path/to/marker.json bash packaging/build-desktop.sh
+```
+
+`build-desktop.sh` validates the file (a JSON object of string fields
+`managedBy` / `updateCommand` / `checkCommand`, under 8 KiB, with an
+`updateCommand` — a marker that disables updates while offering none fails the
+build rather than shipping silently) and copies it to
+`website/electron/EXTERNALLY-MANAGED`, which electron-builder packs **into
+`app.asar` next to `main.js`**. The running app reads that copy first and
+trusts it without any ownership probe, on every platform: it is part of the
+application's own code, so anyone positioned to rewrite it is already
+positioned to rewrite the code that reads it, and no file-ownership check could
+add to that. On macOS the baked copy is additionally sealed by codesign. A baked
+marker outranks a loose one when both exist — a build-time declaration by the
+edition that produced the binary beats a file dropped next to it later.
+
+The default build ships no baked marker (the file is gitignored and removed at
+the start of every build), so a plain checkout keeps the loose-marker contract
+exactly as described above.
+
+The commands themselves still run under the constructed environment described
+above: **no app environment variable reaches them** — not `HOME`, and not
+anything the edition's own wrapper exported before launching the app. So a
+command must not rely on `$HOME` or `~` expanding (derive the home directory
+from `USER`, which is passed through, or name paths that do not depend on it),
+and must not reference a variable it expects the app to have inherited. On
+Windows that failure is silent: `cmd.exe` leaves an undefined `%VAR%` in the
+command line **as the literal text `%VAR%`**, not as an empty string, so a
+wrapper argument such as `"%SOME_VAR%"` arrives as that string. The one value
+the constructed environment does derive for the command is
+`KIROCREW_MANAGED_ARGV0` — the running app executable's absolute path
+(`process.execPath`, taken from the process, never from the environment) — so a
+wrapper that verifies its relaunch target has a trustworthy answer without any
+inheritance.
 
 For local testing, the `KIROCREW_EXTERNALLY_MANAGED` env var points at a marker
 file (any other non-empty value marks the install managed with no metadata).

--- a/packaging/build-desktop.sh
+++ b/packaging/build-desktop.sh
@@ -802,9 +802,73 @@ else
   fi
 fi
 
+# A leftover staged marker from an earlier interrupted build is removed on
+# EVERY run, before any early exit: step 3b re-stages it when asked. This sits
+# ahead of the SKIP_ELECTRON return so a backend-only build cannot leave a
+# stale declaration behind for a hand-run electron-builder to pack.
+rm -f "$ELECTRON_DIR/EXTERNALLY-MANAGED"
+
 if [ "${SKIP_ELECTRON:-0}" = "1" ]; then
   log "SKIP_ELECTRON=1 — backend(s) ready under $ELECTRON_DIR/backend-dist/"
   exit 0
+fi
+
+# --- 3b. Baked EXTERNALLY-MANAGED marker (optional) --------------------------
+# An edition whose installs are owned by an external package manager (a Toolbox,
+# a corporate installer) declares that at BUILD time by naming its marker here.
+# The file is copied to $ELECTRON_DIR/EXTERNALLY-MANAGED, which package.json's
+# `files` list packs INTO app.asar next to main.js -- so the running app reads
+# it as its own code, on every platform, with no ownership probe (see
+# readExternallyManaged in website/electron/auto-update.js). A marker dropped
+# beside the app after the build (`<resources>/EXTERNALLY-MANAGED`) is the
+# repackager affordance and stays gated on file provenance; that gate refuses
+# every user-owned install and can never pass on Windows, which is why an
+# edition bakes instead of dropping.
+#
+# The copy is validated as the JSON object the reader accepts -- string fields
+# only, under the reader's 8 KiB read cap -- and the build FAILS on anything
+# else: the reader treats a malformed marker as "managed, nothing to run", so a
+# typo here would silently ship an app that can neither self-update nor be
+# updated from its About panel. Unset, nothing is staged: the unconditional
+# cleanup above (ahead of the SKIP_ELECTRON exit) already removed any leftover
+# from a previous local build, so a stale declaration cannot ride along.
+if [ -n "${KIROCREW_MANAGED_INSTALL_MARKER:-}" ]; then
+  MARKER_SRC="$KIROCREW_MANAGED_INSTALL_MARKER"
+  test -f "$MARKER_SRC" || { echo "❌ KIROCREW_MANAGED_INSTALL_MARKER does not name a file: $MARKER_SRC" >&2; exit 1; }
+  node -e '
+    const fs = require("fs");
+    const [src] = process.argv.slice(1);
+    const buf = fs.readFileSync(src);
+    if (buf.length > 8192) { console.error(`marker is ${buf.length} bytes; the reader caps at 8192`); process.exit(1); }
+    let parsed;
+    try { parsed = JSON.parse(buf.toString("utf8")); } catch (e) { console.error(`marker is not JSON: ${e.message}`); process.exit(1); }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) { console.error("marker must be a JSON object"); process.exit(1); }
+    const allowed = ["managedBy", "updateCommand", "checkCommand"];
+    // The reader TRIMS each field and slices it to a cap (auto-update.js:
+    // MANAGED_BY_MAX_CHARS / UPDATE_COMMAND_MAX_CHARS / CHECK_COMMAND_MAX_CHARS).
+    // Validate the value the reader will actually see: a whitespace-only
+    // command would trim to nothing and turn the marker bare, and an over-cap
+    // one would be truncated into a DIFFERENT command. Both are refused here.
+    const caps = { managedBy: 128, updateCommand: 512, checkCommand: 512 };
+    for (const k of Object.keys(parsed)) {
+      if (!allowed.includes(k)) { console.error(`marker has unknown field "${k}" (allowed: ${allowed.join(", ")})`); process.exit(1); }
+      if (typeof parsed[k] !== "string") { console.error(`marker field "${k}" must be a string`); process.exit(1); }
+      if (parsed[k].trim() !== parsed[k]) { console.error(`marker field "${k}" has leading/trailing whitespace the reader would trim`); process.exit(1); }
+      if (parsed[k].length > caps[k]) { console.error(`marker field "${k}" is ${parsed[k].length} chars; the reader caps at ${caps[k]} and would truncate the command`); process.exit(1); }
+    }
+    if (!parsed.updateCommand) { console.error("marker has no updateCommand: it would disable updates without offering any"); process.exit(1); }
+  ' "$MARKER_SRC" || { echo "❌ KIROCREW_MANAGED_INSTALL_MARKER rejected: $MARKER_SRC" >&2; exit 1; }
+  # Staged for THIS build only: electron-builder packs it below, and the copy
+  # must not outlive the run -- a later build of a different edition from the
+  # same tree (or a hand-run electron-builder) would otherwise pack the previous
+  # edition's commands. The unconditional rm above covers the next
+  # build-desktop.sh run; this covers every other exit path. The trap is armed
+  # BEFORE the copy so there is no instant at which the file exists without
+  # its cleanup -- an interrupt between the two would leave a stale marker for
+  # a hand-run `npm run dist` to pack.
+  trap 'rm -f "$ELECTRON_DIR/EXTERNALLY-MANAGED"' EXIT
+  cp "$MARKER_SRC" "$ELECTRON_DIR/EXTERNALLY-MANAGED"
+  log "Baking EXTERNALLY-MANAGED marker into the app from $MARKER_SRC"
 fi
 
 # --- 4. Package the desktop app with electron-builder -----------------------

--- a/src/kiro_crew/secrets/vault.py
+++ b/src/kiro_crew/secrets/vault.py
@@ -23,8 +23,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-
 from kiro_crew.atomic_write import atomic_write, fsync_dir
 from kiro_crew.platform_compat import file_lock, restrict_to_owner
 
@@ -318,6 +316,13 @@ class SecretVault:
         return b"v1" + self._SCOPE.encode() + b"\x00" + name.encode()
 
     def _encrypt_entry(self, name: str, plaintext: bytes) -> dict[str, str]:
+        # Imported HERE, not at module top. `kiro_crew.secrets` is reached from
+        # the tool-approval hook's import chain (hooks.on_tool_call ->
+        # slack.gateway -> autonudge -> irq -> cron_script -> secrets), so a
+        # top-level import made every tool approval depend on the `cryptography`
+        # native wheel loading. Only touching a vault entry needs AES-GCM.
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
         key = self._get_or_create_key()
         aesgcm = AESGCM(key)
         nonce = os.urandom(12)
@@ -325,6 +330,8 @@ class SecretVault:
         return {"nonce": nonce.hex(), "ct": ct.hex()}
 
     def _decrypt_entry(self, name: str, entry: dict[str, str], key: bytes) -> bytes:
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # see _encrypt_entry
+
         aesgcm = AESGCM(key)
         # A corrupt / hand-edited store can make ``entry`` any shape (a string,
         # a list, a dict missing ``nonce``/``ct``, or one whose values are not

--- a/src/kiro_crew/wecom/media.py
+++ b/src/kiro_crew/wecom/media.py
@@ -33,8 +33,6 @@ from typing import Any
 from urllib.parse import urlsplit
 
 import aiohttp
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from kiro_crew import link_unfurl
 
@@ -115,6 +113,17 @@ def decrypt_media(ciphertext: bytes, key: bytes) -> bytes:
     # that the URL is single-use and lives ~5 minutes, and that the key is per
     # object rather than shared.
     # nosemgrep: python.cryptography.security.mode-without-authentication.crypto-mode-without-authentication  # noqa: E501
+    # Imported HERE, not at module top. This module is reached from the
+    # tool-approval hook: hooks.on_tool_call -> slack.gateway._is_read_only_tool
+    # -> channels -> wecom.gateway -> wecom.client -> wecom.attachments -> here.
+    # A top-level import made every tool approval on the platform depend on the
+    # `cryptography` native wheel loading -- and on a host where that wheel is
+    # platform-mismatched (an AL2 x86_64 build on an Apple-silicon Mac) the hook
+    # raised ImportError before it could answer. Only decrypting a WeCom media
+    # file needs AES; only that path pays for it.
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
     decryptor = Cipher(algorithms.AES(key), modes.CBC(key[:_IV_BYTES])).decryptor()
     padded = decryptor.update(ciphertext) + decryptor.finalize()
     try:
@@ -252,7 +261,9 @@ async def download_media(
         # The URL lives ~5 minutes; a transport failure is reported, never retried
         # into a window that has already closed.
         raise WeComMediaError(f"media download failed: {type(exc).__name__}") from exc
-    return decrypt_media(b"".join(chunks), key)
+    # Off the loop: AES-CBC over a multi-megabyte body is CPU-bound, and the
+    # first call also pays the lazy ``cryptography`` native-module import.
+    return await asyncio.to_thread(decrypt_media, b"".join(chunks), key)
 
 
 def media_items(body: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/kiro_crew/weixin/media.py
+++ b/src/kiro_crew/weixin/media.py
@@ -17,6 +17,7 @@ data of our own.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import logging
@@ -25,8 +26,6 @@ from typing import Any
 from urllib.parse import quote
 
 import aiohttp
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +96,12 @@ def decrypt_aes_ecb(ciphertext: bytes, key: bytes) -> bytes:
     # ECB is dictated by the remote protocol (see module docstring): the CDN
     # hands us objects it already encrypted this way, and we never encrypt with
     # it. There is no algorithm choice to make here.
+    # Lazy for the same reason as wecom.media.decrypt_media: this module sits on
+    # the tool-approval hook's import chain, and only decrypting a media file
+    # needs the `cryptography` native wheel.
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
     decryptor = Cipher(  # nosec B305  # lgtm[py/weak-cryptographic-algorithm]
         algorithms.AES(key), modes.ECB()
     ).decryptor()
@@ -162,7 +167,9 @@ async def download_media(
     raw = await fetch_cdn_bytes(session, url, max_bytes=max_bytes)
     if not aes_key_b64:
         return raw
-    return decrypt_aes_ecb(raw, parse_aes_key(aes_key_b64))
+    # Off the loop: AES-ECB over the whole body is CPU-bound, and the first
+    # call also pays the lazy ``cryptography`` native-module import.
+    return await asyncio.to_thread(decrypt_aes_ecb, raw, parse_aes_key(aes_key_b64))
 
 
 def media_ref(item: dict[str, Any], kind_field: str) -> tuple[str, str]:

--- a/test/test_approval_chain_no_cryptography.py
+++ b/test/test_approval_chain_no_cryptography.py
@@ -1,0 +1,121 @@
+"""The tool-approval hook's import chain must not depend on the `cryptography`
+native wheel.
+
+Background
+----------
+``hooks.on_tool_call`` -- the function every ACP tool call passes through for
+its approve/deny verdict -- lazily imports ``kiro_crew.slack.gateway`` for
+``_is_read_only_tool``. That module imports ``kiro_crew.channels``, which
+imports every channel gateway, and the WeCom and Weixin gateways reach their
+``media`` modules, which used to import ``cryptography.hazmat`` at module top
+for their AES decryptors. So a host whose ``cryptography`` wheel does not load
+(a platform-mismatched build: the AL2 x86_64 wheel on an Apple-silicon Mac)
+made EVERY tool approval raise ImportError -- not just WeCom media downloads.
+
+The fix moved those imports inside the two decrypt functions. These tests pin
+the property in a subprocess with ``cryptography`` made unimportable, so a
+future top-level import anywhere on the chain fails here rather than in a
+security-path traceback on someone's machine.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+# Makes `import cryptography` (and any submodule) raise ImportError, the way a
+# missing or unloadable wheel does. A meta_path finder rather than a sys.modules
+# None entry, so submodule imports fail too.
+_BLOCK_CRYPTOGRAPHY = textwrap.dedent("""
+    import importlib.abc, sys
+
+    class _Block(importlib.abc.MetaPathFinder):
+        def find_spec(self, name, path=None, target=None):
+            if name == "cryptography" or name.startswith("cryptography."):
+                raise ImportError(f"blocked for this test: {name}")
+            return None
+
+    sys.meta_path.insert(0, _Block())
+    """)
+
+
+def _run(snippet: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        # -B: the child imports repo modules and must not leave __pycache__ beside them.
+        [sys.executable, "-B", "-c", _BLOCK_CRYPTOGRAPHY + textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def test_the_approval_hook_import_chain_loads_without_cryptography() -> None:
+    proc = _run("""
+        # The exact import hooks.on_tool_call performs, then the chain it drags in.
+        from kiro_crew.slack.gateway import _is_read_only_tool
+        import kiro_crew.channels
+        import kiro_crew.wecom.media
+        import kiro_crew.weixin.media
+        import kiro_crew.secrets.vault
+        assert _is_read_only_tool("Read") is True
+        print("chain ok")
+        """)
+    assert proc.returncode == 0, proc.stderr
+    assert "chain ok" in proc.stdout
+
+
+def test_only_decrypting_media_needs_cryptography() -> None:
+    # The dependency did not disappear, it moved to the one place that uses it:
+    # decrypting still fails clearly when the wheel is unavailable.
+    proc = _run("""
+        from kiro_crew.wecom import media as wecom_media
+        from kiro_crew.weixin import media as weixin_media
+        from kiro_crew.secrets.vault import SecretVault
+        import tempfile, pathlib
+        vault = SecretVault.__new__(SecretVault)
+        cases = (
+            (lambda: wecom_media.decrypt_media(b"x" * 32, b"k" * 32)),
+            (lambda: weixin_media.decrypt_aes_ecb(b"x" * 32, b"k" * 16)),
+            (lambda: vault._decrypt_entry("n", {"nonce": "00" * 12, "ct": "00" * 16}, b"k" * 32)),
+        )
+        for fn in cases:
+            try:
+                fn()
+            except ImportError as exc:
+                assert "cryptography" in str(exc), exc
+            else:
+                raise SystemExit("decrypt ran without cryptography?!")
+        print("decrypt needs it")
+        """)
+    assert proc.returncode == 0, proc.stderr
+    assert "decrypt needs it" in proc.stdout
+
+
+def test_no_module_on_the_channel_chain_imports_cryptography_at_top_level() -> None:
+    """Static complement to the subprocess test: the chain's modules must not
+    grow a top-level `cryptography` import back. Scoped to what the approval
+    hook reaches -- the channel tree AND `secrets/` (slack.gateway -> autonudge
+    -> irq -> cron_script -> secrets.vault was the second way in). auth/store.py
+    is not on the chain and keeps its top-level import."""
+    import ast
+    from pathlib import Path
+
+    import kiro_crew
+
+    root = Path(kiro_crew.__file__).parent
+    offenders = []
+    for sub in ("wecom", "weixin", "slack", "secrets", "channels.py"):
+        paths = [root / sub] if sub.endswith(".py") else sorted((root / sub).rglob("*.py"))
+        for path in paths:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in tree.body:  # module top level only
+                names = []
+                if isinstance(node, ast.Import):
+                    names = [a.name for a in node.names]
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    names = [node.module]
+                if any(n == "cryptography" or n.startswith("cryptography.") for n in names):
+                    offenders.append(f"{path.relative_to(root)}:{node.lineno}")
+    assert offenders == [], f"top-level cryptography import on the approval chain: {offenders}"

--- a/test/test_build_desktop_managed_marker.py
+++ b/test/test_build_desktop_managed_marker.py
@@ -1,0 +1,237 @@
+"""Regression guard for the baked ``EXTERNALLY-MANAGED`` marker step in
+``packaging/build-desktop.sh``.
+
+Background
+----------
+An edition whose installs are owned by an external package manager (a Toolbox,
+a corporate installer) names its marker through ``KIROCREW_MANAGED_INSTALL_MARKER``.
+The script copies it to ``website/electron/EXTERNALLY-MANAGED`` so electron-builder
+packs it INTO ``app.asar`` next to ``main.js``, where ``readExternallyManaged``
+(``website/electron/auto-update.js``) trusts it as the application's own code on
+every platform -- unlike a marker dropped beside the app after the build, which
+is gated on file provenance and refused on every user-owned install.
+
+Why this test exists
+--------------------
+The reader treats a malformed marker as "managed, nothing to run": the updater
+is OFF and the About panel offers no command. So a typo in an edition's marker
+would ship an app that can neither self-update nor be updated from the UI, and
+nothing in the running app would say why. The build step is where that must
+fail loudly. These tests extract the step from the shipped script (not a copy,
+so a revert is what runs here) and drive it through the accepted shape and each
+rejected one, plus the "unset removes a stale leftover" contract that keeps a
+previous local build's declaration from riding along.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Tests that RUN the extracted step need bash and node; the pure-source
+# assertions below run everywhere, Windows CI included.
+runs_the_step = pytest.mark.skipif(
+    os.name == "nt" or shutil.which("node") is None,
+    reason="build-desktop.sh is a bash script and the step validates with node",
+)
+
+SCRIPT = Path(__file__).parent.parent / "packaging" / "build-desktop.sh"
+
+
+def _extract_step() -> str:
+    """Pull the marker handling out of the shipped script: the unconditional
+    stale-marker cleanup (which sits ahead of the SKIP_ELECTRON early exit),
+    the SKIP_ELECTRON branch itself, and step 3b, up to the step-4 header."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    m = re.search(
+        r"(# A leftover staged marker from an earlier interrupted build.*?)"
+        r"\n# --- 4\. Package the desktop app",
+        text,
+        re.DOTALL,
+    )
+    assert m, "step 3b (baked EXTERNALLY-MANAGED marker) not found in packaging/build-desktop.sh"
+    return m.group(1)
+
+
+def _run(tmp_path: Path, marker_env: str | None) -> tuple[subprocess.CompletedProcess, Path]:
+    electron_dir = tmp_path / "electron"
+    electron_dir.mkdir(exist_ok=True)
+    env = {k: v for k, v in os.environ.items() if k != "KIROCREW_MANAGED_INSTALL_MARKER"}
+    if marker_env is not None:
+        env["KIROCREW_MANAGED_INSTALL_MARKER"] = marker_env
+    env["ELECTRON_DIR"] = str(electron_dir)
+    # The same strict mode the real script runs under, and its `log` helper.
+    # The step arms an EXIT trap that removes the staged copy, so its content is
+    # captured into a witness file BEFORE the shell exits; the test then asserts
+    # both halves of the contract: packed content right, nothing left behind.
+    script = (
+        'set -euo pipefail\nlog() { echo "$@"; }\n'
+        + _extract_step()
+        + "\n"
+        + 'if [ -f "$ELECTRON_DIR/EXTERNALLY-MANAGED" ]; then cp "$ELECTRON_DIR/EXTERNALLY-MANAGED" "$ELECTRON_DIR/.witness"; fi\n'
+    )
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=tmp_path,
+    )
+    return proc, electron_dir / "EXTERNALLY-MANAGED"
+
+
+def _witness(dest: Path) -> Path:
+    return dest.parent / ".witness"
+
+
+VALID = {
+    "managedBy": "Builder Toolbox",
+    "updateCommand": "/opt/toolbox/bin/toolbox update kirocrew",
+    "checkCommand": "/opt/toolbox/bin/kirocrew-update-check",
+}
+
+
+@runs_the_step
+def test_valid_marker_is_staged_verbatim_and_cleaned_up_on_exit(tmp_path: Path) -> None:
+    src = tmp_path / "marker.json"
+    src.write_text(json.dumps(VALID))
+    proc, dest = _run(tmp_path, str(src))
+    assert proc.returncode == 0, proc.stderr
+    assert (
+        _witness(dest).read_text() == src.read_text()
+    ), "staged copy is byte-identical while the build runs"
+    assert not dest.exists(), "the staged copy must not outlive the build (EXIT trap)"
+    assert "Baking EXTERNALLY-MANAGED marker" in proc.stdout
+
+
+@runs_the_step
+def test_unset_removes_a_stale_leftover(tmp_path: Path) -> None:
+    # A previous local build with the variable set must not leak its
+    # declaration into a build without it.
+    electron_dir = tmp_path / "electron"
+    electron_dir.mkdir()
+    (electron_dir / "EXTERNALLY-MANAGED").write_text(json.dumps(VALID))
+    proc, dest = _run(tmp_path, None)
+    assert proc.returncode == 0, proc.stderr
+    assert not dest.exists()
+
+
+@runs_the_step
+def test_empty_value_means_unset(tmp_path: Path) -> None:
+    proc, dest = _run(tmp_path, "")
+    assert proc.returncode == 0, proc.stderr
+    assert not dest.exists()
+
+
+@runs_the_step
+@pytest.mark.parametrize(
+    "body, reason",
+    [
+        ("not json", "not JSON"),
+        (json.dumps([1, 2]), "must be a JSON object"),
+        (json.dumps({**VALID, "extra": "x"}), "unknown field"),
+        (json.dumps({**VALID, "updateCommand": 7}), "must be a string"),
+        (json.dumps({"managedBy": "x"}), "no updateCommand"),
+        (json.dumps({**VALID, "managedBy": "x" * 9000}), "caps at 8192"),
+        # The reader trims and caps each field; the value it would SEE is what
+        # is validated, or a whitespace-only command turns the marker bare and
+        # an over-cap one is truncated into a different command.
+        (json.dumps({**VALID, "updateCommand": "   "}), "leading/trailing whitespace"),
+        (json.dumps({**VALID, "checkCommand": " /usr/bin/x"}), "leading/trailing whitespace"),
+        (json.dumps({**VALID, "updateCommand": "/usr/bin/" + "x" * 513}), "caps at 512"),
+        (json.dumps({**VALID, "managedBy": "m" * 129}), "caps at 128"),
+    ],
+    ids=[
+        "not-json",
+        "array",
+        "unknown-field",
+        "non-string",
+        "no-updateCommand",
+        "over-cap",
+        "whitespace-only-command",
+        "padded-command",
+        "command-over-512",
+        "managedBy-over-128",
+    ],
+)
+def test_malformed_marker_fails_the_build(tmp_path: Path, body: str, reason: str) -> None:
+    # Each rejection names its cause: a lane operator reading the build log must
+    # not have to diff a JSON file against the reader to find the typo.
+    src = tmp_path / "marker.json"
+    src.write_text(body)
+    proc, dest = _run(tmp_path, str(src))
+    assert proc.returncode != 0
+    assert reason in proc.stderr, proc.stderr
+    assert "KIROCREW_MANAGED_INSTALL_MARKER rejected" in proc.stderr
+    assert not _witness(dest).exists(), "a rejected marker must not be staged"
+
+
+@runs_the_step
+def test_missing_file_fails_the_build(tmp_path: Path) -> None:
+    proc, dest = _run(tmp_path, str(tmp_path / "nope.json"))
+    assert proc.returncode != 0
+    assert "does not name a file" in proc.stderr
+    assert not dest.exists()
+
+
+def test_package_json_packs_the_marker_into_the_asar() -> None:
+    # The copy is pointless unless electron-builder ships it: build.files is an
+    # explicit allowlist, and readExternallyManaged looks next to main.js.
+    pkg = json.loads((SCRIPT.parent.parent / "website" / "electron" / "package.json").read_text())
+    assert "EXTERNALLY-MANAGED" in pkg["build"]["files"]
+    assert "main.js" in pkg["build"]["files"]
+
+
+def test_cleanup_trap_is_armed_before_the_copy_exists() -> None:
+    """There must be no instant at which the staged marker exists without its
+    cleanup: an interrupt between `cp` and `trap` would leave a stale marker
+    for a hand-run electron-builder to pack into a later, different edition."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    trap_at = text.index("trap 'rm -f \"$ELECTRON_DIR/EXTERNALLY-MANAGED\"' EXIT")
+    copy_at = text.index('cp "$MARKER_SRC" "$ELECTRON_DIR/EXTERNALLY-MANAGED"')
+    assert trap_at < copy_at, "arm the EXIT trap before copying the marker"
+
+
+def test_step_caps_match_the_readers_constants() -> None:
+    """Step 3b re-states the reader's caps as literals; keep the two in lockstep
+    so a bumped constant in auto-update.js cannot silently pass a marker the
+    packaged reader will truncate (or reject a marker it would accept)."""
+    reader = (Path(__file__).parent.parent / "website" / "electron" / "auto-update.js").read_text(
+        encoding="utf-8"
+    )
+
+    def const(name: str) -> int:
+        m = re.search(rf"^const {name} = (\d+);", reader, re.M)
+        assert m, name
+        return int(m.group(1))
+
+    step = SCRIPT.read_text(encoding="utf-8")
+    m = re.search(
+        r"const caps = \{ managedBy: (\d+), updateCommand: (\d+), checkCommand: (\d+) \};",
+        step,
+    )
+    assert m, "step 3b caps literal not found"
+    assert tuple(map(int, m.groups())) == (
+        const("MANAGED_BY_MAX_CHARS"),
+        const("UPDATE_COMMAND_MAX_CHARS"),
+        const("CHECK_COMMAND_MAX_CHARS"),
+    )
+    m = re.search(r"buf\.length > (\d+)", step)
+    assert m and int(m.group(1)) == const("EXTERNALLY_MANAGED_MAX_BYTES")
+
+
+def test_stale_marker_cleanup_runs_before_the_skip_electron_exit() -> None:
+    """A backend-only build (SKIP_ELECTRON=1) must still remove a marker left
+    by an earlier interrupted run; otherwise a hand-run electron-builder packs
+    stale updater commands into whatever is built next."""
+    text = SCRIPT.read_text(encoding="utf-8")
+    cleanup_at = text.index('rm -f "$ELECTRON_DIR/EXTERNALLY-MANAGED"')
+    skip_at = text.index('if [ "${SKIP_ELECTRON:-0}" = "1" ]; then')
+    assert cleanup_at < skip_at, "clean the stale marker before the SKIP_ELECTRON early exit"

--- a/website/electron/auto-update.js
+++ b/website/electron/auto-update.js
@@ -106,8 +106,24 @@ const CHECK_COMMAND_MAX_CHARS = 512;
  * metadata — the test-harness seam, mirroring `KIROCREW_UPDATE_FEED`, and
  * honored ONLY on an unpackaged build: in a packaged app one env var in the
  * launch environment would otherwise name the file whose body we execute), then
- * `<resourcesPath>/EXTERNALLY-MANAGED`. I/O-bearing and fully injectable, like
- * resolveLinuxInstall above.
+ * the BAKED marker `<app code>/EXTERNALLY-MANAGED` (inside app.asar, next to
+ * this file — placed there at build time by `packaging/build-desktop.sh` when
+ * `KIROCREW_MANAGED_INSTALL_MARKER` names one; read on a PACKAGED build only,
+ * since in a dev checkout that directory is writable source), then the LOOSE marker
+ * `<resourcesPath>/EXTERNALLY-MANAGED` a repackager drops beside the app.
+ * I/O-bearing and fully injectable, like resolveLinuxInstall above.
+ *
+ * The two on-disk shapes differ in WHO put the file there, which is what its
+ * authority rests on. The loose marker is a post-build affordance for a distro
+ * packager, so it is gated on provenance (below). The baked marker is part of
+ * the application's own code: it ships in the same archive as main.js and this
+ * module, so anyone positioned to rewrite it is already positioned to rewrite
+ * the code that reads it, and no ownership probe can add anything to that. It
+ * is therefore trusted as code is trusted — on every platform, Windows
+ * included — and it outranks a loose marker when both exist, because a
+ * build-time declaration by the edition that produced the binary is a stronger
+ * statement than a file dropped next to it afterwards. On macOS the baked
+ * marker is additionally sealed by codesign for free.
  *
  * The marker body is optional JSON `{managedBy, updateCommand, checkCommand}`:
  * `managedBy` names the owning system for the About panel, `updateCommand` is
@@ -121,19 +137,22 @@ const CHECK_COMMAND_MAX_CHARS = 512;
  * self-updating. Entries are `lstat`ed and only regular files are read, so a
  * symlink can never route this startup-path read into a FIFO or device.
  *
- * INTEGRITY: the metadata is only parsed when neither the marker nor its
- * directory is OWNED by this euid or writable by group/other (see
+ * INTEGRITY (loose marker only): the metadata is only parsed when neither the
+ * marker nor its directory is OWNED by this euid or writable by group/other (see
  * canRewriteMarker) — `updateCommand`/`checkCommand` are SHELLED, so a marker
  * anything running as this user could rewrite is a marker that names arbitrary
  * code to run. A rewritable marker still means MANAGED, just with no metadata:
  * the same degenerate shape as an empty body, which leaves the updater off and
- * nothing to execute. Windows always takes that answer (no POSIX owner to read).
+ * nothing to execute. Windows always takes that answer for a loose marker (no
+ * POSIX owner to read); a baked marker is not probed on any platform.
  *
  * @param {object} [o]
  * @param {object} [o.env=process.env]
  * @param {string} [o.resourcesPath=process.resourcesPath]
  * @param {boolean} [o.isPackaged]  packaged app? gates the env-var seam off
  * @param {(p:string)=>boolean} [o.probeMarkerRewritable=canRewriteMarker]
+ * @param {string} [o.bakedMarkerPath]  where the in-code marker lives; defaults
+ *   to `EXTERNALLY-MANAGED` beside this module (inside app.asar when packaged)
  * @returns {{managedBy:string, updateCommand:string, checkCommand:string}|null} null when not managed
  */
 function readExternallyManaged({
@@ -154,9 +173,16 @@ function readExternallyManaged({
   // Marker-integrity probe, injected for the same reason as the other probes in
   // this module: assertable without a real read-only install directory.
   probeMarkerRewritable = canRewriteMarker,
+  // The in-code marker. `__dirname` is inside app.asar in a packaged build
+  // (Electron's fs shim reads through the archive), and the module directory
+  // in a dev checkout, where the file simply does not exist.
+  bakedMarkerPath = require("path").join(__dirname, EXTERNALLY_MANAGED_MARKER),
 } = {}) {
   let raw = null;
   let markerPath = "";
+  // Which shape was found. Only a LOOSE marker is subject to the provenance
+  // probe below; a baked one is code (see the doc comment).
+  let loose = false;
   try {
     const fs = require("fs");
     const path = require("path");
@@ -184,22 +210,38 @@ function readExternallyManaged({
     if (override) {
       // A value that names a marker file reads it; any other non-empty value
       // (including a dangling path) marks the install managed with no metadata.
+      // Treated like a loose marker: the harness is exercising that path.
       markerPath = override;
+      loose = true;
       raw = readMarkerAt(override);
       if (raw === null) raw = "";
     } else {
-      markerPath = path.join(resourcesPath || "", EXTERNALLY_MANAGED_MARKER);
-      raw = readMarkerAt(markerPath);
-      if (raw === null) return null;
+      // Baked first: a build-time declaration outranks a file dropped later.
+      // PACKAGED builds only. The baked path is `__dirname/EXTERNALLY-MANAGED`,
+      // and in a dev checkout `__dirname` is a plain writable source directory,
+      // not an archive: a file there has none of the provenance the trust rests
+      // on, and the managed lane below arms its launch timer before the
+      // dev-disable gate. An unpackaged run reads no baked marker; the env seam
+      // above is the harness's route.
+      markerPath = isPackaged && bakedMarkerPath ? bakedMarkerPath : "";
+      raw = markerPath ? readMarkerAt(markerPath) : null;
+      if (raw === null) {
+        markerPath = path.join(resourcesPath || "", EXTERNALLY_MANAGED_MARKER);
+        loose = true;
+        raw = readMarkerAt(markerPath);
+        if (raw === null) return null;
+      }
     }
   } catch {
     // fs itself unavailable (non-node runtime): nothing to read, not managed.
     return null;
   }
-  // Integrity gate: a marker this process could rewrite carries no authority,
-  // so it is read as a bare marker (managed, no metadata). Deliberately BEFORE
-  // the parse, so no attacker-chosen string reaches the fields at all.
-  if (raw && probeMarkerRewritable(markerPath)) raw = "";
+  // Integrity gate: a LOOSE marker this process could rewrite carries no
+  // authority, so it is read as a bare marker (managed, no metadata).
+  // Deliberately BEFORE the parse, so no attacker-chosen string reaches the
+  // fields at all. A baked marker skips the probe: it is code, and its
+  // provenance is the application's own.
+  if (raw && loose && probeMarkerRewritable(markerPath)) raw = "";
   let managedBy = "";
   let updateCommand = "";
   let checkCommand = "";
@@ -256,8 +298,10 @@ function readExternallyManaged({
 // answer is only "no metadata", which is the historical bare-marker behavior.
 // Windows takes that answer UNCONDITIONALLY and by declaration: it has no POSIX
 // owner to read, and `access(W_OK)` there does not model ACLs, so there is no
-// honest verdict to give. A Windows install therefore never honors marker
-// commands; see docs/build/desktop-app.md.
+// honest verdict to give. A Windows install therefore never honors a LOOSE
+// marker's commands; a packager that needs them there bakes the marker into the
+// app at build time, where this probe does not apply (see readExternallyManaged
+// and docs/build/desktop-app.md).
 function canRewriteMarker(markerPath) {
   try {
     const fs = require("fs");
@@ -1025,10 +1069,12 @@ function initAutoUpdate(deps) {
     // commands.
     //
     // TRUST / HARDENING: reaching here means the marker's metadata already
-    // passed the integrity gate in readExternallyManaged — neither the marker nor
-    // its directory is owned by this euid or writable by group/other, so it is a
-    // genuine packager artifact rather than a file a prompt-injected agent shell
-    // could have planted. That gate is
+    // passed the provenance test in readExternallyManaged — either it is BAKED
+    // into the application's own code (the same archive as this module, so no
+    // write primitive reaches it that does not already reach main.js), or it is
+    // a LOOSE marker that neither this euid owns nor group/other can write, so
+    // it is a genuine packager artifact rather than a file a prompt-injected
+    // agent shell could have planted. That test is
     // what makes the commands trustworthy at all; the hardening below is about
     // the ENVIRONMENT they run in, not about the command string (see
     // runManagedCommand) — a narrowed system-only PATH so a planted shim on the
@@ -1076,6 +1122,16 @@ function initAutoUpdate(deps) {
             process.env.SystemRoot || "C:\\Windows",
           ].join(";")
         : "/usr/bin:/bin:/usr/sbin:/sbin";
+    // The interpreter the marker command runs under. On Windows `shell: true`
+    // would read `process.env.ComSpec` -- user-level, and therefore settable by
+    // the same agent this whole construction defends against -- so the system
+    // cmd.exe is named by PATH instead, anchored on the SystemRoot that
+    // managedPath() already trusts. On POSIX Node resolves /bin/sh by path, so
+    // `true` is already pinned.
+    const managedShell = () =>
+      process.platform === "win32"
+        ? `${process.env.SystemRoot || "C:\\Windows"}\\System32\\cmd.exe`
+        : true;
     // The child's environment is CONSTRUCTED, not filtered.
     //
     // `shell: true` means a shell interprets the command, and a shell reads its
@@ -1110,12 +1166,32 @@ function initAutoUpdate(deps) {
     ];
     // cmd.exe cannot start without these, so the win32 lane mirrors
     // managedPath()'s win32 branch rather than handing it a shell it cannot run.
+    // COMSPEC is deliberately NOT inherited: the shell is pinned by
+    // managedShell(). (cmd.exe sets COMSPEC to its own path once it starts, so
+    // whatever the child sees IS the pinned shell -- what matters is that the
+    // app's inherited value never reaches it.)
     const MANAGED_ENV_PASSTHROUGH_WIN32 = [
-      "SystemRoot", "SystemDrive", "windir", "COMSPEC",
+      "SystemRoot", "SystemDrive", "windir",
       "PATHEXT", "TEMP", "TMP", "USERPROFILE", "APPDATA", "LOCALAPPDATA",
     ];
     const managedEnv = () => {
-      const e = { PATH: managedPath() };
+      // PYTHONNOUSERSITE is SET, not merely withheld: HOME is excluded above
+      // because Python derives its user-site directory from it, but on Windows
+      // the same directory derives from APPDATA -- which cmd.exe-era tooling
+      // needs and so IS passed through. Rather than reason per platform about
+      // which variable leads to `site-packages`, tell the interpreter directly
+      // that no user site exists. Harmless to every non-Python command.
+      // KIROCREW_MANAGED_ARGV0 is DERIVED, not inherited: process.execPath is
+      // the running executable's absolute path from the kernel command line,
+      // never read from process.env. It is the one fact a relaunch-verifying
+      // wrapper needs (which binary launched the app it is about to replace)
+      // and the only way to get it, since no app environment variable reaches
+      // the command by design.
+      const e = {
+        PATH: managedPath(),
+        PYTHONNOUSERSITE: "1",
+        KIROCREW_MANAGED_ARGV0: process.execPath,
+      };
       const keys = process.platform === "win32"
         ? [...MANAGED_ENV_PASSTHROUGH, ...MANAGED_ENV_PASSTHROUGH_WIN32]
         : MANAGED_ENV_PASSTHROUGH;
@@ -1163,9 +1239,19 @@ function initAutoUpdate(deps) {
         // `command` is NOT user input: it is operator-controlled text from the
         // EXTERNALLY-MANAGED marker, and execution is hardened (narrowed system
         // PATH, cwd="/", bounded output, timeout). See the trust note above.
+        //
+        // The SHELL is pinned, not discovered. `shell: true` on Windows resolves
+        // the interpreter from `process.env.ComSpec`, a user-level variable the
+        // same agent that managedEnv() defends against can set -- so the trusted
+        // command would run under an attacker-chosen shell before its first
+        // token was parsed. managedShell() names the system cmd.exe by path
+        // (the same SystemRoot anchor managedPath() already relies on) and the
+        // app's COMSPEC is not inherited -- cmd.exe sets its own to the pinned
+        // path, so nothing the child re-reads names another shell. POSIX keeps
+        // `shell: true`: Node resolves /bin/sh by path there, not from the env.
         // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
         child = cp.spawn(command, { // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-          shell: true,
+          shell: managedShell(),
           cwd: "/",
           env: managedEnv(),
           ...(timeout ? { timeout } : {}),

--- a/website/electron/package.json
+++ b/website/electron/package.json
@@ -217,7 +217,8 @@
       "icon.png",
       "icon-nightly.png",
       "trayTemplate.png",
-      "trayTemplate@2x.png"
+      "trayTemplate@2x.png",
+      "EXTERNALLY-MANAGED"
     ],
     "extraResources": [
       {

--- a/website/electron/test/auto-update.test.js
+++ b/website/electron/test/auto-update.test.js
@@ -1396,6 +1396,166 @@ test("readExternallyManaged: chmod 0400 on an OWNED marker does not buy trust", 
   });
 });
 
+// --- Baked marker: shipped inside the app's own code ------------------------
+//
+// A marker that lives in app.asar next to main.js has the application's own
+// provenance: nothing can rewrite it without also being able to rewrite the
+// code that reads it. So it is trusted WITHOUT the ownership probe, on every
+// platform, and it outranks a loose marker dropped beside the app afterwards.
+// These tests pin all three properties, plus the degenerate shapes.
+
+function bakedFixture(t, body) {
+  const fs = require("node:fs");
+  const os = require("node:os");
+  const path = require("node:path");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "kc-baked-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const codeDir = path.join(root, "app-code");
+  const resources = path.join(root, "resources");
+  fs.mkdirSync(codeDir);
+  fs.mkdirSync(resources);
+  const baked = path.join(codeDir, "EXTERNALLY-MANAGED");
+  if (body !== undefined) fs.writeFileSync(baked, body);
+  return { root, codeDir, resources, baked };
+}
+
+test("baked marker: trusted as code -- the ownership probe is never consulted", (t) => {
+  // The user-owned, writable file that canRewriteMarker would refuse: exactly
+  // the shape a Toolbox / Homebrew / ~/Applications install has for EVERY file
+  // in the app, main.js included. Baked, it is honored anyway.
+  const { baked, resources } = bakedFixture(t, JSON.stringify({
+    managedBy: "Builder Toolbox",
+    updateCommand: "/opt/toolbox/bin/toolbox update kirocrew",
+    checkCommand: "/opt/toolbox/bin/kirocrew-update-check",
+  }));
+  let probed = 0;
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {},
+    resourcesPath: resources,
+    bakedMarkerPath: baked, isPackaged: true,
+    probeMarkerRewritable: () => { probed += 1; return true; },
+  }), {
+    managedBy: "Builder Toolbox",
+    updateCommand: "/opt/toolbox/bin/toolbox update kirocrew",
+    checkCommand: "/opt/toolbox/bin/kirocrew-update-check",
+  });
+  assert.strictEqual(probed, 0, "a baked marker is not subject to the loose-marker provenance probe");
+});
+
+test("baked marker: read on a PACKAGED build only -- a dev checkout's source dir is not an archive", (t) => {
+  // In a dev checkout `__dirname` is writable source, not app.asar, so a file
+  // there has none of the provenance the baked trust rests on -- and the managed
+  // lane arms its launch timer before the dev-disable gate, so a planted file
+  // would be shelled. Unpackaged: the baked path is not read at all, and the
+  // loose marker keeps its own gated contract.
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const { baked, resources } = bakedFixture(t, JSON.stringify({
+    managedBy: "planted", updateCommand: "/usr/bin/planted-update",
+  }));
+  assert.strictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: false,
+  }), null, "unpackaged: no baked read, no loose marker -> not managed");
+  fs.writeFileSync(path.join(resources, "EXTERNALLY-MANAGED"), JSON.stringify({ managedBy: "loose" }));
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: false,
+    probeMarkerRewritable: () => false,
+  }), { managedBy: "loose", updateCommand: "", checkCommand: "" }, "unpackaged: the loose path is what is read");
+});
+
+test("baked marker: honored with the REAL probe on a user-owned tree (the Windows/Toolbox shape)", (t) => {
+  // No injected probe: canRewriteMarker itself runs, and on this host the
+  // fixture is ours (or we are root, or on Windows) -- every arm of that probe
+  // answers "rewritable". The baked path must not ask it. This is the property
+  // that brings the commands back on Windows, where the probe is fail-closed by
+  // declaration.
+  const { baked, resources } = bakedFixture(t, JSON.stringify({
+    managedBy: "pkgtool", updateCommand: "/usr/bin/pkgtool update",
+  }));
+  assert.strictEqual(canRewriteMarker(baked), true, "precondition: the probe WOULD refuse this file");
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true,
+  }), { managedBy: "pkgtool", updateCommand: "/usr/bin/pkgtool update", checkCommand: "" });
+});
+
+test("baked marker: outranks a loose marker when both exist", (t) => {
+  // A build-time declaration by the edition beats a file dropped later --
+  // including a trusted-looking loose one. The loose body must not leak into
+  // any field.
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const { baked, resources } = bakedFixture(t, JSON.stringify({
+    managedBy: "edition", updateCommand: "/usr/bin/edition-update",
+  }));
+  fs.writeFileSync(path.join(resources, "EXTERNALLY-MANAGED"), JSON.stringify({
+    managedBy: "loose", updateCommand: "/usr/bin/loose-update", checkCommand: "/usr/bin/loose-check",
+  }));
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true,
+    probeMarkerRewritable: () => false, // even a loose marker that WOULD pass
+  }), { managedBy: "edition", updateCommand: "/usr/bin/edition-update", checkCommand: "" });
+});
+
+test("baked marker: absent -> the loose marker keeps its gated behavior", (t) => {
+  // The default build ships no baked marker, so the pre-existing contract must
+  // be untouched: a loose marker is read, and its metadata still depends on the
+  // provenance probe.
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const { baked, resources } = bakedFixture(t /* no body: file absent */);
+  assert.strictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true,
+  }), null, "neither marker present: not managed");
+  fs.writeFileSync(path.join(resources, "EXTERNALLY-MANAGED"), JSON.stringify({
+    managedBy: "loose", updateCommand: "/usr/bin/loose-update",
+  }));
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true, probeMarkerRewritable: () => true,
+  }), { managedBy: "", updateCommand: "", checkCommand: "" }, "rewritable loose marker: bare");
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true, probeMarkerRewritable: () => false,
+  }), { managedBy: "loose", updateCommand: "/usr/bin/loose-update", checkCommand: "" }, "trusted loose marker: metadata");
+});
+
+test("baked marker: degenerate bodies still mean managed, with nothing to run", (t) => {
+  // Same fail-safe as the loose shape: a baked marker that is empty, unparsable,
+  // over-cap or not a regular file leaves the updater OFF and yields no command.
+  // A build that mis-writes its marker must not fall back to self-updating.
+  const fs = require("node:fs");
+  const bare = { managedBy: "", updateCommand: "", checkCommand: "" };
+  for (const body of ["", "not json", "[1,2]", "x".repeat(8193)]) {
+    const { baked, resources } = bakedFixture(t, body);
+    assert.deepStrictEqual(readExternallyManaged({
+      env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true,
+    }), bare, `body ${JSON.stringify(body.slice(0, 12))}`);
+  }
+  const { baked, resources } = bakedFixture(t);
+  fs.mkdirSync(baked); // a directory at the marker's name
+  assert.deepStrictEqual(readExternallyManaged({
+    env: {}, resourcesPath: resources, bakedMarkerPath: baked, isPackaged: true,
+  }), bare, "directory at the baked path");
+});
+
+test("baked marker: the dev/test env seam still wins, and stays a LOOSE read", (t) => {
+  // KIROCREW_EXTERNALLY_MANAGED (unpackaged only) names the file the harness
+  // wants exercised; a baked marker must not pre-empt it, and the env-named
+  // file keeps the provenance probe -- the seam exercises the loose path.
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const { baked, resources, root } = bakedFixture(t, JSON.stringify({ managedBy: "baked" }));
+  const envMarker = path.join(root, "env-marker");
+  fs.writeFileSync(envMarker, JSON.stringify({ managedBy: "env", updateCommand: "/usr/bin/x" }));
+  let probedPath = "";
+  assert.deepStrictEqual(readExternallyManaged({
+    env: { KIROCREW_EXTERNALLY_MANAGED: envMarker },
+    isPackaged: false,
+    resourcesPath: resources,
+    bakedMarkerPath: baked,
+    probeMarkerRewritable: (p) => { probedPath = p; return false; },
+  }), { managedBy: "env", updateCommand: "/usr/bin/x", checkCommand: "" });
+  assert.strictEqual(probedPath, envMarker);
+});
+
 test("canRewriteMarker: a marker we do NOT own and cannot chmod is trusted", (t) => {
   // The positive half: without this the gate could refuse everything and still
   // pass every negative test. Asserted against a real foreign-owned path (the
@@ -1608,6 +1768,29 @@ test("managed command env is CONSTRUCTED: nothing the shell reads as code is inh
   // The rest of the hardened environment is unchanged.
   assert.ok(env.PATH && !env.PATH.includes(require("node:os").homedir()),
     "PATH stays the narrowed system one");
+  // SET, not merely withheld: HOME is excluded so Python cannot find a planted
+  // user-site, but on Windows that directory derives from APPDATA, which IS
+  // passed through. Telling the interpreter directly closes both spellings.
+  assert.strictEqual(env.PYTHONNOUSERSITE, "1",
+    "a Python updater must never import a user-site sitecustomize, on any platform");
+  // The SHELL is pinned, not discovered from the environment. On POSIX Node
+  // resolves /bin/sh by path, so `true` is already pinned; on Windows the
+  // system cmd.exe is named by path, because `shell: true` there reads the
+  // user-level ComSpec -- the same injection class the env construction closes.
+  const shellOpt = optsList[0].shell;
+  if (process.platform === "win32") {
+    assert.match(String(shellOpt), /\\System32\\cmd\.exe$/i, "win32 shell must be the system cmd.exe by path");
+  } else {
+    assert.strictEqual(shellOpt, true);
+  }
+  assert.ok(!("COMSPEC" in env) && !("ComSpec" in env),
+    "the app's COMSPEC is not inherited (cmd.exe sets the child's own to the pinned shell)");
+  // Derived, not inherited: the launching executable's absolute path, from
+  // process.execPath (kernel command line), never from process.env.
+  assert.strictEqual(env.KIROCREW_MANAGED_ARGV0, process.execPath);
+  const src = require("node:fs").readFileSync(require.resolve("../auto-update"), "utf8");
+  assert.match(src, /shell: managedShell\(\)/, "spawn must take its shell from managedShell()");
+  assert.match(src, /System32\\\\cmd\.exe`/, "managedShell() must pin the system cmd.exe on win32");
   assert.strictEqual(optsList[0].cwd, "/");
 });
 

--- a/website/electron/test/build-time-inputs.js
+++ b/website/electron/test/build-time-inputs.js
@@ -1,0 +1,7 @@
+"use strict";
+// Files that package.json's `files` list names but that a plain checkout does
+// not contain: build-desktop.sh stages them on demand (step 3b) and the EXIT
+// trap removes them again, so their absence is not staleness. Shared by the
+// packaging and shell-contract staleness tests so the exemption has one owner.
+// (Not a *.test.js file, so `node --test test/*.test.js` does not run it.)
+module.exports = { BUILD_TIME_INPUTS: new Set(["EXTERNALLY-MANAGED"]) };

--- a/website/electron/test/packaging.test.js
+++ b/website/electron/test/packaging.test.js
@@ -115,6 +115,8 @@ function bmpDarkPixelCount(file, { left, top, right, bottom }) {
   return count;
 }
 
+const { BUILD_TIME_INPUTS } = require("./build-time-inputs");
+
 describe("electron-builder files list", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
   const bundledFiles = pkg.build.files;
@@ -137,8 +139,21 @@ describe("electron-builder files list", () => {
   });
 
   it("does not reference files that no longer exist", () => {
-    const stale = bundledFiles.filter(f => !fs.existsSync(path.join(ROOT, f)));
+    // Every entry is checked-in source EXCEPT the build-time inputs a build
+    // places here on demand (BUILD_TIME_INPUTS, shared with shell-contract.test.js):
+    // absent in a checkout by design, so their absence is not staleness.
+    const stale = bundledFiles.filter(f => !fs.existsSync(path.join(ROOT, f)) && !BUILD_TIME_INPUTS.has(f));
     assert.deepStrictEqual(stale, [], `Stale entries in build.files: ${stale.join(", ")}`);
+  });
+
+  it("lists the baked EXTERNALLY-MANAGED marker so a build that places it packs it into app.asar", () => {
+    // build-desktop.sh copies KIROCREW_MANAGED_INSTALL_MARKER here; without this
+    // entry electron-builder would leave it out and readExternallyManaged would
+    // find nothing beside main.js -- the edition silently ships un-managed.
+    assert.ok(bundledFiles.includes("EXTERNALLY-MANAGED"));
+    const script = fs.readFileSync(path.join(ROOT, "..", "..", "packaging", "build-desktop.sh"), "utf8");
+    assert.match(script, /KIROCREW_MANAGED_INSTALL_MARKER/);
+    assert.match(script, /\$ELECTRON_DIR\/EXTERNALLY-MANAGED/);
   });
 });
 

--- a/website/electron/test/shell-contract.test.js
+++ b/website/electron/test/shell-contract.test.js
@@ -68,7 +68,9 @@ test("packaging allowlist covers every relatively-required module", () => {
 
 test("packaging allowlist has no stale entries", () => {
   const listed = require(path.join(ROOT, "package.json")).build.files;
-  const stale = listed.filter((f) => !fs.existsSync(path.join(ROOT, f)));
+  // Build-time inputs are staged by build-desktop.sh, not present in a checkout.
+  const { BUILD_TIME_INPUTS: buildTimeInputs } = require("./build-time-inputs");
+  const stale = listed.filter((f) => !buildTimeInputs.has(f) && !fs.existsSync(path.join(ROOT, f)));
   assert.deepStrictEqual(
     stale,
     [],


### PR DESCRIPTION
## Problem / Motivation

`release/0.6.0` (the current insider line, `v0.6.0-insider.1`) carries #7959's provenance gate on the loose `EXTERNALLY-MANAGED` marker but not [#8799](https://github.com/kirodotdev/KiroCrew/pull/8799), which restores the edition auto-update path that gate closed. On a 0.6.0 insider build every per-user edition install (a Toolbox, Homebrew or `~/Applications` tree) reads as *bare*: the updater is off, the About panel offers no update, the 30 s / 4 h background check never runs, and a remote Linux gateway hides its Toolbox provider.

## Why it matters

Insiders on an edition build cannot update through their package manager from inside the app until the next release line, and the internal edition's CR that wires its lanes to the baked marker fails closed against a core that does not read one. 0.6.0 is the line those editions ship on.

## What changed (motivation → approach → change)

Straight cherry-pick of `a21546ae593bb5c076a0199a130dec346e06a5b9` ([#8799](https://github.com/kirodotdev/KiroCrew/pull/8799)), same commit, same rationale -- see that PR for the design discussion and the reviewer rounds. In short:

- `website/electron/auto-update.js` -- a **baked** marker (`__dirname/EXTERNALLY-MANAGED`, inside `app.asar`, packaged builds only) is read first and trusted as code on every platform, outranking a loose marker; the loose marker keeps #7959's gate. The managed-command lane pins the Windows shell to `%SystemRoot%\System32\cmd.exe` (no inherited `COMSPEC`), sets `PYTHONNOUSERSITE=1`, and derives `KIROCREW_MANAGED_ARGV0 = process.execPath` for edition wrappers.
- `packaging/build-desktop.sh` step 3b -- `KIROCREW_MANAGED_INSTALL_MARKER=<json>` is validated (string fields, reader caps, `updateCommand` required) and staged for the build only (EXIT trap armed before the copy; stale-marker cleanup ahead of the `SKIP_ELECTRON` exit).
- `fix(hooks)` -- `cryptography` imported lazily in `wecom/media.py`, `weixin/media.py`, `secrets/vault.py`, so the tool-approval import chain no longer needs the wheel; WeCom/Weixin decrypt runs through `asyncio.to_thread`.
- Docs, `package.json` `build.files`, `.gitignore`, and the shared `test/build-time-inputs.js`.

**Dropped from the backport:** the `fix(dashboard)` SEL deny-path piece (`sel.sel_is_warm()`, `_audit_denied`'s warm/cold split, `test_api_health.py` changes, `test_sel_startup_warm.py`). It hardens the direct-enqueue path that #8741 introduced on `main`; `release/0.6.0` does not carry #8741 and its `_audit_denied` still runs every deny audit through `asyncio.to_thread`, so the hazard does not exist on this branch. Those four files stay at the branch's own versions (that was the only cherry-pick conflict).

## Tests

- `website/electron`: `node --test` on `auto-update.test.js` / `packaging.test.js` / `shell-contract.test.js` -- 199 pass, 0 fail (baked-marker precedence and trust, unpackaged-build gate, constructed-env assertions incl. the pinned shell and `KIROCREW_MANAGED_ARGV0`, `build.files` staleness with the shared build-time-inputs set).
- `test/test_build_desktop_managed_marker.py` (18) -- step 3b accept / reject branches, trap-before-copy and cleanup-before-`SKIP_ELECTRON` ordering, caps parity with the reader's constants.
- `test/test_approval_chain_no_cryptography.py` (3) -- the approval chain imports with `cryptography` blocked; the decrypt helpers still raise `ImportError` on use.
- `test_wecom_media.py`, `test_weixin_media.py`, `test_api_health.py` -- 144 Python tests pass together on this branch; flake8 and eslint clean.

## Manual verification

N/A beyond #8799's -- the diff is byte-identical to the merged commit minus the dropped SEL files; the edition-side lanes exercise it end to end once this is on an insider build.

## Related Issues

no linked issue: backport of #8799 to the 0.6.0 insider line.

## Pattern harvest

Not generalizable: a release-line backport of an already-reviewed change; the harvest lives on #8799.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
