### PR TITLE
fix: give the batch-rejection cascade host-decline provenance (#8818)

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -130,6 +130,7 @@ from kiro_crew.dashboard.session_directive_apply import apply_session_directive
 from kiro_crew.dashboard.state import (
     CRON_NOTIFY_PREFIX,
     CRON_NOTIFY_RE,
+    DENY_CAUSE_BATCH_CASCADE,
     DENY_CAUSE_HOOK_ERROR,
     DENY_CAUSE_INVALID_NAME,
     DENY_CAUSE_POLICY,
@@ -6196,6 +6197,12 @@ async def _run_chat(
     # deny sites — a path added later cannot forget to increment a counter.
     _refusal_notices: list[str] = []
     _refusal_notices_settled = 0
+    # Whether the current denied batch's cascade already steered its one
+    # cause-specific notice. One notice covers the whole cascaded remainder, so
+    # this stops the second and later members from repeating it; re-armed each
+    # time ``slot._batch_rejected`` is set, so a second batch denied later in
+    # the same turn gets its own notice.
+    _batch_cascade_steered = False
     # Track how deep an unbroken hook-continuation run is, so the Stop hook can
     # see it: each consecutive hook continuation is one deeper; any other turn
     # (a real user message, a refusal recovery) breaks the run and resets it.
@@ -7445,6 +7452,7 @@ async def _run_chat(
             # saw (#7681). See _BATCH_REJECT_CLEARED_BY.
             if event.kind in _BATCH_REJECT_CLEARED_BY and getattr(slot, "_batch_rejected", False):
                 slot._batch_rejected = False
+                slot._batch_rejected_cause = ""
                 logger.info(
                     "batch rejection cleared on %s — later tool calls in this "
                     "turn are approved independently",
@@ -8870,8 +8878,45 @@ async def _run_chat(
                     continue
                 # Auto-reject remaining tools after one rejection in a batch
                 if getattr(slot, "_batch_rejected", False):
-                    await client.reject_tool(event.request_id)
                     _title = _redact_display_text(event.title)
+                    _cascade_cause = getattr(slot, "_batch_rejected_cause", "")
+                    if _cascade_cause and not _batch_cascade_steered:
+                        # Host-caused cascade: the batch's originating decline
+                        # was an auto-decline (approval timeout, no budget,
+                        # Slack delivery failure), so kiro-cli's "User denied
+                        # tool execution" is FALSE for every cascaded member.
+                        # Steer the real cause in-band, BEFORE the rejection
+                        # goes on the wire (the unanswered permission request is
+                        # what keeps the steer queued instead of dropped). One
+                        # notice covers the whole cascaded remainder; the latch
+                        # is the steer's own return value, so later members skip
+                        # the send once a notice is actually on the wire, while
+                        # a failed or refused attempt leaves the latch clear and
+                        # the next member retries. A throwaway notices list on
+                        # purpose — the batch's ORIGINAL decline already renders
+                        # its own card, and a best-effort correction of cascade
+                        # attribution is not worth a second billed recovery turn
+                        # when steering is unavailable (that leaves exactly
+                        # today's behaviour). slot/state withheld for the same
+                        # reason: each cascaded tool already appends a visible
+                        # 🚫 row, and the inject card's summary line is keyed on
+                        # causes this one is not.
+                        _batch_cascade_steered = await _steer_policy_notice(
+                            client,
+                            _title,
+                            _cascade_cause,
+                            [],
+                            cause=DENY_CAUSE_BATCH_CASCADE,
+                        )
+                    # deny-notice-exempt: user-originated cascade. When the
+                    # person themselves denied the tool that started this
+                    # cascade, that refusal covers the group they refused, so
+                    # kiro-cli's "User denied tool execution" is the TRUE
+                    # attribution for the cascaded remainder and steering a
+                    # host notice would re-attribute the user's own decision.
+                    # Host-caused cascades are corrected by the
+                    # provenance-gated steer above.
+                    await client.reject_tool(event.request_id)
                     slot.append(
                         "tool", f"🚫 {_title} (rejected)", "msg msg-tool", meta=_tool_meta(event)
                     )
@@ -8890,11 +8935,27 @@ async def _run_chat(
                         tool_kind=event.tool_kind,
                         outcome="rejected",
                         request_id=event.request_id,
-                        metadata={"reason": "batch_rejection"},
+                        # Additive provenance: an auditor separating "the user
+                        # refused this group" from "a host auto-decline cut it
+                        # short" needs the cause on the cascaded members too.
+                        metadata=(
+                            {"reason": "batch_rejection", "cause": _cascade_cause}
+                            if _cascade_cause
+                            else {"reason": "batch_rejection"}
+                        ),
                     )
                     logger.warning("AUTO-REJECTED tool=%r (batch rejection)", event.title)
                     continue
                 # Interactive approval — send to frontend, wait for decision
+                #
+                # WHO/WHAT declines this tool, when it is declined. Stays empty
+                # for an interactive user refusal; each host-side auto-decline
+                # below (Slack delivery failure, no turn budget, approval
+                # timeout) overwrites it with a short host-authored sentence.
+                # The batch setter at the bottom copies it onto
+                # ``slot._batch_rejected_cause`` so the cascade site can tell a
+                # person's refusal from an expired prompt.
+                _host_deny_cause = ""
                 perm_meta = {
                     "request_id": str(event.request_id),
                     "tool_call_id": event.tool_call_id or "",
@@ -9034,6 +9095,11 @@ async def _run_chat(
                             state.push_slots_update()
                             if not fut.done():
                                 fut.set_result("rejected")
+                                _host_deny_cause = (
+                                    "the approval prompt for an earlier tool in "
+                                    "this batch could not be delivered to Slack, "
+                                    "so the host declined it"
+                                )
                     except Exception:
                         # Any failure before the future is resolved (ImportError,
                         # post_linked_approval raising, slot.append/push raising in
@@ -9044,6 +9110,11 @@ async def _run_chat(
                         logger.warning("Error mirroring approval prompt to Slack", exc_info=True)
                         if not fut.done():
                             fut.set_result("rejected")
+                            _host_deny_cause = (
+                                "the approval prompt for an earlier tool in "
+                                "this batch could not be delivered to Slack, "
+                                "so the host declined it"
+                            )
                 # Pre-seeded so the `finally` backstop below is total over EVERY
                 # exit from the await — including CancelledError, which slot
                 # deletion / cleanup endpoints raise by cancelling slot.task.
@@ -9086,6 +9157,10 @@ async def _run_chat(
                             event.title,
                         )
                         _approval_card = format_approval_no_budget_card()
+                        _host_deny_cause = (
+                            "the turn had no budget left to wait for approval of "
+                            "an earlier tool in this batch, so the host declined it"
+                        )
                     else:
                         outcome = await asyncio.wait_for(fut, timeout=_approval_window)
                 except asyncio.TimeoutError:
@@ -9101,6 +9176,11 @@ async def _run_chat(
                         _approval_window,
                     )
                     _approval_card = format_approval_timeout_card(_approval_window)
+                    _host_deny_cause = (
+                        "the approval prompt for an earlier tool in this batch "
+                        f"went unanswered for {int(_approval_window)}s, so the "
+                        "host declined it"
+                    )
                     if _unattended_wait:
                         # The card is for the human; this line is for the AGENT.
                         # A denial it cannot read makes it retry the same tool
@@ -9323,6 +9403,15 @@ async def _run_chat(
                     # mark batch_rejected as true and continue loop instead of breaking
                     # This will allow for marking other batched approval requests as rejected too
                     slot._batch_rejected = True
+                    # Provenance travels with the flag: empty means the person
+                    # refused this tool themselves, non-empty names the host
+                    # auto-decline that did. The cascade site branches on it —
+                    # a user's refusal keeps kiro-cli's "User denied tool
+                    # execution" true for the remainder, a host cause makes it
+                    # false and worth an in-band correction.
+                    slot._batch_rejected_cause = _host_deny_cause
+                    # New denied batch, fresh notice budget for its cascade.
+                    _batch_cascade_steered = False
                     logger.warning(
                         "PERM REJECTED tool=%r outcome=%r — auto-rejecting remaining batch",
                         event.title,
@@ -11879,6 +11968,7 @@ async def _run_chat(
             slot._native_subagent_tracker = _retain_terminal_native(_native_tracker)
             slot._native_subagent_output = {}
         slot._batch_rejected = False
+        slot._batch_rejected_cause = ""
         # Stash the hang-attribution snapshot BEFORE dropping the client ref:
         # if this turn was cut by the dashboard ceiling (_bounded_turn), the
         # done-callback (finish_turn_task) runs AFTER this finally, when

--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -2830,12 +2830,13 @@ def build_refusal_recovery_prompt(
 #: The notice's INVARIANT half — that this was not a user action, the generic
 #: string it is correcting, and the instruction to decide inside this turn — is
 #: identical for every cause; only the clause naming the cause and the guidance
-#: about what to do next differ. Kept as data rather than three near-copies of
-#: the notice so the invariant half cannot drift between them, which is the half
-#: doing the actual work of overwriting the model's wrong conclusion.
+#: about what to do next differ. Kept as data rather than a near-copy of the
+#: notice per cause so the invariant half cannot drift between them, which is the
+#: half doing the actual work of overwriting the model's wrong conclusion.
 DENY_CAUSE_POLICY = "policy"
 DENY_CAUSE_INVALID_NAME = "invalid_name"
 DENY_CAUSE_HOOK_ERROR = "hook_error"
+DENY_CAUSE_BATCH_CASCADE = "batch_cascade"
 
 #: cause → (clause completing "The tool call you just made …", what to do next).
 _DENY_CAUSE_TEXT: dict[str, tuple[str, str]] = {
@@ -2856,6 +2857,14 @@ _DENY_CAUSE_TEXT: dict[str, tuple[str, str]] = {
         "treat this as a host fault, not a verdict on the action: nothing judged the "
         "call itself. Retrying the identical call is reasonable once; if it faults "
         "again, say what happened rather than working around it silently.",
+    ),
+    DENY_CAUSE_BATCH_CASCADE: (
+        "was auto-declined along with every remaining call in its batch, because "
+        "the host declined an earlier tool of the same batch",
+        "nothing judged these calls themselves — the group was cut short as a "
+        "whole. Address what declined that earlier tool (the reason above), then "
+        "re-issue the calls you still need; if you genuinely cannot proceed "
+        "without them, say so and stop with the reason.",
     ),
 }
 
@@ -2887,9 +2896,11 @@ def build_refusal_steer_notice(
 
     *cause* selects the wording. The distinction is not cosmetic: a policy block
     is a verdict the model must route around, an invalid tool name is the model's
-    own malformed output and is the one case it can simply fix, and a hook fault
-    judged nothing at all. Telling the model "safety policy" for the latter two
-    would send it looking for an allowed alternative to an action nobody refused.
+    own malformed output and is the one case it can simply fix, a hook fault
+    judged nothing at all, and a batch cascade cut the group short without
+    judging its members. Telling the model "safety policy" for any non-policy
+    cause would send it looking for an allowed alternative to an action nobody
+    refused.
     An unknown cause degrades to the policy wording rather than raising: a wrong
     noun is recoverable, and losing the notice would hand the model back
     kiro-cli's "user denied" with nothing to correct it.
@@ -2901,19 +2912,20 @@ def build_refusal_steer_notice(
         return ""
     clause, guidance = _DENY_CAUSE_TEXT.get(cause, _DENY_CAUSE_TEXT[DENY_CAUSE_POLICY])
     what = f"{title}: {reason}" if reason else title
-    # Class-specific remediation, for the policy cause only. The other two causes
-    # judged nothing about the action — an invalid tool name is the model's own
-    # malformed output and a hook fault is a host fault — so naming a sanctioned
-    # alternative there would answer a question nobody asked and imply the action
-    # itself had been refused.
+    # Class-specific remediation, for the policy cause only. The non-policy
+    # causes judged nothing about the action — an invalid tool name is the
+    # model's own malformed output, a hook fault is a host fault, and a cascaded
+    # batch member was never reached — so naming a sanctioned alternative there
+    # would answer a question nobody asked and imply the action itself had been
+    # refused.
     remediation = (
         remediation_for(reason, title, credential_tool_hint=credential_tool_hint)
         if cause == DENY_CAUSE_POLICY
         else ""
     )
     tail = f"\n\nHow to do this properly: {remediation}" if remediation else ""
-    # "host notice", not "policy notice": the tag has to be true for all three
-    # causes, and only one of them IS a policy. Naming the ACTOR is also what the
+    # "host notice", not "policy notice": the tag has to be true for every
+    # cause, and only one of them IS a policy. Naming the ACTOR is also what the
     # notice exists to do — the model has just been told the user denied this, and
     # every sentence after this one is spent correcting that.
     return (
@@ -3249,6 +3261,7 @@ class _ChatSlot:
         "_promise_only_stop_gen",
         "_compaction_continue_retries",
         "_batch_rejected",
+        "_batch_rejected_cause",
         "_compaction_failed_retries",
         "_compaction_fail_streak",
         "_compaction_fail_cooldown_until",
@@ -3708,6 +3721,15 @@ class _ChatSlot:
         # the other per-turn retry budgets on a landed turn.
         self._compaction_continue_retries: int = 0
         self._batch_rejected: bool = False
+        # WHO/WHAT set ``_batch_rejected``: empty for an interactive user
+        # decline, else a short host-authored sentence naming the auto-decline
+        # (approval timeout, no turn budget, Slack delivery failure). The
+        # cascade site reads it to decide attribution: a user's refusal makes
+        # kiro-cli's "User denied tool execution" TRUE for the cascaded
+        # remainder, while a host-caused decline makes it false and worth a
+        # cause-specific in-band correction. Same lifetime as the flag itself —
+        # set together, cleared together.
+        self._batch_rejected_cause: str = ""
         # Per-turn compaction-status failure tracking (Mesh compaction-spam
         # fix). Distinct from SessionManager._compact_cooldown_until, which
         # only gates the *proactive* session-level auto-compact trigger —

--- a/test/test_dashboard_approval.py
+++ b/test/test_dashboard_approval.py
@@ -963,6 +963,157 @@ class TestDenialCascadeLifetime:
         client.approve_tool.assert_not_called()
 
 
+class TestBatchCascadeAttribution:
+    """A cascade behind a HOST auto-decline must not inherit user attribution.
+
+    Issue #8818: ``_batch_rejected`` is also set by the host-side auto-declines
+    (approval timeout, no turn budget, Slack delivery failure), and the cascade
+    used to answer every remaining batch member with nothing but kiro-cli's
+    generic "User denied tool execution" — a decline no user made. These pin the
+    provenance split: host-caused cascades steer one cause-specific in-band
+    notice for the whole remainder, user-refused batches keep the generic
+    message, which is true there.
+    """
+
+    @pytest.mark.asyncio
+    async def test_timeout_originated_cascade_steers_the_real_cause(self, tmp_path):
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        # Shrink only the per-slot bound; the config ceiling stays at its
+        # default, and the product takes the MINIMUM of the two.
+        state.approval_timeout_for = MagicMock(return_value=0.05)
+        evt1 = _permission_event(title="tool_a")
+        evt1.request_id = "req-1"
+        evt1.tool_call_id = "tc-1"
+        evt2 = _permission_event(title="tool_b")
+        evt2.request_id = "req-2"
+        evt2.tool_call_id = "tc-2"
+        _set_stream(client, [evt1, evt2, _complete_event()])
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+
+        # Nobody answered: the first tool was declined by the host, the second
+        # by the cascade — and the cascade corrected the attribution in-band.
+        client.reject_tool.assert_any_call("req-1")
+        client.reject_tool.assert_any_call("req-2")
+        client.steer.assert_called_once()
+        notice = client.steer.call_args[0][0]
+        assert "every remaining call in its batch" in notice
+        assert "unanswered" in notice
+        assert "User denied tool execution" in notice
+        assert "NOT a user action" in notice
+
+    @pytest.mark.asyncio
+    async def test_no_budget_originated_cascade_steers_the_real_cause(self, tmp_path):
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        # Zero window is the no-budget branch: the host declines without
+        # waiting at all, so no answerer could ever race this decline.
+        state.approval_timeout_for = MagicMock(return_value=0)
+        evt1 = _permission_event(title="tool_a")
+        evt1.request_id = "req-1"
+        evt1.tool_call_id = "tc-1"
+        evt2 = _permission_event(title="tool_b")
+        evt2.request_id = "req-2"
+        evt2.tool_call_id = "tc-2"
+        _set_stream(client, [evt1, evt2, _complete_event()])
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+
+        client.reject_tool.assert_any_call("req-2")
+        client.steer.assert_called_once()
+        notice = client.steer.call_args[0][0]
+        assert "every remaining call in its batch" in notice
+        assert "no budget left" in notice
+
+    @pytest.mark.asyncio
+    async def test_user_refused_batch_cascades_without_a_steer(self, tmp_path):
+        # The exemption half: the person clicked Reject themselves, so the
+        # generic message is the TRUE attribution for the remainder and a host
+        # notice here would re-attribute the user's own decision to the host.
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        evt1 = _permission_event(title="tool_a")
+        evt1.request_id = "req-1"
+        evt1.tool_call_id = "tc-1"
+        evt2 = _permission_event(title="tool_b")
+        evt2.request_id = "req-2"
+        evt2.tool_call_id = "tc-2"
+        _set_stream(client, [evt1, evt2, _complete_event()])
+
+        async def _reject_first() -> None:
+            await _answer_approval(slot, "req-1", "rejected")
+
+        rejecter = asyncio.get_event_loop().create_task(_reject_first())
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+        await _drain(rejecter)
+
+        client.reject_tool.assert_any_call("req-1")
+        client.reject_tool.assert_any_call("req-2")
+        client.steer.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_one_notice_covers_the_whole_cascaded_remainder(self, tmp_path):
+        # The notice speaks for the group, so a three-member batch must not
+        # steer three times — repeated notices are noise the model has to spend
+        # the very turn being corrected on.
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        state.approval_timeout_for = MagicMock(return_value=0.05)
+        events = []
+        for i in (1, 2, 3):
+            evt = _permission_event(title=f"tool_{i}")
+            evt.request_id = f"req-{i}"
+            evt.tool_call_id = f"tc-{i}"
+            events.append(evt)
+        _set_stream(client, [*events, _complete_event()])
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+
+        assert client.reject_tool.call_count == 3
+        client.steer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_provenance_dies_with_the_group_it_belongs_to(self, tmp_path):
+        # Model output ends the denied group (#7681). What is OBSERVABLE here:
+        # the revised later call is prompted — not cascaded, not steered — and
+        # a host-recorded cause never survives past the turn. The paired
+        # cause-clear at each flag-clear site is pinned at source level in
+        # test_refusal_inband_notice.py (a stale cause is unreadable while the
+        # flag is down, so only a source guard can hold that pairing).
+        state, client = _make_state(tmp_path, context_builder=_context_builder())
+        slot = _make_slot()
+        state.approval_timeout_for = MagicMock(return_value=0.05)
+        timed_out = _permission_event(title="tool_a")
+        timed_out.request_id = "req-1"
+        timed_out.tool_call_id = "tc-1"
+        resumed = LLMEvent(kind=EVENT_TEXT_CHUNK, text="Retrying with a narrower edit.")
+        revised = _permission_event(title="tool_b")
+        revised.request_id = "req-2"
+        revised.tool_call_id = "tc-2"
+        _set_stream(client, [timed_out, resumed, revised, _complete_event()])
+
+        async def _approve_revised() -> None:
+            await _answer_approval(slot, "req-2", "approved")
+
+        approver = asyncio.get_event_loop().create_task(_approve_revised())
+
+        with _patch_stats():
+            await _run_chat(state, slot, "hello")
+        await _drain(approver)
+
+        # The revised call was prompted and approved — never cascaded, so the
+        # cascade notice was never sent.
+        client.approve_tool.assert_any_call("req-2")
+        client.steer.assert_not_called()
+        assert slot._batch_rejected_cause == ""
+
+
 class TestDenyOnce:
     """Verify 'rejected_once' denies a single tool without cascading."""
 

--- a/test/test_refusal_inband_notice.py
+++ b/test/test_refusal_inband_notice.py
@@ -27,6 +27,7 @@ from kiro_crew.dashboard.chat_runner import (
     _steer_policy_notice,
 )
 from kiro_crew.dashboard.state import (
+    DENY_CAUSE_BATCH_CASCADE,
     DENY_CAUSE_HOOK_ERROR,
     DENY_CAUSE_INVALID_NAME,
     DENY_CAUSE_POLICY,
@@ -407,10 +408,35 @@ class TestCauseSpecificWording:
             "bash", "denied"
         )
 
+    def test_batch_cascade_names_the_group_and_defers_to_the_reason(self):
+        # The cascade's members were never individually judged, so the wording
+        # must neither claim a policy verdict nor scope itself to one call: the
+        # single notice stands in for every cascaded member of the batch.
+        out = build_refusal_steer_notice(
+            "list_files",
+            "the approval prompt for an earlier tool in this batch went unanswered "
+            "for 600s, so the host declined it",
+            cause=DENY_CAUSE_BATCH_CASCADE,
+        )
+        assert "every remaining call in its batch" in out
+        assert "nothing judged these calls themselves" in out
+        # The reason is where the ORIGINATING host cause lives; the clause must
+        # direct the model at it rather than restating one hardcoded cause.
+        assert "unanswered for 600s" in out
+        assert "safety policy" not in out
+        # Re-issuing is sanctioned once the original decline is addressed — the
+        # opposite of the policy guidance to find a different approach.
+        assert "re-issue" in out.lower()
+
     def test_every_cause_keeps_the_invariant_half(self):
         # The half that does the actual work -- naming the string being corrected
         # and forbidding a hand-back -- must not vary with the cause.
-        for cause in (DENY_CAUSE_POLICY, DENY_CAUSE_INVALID_NAME, DENY_CAUSE_HOOK_ERROR):
+        for cause in (
+            DENY_CAUSE_POLICY,
+            DENY_CAUSE_INVALID_NAME,
+            DENY_CAUSE_HOOK_ERROR,
+            DENY_CAUSE_BATCH_CASCADE,
+        ):
             out = build_refusal_steer_notice("bash", "why", cause=cause)
             assert "User denied tool execution" in out, cause
             assert "NOT a user action" in out, cause
@@ -418,10 +444,15 @@ class TestCauseSpecificWording:
             assert "do not ask the user" in out.lower(), cause
 
     def test_the_bracket_tag_is_cause_neutral(self):
-        # The tag has to be true for all three causes. Saying "policy notice" above
+        # The tag has to be true for every cause. Saying "policy notice" above
         # a sentence that explains the call was NOT a policy matter contradicts the
         # body one line later, and the body is the part doing the correcting.
-        for cause in (DENY_CAUSE_POLICY, DENY_CAUSE_INVALID_NAME, DENY_CAUSE_HOOK_ERROR):
+        for cause in (
+            DENY_CAUSE_POLICY,
+            DENY_CAUSE_INVALID_NAME,
+            DENY_CAUSE_HOOK_ERROR,
+            DENY_CAUSE_BATCH_CASCADE,
+        ):
             out = build_refusal_steer_notice("bash", "why", cause=cause)
             assert out.startswith("[Kiro Crew host notice]"), cause
             # "policy" may still appear in the POLICY cause's own clause; what must
@@ -659,3 +690,99 @@ class TestEveryHostDenyCallSiteIsWired:
             f"{calls - wired} deny call(s) in the interactive approved branch do not "
             "steer -- the user approved, so 'user denied tool execution' is false there"
         )
+
+    def test_cascade_site_branches_on_provenance(self):
+        # The cascade answers ``reject_tool`` for every remaining member of a
+        # denied batch, and its attribution depends on WHO denied the first
+        # member: a host auto-decline must steer a cause-specific correction,
+        # while a person's own refusal keeps kiro-cli's generic message TRUE
+        # for the remainder and stays exempt. Guarded at source level because
+        # the branch lives inside the turn coroutine, where the direct unit
+        # fixtures of this file cannot reach it.
+        src = self._src()
+        anchor = 'if getattr(slot, "_batch_rejected", False):'
+        assert anchor in src, "the cascade site moved -- guard is stale"
+        block = src.split(anchor, 1)[1][:3500]
+        steer_at = block.find("_steer_policy_notice")
+        reject_at = block.find("reject_tool(")
+        assert steer_at != -1, "host-caused cascade no longer steers a notice"
+        assert reject_at != -1, "the cascade site no longer answers the rejection"
+        # Steer while the permission request is still unanswered: that is what
+        # proves the turn is in flight and keeps the notice queued, so a steer
+        # placed after the reject can be silently dropped.
+        assert steer_at < reject_at, "the cascade steers AFTER answering the rejection"
+        assert (
+            "DENY_CAUSE_BATCH_CASCADE" in block[:reject_at]
+        ), "the cascade steer lost its cause-specific wording"
+        # The steer must be GATED on host provenance -- steering for a batch the
+        # person themselves refused would re-attribute their own decision.
+        assert (
+            "_batch_rejected_cause" in block[:steer_at]
+        ), "the cascade steer is no longer gated on rejection provenance"
+        assert (
+            "deny-notice-exempt:" in block[:reject_at]
+        ), "the user-originated cascade lost its exemption marker"
+
+    def test_every_host_decline_arm_records_provenance(self):
+        # Four host-side auto-declines reach the batch setter with
+        # ``outcome == "rejected"``: both Slack-delivery-failure arms, the
+        # no-budget branch, and the approval timeout. Each must overwrite the
+        # per-tool cause IN ITS OWN BRANCH, and the setter must copy it onto
+        # the slot -- an arm that forgets leaves its cascade indistinguishable
+        # from a user refusal, which is exactly the cause-blindness this
+        # provenance exists to remove. Anchored per arm rather than a file-wide
+        # tally: a tally stays green when one arm loses its assignment while
+        # another site gains one. Each window is wide enough to hold the arm's
+        # own assignment but too narrow to reach the next arm's (the nearest
+        # foreign assignment sits ~1.8k chars past the slack-None landmark).
+        src = self._src()
+        arm_anchors = (
+            (
+                "slack delivery-failure (None branch)",
+                "Linked approval delivery to Slack failed; auto-rejecting tool %r",
+                1000,
+            ),
+            (
+                "slack delivery-failure (except arm)",
+                "Error mirroring approval prompt to Slack",
+                800,
+            ),
+            ("no-budget", "format_approval_no_budget_card()", 400),
+            ("approval timeout", "format_approval_timeout_card(_approval_window)", 400),
+        )
+        missing = []
+        for arm, anchor, window in arm_anchors:
+            assert (
+                src.count(anchor) == 1
+            ), f"the {arm} arm's source landmark is no longer unique -- guard is stale"
+            if "_host_deny_cause = (" not in src.split(anchor, 1)[1][:window]:
+                missing.append(arm)
+        assert not missing, (
+            f"these host auto-decline arms no longer record a cause: {missing} -- "
+            "their cascades are again indistinguishable from a user refusal"
+        )
+        assert (
+            "slot._batch_rejected_cause = _host_deny_cause" in src
+        ), "the batch setter no longer copies the decline's provenance onto the slot"
+
+    def test_flag_and_provenance_clear_together(self):
+        # A stale cause is never READ today (the flag gates the only reader and
+        # the setter overwrites before any read), so no behavioural test can pin
+        # these clears -- but letting them drift apart falsifies the slot
+        # field's documented "set together, cleared together" contract and
+        # leaves a debugging trap. Pinned at source level: every clear of the
+        # flag must clear the provenance beside it.
+        src = self._src()
+        sites = [m.end() for m in re.finditer(r"slot\._batch_rejected = False", src)]
+        assert len(sites) >= 2, (
+            "expected the model-output clear and the turn-finally clear -- "
+            f"found {len(sites)} flag clear(s)"
+        )
+        unpaired = [
+            src[max(0, end - 160) : end].splitlines()[-1].strip()
+            for end in sites
+            if 'slot._batch_rejected_cause = ""' not in src[end : end + 120]
+        ]
+        assert (
+            not unpaired
+        ), f"these flag clears do not clear the provenance beside them: {unpaired}"


### PR DESCRIPTION
## Problem / Motivation

In `src/kiro_crew/dashboard/chat_runner.py`, `slot._batch_rejected` has a single cause-blind setter (`if outcome != "approved": slot._batch_rejected = True`) after the interactive approval wait — and every host-side auto-decline reaches it with `outcome == "rejected"`: the approval timeout, the no-budget branch, and both Slack-delivery-failure arms. When one of those declines a tool of a multi-tool batch, the cascade auto-rejects every remaining member, and each rejection reaches the model as kiro-cli's generic "User denied tool execution" — attribution inherited from a decline no user made.

Distinct from #8578 (in-band correction at the three auto-decline decision points themselves) and from #8219/PR #8508 (the timeout steer for the originating tool): the cascade site itself was cause-blind — at `await client.reject_tool` time it could not tell a person's refusal from an expired prompt.

## Why it matters

An unattended session whose approval prompt expires loses not one tool but the whole batch, and the model is told the *user* refused each of them. It then apologises for a cancellation nobody made, abandons the plan, or asks the user whether to retry — burning the turn on a false premise. The per-decision notices tracked by #8578 cannot fix this: even with those landed, the cascaded remainder still carries the wrong attribution.

## What changed (motivation → approach → change)

Symptom → root cause: the boolean flag erases WHO declined. Fix: give it provenance and branch the cascade on it.

- **Provenance capture** (`chat_runner.py`): each of the four host auto-decline arms (both Slack-delivery-failure arms, the no-budget branch, the approval timeout) records a short host-authored cause sentence into a per-tool local; the batch setter copies it onto the new slot field `_batch_rejected_cause`. An interactive user refusal leaves it empty. The Slack arms record only when they actually resolved the future, so a user answer that wins the race keeps user attribution.
- **Provenance-gated cascade** (`chat_runner.py`): for a host-caused cascade, the site steers ONE cause-specific in-band notice (before the first cascaded rejection goes on the wire, while the permission request is still unanswered — the ordering that keeps the steer queued instead of dropped). The latch is the steer's own return value, so a failed send is retried on the next member. For a user-refused batch the exemption is kept and documented with a `deny-notice-exempt:` marker (PR #8815's convention): "User denied tool execution" is the TRUE attribution there, and steering would re-attribute the user's own decision.
- **New cause wording** (`state.py`): `DENY_CAUSE_BATCH_CASCADE` in `_DENY_CAUSE_TEXT`, phrased for a group that was never individually judged ("auto-declined along with every remaining call in its batch…"), with the originating cause carried in the reason. The steer passes a throwaway notices list so no recovery-continuation entry is created (a best-effort attribution correction is not worth a second billed turn when steering is unavailable — that degrades to exactly today's behaviour), and withholds `slot`/`state` so no inject card renders (the frontend's cause→summary map does not know this cause and would mislabel it as a safety-policy block).
- **Lifetime**: the cause shares the flag's lifetime — set together at the batch setter, cleared together on model output (#7681 boundary) and in the turn's `finally`. Additive SEL metadata (`cause`) on cascaded rejections separates "user refused this group" from "a host auto-decline cut it short" for auditors.
- Scope deliberately excludes #8578's three decision-point notices (separate issue, separate PR).

Pre-push review: GPT lane (gpt-5.6-sol) NO-FINDINGS with evidence; Opus lane (claude-opus-5) 0 BLOCKING + 5 advisory findings, all five verified real and fixed at root (stale three-cause counts in comments, "batch's first tool" wording that is wrong when earlier members auto-approve, an unguarded paired clear, a tally-vacuous arm test, and a once-per-batch comment that overclaimed on failed sends).

## Tests

- `test/test_dashboard_approval.py::TestBatchCascadeAttribution` (new, 5 tests): timeout-originated cascade steers the real cause; no-budget-originated cascade steers; user-refused batch cascades **without** a steer; one notice covers a three-member cascaded remainder (no per-member spam); provenance dies with the group (#7681 boundary — a revised later call is prompted, not cascaded).
- `test/test_refusal_inband_notice.py::TestCauseSpecificWording`: new batch-cascade wording test (names the group, defers to the reason, never says "safety policy", sanctions re-issue); the invariant-half and cause-neutral-tag loops extended to the fourth cause.
- `test/test_refusal_inband_notice.py::TestEveryHostDenyCallSiteIsWired`: `test_cascade_site_branches_on_provenance` (steer present, provenance-gated, cause-specific, ordered before the reject, exemption marker present); `test_every_host_decline_arm_records_provenance` (each of the four arms anchored to its own source landmark — not a file-wide tally — plus the setter copy); `test_flag_and_provenance_clear_together` (every flag clear clears the provenance beside it).
- Mutation-verified: seven mutations (never-steer, steer-for-user, steer-per-member, arm loses its cause, setter drops provenance, arm-lost-plus-decoy against the anchored guard, unpaired clear) each caught by a distinct test.

## Manual verification

N/A — unit coverage sufficient: every behavioural branch (four host arms, user refusal, once-per-batch latch, group lifetime) is exercised through the real `_run_chat` turn loop with the same harness the existing batch-rejection tests use. Full local gate floor green (pytest, isort, flake8, mypy, black baseline, brand, harness parity, subprocess-encoding); the 102 pre-existing full-suite failures on this host are byte-identical on pristine main (userns/EPERM sandbox limitation), verified by set comparison.

## Related Issues

Closes #8818

## Pattern harvest

Rule candidate: review-prompt
Pattern: a boolean latch that funnels several distinct causes into one setter erases attribution the downstream consumer needs — record provenance at the setter, not a bare flag.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, behaviour documented in code comments and the slot field docstring
- [x] No secrets, credentials, or internal references in the diff
