### PR TITLE
refactor: single member_turn_context chokepoint for rules currency (#8609)

### DIFF
--- a/src/kiro_crew/context.py
+++ b/src/kiro_crew/context.py
@@ -32,9 +32,12 @@ from kiro_crew.hooks import (
 )
 from kiro_crew.learn import LessonStore
 from kiro_crew.members import (
+    MemberLifecycle,
     MemberSlugError,
     member_briefing_path,
     member_briefing_supported,
+    member_lifecycle,
+    member_turn_context,
     read_member_briefing,
     read_member_rules,
     slug_for_name,
@@ -2691,7 +2694,14 @@ class ContextBuilder:
         # (product-owned, backend-gated) and reads first so the four layers —
         # including the user-owned rules — rank below product protocol, per
         # the earlier-outranks-later convention of this preamble.
-        if member:
+        #
+        # FRESH leg of the member lifecycle: reaching this line means a full
+        # (non-minimal) session-start build — the minimal path early-returned
+        # above — so the verdict comes from the same chokepoint every other
+        # delivery branch consults (kiro_crew.members.member_turn_context).
+        # Delivery enforces the rules gate: the section builder reads
+        # [PERMANENT RULES] fresh and fails closed on an unreadable file.
+        if member_turn_context(member, MemberLifecycle.FRESH).deliver_section:
             _member_section = self._build_member_section(member)
             if _member_section:
                 parts.append(_member_section)
@@ -3115,28 +3125,40 @@ class ContextBuilder:
         is_cc = is_claude_code(provider_type)
 
         # Layer-3 rules gate + section delivery, per session-lifecycle branch.
-        # The INVARIANT (GPT rounds 1-2 in this span): every member turn
-        # passes the fail-closed rules gate, and every turn whose live context
-        # cannot be carrying the CURRENT member section gets it injected
-        # fresh. By branch:
-        #   1. fresh session          -> build_session_context injects the
-        #      full section; the rules read inside enforces the gate.
-        #   2. warm + reinjection     -> the post-compaction block below
-        #      re-injects the current section; same gate inside.
-        #   3. warm, no reinjection   -> THIS block validates rules per-turn
-        #      (a first-turn abort leaves a warm session — the provider
-        #      client survives the raise — and without this the member would
-        #      run with no bounds); the delivered section is still live in
-        #      the provider conversation, so no re-injection.
-        #   4. slim resume            -> handled inside the is_new_session
-        #      branch below: session/load restored the ORIGINAL section,
-        #      whose [PERMANENT RULES] may have changed or become unreadable
-        #      while the session idled, so the CURRENT section is re-injected
-        #      (and its rules read keeps the gate).
-        #   5. minimal_context (cron) -> never a member thread; member is "".
+        # The INVARIANT: every member turn passes the fail-closed rules gate,
+        # and every turn whose live context cannot be carrying the CURRENT
+        # member section gets it injected fresh. The decision lives in ONE
+        # chokepoint — kiro_crew.members.member_turn_context — which every
+        # delivery branch below consults instead of branching by hand, so a
+        # future session-lifecycle branch added here cannot silently skip
+        # both the member section and the rules gate. Per lifecycle state:
+        #   FRESH            -> build_session_context injects the full
+        #      section; the rules read inside enforces the gate.
+        #   WARM_REINJECTION -> the post-compaction block below re-injects
+        #      the current section; same gate inside.
+        #   WARM             -> THIS block validates rules per-turn (a
+        #      first-turn abort leaves a warm session — the provider client
+        #      survives the raise — and without this the member would run
+        #      with no bounds); the delivered section is still live in the
+        #      provider conversation, so no re-injection.
+        #   SLIM_RESUME      -> handled inside the is_new_session branch
+        #      below: session/load restored the ORIGINAL section, whose
+        #      [PERMANENT RULES] may have changed or become unreadable while
+        #      the session idled, so the CURRENT section is re-injected (and
+        #      its rules read keeps the gate).
+        #   MINIMAL (cron)   -> never a member thread; member is "".
         # Missing file still reads as "" (the normal unbounded-by-choice
         # state); a bad slug degrades like the builder.
-        if member and not is_new_session and not needs_reinjection:
+        _member_turn = member_turn_context(
+            member,
+            member_lifecycle(
+                is_new_session=is_new_session,
+                resumed=resumed,
+                minimal_context=minimal_context,
+                needs_reinjection=needs_reinjection,
+            ),
+        )
+        if _member_turn.enforce_rules_gate:
             try:
                 _member_slug: str | None = slug_for_name(member)
             except (MemberSlugError, ValueError):
@@ -3154,7 +3176,14 @@ class ContextBuilder:
             # into the same window and accelerates compaction. Inject only the
             # minimal header (fresh date/time + identity) plus a resume marker
             # so the model knows where the full context lives.
-            slim_resume = resumed and not minimal_context
+            #
+            # Derived FROM the chokepoint's lifecycle rather than re-encoding
+            # ``resumed and not minimal_context`` here: two independent
+            # spellings of the same predicate can drift apart, and the member
+            # re-injection below keys off the lifecycle — a divergence would
+            # leave a resumed member session running on a stale
+            # [PERMANENT RULES] snapshot with nothing failing.
+            slim_resume = _member_turn.lifecycle is MemberLifecycle.SLIM_RESUME
             # Agent prompt goes BEFORE session context wrapper
             # so the LLM treats it as its identity, not background info.
             if slim_resume:
@@ -3247,18 +3276,18 @@ class ContextBuilder:
                         if _agent_includes_crew_context(agent)
                         else ""
                     )
-                    # Branch 4 of the member lifecycle table (see the layer-3
-                    # gate above): the restored transcript carries the
-                    # ORIGINAL member section, but [PERMANENT RULES] may have
-                    # changed — or become unreadable — while the session
-                    # idled. Re-inject the CURRENT section so the boundary the
-                    # member runs under is the one the user set, not a stale
-                    # snapshot; the rules read inside keeps the fail-closed
-                    # gate on this branch. Same marker scrub as the
-                    # post-compaction path: the slim-resume tail is scrubbed
-                    # above, but this section is appended separately.
+                    # SLIM_RESUME leg of the member lifecycle (see the
+                    # chokepoint consult above): the restored transcript
+                    # carries the ORIGINAL member section, but [PERMANENT
+                    # RULES] may have changed — or become unreadable — while
+                    # the session idled. Re-inject the CURRENT section so the
+                    # boundary the member runs under is the one the user set,
+                    # not a stale snapshot; the rules read inside keeps the
+                    # fail-closed gate on this branch. Same marker scrub as
+                    # the post-compaction path: the slim-resume tail is
+                    # scrubbed above, but this section is appended separately.
                     _resume_member = ""
-                    if member:
+                    if _member_turn.deliver_section:
                         _member_section = self._build_member_section(member)
                         if _member_section:
                             _resume_member = (
@@ -3372,8 +3401,10 @@ class ContextBuilder:
             # must be applied here or a forged [CURRENT USER REQUEST —] in the
             # agent-writable briefing would ride the reinjection turn as an
             # authoritative request. The genuine member headers are not in
-            # _STRUCTURAL_MARKER_RES, so they survive intact.
-            if member:
+            # _STRUCTURAL_MARKER_RES, so they survive intact. This is the
+            # WARM_REINJECTION leg of the member lifecycle (see the
+            # chokepoint consult above).
+            if _member_turn.deliver_section:
                 _member_section = self._build_member_section(member)
                 if _member_section:
                     parts.append(_neutralize_structural_markers(_member_section))

--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -210,7 +210,7 @@ from kiro_crew.llm_helpers import (
     usage_has_billing,
 )
 from kiro_crew.mcp_discovery import kirocrew_managed_names
-from kiro_crew.members import record_activity
+from kiro_crew.members import member_lifecycle, record_activity
 from kiro_crew.messaging.display_safety import redact_for_display
 from kiro_crew.messaging.identity import publish_turn_identity
 from kiro_crew.messaging.link import (
@@ -6547,8 +6547,24 @@ async def _run_chat(
         # return between this point and build_message (a blocked/oversized
         # @prompt expansion, a pre-build abort) leaves a warm session whose
         # member section was never delivered, and the finally-block re-arm
-        # reads this flag to make the next turn re-deliver it.
-        _member_session_start_pending = bool(slot.mode == "member" and is_new)
+        # reads this flag to make the next turn re-deliver it. The
+        # delivery-at-stake verdict is the chokepoint's own
+        # (MemberLifecycle.delivers_section — the same source
+        # member_turn_context reads), keyed on the slot's member MODE rather
+        # than the member name: the name is resolved later, at the context
+        # build, and delivery is at stake from this point regardless.
+        # needs_reinjection is pinned False: the one-shot flag is not consumed
+        # until the context build, and an aborted WARM_REINJECTION delivery is
+        # covered by _needs_reinjection in the same finally-block re-arm.
+        _member_session_start_pending = (
+            slot.mode == "member"
+            and member_lifecycle(
+                is_new_session=is_new,
+                resumed=resumed,
+                minimal_context=False,
+                needs_reinjection=False,
+            ).delivers_section
+        )
         # Member activity pointer — once per SESSION, not per turn: the log
         # answers "which sessions did this member take part in", so a per-turn
         # append would inflate every count taken from it. `slot.agent` is the

--- a/src/kiro_crew/dashboard/handlers/members.py
+++ b/src/kiro_crew/dashboard/handlers/members.py
@@ -201,7 +201,11 @@ async def api_members(request: web.Request) -> web.Response:
         for row in rows:
             if not row["slot_key"]:
                 continue
-            log_key = f"dashboard:{row['slot_key']}"
+            # A non-empty slot_key came from read_dm_binding, which refuses
+            # any binding whose slot_key is not the slug's own derivation —
+            # so the canonical alias helper reads the same key the binding
+            # names, and the alias format stays owned by ONE function.
+            log_key = members_mod.member_thread_session_alias(row["slug"])
             mt = state.conversation_log.session_mtime(log_key)
             if not mt:
                 continue
@@ -310,7 +314,7 @@ async def api_member_thread(request: web.Request) -> web.Response:
         # the crew). A member key with NO history binds fresh as usual.
         if member_name and state.conversation_log is not None:
             _log = state.conversation_log
-            _history_key = f"dashboard:{members_mod.member_slot_key(slug)}"
+            _history_key = members_mod.member_thread_session_alias(slug)
             # STRUCTURAL existence, not metadata truthiness: get_metadata
             # answers {} for both "never persisted" and "present but
             # malformed/unreadable", and treating the second as the first
@@ -733,7 +737,7 @@ async def api_member_rules_put(request: web.Request) -> web.Response:
     # teardown needed — and the flag is a no-op when no session is warm.
     try:
         state: DashboardState = request.app["state"]
-        state.sessions.mark_needs_reinjection(f"dashboard:{members_mod.member_slot_key(slug)}")
+        state.sessions.mark_needs_reinjection(members_mod.member_thread_session_alias(slug))
     except Exception:
         # Best-effort: the write LANDED (the durable state is correct), and a
         # cold session picks the new rules up at its next start regardless.

--- a/src/kiro_crew/members.py
+++ b/src/kiro_crew/members.py
@@ -24,7 +24,9 @@ import logging
 import os
 import re
 import stat
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 
 from kiro_crew import platform_compat
@@ -321,6 +323,161 @@ def member_slot_key(slug: str) -> str:
     use the slot layer's RETURNED key as the source of truth.
     """
     return DM_SLOT_KEY_PREFIX + validate_slug(slug)
+
+
+def member_thread_session_alias(slug: str) -> str:
+    """Canonical session-map alias for a member's pinned DM thread.
+
+    ``dashboard:<slot key>`` — the spelling the session manager and the
+    conversation log key a member thread under (see
+    :func:`is_member_session_key` for the full set of prefixes a member key
+    travels through). This is the ONE derivation every out-of-turn touch of a
+    member session goes through — flagging the warm session for re-injection
+    after a rules write, probing the thread's on-disk history — so the key
+    format lives here rather than being hand-built at each site, where one
+    divergent spelling would silently orphan the invariant it serves.
+    """
+    return f"dashboard:{member_slot_key(slug)}"
+
+
+class MemberLifecycle(str, Enum):
+    """Session-lifecycle states a turn can arrive in, as the member-context
+    chokepoint distinguishes them.
+
+    Derived by :func:`member_lifecycle` from the same inputs
+    ``build_message`` already branches on, so the two can never disagree on
+    what state a turn is in:
+
+    * ``FRESH`` — brand-new session; the full session context is built and
+      injected.
+    * ``SLIM_RESUME`` — the provider restored the native transcript
+      (``session/load``); only a minimal header is injected, but the restored
+      member section may be stale.
+    * ``WARM_REINJECTION`` — follow-up turn whose session-start context was
+      compacted away (or deliberately invalidated, e.g. by a rules write);
+      the one-shot re-injection flag was consumed for this turn.
+    * ``WARM`` — ordinary follow-up turn; the delivered section is still live
+      in the provider conversation.
+    * ``MINIMAL`` — minimal-context turn (cron); never a member thread by
+      contract (``member`` is ``""`` on every such call).
+    """
+
+    FRESH = "fresh"
+    SLIM_RESUME = "slim_resume"
+    WARM_REINJECTION = "warm_reinjection"
+    WARM = "warm"
+    MINIMAL = "minimal"
+
+    @property
+    def delivers_section(self) -> bool:
+        """Whether a member turn in this state injects the CURRENT section.
+
+        The lifecycle half of the chokepoint's verdict, exposed on the enum so
+        a caller that knows a turn is member-shaped without holding the member
+        NAME (the chat runner records delivery-at-stake the moment the session
+        client exists, before the context build resolves the name) reads the
+        same single source of truth :func:`member_turn_context` does.
+        """
+        return self in (
+            MemberLifecycle.FRESH,
+            MemberLifecycle.SLIM_RESUME,
+            MemberLifecycle.WARM_REINJECTION,
+        )
+
+
+@dataclass(frozen=True)
+class MemberTurnContext:
+    """What the member layer must do on ONE turn — the chokepoint's verdict.
+
+    Exactly one of the two flags is set for a member turn (both are ``False``
+    only when the turn carries no member, or on ``MINIMAL`` turns, which
+    carry no member by contract):
+
+    * ``deliver_section`` — inject the CURRENT four-layer member section this
+      turn. Delivery itself enforces the rules gate: the section builder
+      reads the user's [PERMANENT RULES] fresh, and an existing-but-unreadable
+      rules file aborts the turn (fail closed) instead of running the member
+      unbounded.
+    * ``enforce_rules_gate`` — the section is already live in the provider
+      conversation, so nothing is injected, but the fail-closed rules read
+      still runs: a first-turn abort leaves a warm session, and without this
+      per-turn check the member would keep running after its rules file went
+      unreadable.
+    """
+
+    member: str
+    lifecycle: MemberLifecycle
+    deliver_section: bool
+    enforce_rules_gate: bool
+
+
+def member_lifecycle(
+    *,
+    is_new_session: bool,
+    resumed: bool,
+    minimal_context: bool,
+    needs_reinjection: bool,
+) -> MemberLifecycle:
+    """Map ``build_message``'s branch inputs to one lifecycle state.
+
+    Mirrors the branch structure of ``build_message`` exactly — including the
+    precedence quirks a hand-written table would have to document:
+    ``minimal_context`` beats ``resumed`` (a minimal resumed build early-returns
+    before any member handling), and ``needs_reinjection`` only matters on warm
+    turns (on a new session the full/slim injection path already delivers).
+    """
+    if is_new_session:
+        if minimal_context:
+            return MemberLifecycle.MINIMAL
+        if resumed:
+            return MemberLifecycle.SLIM_RESUME
+        return MemberLifecycle.FRESH
+    if needs_reinjection:
+        return MemberLifecycle.WARM_REINJECTION
+    return MemberLifecycle.WARM
+
+
+def member_turn_context(member: str, lifecycle: MemberLifecycle) -> MemberTurnContext:
+    """THE decision point for the rules-currency invariant.
+
+    Invariant: **every member turn runs under the user's CURRENT rules.**
+    Every lifecycle state satisfies it one of two ways — deliver the current
+    section (which reads the rules, fail closed), or run the standalone
+    fail-closed rules read against the section already live in the provider
+    conversation. All delivery branches call this function instead of
+    branching by hand, so a future lifecycle state added to ``build_message``
+    cannot silently skip both the member section and the rules gate: it has
+    to be given a verdict here first, where the mapping is pinned by tests.
+
+    ``MINIMAL`` is the one deliberate exception — such turns are never member
+    threads (``member`` is ``""`` by contract at every call site), and a
+    member name arriving anyway gets neither delivery nor gate, exactly as
+    the branch structure disposes of it (the minimal build early-returns
+    before any member handling).
+
+    An empty *member* means the turn has no member layer at all: nothing is
+    delivered and nothing is gated, whatever the lifecycle.
+    """
+    # Deny by default. Both verdict predicates are identity/membership tests
+    # that answer False for anything that is not a genuine enum member — and
+    # the str mixin makes a bare "warm" compare EQUAL to the member while
+    # failing both — so an unrecognized lifecycle would otherwise yield the
+    # one combination the invariant forbids (no delivery, no gate) silently,
+    # at the single decision point the invariant rests on. Refuse loudly
+    # instead.
+    if not isinstance(lifecycle, MemberLifecycle):
+        raise TypeError(f"lifecycle must be MemberLifecycle, got {lifecycle!r}")
+    if not member:
+        return MemberTurnContext(
+            member="", lifecycle=lifecycle, deliver_section=False, enforce_rules_gate=False
+        )
+    gate = lifecycle is MemberLifecycle.WARM
+    return MemberTurnContext(
+        member=member,
+        lifecycle=lifecycle,
+        deliver_section=lifecycle.delivers_section,
+        enforce_rules_gate=gate,
+    )
 
 
 def read_dm_binding(slug: str) -> dict | None:

--- a/test/test_member_turn_context.py
+++ b/test/test_member_turn_context.py
@@ -1,0 +1,379 @@
+"""The member-turn chokepoint: one decision point for the rules-currency invariant.
+
+``kiro_crew.members.member_turn_context`` owns the "every member turn runs
+under current rules" invariant, replacing the hand-coordinated branch table it
+was previously stitched across. Two families of tests pin it:
+
+1. **Behavior** — the lifecycle mapping and the per-lifecycle verdict, so the
+   invariant's shape cannot drift silently.
+2. **Wiring (AST guards)** — every delivery branch structurally routes through
+   the chokepoint, so a future session-lifecycle branch cannot bypass both the
+   member section and the fail-closed rules gate. Same guard style as
+   ``test_no_members_sel_audit_is_offloaded``.
+"""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+import inspect
+from itertools import product
+
+import pytest
+
+from kiro_crew.members import (
+    MemberLifecycle,
+    MemberSlugError,
+    is_member_session_key,
+    member_lifecycle,
+    member_slot_key,
+    member_thread_session_alias,
+    member_turn_context,
+)
+
+MEMBER = "Code Reviewer"
+
+#: Lifecycle states whose turn injects the CURRENT member section (delivery
+#: itself enforces the rules gate: the section builder reads the rules fresh
+#: and fails closed on an unreadable file).
+_DELIVERING = (
+    MemberLifecycle.FRESH,
+    MemberLifecycle.SLIM_RESUME,
+    MemberLifecycle.WARM_REINJECTION,
+)
+
+
+class TestMemberTurnContext:
+    """The chokepoint's verdict, per lifecycle state."""
+
+    @pytest.mark.parametrize(
+        "lifecycle,deliver,gate",
+        [
+            (MemberLifecycle.FRESH, True, False),
+            (MemberLifecycle.SLIM_RESUME, True, False),
+            (MemberLifecycle.WARM_REINJECTION, True, False),
+            (MemberLifecycle.WARM, False, True),
+            (MemberLifecycle.MINIMAL, False, False),
+        ],
+    )
+    def test_verdict_truth_table(self, lifecycle, deliver, gate):
+        ctx = member_turn_context(MEMBER, lifecycle)
+        assert ctx.deliver_section is deliver
+        assert ctx.enforce_rules_gate is gate
+        assert ctx.member == MEMBER
+        assert ctx.lifecycle is lifecycle
+
+    @pytest.mark.parametrize("lifecycle", list(MemberLifecycle))
+    def test_empty_member_never_delivers_or_gates(self, lifecycle):
+        """No member on the turn means no member layer at all."""
+        ctx = member_turn_context("", lifecycle)
+        assert ctx.deliver_section is False
+        assert ctx.enforce_rules_gate is False
+        assert ctx.member == ""
+
+    @pytest.mark.parametrize(
+        "lifecycle", [lc for lc in MemberLifecycle if lc is not MemberLifecycle.MINIMAL]
+    )
+    def test_rules_currency_invariant(self, lifecycle):
+        """THE invariant: every member turn passes the fail-closed rules gate.
+
+        Exactly one of the two mechanisms per turn — deliver the current
+        section (rules read inside) or run the standalone rules gate. Never
+        neither (an unbounded member turn), never both (a double read).
+        """
+        ctx = member_turn_context(MEMBER, lifecycle)
+        assert ctx.deliver_section != ctx.enforce_rules_gate, (
+            f"{lifecycle}: a member turn must either deliver the current section "
+            "or enforce the standalone rules gate, exactly one of the two"
+        )
+
+    def test_minimal_is_the_deliberate_exception(self):
+        """MINIMAL turns are never member threads by contract (member is "").
+
+        The verdict for a member name arriving anyway mirrors the branch
+        structure: the minimal build early-returns before any member handling,
+        so neither delivery nor gate runs. Pinned so a change here is a
+        deliberate decision, not drift.
+        """
+        ctx = member_turn_context(MEMBER, MemberLifecycle.MINIMAL)
+        assert ctx.deliver_section is False
+        assert ctx.enforce_rules_gate is False
+
+    @pytest.mark.parametrize("lifecycle", list(MemberLifecycle))
+    def test_delivers_section_property_agrees_with_the_verdict(self, lifecycle):
+        """MemberLifecycle.delivers_section IS the delivery half of the
+        verdict — one source of truth for both the named-member chokepoint
+        call and the mode-keyed chat-runner re-arm."""
+        assert member_turn_context(MEMBER, lifecycle).deliver_section is lifecycle.delivers_section
+
+    def test_context_is_immutable(self):
+        """The verdict is a value, not a mutable carrier a branch could edit."""
+        ctx = member_turn_context(MEMBER, MemberLifecycle.WARM)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ctx.enforce_rules_gate = False  # type: ignore[misc]
+
+    @pytest.mark.parametrize("bogus", ["warm", "fresh", None, 0, object()])
+    def test_unrecognized_lifecycle_is_refused_not_failed_open(self, bogus):
+        """Deny by default: a non-enum lifecycle raises instead of yielding the
+        one combination the invariant forbids (no delivery, no gate).
+
+        The str mixin is the hazard pinned here: a bare "warm" compares EQUAL
+        to MemberLifecycle.WARM while failing the identity/membership tests
+        both verdict predicates use, so without the isinstance refusal it
+        would silently produce an unbounded member turn.
+        """
+        with pytest.raises(TypeError):
+            member_turn_context(MEMBER, bogus)  # type: ignore[arg-type]
+
+
+class TestMemberLifecycleMapping:
+    """member_lifecycle mirrors build_message's branch structure exactly."""
+
+    @pytest.mark.parametrize(
+        "is_new_session,resumed,minimal_context,needs_reinjection",
+        list(product([False, True], repeat=4)),
+    )
+    def test_exhaustive_mapping(self, is_new_session, resumed, minimal_context, needs_reinjection):
+        expected: MemberLifecycle
+        if is_new_session:
+            # minimal_context beats resumed: a minimal resumed build
+            # early-returns before any member handling.
+            if minimal_context:
+                expected = MemberLifecycle.MINIMAL
+            elif resumed:
+                expected = MemberLifecycle.SLIM_RESUME
+            else:
+                expected = MemberLifecycle.FRESH
+        elif needs_reinjection:
+            # On warm turns minimal_context plays no role — the reinjection
+            # and gate branches never test it.
+            expected = MemberLifecycle.WARM_REINJECTION
+        else:
+            expected = MemberLifecycle.WARM
+        got = member_lifecycle(
+            is_new_session=is_new_session,
+            resumed=resumed,
+            minimal_context=minimal_context,
+            needs_reinjection=needs_reinjection,
+        )
+        assert got is expected
+
+    def test_every_lifecycle_state_is_reachable(self):
+        """The mapping covers the whole enum — no orphaned state."""
+        seen = {
+            member_lifecycle(is_new_session=n, resumed=r, minimal_context=m, needs_reinjection=j)
+            for n, r, m, j in product([False, True], repeat=4)
+        }
+        assert seen == set(MemberLifecycle)
+
+
+class TestMemberThreadSessionAlias:
+    """The canonical dashboard session alias derivation."""
+
+    def test_alias_shape(self):
+        assert member_thread_session_alias("code-reviewer") == (
+            "dashboard:" + member_slot_key("code-reviewer")
+        )
+
+    def test_alias_is_a_member_session_key(self):
+        """The alias round-trips through the member-key predicate."""
+        assert is_member_session_key(member_thread_session_alias("code-reviewer"))
+
+    def test_bad_slug_is_refused(self):
+        with pytest.raises(MemberSlugError):
+            member_thread_session_alias("../escape")
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.AST:
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found")
+
+
+def _guarded_node_ids(func: ast.AST, attr: str) -> set[int]:
+    """ids of all nodes inside an ``if`` whose test reads ``.<attr>``."""
+    guarded: set[int] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.If) and any(
+            isinstance(t, ast.Attribute) and t.attr == attr for t in ast.walk(node.test)
+        ):
+            for stmt in node.body:
+                for inner in ast.walk(stmt):
+                    guarded.add(id(inner))
+    return guarded
+
+
+def _calls_named(func: ast.AST, name: str) -> list[ast.Call]:
+    out = []
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call):
+            f = node.func
+            if (isinstance(f, ast.Name) and f.id == name) or (
+                isinstance(f, ast.Attribute) and f.attr == name
+            ):
+                out.append(node)
+    return out
+
+
+class TestChokepointWiring:
+    """AST guards: every delivery branch routes through the chokepoint.
+
+    These are structural, not behavioral: they fail when a future edit
+    reintroduces a hand-coordinated member branch that bypasses
+    ``member_turn_context``, which is exactly the silent-skip failure mode
+    the chokepoint exists to prevent.
+    """
+
+    def test_build_message_delivery_routes_through_chokepoint(self):
+        """Every member-section injection in build_message is guarded by the
+        chokepoint's ``deliver_section`` verdict."""
+        import kiro_crew.context as context_mod
+
+        tree = ast.parse(inspect.getsource(context_mod))
+        build_message = _find_function(tree, "build_message")
+        assert _calls_named(
+            build_message, "member_turn_context"
+        ), "build_message must consult member_turn_context"
+        section_calls = _calls_named(build_message, "_build_member_section")
+        assert section_calls, "expected member-section injection sites in build_message"
+        guarded = _guarded_node_ids(build_message, "deliver_section")
+        unguarded = [c.lineno for c in section_calls if id(c) not in guarded]
+        assert not unguarded, (
+            f"_build_member_section called outside a deliver_section guard at "
+            f"lines {unguarded}; route the branch through member_turn_context"
+        )
+
+    def test_build_message_rules_gate_routes_through_chokepoint(self):
+        """The standalone fail-closed rules read runs iff the chokepoint says
+        ``enforce_rules_gate`` — not under a hand-written lifecycle test."""
+        import kiro_crew.context as context_mod
+
+        tree = ast.parse(inspect.getsource(context_mod))
+        build_message = _find_function(tree, "build_message")
+        gate_calls = _calls_named(build_message, "read_member_rules")
+        assert gate_calls, "expected the standalone rules-gate read in build_message"
+        guarded = _guarded_node_ids(build_message, "enforce_rules_gate")
+        unguarded = [c.lineno for c in gate_calls if id(c) not in guarded]
+        assert not unguarded, (
+            f"read_member_rules called outside an enforce_rules_gate guard at "
+            f"lines {unguarded}; route the branch through member_turn_context"
+        )
+
+    def test_build_message_derives_lifecycle_from_its_own_inputs(self):
+        """The lifecycle handed to the chokepoint comes from member_lifecycle
+        with build_message's real branch inputs, so the chokepoint and the
+        surrounding branch structure cannot disagree on the turn's state."""
+        import kiro_crew.context as context_mod
+
+        tree = ast.parse(inspect.getsource(context_mod))
+        build_message = _find_function(tree, "build_message")
+        lifecycle_calls = _calls_named(build_message, "member_lifecycle")
+        assert lifecycle_calls, "build_message must derive the lifecycle via member_lifecycle"
+        kw = {k.arg for call in lifecycle_calls for k in call.keywords}
+        assert {"is_new_session", "resumed", "minimal_context", "needs_reinjection"} <= kw
+
+    def test_build_session_context_delivery_routes_through_chokepoint(self):
+        """The fresh-session injection (FRESH leg) consults the chokepoint."""
+        import kiro_crew.context as context_mod
+
+        tree = ast.parse(inspect.getsource(context_mod))
+        build_session_context = _find_function(tree, "build_session_context")
+        section_calls = _calls_named(build_session_context, "_build_member_section")
+        assert section_calls, "expected the FRESH-leg injection in build_session_context"
+        guarded = _guarded_node_ids(build_session_context, "deliver_section")
+        unguarded = [c.lineno for c in section_calls if id(c) not in guarded]
+        assert not unguarded, (
+            f"_build_member_section called outside a deliver_section guard at "
+            f"lines {unguarded} in build_session_context"
+        )
+
+    def test_chat_runner_pending_flag_routes_through_chokepoint(self):
+        """The finally-block re-arm's member flag reads the chokepoint's own
+        delivery verdict (MemberLifecycle.delivers_section), not a hand-written
+        is_new test. Mode-keyed rather than name-keyed: the member NAME is
+        resolved later, at the context build, and delivery is at stake from
+        the moment the session client exists."""
+        import kiro_crew.dashboard.chat_runner as chat_runner_mod
+
+        tree = ast.parse(inspect.getsource(chat_runner_mod))
+        assigns = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "_member_session_start_pending"
+                for t in node.targets
+            )
+        ]
+        assert assigns, "expected _member_session_start_pending assignments in chat_runner"
+        derived = [
+            node
+            for node in assigns
+            # The turn-scope init (`= False`) stays a literal; every DERIVED
+            # assignment must come from the chokepoint.
+            if not (isinstance(node.value, ast.Constant) and node.value.value is False)
+        ]
+        assert derived, "expected a derived _member_session_start_pending assignment"
+        for node in derived:
+            dump = ast.dump(node.value)
+            assert "member_lifecycle" in dump and "delivers_section" in dump, (
+                f"_member_session_start_pending at line {node.lineno} does not "
+                "route through member_lifecycle(...).delivers_section"
+            )
+
+    def test_rules_handler_uses_canonical_alias(self):
+        """The members handler never hand-builds the ``dashboard:<slot key>``
+        alias — the derivation lives in member_thread_session_alias, so the
+        reinjection flag, the thread's history key, and the roster's
+        transcript-tail probe cannot drift apart. Any f-string carrying a
+        ``dashboard:`` constant is flagged, whatever it interpolates."""
+        from kiro_crew.dashboard.handlers import members as members_handler_mod
+
+        tree = ast.parse(inspect.getsource(members_handler_mod))
+        hand_built = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.JoinedStr)
+            and any(
+                isinstance(part, ast.Constant)
+                and isinstance(part.value, str)
+                and "dashboard:" in part.value
+                for part in node.values
+            )
+        ]
+        assert not hand_built, (
+            f"hand-built member session alias (f-string over a 'dashboard:' "
+            f"constant) at lines {hand_built}; use member_thread_session_alias"
+        )
+        marks = _calls_named(tree, "mark_needs_reinjection")
+        assert marks, "expected the rules-write reinjection flag in the members handler"
+        for call in marks:
+            assert "member_thread_session_alias" in ast.dump(call), (
+                f"mark_needs_reinjection at line {call.lineno} does not derive its "
+                "key from member_thread_session_alias"
+            )
+
+    def test_slim_resume_is_derived_from_the_chokepoint_lifecycle(self):
+        """``slim_resume`` reads the chokepoint's lifecycle instead of
+        re-encoding ``resumed and not minimal_context``: two independent
+        spellings of one predicate can drift, and the divergence that matters
+        (branch true, lifecycle no longer SLIM_RESUME) would leave a resumed
+        member session on a stale [PERMANENT RULES] snapshot silently."""
+        import kiro_crew.context as context_mod
+
+        tree = ast.parse(inspect.getsource(context_mod))
+        build_message = _find_function(tree, "build_message")
+        assigns = [
+            node
+            for node in ast.walk(build_message)
+            if isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "slim_resume" for t in node.targets)
+        ]
+        assert assigns, "expected the slim_resume derivation in build_message"
+        for node in assigns:
+            dump = ast.dump(node.value)
+            assert "lifecycle" in dump and "SLIM_RESUME" in dump, (
+                f"slim_resume at line {node.lineno} re-encodes the resume predicate "
+                "instead of reading the chokepoint's lifecycle"
+            )


