### PR TITLE
fix(acp): keep a tail marker across every AcpClient cut, salvage siblings per branch

### DIFF
--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -1322,43 +1322,96 @@ def _dumps_elided_siblings(payload: Any, marker: str) -> str | None:
     reached, and the failure is the same uncaught ``RecursionError`` that kills
     the turn.
 
-    Degrades per FIELD rather than all-or-nothing, because the two possible
+    Degrades per BRANCH rather than all-or-nothing, because the two possible
     losses are not symmetric. A lost directive silently unarms a loop the model
     was told was armed -- there is no error anywhere and no way to notice. Lost
     sibling detail costs transcript content the user can SEE is missing. So the
-    marker (emitted by the caller, not here) always survives, every top-level
-    field that encodes is kept whole, and only the offending branches become
-    :data:`UNSERIALISABLE_SIBLING_VALUE`. Returns None only when even the reduced
-    object will not encode, leaving the caller to emit the directive alone.
+    marker (emitted by the caller, not here) always survives, every subtree that
+    encodes is kept whole at full depth, and only the branches that actually
+    overflow become :data:`UNSERIALISABLE_SIBLING_VALUE`. Returns None only when
+    even the reduced object will not encode, leaving the caller to emit the
+    directive alone.
+
+    Per BRANCH, not per top-level field: a field holding a readable status AND
+    an overflowing branch under one parent must keep the status, so a rejected
+    container is looked inside when it has more than one entry -- one of them may
+    be encodable. A single-entry container is a link in a chain with no sibling
+    to rescue, and descending it is actively harmful: it preserves the chain down
+    to its encodable tail and so reassembles the depth the encoder refused, which
+    then costs the WHOLE frame. Those are cut where they stand.
     """
     elided = _elide_marker_value(payload, marker)
     try:
         return json.dumps(elided, default=str)
     except RecursionError:
         pass
-
-    def _encodable(value: Any) -> bool:
-        try:
-            json.dumps(value, default=str)
-        except RecursionError:
-            return False
-        return True
-
-    # Re-encoding the survivors together adds exactly one level over the deepest
-    # of them, which each one just cleared on its own -- but a value sitting on
-    # the boundary can still fail there, so the outer dump stays guarded too.
-    if isinstance(elided, dict):
-        reduced: Any = {
-            k: (v if _encodable(v) else UNSERIALISABLE_SIBLING_VALUE) for k, v in elided.items()
-        }
-    elif isinstance(elided, list):
-        reduced = [(v if _encodable(v) else UNSERIALISABLE_SIBLING_VALUE) for v in elided]
-    else:
+    if not isinstance(elided, (dict, list)):
         return None
+    # Re-encoding the survivors together can still exceed the ceiling -- each
+    # one cleared it alone, and the frame around them adds depth -- so the outer
+    # dump stays guarded too.
     try:
-        return json.dumps(reduced, default=str)
+        return json.dumps(_salvaged_per_branch(elided), default=str)
     except RecursionError:
         return None
+
+
+# Encode probes one salvage may spend. Each probe serialises one subtree, so an
+# unbounded count is quadratic in the payload; past the budget a rejected
+# container is cut where it stands.
+_MAX_SALVAGE_PROBES = 512
+
+
+def _encodable(value: Any) -> bool:
+    """Whether ``json.dumps`` can encode *value* without overflowing its C stack."""
+    try:
+        json.dumps(value, default=str)
+    except RecursionError:
+        return False
+    return True
+
+
+def _salvaged_per_branch(value: Any) -> Any:
+    """Copy *value*, keeping every subtree the encoder accepts at its FULL depth.
+
+    A child that encodes is attached as-is and never looked inside -- one probe,
+    nothing lost, however deep it is. A child that does not encode is descended
+    when it holds more than one entry (one of them may be an encodable branch
+    worth rescuing) and replaced outright when it holds one (a chain link with
+    nothing to rescue; see :func:`_dumps_elided_siblings` for why descending a
+    chain is worse than cutting it). Iterative over a heap stack, for the same
+    reason :func:`_elide_marker_value` is: the input is by definition deep
+    enough to break a C recursion.
+    """
+    probes = [_MAX_SALVAGE_PROBES]
+
+    def _shell(node: Any) -> Any:
+        return {} if isinstance(node, dict) else []
+
+    root = _shell(value)
+    pending: list[tuple[Any, Any]] = [(value, root)]
+    while pending:
+        source, target = pending.pop()
+        items = source.items() if isinstance(source, dict) else enumerate(source)
+        for key, child in items:
+            if not isinstance(child, (dict, list)):
+                copied: Any = child
+            elif probes[0] <= 0:
+                copied = UNSERIALISABLE_SIBLING_VALUE
+            else:
+                probes[0] -= 1
+                if _encodable(child):
+                    copied = child  # whole, at full depth
+                elif len(child) > 1:
+                    copied = _shell(child)
+                    pending.append((child, copied))
+                else:
+                    copied = UNSERIALISABLE_SIBLING_VALUE
+            if isinstance(target, dict):
+                target[key] = copied
+            else:
+                target.append(copied)
+    return root
 
 
 def _repair_escaped_marker(text: str) -> str | None:

--- a/src/kiro_crew/acp/client.py
+++ b/src/kiro_crew/acp/client.py
@@ -183,7 +183,11 @@ from kiro_crew.sandbox import (
 )
 from kiro_crew.security import is_sensitive_path, redact_credentials, redact_exfiltration_urls
 from kiro_crew.sel import sel
-from kiro_crew.session_directive import content_free_digest
+from kiro_crew.session_directive import (
+    MAX_TOOL_RESULT_CHARS,
+    content_free_digest,
+    preserve_tail_marker,
+)
 from kiro_crew.skill_usage import get_global_skill_read_observer
 
 logger = logging.getLogger(__name__)
@@ -2551,6 +2555,20 @@ def _kill_escaped_children(child_pids: dict[int, int | None] | dict[int, ChildRe
             logger.debug("Killed escaped child PID %d", cpid)
         except (ProcessLookupError, OSError):
             pass
+
+
+_JSONL_PART_MAX_CHARS = 4000
+
+
+def _bounded_part(text: str) -> str:
+    """Bound one replayed output part, keeping a tail-anchored control marker.
+
+    This per-PART cut sits upstream of the frame-level one, so bounding the joined
+    frame is not enough on its own: a directive marker at the end of an oversized
+    part is already gone by the time the join is bounded, and the effect is
+    silently dropped while the model has been told it was requested.
+    """
+    return preserve_tail_marker(text, text[:_JSONL_PART_MAX_CHARS])
 
 
 def _make_unified_diff(old: str, new: str, path: str, max_len: int = 65536) -> str:
@@ -7875,7 +7893,15 @@ class AcpClient:
         # slice keeps "://user:password" and drops the "@" the prefilter needs,
         # so the password reaches the dashboard in clear text. Same ordering as
         # `_dispatch._build_tool_result_event` and as `_compaction_detail` below.
-        final_output = redact_text(final_output)[:8000]
+        _full = redact_text(final_output)
+        # Bound, then re-attach a tail-anchored marker the cut removed. Both
+        # sentinels sit at the END of the frame, and redaction can GROW the text
+        # (a credential becomes a longer placeholder), so bounding after redaction
+        # is necessary but still not enough on its own. `_dispatch`'s builder does
+        # exactly this at its own cut; without it here, the recovery above can push
+        # a marker past the limit and the directive is silently dropped -- the
+        # effect never applies while the model has been told it was requested.
+        final_output = preserve_tail_marker(_full, _full[:MAX_TOOL_RESULT_CHARS])
         return AcpEvent(
             kind=EVENT_TOOL_RESULT,
             tool_call_id=tool_use_id,
@@ -8037,7 +8063,7 @@ class AcpClient:
                                 if isinstance(d, dict) and "stdout" in d:
                                     out = d.get("stdout", "")
                                     if out:
-                                        output_parts.append(out[:4000])
+                                        output_parts.append(_bounded_part(out))
                                 else:
                                     # See the rawOutput Json branch above: a dump
                                     # escapes an embedded directive marker beyond
@@ -8046,20 +8072,25 @@ class AcpClient:
                                         _marker_bearing_text(d) if isinstance(d, dict) else None
                                     )
                                     if _marker is not None:
-                                        output_parts.append(_marker[:4000])
+                                        output_parts.append(_bounded_part(_marker))
                                     else:
-                                        output_parts.append(json.dumps(d, indent=2)[:4000])
+                                        output_parts.append(_bounded_part(json.dumps(d, indent=2)))
                             elif rc.get("kind") == "text":
-                                output_parts.append(str(rc.get("data", ""))[:4000])
+                                output_parts.append(_bounded_part(str(rc.get("data", ""))))
                         if output_parts:
+                            _joined = "\n".join(output_parts)
+                            _whole = _repair_escaped_marker(_joined) or _joined
                             results.append(
                                 AcpEvent(
                                     kind=EVENT_TOOL_RESULT,
                                     tool_call_id=tool_use_id,
-                                    tool_output=(
-                                        _repair_escaped_marker("\n".join(output_parts))
-                                        or "\n".join(output_parts)
-                                    )[:8000],
+                                    # Same marker-preserving cut as the live path
+                                    # above: a replayed frame carries directives
+                                    # too, and a tail marker lost to the bound is
+                                    # a dropped effect either way.
+                                    tool_output=preserve_tail_marker(
+                                        _whole, _whole[:MAX_TOOL_RESULT_CHARS]
+                                    ),
                                 )
                             )
         except Exception:

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -34,6 +34,7 @@ from source_corpus import parsed_candidates, src_root
 
 from kiro_crew import session_directive as sd
 from kiro_crew.acp import _dispatch
+from kiro_crew.acp import client as _client_module
 from kiro_crew.acp._dispatch import (
     ELIDED_MARKER_VALUE,
     UNSERIALISABLE_SIBLING_VALUE,
@@ -515,6 +516,112 @@ class TestRecoveryIsKindAgnostic:
         assert sd.peek(out) == (kind, DIRECTIVE_PAYLOADS[kind])
 
 
+class TestTheClientCutKeepsTheTailMarker:
+    """``AcpClient`` bounds its tool output too, and must not cut the marker off.
+
+    Both sentinels are tail-anchored, so any cut applied to the frame can remove
+    the very token that decides whether the frame is a directive. ``_dispatch``'s
+    builder re-attaches it after its own bound; this client did not, at any of
+    its THREE cuts -- the live frame bound, the replay path's per-PART bound
+    (upstream of the frame bound, so a marker was already gone before the join
+    was measured), and the replay frame bound. An oversized frame -- which the
+    escaped-marker recovery can itself produce, since it moves preserved text
+    AHEAD of the marker -- silently dropped the effect while the model had been
+    told it was requested.
+
+    Redaction is why bounding afterwards is not sufficient on its own: replacing a
+    credential with a placeholder can make the text LONGER, so a frame that fitted
+    before redaction can exceed the bound after it.
+
+    Every test also asserts the bound is still ENFORCED, so the fix cannot
+    degenerate into "stop truncating".
+    """
+
+    @staticmethod
+    def _output(update: dict[str, object]) -> str | None:
+        fake = types.SimpleNamespace(_session_id="sess-1")
+        msg = JsonRpcMessage(method="session/update", params={"update": update})
+        event = AcpClient._extract_tool_call_update(fake, msg)
+        return event.tool_output if event else None
+
+    @staticmethod
+    def _oversized(tail: str) -> str:
+        return "x" * (sd.MAX_TOOL_RESULT_CHARS + 500) + "\n" + tail
+
+    @staticmethod
+    def _replay(tmp_path, monkeypatch, session_id: str, parts: list[dict[str, str]]) -> list[str]:
+        monkeypatch.setattr(_client_module, "kiro_sessions_dir", lambda: tmp_path)
+        (tmp_path / ("%s.jsonl" % session_id)).write_text(
+            json.dumps(
+                {
+                    "kind": "ToolResults",
+                    "data": {
+                        "content": [
+                            {
+                                "kind": "toolResult",
+                                "data": {"toolUseId": "tc-" + session_id, "content": parts},
+                            }
+                        ]
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        client = AcpClient.__new__(AcpClient)
+        client._session_id = session_id
+        client._jsonl_pos = 0
+        return [e.tool_output or "" for e in client._read_new_tool_results_sync()]
+
+    def test_the_live_path_reattaches_the_marker(self):
+        out = self._output(
+            _update(content=[{"content": {"type": "text", "text": self._oversized(_monitor())}}])
+        )
+        assert out is not None
+        assert len(out) <= sd.MAX_TOOL_RESULT_CHARS, "the bound is still enforced"
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS), "the marker survived the cut"
+
+    def test_the_live_path_reattaches_a_refusal_tag(self):
+        # The refusal sentinel is tail-anchored for the same reason, and losing it
+        # makes a by-design decline read as a lost marker.
+        tagged = sd.tag_refusal("Error: monitor_start arguments are too large.")
+        out = self._output(
+            _update(content=[{"content": {"type": "text", "text": self._oversized(tagged)}}])
+        )
+        assert out is not None and sd.is_refusal(out)
+
+    def test_the_jsonl_replay_part_cut_reattaches_the_marker(self, tmp_path, monkeypatch):
+        outputs = self._replay(
+            tmp_path,
+            monkeypatch,
+            "part",
+            [{"kind": "text", "data": self._oversized(_monitor())}],
+        )
+        assert outputs, "the replay produced an event"
+        assert all(len(o) <= sd.MAX_TOOL_RESULT_CHARS for o in outputs), "the bound holds"
+        assert any(sd.peek(o) == ("monitor_start", MONITOR_ARGS) for o in outputs)
+
+    def test_the_jsonl_replay_frame_cut_reattaches_the_marker(self, tmp_path, monkeypatch):
+        # Parts that each fit can still join past the frame bound, so the frame cut
+        # needs the same treatment as the per-part one.
+        parts = [{"kind": "text", "data": "z" * 3500} for _ in range(3)]
+        parts.append({"kind": "text", "data": _monitor()})
+        outputs = self._replay(tmp_path, monkeypatch, "join", parts)
+        assert outputs, "the replay produced an event"
+        assert all(len(o) <= sd.MAX_TOOL_RESULT_CHARS for o in outputs), "the bound holds"
+        assert any(sd.peek(o) == ("monitor_start", MONITOR_ARGS) for o in outputs)
+
+    def test_the_bound_is_still_enforced_for_marker_free_output(self):
+        out = self._output(
+            _update(
+                content=[
+                    {"content": {"type": "text", "text": "y" * (sd.MAX_TOOL_RESULT_CHARS + 500)}}
+                ]
+            )
+        )
+        assert out is not None and len(out) == sd.MAX_TOOL_RESULT_CHARS
+
+
 class TestSurvivesTheAcpClientParser:
     """``providers/acp.py``'s own builder, ``AcpClient._extract_tool_call_update``:
     a second, independent parser with the same envelope shapes and the same
@@ -978,6 +1085,65 @@ class TestPathologicallyNestedEnvelopeDegrades:
             cache_scope="scope",
         )
         assert [e for e in events if e.kind == EVENT_TOOL_RESULT], "the result event still arrives"
+
+
+class TestSalvageIsPerBranchNotPerField:
+    """The encoder-refusal degrade must cut only the branch that overflows.
+
+    A per-FIELD reduce -- probe each top-level child, keep or replace it whole --
+    replaces a container that holds BOTH a healthy branch and an overflowing one,
+    so a readable status vanishes for its neighbour's sake. Probing per branch
+    descends into that container and cuts only the bad chain.
+
+    The one place descent must NOT happen is a single-entry container: it is a
+    link in a chain with no sibling to rescue, and descending it rebuilds the
+    depth the encoder refused, which then costs the whole frame. Both directions
+    are pinned here. Encoder ceilings are simulated (see
+    :func:`_encoder_refusing_past`) so the depths mean the same on every platform.
+    """
+
+    def test_a_healthy_branch_nested_beside_a_bad_one_survives_whole(self, monkeypatch):
+        marker = _monitor()
+        payload = {"out": marker, "result": {"fine": _nest(10, CANARY), "bad": _nest(200, "x")}}
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(20))
+        dumped = _dispatch._dumps_elided_siblings(payload, marker)
+        assert dumped is not None
+        result = json.loads(dumped)["result"]
+        assert isinstance(result, dict), "the shared parent was descended, not replaced"
+        assert _leaf(result["fine"]) == CANARY, "the healthy branch keeps its leaf"
+        assert result["bad"] == UNSERIALISABLE_SIBLING_VALUE, "only the bad branch is cut"
+
+    def test_a_scalar_beside_a_bad_branch_survives(self, monkeypatch):
+        marker = _monitor()
+        payload = {
+            "out": marker,
+            "result": {"status": "ok", "exit_status": 7, "bad": _nest(200, 0)},
+        }
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(20))
+        dumped = _dispatch._dumps_elided_siblings(payload, marker)
+        assert dumped is not None
+        result = json.loads(dumped)["result"]
+        assert result["status"] == "ok" and result["exit_status"] == 7
+
+    def test_a_single_entry_chain_is_cut_not_descended(self, monkeypatch):
+        # Descending the chain would keep it down to its encodable tail and put
+        # the frame back over the ceiling -- the unrelated sibling then pays.
+        marker = _monitor()
+        payload = {"out": marker, "fine": _nest(10, CANARY), "chain": _nest(400, 0)}
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(20))
+        dumped = _dispatch._dumps_elided_siblings(payload, marker)
+        assert dumped is not None
+        restored = json.loads(dumped)
+        assert _leaf(restored["fine"]) == CANARY, "the unrelated sibling is intact"
+        assert restored["chain"] == UNSERIALISABLE_SIBLING_VALUE, "the chain is cut, named"
+
+    def test_a_top_level_healthy_branch_still_survives(self, monkeypatch):
+        # The case the per-field rule already handled must not regress.
+        marker = _monitor()
+        payload = {"out": marker, "fine": _nest(10, CANARY), "bad": _nest(200, 0)}
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(20))
+        dumped = _dispatch._dumps_elided_siblings(payload, marker)
+        assert dumped is not None and _leaf(json.loads(dumped)["fine"]) == CANARY
 
 
 class TestDispatchEncodeRefusalDegrades:


