### PR TITLE
fix: skip the legacy mount-source pass when no root it walks exists

### DIFF
--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -5361,7 +5361,9 @@ def _cleanup_legacy_mount_source_residue() -> int:
 
     - only on the session runtime tmpfs the launcher picks first
       (:func:`_launcher_tmpfs_roots`), never ``/dev/shm`` or the shared system
-      tempdir, where another same-uid program's ``tempfile`` scratch lives;
+      tempdir, where another same-uid program's ``tempfile`` scratch lives —
+      and when no such root is PRESENT the pass returns before the pin scan,
+      because there is nowhere for an entry of this class to be;
     - only ``tempfile``'s exact shape (:data:`_LEGACY_MOUNT_SOURCE_RE`);
     - only DIRECTORIES owned by THIS uid with the exact mode ``mkdtemp``
       creates (0o700) — a hand-made or umask-shaped entry is not one of
@@ -5398,7 +5400,20 @@ def _cleanup_legacy_mount_source_residue() -> int:
             return 0
     except OSError:
         return 0
-    roots = _launcher_tmpfs_roots()
+    roots = [root for root in _launcher_tmpfs_roots() if os.path.isdir(root)]
+    if not roots:
+        # Nothing this pass may walk is present, so no entry of this class can
+        # be here to reclaim: every host off Linux (``/run/user/$UID`` is a
+        # logind construct), and a Linux host whose session runtime dir is
+        # absent. Return BEFORE the pin scan, not after it: that scan reads
+        # ``/proc``, which off Linux does not exist, so the coverage claim below
+        # can never be established there and the pass reported an unprovable
+        # scan at WARNING on every tick — for a root it was never going to
+        # walk. The marker is deliberately NOT stamped: this branch verified no
+        # residue, it merely found nowhere to look, and a repeat pass now costs
+        # one stat, so retiring the pass here would trade a free no-op for a
+        # claim it cannot make.
+        return 0
     coverage = _PinScanCoverage()
     bound, complete = _bound_source_basenames(coverage=coverage)
     if not (complete or coverage.covered):

--- a/test/test_sandbox_mount_source_sweep.py
+++ b/test/test_sandbox_mount_source_sweep.py
@@ -1268,6 +1268,43 @@ class TestLegacyResidueSweep:
         self._fence(monkeypatch, tmp_path, complete=True)
         assert _cleanup_legacy_mount_source_residue() == 1
 
+    def test_an_absent_root_skips_the_pin_scan_without_a_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        """No root present means nowhere for an entry of this class to be, so
+        the pass must not pay for a ``/proc`` scan it cannot use.
+
+        Off Linux ``/run/user/$UID`` never exists and ``/proc`` cannot be read,
+        so the coverage claim was unprovable on every tick and the pass reported
+        a held-back walk at WARNING every few minutes for a root it was never
+        going to touch. It must still not retire itself: the branch found
+        nowhere to look, which is not the same as finding nothing left.
+        """
+        scanned = []
+
+        monkeypatch.setattr(
+            "kiro_crew.sandbox._launcher_tmpfs_roots", lambda: [str(tmp_path / "absent")]
+        )
+
+        def _fake(proc_root="/proc", *, coverage=None, **_kw):
+            scanned.append(proc_root)
+            if coverage is not None:
+                coverage.covered = False
+            return (set(), False)
+
+        monkeypatch.setattr("kiro_crew.sandbox._bound_source_basenames", _fake)
+
+        with caplog.at_level(logging.INFO, logger="kiro_crew.sandbox"):
+            assert _cleanup_legacy_mount_source_residue() == 0
+        assert scanned == []  # the pin scan never ran
+        assert not [r for r in caplog.records if "legacy pass retained" in r.getMessage()]
+
+        # Not retired: a root that does appear is still swept.
+        self._fence(monkeypatch, tmp_path)
+        held = self._legacy_dir(tmp_path)
+        assert _cleanup_legacy_mount_source_residue() == 1
+        assert not held.exists()
+
     def test_bound_entry_is_preserved(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Removing a live mount's source dir S_DEADs it — the bind scan decides."""
         name = "tmpbound123"


### PR DESCRIPTION
## Problem / Motivation

Every macOS and Windows install logs this at the default log level, once per
sweep tick (~10 minutes), forever:

```
WARNING kiro_crew.sandbox: sandbox mount-source sweep: legacy pass retained everything — bind coverage of /proc could not be established (pin scan incomplete, holder coverage unproven); the pass retries on the next tick
```

Nothing is wrong on those hosts, and there is nothing for the pass to reclaim.

## Why it matters

The message is a real diagnostic — on a Linux host it means the legacy reclaim
pass is inert and the inode pile is not shrinking — so a warning that fires
unconditionally off Linux is worse than noise: it trains the reader to ignore
the line that matters. It also costs a full `/proc` walk per tick on hosts where
the walk can never succeed.

## What changed (motivation → approach → change)

`_cleanup_legacy_mount_source_residue` proved bind coverage from `/proc` BEFORE
looking at whether the one root it may walk is present.
`_launcher_tmpfs_roots()` returns `/run/user/$UID`, a logind construct: off
Linux that path never exists, and `/proc` cannot be read either, so
`complete` and `coverage.covered` are both false on every tick and the pass
reports a held-back walk for a root it was never going to touch.

The fix is ordering. Filter the roots to those actually present and return
before the pin scan when none is — there is nowhere for an entry of this class
to be, so no coverage claim is needed to justify removing nothing.

The one-shot marker is deliberately **not** stamped on that path. The branch
found nowhere to look, which is not the same as finding nothing left, so the
pass stays armed; a repeat now costs one `stat` instead of a `/proc` walk. A
root appearing later is therefore still swept.

Linux behaviour with a present root is unchanged: same roots, same pin scan,
same fences, same stamping rules.

## Tests

`test_an_absent_root_skips_the_pin_scan_without_a_warning` (in
`TestLegacyResidueSweep`) points the roots at a non-existent path and asserts
three things: the pin scan is never called, no held-back WARNING is emitted, and
the pass is **not** retired — a subsequent call with a real root still reclaims.

Verified non-vacuous: reverting the guard to the old ordering
(`roots = _launcher_tmpfs_roots()` / `if False:`) turns this test red, and only
this test.

## Manual verification

N/A — the observed symptom is a log line on a code path unit coverage reaches
directly, and the branch is selected by the presence of a directory, which the
test controls.

## Related Issues

Follow-up to #8559, which introduced this pass. No open issue tracks the
off-Linux noise.

## Pattern harvest

Rule candidate: review-prompt
Pattern: an expensive precondition proof runs before the cheap check that
decides whether the work is possible at all — so on a platform where the proof
can never succeed, the failure is reported instead of the work being skipped.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — the function's own docstring fence list records the new short-circuit
- [x] No secrets, credentials, or internal references in the diff
