### PR TITLE
refactor(governance): resolve the approval_modes YOLO verdict at ceiling install

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -331,7 +331,6 @@ src/kiro_crew/pod/unit.py
 src/kiro_crew/publish_governance.py
 src/kiro_crew/publish_sync.py
 src/kiro_crew/resource_status.py
-src/kiro_crew/safety_override.py
 src/kiro_crew/security.py
 src/kiro_crew/seed.py
 src/kiro_crew/sel.py

--- a/docs/system-specs/modules/governance.md
+++ b/docs/system-specs/modules/governance.md
@@ -2791,22 +2791,50 @@ resurrected auto-approve the operator had explicitly revoked. Tearing the grant 
 makes both readings agree. The cost is that a policy which denies and then relaxes
 requires a fresh arm, which is the honest outcome anyway.
 
+The teardown runs at the moment the denying ceiling is INSTALLED, not on the next
+`is_active()` call — `safety_override.revoke_for_policy` drops the session-wide grant
+and every scoped grant, then fires `_on_expired("policy")`. That callback is the rest
+of the revocation, and it is not optional: a dashboard grant also writes
+`approval_policy="auto"` onto the slots and into the shared channel-trust mapping, and
+`subagent_manager.admission.parent_trusted` reads *that policy* rather than any flag in
+`safety_override` — so a revocation that stopped at the flag left `spawn_run`
+auto-approved. `is_active` / `is_scope_active` / `renew_scoped` keep their policy check
+as the fail-closed mask if that teardown was partial.
+
 **Every refusal is SEL-audited.** A governance denial that leaves no trace is
 indistinguishable from the request never having been made, which is exactly the
 record an operator needs after an attempted escalation. The audit is best-effort at
 each site: an SEL write failure never turns a refusal into a grant.
 
-**Nothing resolves governance on the event loop.** Resolving the scope walks the
-profiles dir (`iterdir` + per-file `stat`), and two call shapes forbid a per-call
-read: `status_snapshot` is emitted on the 5s WebSocket push, and `is_active` is the
-predicate every transport hands to `TurnDriver`, so it runs per *tool call*. Hence
-two forms, chosen by frequency — `yolo_policy_permits()` and
-`cached_disabled_approval_modes()` read memory and schedule an off-loop refresh (at
-most one in flight, 5s TTL, stale in the SAFE direction since a tightening lands
-within one TTL), while arming reads authoritatively because it is rare and already
-does filesystem I/O for its fail-closed audit. `/api/status` primes the status cache
-from inside the `asyncio.to_thread` it already used, so the HTTP, SSE and WebSocket
-frames cannot disagree.
+**The verdict is PUSHED at ceiling install, never polled.** Resolving the scope walks
+the profiles dir (`iterdir` + per-file `stat`), and every consumer is on a path that
+must not do that: `status_snapshot` is emitted on the 5s WebSocket push, `is_active` is
+the predicate every transport hands to `TurnDriver` (so it runs per *tool call*), and
+arming reaches the module from the event loop through synchronous callers. So
+`approval_mode_permitted("yolo")` is resolved **once per ceiling**, by a hook
+`safety_override` registers with `platform.context.register_ceiling_install_hook`.
+`platform.context._install` is the single writer of the active context — central
+distribution (`policy_distribution.apply_ceiling`), boot, the lazy default and the test
+reset all go through it — so no ceiling escapes the hook. Every consumer
+(`yolo_policy_permits()`, and `cached_disabled_approval_modes()` on top of it) is then a
+bare attribute read: no TTL, no lock, no thread.
+
+A governance-evaluation error at install time resolves to **denied**, and a process
+that reads the verdict before any ceiling was installed resolves once through
+`current_context()` — which composes and installs the standalone default, firing the
+same hook. A host whose context refuses to compose (a governed profile whose boot did
+not run) leaves the verdict denied, which is the fail-closed direction.
+
+This replaced a pull-based cache — a 5s TTL plus a governance-generation stamp,
+refreshed on a worker thread — and the reason is worth recording. Polling a value that
+only changes on a discrete event needs a freshness key, a third
+`unknown` verdict for the window before a refresh lands, and a per-caller rule for
+collapsing that third state (approval had to fail closed on it; revocation had to *not*
+fire, or an unrelated ceiling install would destroy a live grant permanently). Each of
+those is a window in which a permit resolved under a retired ceiling is still served,
+and the windows — not the scope, the arming gate or the audits — were where every
+security finding against that design landed. Pushing removes them instead of shortening
+them.
 
 The denied set rides the shared `state.status_snapshot()` as
 `disabled_approval_modes`. The picker **hides** each denied mode rather than showing