### PR DESCRIPTION
## Problem / Motivation

Design Review follow-up from PR #7235 (member system prompt for crew DM threads), deferred to #8609 while that PR was at the merge-ready point. The "every member turn runs under current rules" invariant was stitched across five hand-coordinated branches: the lifecycle table in `build_message`, the fresh-session injection in `build_session_context`, the `chat_runner` finally-block re-arm, and the PUT rules handler's `mark_needs_reinjection` with a hand-built `dashboard:{member_slot_key(slug)}` key. No single chokepoint owned the invariant, so a future session-lifecycle branch added to `build_message` could silently skip both the member section and the fail-closed rules gate.

## Why it matters

The rules layer is the user's safety boundary for a crew member. A lifecycle branch that bypasses both delivery and the rules gate would run the member with no `[PERMANENT RULES]` at all, silently — and nothing in the old shape would fail: the coordination lived in a comment table, which no test can pin.

## What changed (motivation → approach → change)

Goal: make the invariant live in one function a test can pin, exactly as the issue specifies. Approach: extract the decision, not the actions — each branch keeps its own injection mechanics and consults a shared verdict, keeping the diff behavior-preserving.

New in `kiro_crew.members`:

- `MemberLifecycle` — the five session-lifecycle states (`FRESH`, `SLIM_RESUME`, `WARM_REINJECTION`, `WARM`, `MINIMAL`), derived by `member_lifecycle()` from the same inputs `build_message` already branches on, with `delivers_section` exposing the delivery half of the verdict.
- `member_turn_context(member, lifecycle)` — THE decision point: every lifecycle either delivers the current section (whose builder reads rules fail-closed) or runs the standalone rules gate; `MINIMAL` is the pinned deliberate exception (never a member thread by contract). Fails closed on a non-enum lifecycle (`TypeError`) — the str mixin makes a bare `"warm"` compare equal to the member while failing the identity tests, which would otherwise yield the one combination the invariant forbids.
- `member_thread_session_alias(slug)` — the canonical `dashboard:<slot key>` alias, replacing the three hand-built f-strings in the members handler (rules-write reinjection flag, thread-open history probe, roster transcript-tail probe).