### PR DESCRIPTION
## Problem / Motivation

Two residuals on the deep-nesting path after #8954 (iterative elision walk, per-field encoder degrade, fixes #8886) and #9039 (degrade every dispatch encode) landed:

1. **`AcpClient` still cuts directives off.** Both sentinels are tail-anchored, so any length bound can remove the token that decides whether a frame is a directive at all. `_dispatch._build_tool_result_event` re-attaches it after its own bound; `AcpClient` did not, at any of its three cuts — the live frame bound, the replay path's per-**part** bound, and the replay frame bound. An oversized frame silently dropped the effect (no loop armed, no card, no project change) while the model had been told it was requested. The escaped-marker recovery can itself produce such a frame, since it moves preserved text *ahead* of the marker.

2. **The encoder-refusal salvage is per top-level field, not per branch.** `_dumps_elided_siblings` probes each top-level child and keeps or replaces it *whole*. A container holding both a healthy branch and an overflowing one is therefore replaced entire, so a readable `status`/`exit_status` vanishes for its neighbour's sake. Reproduced on `main`: `{"result": {"fine": <20 deep>, "bad": <200 deep>}}` under a 30-deep ceiling loses `fine`.

## Why it matters

Both lose transcript or control data that could have been emitted, and the first loses the worst kind: a lost directive silently unarms a monitor loop — the model is told the request was made and no loop exists — with no error anywhere to notice. Redaction is why bounding after redaction is necessary but not sufficient on its own: a credential becomes a longer placeholder, so a frame that fitted before redaction can exceed the bound after it.

