### PR TITLE
fix(auto-improvement): stop a junction widening the do-not-pollute snapshot

### DIFF
--- a/src/kiro_crew/apps/builtins/auto_improvement/spine/pollute.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/spine/pollute.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
+from kiro_crew.platform_compat import is_link_or_junction
+
 # A boot callable: boots the measurement runtime once and tears it down. It returns
 # nothing the spine inspects — the WHOLE point is that the spine measures the host-state
 # delta the boot leaves behind, not anything the boot reports. Target-supplied (opaque).
@@ -75,8 +77,15 @@ def _hash_path(path: Path, exclude: frozenset[str] = frozenset()) -> str:
 
     For a directory we hash the sorted (relpath, size, mtime_ns, content-hash) of every
     file beneath it — so a new/removed/edited file anywhere in the tree changes the hash.
-    For a file we hash its bytes. Symlinks are recorded by their target string (a flipped
-    symlink is a change) without following them (avoids escaping the snapshot scope).
+    For a file we hash its bytes. Links are recorded by their target string (a flipped
+    link is a change) without following them (avoids escaping the snapshot scope).
+
+    "Link" is :func:`platform_compat.is_link_or_junction`, not ``Path.is_symlink``. A
+    Windows directory JUNCTION answers ``False`` to ``is_symlink`` and — unlike a
+    symlink, which ``rglob`` deliberately does not recurse into — is DESCENDED THROUGH
+    by the walk. Naming only symlinks therefore let the hash absorb the link target's
+    whole tree: the snapshot escaped its own root, and any unrelated change under that
+    target read as a leak by the measured runtime.
 
     ``exclude`` is an opaque set of absolute subpaths to SKIP during a directory walk.
     Its sole purpose is to ignore writes the ORCHESTRATOR itself makes inside a snapshot
@@ -90,11 +99,11 @@ def _hash_path(path: Path, exclude: frozenset[str] = frozenset()) -> str:
         # The whole path is excluded — hash to a constant so its before/after are equal
         # regardless of what the orchestrator writes inside it.
         return "\0excluded\0"
-    if not path.exists() and not path.is_symlink():
+    if not path.exists() and not is_link_or_junction(path):
         return "\0missing\0"
     h = hashlib.sha256()
-    if path.is_symlink():
-        # Record the link target, not the resolved tree (a re-pointed symlink is a write).
+    if is_link_or_junction(path):
+        # Record the link target, not the resolved tree (a re-pointed link is a write).
         h.update(b"symlink\0")
         h.update(str(Path(path).readlink()).encode("utf-8", "surrogatepass"))
         return h.hexdigest()
@@ -105,12 +114,20 @@ def _hash_path(path: Path, exclude: frozenset[str] = frozenset()) -> str:
     if path.is_dir():
         h.update(b"dir\0")
         # Walk deterministically (sorted) so the hash is stable across runs.
+        link_roots: list[Path] = []
         for child in sorted(path.rglob("*"), key=lambda p: str(p)):
+            if any(root in child.parents for root in link_roots):
+                # Inside a link already recorded by target. rglob does not recurse into
+                # a POSIX symlink, but it DOES descend through a Windows junction, so
+                # without this the walk hashes the target tree and the snapshot escapes
+                # its own root.
+                continue
             if _is_excluded(child, exclude):
                 continue  # orchestrator-owned subtree — not the measured runtime's write
             rel = child.relative_to(path)
             try:
-                if child.is_symlink():
+                if is_link_or_junction(child):
+                    link_roots.append(child)
                     h.update(b"L\0")
                     h.update(str(rel).encode("utf-8", "surrogatepass"))
                     h.update(str(Path(child).readlink()).encode("utf-8", "surrogatepass"))

--- a/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pollute.py
+++ b/src/kiro_crew/apps/builtins/auto_improvement/tests/test_pollute.py
@@ -19,7 +19,34 @@ from pathlib import Path
 
 import pytest
 
+from kiro_crew import platform_compat
 from kiro_crew.apps.builtins.auto_improvement.spine import pollute
