### PR TITLE
ci: distinguish provider refusal from crash in the fork GPT review lane

### DIFF
--- a/.github/workflows/fork-gpt-review.yml
+++ b/.github/workflows/fork-gpt-review.yml
@@ -449,6 +449,23 @@ jobs:
           # away dies on a named timeout instead of mid-call on an expired
           # token, which reads as a model failure and buries the real cause.
           PASS_WALL: 55m
+          # The provider's own refusal line, verbatim from the CLI's error
+          # output including its line-leading "ERROR: " prefix. A refusal and
+          # a crash both arrive as rc != 0 or an empty pass file, but they
+          # mean opposite things: a crash is fixed by re-running, while a
+          # refusal is caused by what the diff IS and is empirically sticky
+          # across re-runs. This line is the only way to tell them apart. The
+          # classification below matches it ANCHORED at line start and only
+          # in the TAIL of the captured stream, because the stream carries
+          # PR-controlled text with even less trust than the same-repo lane's
+          # (the prompt embeds the fork author's title/body as nonce-wrapped
+          # data, and the reviewer echoes the diff -- which, for any PR
+          # touching this file, contains this very string): an unanchored
+          # whole-stream match would let an echoed copy of the signature
+          # reclassify an ordinary crash as a refusal. The text must stay
+          # free of regex metacharacters -- it is interpolated into an
+          # anchored grep pattern. Keep in sync with codex-review.yml.
+          REFUSAL_SIGNATURE: "ERROR: This request has been flagged for potentially high-risk cyber activity"
         # Pass 1 generates candidates; its output is never posted or gated
         # directly -- the falsification pass below emits the only verdict the
         # comment and gate consume. Mirrors codex-review.yml's two-pass design.
@@ -649,6 +666,7 @@ jobs:
           # form survives any future change to what this lane checks out.
           rm -f codex-failed-passes
           : > codex-failed-passes
+          rm -f "$RUNNER_TEMP/codex-refused-passes"
           BASE_PROMPT="$(cat /tmp/fork-codex-prompt.md)"
           PROMPT=$(printf '%s\n\n%s\n' "$BASE_PROMPT" \
             "DISCOVERY PASS: inspect the full current diff and report every candidate that meets the FINDING BAR. This is candidate generation, not the final verdict.")
@@ -661,13 +679,28 @@ jobs:
           # credentials (zizmor github-env). The path is under RUNNER_TEMP
           # because the manifest that produced it was materialized from the
           # BASE commit, not from this checkout -- see "Install review CLI".
+          #
+          # The CLI's combined stream is tee'd into RUNNER_TEMP (never the
+          # checkout, so a PR cannot plant a symlink at its name) because a
+          # failed pass is classified below by the provider's own words --
+          # only the captured output can tell a refusal from a crash.
           timeout "$PASS_WALL" \
             "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
             --sandbox read-only \
             --output-last-message "codex-pass-1.md" \
-            "$PROMPT" || rc=$?
+            "$PROMPT" 2>&1 | tee "$RUNNER_TEMP/codex-pass-1-log.txt" || rc=$?
           if [ "$rc" -ne 0 ] || [ ! -s codex-pass-1.md ]; then
-            echo "::warning::GPT 5.6 fork review pass 1 did not complete (exit ${rc}); the verdict will fail closed."
+            # Anchored + tail-scoped on purpose: the provider emits the
+            # refusal line at column 0 as the stream's final act, while an
+            # echoed copy of the signature (a diff hunk, quoted prose) is
+            # neither line-leading nor reliably last. The 4000-byte tail fits
+            # a single pipe buffer, so the grep cannot SIGPIPE the tail.
+            if tail -c 4000 "$RUNNER_TEMP/codex-pass-1-log.txt" | grep -q "^$REFUSAL_SIGNATURE"; then
+              echo "::warning::GPT 5.6 fork review pass 1 was refused by the provider (exit ${rc}); the verdict will name the refusal instead of advising a re-run."
+              printf ' 1' >> "$RUNNER_TEMP/codex-refused-passes"
+            else
+              echo "::warning::GPT 5.6 fork review pass 1 did not complete (exit ${rc}); the verdict will fail closed."
+            fi
             printf ' 1' >> codex-failed-passes
           fi
 
@@ -706,6 +739,11 @@ jobs:
           DISCOVERY_OUTPUT_MAX_BYTES: "50000"
           PASS_WALL: 55m
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          # Same signature and same anchored/tail-scoped matching as the
+          # discovery pass: a failed pass carrying it was REFUSED, not
+          # crashed, and the verdict assembly below reports that as its own
+          # terminal state. Keep in sync with codex-review.yml.
+          REFUSAL_SIGNATURE: "ERROR: This request has been flagged for potentially high-risk cyber activity"
         # Pass 2 tries to KILL pass 1's candidates and emits the only verdict the
         # comment and gate consume. Both calls are required: if either failed, no
         # verdict is published and the gate fails closed.
