### PR TITLE
fix(dashboard): end pointer drags when capture is lost (#8271)

### DIFF
--- a/website/src/hooks/usePointerDrag.test.tsx
+++ b/website/src/hooks/usePointerDrag.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * usePointerDrag — a drag must terminate on EVERY capture-ending path.
+ *
+ * The hook's contract is capture-based dragging (setPointerCapture on
+ * pointer-down, per its own doc comment "survives the pointer leaving the
+ * element bounds (capture)"). The Pointer Events spec delivers
+ * `lostpointercapture` as the terminal event when capture ends for any
+ * reason: explicit release, a capture steal by another element, or a
+ * browser-initiated cancellation. If the hook ignores it, a drag whose
+ * capture dies mid-gesture never fires onEnd, and consumer onStart side
+ * effects stay stuck while the component remains mounted — unmount guards
+ * never run. Several resizer consumers set `document.body.style.userSelect =
+ * 'none'` in onStart (one stranded drag makes the whole page unselectable
+ * until some later drag happens to clean it up, #8271's symptom); others
+ * pin body.cursor page-wide or strand teardown-critical dragging flags.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import { usePointerDrag, type PointerDragOptions } from './usePointerDrag'
+
+function Handle(props: PointerDragOptions) {
+  const drag = usePointerDrag(props)
+  return <div data-testid="drag-handle" {...drag} />
+}
+
+function renderHandle(props: PointerDragOptions) {
+  const utils = render(<Handle {...props} />)
+  return { ...utils, handle: utils.getByTestId('drag-handle') }
+}
+
+describe('usePointerDrag capture-loss termination', () => {
+  it('fires onEnd when pointer capture is lost mid-drag (the stuck-drag path)', () => {
+    const onStart = vi.fn()
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onStart, onMove: () => {}, onEnd })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 })
+    expect(onStart).toHaveBeenCalledTimes(1)
+
+    // Capture dies without a pointerup/pointercancel ever reaching the
+    // element (capture steal / browser cancellation). lostpointercapture is
+    // the only notification the element gets.
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports `committed` on a capture-loss end exactly like a normal end', () => {
+    const onEnd = vi.fn()
+    // threshold 0 commits immediately on pointer-down.
+    const { handle } = renderHandle({ onMove: () => {}, onEnd, threshold: 0 })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 })
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({ committed: true })
+  })
+
+  it('normal pointerup still ends the drag exactly once', () => {
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 })
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 12, clientY: 12 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not double-fire onEnd when lostpointercapture follows a normal release', () => {
+    // Browsers fire lostpointercapture after EVERY capture release, including
+    // the releasePointerCapture the hook itself performs in a normal end —
+    // the end path must stay idempotent per drag.
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 })
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 12, clientY: 12 })
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stray lostpointercapture with no active drag', () => {
+    const onStart = vi.fn()
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onStart, onMove: () => {}, onEnd })
+
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 })
+
+    expect(onStart).not.toHaveBeenCalled()
+    expect(onEnd).not.toHaveBeenCalled()
+  })
+
+  it('a new drag after a capture-loss end works from a clean slate', () => {
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd, threshold: 0 })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 })
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 })
+    expect(onEnd).toHaveBeenCalledTimes(1)
+
+    fireEvent.pointerDown(handle, { pointerId: 2, clientX: 30, clientY: 30 })
+    fireEvent.pointerUp(handle, { pointerId: 2, clientX: 35, clientY: 30 })
+    expect(onEnd).toHaveBeenCalledTimes(2)
+  })
+})

--- a/website/src/hooks/usePointerDrag.ts
+++ b/website/src/hooks/usePointerDrag.ts
@@ -102,5 +102,22 @@ export function usePointerDrag(opts: PointerDragOptions) {
     s.committed = false
   }, [])
 
-  return { onPointerDown, onPointerMove, onPointerUp: end, onPointerCancel: end }
+  // lostpointercapture is the terminal event the Pointer Events spec fires
+  // when capture ends for ANY reason (explicit release, a capture steal by
+  // another element, browser-initiated cancellation). Without it, a drag
+  // whose capture dies mid-gesture never delivers onEnd: pointerup stops
+  // being retargeted to this element, so consumer onStart side effects
+  // (several resizers suppress body-wide text selection; others pin
+  // body.cursor or teardown-critical dragging flags) stay stuck while the
+  // component remains mounted and its unmount guards never run. The normal
+  // end path stays single-fire: `end` flips `s.active` false BEFORE calling
+  // releasePointerCapture, so the lostpointercapture that release triggers
+  // is a no-op re-entry.
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: end,
+    onPointerCancel: end,
+    onLostPointerCapture: end,
+  }
 }


### PR DESCRIPTION
## Problem / Motivation

