### PR TITLE
fix(dashboard): name the model that served a turn in its usage row

### DIFF
--- a/src/kiro_crew/dashboard/chat_runner.py
+++ b/src/kiro_crew/dashboard/chat_runner.py
@@ -206,6 +206,7 @@ from kiro_crew.llm_helpers import (
     configured_fallback_chain,
     fallback_rewound_transient_budget,
     probe_fallback_restore,
+    provider_active_model,
     record_interaction_event,
     run_bg_oneliner,
     transient_retry_delay,
@@ -9782,13 +9783,37 @@ async def _run_chat(
                 # `kiro_crew.agent_sdk` — the boundary's sanctioned surface, and an
                 # RFC-governed addition rather than a telemetry change.
                 #
-                # A fallback model serving the turn blanks the ROW's model for the
-                # reason it always has — billing a model that never executed is
-                # wrong, and model_source records what actually ran. The metric
-                # prefers the SERVED id instead (see the emit below): billing and
-                # attribution are different questions.
+                # A fallback model serving the turn records the model that RAN,
+                # not the one the user pinned: billing a model that never
+                # executed is wrong.
+                #
+                # Read from the LIVE client rather than from
+                # `slot._active_fallback_model` directly, because that sticky
+                # field can outlive the swap it records. It deliberately survives
+                # a landed turn (the session stays on the fallback until the
+                # start-of-turn restore probe succeeds), and that probe is skipped
+                # for a synthetic recovery message — so a turn that reset the
+                # session and resumed it on `slot.model` runs on the PRIMARY with
+                # the sticky candidate still set. Recording the candidate there
+                # would bill a model that, again, never executed.
+                #
+                # `provider_active_model` reads the provider's own
+                # `served_model` / `_model` accessor directly — no wrapper walk,
+                # so unlike `persist_token_record_async`'s `model_source` path it
+                # is not subject to `_wrapper_chain`'s 8-node cap (#8531). That
+                # cap is why blanking here and leaving recovery to `model_source`
+                # lost the id outright on a session with accumulated wrapper
+                # layers: the walk reported nothing and the row persisted
+                # `"model": ""`, which read time renders as `unknown`, merging
+                # this turn's credits with genuinely attribute-less rows.
+                #
+                # An unreadable provider still yields `""` and falls through to
+                # the `model_source` walk exactly as before — no worse than the
+                # blank it would have written anyway.
                 _provider_name = "claude_code" if is_claude_backend(client) else "acp"
-                _record_model = "" if slot._active_fallback_model else slot.model
+                _record_model = slot.model
+                if slot._active_fallback_model:
+                    _record_model = provider_active_model(client)
                 # One shared predicate across every persist gate (#6758): a
                 # claude-seam turn ending via a synthetic EVENT_COMPLETE
                 # (timeout, tool-stall, cancel-unacked) can carry cost or cache
@@ -9800,10 +9825,16 @@ async def _run_chat(
                     # slot.model may still be empty here even though the
                     # provider learned the model mid-turn. Read it back
                     # before persisting so tokens.jsonl is never tagged
-                    # with a blank model for CC sessions. Skipped while a
-                    # fallback is active (same guard as the pre-turn site):
-                    # the provider reports the FALLBACK, and writing it into
-                    # slot.model would make the temporary swap a permanent pin.
+                    # with a blank model for CC sessions.
+                    #
+                    # The `_active_fallback_model` clause guards the slot.model
+                    # WRITE, not the row's value: the provider reports the
+                    # FALLBACK, and writing it into slot.model would make the
+                    # temporary swap a permanent pin (same guard as the pre-turn
+                    # site). Kept as its own condition rather than folded into the
+                    # `_record_model` check above, so the write's safety does not
+                    # depend on whether the live provider happened to report a
+                    # served model.
                     #
                     # _record_model / _provider_name are already resolved above
                     # the gate; this only refines the model, and only here
@@ -9879,13 +9910,14 @@ async def _run_chat(
                     # the row store and the instruments describe one turn's
                     # NUMBERS identically.
                     usage=event.usage,
-                    # Attribution, not billing: `_turn_model` is the id the
-                    # backend actually served (read_turn_model), so a turn a
-                    # fallback model served is attributed to the model that ran
-                    # rather than dropped from the split. The row deliberately
-                    # blanks that case instead, because billing a model that never
-                    # executed is a different kind of wrong. `_record_model` is the
-                    # fallback for a backend that reported no id.
+                    # Attribution: `_turn_model` is the id the backend actually
+                    # served (read_turn_model), so a turn a fallback model served
+                    # is attributed to the model that ran rather than dropped
+                    # from the split. `_record_model` is the fallback for a
+                    # backend whose wrapper chain reported no id — which for a
+                    # fallback-served turn is the live served model read off the
+                    # provider directly, so the row and this sample name the same
+                    # model rather than diverging.
                     model=_turn_model or _record_model,
                     provider=_provider_name,
                 )

--- a/test/test_fallback_row_attribution_8560.py
+++ b/test/test_fallback_row_attribution_8560.py
@@ -1,0 +1,261 @@
+"""#8560 — a fallback-served turn must attribute the row to the model that ran.
+
+``chat_runner``'s post-turn persist blanks the caller-side model while a
+throttle fallback is active and leaves the row's attribution entirely to
+``persist_token_record_async``'s ``model_source`` walk. That walk succeeds for a
+shallow provider, which is why the row usually carries the served id — but
+``_wrapper_chain`` collects at most 8 nodes, so a session whose provider has
+accumulated wrapper layers (session sharing, a channel link, a subagent
+companion) hides its model-bearing node past the cap. The walk then reports
+nothing, and the row lands blank: the turn's credits become unattributable even
+though the slot knew exactly which model served them.
+
+The served id is already on the slot as ``_active_fallback_model``, written only
+after ``advance_fallback_candidate`` witnessed the ``set_model``, and cleared by
+the start-of-turn restore probe once the primary is back. Passing it as the
+caller-side model makes the row correct by construction instead of by a
+coincidence in another module's traversal.
+"""
+
+import json
+
+import pytest
+
+# Aliased with a leading underscore so pytest does not COLLECT these borrowed
+# classes a second time under this module (a bare `import Test...` name is
+# collectible, which would re-run both suites here).
+from test_dashboard_chat import TestRunChatModelFallback as _FallbackSuite
+from test_dashboard_chat import TestRunChatTransientRetry as _TransientSuite
+
+
+def _deep_chain_client(stream, *, primary="primary-model", advertised=("fallback-model",)):
+    """A provider whose model state sits BEYOND ``_wrapper_chain``'s 8-node cap.
+
+    Mirrors the real nesting ``_wrapper_chain``'s docstring documents —
+    ``AcpProvider`` -> ``client`` -> ``AcpSessionProvider`` -> ``_handle`` ->
+    ``AcpSessionHandle`` -> ``_runtime`` — with the extra wrapper layers a
+    long-lived shared session accumulates. ``set_model`` writes the handle's
+    ``_model``/``_resolved_model_id`` exactly as ``AcpSessionHandle.set_model``
+    does (``session_handle.py:1379-1384``); the cap is what hides them.
+    """
+
+    class _Runtime:
+        def __init__(self):
+            self._model = "process-level-arg"
+
+    class _Handle:
+        def __init__(self):
+            self._model = primary
+            self._resolved_model_id = primary
+            self._runtime = _Runtime()
+
+    class _SessionProvider:
+        def __init__(self, handle):
+            self._handle = handle
+            self._runtime = handle._runtime
+
+    class _Wrapper:
+        def __init__(self, inner):
+            self._client = inner
+            self.client = inner
+
+    handle = _Handle()
+    node = _SessionProvider(handle)
+    for _ in range(6):
+        node = _Wrapper(node)
+
+    class _Provider:
+        def __init__(self, inner):
+            self._client = inner
+            self.client = inner
+            self.stream = stream
+            self.stream_command = stream
+            # The public served_model seam the poisoned-conversation canary and
+            # the fallback witness read; delegates to the handle like the real
+            # AcpProvider.served_model property does.
+            self._handle_ref = handle
+
+        @property
+        def served_model(self):
+            return self._handle_ref._model or self._handle_ref._resolved_model_id
+
+        def available_models(self):
+            return [{"modelId": m} for m in advertised]
+
+        def context_usage_pct(self):
+            return 0.0
+
+        def context_used_tokens(self):
+            return 0
+
+        def context_window_tokens(self):
+            return 0
+
+        async def set_model(self, model_id):
+            handle._model = model_id
+            handle._resolved_model_id = model_id
+
+    return _Provider(node), handle
+
+
+class TestFallbackServedTurnAttribution:
+    _TRANSIENT = _FallbackSuite._TRANSIENT
+    _make_state = staticmethod(_TransientSuite._make_state)
+    _wire_sessions = staticmethod(_TransientSuite._wire_sessions)
+    _drain_bg = staticmethod(_TransientSuite._drain_bg)
+
+    @staticmethod
+    def _rows(shard_dir):
+        if not shard_dir.exists():
+            return []
+        return [
+            json.loads(line)
+            for shard in sorted(shard_dir.glob("*.jsonl"))
+            for line in shard.read_text().splitlines()
+            if line.strip()
+        ]
+
+    @pytest.mark.asyncio
+    async def test_row_names_the_fallback_that_served_when_the_chain_is_capped(
+        self, tmp_path, monkeypatch
+    ):
+        """A fallback-served turn on a deeply-wrapped provider still attributes
+        its credits to the model that ran, instead of landing in ``unknown``."""
+        from unittest.mock import AsyncMock, patch
+
+        from kiro_crew.acp.client import AcpError
+        from kiro_crew.acp.types import TurnUsage
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.dashboard.handlers import usage as usage_mod
+        from kiro_crew.llm_helpers import TRANSIENT_RETRIES
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        shard_dir = tmp_path / "usage" / "tokens"
+        monkeypatch.setattr(usage_mod, "_TOKEN_USAGE_DIR", shard_dir)
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.chat_runner._agent_fallback_chain",
+            lambda: ("fallback-model",),
+        )
+
+        calls = 0
+
+        async def _stream(msg):
+            nonlocal calls
+            calls += 1
+            if calls <= TRANSIENT_RETRIES + 1:
+                raise AcpError(self._TRANSIENT)
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="fb-result")
+            yield LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(credits=12.5))
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client, handle = _deep_chain_client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        # Preconditions: the fallback really served the turn, and the walk that
+        # the persist site relies on really cannot see it.
+        assert slot._active_fallback_model == "fallback-model"
+        assert handle._model == "fallback-model"
+        assert usage_mod.read_turn_model(client) == "", (
+            "precondition: the wrapper-chain walk must be blind here, otherwise "
+            "this test is not exercising the capped-chain case"
+        )
+
+        rows = self._rows(shard_dir)
+        assert len(rows) == 1, rows
+        assert rows[0]["credits"] == 12.5
+        assert rows[0]["model"] == "fallback-model", (
+            "a fallback-served turn's credits must name the model that ran; "
+            f"got {rows[0]['model']!r} (read time renders a blank as 'unknown')"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_fallback_turn_still_records_the_slot_model(self, tmp_path, monkeypatch):
+        """REGRESSION PIN: with no fallback active the row keeps recording the
+        slot's own model — the change must touch only the fallback branch."""
+        from unittest.mock import AsyncMock, patch
+
+        from kiro_crew.acp.types import TurnUsage
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.dashboard.handlers import usage as usage_mod
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        shard_dir = tmp_path / "usage" / "tokens"
+        monkeypatch.setattr(usage_mod, "_TOKEN_USAGE_DIR", shard_dir)
+
+        async def _stream(msg):
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="ok")
+            yield LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(credits=4.0))
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client, _handle = _deep_chain_client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+        slot.model = "pinned-model"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        assert slot._active_fallback_model == ""
+        rows = self._rows(shard_dir)
+        assert len(rows) == 1, rows
+        assert rows[0]["model"] == "pinned-model", rows[0]
+
+    @pytest.mark.asyncio
+    async def test_stale_sticky_fallback_is_not_billed_after_a_resume(self, tmp_path, monkeypatch):
+        """GPT review finding on 3f55ca11f: the sticky candidate can OUTLIVE the
+        swap it records.
+
+        It deliberately survives a landed turn (`chat_runner.py:10941-10944` --
+        the session stays on the fallback until the start-of-turn restore probe
+        succeeds), that probe is skipped for a synthetic recovery message
+        (`:7317-7320`), and a reset resumes the session by re-sending
+        `slot.model` as a set_model override (`:1156-1159`). So a recovery turn
+        can run on the PRIMARY with `_active_fallback_model` still set. The row
+        must name what the live provider is serving, not the stale candidate.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from kiro_crew.acp.types import TurnUsage
+        from kiro_crew.dashboard.chat import _run_chat
+        from kiro_crew.dashboard.handlers import usage as usage_mod
+        from kiro_crew.providers.base import EVENT_COMPLETE, EVENT_TEXT_CHUNK, LLMEvent
+
+        shard_dir = tmp_path / "usage" / "tokens"
+        monkeypatch.setattr(usage_mod, "_TOKEN_USAGE_DIR", shard_dir)
+
+        async def _stream(msg):
+            yield LLMEvent(kind=EVENT_TEXT_CHUNK, text="recovered")
+            yield LLMEvent(kind=EVENT_COMPLETE, usage=TurnUsage(credits=7.0))
+
+        state = self._make_state(tmp_path, monkeypatch)
+        client, handle = _deep_chain_client(_stream)
+        self._wire_sessions(state, client)
+        slot = state.get_or_create_slot("s1")
+        slot._titled = True
+        slot.model = "primary-model"
+        # The post-resume state: the live session is back on the primary while
+        # the sticky candidate still names the fallback, and the restore probe
+        # has not run to clear it.
+        slot._active_fallback_model = "fallback-model"
+        slot._fallback_primary_model = "primary-model"
+        slot._fallback_candidate_idx = 1  # non-zero: keeps the restore probe off
+        assert handle._model == "primary-model", "precondition: session is on the primary"
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await _run_chat(state, slot, "hello")
+            await self._drain_bg(state)
+
+        rows = self._rows(shard_dir)
+        assert len(rows) == 1, rows
+        assert rows[0]["model"] == "primary-model", (
+            "a stale sticky fallback must not be billed: the live provider is "
+            f"serving 'primary-model', got {rows[0]['model']!r}"
+        )


### PR DESCRIPTION
## 1. What is the problem?

`chat_runner`'s post-turn persist blanked the caller-side model whenever a
throttle fallback was serving the session:

```python
_record_model = "" if slot._active_fallback_model else slot.model
```

That left the row's attribution entirely to `persist_token_record_async`'s
`model_source` walk. The walk *does* recover the served id for a shallow
provider - measured, a flat provider persists `"model": "fallback-model"` - but
`_wrapper_chain` collects at most **8 nodes**, and a session that has
accumulated wrapper layers hides its model-bearing node past that cap. Measured
against the nesting shape `_wrapper_chain`'s own docstring documents
(`AcpProvider` -> `client` -> `AcpSessionProvider` -> `_handle` ->
`AcpSessionHandle`), the resolver holds up to 5 extra wrapper layers and goes
blank from the 6th:

| extra wrapper layers | chain length | `_resolve_model("", src)` |
|---|---|---|
| 0-4 | 4-8 | `'fallback-model'` |
| 5 | 8 (capped) | `'fallback-model'` |
| **6+** | 8 (capped) | **`''`** |

So a fallback-served turn on a deeply-wrapped session persists `"model": ""`
while the live provider knew the answer the whole time.

**Two of the issue's premises did not survive checking, and both are findings.**
The row does **not** blank on the normal path - the shipped behaviour is already
the issue's own suggested direction ("persist the served model id"), decided
silently by the `model_source=client` argument rather than by anyone choosing
it. And three comments in this file asserted the opposite:

> The row deliberately blanks that case instead, because billing a model that
> never executed is a different kind of wrong.

The row did not blank that case, and the row and the metric named the same
model. That false description is what this issue was filed from.

## 2. Why this issue matters to the user

`usage.py` maps a blank model to the literal bucket `unknown` at read time
(`model = str(obj.get("model") or "unknown")`). A blanked row therefore merges
its credits with genuinely attribute-less rows in the developer-telemetry
per-model split.

Scope, stated precisely because this is a billing record: **nothing is
mispriced.** `credits` is persisted verbatim and the read path never derives a
price from the model - it uses the model only as a grouping key for `by_model`.
The window total, the per-slot rollup and the per-channel split are all
unaffected. What is lost is attribution: the spend is real and correctly
totalled, but unassignable to the model that incurred it.

## 3. How our fix solves it

```python
_record_model = slot.model
if slot._active_fallback_model:
    _record_model = provider_active_model(client)
```

`provider_active_model` reads the provider's own `served_model` / `_model`
accessor **directly**. Two properties follow, and they are why this is the right
reader rather than either of the two obvious alternatives:

- **No wrapper walk**, so it is not subject to `_wrapper_chain`'s 8-node cap.
  That is what fixes the blank row: the id is available at the top of the object
  graph, and only the capped traversal could not see it.
- **It reports LIVE state**, so it cannot name a candidate that has gone stale.
  Reading `slot._active_fallback_model` directly would: that sticky field
  deliberately survives a landed turn (`chat_runner.py:10941-10944`), the
  start-of-turn restore probe that clears it is skipped for a synthetic recovery
  message (`:7317-7320`), and a reset resumes the session by re-sending
  `slot.model` as a `set_model` override (`:1156-1159`) - so a recovery turn can
  run on the **primary** with the sticky candidate still set. This was GPT's
  BLOCKING finding on the first revision; its trigger chain was verified step by
  step against those three code sites before the fix changed, and the second
  revision closes it with a regression test.

An unreadable provider still yields `""` and falls through to the `model_source`
walk exactly as before, so no case is made worse than the blank it would have
written anyway.

Chain from symptom to root cause: blank row -> read time renders `unknown` ->
`_resolve_model` returned `""` -> the `model_source` walk found no model -> the
walk is capped at 8 nodes and the handle sits past the cap -> the caller had
blanked the one value that needed no walk at all.

The three false comments are corrected to describe what the code does. The
backfill guard keeps its `_active_fallback_model` clause and is documented as
guarding the `slot.model` **write** (writing the fallback there would make a
temporary swap a permanent pin) - deliberately kept as its own condition so the
write's safety does not depend on whether the provider reported a served model.

## 4. What tests we did

`test/test_fallback_row_attribution_8560.py`, three cases driven through the real
`_run_chat` and asserted against the persisted shard:

| case | on clean `origin/main` | with the fix |
|---|---|---|
| fallback-served turn, provider state past the cap | `assert '' == 'fallback-model'` | passes |
| stale sticky candidate after a resume onto the primary | `assert '' == 'primary-model'` | passes |
| no fallback active (regression pin) | passes | passes |

The stale-candidate case was also run against the **first revision** of this PR
to confirm it pins the finding rather than merely passing: it failed there with
`assert 'fallback-model' == 'primary-model'`.

The capped-chain case asserts three preconditions before it reads the shard (the
swap happened, the handle really carries the fallback, and `read_turn_model`
really is blind), so it cannot silently stop exercising the case it is named for.

Detector proven on known positives before any negative was believed: a
model-less source resolves to `""` and persists a row with `"model": ""`, so a
non-blank reading is a real reading rather than a blind probe.

Also run green, targeted: `test_dashboard_chat.py::TestRunChatModelFallback`,
`::TestSlotProbeWrapsSharedRestoreBody`, `test_usage.py`, `test_turn_stats.py`,
`metrics/test_usage_turns.py`, `test_llm_helpers.py` (151 + 136 passed).
`black --target-version py310` and `ruff` clean on both touched files, and the
`agent-sdk-boundary` gate passes in scope.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a comment that describes intent the code does not implement. All three
corrected comments here asserted the row blanks a fallback-served turn while the
`model_source` argument two lines below was already recovering the served id.
The issue this PR closes was filed **from the comment**, not from a measurement -
so the false comment did not merely mislead a reader, it manufactured work. The
generalizable rule: when a comment states that a value is deliberately withheld,
the review should require that the withholding be observable at the value's
destination, because a same-call-site recovery argument silently negates it.

A second, narrower candidate worth recording: a sticky field whose comment says
it "deliberately survives" a lifecycle event is a staleness hazard at every read
site that is not the one it was written for. That is exactly the shape of the
BLOCKING finding this PR took in round one.

## 5. Any other suggestions on the work

**What this PR does NOT close: the `_wrapper_chain` 8-node cap itself.** It is
untouched here, still on `main`, and still the mechanism behind blank rows on
every *other* persist surface (`llm_helpers` background turns, cron, subagents),
which this fix cannot reach because only the dashboard slot knows a fallback is
active. That cap is already reported and measured in #8531 - deliberately not
re-filed, and deliberately not folded into this PR.

Also measured and worth naming rather than silencing: `read_effective_model`
walks the chain for `_resolved_model_id` / `_model` but never reads the public
`served_model` accessor, which is why the capped walk goes blind on a provider
whose top-level accessor would have answered immediately. That asymmetry is the
cheapest available mitigation for #8531 and belongs there, not here.

The design question the issue asks for a ruling on is answered by measurement
rather than by preference: of the three candidates (requested / served /
sentinel), **served** was already the shipped behaviour on the shallow path, and
it is strictly more informative than a `fallback` sentinel - it names the model
*and* the row remains joinable to the per-model split. This PR makes that
existing answer hold on every path instead of only the shallow one.

Closes #8560
Refs #8531