@@ -752,25 +790,67 @@ jobs:
 
           rm -f codex-pass-2.md
           rc=0
+          # tee'd into RUNNER_TEMP for the same reason as pass 1: the captured
+          # stream is what classifies a failed pass as refused vs crashed.
           timeout "$PASS_WALL" \
             "$RUNNER_TEMP/review-cli/node_modules/.bin/codex" exec \
             --sandbox read-only \
             --output-last-message "codex-pass-2.md" \
-            "$PROMPT" || rc=$?
+            "$PROMPT" 2>&1 | tee "$RUNNER_TEMP/codex-pass-2-log.txt" || rc=$?
           if [ "$rc" -ne 0 ] || [ ! -s codex-pass-2.md ]; then
-            echo "::warning::GPT 5.6 fork review pass 2 did not complete (exit ${rc}); the verdict will fail closed."
+            if tail -c 4000 "$RUNNER_TEMP/codex-pass-2-log.txt" | grep -q "^$REFUSAL_SIGNATURE"; then
+              echo "::warning::GPT 5.6 fork review pass 2 was refused by the provider (exit ${rc}); the verdict will name the refusal instead of advising a re-run."
+              printf ' 2' >> "$RUNNER_TEMP/codex-refused-passes"
+            else
+              echo "::warning::GPT 5.6 fork review pass 2 did not complete (exit ${rc}); the verdict will fail closed."
+            fi
             failed_passes="${failed_passes} 2"
           fi
 
+          refused_passes="$(cat "$RUNNER_TEMP/codex-refused-passes" 2>/dev/null || true)"
+          refused="false"
           if [ -n "$failed_passes" ]; then
-            {
-              echo "> **Incomplete review:** pass(es)${failed_passes} did not complete."
-              echo
-              echo "The pass-2 verdict was not published because both calls are required. Re-run the workflow for a complete review."
-            } > codex-review-output.md
+            if [ -n "$refused_passes" ]; then
+              # A refusal is not a crash: the provider declined because of
+              # what the reviewed content IS, and measured refusals of this
+              # class recur identically across re-runs, so advising a re-run
+              # points the operator at a remedy that has never been observed
+              # to work. Publish a distinct terminal state -- it still carries
+              # no [GPT-REVIEWED] marker, so the check-run still fails closed
+              # and a declined review can never read as an approval -- that
+              # names the refusal. The refusal dominates a mixed failure (one
+              # pass refused, the other crashed) because a re-run only helps
+              # if the refusal does not recur. Unlike codex-review.yml, the
+              # remedy text names direct maintainer review rather than
+              # /ai-review override: this lane resolves no override record
+              # (see "the fork lane has no override" below), so promising
+              # that command here would route a maintainer to a clearance
+              # path that cannot clear this check.
+              refused="true"
+              {
+                echo "> **Reviewer refused:** the provider declined to review this diff (pass(es)${refused_passes})."
+                echo
+                echo "The refusal is caused by the reviewed content, not by a transient failure, so a re-run is very unlikely to produce a verdict. A declined review is not an approval: a maintainer must review this change directly."
+              } > codex-review-output.md
+            else
+              {
+                echo "> **Incomplete review:** pass(es)${failed_passes} did not complete."
+                echo
+                echo "The pass-2 verdict was not published because both calls are required. Re-run the workflow for a complete review."
+              } > codex-review-output.md
+            fi
           else
             cp codex-pass-2.md codex-review-output.md
           fi
+          # The refusal classification travels as a step OUTPUT, never by
+          # re-grepping codex-review-output.md downstream: on the clean path
+          # that file is verbatim model prose, so a review that merely QUOTED
+          # a refusal phrase (say, while reviewing this workflow) would
+          # otherwise reclassify a completed verdict. There is deliberately
+          # no refusal marker in the body itself — the prose names the
+          # refusal for human readers, and a marker nothing may parse would
+          # only invite a future step to start grepping model prose for it.
+          echo "refused=$refused" >> "$GITHUB_OUTPUT"
 
           # Gate the adjudication pass below on the verdict THIS step produced,
           # so a clean PR never pays for it. Mirrors codex-review.yml.
@@ -1232,6 +1312,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR: ${{ steps.pr.outputs.pr }}
           HEAD: ${{ steps.pr.outputs.head_sha }}
+          REFUSED: ${{ steps.gpt_pass2.outputs.refused }}
           ADJ_DECISION: ${{ steps.adj.outputs.decision }}
           ADJ_NOTE: ${{ steps.adj.outputs.note }}
         run: |
@@ -1239,6 +1320,15 @@ jobs:
           [ -z "${PR:-}" ] && { echo "no PR resolved; skipping comment"; exit 0; }
           MARKER="<!-- codex-ai-review -->"
           kind="incomplete"; verdict="⚠️ review incomplete"; note=""
