### PR TITLE
fix(config): hold the sidecar advisory lock in save() and offload async callers (#4767)

### DIFF
--- a/.github/black-baseline.txt
+++ b/.github/black-baseline.txt
@@ -590,7 +590,6 @@ test/test_dashboard_sessions_search.py
 test/test_dashboard_start_site.py
 test/test_dashboard_state_ws.py
 test/test_dashboard_themes_coverage.py
-test/test_dashboard_updates_coverage.py
 test/test_dashboard_worktree_coverage.py
 test/test_dashboard_ws_offloop_fanout.py
 test/test_dashboard_ws_task_tracking.py

--- a/src/kiro_crew/cli_commands.py
+++ b/src/kiro_crew/cli_commands.py
@@ -19,6 +19,7 @@ import traceback
 import urllib.error
 import urllib.parse
 import urllib.request
+import uuid
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -50,6 +51,7 @@ from kiro_crew.config.loader import (
     KiroCrewConfig,
     WorkspaceConfig,
     build_provider_factory,
+    coerce_dict_section,
     config_local_path,
     config_path,
     read_config_for_update,
@@ -307,6 +309,46 @@ def _spawn_run(args: argparse.Namespace, base: str) -> None:
             return
 
 
+class _CliConflict(Exception):
+    """An in-lock precondition re-check failed for a CLI config CRUD write.
+
+    The CLI pre-checks its inputs against a config snapshot for fast, friendly
+    errors, but the snapshot can be stale by the time the write runs. The
+    mutate callbacks below re-decide every state-dependent precondition on the
+    document read INSIDE the sidecar flock (#4767) and raise this to refuse.
+    """
+
+
+def _locked_config_write(mutate, *, cleanup_conflict=None, cleanup_failure=None) -> None:
+    """Run one config delta under the sidecar flock; exit(1) on a conflict.
+
+    Replaces the load -> mutate dataclass -> ``cfg.save()`` shape, whose
+    whole-document rename silently discarded any change another process
+    landed between the load and the save (#4767).
+
+    Resolved through the loader MODULE, not this module's by-value imports,
+    so it honors the same ``kiro_crew.config.loader.config_path`` patches the
+    old ``cfg.save()`` path did (save() resolves its path inside loader).
+
+    ``cleanup_conflict`` runs before the exit(1) on a refused precondition;
+    ``cleanup_failure`` runs when the write itself fails -- the workspace
+    create passes its staging-drop / install-rollback handlers here.
+    """
+    from kiro_crew.config import loader as _loader
+
+    try:
+        _loader.update_config_locked(_loader.config_path(), mutate=mutate)
+    except _CliConflict as exc:
+        if cleanup_conflict is not None:
+            cleanup_conflict()
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except BaseException:
+        if cleanup_failure is not None:
+            cleanup_failure()
+        raise
+
+
 def _handle_workspace(args: argparse.Namespace) -> None:
     """Dispatch workspace subcommands: list, create, update, delete."""
 
@@ -331,6 +373,8 @@ def _handle_workspace(args: argparse.Namespace) -> None:
             print(f"Error: workspace '{args.name}' already exists", file=sys.stderr)
             sys.exit(1)
         copy_from = getattr(args, "copy_from", None)
+        staged_path: Path | None = None
+        install_state = {"installed": False}
         if copy_from:
             if copy_from not in cfg.workspaces:
                 print(
@@ -392,13 +436,23 @@ def _handle_workspace(args: argparse.Namespace) -> None:
                             skip.add(entry)
                     return skip
 
-                shutil.copytree(
-                    src_path,
-                    dst_path,
-                    dirs_exist_ok=True,
-                    symlinks=True,
-                    ignore=_ignore_sensitive,
-                )
+                # Copy to a STAGING sibling, not the destination: the copy
+                # runs before the locked registration, so a losing same-name
+                # race must leave the winner's directory untouched (#4767
+                # round 8). The staged tree is installed inside the locked
+                # mutate below, only after the in-lock checks pass.
+                staging = dst_path.parent / f".{dst_path.name}.staging-{uuid.uuid4().hex[:8]}"
+                try:
+                    shutil.copytree(
+                        src_path,
+                        staging,
+                        symlinks=True,
+                        ignore=_ignore_sensitive,
+                    )
+                except BaseException:
+                    shutil.rmtree(staging, ignore_errors=True)
+                    raise
+                staged_path = staging
         else:
             ws_dir = args.dir if args.dir is not None else f"workspace-{args.name}"
 
@@ -430,8 +484,51 @@ def _handle_workspace(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        cfg.workspaces[args.name] = WorkspaceConfig(dir=ws_dir)
-        cfg.save()
+
+        def _mutate_ws_create(doc: dict) -> dict:
+            workspaces = coerce_dict_section(doc, "workspaces")
+            if args.name in workspaces:
+                raise _CliConflict(f"workspace '{args.name}' already exists")
+            used = {str(ws.get("dir", "")) for ws in workspaces.values() if isinstance(ws, dict)}
+            if ws_dir in used:
+                raise _CliConflict(f"directory '{ws_dir}' is already used by another workspace")
+            if staged_path is not None:
+                # Same install invariant as the dashboard handler: the
+                # destination must not exist AT ALL. publish_dir_noreplace,
+                # not check-then-rename: POSIX os.rename silently replaces an
+                # EMPTY destination, so a racer's directory created between
+                # the check and the rename would be destroyed (#4767 round 9).
+                if dst_path.exists():
+                    raise _CliConflict(
+                        f"destination directory '{ws_dir}' already exists; "
+                        "choose another dir or remove it first"
+                    )
+                try:
+                    platform_compat.publish_dir_noreplace(staged_path, dst_path)
+                except (FileExistsError, OSError) as exc:
+                    raise _CliConflict(
+                        f"destination directory '{ws_dir}' already exists; "
+                        "choose another dir or remove it first"
+                    ) from exc
+                install_state["installed"] = True
+            workspaces[args.name] = dataclasses.asdict(WorkspaceConfig(dir=ws_dir))
+            return doc
+
+        def _drop_staging() -> None:
+            if staged_path is not None and not install_state["installed"]:
+                shutil.rmtree(staged_path, ignore_errors=True)
+
+        def _rollback_install() -> None:
+            if install_state["installed"]:
+                shutil.rmtree(dst_path, ignore_errors=True)
+            elif staged_path is not None:
+                shutil.rmtree(staged_path, ignore_errors=True)
+
+        _locked_config_write(
+            _mutate_ws_create,
+            cleanup_conflict=_drop_staging,
+            cleanup_failure=_rollback_install,
+        )
         sel().log_api_access(
             caller="cli",
             operation="workspace.create",
@@ -474,8 +571,26 @@ def _handle_workspace(args: argparse.Namespace) -> None:
                     file=sys.stderr,
                 )
                 sys.exit(1)
-            cfg.workspaces[args.name].dir = args.dir
-        cfg.save()
+
+        def _mutate_ws_update(doc: dict) -> dict:
+            workspaces = coerce_dict_section(doc, "workspaces")
+            entry = workspaces.get(args.name)
+            if not isinstance(entry, dict):
+                raise _CliConflict(f"workspace '{args.name}' not found")
+            if args.dir is not None:
+                used = {
+                    str(ws.get("dir", ""))
+                    for n, ws in workspaces.items()
+                    if n != args.name and isinstance(ws, dict)
+                }
+                if args.dir in used:
+                    raise _CliConflict(
+                        f"directory '{args.dir}' is already used by another workspace"
+                    )
+                entry["dir"] = args.dir
+            return doc
+
+        _locked_config_write(_mutate_ws_update)
         sel().log_api_access(
             caller="cli",
             operation="workspace.update",
@@ -524,8 +639,32 @@ def _handle_workspace(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        del cfg.workspaces[args.name]
-        cfg.save()
+
+        def _mutate_ws_delete(doc: dict) -> dict:
+            workspaces = coerce_dict_section(doc, "workspaces")
+            if args.name not in workspaces:
+                raise _CliConflict(f"workspace '{args.name}' not found")
+            # Re-check the TOP-LEVEL default in-lock: a concurrent default
+            # change between this command's snapshot and the lock would
+            # otherwise leave config pointing at a deleted workspace.
+            if doc.get("default_workspace") == args.name:
+                raise _CliConflict(f"cannot delete default workspace '{args.name}'")
+            agents = doc.get("agents")
+            if isinstance(agents, dict):
+                still_referencing = sorted(
+                    a
+                    for a, ac in agents.items()
+                    if isinstance(ac, dict) and ac.get("workspace") == args.name
+                )
+                if still_referencing:
+                    raise _CliConflict(
+                        f"workspace '{args.name}' is referenced by agents: "
+                        + ", ".join(still_referencing)
+                    )
+            del workspaces[args.name]
+            return doc
+
+        _locked_config_write(_mutate_ws_delete)
         sel().log_api_access(
             caller="cli",
             operation="workspace.delete",
@@ -893,26 +1032,42 @@ def _handle_agent(args: argparse.Namespace) -> None:
         if args.name in cfg.agents:
             print(f"Error: agent '{args.name}' already exists", file=sys.stderr)
             sys.exit(1)
-        cfg.agents[args.name] = KiroCrewAgentConfig(
-            kiro_agent=args.kiro_agent,
-            workspace=args.workspace,
-            memory_store=args.memory_store,
-        )
-        cfg.save()
+
+        def _mutate_agent_create(doc: dict) -> dict:
+            agents = coerce_dict_section(doc, "agents")
+            if args.name in agents:
+                raise _CliConflict(f"agent '{args.name}' already exists")
+            agents[args.name] = dataclasses.asdict(
+                KiroCrewAgentConfig(
+                    kiro_agent=args.kiro_agent,
+                    workspace=args.workspace,
+                    memory_store=args.memory_store,
+                )
+            )
+            return doc
+
+        _locked_config_write(_mutate_agent_create)
         print(f"Created agent: {args.name}")
 
     elif action == "update":
         if args.name not in cfg.agents:
             print(f"Error: agent '{args.name}' not found", file=sys.stderr)
             sys.exit(1)
-        agent = cfg.agents[args.name]
-        if args.kiro_agent is not None:
-            agent.kiro_agent = args.kiro_agent
-        if args.workspace is not None:
-            agent.workspace = args.workspace
-        if args.memory_store is not None:
-            agent.memory_store = args.memory_store
-        cfg.save()
+
+        def _mutate_agent_update(doc: dict) -> dict:
+            agents = coerce_dict_section(doc, "agents")
+            entry = agents.get(args.name)
+            if not isinstance(entry, dict):
+                raise _CliConflict(f"agent '{args.name}' not found")
+            if args.kiro_agent is not None:
+                entry["kiro_agent"] = args.kiro_agent
+            if args.workspace is not None:
+                entry["workspace"] = args.workspace
+            if args.memory_store is not None:
+                entry["memory_store"] = args.memory_store
+            return doc
+
+        _locked_config_write(_mutate_agent_update)
         print(f"Updated agent: {args.name}")
 
     elif action == "delete":
@@ -925,8 +1080,23 @@ def _handle_agent(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
-        del cfg.agents[args.name]
-        cfg.save()
+
+        def _mutate_agent_delete(doc: dict) -> dict:
+            agents = coerce_dict_section(doc, "agents")
+            if args.name not in agents:
+                raise _CliConflict(f"agent '{args.name}' not found")
+            # Re-check the default in-lock, at the authoritative TOP-LEVEL key
+            # (loader reads `data.get("default_agent")`); the agent-section
+            # key is the migration-era location and is checked as well.
+            agent_section = doc.get("agent")
+            if doc.get("default_agent") == args.name or (
+                isinstance(agent_section, dict) and agent_section.get("default_agent") == args.name
+            ):
+                raise _CliConflict(f"cannot delete default agent '{args.name}'")
+            del agents[args.name]
+            return doc
+
+        _locked_config_write(_mutate_agent_delete)
         print(f"Deleted agent: {args.name}")
 
     elif action == "reset-model":

--- a/src/kiro_crew/cli_server.py
+++ b/src/kiro_crew/cli_server.py
@@ -1822,7 +1822,13 @@ async def _gateway(
 
     if not config_path().exists():
         cfg = KiroCrewConfig()
-        cfg.save()
+        # _gateway is a coroutine, so this runs on the event loop: save() takes
+        # the sidecar advisory flock (#4767) and a contended wait (another
+        # process writing config at boot) must block a worker thread, not the
+        # loop. run_config_write does not fit here — the dashboard's asyncio
+        # config lock guards loop-side handler writers, none of which exist
+        # before run_gateway starts serving.
+        await asyncio.to_thread(cfg.save)
         print(f"👻 Created default config: {config_path()}")
 
     cfg = KiroCrewConfig.load()

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -12,6 +12,7 @@ dashboard URL via the config file. (The dashboard *port* is set with the
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import copy
 import json
 import logging
@@ -22,7 +23,7 @@ import shutil
 import stat as _stat
 import threading
 import uuid
-from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1152,6 +1153,66 @@ def write_config_atomically(path: Path, data: dict, *, fsync: bool = False) -> N
         atomic_write(path, payload, fsync=fsync, mode=mode)
 
 
+def coerce_dict_section(doc: dict, key: str) -> dict:
+    """Return ``doc[key]`` as a dict, REPLACING a degraded (non-dict) value.
+
+    The validated loader treats a malformed top-level section (``"workspaces":
+    []``, ``"agents": "oops"``) as absent and supplies defaults, so the
+    dataclass view never sees the damage. A raw delta mutator working on the
+    document as read (``update_config_locked``'s ``mutate``) must take the
+    same posture: a plain ``doc.setdefault(key, {})`` hands the degraded value
+    straight back, and the mutator then crashes on ``.values()``/``[name]``
+    with an HTTP 500 for the caller. Replacing the degraded section with a
+    fresh dict matches what the validated load already presents everywhere
+    else, and happens inside the same locked write, so the repair is atomic
+    with the mutation that needed it.
+    """
+    section = doc.get(key)
+    if not isinstance(section, dict):
+        section = {}
+        doc[key] = section
+    return section
+
+
+@contextlib.contextmanager
+def _config_write_lock(p: Path, *, wait: bool = True) -> Iterator[None]:
+    """Hold the sidecar advisory lock that serializes config-file writers.
+
+    THE one lock path for a config write: :func:`update_config_locked` and
+    :meth:`KiroCrewConfig.save` both come through here, so a second, subtly
+    different lock file can never reappear — the sidecar is always
+    ``<p>.lock`` beside the file being written (callers resolve a symlinked
+    config first, so it lands beside the TARGET; see :func:`_lock_target`).
+
+    The sidecar is opened (created if absent) and the advisory lock is taken
+    via :func:`platform_compat.file_lock` — ``fcntl.flock`` on POSIX, a bounded
+    ``msvcrt.locking`` spin on Windows, both fail-closed. The sidecar file
+    itself is deliberately left in place on exit: unlinking a lockfile that a
+    concurrent waiter has already opened re-introduces the race the lock
+    exists to prevent (the waiter would hold a lock on an unlinked inode while
+    a third writer creates a fresh sidecar and locks that instead), and on
+    Windows deleting a file another process holds open fails outright. One
+    stable sidecar per config file is the whole lifecycle.
+
+    **Lock ordering.** A caller that also holds the loop-side asyncio config
+    lock (``dashboard/handlers/agents._get_config_lock``) must acquire that
+    FIRST and this flock second, from a worker thread — the order
+    ``dashboard/chat_utils.run_config_write`` documents. Taking them in the
+    other order can deadlock against ``run_config_write`` holders. A POSIX
+    ``flock`` wait blocks its thread, so this must never be entered on the
+    event-loop thread with ``wait=True``; async callers offload (see
+    :meth:`KiroCrewConfig.save`).
+    """
+    lock_path = p.parent / (p.name + ".lock")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        with platform_compat.file_lock(fd, exclusive=True, wait=wait):
+            yield
+    finally:
+        os.close(fd)
+
+
 def update_config_locked(
     path: Path | None = None,
     *,
@@ -1177,29 +1238,25 @@ def update_config_locked(
     Read "direct caller outside this module" strictly: it is the exact set the
     ratchet checks, and it is NOT the same as "every writer that reaches
     ``config.json``".  :meth:`KiroCrewConfig.save` calls
-    :func:`write_config_atomically` and does NOT come through here -- see the
-    second family below.
+    :func:`write_config_atomically` and does NOT come through here -- but since
+    #4767 it holds the SAME sidecar lock (via :func:`_config_write_lock`), so
+    its rename can no longer land inside this function's read-modify-write.
+    ``save`` is still a whole-document publish of in-memory state, not an RMW:
+    a stale snapshot saved after a locked update overwrites it with older
+    values.  The lock fixes interleaving, not staleness.
 
     A SECOND family of writers still bypasses this lock, and the ratchet does
-    NOT reach it -- for two different reasons, neither of which is visible from a
-    call site:
+    NOT reach it: writers that reach ``config_path()`` through
+    ``kiro_crew.agent._atomic_json_write`` (``messaging.py``'s per-channel
+    savers, ``core.py``'s STT PUT, ``mcp.py``'s gateway-enable). The ratchet
+    matches calls to :func:`write_config_atomically`, and these make none.
 
-    * Writers that reach ``config_path()`` through
-      ``kiro_crew.agent._atomic_json_write`` (``messaging.py``'s per-channel
-      savers, ``core.py``'s STT PUT, ``mcp.py``'s gateway-enable). The ratchet
-      matches calls to :func:`write_config_atomically`, and these make none.
-    * Writers that go through :meth:`KiroCrewConfig.save` (``updates.py``'s
-      log-level PUT, ``core.py``'s theme PUT, several ``agents.py`` agent CRUD
-      endpoints). ``save`` DOES call :func:`write_config_atomically` directly,
-      but it does so from inside this module, which the ratchet exempts -- so the
-      write is invisible to it at every caller.
-
-    Both rely on the in-process asyncio ``_get_config_lock()`` only, which
-    serializes same-loop callers and nothing else, so they can still interleave
-    with a holder of this lock.  Converting them is follow-up work; do not read
-    the ratchet's green as covering them, and note that an ALIASED import of
-    :func:`write_config_atomically` would evade it for the same matching reason
-    as the first bullet.
+    That family relies on the in-process asyncio ``_get_config_lock()`` only,
+    which serializes same-loop callers and nothing else, so it can still
+    interleave with a holder of this lock.  Converting it is follow-up work; do
+    not read the ratchet's green as covering it, and note that an ALIASED
+    import of :func:`write_config_atomically` would evade it for the same
+    matching reason.
 
     Contract:
 
@@ -1283,27 +1340,21 @@ def update_config_locked(
             p = p.resolve()
     except OSError:
         pass
-    lock_path = p.parent / (p.name + ".lock")
-    p.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
-    try:
-        with platform_compat.file_lock(fd, exclusive=True, wait=wait_for_lock):
-            try:
-                data = read_config_for_update(p)
-            except ConfigReadError:
-                if on_corrupt == "fail":
-                    raise
-                # on_corrupt="reset": treat as empty inside the same lock hold.
-                data = {}
-            result = mutate(data)
-            if result is None:
-                return data
-            if stamp_meta:
-                result = stamp_config_meta(result)
-            write_config_atomically(p, result, fsync=fsync)
-            return result
-    finally:
-        os.close(fd)
+    with _config_write_lock(p, wait=wait_for_lock):
+        try:
+            data = read_config_for_update(p)
+        except ConfigReadError:
+            if on_corrupt == "fail":
+                raise
+            # on_corrupt="reset": treat as empty inside the same lock hold.
+            data = {}
+        result = mutate(data)
+        if result is None:
+            return data
+        if stamp_meta:
+            result = stamp_config_meta(result)
+        write_config_atomically(p, result, fsync=fsync)
+        return result
 
 
 # Keys already warned about in this process. The gateway loads config repeatedly
@@ -3945,6 +3996,34 @@ class KiroCrewConfig:
 
         Values that exist in ``config.local.json`` are stripped from the
         output to prevent overlay settings from leaking into the base file.
+
+        **The write happens under the sidecar advisory lock** — the same
+        ``<config>.lock`` that :func:`update_config_locked` holds (#4767).
+        Without it, this whole-document rename could land INSIDE another
+        writer's read-modify-write (a CLI ``update_config_locked`` holder, a
+        boot refresh, a second gateway), and whichever renamed second
+        published a document that never saw the other's change. The lock
+        serializes the writes; it does NOT re-read the file — ``save()``
+        still publishes this object's in-memory snapshot.
+
+        **The staleness contract that follows.** Because the snapshot is
+        taken at ``load()`` and only the rename is locked, any suspension
+        point (an ``await``, a lock wait, a long computation) between the
+        load and this call is a window in which a concurrent writer's change
+        is silently overwritten by the eventual publish. ``save()`` is
+        therefore ONLY for single-flow callers with no suspension between
+        their load and their save — CLI one-shots and the boot default-config
+        write. Every read-modify-write flow, and every dashboard/coroutine
+        caller, belongs on :func:`update_config_locked` (via
+        ``dashboard/chat_utils.run_config_write``), which holds the flock
+        across the WHOLE read-mutate-write transaction; as of #4767 no
+        coroutine in the tree calls ``save()`` at all
+        (``TestNoInlineSaveOnTheEventLoop`` pins that structurally).
+
+        **Async callers must offload.** A contended POSIX ``flock`` blocks
+        the calling thread for as long as the holder keeps it, which on the
+        event-loop thread stalls the whole gateway — the exact failure that
+        reverted the first attempt at this lock (#4371).
         """
 
         d = self.to_dict()
@@ -3981,7 +4060,19 @@ class KiroCrewConfig:
         # Atomic + mode-preserving: a concurrent reader must never observe a
         # half-written config, and the write must not widen who can read a file
         # that may hold inline credentials. See write_config_atomically.
-        write_config_atomically(config_path(), stamp_config_meta(d))
+        #
+        # Resolve a symlinked config BEFORE locking (same logic as
+        # update_config_locked) so the sidecar sits beside the ACTUAL file the
+        # rename will replace — a lock beside the symlink would not serialize
+        # against a writer that resolved first.
+        p = config_path()
+        try:
+            if p.is_symlink():
+                p = p.resolve()
+        except OSError:
+            pass
+        with _config_write_lock(p):
+            write_config_atomically(p, stamp_config_meta(d))
         # Drop the validated-data cache so the next load() re-reads this write.
         # mtime-keying already detects the change; this makes it immediate even
         # if the filesystem mtime resolution is coarse.

--- a/src/kiro_crew/dashboard/chat_utils.py
+++ b/src/kiro_crew/dashboard/chat_utils.py
@@ -127,6 +127,34 @@ async def run_config_write(fn, /, *args, **kwargs):
         return result
 
 
+async def drained_to_thread(fn, /, *args):
+    """``asyncio.to_thread`` that a cancellation cannot abandon mid-mutation.
+
+    A plain ``await to_thread(...)`` raises ``CancelledError`` at the await
+    while the worker THREAD keeps running — a handler that then performs
+    cleanup (releasing a lock, removing a staging directory) races its own
+    still-running worker. Shielding the task keeps the await alive until the
+    worker actually finishes, then re-raises the cancellation, so control only
+    ever returns with no mutation in flight. Shared by the agents handler's
+    config writers and the files handler's workspace-copy staging.
+    """
+    task = asyncio.ensure_future(asyncio.to_thread(fn, *args))
+    cancelled: asyncio.CancelledError | None = None
+    while True:
+        try:
+            result = await asyncio.shield(task)
+            break
+        except asyncio.CancelledError as exc:
+            if task.cancelled():
+                raise
+            # OUR await was cancelled, not the worker: remember it, keep
+            # draining the still-running thread.
+            cancelled = exc
+    if cancelled is not None:
+        raise cancelled
+    return result
+
+
 # Per-turn compaction-failure backoff. See
 # _broadcast_compaction_result for the full rationale. Kept small: this is a
 # UX/spam guard, not a correctness gate — the underlying compaction attempt

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -54,6 +54,7 @@ from kiro_crew.config.loader import (
     KiroCrewAgentConfig,
     KiroCrewConfig,
     _safe_color,
+    coerce_dict_section,
     coerce_effort,
     inject_kiro_cli_api_key,
     normalize_agent_model,
@@ -80,6 +81,7 @@ from kiro_crew.dashboard.chat_utils import (
     _SLASH_COMMANDS,
     SLASH_COMMAND_DESCRIPTIONS,
     _history_key_for,
+    drained_to_thread,
     is_deprecated_model,
     run_config_write,
 )
@@ -2981,6 +2983,21 @@ async def api_kirocrew_agents(request: web.Request) -> web.Response:
 _config_lock = LoopBoundLock()
 
 
+class _AgentExistsError(Exception):
+    """An agent name re-check failed against the document INSIDE the flock.
+
+    The handler's 409 pre-check runs on a snapshot under the asyncio lock,
+    which excludes in-process races only; a cross-process create (the CLI)
+    can land between that check and the write. The delta mutate re-checks
+    against the document as read inside the sidecar lock and raises this,
+    which the handler maps to the same 409 (#4767).
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.name = name
+
+
 def _get_config_lock() -> LoopBoundLock:
     """Return the config lock (loop-bound; rebinds when the running loop changes)."""
     return _config_lock
@@ -3000,6 +3017,7 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
     cfg = KiroCrewConfig.load()
     synced: list[str] = []
     pruned: list[str] = []
+    prune_candidates: dict[str, dict] = {}
     try:
         discovered_agents = await asyncio.get_running_loop().run_in_executor(
             discovery_executor(), lambda: list(list_agents())
@@ -3089,6 +3107,11 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
                 if agent_cfg.source in ("package", "aim") and (
                     agent_cfg.kiro_agent not in discovered_names
                 ):
+                    # Record the SNAPSHOT entry: the locked mutate below only
+                    # prunes a name whose in-lock entry still equals this one,
+                    # so an agent (re)added by a newer sync between this
+                    # snapshot and the lock is never deleted on stale evidence.
+                    prune_candidates[name] = dataclasses.asdict(agent_cfg)
                     del cfg.agents[name]
                     pruned.append(name)
     except Exception:
@@ -3106,7 +3129,38 @@ async def _do_agents_sync(request: web.Request) -> web.Response:
 
     if synced or pruned:
         try:
-            cfg.save()
+            # The caller (api_kirocrew_agents_sync) holds _get_config_lock().
+            # Persist as a DELTA read-modify-write inside a single sidecar-
+            # flock hold (#4767): the adds and prunes decided on the snapshot
+            # above are re-applied to the document as read inside the lock,
+            # so a concurrent writer's unrelated settings are untouchable --
+            # a whole-document save() would publish the stale snapshot over
+            # them. _drained_to_thread so a cancellation cannot release the
+            # asyncio lock while the worker is mid-write.
+            to_add = {n: cfg.agents[n] for n in synced if n in cfg.agents}
+
+            def _write_sync() -> None:
+                def _mutate(doc: dict) -> dict | None:
+                    agents = coerce_dict_section(doc, "agents")
+                    changed = False
+                    for aname, acfg in to_add.items():
+                        if aname not in agents:
+                            agents[aname] = dataclasses.asdict(acfg)
+                            changed = True
+                    # Prune ONLY this sync's snapshot candidates, and only
+                    # while the in-lock entry still equals the snapshot entry:
+                    # an agent (re)added or edited between the discovery
+                    # snapshot and this lock hold is newer evidence than the
+                    # stale discovered_names and must survive (#4767 round 8).
+                    for aname, snap_entry in prune_candidates.items():
+                        if agents.get(aname) == snap_entry:
+                            del agents[aname]
+                            changed = True
+                    return doc if changed else None
+
+                update_config_locked(mutate=_mutate)
+
+            await _drained_to_thread(_write_sync)
         except Exception:
             logger.warning("Failed to save config after agent sync", exc_info=True)
             try:
@@ -3465,7 +3519,7 @@ async def api_kirocrew_agents_create(request: web.Request) -> web.Response:
         model_reason = _model_pin_rejected(model, request, cfg.agent.provider)
         if model_reason:
             return web.json_response({"error": model_reason, "code": "invalid_model"}, status=400)
-        cfg.agents[name] = KiroCrewAgentConfig(
+        new_agent = KiroCrewAgentConfig(
             kiro_agent=kiro_agent,
             workspace=body.get("workspace", "default"),
             memory_store=body.get("memory_store", "default"),
@@ -3477,7 +3531,33 @@ async def api_kirocrew_agents_create(request: web.Request) -> web.Response:
             session_color=session_color,
             avatar=avatar,
         )
-        cfg.save()
+
+        # Under _get_config_lock() (the async with above): persist as a DELTA
+        # read-modify-write of this one agent entry inside a single sidecar-
+        # flock hold (#4767) -- a whole-document save() would publish the
+        # handler's snapshot and could revert a concurrent writer's unrelated
+        # settings. _drained_to_thread, not bare to_thread: a cancellation at
+        # the await must not release the asyncio lock while the worker is
+        # still inside the write (see its docstring).
+        def _write_agent() -> None:
+            def _mutate(doc: dict) -> dict:
+                agents = coerce_dict_section(doc, "agents")
+                if name in agents:
+                    # A cross-process create (CLI) won the race after our
+                    # snapshot check above.
+                    raise _AgentExistsError(name)
+                agents[name] = dataclasses.asdict(new_agent)
+                return doc
+
+            update_config_locked(mutate=_mutate)
+
+        try:
+            await _drained_to_thread(_write_agent)
+        except _AgentExistsError:
+            return web.json_response(
+                {"error": f"Agent '{name}' already exists", "code": "agent_exists"},
+                status=409,
+            )
     # A crew APPEARING changes what the effort chain resolves even with no pin of
     # its own: the factory's captured config does not know the crew, so it cannot
     # read the binding the role default keys on, and a scheduled or messaging
@@ -4047,32 +4127,10 @@ def _live_avatar_file(name: str, pin: object) -> Path | None:
     return None
 
 
-async def _drained_to_thread(fn, /, *args):
-    """``asyncio.to_thread`` that a cancellation cannot abandon mid-mutation.
-
-    A plain ``await to_thread(...)`` raises ``CancelledError`` at the await
-    while the worker THREAD keeps running — inside ``async with
-    _get_config_lock()`` that releases the lock with the filesystem/config
-    mutation still in flight, so a concurrent save interleaves with it.
-    Shielding the task keeps the await alive until the worker actually
-    finishes, then re-raises the cancellation, so the lock is only ever
-    released with no mutation in flight.
-    """
-    task = asyncio.ensure_future(asyncio.to_thread(fn, *args))
-    cancelled: asyncio.CancelledError | None = None
-    while True:
-        try:
-            result = await asyncio.shield(task)
-            break
-        except asyncio.CancelledError as exc:
-            if task.cancelled():
-                raise
-            # OUR await was cancelled, not the worker: remember it, keep
-            # draining the still-running thread.
-            cancelled = exc
-    if cancelled is not None:
-        raise cancelled
-    return result
+# ``asyncio.to_thread`` that a cancellation cannot abandon mid-mutation --
+# moved to chat_utils so the files handler's staging copy can share the one
+# implementation; the local name is kept for the call sites below.
+_drained_to_thread = drained_to_thread
 
 
 def _sniff_image_ext(head: bytes) -> str:

--- a/src/kiro_crew/dashboard/handlers/files.py
+++ b/src/kiro_crew/dashboard/handlers/files.py
@@ -21,6 +21,7 @@ import time
 import urllib.parse
 import uuid
 import zipfile
+from dataclasses import asdict
 from pathlib import Path
 from typing import BinaryIO, NamedTuple
 
@@ -35,9 +36,20 @@ from kiro_crew.atomic_write import (
     pinned_parent_replace_supported,
 )
 from kiro_crew.config import loader as config_loader
-from kiro_crew.config.loader import KiroCrewConfig, WorkspaceConfig, config_dir, data_home
+from kiro_crew.config.loader import (
+    KiroCrewConfig,
+    WorkspaceConfig,
+    coerce_dict_section,
+    config_dir,
+    data_home,
+    update_config_locked,
+)
 from kiro_crew.dashboard import part_stream, upload_destination
-from kiro_crew.dashboard.chat_utils import dashboard_slot_key
+from kiro_crew.dashboard.chat_utils import (
+    dashboard_slot_key,
+    drained_to_thread,
+    run_config_write,
+)
 from kiro_crew.dashboard.file_index import _SKIP_DIRS as _WALK_SKIP_DIRS
 from kiro_crew.dashboard.handlers._shared import _probe_persisted_session, read_bounded_json
 from kiro_crew.dashboard.origin import is_direct_local_request
@@ -1520,6 +1532,31 @@ async def api_workspaces(request: web.Request) -> web.Response:
     return web.json_response({"workspaces": result, "default": default_ws})
 
 
+def _resolve_ws_dir(d: str) -> Path:
+    """Resolve a workspace dir string the way collision checks compare them."""
+    p = Path(d).expanduser()
+    return p.resolve() if p.is_absolute() else (data_home() / d).resolve()
+
+
+class _WorkspaceConflict(Exception):
+    """A workspace precondition failed against FRESH state inside the lock.
+
+    The handlers validate on a snapshot loaded before their awaits (fast 4xxs
+    for the common case), but the decision that guards config integrity --
+    name/directory collisions, default-workspace and agent references -- must
+    be re-made against the state the mutation actually lands on, inside the
+    run_config_write critical section, or two overlapping owner requests can
+    both pass the stale check and persist a conflicting document (#4767 GPT
+    review round 1). Carries the response payload the handler returns.
+    """
+
+    def __init__(self, status: int, error: str, code: str) -> None:
+        super().__init__(error)
+        self.status = status
+        self.error = error
+        self.code = code
+
+
 async def api_workspaces_create(request: web.Request) -> web.Response:
     """POST /api/workspaces — create a new workspace."""
     import shutil  # noqa: F811
@@ -1551,6 +1588,13 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
     if name in cfg.workspaces:
         return web.json_response({"error": f"Workspace '{name}' already exists"}, status=409)
     copy_from = body.get("copy_from", "").strip()
+    # Set only once ALL validation has passed (staging is the LAST pre-persist
+    # step): the staged tree awaiting install, and the destination it installs
+    # into once the in-lock checks pass. copy_pending records that the branch
+    # wants a copy, deferred until after the shared path validation below.
+    staged_path: Path | None = None
+    install_dst: Path | None = None
+    copy_pending = False
     if copy_from:
         if copy_from not in cfg.workspaces:
             return web.json_response(
@@ -1601,27 +1645,7 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
                 {"error": "Cannot use config root as workspace directory"}, status=400
             )
         if src_path.is_dir():
-            # Use the module-level is_sensitive_path alias to filter entries
-            # instead of hardcoded names -- one binding for one guard.
-
-            def _ignore_sensitive(directory: str, entries: list[str]) -> set[str]:
-                from pathlib import Path as _Path  # noqa: F811
-
-                skip: set[str] = set()
-                for entry in entries:
-                    full = str(_Path(directory, entry).resolve())
-                    if is_sensitive_path(full):
-                        skip.add(entry)
-                return skip
-
-            await asyncio.to_thread(
-                shutil.copytree,
-                src_path,
-                dst_path,
-                dirs_exist_ok=True,
-                symlinks=True,
-                ignore=_ignore_sensitive,
-            )
+            copy_pending = True
     else:
         ws_dir = body.get("dir", f"workspace-{name}")
     # Guard against path traversal for relative paths; absolute paths are allowed
@@ -1635,10 +1659,6 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
     )
 
     # Check for directory collision with existing workspaces (resolve both sides)
-    def _resolve_ws_dir(d: str) -> Path:
-        p = Path(d).expanduser()
-        return p.resolve() if p.is_absolute() else (data_home() / d).resolve()
-
     existing_resolved = {_resolve_ws_dir(ws.dir) for ws in cfg.workspaces.values()}
     if _resolve_ws_dir(ws_dir) in existing_resolved:
         return web.json_response(
@@ -1674,8 +1694,131 @@ async def api_workspaces_create(request: web.Request) -> web.Response:
         return web.json_response(
             {"error": "Cannot use config root as workspace directory"}, status=400
         )
-    cfg.workspaces[name] = WorkspaceConfig(dir=ws_dir)
-    cfg.save()
+    if copy_pending:
+        # STAGE the copy_from tree only now, after EVERY validation above has
+        # passed -- a stage before validation leaks the copied tree on any 4xx
+        # (#4767 review round 3). It is INSTALLED into place inside the locked
+        # persist below, so a losing create never mutates the destination.
+
+        def _ignore_sensitive(directory: str, entries: list[str]) -> set[str]:
+            # Module-level is_sensitive_path alias -- one binding for one guard.
+            from pathlib import Path as _Path  # noqa: F811
+
+            skip: set[str] = set()
+            for entry in entries:
+                full = str(_Path(directory, entry).resolve())
+                if is_sensitive_path(full):
+                    skip.add(entry)
+            return skip
+
+        staging = dst_path.parent / f".{dst_path.name}.staging-{uuid.uuid4().hex[:8]}"
+
+        def _copy_staged() -> None:
+            shutil.copytree(src_path, staging, symlinks=True, ignore=_ignore_sensitive)
+
+        def _drop_staging() -> None:
+            shutil.rmtree(staging, ignore_errors=True)
+
+        try:
+            # drained_to_thread, not bare to_thread: a cancellation at the
+            # await would leave the copytree THREAD still writing while the
+            # cleanup below rmtrees the same tree -- the race can strand
+            # partial ``.staging-*`` residue (#4767 review round 6). Draining
+            # runs the copy to completion first, so the cleanup only ever
+            # starts on a quiescent tree, and the cleanup itself is drained so
+            # it cannot be abandoned mid-delete either.
+            await drained_to_thread(_copy_staged)
+        except BaseException:
+            await drained_to_thread(_drop_staging)
+            raise
+        staged_path = staging
+        install_dst = dst_path
+
+    # Persist as ONE delta read-modify-write on the raw document, inside a
+    # single hold of the sidecar flock (update_config_locked), dispatched off
+    # the loop with both locks via run_config_write -- the transaction shape
+    # run_config_write's own docstring prescribes (#4767 review round 3). The
+    # handler's `cfg` was loaded before awaits above (the copytree can run for
+    # seconds), so the state-dependent preconditions are re-decided against
+    # the document as read INSIDE the lock, and only the keys this create owns
+    # are written -- a concurrent write to any other setting is untouchable.
+    def _mutate_create(doc: dict) -> dict:
+        workspaces = coerce_dict_section(doc, "workspaces")
+        if name in workspaces:
+            raise _WorkspaceConflict(409, f"Workspace '{name}' already exists", "workspace_exists")
+        raw_dirs = {
+            _resolve_ws_dir(str(ws.get("dir", "")))
+            for ws in workspaces.values()
+            if isinstance(ws, dict)
+        }
+        if _resolve_ws_dir(ws_dir) in raw_dirs:
+            raise _WorkspaceConflict(
+                409,
+                f"Directory '{ws_dir}' is already used by another workspace",
+                "workspace_dir_in_use",
+            )
+        # Checks passed: INSTALL the staged tree now (we are in a worker
+        # thread, inside the flock hold), before the config write, so a
+        # directory only ever appears at the destination for a create that is
+        # actually being persisted. The install invariant that makes rollback
+        # TOTAL: the destination must not exist AT ALL -- any pre-existing
+        # directory (even empty: its inode and metadata are not ours to
+        # replace) is refused. publish_dir_noreplace, not check-then-rename:
+        # POSIX os.rename silently replaces an EMPTY destination, so a racer's
+        # directory created between a check and the rename would be destroyed
+        # (#4767 round 9); the no-replace rename closes that window in the
+        # filesystem itself.
+        if staged_path is not None and install_dst is not None:
+            if install_dst.exists():
+                raise _WorkspaceConflict(
+                    409,
+                    f"Destination directory '{ws_dir}' already exists; choose "
+                    "another dir or remove it first",
+                    "workspace_dir_occupied",
+                )
+            try:
+                platform_compat.publish_dir_noreplace(staged_path, install_dst)
+            except (FileExistsError, OSError) as exc:
+                # A filesystem racer created the destination between the check
+                # and the rename; refuse rather than replace anything.
+                raise _WorkspaceConflict(
+                    409,
+                    f"Destination directory '{ws_dir}' already exists; choose "
+                    "another dir or remove it first",
+                    "workspace_dir_occupied",
+                ) from exc
+            install_state["installed"] = True
+        workspaces[name] = asdict(WorkspaceConfig(dir=ws_dir))
+        return doc
+
+    install_state: dict = {"installed": False}
+    try:
+        await run_config_write(update_config_locked, mutate=_mutate_create)
+    except _WorkspaceConflict as conflict:
+        # The staged tree was never installed; drop it in a worker -- an
+        # inline rmtree of a large copied workspace would stall the loop.
+        if staged_path is not None:
+            await asyncio.to_thread(shutil.rmtree, staged_path, ignore_errors=True)
+        return web.json_response({"error": conflict.error, "code": conflict.code}, status=409)
+    except asyncio.CancelledError:
+        # run_config_write SHIELDS and DRAINS the worker: a CancelledError
+        # surfacing here means the worker ran to completion -- the install
+        # landed AND the config write registered the workspace (a worker
+        # failure would surface as that failure, not as cancellation).
+        # Rolling back would delete a directory config.json now points at.
+        # Nothing to clean: the staged tree was consumed by the install.
+        raise
+    except BaseException:
+        # The worker itself failed (unreadable config, a failed atomic
+        # write): the workspace was NOT registered, so an installed tree is a
+        # phantom -- roll it back; an uninstalled staging tree is residue --
+        # drop it. Both off the loop. The rollback can only remove a tree
+        # this request created (see the install invariant above).
+        if install_state["installed"] and install_dst is not None:
+            await asyncio.to_thread(shutil.rmtree, install_dst, ignore_errors=True)
+        elif staged_path is not None:
+            await asyncio.to_thread(shutil.rmtree, staged_path, ignore_errors=True)
+        raise
     _sel().log_api_access(
         caller=request.get("user", "dashboard"),
         operation="workspace.create",
@@ -1753,8 +1896,43 @@ async def api_workspaces_update(request: web.Request) -> web.Response:
                 {"error": f"Directory '{new_dir}' is already used by another workspace"},
                 status=409,
             )
-        cfg.workspaces[name].dir = new_dir
-    cfg.save()
+
+    # Persist as ONE delta RMW on the raw document inside the flock hold (see
+    # workspace.create): the mutation AND its state-dependent precondition
+    # (dir collision) are re-decided against the document as read inside the
+    # lock, and only this workspace's entry is written.
+    def _mutate_update(doc: dict) -> dict | None:
+        workspaces = coerce_dict_section(doc, "workspaces")
+        ws = workspaces.get(name)
+        if not isinstance(ws, dict):
+            # A concurrent delete won the race after our 404 check; recreating
+            # the workspace from this handler's older view would undo it.
+            raise _WorkspaceConflict(404, f"Workspace '{name}' not found", "workspace_not_found")
+        if "dir" in body:
+            new_resolved = _resolve_ws_dir(body["dir"])
+            others = {
+                _resolve_ws_dir(str(w.get("dir", "")))
+                for n2, w in workspaces.items()
+                if n2 != name and isinstance(w, dict)
+            }
+            if new_resolved in others:
+                raise _WorkspaceConflict(
+                    409,
+                    f"Directory '{body['dir']}' is already used by another workspace",
+                    "workspace_dir_in_use",
+                )
+            ws["dir"] = body["dir"]
+            return doc
+        return None  # nothing to change -- skip the write
+
+    try:
+        await run_config_write(update_config_locked, mutate=_mutate_update)
+    except _WorkspaceConflict as conflict:
+        if conflict.status == 404:
+            return web.json_response(
+                {"error": conflict.error, "code": conflict.code}, status=404
+            )
+        return web.json_response({"error": conflict.error, "code": conflict.code}, status=409)
     _sel().log_api_access(
         caller=request.get("user", "dashboard"),
         operation="workspace.update",
@@ -1790,8 +1968,38 @@ async def api_workspaces_delete(request: web.Request) -> web.Response:
             {"error": f"Workspace '{name}' is referenced by agents: {', '.join(referencing)}"},
             status=409,
         )
-    del cfg.workspaces[name]
-    cfg.save()
+    # Persist as ONE delta RMW on the raw document inside the flock hold (see
+    # workspace.create); the referential guards (default workspace, agent
+    # references) are re-run against the document as read inside the lock.
+
+    def _mutate_delete(doc: dict) -> dict | None:
+        workspaces = coerce_dict_section(doc, "workspaces")
+        if name not in workspaces:
+            return None  # already gone -- a concurrent delete landed first
+        if name == doc.get("default_workspace", "default"):
+            raise _WorkspaceConflict(
+                409,
+                f"Cannot delete default workspace '{name}'. Change default_workspace first.",
+                "workspace_is_default",
+            )
+        fresh_refs = [
+            a
+            for a, ac in coerce_dict_section(doc, "agents").items()
+            if isinstance(ac, dict) and ac.get("workspace") == name
+        ]
+        if fresh_refs:
+            raise _WorkspaceConflict(
+                409,
+                f"Workspace '{name}' is referenced by agents: {', '.join(fresh_refs)}",
+                "workspace_referenced",
+            )
+        del workspaces[name]
+        return doc
+
+    try:
+        await run_config_write(update_config_locked, mutate=_mutate_delete)
+    except _WorkspaceConflict as conflict:
+        return web.json_response({"error": conflict.error, "code": conflict.code}, status=409)
     _sel().log_api_access(
         caller=request.get("user", "dashboard"),
         operation="workspace.delete",

--- a/src/kiro_crew/dashboard/handlers/onboarding_import.py
+++ b/src/kiro_crew/dashboard/handlers/onboarding_import.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from aiohttp import web
 
-from kiro_crew.config.loader import KiroCrewConfig
+from kiro_crew.config.loader import coerce_dict_section, update_config_locked
+from kiro_crew.dashboard.chat_utils import run_config_write
 from kiro_crew.loop_lock import LoopBoundLock
 
 logger = logging.getLogger(__name__)
@@ -465,13 +466,6 @@ def _merge_import_results(
     return merged
 
 
-def _get_config_lock() -> LoopBoundLock:
-    # Circular import: handlers.agents is re-exported by the package that imports us.
-    from kiro_crew.dashboard.handlers.agents import _get_config_lock as get_lock
-
-    return get_lock()
-
-
 def _audit_item_outcomes(caller: str, result: object) -> None:
     if not isinstance(result, dict):
         return
@@ -579,9 +573,15 @@ def _rebuild_agent_config() -> None:
 
 
 def _persist_state(completed: bool) -> None:
-    config = KiroCrewConfig.load()
-    config.dashboard.import_onboarded = completed
-    config.save()
+    # DELTA read-modify-write of the one key this endpoint owns, inside a
+    # single sidecar-flock hold -- a whole-document save() would publish a
+    # snapshot that can revert a concurrent writer's unrelated settings
+    # (#4767). Called off the loop via run_config_write.
+    def _mutate(doc: dict) -> dict:
+        coerce_dict_section(doc, "dashboard")["import_onboarded"] = completed
+        return doc
+
+    update_config_locked(mutate=_mutate)
 
 
 async def api_onboarding_import_scan(request: web.Request) -> web.Response:
@@ -636,18 +636,22 @@ async def api_onboarding_import_apply(request: web.Request) -> web.Response:
             mcp_selected = {pair for pair in selected if pair[1] == "mcp_servers"}
             results: list[object] = []
             if config_selected:
-                async with _get_config_lock():
-                    results.append(
-                        await asyncio.to_thread(
-                            _apply_import,
-                            source_ids,
-                            config_selected,
-                            cron_service,
-                            vector_store,
-                            lesson_store,
-                            conflict_strategy,
-                        )
+                # run_config_write, not a manual lock + bare to_thread: the
+                # config-category importer read-modify-writes config.json, and
+                # a cancellation at a bare `await to_thread(...)` would release
+                # _get_config_lock() while the worker is still mid-rewrite --
+                # the same defect class fixed at the state handler (#4767).
+                results.append(
+                    await run_config_write(
+                        _apply_import,
+                        source_ids,
+                        config_selected,
+                        cron_service,
+                        vector_store,
+                        lesson_store,
+                        conflict_strategy,
                     )
+                )
             if mcp_selected:
                 # MCP handlers acquire the MCP file lock before the config lock.
                 # Keep this phase outside the config lock to avoid lock inversion.
@@ -705,8 +709,11 @@ async def api_onboarding_import_state(request: web.Request) -> web.Response:
         )
 
     try:
-        async with _get_config_lock():
-            await asyncio.to_thread(_persist_state, body["completed"])
+        # run_config_write holds _get_config_lock() itself and shields the
+        # worker against cancellation -- a bare to_thread under a manual lock
+        # hold releases the lock on cancellation while the thread is still
+        # rewriting config.json (#4767).
+        await run_config_write(_persist_state, body["completed"])
     except Exception:
         logger.exception("Onboarding import state update failed")
         _audit(caller=caller, operation=operation, outcome="failed", error="state_failed")

--- a/src/kiro_crew/dashboard/handlers/updates.py
+++ b/src/kiro_crew/dashboard/handlers/updates.py
@@ -23,9 +23,11 @@ from kiro_crew.changelog import Release, base_version, build_release_list, relea
 from kiro_crew.config.loader import (
     ConfigReadError,
     KiroCrewConfig,
+    coerce_dict_section,
     config_path,
     update_config_locked,
 )
+from kiro_crew.dashboard.chat_utils import run_config_write
 from kiro_crew.dashboard.handlers._shared import read_capped_response
 from kiro_crew.dashboard.state import DashboardState, chat_message_frame
 from kiro_crew.executors import subprocess_executor
@@ -1763,12 +1765,19 @@ async def api_log_level(request: web.Request) -> web.Response:
     root.setLevel(_LOG_LEVELS[level_name])
     logger.info("Log level changed to %s via dashboard", level_name)
 
-    # Persist to config so the level survives restarts.
+    # Persist to config so the level survives restarts: a DELTA read-modify-
+    # write of the one key this endpoint owns, inside a single sidecar-flock
+    # hold (update_config_locked), dispatched off the loop with both config
+    # locks via run_config_write -- the transaction shape run_config_write's
+    # docstring prescribes (#4767). A whole-document save() here would publish
+    # a snapshot that can revert a concurrent writer's unrelated settings.
+    def _set_level(doc: dict) -> dict:
+        coerce_dict_section(doc, "agent")["log_level"] = level_name
+        return doc
+
     persisted = False
     try:
-        cfg = KiroCrewConfig.load()
-        cfg.agent.log_level = level_name
-        cfg.save()
+        await run_config_write(update_config_locked, mutate=_set_level)
         persisted = True
     except Exception:
         logger.warning("Failed to persist log level to config", exc_info=True)

--- a/src/kiro_crew/onboarding_import.py
+++ b/src/kiro_crew/onboarding_import.py
@@ -37,6 +37,7 @@ from croniter import croniter  # type: ignore[import-untyped]
 
 from kiro_crew import platform_compat
 from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.loader import ConfigReadError, update_config_locked
 from kiro_crew.config.paths import config_dir
 from kiro_crew.embeddings import make_sync_embed_fn
 from kiro_crew.frontmatter import ONBOARDING_IMPORT, parse_block_scalar_header, split_frontmatter
@@ -4395,51 +4396,72 @@ def _write_workspace(
         return _WriteOutcome("rejected")
 
     path = data_home / "config.json"
-    data = _load_json_dict(path, fail_closed=True)
-    workspaces = data.get("workspaces")
-    if workspaces is None:
-        workspaces = {}
-        data["workspaces"] = workspaces
-    if not isinstance(workspaces, dict):
-        return _WriteOutcome("conflict")
+    # ONE locked read-modify-write (#4767): the raw _load_json_dict +
+    # _write_json pair this replaces took no advisory lock, so a concurrent
+    # locked writer (CLI, dashboard) landing between the read and the atomic
+    # write was silently reverted by this import's whole-document publish.
+    outcome: _WriteOutcome | None = None
 
-    canonical = str(workspace)
-    for existing in workspaces.values():
-        if isinstance(existing, dict):
-            existing_dir = existing.get("dir")
-        elif isinstance(existing, str):
-            existing_dir = existing
-        else:
-            existing_dir = None
-        if not isinstance(existing_dir, str):
-            continue
-        try:
-            if str(Path(existing_dir).expanduser().resolve()) == canonical:
-                return _WriteOutcome("existing")
-        except (OSError, RuntimeError):
-            continue
+    def _mutate(data: dict) -> dict | None:
+        nonlocal outcome
+        workspaces = data.get("workspaces")
+        if workspaces is None:
+            workspaces = {}
+            data["workspaces"] = workspaces
+        if not isinstance(workspaces, dict):
+            outcome = _WriteOutcome("conflict")
+            return None
 
-    base_name = _SAFE_NAME_RE.sub("-", workspace.name).strip("-._").lower()
-    base_name = base_name[:64] or f"imported-{item.source_id}"
-    if base_name not in workspaces:
-        workspaces[base_name] = {"dir": canonical}
-        _write_json(path, data)
-        return _WriteOutcome("imported")
+        canonical = str(workspace)
+        for existing in workspaces.values():
+            if isinstance(existing, dict):
+                existing_dir = existing.get("dir")
+            elif isinstance(existing, str):
+                existing_dir = existing
+            else:
+                existing_dir = None
+            if not isinstance(existing_dir, str):
+                continue
+            try:
+                if str(Path(existing_dir).expanduser().resolve()) == canonical:
+                    outcome = _WriteOutcome("existing")
+                    return None
+            except (OSError, RuntimeError):
+                continue
 
-    # The name is taken by a DIFFERENT directory. Deriving a suffixed name is a
-    # rename, so it now requires the user to have asked for one; a plain skip
-    # reports the collision instead of quietly inventing a name.
-    if strategy != STRATEGY_RENAME:
-        return _WriteOutcome("conflict")
-    for candidate in (
-        f"{base_name}-{item.source_id}"[:64],
-        f"{base_name[:55]}-{item.fingerprint[:8]}",
-    ):
-        if candidate not in workspaces:
-            workspaces[candidate] = {"dir": canonical}
-            _write_json(path, data)
-            return _WriteOutcome("imported", renamed_to=candidate)
-    return _WriteOutcome("conflict")
+        base_name = _SAFE_NAME_RE.sub("-", workspace.name).strip("-._").lower()
+        base_name = base_name[:64] or f"imported-{item.source_id}"
+        if base_name not in workspaces:
+            workspaces[base_name] = {"dir": canonical}
+            outcome = _WriteOutcome("imported")
+            return data
+
+        # The name is taken by a DIFFERENT directory. Deriving a suffixed name
+        # is a rename, so it now requires the user to have asked for one; a
+        # plain skip reports the collision instead of quietly inventing a name.
+        if strategy != STRATEGY_RENAME:
+            outcome = _WriteOutcome("conflict")
+            return None
+        for candidate in (
+            f"{base_name}-{item.source_id}"[:64],
+            f"{base_name[:55]}-{item.fingerprint[:8]}",
+        ):
+            if candidate not in workspaces:
+                workspaces[candidate] = {"dir": canonical}
+                outcome = _WriteOutcome("imported", renamed_to=candidate)
+                return data
+        outcome = _WriteOutcome("conflict")
+        return None
+
+    # stamp_meta=False: this import is merge-only and must not alter any byte
+    # it did not add; a ConfigReadError keeps the old fail_closed contract
+    # (ValueError), which the apply loop maps to a rejected outcome.
+    try:
+        update_config_locked(path, mutate=_mutate, stamp_meta=False)
+    except ConfigReadError as exc:
+        raise ValueError("invalid destination JSON") from exc
+    assert outcome is not None  # every _mutate path sets it
+    return outcome
 
 
 @contextmanager
@@ -4838,12 +4860,20 @@ def _write_schedule(item: _Item, cron_service: Any) -> _WriteOutcome:
 
 def _write_settings(item: _Item, data_home: Path) -> _WriteOutcome:
     path = data_home / "config.json"
-    data = _load_json_dict(path, fail_closed=True)
-    changed = _merge_missing(data, item.payload)
-    if not changed:
-        return _WriteOutcome("existing")
-    _write_json(path, data)
-    return _WriteOutcome("imported")
+    # ONE locked read-modify-write (#4767) -- see the workspace importer above
+    # for why the raw read+write pair this replaces lost concurrent updates.
+    changed = False
+
+    def _mutate(data: dict) -> dict | None:
+        nonlocal changed
+        changed = _merge_missing(data, item.payload)
+        return data if changed else None
+
+    try:
+        update_config_locked(path, mutate=_mutate, stamp_meta=False)
+    except ConfigReadError as exc:
+        raise ValueError("invalid destination JSON") from exc
+    return _WriteOutcome("imported" if changed else "existing")
 
 
 def apply_import(

--- a/src/kiro_crew/platform_compat.py
+++ b/src/kiro_crew/platform_compat.py
@@ -321,6 +321,62 @@ def rename_noreplace(
     raise OSError(error, os.strerror(error), os.fspath(dst))
 
 
+def publish_dir_noreplace(src: str | os.PathLike, dst: str | os.PathLike) -> None:
+    """Atomically rename directory *src* to an ABSENT *dst*, never replacing.
+
+    POSIX ``os.rename`` silently replaces an EMPTY destination directory, so a
+    check-then-rename publish can destroy a racer's just-created directory and
+    its metadata. This wrapper closes that window: on POSIX it uses
+    :func:`rename_noreplace` with both names pinned to their shared parent's
+    directory descriptor; on Windows plain ``os.rename`` already refuses any
+    existing destination. Raises :class:`FileExistsError` when *dst* exists,
+    and :class:`ValueError` when the two paths do not share a parent (the
+    staging-sibling contract every caller follows).
+
+    Hosts without the no-replace primitive (glibc < 2.28, and NFS/SMB/FUSE
+    filesystems that reject RENAME_NOREPLACE with ENOSYS/EINVAL/EOPNOTSUPP)
+    fall back to an atomic-exclusive ``os.mkdir`` CLAIM of the destination
+    followed by a plain rename: the mkdir raises :class:`FileExistsError` when
+    the destination is occupied, and the only directory the rename can then
+    replace is the empty claim this very call created -- the no-replace
+    guarantee for creation races is preserved, and the operation keeps working
+    instead of crashing with ``NotImplementedError``.
+    """
+    if IS_WINDOWS:
+        os.rename(src, dst)
+        return
+    src_abs = os.path.abspath(os.fspath(src))
+    dst_abs = os.path.abspath(os.fspath(dst))
+    parent = os.path.dirname(dst_abs)
+    if os.path.dirname(src_abs) != parent:
+        raise ValueError("publish_dir_noreplace requires sibling src and dst")
+    parent_fd = os.open(parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        try:
+            rename_noreplace(
+                os.path.basename(src_abs),
+                os.path.basename(dst_abs),
+                src_dir_fd=parent_fd,
+                dst_dir_fd=parent_fd,
+            )
+            return
+        except NotImplementedError:
+            pass
+    finally:
+        os.close(parent_fd)
+    os.mkdir(dst_abs)
+    try:
+        os.rename(src_abs, dst_abs)
+    except BaseException:
+        # Drop OUR claim so a retry is not permanently blocked by an orphaned
+        # empty directory. os.rmdir only ever removes an empty directory, so
+        # the worst it can touch is the claim this call just created; its own
+        # failure is suppressed in favour of the original rename error.
+        with contextlib.suppress(OSError):
+            os.rmdir(dst_abs)
+        raise
+
+
 def tcc_protected_dirs_for_walk(root: str | os.PathLike) -> frozenset[str]:
     """Return the TCC-protected dir names to prune when walking *root*.
 

--- a/test/test_agent_sync_prune.py
+++ b/test/test_agent_sync_prune.py
@@ -32,7 +32,13 @@ def _make_config(agents: dict[str, KiroCrewAgentConfig]) -> KiroCrewConfig:
 
 
 async def _run_sync(cfg: KiroCrewConfig, aim_agents_list: list[AgentInfo]) -> dict:
-    """Invoke the production _do_agents_sync with mocked dependencies and return parsed body."""
+    """Invoke the production _do_agents_sync with mocked dependencies and return parsed body.
+
+    The sync persists via a delta mutate through ``update_config_locked``
+    (#4767); the patch below records each call on ``cfg.save`` (so the
+    existing called/not-called assertions keep their meaning) and stores the
+    mutated document on ``cfg.written_doc``.
+    """
     from kiro_crew.dashboard.handlers.agents import _do_agents_sync
 
     request = MagicMock()
@@ -40,9 +46,20 @@ async def _run_sync(cfg: KiroCrewConfig, aim_agents_list: list[AgentInfo]) -> di
 
     sel_mock = MagicMock()
 
+    def _fake_update_config_locked(*args, **kwargs):
+        doc: dict = {"agents": {}}
+        result = kwargs["mutate"](doc)
+        cfg.save()
+        cfg.written_doc = result
+        return result
+
     with (
         patch("kiro_crew.dashboard.handlers.agents.KiroCrewConfig.load", return_value=cfg),
         patch("kiro_crew.dashboard.handlers.agents.list_agents", return_value=aim_agents_list),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.update_config_locked",
+            new=_fake_update_config_locked,
+        ),
         patch("kiro_crew.dashboard.handlers.agents._sel", return_value=sel_mock),
     ):
         response = await _do_agents_sync(request)
@@ -213,3 +230,55 @@ class TestAgentSyncFsCheckIsOffloaded:
         src = inspect.getsource(agents._do_agents_sync)
         assert "await asyncio.to_thread(" in src
         assert "_namespaced_agent_file_exists(_dn)" in src, "the FS check must run off-loop"
+
+
+class TestPruneOnlySnapshotMatchedEntries:
+    """#4767 round 8: the locked prune only deletes entries that still equal
+    this sync's own snapshot -- an agent (re)added by a NEWER sync between the
+    discovery snapshot and the lock hold must survive a stale prune."""
+
+    @pytest.mark.asyncio
+    async def test_agent_added_or_changed_after_snapshot_survives_stale_prune(self):
+        from kiro_crew.dashboard.handlers.agents import _do_agents_sync
+
+        cfg = _make_config({"stale": KiroCrewAgentConfig(kiro_agent="stale-spec", source="aim")})
+        request = MagicMock()
+        request.get.return_value = "dashboard"
+
+        # Discovery finds one unrelated agent, so "stale" (spec gone) is this
+        # sync's prune candidate. The in-lock document simulates a NEWER sync
+        # having landed between the snapshot and the lock hold: "stale" was
+        # re-added with a DIFFERENT spec name, and "fresh" is brand new.
+        # Neither equals this sync's snapshot entry, so neither is pruned.
+        in_lock_doc = {
+            "agents": {
+                "stale": {"kiro_agent": "renewed-spec", "source": "aim"},
+                "fresh": {"kiro_agent": "fresh-spec", "source": "aim"},
+            }
+        }
+        written: dict = {}
+
+        def _fake_update_config_locked(*args, **kwargs):
+            result = kwargs["mutate"](in_lock_doc)
+            written["doc"] = result if result is not None else in_lock_doc
+            return result
+
+        with (
+            patch("kiro_crew.dashboard.handlers.agents.KiroCrewConfig.load", return_value=cfg),
+            patch(
+                "kiro_crew.dashboard.handlers.agents.list_agents",
+                return_value=[_make_aim_agent("unrelated")],
+            ),
+            patch(
+                "kiro_crew.dashboard.handlers.agents.update_config_locked",
+                new=_fake_update_config_locked,
+            ),
+            patch("kiro_crew.dashboard.handlers.agents._sel", return_value=MagicMock()),
+        ):
+            await _do_agents_sync(request)
+
+        agents_after = written["doc"]["agents"]
+        assert "fresh" in agents_after, "an agent added after the snapshot was pruned"
+        assert (
+            agents_after["stale"]["kiro_agent"] == "renewed-spec"
+        ), "a re-added (changed) entry was deleted on stale snapshot evidence"

--- a/test/test_api_agents_create_template.py
+++ b/test/test_api_agents_create_template.py
@@ -46,7 +46,13 @@ def _owner_caller(monkeypatch):
 
 
 def _fake_config():
-    """A stand-in KiroCrewConfig recording whether save() was reached."""
+    """A stand-in KiroCrewConfig snapshot.
+
+    The handler persists via a delta mutate through ``update_config_locked``
+    (#4767) -- ``_post`` patches that and records the mutated document into
+    ``written`` -- so ``saved``/``written`` observe whether and what the
+    endpoint persisted.
+    """
     saved: list[bool] = []
     return SimpleNamespace(
         agent=SimpleNamespace(provider="acp"),
@@ -54,6 +60,7 @@ def _fake_config():
         default_agent="kirocrew",
         save=lambda: saved.append(True),
         saved=saved,
+        written={},
     )
 
 
@@ -80,10 +87,21 @@ async def _post(body, cfg, installed=(), spy=None):
             spy.append(True)
         return rows
 
+    def _fake_update_config_locked(*args, **kwargs):
+        doc: dict = {"agents": {}}
+        result = kwargs["mutate"](doc)
+        cfg.written["doc"] = result
+        cfg.saved.append(True)
+        return result
+
     with (
         patch(
             "kiro_crew.dashboard.handlers.agents.KiroCrewConfig.load",
             return_value=cfg,
+        ),
+        patch(
+            "kiro_crew.dashboard.handlers.agents.update_config_locked",
+            new=_fake_update_config_locked,
         ),
         patch(
             "kiro_crew.dashboard.handlers.agents.list_agents",
@@ -188,7 +206,7 @@ class TestTemplateNameGrammar:
             {"name": "crew-d", "kiro_agent": "my_agent2"}, cfg, installed=("my_agent2",)
         )
         assert status == 200
-        assert cfg.agents["crew-d"].kiro_agent == "my_agent2"
+        assert cfg.written["doc"]["agents"]["crew-d"]["kiro_agent"] == "my_agent2"
 
 
 class TestExplicitTemplateStillWorks:
@@ -203,8 +221,8 @@ class TestExplicitTemplateStillWorks:
         )
         assert status == 200
         assert data["ok"] is True
-        assert cfg.agents["researcher"].kiro_agent == "kirocrew"
-        assert cfg.agents["researcher"].workspace == "research"
+        assert cfg.written["doc"]["agents"]["researcher"]["kiro_agent"] == "kirocrew"
+        assert cfg.written["doc"]["agents"]["researcher"]["workspace"] == "research"
 
     @pytest.mark.asyncio
     async def test_listed_template_creates_without_warning(self, caplog):
@@ -231,7 +249,7 @@ class TestMissingTemplateWarnsButCreates:
             )
         # Accepted (an edition may resolve it even when unlisted)…
         assert status == 200
-        assert cfg.agents["crew-c"].kiro_agent == "not-installed"
+        assert cfg.written["doc"]["agents"]["crew-c"]["kiro_agent"] == "not-installed"
         # …but the substitution risk is on the record rather than silent.
         assert "not in the installed agent listing" in caplog.text
         assert "not-installed" in caplog.text

--- a/test/test_api_onboarding_import.py
+++ b/test/test_api_onboarding_import.py
@@ -526,17 +526,15 @@ async def test_state_persists_import_onboarded(monkeypatch, tmp_path) -> None:
     module = _handler_module()
     audit = _AuditLog()
     saved = tmp_path / "saved.txt"
-    dashboard = SimpleNamespace(import_onboarded=False)
 
-    class Config:
-        def __init__(self) -> None:
-            self.dashboard = dashboard
+    def _fake_update_config_locked(*args, **kwargs):
+        # The handler persists via a delta mutate through update_config_locked
+        # (#4767): apply it to an empty document and record what it wrote.
+        doc = kwargs["mutate"]({})
+        saved.write_text(str(doc["dashboard"]["import_onboarded"]), encoding="utf-8")
+        return doc
 
-        def save(self) -> None:
-            saved.write_text(str(self.dashboard.import_onboarded), encoding="utf-8")
-
-    config = Config()
-    monkeypatch.setattr(module.KiroCrewConfig, "load", lambda: config)
+    monkeypatch.setattr(module, "update_config_locked", _fake_update_config_locked)
     monkeypatch.setattr(module, "_sel", lambda: audit)
 
     async with TestClient(TestServer(_make_app(module))) as client:
@@ -612,10 +610,10 @@ async def test_state_failure_is_generic_and_credential_free(monkeypatch) -> None
     audit = _AuditLog()
     private_detail = "/Users/alice/.kiro/crew/config.json"
 
-    def fail_load():
+    def fail_write(*args, **kwargs):
         raise OSError(private_detail)
 
-    monkeypatch.setattr(module.KiroCrewConfig, "load", fail_load)
+    monkeypatch.setattr(module, "update_config_locked", fail_write)
     monkeypatch.setattr(module, "_sel", lambda: audit)
 
     async with TestClient(TestServer(_make_app(module))) as client:
@@ -1141,10 +1139,10 @@ async def test_state_failure_code_equals_the_audited_error(monkeypatch) -> None:
     module = _handler_module()
     audit = _AuditLog()
 
-    def fail_load():
+    def fail_write(*args, **kwargs):
         raise OSError("boom")
 
-    monkeypatch.setattr(module.KiroCrewConfig, "load", fail_load)
+    monkeypatch.setattr(module, "update_config_locked", fail_write)
     monkeypatch.setattr(module, "_sel", lambda: audit)
 
     async with TestClient(TestServer(_make_app(module))) as client:

--- a/test/test_cli_commands_coverage.py
+++ b/test/test_cli_commands_coverage.py
@@ -16,6 +16,7 @@ Follows the style already established by ``test_cli.py`` (``argparse.Namespace``
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import io
 import json
 import urllib.error
@@ -91,6 +92,28 @@ def _cfg_with(
     cfg.default_workspace = default_workspace
     cfg.save = MagicMock()  # type: ignore[method-assign]
     return cfg
+
+
+def _seed_doc_file(tmp_path: Path, cfg: KiroCrewConfig) -> Path:
+    """Materialize *cfg* as a real config.json for the locked-delta writers.
+
+    The CLI CRUD commands no longer mutate the loaded snapshot and ``save()``
+    it -- they write a delta on the document read inside the sidecar flock
+    (#4767 round 7), so tests that check persistence must seed and read the
+    FILE, not the in-memory dataclass.
+    """
+    doc = {
+        "workspaces": {n: dataclasses.asdict(w) for n, w in cfg.workspaces.items()},
+        "agents": {n: dataclasses.asdict(a) for n, a in cfg.agents.items()},
+        "agent": {"default_agent": cfg.default_agent},
+    }
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(doc), encoding="utf-8")
+    return p
+
+
+def _read_doc(p: Path) -> dict:
+    return json.loads(p.read_text(encoding="utf-8"))
 
 
 # ── _internal_secret / _format_schedule ──
@@ -706,9 +729,15 @@ class TestAgentCli:
         out = capsys.readouterr().out
         assert "default *" in out and "other" in out and "alt" in out
 
-    def test_create_persists_new_agent(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_create_persists_new_agent(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         cfg = _cfg_with(agents={})
-        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        cfg_path = _seed_doc_file(tmp_path, cfg)
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+        ):
             cc._handle_agent(
                 _ns(
                     agent_action="create",
@@ -718,9 +747,9 @@ class TestAgentCli:
                     memory_store="ms",
                 )
             )
-        assert cfg.agents["new"].kiro_agent == "ka"
-        assert cfg.agents["new"].workspace == "ws"
-        cfg.save.assert_called_once()  # type: ignore[attr-defined]
+        doc = _read_doc(cfg_path)
+        assert doc["agents"]["new"]["kiro_agent"] == "ka"
+        assert doc["agents"]["new"]["workspace"] == "ws"
         assert "Created agent: new" in capsys.readouterr().out
 
     def test_create_duplicate_exits_1_without_saving(
@@ -744,11 +773,15 @@ class TestAgentCli:
         cfg.save.assert_not_called()  # type: ignore[attr-defined]
         assert "already exists" in capsys.readouterr().err
 
-    def test_update_applies_only_provided_fields(self) -> None:
+    def test_update_applies_only_provided_fields(self, tmp_path: Path) -> None:
         cfg = _cfg_with(
             agents={"a": KiroCrewAgentConfig(kiro_agent="old", workspace="ws0", memory_store="m0")}
         )
-        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        cfg_path = _seed_doc_file(tmp_path, cfg)
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+        ):
             cc._handle_agent(
                 _ns(
                     agent_action="update",
@@ -758,13 +791,18 @@ class TestAgentCli:
                     memory_store=None,
                 )
             )
-        assert cfg.agents["a"].kiro_agent == "new"
-        assert cfg.agents["a"].workspace == "ws0"
-        assert cfg.agents["a"].memory_store == "m0"
+        agent = _read_doc(cfg_path)["agents"]["a"]
+        assert agent["kiro_agent"] == "new"
+        assert agent["workspace"] == "ws0"
+        assert agent["memory_store"] == "m0"
 
-    def test_update_all_fields(self) -> None:
+    def test_update_all_fields(self, tmp_path: Path) -> None:
         cfg = _cfg_with(agents={"a": KiroCrewAgentConfig()})
-        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        cfg_path = _seed_doc_file(tmp_path, cfg)
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+        ):
             cc._handle_agent(
                 _ns(
                     agent_action="update",
@@ -774,8 +812,12 @@ class TestAgentCli:
                     memory_store="m",
                 )
             )
-        agent = cfg.agents["a"]
-        assert (agent.kiro_agent, agent.workspace, agent.memory_store) == ("k", "w", "m")
+        agent = _read_doc(cfg_path)["agents"]["a"]
+        assert (agent["kiro_agent"], agent["workspace"], agent["memory_store"]) == (
+            "k",
+            "w",
+            "m",
+        )
 
     def test_update_missing_exits_1(self, capsys: pytest.CaptureFixture[str]) -> None:
         cfg = _cfg_with(agents={})
@@ -795,13 +837,19 @@ class TestAgentCli:
         assert exc.value.code == 1
         assert "not found" in capsys.readouterr().err
 
-    def test_delete_removes_non_default(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_delete_removes_non_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         cfg = _cfg_with(
             agents={"default": KiroCrewAgentConfig(), "spare": KiroCrewAgentConfig()},
         )
-        with patch.object(KiroCrewConfig, "load", return_value=cfg):
+        cfg_path = _seed_doc_file(tmp_path, cfg)
+        with (
+            patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+        ):
             cc._handle_agent(_ns(agent_action="delete", name="spare"))
-        assert "spare" not in cfg.agents
+        assert "spare" not in _read_doc(cfg_path)["agents"]
         assert "Deleted agent: spare" in capsys.readouterr().out
 
     def test_delete_default_is_refused(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -860,16 +908,18 @@ class TestWorkspaceCopyFrom:
         (src / "memory").mkdir(parents=True)
         (src / "memory" / "notes.md").write_text("hi", encoding="utf-8")
         cfg = self._base()
+        cfg_path = _seed_doc_file(tmp_path, cfg)
         with (
             patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
             patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
             patch("kiro_crew.cli_commands.sel"),
         ):
             cc._handle_workspace(
                 _ns(workspace_action="create", name="copy1", dir=None, copy_from="src")
             )
         assert (tmp_path / "workspace-copy1" / "memory" / "notes.md").read_text() == "hi"
-        assert cfg.workspaces["copy1"].dir == "workspace-copy1"
+        assert _read_doc(cfg_path)["workspaces"]["copy1"]["dir"] == "workspace-copy1"
         assert "Created workspace: copy1" in capsys.readouterr().out
 
     def test_copy_from_skips_sensitive_entries(self, tmp_path: Path) -> None:
@@ -928,15 +978,17 @@ class TestWorkspaceCopyFrom:
     def test_copy_from_missing_source_dir_still_registers(self, tmp_path: Path) -> None:
         """A source workspace with no directory on disk is a config-only copy."""
         cfg = self._base()
+        cfg_path = _seed_doc_file(tmp_path, cfg)
         with (
             patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
             patch.object(KiroCrewConfig, "load", return_value=cfg),
+            patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
             patch("kiro_crew.cli_commands.sel"),
         ):
             cc._handle_workspace(
                 _ns(workspace_action="create", name="copy3", dir=None, copy_from="src")
             )
-        assert "copy3" in cfg.workspaces
+        assert "copy3" in _read_doc(cfg_path)["workspaces"]
         assert not (tmp_path / "workspace-copy3").exists()
 
 

--- a/test/test_config_rmw_preserves_settings.py
+++ b/test/test_config_rmw_preserves_settings.py
@@ -640,16 +640,20 @@ class TestEveryConfigWriterIsLocked:
 
     **What it does NOT cover.** Only calls to ``write_config_atomically``. A
     second family of writers reaches ``config.json`` through
-    ``kiro_crew.agent._atomic_json_write`` or :meth:`KiroCrewConfig.save`
-    (``messaging.py``'s channel savers, ``core.py``'s STT and theme PUTs,
-    ``mcp.py``'s gateway-enable, ``updates.py``'s log-level PUT, several
-    ``agents.py`` CRUD endpoints) and still bypasses the lock. Green here does
-    not mean every config writer is locked -- it means this class of them is.
+    ``kiro_crew.agent._atomic_json_write`` (``messaging.py``'s channel savers,
+    ``core.py``'s STT PUT, ``mcp.py``'s gateway-enable) and still bypasses the
+    lock. :meth:`KiroCrewConfig.save` (``updates.py``'s log-level PUT, the
+    workspace CRUD in ``files.py``, several ``agents.py`` CRUD endpoints) used
+    to be in that family and no longer is: since #4767 it holds the same
+    ``<path>.lock`` sidecar — see ``TestSaveHoldsTheAdvisoryLock`` in
+    ``test_config_save_locking.py``. Green here does not mean every config
+    writer is locked -- it means this class of them is.
     """
 
     #: The primitive itself writes through ``write_config_atomically`` by
-    #: definition, and ``KiroCrewConfig.save`` is the head of the second family
-    #: above. Both live here, so the module is exempt as a whole.
+    #: definition, and ``KiroCrewConfig.save`` writes under the same sidecar
+    #: lock via ``_config_write_lock``. Both live here, so the module is
+    #: exempt as a whole.
     _ALLOWED_FILES = {"loader.py"}
 
     #: Resolvers whose return value IS a config document path.

--- a/test/test_config_save_locking.py
+++ b/test/test_config_save_locking.py
@@ -1,0 +1,377 @@
+"""``KiroCrewConfig.save()`` holds the sidecar advisory lock (#4767).
+
+``save()`` used to be an UNLOCKED whole-document replace: its rename could land
+inside an ``update_config_locked`` holder's read-modify-write (a CLI writer, a
+boot refresh, a second gateway), and whichever renamed second published a
+document that never saw the other's change — every field in the file exposed,
+not one.
+
+Simply adding the lock was tried and REVERTED once (#4371): ``save()`` is a
+sync method reached from async handlers, so a contended POSIX ``flock`` inline
+on the event loop stalls the whole gateway, and the sidecar lifecycle left
+residue a Windows test caught. The fix that landed has two halves, and this
+file pins both:
+
+* **HALF 1 — the writer is locked.** ``save()`` writes under the SAME
+  ``<config>.lock`` sidecar ``update_config_locked`` holds
+  (``TestSaveHoldsTheAdvisoryLock``), and the sidecar lifecycle leaves nothing
+  behind but that one shared file (``TestSidecarLifecycle``).
+* **HALF 2 — the loop never waits on it.** Every coroutine reaches ``save()``
+  through ``dashboard/chat_utils.run_config_write`` or ``asyncio.to_thread``,
+  never inline — pinned structurally over the whole tree by
+  ``TestNoInlineSaveOnTheEventLoop`` and at runtime for the log-level PUT.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import json
+import os
+import pathlib
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from kiro_crew import platform_compat
+from kiro_crew.config import loader as loader_module
+from kiro_crew.config.loader import KiroCrewConfig
+
+
+def _write_config(directory: Path, data: dict) -> Path:
+    path = directory / "config.json"
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_config(directory: Path) -> dict:
+    return json.loads((directory / "config.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture()
+def cfg_home(tmp_path, monkeypatch):
+    """A private config home: every path save() touches derives from config_dir()."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(loader_module, "config_dir", lambda: home)
+    return home
+
+
+class TestSaveHoldsTheAdvisoryLock:
+    _TIMEOUT = 30.0
+
+    def test_save_waits_for_a_held_sidecar_lock(self, cfg_home):
+        """RED before #4767: save() sailed past a held ``<config>.lock``.
+
+        The holder here is the raw sidecar acquire — byte-for-byte what
+        ``update_config_locked`` takes — so the assertion is exactly "save()
+        participates in that lock", with no second writer's semantics mixed in.
+        """
+        _write_config(cfg_home, {"agent": {"log_level": "INFO"}})
+        cfg = KiroCrewConfig()
+
+        lock_fd = os.open(str(cfg_home / "config.json.lock"), os.O_RDWR | os.O_CREAT, 0o600)
+        saver = threading.Thread(target=cfg.save, daemon=True)
+        try:
+            with platform_compat.file_lock(lock_fd, exclusive=True):
+                saver.start()
+                # Poll instead of one fixed sleep: the unfixed save() finishes
+                # in milliseconds, so any completion inside the hold is the bug.
+                deadline = time.monotonic() + 1.0
+                while time.monotonic() < deadline and saver.is_alive():
+                    time.sleep(0.05)
+                assert saver.is_alive(), (
+                    "save() completed while another writer held the sidecar "
+                    "advisory lock — it is not participating in the lock"
+                )
+        finally:
+            saver.join(timeout=self._TIMEOUT)
+            os.close(lock_fd)
+        assert not saver.is_alive(), "save() never completed after the lock was released"
+        assert "agent" in _read_config(cfg_home)
+
+    def test_a_locked_writer_landing_inside_save_is_not_discarded(self, cfg_home, monkeypatch):
+        """RED before #4767: the interleave the issue describes, end to end.
+
+        A ``save()`` is paused INSIDE its critical window (between building its
+        document and its rename landing). An ``update_config_locked`` writer
+        starts in that window. Unlocked, the writer's read-modify-write ran to
+        completion inside the window and ``save()``'s rename then published a
+        document that never saw it — the writer's change silently discarded.
+        Locked, the writer blocks until ``save()``'s rename lands, reads THAT
+        document, and both changes survive.
+        """
+        _write_config(cfg_home, {"agent": {"log_level": "INFO"}})
+        cfg = KiroCrewConfig()
+        cfg.agent.log_level = "DEBUG"  # save()'s own change, must survive
+
+        entered = threading.Event()
+        release = threading.Event()
+        real_write = loader_module.write_config_atomically
+        trapped_once = threading.Event()
+
+        def _trapped_write(path, data, **kwargs):
+            # One-shot: pause only save()'s write. The locked writer's write
+            # (second call) passes straight through.
+            if not trapped_once.is_set():
+                trapped_once.set()
+                entered.set()
+                assert release.wait(self._TIMEOUT), "test orchestration stalled"
+            return real_write(path, data, **kwargs)
+
+        monkeypatch.setattr(loader_module, "write_config_atomically", _trapped_write)
+
+        def _locked_writer() -> None:
+            def _mutate(current: dict) -> dict:
+                current["concurrent_marker"] = "landed"
+                return current
+
+            loader_module.update_config_locked(cfg_home / "config.json", mutate=_mutate)
+
+        saver = threading.Thread(target=cfg.save, daemon=True)
+        writer = threading.Thread(target=_locked_writer, daemon=True)
+        try:
+            # Everything from the first start() lives inside this try: any
+            # failing orchestration assert must still release the trapped
+            # saver and join both threads, or they outlive the test with the
+            # monkeypatched writer still referenced (no-test-side-effects).
+            saver.start()
+            assert entered.wait(self._TIMEOUT), "save() never reached its write"
+            writer.start()
+            # Give an UNLOCKED writer (the regression) ample time to complete
+            # inside save()'s window; a locked one blocks here on the sidecar.
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline and writer.is_alive():
+                time.sleep(0.05)
+            assert writer.is_alive(), (
+                "update_config_locked completed inside save()'s critical window "
+                "— save() is not holding the sidecar lock"
+            )
+        finally:
+            release.set()
+            for thread in (saver, writer):
+                if thread.ident is not None:
+                    thread.join(timeout=self._TIMEOUT)
+        assert not saver.is_alive() and not writer.is_alive()
+
+        final = _read_config(cfg_home)
+        assert (
+            final.get("concurrent_marker") == "landed"
+        ), "the locked writer's change was discarded by save()'s rename"
+        assert final["agent"]["log_level"] == "DEBUG", "save()'s own change was lost"
+
+
+class TestSidecarLifecycle:
+    """The #4371 regression gate: the lock adds ONE shared sidecar, nothing else.
+
+    On Windows a leftover extra file beside ``config.json`` is exactly what the
+    orphan-lockfile test in that round caught. The sidecar itself is shared
+    state — ``update_config_locked`` creates and keeps the same one — so the
+    contract is: after ``save()``, the directory holds the config and the one
+    ``config.json.lock`` that every locked writer reuses, and nothing more.
+    """
+
+    def test_save_leaves_only_the_shared_sidecar(self, cfg_home):
+        _write_config(cfg_home, {"agent": {}})
+        cfg = KiroCrewConfig()
+        cfg.save()
+        after_save = {p.name for p in cfg_home.iterdir()}
+        assert after_save == {
+            "config.json",
+            "config.json.lock",
+        }, "save() left residue beside config.json: %s" % sorted(
+            after_save - {"config.json", "config.json.lock"}
+        )
+        # And it is THE sidecar update_config_locked uses — a second locked
+        # writer adds no new file, because they share the lock path.
+        loader_module.update_config_locked(cfg_home / "config.json", mutate=lambda d: d)
+        assert {p.name for p in cfg_home.iterdir()} == after_save
+
+    def test_save_locks_beside_a_symlinked_configs_target(self, tmp_path, monkeypatch):
+        """Same placement rule as update_config_locked: the sidecar follows the
+        TARGET the rename replaces, so the two writer families contend on one
+        lock even for a symlinked config."""
+        home = tmp_path / "home"
+        home.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        target = elsewhere / "real-config.json"
+        target.write_text(json.dumps({"agent": {}}), encoding="utf-8")
+        try:
+            (home / "config.json").symlink_to(target)
+        except OSError:
+            pytest.skip("symlinks unavailable on this platform/runner")
+        monkeypatch.setattr(loader_module, "config_dir", lambda: home)
+
+        KiroCrewConfig().save()
+
+        assert (elsewhere / "real-config.json.lock").exists(), (
+            "the sidecar must land beside the resolved target, where "
+            "update_config_locked puts its own"
+        )
+        assert not (home / "config.json.lock").exists(), (
+            "a sidecar beside the symlink would not serialize against a writer "
+            "that resolved the link first"
+        )
+
+
+def _on_running_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
+class TestAsyncCallersOffload:
+    @pytest.mark.asyncio
+    async def test_log_level_put_persists_off_the_event_loop(self, monkeypatch):
+        """The #4371 revert reason, as a runtime probe on a converted handler:
+        the persist -- a delta RMW through update_config_locked, whose flock
+        wait blocks its thread -- must run in a worker, never inline on the
+        loop, and must write only the key this endpoint owns."""
+        from kiro_crew.dashboard.handlers import updates
+
+        seen: dict[str, object] = {}
+
+        def _fake_update_config_locked(*args, **kwargs):
+            seen["on_loop"] = _on_running_loop()
+            doc: dict = {"unrelated": {"key": "untouched"}}
+            result = kwargs["mutate"](doc)
+            seen["doc"] = result
+            return result
+
+        monkeypatch.setattr(updates, "update_config_locked", _fake_update_config_locked)
+
+        class _Req:
+            async def json(self):
+                return {"level": "DEBUG"}
+
+        resp = await updates.api_log_level(_Req())
+        assert resp.status == 200
+        assert (
+            seen.get("on_loop") is False
+        ), "api_log_level ran the locked config RMW inline on the event loop"
+        assert seen["doc"]["agent"]["log_level"] == "DEBUG"
+        assert seen["doc"]["unrelated"] == {
+            "key": "untouched"
+        }, "the delta mutate must not touch keys the endpoint does not own"
+
+
+class TestNoInlineSaveOnTheEventLoop:
+    """Structural ratchet over ``src/kiro_crew``: no coroutine calls
+    ``KiroCrewConfig.save()`` inline.
+
+    ``save()`` holds the sidecar advisory ``flock`` (#4767); a contended
+    acquire blocks its thread, so a coroutine that calls it inline blocks the
+    one event loop the gateway shares — the exact failure that reverted #4371.
+    The sanctioned shapes are ``await run_config_write(...)`` (preferred, holds
+    the loop-side asyncio config lock too) and ``await asyncio.to_thread(...)``
+    where a caller already holds that lock. In both, ``.save`` appears as a
+    reference handed to the offloader, never as a call inside the coroutine.
+
+    Walks the AST in the shape ``TestEveryConfigWriterIsLocked`` established:
+    inside every ``async def``, a call ``X.save()`` is an offender when ``X``
+    is bound from ``KiroCrewConfig(...)`` or ``KiroCrewConfig.load(...)`` in
+    the same function — or is such a call chained directly. Nested SYNC
+    functions are excluded: they execute wherever they are invoked, and the
+    sanctioned pattern is precisely to define one and hand it to the offloader.
+    """
+
+    @staticmethod
+    def _is_kirocrew_config_source(node: ast.AST) -> bool:
+        """True for ``KiroCrewConfig(...)`` and ``KiroCrewConfig.load(...)``."""
+        if not isinstance(node, ast.Call):
+            return False
+        func = node.func
+        if isinstance(func, ast.Name):
+            return func.id == "KiroCrewConfig"
+        if isinstance(func, ast.Attribute) and func.attr == "load":
+            return isinstance(func.value, ast.Name) and func.value.id == "KiroCrewConfig"
+        return False
+
+    @classmethod
+    def _offenders_in(cls, tree: ast.AST, filename: str) -> list[str]:
+        offenders: list[str] = []
+        async_funcs = [n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef)]
+        for func in async_funcs:
+            config_names: set[str] = set()
+            for node in ast.walk(func):
+                if isinstance(node, ast.Assign) and cls._is_kirocrew_config_source(node.value):
+                    for tgt in node.targets:
+                        if isinstance(tgt, ast.Name):
+                            config_names.add(tgt.id)
+
+            for node in cls._walk_pruning_sync_defs(func):
+                if not isinstance(node, ast.Call):
+                    continue
+                f = node.func
+                if not (isinstance(f, ast.Attribute) and f.attr == "save"):
+                    continue
+                recv = f.value
+                hit = (isinstance(recv, ast.Name) and recv.id in config_names) or (
+                    cls._is_kirocrew_config_source(recv)
+                )
+                if hit:
+                    offenders.append(f"{filename}:{node.lineno} ({func.name})")
+        return offenders
+
+    @staticmethod
+    def _walk_pruning_sync_defs(func: ast.AsyncFunctionDef):
+        """Yield descendants of *func*, skipping nested sync ``def`` bodies."""
+        stack: list[ast.AST] = list(ast.iter_child_nodes(func))
+        while stack:
+            node = stack.pop()
+            if isinstance(node, ast.FunctionDef):
+                continue
+            yield node
+            stack.extend(ast.iter_child_nodes(node))
+
+    def test_no_coroutine_calls_save_inline(self):
+        root = pathlib.Path(__file__).resolve().parents[1] / "src" / "kiro_crew"
+        offenders: list[str] = []
+        for path in root.rglob("*.py"):
+            if "_vendor" in path.parts:
+                continue
+            src = path.read_text(encoding="utf-8", errors="replace")
+            if ".save()" not in src or "KiroCrewConfig" not in src:
+                continue
+            try:
+                tree = ast.parse(src)
+            except SyntaxError:
+                continue
+            offenders.extend(self._offenders_in(tree, path.name))
+        assert not offenders, (
+            "KiroCrewConfig.save() holds the sidecar advisory flock (#4767); a "
+            "coroutine must never call it inline on the event loop. Offload via "
+            "dashboard/chat_utils.run_config_write (preferred) or "
+            "asyncio.to_thread when the asyncio config lock is already held.\n  "
+            + "\n  ".join(sorted(set(offenders)))
+        )
+
+    def test_the_ratchet_would_catch_a_reintroduced_inline_save(self):
+        """The scan is not vacuous: both offending spellings are detected, and
+        the two sanctioned shapes are not."""
+        source = (
+            "async def offender_via_binding():\n"
+            "    cfg = KiroCrewConfig.load()\n"
+            "    cfg.save()\n"
+            "\n"
+            "async def offender_chained():\n"
+            "    KiroCrewConfig().save()\n"
+            "\n"
+            "async def sanctioned_to_thread():\n"
+            "    cfg = KiroCrewConfig.load()\n"
+            "    await asyncio.to_thread(cfg.save)\n"
+            "\n"
+            "async def sanctioned_nested_worker():\n"
+            "    def _persist():\n"
+            "        cfg = KiroCrewConfig.load()\n"
+            "        cfg.save()\n"
+            "    await run_config_write(_persist)\n"
+        )
+        offenders = self._offenders_in(ast.parse(source), "synthetic.py")
+        names = {o.rsplit("(", 1)[1].rstrip(")") for o in offenders}
+        assert names == {"offender_via_binding", "offender_chained"}, offenders

--- a/test/test_dashboard_updates_coverage.py
+++ b/test/test_dashboard_updates_coverage.py
@@ -775,9 +775,15 @@ class TestLogLevel:
     @pytest.mark.asyncio
     async def test_applies_and_persists_a_valid_level_case_insensitively(self, monkeypatch):
         saved: list[str] = []
-        cfg = MagicMock()
-        cfg.save = lambda: saved.append(cfg.agent.log_level)
-        monkeypatch.setattr(updates.KiroCrewConfig, "load", staticmethod(lambda: cfg))
+
+        def _fake_update_config_locked(*args, **kwargs):
+            # The handler persists via a delta mutate through
+            # update_config_locked (#4767); record what it wrote.
+            doc = kwargs["mutate"]({})
+            saved.append(doc["agent"]["log_level"])
+            return doc
+
+        monkeypatch.setattr(updates, "update_config_locked", _fake_update_config_locked)
 
         resp = await updates.api_log_level(_request({"level": "warning"}))
 
@@ -795,9 +801,9 @@ class TestLogLevel:
         from blocking a debugging session.
         """
         monkeypatch.setattr(
-            updates.KiroCrewConfig,
-            "load",
-            staticmethod(MagicMock(side_effect=OSError("read-only fs"))),
+            updates,
+            "update_config_locked",
+            MagicMock(side_effect=OSError("read-only fs")),
         )
 
         resp = await updates.api_log_level(_request({"level": "DEBUG"}))
@@ -967,9 +973,7 @@ class TestRingLogHandler:
         state._ws_log_subscribers = {MagicMock()}
         handler._state = state
         state.serving_loop = MagicMock()
-        state.serving_loop.call_soon_threadsafe.side_effect = RuntimeError(
-            "event loop is closed"
-        )
+        state.serving_loop.call_soon_threadsafe.side_effect = RuntimeError("event loop is closed")
 
         handler.emit(_record("during shutdown"))
 
@@ -1043,8 +1047,7 @@ class TestLogsStream:
         # The queue handler is only installed AFTER the replay, so an abort here
         # must not leave one attached to the logger.
         assert not any(
-            isinstance(h, updates._QueueLogHandler)
-            for h in logging.getLogger("kiro_crew").handlers
+            isinstance(h, updates._QueueLogHandler) for h in logging.getLogger("kiro_crew").handlers
         )
 
     @pytest.mark.parametrize("raw", ["not-a-number", "", "1e5"])

--- a/test/test_platform_compat.py
+++ b/test/test_platform_compat.py
@@ -4385,3 +4385,109 @@ class TestKillAndReap:
         with pytest.raises(asyncio.CancelledError):
             await task
         assert events == ["killed", "reap-started", "reaped"]
+
+
+class TestPublishDirNoreplace:
+    """#4767 round 9: workspace installs must never replace a raced empty
+    destination -- POSIX os.rename silently replaces an empty directory, so
+    the publish goes through the no-replace rename primitive."""
+
+    def test_publishes_into_absent_destination(self, tmp_path):
+        src = tmp_path / ".ws.staging-abc"
+        src.mkdir()
+        (src / "f.txt").write_text("x", encoding="utf-8")
+        dst = tmp_path / "ws"
+        pc.publish_dir_noreplace(src, dst)
+        assert (dst / "f.txt").read_text(encoding="utf-8") == "x"
+        assert not src.exists()
+
+    def test_refuses_an_existing_empty_destination(self, tmp_path):
+        """The exact race: an EMPTY directory at the destination survives."""
+        src = tmp_path / ".ws.staging-abc"
+        src.mkdir()
+        (src / "f.txt").write_text("x", encoding="utf-8")
+        dst = tmp_path / "ws"
+        dst.mkdir()  # a racer's just-created empty dir
+        before = dst.stat().st_ino
+        with pytest.raises((FileExistsError, OSError)):
+            pc.publish_dir_noreplace(src, dst)
+        assert dst.stat().st_ino == before, "the racer's directory was replaced"
+        assert src.exists(), "the staged tree was consumed by a refused publish"
+
+    def test_refuses_non_sibling_paths(self, tmp_path):
+        src = tmp_path / "a" / ".ws.staging-abc"
+        src.mkdir(parents=True)
+        dst = tmp_path / "b" / "ws"
+        (tmp_path / "b").mkdir()
+        if pc.IS_WINDOWS:
+            pytest.skip("sibling contract is POSIX-only (Windows uses os.rename)")
+        with pytest.raises(ValueError):
+            pc.publish_dir_noreplace(src, dst)
+
+    def test_fallback_without_renameat2_publishes_and_still_refuses_occupied(
+        self, tmp_path, monkeypatch
+    ):
+        """#4767 round 10: a host without renameat2 (glibc < 2.28, NFS/FUSE)
+        must not crash with NotImplementedError -- the mkdir-claim fallback
+        publishes into an absent destination and still refuses an existing
+        one, preserving the no-replace guarantee for creation races."""
+        if pc.IS_WINDOWS:
+            pytest.skip("fallback is POSIX-only (Windows os.rename never replaces)")
+
+        def _unsupported(*args, **kwargs):
+            raise NotImplementedError("filesystem lacks atomic no-replace rename")
+
+        monkeypatch.setattr(pc, "rename_noreplace", _unsupported)
+
+        # Publishes into an absent destination.
+        src = tmp_path / ".ws.staging-abc"
+        src.mkdir()
+        (src / "f.txt").write_text("x", encoding="utf-8")
+        dst = tmp_path / "ws"
+        pc.publish_dir_noreplace(src, dst)
+        assert (dst / "f.txt").read_text(encoding="utf-8") == "x"
+        assert not src.exists()
+
+        # Refuses an existing EMPTY destination; nothing is consumed.
+        src2 = tmp_path / ".ws2.staging-abc"
+        src2.mkdir()
+        dst2 = tmp_path / "ws2"
+        dst2.mkdir()  # a racer's just-created empty dir
+        before = dst2.stat().st_ino
+        with pytest.raises(FileExistsError):
+            pc.publish_dir_noreplace(src2, dst2)
+        assert dst2.stat().st_ino == before, "the racer's directory was replaced"
+        assert src2.exists(), "the staged tree was consumed by a refused publish"
+
+    def test_fallback_rename_failure_drops_the_claim(self, tmp_path, monkeypatch):
+        """#4767 round 11: when the fallback's rename fails, the empty mkdir
+        claim is removed so a retry is not permanently blocked, and the
+        staged tree is not consumed."""
+        if pc.IS_WINDOWS:
+            pytest.skip("fallback is POSIX-only")
+
+        def _unsupported(*args, **kwargs):
+            raise NotImplementedError("filesystem lacks atomic no-replace rename")
+
+        monkeypatch.setattr(pc, "rename_noreplace", _unsupported)
+
+        real_rename = os.rename
+
+        def _failing_rename(src, dst, **kwargs):
+            raise OSError(errno.EXDEV, "simulated cross-device rename failure")
+
+        src = tmp_path / ".ws.staging-abc"
+        src.mkdir()
+        (src / "f.txt").write_text("x", encoding="utf-8")
+        dst = tmp_path / "ws"
+        monkeypatch.setattr(os, "rename", _failing_rename)
+        try:
+            with pytest.raises(OSError):
+                pc.publish_dir_noreplace(src, dst)
+        finally:
+            monkeypatch.setattr(os, "rename", real_rename)
+        assert not dst.exists(), (
+            "the failed fallback left an orphaned empty claim that would "
+            "permanently block retries"
+        )
+        assert (src / "f.txt").exists(), "the staged tree was consumed by a failed publish"

--- a/test/test_workspace_crud_cli.py
+++ b/test/test_workspace_crud_cli.py
@@ -604,3 +604,194 @@ class TestWorkspaceDirContainmentMessage:
             pytest.raises(SystemExit),
         ):
             main()
+
+
+# ── #4767: CLI CRUD writes are locked deltas, not whole-document saves ──
+
+
+class TestCliCrudIsLockedDelta:
+    """The CLI CRUD commands persist via ``update_config_locked`` deltas.
+
+    Round 7 of the #4767 review: the old load -> mutate dataclass ->
+    ``cfg.save()`` shape re-serialized the command's stale snapshot, so a
+    change another process landed between the load and the save was silently
+    erased. A delta on the document read inside the flock cannot lose it.
+    """
+
+    def _run(self, argv: list[str], cfg_path: Path, tmp_path: Path) -> None:
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch("sys.argv", ["kirocrew", *argv]),
+        ):
+            main()
+
+    def test_workspace_create_preserves_a_concurrently_landed_key(self, tmp_path: Path) -> None:
+        """A document key the CLI's snapshot never saw survives the write.
+
+        ``KiroCrewConfig`` drops unknown keys on re-serialization, so under
+        the old ``cfg.save()`` path the marker below was erased; the delta
+        write rewrites only the workspaces section and keeps it.
+        """
+        data = _base_config()
+        data["zz_concurrent_marker"] = {"landed": True}
+        cfg_path = _write_config(tmp_path, data)
+        self._run(
+            ["workspace", "create", "--name", "fresh", "--dir", "workspace-fresh"],
+            cfg_path,
+            tmp_path,
+        )
+        doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert doc["workspaces"]["fresh"]["dir"] == "workspace-fresh"
+        assert doc.get("zz_concurrent_marker") == {"landed": True}, (
+            "the CLI create rewrote the whole document from its stale "
+            "snapshot and erased a concurrently landed change"
+        )
+
+    def test_agent_update_preserves_a_concurrently_landed_key(self, tmp_path: Path) -> None:
+        data = _base_config()
+        data["zz_concurrent_marker"] = {"landed": True}
+        cfg_path = _write_config(tmp_path, data)
+        self._run(
+            ["agent", "update", "default", "--workspace", "staging"],
+            cfg_path,
+            tmp_path,
+        )
+        doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert doc["agents"]["default"]["workspace"] == "staging"
+        assert doc.get("zz_concurrent_marker") == {"landed": True}
+
+    def test_workspace_create_recheck_conflicts_in_lock(self, tmp_path: Path) -> None:
+        """The in-lock re-check refuses a name the pre-check snapshot missed."""
+        cfg_path = _write_config(tmp_path, _base_config())
+        real_load = json.loads
+
+        # Simulate a racer: the name is free in the CLI's snapshot but taken
+        # by the time the locked read runs. Patch the loader's snapshot load
+        # to hide the workspace from the pre-check only.
+        import kiro_crew.cli_commands as cli_commands_module
+
+        original_mutator_runner = cli_commands_module._locked_config_write
+
+        def _inject_racer_then_run(mutate, **kwargs):
+            doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+            doc["workspaces"]["fresh"] = {"dir": "workspace-racer"}
+            cfg_path.write_text(json.dumps(doc), encoding="utf-8")
+            original_mutator_runner(mutate, **kwargs)
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch.object(
+                cli_commands_module, "_locked_config_write", _inject_racer_then_run
+            ),
+            unittest.mock.patch(
+                "sys.argv",
+                ["kirocrew", "workspace", "create", "--name", "fresh", "--dir", "workspace-f2"],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+        assert exc_info.value.code == 1
+        doc = real_load(cfg_path.read_text(encoding="utf-8"))
+        assert (
+            doc["workspaces"]["fresh"]["dir"] == "workspace-racer"
+        ), "the CLI overwrote a workspace the racer created first"
+
+
+# ── #4767 round 8: in-lock default re-checks + staged copy_from install ──
+
+
+class TestCliRound8Hardening:
+    def _base_with_defaults(self) -> dict:
+        data = _base_config()
+        return data
+
+    def test_workspace_delete_refuses_a_concurrently_selected_default(self, tmp_path: Path) -> None:
+        """A racer makes the workspace the default between snapshot and lock."""
+        data = _base_config()
+        cfg_path = _write_config(tmp_path, data)
+
+        import kiro_crew.cli_commands as cc
+
+        original = cc._locked_config_write
+
+        def _racer_selects_default_then_run(mutate, **kwargs):
+            doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+            doc["default_workspace"] = "staging"
+            cfg_path.write_text(json.dumps(doc), encoding="utf-8")
+            original(mutate, **kwargs)
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch.object(cc, "_locked_config_write", _racer_selects_default_then_run),
+            unittest.mock.patch("sys.argv", ["kirocrew", "workspace", "delete", "staging"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+        assert exc_info.value.code == 1
+        doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert (
+            "staging" in doc["workspaces"]
+        ), "the delete removed a workspace a racer had just made the default"
+
+    def test_agent_delete_refuses_top_level_default(self, tmp_path: Path) -> None:
+        """The authoritative default_agent key is TOP-LEVEL; the in-lock
+        re-check must read it there, not only the migration-era agent section."""
+        data = _base_config()
+        data["agents"]["spare"] = dict(data["agents"]["default"])
+        data["default_agent"] = "spare"
+        cfg_path = _write_config(tmp_path, data)
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch("sys.argv", ["kirocrew", "agent", "delete", "spare"]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+        assert exc_info.value.code == 1
+        doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+        assert "spare" in doc["agents"]
+
+    def test_losing_copy_from_race_leaves_winner_untouched(self, tmp_path: Path) -> None:
+        """The copy is STAGED: when the locked check refuses (racer took the
+        name), the winner's directory contains none of the loser's files and
+        no staging residue remains."""
+        src = tmp_path / "workspace"
+        src.mkdir()
+        (src / "loser-file.md").write_text("x", encoding="utf-8")
+        cfg_path = _write_config(tmp_path, _base_config())
+
+        import kiro_crew.cli_commands as cc
+
+        original = cc._locked_config_write
+
+        def _racer_takes_name_then_run(mutate, **kwargs):
+            winner_dir = tmp_path / "workspace-copied"
+            winner_dir.mkdir()
+            (winner_dir / "winner-file.md").write_text("w", encoding="utf-8")
+            doc = json.loads(cfg_path.read_text(encoding="utf-8"))
+            doc["workspaces"]["copied"] = {"dir": "workspace-copied"}
+            cfg_path.write_text(json.dumps(doc), encoding="utf-8")
+            original(mutate, **kwargs)
+
+        with (
+            unittest.mock.patch("kiro_crew.config.loader.config_path", return_value=cfg_path),
+            unittest.mock.patch("kiro_crew.config.loader.config_dir", return_value=tmp_path),
+            unittest.mock.patch("kiro_crew.cli_commands.config_dir", return_value=tmp_path),
+            unittest.mock.patch.object(cc, "_locked_config_write", _racer_takes_name_then_run),
+            unittest.mock.patch(
+                "sys.argv",
+                ["kirocrew", "workspace", "create", "--name", "copied", "--copy-from", "default"],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            main()
+        assert exc_info.value.code == 1
+        winner_dir = tmp_path / "workspace-copied"
+        assert sorted(p.name for p in winner_dir.iterdir()) == [
+            "winner-file.md"
+        ], "the losing create's copied files leaked into the winner's workspace"
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"staging residue: {leftovers}"

--- a/test/test_workspace_crud_handlers.py
+++ b/test/test_workspace_crud_handlers.py
@@ -73,6 +73,30 @@ _CFGDIR = "kiro_crew.config.loader.config_dir"
 _DATAHOME = "kiro_crew.dashboard.handlers.files.data_home"
 
 
+def _seed_file(directory: Path, cfg: KiroCrewConfig) -> Path:
+    """Write *cfg*'s document shape as the on-disk config.
+
+    The handlers persist via a delta read-modify-write on the RAW document
+    inside ``update_config_locked`` (#4767), so the authoritative post-call
+    state is the FILE at ``config_dir()/config.json`` -- not the ``cfg``
+    object handed to the handler, which is only its pre-await snapshot.
+    """
+    from dataclasses import asdict
+
+    doc = {
+        "workspaces": {n: asdict(w) for n, w in cfg.workspaces.items()},
+        "default_workspace": cfg.default_workspace,
+        "agents": {n: asdict(a) for n, a in cfg.agents.items()},
+    }
+    path = directory / "config.json"
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+def _read_doc(directory: Path) -> dict:
+    return json.loads((directory / "config.json").read_text(encoding="utf-8"))
+
+
 # ── Create handler ──
 
 
@@ -116,9 +140,9 @@ class TestCreateHandler:
     @pytest.mark.asyncio
     async def test_create_success(self, tmp_path: Path) -> None:
         cfg = _cfg()
+        _seed_file(tmp_path, cfg)
         with (
             patch(_LOAD, return_value=cfg),
-            patch.object(cfg, "save"),
             patch(_CFGDIR, return_value=tmp_path),
             patch(_DATAHOME, return_value=tmp_path),
             patch(_SEL) as mock_sel,
@@ -128,28 +152,32 @@ class TestCreateHandler:
         body = json.loads(resp.body)
         assert body["ok"] is True
         assert body["name"] == "staging"
-        assert "staging" in cfg.workspaces
+        doc = _read_doc(tmp_path)
+        assert doc["workspaces"]["staging"]["dir"] == "workspace-staging"
+        assert "default" in doc["workspaces"], "the delta write dropped an unrelated entry"
         mock_sel().log_api_access.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_create_with_copy_from(self, tmp_path: Path) -> None:
         cfg = _cfg()
+        _seed_file(tmp_path, cfg)
         src_dir = tmp_path / "workspace"
         src_dir.mkdir()
         (src_dir / "data.txt").write_text("hello")
         with (
             patch(_LOAD, return_value=cfg),
-            patch.object(cfg, "save"),
             patch(_CFGDIR, return_value=tmp_path),
             patch(_DATAHOME, return_value=tmp_path),
             patch(_SEL),
         ):
             resp = await api_workspaces_create(_req({"name": "copied", "copy_from": "default"}))
         assert resp.status == 200
-        assert "copied" in cfg.workspaces
+        assert "copied" in _read_doc(tmp_path)["workspaces"]
         # Verify the copy happened (symlinks=True means it's a real copy)
         dst = tmp_path / "workspace-copied" / "data.txt"
         assert dst.exists()
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"staged copy not cleaned up: {leftovers}"
 
     @pytest.mark.asyncio
     async def test_create_path_traversal_rejected(self, tmp_path: Path) -> None:
@@ -190,9 +218,9 @@ class TestUpdateHandler:
     @pytest.mark.asyncio
     async def test_update_dir_success(self, tmp_path: Path) -> None:
         cfg = _cfg()
+        _seed_file(tmp_path, cfg)
         with (
             patch(_LOAD, return_value=cfg),
-            patch.object(cfg, "save"),
             patch(_CFGDIR, return_value=tmp_path),
             patch(_DATAHOME, return_value=tmp_path),
             patch(_SEL) as mock_sel,
@@ -201,7 +229,7 @@ class TestUpdateHandler:
                 _req({"dir": "new-dir"}, match_info={"name": "default"})
             )
         assert resp.status == 200
-        assert cfg.workspaces["default"].dir == "new-dir"
+        assert _read_doc(tmp_path)["workspaces"]["default"]["dir"] == "new-dir"
         mock_sel().log_api_access.assert_called_once()
 
     @pytest.mark.asyncio
@@ -220,9 +248,9 @@ class TestUpdateHandler:
     @pytest.mark.asyncio
     async def test_update_no_dir_is_noop(self, tmp_path: Path) -> None:
         cfg = _cfg()
+        _seed_file(tmp_path, cfg)
         with (
             patch(_LOAD, return_value=cfg),
-            patch.object(cfg, "save"),
             patch(_CFGDIR, return_value=tmp_path),
             patch(_DATAHOME, return_value=tmp_path),
             patch(_SEL),
@@ -231,7 +259,7 @@ class TestUpdateHandler:
                 _req({"other": "field"}, match_info={"name": "default"})
             )
         assert resp.status == 200
-        assert cfg.workspaces["default"].dir == "workspace"
+        assert _read_doc(tmp_path)["workspaces"]["default"]["dir"] == "workspace"
 
 
 # ── Delete handler ──
@@ -270,19 +298,388 @@ class TestDeleteHandler:
         assert b"referenced by agents" in resp.body
 
     @pytest.mark.asyncio
-    async def test_delete_success(self) -> None:
+    async def test_delete_success(self, tmp_path: Path) -> None:
         cfg = _cfg(
             workspaces={
                 "default": WorkspaceConfig(dir="workspace"),
                 "staging": WorkspaceConfig(dir="workspace-staging"),
             },
         )
+        _seed_file(tmp_path, cfg)
         with (
             patch(_LOAD, return_value=cfg),
-            patch.object(cfg, "save"),
+            patch(_CFGDIR, return_value=tmp_path),
             patch(_SEL) as mock_sel,
         ):
             resp = await api_workspaces_delete(_req(match_info={"name": "staging"}))
         assert resp.status == 200
-        assert "staging" not in cfg.workspaces
+        doc = _read_doc(tmp_path)
+        assert "staging" not in doc["workspaces"]
+        assert "default" in doc["workspaces"], "the delta write dropped an unrelated entry"
         mock_sel().log_api_access.assert_called_once()
+
+
+# ── In-lock precondition re-check (#4767 review rounds 1-3) ──
+
+
+class TestInLockRecheck:
+    """The state-dependent preconditions are re-decided against FRESH state.
+
+    The handlers validate on a snapshot loaded before their awaits (create's
+    window straddles an awaited copytree that can run for seconds). Two
+    overlapping owner requests could both pass those stale checks; the delta
+    mutate inside update_config_locked must therefore re-run the decisive
+    checks against the DOCUMENT as read inside the sidecar lock, and surface
+    a conflict instead of persisting a duplicate directory or a dangling
+    reference. Each test hands the handler a stale snapshot that passes and
+    seeds the on-disk document with fresh state that must refuse -- red
+    against a mutate that re-applies the mutation without re-checking.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_rechecks_name_collision_inside_the_lock(self, tmp_path: Path) -> None:
+        stale = _cfg()  # no "staging" -> handler checks pass
+        fresh = _cfg(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "staging": WorkspaceConfig(dir="workspace-staging"),  # concurrent create won
+            },
+        )
+        _seed_file(tmp_path, fresh)
+        with (
+            patch(_LOAD, return_value=stale),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(_req({"name": "staging"}))
+        assert resp.status == 409
+        assert b"already exists" in resp.body
+        assert _read_doc(tmp_path)["workspaces"]["staging"]["dir"] == "workspace-staging"
+
+    @pytest.mark.asyncio
+    async def test_create_rechecks_dir_collision_inside_the_lock(self, tmp_path: Path) -> None:
+        stale = _cfg()
+        fresh = _cfg(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "other": WorkspaceConfig(dir="workspace-staging"),  # same dir, other name
+            },
+        )
+        _seed_file(tmp_path, fresh)
+        with (
+            patch(_LOAD, return_value=stale),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(
+                _req({"name": "staging", "dir": "workspace-staging"})
+            )
+        assert resp.status == 409
+        assert b"already used" in resp.body
+        assert "staging" not in _read_doc(tmp_path)["workspaces"]
+
+    @pytest.mark.asyncio
+    async def test_update_surfaces_a_concurrent_delete_as_404(self, tmp_path: Path) -> None:
+        stale = _cfg(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "staging": WorkspaceConfig(dir="workspace-staging"),
+            },
+        )
+        fresh = _cfg()  # "staging" deleted concurrently
+        _seed_file(tmp_path, fresh)
+        with (
+            patch(_LOAD, return_value=stale),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_update(
+                _req({"dir": "workspace-new"}, match_info={"name": "staging"})
+            )
+        assert resp.status == 404
+        assert "staging" not in _read_doc(tmp_path)["workspaces"]
+
+    @pytest.mark.asyncio
+    async def test_delete_rechecks_agent_references_inside_the_lock(self, tmp_path: Path) -> None:
+        stale = _cfg(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "staging": WorkspaceConfig(dir="workspace-staging"),
+            },
+        )
+        fresh = _cfg(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "staging": WorkspaceConfig(dir="workspace-staging"),
+            },
+            agents={"bot": KiroCrewAgentConfig(kiro_agent="kirocrew", workspace="staging")},
+        )
+        _seed_file(tmp_path, fresh)
+        with (
+            patch(_LOAD, return_value=stale),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_delete(_req(match_info={"name": "staging"}))
+        assert resp.status == 409
+        assert b"referenced by agents" in resp.body
+        assert "staging" in _read_doc(tmp_path)["workspaces"]
+
+    @pytest.mark.asyncio
+    async def test_conflicting_copy_from_create_leaves_no_destination_residue(
+        self, tmp_path: Path
+    ) -> None:
+        """The copy is STAGED after all validation and only installed inside
+        the locked mutate once its checks pass: a create that loses the race
+        must not have mutated the destination directory, and must clean its
+        staged tree off the loop (review rounds 2-3)."""
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("source content", encoding="utf-8")
+        stale = _cfg()  # "staging" absent -> handler checks pass, copy runs
+        fresh = _cfg(
+            workspaces={
+                "default": WorkspaceConfig(dir="workspace"),
+                "staging": WorkspaceConfig(dir="workspace-staging"),  # concurrent create won
+            },
+        )
+        _seed_file(tmp_path, fresh)
+        with (
+            patch(_LOAD, return_value=stale),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(_req({"name": "staging", "copy_from": "default"}))
+        assert resp.status == 409
+        assert not (tmp_path / "workspace-staging").exists(), (
+            "the losing create wrote into the destination before its in-lock " "check refused it"
+        )
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"staged copy not cleaned up: {leftovers}"
+
+    @pytest.mark.asyncio
+    async def test_failed_validation_after_copy_request_leaves_no_staging(
+        self, tmp_path: Path
+    ) -> None:
+        """Staging happens strictly AFTER path validation: a copy_from create
+        whose dir fails the sensitive/traversal checks must return 4xx with
+        zero staged residue (review round 3: staging-before-validation)."""
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("x", encoding="utf-8")
+        cfg = _cfg()
+        _seed_file(tmp_path, cfg)
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(
+                _req({"name": "evil", "copy_from": "default", "dir": "../../etc"})
+            )
+        assert resp.status == 400
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"validation failure left a staged copy behind: {leftovers}"
+
+
+# ── Round-4 hardening: degraded sections, install rollback, occupied dst ──
+
+
+class TestDeltaMutatorHardening:
+    @pytest.mark.asyncio
+    async def test_degraded_workspaces_section_is_coerced_not_crashed(self, tmp_path: Path) -> None:
+        """A malformed `"workspaces": []` on disk must not 500 the raw delta
+        mutate: the section is replaced with a dict, matching what the
+        validated load already presents (review round 4)."""
+        (tmp_path / "config.json").write_text(
+            json.dumps({"workspaces": [], "default_workspace": "default"}), encoding="utf-8"
+        )
+        cfg = _cfg(workspaces={})
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(_req({"name": "staging"}))
+        assert resp.status == 200
+        doc = _read_doc(tmp_path)
+        assert isinstance(doc["workspaces"], dict)
+        assert doc["workspaces"]["staging"]["dir"] == "workspace-staging"
+
+    @pytest.mark.asyncio
+    async def test_failed_config_write_rolls_back_the_installed_tree(self, tmp_path: Path) -> None:
+        """ENOSPC-class failure AFTER the staged tree is installed must not
+        leave an unregistered workspace directory behind (review round 4)."""
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("x", encoding="utf-8")
+        cfg = _cfg()
+        _seed_file(tmp_path, cfg)
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(
+                "kiro_crew.config.loader.write_config_atomically",
+                side_effect=OSError("no space left on device"),
+            ),
+            patch(_SEL),
+        ):
+            with pytest.raises(OSError):
+                await api_workspaces_create(_req({"name": "copied", "copy_from": "default"}))
+        assert not (tmp_path / "workspace-copied").exists(), (
+            "the installed destination was not rolled back after the config "
+            "write failed -- an unregistered workspace directory remains"
+        )
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"staged copy not cleaned up: {leftovers}"
+
+    @pytest.mark.asyncio
+    async def test_occupied_destination_is_refused_not_merged(self, tmp_path: Path) -> None:
+        """A copy_from create whose destination already exists non-empty is
+        refused: merging into it cannot be rolled back if the config write
+        then fails, so the un-rollbackable branch is eliminated (round 4)."""
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("x", encoding="utf-8")
+        occupied = tmp_path / "workspace-copied"
+        occupied.mkdir()
+        (occupied / "precious.txt").write_text("keep me", encoding="utf-8")
+        cfg = _cfg()
+        _seed_file(tmp_path, cfg)
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(_req({"name": "copied", "copy_from": "default"}))
+        assert resp.status == 409
+        assert json.loads(resp.body)["code"] == "workspace_dir_occupied"
+        assert (occupied / "precious.txt").read_text(encoding="utf-8") == "keep me"
+        assert "copied" not in _read_doc(tmp_path)["workspaces"]
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"staged copy not cleaned up: {leftovers}"
+
+    @pytest.mark.asyncio
+    async def test_preexisting_empty_destination_is_refused_and_survives(
+        self, tmp_path: Path
+    ) -> None:
+        """Round 5: even an EMPTY pre-existing destination is refused -- its
+        inode and metadata are not ours to replace, and a later rollback
+        could otherwise delete a directory this request did not create."""
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("x", encoding="utf-8")
+        empty_dst = tmp_path / "workspace-copied"
+        empty_dst.mkdir()
+        cfg = _cfg()
+        _seed_file(tmp_path, cfg)
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            resp = await api_workspaces_create(_req({"name": "copied", "copy_from": "default"}))
+        assert resp.status == 409
+        assert json.loads(resp.body)["code"] == "workspace_dir_occupied"
+        assert empty_dst.is_dir(), "the pre-existing empty destination was destroyed"
+        assert "copied" not in _read_doc(tmp_path)["workspaces"]
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"staged copy not cleaned up: {leftovers}"
+
+    @pytest.mark.asyncio
+    async def test_cancellation_after_persist_success_does_not_roll_back(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Round 5 (Opus): run_config_write drains the worker to completion
+        before re-raising a cancellation, so a CancelledError out of the
+        persist means the install AND the config registration LANDED --
+        rolling back would leave config.json pointing at a deleted tree."""
+        import asyncio as _asyncio
+
+        from kiro_crew.dashboard.handlers import files as files_module
+
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("x", encoding="utf-8")
+        cfg = _cfg()
+        _seed_file(tmp_path, cfg)
+
+        real_ucl = files_module.update_config_locked
+
+        async def _drained_then_cancelled(fn, /, *args, **kwargs):
+            # Mirror run_config_write's contract in the cancel case: the
+            # worker ran to completion; the cancellation is re-raised after.
+            fn(*args, **kwargs)
+            raise _asyncio.CancelledError
+
+        monkeypatch.setattr(files_module, "run_config_write", _drained_then_cancelled)
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            with pytest.raises(_asyncio.CancelledError):
+                await api_workspaces_create(_req({"name": "copied", "copy_from": "default"}))
+        assert real_ucl is files_module.update_config_locked  # patch scoped to run_config_write
+        assert (tmp_path / "workspace-copied" / "notes.md").exists(), (
+            "the installed tree of a SUCCESSFULLY persisted create was rolled "
+            "back on cancellation -- config.json now points at a deleted dir"
+        )
+        assert "copied" in _read_doc(tmp_path)["workspaces"]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_staging_copy_leaves_no_residue(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Round 6 (GPT): a cancellation during the staging copytree must not
+        race the cleanup rmtree -- the copy worker is drained to completion
+        first, then the staged tree is removed, so no partial ``.staging-*``
+        residue survives a gateway shutdown mid-copy."""
+        import asyncio as _asyncio
+        import shutil as _shutil
+        import threading as _threading
+
+        (tmp_path / "workspace").mkdir()
+        (tmp_path / "workspace" / "notes.md").write_text("x", encoding="utf-8")
+        cfg = _cfg()
+        _seed_file(tmp_path, cfg)
+
+        started = _threading.Event()
+        release = _threading.Event()
+        real_copytree = _shutil.copytree
+
+        def _slow_copytree(src, dst, **kwargs):
+            started.set()
+            assert release.wait(30), "test orchestration stalled"
+            return real_copytree(src, dst, **kwargs)
+
+        monkeypatch.setattr(_shutil, "copytree", _slow_copytree)
+        with (
+            patch(_LOAD, return_value=cfg),
+            patch(_CFGDIR, return_value=tmp_path),
+            patch(_DATAHOME, return_value=tmp_path),
+            patch(_SEL),
+        ):
+            task = _asyncio.ensure_future(
+                api_workspaces_create(_req({"name": "copied", "copy_from": "default"}))
+            )
+            try:
+                await _asyncio.to_thread(started.wait, 30)
+                task.cancel()
+                # Give the cancellation a chance to land at the drained await
+                # while the copy thread is still blocked -- the exact race the
+                # finding describes.
+                await _asyncio.sleep(0.05)
+            finally:
+                release.set()
+            with pytest.raises(_asyncio.CancelledError):
+                await task
+        leftovers = [p.name for p in tmp_path.iterdir() if ".staging-" in p.name]
+        assert leftovers == [], f"partial staging residue survived: {leftovers}"
+        assert not (tmp_path / "workspace-copied").exists()
+        assert "copied" not in _read_doc(tmp_path)["workspaces"]


### PR DESCRIPTION
## Problem / Motivation

`KiroCrewConfig.save()` serializes the merged config and renames it over
`config.json` with **no advisory lock**. A write from another process — a CLI
`kirocrew config set`, a boot refresh, a second gateway — landing between an
`update_config_locked` holder's read and `save()`'s rename is silently
discarded, and because `save()` publishes the whole document, **every field is
exposed, not one**. Two writer families never serialized against each other:
`update_config_locked` takes the sidecar flock, while legacy dashboard handlers
took only the loop-side asyncio lock.

Simply adding the lock was tried and reverted (#4371): `save()` is sync and
reached from async handlers, so a contended POSIX `flock` inline on the event
loop stalls the whole gateway, and the sidecar lifecycle left residue a Windows
test caught.

## Why it matters

Silently lost user configuration — settings revert with no error, no log, and
no way to tell which writer won. The wider the config document grows, the more
collateral each lost rename carries.

## What changed (motivation → approach → change)

Two halves, landing together per the issue's own prescription and the recorded
failure modes of #4371:

**Half 1 — lock the writer.** The sidecar acquire in `update_config_locked` is
extracted into `_config_write_lock()` (same `<config>.lock`, created beside the
resolved symlink target, deliberately never unlinked — one stable sidecar per
config file is the whole lifecycle, avoiding both the unlink race and the
Windows delete-while-open failure). `save()` now takes it around its rename.
The write stays atomic + mode-preserving via `write_config_atomically`, and the
overlay-subtraction content is untouched. `save()` remains a whole-document
publish of in-memory state — the lock fixes interleaving, not staleness — and
its docstring plus `update_config_locked`'s writer-family notes are updated to
say exactly that.

**Half 2 — dashboard writers become delta read-modify-writes, off the loop.**
Every `.save()` call site enumerated and classified. Coroutine callers no
longer call `save()` at all: each persists the keys it owns as a delta mutate
through `update_config_locked` — read, re-check, and write inside ONE flock
hold — dispatched off the loop via `run_config_write` (the transaction shape
its docstring prescribes) or, where the asyncio config lock is already held,
via the module's cancellation-draining `_drained_to_thread`:

- `dashboard/handlers/updates.py` (log-level PUT): delta on
  `agent.log_level`.
- `dashboard/handlers/files.py` (workspace create/update/delete): delta on
  the one workspaces entry, with the state-dependent preconditions (name/dir
  collision, default-workspace and agent references) re-run against the
  document as read inside the lock and surfaced as coded 4xx conflicts. The
  `copy_from` tree is staged only after ALL path validation passes, installed
  inside the locked mutate (atomic `os.replace`, or a merge copy when the
  destination pre-exists), and every staged-tree cleanup runs in a worker,
  never inline on the loop.
- `dashboard/handlers/agents.py` (agents-sync, agent-create): delta on the
  agents entries — adds re-checked, package/aim prunes re-derived, and name
  conflicts re-checked against the in-lock document — via `_drained_to_thread`
  under the held asyncio lock (a cancellation cannot release the lock while
  the worker is mid-write).
- `dashboard/handlers/onboarding_import.py`: both former manual-lock sites
  route through `run_config_write`; the state PUT is a delta on
  `dashboard.import_onboarded`; the unused local `_get_config_lock` wrapper
  removed.
- `cli_server.py` gateway-boot default-config write: `asyncio.to_thread` (file
  absent, nothing to lose, no loop-side writers exist before the gateway
  serves).
- The CLI CRUD commands (`kirocrew workspace/agent create|update|delete` in
  `cli_commands.py`) are converted to `update_config_locked` deltas via a
  shared `_locked_config_write` helper. Each mutate re-checks its
  state-dependent preconditions (name/dir collisions, agent references, the
  default-agent guard) on the document read inside the flock and refuses with
  the same CLI error text on a lost race. The remaining direct `save()`
  callers are single-flow only (the create-default-config-when-missing
  bootstrap in `cli_config.py` and `cli_server.py`), matching the contract
  `save()`'s docstring now states; `cli_cloud`/`cloud/wizard` write
  `CloudConfig`, a separate store.
- `crew_chat.py` `st.save()`/`self.save()` are `CrewStore`, and mochi
  `stats_service` `self.save()` is its own persistence — not `KiroCrewConfig`.

Lock ordering everywhere matches what `run_config_write` documents: asyncio
config lock first (on the loop), sidecar flock second (in the worker thread).

## Tests

`test/test_config_save_locking.py` (new):

- **Red-before-green concurrency pair** — `save()` blocks on a held sidecar
  lock, and an `update_config_locked` writer landing inside `save()`'s critical
  window survives (both fail against the unlocked `save()`; verified by
  revert).
- **Sidecar lifecycle** — after `save()` the directory holds exactly
  `config.json` + the one shared `config.json.lock` (the #4371 Windows
  orphan-residue regression gate), and a symlinked config locks beside the
  target, where `update_config_locked` puts its own.
- **Runtime off-loop probe** — the converted log-level PUT runs its locked
  delta RMW in a worker, never inline on the loop, and touches only the key it
  owns.
- **Self-tested AST ratchet** — no coroutine in `src/kiro_crew` may call
  `KiroCrewConfig.save()` inline; both offending spellings are detected and the
  two sanctioned shapes pass.

`test/test_workspace_crud_handlers.py`: in-lock precondition re-check suite
(stale snapshot passes, fresh on-disk document refuses — name collision, dir
collision, concurrent delete, agent references; unrelated entries survive the
delta) plus staging-lifecycle tests (no destination mutation and no staged
residue on conflict or failed validation). Existing CRUD tests reworked to
assert on the persisted document.

`test/test_dashboard_updates_coverage.py`, `test_api_onboarding_import.py`,
`test_agent_sync_prune.py`, `test_api_agents_create_template.py`: harnesses
updated from the `save()` shape to the locked delta-mutate shape.

`test/test_config_rmw_preserves_settings.py`: ratchet docstrings updated —
`save()` left the unlocked second family.

`test/test_workspace_crud_cli.py` `TestCliCrudIsLockedDelta` (new) +
`test/test_cli_commands_coverage.py` reworked: the CLI CRUD commands persist
via locked deltas — a concurrently landed document key survives a CLI
create/update (the old whole-document `save()` erased it), and the in-lock
re-check refuses a racer's name instead of overwriting its workspace.

## Manual verification

N/A — unit coverage sufficient: the concurrency pair exercises real `flock`
contention across threads with separate fds, which is the same primitive the
cross-process case uses, and the full backend suite (88.9k tests) matches the
pristine-main baseline on this host.

## Related Issues

Closes #4767

## Pattern harvest

Rule candidate: review-prompt
Pattern: "a bare `await asyncio.to_thread(...)` inside a manually held asyncio lock releases the lock on cancellation while the worker thread keeps mutating — use the drain/shield pattern (`run_config_write` / `_drained_to_thread`)"

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff

