### PR TITLE
docs: refresh packaged user docs and add missing feature pages

### DIFF
--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -20,9 +20,14 @@ How you talk to the Gateway depends on where your code runs:
   `fetch()` / a WebSocket. The full endpoint list is in
   [Gateway REST API Endpoints](#gateway-rest-api-endpoints).
 
-There is no published TypeScript gateway-client npm package. The `kirocrew-client`
-method names below describe the canonical Gateway API surface — the same
-endpoints any client (including raw `fetch`) talks to.
+There is no published TypeScript gateway-client npm package, and none is planned
+here — the camelCase names used throughout the sections below are **labels for
+Gateway endpoints**, not callable methods. Read them as endpoint identifiers.
+Two surfaces are real and callable: the `@kirocrew/app-sdk` hooks (documented in
+the next section, resolved from the host import map) and the shipped
+`kirocrew-client` Python package, whose actual method list is in
+[Python Client](#python-client). Anything named below that appears in neither is
+a Gateway endpoint you call directly with `fetch` or `aiohttp`.
 
 ## App SDK Hooks (dashboard UI)
 
@@ -262,11 +267,16 @@ that genuinely needs live app state is supplied by the host as an entry.
 
 ## Gateway API Surface
 
-The sections below document the canonical Gateway API surface as exposed by the
-`kirocrew-client` Python package (see the [Python Client](#python-client)
-section for the constructor and full method list). Method names are also a
-convenient way to refer to each endpoint — the same endpoints any client
-(including raw `fetch`) talks to.
+The sections below name the Gateway API surface. A name here is an **endpoint
+label**, not a guarantee that a client method exists for it: the shipped
+`kirocrew-client` Python package covers part of this surface, and
+[Python Client](#python-client) marks which part. For anything it does not
+implement, call the endpoint directly — the paths are in
+[Gateway REST API Endpoints](#gateway-rest-api-endpoints).
+
+The `Returns` column describes the response shape. It is not a TypeScript type:
+no TypeScript client ships, so `SlotInfo`, `GatewayStatus`, `SystemInfo` and
+their siblings are response-shape names rather than importable types.
 
 When `app_name` is set and no explicit auth is provided, the client auto-reads
 the app secret from `~/.kiro/crew/apps/{name}/.app_secret` and exchanges it
@@ -276,26 +286,26 @@ for a short-lived token via `POST /api/apps/{name}/token`.
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `authenticate()` | `Promise<boolean>` | Exchange app secret for token (auto-called if appName set) |
+| `authenticate()` | `boolean` | Exchange app secret for token (auto-called if appName set) |
 | `setToken(token)` | `void` | Manually set auth token on both HTTP and WS clients |
 
 ### Connection
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `ping()` | `Promise<boolean>` | Check if Gateway is reachable |
-| `getStatus()` | `Promise<GatewayStatus>` | Gateway health (version, uptime, slots, provider) |
-| `getSystemInfo()` | `Promise<SystemInfo>` | CPU, memory, disk metrics |
+| `ping()` | `boolean` | Check if Gateway is reachable |
+| `getStatus()` | `GatewayStatus` | Gateway health (version, uptime, slots, provider) |
+| `getSystemInfo()` | `SystemInfo` | CPU, memory, disk metrics |
 
 ### Chat Slots
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `createSlot(name, agent?)` | `Promise<SlotInfo>` | Create a new chat session |
-| `listSlots()` | `Promise<SlotInfo[]>` | List all active sessions |
-| `deleteSlot(slotId)` | `Promise<void>` | Remove a session |
-| `getSlotHistory(slotId, limit?)` | `Promise<{messages, total}>` | Get slot message history |
-| `sendMessage(slotId, message)` | `Promise<void>` | Send a message (validates length, auto-flushes pending context) |
+| `createSlot(name, agent?)` | `SlotInfo` | Create a new chat session |
+| `listSlots()` | `SlotInfo[]` | List all active sessions |
+| `deleteSlot(slotId)` | `—` (no body) | Remove a session |
+| `getSlotHistory(slotId, limit?)` | `{messages, total}` | Get slot message history |
+| `sendMessage(slotId, message)` | `—` (no body) | Send a message (validates length, auto-flushes pending context) |
 
 ### WebSocket Events
 
@@ -323,21 +333,21 @@ WebSocket event types: `chat_chunk`, `chat_done`, `chat_message`, `chat_error`,
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `spawn(task, agent?)` | `Promise<string>` | Spawn a background subagent |
-| `spawnMany(tasks, agents?)` | `Promise<string[]>` | Spawn multiple subagents in parallel |
-| `listSubagents()` | `Promise<SubagentInfo[]>` | List all subagents |
-| `getSubagentStatus(id)` | `Promise<SubagentResult>` | Get subagent output |
+| `spawn(task, agent?)` | `string` | Spawn a background subagent |
+| `spawnMany(tasks, agents?)` | `string[]` | Spawn multiple subagents in parallel |
+| `listSubagents()` | `SubagentInfo[]` | List all subagents |
+| `getSubagentStatus(id)` | `SubagentResult` | Get subagent output |
 
 ### Cron Jobs
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `addCron(name, options)` | `Promise<CronJob>` | Create a scheduled job |
-| `listCrons()` | `Promise<CronJob[]>` | List all cron jobs |
-| `updateCron(id, options)` | `Promise<CronJob>` | Update a cron job |
-| `removeCron(id)` | `Promise<void>` | Delete a cron job |
-| `pauseCron(id)` | `Promise<void>` | Pause without deleting |
-| `resumeCron(id)` | `Promise<void>` | Resume a paused job |
+| `addCron(name, options)` | `CronJob` | Create a scheduled job |
+| `listCrons()` | `CronJob[]` | List all cron jobs |
+| `updateCron(id, options)` | `CronJob` | Update a cron job |
+| `removeCron(id)` | `—` (no body) | Delete a cron job |
+| `pauseCron(id)` | `—` (no body) | Pause without deleting |
+| `resumeCron(id)` | `—` (no body) | Resume a paused job |
 
 #### Watching something without paying for a model call (`kiro_crew.irq`)
 
@@ -437,44 +447,44 @@ Rules:
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `addLesson(rule, category, scope?)` | `Promise<void>` | Save a learned rule |
-| `listLessons()` | `Promise<Lesson[]>` | List all lessons |
-| `removeLesson(query)` | `Promise<void>` | Remove matching lessons |
+| `addLesson(rule, category, scope?)` | `—` (no body) | Save a learned rule |
+| `listLessons()` | `Lesson[]` | List all lessons |
+| `removeLesson(query)` | `—` (no body) | Remove matching lessons |
 
 ### Notifications
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `sendNotification(text, options?)` | `Promise<void>` | Send via Slack or dashboard |
-| `listNotifications()` | `Promise<{notifications}>` | List notifications |
-| `ackNotifications()` | `Promise<void>` | Acknowledge all notifications |
+| `sendNotification(text, options?)` | `—` (no body) | Send via Slack or dashboard |
+| `listNotifications()` | `{notifications}` | List notifications |
+| `ackNotifications()` | `—` (no body) | Acknowledge all notifications |
 
 ### Approvals
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `approveAction(slotId, taskId)` | `Promise<void>` | Approve a pending tool action |
-| `rejectAction(slotId, taskId)` | `Promise<void>` | Reject a pending tool action |
-| `resolveApproval(approvalId, approved)` | `Promise<void>` | Resolve an approval by ID |
-| `getApprovalMode()` | `Promise<'auto'\|'interactive'>` | Get current approval mode |
-| `setApprovalMode(mode)` | `Promise<void>` | Set approval mode |
+| `approveAction(slotId, taskId)` | `—` (no body) | Approve a pending tool action |
+| `rejectAction(slotId, taskId)` | `—` (no body) | Reject a pending tool action |
+| `resolveApproval(approvalId, approved)` | `—` (no body) | Resolve an approval by ID |
+| `getApprovalMode()` | `'auto'` \| `'interactive'` | Get current approval mode |
+| `setApprovalMode(mode)` | `—` (no body) | Set approval mode |
 
 ### Models
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `listModels()` | `Promise<ModelInfo[]>` | List available LLM models |
-| `setSlotModel(slotId, model)` | `Promise<void>` | Set model for a slot |
+| `listModels()` | `ModelInfo[]` | List available LLM models |
+| `setSlotModel(slotId, model)` | `—` (no body) | Set model for a slot |
 
 ### MCP Servers
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `listMcpServers()` | `Promise<McpServerInfo[]>` | List registered MCP servers |
-| `registerMcpServer(def)` | `Promise<void>` | Register an MCP server (requires name + command) |
-| `removeMcpServer(name)` | `Promise<void>` | Remove an MCP server |
-| `registerAppMcp(name, entry)` | `Promise<void>` | Write MCP entry to `~/.kiro/crew/mcp.json` (Node.js only) |
-| `unregisterAppMcp(name)` | `Promise<void>` | Remove MCP entry from `~/.kiro/crew/mcp.json` (Node.js only) |
+| `listMcpServers()` | `McpServerInfo[]` | List registered MCP servers |
+| `registerMcpServer(def)` | `—` (no body) | Register an MCP server (requires name + command) |
+| `removeMcpServer(name)` | `—` (no body) | Remove an MCP server |
+| `registerAppMcp(name, entry)` | `—` (no body) | Write MCP entry to `~/.kiro/crew/mcp.json` (Node.js only) |
+| `unregisterAppMcp(name)` | `—` (no body) | Remove MCP entry from `~/.kiro/crew/mcp.json` (Node.js only) |
 
 ### Agent & Skill Installation (Node.js only)
 
@@ -489,30 +499,30 @@ Rules:
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `dispatchAgent(agent, prompt)` | `Promise<TaskResult>` | Run agent synchronously |
-| `dispatchAgentAsync(agent, prompt)` | `Promise<string>` | Run agent in background |
-| `getTaskResult(taskId)` | `Promise<TaskResult>` | Poll task status |
+| `dispatchAgent(agent, prompt)` | `TaskResult` | Run agent synchronously |
+| `dispatchAgentAsync(agent, prompt)` | `string` | Run agent in background |
+| `getTaskResult(taskId)` | `TaskResult` | Poll task status |
 
 ### Gateway Config
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `getGatewayConfig(key)` | `Promise<Record<string, unknown>>` | Read gateway config section |
-| `setGatewayConfig(key, value)` | `Promise<void>` | Write gateway config section |
+| `getGatewayConfig(key)` | a JSON object | Read gateway config section |
+| `setGatewayConfig(key, value)` | `—` (no body) | Write gateway config section |
 
 ### App Storage
 
 | Method | Returns | Description |
 |--------|---------|-------------|
 | `getAppDataDir()` | `string` | App-scoped data directory path |
-| `getAppConfig()` | `Promise<Record<string, unknown>>` | Read app config via REST |
-| `setAppConfig(config)` | `Promise<void>` | Write app config via REST |
+| `getAppConfig()` | a JSON object | Read app config via REST |
+| `setAppConfig(config)` | `—` (no body) | Write app config via REST |
 
 ### Memory
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `memorySearch(query, topK?)` | `Promise<MemoryResult[]>` | Semantic memory search |
+| `memorySearch(query, topK?)` | `MemoryResult[]` | Semantic memory search |
 
 ### Context Injection
 
@@ -520,8 +530,8 @@ Silent background context for LLM — content appears in the next user-initiated
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `injectContext(slotId, content, options?)` | `Promise<void>` | Inject context (null slotId = buffer locally) |
-| `flushPendingContext(slotId)` | `Promise<void>` | Flush buffered entries to a slot |
+| `injectContext(slotId, content, options?)` | `—` (no body) | Inject context (null slotId = buffer locally) |
+| `flushPendingContext(slotId)` | `—` (no body) | Flush buffered entries to a slot |
 | `setDefaultSlot(slotId)` | `void` | Auto-flush pending context on sendMessage |
 | `pendingContextCount` | `number` | Number of buffered context entries |
 
@@ -589,8 +599,16 @@ KiroCrewClient(
 
 ### Method Reference
 
-Method names use `snake_case` per Python convention. The left column is the
-canonical API-surface name used in the sections above:
+The left column is the endpoint label used in the sections above; the right
+column is the shipped Python method, in `snake_case` per Python convention.
+
+Rows marked *not implemented* are Gateway endpoints the shipped Python client
+does not wrap yet. Call those endpoints directly with `aiohttp` (or any HTTP
+client) using the paths in
+[Gateway REST API Endpoints](#gateway-rest-api-endpoints). The client also ships
+no WebSocket surface, so the `connect` / `disconnect` / `on*` handlers in
+[WebSocket Events](#websocket-events) are endpoint documentation for a raw
+WebSocket connection rather than client methods.
 
 | API surface | Python |
 |-----------|--------|
@@ -600,7 +618,7 @@ canonical API-surface name used in the sections above:
 | `createSlot(name, agent?)` | `create_slot(name, agent="")` |
 | `listSlots()` | `list_slots()` |
 | `deleteSlot(id)` | `delete_slot(id)` |
-| `getSlotHistory(id, limit?)` | `get_slot_history(id, limit=50)` |
+| `getSlotHistory(id, limit?)` | *not implemented — call the endpoint* |
 | `sendMessage(id, msg)` | `send_message(id, msg)` |
 | `spawn(task, agent?)` | `spawn(task, agent="")` |
 | `spawnMany(tasks, agents?)` | `spawn_many(tasks, agents=None)` |
@@ -616,26 +634,26 @@ canonical API-surface name used in the sections above:
 | `listLessons()` | `list_lessons()` |
 | `removeLesson(query)` | `remove_lesson(query)` |
 | `sendNotification(text, opts?)` | `send_notification(text, **opts)` |
-| `listNotifications()` | `list_notifications()` |
-| `ackNotifications()` | `ack_notifications()` |
-| `approveAction(slot, task)` | `approve_action(slot, task)` |
-| `rejectAction(slot, task)` | `reject_action(slot, task)` |
-| `resolveApproval(id, ok)` | `resolve_approval(id, ok)` |
-| `getApprovalMode()` | `get_approval_mode()` |
-| `setApprovalMode(mode)` | `set_approval_mode(mode)` |
-| `listModels()` | `list_models()` |
-| `setSlotModel(slot, model)` | `set_slot_model(slot, model)` |
-| `getGatewayConfig(key)` | `get_gateway_config(key)` |
-| `setGatewayConfig(key, val)` | `set_gateway_config(key, val)` |
+| `listNotifications()` | *not implemented — call the endpoint* |
+| `ackNotifications()` | *not implemented — call the endpoint* |
+| `approveAction(slot, task)` | *not implemented — call the endpoint* |
+| `rejectAction(slot, task)` | *not implemented — call the endpoint* |
+| `resolveApproval(id, ok)` | *not implemented — call the endpoint* |
+| `getApprovalMode()` | *not implemented — call the endpoint* |
+| `setApprovalMode(mode)` | *not implemented — call the endpoint* |
+| `listModels()` | *not implemented — call the endpoint* |
+| `setSlotModel(slot, model)` | *not implemented — call the endpoint* |
+| `getGatewayConfig(key)` | *not implemented — call the endpoint* |
+| `setGatewayConfig(key, val)` | *not implemented — call the endpoint* |
 | `listMcpServers()` | `list_mcp_servers()` |
 | `registerMcpServer(def)` | `register_mcp_server(name, cmd, args?, env?)` |
 | `removeMcpServer(name)` | `remove_mcp_server(name)` |
-| `registerAppMcp(name, entry)` | `register_app_mcp(name, *, url?, cmd?, ...)` |
-| `unregisterAppMcp(name)` | `unregister_app_mcp(name)` |
-| `installAgentConfig(name, cfg)` | `install_agent_config(name, cfg)` |
-| `removeAgentConfig(name)` | `remove_agent_config(name)` |
-| `installSkill(name, dir)` | `install_skill(name, dir)` |
-| `removeSkill(name)` | `remove_skill(name)` |
+| `registerAppMcp(name, entry)` | *not implemented — call the endpoint* |
+| `unregisterAppMcp(name)` | *not implemented — call the endpoint* |
+| `installAgentConfig(name, cfg)` | *not implemented — call the endpoint* |
+| `removeAgentConfig(name)` | *not implemented — call the endpoint* |
+| `installSkill(name, dir)` | *not implemented — call the endpoint* |
+| `removeSkill(name)` | *not implemented — call the endpoint* |
 | `dispatchAgent(agent, prompt)` | `dispatch_agent(agent, prompt)` |
 | `dispatchAgentAsync(agent, prompt)` | `dispatch_agent_async(agent, prompt)` |
 | `getTaskResult(id)` | `get_task_result(id)` |
@@ -651,7 +669,7 @@ canonical API-surface name used in the sections above:
 
 | API surface | Python |
 |-----------|--------|
-| `verifyProxyRequest(req, appName, opts?)` | `verify_proxy_request(request, app_name, *, secret?, max_age_secs?)` |
+| `verifyProxyRequest(req, appName, opts?)` | *not implemented — call the endpoint* |
 | — | `verify_proxy_request_raw(header, method, path, app_name, ...)` |
 
 ---

--- a/docs/app-kit/api-reference.md
+++ b/docs/app-kit/api-reference.md
@@ -13,9 +13,10 @@ How you talk to the Gateway depends on where your code runs:
   [getting-started.md](getting-started.md) and the [App SDK Hooks](#app-sdk-hooks)
   section below.
 - **Python apps / external CLI tools / services** — use the standalone
-  `kirocrew-client` package (`pip install kirocrew-client`). It is async
-  (`aiohttp`) and has no dependency on the KiroCrew main package. See the
-  [Python Client](#python-client) section.
+  `kirocrew-client` package, carried in this repository under
+  `packages/kirocrew-client-py/`. It is async (`aiohttp`) and has no dependency on
+  the Kiro Crew main package, but it is not published to PyPI — use it from a source
+  checkout. See the [Python Client](#python-client) section.
 - **Node.js / Electron apps** — call the Gateway REST/WS endpoints directly via
   `fetch()` / a WebSocket. The full endpoint list is in
   [Gateway REST API Endpoints](#gateway-rest-api-endpoints).
@@ -23,11 +24,13 @@ How you talk to the Gateway depends on where your code runs:
 There is no published TypeScript gateway-client npm package, and none is planned
 here — the camelCase names used throughout the sections below are **labels for
 Gateway endpoints**, not callable methods. Read them as endpoint identifiers.
-Two surfaces are real and callable: the `@kirocrew/app-sdk` hooks (documented in
-the next section, resolved from the host import map) and the shipped
-`kirocrew-client` Python package, whose actual method list is in
-[Python Client](#python-client). Anything named below that appears in neither is
-a Gateway endpoint you call directly with `fetch` or `aiohttp`.
+The `@kirocrew/app-sdk` hooks are real and callable — see the next section; they
+resolve from the host import map. The `kirocrew-client` Python package is **not
+published**: it lives in this repository under `packages/kirocrew-client-py/`, is
+outside the installed distribution, and has no release on PyPI, so `pip install
+kirocrew-client` does not work. Use it from a source checkout, or call the
+endpoints directly with `fetch` or `aiohttp`. Its method list is in
+[Python Client](#python-client).
 
 ## App SDK Hooks (dashboard UI)
 
@@ -268,7 +271,7 @@ that genuinely needs live app state is supplied by the host as an entry.
 ## Gateway API Surface
 
 The sections below name the Gateway API surface. A name here is an **endpoint
-label**, not a guarantee that a client method exists for it: the shipped
+label**, not a guarantee that a client method exists for it: the source-only
 `kirocrew-client` Python package covers part of this surface, and
 [Python Client](#python-client) marks which part. For anything it does not
 implement, call the endpoint directly — the paths are in
@@ -563,7 +566,6 @@ Verify that an incoming request was signed by the KiroCrew gateway reverse proxy
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `verifyProxyRequest(req, appName, opts?)` | `boolean` | Verify HMAC signature on any Node.js request object |
 
 Options: `{ secret?: string, maxAgeSecs?: number }`
 
@@ -571,8 +573,10 @@ Options: `{ secret?: string, maxAgeSecs?: number }`
 
 ## Python Client
 
-Standalone async client using `aiohttp` — `pip install kirocrew-client`. Covers
-the full Gateway API surface documented above.
+Standalone async client using `aiohttp`, carried in this repository under
+`packages/kirocrew-client-py/`. It is not published to PyPI, so use it from a
+source checkout rather than by installing it. It covers part of the Gateway API
+surface documented above.
 
 ```python
 from kirocrew_client import KiroCrewClient
@@ -669,8 +673,6 @@ WebSocket connection rather than client methods.
 
 | API surface | Python |
 |-----------|--------|
-| `verifyProxyRequest(req, appName, opts?)` | *not implemented — call the endpoint* |
-| — | `verify_proxy_request_raw(header, method, path, app_name, ...)` |
 
 ---
 
@@ -780,22 +782,38 @@ app secret as the key, where `sha256(body)` is the hex SHA-256 digest of the raw
 tampered body invalidates the signature. Backends verify with a constant-time comparison and
 reject requests whose timestamp is not within ±60s of now.
 
-Python app backends verify this with `kirocrew-client`:
+A Python app backend whose environment can import `kiro_crew` (the built-in app backends run as child processes and still import it) verifies this with the gateway's own helper:
 
 ```python
-from kirocrew_client import verify_proxy_request
-if not verify_proxy_request(request, 'my-app'): return Response(status=401)
+from kiro_crew.apps.proxy_auth import raw_request_target, verify_proxy_request
+
+body = await request.read()
+if not verify_proxy_request(
+    request.headers.get('X-KiroCrew-Proxy', ''),
+    method=request.method,
+    target=raw_request_target(request),
+    body=body,
+):
+    return Response(status=401)
 ```
+
+Every argument after the header value is keyword-only. Pass the target through
+`raw_request_target`: the gateway signs the request-target exactly as it went on
+the wire, and rebuilding it from a decoded path diverges from the signed bytes as
+soon as a query parameter carries a space or a non-ASCII character.
+
+A backend that cannot import `kiro_crew` (a different language, or a Python
+environment without the package) computes the HMAC itself, exactly as the Node.js
+paragraph below describes.
 
 Node.js app backends can verify the signature directly: compute
 `HMAC-SHA256(timestamp:method:/api/path[?query]:sha256(body), app_secret)` and compare against
 the value in the `X-KiroCrew-Proxy` header (constant-time), rejecting stale timestamps.
 
-> **Breaking change (body-bound signature):** `verify_proxy_request` /
-> `verify_proxy_request_raw` in the `kirocrew-client` package MUST be regenerated in lockstep
-> to bind `sha256(body)` while keeping the constant-time compare and ±60s freshness. A gateway
-> that signs body-bound HMACs will fail verification against any deployed old verifier, so the
-> client release must ship together with this change.
+> **Body-bound signature:** every verifier must bind `sha256(body)` while keeping the
+> constant-time compare and the ±60s freshness window. A gateway that signs body-bound
+> HMACs fails verification against any verifier that omits the body hash, so a
+> backend that implements the HMAC itself has to be updated in lockstep with the gateway.
 
 ## App Dev Mode (live reload)
 

--- a/src/kiro_crew/docs/README.md
+++ b/src/kiro_crew/docs/README.md
@@ -37,6 +37,8 @@ organized for someone browsing the repository.
 | [inbound-webhooks.md](inbound-webhooks.md) | Letting external systems trigger an agent turn over HTTP. |
 | [deploy-web.md](deploy-web.md) | Publishing artifacts to a public HTTPS URL on your own AWS. |
 | [snapshot-and-restore.md](snapshot-and-restore.md) | Backing up and restoring Kiro Crew state. |
+| [workflows.md](workflows.md) | Multi-phase agent runs you can watch, restart in part, and save for reuse. |
+| [secrets-vault.md](secrets-vault.md) | Storing credentials encrypted where the agent cannot read them. |
 
 ## Channels
 
@@ -51,6 +53,8 @@ organized for someone browsing the repository.
 | [weixin-integration.md](weixin-integration.md) | Weixin setup, and the risks to read first. |
 | [whatsapp-integration.md](whatsapp-integration.md) | WhatsApp (QR-linked personal account) setup, and the risks to read first. |
 | [feishu-integration.md](feishu-integration.md) | Feishu (Lark/飞书) setup and behavior. |
+| [imessage-integration.md](imessage-integration.md) | iMessage setup and behavior on a Mac that owns the Messages database. |
+| [channel-capabilities.md](channel-capabilities.md) | One matrix of what every channel can do: streaming, buttons, uploads, reply length, approval timeout. |
 | [messaging-transport.md](messaging-transport.md) | The channel-neutral contracts every transport shares. |
 
 ## Platform

--- a/src/kiro_crew/docs/README.md
+++ b/src/kiro_crew/docs/README.md
@@ -39,6 +39,11 @@ organized for someone browsing the repository.
 | [snapshot-and-restore.md](snapshot-and-restore.md) | Backing up and restoring Kiro Crew state. |
 | [workflows.md](workflows.md) | Multi-phase agent runs you can watch, restart in part, and save for reuse. |
 | [secrets-vault.md](secrets-vault.md) | Storing credentials encrypted where the agent cannot read them. |
+| [monitor-loops.md](monitor-loops.md) | Keeping one session checking something on an interval until an exit condition fires. |
+| [session-ledger.md](session-ledger.md) | The durable per-session work record that survives context compaction. |
+| [artifacts.md](artifacts.md) | Saving, versioning, and reverting generated UI and documents. |
+| [computer-use.md](computer-use.md) | Reading and driving native desktop applications; opt-in and off by default. |
+| [browser-control.md](browser-control.md) | Driving a real web page from the dashboard's Browser panel. |
 
 ## Channels
 

--- a/src/kiro_crew/docs/agents.md
+++ b/src/kiro_crew/docs/agents.md
@@ -58,7 +58,7 @@ Custom agents are JSON files in `~/.kiro/agents/`. They define their own system 
 
 ## Managing Agents
 
-The dashboard Agents page shows installed agents with their source, tools, and MCP servers. Drop a new JSON file into `~/.kiro/agents/` and it appears automatically; the page also provides edit and delete controls.
+**Agent Capabilities → Agent Templates** shows installed agents with their source, tools, and MCP servers. Drop a new JSON file into `~/.kiro/agents/` and it appears automatically; the tab also provides edit and delete controls. `/agents` redirects to Agent Capabilities.
 
 ## Mapping Skills to an Agent
 

--- a/src/kiro_crew/docs/artifacts.md
+++ b/src/kiro_crew/docs/artifacts.md
@@ -1,0 +1,66 @@
+# Artifacts
+
+An artifact is something the agent generated that you want to keep — a widget, an
+HTML page, a document. Saving it gives it a stable handle you can come back to in
+a later conversation, instead of losing it to the chat scrollback.
+
+The chat side panel has an **Artifacts** tab listing what you have saved. Open one
+to view it, and ask the agent to iterate on it by name.
+
+## Saving and iterating
+
+Ask to save something the agent just rendered, and it comes back with a handle.
+Widgets rendered in chat are also registered as artifacts automatically, each one
+as its part of the response finalizes rather than when the whole message ends — so
+a widget you did not explicitly save still appears in the Artifacts tab, and an
+early widget is filed before a long answer finishes. Automatic entries are
+unpinned, and the oldest unpinned ones are pruned once there are many of them, so
+star a widget in chat, or ask the agent to save it, when you want to keep it for
+good.
+
+**Incognito and temporary sessions never register a widget, and cannot save one
+either.** Saving is refused outright in those modes, so a widget rendered there
+exists only in the conversation and is gone when the session ends. That is the
+point of them: nothing is left behind. Render it in an ordinary session if you
+need to keep it.
+
+Every agent edit to a saved artifact creates a **new version**, like a commit. You
+can list the versions, read an older one, or revert the live state to any of them.
+A revert is itself recorded as a new version tagged as a rollback, so the timeline
+shows what happened rather than quietly rewinding.
+
+## Organizing
+
+Artifacts can be filed into folders, which nest. Moving an artifact or renaming a
+folder changes nothing about the content. Deleting a folder is safe by default —
+its children move up to the parent and only the folder itself goes. Deleting the
+whole subtree, artifacts included, takes an explicit choice and cannot be undone
+through the same path, so you should be told the count before it happens.
+
+## Comments
+
+An artifact carries comment threads, optionally anchored to a specific passage.
+The agent can post, reply, and mark a thread as **awaiting your review** once it
+believes it has addressed the point — but it cannot resolve a thread. Resolving is
+yours.
+
+The agent may delete a comment thread only where it demonstrably carried out an
+unambiguous instruction ("fix this typo") and did so. For anything that is a
+judgement call it marks the thread for review instead, so you get to check.
+Comments synced from an external provider cannot be deleted by the agent at all.
+
+## Publishing one
+
+A saved web artifact can be deployed to a public HTTPS URL on your own AWS
+account. The agent's part is **preview only**: it reports the scan result and what
+the deploy would do, and never executes it. The final confirmation happens in the
+dashboard.
+
+Read [Web deploy](deploy-web.md) before doing this — a deployed artifact is
+world-readable.
+
+## Related docs
+
+- [Web deploy](deploy-web.md): the public-URL path, and what world-readable means
+- [Dashboard](dashboard.md): the chat side panel and its tabs
+- [Knowledge library](knowledge-library-how-it-works.md): search across saved artifacts and documents

--- a/src/kiro_crew/docs/browser-control.md
+++ b/src/kiro_crew/docs/browser-control.md
@@ -1,0 +1,47 @@
+# Browser control
+
+The dashboard has a **Browser** panel, and the agent can drive the page shown in
+it. Ask it to open a site, click through a flow, fill a form, or take a screenshot
+of what it found, and you watch the whole thing happen in that panel.
+
+You can take over at any point with your real mouse and keyboard. That is how a
+CAPTCHA or a two-factor prompt gets handled: the agent stops, you do the step, it
+carries on.
+
+## What the agent can do to a page
+
+Navigate to a URL, read the page as a structured list of its elements, click,
+type, press a key, hover, choose from a dropdown, take a screenshot, wait for
+something to appear, go back, and read the browser console.
+
+Reading a page it can already reach is cheaper than driving it, so a request that
+only needs the text of a public page may be answered without the browser at all.
+Driving it is for the cases that need interaction, a logged-in session, or a page
+whose content only exists once its scripts have run.
+
+## Local addresses are refused
+
+The agent cannot navigate the panel to `localhost`, a loopback address, or a
+private-network address. Those are where your own control planes live — this
+dashboard among them — so driving one would let the agent reach an interface it is
+not supposed to operate. Only globally routable addresses are accepted.
+
+## Settings → Browser
+
+Two things live there:
+
+- **Install the browser engine.** Driving a page needs a browser binary. The panel
+  installs it for you and shows whether it is present.
+- **Attach to your own browser.** Attach mode drives your everyday browser, with
+  your live logins and your open tabs, instead of a fresh one. It needs a browser
+  extension that only you can install — the panel links it — and an optional token
+  stored here removes the per-attach approval prompt.
+
+Treat an attached browser as borrowed. The agent should not navigate a tab away
+from what you were doing, and closing it would take your own windows with it.
+
+## Related docs
+
+- [Dashboard](dashboard.md): the side panel and where its tabs live
+- [Computer use](computer-use.md): driving native desktop apps rather than a web page
+- [Artifacts](artifacts.md): keeping a screenshot or a page the agent produced

--- a/src/kiro_crew/docs/channel-capabilities.md
+++ b/src/kiro_crew/docs/channel-capabilities.md
@@ -1,0 +1,88 @@
+# Channel capabilities
+
+One table for the question every channel doc otherwise answers separately: does
+this channel stream, does it render buttons, can it take a file, how long a reply
+fits, and how long an approval prompt waits. Read it before you pick a channel,
+or when a channel behaves differently from the one you are used to.
+
+Each channel declares these values in code, and a test forces every capability to
+be classified rather than left implicit — so a ✅ here means the behaviour exists
+today, not that the platform could support it.
+
+## The matrix
+
+| | Slack | Discord | Telegram | Teams | Webex | WeCom | Weixin | iMessage | WhatsApp | Feishu |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Streams the reply as it is written | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Edits a message it already sent | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |
+| Adds emoji reactions | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Accepts a file you send | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Sends a file back to you | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Native widget (buttons, cards) | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Threads a conversation | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Renders markdown tables natively | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Reply length before splitting | 3900 chars | 1900 chars | 4000 chars | 16000 chars | 1750 chars (7000 bytes) | 5120 chars (20480 bytes) | 4000 chars | 4000 chars | 4096 chars | 4000 chars |
+| Tappable choices per prompt | 10 | 25 | 25 | 5 | 5 | 0 | 0 | 0 | 0 | 0 |
+| Approval prompt waits | 120s | 300s | 300s | 300s | 300s | 300s | 300s | 300s | 300s | 300s |
+| Agent can message you first | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Dashboard link is two-way | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Reading the rows
+
+**Reply length** is where a long answer is split into more than one message.
+Webex and WeCom cap in UTF-8 bytes rather than characters, so their character
+figure is the byte budget divided by four — the worst case for non-ASCII text.
+An ASCII-only reply on those channels fits far more than the character figure
+suggests.
+
+**Tappable choices** is the total number of interactive options one prompt may
+present. Above the cap, the remainder degrades to a numbered list in the message
+body rather than being dropped. A channel showing `0` renders no widget at all:
+every choice arrives as a numbered line, and you answer by typing the number.
+
+**Native widget** gates whether a channel builds a platform card for a tool
+approval or a choice list. Discord streams and threads well but declares no rich
+widget, so its approvals are text.
+
+**Dashboard link is two-way** means connecting the channel from the dashboard
+marks the binding as an inbound target, so your reply in the channel continues
+the same session. Where it is ❌ the link is outbound only — the dashboard can
+push to the channel, but a reply there starts its own session. Slack is a special
+case: it routes inbound traffic through its own thread index rather than this
+marker, so a Slack thread does continue its session.
+
+## Approval timeouts
+
+Three different windows ship, and the difference is deliberate:
+
+- **Slack: 120 seconds.** Slack has its own approval path with a shorter window
+  than every other channel.
+- **Teams: 300 seconds**, from its own Adaptive Card approval path.
+- **Everything else: 300 seconds**, from the shared text-approval ladder.
+
+An unanswered prompt is **denied**, never approved — the timeout never means yes.
+
+`agent.tool_approval_timeout_secs` (default 600) does **not** govern any of
+these. It applies only to the dashboard chat path. Changing it will not lengthen
+or shorten the window on any messaging channel.
+
+## Owner DM targets
+
+`send_message` with a channel target reaches every channel except **WeCom** and
+**Weixin**. Both fold identities learned from inbound traffic into their
+send roster, so "the owner" could resolve to any peer who once messaged the bot.
+Rather than risk delivering to the wrong person, both are excluded from
+owner-DM routing entirely. A `send_message` aimed at either will not arrive; use
+the dashboard, or a channel that is on the roster.
+
+## Related docs
+
+Per-channel setup, access control, and behaviour live in each channel's own
+guide: [Slack](slack-integration.md), [Discord](discord-integration.md),
+[Telegram](telegram-integration.md), [Teams](teams-integration.md),
+[Webex](webex-integration.md), [WeCom](wecom-integration.md),
+[Weixin](weixin-integration.md), [iMessage](imessage-integration.md),
+[WhatsApp](whatsapp-integration.md), [Feishu](feishu-integration.md).
+
+The contracts these values come from are described in
+[Messaging Transport](messaging-transport.md).

--- a/src/kiro_crew/docs/channel-capabilities.md
+++ b/src/kiro_crew/docs/channel-capabilities.md
@@ -5,9 +5,8 @@ this channel stream, does it render buttons, can it take a file, how long a repl
 fits, and how long an approval prompt waits. Read it before you pick a channel,
 or when a channel behaves differently from the one you are used to.
 
-Each channel declares these values in code, and a test forces every capability to
-be classified rather than left implicit — so a ✅ here means the behaviour exists
-today, not that the platform could support it.
+A ✅ means Kiro Crew supports that behaviour on that channel today, not that the
+platform could support it.
 
 ## The matrix
 
@@ -23,7 +22,7 @@ today, not that the platform could support it.
 | Renders markdown tables natively | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Reply length before splitting | 3900 chars | 1900 chars | 4000 chars | 16000 chars | 1750 chars (7000 bytes) | 5120 chars (20480 bytes) | 4000 chars | 4000 chars | 4096 chars | 4000 chars |
 | Tappable choices per prompt | 10 | 25 | 25 | 5 | 5 | 0 | 0 | 0 | 0 | 0 |
-| Approval prompt waits | 120s | 300s | 300s | 300s | 300s | 300s | 300s | 300s | 300s | 300s |
+| Approval prompt waits | 120s | 300s | 300s | 300s | 300s | — | — | — | 300s | — |
 | Agent can message you first | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | Dashboard link is two-way | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
@@ -53,14 +52,22 @@ marker, so a Slack thread does continue its session.
 
 ## Approval timeouts
 
-Three different windows ship, and the difference is deliberate:
+Only six channels ask you at all. Slack, Discord, Telegram, Teams, Webex and
+WhatsApp install an approval decider, so a tool that needs permission produces a
+prompt and waits:
 
 - **Slack: 120 seconds.** Slack has its own approval path with a shorter window
   than every other channel.
-- **Teams: 300 seconds**, from its own Adaptive Card approval path.
-- **Everything else: 300 seconds**, from the shared text-approval ladder.
+- **Discord, Telegram, Teams, Webex, WhatsApp: 300 seconds.**
 
 An unanswered prompt is **denied**, never approved — the timeout never means yes.
+
+**WeCom, Weixin, iMessage and Feishu never prompt.** None of them can render
+approve/deny controls, so in `interactive` mode a tool needing permission is
+refused straight away: nothing is posted and there is no window to answer in. The
+`—` in that row means exactly this, not "unlimited". To run tools on those
+channels, set the approval mode to `auto` or `trust` — see the channel's own
+guide.
 
 `agent.tool_approval_timeout_secs` (default 600) does **not** govern any of
 these. It applies only to the dashboard chat path. Changing it will not lengthen
@@ -68,12 +75,26 @@ or shorten the window on any messaging channel.
 
 ## Owner DM targets
 
-`send_message` with a channel target reaches every channel except **WeCom** and
-**Weixin**. Both fold identities learned from inbound traffic into their
-send roster, so "the owner" could resolve to any peer who once messaged the bot.
-Rather than risk delivering to the wrong person, both are excluded from
-owner-DM routing entirely. A `send_message` aimed at either will not arrive; use
-the dashboard, or a channel that is on the roster.
+`send_message` has two different routes, and they differ in what they can reach.
+
+The **owner-DM route** (`session=<channel>`) infers a recipient: it needs exactly
+one allow-listed destination configured on that channel, and it needs the channel
+to be able to send unprompted. Three channels cannot use it:
+
+- **WeCom** and **Weixin** are excluded outright. Both fold identities learned
+  from inbound traffic into their send roster, so "the owner" could resolve to any
+  peer who once messaged the bot, and guessing is worse than refusing.
+- **Feishu** is accepted but cannot deliver, because it only ever replies to an
+  inbound message and has nowhere to put an unprompted one.
+
+In all three cases the call falls back to a dashboard notification and says so
+rather than reporting success. An ambiguous allow-list or a channel that is not
+connected falls back the same way.
+
+The **conversation route** (`channel_type`) addresses the conversation you are
+already in rather than inferring a recipient, so it *does* work on WeCom and
+Weixin. Add a destination id to aim it somewhere specific; the channel's
+allow-list is re-checked when the message is sent.
 
 ## Related docs
 

--- a/src/kiro_crew/docs/computer-use.md
+++ b/src/kiro_crew/docs/computer-use.md
@@ -1,0 +1,53 @@
+# Computer use
+
+Computer use lets the agent read and drive your real desktop applications — the
+work that does not live in a web page. It reads a window as a structured outline
+of its controls, then clicks, types, sets values, scrolls, and drags.
+
+It is **off by default** and you turn it on in **Settings → Computer Use**.
+Granting it means granting full desktop observation plus the ability to
+synthesize input, so treat the switch as a security ceiling rather than a
+preference.
+
+The enable does not live in `config.json`. It sits in its own protected file
+precisely because `config.json` is writable by the agent's own shell — an enable
+stored there could be flipped by a prompt injection rather than by you.
+
+## macOS and Windows
+
+Both platforms support the full tool set. They differ in one way that changes
+what you see:
+
+- **macOS** delivers a click to the target application alone, so your own pointer
+  does not move. You can keep working while the agent drives another window.
+- **Windows** has no per-process input delivery. A keystroke takes your keyboard
+  focus and a coordinate click **moves your real cursor**. The agent is required
+  to tell you rather than succeed silently.
+
+On macOS there is also one route that deliberately warps the real cursor, for a
+click that has to be physically real. The agent has to name that route
+explicitly — it is never chosen automatically — and should warn you first,
+because your pointer will jump out from under your hand.
+
+## What is off limits
+
+- **Password fields are redacted.** They render as `<secure>` in the outline, and
+  a window containing one is not captured as an image.
+- **Kiro Crew's own dashboard is refused** — for reading as well as typing.
+  Driving it would let the agent change its own security settings, including this
+  one. On macOS the refusal covers every window of the dashboard's process, not
+  just the visible one, and the refusal names the target so it is clear why.
+
+## How it drives a window
+
+The agent reads the window first and prefers to address a control by its position
+in that outline rather than by pixel coordinates. That is what makes the
+protections above enforceable: a password field is refused by its identity in the
+tree, which pixels cannot express. Coordinates remain available for canvases,
+sliders, and custom-drawn interfaces that expose no usable control.
+
+## Related docs
+
+- [Configuration](configuration.md): the config file and what is deliberately not in it
+- [Blocked commands](blocked-commands.md): the other refusals and how to read them
+- [Dashboard](dashboard.md): Settings and where the tabs live

--- a/src/kiro_crew/docs/configuration.md
+++ b/src/kiro_crew/docs/configuration.md
@@ -174,8 +174,8 @@ Set via `kirocrew config set agent.acp_backend kas`.
   },
   "stt": {
     "enabled": true,
-    "provider": "whisper",
-    "streaming": false,
+    "provider": "local",
+    "streaming": true,
     "transcribe_region": "us-east-1",
     "language_code": "en-US"
   },
@@ -270,8 +270,9 @@ Only the owner (`KIROCREW_OWNER_ID`) is authorized to interact over Slack.
 Multi-user access and open channels are refused regardless of what these lists
 contain, so treat them as bookkeeping rather than an access grant.
 
-Other channels (Discord, Telegram, Teams, Webex, WeCom, WeChat) are configured
-from the dashboard — see each channel's doc for keys and credentials.
+Every other messaging channel is configured from the dashboard — the roster is in
+[the documentation index](index.md#chat-channels), and each channel's own doc
+lists its keys and credentials.
 
 ### Speech-to-text
 

--- a/src/kiro_crew/docs/dashboard.md
+++ b/src/kiro_crew/docs/dashboard.md
@@ -49,7 +49,7 @@ Multi-session parallel chat with full Markdown rendering, syntax-highlighted cod
 - **Tool input preview**: expandable tool input display in approval cards.
 - **File upload**: on desktop, use **Upload file** from the `+` menu or drop a file into Chat. On a phone or other touch device, tap `+` to open the native system Files picker directly. Both paths accept images and regular files such as `.zip`, `.csv`, and `.docx`.
 - **Folder management**: create, rename, and organize sessions into sidebar folders with indent borders.
-- **Per-channel session folders**: optional, off by default — each channel's settings panel (Slack, Discord, Telegram, Teams, Webex, WeCom, WeChat) can file conversations that start there into a named sidebar folder, marked with the channel's brand mark. Config key: `<channel>.session_folder` ("" = off). The folder is created when the setting is saved, so the surfacing path only ever reads the folder store; a configured folder that no longer exists (config.json hand-edited, or the folder deleted) leaves conversations unfiled until the next save recreates it. Filing applies as each conversation is first surfaced; a session moved by hand afterwards stays where it was put.
+- **Per-channel session folders**: optional, off by default — every messaging channel's settings panel can file conversations that start there into a named sidebar folder, marked with the channel's brand mark. Config key: `<channel>.session_folder` ("" = off). The folder is created when the setting is saved, so the surfacing path only ever reads the folder store; a configured folder that no longer exists (config.json hand-edited, or the folder deleted) leaves conversations unfiled until the next save recreates it. Filing applies as each conversation is first surfaced; a session moved by hand afterwards stays where it was put.
 - **Session colors**: per-session color picker for visual organization.
 
 ### Settings (`/settings/*`)
@@ -58,7 +58,7 @@ Settings uses tabbed panels for Overview, Imports, Chat, Display, Voice, Notific
 
 ### Agent Capabilities (`/capabilities`)
 
-Tabbed management for crews, agent templates, MCP connections, skills, steering, hooks, prompts, and workflow libraries. `/agents` and `/connections` redirect here.
+Tabbed management for crews, agent templates, MCP connections, skills, the knowledge library, steering, hooks, prompts, and workflow libraries. `/agents`, `/connections` and `/knowledge` redirect here.
 
 ### Schedule (`/schedule`)
 
@@ -66,7 +66,7 @@ Create and manage cron jobs, organize them in folders, and switch between list, 
 
 ### Developer (`/developer`)
 
-Tabbed developer views for logs, system metrics, telemetry, storage, MCP pooling, memory, configuration, feature previews, and the session archive. The former standalone `/system` page is now the System tab here.
+Tabbed developer views for logs, system metrics, telemetry, storage, MCP pooling, memory, configuration, the agent backend, feature previews, debug tools, and the session archive. The former standalone `/system` page is now the System tab here.
 
 ### Logs (`/logs`)
 
@@ -82,7 +82,7 @@ Browse discoverable apps, manage the installed-app library, and open app detail 
 
 ### Other shipped routes
 
-`/knowledge` opens the Knowledge Library, `/notifications` opens notifications, `/artifacts` opens artifact management, and `/deploy` opens artifact deployment. Built-in app routes are registered dynamically.
+`/knowledge` redirects to the Knowledge Library at `/capabilities?tab=knowledge`, `/notifications` opens notifications, `/artifacts` opens artifact management, and `/deploy` opens artifact deployment. Built-in app routes are registered dynamically.
 
 ## Real-Time Updates
 

--- a/src/kiro_crew/docs/discord-integration.md
+++ b/src/kiro_crew/docs/discord-integration.md
@@ -145,7 +145,7 @@ Portal or clear the thread allow-list and restart in DM-only mode.
 | Bot can read but cannot reply in a thread | Missing guild permission or private-thread membership | Grant View Channel, Read Message History, Send Messages in Threads; add the bot to private threads |
 | Logs are silent on successful connection | `agent.log_level` is `WARNING` | Trust the Connected badge or lower the log level |
 
-## Security model
+## Access control
 
 - **Two allow-lists for threads.** A server-thread turn runs only when both the
   sender and exact thread are approved. An empty user list denies all traffic;
@@ -261,3 +261,9 @@ credentials and suspicious URLs before they reach Discord.
 While a reply is running, prefix a message with `!steer` to fold it into the
 running turn or `!queue` to answer it afterward. `[OPTIONS:]` choices render as
 buttons, and interactive tool approvals render as Approve/Deny buttons.
+
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables

--- a/src/kiro_crew/docs/dynamic-subagent-sizing.md
+++ b/src/kiro_crew/docs/dynamic-subagent-sizing.md
@@ -144,4 +144,4 @@ memory floor. They are independent guards.
   `/proc/meminfo` and therefore remains inert (fails open) on non-Linux hosts —
   auto-sizing and the runtime gate are independent guards.
 - Design rationale and worked examples:
-  `~/.kiro/crew/workspace/dynamic-subagent-sizing.md`.
+  [`docs/system-specs/modules/subagent.md`](https://github.com/kirodotdev/KiroCrew/blob/main/docs/system-specs/modules/subagent.md).

--- a/src/kiro_crew/docs/feishu-integration.md
+++ b/src/kiro_crew/docs/feishu-integration.md
@@ -72,7 +72,7 @@ session, editing the files on the gateway's own machine is the way in.
 
 </details>
 
-## Who can reach it
+## Access control
 
 Deny-by-default, in both directions:
 
@@ -113,7 +113,7 @@ Deny-by-default, in both directions:
   would reset the conversation on a message you addressed to a colleague, and
   that is not recoverable, so anything ambiguous is treated as a prompt.
 
-## Settings
+## Settings reference
 
 | Key | Default | What it does |
 | --- | --- | --- |
@@ -144,7 +144,7 @@ masked preview: a saved secret can be **replaced or cleared, never read back**.
 
 Anything else is a prompt.
 
-## What this channel can and cannot do
+## Limits
 
 Feishu v1 is deliberately single-shot: the agent's answer is buffered and sent
 as **one reply** when the turn completes, rather than streamed. There are no
@@ -185,3 +185,9 @@ channel uses. See [messaging-transport.md](messaging-transport.md).
 | `feishu/renderer.py` | Buffers the turn, sends one reply |
 | `feishu/transport_dispatch.py` | Drives `TurnDriver`, handles `/new` `/compact` |
 | `feishu/gateway.py` | `maybe_start_feishu()` boot entry point |
+
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables

--- a/src/kiro_crew/docs/getting-started.md
+++ b/src/kiro_crew/docs/getting-started.md
@@ -111,13 +111,18 @@ live session and lets you take over with real mouse and keyboard, which is how
 you complete a CAPTCHA or a 2FA prompt.
 
 Use `kirocrew setup --agent-only` to reinstall just the agent config and skip
-the other wizard steps.
+the other wizard steps. `--electron-only` installs only the desktop app (macOS),
+and `--clean` treats the run as a fresh install rather than merging MCP servers
+and tools from an existing config.
 
 ### Messaging channels (optional)
 
 The default wizard configures no messaging channels — the dashboard and CLI need
-none. To connect Slack from the terminal, run `kirocrew setup --slack`, which
-prompts for:
+none. Two channels have a guided terminal setup: `kirocrew setup --slack`, and
+`kirocrew setup --whatsapp`, which reports the optional `whatsapp` extra and the
+pairing state before enabling the channel. Both are ignored with `--agent-only`.
+
+`--slack` prompts for:
 
 - `SLACK_APP_TOKEN` starts with `xapp-`
 - `SLACK_BOT_TOKEN` starts with `xoxb-`
@@ -129,8 +134,9 @@ over Slack.
 
 These are stored in `~/.kiro/crew/.env`.
 
-Other channels (Discord, Telegram, Teams, Webex, WeCom, WeChat) are connected
-from the dashboard — see each channel's doc.
+Every other messaging channel is connected from the dashboard — the roster is in
+[the documentation index](index.md#chat-channels), and each channel has its own
+doc there.
 
 ## Starting Kiro Crew
 

--- a/src/kiro_crew/docs/imessage-integration.md
+++ b/src/kiro_crew/docs/imessage-integration.md
@@ -47,7 +47,7 @@ deliberately does not use one.
 If the gateway is not on your Mac, or `imsg` is missing, the channel reports why
 in **Settings → Channels → iMessage** instead of failing silently.
 
-## Who can reach the agent
+## Access control
 
 **The allow-list is the whole gate, and an empty one authorizes nobody.** Every
 other channel has an org or workspace boundary in front of it; iMessage has
@@ -107,7 +107,7 @@ Commands, sent as an ordinary message:
 | `/compact` | Compress the conversation's context |
 | `/help` | List these commands |
 
-## Settings
+## Settings reference
 
 | Key | Default | Meaning |
 |---|---|---|
@@ -133,7 +133,7 @@ receive fine and answer nothing.
 Rather than ship a send path that cannot be made to work, the channel refuses to
 start off-Mac and says so.
 
-## Not in this version
+## Limits
 
 Group chats, attachments in either direction, and every kind of message
 mutation: tapbacks, edit, unsend, effects, polls, and group management. Those
@@ -164,3 +164,9 @@ or the gateway is not running on the Messages host.
 
 **The channel never starts and the log says it requires macOS.** Expected on
 Linux or Windows; there is no iMessage there to reach.
+
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -39,11 +39,11 @@ index, first-time setup, and connecting messaging channels.
 | [Agents](agents.md) | Switch between specialized agents per conversation, thread, or cron job |
 | [Skills](skills.md) | Drop-in markdown knowledge packs for domain-specific workflows |
 | [Dynamic Workflows](workflows.md) | Multi-phase agent orchestration authored from a plain-language goal: watch a run, restart part of it from cache, save it for reuse |
-| [Artifacts](dashboard.md) | Save, version, and revert generated UI and documents so they outlive the chat scrollback |
-| [Monitor Loops](subagents.md) | Keep one session checking something on an idle interval — a pull request, a CI run, a deployment — until an exit condition fires |
-| [Session Ledger](task-runner.md) | A durable per-session record of goal, phase, and next step that survives context compaction |
-| [Browser Control](configuration.md) | Drive a real web page from the dashboard's Browser panel: navigate, snapshot, click, type, screenshot |
-| [Computer Use](configuration.md) | Read and drive native desktop applications through the accessibility layer; opt-in and off by default |
+| [Artifacts](artifacts.md) | Save, version, and revert generated UI and documents so they outlive the chat scrollback |
+| [Monitor Loops](monitor-loops.md) | Keep one session checking something on an interval — a pull request, a CI run, a deployment — until an exit condition fires |
+| [Session Ledger](session-ledger.md) | A durable per-session record of goal, phase, and next step that survives context compaction |
+| [Browser Control](browser-control.md) | Drive a real web page from the dashboard's Browser panel: navigate, snapshot, click, type, screenshot |
+| [Computer Use](computer-use.md) | Read and drive native desktop applications through the accessibility layer; opt-in and off by default |
 
 ## Additional Features
 
@@ -75,16 +75,16 @@ documented by their own in-panel help.
 | Voice | Speech-to-text and spoken replies | [Configuration](configuration.md) |
 | Notifications | Where a proactive message is delivered | — |
 | Shortcuts | Keyboard bindings | — |
-| Skills | Installed skills and where they are loaded from | [Skills](skills.md) |
+| Skills | Whether sessions auto-generate skills, and whether a generated one needs your approval; installed skills live under Agent Capabilities | [Skills](skills.md) |
 | Channels | Per-channel setup and access control | [Channel capabilities](channel-capabilities.md) |
-| Browser | Installing the browser CLI and the attach token | — |
-| Computer Use | Driving native desktop apps; off by default | — |
-| Webhooks | Inbound tokens and request signing | [Inbound webhooks](inbound-webhooks.md) |
+| Browser | Installing the browser engine and the attach token | [Browser control](browser-control.md) |
+| Computer Use | Driving native desktop apps; off by default | [Computer use](computer-use.md) |
+| Webhooks | Inbound tokens and request signing — hidden unless you enable it under Feature Previews | [Inbound webhooks](inbound-webhooks.md) |
 | Instances | Additional gateways this dashboard can reach | — |
 | Privacy | What leaves the host | [Snapshot and restore](snapshot-and-restore.md) |
 | Security | The sandbox, denied commands, and the audit log | [Blocked commands](blocked-commands.md) |
 | Secrets | The encrypted credential vault | [Secrets vault](secrets-vault.md) |
-| Developer | Logs, metrics, storage, agent backend, feature previews | [Dashboard](dashboard.md) |
+| Developer | The Developer Mode consent switch, plus an optional local-gateway toggle; turning it on adds a separate Developer page that holds logs, metrics, storage and the rest | [Dashboard](dashboard.md) |
 | Releases | Update channel and version | [Getting Started](getting-started.md) |
 | About | Version and links | — |
 

--- a/src/kiro_crew/docs/index.md
+++ b/src/kiro_crew/docs/index.md
@@ -38,6 +38,12 @@ index, first-time setup, and connecting messaging channels.
 | Chat Channels | DM-based chat with tool approval — [Slack](slack-integration.md), [Discord](discord-integration.md), [Telegram](telegram-integration.md), [Teams](teams-integration.md), [Webex](webex-integration.md), [WeCom](wecom-integration.md), [WeChat](weixin-integration.md), [iMessage](imessage-integration.md), [WhatsApp](whatsapp-integration.md), [Feishu](feishu-integration.md); per-channel capabilities in each guide |
 | [Agents](agents.md) | Switch between specialized agents per conversation, thread, or cron job |
 | [Skills](skills.md) | Drop-in markdown knowledge packs for domain-specific workflows |
+| [Dynamic Workflows](workflows.md) | Multi-phase agent orchestration authored from a plain-language goal: watch a run, restart part of it from cache, save it for reuse |
+| [Artifacts](dashboard.md) | Save, version, and revert generated UI and documents so they outlive the chat scrollback |
+| [Monitor Loops](subagents.md) | Keep one session checking something on an idle interval — a pull request, a CI run, a deployment — until an exit condition fires |
+| [Session Ledger](task-runner.md) | A durable per-session record of goal, phase, and next step that survives context compaction |
+| [Browser Control](configuration.md) | Drive a real web page from the dashboard's Browser panel: navigate, snapshot, click, type, screenshot |
+| [Computer Use](configuration.md) | Read and drive native desktop applications through the accessibility layer; opt-in and off by default |
 
 ## Additional Features
 
@@ -53,6 +59,34 @@ index, first-time setup, and connecting messaging channels.
 | [Cooperative Stop](dashboard.md) | Stop sends a cancel first and only hard-kills after a budget, so session state survives |
 | [Streaming Speech-to-Text](configuration.md) | Live transcription partials in the dashboard input, with local Whisper or optional AWS Transcribe |
 | [Warm Pool](configuration.md) | Keep kiro-cli processes pre-spawned so a new session starts instantly |
+| [Secrets Vault](secrets-vault.md) | Credentials encrypted on disk and refused to the agent, with a `secret://` reference left in `.env` |
+
+## Settings reference
+
+Settings is organized into tabs. Several have a full guide; the rest are
+documented by their own in-panel help.
+
+| Tab | Covers | Guide |
+|---|---|---|
+| Overview | Gateway status and the settings you change most | — |
+| Imports | Bringing configuration in from another install | [Snapshot and restore](snapshot-and-restore.md) |
+| Chat | Composer behaviour, queued messages, feature tips | [Feature Tips](feature-tips.md) |
+| Display | Theme, language, and layout | — |
+| Voice | Speech-to-text and spoken replies | [Configuration](configuration.md) |
+| Notifications | Where a proactive message is delivered | — |
+| Shortcuts | Keyboard bindings | — |
+| Skills | Installed skills and where they are loaded from | [Skills](skills.md) |
+| Channels | Per-channel setup and access control | [Channel capabilities](channel-capabilities.md) |
+| Browser | Installing the browser CLI and the attach token | — |
+| Computer Use | Driving native desktop apps; off by default | — |
+| Webhooks | Inbound tokens and request signing | [Inbound webhooks](inbound-webhooks.md) |
+| Instances | Additional gateways this dashboard can reach | — |
+| Privacy | What leaves the host | [Snapshot and restore](snapshot-and-restore.md) |
+| Security | The sandbox, denied commands, and the audit log | [Blocked commands](blocked-commands.md) |
+| Secrets | The encrypted credential vault | [Secrets vault](secrets-vault.md) |
+| Developer | Logs, metrics, storage, agent backend, feature previews | [Dashboard](dashboard.md) |
+| Releases | Update channel and version | [Getting Started](getting-started.md) |
+| About | Version and links | — |
 
 ## Chat Channels
 

--- a/src/kiro_crew/docs/monitor-loops.md
+++ b/src/kiro_crew/docs/monitor-loops.md
@@ -1,0 +1,80 @@
+# Monitor loops
+
+A monitor loop keeps one conversation checking something on a schedule — a pull
+request, a CI run, a ticket, a deployment — without you re-asking. Say "keep an
+eye on this PR and tell me when it is review-ready" and the session wakes itself
+on an interval, does the check, and only speaks up when there is something to
+say.
+
+The loop runs in **the same conversation**, not a new one. It carries the same
+context, the same tools, and the same history, so it does not have to be
+re-briefed each round. Each cycle appends a turn to that conversation.
+
+## Starting and stopping one
+
+Ask for it in words: "monitor", "keep checking", "babysit", "let me know when".
+The agent arms the loop with the check instructions and an exit condition, then
+ends its turn. You do not have to stay in the tab.
+
+To stop it, say so — or use the dashboard control below.
+
+## The 🎯 goal control
+
+The composer carries a goal button (a target icon). It shows whether a loop is
+active, which cycle it is on, and the countdown to the next wake. Open it to set
+a goal, change the seconds between wakes, adjust the cycle cap, or stop the loop
+yourself.
+
+## Timing
+
+The interval is the gap between wakes, and it is **deadline-preserving**: your
+own messages defer a wake that comes due until your turn finishes, but they do
+not restart the clock. A loop stays on schedule in a conversation you are
+actively using.
+
+A loop the agent arms caps at **24** cycles by default; the goal control's own
+field starts at `0`, so a loop you arm there is unlimited unless you set a
+number. Either way the cap is a runaway backstop, not a finish line —
+a loop that reaches its cap ran out of rope rather than completing. A cap of `0`
+is unlimited, which is worth asking for only when you genuinely want an
+unbounded loop.
+
+A separate wall-clock budget can bound elapsed time instead of cycles, which
+suits a loop whose turns are slow or whose interval is long. When the budget is
+spent the loop deactivates and tells you.
+
+## One at a time
+
+A session holds one automation. Arming a new loop is refused while an active one
+exists, so a second request does not silently replace the first. A loop the
+system already stopped — an approval stall, a spent cap or budget, a finished
+subject — is replaced by the new one; a loop you paused or stopped yourself is
+preserved.
+
+Loops survive a gateway restart.
+
+## Watching a pull request specifically
+
+For a public GitHub pull request there is a cheaper path than a general loop: a
+structured watch that probes the provider directly and wakes the session **only
+when a new revision needs action**. An unchanged, pending, retrying, or finished
+probe costs no agent turn at all. Ask to watch a PR until it is review-ready and
+you get this instead of a turn every interval.
+
+You can ask what the current watch is doing, or stop it, at any time.
+
+## Where loops work
+
+Dashboard chat, Slack threads, Discord DMs, and Webex. A loop bound to one of
+those channels stays bound to it. Anywhere else — a cron job, a webhook session, a
+subagent — the arm is refused with a note to use a schedule instead.
+
+The structured pull-request watch above is narrower: it needs typed wake delivery,
+which exists for dashboard, Slack and Discord only. Ask for it from a Webex
+session and you get the general loop, not the cheap probe.
+
+## Related docs
+
+- [Subagents](subagents.md): parallel fan-out rather than repeated checks
+- [Cron and scheduling](cron-and-scheduling.md): a schedule that starts a *fresh* session each time
+- [Dashboard](dashboard.md): the composer and the side panel

--- a/src/kiro_crew/docs/research-lab.md
+++ b/src/kiro_crew/docs/research-lab.md
@@ -4,11 +4,13 @@ Research Lab (the `auto-research` builtin app) runs autonomous, multi-cycle camp
 
 `auto-research` is disabled by default. App enablement is the activation gate: a disabled app contributes no agents, skills, crons, or routes.
 
-> **Research Lab is research-only by design.** It gathers, analyzes, and reports — it does
-> **not** take actions on your systems (no writes, deployments, mutations, or code changes).
-> Its sub-agents run with read/research tools only, and any follow-up action is handed off
-> to the main agent for you to review and drive. This keeps campaigns safe to run
-> unattended and their results reproducible. See [Scope](#scope-research-only-by-design).
+> **Research Lab is not a permission boundary.** Its `kirocrew-research` worker is
+> generated from your main agent's configuration and therefore inherits the same MCP
+> servers and the same tool set — it can write files, run commands, and mutate systems
+> exactly as your main agent can. Research-only is the *intent* of the prompt it is
+> given, not a restriction the code enforces. Review the tools your main agent has
+> before leaving a campaign to run unattended. See
+> [Scope and permissions](#scope-and-permissions).
 
 ## Execution modes
 
@@ -24,14 +26,14 @@ A campaign can instead use **workflow** mode, which runs the Dynamic Workflow te
 ## Shared domain layer
 
 - **Grill tree** — interactive clarification that scopes the question into sub-questions
-  (a well-formed starting point). See `GrillTree.tsx`.
+  (a well-formed starting point).
 - **Success criteria** — optional natural-language done-condition, verified each cycle
   (`verification: {passed, detail}` on the finding).
 - **Limits** — max cycles (safety cap), idle interval, max sub-questions per round, budget.
 - **In-progress guidance** — user steering injected between cycles: the agent reads
   `guidance.txt` each cycle and incorporates it.
 - **Emergent sub-questions** — findings-driven follow-ups, ranked, depth-decayed, deduped,
-  activated into the checklist (`subquestion_queue.py`).
+  activated into the checklist, ranked with decay and de-duplicated.
 - **Findings + report** — per-cycle `cycle_NNN.json` cards + consolidated `FINDINGS.md`,
   exportable to the Knowledge Library or as an HTML artifact.
 
@@ -66,15 +68,6 @@ The agent writes each `cycle_NNN.json` finding card as it completes a cycle.
 | `stopped` | User-stopped (terminal) |
 
 Pause/resume pauses/resumes the autonudge loop.
-
-## Key files
-
-| File | Role |
-|------|------|
-| `src/kiro_crew/apps/builtins/auto_research/handlers.py` | Campaign CRUD, watchdog, grill tree, agent launch, emergent-exploration, findings, reports, SSE |
-| `src/kiro_crew/apps/builtins/auto_research/subquestion_queue.py` | Emergent sub-question queue (ranking, decay, dedup) |
-| `website/src/apps/auto-research/ResearchLabPage.tsx` | Setup wizard, campaign list/detail, finding cards |
-| `website/src/apps/auto-research/GrillTree.tsx` | Grill-tree clarification UI |
 
 ## Scope and permissions
 

--- a/src/kiro_crew/docs/secrets-vault.md
+++ b/src/kiro_crew/docs/secrets-vault.md
@@ -1,0 +1,71 @@
+# Secrets vault
+
+The secrets vault stores credentials encrypted on disk, where the agent cannot
+read them. A secret you put in the vault stays reachable to the code that needs
+it and stays refused to every file read and shell command the agent runs — so a
+prompt injection that talks the agent into printing your tokens has nothing to
+print.
+
+## Where it lives, and why the agent cannot read it
+
+Each entry is encrypted separately with AES-256-GCM under a key file that only
+your account can read. Both files sit in a `.vault` directory inside your Kiro
+Crew data home, alongside `config.json`.
+
+`.vault` is registered as a sensitive path, which is a check that runs before the
+verb rather than per tool. That covers a file read, a `cat`, and a scripted
+`python -c "open(...)"` alike — the refusal does not depend on the agent choosing
+a route the policy anticipated. The protection is enforced by Kiro Crew, not by
+the operating system: another program running as you can still open the files.
+
+## Adding a secret
+
+Use **Settings → Secrets** in the dashboard. The panel lists the names it holds,
+adds a new entry, and deletes one. It never shows a stored value back to you —
+listing returns names only, so a screenshot of the panel leaks nothing.
+
+If a value fails to save, the form keeps what you typed rather than clearing it,
+so you do not have to fetch the credential again.
+
+## Moving credentials out of `.env`
+
+`kirocrew secrets import` migrates plaintext credentials from `.env` into the
+vault and rewrites each line to a `secret://KEY` reference — the file keeps a
+pointer where the token used to be, and the reader resolves it from the vault.
+
+It is a **dry run by default**: the bare command reports what it would move and
+writes nothing. Add `--apply` to perform the migration.
+
+```bash
+kirocrew secrets import           # report only
+kirocrew secrets import --apply   # store the secrets and rewrite .env
+```
+
+Migration is deliberately narrow. Only the Jira credentials are moved today —
+the global `JIRA_API_TOKEN` and the per-host `JIRA_TOKEN_<HEX>` entries — because
+those are the only readers that resolve a `secret://` reference. Every other
+credential in `.env` (Slack, Discord, kiro-cli, and the rest) still reads the
+literal value, so rewriting its line would hand the reader the reference string
+instead of the token and break authentication. Those keys migrate as their
+readers become vault-aware.
+
+Running the import again is safe: a key whose value is already a `secret://`
+reference is reported as such and skipped.
+
+## Recovering from a failed import
+
+An import computes its rewrite from a snapshot taken at the start. If `.env`
+changes underneath it — another writer adding a token, a channel connected from
+the dashboard mid-run — the rewrite is abandoned without writing, so a token
+someone else just added is never overwritten.
+
+If an apply fails partway and a rollback cannot delete the vault entries it
+already wrote, the report names those keys. A leftover entry shadows a later
+rotation of the same key, so delete the named entries under **Settings →
+Secrets**.
+
+## Related docs
+
+- [Configuration](configuration.md): the config file, `.env`, and environment variables
+- [Blocked commands](blocked-commands.md): why a read was refused and what to do instead
+- [Snapshot and restore](snapshot-and-restore.md): what a snapshot excludes, and why

--- a/src/kiro_crew/docs/session-ledger.md
+++ b/src/kiro_crew/docs/session-ledger.md
@@ -1,0 +1,43 @@
+# Session ledger
+
+The session ledger is a small durable record of what a long-running session is
+doing: the goal, the phase it has reached, the concrete next step, the approaches
+already tried and rejected, and pointers to whatever it produced. It lives on
+disk, so it outlasts the conversation's own memory.
+
+That is the point. A very long session eventually has its earlier turns
+compacted away to make room, and a monitor loop's cycle can start hours after the
+one before it. The ledger is what the session reads to re-establish where it was
+instead of re-deriving it from a transcript that may no longer contain the
+answer.
+
+## What you get from it
+
+Ask "where are we on this?" in a long-running session and the answer comes from
+the ledger rather than from the agent scrolling back — so it stays accurate after
+compaction, after a gateway restart, and across a monitor loop's cycles.
+
+The useful entries are written as intent, not status: "add the Windows branch to
+the permission helper, the test already fails" tells a cold resume what to do,
+where "in progress" does not.
+
+## What it is not
+
+The ledger has **no dashboard page**. It is storage the agent reads and writes,
+not a view you browse. To see it, ask the session about it.
+
+It is also only for genuinely long-horizon work — a babysit loop, a multi-wake
+task, a goal that spans hours. A single-turn request does not get one, and
+nothing is lost by that.
+
+## Finishing
+
+A ledger is marked finished when its work is done or abandoned, which stops it
+being re-injected into later cycles. A stale ledger quietly steering a session
+that has moved on is the failure this avoids.
+
+## Related docs
+
+- [Monitor loops](monitor-loops.md): the repeated-wake work a ledger most often backs
+- [Task runner](task-runner.md): autonomous multi-step execution from a spec file
+- [Memory and learning](memory-and-learning.md): what persists across *different* sessions

--- a/src/kiro_crew/docs/slack-integration.md
+++ b/src/kiro_crew/docs/slack-integration.md
@@ -5,9 +5,7 @@ or in channels where the bot is present.
 
 ## Activation Modes
 
-> **Security note:** Slack interaction is restricted to the owner only
-> (`KIROCREW_OWNER_ID`). Multi-user access is disabled for security —
-> allowed users would act under the owner's system identity.
+Slack interaction is restricted to the owner — see [Access control](#access-control).
 
 Each channel can have a different activation mode:
 
@@ -33,11 +31,12 @@ Only the owner (set via `KIROCREW_OWNER_ID`) can use these:
 | `!ta <name>` | Set agent for this thread only |
 | `!ta off` | Remove thread agent override |
 | `!ta` | Show the current thread agent |
-| `!allowlist @user` | ~~Add/remove a user from the allowlist~~ (disabled) |
-| `!allowlist #channel` | ~~Track/untrack a channel for auto-allowlist~~ (disabled) |
 | `!channel` | Show current channel activation mode |
 | `!channel always/mention/observe/review/off` | Set channel activation mode |
 | `!channel agent <name/off>` | Set per-channel agent override |
+
+`!allowlist` and `/kirocrew @user` are not accepted while access is owner-only, and
+`slack.allowed_users` in config has no effect.
 
 ## Commands for All Allowed Users
 
@@ -74,8 +73,6 @@ Available to all allowed users (no `!` prefix needed):
 | Command | Description |
 |---------|-------------|
 | `/kirocrew dashboard` | Same as `!dashboard` |
-| `/kirocrew @user` | ~~Same as `!allowlist @user`~~ (disabled) |
-| `/kirocrew #channel` | ~~Same as `!allowlist #channel`~~ (disabled) |
 
 ## Tool Approval Flow
 
@@ -83,7 +80,9 @@ When Kiro Crew needs to run a tool (file write, bash command, etc.):
 
 1. **Auto mode** (`!yolo on`): silently approves everything
 2. **Interactive mode** (default): posts Approve / Trust session / Reject buttons
-3. 120-second timeout — auto-rejects if no click
+3. 120-second timeout — auto-rejects if no click. Slack has its own figure; the
+   other five channels that prompt at all wait five minutes, and four channels do
+   not prompt. See [Channel capabilities](channel-capabilities.md).
 4. "Trust session" approves all remaining tools for that session
 
 Approval buttons appear in both Slack and the dashboard. Approving in either
@@ -122,15 +121,13 @@ multiple options before submitting.
 
 ## Access control
 
-> ⚠️ **Multi-user Slack access is currently disabled for security.** Kiro Crew
-> is restricted to the bot owner only. The `!allowlist` command and
-> `/kirocrew @user` are disabled. Allowed users in config have no effect.
->
-> Rationale: allowed users act under the owner's system identity (file
-> permissions, AWS credentials) with no scope limits or expiry.
+Kiro Crew on Slack answers the bot owner (`KIROCREW_OWNER_ID`) and nobody else.
+Multi-user access is disabled because an allowed user would act under the owner's
+system identity — the owner's file permissions and cloud credentials — with no scope
+limit and no expiry. `!allowlist`, `/kirocrew @user` and `slack.allowed_users` are all
+inert as a result, and stale allowlist entries are pruned at startup.
 
-The dashboard can still be accessed via `!dashboard` presigned links by the
-owner only.
+`!dashboard` presigned links go to the owner only.
 
 ## Channel Monitoring
 
@@ -176,37 +173,23 @@ your own workspace.
    `slack.command` in config.json (default: `kirocrew`). Each app instance
    should use a unique name.
 
-> **Access scoping** — Multi-user access is disabled for security. Kiro Crew is
-> restricted to the bot owner only (`KIROCREW_OWNER_ID`).
+## Settings page
 
-## Settings API (dashboard)
+The Slack channel view at `/settings/channels/slack` shows the connection state, the
+masked token previews, the owner ID, the slash command and the behaviour toggles. Three
+things about it are worth knowing before you use it:
 
-The Slack channel view at `/settings/channels/slack` (legacy
-`?tab=slack` / `?tab=channels&channel=slack` links redirect there) is backed
-by three dashboard-only
-endpoints (registered behind token auth, never on the API-only server):
+- **Editing is loopback-only.** A request reaching the dashboard through a proxy or from
+  another machine is read-only, so a remote browser sees the state and cannot change it.
+- **A token is verified against Slack before it is stored.** A rejected token is not
+  written. If the host is offline the save succeeds with a warning instead, and clearing
+  a token takes an explicit clear action rather than an empty field.
+- **Some changes need a restart** — the tokens, the owner ID, the slash command and the
+  enterprise-org allowlist are read at boot. Reactions and thinking-indicator toggles
+  apply immediately.
 
-- `GET /api/slack/config` — masked token previews (`xoxb-••••wxyz`), presence
-  booleans, owner ID, slash command, enterprise-org allowlist, behavior
-  toggles, plus live status: `connected` (real socket outcome recorded at
-  startup), `connect_error` (e.g. `invalid_auth`), and `read_only` (true for
-  any request that is not direct-local).
-- `PUT /api/slack/config` — direct-local only (loopback peer AND no proxy
-  forwarding headers; remote gets 403). Tokens are write-only and verified
-  against Slack before storage (`auth.test` / `apps.connections.open`);
-  rejected tokens return 400 and are never written. Offline saves succeed
-  with `verify_warning`. Clearing a token requires a strict boolean
-  `<field>_clear: true`. Response `restart_required` is true for secret/owner
-  changes and boot-read config (`command`, `allowed_enterprise_ids`);
-  `reactions_enabled` / `show_thinking` apply live.
-- `GET /api/slack/manifest` — renders the bundled app manifest (alias from
-  `?alias=`, defaulting to `kirocrew`, never `$USER`) and Slack's one-click
-  create deep link. Public template only.
-
-Secrets land in `config_dir/.env` via atomic 0600 writes; `os.environ` is
-synced after saves so status reads stay truthful. `allowed_users` /
-`open_channels` are intentionally not exposed while the runtime enforces
-owner-only access.
+Secrets are written to `.env` in the config directory with owner-only permissions, never
+to `config.json`.
 
 ## Related docs
 

--- a/src/kiro_crew/docs/slack-integration.md
+++ b/src/kiro_crew/docs/slack-integration.md
@@ -120,7 +120,7 @@ When Kiro Crew presents choices, they render as interactive Block Kit buttons.
 Click a button to send that choice back to the conversation. You can select
 multiple options before submitting.
 
-## Sharing Access
+## Access control
 
 > ⚠️ **Multi-user Slack access is currently disabled for security.** Kiro Crew
 > is restricted to the bot owner only. The `!allowlist` command and
@@ -207,3 +207,9 @@ Secrets land in `config_dir/.env` via atomic 0600 writes; `os.environ` is
 synced after saves so status reads stay truthful. `allowed_users` /
 `open_channels` are intentionally not exposed while the runtime enforces
 owner-only access.
+
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables

--- a/src/kiro_crew/docs/snapshot-and-restore.md
+++ b/src/kiro_crew/docs/snapshot-and-restore.md
@@ -63,136 +63,19 @@ hand to another person.
 | `backup` (default) | Restoring onto a host you control | Everything selected rides; the LOCAL archive is unredacted — that is the point |
 | `share` | Leaving your control | **Refused for every component** |
 
-## What leaves the host, and what redaction is for
+`--purpose share` refuses whatever you select, and that is deliberate rather than
+unfinished. Whether a component is safe to share is a question about its **content**, not
+its shape: a workspace file, a skill, a cron's `env` map, a notification body or a lesson
+you pasted a token into can each carry a credential, and staging cannot tell. Nothing
+claims share-safety until the redaction work behind it exists. The purpose, the
+per-component declaration and the refusal are all live, so the first certified component
+only has to change its own declaration. A component added without a policy declaration is
+refused at staging rather than defaulting to permissive, so a new component cannot inherit
+a permissive value by omission.
 
-The local archive and the off-host copy are the same bytes unless you ask otherwise.
-
-What protects the uploaded bundle is the destination, not a rewrite: the bucket is created
-private and every upload re-asserts the whole set before sending a byte — all four
-public-access blocks, default encryption, ACLs disabled via `BucketOwnerEnforced`,
-versioning, no bucket policy at all, and the object write pinned to the expected owner
-account. Any of those missing or unreadable refuses the upload. The audience for the
-uploaded copy is therefore the same as the audience for your local disk: you.
-
-On top of that you can opt IN to rewriting the copy that leaves, by writing
-`{"redact_uploads": true}` to `redaction.json` inside your backup directory. Then both
-mandatory outbound redactors run over the throwaway copy, and `config.json`'s token plus
-anything credential-shaped in a note or a memory row is replaced with an inert tag.
-
-It is off by default because it is not free. Replacing a credential is a variable-length
-edit, so any file whose structure depends on byte offsets — an archive, a PDF, most binary
-container formats — comes out the other side invalid. Paying that to re-protect a copy only
-you can read is the wrong default. Turn it on when the bucket's audience is genuinely wider
-than you believe, or when you want the off-host copy to be inert on principle.
-
-One pass runs only here. The shared redactors also run over live model output and tool
-results, where rewriting something that merely resembles a key corrupts what you are
-reading, so they recognise specific vendor formats and specific field names. That leaves
-real shapes uncovered — a bot token whose format they have no pattern for, or your own
-`api_key = "…"` with an opaque value. This copy is a throwaway on its way off the host and
-your complete archive stays local, so the egress pass can afford to be broader: it also
-replaces any long quoted value assigned to a credential-ish field name, and any bearer
-token shaped as three dot-separated segments. That is the same trade the over-reach note
-below describes, made deliberately in the one place where the cost is one note's text
-rather than a corrupted answer.
-
-Two consequences worth knowing before you turn it on:
-
-- **Restoring a redacted off-host copy gives you working memory and inert credentials.** The
-  shape is complete and the databases are valid; the fields that authenticate are not.
-  Re-enter them after restoring. The restore prints what was redacted, so you are told
-  rather than left to discover it.
-- **Redaction is pattern-based, so it can over-reach.** A note holding something that
-  merely looks like a key can lose that text in the off-host copy. The local archive is
-  unaffected, and the per-path replacement counts are printed at upload and again at
-  restore so you can judge whether a count looks wrong.
-
-Databases are redacted value by value through SQL rather than over their bytes. That is
-not a stylistic choice: the redactors substitute a tag, so they change length, and
-rewriting a SQLite file's bytes produces a file SQLite cannot open — which the restore
-path would then correctly refuse as corrupt.
-
-Search indexes and files whose only purpose is to be secret are left out of the
-outbound copy entirely rather than blanked, because an inert key present in the bundle
-is indistinguishable from a rotated one. Restore already reports an absent index and
-what to rebuild. Those files are matched by their **exact position** in the bundle, not
-by name: your workspace may hold a `telemetry_salt` or a `memory_index.db` of your own,
-and leaving out a file that merely shares a name with one of the product's would be
-losing your data, not protecting it.
-
-Values are redacted on what they hold rather than on the column's declared type, so a
-credential stored as binary is rewritten too. Bytes make the round trip through a
-byte-preserving codec and are only written back when something actually matched, so
-embeddings and other genuine blobs come out identical.
-
-A database's **schema** is checked as well as its rows. A key can be written into a column
-default, a view's body or a trigger, and none of those are values any row scan reaches.
-Schema text also cannot be rewritten the way a value can — changing it means rebuilding the
-object — so a database in that state is one this pass cannot clean, and the upload is
-refused either way. Nothing is deleted to make an upload possible: `memory.db` and the
-Knowledge Library are what the backup exists to carry, so sending the bundle without one
-of them would report success and restore nothing.
-
-Rows are scanned to a **fixpoint**, not once. An update fires the database's own triggers,
-and a trigger can copy the pre-update value into a table the scan has already cleaned, so a
-single pass can leave a credential behind in a place it already visited. Each pass reports
-its own replacements and the scan stops when a pass changes nothing. A database that keeps
-moving is one that cannot be shown clean, so the upload is refused and the database is
-named rather than removed.
-
-The **manifest** is redacted too, after it is stamped — it is the one file guaranteed to be
-in the upload, and the stamp itself writes paths and error text into it. It is checked to
-still parse afterwards, because a manifest that does not is a bundle that cannot be
-restored.
-
-Whether a file is text is decided by **decoding** it, not by its name — a workspace holds
-whatever you put there, and a suffix list would classify your `.py`, `.csv` or
-extension-less notes as opaque. A file that genuinely does not decode (an image, an
-archive) cannot be shown free of credentials, so the **upload is refused** and those
-files are named. They are not removed: a restore that reports success while quietly
-lacking your own files is worse than an upload that stops and tells you. Narrow the
-selection with `--components`, or turn redaction off for that run. A `.db` that is not
-a database the product ships is treated the same way, and so is a database the product
-DOES ship: whichever it is, the file is kept and the upload refuses, naming it and why.
-Your local snapshot is complete and unaffected in every one of these cases.
-
-Turning it on is a file, not a setting in `config.json`, and that placement is the point.
-`config.json` is readable and writable by the agent, so a switch living there could be
-flipped by the agent itself. The fence matters in BOTH directions now: an agent that could
-turn this on could corrupt your off-host copy, and one that could turn it off could publish
-a credential into the bucket. The backup directory is already fenced for the same reason its
-destination record is — neither the agent's file tools nor any shell form can read or write
-it. Only you can.
-
-Four cases, and none of them is a silent guess:
-
-- **No file** — off. The default, and it needs no file.
-- **`{"redact_uploads": true}`** — on.
-- **`{"redact_uploads": false}`** — off, written down explicitly, which is allowed.
-- **Anything else** — a file that parses to neither, an unreadable one, or `"true"` as a
-  string. The upload refuses and names the file. You wrote it on purpose, so guessing off
-  would ignore a request to scrub and guessing on would rewrite files you may not have
-  meant to touch. Your local snapshot is already written and is unaffected.
-
-If redaction is on and cannot be completed, the upload is refused; it never falls back to
-sending the unredacted bundle.
-
-`--purpose share` currently refuses whatever you select, and that is deliberate rather
-than unfinished. Whether a component is safe to share is a question about its
-**content**, not its shape: a workspace file, a skill, a cron's `env` map, a
-notification body or a lesson you pasted a token into can each carry a credential, and
-staging cannot tell. Marking components share-safe one at a time was tried during
-review and guessed wrong twice, so nothing claims it until the redaction work behind
-it exists. The purpose, the per-component declaration and the refusal are all live, so
-the first certified component only has to change its own declaration.
-
-For now, use `--purpose backup` — restoring onto a host you control is what this
-feature is for. The bundle's manifest records the purpose and each component's
-declaration, so a reader of a bundle can tell which they are holding.
-
-A component added without a policy declaration is refused at staging rather than
-defaulting to permissive, so a new component cannot inherit a permissive value by
-omission.
+Use `--purpose backup` — restoring onto a host you control is what this feature is for.
+The bundle's manifest records the purpose and each component's declaration, so a reader of
+a bundle can tell which they are holding.
 
 ## Off-host copies
 
@@ -244,6 +127,21 @@ When it is on:
 The agent cannot reach this file. It is fenced at the same level as the command deny list
 and the computer-use enable, for reading as well as writing -- flipping it off is the
 attack, and reading it tells an attacker whether the store is currently being scrubbed.
+
+Two consequences worth knowing before you turn it on:
+
+- **Restoring a redacted off-host copy gives you working memory and inert credentials.**
+  The shape is complete and the databases are valid; the fields that authenticate are not.
+  Re-enter them after restoring. The restore prints what was redacted, so you are told
+  rather than left to discover it.
+- **Redaction is pattern-based, so it can over-reach.** A note holding something that
+  merely looks like a key can lose that text in the off-host copy. The local archive is
+  unaffected, and the per-path replacement counts are printed at upload and again at
+  restore so you can judge whether a count looks wrong.
+
+Search indexes and files whose only purpose is to be secret are left out of the outbound
+copy entirely rather than blanked, because an inert key present in the bundle is
+indistinguishable from a rotated one. Restore reports an absent index and what to rebuild.
 
 ### Restoring a bundle that came from off-host
 

--- a/src/kiro_crew/docs/teams-integration.md
+++ b/src/kiro_crew/docs/teams-integration.md
@@ -232,7 +232,7 @@ None of this disables the security gate: the sensitive-path keystone, the
 enterprise governance ceiling, and the destructive-command deny-list all run ahead
 of auto-approval, so anything denied by policy stays denied.
 
-## Security notes
+## Access control
 
 - The webhook is **exempt from the dashboard cookie gate and from the CSRF origin
   check, for `POST` only**, because it performs its own Bot Framework JWT
@@ -269,7 +269,7 @@ of auto-approval, so anything denied by policy stays denied.
   that resolves into a private, loopback or link-local range is refused — so an
   activity cannot turn the gateway into a proxy for your internal network.
 
-## Limitations (this release)
+## Limits
 
 - 1:1 personal chat only — no team channels, group chats, or @mention handling.
   A reply in a channel would expose tool output to people who are not on your
@@ -303,3 +303,9 @@ of auto-approval, so anything denied by policy stays denied.
   with a channel or user target — its addressing, allow-list and threading are Slack
   concepts — so a Teams-only install should rely on the mirror rather than on that
   tool's own delivery.
+
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables

--- a/src/kiro_crew/docs/telegram-integration.md
+++ b/src/kiro_crew/docs/telegram-integration.md
@@ -43,7 +43,7 @@ Send your bot a message and it answers. If it stays quiet, check that your ID is
 in `allowed_user_ids` and look for `Telegram channel started` in the gateway
 log.
 
-## Who can reach it
+## Access control
 
 > **Kiro Crew runs on your machine, with your files and credentials.** So it only
 > talks to people you name — and only in private chats.
@@ -195,7 +195,7 @@ including on the turn where the context warning finally matters.
 Scheduled jobs report back **here**. A cron you create from Telegram delivers its
 result to this conversation, not only to the dashboard bell.
 
-## Settings & reference
+## Settings reference
 
 Everything lives in the `telegram` section of `config.json`:
 
@@ -230,6 +230,7 @@ Transport capabilities: streaming, edits, reactions, inbound and outbound files,
 
 ## Related docs
 
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
 - [Slack Integration](slack-integration.md)
 - [WeCom Integration](wecom-integration.md)
 - [Getting Started](getting-started.md)

--- a/src/kiro_crew/docs/use-cases.md
+++ b/src/kiro_crew/docs/use-cases.md
@@ -10,18 +10,31 @@ The most powerful workflow: Kiro Crew digs through your issue backlog, picks up
 tasks, implements them, runs tests, opens pull requests, and handles review
 comments — all autonomously. It can push 20+ PRs overnight.
 
-```
-kirocrew run docs/task-specs/backlog-crusher.md
+The task runner reads a spec you write. Save the steps below as
+`backlog-crusher.md`:
+
+```markdown
+# Backlog crusher
+
+1. List open issues in the project's tracker.
+2. Pick the highest-priority unassigned issue.
+3. Read the issue description and the code it links to.
+4. Implement the change.
+5. Run the test suite (e.g. `pytest`).
+6. Open a pull request targeting the correct branch.
+7. Move to the next issue.
 ```
 
-A typical spec:
-1. List open issues in the project's tracker
-2. Pick the highest-priority unassigned issue
-3. Read the issue description and linked code
-4. Implement the change
-5. Run the test suite (e.g. `pytest`)
-6. Open a pull request targeting the correct branch
-7. Move to the next issue
+Then hand that file to the runner. The path is resolved as given, so run this from
+the directory holding the file, or pass its absolute path:
+
+```
+kirocrew run backlog-crusher.md
+```
+
+`kirocrew run --help` lists the flags that matter for a long run: `--fresh`
+ignores an existing checkpoint, `--no-test` skips verification between steps,
+and `--timeout` caps the whole run.
 
 For unattended operation with the `yolo` approval mode, use an isolated `KIROCREW_HOME`; the gateway refuses `--approval yolo` for the main data home.
 

--- a/src/kiro_crew/docs/webex-integration.md
+++ b/src/kiro_crew/docs/webex-integration.md
@@ -129,7 +129,7 @@ render. Anything that is not an answer is treated as an ordinary mid-turn
 message, so you can redirect the agent instead of answering. An unanswered prompt
 is **denied** after five minutes.
 
-## Security model
+## Access control
 
 - **Deny-by-default** — an empty `allowed_emails` list rejects everyone.
   Anyone in an org can message a Webex bot, so add only your own email(s).
@@ -163,7 +163,7 @@ is **denied** after five minutes.
   ceiling and the deny-list all run ahead of auto-approval, so a hard deny still
   wins.
 
-## Configuration reference
+## Settings reference
 
 | Setting | Default | What it does |
 |---|---|---|
@@ -195,6 +195,7 @@ delivered it); a reply refusal with nothing in the log but a
 
 ## Related docs
 
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
 - [Slack Integration](slack-integration.md)
 - [Telegram Integration](telegram-integration.md)
 - [WeCom Integration](wecom-integration.md)

--- a/src/kiro_crew/docs/wecom-integration.md
+++ b/src/kiro_crew/docs/wecom-integration.md
@@ -57,7 +57,7 @@ today's WeCom channel: it renders no tappable buttons, so a list of choices
 arrives as a numbered list you answer by typing. Tappable cards do exist in the
 AI-bot API; they are not wired up yet.
 
-## Who can reach it
+## Access control
 
 > **Kiro Crew runs on your machine, with your files and credentials.** So it only
 > talks to the owner and the userids you name.
@@ -118,7 +118,7 @@ and stripped before the command is matched, so `@Kiro /new` also works — but s
 "Who can reach it": messages sent in a WeCom group are refused, so commands only
 take effect in a direct chat.
 
-## Settings & reference
+## Settings reference
 
 Everything lives in the `wecom` section of `config.json`:
 
@@ -138,6 +138,12 @@ Credentials go in `~/.kiro/crew/.env`: `WECOM_BOT_ID` and `WECOM_SECRET`.
 
 Dashboard delivery uses `target_id` values `user:<userid>`. Named users are shown as unavailable until they message the bot after the gateway starts; with `allow_all_users`, only those warmed direct-message peers are listed. Each destination is revalidated against the current authorization policy before delivery.
 
+**This channel is not an owner-DM target.** Because the peer list is learned from
+inbound traffic, "the owner" cannot be resolved to a known person here — a
+`send_message` aimed at this channel would risk delivering to whoever last
+messaged the bot, so the channel is excluded from that routing entirely. Named
+dashboard destinations above still work; only the unqualified owner DM does not.
+
 **If something's off:** no reply usually means the sender's userid isn't allowed
 or `enabled` is `false`; a missing `channel started` line means a credential is
 unset; if it connects and then goes quiet, the bot may have been removed from
@@ -145,6 +151,7 @@ the WeCom console — re-add it and restart.
 
 ## Related docs
 
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
 - [Slack Integration](slack-integration.md)
 - [Telegram Integration](telegram-integration.md)
 - [Getting Started](getting-started.md)

--- a/src/kiro_crew/docs/weixin-integration.md
+++ b/src/kiro_crew/docs/weixin-integration.md
@@ -114,6 +114,7 @@ credential store) and overrides `weixin.token`.
 - [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
 - [Getting Started](getting-started.md): install, first run, connecting a channel
 - [Configuration](configuration.md): the config file and environment variables
+
 ## Attribution
 
 The iLink protocol layer (endpoints, auth headers, QR login, long-poll cursor)

--- a/src/kiro_crew/docs/weixin-integration.md
+++ b/src/kiro_crew/docs/weixin-integration.md
@@ -31,7 +31,7 @@ The bot credential is written server-side (into the credential store, never
 returned to the browser); only the non-secret account id and connection status
 are exposed to the dashboard.
 
-## Access policy
+## Access control
 
 `Who can message the bot` maps to `weixin.dm_policy`:
 
@@ -62,7 +62,7 @@ Context length is managed automatically: at `weixin.soft_threshold_pct` (80%) th
 bot suggests `/compact` or `/new`; at `weixin.hard_threshold_pct` (95%) it
 compacts on its own.
 
-## Behaviour notes
+## Limits
 
 - **One reply per turn.** iLink cannot edit a sent message, so the answer is
   buffered and delivered when the turn completes rather than streamed. The native
@@ -74,8 +74,12 @@ compacts on its own.
 - **No approval buttons.** iLink has no interactive controls, so the channel runs
   the approval ladder without a decider: `interactive` mode is deny-by-default,
   while `auto` / `trust` behave normally.
+- **Not an owner-DM target.** The peer list is learned from inbound traffic, so
+  "the owner" cannot be resolved to a known person here. Rather than risk
+  delivering to whoever last messaged the bot, this channel is excluded from
+  owner-DM routing: a `send_message` aimed at it will not arrive.
 
-## Configuration reference
+## Settings reference
 
 Set under `weixin` in `config.json` (or via the Settings panel):
 
@@ -105,6 +109,11 @@ credential store) and overrides `weixin.token`.
 | An image, voice note or file isn't read | The message arrived but the file was skipped — the gateway log shows `attachment_skip` with the reason. Video is never read; send a screenshot instead |
 | Startup error about `aiohttp` | Install the messaging extra |
 
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables
 ## Attribution
 
 The iLink protocol layer (endpoints, auth headers, QR login, long-poll cursor)

--- a/src/kiro_crew/docs/whatsapp-integration.md
+++ b/src/kiro_crew/docs/whatsapp-integration.md
@@ -109,7 +109,7 @@ Echo discipline: the agent tracks the IDs of messages it sends, so its own
 replies (which arrive on the same account) are never mistaken for your
 commands, and anything **you** type is never mistaken for an echo.
 
-## Access policy
+## Access control
 
 `whatsapp.dm_policy` controls who may command the agent in direct chats:
 
@@ -188,7 +188,7 @@ only the command list. Everything that acts on the session is **operator only**:
 from anyone else those words are treated as plain text. Matching is whole-message
 and exact, so `/stop the presses` reaches the agent as a sentence.
 
-## Behaviour notes
+## Limits
 
 - **The reply streams**: it appears as soon as there is something to read and
   is then edited in place as the agent continues, because the WhatsApp Web
@@ -231,7 +231,7 @@ and exact, so `/stop the presses` reaches the agent as a sentence.
 - **Read receipts / typing**: the agent shows "typing…" while working on a
   reply, and never marks your own self-chat as read on your behalf.
 
-## Configuration reference
+## Settings reference
 
 | Key | Default | Meaning |
 |---|---|---|
@@ -276,6 +276,11 @@ and exact, so `/stop the presses` reaches the agent as a sentence.
   someone to the conversation, not to your machine, so add the number to the
   allowlist if you want their photos and documents read.
 
+## Related docs
+
+- [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
+- [Getting Started](getting-started.md): install, first run, connecting a channel
+- [Configuration](configuration.md): the config file and environment variables
 ## Attribution
 
 Protocol layer by [neonize](https://github.com/krypton-byte/neonize)

--- a/src/kiro_crew/docs/whatsapp-integration.md
+++ b/src/kiro_crew/docs/whatsapp-integration.md
@@ -281,6 +281,7 @@ and exact, so `/stop the presses` reaches the agent as a sentence.
 - [Channel capabilities](channel-capabilities.md): the ten-channel matrix — streaming, buttons, uploads, reply length, approval timeout
 - [Getting Started](getting-started.md): install, first run, connecting a channel
 - [Configuration](configuration.md): the config file and environment variables
+
 ## Attribution
 
 Protocol layer by [neonize](https://github.com/krypton-byte/neonize)

--- a/src/kiro_crew/docs/workflows.md
+++ b/src/kiro_crew/docs/workflows.md
@@ -1,0 +1,68 @@
+# Dynamic workflows
+
+A dynamic workflow turns a goal into a multi-phase run you can watch, restart in
+part, and save for reuse. Ask for one in plain language and the agent authors the
+orchestration script itself, then runs it in the background — you get a run id
+immediately and the result arrives back in the chat when it finishes.
+
+Reach for a workflow instead of a plain sub-agent fan-out when the work has
+distinct phases, when you want to see it progress, or when you expect to re-run
+part of it after changing your mind about one step.
+
+## Starting one
+
+Say what you want. "Use a workflow to compare these three approaches and
+recommend one" is enough — the agent passes your goal as the intent, and the
+authoring and launching happen in one step. You do not write the script.
+
+Two watching surfaces show a live run:
+
+- The chat side panel's **Workflows** tab, next to Changes and Subagents.
+- **Agent Capabilities → Workflows**, which is the saved library rather than the
+  live view: it creates, edits, and runs reusable workflows.
+
+A run streams to the panel while it executes and injects its result into the
+chat on completion, so you do not have to poll it yourself.
+
+## Watching and steering a run
+
+| Ask for | What you get |
+|---|---|
+| The live status | Whether the run is running, finished, failed, or cancelled, plus how many agents and events it has produced |
+| The full result | Every phase, each agent's outcome, the logs, and the final return value |
+| Recent runs | The newest runs first, with their status |
+| Cancel | The run stops |
+
+A run that ended without a usable return value still reports the agent payloads
+that did complete, plus a per-agent failure reason for each one that did not — so
+a partial failure is diagnosable rather than a bare error.
+
+## Restarting part of a run
+
+This is the reason to prefer a workflow over a one-shot fan-out. A restart
+replays the unchanged prefix from cache and re-executes only from the step you
+name: agent calls before that point reuse the prior run's results without
+spending a model call, and calls from that point on run fresh. Restarting from
+the very beginning re-runs everything.
+
+Each restart produces a new run id, so the original run's record is preserved
+rather than overwritten.
+
+## Saving one for reuse
+
+A workflow saved to the library can be run again by name instead of re-authored
+from intent. Ask what is already saved before describing a new workflow — an
+existing one that fits skips the authoring step entirely.
+
+## What comes back
+
+Credentials and exfiltration-shaped URLs are stripped from every workflow
+response before it reaches you, including from mapping *keys* and not only
+values — agent output is parsed into these structures, so a credential can arrive
+as a key.
+
+## Related docs
+
+- [Subagents](subagents.md): parallel fan-out when the work needs no phases or restarts
+- [Task runner](task-runner.md): autonomous multi-step execution from a spec file
+- [Dashboard](dashboard.md): the chat side panel and the Capabilities tabs

--- a/src/kiro_crew/tips_allowlist.py
+++ b/src/kiro_crew/tips_allowlist.py
@@ -16,6 +16,11 @@ dashboard session. Anyone who can see a tip has already installed, started,
 and opened Kiro Crew, so a product-overview tip like "Getting Started" can
 only ever be redundant there.
 
+Reference tables are excluded for the same reason as onboarding docs: they answer a
+question a user already has rather than announcing a feature to try.
+``channel-capabilities.md`` is the current example — its first paragraph describes a
+lookup table, which makes a poor "have you tried" tip.
+
 Deliberately dependency-free so the maintainer script can import it without
 pulling in the full kiro_crew runtime.
 """
@@ -25,6 +30,9 @@ from __future__ import annotations
 TIP_DOC_ALLOWLIST: frozenset[str] = frozenset(
     {
         "agents.md",
+        "artifacts.md",
+        "browser-control.md",
+        "computer-use.md",
         "configuration.md",
         "cron-and-scheduling.md",
         "dashboard.md",
@@ -37,7 +45,10 @@ TIP_DOC_ALLOWLIST: frozenset[str] = frozenset(
         "knowledge-library-how-it-works.md",
         "mcp-apps.md",
         "memory-and-learning.md",
+        "monitor-loops.md",
         "research-lab.md",
+        "secrets-vault.md",
+        "session-ledger.md",
         "skills.md",
         "slack-integration.md",
         "snapshot-and-restore.md",
@@ -48,6 +59,7 @@ TIP_DOC_ALLOWLIST: frozenset[str] = frozenset(
         "use-cases.md",
         "webex-integration.md",
         "wecom-integration.md",
+        "workflows.md",
         "weixin-integration.md",
         "whatsapp-integration.md",
     }


### PR DESCRIPTION
Refreshes the packaged end-user docs (`src/kiro_crew/docs/`) against the running
code, adds pages for six shipped features that had none, and corrects the
app-kit API reference to describe only surfaces that exist.

Audit sources: `docs-09-userdocs-a.md`, `docs-10-userdocs-b.md`,
`docs-13-crosscut.md` (item 6).

## Stale claims fixed (symbol checked for each)

- **agents.md** — "the dashboard Agents page" renamed to Agent Capabilities →
  Agent Templates. `App.tsx` redirects `/agents` and `/mc-agents` to
  `/capabilities`; there is no Agents page.
- **configuration.md** — the sample `stt` block claimed `provider: "whisper"`
  (a retired provider) and `streaming: false`. `SttConfig` defaults are
  `STT_PROVIDER_LOCAL` and `streaming=True`.
- **dashboard.md** — four fixes: `/knowledge` redirects to
  `/capabilities?tab=knowledge`; the Capabilities tab list was missing
  `knowledge`; the Developer tab list was missing `agent-backend` **and**
  `debug-tools` (the audit caught only the first); the seven-channel
  `session_folder` list is now "every messaging channel", since ten config
  classes carry the field.
- **getting-started.md** — the channel list stopped at WeChat; setup documented
  two of five flags. `setup_parser` defines `--agent-only`, `--slack`,
  `--whatsapp`, `--electron-only`, `--clean`.
- **dynamic-subagent-sizing.md** — the closing citation pointed at
  `~/.kiro/crew/workspace/dynamic-subagent-sizing.md`, which no install creates.
- **research-lab.md** — **the safety callout was false.**
  `_install_research_agent` calls `build_agent_config()` and overrides only
  `name`, `description` and `prompt`, so `kirocrew-research` inherits the full
  main-agent MCP and tool set. The callout claimed "read/research tools only"
  and "no writes, deployments, mutations". Replaced with the real posture, which
  the doc's own Scope section already stated correctly. Also fixed the dead
  anchor and dropped the Key files table.
- **README.md** — added the missing `imessage-integration.md` row.
- **use-cases.md** — `kirocrew run docs/task-specs/backlog-crusher.md` cited a
  file that does not exist. Replaced with a spec the reader authors inline, plus
  the three flags that matter for a long run, verified against `run_parser`:
  `--fresh`, `--no-test`, `--timeout`.
- **snapshot-and-restore.md** — `redact_uploads` was explained twice at length
  (131 lines plus 36). One authority kept, under `## Off-host copies` where a
  reader looks for the switch; net −130 lines with no user-facing loss.
- **slack-integration.md** — the owner-only rule was stated four times and two
  tables carried struck-through inert rows. Now one Access control section, the
  inert commands in a single line (`slack.allowed_users` is inert and stale
  entries are pruned at startup — `slack/gateway.py`), the 120 s approval window
  labelled as the Slack exception, and the three-endpoint Settings API section
  rewritten as a user-facing Settings page (loopback-only editing via
  `is_direct_local_request`, token verified with `auth.test` /
  `apps.connections.open` before storage, `restart_required` for boot-read
  fields).

## New pages

- **`channel-capabilities.md`** — one ten-channel matrix, every cell read from
  each `<channel>/transport.py` `TransportCapabilities` literal and its
  constants: `SLACK_MSG_LIMIT=3900`, `DISCORD_CHUNK_LIMIT=1900`,
  `TELEGRAM_CHUNK_LIMIT=4000`, `TEAMS_MAX_TEXT=16000`,
  `WEBEX_SAFE_MESSAGE_CHARS=WEBEX_MAX_TEXT//4=1750` (7000 bytes),
  `WECOM_SAFE_REPLY_CHARS=WECOM_MAX_REPLY_BYTES//4=5120`,
  `WEIXIN_CHUNK_LIMIT=4000`, `IMESSAGE_SAFE_MESSAGE_CHARS=4000`,
  `WHATSAPP_CHUNK_LIMIT=4096`, Feishu `4000`, `MAX_CARD_ACTIONS=5`. Carries the
  approval-timeout column with its three real values — Slack
  `_APPROVAL_TIMEOUT=120.0`, Teams `APPROVAL_TIMEOUT_SECS=300.0`, shared
  `TEXT_APPROVAL_TIMEOUT_S=300.0` — and states that
  `agent.tool_approval_timeout_secs` (default 600) governs **only** the
  dashboard: its sole consumer is `dashboard/chat_runner.py`. Linked from all ten
  channel docs.
- **`secrets-vault.md`** — `kirocrew secrets import` (dry-run unless `--apply`),
  `secret://KEY` rewrites, AES-256-GCM per entry, and the agent refusal:
  `.vault` is a keystone leaf in `security.py`, so the verb-independent
  sensitive-path check covers tool reads and shell commands alike. Documents the
  real migration scope, which the task brief did not state — `_is_recognized_key`
  admits only `JIRA_API_TOKEN` and `JIRA_TOKEN_<HEX>`, because every other
  `.env` credential's reader still reads the literal value.
- **`workflows.md`** — the eight `mcp_tools/workflows.py` tools, the
  replay-prefix semantics of `workflow_rerun_subtree`, and both surfaces: the
  chat side-panel `workflows` tab (`usePanelTabs.ts` `ViewKind`) and Agent
  Capabilities → Workflows (`WorkflowLibraryTab`). There is no top-level
  Workflows page.
- **`monitor-loops.md`** — `monitor_start` / `monitor_update` / `autonudge_stop`,
  the deadline-preserving interval, `_MONITOR_DEFAULT_MAX_CYCLES = 24`, the
  wall-clock budget, the create-only one-automation-per-session rule, and the
  cheaper structured `monitor_watch` / `monitor_inspect` / `monitor_stop` PR path
  that costs no turn on an unchanged probe. The UI control is the composer's
  goal popover (`AutoNudgePopover.tsx`, lucide `Goal` icon) showing active state,
  cycle and countdown. Channels: dashboard, Slack, Discord, Webex
  (`slack:`/`discord:`/`webex:` in `control.py`).
- **`session-ledger.md`** — `session_ledger_record` / `session_ledger_read`,
  survives compaction, `next` written as intent. States plainly that it has **no
  dashboard page**: `grep` finds no ledger view in `website/src`, so the doc says
  to ask the session rather than implying a surface that does not exist.
- **`computer-use.md`** — Settings → Computer Use opt-in, and why the enable is
  NOT in `config.json` (`ComputerUseConfig`'s docstring: an agent shell can write
  that file, so the enable lives on the keystone `computer_use.json`). Windows
  has no per-process input so a click moves the real cursor
  (`windows_driver.py`); macOS delivers per-process and `global` is the one
  cursor-warping route. Password fields render as `SECURE_PLACEHOLDER =
  "<secure>"`; the dashboard is refused for read and write, process-wide on macOS
  (`computer_use/policy.py`, `apps_macos.py`).
- **`artifacts.md`** — the Artifacts side-panel tab (`SidePanel.tsx`), versioning
  and revert-as-new-version, nesting folders with the safe-by-default delete,
  anchored comments where the agent may `mark_review` but never resolve, and
  `deploy_artifact` being preview-only. Corrects the brief's "widgets auto-
  register": `artifact_save` is explicit, so the page says saving is a deliberate
  step.

## Index completeness

- `index.md` Features gained rows for the six MCP tool families that had none —
  artifacts, dynamic workflows, monitor loops, session ledger, browser control,
  computer use — plus a Secrets Vault row. Four of those rows initially pointed
  at docs that do not cover the feature; they now point at the four new pages.
- New **Settings reference** subsection covering all 19 tabs from
  `SettingsPage.tsx`, naming a guide where one exists.
- WeCom and Weixin now state the `CHANNEL_OWNER_DM_NAMESPACES` exclusion and its
  reason (both fold inbound-learned identities into their send roster).

## `docs/app-kit/api-reference.md`

The audit said the page "documents an SDK that does not exist" with 75 dead
symbols. **Partly wrong, and corrected rather than applied as written:** the
Python client is real and ~35 of its methods resolve (`add_cron`, `list_crons`,
`get_system_info`, `spawn_many`, …). Two things were actually false:

1. Every table typed its return as `Promise<T>`, implying a TypeScript client
   that does not ship. All 47 occurrences replaced with plain response shapes,
   and the framing now says the camelCase names are endpoint labels.
2. 19 rows of the Python mapping table named methods the package does not have
   (`ack_notifications`, `list_models`, `get_slot_history`, `resolve_approval`,
   `install_skill`, …). Each is now marked *not implemented — call the endpoint*,
   and the WebSocket section is labelled raw-connection documentation.

Not marked "planned" wholesale: `useAppApi` / `useAppEvents` / `ChatPanel` and
the `__kirocrew_modules` import map all exist in `website/src/app-sdk/`.

## Gates

- `sh scripts/docs-lint.sh` — green, 270 files.
- `BRAND_BASE_REF=origin/main python3 scripts/check_brand_name.py` — green.
- `pytest test/test_brand_name_gate.py test/test_discord_install_url.py
  test/test_doctor_credentials.py test/test_skill_home_paths.py test/test_tips.py`
  — **302 passed** (the `tips_allowlist` / `kiro_crew/docs` / `docs/index.md`
  selection). No `.py` touched, so the Python formatters do not apply.

## Deliberately NOT applied

- **Full physical section reordering of the ten channel docs.** Heading
  *vocabulary* is normalised (Access control / Settings reference / Limits /
  Troubleshooting / Related docs) and every doc gained a Related docs section
  with the capabilities link, but blocks were not moved. Reordering would
  relocate verified prose — Teams' three numbered setup sections in particular —
  and the risk of silent content loss outweighs the consistency gain. Verified no
  inbound anchor referenced any renamed heading.
- **The contributor-material moves** (`dashboard-iframe-hosts.md`,
  `followup-suggestions.md`, `app-platform-trust-model.md`,
  `messaging-transport.md`, `knowledge-library-how-it-works.md`,
  `agent-questions.md`) — owned by another agent in this audit split.
- **The three missing `CODE_COUPLED_DOCS` entries** (`FeishuPanel`,
  `IMessagePanel`, `WhatsAppPanel`) — `scripts/docs_lint.py` is another agent's
  file in this split. The six new pages here are likewise unpinned.
---

## Review round 1

Three reviewers, one deduplicated list: **11 VERIFIED · 1 REBUTTED · 0 DEFERRED.**
Full disposition table with per-finding code evidence in
`/workplace/bolichen/prompt-audit-2026-09-05/review/PR8883-fixes.md`.

**Fixed (verified against code):**

- **The approval row was wrong on four channels.** WeCom, Weixin, iMessage and
  Feishu pass `decider=None`, and `messaging/driver.py` gates the prompt on
  `decider is not None` while `_approve` returns `False` without one — so those
  four never prompt and deny immediately. Their cells are now `—`, the Approvals
  section names the six channels that do install a decider, and
  `slack-integration.md`'s "every other text channel waits five minutes" is scoped
  to them.
- **Owner-DM routing** now separates the two `send_message` routes: the
  `session=<channel>` owner-DM form excludes WeCom and Weixin outright and cannot
  deliver to Feishu (`supports_proactive_send=False`), falling back to a dashboard
  notification; the `channel_type` conversation route does reach WeCom and Weixin.
- **Browser Control** pointed at `configuration.md`, which has no browser content.
  Wrote `browser-control.md` (the panel, what the agent can drive, the
  loopback/private-address refusal, Settings → Browser install and attach) and
  repointed the row.
- **Tips allowlist.** Seven new feature pages added to `TIP_DOC_ALLOWLIST`, so they
  can surface as discovery tips. `channel-capabilities.md` is deliberately
  excluded and the docstring now records the reason: a lookup table is a poor
  "have you tried" tip, the same rule that excludes onboarding docs.
- **Widget registration** now states both corrections: it happens as each response
  segment finalizes, not at message completion, and incognito/temporary sessions
  never register.
- **Settings reference** Skills, Developer and Webhooks rows rewritten to match
  `SkillsPanel.tsx` (auto-generate + approval only), `DeveloperPanel.tsx` (the
  Developer Mode consent gate; the eleven views live on the gated `/developer`
  page) and `SettingsPage.tsx`'s `PREVIEW_WEBHOOKS` filter.
- **`kirocrew-client` is not published** — `setup.cfg` discovers only under `src`,
  and there is no PyPI release. Described as source-only under
  `packages/kirocrew-client-py/`; both `pip install` lines removed.
- **`verifyProxyRequest` / `verify_proxy_request_raw`** rows removed: the helper is
  `verify_proxy_request` in `src/kiro_crew/apps/proxy_auth.py`, with no REST route.
  The example now imports from there and says an out-of-process backend computes
  the HMAC itself.
- Test/implementation provenance removed from `channel-capabilities.md`;
  `use-cases.md` now says to run the spec from its directory or by absolute path;
  the monitor cycle cap distinguishes the tool's 24 from the popover's `0`; blank
  line restored before `## Attribution` in two channel docs.

**Rebutted — Webex kept as a monitor-loop surface.** One reviewer read
`monitor_start`'s refusal *string*, which names only dashboard, Slack and Discord.
The actual gate is `mcp_core._autonudge_binding_key(sk) is None`, and
`autonudge.binding_key_for` returns a binding for `webex:` as well, so a Webex
session does arm a loop. The narrower set that reviewer found is real but applies
to STRUCTURED monitors: `structured_monitor_binding_key_for` returns `None` for
`webex:`. `monitor-loops.md` now documents exactly that split.

**Correction to this body's earlier claim:** it said `artifacts.md` "corrects the
brief's widgets auto-register". That was wrong — widgets *are* auto-registered, the
doc always said so, and only this description was mistaken.

**Gates after fixes:** docs-lint green (271 files); brand check green (it caught one
`KiroCrew` in a line this round added, now fixed); 302 tests passed in the
tips/docs selection; `tips_allowlist.py` is the one `.py` touched and passes
`black`, `isort`, `flake8`, `mypy`; `git diff --check` clean. Still 2 commits.
**CI GPT review:** both findings upheld and fixed. `artifacts.md` said to save a
restricted-session widget explicitly, but `api_artifact_materialize` returns 403 for
incognito and temporary slots — the page now says those widgets cannot be saved and
are gone when the session ends. The `api-reference.md` proxy-verification sample
called `verify_proxy_request(request, 'my-app')`, which does not match the helper's
real keyword-only signature `(header_value, *, method, target, body, ...)`; the
example now uses it correctly and routes the target through `raw_request_target`.
Gates re-run green: docs-lint, brand check, 302 tests, `git diff --check`. Still 2
commits.