+          # $REFUSED is the verdict assembly's step output, never a grep of
+          # the review body: on the clean path that body is model prose, and
+          # a review merely QUOTING the refusal wording must not reclassify a
+          # completed verdict. The assembly only ever emits refused=true on a
+          # run whose body it wrote itself, with no [GPT-REVIEWED] marker, so
+          # the completed-verdict branch below can never race this one.
+          if [ "${REFUSED:-}" = "true" ]; then
+            kind="refused"; verdict="⛔ reviewer refused this diff"
+          fi
           if [ -s codex-review-output.md ] && grep -Fq "[GPT-REVIEWED] $HEAD" codex-review-output.md; then
             if grep -Fq "[BLOCK-MERGE] $HEAD" codex-review-output.md; then
               # Rendered from the SAME parsed decision the check-run acts on,
@@ -1277,6 +1367,12 @@ jobs:
               sed -E 's/\[BLOCK-MERGE\]([[:space:]]+[0-9a-fA-F]{7,40})/[BLOCK-MERGE-DOWNGRADED]\1/g' codex-review-output.md
               echo
               echo "</details>"
+            elif [ "$kind" = "refused" ]; then
+              # No override command here, deliberately: this lane resolves no
+              # override record, and its comment carries no override command
+              # (see the fence text below). The honest remedy on a fork PR is
+              # a maintainer reading the change itself.
+              echo "_The provider declined to review this commit; the refusal text is in the Fork GPT 5.6 Review job logs. It is caused by the diff's own content: re-runs have not been observed to clear this class of refusal. A declined review is not an approval — a maintainer must review this change directly._"
             else
               echo "_No completed GPT verdict for this commit; see the Fork GPT 5.6 Review job logs._"
               # REPORTING ONLY. Without this, a review that ran to completion but
@@ -1491,11 +1587,25 @@ jobs:
           HEAD: ${{ steps.pr.outputs.head_sha || github.event.workflow_run.head_sha }}
           CHECK_ID: ${{ steps.check.outputs.id }}
           PR: ${{ steps.pr.outputs.pr }}
+          REFUSED: ${{ steps.gpt_pass2.outputs.refused }}
           ADJ_DECISION: ${{ steps.adj.outputs.decision }}
           ADJ_NOTE: ${{ steps.adj.outputs.note }}
         run: |
           set -uo pipefail
           conclusion="failure"; title="review incomplete"; extra=""
+          # A refusal is its own terminal state, distinct from a crash. Still
+          # fail CLOSED -- a declined review is not an approval, and passing
+          # here would turn the provider's content filter into a bypass of
+          # the repo's own review requirement -- but the required check's
+          # title must name the true cause: "review incomplete" tells a
+          # maintainer to re-run, and re-runs have not been observed to clear
+          # this class. $REFUSED is the verdict assembly's step output for
+          # THIS run; the assembly only ever emits refused=true on a run
+          # whose marker-less body it wrote itself, so the completed-verdict
+          # branch below can never override this title with a stale verdict.
+          if [ "${REFUSED:-}" = "true" ]; then
+            title="reviewer refused this diff"
+          fi
           if [ -s codex-review-output.md ] && grep -Fq "[GPT-REVIEWED] $HEAD" codex-review-output.md; then
             if grep -Fq "[BLOCK-MERGE] $HEAD" codex-review-output.md; then
               # [BLOCK-MERGE] is relaxed by exactly one thing: a fully reconciled

--- a/docs/ci/ci-and-reviews.md
+++ b/docs/ci/ci-and-reviews.md
@@ -626,23 +626,25 @@ The markers are the **only** gate:
   failing this gate closed on healthy reviews.
 - GPT 5.6 emits `[GPT-REVIEWED] <sha>` / `[BLOCK-MERGE] <sha>`. When the provider
   *refuses* the request — declines to review the diff because of what it contains,
-  as opposed to crashing or timing out — the **same-repo lane** publishes a distinct
+  as opposed to crashing or timing out — both GPT lanes publish a distinct
   terminal state: the synthetic verdict body names the refusal in prose (no
   reviewed marker, so the gate still fails closed), and the classification rides
   the verdict assembly's `refused` step output. There is deliberately no refusal
   marker in the body — the body on the clean path is model prose, and a marker
   would invite prose-grepping, so a review that merely quotes the refusal wording
