### PR TITLE
test(api-health): warm SEL in the deny-audit thread assertion

### DIFF
--- a/test/test_api_health.py
+++ b/test/test_api_health.py
@@ -608,7 +608,7 @@ async def test_a_forgetful_pre_audit_refusal_is_still_audited_by_position(
     This barrier raises a bare 403 and audits nothing — exactly the omission
     that used to leave a refusal in no log at all, because
     ``sel_audit_middleware`` is registered inner to it. The record must appear
-    anyway, off the event loop, and the 403 must still reach the client.
+    anyway, on the event loop's thread, and the 403 must still reach the client.
     """
     from aiohttp.test_utils import TestClient, TestServer
 
@@ -616,6 +616,13 @@ async def test_a_forgetful_pre_audit_refusal_is_still_audited_by_position(
 
     spy = _SelSpy()
     monkeypatch.setattr(server_mod, "sel", lambda: spy)
+    # Establish the warm precondition HERE rather than inheriting it: production
+    # awaits sel.warm_sel_singleton() before the middleware chain is built, but
+    # this test builds its own chain and performs no warm, so whether the real
+    # sel_is_warm() answers True depends on what else ran first in this worker
+    # (#8885). Patching it — like server_mod.sel above — keeps the test hermetic
+    # and pins the warm path's contract: a direct enqueue, no thread hop (#8608).
+    monkeypatch.setattr(server_mod, "sel_is_warm", lambda: True)
 
     @web.middleware
     async def forgetful_barrier(request: web.Request, handler: object) -> web.StreamResponse:
@@ -631,10 +638,49 @@ async def test_a_forgetful_pre_audit_refusal_is_still_audited_by_position(
     assert denials[0]["operation"] == "GET /api/sessions"
     assert denials[0]["resources"] == "/api/sessions"
     assert "403" in denials[0]["error"]
-    # A direct enqueue on the loop thread via the shared helper — the
-    # singleton is warmed at startup (sel.warm_sel_singleton, #8608), so no
-    # per-call thread hop remains to reintroduce.
+    # Warm singleton (patched above) ⇒ a direct enqueue on the loop thread via
+    # the shared helper — no per-call thread hop on the healthy path (#8608).
     assert spy.threads[0] == "MainThread"
+
+
+@pytest.mark.asyncio
+async def test_a_pre_audit_refusal_on_a_cold_sel_is_audited_off_the_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same refusal when the startup warm FAILED: recorded, but never on the loop.
+
+    ``warm_sel_singleton`` is best-effort, so a cold singleton is a real
+    production state: the next ``sel()`` retries construction — blocking file
+    I/O — on the caller's thread. ``_audit_denied`` keeps a thread hop for
+    exactly that case (``server.py``'s warm/cold branch, #8608/#8885), and this
+    pins its side of the contract: the record still lands, off the loop thread.
+    The assertion is on the contract (not MainThread), not on the executor's
+    ``asyncio_N`` naming, which is an environment detail.
+    """
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from kiro_crew.dashboard import server as server_mod
+
+    spy = _SelSpy()
+    monkeypatch.setattr(server_mod, "sel", lambda: spy)
+    monkeypatch.setattr(server_mod, "sel_is_warm", lambda: False)
+
+    @web.middleware
+    async def forgetful_barrier(request: web.Request, handler: object) -> web.StreamResponse:
+        raise web.HTTPForbidden(text="nope")
+
+    async with TestClient(TestServer(_boundary_app(forgetful_barrier))) as client:
+        resp = await client.get("/api/sessions")
+        assert resp.status == 403
+        assert await resp.text() == "nope"
+
+    denials = spy.denials()
+    assert len(denials) == 1, f"the refusal was not audited: {spy.calls}"
+    assert denials[0]["operation"] == "GET /api/sessions"
+    assert denials[0]["resources"] == "/api/sessions"
+    assert "403" in denials[0]["error"]
+    # Cold singleton (patched above) ⇒ the write took the asyncio.to_thread hop.
+    assert spy.threads[0] != "MainThread"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #8885

## Symptom

`test/test_api_health.py::test_a_forgetful_pre_audit_refusal_is_still_audited_by_position` fails intermittently in CI with `assert 'asyncio_0' == 'MainThread'` — including on a PR whose diff was a black-format-only change to an unrelated file.

## Root cause — in the test's setup, not in production code

The test asserts its SEL write happened on the event-loop thread, but which thread `_audit_denied` writes on is decided by `sel_is_warm()` — a read of the process-global `SecurityEventLog._instance` singleton that the test never establishes. Warm ⇒ direct enqueue on the loop thread; cold ⇒ `asyncio.to_thread` hop onto an `asyncio_N` executor worker. The test monkeypatches `server_mod.sel` but leaves `server_mod.sel_is_warm` reading real global state, so its outcome is inherited from whatever else ran first in the same xdist worker. The test's own comment cited the production startup warm (`warm_sel_singleton()`, awaited before the middleware chain is built on both start paths) as justification while performing no warm itself.

**`_audit_denied`'s two-path design is unchanged and deliberate** (#8608): a failed best-effort warm must not put blocking file I/O on the loop, so the cold path keeps its thread hop. This PR touches only `test/test_api_health.py`.

## Fix

- **Warm case (existing test):** establish the precondition instead of inheriting it — `monkeypatch.setattr(server_mod, "sel_is_warm", lambda: True)`, the exact shape of the adjacent `server_mod.sel` patch on the line above. Hermetic: no real singleton, no trust-dir or key material, and no warmth leaked to other tests on the worker (awaiting the real `warm_sel_singleton()` would construct process-global state other tests then inherit — the same coupling this issue is about, pointed the other way).
- **Cold case (new test):** the same request with `sel_is_warm` patched to `lambda: False` — a real production state, since the startup warm is best-effort — asserting the denial still lands with the same operation/resources/error fields and that the write ran off the loop thread. Asserts the contract shape (`spy.threads[0] != "MainThread"`), not the literal `asyncio_0`, which is an executor naming detail.
- Corrected the stale comment that cited a startup warm the test never performed.

The determinism convention this violated is already documented (`docs/system-specs/common/testing-conventions.md` § 4 "Order dependence and shared state"), so no doc delta is needed.

## Verification

- **Red first (order dependence proven both directions, on unmodified main `235d36a`):** solo run fails every time — `pytest -n0 test/test_api_health.py::test_a_forgetful_pre_audit_refusal_is_still_audited_by_position` → `AssertionError: assert 'asyncio_0' == 'MainThread'`; whole-file run on the same tree passes (35 passed) because an earlier test in the file leaves the singleton warm. Under the default `-n auto --dist loadgroup` the outcome varies with worker placement — reproduced all three ways.
- **After the fix:** solo `-n0` passes; whole file `-n0` passes (36); whole file `-n auto --dist loadgroup` passes (36); re-verified on the rebased head. `pytest-randomly` is not installed in this environment, so default ordering and `-p no:randomly` are the same collection order.
- **Mutation checks (all killed, cp-aside/cp-back):**
  - (a) drop the warm patch → the existing test reds again (`asyncio_0 == MainThread` fails);
  - (b) invert the cold patch to `lambda: True` → the new test reds (`'MainThread' != 'MainThread'` fails);
  - (c) flip `server.py`'s `if sel_is_warm():` to `if not sel_is_warm():` on unmodified production → BOTH tests red, each on the side it owns; restored, all green.
- **Zero-regression:** full backend suite, identical invocation (`pytest -q -n auto --dist loadgroup`) on this branch and on a `git worktree` at `origin/main`: 88,832 passed on both; failing+error id sets (ANSI-stripped, sorted) are identical in both directions except one branch-run-only entry, `test_snapshot.py::TestNotificationCopyWhenNoLiveFileExists::test_a_FRESH_gateway_still_orders_the_copy_against_a_delivery` — an unrelated concurrency-timing test whose source is byte-identical on both trees (this diff touches only `test/test_api_health.py`) and which passes 3/3 solo on this branch; a load-sensitive flake of the known environmental baseline (~238 environmental failures on both trees), not a regression.
- **Frontend cross-surface guards** (the `local-gate.py --base origin/main` selection for a backend-only diff): 212 spec files / 5,792 tests, all passed.
- Lint: black gate, flake8, isort clean. mypy on the file reports 34 pre-existing errors — identical count and error classes on the `origin/main` worktree; this diff adds none.

<!-- no-visual-delta --> No frontend or visual change — test-only Python diff; evidence is the assertion/mutation dump above.

## Pattern harvest

Rule candidate: a test asserting WHICH THREAD a dual-path (warm/cold) helper ran on must establish the path-selector's precondition itself (monkeypatch the predicate, e.g. `sel_is_warm`) rather than inheriting process-global singleton state from earlier tests in the worker — and each path of the branch deserves its own test asserting the contract shape (on-loop vs off-loop), never the executor's `asyncio_N` naming. Knowingly out of scope: #8687 and #1673 are the same family of order-dependent / wall-clock flakes named in the report; fixed only this test per the spec.
