### PR TITLE
fix: black-format test_ai_review_workflows.py (#8838)

### DIFF
--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -2091,7 +2091,9 @@ class TestUxReviewReadsTheScreenshotsBlindFirst:
         assert "every user-visible control this PR adds or changes is an evidence gap" in prompt
 
     @pytest.mark.parametrize("lane", UX_LANES)
-    def test_review_prompts_carry_no_expression_so_the_21000_cap_cannot_bite(self, lane: str) -> None:
+    def test_review_prompts_carry_no_expression_so_the_21000_cap_cannot_bite(
+        self, lane: str
+    ) -> None:
         """GitHub rejects the whole workflow file -- zero jobs, no error on the
         PR -- when any expression-bearing string exceeds 21000 characters. Both
         UX prompts sat at ~19000 WITH expressions before these rules were
@@ -2106,7 +2108,9 @@ class TestUxReviewReadsTheScreenshotsBlindFirst:
             args = with_["claude_args"]
             for value in args.split("\n"):
                 if "${{" in value:
-                    assert len(value) < 2000, f"{lane}: an expression-bearing claude_args line is {len(value)} chars"
+                    assert (
+                        len(value) < 2000
+                    ), f"{lane}: an expression-bearing claude_args line is {len(value)} chars"
         review = _step(lane, UX_REVIEW_STEP)["with"]
         system = _line_containing(review["claude_args"], "--append-system-prompt")
         assert "HEAD sha ${{" in system, f"{lane}: the HEAD sha is not handed to the reviewer"
@@ -2114,7 +2118,9 @@ class TestUxReviewReadsTheScreenshotsBlindFirst:
         # action's parser; the PR number must not be written as `#N` at a line
         # start, and no claude_args line may begin with `#`.
         for value in review["claude_args"].split("\n"):
-            assert not value.strip().startswith("#"), f"{lane}: claude_args line would be stripped as a comment"
+            assert not value.strip().startswith(
+                "#"
+            ), f"{lane}: claude_args line would be stripped as a comment"
         prompt = _flat(review["prompt"])
         assert "[UX-REVIEWED] <HEAD sha>" in prompt
         assert "copied verbatim from your system prompt" in prompt
@@ -2156,7 +2162,10 @@ class TestUxReviewReadsTheScreenshotsBlindFirst:
         assert "Read it FIRST" not in prompt
         # The fork head is never checked out, so the fork lane must not claim
         # to hand the reviewer a screenshot list or a report it cannot have.
-        system = _line_containing(_step("fork-ux-review.yml", UX_REVIEW_STEP)["with"]["claude_args"], "--append-system-prompt")
+        system = _line_containing(
+            _step("fork-ux-review.yml", UX_REVIEW_STEP)["with"]["claude_args"],
+            "--append-system-prompt",
+        )
         assert "ux-blind-read.md" not in system
         assert "ux-screenshots.txt" not in system
         assert "authentic.patch" in system
@@ -2231,7 +2240,9 @@ class TestUxReviewReadsTheScreenshotsBlindFirst:
             env=self._git_env(repo.parent),
         ).stdout.strip()
 
-    def test_the_evidence_step_copies_regular_images_under_opaque_names(self, tmp_path: Path) -> None:
+    def test_the_evidence_step_copies_regular_images_under_opaque_names(
+        self, tmp_path: Path
+    ) -> None:
         """Execute the ACTUAL evidence script. The blind reader is handed
         copies named shot-NN.<ext>, never the repository paths: an author-named
         `pinned-turn-chip.png` would prime it with the exact word the wall
@@ -2277,10 +2288,15 @@ class TestUxReviewReadsTheScreenshotsBlindFirst:
         ]
         # `git diff --name-only` orders by path, so the recording list is
         # byte-ordered too: c.webm sorts before restore.GIF.
-        assert clip_list.splitlines() == ["temp-screenshots/f/c.webm", "temp-screenshots/f/restore.GIF"]
+        assert clip_list.splitlines() == [
+            "temp-screenshots/f/c.webm",
+            "temp-screenshots/f/restore.GIF",
+        ]
         assert "screens=true" in output
 
-    def test_the_evidence_step_reports_no_screens_for_a_code_only_ui_change(self, tmp_path: Path) -> None:
+    def test_the_evidence_step_reports_no_screens_for_a_code_only_ui_change(
+        self, tmp_path: Path
+    ) -> None:
         repo = tmp_path / "repo"
         repo.mkdir()
         self._git(repo, "init", "-q")


### PR DESCRIPTION
## Problem / Motivation

Ratchet-gates CI on main fails on every run: `test/test_ai_review_workflows.py` is not black-formatted. The file is not listed in `.github/black-baseline.txt`, so the black ratchet gate requires it to stay clean, and it drifted (most likely via a merge that landed unformatted lines). Verified on main HEAD `424efa423`: `black --check --target-version py310` would reformat it, and `scripts/check_black_formatting.py` reports it as a new offender.

## Why it matters

The black ratchet gate is red on main, so via the `refs/pull/N/merge` mechanism every open PR pays for the drift: each PR's Ratchet-gates run fails regardless of its own diff, blocking unrelated work until main is clean again. Same class as issues #8803 and #8346.

## What changed (motivation → approach → change)

Symptom: Ratchet-gates red on main → root cause: one file drifted out of black formatting while being black-enforced (not baselined) → change: reformat exactly that file with the CI-pinned toolchain, `black==26.3.1 --target-version py310` (the same invocation `scripts/check_black_formatting.py` names). `scripts/check_black_formatting.py` reports no other drifted file at fix time, so the diff is exactly one file, 23+/7−, six hunks.

The change is cosmetic only, verified structurally: the before/after `ast.dump` outputs are byte-identical. In particular, the two reformatted multi-line `assert` statements keep the condition parenthesized with the message comma outside the parentheses, so neither became an always-true `assert (cond, msg)` tuple form (confirmed: zero `ast.Assert` nodes with a `Tuple` test in the head file).

## Tests

No test behavior changed (AST-identical reformat). `python -m pytest test/test_ai_review_workflows.py` passes: 389 passed. Local gates green with CI-pinned versions: `scripts/check_black_formatting.py` (passes, 0 offenders), `isort --check-only` (6.0.0), `flake8` (7.1.0), `mypy src/kiro_crew/` (1.14.1), plus `check_subprocess_encoding.py`, `check_brand_name.py`, `check_harness_parity.py`.

## Manual verification

N/A — the gate script and AST-equivalence check fully cover a formatting-only diff.

## Related Issues

Closes #8838

## Pattern harvest

Rule candidate: agents-md
Pattern: black drift on main recurs (#8346, #8803, #8838) because a merge can land unformatted lines in a non-baselined file; a pre-merge ratchet run on the merge ref (or a required fast-gate black check on every PR head) would stop the class at the door instead of billing every downstream PR.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