All delivery branches now route through the chokepoint: the gate and both re-injection sites in `build_message` test `enforce_rules_gate` / `deliver_section`, the `build_session_context` fresh-session site consults the `FRESH` verdict, `slim_resume` is derived from the chokepoint's lifecycle rather than re-encoding the resume predicate, and the `chat_runner` pending flag reads `MemberLifecycle.delivers_section` (mode-keyed — the member name resolves later, at the context build).

Zero behavior change: every replaced predicate is equivalent to the original on all reachable input combinations.

## Tests

New module `test/test_member_turn_context.py`:

- Verdict truth table across all five lifecycle states; empty-member always inert; frozen dataclass; `delivers_section` agrees with the verdict.
- The rules-currency invariant itself: every non-`MINIMAL` lifecycle takes exactly one of the two mechanisms.
- Exhaustive 16-combination `member_lifecycle` mapping (including the `minimal_context`-beats-`resumed` precedence) and full-enum reachability.
- Fail-closed chokepoint: a non-enum lifecycle (including the str-mixin hazard `"warm"`) raises `TypeError`.
- Canonical alias shape, round-trip through `is_member_session_key`, bad-slug refusal.
- AST wiring guards (same style as the SEL offload guard): every `_build_member_section` call in `build_message` / `build_session_context` sits under a `deliver_section` test, the standalone rules read sits under `enforce_rules_gate`, the lifecycle is derived from `member_lifecycle` with the real branch inputs, `slim_resume` reads the chokepoint's lifecycle, the chat_runner flag routes through `delivers_section`, and no f-string in the members handler carries a `dashboard:` constant.

Existing member-prompt suites (~270 tests, early-exit re-arm paths included) pass unchanged — no existing test was edited.

## Manual verification

N/A — unit coverage sufficient: the change is a behavior-preserving extraction pinned by the existing behavioral suites plus the new structural guards; no user-visible surface changed.

## Related Issues

Closes #8609

## Pattern harvest

Rule candidate: review-prompt
Pattern: an invariant coordinated across branches by a comment table instead of a callable chokepoint a test can pin

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