+from kiro_crew.platform_compat import unlink_link_or_junction
+
+
+def _make_dir_link(link: Path, target: Path) -> None:
+    """Create a reparse point at *link* resolving to the directory *target*.
+
+    A local mirror of ``test/conftest.py::make_dir_link``, which these in-package
+    tests cannot import: only the ``test/`` testpath gets that conftest.
+
+    ``platform_compat.symlink_or_junction`` is deliberately NOT used here. It
+    tries ``os.symlink`` FIRST and falls back to a junction only where the
+    privilege is missing, so a runner with Developer Mode or an elevated shell
+    gets a SYMLINK and the junction arm these tests exist for is never exercised
+    -- silently, while still reporting green. ``CreateJunction`` is what that
+    helper falls back to, taken directly so the link type is not left to the host.
+    """
+    if platform_compat.IS_WINDOWS:
+        # Function-local because the module does not exist off Windows, so a
+        # top-level import would break collection on POSIX. Both in-repo callers
+        # of CreateJunction do the same -- test/conftest.py::make_dir_link and
+        # platform_compat.symlink_or_junction.
+        import _winapi
+
+        _winapi.CreateJunction(str(target), str(link))  # type: ignore[attr-defined]
+        return
+    link.symlink_to(target, target_is_directory=True)
 
 
 def _symlinks_supported(tmp: Path) -> bool:
@@ -305,3 +332,71 @@ class TestTheGateFailsLoudlyRatherThanSilently:
         result = pollute.run_do_not_pollute(paths=[], boot=lambda: None)
         assert result.zero_diff is True
         assert result.snapshotted == 0
+
+
+class TestALinkDoesNotWidenTheSnapshot:
+    """A link inside a watched tree is recorded BY TARGET and never followed, so the
+    snapshot cannot escape its own root -- and a flipped link is still a write.
+
+    Both directions were broken for a junction: the walk descended through it (a write
+    outside the root read as a leak) AND it was hashed as a plain directory (re-pointing
+    it read as no change at all).
+
+    Staged with ``_make_dir_link`` -- a plain symlink on POSIX, a real directory
+    JUNCTION on Windows -- so these run on every platform and the junction arm is
+    the one actually exercised there. The symlink tests above are gated on
+    ``_symlinks_supported`` and SKIP on an ordinary Windows host, which is exactly
+    where the junction case lives.
+    """
+
+    def test_the_staged_plant_is_really_a_junction_on_windows(self, tmp_path: Path) -> None:
+        """Guards the guard: if the plant were something ``Path.is_symlink()`` already
+        catches on this host, the two tests below would stop exercising the junction arm
+        and quietly cease to be evidence."""
+        target = tmp_path / "target"
+        target.mkdir()
+        link = tmp_path / "link"
+        _make_dir_link(link, target)
+        assert platform_compat.is_link_or_junction(link)
+        if os.name == "nt":
+            assert not link.is_symlink(), "expected a junction -- the arm under test"
+
+    def test_a_write_under_a_linked_child_is_not_a_leak(self, tmp_path: Path) -> None:
+        """The defect. ``rglob`` deliberately does not recurse into a symlink, but it
+        DOES descend through a junction -- so on Windows the walk pulled the link
+        target's whole tree into the hash. An unrelated write out there, by anything on
+        the machine, then read as a leak by the measured runtime and blocked the run."""
+        home = tmp_path / "home"
+        watched = _seed(home)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "unrelated.txt").write_text("before", encoding="utf-8")
+        _make_dir_link(watched / "link", outside)
+
+        def write_outside_the_watched_root() -> None:
+            # Not under `watched`. Only reachable from it by following the link.
+            (outside / "unrelated.txt").write_text("after", encoding="utf-8")
+
+        result = pollute.run_do_not_pollute(paths=[watched], boot=write_outside_the_watched_root)
+        assert result.blocked is False, "a write outside the watched root is not a leak"
+
+    def test_a_repointed_link_still_blocks(self, tmp_path: Path) -> None:
+        """The same defect in the opposite direction. A junction was hashed as a plain
+        directory (a ``D`` marker plus its relative name), so re-pointing one to another empty
+        directory produced an IDENTICAL hash and the flip was invisible -- a real host
+        write the gate was built to catch, passing as hermetic. Recording it by target
+        restores the symlink behaviour the docstring already promised."""
+        home = tmp_path / "home"
+        watched = _seed(home)
+        one = tmp_path / "one"
+        one.mkdir()
+        two = tmp_path / "two"
+        two.mkdir()
+        link = watched / "link"
+        _make_dir_link(link, one)
+
+        def repoint() -> None:
+            unlink_link_or_junction(link)
+            _make_dir_link(link, two)
+
+        assert pollute.run_do_not_pollute(paths=[watched], boot=repoint).blocked is True


### PR DESCRIPTION
## Problem / Motivation

`spine/pollute.py::_hash_path` is the blocking do-not-pollute gate: it snapshots the host paths the measurement runtime may write under, boots that runtime once, re-snapshots, and refuses the whole experiment on any diff. Its contract for links is explicit in the docstring:

> Symlinks are recorded by their target string (a flipped symlink is a change) **without following them (avoids escaping the snapshot scope)**

The predicate was `Path.is_symlink()`, which is `False` for a **Windows directory junction**. Both halves of that contract broke there, in opposite directions:

* **The snapshot escaped its own root.** `pathlib` deliberately does not recurse into a symlink, but it *does* descend through a junction — measured:

  ```
  rglob under root: ['j', 'j\secret', 'j\secret\leak.txt']
  descended through the junction? True
  ```

  So the walk hashed the link target's whole tree. Any unrelated write under that target — by anything on the machine, not the measured runtime — then read as a leak and blocked the run.

* **A re-pointed junction became invisible.** A junction was hashed as a plain directory (a `D` marker plus its relative name), so flipping one to another empty directory produced an *identical* hash. A real host write the gate exists to catch passed as hermetic.

## Why it matters

This gate decides whether an autonomous run may start at all. The first failure makes it refuse clean runs for a reason the operator cannot see in any diff — the changed content is outside every watched path. The second is worse in kind: it is a leak the detector was built to catch, reported as hermetic.

The file's own test module opens by noting that a detector which always answers "hermetic" *"passes every test a green-path suite can write, and is worthless"*. That is precisely the state of the re-pointing case on Windows.

## What changed (motivation → approach → change)

Root cause is the link **predicate**, not the walk.

Both the top-level check and the per-child check now route through `platform_compat.is_link_or_junction` — the shim-table row for this exact question (`AGENTS.md`: *"Detect/remove a dir link → `is_link_or_junction(path)` NOT `path.is_symlink()` (misses a Windows junction)"*). That alone fixes the re-pointing case, because the existing record-by-target branch then runs; `readlink()` resolves a junction on Windows, so nothing else in that branch needed changing.

Fixing the *escape* needs one more step, because `rglob` has already yielded the descendants by the time the link is seen. A `link_roots` list suppresses any child that sits under a link already recorded by target. The walk is **already** sorted by path string for determinism, and that ordering is what puts a link ahead of everything beneath it — so a single pass is sufficient and no second traversal is introduced.

Exclusion ordering is deliberately unchanged: an excluded link is skipped before it is recorded, and its descendants are still excluded because `_is_excluded` resolves each child and prefix-matches against the resolved exclude set.

## Tests

`tests/test_pollute.py`. The plant is staged with a local mirror of `test/conftest.py::make_dir_link`, which calls `_winapi.CreateJunction` **unconditionally** on Windows — a plain symlink on POSIX, a real directory junction on Windows — so these run on **every** platform *and the junction arm is the one actually exercised there*.

It is deliberately **not** `platform_compat.symlink_or_junction`: that tries `os.symlink` FIRST and falls back to a junction only where the privilege is missing, so a runner with Developer Mode gets a SYMLINK and the junction arm is never exercised — silently, while still reporting green. The first head of this PR shipped that mistake; a *guard-the-guard* test asserting the plant really was a junction is what caught it, on the Windows CI shard. It is mirrored rather than imported because only the `test/` testpath gets that conftest.

**Both behavioural tests fail on `origin/main`:**

* `test_a_write_under_a_linked_child_is_not_a_leak` — `assert True is False`: main blocks on a write that is outside the watched root and only reachable by following the link.
* `test_a_repointed_link_still_blocks` — `assert False is True`: main does not notice the flip at all.

**Green on both sides:**

* `test_the_staged_plant_is_really_a_junction_on_windows` — guards the guard: it asserts the plant really is a junction on Windows, so the two tests above cannot quietly stop exercising the junction arm. This is the test that caught the `symlink_or_junction` mistake on the first head.

Local (Windows, repo-pinned toolchain): `test_pollute.py` 21 passed / 4 skipped (the 4 are the pre-existing symlink tests). Full `auto_improvement` suite: **1042 passed / 64 skipped / 0 failed**. `flake8` clean; `scripts/check_black_formatting.py` passes in scope (the one file it flagged was formatted with `black --target-version py310`, a three-line change confined to a line this PR added).

## Manual verification

N/A — unit coverage sufficient: the change is one predicate plus a descendant filter inside a single function, and the tests drive the real `run_do_not_pollute` against a tmp fake-HOME with the real plant on the affected platform, as the module's own test conventions require.

## Related Issues

None — found by source review of the `is_symlink()`-versus-junction seam after #8766 and #8767.

## Pattern harvest

Rule candidate: `semgrep`
Pattern: `Path.is_symlink()` used to decide whether a directory walk may descend. It is `False` for a Windows junction, and — unlike a symlink, which `pathlib` refuses to recurse into — a junction is traversed, so the walk silently leaves its intended root. Two distinct failures follow from the one predicate: content from outside the root enters the result, and the link's own identity (its target) is never recorded. The repo's shim table already names `is_link_or_junction`; the residual risk is any walk that predates it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