## What changed (motivation → approach → change)

**`src/kiro_crew/acp/client.py`.** All three cuts go through `preserve_tail_marker`, and the literal `8000` becomes the `MAX_TOOL_RESULT_CHARS` constant that exists for it. The per-part bound gets a small `_bounded_part` helper because it sits *upstream* of the frame bound — a marker at the end of an oversized part is already gone before the join is even measured, so bounding the join alone cannot recover it.

**`src/kiro_crew/acp/_dispatch.py`.** `_dumps_elided_siblings`'s reduce step becomes `_salvaged_per_branch`. A child the encoder accepts is kept whole at full depth (one probe, nothing lost). A rejected container is **looked inside when it has more than one entry**, because one of them may be the encodable branch worth rescuing. A **single-entry** container is a chain link with no sibling to rescue, and descending it is actively harmful: it keeps the chain down to its encodable tail and so rebuilds the depth the encoder refused, which then costs the *whole frame* the outer fallback. Those are cut where they stand. The walk is iterative for the same reason `_elide_marker_value` is, and probes are budgeted (`_MAX_SALVAGE_PROBES`) so the salvage stays linear in the payload.

Kept from `main` unchanged: the iterative elision walk, `UNSERIALISABLE_SIBLING_VALUE`, the `json.loads` `RecursionError` guard, `_dumps_degraded`. This is a delta on #8954's design, not a replacement.

