### PR TITLE
fix(dashboard): say policy, not "expired", when governance revokes auto-approve

### DIFF
--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -2131,7 +2131,36 @@ def _armed_unattended_loops() -> "list[Any]":
 _UNATTENDED_EXPIRY_TITLE = "🔒 Auto-approve expired while an unattended run was in progress"
 
 
-def _unattended_expiry_text(loop_count: int) -> str:
+def _override_expiry_text(source: str) -> str:
+    """Owner-DM body for an expired override, keyed by what ended the grant.
+
+    A TTL lapse and a policy revocation leave the operator in different positions,
+    so one string cannot serve both. After a policy revocation ``/kirocrew yolo``
+    is refused by the fail-closed ``approval_modes`` gate in
+    ``SafetyOverride._commit_activation``, so telling the operator to re-authorize
+    sends them into a wall and never names the cause. ``source`` is the literal
+    ``"policy"`` the revocation branch of ``is_active`` passes; an unresolvable
+    governance read tears nothing down, so it reaches no DM at all and needs no
+    variant of its own.
+
+    "Governance policy" rather than "organization policy": ``approval_modes`` is
+    resolved against the host profile as well as any enterprise ceiling, so a
+    deny can be entirely local and naming an organization would send a solo
+    operator to a party that does not exist.
+    """
+    if source == "policy":
+        return (
+            "\U0001f512 Auto-approve is disabled by governance policy "
+            "(`approval_modes`). Tools now require approval, and `/kirocrew yolo` "
+            "will be refused until that policy changes."
+        )
+    return (
+        "\U0001f512 Safety override expired. Tools now require approval. "
+        "Reply `/kirocrew yolo` to re-authorize."
+    )
+
+
+def _unattended_expiry_text(loop_count: int, source: str = "") -> str:
     """Body shared by the dashboard note and the owner DM, so the two cannot drift.
 
     Names the remedy as well as the cause: ``agent.yolo_duration`` accepts
@@ -2143,14 +2172,29 @@ def _unattended_expiry_text(loop_count: int) -> str:
     path to one: a slot carrying its own trust grant is approved by ``slot._trust``
     independently of the grant, so its cycles keep running after this expiry.
     Claiming the run has stopped would send an operator to rescue a healthy one.
+
+    The REMEDY is keyed by ``source`` because a policy revocation invalidates both
+    halves of the ordinary one: re-arming is refused by the same policy, and no
+    duration outlives a deny. This notice is delivered alongside
+    ``_override_expiry_text``, so repeating the ordinary remedy here would hand the
+    operator two contradictory instructions in the same moment.
     """
+    if source == "policy":
+        remedy = (
+            "Governance policy now forbids auto-approve, so it cannot be re-enabled "
+            "until that policy changes."
+        )
+    else:
+        remedy = (
+            "Re-enable auto-approve to resume. For runs meant to go unattended "
+            "overnight, Settings → agent.yolo_duration has an 'until_shutdown' "
+            "option that has no timed expiry."
+        )
     return (
         f"{loop_count} monitor loop(s) are still running, but auto-approval has "
         f"ended, so any cycle that relied on it now waits on a per-tool approval "
         f"that nobody is there to give. (A session granted its own trust is "
-        f"unaffected.) Re-enable auto-approve to resume. For runs meant to go "
-        f"unattended overnight, Settings → agent.yolo_duration has an "
-        f"'until_shutdown' option that has no timed expiry."
+        f"unaffected.) {remedy}"
     )
 
 
@@ -2177,7 +2221,7 @@ def _notify_unattended_expiry(state: "DashboardState", source: str) -> None:
         "every further cycle will wait on per-tool approval",
         len(armed),
     )
