### PR TITLE
fix(dashboard): name the offender when the slots flush fails to serialize

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -13,6 +13,7 @@ import math
 import os
 import re
 import shlex
+import sys
 import threading
 import time
 import traceback
@@ -265,6 +266,57 @@ def _safe_folder_tree(folders: object) -> list[dict[str, Any]]:
     if not isinstance(folders, list):
         return []
     return [f for f in folders if isinstance(f, dict) and isinstance(f.get("id"), str)]
+
+
+def _slots_serialization_note(slots_data: object) -> str:
+    """Name the slot and field that broke JSON serialization, for a traceback note.
+
+    A dump failure on the slots projection means EVERY slots read path is broken
+    (GET ``/api/chat/slots``, the WS snapshot, and this broadcast all serialize
+    the same shape), and the stock message — "Object of type X is not JSON
+    serializable" — names neither the slot nor the field, which is how #6522 was
+    first misread as a broadcast bug (#8745). Values are withheld by design: slot
+    state can carry user text, and the type is enough to find the producer.
+
+    Diagnosis must never make the failure worse, so any surprise in the walk
+    degrades to a generic note instead of raising.
+    """
+    try:
+        if not isinstance(slots_data, list):
+            return (
+                "[slots-broadcast] slot projection is "
+                f"{type(slots_data).__name__}, not a list (value withheld)"
+            )
+        for i, entry in enumerate(slots_data):
+            try:
+                json.dumps(entry)
+                continue
+            except (TypeError, ValueError):
+                pass
+            if not isinstance(entry, dict):
+                return (
+                    f"[slots-broadcast] slot entry #{i} is not JSON-serializable: "
+                    f"type {type(entry).__name__} (value withheld)"
+                )
+            key = entry.get("key")
+            slot_name = key if isinstance(key, str) else f"#{i}"
+            for field, value in entry.items():
+                try:
+                    json.dumps(value)
+                except (TypeError, ValueError):
+                    return (
+                        f"[slots-broadcast] slot {slot_name!r} field {field!r} is not "
+                        f"JSON-serializable: type {type(value).__name__} (value withheld)"
+                    )
+            # Every field dumps on its own, yet the entry does not: a non-string
+            # key is the one shape that gets here.
+            return (
+                f"[slots-broadcast] slot {slot_name!r} fails serialization as a whole; "
+                "no single offending field — check for non-string dict keys (value withheld)"
+            )
+        return "[slots-broadcast] slot list fails serialization; no offending entry found"
+    except Exception:  # pragma: no cover - defensive: a diagnostic must not raise
+        return "[slots-broadcast] slot projection is not JSON-serializable (offender walk failed)"
 
 
 def _slots_ws_frame(
@@ -7577,7 +7629,11 @@ class DashboardState:
 
         Depth-counted so nested use is safe (an inner block must not flush early),
         and ``@contextmanager``'s try/finally unwinds the depth even if the body
-        raises. Only flushes if something actually asked to push.
+        raises. Only flushes if something actually asked to push. A flush that
+        itself fails while the body's own exception is unwinding annotates its
+        exception (`PEP 678`) so the buried original stays visible — the flush's
+        exception otherwise replaces the body's in the caller's view, demoting
+        the actual fault to ``__context__`` (how #6522 was first misread).
         """
         self._slots_push_suspend += 1
         try:
@@ -7586,7 +7642,19 @@ class DashboardState:
             self._slots_push_suspend -= 1
             if self._slots_push_suspend == 0 and self._slots_push_pending:
                 self._slots_push_pending = False
-                self.push_slots_update()
+                # Captured BEFORE the flush call: inside the `except` block below,
+                # sys.exc_info() would already name the flush's own exception.
+                unwinding_over = sys.exc_info()[1]
+                try:
+                    self.push_slots_update()
+                except BaseException as flush_exc:
+                    if unwinding_over is not None and unwinding_over is not flush_exc:
+                        flush_exc.add_note(
+                            "[slots-flush] the owed slots flush raised while unwinding "
+                            f"over an in-flight {type(unwinding_over).__name__}; that "
+                            "original exception is chained below as __context__"
+                        )
+                    raise
 
     def push_slots_update(self) -> None:
         """Push slots, keeping provider status confined to owner websockets.
@@ -7729,6 +7797,18 @@ class DashboardState:
         # ``_serialize_for_client`` re-filters app tokens.
         slots_data = self.serialize_slots()
         slots_data_ws = self.serialize_slots(dashboard_user=True)
+        # The evidenced way this broadcast fails is a non-serializable value in
+        # slot state (#6522, #8745): the dump raises, and the bare TypeError
+        # names neither the slot nor the field. Serialize up front and annotate
+        # the failure with the offender so one traceback is enough to find it.
+        # Both coalescing branches (leading edge and trailing timer) funnel
+        # through this method, so both report identically by construction.
+        # Diagnosis only: the exception still propagates unchanged.
+        try:
+            slots_json = json.dumps(slots_data)
+        except (TypeError, ValueError) as exc:
+            exc.add_note(_slots_serialization_note(slots_data))
+            raise
         mgr = getattr(self, "channel_manager", None)
         ch_trusted = bool(mgr and any(ch.trusted for ch in mgr._channels.values()))
         # Piggyback the allowlist generation so clients invalidate the cached
@@ -7757,7 +7837,7 @@ class DashboardState:
                 # unfiltered stream.
                 "_slots_list_ws": slots_data_ws,
                 "_yolo": yolo_active,
-                "slots": json.dumps(slots_data),
+                "slots": slots_json,
                 "channelTrusted": ch_trusted,
                 "gitlabHostsGeneration": gitlab_hosts_generation(),
                 # getattr, not self._folders: this read path runs on EVERY slots

--- a/test/test_open_slots_persistence.py
+++ b/test/test_open_slots_persistence.py
@@ -960,6 +960,112 @@ def test_suspend_slots_push_no_push_means_no_broadcast(tmp_path, monkeypatch):
     assert seen.count("slots") == 0
 
 
+# ── #8745: a serialization failure in the slots flush must name its offender ──
+#
+# The evidenced failure class behind a slots-broadcast 500 is a non-serializable
+# value in slot state: json.dumps raises deep in the flush, every slots read
+# path is equally broken, and the stock TypeError names neither the slot nor
+# the field. Worse, when the flush fails while a suspend block is unwinding
+# over the body's own exception, the flush's exception REPLACES the body's in
+# the caller's view (the original demoted to __context__) — exactly how #6522
+# was first misread as a broadcast bug. These pin the two diagnostics: the
+# offender note on BOTH coalescing branches, and the unwinding-over note.
+# Semantics stay untouched: same exception types, same propagation, same
+# chaining, no caught-and-swallowed anything.
+
+
+def _poison_slots_projection(state):
+    """Make serialize_slots return one slot whose ``title`` cannot be dumped."""
+    entry = {"key": "chat-poison", "title": object()}
+    state.serialize_slots = lambda **kw: [dict(entry)]  # type: ignore[method-assign]
+
+
+def test_leading_edge_serialization_failure_names_the_offender(tmp_path, monkeypatch):
+    """The immediate (leading-edge) broadcast annotates the raising TypeError."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    with pytest.raises(TypeError) as excinfo:
+        state.push_slots_update()
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "'chat-poison'" in notes, f"note must name the slot key, got: {notes!r}"
+    assert "'title'" in notes, "note must name the offending field"
+    assert "object" in notes, "note must name the value's type"
+    assert "value withheld" in notes, "note must never carry the value itself"
+
+
+def test_trailing_flush_serialization_failure_names_the_offender(tmp_path, monkeypatch):
+    """The trailing-edge callback funnels through the same annotated dump.
+
+    Both timing branches converge on _do_slots_broadcast, so the diagnostic
+    covers them by construction — this pins the trailing half of that claim.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    with pytest.raises(TypeError) as excinfo:
+        state._trailing_slots_flush()
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "'chat-poison'" in notes
+    assert "'title'" in notes
+
+
+def test_flush_failure_during_unwind_names_the_masked_exception(tmp_path, monkeypatch):
+    """A flush failing during exception unwind must say whose funeral it crashed.
+
+    The body's RuntimeError is the actual fault; the flush's TypeError merely
+    reports a broken projection. Today's chaining (body as __context__) is
+    preserved and now NAMED, so the top of the traceback stops eating the lede.
+    """
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    with pytest.raises(TypeError) as excinfo:
+        with state.suspend_slots_push():
+            state.push_slots_update()  # queue the owed push
+            raise RuntimeError("boom")  # the body's actual fault
+
+    exc = excinfo.value
+    assert isinstance(exc.__context__, RuntimeError), "implicit chaining must survive"
+    notes = "\n".join(getattr(exc, "__notes__", []))
+    assert "unwinding over" in notes and "RuntimeError" in notes
+    assert "__context__" in notes, "note must point at where the original went"
+    assert "'chat-poison'" in notes, "offender note must also be present"
+    assert state._slots_push_suspend == 0, "depth must still unwind"
+
+
+def test_flush_failure_without_inflight_exception_has_no_unwind_note(tmp_path, monkeypatch):
+    """A plain flush failure (body exited normally) gets the offender note only."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    _poison_slots_projection(state)
+
+    with pytest.raises(TypeError) as excinfo:
+        with state.suspend_slots_push():
+            state.push_slots_update()  # owed flush raises on a clean exit
+
+    notes = "\n".join(getattr(excinfo.value, "__notes__", []))
+    assert "'chat-poison'" in notes
+    assert "unwinding over" not in notes, "no body exception, so no unwind note"
+
+
+def test_healthy_flush_is_unchanged_by_the_diagnostics(tmp_path, monkeypatch):
+    """Benign control: the hoisted dump changes nothing on the happy path."""
+    monkeypatch.setenv("KIROCREW_HOME", str(tmp_path))
+    state = _make_state(tmp_path / "sessions")
+    seen: list[str] = []
+    state._broadcast = lambda note: seen.append(note.get("_type"))  # type: ignore[method-assign]
+
+    state.push_slots_update()
+
+    assert seen.count("slots") == 1
+
+
 # ── The deferred restore must not let a flush truncate the snapshot ──
 #
 # start_flush_loop() is running (every 5s) BEFORE the startup restore. While the


### PR DESCRIPTION
## Problem / Motivation

A non-serializable value in slot state breaks every slots read path at once (`GET /api/chat/slots`, the WS snapshot, and the debounced broadcast all serialize the same projection), but the operator gets two unhelpful tracebacks (#8745, and #6522 before it):

1. The stock error names neither the slot nor the field. Measured on `main` (235d36a62), with one slot's `title` poisoned:

```
TypeError: Object of type object is not JSON serializable
```

2. When the owed flush of `suspend_slots_push` raises while the body's own exception is already unwinding, the flush's exception **replaces** the body's in the caller's view — the actual fault is demoted to `__context__`, which is exactly how #6522 was first misread as a broadcast bug:

```
Traceback (most recent call last):
  File ".../state.py", line 7584, in suspend_slots_push
    yield
  File "probe.py", line 48, in unwind_case
    raise RuntimeError("the body's actual fault")
RuntimeError: the body's actual fault

During handling of the above exception, another exception occurred:
...
TypeError: Object of type object is not JSON serializable
```

## Why it matters

This is the diagnostic half that issue #8745 explicitly asks to land regardless of the wider decision ("Land the masking diagnostic regardless, since it changes no observable behaviour"). Without it, the next poisoned-slot incident starts the same way #6522 did: an operator staring at a bare `TypeError` at the top of a traceback whose real story is one exception down, with no pointer to which slot or field to look at.

## What changed (motivation → approach → change)

- **Symptom**: the two tracebacks above — no offender named, and the top of the unwind traceback eats the lede.
- **Root cause**: the dump raises deep in `_do_slots_broadcast` with no context attached, and `suspend_slots_push`'s finally-block flush is positioned to raise over an in-flight body exception, where Python's implicit chaining preserves the original only as `__context__` without saying so.
- **Change**: two additive PEP 678 traceback notes (`requires-python >= 3.12`); no semantics change — same exception types, same propagation, same chaining:
  - `_do_slots_broadcast` hoists the general-frame `json.dumps` and, on `TypeError`/`ValueError`, annotates it via a new `_slots_serialization_note()` helper that names the offending slot key, field name, and value **type**. Values are withheld by design: slot state can carry user text, and the type is enough to find the producer. Both coalescing branches (leading edge and trailing timer) funnel through this method, so both report identically by construction. The helper is defensive end-to-end — any surprise in the offender walk degrades to a generic note rather than raising.
  - `suspend_slots_push` captures `sys.exc_info()` before the owed flush and, if the flush raises during unwind over a distinct in-flight exception, annotates the flush's exception naming the buried original and pointing at `__context__`.

Same probe, after:

```
TypeError: Object of type object is not JSON serializable
[slots-broadcast] slot 'chat-poison' field 'title' is not JSON-serializable: type object (value withheld)
[slots-flush] the owed slots flush raised while unwinding over an in-flight RuntimeError; that original exception is chained below as __context__
```

Deliberately **not** in scope: the failure-semantics decision the issue frames as options 1/2/3 (catch-at-flush vs fail-loud vs validate-at-write). That is a behavior choice the issue leaves open, and this diagnostic is useful under any of the three outcomes.

## Tests

Five tests added to `test/test_open_slots_persistence.py` (file: 67 passed; slots push/broadcast neighbors: 191 passed). Before the fix, the four diagnostic tests fail (`4 failed, 1 passed`); after, `5 passed`:

- `test_leading_edge_serialization_failure_names_the_offender` — the immediate broadcast annotates the raising `TypeError` with slot key, field, and type, and never the value.
- `test_trailing_flush_serialization_failure_names_the_offender` — the trailing-edge callback funnels through the same annotated dump (pins the both-branches claim).
- `test_flush_failure_during_unwind_names_the_masked_exception` — implicit chaining survives (`__context__` is the body's `RuntimeError`), the note names the buried original, and the suspend depth still unwinds to zero.
- `test_flush_failure_without_inflight_exception_has_no_unwind_note` — a clean-exit flush failure gets the offender note only; no phantom unwind note.
- `test_healthy_flush_is_unchanged_by_the_diagnostics` — benign control: exactly one broadcast on the happy path, no new denials, no behavior change.

## Manual verification

N/A — unit coverage sufficient: the seam is deterministic (poisoned projection in → annotated exception out) and the probe outputs above are the manual scenario, pasted from a fresh run on this branch.

## Related Issues

Refs #8745 (the separable diagnostic half; the failure-semantics decision stays open there). Context: #6522.

## Pattern harvest

Pattern: a cleanup step positioned to raise during exception unwind masks the body's exception (visible only as an unlabeled `__context__`), and serialization errors deep in a shared projection name no offender.
Rule candidate: review-prompt — "any `finally`/`__exit__`/context-manager cleanup that can itself raise should annotate its exception when unwinding over an in-flight one; any `json.dumps` on a composite projection should name the offending element on failure."

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A for spec docs: no system-spec module documents this flush seam; the updated docstrings on `suspend_slots_push` and the new helper are the doc-of-record
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835).
