### PR TITLE
fix(papyrus): refuse a junctioned project config, not just a symlinked one

### DIFF
--- a/src/kiro_crew/apps/builtins/papyrus/backend/store.py
+++ b/src/kiro_crew/apps/builtins/papyrus/backend/store.py
@@ -335,11 +335,20 @@ def _config_path(project: Path) -> Path | None:
     #
     # Same reasoning as the generated-artifact guard in `latex`: for a path the app
     # writes by name, the presence of a link is itself the problem.
+    #
+    # `is_reparse_link`, not `is_symlink()`: a Windows directory JUNCTION is a reparse
+    # point `is_symlink()` does not report, and it is the one link type a user can
+    # create there without elevation, so a symlink-only check makes this refusal
+    # POSIX-only -- which is exactly what that helper's docstring says every guard in
+    # this module must avoid. A junction is directory-only, so it cannot stand in for
+    # the `.papyrus.json -> paper.tex` overwrite above; what it does is slip past the
+    # refusal, take the write no further than an opaque later failure, and lose the
+    # warning that says why.
     candidate = project / PROJECT_CONFIG_FILENAME
     try:
-        if candidate.is_symlink():
+        if is_reparse_link(candidate):
             logger.warning(
-                "papyrus: refused a symlinked project config in %s", project.name
+                "papyrus: refused a linked project config in %s", project.name
             )
             return None
     except OSError:  # pragma: no cover - defensive

--- a/test/test_papyrus_store.py
+++ b/test/test_papyrus_store.py
@@ -585,6 +585,30 @@ class TestProjectConfigIsContained:
         store.write_project_config(project, {"main_file": "x.tex"})
         assert secret.read_text(encoding="utf-8") == original
 
+    def test_a_junctioned_config_is_refused(self, project: Path, tmp_path: Path) -> None:
+        """The two tests above skip on Windows, where os.symlink needs
+        SeCreateSymbolicLinkPrivilege -- so the one link type an unprivileged
+        Windows user CAN create had no coverage here at all.
+
+        The link points INSIDE the project on purpose: `safe_child` answers "does
+        this resolve inside the project", and an in-project link satisfies it, so
+        an out-of-project link is refused by containment whether or not the link
+        guard fires and cannot tell the two builds apart. Asserted on
+        `_config_path` rather than `read_project_config`, because reading a
+        directory fails anyway and the outcome would look right while the guard
+        was never consulted.
+
+        A junction is directory-only, so it cannot stand in for the
+        `.papyrus.json -> paper.tex` overwrite the symlink tests cover; what it
+        does is slip past a refusal this module documents as link-type-agnostic.
+        """
+        inside = project / "chapters"
+        inside.mkdir(exist_ok=True)
+        (project / store.PROJECT_CONFIG_FILENAME).unlink(missing_ok=True)
+        make_dir_link(project / store.PROJECT_CONFIG_FILENAME, inside)
+
+        assert store._config_path(project) is None
+
     @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation needs privilege on Windows")
     def test_an_in_project_config_symlink_cannot_overwrite_the_manuscript(
         self, project: Path


### PR DESCRIPTION
## Problem / Motivation

`store.is_reparse_link` exists in this module precisely because a Windows directory junction is a reparse point `is_symlink()` does not report, and its docstring states the rule it was added to enforce:

> every place this module refuses a link at a name KiroCrew owns has to refuse a junction too, or the refusal is POSIX-only
>
> Shared so the project-entry guard and `gitops`'s attributes guard cannot drift apart on which link types they cover.

It is used at `gitops.py:287-289`, `latex.py:617`, `store.py:215` and `store.py:503` — five sites, each carrying a comment explaining why. **`_config_path` was the one site still asking `is_symlink()`.**

Measured on `origin/main` (`9f3c07dc7`), with a junction planted at `.papyrus.json` pointing at an in-project directory:

```
AssertionError: assert WindowsPath('.../projects/my-paper/chapters') is None
```

`_config_path` returns that resolved directory instead of `None`. The link guard does not fire, and `safe_child` cannot catch it either — an **in-project** link satisfies containment, which is the whole reason this guard sits *ahead* of containment rather than relying on it.

## Why it matters

The refusal is currently POSIX-only, for the one link type an unprivileged Windows user can create — `os.symlink` there needs `SeCreateSymbolicLinkPrivilege`, a junction needs nothing. So the platform where the plant is cheapest to stage is the platform with no guard.

**Scope, stated plainly:** a junction is directory-only, so it **cannot** stand in for the `.papyrus.json -> paper.tex` overwrite the symlink tests cover — a write would land on a directory and fail. What it does is slip past a refusal this module documents as link-type-agnostic, and lose the `logger.warning` that says why, so the failure surfaces later and opaquely instead of at the guard that was written to name it.

This is a completeness fix for the module, finishing what merged #8766 started on `latex.py`.

## What changed (motivation → approach → change)

One predicate: `candidate.is_symlink()` → `is_reparse_link(candidate)`, the module's own shared helper, with a comment matching the four sites that already call it. The warning text drops "symlinked" for "linked" now that both link types reach it.

**Zero unfixed siblings**, checked individually rather than asserted:

* `tectonic.py:550` — also pairs `is_file()` with `is_symlink()`, but it *requires* `is_file()`, which a junction fails, so it already declines.
* `store.py:183` is `is_reparse_link`'s own body; the remaining `is_symlink()` mentions in `latex.py:555` and `store.py:169` are prose in docstrings.

## Tests

`test/test_papyrus_store.py`, **one added test, 24 lines, no deletions**. The plant is staged with `test/conftest.py::make_dir_link` — the repo's own seam, already imported in this file — which calls `_winapi.CreateJunction` **unconditionally** on Windows. Note the reversed argument order, `(link, target)`.

It is deliberately **not** `platform_compat.symlink_or_junction`: that tries `os.symlink` FIRST and falls back to a junction only where the privilege is missing, so a runner with Developer Mode gets a SYMLINK and the junction arm is never exercised. The first head of this PR staged it that way and the Windows CI shard caught it.

The file's existing config-link tests are `@pytest.mark.skipif(sys.platform == "win32")` and therefore left the junction case with no coverage at all.

Two choices in the test are load-bearing, and a first draft got both wrong:

* It asserts on **`_config_path`**, not `read_project_config`. Reading a directory fails anyway, so the outcome would look correct while the guard was never consulted — a green test proving nothing.
* The junction points **inside** the project. An out-of-project link is refused by `safe_child`'s containment whether or not the link guard fires, so it cannot tell the two builds apart. In-project is the case the guard exists for.

**Red on `origin/main`:** `test_a_junctioned_config_is_refused` — the resolved `chapters/` directory in place of `None`.

**No guard-the-guard test is added here.** The first head had one; review correctly counted it as duplicate evidence, because `TestIsReparseLink::test_a_directory_link_is_a_reparse_link` already stages with `make_dir_link` and asserts `is_reparse_link(link) is True`. It proved no additional production contract, so it was removed rather than kept for symmetry.

Local (Windows, repo-pinned toolchain): `test_papyrus_store.py` **115 passed / 16 skipped**. `flake8`, `isort` and `scripts/check_black_formatting.py` all clean in scope.

**On formatting:** this file is in `.github/black-baseline.txt`. The first head ran `black` over it and carried ~15 unrelated reformatting hunks, which the baselined Black gate correctly failed. That is reverted — the diff is now purely additive.

## Manual verification

N/A — unit coverage sufficient: the change is a single predicate swap to an existing in-module helper, and the test stages the real plant on the affected platform through the repo's own link seam.

## Related Issues

None — found by source review while completing the `is_symlink()`-versus-junction seam after #8766.

## Pattern harvest

Rule candidate: `review-prompt`
Pattern: a module that introduces a shared, platform-correct predicate (here `is_reparse_link`) and converts *most* of its call sites leaves the unconverted ones strictly worse off than before — the helper's existence reads as proof the module is covered, so the remaining raw `is_symlink()` stops looking like a gap. When a helper's docstring says the sites "cannot drift apart", that is a claim to verify by enumeration at review time, not a guarantee. The check is cheap: grep the module for the raw call the helper replaces.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

<!-- PLACEHOLDER: The exact CLA wording will be supplied by OSPO before the first public PR.
     Do not invent CLA text — it will be added here once Legal provides it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