Chat message bubbles intermittently become unselectable: the cursor shows as an arrow over bubble text instead of an I-beam, and click-drag selects nothing. The input box keeps working. It comes and goes — "one minute it works fine, the next it doesn't" (#8271) — which is exactly why it has resisted diagnosis: by the time anyone looks, it has often healed itself.

## Why it matters

Selecting and copying text out of chat bubbles is a constant operation on the dashboard's primary surface. An intermittent, self-healing failure is the worst kind for users: it is real, it interrupts work, and it is nearly impossible to report with steps. Until the termination gap is closed, every drag riding this hook is a chance to strand its consumer's onStart side effects: several resizers suppress body-wide text selection (#8271's symptom), others pin body.cursor page-wide or strand teardown-critical dragging flags.

## What changed (motivation → approach → change)

- Observed symptom: bubbles unselectable with an arrow cursor, input box unaffected, self-healing. All three details match one state: a stuck `document.body.style.userSelect = 'none'`. Under `user-select: none` browsers show the default cursor over text (the I-beam only appears over selectable text), text controls remain selectable under an ancestor `user-select: none` (so the input box keeps working), and any later successful drag clears the same shared body property in its `onEnd` (self-healing).
- Root cause: several resizers set that body property in their drag `onStart` and clear it in `onEnd`/unmount (others pin `body.cursor` or hold local dragging flags whose teardown is equally `onEnd`-dependent). The shared drag primitive, `usePointerDrag`, takes pointer capture on pointer-down and terminates only on `pointerup`/`pointercancel`. When capture dies mid-drag — a capture steal by another element, or a browser-initiated cancellation — neither event is retargeted to the handle again. `onEnd` never fires, the component stays mounted so unmount guards never run, and the suppression sticks until some later drag cleans it up. The Pointer Events spec provides a terminal notification for precisely this: `lostpointercapture` fires at the capturing element whenever capture ends, for any reason. The hook ignored it.
- Change: handle `lostpointercapture` as an end, alongside `pointerup` and `pointercancel`. The normal path stays single-fire because `end()` clears its active flag before calling `releasePointerCapture`, so the `lostpointercapture` that the release itself triggers is a no-op re-entry (a test pins this). One seam heals every consumer: ChatInput's composer resize, the bottom terminal panel, column resizers, the session grid, and the spec-builder splitter all ride the same hook.
- Alternative considered and rejected: patching each consumer's cleanup individually. The consumers are correct — they pair `onStart` with `onEnd` exactly as the hook's contract tells them to. The defect is the hook promising capture-based dragging (its doc comment: "survives the pointer leaving the element bounds (capture)") while not listening to the capture-terminal event.

## Tests

New `website/src/hooks/usePointerDrag.test.tsx` (6 tests):

- attack: `lostpointercapture` mid-drag fires `onEnd` (the stuck-drag path);
- payload: a capture-loss end reports `committed` exactly like a normal end;
- control: a normal `pointerup` still ends the drag exactly once;
- control: `lostpointercapture` following a normal release does not double-fire `onEnd`;
- benign: a stray `lostpointercapture` with no active drag calls nothing;
- recovery: a new drag after a capture-loss end works from a clean slate.

Reproducer output, before (tests added, source unfixed):

```
FAIL src/hooks/usePointerDrag.test.tsx > usePointerDrag capture-loss termination > fires onEnd when pointer capture is lost mid-drag (the stuck-drag path)
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
Test Files  1 failed (1) · Tests  3 failed | 3 passed (6)
```

The three failures are the three capture-loss paths; the three passes are the controls (normal end, no-double-fire, benign), proving the harness and the existing behavior. After the fix: `Test Files 1 passed · Tests 6 passed`. Drag-seam consumer suites (ChatInput resize handle + badge, SessionGridLayout, ChatSidebar resize + drag sensors, useColumnResize both, ColumnSplitter, BottomTerminalPanel both, DetailPanel): 11 files, 71 tests, all passing.

## Manual verification

jsdom does not model real pointer-capture bookkeeping (its `setPointerCapture` throws, which the hook's existing best-effort catch absorbs), so the tests prove the handler contract: when `lostpointercapture` is delivered to the handle, the drag ends. Real-browser delivery of that event on capture loss is the Pointer Events spec's defined behavior, the same mechanism the hook already relies on for capture itself. Reproducing the original intermittency on demand requires forcing a capture steal mid-drag in a live browser, which is inherently timing-dependent — that irreproducibility is the reported bug.

## Related Issues

Fixes #8271

## Pattern harvest

Rule candidate: review-prompt
Pattern: a paired global side effect (body-wide style, scroll lock, event suppression) keyed to gesture completion must cover every termination path the platform defines, not just the happy ones — for pointer-capture drags that set is `pointerup` + `pointercancel` + `lostpointercapture`. Review prompt: when a hook or component takes pointer capture, check that `lostpointercapture` is handled; when a global style is set in a gesture's start, enumerate the terminations that clear it.

Two adjacent hardenings in the same seam are intentionally out of scope for this one-topic fix and are worth their own passes: (1) the hook swallows `setPointerCapture` failure, and an uncaptured drag whose `pointerup` lands outside the handle also never terminates — a window-listener fallback would close it; (2) `ChatInput`'s drag `onEnd` early-returns without clearing the suppression when its wrapper ref is null while still mounted.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: behavioral fix, contract documented in-file at the changed seam
- [x] No secrets, credentials, or internal references in the diff

## Contribution License Agreement

I confirm this contribution is my own work, derived from the public repository and public web-platform documentation, and I license it under the project's existing license terms. (Formal CLA text placeholder per template — no legal wording invented.)