## Tests

`test/test_session_directive_transport.py`:

`TestTheClientCutKeepsTheTailMarker` — one test per cut site, each also asserting the bound is still **enforced** so the fix cannot degenerate into "stop truncating": the live frame bound (marker and refusal tag both), the replay per-part bound, and the replay frame bound (parts that each fit joining past the limit).

`TestSalvageIsPerBranchNotPerField` — a healthy branch nested beside a bad one under a shared parent survives to its leaf while only the bad one is cut; a scalar beside a bad branch survives; a single-entry chain is cut rather than descended so an unrelated sibling stays intact; the top-level case the per-field rule already handled does not regress. Encoder ceilings are simulated via the file's existing `_encoder_refusing_past`, so the depths mean the same on every platform.

Revert-verified load-bearing: **3/3** client mutations (one per cut) and **3/3** salvage mutations (restore `main`'s per-field reduce / descend chains too / never descend) each red their class; all 93 pass restored.

## Manual verification

N/A — unit coverage sufficient. Both defects are a bounded string and a pure function; the second was reproduced against `main`'s code with a probe script before the change and re-run after.

## Related Issues

no linked issue: both residuals surfaced by the GPT review lane on this PR's earlier revisions; #8886 was closed by #8954.

Related: #8962 — `preserve_tail_marker` picks the last sentinel *substring* rather than the parseable marker, so a directive whose own args contain the sentinel is mis-anchored. Pre-existing in `session_directive.py`, not changed here; this PR adds call sites to a helper `main` already uses.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a tail-anchored control token and a length bound are a standing hazard wherever they meet, and the bound is rarely in one place — this path had three cuts in one module, two of them upstream of the one that looked authoritative. Any new cut on a frame that can carry a marker has to re-attach it.

Second: when a transport genuinely cannot represent an input, the *granularity* of the replacement is the whole design. Frame, field, and global depth each discard data that could have been emitted; probing per branch is the first rule where only the unrepresentable part is lost — with the one caveat that descending a single-entry chain rebuilds the refused depth, so "descend" has to mean "descend where there is a sibling to save".

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A, no user-facing surface
- [x] No secrets, credentials, or internal references in the diff