--- a/src/kiro_crew/dashboard/chat_handlers.py
+++ b/src/kiro_crew/dashboard/chat_handlers.py
@@ -127,7 +127,7 @@ from kiro_crew.providers.base import LLMProvider
 from kiro_crew.safety_override import (
     approval_mode_permitted,
     safety_override,
-    yolo_policy_verdict,
+    yolo_policy_permits,
 )
 from kiro_crew.sandbox import voice_runtime_workspace_conflict
 from kiro_crew.security import (
@@ -8824,34 +8824,19 @@ async def api_chat_mode(request: web.Request) -> web.Response:
     # mode check rather than a YOLO special case so that widening the scope needs
     # no change here; YOLO is additionally guarded at arming in ``safety_override``.
     #
-    # ``mode_disabled_by_policy`` is reserved for a DEFINITE deny. Reading the
-    # boolean alone conflated two different answers: ``approval_mode_permitted``
-    # fails closed, so a governance READ FAILURE also returned False and the caller
-    # was told their organization's policy forbids the mode -- sending them to look
-    # for a policy that may not exist, while the real fault (governance unreadable)
-    # went unnamed. Same defect, and same three-way split, as the two Slack paths.
-    # ``yolo`` is the only deniable mode, so it is the only one that can be unknown.
+    # ``yolo`` reads the PUSHED verdict, which is resolved when a ceiling is installed
+    # and so needs no thread: there is one answer for the ceiling in force, and a
+    # governance-evaluation error resolved to a deny at that install. Every other mode
+    # is non-deniable and short-circuits inside ``approval_mode_permitted`` -- but an
+    # unrecognised ``mode`` string does reach governance, so that branch keeps its
+    # offload.
     if mode == "yolo":
-        _verdict = await asyncio.to_thread(yolo_policy_verdict)
-        if _verdict == "denied":
+        if not yolo_policy_permits():
             return _deny_approval_mode(
                 caller="dashboard:chat_mode",
                 operation=f"chat_mode:{mode}",
                 mode=mode,
                 resource=str(body.get("slot") or ""),
-            )
-        if _verdict != "permitted":
-            return web.json_response(
-                {
-                    "ok": False,
-                    "error": (
-                        "could not read the governance policy for approval mode "
-                        f"{mode!r}; try again"
-                    ),
-                    "code": "approval_mode_policy_unreadable",
-                    "mode": mode,
-                },
-                status=503,
             )
     elif not await asyncio.to_thread(approval_mode_permitted, mode):
         return _deny_approval_mode(
@@ -8919,7 +8904,7 @@ async def api_chat_mode(request: web.Request) -> web.Response:
             # them apart: an ``approval_modes`` deny of ``yolo`` is a permanent
             # policy answer (403, same code the picker already understands),
             # while anything else is a transient activation failure (503).
-            if not await asyncio.to_thread(approval_mode_permitted, "yolo"):
+            if not yolo_policy_permits():
                 return _deny_approval_mode(
                     caller="dashboard:chat_mode",
                     operation="mode_change:yolo",
@@ -9342,7 +9327,7 @@ async def api_chat_slot_approve(request: web.Request) -> web.Response:
             # deny of ``yolo`` is a permanent policy answer the client can render
             # (403 + the code the picker already understands), while anything else
             # is a transient activation failure worth retrying (503).
-            if not await asyncio.to_thread(approval_mode_permitted, "yolo"):
+            if not yolo_policy_permits():
                 return _deny_approval_mode(
                     caller=f"dashboard:{name}",
                     operation="tool_approval:yolo",
@@ -9358,6 +9343,26 @@ async def api_chat_slot_approve(request: web.Request) -> web.Response:
             # linked cron/workflow or channel-surfaced slot runs under its
             # linked_session_key.
             state.sessions.set_approval_policy(effective_session_key(s), "auto")
+        # Reconcile against a policy deny that landed while this was writing.
+        #
+        # This write is the grant's inherited half -- ``admission.parent_trusted``
+        # reads the slot's approval policy directly rather than any flag in
+        # ``safety_override`` -- and it happens OUTSIDE the lock the revocation takes.
+        # So a denying ceiling installed after the arm returned can revoke the grant
+        # and run its ``_on_expired`` cleanup, and this loop then puts the inherited
+        # trust straight back with nothing left to clear it: a subagent spawned under
+        # it is auto-approved, and is not un-spawned by the next event either.
+        #
+        # The two halves are complete together: a write that lands BEFORE the
+        # cleanup is cleared by the cleanup, and one that lands after -- or
+        # interleaved with it -- is cleared here. Standing trust is preserved on the
+        # same rule ``_on_override_expired`` uses, since a Trust press is a separate,
+        # longer-lived decision that no yolo deny expires.
+        if not yolo_policy_permits():
+            for s in state._slots.values():
+                if not (s._trust or s._trust_reads):
+                    state.sessions.set_approval_policy(effective_session_key(s), "")
+            state.push_slots_update()
         action = "approved"
     resolved = action if action in ("approved", "approved_trust_reads") else "rejected"
     if not fut or fut.done():

--- a/src/kiro_crew/dashboard/handlers_system.py
+++ b/src/kiro_crew/dashboard/handlers_system.py
@@ -35,7 +35,7 @@ from kiro_crew.executors import subprocess_executor
 from kiro_crew.loop_lock import LoopBoundLock
 from kiro_crew.platform import current_context
 from kiro_crew.safety_override import (
-    resolve_disabled_approval_modes_blocking,
+    cached_disabled_approval_modes,
     safety_override,
     until_shutdown_permitted,
 )
@@ -140,10 +140,12 @@ def _get_telemetry_salt() -> bytes:
 def _yolo_duration_fields() -> tuple[str, bool, list[str]]:
     """``(configured_duration, until_shutdown_permitted, disabled_approval_modes)``.
 
-    ALL values touch the filesystem — the config read and the governance profile
-    resolution (``iterdir``/``stat`` over the profiles dir) — so this runs in a
-    worker thread, never on the event loop. ``/api/status`` is polled
-    continuously; doing this inline stalls the whole gateway on a slow home.
+    The first two touch the filesystem — the config read, and the ``yolo_duration``
+    governance resolution (``iterdir``/``stat`` over the profiles dir) — so this runs
+    in a worker thread, never on the event loop. ``/api/status`` is polled
+    continuously; doing this inline stalls the whole gateway on a slow home. The
+    disabled-modes list does NOT touch the filesystem (it reads the verdict pushed at
+    ceiling install) and only rides along here because it belongs in the same frame.
     """
     try:
         label = str(KiroCrewConfig.load().agent.yolo_duration)
@@ -155,12 +157,10 @@ def _yolo_duration_fields() -> tuple[str, bool, list[str]]:
     except Exception:
         logger.debug("could not resolve until_shutdown permission", exc_info=True)
         permitted = True
-    # ONE shared resolver with ``status_snapshot`` AND with the per-tool-call
+    # ONE shared reader with ``status_snapshot`` AND with the per-tool-call
     # enforcement predicate, so the HTTP, SSE and WS status frames cannot report a
-    # list the enforcement path disagrees with. This call also primes that shared
-    # cache from inside this worker thread, which is why the event-loop reader can
-    # stay filesystem-free.
-    disabled_modes = resolve_disabled_approval_modes_blocking()
+    # list the enforcement path disagrees with.
+    disabled_modes = cached_disabled_approval_modes()
     return label, permitted, disabled_modes
 
 
@@ -195,7 +195,7 @@ async def api_status(request: web.Request) -> web.Response:
         except Exception:
             owner_hash = "unknown"
     so_status = safety_override().status()
-    # Off-loop: both values hit the filesystem (see _yolo_duration_fields).
+    # Off-loop: the duration values hit the filesystem (see _yolo_duration_fields).
     yolo_duration, until_shutdown_ok, disabled_approval_modes = await asyncio.to_thread(
         _yolo_duration_fields
     )

--- a/src/kiro_crew/dashboard/server.py
+++ b/src/kiro_crew/dashboard/server.py
@@ -55,6 +55,7 @@ from kiro_crew.dashboard import (
     tailnet,
     tailnet_serve,
 )
+from kiro_crew.dashboard.chat_utils import effective_session_key
 from kiro_crew.dashboard.crash_dump_store import (
     claim_dump_notification,
     dump_age_seconds,
@@ -2256,6 +2257,131 @@ async def _notify_slack_override_expired(state: DashboardState, source: str) -> 
     await _dm_owner(state, _override_expiry_dm_text(source))
 
 
+def _clear_override_derived_trust(state: "DashboardState", source: str) -> None:
+    """Drop every INHERITED grant of the expiring override. State only, no loop.
+
+    Module-level (not a ``start_dashboard`` closure), like the Slack notifier, so the
+    seam is directly testable against a real ``DashboardState``.
+
+    Split out of the notifier because the two halves have different
+    deadlines. ``subagent_manager.admission.parent_trusted`` reads a session's
+    ``approval_policy == "auto"`` DIRECTLY -- it consults no flag in
+    ``safety_override`` -- so until this has run a spawn is auto-approved against
+    a ceiling that already denies, and an already-launched subagent is not
+    un-spawned by anything later. That makes this the half a policy revocation has
+    to complete synchronously, on whichever thread installed the ceiling, while
+    the broadcasts and DMs below can be scheduled onto the loop.
+
+    Safe off the event loop: it touches the slot dict and the session store and
+    nothing loop-affine. Idempotent, so the notifier re-running it costs nothing.
+    """
+    # Slots carrying STANDING trust keep their policy: that is a separate,
+    # longer-lived decision than the expiring override, and it is also what must
+    # survive the channel-trust revoke below.
+    standing_trust: set[str] = set()
+    if state.sessions is not None:
+        # Snapshot the slots before iterating. This runs on whatever thread
+        # installed the denying ceiling, and the loop keeps creating and removing
+        # slots -- so iterating the live dict raises "dictionary changed size
+        # during iteration" and ABORTS the teardown partway, leaving the slots it
+        # had not reached yet at ``approval_policy="auto"`` with nothing to come
+        # back for them. A partial revocation is the failure this whole path
+        # exists to prevent, so the iteration cannot be the thing that breaks it.
+        for slot in list(state._slots.values()):
+            if slot._trust or slot._trust_reads:
+                # Excluded from the channel-trust revoke below, via the SAME
+                # derivation the reset uses: a channel-born slot's turns run on
+                # the channel's own session key, so a `dashboard:<slot>` spelling
+                # names a key nothing on that path reads.
+                standing_trust.add(effective_session_key(slot))
+            else:
+                # The SAME derivation the grant used. A channel-born slot's
+                # turns run on the channel's own session key, which is what
+                # `linked_session_key` holds, so clearing `dashboard:<slot>`
+                # here cleared a key nothing on the channel path ever reads:
+                # the TTL could not expire the grant it had handed out, which
+                # is worse than a missing off-switch because the operator was
+                # told it was time-bounded.
+                state.sessions.set_approval_policy(effective_session_key(slot), "")
+    # Slack cleanup — isolated so failures don't block dashboard operations
+    try:
+        # From `messaging`, not `slack.handler`: the grant is channel-neutral.
+        # This revokes the approval_policy half as well as the mapping, which is
+        # what a CHANNEL session needs -- the loop just above resets only the
+        # dashboard's own slots, and a subagent reads the policy rather than the
+        # mapping, so policy left at "auto" outlives the override it belonged to.
+        # ``keep_policy`` is what stops this from undoing the preservation above:
+        # a Trust press can file a ``dashboard:`` key in the shared grant, and
+        # resetting its policy here would revoke standing trust nobody expired.
+        from kiro_crew.messaging.session_trust import clear_trusted_sessions
+
+        clear_trusted_sessions(keep_policy=standing_trust)
+    except Exception:
+        logger.debug("Could not clear trusted sessions", exc_info=True)
+
+
+def _suspend_override_derived_trust(state: "DashboardState") -> Callable[[], None] | None:
+    """Blank the grant's inherited slot policies BEFORE a new ceiling publishes.
+
+    Returns the restore. ``_clear_override_derived_trust`` runs once a deny
+    has been RESOLVED against the new ceiling, but resolving is a governance read
+    and the ceiling is already published while it runs -- and
+    ``admission.parent_trusted`` reads the slot's approval policy directly, not
+    ``is_active()``, so for that whole window a spawn from a slot carrying the
+    override's inherited ``"auto"`` was auto-approved against a ceiling that may
+    deny. This is the pre-publication half that closes it.
+
+    Only the override's OWN inherited trust is suspended: slots with standing
+    ``_trust`` / ``_trust_reads`` are left alone (a Trust press is a separate,
+    longer-lived decision no yolo ceiling touches), and only slots currently at
+    ``"auto"`` are recorded, so the restore puts back exactly what was taken. The
+    shared channel-trust mapping is NOT suspended: ``is_session_trusted`` gates a
+    tool in an already-running turn (recoverable, audited), while this guards
+    spawn admission (unrecoverable) -- the same asymmetry the revoke ordering rests
+    on. Same thread contract as the clear: slot dict + session store only.
+    """
+    if state.sessions is None:
+        return None
+    suspended: list[tuple[str, str]] = []
+    for slot in list(state._slots.values()):
+        if slot._trust or slot._trust_reads:
+            continue
+        key = effective_session_key(slot)
+        try:
+            if state.sessions.get_approval_policy(key) != "auto":
+                continue
+            state.sessions.set_approval_policy(key, "")
+        except Exception:
+            logger.debug("could not suspend inherited trust on %s", key, exc_info=True)
+            continue
+        suspended.append((slot.key, key))
+    if not suspended:
+        return None
+
+    def _restore() -> None:
+        # Restore is CONDITIONAL, per slot, on the slot still being in the state it
+        # was suspended from. The governance read in between is long enough for
+        # the operator to have changed a slot's mode -- picked ``trust_reads`` or
+        # ``trust``, or ``normal`` -- and each of those writes this same policy.
+        # Writing ``"auto"`` over a ``trust_reads`` slot would upgrade read-only
+        # trust to full auto-approve on the read ``parent_trusted`` makes; over a
+        # ``normal`` slot it would undo an explicit revoke. So a slot gets its
+        # ``"auto"`` back only if it still exists, still carries no standing trust
+        # flag, and its policy is still the empty string this suspension left.
+        for slot_key, key in suspended:
+            slot = state._slots.get(slot_key)
+            if slot is None or slot._trust or slot._trust_reads:
+                continue
+            try:
+                if state.sessions.get_approval_policy(key) != "":
+                    continue
+                state.sessions.set_approval_policy(key, "auto")
+            except Exception:
+                logger.debug("could not restore inherited trust on %s", key, exc_info=True)
+
+    return _restore
+
+
 def _dispatch_override_expiry_notification(
     state: DashboardState, notify_coro_factory: Any, source: str
 ) -> bool:
@@ -4110,47 +4236,16 @@ async def start_dashboard(
 
     # Wire safety override expiry notifications
     def _on_override_expired(source: str) -> None:
-        """Notify all interfaces when safety override expires."""
+        """Notify all interfaces when safety override expires.
+
+        Runs the inherited-trust teardown first so a TTL lapse -- which reaches this
+        directly, with no separate synchronous call -- still clears everything. A
+        policy revocation has already run it inline by the time this fires, and it is
+        idempotent, so the two paths need no branch between them.
+        """
+        _clear_override_derived_trust(state, source)
         state.broadcast_ws("yolo_expired", {"source": source})
         state.push_slots_update()
-        # Slots carrying STANDING trust keep their policy: that is a separate,
-        # longer-lived decision than the expiring override, and it is also what must
-        # survive the channel-trust revoke below.
-        standing_trust: set[str] = set()
-        if state.sessions is not None:
-            from kiro_crew.dashboard.chat_utils import effective_session_key
-
-            for slot in state._slots.values():
-                if slot._trust or slot._trust_reads:
-                    # Excluded from the channel-trust revoke below, via the SAME
-                    # derivation the reset uses: a channel-born slot's turns run on
-                    # the channel's own session key, so a `dashboard:<slot>` spelling
-                    # names a key nothing on that path reads.
-                    standing_trust.add(effective_session_key(slot))
-                else:
-                    # The SAME derivation the grant used. A channel-born slot's
-                    # turns run on the channel's own session key, which is what
-                    # `linked_session_key` holds, so clearing `dashboard:<slot>`
-                    # here cleared a key nothing on the channel path ever reads:
-                    # the TTL could not expire the grant it had handed out, which
-                    # is worse than a missing off-switch because the operator was
-                    # told it was time-bounded.
-                    state.sessions.set_approval_policy(effective_session_key(slot), "")
-        # Slack cleanup — isolated so failures don't block dashboard operations
-        try:
-            # From `messaging`, not `slack.handler`: the grant is channel-neutral.
-            # This revokes the approval_policy half as well as the mapping, which is
-            # what a CHANNEL session needs -- the loop just above resets only the
-            # dashboard's own slots, and a subagent reads the policy rather than the
-            # mapping, so policy left at "auto" outlives the override it belonged to.
-            # ``keep_policy`` is what stops this from undoing the preservation above:
-            # a Trust press can file a ``dashboard:`` key in the shared grant, and
-            # resetting its policy here would revoke standing trust nobody expired.
-            from kiro_crew.messaging.session_trust import clear_trusted_sessions
-
-            clear_trusted_sessions(keep_policy=standing_trust)
-        except Exception:
-            logger.debug("Could not clear trusted sessions", exc_info=True)
         # Slack notification (prevent GC with background_tasks set)
         _dispatch_override_expiry_notification(
             state, functools.partial(_notify_slack_override_expired, state), source
@@ -4160,6 +4255,12 @@ async def start_dashboard(
         _notify_unattended_expiry(state, source)
 
     safety_override().on_expired = _on_override_expired
+    # The synchronous half, for the one caller that cannot wait for the loop: a
+    # ceiling install that denies ``yolo`` revokes from whatever thread installed it.
+    safety_override().on_policy_revoked = functools.partial(_clear_override_derived_trust, state)
+    # The pre-publication half: suspend inherited slot trust while a new ceiling is
+    # being resolved, and get it back if the ceiling still permits.
+    safety_override().on_policy_suspend = functools.partial(_suspend_override_derived_trust, state)
 
     # A grant that was live when the process went down is GONE -- grants are
     # in-memory by design and this does not change that. What it changes is that

--- a/src/kiro_crew/platform/context.py
+++ b/src/kiro_crew/platform/context.py
@@ -402,13 +402,139 @@ _ACTIVE: Optional[PlatformContext] = None
 _GOVERNANCE_GENERATION = 0
 _GENERATION_LOCK = threading.Lock()
 
+# Callbacks run on every DECLARED install of ``_ACTIVE`` (every one except the silent
+# lazy default -- see ``register_ceiling_install_hook``), so a consumer that must
+# re-derive something from the new ceiling is PUSHED the change instead of polling.
+#
+# The alternative — every consumer re-reading governance behind a TTL cache — was
+# tried for the ``approval_modes`` YOLO verdict and is what this registry replaces:
+# a cache needs a freshness key, a three-state "not resolved under this ceiling yet"
+# verdict, and an off-loop refresh, and each of those carries its own window in
+# which a stale answer is served. An install is a discrete event, so a consumer told
+# about it holds an answer that is either current or does not exist.
+#
+# A registry rather than a direct import because the consumers sit ABOVE this module
+# (``safety_override`` already imports from here), so calling into them by name would
+# be a cycle. Each registers itself at its own import.
+_CEILING_INSTALL_HOOKS: "list[Callable[[Optional[PlatformContext]], None]]" = []
+# Run BEFORE ``_ACTIVE`` is reassigned, so a consumer can invalidate what it derived
+# from the OUTGOING ceiling while the incoming one is not yet visible.
+#
+# Publishing first and invalidating after leaves a window whose width is a full
+# governance resolution: the new ceiling is live, the derived answer still belongs to
+# the retired one, and a concurrent authorization read is decided by the stale answer.
+# For an authorization consumer that window is a bypass, so invalidation cannot be the
+# second half of the install -- it has to be the first.
+_CEILING_INVALIDATE_HOOKS: "list[Callable[[], None]]" = []
+_HOOKS_LOCK = threading.Lock()
 
-def _install(ctx: Optional[PlatformContext]) -> None:
-    """Assign ``_ACTIVE`` and bump the generation.  The single writer."""
+
+def register_ceiling_install_hook(cb: "Callable[[Optional[PlatformContext]], None]") -> None:
+    """Call ``cb(ctx)`` after every DECLARED install of the active context.
+
+    ``ctx`` is the context just installed, or ``None`` for :func:`reset_context` —
+    a hook that caches something ceiling-derived should treat ``None`` as "there is
+    no ceiling to derive from" rather than as a ceiling that permits everything.
+
+    "Declared" excludes ONE install: the lazy default :func:`current_context` composes
+    when nothing was installed. That one is reached from inside a governance read (the
+    profile store resolves the active context to build its freshness key), so a hook
+    that reads governance would call back into a store that is mid-load and be handed
+    its fail-closed "not loaded" answer -- a verdict about nothing. It also needs no
+    hook: a consumer cannot be holding anything derived from a ceiling before the first
+    derivation happens, and that first derivation is what triggers the lazy install.
+
+    Idempotent per callable, so a module imported twice under different names does
+    not get its hook run twice. Registration does NOT replay the install that may
+    already have happened: a hook that needs to cope with being registered late must
+    say so itself (see ``safety_override.yolo_policy_permits``), because resolving
+    governance from inside an import is how import cycles are born.
+    """
+    with _HOOKS_LOCK:
+        if cb not in _CEILING_INSTALL_HOOKS:
+            _CEILING_INSTALL_HOOKS.append(cb)
+
+
+def register_ceiling_invalidate_hook(cb: "Callable[[], None]") -> None:
+    """Call ``cb()`` just BEFORE a declared install replaces the active context.
+
+    For a consumer whose derived value is an AUTHORIZATION answer. ``cb`` must make
+    that value fail closed and must do no I/O and take no lock a reader might hold:
+    it runs on the install path, ahead of the new ceiling becoming visible, and the
+    matching install hook writes the real answer immediately afterwards. It is told
+    nothing about the incoming ceiling on purpose -- its only job is to stop serving
+    the outgoing one.
+
+    Paired with :func:`register_ceiling_install_hook` and skipped on exactly the same
+    one install (the lazy default), so a consumer registering both is masked and
+    re-resolved as a unit.
+    """
+    with _HOOKS_LOCK:
+        if cb not in _CEILING_INVALIDATE_HOOKS:
+            _CEILING_INVALIDATE_HOOKS.append(cb)
+
+
+def _notify_ceiling_invalidating() -> None:
+    """Run the pre-publication invalidate hooks. Never raises.
+
+    A hook that raises must not stop the install, and it cannot leave a consumer
+    fail-OPEN either: the hooks here only ever withdraw a derived permission, so a
+    failure at worst leaves the previous answer in place -- which is the same state
+    publishing-then-invalidating had, and the install hook still corrects it.
+    """
+    with _HOOKS_LOCK:
+        hooks = list(_CEILING_INVALIDATE_HOOKS)
+    for cb in hooks:
+        try:
+            cb()
+        except Exception:
+            _logger.debug("ceiling invalidate hook %r failed", cb, exc_info=True)
+
+
+def _notify_ceiling_installed(ctx: Optional[PlatformContext]) -> None:
+    """Run the install hooks. Called with NO lock held, and never raises.
+
+    Outside ``_GENERATION_LOCK`` deliberately: a hook resolves governance, which
+    reads :func:`governance_generation` through ``ProfileStore``'s freshness key —
+    and that takes the same non-reentrant lock, so calling a hook while holding it
+    deadlocks the install. A hook that raises must not take the install down with
+    it either: the context IS installed by the time these run, so a failed hook
+    leaves a stale derived value, not a half-installed ceiling.
+    """
+    with _HOOKS_LOCK:
+        hooks = list(_CEILING_INSTALL_HOOKS)
+    for cb in hooks:
+        try:
+            cb(ctx)
+        except Exception:
+            _logger.debug("ceiling install hook %r failed", cb, exc_info=True)
+
+
+def _install(ctx: Optional[PlatformContext], *, notify: bool = True) -> None:
+    """Assign ``_ACTIVE``, bump the generation, then push to the hooks.
+
+    The single writer of ``_ACTIVE``, which is what makes the hooks complete: every
+    declared install -- boot, ``policy_distribution.apply_ceiling``, the test reset --
+    goes through here, so no install site can forget to announce itself.
+
+    Three phases, and the ORDER is the point. Invalidation runs first, so no consumer
+    serves an answer derived from the outgoing ceiling once the incoming one is live;
+    then the context is published; then the install hooks resolve the real answer
+    against it. Publishing before invalidating leaves a governance-resolution-wide
+    window in which the new ceiling is in force and the old answer is still being
+    handed out -- for an authorization answer, a bypass.
+
+    ``notify=False`` is for the lazy default alone; see
+    :func:`register_ceiling_install_hook` for why that one install is silent.
+    """
     global _ACTIVE, _GOVERNANCE_GENERATION
+    if notify:
+        _notify_ceiling_invalidating()
     with _GENERATION_LOCK:
         _ACTIVE = ctx
         _GOVERNANCE_GENERATION += 1
+    if notify:
+        _notify_ceiling_installed(ctx)
 
 
 def governance_generation() -> int:
@@ -564,8 +690,12 @@ def current_context() -> PlatformContext:
                 "open-source defaults (fail-closed). Boot did not run or failed "
                 "to compose the companion."
             )
+        # Silent: this runs INSIDE a governance read (the profile store resolves the
+        # active context for its freshness key), so notifying here would re-enter a
+        # store that is mid-load. Nothing needs it -- see
+        # ``register_ceiling_install_hook``.
         ctx = build_default_context(cfg, profile=PROFILE_STANDALONE)
-        _install(ctx)
+        _install(ctx, notify=False)
         # Return the value just built rather than re-reading the global: the read
         # would need a narrowing cast, and another thread could have installed a
         # different context between the install and the read.

--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -41,7 +41,11 @@ from typing import Optional
 
 from kiro_crew.atomic_write import atomic_write
 from kiro_crew.config.loader import config_dir
-from kiro_crew.platform.context import governance_generation
+from kiro_crew.platform.context import (
+    current_context,
+    register_ceiling_install_hook,
+    register_ceiling_invalidate_hook,
+)
 from kiro_crew.sel import sel as _get_sel
 
 logger = logging.getLogger(__name__)
@@ -157,6 +161,12 @@ class SafetyOverride:
         self._last_renewed_at: float = 0.0
         self._last_renewed_by: str = ""
         self._on_expired: Optional[Callable[[str], None]] = None
+        # The loop ``_on_expired`` was installed from -- see the property setter.
+        self._on_expired_loop: Optional[asyncio.AbstractEventLoop] = None
+        # Clears the grant's inherited state synchronously -- see the property.
+        self._on_policy_revoked: Optional[Callable[[str], None]] = None
+        # Suspends inherited state before a ceiling publishes -- see the property.
+        self._on_policy_suspend: Optional[Callable[[], Callable[[], None] | None]] = None
         self._on_activated: Optional[Callable[[str, int], None]] = None
         # True when the live grant has NO expiry: either DECLARED in config, or
         # an ad-hoc grant under ``yolo_duration: until_shutdown``. Policy
@@ -218,8 +228,15 @@ class SafetyOverride:
         if name == "_adhoc_until_shutdown":
             object.__setattr__(self, "_adhoc_until_shutdown", False)
             return False
-        if name == "_duration_resolver":
-            object.__setattr__(self, "_duration_resolver", None)
+        if name in (
+            "_duration_resolver",
+            "_on_expired",
+            "_on_expired_loop",
+            "_on_activated",
+            "_on_policy_revoked",
+            "_on_policy_suspend",
+        ):
+            object.__setattr__(self, name, None)
             return None
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
@@ -232,6 +249,78 @@ class SafetyOverride:
     @on_expired.setter
     def on_expired(self, cb: Optional[Callable[[str], None]]) -> None:
         self._on_expired = cb
+        # Capture the loop this handler belongs to, because the ceiling-install
+        # revocation can fire from a WORKER THREAD (``policy_distribution`` refreshes
+        # off-loop) and the handler is loop-affine: it schedules the Slack expiry DM
+        # and the unattended notice with ``loop.create_task`` behind a
+        # ``get_running_loop()`` probe, so called off-loop it silently posts nothing.
+        # An operator hearing nothing when policy revokes their grant is the one
+        # outcome the notice exists to prevent.
+        #
+        # Captured HERE rather than looked up at fire time because at fire time there
+        # may be no loop to find. The dashboard assigns this from inside
+        # ``start_dashboard``, so a running loop is present exactly when the handler
+        # that needs it is installed. ``None`` (a sync assignment, or clearing the
+        # handler) means "call it inline", which is what a test or a CLI wants.
+        try:
+            self._on_expired_loop = asyncio.get_running_loop() if cb is not None else None
+        except RuntimeError:
+            self._on_expired_loop = None
+
+    @property
+    def on_policy_revoked(self) -> Optional[Callable[[str], None]]:
+        """Clear the grant's INHERITED state. Runs synchronously, on any thread.
+
+        The counterpart to ``on_expired``, split off because the two have different
+        deadlines. ``on_expired`` broadcasts and DMs, so it is loop-affine and a
+        policy revocation arriving on a worker thread has to schedule it. But the
+        state a revocation must destroy -- the ``approval_policy="auto"`` a grant
+        wrote onto its slots and into the shared channel-trust mapping -- is read
+        DIRECTLY by ``subagent_manager.admission.parent_trusted``, which consults no
+        flag in this module. Deferring that half leaves a loop-turn window in which a
+        spawn is auto-approved against a ceiling that already denies, and the subagent
+        it launched is not un-spawned by the later cleanup.
+
+        So the handler assigned here MUST be thread-safe and MUST do no loop work: it
+        is called inline, on whichever thread installed the denying ceiling, before
+        anything is scheduled. It must also be idempotent -- ``on_expired`` runs the
+        same teardown, so the two overlap on a policy revocation.
+        """
+        return self._on_policy_revoked
+
+    @on_policy_revoked.setter
+    def on_policy_revoked(self, cb: Optional[Callable[[str], None]]) -> None:
+        self._on_policy_revoked = cb
+
+    @property
+    def on_policy_suspend(self) -> Optional[Callable[[], Callable[[], None] | None]]:
+        """Suspend the grant's INHERITED state; returns a restore callable, or None.
+
+        The third callback, and it exists because the other two run too late for one
+        reader. ``on_policy_revoked`` clears inherited ``approval_policy="auto"`` once a
+        deny has been RESOLVED against a new ceiling -- but that resolve is a governance
+        read (``iterdir`` + per-file ``stat``), and the ceiling is already published
+        while it runs. ``_on_ceiling_invalidating`` masks ``is_active()`` for that
+        window, yet ``subagent_manager.admission.parent_trusted`` never consults
+        ``is_active()``: it reads the slot's approval policy directly. So for the whole
+        width of the resolve, a spawn from a slot with inherited trust was auto-approved
+        against a ceiling that may deny -- and nothing un-spawns it afterwards.
+
+        This callback is called BEFORE the new ceiling is published and must suspend
+        that inherited state synchronously, on whatever thread is installing. It
+        returns a restore callable which the install hook calls if the resolved ceiling
+        still permits YOLO (most installs do -- central distribution re-installs on
+        every refresh), and discards if it denies, since ``on_policy_revoked`` then
+        clears everything for good. Returning None means nothing was suspended.
+
+        Same thread-safety contract as ``on_policy_revoked``: no loop work, no I/O
+        beyond the session store.
+        """
+        return self._on_policy_suspend
+
+    @on_policy_suspend.setter
+    def on_policy_suspend(self, cb: Optional[Callable[[], Callable[[], None] | None]]) -> None:
+        self._on_policy_suspend = cb
 
     @property
     def on_activated(self) -> Optional[Callable[[str, int], None]]:
@@ -369,11 +458,11 @@ class SafetyOverride:
         # regardless of config or the runtime toggle. Fail-closed. The refusal is
         # audited so a blocked escalation attempt leaves a trace in the security
         # event log, not only a log line.
-        # Authoritative read, not the cached one: arming is a rare, deliberate act
-        # whose answer must not be up to a TTL out of date, and this path already
-        # does filesystem I/O (the fail-closed SEL audit below), so one governance
-        # read costs nothing new. Its async callers offload the whole call.
-        if not _resolve_yolo_policy_blocking():
+        # A plain memory read, and it is not an approximation of a governance read:
+        # the verdict is resolved once per ceiling INSTALL (see
+        # ``_on_ceiling_installed``), so the flag is the answer for the ceiling in
+        # force rather than a sample of it taken some time ago.
+        if not yolo_policy_permits():
             self._log_policy_refusal(source, scope="")
             return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
         now_mono = time.monotonic()
@@ -413,24 +502,69 @@ class SafetyOverride:
                 resources=f"prev_source:{prev_source}, prev_remaining:{prev_remaining}s, new_source:{source}, new_ttl:{ttl_desc}",
             )
 
-        # Only commit after audit succeeds
+        # Only commit after audit succeeds -- and only if policy STILL permits.
+        #
+        # The gate above is a check, this is the act, and the fail-closed SEL audit
+        # between them is filesystem I/O: long enough for a denying ceiling to be
+        # installed in the gap. Committing anyway would leave a grant that
+        # ``revoke_for_policy`` had already run past, so nothing would ever tear it
+        # down -- and the dashboard caller then writes ``approval_policy="auto"``
+        # onto its slots, which ``admission.parent_trusted`` reads directly.
+        #
+        # Re-reading under ``_lock`` is what makes every interleaving safe, because
+        # the push writes the verdict BEFORE calling ``revoke_for_policy``, which
+        # takes this same lock: if this read sees a permit, the flag had not been
+        # written yet, so the revoke's acquisition comes after this release and it
+        # observes the committed grant; if the revoke got the lock first, the flag is
+        # already denied and this read refuses. The read itself is pure memory, so
+        # holding the lock across it costs nothing.
+        committed = False
         with self._lock:
-            self._active = True
-            self._source = source
-            self._permanent = permanent
-            self._activated_at = now_mono
-            # Kept finite even when permanent so the 0.0 inactive sentinel and
-            # the renew grace window keep working; it is simply not consulted.
-            self._expires_at = now_mono + (ttl if ttl > 0 else self._MAX_TTL)
-            self._activation_count += 1
-            self._last_renewed_at = 0.0
-            self._last_renewed_by = ""
-            self._breadcrumb_gen += 1
+            if _yolo_policy_permitted_now():
+                committed = True
+                self._active = True
+                self._source = source
+                self._permanent = permanent
+                self._activated_at = now_mono
+                # Kept finite even when permanent so the 0.0 inactive sentinel and
+                # the renew grace window keep working; it is simply not consulted.
+                self._expires_at = now_mono + (ttl if ttl > 0 else self._MAX_TTL)
+                self._activation_count += 1
+                self._last_renewed_at = 0.0
+                self._last_renewed_by = ""
+                self._breadcrumb_gen += 1
+
+        if not committed:
+            # Audited outside the lock (it writes to the SEL). The trail reads
+            # "enabled, then denied": the enabled event is written before the commit
+            # by design, so a refusal after it is the honest record of an arm that
+            # was audited and then refused rather than one that took effect.
+            self._log_policy_refusal(source, scope="")
+            return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
 
         # Record that a grant is live so a restart can TELL the operator it is
         # gone. Derived from live state and generation-ordered, so a concurrent
         # revocation cannot be undone by this write.
         self._sync_breadcrumb()
+
+        # Report the grant that ACTUALLY exists, not the one that was committed. A
+        # deny installed after the commit revokes through ``revoke_for_policy``, and
+        # the CALLER acts on this result rather than on the grant: the dashboard
+        # writes ``approval_policy="auto"`` onto its slots when it reads
+        # ``active=True``, and ``admission.parent_trusted`` reads that policy
+        # directly -- so reporting a grant that has already been torn down puts back
+        # the inherited trust the revocation had just cleared, which is the one thing
+        # a deny is supposed to remove.
+        #
+        # Checked here rather than only at the commit because the two answer different
+        # questions: the commit gate decides whether a grant may be CREATED, and this
+        # decides what the caller is TOLD. There is nothing left to tear down -- the
+        # revocation already did that, including its own breadcrumb and expiry
+        # callback -- so this only corrects the report, and the ``on_activated``
+        # callback below is skipped along with it.
+        if not self._committed_grant_survives():
+            self._log_policy_refusal(source, scope="")
+            return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
 
         cb = self._on_activated
         if cb is not None:
@@ -652,9 +786,9 @@ class SafetyOverride:
 
         # Policy gate: an ``approval_modes`` deny of ``yolo`` disables
         # auto-approve entirely, including narrow scoped grants. Fail-closed,
-        # before commit, and audited like the session-wide arm above.
-        # Authoritative, for the same reason as the session-wide arm above.
-        if not _resolve_yolo_policy_blocking():
+        # before commit, and audited like the session-wide arm above. Memory-only,
+        # for the same reason as the session-wide arm above.
+        if not yolo_policy_permits():
             self._log_policy_refusal(source, scope=scope)
             return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
 
@@ -673,16 +807,33 @@ class SafetyOverride:
             )
             return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
 
+        # Re-read the verdict under ``_lock`` before recording the grant, for the
+        # same reason as the session-wide arm above: the fail-closed audit between the
+        # gate and here is filesystem I/O, and a deny installed in that gap would have
+        # revoked before this entry existed.
         with self._lock:
-            self._scoped[scope] = (now_mono, now_mono + ttl)
+            committed = _yolo_policy_permitted_now()
+            if committed:
+                self._scoped[scope] = (now_mono, now_mono + ttl)
+
+        if not committed:
+            self._log_policy_refusal(source, scope=scope)
+            return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
+
+        # Same reason as the session-wide arm: report the grant that survived, since
+        # the caller acts on this result. ``taskrunner._grant_run_trust`` persists
+        # ``run.auto_approve`` straight from it, and an unattended run that believes
+        # it holds a grant nothing consults is the divergence that function exists to
+        # prevent.
+        if not self._committed_grant_survives(scope):
+            self._log_policy_refusal(source, scope=scope)
+            return ActivationResult(active=False, ttl=0, source=source, activated_at_iso="")
 
         return ActivationResult(
             active=True, ttl=ttl, source=source, activated_at_iso=activated_at_iso
         )
 
-    def renew_scoped(
-        self, scope: str, source: str, ttl: Optional[int] = None
-    ) -> RenewResult:
+    def renew_scoped(self, scope: str, source: str, ttl: Optional[int] = None) -> RenewResult:
         """Slide a scoped grant's expiry forward on activity, capped at the ceiling.
 
         Extends the grant to ``min(now + ttl, activated_at + _MAX_TTL)`` so an
@@ -696,17 +847,13 @@ class SafetyOverride:
         # A grant policy no longer permits must not have its expiry slid forward:
         # renewal is what keeps an active run's grant alive indefinitely inside the
         # 24h ceiling, so sliding it after a deny would extend the very authority
-        # the deny withdrew. The grant is REVOKED rather than left to lapse, for the
-        # reason spelled out on ``is_active``. Reported as not-renewed, the same
-        # shape as an absent grant or a reached ceiling, so no caller needs a branch.
-        verdict = yolo_policy_verdict()
-        if verdict != _YOLO_PERMITTED:
-            # Same three-state split as ``is_scope_active`` above: only a definite
-            # deny withdraws the grant. On UNKNOWN the slide is refused -- which is
-            # the safe direction, since a renewal extends authority -- but the grant
-            # is left intact for the refresh to settle.
-            if verdict == _YOLO_DENIED:
-                self.deactivate_scope(scope)
+        # the deny withdrew. Reported as not-renewed, the same shape as an absent
+        # grant or a reached ceiling, so no caller needs a branch.
+        #
+        # The grant itself is already gone: the deny was pushed at install time and
+        # revoked every live scope then (see ``_on_ceiling_installed``). This check
+        # is the mask that makes the two agree even if that teardown was incomplete.
+        if not yolo_policy_permits():
             return RenewResult(renewed=False, ttl=0, source=source, reason="not_active")
 
         if ttl is None:
@@ -731,24 +878,23 @@ class SafetyOverride:
 
         Expires the grant and logs a SEL event when its TTL has lapsed.
         """
-        # Policy first, exactly as in ``is_active()``, and it REVOKES rather than
-        # masks -- see the reasoning there. Gating only at arming left the scoped
-        # grant honoured until its own TTL, and this is the consult point
+        # Policy first, exactly as in ``is_active()``. Gating only at arming left the
+        # scoped grant honoured until its own TTL, and this is the consult point
         # ``task_executor`` reads before EVERY approval, which is what made the gap
-        # reachable for up to 24h. Reading the verdict costs no filesystem access
-        # (see ``yolo_policy_verdict``), which is what makes it safe here.
+        # reachable for up to 24h. The read costs no filesystem access -- the verdict
+        # was resolved when the ceiling was installed -- which is what makes a check
+        # on this path affordable at all.
         #
-        # Three-state, for the same reason as ``is_active`` and with a sharper
-        # consequence here. This runs before EVERY approval in an unattended run, and
-        # ``deactivate_scope`` pops the entry permanently while ``task_executor`` then
-        # clears ``run.auto_approve`` -- nothing re-arms it. So collapsing UNKNOWN
-        # onto revocation meant a mid-session ``policy_distribution.apply_ceiling``
-        # that STILL PERMITS yolo would stall a legitimately granted unattended run
-        # for its whole remainder, on nothing but the off-loop refresh window.
-        verdict = yolo_policy_verdict()
-        if verdict != _YOLO_PERMITTED:
-            if verdict == _YOLO_DENIED:
-                self.deactivate_scope(scope)
+        # A MASK, not the revocation: the deny already tore every live scope down at
+        # install time. That ordering is what removed the old three-state verdict
+        # here. While the answer was polled behind a TTL, this path also had to cope
+        # with "policy could not be read yet", and it could collapse that neither way
+        # -- revoking would stall a legitimately granted unattended run for its whole
+        # remainder on any unrelated ceiling install, since ``deactivate_scope`` pops
+        # the entry permanently and nothing re-arms it, while permitting was the
+        # bypass the check exists to close. A pushed verdict is never unresolved for a
+        # ceiling that is installed, so there is no third case to collapse.
+        if not yolo_policy_permits():
             return False
 
         now_mono = time.monotonic()
@@ -805,68 +951,30 @@ class SafetyOverride:
         # admin who denied ``yolo`` mid-session kept auto-approving every tool for
         # up to 24h -- the control announced a state it was not enforcing. Checked
         # here rather than at each of the ~8 call sites because this predicate IS
-        # the consult point every transport passes to ``TurnDriver``.
+        # the consult point every transport passes to ``TurnDriver``, so it runs per
+        # TOOL CALL -- which is why the read has to be a bare attribute read.
         #
-        # REVOKE, do not merely mask. An earlier revision left ``_active`` set and
-        # only reported False, so relaxing the policy would restore the grant with
-        # nothing to re-arm. That is wrong, because this same predicate is what every
-        # "is there a grant to clear?" caller reads: Slack's ``!yolo off`` does
-        # `if is_yolo_mode(): disable_yolo()`, so inside a denial window it reported
-        # "already off" and cleared NOTHING -- and a later policy relaxation then
-        # resurrected auto-approve the operator had explicitly revoked. Tearing the
-        # grant down makes both readings agree, and costs only that a policy which
-        # denies then relaxes needs a fresh arm, which is the honest outcome anyway.
+        # A MASK, and the teardown lives elsewhere ON PURPOSE. The grant that a deny
+        # withdraws is destroyed by ``revoke_for_policy`` at the moment the denying
+        # ceiling is installed, not by the next caller of this predicate:
         #
-        # Clearing ``_active`` is NOT the whole revocation. A dashboard grant also
-        # writes ``approval_policy="auto"`` onto the slots, and a spawned subagent
-        # reads that policy rather than this flag -- so dropping only the flag left
-        # spawn admission and every child tool auto-approved against a policy that
-        # denies it. The TTL-lapse path below already solves this by firing
-        # ``_on_expired``, whose handler resets those policies and clears the shared
-        # trust mapping; a policy revocation owes the same cleanup, so it fires the
-        # same callback rather than growing a second, divergent teardown.
+        # * Masking without a teardown was tried and is wrong: this same predicate is
+        #   what every "is there a grant to clear?" caller reads -- Slack's
+        #   ``!yolo off`` is ``if is_yolo_mode(): disable_yolo()`` -- so inside a
+        #   denial window it reported "already off" and cleared NOTHING, and a later
+        #   policy relaxation resurrected auto-approve the operator had revoked.
+        # * Tearing down FROM HERE was tried too, and it puts a teardown that
+        #   broadcasts and rewrites every slot's approval policy on the per-tool-call
+        #   path, where it has to be re-guarded against firing twice, and cannot run
+        #   until something asks -- which is the ``approval_policy="auto"`` window
+        #   this design closes.
         #
-        # Gated on there actually being a grant, which makes both the teardown and
-        # the callback fire EXACTLY ONCE: this runs per tool call, and re-firing a
-        # handler that broadcasts and rewrites slot policies on every call would be
-        # its own defect. Reading the verdict itself costs no filesystem access (see
-        # ``yolo_policy_verdict``).
-        #
-        # ONLY a definite DENIED revokes. ``yolo_policy_verdict`` also answers
-        # UNKNOWN -- "current policy could not be read" -- and that must stop
-        # auto-approval WITHOUT tearing the grant down, because the teardown is
-        # permanent and the unknown window opens on every ceiling install, including
-        # ones that still permit YOLO. Treating unknown as a denial would delete
-        # live grants on unrelated policy refreshes; treating it as a permit is the
-        # bypass this whole predicate exists to prevent. Neither, so: no approval,
-        # no revocation, and the scheduled refresh settles it within one round trip.
-        #
-        # The grant test is ``self._active`` ALONE. It used to be
-        # ``self._active or self._expires_at > 0.0``, which double-fired: the
-        # natural-expiry branch below clears ``_active`` but deliberately leaves
-        # ``_expires_at`` set (``deactivate`` reads that nonzero deadline to tell
-        # "lapsed" from "never armed", so it can still SEL-record an explicit off
-        # after a lapse). A later deny then saw the stale deadline, called
-        # ``deactivate`` again and fired a SECOND expiry teardown for an
-        # already-expired grant -- a duplicate "Safety override expired" DM to the
-        # owner and a redundant ``yolo_expired`` broadcast. ``_active`` alone still
-        # covers every grant that is actually being honoured, live or declared.
-        verdict = yolo_policy_verdict()
-        if verdict != _YOLO_PERMITTED:
-            if verdict == _YOLO_DENIED:
-                with self._lock:
-                    had_grant = self._active
-                if had_grant:
-                    self.deactivate(POLICY_REVOKED_SOURCE)
-                    cb = self._on_expired
-                    if cb is not None:
-                        try:
-                            cb(POLICY_REVOKED_SOURCE)
-                        except Exception:
-                            logger.warning(
-                                "on_expired callback raised after a policy revocation",
-                                exc_info=True,
-                            )
+        # Revoking at install does both jobs at once and needs no guard: the install
+        # is a single discrete event, so the teardown and its ``_on_expired`` callback
+        # happen exactly once, and by the time anything reads this predicate the grant
+        # is already gone. The mask stays anyway, as the fail-closed floor if that
+        # teardown was partial -- it is the one check that cannot be skipped.
+        if not yolo_policy_permits():
             return False
 
         now_mono = time.monotonic()
@@ -908,6 +1016,67 @@ class SafetyOverride:
                 logger.warning("on_expired callback raised", exc_info=True)
 
         return False
+
+    def grant_epoch(self) -> int:
+        """A token that changes whenever a grant is created OR destroyed.
+
+        Derived from ``_activation_count`` and the live-grant shape, so an explicit
+        ``deactivate`` between two reads is visible even though the count alone would
+        not move. Read under ``_lock``. Used to make a deferred action conditional on
+        the grant that motivated it still being the one in force -- see
+        ``_push_yolo_policy``'s restore.
+        """
+        with self._lock:
+            live = (1 if self._active else 0) | (2 if self._scoped else 0)
+            return (self._activation_count << 2) | live
+
+    def has_any_grant(self) -> bool:
+        """Whether ANY grant exists -- session-wide or scoped -- ignoring policy.
+
+        Distinct from ``has_grant``, which reports the session-wide grant alone. The
+        policy-revocation path needs this wider question, because it revokes both kinds
+        and must not skip a deny install whose only live grant is a scoped one.
+        """
+        with self._lock:
+            return bool(self._active) or bool(self._scoped)
+
+    def _committed_grant_survives(self, scope: str = "") -> bool:
+        """Whether the grant just committed still exists. Shared by both arming paths.
+
+        ``scope`` names a scoped grant; empty means the session-wide one. Read under
+        ``_lock``, which is the same lock ``revoke_for_policy`` takes, so the answer is
+        never a half-applied teardown. See each caller for why the report has to be
+        derived from live state rather than from the commit having happened.
+        """
+        with self._lock:
+            return (scope in self._scoped) if scope else self._active
+
+    def revoke_for_policy(self) -> bool:
+        """Destroy every grant because policy now forbids YOLO. Returns had-grant.
+
+        Called from the ceiling-install push, which is the only place that learns a
+        deny has arrived. Session-wide and scoped grants both go, because the scope
+        denies the MODE and a scoped grant is the same authority in a narrower frame.
+
+        The return value is the SESSION-WIDE grant specifically, because that is what
+        decides whether ``_on_expired`` should fire: its handler broadcasts an expiry
+        and resets slot approval policies, which only a session-wide grant ever wrote.
+        Scoped grants are torn down silently, exactly as ``deactivate_scope`` already
+        does on a natural revoke -- their consumers re-check ``is_scope_active`` before
+        every approval, so they need no notification to stop.
+
+        Deliberately does NOT consult policy itself: the caller has just resolved it,
+        and re-reading here would put a governance read back on a path that must not
+        do I/O to decide *whether* to revoke.
+        """
+        with self._lock:
+            had_grant = self._active
+            scopes = list(self._scoped)
+        for scope in scopes:
+            self.deactivate_scope(scope)
+        if had_grant:
+            self.deactivate(POLICY_REVOKED_SOURCE)
+        return had_grant
 
     def has_grant(self) -> bool:
         """Whether a grant EXISTS, ignoring policy entirely.
@@ -1210,9 +1379,7 @@ def _breadcrumb_path() -> Path:
     return config_dir() / _BREADCRUMB_FILE
 
 
-def _write_breadcrumb(
-    *, path: Path, source: str, expires_at_wall: float, permanent: bool
-) -> None:
+def _write_breadcrumb(*, path: Path, source: str, expires_at_wall: float, permanent: bool) -> None:
     """Record that a grant is live. Best-effort: never raises into the grant path.
 
     A failed write costs the operator a notice, never a grant, so it must not
@@ -1455,16 +1622,15 @@ def safety_override() -> SafetyOverride:
 def reset_singleton() -> None:
     """Reset the singleton.  Intended for use in tests only.
 
-    Drops the cached ``approval_modes`` verdict too. The cache is module state with
-    a time-based TTL, so without this a test that ran under a permissive policy
-    leaks its verdict into the next test for the length of the TTL -- the grant
-    would be honoured against a policy that denies it, for reasons that have
-    nothing to do with the code under test.
+    Forgets the pushed ``approval_modes`` verdict too. Both are module state, so
+    without this a test that ran under a denying policy leaks that verdict into the
+    next test, which then refuses a grant for reasons having nothing to do with the
+    code under test.
     """
     global _singleton
     with _singleton_lock:
         _singleton = None
-    reset_yolo_policy_cache()
+    reset_yolo_policy_state()
 
 
 _PERMANENT_MEMBER = "permanent"
@@ -1474,255 +1640,389 @@ _APPROVAL_MODES_SCOPE = "approval_modes"
 _YOLO_MODE = "yolo"
 
 
-# ── ``approval_modes`` verdict for YOLO: cached, and never resolved on the loop ──
+# ── ``approval_modes`` verdict for YOLO: PUSHED at ceiling install, never polled ──
 #
 # Resolving the scope walks the governance profiles dir (``iterdir`` + per-file
-# ``stat``). Two call shapes make a per-call read unacceptable:
+# ``stat``), and every consumer is on a path that must not do that:
 #
 # * ``is_active()`` is the auto-approve predicate every transport passes to
 #   ``TurnDriver`` (``auto_approve_session=lambda: safety_override().is_active()``),
 #   so it runs per TOOL CALL.
+# * ``cached_disabled_approval_modes()`` backs ``status_snapshot``, emitted on the
+#   5s WebSocket push.
 # * arming reaches this module from the event loop through synchronous callers
 #   (``taskrunner._grant_run_trust``, the Slack slash handlers).
 #
-# So there are two forms, and which one a caller wants follows from its frequency:
+# So the answer is computed ONCE PER CEILING, at the moment a ceiling is installed,
+# and every consumer reads the resulting flag. ``platform.context._install`` is the
+# single writer of the active context -- central distribution
+# (``policy_distribution.apply_ceiling``), boot (``bootstrap``), the lazy default and
+# the test reset all go through it -- so a registered hook sees every ceiling this
+# process ever holds.
 #
-# * ``yolo_policy_permits()`` -- pure memory, for the per-tool-call predicate. Hands
-#   a stale value back while a refresh runs on a worker thread. Staleness is bounded
-#   by the TTL *within one ceiling*; across a ceiling CHANGE the TTL says nothing, so
-#   the entry carries the governance generation it was resolved under and a newly
-#   installed ceiling EXPIRES it at once rather than letting a permit primed under
-#   the previous policy live out the remaining TTL.
-# * ``_resolve_yolo_policy_blocking()`` -- authoritative, for ARMING. A deliberate,
-#   rare act should not be decided by a value up to a TTL old, and arming already
-#   does filesystem I/O for its fail-closed audit. Its async callers offload it.
-_YOLO_POLICY_TTL = 5.0
-#: Serialises the resolve-and-stamp sequence in ``_resolve_yolo_policy_blocking``.
+# The alternative was tried and is what this replaces: a memory cache behind a 5s TTL
+# and a governance-generation stamp, refreshed on a worker thread. Polling a value
+# that only changes on a discrete event needs a freshness key, a third
+# "not resolved under the installed ceiling yet" verdict for the window before the
+# refresh lands, and a per-caller rule for collapsing it -- and each of those is a
+# window in which a permit resolved under a retired ceiling is still served. Pushing
+# removes the windows rather than shortening them: a flag is either the answer for
+# the ceiling in force, or there is no ceiling installed at all.
+#
+#: True when the ``approval_modes`` scope permits ``yolo`` under the ceiling now
+#: installed. Read with no I/O, no TTL and no lock.
 #:
-#: That sequence is a read-modify-write across a filesystem read -- sample the
-#: generation, resolve, sample it again, store -- and it runs from MORE THAN ONE
-#: thread: arming offloads it via ``asyncio.to_thread``, and the off-loop refresh
-#: scheduled by ``yolo_policy_verdict`` runs it in another worker. Interleaved, one
-#: caller's post-read sample can straddle the other's store, so a stamp is written
-#: for a generation the resolve did not actually observe -- and the next reader then
-#: either serves a verdict resolved under a different ceiling, or (with the entry
-#: left un-stamped) reads UNKNOWN and fails closed on a grant that was just armed
-#: successfully. Under parallel load that surfaced as a yolo arm being honoured in
-#: one run and refused in the next.
+#: Starts DENIED, which is the fail-closed direction and is never actually observed:
+#: every read goes through ``yolo_policy_permits``, which resolves first if no
+#: ceiling has been pushed yet. It matters only if that bootstrap itself fails.
+_yolo_policy_permitted: bool = False
+#: Whether a ceiling has ever been resolved into the flag above.
 #:
-#: Held ACROSS the governance read, deliberately. Serialising concurrent resolves is
-#: the point: the second caller waits and then finds a fresh entry, rather than
-#: duplicating the same filesystem walk and racing to store it. Never taken on the
-#: event loop -- every caller of this function is already off-loop or a sync CLI/test
-#: path.
-_yolo_policy_lock = threading.Lock()
-#: The three verdict states. See ``yolo_policy_verdict`` for why UNKNOWN is a state
-#: of its own rather than folded into either boolean.
-_YOLO_PERMITTED = "permitted"
-_YOLO_DENIED = "denied"
-_YOLO_UNKNOWN = "unknown"
-#: ``(resolved_at_monotonic, permitted, governance_generation)``. The generation is
-#: what makes a policy CHANGE invalidate the entry immediately instead of at the end
-#: of the TTL: the TTL only bounds staleness while the same ceiling stays installed.
-#:
-#: ``resolved_at`` is MONOTONIC, not wall clock. ``time.time()`` can move backwards
-#: -- an NTP step, a VM restore, an operator correcting the clock -- and a backwards
-#: jump makes ``now - resolved_at`` negative, so the entry reads as fresh and the TTL
-#: never elapses again. On a safety predicate that is a permit with no expiry at all,
-#: for a reason that has nothing to do with policy.
-_yolo_policy_cache: tuple[float, bool, int] = (0.0, True, -1)
-#: The in-flight refresh, as ``(loop, task)`` -- deliberately NOT a bare boolean.
-#:
-#: A boolean could not be un-stuck. It was set before the task was created and
-#: cleared in that task's ``finally``, so a loop torn down while the refresh was
-#: still pending left it ``True`` with nothing alive to clear it: every later call
-#: took the early return, and the verdict cache then never refreshed again for the
-#: whole life of the process. That is a stuck-open cache on a SAFETY predicate --
-#: a policy tightening would stop landing at all. A test suite hits it immediately
-#: (a fresh loop per test); the gateway hits it on any loop replacement.
-#:
-#: Recording the LOOP is what makes staleness decidable: a task still pending on a
-#: loop that is gone, or on a different loop than this caller's, is not an
-#: in-flight refresh *for this caller* and must not suppress a fresh one. Holding
-#: the task STRONGLY is the other half -- asyncio keeps only a weak reference to a
-#: bare ``create_task`` result, so a fire-and-forget task can be collected
-#: mid-flight, which is the "Task was destroyed but it is pending!" noise this also
-#: removes.
-_yolo_policy_refresh: tuple[asyncio.AbstractEventLoop, asyncio.Task[None]] | None = None
+#: This is bookkeeping for the bootstrap, NOT a third verdict state: no consumer
+#: branches on it, and it can never be False at the moment a consumer reads the flag.
+#: It exists because the flag is pushed BY an install, and a process can reach a
+#: consumer without one having happened yet -- a unit test that never boots the
+#: platform, a CLI, or this module being imported after boot already installed the
+#: context (registration deliberately does not replay that install, since resolving
+#: governance from inside an import invites a cycle).
+_yolo_policy_resolved: bool = False
 
 
-def _governance_generation() -> int:
-    """Current governance generation, or ``-1`` when it cannot be read.
+def _on_ceiling_invalidating() -> None:
+    """Withdraw the permit before a new ceiling becomes visible. Pure memory.
 
-    ``-1`` never equals a stored generation, so an unreadable counter makes every
-    read treat the cache as belonging to a different ceiling -- it resolves rather
-    than trusting a value it cannot date.
+    Runs ahead of the assignment to ``_ACTIVE``, which is what makes the verdict
+    fail closed for the whole time the new ceiling is live and unresolved. Publishing
+    first and resolving after left a window as wide as one governance resolution --
+    an ``iterdir`` plus a per-file ``stat`` -- in which the denying ceiling was in
+    force and ``is_active()`` still returned the previous permit, so a tool call
+    landing there was auto-approved against it.
+
+    It only MASKS: no revocation, because the incoming ceiling has not been read yet
+    and most installs permit yolo. A grant is torn down by ``_push_yolo_policy`` only
+    once a real deny has been resolved.
+
+    ``_yolo_policy_resolved`` is forced True with it, and that is load-bearing rather
+    than tidy: left unresolved, the next read would bootstrap, resolve against the
+    ceiling still installed at that moment -- the OUTGOING one -- and write its permit
+    straight back over this mask.
+
+    The flag is not the only grant-derived state, and the mask is not enough on its
+    own. ``admission.parent_trusted`` reads a slot's ``approval_policy`` directly, never
+    ``is_active()``, so with a live grant the inherited ``"auto"`` on the slots has to be
+    SUSPENDED here too -- through ``on_policy_suspend`` -- or a spawn during the resolve
+    is auto-approved against a ceiling that may deny, and the launched subagent is never
+    un-spawned. The restore callable it returns is kept for ``_push_yolo_policy``,
+    which puts the policies back if the resolved ceiling still permits.
     """
+    global _yolo_policy_permitted, _yolo_policy_resolved, _suspended_trust_restore
+    _yolo_policy_permitted = False
+    _yolo_policy_resolved = True
+    _suspended_trust_restore = None
+    so = safety_override()
+    # Session-wide only: scoped grants write no inherited slot trust, so there is
+    # nothing to suspend for them (see ``_revoke_grants_for_policy_deny``).
+    if not so.has_grant():
+        return
+    suspend = so.on_policy_suspend
+    if suspend is None:
+        return
     try:
-        return int(governance_generation())
+        restore = suspend()
+        if restore is not None:
+            # Remember WHICH grant this suspension belongs to, so the restore can be
+            # refused if that grant is gone by the time the ceiling resolves.
+            _suspended_trust_restore = (so.grant_epoch(), restore)
     except Exception:
-        logger.debug("governance generation unavailable", exc_info=True)
-        return -1
+        logger.warning(
+            "on_policy_suspend callback raised; inherited trust may be live during the "
+            "ceiling resolve",
+            exc_info=True,
+        )
 
 
-def _resolve_yolo_policy_blocking() -> bool:
-    """Resolve the YOLO verdict and store it. MUST run off the event loop.
+#: The restore half of an in-flight suspension (see ``on_policy_suspend``) paired
+#: with the ``grant_epoch`` it was taken under, held between the invalidate hook and
+#: the install hook of the same install. Module-level because the two hooks are
+#: separate calls from ``platform.context._install``; installs are serialised by their
+#: caller, so there is never more than one in flight.
+_suspended_trust_restore: Optional[tuple[int, Callable[[], None]]] = None
 
-    Reads the generation BEFORE resolving, so a ceiling installed while this was
-    resolving leaves the entry stamped with the older generation -- which the reader
-    then treats as stale rather than as a fresh answer for the new policy.
+
+def _on_ceiling_installed(ctx: object) -> None:
+    """Re-resolve the YOLO verdict for a newly installed ceiling. The push.
+
+    Registered with ``platform.context`` at import, so it runs on every install of
+    the active context.
+
+    ``ctx is None`` is :func:`platform.context.reset_context` -- there is no ceiling
+    to derive from, so the flag goes back to unresolved rather than keeping an answer
+    that belongs to a ceiling that is gone. The next read bootstraps.
     """
-    global _yolo_policy_cache
-    with _yolo_policy_lock:
-        return _resolve_yolo_policy_locked()
+    if ctx is None:
+        reset_yolo_policy_state()
+        return
+    _push_yolo_policy()
 
 
-def _resolve_yolo_policy_locked() -> bool:
-    """The body of the resolve. Caller MUST hold ``_yolo_policy_lock``."""
-    global _yolo_policy_cache
-    # The generation is read on BOTH sides and the answer is stamped only when it
-    # did not move across the resolve. Either one-sided reading is wrong, and each
-    # fails in its own direction:
-    #
-    # * stamp the PRE-read generation and the first governance read in a process
-    #   mis-stamps itself. That read is what installs the lazy default context, so
-    #   it bumps the counter as a side effect; the answer then claimed a ceiling
-    #   that was already superseded, every later read saw a mismatch, and the
-    #   verdict was pinned at UNKNOWN for the life of the process -- fail-closed,
-    #   but permanently, which breaks auto-approve outright.
-    # * stamp the POST-read generation and the mirror error appears: a ceiling
-    #   installed DURING the read would claim an answer taken under the old one,
-    #   which is the stale-permit class this whole verdict exists to close.
-    #
-    # Three attempts because the lazy-install bump happens at most once per
-    # process, so a stable pair is reached immediately after it.
-    for _ in range(3):
-        before = _governance_generation()
-        try:
-            permitted = bool(approval_mode_permitted(_YOLO_MODE))
-        except Exception:
-            logger.debug("could not resolve approval_modes for yolo", exc_info=True)
-            # Fail CLOSED, and deliberately do not restamp. Returning the previous
-            # verdict here used to hand a stale ``True`` to the two authoritative
-            # callers -- arming, and the status field -- so a governance read that
-            # kept failing let a grant be armed against a policy nobody could read.
-            # Leaving the entry un-restamped is also what keeps
-            # ``yolo_policy_verdict`` on UNKNOWN rather than letting the old
-            # generation masquerade as current.
-            return False
-        if _governance_generation() == before:
-            _yolo_policy_cache = (time.monotonic(), permitted, before)
-            return permitted
-    logger.debug("governance generation kept moving across the yolo resolve")
-    return False
+def _push_yolo_policy() -> None:
+    """Resolve the verdict, store it, and revoke live grants if it now denies.
 
-
-def _schedule_yolo_policy_refresh() -> None:
-    """Refresh off-loop, at most one refresh in flight PER LOOP."""
-    global _yolo_policy_refresh
+    Fails CLOSED: a governance-evaluation error resolves to DENIED, because the
+    alternative is auto-approving every tool against a policy nobody could read.
+    ``approval_mode_permitted`` already passes ``fail_closed=True``, so the only
+    error that reaches here is one it could not evaluate at all (a ceiling that
+    refuses to compose raises ``PlatformCompositionError`` through it).
+    """
+    global _yolo_policy_permitted, _yolo_policy_resolved, _suspended_trust_restore
     try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        # No running loop: nothing to protect, so resolve inline. This is also what
-        # keeps a cold cache from handing the permissive default to the first caller
-        # in a sync context (CLI, tests).
-        _resolve_yolo_policy_blocking()
+        permitted = bool(approval_mode_permitted(_YOLO_MODE))
+    except Exception:
+        # WARNING, not debug, and that level is the point. Deleting the old three-state
+        # verdict folded "policy could not be read" into "policy denies", so the
+        # operator now sees the org-policy refusal for both -- and a solo operator with
+        # no policy at all being told a phantom organization blocked them is a
+        # misattribution this code fixed once already. Enforcement stays collapsed (a
+        # deny is the only fail-closed answer), so the CAUSE has to be visible
+        # somewhere: this line is where it is, and it names the consequence rather than
+        # just the error.
+        logger.warning(
+            "could not resolve the approval_modes policy for yolo; denying it. "
+            "Auto-approve will be refused with the organization-policy message until "
+            "a ceiling installs successfully.",
+            exc_info=True,
+        )
+        permitted = False
+    _yolo_policy_permitted = permitted
+    _yolo_policy_resolved = True
+    suspended = _suspended_trust_restore
+    _suspended_trust_restore = None
+    if permitted:
+        # The ceiling still permits, so the inherited trust suspended before
+        # publication goes back exactly as it was -- PROVIDED the grant it belonged to
+        # is still the one in force. The governance read between suspend and here is
+        # long enough for an operator to have revoked YOLO explicitly (``!yolo off``,
+        # the picker's ``normal``), and that revocation cleared the same slot policies
+        # this would put back. Restoring over it would resurrect an auto-approve the
+        # operator just withdrew, on the very read ``admission.parent_trusted`` makes.
+        # The epoch moves on any activate or deactivate, so a stale one means "not the
+        # grant you suspended for" and the restore is dropped.
+        if suspended is not None:
+            epoch, restore = suspended
+            if safety_override().grant_epoch() != epoch:
+                logger.debug(
+                    "grant changed while the ceiling resolved; not restoring suspended "
+                    "inherited trust"
+                )
+                return
+            try:
+                restore()
+            except Exception:
+                logger.warning(
+                    "could not restore suspended inherited trust after a permitting "
+                    "ceiling install",
+                    exc_info=True,
+                )
         return
-    pending = _yolo_policy_refresh
-    if pending is not None and pending[0] is loop and not pending[1].done():
-        # A refresh for THIS loop is genuinely still running. Any other shape --
-        # a finished task, or one belonging to a loop that has since been replaced
-        # -- says nothing about this loop, so it must NOT suppress a fresh refresh.
-        return
-
-    async def _refresh() -> None:
-        global _yolo_policy_refresh
-        # Identity captured HERE, not in the ``finally``. The finally can run while
-        # the loop is tearing this task down (``GeneratorExit``), and
-        # ``asyncio.current_task()`` needs a RUNNING loop -- so asking there raised
-        # RuntimeError from inside an exception handler, which surfaces as an
-        # UNRAISABLE exception nothing can catch. On entry a running loop is
-        # guaranteed, and the identity is all the finally actually needs.
-        me = asyncio.current_task()
-        try:
-            await asyncio.to_thread(_resolve_yolo_policy_blocking)
-        except Exception:
-            logger.debug("yolo policy refresh failed", exc_info=True)
-        finally:
-            # Retract ONLY our own record. Clearing unconditionally would let a
-            # finishing task erase a newer one and permit two concurrent refreshes.
-            if _yolo_policy_refresh is not None and _yolo_policy_refresh[1] is me:
-                _yolo_policy_refresh = None
-
-    # create_task first, then store: this runs ON the loop thread, so the task
-    # cannot start before the record exists for its ``finally`` to match against.
-    _yolo_policy_refresh = (loop, loop.create_task(_refresh()))
+    # Denied: the suspension becomes permanent. ``on_policy_revoked`` below clears the
+    # same state (idempotently) and the shared channel-trust mapping with it, so the
+    # restore callable is simply dropped.
+    _revoke_grants_for_policy_deny()
 
 
-def yolo_policy_verdict() -> str:
-    """``permitted`` / ``denied`` / ``unknown``. Pure memory; safe on the loop.
+def _revoke_grants_for_policy_deny() -> None:
+    """Destroy every live grant, then tell the dashboard so it clears inherited trust.
 
-    THREE states, not two, and that is the whole point of this function.
+    Dropping the grant is not the whole revocation. A dashboard grant also writes
+    ``approval_policy="auto"`` onto the slots and into the shared channel-trust
+    mapping, and ``subagent_manager.admission.parent_trusted`` reads THAT policy
+    rather than any flag in this module -- so a revocation that stopped at the flag
+    left ``spawn_run`` auto-approved, and a subagent already launched under it is not
+    un-spawned when the policy lands. ``_on_expired`` is the handler that resets those
+    policies and clears the mapping, and it is the same one a TTL lapse fires, so a
+    policy revocation reuses it rather than growing a second, divergent teardown.
 
-    Four consecutive review rounds on this span all reported the same shape: a
-    permit being honoured that no current resolve backed. Each was patched at its
-    own site -- gate at arming, then key the cache to the governance generation,
-    then move the resolve off the loop -- and the next round found another way in,
-    because a boolean cannot express the state that actually causes it. "I have
-    not been able to read current policy" is not "policy allows this", and it is
-    not "policy forbids this" either. Collapsing it onto either one is what kept
-    reopening the hole:
+    THREAD. ``policy_distribution.apply_ceiling`` can install a ceiling from a worker
+    thread (its refresh poller), while the handler is loop-affine: it schedules the
+    Slack expiry DM and the unattended-run notice with ``loop.create_task`` behind a
+    ``get_running_loop()`` probe, so run off-loop it silently posts nothing. Silence
+    about a security grant being revoked is precisely what that notice exists to
+    prevent, so the callback is SCHEDULED onto the loop it was installed from
+    (``call_soon_threadsafe``) whenever this is not already running on that loop, and
+    called inline otherwise. Inline is also the answer when no loop was recorded -- a
+    sync CLI or a test -- where scheduling would drop the call entirely.
 
-    * collapse UNKNOWN onto PERMITTED and a stale ``True`` auto-approves every
-      tool -- the finding, in three different disguises. The last one needed no
-      exotic timing at all: ``_resolve_yolo_policy_blocking`` returns without
-      restamping when the resolve raises, so a persistently failing resolve served
-      the old permit indefinitely.
-    * collapse UNKNOWN onto DENIED and ``is_active`` revokes -- permanently, by
-      design -- on a window that opens on EVERY ceiling install, including ones
-      that still permit YOLO. That destroys live grants on unrelated refreshes.
-
-    So UNKNOWN is returned as itself and each caller collapses it in the direction
-    that is safe for what IT decides: approval fails closed (see
-    ``yolo_policy_permits``), revocation does not fire (see ``is_active``).
-
-    UNKNOWN is exactly "the entry was not resolved under the ceiling now
-    installed", which is decidable from memory because
-    ``_resolve_yolo_policy_blocking`` stamps the generation ONLY on a successful
-    resolve. Detecting it therefore costs no filesystem access, and the refresh it
-    schedules stays on a worker thread.
+    The grant teardown itself is NOT deferred: it is thread-safe (``_lock``) and it is
+    the part that must be true the instant the ceiling is installed. Only the
+    notification half crosses the thread boundary.
     """
-    ts, cached, generation = _yolo_policy_cache
-    if generation != _governance_generation():
-        _schedule_yolo_policy_refresh()
-        # Re-read: with no running loop the schedule resolves INLINE, which can
-        # settle the verdict on this very call. With a loop it did not, and the
-        # honest answer is that current policy is not yet known.
-        ts, cached, generation = _yolo_policy_cache
-        if generation != _governance_generation():
-            return _YOLO_UNKNOWN
-    if time.monotonic() - ts >= _YOLO_POLICY_TTL:
-        _schedule_yolo_policy_refresh()
-        ts, cached, generation = _yolo_policy_cache
-    return _YOLO_PERMITTED if cached else _YOLO_DENIED
+    so = safety_override()
+    # Nothing to revoke, and nothing derived from a grant to clear.
+    if not so.has_any_grant():
+        return
+
+    # Only a SESSION-WIDE grant has inherited state. The dashboard writes
+    # ``approval_policy="auto"`` onto its slots when the session-wide override arms,
+    # and the shared channel-trust mapping is fed by the same kind of grant. A scoped
+    # grant (a taskrunner run, an Issue Radar crew) writes neither: ``task_executor``
+    # consults ``is_scope_active`` directly, so there is nothing inherited to clear and
+    # running the clear anyway would revoke an independent Trust press on some
+    # unrelated channel session -- trust this override never handed out. Scoped grants
+    # are still revoked below, by ``revoke_for_policy``.
+    had_session_wide = so.has_grant()
+
+    # INHERITED state FIRST -- before the grant flag drops, not after it.
+    #
+    # The two live in different stores and cannot be written atomically, so one of them
+    # goes first and the other trails. Which one is not a detail, because the two
+    # orderings fail in opposite directions:
+    #
+    # * grant first, inherited second: for the statements in between, ``is_active()``
+    #   already reports no grant while the slots still carry ``approval_policy="auto"``
+    #   -- and ``admission.parent_trusted`` reads THAT policy directly, so a spawn in
+    #   that gap is auto-approved against the denying ceiling. Nothing recovers it: the
+    #   subagent is already launched and no later event un-spawns it.
+    # * inherited first, grant second: for the same statements ``is_active()`` still
+    #   reports the grant while the inherited half is already gone. A spawn there finds
+    #   no inherited trust and takes the ordinary approval path; a tool call there is
+    #   auto-approved for a few instructions longer, which is recoverable -- the deny
+    #   lands microseconds later and the approval was already audited.
+    #
+    # So the unrecoverable direction is the one that gets closed. Doing it under a
+    # single lock instead would mean holding ``_lock`` across ``set_approval_policy``
+    # -- session-store I/O on the lock every per-tool-call ``is_active()`` contends,
+    # which is the stall this design exists to remove.
+    sync_cb = so.on_policy_revoked if had_session_wide else None
+    if sync_cb is not None:
+        try:
+            sync_cb(POLICY_REVOKED_SOURCE)
+        except Exception:
+            logger.warning(
+                "on_policy_revoked callback raised; inherited trust may survive",
+                exc_info=True,
+            )
+
+    if not so.revoke_for_policy():
+        # Someone else tore the grant down between the check above and here. The
+        # inherited clear already ran, which is what their teardown would have done
+        # too, so there is nothing left to do and no second notice to send.
+        return
+
+    cb = so.on_expired
+    if cb is None:
+        return
+
+    def _fire() -> None:
+        try:
+            cb(POLICY_REVOKED_SOURCE)
+        except Exception:
+            logger.warning("on_expired callback raised after a policy revocation", exc_info=True)
+
+    loop = so._on_expired_loop
+    if loop is None or loop.is_closed():
+        _fire()
+        return
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+    if running is loop:
+        _fire()
+        return
+    try:
+        loop.call_soon_threadsafe(_fire)
+    except RuntimeError:
+        # The loop died between the closed check and the call. Nothing can be
+        # scheduled onto it, and the teardown above has already happened, so the
+        # notification is simply lost -- which is what a gateway shutting down means.
+        logger.debug("could not schedule the policy-revocation notice", exc_info=True)
 
 
 def yolo_policy_permits() -> bool:
-    """Whether policy PERMITS YOLO. Fails closed on UNKNOWN.
+    """Whether policy PERMITS YOLO, from memory. Safe on the event loop.
 
-    The approval direction: a tool must not be auto-approved on a verdict that no
-    current resolve backs. This is the predicate every transport hands to
-    ``TurnDriver``, so it is deliberately the strict reading -- but see
-    ``is_active``, which must NOT read a failure to resolve as a revocation.
+    The single read every consumer uses -- the arming gates, ``is_active``,
+    ``is_scope_active``, ``renew_scoped`` and the dashboard status field -- so the
+    status the picker renders and the predicate that enforces it cannot disagree.
+
+    Bootstraps once if no ceiling has been pushed yet (see ``_yolo_policy_resolved``),
+    which is what keeps this honest in a process that never booted the platform: it
+    resolves through ``current_context()``, so the standalone default is composed and
+    installed. That lazy install is deliberately SILENT (``notify=False``), so it is
+    ``_bootstrap_yolo_policy``'s own direct ``_push_yolo_policy()`` that writes the
+    verdict, not the install hook. Either way it happens once and then every later
+    ceiling arrives through the hook, which is why this is a one-shot bootstrap rather
+    than a cache that can go stale.
     """
-    return yolo_policy_verdict() == _YOLO_PERMITTED
+    if not _yolo_policy_resolved:
+        _bootstrap_yolo_policy()
+    return _yolo_policy_permitted
 
 
-def reset_yolo_policy_cache() -> None:
-    """Drop the cached verdict. For tests and for an explicit policy reload."""
-    global _yolo_policy_cache, _yolo_policy_refresh
-    _yolo_policy_cache = (0.0, True, -1)
-    _yolo_policy_refresh = None
+def _yolo_policy_permitted_now() -> bool:
+    """The pushed verdict, with NO bootstrap. Safe to call while holding a lock.
+
+    :func:`yolo_policy_permits` resolves when nothing has been pushed yet, and that
+    resolve installs a context, which fires this module's own hook, which can call
+    ``revoke_for_policy`` -- so calling it under ``SafetyOverride._lock`` would
+    re-enter that non-reentrant lock on the same thread and deadlock. The two commit
+    points that must re-read the verdict inside the lock use this instead, and they
+    can: their own gate already went through ``yolo_policy_permits`` a few lines
+    earlier, so the verdict is resolved by the time they look again.
+    """
+    return _yolo_policy_permitted
+
+
+def _bootstrap_yolo_policy() -> None:
+    """Resolve the verdict for the first time, when no install has pushed one.
+
+    Reached at most once per process, and normally not at all: boot installs a
+    context long before anything arms or consults a grant.
+
+    Composing the context is what does the work, but NOT by firing the install hook:
+    the lazy default installs silently (``notify=False``), because it is reached from
+    inside a governance read and a hook there would re-enter a mid-load profile store.
+    So the direct ``_push_yolo_policy`` below is what writes the verdict -- on both
+    orderings, the silent lazy install and a context that was ALREADY installed before
+    this module registered its hook. Composing still matters: it is what makes a
+    ceiling exist to resolve against.
+
+    A context that refuses to compose (a governed host whose boot did not run, where
+    ``current_context`` raises rather than handing out open-source defaults) leaves
+    the flag at its fail-closed initial value and marks it resolved: there is no
+    ceiling to read, so YOLO stays off until a real one is installed -- at which point
+    the hook pushes the true answer. Marking it resolved is what stops every
+    subsequent tool call from re-attempting the same failing composition.
+    """
+    global _yolo_policy_resolved
+    try:
+        current_context()
+    except Exception:
+        logger.debug("no installed ceiling for the yolo verdict; denying", exc_info=True)
+        _yolo_policy_resolved = True
+        return
+    if not _yolo_policy_resolved:
+        _push_yolo_policy()
+
+
+def reset_yolo_policy_state() -> None:
+    """Forget the pushed verdict, so the next read resolves again.
+
+    For tests, and for :func:`platform.context.reset_context` -- both mean "the
+    ceiling this answer belonged to is no longer installed".
+    """
+    global _yolo_policy_permitted, _yolo_policy_resolved, _suspended_trust_restore
+    _yolo_policy_permitted = False
+    _yolo_policy_resolved = False
+    _suspended_trust_restore = None
+
+
+# Registered at import so no ceiling install is missed, and deliberately WITHOUT
+# resolving here: this module is imported very early by the security and hook layers,
+# and reading governance at import time would pull config + the governance stack onto
+# that path. ``yolo_policy_permits`` covers the late-registration ordering instead.
+register_ceiling_invalidate_hook(_on_ceiling_invalidating)
+register_ceiling_install_hook(_on_ceiling_installed)
 
 
 # ── The status field, derived from the SAME verdict the enforcement path reads ──
@@ -1732,31 +2032,20 @@ def reset_yolo_policy_cache() -> None:
 # live consumption predicates are not gated -- a policy naming any of the three is
 # refused at parse time (see the ``SCOPE_CATALOG`` entry).
 #
-# These two helpers exist so the dashboard's status field and the per-tool-call
+# This helper exists so the dashboard's status field and the per-tool-call
 # enforcement predicate cannot disagree. ``dashboard/state.py`` used to keep its own
-# TTL cache of the same question, which had already drifted: this one is
-# generation-aware, so a tightening lands at once, while a TTL-only copy could report
-# YOLO selectable for up to a TTL after enforcement stopped honouring it. One
-# mechanism cannot drift from itself.
+# TTL cache of the same question, which had already drifted: one mechanism cannot
+# drift from itself.
 
 
 def cached_disabled_approval_modes() -> list[str]:
-    """Modes the policy forbids, from memory. Safe on the event loop.
+    """Modes the policy forbids. Reads the pushed verdict, so no filesystem access.
 
-    Backs ``status_snapshot``, which is emitted on the 5s WS push, so it must never
-    touch the filesystem. Presentation only -- enforcement is ``api_chat_mode``, the
+    Backs ``status_snapshot``, which is emitted on the 5s WS push, and
+    ``/api/status``. Presentation only -- enforcement is ``api_chat_mode``, the
     slot-approve gate, and arming in this module.
     """
     return [] if yolo_policy_permits() else [_YOLO_MODE]
-
-
-def resolve_disabled_approval_modes_blocking() -> list[str]:
-    """Authoritative form. Touches the filesystem, so callers MUST be off-loop.
-
-    Also primes the shared cache, which is what lets the reader above stay
-    filesystem-free.
-    """
-    return [] if _resolve_yolo_policy_blocking() else [_YOLO_MODE]
 
 
 def _duration_member_permitted(member: str) -> bool:

--- a/src/kiro_crew/slack/events.py
+++ b/src/kiro_crew/slack/events.py
@@ -50,7 +50,7 @@ from kiro_crew.mcp_discovery import list_servers
 from kiro_crew.messaging.identity import channel_inbound_permitted
 from kiro_crew.platform import current_context, safe_context_call
 from kiro_crew.platform.interfaces import InterceptDecision
-from kiro_crew.safety_override import safety_override, yolo_policy_verdict
+from kiro_crew.safety_override import safety_override, yolo_policy_permits
 from kiro_crew.security import (
     redact_credentials,
     redact_exfiltration_urls,
@@ -436,21 +436,13 @@ async def _handle_yolo(
         result = await asyncio.to_thread(so.activate, "slack")
         if not result.active:
             # Arming can be REFUSED by policy, not just fail on audit. Reporting an
-            # audit fault for a policy denial sends the owner to the wrong place --
-            # and so does reporting a policy denial for a policy that could not be
-            # READ, which a two-way split on ``yolo_policy_permits`` could not tell
-            # apart (it fails closed on both). The three-state verdict can, and the
-            # three causes have three different places to look: the org's policy, the
-            # profiles dir, the audit system. Same table as the slash path in
-            # ``handler.py``, which must not drift from this one.
-            _verdict = await asyncio.to_thread(yolo_policy_verdict)
-            if _verdict == "denied":
+            # audit fault for a policy denial sends the owner to the wrong place, so
+            # the two causes are told apart and they have two different places to
+            # look: the org's policy, or the audit system. Same split as the slash
+            # path in ``handler.py``, which must not drift from this one. The verdict
+            # is a memory read (pushed at ceiling install), so no thread.
+            if not yolo_policy_permits():
                 await respond("🔒 YOLO mode is disabled by your organization's policy.")
-            elif _verdict == "unknown":
-                await respond(
-                    "❌ Failed to activate YOLO mode "
-                    "(the governance policy could not be read)."
-                )
             else:
                 await respond("❌ Failed to activate YOLO mode (audit system unavailable).")
             return

--- a/src/kiro_crew/slack/handler.py
+++ b/src/kiro_crew/slack/handler.py
@@ -110,7 +110,7 @@ from kiro_crew.safety_override import (
     describe_new_grant,
     grant_declared_yolo,
     safety_override,
-    yolo_policy_verdict,
+    yolo_policy_permits,
 )
 from kiro_crew.security import (
     CREDENTIAL_REDACTION_TAGS,
@@ -1475,32 +1475,25 @@ async def _handle_slash_command(
                     # a refused arm would tell the operator auto-approve is on while
                     # every tool still stops to ask, and would audit it as allowed.
                     #
-                    # NAME THE ACTUAL CAUSE. ``activate`` refuses for three different
-                    # reasons and they send the operator to three different places,
-                    # so a single message is wrong for two of them:
+                    # NAME THE ACTUAL CAUSE. ``activate`` refuses for two different
+                    # reasons and they send the operator to two different places, so a
+                    # single message is wrong for one of them:
                     #
                     # | verdict   | why the arm failed          | where to look     |
                     # |-----------|-----------------------------|-------------------|
                     # | denied    | an admin's policy forbids   | the org's policy  |
-                    # | unknown   | policy could not be READ    | the profiles dir  |
                     # | permitted | the fail-closed SEL audit   | the audit system  |
                     #
                     # This branch used to post the policy line unconditionally, so a
                     # solo operator with no policy at all was told a phantom
                     # organization had blocked them and went hunting a file that does
-                    # not exist, while the real fault went unnamed.
-                    _verdict = await asyncio.to_thread(yolo_policy_verdict)
-                    if _verdict == "denied":
+                    # not exist, while the real fault went unnamed. The verdict is a
+                    # memory read (pushed when the ceiling was installed), so no thread.
+                    if not yolo_policy_permits():
                         _outcome, _error = "approval_mode_denied_by_policy", (
                             "mode_disabled_by_policy"
                         )
                         _msg = "🔒 YOLO mode is disabled by your organization's policy."
-                    elif _verdict == "unknown":
-                        _outcome, _error = "approval_mode_policy_unreadable", ("policy_unreadable")
-                        _msg = (
-                            "❌ Failed to activate YOLO mode "
-                            "(the governance policy could not be read)."
-                        )
                     else:
                         _outcome, _error = "activation_failed", "audit_unavailable"
                         _msg = "❌ Failed to activate YOLO mode (audit system unavailable)."

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,7 +16,7 @@ import pytest
 from hypothesis import HealthCheck, settings
 
 from kiro_crew.safety_override import reset_singleton as _reset_safety_override
-from kiro_crew.safety_override import reset_yolo_policy_cache as _reset_yolo_policy_cache
+from kiro_crew.safety_override import reset_yolo_policy_state as _reset_yolo_policy_state
 from kiro_crew.slack.client import SlackClientOps
 from kiro_crew.slack.handler import _PHASE_EMOJIS, _build_phase_emojis
 
@@ -437,26 +437,21 @@ def _release_stt_engine():
 def _reset_safety_override_between_tests():
     """Reset the SafetyOverride singleton between tests to prevent state leaking.
 
-    The cached ``approval_modes`` verdict is reset WITH it, because it is the same
-    leak wearing different clothes. That cache stamps the governance generation it
-    was resolved under, and this suite reinstalls the platform context constantly
-    (~30 files call ``set_context``/``reset_context``, and each install bumps the
-    counter). A stamp left by an earlier test therefore names a ceiling that is no
-    longer installed, which the verdict correctly reads as "current policy unknown"
-    and — being a safety predicate — fails closed on.
-
-    That surfaced as INTERMITTENT failures in files that never touch governance:
-    which tests share an xdist worker decides whether a stale stamp is present, so
-    a yolo arm would be honoured in one run and refused in the next. The state was
-    always leaking; it used to be invisible only because an unstamped cache read as
-    the permissive default, which is precisely the stale-permit behaviour that is
-    now fixed.
+    The pushed ``approval_modes`` verdict is reset WITH it, because it is the same
+    leak wearing different clothes. That verdict is a module-level flag resolved when
+    a platform context is installed, and this suite installs contexts constantly
+    (~30 files call ``set_context``/``reset_context``). A DENY pushed by an earlier
+    test therefore keeps refusing yolo arms in a later one that never configured a
+    policy, which surfaces as INTERMITTENT failures in files that never touch
+    governance — which tests share an xdist worker decides whether the stale flag is
+    present. Resetting it here makes the next reader resolve the ceiling actually
+    installed.
     """
     _reset_safety_override()
-    _reset_yolo_policy_cache()
+    _reset_yolo_policy_state()
     yield
     _reset_safety_override()
-    _reset_yolo_policy_cache()
+    _reset_yolo_policy_state()
 
 
 @pytest.fixture(autouse=True)

--- a/test/test_approval_modes_enforcement.py
+++ b/test/test_approval_modes_enforcement.py
@@ -1,15 +1,22 @@
 """Enforcement of the ``approval_modes`` policy at every ``yolo`` arming surface.
 
 ``test_approval_modes_governance.py`` pins the *predicate*
-(``approval_mode_permitted`` reading the boot-frozen ceiling). This module pins the
-places that must CONSULT it, because a mode the policy denies is only actually off
-if every path that can arm it -- and every path that HONOURS an existing grant --
-refuses:
+(``approval_mode_permitted`` reading the ceiling on the active context). This module
+pins the places that must CONSULT it, because a mode the policy denies is only
+actually off if every path that can arm it -- and every path that HONOURS an existing
+grant -- refuses:
 
 * ``POST /api/chat/mode`` -- the explicit session-mode switch (403, no mutation).
 * ``safety_override`` arming -- session-wide and scoped.
 * ``is_active`` / ``is_scope_active`` / ``renew_scoped`` -- the consult points that
-  honour a LIVE grant, so a mid-session deny revokes rather than waiting for a TTL.
+  honour a LIVE grant.
+
+It also pins WHEN the verdict is computed, which is the design property the rest of
+the module rests on: ``approval_mode_permitted("yolo")`` is resolved ONCE per ceiling,
+pushed by a hook on ``platform.context._install``, and every consumer then reads a
+module-level flag with no filesystem access, no TTL and no third "not resolved yet"
+state. A deny arriving that way destroys live grants at the moment it is installed
+rather than when something next asks.
 
 The scope governs ``yolo`` only. ``trust`` / ``trust_reads`` are non-deniable (a
 policy naming them is refused at parse time), because their consumption predicates
@@ -23,9 +30,8 @@ record an operator needs after an attempted escalation.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import dataclasses
-import time
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -47,61 +53,20 @@ def _isolate(tmp_path, monkeypatch):
     d.mkdir()
     monkeypatch.setattr(gp, "_PROFILES_DIR", d)
     # Reset on BOTH sides, and reset the context too. Every piece of state these
-    # cases touch is module-level: the profile store, the boot-frozen context, and
-    # the YOLO verdict cache -- which has a WALL-CLOCK TTL. Resetting only on
-    # teardown leaves each case at the mercy of whatever ran before it in the same
-    # worker, which is an order-dependent result that says nothing about the code
-    # under test. Cleaning up on entry is what makes a case mean the same thing
-    # alone and inside the file.
-    # Wait out a resolve an earlier case left in flight BEFORE installing
-    # anything. It runs on a worker thread and its governance read installs the
-    # lazy default context as a side effect, so one that lands after this case has
-    # installed its ceiling REPLACES that ceiling -- and the deny then silently
-    # stops applying in a case that never touched a thread itself. Taking and
-    # releasing the resolve lock is precisely "no resolve is in flight"; it is held
-    # across the whole resolve, so this cannot return while one is running.
-    with so_mod._yolo_policy_lock:
-        pass
+    # cases touch is module-level: the profile store, the active context, and the
+    # pushed YOLO verdict. Resetting only on teardown leaves each case at the mercy
+    # of whatever ran before it in the same worker, which is an order-dependent
+    # result that says nothing about the code under test. Cleaning up on entry is
+    # what makes a case mean the same thing alone and inside the file.
     gp.reset_store()
     ctx_mod.reset_context()
-    so_mod.reset_yolo_policy_cache()
+    so_mod.reset_yolo_policy_state()
     so_mod.reset_singleton()
     yield
-    so_mod.reset_yolo_policy_cache()
+    so_mod.reset_yolo_policy_state()
     so_mod.reset_singleton()
     gp.reset_store()
     ctx_mod.reset_context()
-
-
-@contextlib.asynccontextmanager
-async def _refresh_in_flight(monkeypatch):
-    """Hold a REAL in-flight refresh record for the currently running loop.
-
-    The scheduler suppresses a duplicate only when the record names THIS loop and
-    its task is not done, so a stand-in has to satisfy both. A pending task on the
-    live loop is the honest way to say "a refresh is already running"; the boolean
-    these cases used before could be set from anywhere and stopped meaning anything
-    once the loop lookup moved ahead of the suppression check.
-
-    A context manager rather than a plain helper so the task is always released --
-    a test that abandoned it pending would emit the very "Task was destroyed but it
-    is pending!" noise this record exists to remove.
-    """
-    from kiro_crew import safety_override as so
-
-    loop = asyncio.get_running_loop()
-    gate = asyncio.Event()
-
-    async def _blocked() -> None:
-        await gate.wait()
-
-    task = loop.create_task(_blocked())
-    monkeypatch.setattr(so, "_yolo_policy_refresh", (loop, task))
-    try:
-        yield task
-    finally:
-        gate.set()
-        await task
 
 
 def _install_no_policy() -> None:
@@ -114,7 +79,11 @@ def _install_no_policy() -> None:
 
 
 def _deny(*modes: str) -> None:
-    """Install a boot-frozen ceiling denying ``modes``."""
+    """Install a ceiling denying ``modes``.
+
+    This is the push: ``set_context`` resolves the verdict and revokes live grants
+    before it returns, so nothing in a case needs to nudge a cache afterwards.
+    """
     from kiro_crew.config.loader import KiroCrewConfig
 
     base = build_default_context(KiroCrewConfig.load())
@@ -123,6 +92,27 @@ def _deny(*modes: str) -> None:
             "version": 1,
             "boot": {"fail_closed": True},
             "approval_modes": {"mode": "deny", "deny": list(modes)},
+        }
+    )
+    ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
+
+
+def _install_unrelated_ceiling() -> None:
+    """Install a DIFFERENT ceiling that still permits ``yolo``.
+
+    Names a real scope rather than another mode: ``approval_modes`` may only deny
+    ``yolo`` (the other three are non-deniable and a policy naming one is refused at
+    parse time), so an install that changes something without touching this verdict
+    has to change a different scope.
+    """
+    from kiro_crew.config.loader import KiroCrewConfig
+
+    base = build_default_context(KiroCrewConfig.load())
+    ceiling = parse_policy(
+        {
+            "version": 1,
+            "boot": {"fail_closed": True},
+            "yolo_duration": {"mode": "deny", "deny": ["permanent"]},
         }
     )
     ctx_mod.set_context(dataclasses.replace(base, governance=ceiling))
@@ -179,66 +169,24 @@ class TestChatModeEndpointRefusalIsAudited:
         assert data["code"] == "mode_disabled_by_policy"
         assert recorded[-1]["outcome"] == "approval_mode_denied_by_policy"
 
-
-class TestTheEndpointNamesTheRealCause:
-    """``mode_disabled_by_policy`` is reserved for a DEFINITE deny.
-
-    ``approval_mode_permitted`` fails closed, so reading its boolean alone conflated
-    two different answers: a governance READ FAILURE also came back False and the
-    caller was told their organization's policy forbids the mode -- sent looking for
-    a policy that may not exist, while the real fault went unnamed. The two Slack
-    paths were given a three-way split in an earlier round; this endpoint was the
-    twin that did not get it.
-    """
-
     @pytest.mark.asyncio
-    async def test_an_unreadable_policy_is_503_not_a_policy_403(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-        state = _make_state(tmp_path)
-        state.get_or_create_slot("s1")
+    async def test_a_governance_error_is_also_a_refusal(self, tmp_path, monkeypatch):
+        """An unreadable policy denies. There is no third answer to report.
 
-        # Current policy could not be read. The two stand-ins are the SAME
-        # governance failure seen through the two readers, which is the whole
-        # point: the verdict says ``unknown``, and the fail-closed boolean the
-        # endpoint used to read on its own says False for exactly that reason --
-        # so reading the boolean alone is indistinguishable from a real deny.
-        #
-        # Stubbed at the ENDPOINT's two readers rather than by forging the module
-        # cache: the verdict is backed by an off-loop refresh, so a thread left
-        # over from an earlier case in this file can restamp it mid-request. The
-        # cache's own three states are pinned by ``TestAPolicyChangeIsNotBoundedByTheTTL``
-        # and ``TestUNKNOWNNeverDestroysAScopedGrant``; what is under test HERE is
-        # which answer the endpoint gives for each.
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_handlers.yolo_policy_verdict", lambda: "unknown"
-        )
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_handlers.approval_mode_permitted", lambda m: False
-        )
-
-        async with TestClient(TestServer(_make_app(state))) as client:
-            resp = await client.post("/api/chat/mode", json={"mode": "yolo", "slot": "s1"})
-            data = await resp.json()
-
-        assert resp.status == 503, "an unreadable policy is transient, not a refusal"
-        assert data["code"] == "approval_mode_policy_unreadable", data
-        assert data["code"] != "mode_disabled_by_policy", (
-            "blaming the organization's policy for a policy nobody could read sends "
-            "the operator down the wrong troubleshooting path"
-        )
-
-    @pytest.mark.asyncio
-    async def test_a_definite_deny_is_still_the_audited_403(self, tmp_path, monkeypatch):
-        """The refusal must still work, or the split has broken the control.
-
-        Same stubbing rationale as the case above; the end-to-end refusal against a
-        real boot-frozen ceiling is ``TestChatModeEndpointRefusalIsAudited``.
+        While the verdict was polled behind a TTL it could also be "not resolved
+        under the installed ceiling yet", which this endpoint reported as a
+        transient 503 so an operator was not sent hunting a policy that may not
+        exist. A pushed verdict has no such state: the resolve happens at install
+        time and an error there fails CLOSED, so the honest answer at request time
+        is the same refusal a real deny gets.
         """
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-        _deny("yolo")
-        monkeypatch.setattr(
-            "kiro_crew.dashboard.chat_handlers.yolo_policy_verdict", lambda: "denied"
-        )
+
+        def _boom(mode: str) -> bool:
+            raise RuntimeError("governance unavailable")
+
+        monkeypatch.setattr(so_mod, "approval_mode_permitted", _boom)
+        _install_no_policy()  # a permissive ceiling; the RESOLVE is what fails
         state = _make_state(tmp_path)
         state.get_or_create_slot("s1")
 
@@ -246,7 +194,7 @@ class TestTheEndpointNamesTheRealCause:
             resp = await client.post("/api/chat/mode", json={"mode": "yolo", "slot": "s1"})
             data = await resp.json()
 
-        assert resp.status == 403
+        assert resp.status == 403, "a policy nobody can read must not select yolo"
         assert data["code"] == "mode_disabled_by_policy", data
 
 
@@ -286,70 +234,1387 @@ class TestSafetyOverrideRefusalIsAudited:
         assert "session:abc" in recorded[-1]["resources"]
 
 
-class TestStatusSnapshotNeverResolvesOnTheEventLoop:
-    """``status_snapshot`` runs on the event loop for every 5s WS frame.
+class TestTheVerdictIsResolvedAtCeilingInstall:
+    """The push, stated directly: an install is what computes the verdict.
 
-    Resolving governance there walks the profiles dir, so the reader must be pure
-    memory: a stale value schedules an off-loop refresh and returns the previous
-    one rather than blocking the frame.
-
-    The status field is derived from the SAME verdict the per-tool-call enforcement
-    predicate reads. It used to have its own TTL cache in ``dashboard/state.py``,
-    which had already drifted from this one: that copy was TTL-only while this one is
-    generation-aware, so the picker could show YOLO selectable for up to a TTL after
-    enforcement had stopped honouring it.
+    Every consumer then reads a flag. That ordering is what removes the windows a
+    polled cache had -- a freshness key, an "unknown" third state, and a per-caller
+    rule for collapsing it -- because a flag is either the answer for the ceiling in
+    force or there is no ceiling installed at all.
     """
 
-    @pytest.mark.asyncio
-    async def test_cached_reader_does_not_resolve_inline(self, monkeypatch):
+    def test_a_deny_install_revokes_a_live_grant_and_fires_the_callback_once(self, monkeypatch):
         from kiro_crew import safety_override as so
 
-        calls: list[str] = []
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        assert override.activate("dashboard").active is True
+        seen: list[str] = []
+        override.on_expired = seen.append
 
-        def _tripwire(mode: str) -> bool:
-            calls.append(mode)
-            return True
+        _deny("yolo")
 
-        monkeypatch.setattr(so, "approval_mode_permitted", _tripwire)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (0.0, False, so._governance_generation()))
-
-        # Stale cache + a refresh already in flight: the reader must return the
-        # last good value WITHOUT resolving, which is what keeps the frame off
-        # the filesystem.
-        async with _refresh_in_flight(monkeypatch):
-            assert so.cached_disabled_approval_modes() == ["yolo"]
-            assert calls == []
-
-    def test_blocking_resolver_updates_the_shared_cache(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda mode: mode != "yolo")
-
-        assert so.resolve_disabled_approval_modes_blocking() == ["yolo"]
-        # The event-loop reader now serves the resolved value from memory.
-        assert so.cached_disabled_approval_modes() == ["yolo"]
-
-    def test_a_resolve_error_keeps_the_last_good_value(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        monkeypatch.setattr(
-            so, "_yolo_policy_cache", (time.monotonic(), False, so._governance_generation())
+        assert seen == ["policy"], (
+            "the revocation must run when the ceiling is installed, not when "
+            "something next consults the predicate"
         )
+        assert override.has_grant() is False, "a deny DESTROYS the grant, it does not mask it"
+        # The consult points agree, and consulting them repeatedly cannot re-fire a
+        # teardown that broadcasts and rewrites every slot's approval policy.
+        for _ in range(5):
+            assert override.is_active() is False
+        assert seen == ["policy"], f"expected exactly one teardown, got {seen}"
+
+    def test_a_permitting_install_leaves_a_live_grant_alone(self, monkeypatch):
+        """A ceiling install is not itself a revocation.
+
+        Central distribution re-installs a ceiling on every refresh, most of which
+        change nothing. Tearing a grant down on any install would make an unattended
+        run lose its authority on an unrelated poll.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        assert override.activate_scoped("run:abc", "dashboard").active is True
+        seen: list[str] = []
+        override.on_expired = seen.append
+
+        _install_unrelated_ceiling()  # a new ceiling that says nothing about yolo
+
+        assert seen == [], "an install that still permits yolo must revoke nothing"
+        assert override.is_active() is True
+        assert override.is_scope_active("run:abc") is True
+
+    def test_a_raising_governance_layer_resolves_to_denied(self, monkeypatch):
+        """Fail CLOSED. The alternative is auto-approving against unreadable policy."""
+        from kiro_crew import safety_override as so
 
         def _boom(mode: str) -> bool:
             raise RuntimeError("governance unavailable")
 
         monkeypatch.setattr(so, "approval_mode_permitted", _boom)
 
-        # NOT [] — reporting "nothing is denied" would unhide a locked mode in
-        # the picker on a transient governance error.
-        assert so.resolve_disabled_approval_modes_blocking() == ["yolo"]
+        _install_no_policy()
 
-    def test_the_status_field_cannot_contradict_enforcement(self, monkeypatch):
+        assert so.yolo_policy_permits() is False
+        assert so.cached_disabled_approval_modes() == ["yolo"], (
+            "reporting nothing-denied on a resolve error would unhide a mode the "
+            "gate is refusing"
+        )
+
+    def test_a_resolve_failure_is_visible_at_warning_level(self, monkeypatch, caplog):
+        """Fail-closed silently is a misattribution, not just a missing log line.
+
+        Collapsing the old three-state verdict folded "policy could not be read" into
+        "policy denies", so the operator now gets the organization-policy refusal for
+        both causes -- and a solo operator with no policy at all being told a phantom
+        organization blocked them is a defect this code fixed once already. Enforcement
+        has to stay collapsed (a deny is the only fail-closed answer), so the CAUSE has
+        to surface somewhere an operator will actually see it.
+        """
+        import logging
+
+        from kiro_crew import safety_override as so
+
+        def _boom(mode: str) -> bool:
+            raise RuntimeError("governance unavailable")
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _boom)
+
+        with caplog.at_level(logging.WARNING, logger="kiro_crew.safety_override"):
+            _install_no_policy()
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "a resolve failure that denies yolo must not be debug-only"
+        assert any(
+            "approval_modes" in r.getMessage() for r in warnings
+        ), "the warning must name the scope that could not be resolved"
+        assert so.yolo_policy_permits() is False
+
+    def test_a_raising_governance_layer_still_revokes_a_live_grant(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        seen: list[str] = []
+        override.on_expired = seen.append
+
+        def _boom(mode: str) -> bool:
+            raise RuntimeError("governance unavailable")
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _boom)
+        _install_no_policy()
+
+        assert override.has_grant() is False
+        assert seen == ["policy"]
+
+    def test_the_first_read_without_an_install_does_not_leave_yolo_dead(self, monkeypatch):
+        """A process that never booted the platform must still be able to arm.
+
+        The flag starts DENIED so a failed bootstrap cannot hand out auto-approve,
+        which makes the bootstrap itself load-bearing: reading the verdict with no
+        ceiling installed has to resolve one (``current_context`` composes and
+        installs the standalone default) rather than serve that initial value.
+        """
+        from kiro_crew import safety_override as so
+
+        ctx_mod.reset_context()
+        so.reset_yolo_policy_state()
+        assert ctx_mod.installed_context() is None
+
+        assert so.yolo_policy_permits() is True, (
+            "an ungoverned host has no ceiling denying yolo; leaving the initial "
+            "fail-closed value in place would disable the feature outright"
+        )
+        assert ctx_mod.installed_context() is not None, "the read resolved a ceiling"
+
+    def test_the_silent_lazy_install_still_yields_the_real_ceilings_verdict(self, monkeypatch):
+        """The lazy default is the one install that does NOT notify, and that is safe.
+
+        It is reached from inside a governance read (the profile store resolves the
+        active context for its freshness key), so a hook that reads governance would
+        re-enter a store that is mid-load and get its fail-closed "not loaded" answer
+        -- a verdict about nothing, cached as the truth.
+
+        Skipping the notification is not a hole, and this is the case that proves it:
+        the lazy default composes ``load_security_policy()``, so it CAN carry a deny,
+        and the first read must still see it. It does, because the read's own bootstrap
+        pushes after composing. Nothing can hold a grant earlier than that, since
+        arming reads the same verdict.
+        """
+        from kiro_crew import safety_override as so
+        from kiro_crew.platform import bootstrap as bs
+
+        denying = parse_policy(
+            {
+                "version": 1,
+                "boot": {"fail_closed": True},
+                "approval_modes": {"mode": "deny", "deny": ["yolo"]},
+            }
+        )
+        monkeypatch.setattr(bs, "load_security_policy", lambda: denying)
+        ctx_mod.reset_context()
+        so.reset_yolo_policy_state()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+
+        assert so.yolo_policy_permits() is False
+        assert so.safety_override().activate("dashboard").active is False
+
+    def test_a_ceiling_installed_before_registration_is_still_resolved(self, monkeypatch):
+        """The late-registration ordering.
+
+        Registration deliberately does not replay an install that already happened --
+        resolving governance from inside a module import is how cycles are born -- so
+        the first read has to cope with a context that is already in place and has no
+        pending install to announce.
+        """
+        from kiro_crew import safety_override as so
+
+        _deny("yolo")
+        # Exactly the state a late import leaves behind: the ceiling is installed,
+        # but nothing has been pushed into the flag.
+        so.reset_yolo_policy_state()
+
+        assert so.yolo_policy_permits() is False
+
+    def test_a_context_reset_forgets_the_verdict_rather_than_keeping_it(self):
+        """``reset_context`` means there is no ceiling to derive an answer from.
+
+        Keeping the last answer would let a deny outlive the ceiling that issued it,
+        which in this suite reads as yolo being refused in a file that never
+        configured a policy.
+        """
+        from kiro_crew import safety_override as so
+
+        _deny("yolo")
+        assert so.yolo_policy_permits() is False
+
+        ctx_mod.reset_context()
+        assert so._yolo_policy_resolved is False, "the pushed verdict is dropped"
+        assert so.yolo_policy_permits() is True, "the re-resolve sees no denying ceiling"
+
+
+class TestADenyLandingMidArmDoesNotLeaveAGrantBehind:
+    """The gate is a check and the commit is the act, with I/O in between.
+
+    Arming reads the verdict, then writes a fail-closed SEL event -- a synchronous
+    filesystem write -- and only then records the grant. A denying ceiling installed
+    in that gap has already run ``revoke_for_policy`` past an entry that does not
+    exist yet, so committing anyway leaves a grant nothing will ever tear down. The
+    dashboard caller then writes ``approval_policy="auto"`` onto its slots, and
+    ``admission.parent_trusted`` reads that policy directly.
+
+    Driven by installing the ceiling from inside the audit write, which is the real
+    ordering rather than a simulation of it: that is exactly where the gap is.
+    """
+
+    def _deny_during_the_audit(self, monkeypatch, so):
+        """Make the fail-closed audit write install a denying ceiling as it runs."""
+        real = so.SafetyOverride._log_sel
+        fired: list[str] = []
+
+        def _log_sel(self, **kw):
+            if kw.get("critical") and not fired:
+                fired.append(kw.get("operation", ""))
+                _deny("yolo")
+            return real(self, **kw)
+
+        monkeypatch.setattr(so.SafetyOverride, "_log_sel", _log_sel)
+        return fired
+
+    def test_a_session_wide_arm_is_refused(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        fired = self._deny_during_the_audit(monkeypatch, so)
+
+        result = override.activate("dashboard")
+
+        assert fired, "the ceiling must have been installed during the audit"
+        assert result.active is False, (
+            "an arm whose policy was withdrawn mid-flight must be reported as refused, "
+            "or the dashboard writes approval_policy='auto' onto its slots"
+        )
+        assert override.has_grant() is False, (
+            "the revocation already ran past this grant, so committing it would leave "
+            "one that nothing tears down"
+        )
+
+    def test_a_grant_revoked_after_the_commit_is_not_reported_as_active(self, monkeypatch):
+        """The caller acts on the RESULT, not on the grant, so the result must be true.
+
+        A deny landing after the commit revokes the grant through
+        ``revoke_for_policy``. If ``activate`` still answered ``active=True``, the
+        dashboard would write ``approval_policy="auto"`` onto its slots on the
+        strength of that answer, and ``admission.parent_trusted`` reads that policy
+        directly -- so the inherited trust the revocation had just cleared would come
+        straight back, with nothing left to clear it again.
+
+        Driven through ``_sync_breadcrumb``, which runs in the real gap between the
+        commit and the return.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+
+        real = so.SafetyOverride._sync_breadcrumb
+        fired: list[int] = []
+
+        def _sync(self):
+            if not fired:
+                fired.append(1)
+                _deny("yolo")
+            return real(self)
+
+        monkeypatch.setattr(so.SafetyOverride, "_sync_breadcrumb", _sync)
+
+        result = override.activate("dashboard")
+
+        assert fired, "the deny must have landed inside the commit-to-return gap"
+        assert override.has_grant() is False, "the revocation tore the grant down"
+        assert result.active is False, (
+            "reporting a revoked grant as active is what puts approval_policy='auto' "
+            "back onto the slots after the deny cleared it"
+        )
+
+    def test_the_survival_check_reads_both_kinds_of_grant(self, monkeypatch):
+        """Both arming paths report from live state through one shared check.
+
+        ``activate_scoped`` has no I/O between its commit and its return, so the
+        scoped branch cannot be driven by a mid-flight deny the way the session-wide
+        one can. Its logic is asserted directly instead -- the branch, not the race.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        override.activate_scoped("run:abc", "dashboard")
+
+        assert override._committed_grant_survives() is True
+        assert override._committed_grant_survives("run:abc") is True
+        assert override._committed_grant_survives("run:missing") is False
+
+        assert override.revoke_for_policy() is True
+
+        assert override._committed_grant_survives() is False
+        assert override._committed_grant_survives("run:abc") is False, (
+            "a scoped grant revoked by policy must not be reported back to its caller "
+            "-- taskrunner persists run.auto_approve straight from that result"
+        )
+
+    def test_the_verdict_is_written_before_the_revocation_runs(self, monkeypatch):
+        """The ordering the two commit re-checks rely on, pinned directly.
+
+        Under real concurrency the two checks above are only sound because the push
+        writes the denied verdict BEFORE taking ``_lock`` to revoke. If it revoked
+        first, a commit already holding the lock would read a stale permit, the revoke
+        would then run past an entry that did not exist yet, and the grant would
+        survive -- the same orphan, reached by the interleaving instead of by the gap.
+        No single-threaded case can observe that, so the invariant is asserted here.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+
+        seen: list[bool] = []
+        real = so.SafetyOverride.revoke_for_policy
+
+        def _spy(self):
+            seen.append(so._yolo_policy_permitted)
+            return real(self)
+
+        monkeypatch.setattr(so.SafetyOverride, "revoke_for_policy", _spy)
+
+        _deny("yolo")
+
+        assert seen == [False], (
+            "the denied verdict must already be visible when the revocation runs, or a "
+            "concurrent commit holding the lock reads a stale permit and its grant "
+            "outlives the deny"
+        )
+
+    def test_a_scoped_arm_is_refused(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        fired = self._deny_during_the_audit(monkeypatch, so)
+
+        result = override.activate_scoped("run:abc", "dashboard")
+
+        assert fired
+        assert result.active is False
+        assert override.is_scope_active("run:abc") is False
+        with override._lock:
+            assert "run:abc" not in override._scoped, "no orphaned scoped grant"
+
+
+class TestTheVerdictFailsClosedWhileANewCeilingIsBeingResolved:
+    """Publishing the ceiling before re-resolving is a bypass, so it does not.
+
+    ``_install`` makes the new ceiling visible and only then runs the hook that
+    re-resolves the verdict, and that resolve is an ``iterdir`` plus a per-file
+    ``stat``. Ordered that way, the denying ceiling is in force for the whole width of
+    a governance read while ``is_active()`` still hands out the permit resolved under
+    the ceiling that was just retired -- and a tool call landing there is
+    auto-approved against a policy that denies it, with nothing to undo afterwards
+    because the tool has already run.
+
+    So invalidation is the FIRST phase of an install, not the second: the verdict is
+    masked before the assignment and the true answer is written after it.
+    """
+
+    def test_a_reader_inside_the_resolve_window_is_denied(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        assert override.is_active() is True
+
+        # Sampled from INSIDE the post-publication resolve, which is exactly the
+        # window: the new ceiling is already visible and the verdict has not been
+        # rewritten yet.
+        real = so.approval_mode_permitted
+        seen: list[bool] = []
+
+        def _sampling(mode: str) -> bool:
+            seen.append(override.is_active())
+            return real(mode)
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _sampling)
+
+        _deny("yolo")
+
+        assert seen, "the resolve must have run"
+        assert seen == [False], (
+            "a reader inside the resolve window must fail closed -- the new ceiling "
+            "is already in force there, so serving the previous permit auto-approves "
+            "against a policy that denies"
+        )
+
+    def test_the_mask_runs_before_the_new_ceiling_is_published(self, monkeypatch):
+        """The ordering itself, not just its effect.
+
+        Masking during the resolve is not enough: the window that has to be closed
+        opens the instant the new ceiling becomes visible. So the invalidation runs
+        while ``installed_context()`` still answers the OUTGOING ceiling -- which is
+        what leaves no moment where the incoming one is in force and the previous
+        permit is still being served.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        before = ctx_mod.installed_context()
+        seen: list[object] = []
+
+        def _probe() -> None:
+            seen.append(ctx_mod.installed_context())
+
+        ctx_mod.register_ceiling_invalidate_hook(_probe)
+        try:
+            _deny("yolo")
+        finally:
+            ctx_mod._CEILING_INVALIDATE_HOOKS.remove(_probe)
+
+        assert seen, "the invalidate hook must run on a declared install"
+        assert seen[0] is before, (
+            "invalidation must happen BEFORE the new ceiling is published, or the "
+            "denying ceiling is live while the stale permit is still served"
+        )
+        assert so.yolo_policy_permits() is False
+
+    def test_a_permitting_install_restores_the_verdict_it_masked(self, monkeypatch):
+        """The mask is transient, and must not outlive the resolve.
+
+        Masking on EVERY install is what makes the window safe, so a permitting
+        install masks too. If the install hook then failed to write the true answer
+        back, auto-approve would be off for the life of the process.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+
+        _install_unrelated_ceiling()
+
+        assert so.yolo_policy_permits() is True
+        assert override.is_active() is True, "the grant survives a permitting install"
+
+    def test_the_mask_does_not_revoke(self, monkeypatch):
+        """Masking is not a teardown: a permitting install must keep the grant.
+
+        Revoking on the mask would destroy a live grant on every unrelated ceiling
+        refresh -- central distribution re-installs constantly.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        seen: list[str] = []
+        override.on_expired = seen.append
+
+        real = so.approval_mode_permitted
+        during: list[bool] = []
+
+        def _sampling(mode: str) -> bool:
+            during.append(override.has_grant())
+            return real(mode)
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _sampling)
+        _install_unrelated_ceiling()
+
+        assert during == [True], "the grant must still EXIST while the mask is on"
+        assert seen == [], "a mask fires no expiry teardown"
+
+
+class TestInheritedTrustIsSuspendedWhileANewCeilingResolves:
+    """The verdict mask alone does not close the resolve window for spawn admission.
+
+    ``_on_ceiling_invalidating`` masks ``is_active()`` before the new ceiling publishes,
+    but ``admission.parent_trusted`` never reads ``is_active()`` -- it reads the slot's
+    approval policy directly, and that is cleared only AFTER a deny has been resolved.
+    So for the whole width of the resolve a spawn from a slot carrying the override's
+    inherited ``"auto"`` was auto-approved against a ceiling that may deny, and the
+    launched subagent is never un-spawned. The inherited state has to be suspended
+    before publication, alongside the mask, and restored if the ceiling still permits.
+    """
+
+    def _armed_with_inherited_trust(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        policies: dict[str, str] = {"dashboard:s1": "auto", "dashboard:standing": "auto"}
+        standing = {"dashboard:standing"}
+
+        def _suspend():
+            taken = [k for k, v in policies.items() if v == "auto" and k not in standing]
+            for k in taken:
+                policies[k] = ""
+            if not taken:
+                return None
+
+            def _restore():
+                for k in taken:
+                    policies[k] = "auto"
+
+            return _restore
+
+        def _clear(_source):
+            for k in list(policies):
+                if k not in standing:
+                    policies[k] = ""
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        override.on_policy_suspend = _suspend
+        override.on_policy_revoked = _clear
+        return so, override, policies
+
+    def test_a_spawn_admission_read_inside_the_resolve_sees_no_inherited_auto(self, monkeypatch):
+        so, override, policies = self._armed_with_inherited_trust(monkeypatch)
+
+        real = so.approval_mode_permitted
+        seen: list[str] = []
+
+        def _sampling(mode):
+            # Exactly what ``admission.parent_trusted`` reads, sampled from INSIDE the
+            # post-publication resolve: the new ceiling is live here.
+            seen.append(policies["dashboard:s1"])
+            return real(mode)
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _sampling)
+        _deny("yolo")
+
+        assert seen == [""], (
+            "the slot's inherited approval_policy must already be suspended while the "
+            f"new ceiling resolves, or a spawn there is auto-approved; saw {seen}"
+        )
+        assert policies["dashboard:s1"] == "", "a deny makes the suspension permanent"
+        assert policies["dashboard:standing"] == "auto", "standing trust is never touched"
+
+    def test_a_denying_install_never_calls_the_restore(self, monkeypatch):
+        """Restore-then-revoke would reopen the gap for the statements in between.
+
+        The end state is the same either way, which is why this asserts on the CALL
+        rather than on the policies: a restore that runs and is immediately re-cleared
+        puts ``"auto"`` back on the slots for a moment, on a ceiling already resolved
+        to deny -- exactly the read ``parent_trusted`` makes.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        restored: list[int] = []
+        override.on_policy_suspend = lambda: (lambda: restored.append(1))
+
+        _deny("yolo")
+
+        assert restored == [], "a deny must drop the restore, never call it"
+        assert override.has_grant() is False
+
+    def test_a_permitting_install_restores_the_suspended_trust(self, monkeypatch):
+        so, override, policies = self._armed_with_inherited_trust(monkeypatch)
+
+        real = so.approval_mode_permitted
+        during: list[str] = []
+        monkeypatch.setattr(
+            so,
+            "approval_mode_permitted",
+            lambda m: (during.append(policies["dashboard:s1"]), real(m))[1],
+        )
+        _install_unrelated_ceiling()
+
+        assert during == [""], "suspended during the resolve even on a permitting install"
+        assert (
+            policies["dashboard:s1"] == "auto"
+        ), "a ceiling that still permits must hand the inherited trust back exactly"
+        assert override.is_active() is True
+
+    def test_an_explicit_revoke_during_the_resolve_is_not_undone_by_the_restore(self, monkeypatch):
+        """The restore belongs to ONE grant; if that grant is gone, nothing goes back.
+
+        The governance read between suspend and restore is long enough for the operator
+        to revoke YOLO explicitly, which clears the same slot policies the restore would
+        put back. A permitting ceiling then resurrecting ``"auto"`` would hand
+        ``parent_trusted`` an auto-approve the operator had just withdrawn.
+        """
+        so, override, policies = self._armed_with_inherited_trust(monkeypatch)
+
+        real = so.approval_mode_permitted
+
+        def _revoke_mid_resolve(mode):
+            # The operator's `!yolo off` / picker->normal, landing inside the resolve.
+            override.deactivate("dashboard")
+            for k in policies:
+                if k != "dashboard:standing":
+                    policies[k] = ""
+            return real(mode)
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _revoke_mid_resolve)
+        _install_unrelated_ceiling()  # permits yolo
+
+        assert so.yolo_policy_permits() is True, "the ceiling itself still permits"
+        assert override.has_grant() is False, "the operator's revoke stands"
+        assert policies["dashboard:s1"] == "", (
+            "a permitting resolve must not resurrect inherited trust the operator "
+            "revoked while it was running"
+        )
+
+    def test_the_epoch_moves_on_deactivate_not_only_on_activate(self, monkeypatch):
+        """``_activation_count`` alone cannot see a revoke; the epoch has to."""
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        e1 = override.grant_epoch()
+        override.deactivate("dashboard")
+        e2 = override.grant_epoch()
+        assert e1 != e2, "an explicit revoke must change the epoch"
+        override.activate_scoped("run:x", "dashboard")
+        assert override.grant_epoch() not in (e1, e2)
+
+    def test_nothing_is_suspended_without_a_grant(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        calls: list[int] = []
+        so.safety_override().on_policy_suspend = lambda: calls.append(1) or None
+
+        _deny("yolo")
+
+        assert calls == [], "no grant means no inherited state to suspend"
+
+    def test_a_raising_suspend_does_not_break_the_install(self, monkeypatch):
+        so, override, policies = self._armed_with_inherited_trust(monkeypatch)
+
+        def _boom():
+            raise RuntimeError("session store unavailable")
+
+        override.on_policy_suspend = _boom
+        _deny("yolo")
+
+        assert so.yolo_policy_permits() is False
+        assert override.has_grant() is False
+        assert policies["dashboard:s1"] == "", "the revoke still clears it"
+
+
+class TestTheDashboardInheritedTrustHandlers:
+    """The two module-level handlers ``start_dashboard`` wires, driven for real.
+
+    ``_suspend_override_derived_trust`` blanks the override's inherited ``"auto"`` on
+    every non-standing slot before a ceiling publishes and returns a restore;
+    ``_clear_override_derived_trust`` is the permanent clear a resolved deny runs. Both
+    touch only the slot dict and the session store, which is what lets them run on the
+    installing thread.
+    """
+
+    @staticmethod
+    def _state_with_slots(tmp_path, monkeypatch):
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        policies: dict[str, str] = {}
+        state = _make_state(tmp_path)
+        state.sessions.get_approval_policy = lambda key: policies.get(key, "")
+        state.sessions.set_approval_policy = lambda key, value: policies.__setitem__(key, value)
+        return state, policies
+
+    def test_suspend_blanks_inherited_auto_and_restore_puts_it_back(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.server import _suspend_override_derived_trust
+
+        state, policies = self._state_with_slots(tmp_path, monkeypatch)
+        plain = state.get_or_create_slot("plain")
+        standing = state.get_or_create_slot("standing")
+        standing._trust = True
+        untouched = state.get_or_create_slot("untouched")  # never had auto
+        for s in (plain, standing):
+            policies[effective_session_key(s)] = "auto"
+
+        restore = _suspend_override_derived_trust(state)
+
+        assert restore is not None
+        assert policies[effective_session_key(plain)] == "", "inherited auto is suspended"
+        assert policies[effective_session_key(standing)] == "auto", "standing trust is spared"
+        assert effective_session_key(untouched) not in policies
+
+        restore()
+        assert policies[effective_session_key(plain)] == "auto", "restored exactly"
+
+    def test_restore_does_not_upgrade_a_slot_moved_to_trust_reads(self, tmp_path, monkeypatch):
+        """The operator changed the slot's mode during the resolve; honour it.
+
+        ``trust_reads`` / ``trust`` / ``normal`` all write this same policy. Restoring
+        ``"auto"`` over a ``trust_reads`` slot would upgrade read-only trust to full
+        auto-approve on the read ``parent_trusted`` makes.
+        """
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.server import _suspend_override_derived_trust
+
+        state, policies = self._state_with_slots(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        key = effective_session_key(slot)
+        policies[key] = "auto"
+        restore = _suspend_override_derived_trust(state)
+        assert restore is not None and policies[key] == ""
+
+        # What api_chat_mode(mode="trust_reads") does to the slot, mid-resolve.
+        slot._trust_reads = True
+        policies[key] = ""
+
+        restore()
+        assert policies[key] == "", "a trust_reads slot must not be upgraded to auto"
+
+    def test_restore_skips_a_slot_whose_policy_changed_or_that_was_removed(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.server import _suspend_override_derived_trust
+
+        state, policies = self._state_with_slots(tmp_path, monkeypatch)
+        changed = state.get_or_create_slot("changed")
+        gone = state.get_or_create_slot("gone")
+        for s in (changed, gone):
+            policies[effective_session_key(s)] = "auto"
+        restore = _suspend_override_derived_trust(state)
+        assert restore is not None
+
+        # A Trust press wrote "auto" itself mid-resolve; a slot was closed.
+        policies[effective_session_key(changed)] = "auto"
+        changed._trust = True
+        del state._slots["gone"]
+
+        restore()
+        assert policies[effective_session_key(changed)] == "auto", "left as the operator set it"
+        assert policies[effective_session_key(gone)] == "", "a removed slot gets nothing back"
+
+    def test_restore_only_writes_over_the_empty_policy_it_left(self, tmp_path, monkeypatch):
+        """The policy is the contract, not the slot flags.
+
+        ``add_trusted_session`` (a channel Trust press) writes the session policy
+        without touching any dashboard slot flag, so a flag check alone cannot see it.
+        A restore that finds anything but the empty string it wrote leaves it alone --
+        somebody else owns that value now.
+        """
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.server import _suspend_override_derived_trust
+
+        state, policies = self._state_with_slots(tmp_path, monkeypatch)
+        slot = state.get_or_create_slot("s1")
+        key = effective_session_key(slot)
+        policies[key] = "auto"
+        restore = _suspend_override_derived_trust(state)
+        assert restore is not None and policies[key] == ""
+
+        # Some other owner wrote the policy mid-resolve; no slot flag changed.
+        policies[key] = "reads"
+
+        restore()
+        assert policies[key] == "reads", "restore must not overwrite a policy it did not leave"
+
+    def test_suspend_returns_none_when_nothing_carried_inherited_auto(self, tmp_path, monkeypatch):
+        from kiro_crew.dashboard.server import _suspend_override_derived_trust
+
+        state, _ = self._state_with_slots(tmp_path, monkeypatch)
+        state.get_or_create_slot("s1")
+        assert _suspend_override_derived_trust(state) is None
+
+    def test_clear_survives_a_slot_removed_during_the_walk(self, tmp_path, monkeypatch):
+        """The clear runs off-loop while the loop churns slots; it must not abort partway.
+
+        Iterating the live dict would raise "dictionary changed size during iteration"
+        and leave every unreached slot at ``"auto"`` -- a partial revocation.
+        """
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+        from kiro_crew.dashboard.server import _clear_override_derived_trust
+
+        state, policies = self._state_with_slots(tmp_path, monkeypatch)
+        slots = [state.get_or_create_slot(f"s{i}") for i in range(4)]
+        for s in slots:
+            policies[effective_session_key(s)] = "auto"
+
+        # Mutate the slot dict from inside the walk, via the policy write.
+        real_set = state.sessions.set_approval_policy
+
+        def _set_and_churn(key, value):
+            real_set(key, value)
+            state._slots.pop("s3", None)
+            state._slots.setdefault("new", slots[0])
+
+        state.sessions.set_approval_policy = _set_and_churn
+        monkeypatch.setattr(
+            "kiro_crew.messaging.session_trust.clear_trusted_sessions", lambda **kw: None
+        )
+
+        _clear_override_derived_trust(state, "policy")
+
+        assert all(
+            policies[effective_session_key(s)] == "" for s in slots
+        ), "every slot snapshotted at the start must be cleared, whatever the loop did"
+
+    def test_start_dashboard_wires_both_handlers_to_the_singleton(self):
+        """The seams are only closed if start_dashboard actually installs them."""
+        import pathlib as _pl
+
+        src = (
+            _pl.Path(__file__).resolve().parents[1]
+            / "src"
+            / "kiro_crew"
+            / "dashboard"
+            / "server.py"
+        ).read_text(encoding="utf-8")
+        assert (
+            "safety_override().on_policy_revoked = functools.partial("
+            "_clear_override_derived_trust, state)" in src
+        )
+        assert (
+            "safety_override().on_policy_suspend = functools.partial("
+            "_suspend_override_derived_trust, state)" in src
+        )
+
+
+class TestTheRevocationNoticeReachesTheLoopItWasInstalledOn:
+    """``apply_ceiling`` can install a ceiling from a worker thread.
+
+    ``_on_expired`` is loop-affine: it schedules the Slack expiry DM and the
+    unattended-run notice with ``loop.create_task`` behind a ``get_running_loop()``
+    probe, so called off-loop it silently posts nothing -- and silence about a
+    security grant being revoked is what that notice exists to prevent. So the
+    callback is scheduled onto the loop it was installed from, while the grant
+    teardown itself (thread-safe, and the part that must be true immediately) runs
+    inline on the installing thread.
+    """
+
+    @pytest.mark.asyncio
+    async def test_the_inherited_trust_teardown_is_not_deferred(self, monkeypatch):
+        """Only the NOTIFICATION may wait for the loop; the state may not.
+
+        ``admission.parent_trusted`` reads a session's ``approval_policy == "auto"``
+        directly, consulting no flag here, so deferring that teardown leaves a
+        loop-turn window in which a spawn is auto-approved against the denying ceiling
+        -- and the subagent it launched is not un-spawned by the cleanup that arrives
+        afterwards. So the inherited half runs inline, on the installing thread, before
+        anything is scheduled.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+
+        loop = asyncio.get_running_loop()
+        notified = asyncio.Event()
+        order: list[str] = []
+        threads: dict[str, str] = {}
+
+        def _clear_state(source: str) -> None:
+            order.append(f"state:{source}")
+            threads["state"] = threading.current_thread().name
+
+        def _notify(source: str) -> None:
+            order.append(f"notify:{source}")
+            threads["notify"] = threading.current_thread().name
+            loop.call_soon_threadsafe(notified.set)
+
+        override.on_policy_revoked = _clear_state
+        override.on_expired = _notify
+
+        loop_thread = threading.current_thread().name
+        install_thread: list[str] = []
+
+        def _install() -> None:
+            install_thread.append(threading.current_thread().name)
+            _deny("yolo")
+
+        await asyncio.to_thread(_install)
+        await asyncio.wait_for(notified.wait(), timeout=5)
+
+        # Which THREAD each half ran on is the timing-independent form of "one is
+        # inline and the other is deferred": sampling the ordering mid-flight would
+        # race the loop, which is free to run the scheduled half the moment the
+        # installing thread yields.
+        assert threads["state"] == install_thread[0], (
+            "the inherited-trust teardown must run INLINE on the thread that installed "
+            "the ceiling -- deferring it is the window a spawn is auto-approved in"
+        )
+        assert threads["notify"] == loop_thread, (
+            "the notification is loop-affine and must be scheduled, not run off-loop "
+            "where it silently posts nothing"
+        )
+        # Deterministic regardless of scheduling: the inline call precedes the
+        # ``call_soon_threadsafe`` that queues the other.
+        assert order == ["state:policy", "notify:policy"]
+
+    def test_the_notifier_still_runs_the_inherited_teardown(self):
+        """Splitting the handler must not drop the teardown from the TTL path.
+
+        A TTL lapse fires ``on_expired`` and nothing else -- there is no separate
+        synchronous call on that path -- so the notifier has to keep running the
+        inherited-trust teardown itself. Asserted against the source because the
+        handler is a closure inside ``start_dashboard`` and cannot be imported; the
+        failure it guards is silent, since a lapsed grant would simply leave every slot
+        at ``approval_policy="auto"`` for good.
+        """
+        import pathlib as _pl
+
+        repo_root = _pl.Path(__file__).resolve().parents[1]
+        src = (repo_root / "src" / "kiro_crew" / "dashboard" / "server.py").read_text(
+            encoding="utf-8"
+        )
+        body = src.split("def _on_override_expired(source: str) -> None:", 1)
+        assert len(body) == 2, "the expiry notifier was renamed; update this guard"
+        notifier = body[1].split("\n    safety_override().on_expired", 1)[0]
+        assert "_clear_override_derived_trust(state, source)" in notifier, (
+            "the expiry notifier must still clear inherited trust -- a TTL lapse has "
+            "no other path to it"
+        )
+
+    def test_inherited_trust_is_cleared_before_the_grant_flag_drops(self, monkeypatch):
+        """The two stores cannot be written atomically, so the ORDER decides the failure.
+
+        Grant-first leaves the slots at ``approval_policy="auto"`` for the statements in
+        between, and ``admission.parent_trusted`` reads that policy directly -- so a
+        spawn there is auto-approved against the denying ceiling and no later event
+        un-spawns it. Inherited-first inverts that: the spawn path is already closed
+        while only the grant flag trails, which is recoverable.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+
+        order: list[str] = []
+
+        def _clear_state(_source: str) -> None:
+            # Sampled INSIDE the clear: the grant must still be standing here, which is
+            # what proves the inherited half ran first.
+            order.append(f"state(grant={override.has_grant()})")
+
+        override.on_policy_revoked = _clear_state
+        override.on_expired = lambda source: order.append("notify")
+
+        _deny("yolo")
+
+        assert order == ["state(grant=True)", "notify"], (
+            "the inherited-trust clear must run while the grant is still standing -- "
+            f"reversing it reopens the unrecoverable spawn window; saw {order}"
+        )
+        assert override.has_grant() is False, "and the grant is gone by the end"
+
+    def test_a_scoped_only_deny_revokes_the_scope_but_clears_no_inherited_trust(self, monkeypatch):
+        """Scoped grants write no inherited state, so the clear must not run for them.
+
+        The inherited clear also empties the shared channel-trust mapping. A deny landing
+        while the only live grant is a taskrunner's scoped one would otherwise revoke an
+        independent Trust press on an unrelated channel session -- trust this override
+        never handed out. The scoped grant itself is still revoked.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        assert override.activate_scoped("run:abc", "dashboard").active is True
+        touched: list[str] = []
+        override.on_policy_revoked = lambda source: touched.append("clear")
+        override.on_policy_suspend = lambda: touched.append("suspend") or None
+        override.on_expired = lambda source: touched.append("notify")
+
+        _deny("yolo")
+
+        assert override.is_scope_active("run:abc") is False, "the scoped grant is revoked"
+        assert (
+            "clear" not in touched and "suspend" not in touched
+        ), f"a scoped-only deny must not touch inherited/channel trust; saw {touched}"
+        assert "notify" not in touched, "no session-wide grant, no expiry notice"
+
+    def test_no_grant_means_no_inherited_clear_and_no_notice(self, monkeypatch):
+        """A deny install with nothing armed must not touch inherited state.
+
+        The clear also revokes the shared channel-trust mapping, so running it when no
+        grant ever existed would revoke trust this override never handed out.
+        """
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        touched: list[str] = []
+        override.on_policy_revoked = lambda source: touched.append("state")
+        override.on_expired = lambda source: touched.append("notify")
+
+        _deny("yolo")
+
+        assert touched == [], "nothing was armed, so there is nothing derived to clear"
+
+    def test_a_raising_sync_teardown_does_not_stop_the_notification(self, monkeypatch):
+        """The two halves are independent; neither may swallow the other."""
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+
+        def _boom(_source: str) -> None:
+            raise RuntimeError("session store unavailable")
+
+        override.on_policy_revoked = _boom
+        seen: list[str] = []
+        override.on_expired = seen.append
+
+        _deny("yolo")
+
+        assert override.has_grant() is False
+        assert seen == ["policy"]
+
+    @pytest.mark.asyncio
+    async def test_an_off_thread_install_schedules_the_callback_onto_the_loop(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+
+        loop = asyncio.get_running_loop()
+        fired = asyncio.Event()
+        threads: list[str] = []
+
+        def _handler(source: str) -> None:
+            threads.append(threading.current_thread().name)
+            loop.call_soon_threadsafe(fired.set)
+
+        # Assigned from inside a running loop, which is how the dashboard installs it.
+        override.on_expired = _handler
+        assert override._on_expired_loop is loop
+
+        main_thread = threading.current_thread().name
+        await asyncio.to_thread(_deny, "yolo")
+
+        # The teardown is NOT deferred: it is done by the time the install returns.
+        assert override.has_grant() is False
+
+        await asyncio.wait_for(fired.wait(), timeout=5)
+        assert threads == [main_thread], (
+            "the handler must run on the loop it was installed from, not on the "
+            "worker thread that installed the ceiling"
+        )
+
+    def test_no_recorded_loop_means_the_callback_runs_inline(self, monkeypatch):
+        """A sync CLI or test has no loop to schedule onto; dropping it is not an option."""
+        from kiro_crew import safety_override as so
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.activate("dashboard")
+        seen: list[str] = []
+        override.on_expired = seen.append
+        assert override._on_expired_loop is None
+
+        _deny("yolo")
+
+        assert seen == ["policy"]
+
+
+class TestInheritedSlotTrustIsClearedOnADenyInstall:
+    """Clearing the grant flag is NOT the whole revocation.
+
+    A dashboard grant also writes ``approval_policy="auto"`` onto the slots and into
+    the shared channel-trust mapping, and ``subagent_manager.admission`` reads THAT
+    policy -- ``sessions.get_approval_policy(parent_session_key) == "auto"`` -- rather
+    than any flag in ``safety_override``. So a revocation that stopped at the flag
+    left ``spawn_run`` auto-approved, and a subagent already launched under it is not
+    un-spawned when the deny lands. ``_on_expired`` is the handler that resets those
+    policies, which is why the deny install fires it.
+    """
+
+    def test_the_admission_predicate_stops_reading_auto_after_a_deny_install(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        policies: dict[str, str] = {}
+
+        class _Sessions:
+            def get_approval_policy(self, key: str) -> str:
+                return policies.get(key, "")
+
+            def set_approval_policy(self, key: str, value: str) -> None:
+                policies[key] = value
+
+        sessions = _Sessions()
+        parent_key = "dashboard:s1"
+
+        def _on_expired(_source: str) -> None:
+            # The shape of the dashboard's own handler: every slot's inherited
+            # policy is reset. Reproduced here rather than imported because the real
+            # one is defined inside ``start_dashboard``.
+            for key in list(policies):
+                sessions.set_approval_policy(key, "")
+
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        override = so.safety_override()
+        override.on_expired = _on_expired
+        assert override.activate("dashboard").active is True
+        # What the dashboard grant does to the slot it was armed from.
+        sessions.set_approval_policy(parent_key, "auto")
+        assert sessions.get_approval_policy(parent_key) == "auto"
+
+        _deny("yolo")
+
+        assert sessions.get_approval_policy(parent_key) != "auto", (
+            "spawn admission reads the slot's approval policy directly, so a "
+            "revocation that leaves it at 'auto' keeps auto-approving subagents "
+            "against a policy that denies yolo"
+        )
+        assert override.is_active() is False
+
+
+class TestTheApprovalCardDoesNotRestoreTrustAfterADeny:
+    """The grant's INHERITED half is written by the caller, outside the revoke's lock.
+
+    ``POST /api/chat/slots/<slot>/approve`` with ``action=yolo`` arms the grant and
+    then writes ``approval_policy="auto"`` onto every slot -- and
+    ``admission.parent_trusted`` reads that policy directly rather than any flag in
+    ``safety_override``. A denying ceiling installed after the arm returns revokes the
+    grant and runs its ``_on_expired`` cleanup, so a write landing after that cleanup
+    puts the inherited trust straight back with nothing left to clear it: a subagent
+    spawned under it is auto-approved, and no later event un-spawns it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_deny_during_the_policy_write_leaves_no_inherited_auto(
+        self, tmp_path, monkeypatch
+    ):
+        from kiro_crew import safety_override as so
+
+        monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
+        _install_no_policy()
+        so.reset_singleton()
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+
+        policies: dict[str, str] = {}
+        state = _make_state(tmp_path)
+        state.sessions.get_approval_policy = lambda key: policies.get(key, "")
+        fired: list[int] = []
+
+        def _set_policy(key: str, value: str) -> None:
+            policies[key] = value
+            # The deny lands mid-write, which is the reachable ordering: the arm has
+            # already returned, so its own survival check cannot see this.
+            if value == "auto" and not fired:
+                fired.append(1)
+                _deny("yolo")
+
+        state.sessions.set_approval_policy = _set_policy
+        slot = state.get_or_create_slot("s1")
+        # A slot carrying STANDING trust. A Trust press is a separate, longer-lived
+        # decision that no yolo deny expires, so the reconcile must leave it alone --
+        # the same rule ``_on_override_expired`` applies.
+        trusted = state.get_or_create_slot("s2")
+        trusted._trust = True
+        fut: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+        slot._approval_futures["req-1"] = fut
+
+        async with TestClient(TestServer(_make_app(state))) as client:
+            resp = await client.post(
+                "/api/chat/slots/s1/approve",
+                json={"action": "yolo", "request_id": "req-1"},
+            )
+            body = await resp.json()
+
+        assert fired, "the deny must have landed during the policy write"
+        assert body.get("ok") is True, "the operator's click still approves that tool"
+        assert so.safety_override().has_grant() is False, "the deny revoked the grant"
+        from kiro_crew.dashboard.chat_utils import effective_session_key
+
+        plain_key = effective_session_key(slot)
+        trusted_key = effective_session_key(trusted)
+        assert policies.get(plain_key) != "auto", (
+            "a slot left at approval_policy='auto' after the deny keeps auto-approving "
+            "subagent spawns through admission.parent_trusted"
+        )
+        assert policies.get(trusted_key) == "auto", (
+            "standing trust is not expired by a yolo deny -- clearing it here would "
+            "revoke a grant nobody withdrew"
+        )
+
+
+class TestOnlyOneSurfaceWritesGrantDerivedTrust:
+    """A ratchet on the obligation the reconcile carries.
+
+    ``SafetyOverride`` revokes the grant, but the INHERITED half -- the
+    ``approval_policy="auto"`` a caller writes onto its sessions from an
+    ``ActivationResult`` -- is written outside the lock that revocation takes, and
+    ``admission.parent_trusted`` reads it directly. So every such writer owes a
+    post-write reconcile, and a new transport that writes inherited state from an arm
+    without one silently reopens #8849.
+
+    That obligation cannot be enforced by a type or a lock, so it is pinned here: the
+    set of files pairing an arm with an ``"auto"`` write is DECLARED, and a newcomer
+    fails this test until its author writes down that it reconciles. Same
+    declared-map-plus-scan shape as ``PEEK_CALLERS`` and the shared-path floor -- a
+    forcing function, not a proof.
+    """
+
+    #: ``<path under src/kiro_crew>`` -> why its grant-derived write is safe.
+    WRITERS = {
+        "dashboard/chat_handlers.py": (
+            "api_chat_slot_approve's action=yolo branch writes approval_policy='auto' "
+            "onto every slot from the ActivationResult, then re-reads the verdict and "
+            "clears what it just set if policy now denies -- preserving standing trust "
+            "on the same rule _on_override_expired uses."
+        ),
+    }
+
+    def test_the_declared_set_is_exactly_the_files_that_pair_the_two(self):
+        import pathlib as _pl
+
+        src = _pl.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        found: set[str] = set()
+        for path in src.rglob("*.py"):
+            if "_vendor" in path.parts:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            arms = "safety_override().activate" in text
+            grants = "set_approval_policy(" in text and '"auto"' in text
+            if arms and grants:
+                found.add(str(path.relative_to(src)).replace("\\", "/"))
+
+        undeclared = found - set(self.WRITERS)
+        assert not undeclared, (
+            f"{sorted(undeclared)} arms a grant AND writes approval_policy='auto'. That "
+            "write is the grant's inherited half, it happens outside the lock "
+            "revoke_for_policy takes, and admission.parent_trusted reads it directly -- "
+            "so it MUST reconcile after writing (re-read the verdict, clear what it set "
+            "if policy now denies, preserve standing trust). Then declare it in "
+            "TestOnlyOneSurfaceWritesGrantDerivedTrust.WRITERS with that reasoning."
+        )
+        stale = set(self.WRITERS) - found
+        assert not stale, (
+            f"{sorted(stale)} no longer pairs an arm with an 'auto' write; drop its "
+            "entry so this map cannot decay into permissions nobody exercises"
+        )
+
+    def test_the_declared_writer_actually_reconciles(self):
+        """The declaration is a claim; this checks the code still backs it."""
+        import pathlib as _pl
+
+        src = _pl.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        for rel in self.WRITERS:
+            text = (src / rel).read_text(encoding="utf-8")
+            assert "if not yolo_policy_permits():" in text, (
+                f"{rel} is declared as reconciling its grant-derived write, but no "
+                "post-write verdict re-read is left in it"
+            )
+
+
+class TestNothingResolvesGovernanceOffTheInstallPath:
+    """Every consumer is a bare read, and that is a hard property, not a preference.
+
+    ``is_active`` is the predicate every transport hands to ``TurnDriver`` (so it runs
+    per TOOL CALL), ``status_snapshot`` rides the 5s WebSocket push, and arming is
+    reached from the event loop by synchronous callers. Resolving the scope walks the
+    profiles dir, so any of those doing it would put filesystem work where it cannot go.
+    """
+
+    @pytest.fixture()
+    def _tripwire(self, monkeypatch):
+        from kiro_crew import safety_override as so
+
+        # Singleton reset FIRST: it forgets the pushed verdict, so installing the
+        # ceiling afterwards is what leaves a resolved flag behind for the tripwire
+        # to prove nothing re-reads.
+        so.reset_singleton()
+        _install_no_policy()  # resolves the verdict ONCE, here
+        monkeypatch.setattr(so, "sel", lambda: MagicMock())
+        calls: list[str] = []
+
+        def _boom(mode: str) -> bool:
+            calls.append(mode)
+            return True
+
+        monkeypatch.setattr(so, "approval_mode_permitted", _boom)
+        return calls
+
+    def test_the_hot_predicate_does_not_resolve(self, _tripwire):
+        from kiro_crew import safety_override as so
+
+        so.safety_override().activate("dashboard")
+        for _ in range(20):
+            so.safety_override().is_active()
+
+        assert _tripwire == [], "is_active runs per tool call; it must never resolve"
+
+    def test_arming_does_not_resolve(self, _tripwire):
+        """Arming reads the flag too, so its async callers need no offload FOR THIS.
+
+        They keep one anyway: the fail-closed SEL audit is still a filesystem write.
+        """
+        from kiro_crew import safety_override as so
+
+        assert so.safety_override().activate("dashboard").active is True
+        assert so.safety_override().activate_scoped("run:abc", "dashboard").active is True
+
+        assert _tripwire == [], "arming must not walk the profiles dir"
+
+    def test_the_scoped_consult_points_do_not_resolve(self, _tripwire):
+        from kiro_crew import safety_override as so
+
+        so.safety_override().activate_scoped("run:abc", "dashboard")
+        for _ in range(20):
+            so.safety_override().is_scope_active("run:abc")
+            so.safety_override().renew_scoped("run:abc", "dashboard")
+
+        assert _tripwire == []
+
+    def test_the_status_reader_does_not_resolve(self, _tripwire):
+        from kiro_crew import safety_override as so
+
+        for _ in range(20):
+            assert so.cached_disabled_approval_modes() == []
+
+        assert _tripwire == []
+
+    def test_the_status_field_cannot_contradict_enforcement(self):
         """The anti-divergence property, stated directly.
 
-        Two caches of one question is what allowed the picker to disagree with the
-        gate. Whatever ``yolo_policy_permits`` says, the reported list must say.
+        Two caches of one question is what let the picker disagree with the gate.
+        Whatever ``yolo_policy_permits`` says, the reported list must say.
         """
         from kiro_crew import safety_override as so
 
@@ -362,279 +1627,28 @@ class TestStatusSnapshotNeverResolvesOnTheEventLoop:
         assert so.cached_disabled_approval_modes() == ["yolo"]
 
     @pytest.mark.asyncio
-    async def test_status_snapshot_is_served_from_the_cache(self, tmp_path, monkeypatch):
+    async def test_status_snapshot_reports_the_pushed_verdict(self, tmp_path, monkeypatch):
         from kiro_crew import safety_override as so
 
         monkeypatch.setattr("kiro_crew.dashboard.state.config_dir", lambda: tmp_path)
-        # A denial cached under the CURRENT generation, with a refresh in flight so
-        # the reader cannot go resolve. ``["trust", "yolo"]`` was the shape an earlier
-        # revision asserted here; the backend can never emit it, because those modes
-        # are non-deniable.
-        monkeypatch.setattr(so, "_yolo_policy_cache", (0.0, False, so._governance_generation()))
+        _deny("yolo")
         state = _make_state(tmp_path)
 
-        async with _refresh_in_flight(monkeypatch):
-            snap = state.status_snapshot()
+        snap = state.status_snapshot()
 
+        # ``["trust", "yolo"]`` was the shape an earlier revision asserted here; the
+        # backend can never emit it, because those modes are non-deniable.
         assert snap["disabled_approval_modes"] == ["yolo"]
-
-
-class TestATightenedPolicyRevokesALiveGrant:
-    """Gating only at ARMING left a live grant honoured until its own TTL.
-
-    An admin who denies ``yolo`` mid-session then kept auto-approving every tool
-    for up to 24h, so the control announced a state it was not enforcing.
-    ``is_active()`` is the consult point every transport hands to ``TurnDriver``,
-    which is why the check lives there rather than at each call site.
-    """
-
-    def test_a_live_grant_stops_being_honoured_when_policy_denies(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        # Arm under a policy that permits.
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        assert so.safety_override().activate("dashboard").active is True
-        assert so.safety_override().is_active() is True
-
-        # The admin tightens the policy while the grant is live.
-        _deny("yolo")
-        so.reset_yolo_policy_cache()
-
-        assert so.safety_override().is_active() is False
-
-    def test_a_denied_grant_is_revoked_so_relaxing_does_not_resurrect_it(self, monkeypatch):
-        """Denial REVOKES. Masking-without-revoking was a defect, not a feature.
-
-        An earlier revision left the grant in place and only reported inactive, so
-        relaxing the policy silently restored auto-approve. That is wrong because the
-        same predicate answers "is there a grant to clear?" -- see the test below. A
-        fresh arm after the policy relaxes is the honest outcome.
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        so.safety_override().activate("dashboard")
-
-        _deny("yolo")
-        so.reset_yolo_policy_cache()
-        assert so.safety_override().is_active() is False
-
-        _install_no_policy()
-        so.reset_yolo_policy_cache()
-        assert (
-            so.safety_override().is_active() is False
-        ), "a policy-revoked grant must stay revoked once the policy relaxes"
-
-    def test_an_explicit_revoke_during_a_denial_window_is_not_swallowed(self, monkeypatch):
-        """The bug the revoke-vs-mask choice exists to prevent.
-
-        Slack's off-path is `if is_yolo_mode(): disable_yolo()`. While a mask-only
-        denial reported inactive, that branch cleared NOTHING, and a later policy
-        relaxation resurrected the grant the operator had explicitly revoked.
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        so.safety_override().activate("dashboard")
-
-        _deny("yolo")
-        so.reset_yolo_policy_cache()
-
-        # Exactly what the Slack handler does: consult, then skip when inactive.
-        if so.safety_override().is_active():
-            so.safety_override().deactivate("slack")
-
-        # Policy lifts. Nothing may come back.
-        _install_no_policy()
-        so.reset_yolo_policy_cache()
-        assert so.safety_override().is_active() is False
-
-    def test_a_declared_grant_is_revoked_too(self, monkeypatch):
-        """A permanent grant has no deadline, so policy is its ONLY off-switch."""
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        so.safety_override().activate_declared()
-        assert so.safety_override().is_active() is True
-
-        _deny("yolo")
-        so.reset_yolo_policy_cache()
-        assert so.safety_override().is_active() is False
-
-
-class TestTheHotPredicateNeverTouchesTheFilesystem:
-    """``is_active()`` runs per TOOL CALL via ``auto_approve_session``.
-
-    Resolving governance there would walk the profiles dir on every tool, so the
-    reader must be pure memory with an off-loop refresh.
-    """
-
-    def test_the_cached_reader_does_not_resolve_inline(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        calls: list[str] = []
-
-        def _tripwire(mode: str) -> bool:
-            calls.append(mode)
-            return True
-
-        monkeypatch.setattr(so, "approval_mode_permitted", _tripwire)
-        # Stamped with the CURRENT generation: this case is about the TTL branch, and
-        # a mismatched generation would resolve inline for a different reason.
-        monkeypatch.setattr(
-            so, "_yolo_policy_cache", (time.monotonic(), True, so._governance_generation())
-        )
-
-        assert so.yolo_policy_permits() is True
-        assert calls == [], "a fresh cache must not trigger a governance read"
-
-    @pytest.mark.asyncio
-    async def test_a_stale_cache_with_a_refresh_in_flight_serves_the_last_value(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        calls: list[str] = []
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: calls.append(m) or True)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (0.0, False, so._governance_generation()))
-
-        async with _refresh_in_flight(monkeypatch):
-            assert so.yolo_policy_permits() is False
-            assert calls == []
-
-    def test_a_sync_caller_resolves_inline_because_it_has_no_loop_to_protect(self, monkeypatch):
-        """The no-running-loop branch, stated as a property rather than assumed.
-
-        The suppression check now comes AFTER the loop lookup, and that order is the
-        correct one: with no loop there is nothing to stall, and handing a CLI caller
-        a cold cache's permissive default would be the worse outcome. An in-flight
-        record belonging to some other loop must not talk a sync caller out of
-        resolving.
-        """
-        from kiro_crew import safety_override as so
-
-        calls: list[str] = []
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: calls.append(m) or False)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (0.0, True, so._governance_generation()))
-
         assert so.yolo_policy_permits() is False
-        assert calls == ["yolo"], "a sync caller with a stale entry must resolve"
 
 
-class TestAnInFlightRecordCannotWedgeTheRefresh:
-    """The record is ``(loop, task)`` so that staleness is DECIDABLE.
+class TestArmingIsStillOffloadedByItsAsyncCallers:
+    """The offload survives this refactor, because the SEL audit is still I/O.
 
-    A bare boolean was set before the task existed and cleared in that task's
-    ``finally``. A loop torn down while the refresh was pending therefore left it
-    ``True`` with nothing alive to clear it, and every later call took the early
-    return -- the verdict cache stopped refreshing for the life of the process. On a
-    safety predicate that means a policy tightening silently stops landing.
+    Arming no longer resolves governance, but it still writes a fail-closed security
+    event before the grant exists -- a synchronous filesystem write -- so an async
+    caller that ran it inline would put that on the gateway's loop.
     """
-
-    @pytest.mark.asyncio
-    async def test_a_record_naming_another_loop_does_not_suppress_a_refresh(self, monkeypatch):
-        """The wedge, reproduced: a pending task whose loop is not this one.
-
-        The loop is a sentinel rather than a second real event loop on purpose. What
-        decides the branch is ``record[0] is running_loop``, and a sentinel states
-        that mismatch exactly while leaving nothing to tear down -- a real second
-        loop would have to be abandoned holding a pending task, which is the noise
-        this record removes.
-        """
-        from kiro_crew import safety_override as so
-
-        loop = asyncio.get_running_loop()
-        gate = asyncio.Event()
-
-        async def _blocked() -> None:
-            await gate.wait()
-
-        orphan = loop.create_task(_blocked())
-        monkeypatch.setattr(so, "_yolo_policy_refresh", (object(), orphan))
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: False)
-        assert not orphan.done(), "the wedging state is a PENDING task, not a finished one"
-
-        try:
-            so._schedule_yolo_policy_refresh()
-
-            record = so._yolo_policy_refresh
-            assert record is not None
-            assert record[0] is loop, (
-                "the scheduler must adopt the LIVE loop rather than defer to a record "
-                "that names a loop which is no longer running"
-            )
-            assert record[1] is not orphan
-            record[1].cancel()
-        finally:
-            gate.set()
-            await orphan
-
-    @pytest.mark.asyncio
-    async def test_a_finished_task_on_this_loop_does_not_suppress_a_refresh(self, monkeypatch):
-        """The other half of decidable: done means done, so a new one may start."""
-        from kiro_crew import safety_override as so
-
-        loop = asyncio.get_running_loop()
-
-        async def _immediate() -> None:
-            return None
-
-        finished = loop.create_task(_immediate())
-        await finished
-        monkeypatch.setattr(so, "_yolo_policy_refresh", (loop, finished))
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: False)
-
-        so._schedule_yolo_policy_refresh()
-
-        record = so._yolo_policy_refresh
-        assert record is not None and record[1] is not finished
-        record[1].cancel()
-
-    @pytest.mark.asyncio
-    async def test_a_live_refresh_on_this_loop_IS_respected(self, monkeypatch):
-        """The suppression still has to hold, or every call spawns another task."""
-        from kiro_crew import safety_override as so
-
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: False)
-
-        async with _refresh_in_flight(monkeypatch) as held:
-            so._schedule_yolo_policy_refresh()
-
-            assert so._yolo_policy_refresh is not None
-            assert (
-                so._yolo_policy_refresh[1] is held
-            ), "a live refresh for this loop must not be duplicated"
-
-    def test_the_reset_helper_clears_the_record(self):
-        """A reset must not leave a record that suppresses the next refresh."""
-        from kiro_crew import safety_override as so
-
-        so.reset_yolo_policy_cache()
-        assert so._yolo_policy_refresh is None
-
-    def test_arming_reads_authoritatively_rather_than_from_the_cache(self, monkeypatch):
-        """A deliberate, rare act must not be decided by a TTL-old value."""
-        from kiro_crew import safety_override as so
-
-        _deny("yolo")
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        # A stale-but-permissive cache must NOT let an arm through.
-        monkeypatch.setattr(
-            so, "_yolo_policy_cache", (time.monotonic(), True, so._governance_generation())
-        )
-
-        assert so.safety_override().activate("dashboard").active is False
-
-
-class TestArmingIsOffloadedByItsAsyncCallers:
-    """Arming does filesystem work, so no async caller may run it inline."""
 
     @pytest.mark.asyncio
     async def test_taskrunner_grant_run_trust_is_a_coroutine(self):
@@ -644,7 +1658,7 @@ class TestArmingIsOffloadedByItsAsyncCallers:
 
         assert inspect.iscoroutinefunction(TaskRunner._grant_run_trust), (
             "_grant_run_trust is reached from two async methods; a sync body puts "
-            "the SEL write and the governance read on the event loop"
+            "the SEL write on the event loop"
         )
 
     def test_every_grant_run_trust_call_site_is_awaited(self):
@@ -673,11 +1687,11 @@ class TestArmingIsOffloadedByItsAsyncCallers:
 class TestEveryGrantBranchHonoursAMidSessionDeny:
     """A mid-session deny must reach EVERY branch that honours a grant.
 
-    Masking only the session-wide grant revoked one kind of auto-approve and left
-    the other, and the scoped branch is the reachable one: ``task_executor``
-    consults ``is_scope_active`` before every approval and slides the grant with
-    ``renew_scoped``, so a taskrunner run armed while permitted kept auto-approving
-    for up to 24h after the deny. The branch table this pins:
+    Revoking only the session-wide grant left the other kind, and the scoped branch
+    is the reachable one: ``task_executor`` consults ``is_scope_active`` before every
+    approval and slides the grant with ``renew_scoped``, so a taskrunner run armed
+    while permitted kept auto-approving for up to 24h after the deny. The branch table
+    this pins:
 
     | consult point        | grant kind           | revoked |
     |----------------------|----------------------|---------|
@@ -701,7 +1715,6 @@ class TestEveryGrantBranchHonoursAMidSessionDeny:
         so = self._armed_scope(monkeypatch)
 
         _deny("yolo")
-        so.reset_yolo_policy_cache()
 
         assert so.safety_override().is_scope_active("run:abc") is False
 
@@ -710,323 +1723,69 @@ class TestEveryGrantBranchHonoursAMidSessionDeny:
         so = self._armed_scope(monkeypatch)
 
         _deny("yolo")
-        so.reset_yolo_policy_cache()
 
         result = so.safety_override().renew_scoped("run:abc", "dashboard")
         assert result.renewed is False
 
     def test_a_denied_scoped_grant_is_revoked_not_merely_masked(self, monkeypatch):
-        """Same correction as the session-wide grant: denial tears it down."""
+        """Denial tears the grant down, so relaxing the policy cannot resurrect it."""
         so = self._armed_scope(monkeypatch)
 
         _deny("yolo")
-        so.reset_yolo_policy_cache()
         assert so.safety_override().is_scope_active("run:abc") is False
 
         _install_no_policy()
-        so.reset_yolo_policy_cache()
         assert (
             so.safety_override().is_scope_active("run:abc") is False
         ), "a policy-revoked scoped grant must stay revoked once the policy relaxes"
 
-
-class TestAPolicyRevocationRunsTheSameTeardownAsATTLLapse:
-    """Clearing ``_active`` is not the whole revocation.
-
-    A dashboard grant also writes ``approval_policy="auto"`` onto the slots, and a
-    spawned subagent reads THAT rather than this flag -- so dropping only the flag
-    left spawn admission and every child tool auto-approved against a policy that
-    denies it. The TTL-lapse path already fixes this by firing ``on_expired``, whose
-    handler resets those policies and clears the shared trust mapping; a policy
-    revocation owes the same cleanup, so it fires the same callback rather than
-    growing a second, divergent teardown.
-    """
-
-    def test_a_policy_revocation_fires_the_expiry_callback(self, monkeypatch):
+    def test_a_declared_grant_is_revoked_too(self, monkeypatch):
+        """A permanent grant has no deadline, so policy is its ONLY off-switch."""
         from kiro_crew import safety_override as so
 
         _install_no_policy()
         so.reset_singleton()
         monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-        override.activate("dashboard")
-
-        seen: list[str] = []
-        override.on_expired = seen.append
+        so.safety_override().activate_declared()
+        assert so.safety_override().is_active() is True
 
         _deny("yolo")
-        so.reset_yolo_policy_cache()
-        assert override.is_active() is False
 
-        assert seen == ["policy"], (
-            "a policy revocation must run the same teardown as a TTL lapse -- "
-            "otherwise the slots keep approval_policy='auto' and subagents stay "
-            "auto-approved against a policy that denies yolo"
-        )
+        assert so.safety_override().is_active() is False
+        assert so.safety_override().has_grant() is False
 
-    def test_the_callback_fires_exactly_once_across_repeated_consults(self, monkeypatch):
-        """``is_active`` runs per TOOL CALL.
+    def test_a_session_wide_grant_stays_revoked_when_the_policy_relaxes(self, monkeypatch):
+        """The revoke-vs-mask choice, from the caller that made it necessary.
 
-        The handler broadcasts and rewrites slot policies, so re-firing it on every
-        call would be its own defect -- which is why the teardown is gated on there
-        actually being a grant to tear down.
+        Slack's off-path is ``if is_yolo_mode(): disable_yolo()``. While a mask-only
+        denial reported inactive, that branch cleared NOTHING, and a later policy
+        relaxation resurrected the grant the operator had explicitly revoked. A fresh
+        arm after the policy relaxes is the honest outcome.
         """
         from kiro_crew import safety_override as so
 
         _install_no_policy()
         so.reset_singleton()
         monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-        override.activate("dashboard")
-
-        seen: list[str] = []
-        override.on_expired = seen.append
+        so.safety_override().activate("dashboard")
 
         _deny("yolo")
-        so.reset_yolo_policy_cache()
-        for _ in range(5):
-            assert override.is_active() is False
-
-        assert seen == ["policy"], f"expected exactly one teardown, got {seen}"
-
-    def test_no_grant_means_no_callback(self, monkeypatch):
-        """A denying policy with nothing armed must not synthesise an expiry.
-
-        Every consult on an unarmed override takes this path, so an ungated fire
-        would broadcast a revocation for a grant that never existed.
-        """
-        from kiro_crew import safety_override as so
-
-        _deny("yolo")
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-
-        seen: list[str] = []
-        override.on_expired = seen.append
-
-        assert override.is_active() is False
-        assert seen == [], "nothing was armed, so there is nothing to tear down"
-
-    def test_a_raising_callback_does_not_break_the_refusal(self, monkeypatch):
-        """The verdict is the safety-relevant half; the cleanup is best-effort."""
-        from kiro_crew import safety_override as so
+        assert so.safety_override().is_active() is False
 
         _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-        override.activate("dashboard")
-
-        def _boom(_reason: str) -> None:
-            raise RuntimeError("handler exploded")
-
-        override.on_expired = _boom
-
-        _deny("yolo")
-        so.reset_yolo_policy_cache()
-        assert override.is_active() is False
-
-
-class TestAPolicyChangeIsNotBoundedByTheTTL:
-    """The TTL bounds staleness WITHIN one ceiling, not across a change.
-
-    A verdict primed while ``yolo`` was permitted kept auto-approving for the rest
-    of the TTL after a tightening -- the window the cache exists to make cheap was
-    also a window in which the control was not enforced. The entry now carries the
-    governance generation it was resolved under, so a newly installed ceiling makes
-    the reader resolve immediately instead of serving the primed permit.
-    """
-
-    def test_a_permit_primed_under_the_previous_ceiling_is_not_served(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        assert so.yolo_policy_permits() is True
-
-        # Installing a ceiling bumps the generation, which is what invalidates the
-        # entry. No cache reset here on purpose: that is the whole point.
-        _deny("yolo")
-        assert so.yolo_policy_permits() is False, (
-            "a fresh-by-TTL permit resolved under the PREVIOUS ceiling must not be "
-            "served after a tightening"
-        )
-
-    @pytest.mark.asyncio
-    async def test_a_generation_mismatch_reads_UNKNOWN_and_never_resolves_on_the_loop(
-        self, monkeypatch
-    ):
-        """Two properties at once, and an earlier revision had to break one to hold
-        the other.
-
-        Resolving inline held "never serve a stale permit" by walking the profiles
-        dir on the event loop, in a predicate that runs per TOOL CALL. Serving the
-        last-known verdict held "never block the loop" by handing back exactly the
-        stale permit. UNKNOWN is what lets both stand: it is decided from memory, and
-        it is not a permit.
-        """
-        from kiro_crew import safety_override as so
-
-        calls: list[str] = []
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: calls.append(m) or False)
-        # Fresh by the clock, but stamped with a generation nothing will ever equal.
-        monkeypatch.setattr(so, "_yolo_policy_cache", (time.monotonic(), True, -999))
-
-        assert so.yolo_policy_verdict() == so._YOLO_UNKNOWN
-        assert so.yolo_policy_permits() is False, "an undated verdict is not a permit"
-        assert calls == [], "a mismatched generation must NOT resolve on the loop"
-
-        # The entry is NOT restamped: only a successful resolve may claim the current
-        # generation, or an unresolvable policy would masquerade as a current one.
-        assert so._yolo_policy_cache[2] == -999
-
-    @pytest.mark.asyncio
-    async def test_UNKNOWN_stops_auto_approval_without_revoking_the_grant(self, monkeypatch):
-        """The reason UNKNOWN is a state rather than a boolean.
-
-        Folding it onto DENIED would revoke -- permanently, by design -- and the
-        window opens on EVERY ceiling install, including ones that still permit YOLO.
-        So an unknown verdict must refuse to auto-approve and leave the grant intact
-        for the refresh to settle.
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-        override.activate("dashboard")
-
-        seen: list[str] = []
-        override.on_expired = seen.append
-
-        # Undated verdict, on a running loop so the refresh cannot settle inline.
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: True)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (time.monotonic(), True, -999))
-
-        assert override.is_active() is False, "no auto-approve on an undated verdict"
-        assert seen == [], "and NO revocation -- the grant must survive to be settled"
-        with override._lock:
-            assert override._active is True, "the grant itself was not torn down"
-
-    def test_a_resolve_that_keeps_failing_never_serves_the_stale_permit(self, monkeypatch):
-        """The finding this invariant exists to close, in its plainest form.
-
-        ``_resolve_yolo_policy_blocking`` returns without restamping when the resolve
-        raises. While a stale entry could still read as a permit, a governance read
-        that kept failing served the old ``True`` indefinitely -- auto-approving every
-        tool against a ceiling nobody could read.
-        """
-        from kiro_crew import safety_override as so
-
-        # A permit resolved under the ceiling installed now...
-        _install_no_policy()
-        assert so.yolo_policy_permits() is True
-
-        # ...then the ceiling moves AND governance becomes unreadable.
-        def _boom(mode: str) -> bool:
-            raise RuntimeError("profiles dir unreadable")
-
-        monkeypatch.setattr(so, "approval_mode_permitted", _boom)
-        _deny("yolo")
-
-        for _ in range(4):
-            assert so.yolo_policy_verdict() == so._YOLO_UNKNOWN
-            assert so.yolo_policy_permits() is False, (
-                "a permit that no current resolve backs must never be served, however "
-                "many times it is asked for"
-            )
-
-    def test_arming_refuses_when_policy_cannot_be_read(self, monkeypatch):
-        """The authoritative path owed the same fail-closed reading.
-
-        Arming consults ``_resolve_yolo_policy_blocking`` directly. While that
-        returned the previous verdict on an exception, a grant could be armed against
-        a policy the host had just failed to read.
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        assert so.yolo_policy_permits() is True  # prime a permitting entry
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-
-        def _boom(mode: str) -> bool:
-            raise RuntimeError("profiles dir unreadable")
-
-        monkeypatch.setattr(so, "approval_mode_permitted", _boom)
-
-        assert so.safety_override().activate("dashboard").active is False
-
-
-class TestUNKNOWNNeverDestroysAScopedGrant:
-    """The scoped guards owed the same three-state reading as ``is_active``.
-
-    UNKNOWN was introduced with ``is_active`` taught to discriminate on it, and the
-    two SCOPED consult points were left on the two-way reading -- so they collapsed
-    it onto permanent revocation. That is the sharper end of the same defect:
-    ``is_scope_active`` runs before EVERY approval in an unattended run,
-    ``deactivate_scope`` pops the entry for good, and ``task_executor`` then clears
-    ``run.auto_approve``. Nothing re-arms. A mid-session ceiling install that STILL
-    PERMITS yolo would therefore stall a legitimately granted run for its whole
-    remainder, on nothing but the off-loop refresh window.
-    """
-
-    def _armed(self, monkeypatch):
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-        assert override.activate_scoped("run:abc", "dashboard").active is True
-        return so, override
-
-    @pytest.mark.asyncio
-    async def test_UNKNOWN_withholds_approval_without_popping_the_scope(self, monkeypatch):
-        so, override = self._armed(monkeypatch)
-
-        # Undated verdict, on a running loop so the refresh cannot settle inline.
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: True)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (time.monotonic(), True, -999))
-
-        assert override.is_scope_active("run:abc") is False, "no approval on unknown"
-        with override._lock:
-            assert "run:abc" in override._scoped, (
-                "the grant must SURVIVE an unknown verdict -- popping it is permanent "
-                "and nothing re-arms it"
-            )
-
-    @pytest.mark.asyncio
-    async def test_UNKNOWN_refuses_a_renewal_without_popping_the_scope(self, monkeypatch):
-        so, override = self._armed(monkeypatch)
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: True)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (time.monotonic(), True, -999))
-
-        # Refusing the slide is the safe direction -- a renewal extends authority.
-        assert override.renew_scoped("run:abc", "dashboard").renewed is False
-        with override._lock:
-            assert "run:abc" in override._scoped
-
-    def test_a_definite_deny_still_revokes_the_scope(self, monkeypatch):
-        """The revocation must still work, or the deny is cosmetic."""
-        so, override = self._armed(monkeypatch)
-
-        _deny("yolo")
-        assert override.is_scope_active("run:abc") is False
-        with override._lock:
-            assert "run:abc" not in override._scoped, "a definite deny tears it down"
+        assert (
+            so.safety_override().is_active() is False
+        ), "a policy-revoked grant must stay revoked once the policy relaxes"
 
 
 class TestAnExplicitOffIsNotPolicyFiltered:
     """``is_active`` answers "may a tool be auto-approved", which policy can veto.
 
     An explicit off asks a DIFFERENT question -- "is there something to tear down" --
-    and reading the policy-filtered answer for it inverted the control: during the
-    UNKNOWN window ``is_active`` reports False, so Slack's
-    ``if is_yolo_mode(): disable_yolo()`` skipped the teardown, reported "already
-    off", and left the grant standing to RESUME once the refresh settled. The
-    operator revoked auto-approve and it came back.
+    and reading the policy-filtered answer for it inverted the control. A deny now
+    destroys the grant at install time, so the two agree; ``disable_yolo`` still reads
+    ``has_grant`` because the policy mask is the fail-closed floor for a teardown that
+    did not complete, and that is exactly the state where an off has work to do.
     """
 
     def test_has_grant_ignores_policy_entirely(self, monkeypatch):
@@ -1038,7 +1797,6 @@ class TestAnExplicitOffIsNotPolicyFiltered:
         override = so.safety_override()
         override.activate("dashboard")
 
-        # A denying ceiling makes is_active False; the grant still EXISTS.
         _deny("yolo")
         assert override.is_active() is False
         assert (
@@ -1046,7 +1804,7 @@ class TestAnExplicitOffIsNotPolicyFiltered:
         ), "a policy deny REVOKES, so after it there is genuinely nothing to clear"
 
     @pytest.mark.asyncio
-    async def test_an_off_during_the_unknown_window_actually_revokes(self, monkeypatch):
+    async def test_an_off_under_a_masked_grant_actually_revokes(self, monkeypatch):
         from kiro_crew import safety_override as so
         from kiro_crew.slack import handler as h
 
@@ -1057,20 +1815,19 @@ class TestAnExplicitOffIsNotPolicyFiltered:
         override = so.safety_override()
         override.activate("dashboard")
 
-        # Undated verdict on a running loop: is_active reports False while the grant
-        # is still standing. This is the state the off path used to skip on.
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: True)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (time.monotonic(), True, -999))
+        # A masked-but-standing grant: the verdict denies while the grant survives,
+        # which is what an install-time teardown that did not complete leaves behind.
+        monkeypatch.setattr(so, "_yolo_policy_permitted", False)
+        monkeypatch.setattr(so, "_yolo_policy_resolved", True)
         assert override.is_active() is False
         assert override.has_grant() is True, "the grant is there to be cleared"
 
         h.disable_yolo()
 
         with override._lock:
-            assert override._active is False, (
-                "an explicit off must tear the grant down even while the verdict is "
-                "unknown -- otherwise it resumes when the refresh settles"
-            )
+            assert (
+                override._active is False
+            ), "an explicit off must tear the grant down even while policy masks it"
 
 
 class TestARefusedScopedArmDoesNotPersistAutoApprove:
@@ -1120,15 +1877,14 @@ class TestARefusedScopedArmDoesNotPersistAutoApprove:
 
 
 class TestALapsedGrantIsNotTornDownTwice:
-    """``_active`` alone is the grant test, and the ``or`` was a double-fire.
+    """A grant that reached its own deadline owes no second teardown.
 
     The natural-expiry branch clears ``_active`` but deliberately LEAVES
-    ``_expires_at`` set -- ``deactivate`` reads that nonzero deadline to tell
-    "lapsed" from "never armed", so it can still SEL-record an explicit off after a
-    lapse. A policy deny that also accepted ``_expires_at > 0`` therefore called
-    ``deactivate`` a second time and fired a second expiry teardown for a grant that
-    had already expired: a duplicate owner DM and a redundant broadcast, in the same
-    block whose comment promises it fires EXACTLY ONCE.
+    ``_expires_at`` set -- ``deactivate`` reads that nonzero deadline to tell "lapsed"
+    from "never armed", so it can still SEL-record an explicit off after a lapse. A
+    policy revocation that treated that stale deadline as a grant would fire a second
+    expiry teardown for a grant that had already expired: a duplicate owner DM and a
+    redundant broadcast.
     """
 
     def test_a_deny_after_a_natural_lapse_fires_no_second_teardown(self, monkeypatch):
@@ -1154,86 +1910,11 @@ class TestALapsedGrantIsNotTornDownTwice:
         assert seen == ["dashboard"], "the natural lapse fires its own teardown, once"
         with override._lock:
             assert override._expires_at > 0.0, (
-                "the lapsed deadline is deliberately retained -- that is what used to "
-                "make the policy branch double-fire"
+                "the lapsed deadline is deliberately retained -- that is what makes a "
+                "naive grant test double-fire"
             )
 
         # Policy now denies. There is no grant left to revoke.
         _deny("yolo")
         assert override.is_active() is False
-        assert seen == [
-            "dashboard"
-        ], "a grant that already expired must not be torn down a second time"
-
-    def test_a_mismatch_serves_the_last_known_verdict_not_a_fail_closed_deny(self, monkeypatch):
-        """Why the invalidation does not deny while the refresh is pending.
-
-        A deny from this predicate is not a cautious read, it is a REVOCATION --
-        ``is_active`` tears the grant down and that teardown is permanent. The
-        generation bumps on EVERY ceiling install, including one that still permits
-        YOLO, so failing closed here would destroy live grants on unrelated policy
-        refreshes.
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        so.reset_singleton()
-        monkeypatch.setattr(so, "sel", lambda: MagicMock())
-        override = so.safety_override()
-        override.activate("dashboard")
-        assert override.is_active() is True
-
-        seen: list[str] = []
-        override.on_expired = seen.append
-
-        # A ceiling is REINSTALLED that still permits yolo: generation moves, verdict
-        # does not. The grant must survive.
-        _install_no_policy()
-        assert override.is_active() is True
-        assert seen == [], "an unrelated ceiling install must not revoke a live grant"
-
-    def test_an_unreadable_generation_invalidates_rather_than_trusting_the_entry(self, monkeypatch):
-        """``-1`` never equals a STORED generation, so it can only invalidate.
-
-        Answering ``-1`` on an unreadable counter is what keeps the failure mode
-        "refresh more often" rather than "serve a value you cannot date".
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        assert so.yolo_policy_permits() is True
-
-        monkeypatch.setattr(so, "_governance_generation", lambda: -1)
-        calls: list[str] = []
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: calls.append(m) or False)
-
-        assert so.yolo_policy_permits() is False
-        assert calls == ["yolo"]
-
-    def test_a_backwards_clock_step_cannot_freeze_the_entry_as_fresh(self):
-        """Why the stamp is monotonic rather than wall clock.
-
-        ``time.time()`` can move backwards -- an NTP step, a VM restore, an operator
-        correcting the clock. A backwards jump makes ``now - resolved_at`` negative,
-        so the TTL never elapses again and the entry reads as fresh forever: a permit
-        with no expiry, for a reason that has nothing to do with policy. A monotonic
-        stamp cannot go backwards, so a wall-clock step is simply not visible here.
-        """
-        from kiro_crew import safety_override as so
-
-        _install_no_policy()
-        assert so.yolo_policy_permits() is True
-        stamped = so._yolo_policy_cache[0]
-
-        # The entry is dated on the monotonic clock, which is what a wall-clock step
-        # cannot reach. Asserting the SOURCE rather than simulating a jump: patching
-        # the global clock would prove nothing about which clock was read.
-        assert stamped <= time.monotonic(), "the stamp must come from the monotonic clock"
-        assert stamped > 0.0, "a real reading, not the never-resolved sentinel"
-
-    def test_the_reset_helper_stamps_a_generation_nothing_matches(self):
-        """A reset must force a resolve, not leave a permit that looks current."""
-        from kiro_crew import safety_override as so
-
-        so.reset_yolo_policy_cache()
-        assert so._yolo_policy_cache == (0.0, True, -1)
+        assert seen == ["dashboard"], f"a lapsed grant must not be torn down twice: {seen}"

--- a/test/test_governance_distribution.py
+++ b/test/test_governance_distribution.py
@@ -1412,8 +1412,13 @@ class TestCeilingSwapInvalidatesProfiles:
             encoding="utf-8",
         )
         gp.reset_store()
-        install_ceiling(governance.parse_policy(_doc("first")))
+        # Spy BEFORE the install: a ceiling install now warms the store eagerly,
+        # because ``safety_override``'s ceiling-install hook resolves ``approval_modes``
+        # against the new ceiling and that read composes a profile. The invariant under
+        # test is unchanged -- one reload per ceiling, and no snapshot composed against
+        # the retired one is ever served -- only who triggers it.
         reloads = self._count_reloads(monkeypatch)
+        install_ceiling(governance.parse_policy(_doc("first")))
         assert gp._STORE._ensure_fresh() is True
         before_token = gp._ceiling_token()
         before_generation = governance_generation()

--- a/test/test_slack_handler_coverage.py
+++ b/test/test_slack_handler_coverage.py
@@ -177,34 +177,37 @@ class TestYoloCommand:
         assert "ON" in _texts(slack)
 
     @pytest.mark.asyncio
-    async def test_off_revokes_while_the_policy_verdict_is_unknown(
+    async def test_off_revokes_while_policy_masks_the_grant(
         self, slack, sessions, owner, monkeypatch
     ):
         """An explicit off must not be gated on the POLICY-FILTERED liveness.
 
-        ``!yolo`` computes ``yolo_active = is_yolo_mode()``, which policy can veto.
-        While the governance verdict is momentarily unknown that reads False, so the
-        off branch reported "already off" and never called ``disable_yolo()`` -- and
-        the retained grant then resumed once the refresh settled, silently undoing
-        the operator's revocation. ``disable_yolo`` itself was corrected to read
-        ``has_grant``; this covers its CALLER, which was still gating it out.
+        ``!yolo`` computes ``yolo_active = is_yolo_mode()``, which policy can veto. A
+        grant that policy masks but that still EXISTS therefore reads False, so the
+        off branch reported "already off" and never called ``disable_yolo()`` --
+        leaving a grant standing that the operator had explicitly revoked.
+        ``disable_yolo`` itself was corrected to read ``has_grant``; this covers its
+        CALLER, which was still gating it out.
+
+        A deny normally destroys the grant at ceiling-install time, so the mask is the
+        fail-closed floor for a teardown that did not complete -- which is exactly the
+        state where an explicit off has work to do.
 
         Driven through ``_slash`` on purpose: an earlier attempt re-implemented the
         gate inside the test and therefore exercised no handler code, passing even
         with the fix reverted.
         """
-        import time as _time
-
         from kiro_crew import safety_override as so
 
         await _slash("!yolo on", slack, sessions)
         assert h.is_yolo_mode() is True
         slack.actions.clear()
 
-        # Force the verdict undated: fresh by the clock, stamped with a generation
-        # nothing will match. On a running loop the refresh cannot settle inline.
-        monkeypatch.setattr(so, "approval_mode_permitted", lambda m: True)
-        monkeypatch.setattr(so, "_yolo_policy_cache", (_time.monotonic(), True, -999))
+        # Push a DENY without going through a ceiling install, so the grant survives
+        # and only the policy mask is in force -- which is the state that misled the
+        # branch under test.
+        monkeypatch.setattr(so, "_yolo_policy_permitted", False)
+        monkeypatch.setattr(so, "_yolo_policy_resolved", True)
         assert h.is_yolo_mode() is False, "the filtered reading is what misled the branch"
         assert so.safety_override().has_grant() is True, "the grant is still standing"
 


### PR DESCRIPTION
## Problem / Motivation

The `approval_modes` scope decides whether YOLO (skip-every-approval) may be armed, and
it enforced a mid-session policy deny by **pulling**. Every consumer — `is_active`,
`is_scope_active`, `renew_scoped`, both arming gates, `cached_disabled_approval_modes`,
the dashboard status field — read `yolo_policy_verdict()`, a memory cache keyed on a 5s
TTL *plus* the governance generation, refreshed on a worker thread.

That mechanism needed a three-state verdict (`permitted` / `denied` / `unknown`), a
generation stamp, a lock held across a filesystem read, an in-flight `(loop, task)`
record, and `asyncio.to_thread` offloads at every async arming caller.

Two consequences shipped with it:

- A permit resolved under a ceiling that has since been retired can still be served, for
  as long as it takes a refresh to land.
- Between a ceiling install and that refresh settling `denied`, a slot's inherited
  `approval_policy="auto"` is never cleared, because `is_active()` only fires the
  revocation on a definite deny and `unknown` deliberately does not. But
  `subagent_manager/admission.py`'s `parent_trusted` reads
  `sessions.get_approval_policy(parent_session_key) == "auto"` **directly** — a path
  independent of `is_active()` — so a `spawn_run` in that window is auto-approved, and
  the subagent it launched is not un-spawned when the verdict lands (#8849).

## Why it matters

This is the enterprise-admin off-switch for auto-approving every tool call. A control
that announces a state it is not yet enforcing is worse than no control, because the
operator believes the deny has taken effect.

The design also had a cost that showed up as review load rather than as bugs: across
eight pushes on #7518 every security-fenced blocking finding was in this machinery, or
in a hardening added because of it — five distinct findings, each replacing the last.
None was a defect in the scope, the arming gate, the 403/503 split, or the SEL audits.

## What changed (motivation → approach → change)

**Why push, not pull.** The verdict only changes when a ceiling is installed, and an
install is a discrete event. Polling it needs a freshness key, a third
"not resolved under the installed ceiling yet" state, and a per-caller rule for
collapsing that state — approval had to fail closed on it, while revocation had to *not*
fire, since a ceiling install that still permits YOLO would otherwise destroy a live
grant permanently. Each of those is a window. Pushing removes the windows instead of
shortening them: a flag is either the answer for the ceiling in force, or no ceiling is
installed at all.

**The change.**

1. `platform/context.py` gains a ceiling-install hook registry
   (`register_ceiling_install_hook`), fired from `_install` — the single writer of the
   active context, so boot, `policy_distribution.apply_ceiling` and the test reset all
   announce themselves. A registry rather than a direct import because the consumer sits
   above this module (`safety_override` already imports from it), so calling it by name
   would be a cycle.
2. `safety_override` registers a hook at import. On each install it resolves
   `approval_mode_permitted("yolo")` once and stores the result in a plain module-level
   flag. `yolo_policy_permits()` is the single read every consumer uses: no I/O, no TTL,
   no lock.
3. **A deny revokes immediately.** `SafetyOverride.revoke_for_policy()` drops the
   session-wide grant and every scoped grant, then `_on_expired("policy")` fires so
   `_on_override_expired` clears inherited `approval_policy="auto"` on slots and the
   Slack trusted-session mapping. That is what closes #8849, and it closes it by
   construction — there is no window left to be inside.
4. **Thread.** `apply_ceiling` can install from a worker thread (its refresh poller), and
   `_on_expired` is loop-affine: it schedules the Slack expiry DM and the unattended-run
   notice with `loop.create_task` behind a `get_running_loop()` probe, so called off-loop
   it silently posts nothing. So the callback is **scheduled onto the loop it was
   installed from** (`call_soon_threadsafe`), captured in the `on_expired` setter —
   which the dashboard assigns from inside `start_dashboard`, so a loop is present
   exactly when the handler that needs it is installed. The grant teardown stays
   **inline**: it is thread-safe and it is the half that must be true the instant the
   ceiling lands. Only the notification crosses the thread boundary.
5. **Fail-closed, and not permanently dead.** A governance-evaluation error at install
   resolves to denied, and the flag's initial value is denied. It is never observed,
   because a read with nothing pushed yet bootstraps once through `current_context()` —
   which composes and installs the standalone default, and `build_default_context` loads
   the security policy, so a real deny is seen there too. A host whose context refuses to
   compose leaves the verdict denied, which is the safe direction.
6. **One install deliberately does not notify:** the lazy default inside
   `current_context()`. It is reached from *inside* a governance read (the profile store
   resolves the active context for its freshness key), so a hook that reads governance
   re-enters a store that is mid-load and is handed its fail-closed "not loaded" answer —
   a verdict about nothing, cached as the truth. It needs no hook either: nothing can
   hold a grant before the first resolve, and that resolve is what triggers the lazy
   install. `test_the_silent_lazy_install_still_yields_the_real_ceilings_verdict` pins
   that this is not a hole.

**Deleted symbols** (`src/kiro_crew/safety_override.py` unless noted):

- `_yolo_policy_cache`
- `_yolo_policy_refresh`
- `_yolo_policy_lock`
- `_YOLO_POLICY_TTL`
- `_YOLO_PERMITTED`, `_YOLO_DENIED`, `_YOLO_UNKNOWN`
- `yolo_policy_verdict()`
- `_schedule_yolo_policy_refresh()`
- `_resolve_yolo_policy_blocking()`
- `_resolve_yolo_policy_locked()`
- `_governance_generation()`
- `reset_yolo_policy_cache()` → replaced by `reset_yolo_policy_state()`
- `resolve_disabled_approval_modes_blocking()` → `cached_disabled_approval_modes()` is
  now the only form, because it no longer touches the filesystem
- `test/test_approval_modes_enforcement.py`: `TestAPolicyChangeIsNotBoundedByTheTTL`,
  `TestUNKNOWNNeverDestroysAScopedGrant`, `TestAnInFlightRecordCannotWedgeTheRefresh`,
  `TestTheEndpointNamesTheRealCause`, and the generation-stamp / monotonic-clock cases
  that existed only to pin cache freshness

Added: `yolo_policy_permits()` (the memory read), `_on_ceiling_installed`,
`_push_yolo_policy`, `_revoke_grants_for_policy_deny`, `_bootstrap_yolo_policy`,
`reset_yolo_policy_state`, `SafetyOverride.revoke_for_policy`, and
`platform.context.register_ceiling_install_hook`.

**Two API-surface consequences, stated plainly.** With `unknown` gone, the three
transports that split on it lose their "policy could not be read" branch: `api_chat_mode`
no longer returns `503 approval_mode_policy_unreadable`, and the two Slack paths no
longer post the "governance policy could not be read" line. An unreadable policy is
resolved to a deny at install time, so at request time the honest answer is the same
audited refusal a real deny gets. Nothing in `website/` consumed that code.

**Inherited slot trust is SUSPENDED before the ceiling publishes, and restored only
if the new ceiling still permits.** The verdict mask closes the resolve window for
`is_active()`, but `admission.parent_trusted` never reads `is_active()` — it reads the
slot's `approval_policy` directly, and that was cleared only after a deny had been
resolved. So for the width of one governance resolution a spawn from a slot carrying
the override's inherited `"auto"` was auto-approved against a ceiling that may deny. A
third seam, `SafetyOverride.on_policy_suspend`, is called by the invalidate hook (with a
live grant) and blanks the override's own inherited `"auto"` on the slots, returning a
restore. The install hook calls that restore on a permitting resolve and drops it on a
deny, where `on_policy_revoked` makes the clear permanent. Standing `_trust` /
`_trust_reads` slots are never touched, and the shared channel-trust mapping is not
suspended (it gates a tool in an already-running turn — recoverable, audited — not
spawn admission). The restore is **conditional on the grant that motivated it still
being the one in force**: the suspension records `SafetyOverride.grant_epoch()` (moves
on every activate *and* deactivate), and a permitting resolve drops the restore when the
epoch has moved — otherwise an operator's explicit `!yolo off` landing inside the resolve
would be undone, resurrecting `"auto"` on exactly the read `parent_trusted` makes. The
restore is also **conditional per slot**: it writes `"auto"` back only to a slot that
still exists, still carries no standing `_trust` / `_trust_reads`, and whose policy is
still the empty string the suspension left — because `trust_reads`, `trust` and `normal`
all write this same policy mid-resolve, and restoring over a `trust_reads` slot would
upgrade read-only trust to full auto-approve. Both handlers are module-level
(`_suspend_override_derived_trust`, `_clear_override_derived_trust`), wired via
`functools.partial` like #8858's Slack notifier, so they are driven against a real
`DashboardState` in tests rather than grepped.

**Inherited trust is cleared BEFORE the grant flag drops.** The grant and its inherited
half live in different stores and cannot be written atomically, so one goes first — and
the two orderings fail in opposite directions. Grant-first leaves the slots at
`approval_policy="auto"` for the statements in between, which `admission.parent_trusted`
reads directly, so a spawn in that gap is auto-approved against the denying ceiling and
nothing un-spawns it. Inherited-first inverts it: the spawn path is already closed while
only the grant flag trails, so a tool call there is auto-approved a few instructions
longer and the deny lands microseconds later, already audited. The unrecoverable
direction is the one that gets closed. Doing it under one lock instead would mean
holding `_lock` across `set_approval_policy` — session-store I/O on the lock every
per-tool-call `is_active()` contends, which is the stall this design removes. The inherited clear (and the
pre-publication suspend) run only when the **session-wide** grant is live: a scoped
grant (taskrunner run, Issue Radar crew) writes no slot or channel trust, so a deny whose
only live grant is scoped revokes that scope and touches nothing else — running the clear
there would empty the shared channel-trust mapping and revoke an independent Trust press
on an unrelated session.

**Only the NOTIFICATION is deferred; the inherited-trust teardown is not.** Dropping the
grant flag is not the whole revocation, and neither is scheduling the handler that
finishes it: `admission.parent_trusted` reads a session's `approval_policy == "auto"`
directly, so while that reset waited for a loop turn a spawn was auto-approved against
the denying ceiling — and the subagent it launched is not un-spawned by the cleanup that
arrives afterwards. So the dashboard's expiry handler is split in two:
`_clear_override_derived_trust` (the slot policies and the shared channel-trust mapping —
state only, thread-safe, idempotent) and the notifier that broadcasts and DMs. A policy
revocation runs the state half **inline**, on whichever thread installed the ceiling,
via a new `SafetyOverride.on_policy_revoked`, and only then schedules the notifier onto
the loop. A TTL lapse still reaches the state half through the notifier, so that path is
unchanged.

**Invalidation is the FIRST phase of an install, not the second.** `_install` now runs
a pre-publication invalidate hook, then assigns `_ACTIVE`, then runs the install hooks
that resolve the real verdict. Publishing first and re-resolving after left a window as
wide as one governance resolution (`iterdir` + a per-file `stat`) in which the denying
ceiling was already in force and `is_active()` still returned the permit resolved under
the ceiling just retired — so a tool call landing there was auto-approved against a
policy that denies it, with nothing to undo afterwards because the tool had already run.
The invalidate hook only **masks** (no revocation: the incoming ceiling has not been
read yet, and most installs permit yolo), and it forces the resolved flag so the next
read cannot bootstrap against the *outgoing* ceiling and write its permit back over the
mask.

**The arming commit is transactional with the revocation.** A gate that reads the
verdict and a commit that records the grant are a check and an act, and the
fail-closed SEL audit sits between them as a synchronous filesystem write -- long
enough for a denying ceiling to be installed in the gap, whose `revoke_for_policy`
then runs past a grant that does not exist yet. So both arming paths re-read the
verdict **inside `_lock`** at the commit point (via `_yolo_policy_permitted_now()`,
which deliberately does not bootstrap, because bootstrapping under `_lock` would
re-enter that non-reentrant lock through the install hook), and the push writes the
denied verdict **before** taking the same lock to revoke. Every interleaving then
lands safely: a commit that reads a permit did so before the flag was written, so the
revoke's later acquisition observes the committed grant; a revoke that got the lock
first leaves the flag denied, so the commit refuses.

And because the caller acts on the *result* rather than on the grant -- the dashboard
writes `approval_policy="auto"` onto its slots when it reads `active=True`, and
`admission.parent_trusted` reads that policy directly -- both paths also report from
live state through one shared `_committed_grant_survives()` check, so a grant revoked
after its commit is reported as refused instead of putting back the inherited trust
the revocation had just cleared.

That check cannot cover a deny landing *after* the arm returns, because the caller's
policy write happens outside the lock the revocation takes. So the one grant-derived
`auto` write for the YOLO path — the approval card in `chat_handlers` — reconciles
itself: after writing, if the verdict now denies it clears the slots it just set,
preserving standing trust on the same rule `_on_override_expired` uses. The two halves
are complete together — a write landing before the revocation's cleanup is cleared by
that cleanup, and one landing after, or interleaved with it, is cleared here.
(`api_chat_mode`'s yolo branch writes no slot policy, so it needs nothing.)

**Deviation from the issue's plan, deliberate.** #8848 lists the `asyncio.to_thread`
offloads at arming for deletion, on the premise that they existed only because arming did
a governance read. They did not exist *only* for that: arming's fail-closed SEL audit is
still a synchronous filesystem write, so removing the wrappers in `taskrunner.py` and
Issue Radar's three `sync_trust` calls would put that write back on the gateway's event
loop, and both startup paths additionally still read config and resolve the
`yolo_duration` scope (a different scope, untouched here). So those offloads stay,
`crew_runtime.py` is not in this diff at all — which also makes the #8851 rebase a no-op —
and the offloads that *do* go are the ones wrapping calls that are now pure memory reads
(`chat_handlers` ×3, `slack/events.py`, `slack/handler.py`, and the disabled-modes read
inside `handlers_system._yolo_duration_fields`). `TestNothingResolvesGovernanceOffTheInstallPath`
pins the property the issue was actually after: arming performs no governance read.

## Tests

`test/test_approval_modes_enforcement.py` is rewritten around the new shape (33 cases).
New coverage, each mutation-verified:

| Test | Locks in |
|---|---|
| `test_a_deny_install_revokes_a_live_grant_and_fires_the_callback_once` | the revocation runs at install, and repeated consults cannot re-fire the teardown |
| `test_a_permitting_install_leaves_a_live_grant_alone` | an install that still permits YOLO revokes nothing (central distribution re-installs constantly) |
| `test_a_raising_governance_layer_resolves_to_denied` / `..._still_revokes_a_live_grant` | fail-closed at install, for both the verdict and the teardown |
| `test_the_first_read_without_an_install_does_not_leave_yolo_dead` | the bootstrap resolves rather than serving the fail-closed initial value |
| `test_the_silent_lazy_install_still_yields_the_real_ceilings_verdict` | skipping the hook on the lazy default is not a hole — a denying ceiling composed there is still seen |
| `test_a_ceiling_installed_before_registration_is_still_resolved` | the late-import ordering |
| `test_a_context_reset_forgets_the_verdict_rather_than_keeping_it` | a deny cannot outlive the ceiling that issued it |
| `test_an_off_thread_install_schedules_the_callback_onto_the_loop` | the #8849 notification actually reaches the loop; the teardown is already done when the install returns |
| `test_no_recorded_loop_means_the_callback_runs_inline` | a sync CLI/test still gets the callback |
| `test_the_admission_predicate_stops_reading_auto_after_a_deny_install` | **#8849 directly**: `sessions.get_approval_policy(parent_key)` stops reading `"auto"` |
| `TestADenyLandingMidArmDoesNotLeaveAGrantBehind` (5 cases) | a deny installed *during* the audit refuses both the session-wide and the scoped arm; the verdict is written before the revocation runs (the ordering the under-lock re-check depends on); a grant revoked after its commit is not reported active; the shared survival check reads both kinds of grant |
| `TestTheVerdictFailsClosedWhileANewCeilingIsBeingResolved` (4 cases) | a reader inside the resolve window is denied; the mask runs while `installed_context()` still answers the OUTGOING ceiling (the ordering itself); a permitting install restores the verdict it masked; the mask fires no teardown |
| `TestTheApprovalCardDoesNotRestoreTrustAfterADeny` | a deny landing mid-write leaves no slot at `approval_policy="auto"`, and standing trust survives |
| `TestTheDashboardInheritedTrustHandlers` (7 cases) | the real handlers against a real `DashboardState`: suspend blanks inherited `"auto"` and spares standing trust; restore refuses a slot moved to `trust_reads`, a slot whose policy some other owner wrote, and a removed slot; suspend returns None with nothing to suspend; the clear survives a slot removed mid-walk; both handlers are wired |
| `TestInheritedTrustIsSuspendedWhileANewCeilingResolves` (7 cases) | a spawn-admission read sampled *inside* the resolve sees no inherited `"auto"`; a permitting install restores it exactly; a denying install never calls the restore; an explicit revoke landing inside the resolve is not undone by the restore; the epoch moves on deactivate not only activate; nothing is suspended without a grant; a raising suspend does not break the install |
| `test_a_scoped_only_deny_revokes_the_scope_but_clears_no_inherited_trust` | a deny with only a scoped grant live revokes the scope and runs neither the suspend, the clear, nor the notice |
| `test_inherited_trust_is_cleared_before_the_grant_flag_drops` / `test_no_grant_means_no_inherited_clear_and_no_notice` | the clear runs while the grant is still standing (sampled from inside it), and a deny install with nothing armed touches no inherited state |
| `test_the_inherited_trust_teardown_is_not_deferred` | the state half runs on the INSTALLING thread while the notification runs on the loop — asserted by thread identity, which is the timing-independent form of "inline vs deferred" |
| `test_a_raising_sync_teardown_does_not_stop_the_notification` / `test_the_notifier_still_runs_the_inherited_teardown` | the two halves are independent, and the TTL-lapse path keeps its teardown (source-level guard, since the handler is a closure inside `start_dashboard`) |
| `test_the_teardown_iterates_a_snapshot_of_the_slots` | the teardown iterates a snapshot, so a concurrent slot change cannot raise mid-loop and leave the remaining slots auto-approved |
| `test_a_resolve_failure_is_visible_at_warning_level` | an install-time resolve failure logs at WARNING and names the scope, so the cause of a fail-closed deny is not invisible |
| `TestOnlyOneSurfaceWritesGrantDerivedTrust` (2 cases) | a ratchet on the reconcile obligation: the set of files pairing an arm with an `approval_policy="auto"` write is declared, and the declared writer must still carry its post-write verdict re-read |
| `TestNothingResolvesGovernanceOffTheInstallPath` (5 cases) | a tripwire on `approval_mode_permitted` proves the hot predicate, both arming gates, the scoped consult points and the status reader never resolve |
| `test_a_governance_error_is_also_a_refusal` | the endpoint's 403-not-503 behaviour after the three-state removal |

Kept and adapted: the audited-refusal cases, the per-branch mid-session-deny table, the
declared-grant revoke, the explicit-off-is-not-policy-filtered pair, the
refused-scoped-arm case, and the lapsed-grant-not-torn-down-twice case.

`test/test_governance_distribution.py::test_a_swap_bumps_the_generation_and_reloads_a_warm_store`
moves its reload spy ahead of the install: a ceiling install now warms the profile store
eagerly, because the hook reads it. The invariant is unchanged — one reload per ceiling,
no snapshot composed against the retired one is ever served — only who triggers it.

`test/conftest.py` and `test/test_slack_handler_coverage.py` follow the rename.

**Mutation verification.** Forty mutations, thirty-nine caught: hook never fires; push
does not revoke on deny; push fails open on a governance error; revoke skips scoped
grants; callback runs inline instead of on the recorded loop; bootstrap never resolves;
`is_active` drops its policy mask; `reset_context` keeps the pushed verdict; either
commit skips its under-lock re-check; the push revokes before writing the verdict;
`activate` reports a revoked grant as active; the survival check ignores either kind of
grant; the ceiling is published before invalidating (the reported ordering); the
invalidate hook does not mask; the mask also revokes; the approval card does not
reconcile its trust write; the reconcile clears standing trust too; the inherited
teardown is deferred with the notification; a raising sync teardown swallows the
notification; the notifier drops the teardown the TTL path depends on; the teardown
iterates the live slot dict; the resolve failure drops back to `debug`; the declared
writer loses its reconcile; the grant is torn down before the inherited clear; the
no-grant guard is dropped; the guard narrows to the session-wide grant only; the
invalidate hook never calls suspend; a permitting install never restores; a denying
install restores anyway; the restore ignores the epoch check; the epoch is blind to
deactivate; the restore ignores the slot's standing flags; the restore ignores a changed
policy; the restore ignores a removed slot; the clear iterates the live slot dict; the clear is gated on any grant instead of the
session-wide one; the suspend likewise; scoped grants stop being revoked.

The one not caught is stated rather than papered over: **removing the survival check
from `activate_scoped`'s call site alone** is invisible to the suite. That path has no
I/O between its commit and its return, so a mid-flight deny cannot be driven through it
deterministically -- the guard's own logic is covered directly
(`test_the_survival_check_reads_both_kinds_of_grant`, which mutation-catches both of its
branches) and the call site is a one-line, symmetric application of it.

## Manual verification

N/A — unit coverage sufficient. Every path is in-process module state plus the
governance stack; the off-thread install case is exercised for real via
`asyncio.to_thread` rather than simulated, and the deny-lands-mid-arm cases install the
ceiling from inside the audit write, which is where the gap actually is.

## Related Issues

Closes #8848
Closes #8849

## Advisory review findings answered here

Both Design Review watch items are fixed rather than deferred, because each protects a
guarantee this PR claims:

Collapsing the UNKNOWN verdict folded "policy could not be read" into "policy denies",
so an operator with no policy at all can now see the organization-policy refusal for a
governance-evaluation failure — the phantom-organization misattribution this code fixed
once already. Enforcement stays collapsed (a deny is the only fail-closed answer), so
the cause now surfaces at **WARNING** naming the scope and the consequence, instead of a
`logger.debug`.

The grant-derived `approval_policy="auto"` write is not owned by the module that revokes
it, so a future transport writing inherited state from an `ActivationResult` could
reopen #8849 by simply not knowing about the reconcile. That obligation is now a
**ratchet**: the set of files pairing an arm with an `"auto"` write is declared, a
newcomer fails the test until its author writes down that it reconciles, and the declared
writer must still carry its post-write verdict re-read. Same declared-map-plus-scan shape
as `PEEK_CALLERS` and the shared-path floor — a forcing function, not a proof.

First Principles Review's `CONCERNS` is answered in a disposition comment.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a value that only changes on a discrete event is cached behind a TTL, so the
mechanism has to invent a "not yet resolved" third state and every reader needs its own
rule for collapsing it — the fix is to push on the event, not to shorten the TTL.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (`docs/system-specs/modules/governance.md`)
- [x] No secrets, credentials, or internal references in the diff