-  cannot be reclassified. The gate's message names human adjudication
-  (`/ai-review override`) instead of advising a re-run: the refusal is caused by
-  the reviewed content and is empirically sticky — 12 consecutive identical
-  refusals across 10 heads were measured on one PR — so a re-run is not a workable
-  remedy. A failed pass is classified as refused only when the provider's own
-  error line appears line-anchored in the tail of that pass's captured stream,
-  because the stream also carries PR-controlled text (the prompt embeds the PR
-  title/body, and the reviewer echoes the diff). Without the distinction, every
-  security fix whose evidence is a working exploit read as a permanently
-  re-runnable crash (#8685). The fork GPT lane (`fork-gpt-review.yml`) still
-  reports only the generic incomplete state and is tracked separately.
+  cannot be reclassified. The refusal is caused by the reviewed content and is
+  empirically sticky — 12 consecutive identical refusals across 10 heads were
+  measured on one PR — so neither lane advises a re-run. The remedy each lane
+  names is the one that exists for it: the same-repo gate names human
+  adjudication (`/ai-review override`), while the fork lane
+  (`fork-gpt-review.yml`) resolves no override record, so its refused comment
+  and check-run title route to direct maintainer review instead of naming a
+  command that cannot clear that check. A failed pass is classified as refused
+  only when the provider's own error line appears line-anchored in the tail of
+  that pass's captured stream, because the stream also carries PR-controlled
+  text (the prompt embeds the PR title/body, and the reviewer echoes the diff).
+  Without the distinction, every security fix whose evidence is a working
+  exploit read as a permanently re-runnable crash (#8685).
 - Design and UX emit `Design-Verdict:` / `UX-Verdict: PASS | CONCERNS | BLOCK`,
   parsed from a header line.
 

--- a/test/test_ai_review_workflows.py
+++ b/test/test_ai_review_workflows.py
@@ -7402,3 +7402,317 @@ class TestModelStepsRunAfterTheCredentialFilesAreScrubbed:
             env={**os.environ, "RUNNER_TEMP": str(tmp_path / "absent")},
         )
         assert proc.returncode == 0, proc.stderr
+
+
+class TestForkGptRefusalTerminalState:
+    """The fork GPT lane's port of the refusal/crash distinction (#8739).
+
+    Fork PRs are where an untrusted working exploit is most likely to arrive,
+    so this lane needs the distinction most: a provider refusal is caused by
+    what the diff IS and recurs identically across re-runs, while a crash is
+    fixed by re-running. The port mirrors ``codex-review.yml``'s classification
+    (line-anchored signature match in the tail of the tee'd stream, refusal
+    riding the assembly's ``refused`` step output, never a body grep) with one
+    deliberate difference: this lane resolves no ``/ai-review override``
+    record, so its refused copy routes to direct maintainer review instead of
+    naming a command that cannot clear this check. The comment/check-run
+    publication path differs from the same-repo lane (marker comment plus
+    check-run, no exit-1 gate step), so the refused kind is pinned on both.
+    """
+
+    HEAD = "0123456789abcdef0123456789abcdef01234567"
+
+    @staticmethod
+    def _pass_step(name: str) -> dict:
+        doc = yaml.safe_load(_workflow("fork-gpt-review.yml"))
+        for step in list(doc["jobs"].values())[0]["steps"]:
+            if step.get("name") == name:
+                return step
+        raise AssertionError(f"step not found: {name}")
+
+    def test_refusal_is_classified_where_rc_is_captured(self) -> None:
+        workflow = _workflow("fork-gpt-review.yml")
+        discovery_step = workflow[
+            workflow.index("- name: GPT 5.6 review (discovery pass)") : workflow.index(
+                "- name: GPT 5.6 review (falsification pass)"
+            )
+        ]
+        review_step = workflow[
+            workflow.index("- name: GPT 5.6 review (falsification pass)") : workflow.index(
+                "- name: Redact credential shapes"
+            )
+        ]
+        for step, n in ((discovery_step, 1), (review_step, 2)):
+            # The signature can only be matched against output that was
+            # captured; the CLI's combined stream is tee'd where rc is
+            # captured, into RUNNER_TEMP so a PR cannot plant a symlink at
+            # the log's name. The match is line-anchored and tail-scoped
+            # because the stream carries PR-controlled text with even less
+            # trust than the same-repo lane's: the prompt embeds the fork
+            # author's title/body as nonce-wrapped data, and the reviewer
+            # echoes the diff — which, for a PR touching the workflow itself,
+            # contains the signature verbatim. An unanchored whole-stream
+            # match would let an echoed copy reclassify an ordinary crash as
+            # a refusal.
+            assert f'tee "$RUNNER_TEMP/codex-pass-{n}-log.txt"' in step
+            assert "REFUSAL_SIGNATURE:" in step
+            assert (
+                f'tail -c 4000 "$RUNNER_TEMP/codex-pass-{n}-log.txt" | grep -q "^$REFUSAL_SIGNATURE"'
+                in step
+            )
+            assert f"printf ' {n}' >> \"$RUNNER_TEMP/codex-refused-passes\"" in step
+        # A stale refusal record from an earlier run of the same job must not
+        # classify a fresh failure, so the record is re-initialized with the
+        # crash record.
+        assert 'rm -f "$RUNNER_TEMP/codex-refused-passes"' in discovery_step
+        # The signature is interpolated into an anchored grep pattern, so it
+        # must carry the provider's line-leading prefix and stay free of
+        # basic-regex metacharacters.
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        assert signature.startswith("ERROR: ")
+        assert re.search(r"[.*\[\]^$\\]", signature) is None
+
+    def test_signature_stays_in_sync_with_the_same_repo_lane(self) -> None:
+        # Both lanes classify against the same provider's error line. A
+        # signature that drifts between them would silently split the refusal
+        # semantics: one lane names the refusal while the other advises the
+        # futile re-run for the identical event.
+        fork_doc = yaml.safe_load(_workflow("fork-gpt-review.yml"))
+        same_doc = yaml.safe_load(_workflow("codex-review.yml"))
+
+        def _signatures(doc: dict) -> set[str]:
+            return {
+                step["env"]["REFUSAL_SIGNATURE"]
+                for job in doc["jobs"].values()
+                for step in job["steps"]
+                if isinstance(step.get("env"), dict) and "REFUSAL_SIGNATURE" in step["env"]
+            }
+
+        fork_signatures = _signatures(fork_doc)
+        same_signatures = _signatures(same_doc)
+        assert len(fork_signatures) == 1, "fork lane passes must share one signature"
+        assert fork_signatures == same_signatures
+
+    def _classify(self, tmp_path: Path, log: str) -> str:
+        """Run the fork discovery pass's failure-classification block against a
+        fabricated captured stream and return the refused-passes record."""
+        bash = _bash()
+        if bash is None:
+            pytest.skip("classification requires Bash")
+        step = self._pass_step("GPT 5.6 review (discovery pass)")
+        script = step["run"]
+        snippet = script[script.index('if [ "$rc" -ne 0 ]') :]
+        runner_temp = tmp_path / "rt"
+        runner_temp.mkdir()
+        (runner_temp / "codex-pass-1-log.txt").write_text(log, encoding="utf-8")
+        result = subprocess.run(
+            [bash, "-c", f"set -uo pipefail\nrc=124\n{snippet}"],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "RUNNER_TEMP": str(runner_temp),
+                "REFUSAL_SIGNATURE": step["env"]["REFUSAL_SIGNATURE"],
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        record = runner_temp / "codex-refused-passes"
+        return record.read_text(encoding="utf-8") if record.exists() else ""
+
+    def test_provider_emitted_refusal_line_classifies_as_refused(self, tmp_path: Path) -> None:
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        log = f"some progress output\n{signature}.\nLearn more here: https://example.invalid\n"
+        assert self._classify(tmp_path, log) == " 1"
+
+    def test_echoed_signature_in_pr_controlled_text_stays_a_crash(self, tmp_path: Path) -> None:
+        # This lane hands the model MORE attacker-controlled text than the
+        # same-repo lane: the fork author's PR title/body ride the prompt as
+        # nonce-wrapped data, and the reviewer echoes the diff. A fork author
+        # can therefore WRITE the signature into their description or diff —
+        # quoted or indented, never line-leading — and a crash on such a PR
+        # must stay a crash: mislabeling it as refused tells a maintainer the
+        # re-run that would have worked is futile.
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        log = f'+          REFUSAL_SIGNATURE: "{signature}"\n> quoted: {signature}\n'
+        assert self._classify(tmp_path, log) == ""
+
+    def test_signature_outside_the_stream_tail_stays_a_crash(self, tmp_path: Path) -> None:
+        # The provider emits the refusal as the stream's final act. A copy of
+        # the line early in a long stream (echoed content scrolled past) must
+        # not classify a later, unrelated crash.
+        signature = self._pass_step("GPT 5.6 review (discovery pass)")["env"]["REFUSAL_SIGNATURE"]
+        log = f"{signature}.\n" + ("x" * 80 + "\n") * 100
+        assert self._classify(tmp_path, log) == ""
+
+    def _assemble_verdict(
+        self,
+        tmp_path: Path,
+        *,
+        failed_passes: str,
+        refused_passes: str | None,
+        pass2: str | None,
+    ) -> tuple[str, str]:
+        bash = _bash()
+        if bash is None:
+            pytest.skip("verdict assembly requires Bash")
+        script = _step_script(
+            _workflow("fork-gpt-review.yml"), "GPT 5.6 review (falsification pass)"
+        )
+        snippet = script[
+            script.index("refused_passes=") : script.index("# Gate the adjudication pass below")
+        ]
+        runner_temp = tmp_path / "rt"
+        runner_temp.mkdir()
+        gh_output = tmp_path / "gh-output"
+        gh_output.write_text("", encoding="utf-8")
+        if refused_passes is not None:
+            (runner_temp / "codex-refused-passes").write_text(refused_passes, encoding="utf-8")
+        if pass2 is not None:
+            (tmp_path / "codex-pass-2.md").write_text(pass2, encoding="utf-8")
+        harness = f"set -uo pipefail\nfailed_passes='{failed_passes}'\n{snippet}\ncat codex-review-output.md\n"
+        result = subprocess.run(
+            [bash, "-c", harness],
+            check=False,
+            capture_output=True,
+            encoding="utf-8",
+            cwd=tmp_path,
+            env={
+                **os.environ,
+                "HEAD": self.HEAD,
+                "RUNNER_TEMP": str(runner_temp),
+                "GITHUB_OUTPUT": str(gh_output),
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout, gh_output.read_text(encoding="utf-8")
+
+    def test_refused_pass_publishes_its_own_terminal_state(self, tmp_path: Path) -> None:
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes=" 2", refused_passes=" 2", pass2=None
+        )
+        assert "Reviewer refused" in out
+        # The refusal must not read as a completed review, must not prescribe
+        # the re-run that has never been observed to work, and deliberately
+        # carries NO machine marker: classification rides the step output.
+        assert "[GPT-REVIEWED]" not in out
+        assert "[GPT-REFUSED]" not in out
+        assert "Re-run the workflow" not in out
+        # The fork-specific remedy: this lane resolves no override record, so
+        # its refused body must NOT name /ai-review override — the same-repo
+        # lane's remedy — and must route to direct maintainer review instead.
+        assert "/ai-review override" not in out
+        assert "review this change directly" in out
+        # Downstream classification rides this output, never a body grep.
+        assert "refused=true" in gh_output
+
+    def test_crashed_pass_keeps_the_rerunnable_incomplete_state(self, tmp_path: Path) -> None:
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes=" 1", refused_passes=None, pass2=None
+        )
+        assert "Incomplete review" in out
+        assert "Re-run the workflow" in out
+        assert "refused=false" in gh_output
+
+    def test_refusal_dominates_a_mixed_failure(self, tmp_path: Path) -> None:
+        # Pass 1 crashed AND pass 2 was refused: a re-run only helps if the
+        # refusal does not recur, so the refusal is what the maintainer is
+        # told about.
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes=" 1 2", refused_passes=" 2", pass2=None
+        )
+        assert "Reviewer refused" in out
+        assert "Re-run the workflow" not in out
+        assert "refused=true" in gh_output
+
+    def test_clean_run_still_publishes_pass_2_verbatim(self, tmp_path: Path) -> None:
+        verdict = f"all good\n[GPT-REVIEWED] {self.HEAD}\n"
+        out, gh_output = self._assemble_verdict(
+            tmp_path, failed_passes="", refused_passes=None, pass2=verdict
+        )
+        assert f"[GPT-REVIEWED] {self.HEAD}" in out
+        assert "refused=false" in gh_output
+
+    def test_refused_run_never_modifies_an_existing_comment(self, tmp_path: Path) -> None:
+        # A refused run is verdict-less exactly like an incomplete one, so the
+        # guarded upsert's no-touch transition (#8292/#8344) must cover it:
+        # with an existing bot comment present, the run makes no edit of any
+        # kind. The refused body carries no "[GPT-REVIEWED] <head>" proof
+        # marker, so the shared guarded_comment_upsert withholds it -- this
+        # test pins that the refusal classification rides that path rather
+        # than growing a posting branch of its own.
+        vis = TestReviewLaneVerdictVisibility()
+        lane = next(entry for entry in _GUARDED_LANES if entry["id"] == "fork-gpt")
+        calls, result = vis._run_step(
+            lane,
+            tmp_path,
+            existing_body=vis._verdict_body(lane, vis.OLD),
+            kind="refused",
+            extra_env={"REFUSED": "true"},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        assert not (calls / "patch-calls.txt").exists()
+        assert not (calls / "patched-body.md").exists()
+        assert not (calls / "created-body.md").exists()
+        stdout = result.stdout.decode()
+        assert "left existing comment #123 untouched" in stdout
+
+    def test_refused_run_with_no_existing_comment_creates_the_refused_placeholder(
+        self, tmp_path: Path
+    ) -> None:
+        # The check-run title alone cannot say WHY the gate is red, so the
+        # first comment a refusal creates must carry the refused verdict and
+        # the fork-honest remedy: no override command (this lane resolves no
+        # override record), no re-run advice. Creation is legitimate here
+        # because the lookup SUCCEEDED and found nothing -- there is no
+        # verdict to lose.
+        vis = TestReviewLaneVerdictVisibility()
+        lane = next(entry for entry in _GUARDED_LANES if entry["id"] == "fork-gpt")
+        calls, result = vis._run_step(
+            lane,
+            tmp_path,
+            existing_body=None,
+            kind="refused",
+            extra_env={"REFUSED": "true"},
+        )
+
+        assert result.returncode == 0, result.stderr.decode()
+        created = (calls / "created-body.md").read_text(encoding="utf-8")
+        assert created.startswith(str(lane["marker"]))
+        assert "⛔ reviewer refused this diff" in created
+        assert "review this change directly" in created
+        assert "/ai-review override" not in created
+        assert "Re-run the workflow" not in created
+        assert not (calls / "patch-calls.txt").exists()
+        assert not (calls / "patched-body.md").exists()
+
+    def test_refused_classification_rides_step_outputs_into_both_publishers(self) -> None:
+        # The comment step and the fail-closed finalize step each read the
+        # assembly's `refused` step OUTPUT through their env, never a grep of
+        # the body: on the clean path the body is model prose, and a verdict
+        # that merely QUOTES the refusal wording must not be reclassified.
+        comment_env = self._pass_step("Post/update summary comment")["env"]
+        finalize_env = self._pass_step("Finalize check-run (fail closed)")["env"]
+        expected = "${{ steps.gpt_pass2.outputs.refused }}"
+        assert comment_env["REFUSED"] == expected
+        assert finalize_env["REFUSED"] == expected
+
+        workflow = _workflow("fork-gpt-review.yml")
+        comment_step = _step_script(workflow, "Post/update summary comment")
+        assert 'if [ "${REFUSED:-}" = "true" ]; then' in comment_step
+        assert 'kind="refused"' in comment_step
+
+        finalize_step = _step_script(workflow, "Finalize check-run (fail closed)")
+        # The required check stays a FAILURE — a declined review is not an
+        # approval — but its title names the true cause instead of the
+        # re-run advice "review incomplete" implies.
+        assert 'if [ "${REFUSED:-}" = "true" ]; then' in finalize_step
+        assert 'title="reviewer refused this diff"' in finalize_step
+        refused_branch = finalize_step[
+            finalize_step.index('if [ "${REFUSED:-}" = "true" ]; then') : finalize_step.index(
+                "if [ -s codex-review-output.md ]"
+            )
+        ]
+        assert "conclusion=" not in refused_branch


### PR DESCRIPTION
## Problem / Motivation

When the review provider *refuses* to review a fork PR's diff — declines because of what the content is, as opposed to crashing or timing out — the fork GPT lane (`fork-gpt-review.yml`) reports the generic "review incomplete" state and advises re-running the workflow. Issue #8739 tracks porting the refusal/crash distinction that landed for the same-repo lane in #8738 (issue #8685).

The two failure modes need opposite remedies: a crash is fixed by re-running, while a refusal is caused by the diff itself and is empirically sticky — 12 consecutive identical refusals across 10 heads were measured on one PR (#8685). Fork PRs are where this matters most: an external contributor's security fix whose evidence is a working exploit is exactly the diff a provider content filter refuses, and today that contributor (and the maintainer triaging the red check) is told to re-run forever.

## Why it matters

A maintainer looking at "review incomplete" on a fork PR has no way to tell a transient infrastructure failure from a permanent content refusal. The advised remedy (re-run) has never been observed to clear a refusal, so the check stays red with a misleading title, the contributor's PR looks broken rather than needing-human-review, and the one remedy that works — a maintainer reading the change directly — is never named.

## What changed (motivation → approach → change)

Observed symptom: a provider refusal on a fork PR surfaces as "review incomplete" with re-run advice that does not work.

Root cause: the fork lane discards each pass's output stream, so when a pass fails (`rc != 0` or empty pass file) there is nothing to distinguish the provider's refusal line from a crash — the same gap #8738 closed for `codex-review.yml`.

The change, a mechanical port of #8738's classification with one deliberate fork-specific difference:

- Each review pass's combined stream is now tee'd into `RUNNER_TEMP` (never the checkout, so a PR cannot plant a symlink at the log's name) where the exit code is captured.
- A failed pass is classified as refused only when the provider's own error line appears **anchored at line start** and **only in the 4000-byte tail** of that pass's captured stream. Both constraints are load-bearing here — this lane hands the model more attacker-controlled text than the same-repo lane (the prompt embeds the fork author's title/body, and the reviewer echoes the diff, which for a PR touching this workflow contains the signature verbatim) — so an echoed copy of the signature must not reclassify an ordinary crash.
- The classification rides the verdict assembly's `refused` step output into both publishers (summary comment and fail-closed check-run), never a grep of the review body: on the clean path that body is model prose, and a verdict that merely quotes the refusal wording must not be reclassified.
- The refused terminal state still **fails closed** — no `[GPT-REVIEWED]` marker, so a declined review can never read as an approval — but the check-run title says "reviewer refused this diff" and the comment names the honest remedy.
- Fork-specific difference, and why this is not a blind copy: the same-repo lane's refused copy routes to `/ai-review override`. This lane resolves no override record, so promising that command here would route a maintainer to a clearance path that cannot clear this check. The refused copy routes to direct maintainer review instead.
- A refused run rides the shared `guarded_comment_upsert` withhold path (#8344, #8450): the refused body carries no `[GPT-REVIEWED]` proof marker, so it never modifies an existing comment and only creates the first placeholder when a successful lookup confirms none exists. This PR pins that behavior for the refused kind with tests rather than growing a posting branch of its own.
- A refusal dominates a mixed failure (one pass crashed, the other refused), because a re-run only helps if the refusal does not recur.

Alternatives considered: grepping the review body for a refusal marker downstream (rejected — the body on the clean path is model prose, and a marker nothing may parse would invite prose-grepping); matching the signature anywhere in the whole stream (rejected — an echoed copy in PR-controlled text would reclassify crashes); porting the same-repo lane's `/ai-review override` remedy text verbatim (rejected — this lane cannot resolve an override record, see above).

The `claude-review.yml` half of #8739 is deliberately not included: that lane's output is action-mediated, so refusal classification needs its own signature source rather than this mechanical port. See Pattern harvest.

`docs/ci/ci-and-reviews.md` (the owning doc for the reviewer lanes) is updated in the same commit: the refusal paragraph now covers both GPT lanes and names each lane's remedy.

## Tests

New class `TestForkGptRefusalTerminalState` (12 tests) in `test/test_ai_review_workflows.py`, mirroring the same-repo lane's coverage plus the fork-specific attack surface:

- `test_refusal_is_classified_where_rc_is_captured` — both passes tee into `RUNNER_TEMP`, match line-anchored against the tail, and record into the re-initialized refused-passes file; the signature carries the provider's `ERROR: ` prefix and stays free of regex metacharacters (it is interpolated into an anchored grep pattern).
- `test_signature_stays_in_sync_with_the_same_repo_lane` — both lanes classify against one identical signature; drift would silently split refusal semantics between lanes.
- `test_provider_emitted_refusal_line_classifies_as_refused` — executes the workflow's real classification block (extracted from the YAML, run under bash) against a fabricated stream carrying the provider's line: classified refused.
- `test_echoed_signature_in_pr_controlled_text_stays_a_crash` — the signature quoted/indented in PR-controlled text (exactly what this PR's own diff looks like to the reviewer) does not classify: a crash on such a PR stays re-runnable.
- `test_signature_outside_the_stream_tail_stays_a_crash` — an early echoed copy scrolled past by 8000 bytes of output does not classify.
- `test_refused_pass_publishes_its_own_terminal_state` — refused body carries no `[GPT-REVIEWED]`/`[GPT-REFUSED]` marker, no re-run advice, no `/ai-review override`, routes to direct maintainer review, and emits `refused=true` to `GITHUB_OUTPUT`.
- `test_crashed_pass_keeps_the_rerunnable_incomplete_state` — the pre-existing incomplete state and its re-run advice are untouched for genuine crashes.
- `test_refusal_dominates_a_mixed_failure` — one crashed + one refused ⇒ refused wins.
- `test_clean_run_still_publishes_pass_2_verbatim` — the happy path is byte-identical.
- `test_refused_run_never_modifies_an_existing_comment` — the #8292 stale-read guard covers the refused kind (no PATCH, no create with an existing comment).
- `test_refused_run_with_no_existing_comment_creates_the_refused_placeholder` — first comment carries the refused verdict and fork-honest remedy.
- `test_refused_classification_rides_step_outputs_into_both_publishers` — comment and finalize steps read `steps.gpt_pass2.outputs.refused` through env, never a body grep; the check-run title changes but its failure conclusion does not.

Fails-before, run at base `d4c2cbf22` with the new tests committed onto the pristine tree (full targeted file, tests only):

```
11 failed, 443 passed
(the new class alone: 11 failed, 1 passed — the 1 pass is the
 stale-read-guard control, which holds via the shared
 guarded_comment_upsert withhold path (#8344, #8450) — correct
 control behavior)
```

With the fix: `12 passed`; full targeted file: `454 passed`.

## Manual verification

N/A — the workflow's classification and publication logic is executed directly by the tests (the classification block and verdict assembly are extracted from the YAML and run under bash with fabricated streams), which is the same technique the file's existing suites use for this lane. A live refusal requires the provider to refuse a real diff on a real fork PR, which cannot be staged deterministically.

## Related Issues

Fixes #8739 (the `fork-gpt-review.yml` half; the `claude-review.yml` half needs its own signature source — see Pattern harvest). Ports #8738 (#8685). Interacts with the shared `guarded_comment_upsert` withhold path (#8344, #8450), which this pins for the refused kind with tests.

## Pattern harvest

Rule candidate: review-prompt
Pattern: "failure-state classification must ride step outputs, never a grep of content that is model prose or attacker-influenced on other paths"

The remaining half of #8739 — `claude-review.yml`'s action-mediated lane, where the provider's stderr is not directly capturable and refusal classification needs its own signature source — is a distinct follow-up, not covered by this port.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

Per the template, the CLA wording is a placeholder pending OSPO/Legal; nothing to affirm beyond the checklist until it is supplied.
