### PR TITLE
fix: word the Slack override-expiry DM by cause, no re-arm hint on policy revocation (#8850)

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import errno
 import faulthandler
+import functools
 import logging
 import os
 import stat
@@ -172,6 +173,7 @@ from kiro_crew.platform import (
 )
 from kiro_crew.power import SleepInhibitor
 from kiro_crew.safety_override import (
+    POLICY_REVOKED_SOURCE,
     apply_config_duration,
     describe_dropped_grant,
     grant_declared_yolo,
@@ -2118,7 +2120,7 @@ def _armed_unattended_loops() -> "list[Any]":
 _UNATTENDED_EXPIRY_TITLE = "🔒 Auto-approve expired while an unattended run was in progress"
 
 
-def _unattended_expiry_text(loop_count: int) -> str:
+def _unattended_expiry_text(loop_count: int, source: str) -> str:
     """Body shared by the dashboard note and the owner DM, so the two cannot drift.
 
     Names the remedy as well as the cause: ``agent.yolo_duration`` accepts
@@ -2126,16 +2128,32 @@ def _unattended_expiry_text(loop_count: int) -> str:
     problem is that operators do not know that option exists, and the moment it
     would have helped is the moment worth saying so.
 
+    EXCEPT after a policy revocation (``source == POLICY_REVOKED_SOURCE``): both
+    halves of that remedy — re-enabling auto-approve and ``until_shutdown``, a
+    ``yolo_duration`` scope member — are refused by the same fail-closed
+    ``approval_modes`` gate that revoked the grant, so suggesting them directs
+    the one operator who is not present into a wall (issue #8850). The stall
+    description stays; only the remedy is replaced with the actual cause.
+
     The stall is stated conditionally because global auto-approve is not the only
     path to one: a slot carrying its own trust grant is approved by ``slot._trust``
     independently of the grant, so its cycles keep running after this expiry.
     Claiming the run has stopped would send an operator to rescue a healthy one.
     """
-    return (
+    stall = (
         f"{loop_count} monitor loop(s) are still running, but auto-approval has "
         f"ended, so any cycle that relied on it now waits on a per-tool approval "
         f"that nobody is there to give. (A session granted its own trust is "
-        f"unaffected.) Re-enable auto-approve to resume. For runs meant to go "
+        f"unaffected.)"
+    )
+    if source == POLICY_REVOKED_SOURCE:
+        return (
+            f"{stall} Auto-approve was disabled by organization policy, so it "
+            f"cannot be re-enabled while the policy is in effect — contact your "
+            f"administrator if you believe this is unexpected."
+        )
+    return (
+        f"{stall} Re-enable auto-approve to resume. For runs meant to go "
         f"unattended overnight, Settings → agent.yolo_duration has an "
         f"'until_shutdown' option that has no timed expiry."
     )
@@ -2164,7 +2182,7 @@ def _notify_unattended_expiry(state: "DashboardState", source: str) -> None:
         "every further cycle will wait on per-tool approval",
         len(armed),
     )
-    body = _unattended_expiry_text(len(armed))
+    body = _unattended_expiry_text(len(armed), source)
     try:
         state.notify(
             "safety_override",
@@ -2191,12 +2209,54 @@ def _notify_unattended_expiry(state: "DashboardState", source: str) -> None:
     task.add_done_callback(state._background_tasks.discard)
 
 
-def _dispatch_override_expiry_notification(state: DashboardState, notify_coro_factory: Any) -> bool:
+def _override_expiry_dm_text(source: str) -> str:
+    """Owner-DM body for an override expiry, worded by what actually happened.
+
+    A POLICY revocation (``source == POLICY_REVOKED_SOURCE``) is not an expiry
+    the operator can undo: ``_commit_activation``'s fail-closed
+    ``approval_modes`` gate refuses the very ``/kirocrew yolo`` this message
+    used to suggest, so the old text directed the operator into a wall without
+    naming the cause. Presentation only — the gate and its SEL audit are
+    unchanged. (The unattended-run notice applies the same source split in
+    ``_unattended_expiry_text``.)
+
+    Every other source keeps the original wording byte-identical: a TTL lapse
+    IS re-armable, and that text is pinned by tests.
+    """
+    if source == POLICY_REVOKED_SOURCE:
+        return (
+            "\U0001f512 Auto-approve was disabled by organization policy, and the "
+            "active safety override has been revoked. Tools now require approval. "
+            "Re-authorization is refused while the policy is in effect — contact "
+            "your administrator if you believe this is unexpected."
+        )
+    return "\U0001f512 Safety override expired. Tools now require approval. Reply `/kirocrew yolo` to re-authorize."
+
+
+async def _notify_slack_override_expired(state: DashboardState, source: str) -> None:
+    """Post the override expiry notice to the owner DM, worded by cause.
+
+    Module-level (not a ``start_dashboard`` closure) so the seam this fix added —
+    ``source`` travelling from the expiry callback into the DM body — is
+    directly testable; a closure would leave that wiring uncovered.
+    """
+    await _dm_owner(state, _override_expiry_dm_text(source))
+
+
+def _dispatch_override_expiry_notification(
+    state: DashboardState, notify_coro_factory: Any, source: str
+) -> bool:
     """Schedule the Slack override-expiry DM unless disabled via config.
 
     Gated by ``agent.notify_override_expiry`` (read live so it can be toggled
     without a restart). Returns True if a notification task was scheduled, False
     if skipped — either disabled via config or no running event loop.
+
+    ``source`` is the expiry trigger (``policy`` for a policy revocation, else
+    the activating source) and is handed to ``notify_coro_factory`` so the DM
+    can word the notice by cause. The config gate deliberately does not vary by
+    source: ``agent.notify_override_expiry`` mutes the recurring expiry notice
+    as a class, whichever way the grant ended.
     """
     if not KiroCrewConfig.load().agent.notify_override_expiry:
         return False
@@ -2205,7 +2265,7 @@ def _dispatch_override_expiry_notification(state: DashboardState, notify_coro_fa
     except RuntimeError:
         logger.debug("No running event loop — Slack expiry notification skipped")
         return False
-    task = loop.create_task(notify_coro_factory())
+    task = loop.create_task(notify_coro_factory(source))
     state._background_tasks.add(task)
     task.add_done_callback(state._background_tasks.discard)
     return True
@@ -4036,13 +4096,6 @@ async def start_dashboard(
     await asyncio.to_thread(_apply_startup_yolo, state, cfg)
 
     # Wire safety override expiry notifications
-    async def _notify_slack_override_expired() -> None:
-        """Post override expiry notice to Slack owner DM."""
-        await _dm_owner(
-            state,
-            "\U0001f512 Safety override expired. Tools now require approval. Reply `/kirocrew yolo` to re-authorize.",
-        )
-
     def _on_override_expired(source: str) -> None:
         """Notify all interfaces when safety override expires."""
         state.broadcast_ws("yolo_expired", {"source": source})
@@ -4086,7 +4139,9 @@ async def start_dashboard(
         except Exception:
             logger.debug("Could not clear trusted sessions", exc_info=True)
         # Slack notification (prevent GC with background_tasks set)
-        _dispatch_override_expiry_notification(state, _notify_slack_override_expired)
+        _dispatch_override_expiry_notification(
+            state, functools.partial(_notify_slack_override_expired, state), source
+        )
         # An expiry that lands on an unattended run is the one case that cannot
         # self-report: nobody is present to answer the prompts it produces.
         _notify_unattended_expiry(state, source)

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -55,6 +55,14 @@ def sel():  # noqa: ANN201 — thin wrapper kept for test patchability
     return _get_sel()
 
 
+# The ``source`` sentinel a policy revocation carries into ``deactivate`` and the
+# ``on_expired`` callback. Exported as a module constant because the OTHER end of
+# the contract lives in ``dashboard/server.py`` (the expiry DM words the notice by
+# this value): a bare literal on both ends lets a re-spelling here silently drop
+# the policy-specific wording there with every test still green.
+POLICY_REVOKED_SOURCE = "policy"
+
+
 # ─── Result dataclasses ──────────────────────────────────────────────────────
 
 
@@ -849,11 +857,11 @@ class SafetyOverride:
                 with self._lock:
                     had_grant = self._active
                 if had_grant:
-                    self.deactivate("policy")
+                    self.deactivate(POLICY_REVOKED_SOURCE)
                     cb = self._on_expired
                     if cb is not None:
                         try:
-                            cb("policy")
+                            cb(POLICY_REVOKED_SOURCE)
                         except Exception:
                             logger.warning(
                                 "on_expired callback raised after a policy revocation",

--- a/test/test_override_expiry_notice.py
+++ b/test/test_override_expiry_notice.py
@@ -123,7 +123,7 @@ class TestBothSurfacesAreNotified:
         note cannot drift into saying different things about the same event."""
         state = _fake_state()
         dm = self._drive(state, _svc_with(_loop()))
-        body = _unattended_expiry_text(1)
+        body = _unattended_expiry_text(1, "dashboard")
         assert state.notify.call_args.args[2] == body
         assert body in dm.call_args.args[1]
 
@@ -171,14 +171,14 @@ class TestTheNoticeNamesTheRemedy:
 
         Mutation: drop the mention -- this test fails.
         """
-        body = _unattended_expiry_text(3)
+        body = _unattended_expiry_text(3, "dashboard")
         assert "until_shutdown" in body
         assert "yolo_duration" in body
 
     def test_the_body_states_the_consequence_not_just_the_event(self) -> None:
         """"Your grant expired" is not actionable at 4am; "your run is now waiting
         on approvals nobody will give" is."""
-        body = _unattended_expiry_text(2)
+        body = _unattended_expiry_text(2, "dashboard")
         assert "2 monitor loop(s)" in body
         assert "approval" in body
 
@@ -243,7 +243,7 @@ class TestTheNoticeDoesNotOverclaimTheStall:
 
     def test_the_stall_is_conditional_not_asserted_of_every_cycle(self) -> None:
         """Mutation: restore the unconditional 'each cycle now waits' -- fails here."""
-        body = _unattended_expiry_text(1)
+        body = _unattended_expiry_text(1, "dashboard")
         assert "each cycle now waits" not in body
         assert "relied on it" in body
 
@@ -251,7 +251,34 @@ class TestTheNoticeDoesNotOverclaimTheStall:
         """An operator whose loop keeps working needs to know why, or the notice
         reads as a bug in the notice rather than a description of their setup.
         """
-        assert "trust" in _unattended_expiry_text(1).lower()
+        assert "trust" in _unattended_expiry_text(1, "dashboard").lower()
+
+
+class TestPolicyRevocationSuppressesTheUnFollowableRemedy:
+    """After a POLICY revocation both halves of the usual remedy — re-enabling
+    auto-approve and ``until_shutdown`` (a ``yolo_duration`` scope member) — are
+    refused by the same fail-closed ``approval_modes`` gate that revoked the
+    grant. Suggesting them directs the one operator who is not present into a
+    wall (issue #8850), so the policy-source body names the cause instead. The
+    stall description is unchanged: the loops really are waiting either way.
+    """
+
+    def test_policy_source_drops_the_remedy_and_names_the_cause(self) -> None:
+        from kiro_crew.safety_override import POLICY_REVOKED_SOURCE
+
+        body = _unattended_expiry_text(2, POLICY_REVOKED_SOURCE)
+        assert "organization policy" in body
+        assert "Re-enable auto-approve" not in body
+        assert "until_shutdown" not in body
+        # The stall description survives the split.
+        assert "monitor loop(s) are still running" in body
+
+    def test_non_policy_sources_keep_the_remedy(self) -> None:
+        for source in ("slack", "dashboard", "config"):
+            body = _unattended_expiry_text(1, source)
+            assert "Re-enable auto-approve" in body
+            assert "until_shutdown" in body
+            assert "organization policy" not in body
 
 
 class TestTheNoticeHasItsOwnChannel:

--- a/test/test_override_expiry_notification.py
+++ b/test/test_override_expiry_notification.py
@@ -28,7 +28,7 @@ def test_dispatch_skipped_when_disabled() -> None:
     state = _make_state()
     factory = MagicMock()
     with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(False)):
-        scheduled = _dispatch_override_expiry_notification(state, factory)
+        scheduled = _dispatch_override_expiry_notification(state, factory, "slack")
 
     assert scheduled is False
     assert state._background_tasks == set()
@@ -41,11 +41,11 @@ def test_dispatch_schedules_when_enabled() -> None:
     async def _run() -> bool:
         state = _make_state()
 
-        async def _noop() -> None:
+        async def _noop(source: str) -> None:
             return None
 
         with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(True)):
-            scheduled = _dispatch_override_expiry_notification(state, _noop)
+            scheduled = _dispatch_override_expiry_notification(state, _noop, "slack")
         # A task was registered (tracked to prevent GC); drain it to completion.
         assert len(state._background_tasks) == 1
         await asyncio.gather(*list(state._background_tasks))
@@ -59,10 +59,96 @@ def test_dispatch_skipped_without_event_loop() -> None:
     state = _make_state()
     factory = MagicMock()
     with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(True)):
-        scheduled = _dispatch_override_expiry_notification(state, factory)
+        scheduled = _dispatch_override_expiry_notification(state, factory, "slack")
 
     assert scheduled is False
     assert state._background_tasks == set()
+
+
+class TestOverrideExpiryDmWording:
+    """The DM must be worded by CAUSE (issue #8850).
+
+    After a POLICY revocation, ``_commit_activation``'s fail-closed
+    ``approval_modes`` gate refuses the very ``/kirocrew yolo`` the generic text
+    suggests, so the policy-source DM must name organization policy and must NOT
+    direct the operator into that wall. Every other source keeps the original
+    re-armable wording byte-identical.
+    """
+
+    # The pre-#8850 string, pinned byte-for-byte for every non-policy source.
+    _LEGACY_TEXT = (
+        "\U0001f512 Safety override expired. Tools now require approval. "
+        "Reply `/kirocrew yolo` to re-authorize."
+    )
+
+    def test_policy_source_names_policy_and_omits_the_rearm_instruction(self) -> None:
+        # Imported inside the test so a revert of the production hunks fails
+        # HERE (phase call), proving red-before-green. The source sentinel is
+        # imported from safety_override — the EMITTING end of the contract — so
+        # a re-spelling there cannot silently strand this branch (round-trip
+        # assertion, not a copied literal).
+        from kiro_crew.dashboard.server import _override_expiry_dm_text
+        from kiro_crew.safety_override import POLICY_REVOKED_SOURCE
+
+        text = _override_expiry_dm_text(POLICY_REVOKED_SOURCE)
+        assert "organization policy" in text
+        # The re-arm instruction must be absent: the approval_modes gate refuses it.
+        assert "/kirocrew yolo" not in text
+        assert "re-authorize" not in text
+
+    def test_non_policy_sources_keep_the_legacy_text_byte_identical(self) -> None:
+        from kiro_crew.dashboard.server import _override_expiry_dm_text
+
+        for source in ("slack", "dashboard", "config", "declared", ""):
+            assert _override_expiry_dm_text(source) == self._LEGACY_TEXT
+
+    def test_the_slack_notify_path_composes_source_into_the_dm(self) -> None:
+        """End-to-end through the module-level notify function: the seam this fix
+        added (source travelling from the expiry callback into the DM body) is
+        asserted as a composition, not two separately-stubbed halves."""
+        from kiro_crew.dashboard.server import _notify_slack_override_expired
+        from kiro_crew.safety_override import POLICY_REVOKED_SOURCE
+
+        state = _slack_state()
+        asyncio.run(_notify_slack_override_expired(state, POLICY_REVOKED_SOURCE))
+        body = state.slack_client.post_message.await_args.args[1]
+        assert "organization policy" in body
+        assert "/kirocrew yolo" not in body
+
+    def test_the_slack_notify_path_keeps_the_legacy_text_for_a_ttl_lapse(self) -> None:
+        from kiro_crew.dashboard.server import _notify_slack_override_expired
+
+        state = _slack_state()
+        asyncio.run(_notify_slack_override_expired(state, "slack"))
+        body = state.slack_client.post_message.await_args.args[1]
+        assert body == self._LEGACY_TEXT
+
+    def test_dispatch_threads_source_to_the_factory(self) -> None:
+        """The dedup/config gate path hands ``source`` through unchanged, and the
+        gate itself does not vary by source (the mute covers the class)."""
+
+        async def _run() -> None:
+            state = _make_state()
+            seen: list[str] = []
+
+            async def _record(source: str) -> None:
+                seen.append(source)
+
+            with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(True)):
+                assert _dispatch_override_expiry_notification(state, _record, "policy") is True
+            await asyncio.gather(*list(state._background_tasks))
+            assert seen == ["policy"]
+
+        asyncio.run(_run())
+
+    def test_dispatch_config_mute_covers_the_policy_source_too(self) -> None:
+        """The recurring-expiry mute is class-wide: disabling the config skips the
+        DM for a policy revocation exactly as for a TTL lapse."""
+        state = _make_state()
+        factory = MagicMock()
+        with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(False)):
+            assert _dispatch_override_expiry_notification(state, factory, "policy") is False
+        factory.assert_not_called()
 
 
 def _slack_state(slack_client=..., owner_id="U123") -> MagicMock:


### PR DESCRIPTION
## Problem / Motivation

When organization policy disables auto-approve (`approval_modes` scope) while a safety override is live, `is_active()`'s DENIED branch revokes the grant and fires the expiry notifications. The Slack owner DM was a fixed string: "Safety override expired. Tools now require approval. Reply `/kirocrew yolo` to re-authorize." After a policy revocation that suggestion is refused by `_commit_activation`'s fail-closed `approval_modes` gate — the operator is directed into a wall and never told organization policy is the cause. (Maintainer-filed follow-up from PR #7518, an Opus review advisory accepted-and-deferred at merge.)

## Why it matters

The DM is often the only signal an away operator gets. Telling them "reply `/kirocrew yolo`" when that exact command will be refused wastes their one recovery attempt and hides the actual cause (a policy decision only their administrator can change), turning a deliberate governance action into what looks like a product bug.

## What changed (motivation → approach → change)

Symptom: the DM text is source-blind. Root cause: `_on_override_expired(source)` receives the trigger (`"policy"` for a revocation) but dropped it before the notification path. Change: thread `source` through `_dispatch_override_expiry_notification` into the notify coroutine, and word the DM by cause in a new `_override_expiry_dm_text(source)` helper — the policy branch names organization policy and omits the re-arm hint; every other source keeps the previous wording byte-identical. Presentation-only: no gate, grant, or SEL-audit behavior changes.

Review-driven hardening in the same PR (local Opus lane advisories, all fixed rather than deferred):
- The sibling unattended-run notice (`_unattended_expiry_text`) had the same wall: on a policy revocation it suggested "Re-enable auto-approve" and `until_shutdown`, both refused by the same gate. It now applies the same source split, keeping the stall description intact.
- The `"policy"` sentinel is now a shared constant `POLICY_REVOKED_SOURCE` exported by `safety_override.py` and used at both the emitting (`deactivate`/`cb`) and matching (DM text) ends, so a re-spelling cannot silently strand the branch with tests still green.
- `_notify_slack_override_expired` is lifted from a `start_dashboard` closure to a module-level function so the seam this fix added (source → DM body) is directly testable; the call site binds `state` via `functools.partial`.

## Tests

- `test_policy_source_names_policy_and_omits_the_rearm_instruction` — red-before-green (fails on pre-fix code): the policy DM names organization policy and contains no `/kirocrew yolo` / re-authorize instruction. Imports `POLICY_REVOKED_SOURCE` from the emitting module rather than hardcoding the literal.
- `test_non_policy_sources_keep_the_legacy_text_byte_identical` — pins the pre-change string byte-for-byte for `slack`/`dashboard`/`config`/`declared`/empty sources.
- `test_the_slack_notify_path_composes_source_into_the_dm` / `..._keeps_the_legacy_text_for_a_ttl_lapse` — end-to-end through the module-level notify function against a Slack double, asserting the composition rather than two stubbed halves.
- `test_dispatch_threads_source_to_the_factory` / `test_dispatch_config_mute_covers_the_policy_source_too` — the dispatcher's config-mute path hands `source` through unchanged and the mute stays class-wide; existing dispatch tests updated for the threaded parameter.
- `TestPolicyRevocationSuppressesTheUnFollowableRemedy` (in `test_override_expiry_notice.py`) — the unattended-run body drops the un-followable remedy on the policy source and keeps it for all others.

Verified red-before-green against pristine main: 7 failures at test-call phase (TypeError on the threaded parameter, ImportError on the new helper), all green on the branch.

## Manual verification

N/A — unit coverage sufficient: the change is pure message selection and parameter threading, exercised end-to-end through the module-level notify function against a Slack client double.

## Related Issues

Closes #8850

## Pattern harvest

Rule candidate: review-prompt
Pattern: user-facing remediation text must be selected by failure cause — a fixed "how to recover" string is wrong whenever one trigger's recovery path is gated off.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