-    body = _unattended_expiry_text(len(armed))
+    body = _unattended_expiry_text(len(armed), source)
     try:
         state.notify(
             "safety_override",
@@ -2204,12 +2248,18 @@ def _notify_unattended_expiry(state: "DashboardState", source: str) -> None:
     task.add_done_callback(state._background_tasks.discard)
 
 
-def _dispatch_override_expiry_notification(state: DashboardState, notify_coro_factory: Any) -> bool:
+def _dispatch_override_expiry_notification(
+    state: DashboardState, notify_coro_factory: Any, source: str
+) -> bool:
     """Schedule the Slack override-expiry DM unless disabled via config.
 
     Gated by ``agent.notify_override_expiry`` (read live so it can be toggled
     without a restart). Returns True if a notification task was scheduled, False
     if skipped — either disabled via config or no running event loop.
+
+    ``source`` is passed to the factory rather than captured by it so the DM can
+    say WHY the grant ended; a policy revocation and a TTL lapse offer the
+    operator different remedies.
     """
     if not KiroCrewConfig.load().agent.notify_override_expiry:
         return False
@@ -2218,7 +2268,7 @@ def _dispatch_override_expiry_notification(state: DashboardState, notify_coro_fa
     except RuntimeError:
         logger.debug("No running event loop — Slack expiry notification skipped")
         return False
-    task = loop.create_task(notify_coro_factory())
+    task = loop.create_task(notify_coro_factory(source))
     state._background_tasks.add(task)
     task.add_done_callback(state._background_tasks.discard)
     return True
@@ -4049,12 +4099,9 @@ async def start_dashboard(
     await asyncio.to_thread(_apply_startup_yolo, state, cfg)
 
     # Wire safety override expiry notifications
-    async def _notify_slack_override_expired() -> None:
+    async def _notify_slack_override_expired(source: str) -> None:
         """Post override expiry notice to Slack owner DM."""
-        await _dm_owner(
-            state,
-            "\U0001f512 Safety override expired. Tools now require approval. Reply `/kirocrew yolo` to re-authorize.",
-        )
+        await _dm_owner(state, _override_expiry_text(source))
 
     def _on_override_expired(source: str) -> None:
         """Notify all interfaces when safety override expires."""
@@ -4099,7 +4146,7 @@ async def start_dashboard(
         except Exception:
             logger.debug("Could not clear trusted sessions", exc_info=True)
         # Slack notification (prevent GC with background_tasks set)
-        _dispatch_override_expiry_notification(state, _notify_slack_override_expired)
+        _dispatch_override_expiry_notification(state, _notify_slack_override_expired, source)
         # An expiry that lands on an unattended run is the one case that cannot
         # self-report: nobody is present to answer the prompts it produces.
         _notify_unattended_expiry(state, source)

--- a/test/test_override_expiry_notice.py
+++ b/test/test_override_expiry_notice.py
@@ -294,3 +294,31 @@ class TestTheNoticeHasItsOwnChannel:
 
         assert SYSTEM_CHANNELS["system.safety_override"] == SYSTEM_CHANNELS["system.skills"]
         assert SYSTEM_CHANNELS["system.safety_override"] != SYSTEM_CHANNELS["system.approval"]
+
+
+class TestThePolicyRemedyDoesNotContradictTheExpiryDm:
+    """Both notices reach the same owner in the same moment.
+
+    A policy revocation fires this notice AND ``_override_expiry_text``'s DM, which
+    states that ``/kirocrew yolo`` will be refused. Keeping the ordinary
+    "re-enable auto-approve" remedy here would answer that with the opposite
+    instruction, in the one case where the DM is the operator's only signal.
+    """
+
+    def test_a_policy_revocation_drops_the_re_enable_remedy(self) -> None:
+        """Mutation: make the remedy unconditional again -- fails here."""
+        body = _unattended_expiry_text(1, "policy")
+        assert "Re-enable auto-approve" not in body
+        assert "until_shutdown" not in body
+        assert "policy" in body.lower()
+
+    def test_a_ttl_lapse_keeps_the_re_enable_remedy(self) -> None:
+        body = _unattended_expiry_text(1, "slack")
+        assert "Re-enable auto-approve" in body
+        assert "until_shutdown" in body
+
+    def test_the_stall_description_is_shared_by_both_remedies(self) -> None:
+        """Only the remedy is keyed by source; the fact of the stall is not."""
+        for body in (_unattended_expiry_text(2, "policy"), _unattended_expiry_text(2, "slack")):
+            assert "2 monitor loop(s) are still running" in body
+            assert "trust" in body.lower()

--- a/test/test_override_expiry_notification.py
+++ b/test/test_override_expiry_notification.py
@@ -10,6 +10,7 @@ from kiro_crew.dashboard.server import (
     _dispatch_override_expiry_notification,
     _dispatch_owner_dm,
     _dm_owner,
+    _override_expiry_text,
 )
 
 
@@ -28,7 +29,7 @@ def test_dispatch_skipped_when_disabled() -> None:
     state = _make_state()
     factory = MagicMock()
     with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(False)):
-        scheduled = _dispatch_override_expiry_notification(state, factory)
+        scheduled = _dispatch_override_expiry_notification(state, factory, "slack")
 
     assert scheduled is False
     assert state._background_tasks == set()
@@ -41,14 +42,19 @@ def test_dispatch_schedules_when_enabled() -> None:
     async def _run() -> bool:
         state = _make_state()
 
-        async def _noop() -> None:
-            return None
+        seen: list[str] = []
+
+        async def _noop(source: str) -> None:
+            seen.append(source)
 
         with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(True)):
-            scheduled = _dispatch_override_expiry_notification(state, _noop)
+            scheduled = _dispatch_override_expiry_notification(state, _noop, "policy")
         # A task was registered (tracked to prevent GC); drain it to completion.
         assert len(state._background_tasks) == 1
         await asyncio.gather(*list(state._background_tasks))
+        # The expiry source reaches the factory, which is what lets the DM name
+        # a policy revocation instead of a TTL lapse.
+        assert seen == ["policy"]
         return scheduled
 
     assert asyncio.run(_run()) is True
@@ -59,7 +65,7 @@ def test_dispatch_skipped_without_event_loop() -> None:
     state = _make_state()
     factory = MagicMock()
     with patch("kiro_crew.dashboard.server.KiroCrewConfig.load", return_value=_cfg(True)):
-        scheduled = _dispatch_override_expiry_notification(state, factory)
+        scheduled = _dispatch_override_expiry_notification(state, factory, "slack")
 
     assert scheduled is False
     assert state._background_tasks == set()
@@ -309,3 +315,70 @@ class TestDispatchOwnerDm:
         state = _slack_state()
         _dispatch_owner_dm(state, "warn")
         assert state._background_tasks == set()
+
+
+class TestOverrideExpiryText:
+    """The DM must not send a policy-revoked operator to a re-arm that is refused.
+
+    ``_commit_activation`` fail-closes on an ``approval_modes`` policy that denies
+    yolo, so ``/kirocrew yolo`` cannot succeed after a policy revocation. A DM that
+    still says "reply to re-authorize" therefore describes a step that is guaranteed
+    to fail, and never names policy as the cause.
+    """
+
+    def test_a_ttl_lapse_still_offers_the_re_arm(self) -> None:
+        text = _override_expiry_text("slack")
+        assert "expired" in text
+        assert "/kirocrew yolo" in text
+        assert "re-authorize" in text
+
+    def test_a_policy_revocation_names_policy_and_does_not_offer_a_re_arm(self) -> None:
+        text = _override_expiry_text("policy")
+        assert "policy" in text.lower()
+        assert "re-authorize" not in text
+        # Naming the command is fine — promising it works is not.
+        assert "refused" in text.lower()
+
+    def test_the_two_variants_differ(self) -> None:
+        assert _override_expiry_text("policy") != _override_expiry_text("slack")
+
+    def test_every_non_policy_source_gets_the_ttl_text(self) -> None:
+        """Only the literal ``"policy"`` branches; ``is_active``'s TTL path passes
+        the grant's own activation source, which is any transport name."""
+        ttl = _override_expiry_text("slack")
+        for source in ("dashboard", "config", "discord", ""):
+            assert _override_expiry_text(source) == ttl
+
+
+class TestTheExpiryCallbackForwardsItsOwnSource:
+    """A literal in the wiring would leave the whole suite green and the bug back.
+
+    Every test above hands the dispatcher a source directly, so none of them sees
+    ``_on_override_expired`` itself. Passing ``""`` or the wrong local there would
+    restore the pre-fix DM on every policy revocation with nothing red, so the
+    handler's own source is pinned at the call sites. The handler is nested inside
+    ``start_dashboard``, so the enclosing function is sliced to it -- the same
+    approach ``test_channel_trust_revoke`` uses on this handler.
+    """
+
+    def _expiry_handler_source(self) -> str:
+        import inspect
+        import re
+
+        from kiro_crew.dashboard import server
+
+        setup_src = inspect.getsource(server.start_dashboard)
+        start = setup_src.index("def _on_override_expired(")
+        end = setup_src.index("safety_override().on_expired", start)
+        return re.sub(r"\s+", "", setup_src[start:end])
+
+    def test_the_slack_dm_is_dispatched_with_the_handler_s_source(self) -> None:
+        compact = self._expiry_handler_source()
+        assert (
+            "_dispatch_override_expiry_notification(state,_notify_slack_override_expired,source)"
+            in compact
+        )
+
+    def test_the_unattended_notice_is_dispatched_with_the_handler_s_source(self) -> None:
+        compact = self._expiry_handler_source()
+        assert "_notify_unattended_expiry(state,source)" in compact


### PR DESCRIPTION
## Problem / Motivation

When the `approval_modes` governance policy denies `yolo`, `SafetyOverride.is_active()`
revokes the live grant and fires `on_expired("policy")`. The Slack owner DM that follows
was a fixed string:

> 🔒 Safety override expired. Tools now require approval. Reply `/kirocrew yolo` to re-authorize.

That instruction cannot succeed. `_commit_activation` fail-closes on the same policy, so
`/kirocrew yolo` is refused (`reason:approval_modes_policy_denies_yolo`). The operator is
sent into a wall and is never told policy is the cause.

## Why it matters

The DM is the only operator-visible trace of a policy revocation, and it named the wrong
cause and the wrong remedy. An operator follows it, gets refused with no explanation, and
has no way to learn that governance — not a clock — ended the grant. `_on_override_expired`
already received `source`; only the text ignored it.

## What changed (motivation → approach → change)

Symptom: one fixed DM for two different endings. Root cause: `source` reached
`_on_override_expired` but stopped there — `_dispatch_override_expiry_notification` called
its factory with no arguments, so the notifier had nothing to branch on.

- `_override_expiry_text(source)` is a new module-level helper holding both variants so the
  two cannot drift. On `source == "policy"` it names the policy and says `/kirocrew yolo`
  will be refused until that policy changes; every other source keeps the existing
  TTL-lapse text verbatim.
- `_dispatch_override_expiry_notification` takes `source` and passes it to the factory;
  `_notify_slack_override_expired(source)` renders through the helper.
- `_unattended_expiry_text` takes the same `source`. It is delivered **alongside** the DM
  on a policy revocation that lands on an armed monitor loop, and its
  "Re-enable auto-approve to resume … `until_shutdown`" remedy would then contradict the DM
  in the one case where the DM is the operator's only signal. Under `"policy"` it states
  that auto-approve cannot be re-enabled until the policy changes; the stall description
  itself is unchanged and shared by both branches.

Two wording decisions worth stating, both raised in local review:

- **"governance policy", not "organization policy".** `approval_modes` is resolved against
  the host profile as well as any enterprise ceiling, so a deny can be entirely local.
  Naming an organization would send a solo operator to a party that does not exist.
- **No variant for an unresolvable governance read.** `is_active()` tears the grant down
  only on a definite `_YOLO_DENIED`; an `_YOLO_UNKNOWN` verdict deliberately revokes
  nothing, so that path sends no DM at all and needs no text of its own.

Presentation only. The gate, its fail-closed behaviour and its SEL audit record are
unchanged.

## Tests

`test/test_override_expiry_notification.py`

- `TestOverrideExpiryText` — the policy variant names policy and says the re-arm is
  `refused`, and carries no `re-authorize` instruction; the TTL variant still offers it;
  the two strings differ; and every non-`policy` source (`dashboard`, `config`, `discord`,
  `""`) resolves to the TTL text, since the TTL path passes the grant's own activation
  source.
- `TestTheExpiryCallbackForwardsItsOwnSource` — slices `_on_override_expired` out of
  `start_dashboard` (the approach `test_channel_trust_revoke` already uses on this handler)
  and pins that BOTH notices are dispatched with the handler's own `source`. Without this,
  a later edit passing `""` there would restore the pre-fix DM with the whole suite green.
- `test_dispatch_schedules_when_enabled` now asserts the source reaches the factory.

`test/test_override_expiry_notice.py`

- `TestThePolicyRemedyDoesNotContradictTheExpiryDm` — the policy body drops both
  `Re-enable auto-approve` and `until_shutdown`; the TTL body keeps both; the loop-count
  stall description and the standing-trust caveat are shared by both.

Mutation-verified, four mutations each caught by the test named for it: forcing the
`source == "policy"` branch off in either helper, and passing a literal `""` at the
dispatch site.

## Manual verification

N/A — unit coverage sufficient. The change selects between two strings on a value the
caller already holds; it adds no I/O, no transport behaviour and no gate behaviour.

## Related Issues

Closes #8850

## Pattern harvest

Rule candidate: review-prompt
Pattern: a notification that already receives a discriminating `source`/`reason` argument
but renders one fixed string — the remedy it prints can be one the same code path refuses.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
