### PR TITLE
fix(subagent): refuse a spawn whose approval prompt has no surface (#2381)

### DIFF
--- a/src/kiro_crew/dashboard/state.py
+++ b/src/kiro_crew/dashboard/state.py
@@ -8151,6 +8151,9 @@ class DashboardState:
     def ws_client_count(self) -> int:
         return _websocket_for(self).ws_client_count()
 
+    def dashboard_user_ws_count(self) -> int:
+        return _websocket_for(self).dashboard_user_ws_count()
+
     def broadcast_browser_event(self, event_type: str, data: dict) -> None:
         _websocket_for(self).broadcast_browser_event(event_type, data)
 

--- a/src/kiro_crew/dashboard/websocket_hub.py
+++ b/src/kiro_crew/dashboard/websocket_hub.py
@@ -341,6 +341,25 @@ class WebSocketHub:
     def ws_client_count(self) -> int:
         return len(self._owner._ws_clients)
 
+    def dashboard_user_ws_count(self) -> int:
+        """Count open sockets belonging to a dashboard USER, not an app token.
+
+        ``ws_client_count`` counts every ``/api/ws`` registration, and an app
+        token is one of them (``_is_dashboard_user`` False, set from the auth
+        middleware in ``dashboard/ws.py``). Such a socket does not receive an
+        owner-surface frame unless its manifest declared that event -- the same
+        first line ``_ws_client_allowed`` gates on -- so a caller asking "is a
+        human watching?" must not count it.
+
+        Closed-but-not-yet-pruned sockets are skipped: the registry prunes
+        lazily, on the next broadcast.
+        """
+        return sum(
+            1
+            for ws in list(self._owner._ws_clients)
+            if not ws.closed and ws.get("_is_dashboard_user", False)
+        )
+
     def broadcast_browser_event(self, event_type: str, data: dict[str, Any]) -> None:
         """Redact and broadcast a browser activity event."""
         redact_credentials = self._redact_credentials_provider()

--- a/src/kiro_crew/slack/gateway.py
+++ b/src/kiro_crew/slack/gateway.py
@@ -299,6 +299,7 @@ from kiro_crew.subagent import (
     _TRANSIENT_CONTINUE_MSG,
     DIGEST_HOLD_SECS,
     INJECTION_TIMEOUT,
+    SpawnApprovalUnreachable,
     SubagentInfo,
     SubagentManager,
     ToolApprovalCallback,
@@ -1818,11 +1819,53 @@ class GatewayOrchestrator:
     # Tool approval callback (shared by cron, heartbeat, subagent, task)
     # ------------------------------------------------------------------
 
+    def _dashboard_client_attached(self) -> bool:
+        """Report whether an attached dashboard client could answer a prompt NOW.
+
+        Asked at exactly one place: the dashboard-only fallback in
+        ``_interactive_approval``. Reaching it means Slack has already had its
+        turn — either no owner DM was configured, or posting the prompt to it
+        raised and the callback fell through — so the question left is only about
+        the dashboard, and a Slack term here would report a surface that
+        demonstrably did NOT receive the prompt.
+
+        Counts DASHBOARD-USER sockets, not every ``/api/ws`` registration. An app
+        token registers as a client too, and the broadcast chokepoint sends it an
+        owner-surface frame only if its manifest declared that event -- so an open
+        app UI is not somebody who can answer the prompt, for the same reason a
+        configured-but-failed Slack DM is not.
+
+        Deliberately narrow, because a false "attached" merely restores today's
+        behaviour while a false "detached" refuses a spawn a human WOULD have
+        approved:
+
+        * an unreadable client count is treated as attached;
+        * no ``dashboard_state`` at all is genuinely no surface, but the caller
+          reaches its own no-UI branch before asking, so that answer is never
+          used to refuse anything.
+
+        A relay reader is not a false positive here: it consumes the SSE stream
+        (``dashboard/remote_mirror``), never registers on ``/api/ws``, and so is
+        not in ``_ws_clients`` at all.
+        """
+        if self.dashboard_state is None:
+            return False
+        try:
+            return int(self.dashboard_state.dashboard_user_ws_count()) > 0
+        except Exception:
+            logger.debug(
+                "dashboard_user_ws_count failed; treating the dashboard as attached",
+                exc_info=True,
+            )
+            return True
+
     def _interactive_approval(
         self,
         source: str,
         slot_resolver: Callable[[str], str] | None = None,
         nudge_key: str = "",
+        *,
+        raise_when_unreachable: bool = False,
     ) -> ToolApprovalCallback:
         """Return an approval callback that races dashboard vs Slack DM.
 
@@ -1835,6 +1878,12 @@ class GatewayOrchestrator:
         through the dashboard runner, so without it an unanswered prompt on this
         path records no evidence and such a loop keeps waking, being declined and
         spending its cycle cap -- while the expiry notice still promises a stop.
+
+        ``raise_when_unreachable`` opts this callback into raising
+        ``SpawnApprovalUnreachable`` instead of parking on a prompt no surface
+        received. Only the spawn gate sets it, because only the spawn gate has a
+        terminal path that can report the refusal to the calling agent; a mid-run
+        tool approval has no such path and keeps parking exactly as before.
         """
 
         is_background = source in _BACKGROUND_APPROVAL_SOURCES
@@ -2194,6 +2243,14 @@ class GatewayOrchestrator:
 
             # Fallback: dashboard only
             if self.dashboard_state:
+                # The single park-with-nobody-attached point. Every non-human
+                # shortcut above has already been evaluated and skipped, and the
+                # Slack branch either was not taken or fell through after failing
+                # to post — so "nobody received this prompt" is now the only
+                # remaining reading, which is what makes the check sound here and
+                # nowhere else.
+                if raise_when_unreachable and not self._dashboard_client_attached():
+                    raise SpawnApprovalUnreachable("no dashboard client is connected")
                 return await self.dashboard_state.request_approval(
                     request_id,
                     source,
@@ -8317,12 +8374,20 @@ class GatewayOrchestrator:
         _approve_subagent = self._interactive_approval(
             "subagent", slot_resolver=_spawn_slot_resolver
         )
+        # A SECOND instance of the same callback, differing only in the
+        # unreachable behaviour. It is a separate closure because the one above is
+        # also wired as ``on_tool_approval``: a mid-run tool prompt has no
+        # terminal path that could report the refusal, so raising there would turn
+        # a recoverable park into a lost turn.
+        _approve_spawn_gate = self._interactive_approval(
+            "subagent", slot_resolver=_spawn_slot_resolver, raise_when_unreachable=True
+        )
 
         async def _spawn_approve(
             request_id: str, description: str, parent_session_key: str = ""
         ) -> bool:
             event = LLMEvent(kind="permission_request", request_id=request_id, title=description)
-            return await _approve_subagent(event, parent_session_key)
+            return await _approve_spawn_gate(event, parent_session_key)
 
         # Debounced slots push: keep slots[].subagents_running live for every
         # SSE consumer (composer busy affordance, Board "working" lane, and

--- a/src/kiro_crew/subagent.py
+++ b/src/kiro_crew/subagent.py
@@ -1513,6 +1513,37 @@ class ToolApprovalCallback(Protocol):
         pass
 
 
+class SpawnApprovalUnreachable(Exception):
+    """A spawn-approval prompt has no surface that could ever answer it.
+
+    Raised BY a :class:`SpawnApprovalCallback`, at the point it would otherwise
+    park, and handled by the spawn gate in ``subagent_manager/admission.py``.
+
+    Why an exception rather than a ``False`` return, and why the callback rather
+    than the gate decides:
+
+    * ``False`` already means "a human refused", and the two must not collapse:
+      a refusal is a decision, this is the absence of anyone who could decide.
+      They want different prose, and only this one is a misconfiguration.
+    * The gate cannot compute the answer. Every non-human auto-approve shortcut
+      the callback owns -- ``hooks.auto_approve_sources``, the CLI ``--approval``
+      mode, the YOLO override, slot trust -- is evaluated inside the callback and
+      never reaches the gate's cascade, so a gate-side probe would have to
+      re-derive all four and would reject spawns those rungs mean to allow (the
+      ``auto_approve_sources`` opt-in is issue #2381's own documented
+      workaround). Raising from the callback puts the check where "we are about
+      to park with nobody attached" is the only remaining possibility.
+
+    The message SHOULD name the surface that was missing ("no dashboard client is
+    connected"), because the raiser is the only party that knows what the
+    surfaces are. The gate quotes it and adds the config rungs, which are the
+    gate's own; that split is what keeps the gate's prose from going stale when
+    channel-side delivery lands.
+
+    A callback that never raises it keeps today's behaviour unchanged.
+    """
+
+
 class SpawnApprovalCallback(Protocol):
     async def __call__(
         self, request_id: str, description: str, parent_session_key: str = ""

--- a/src/kiro_crew/subagent_manager/admission.py
+++ b/src/kiro_crew/subagent_manager/admission.py
@@ -9,6 +9,7 @@ from ._component import ManagerComponent
 if TYPE_CHECKING:
     from ..subagent import (
         KiroCrewConfig,
+        SpawnApprovalUnreachable,
         Stats,
         SubagentInfo,
         _context_groups_field,
@@ -64,9 +65,14 @@ class SpawnAdmissionCoordinator(ManagerComponent):
 
         1. YOLO mode → immediate execution
         2. ``approval_mode="auto"`` from caller → immediate execution
-        3. ``auto_approve_subagent_spawn`` config → auto-approved execution
-        4. ``on_spawn_approval`` callback → interactive approval
-        5. Otherwise → rejected
+        3. parent session trust (``approval_policy == "auto"``, the dashboard
+           Trust toggle) → auto-approved execution
+        4. ``auto_approve_subagent_spawn`` config → auto-approved execution
+        5. ``on_spawn_approval`` callback → interactive approval, unless the
+           callback reports it has no surface to raise the prompt on, in which
+           case the spawn is refused immediately (see
+           ``_spawn_with_approval_impl``)
+        6. Otherwise → rejected
 
         When ``approval_mode="auto"`` is set, it has two effects:
         - Skips the spawn approval gate (this method)
@@ -707,11 +713,22 @@ class SpawnAdmissionCoordinator(ManagerComponent):
         If approval is denied the subagent is marked as done with an
         error and the running count is decremented without executing.
 
+        A callback that has nowhere to raise the prompt reports it by raising
+        ``SpawnApprovalUnreachable``, and the spawn is refused right here rather
+        than left registered until the reaper's deadline. Waiting is only correct
+        when a prompt actually reached a surface and went unanswered; when it
+        reached none, the wait can only end one way and costs the caller the full
+        deadline to learn it (issue #2381).
+
         Args:
             info (SubagentInfo): The subagent metadata.
         """
         assert self._manager._on_spawn_approval is not None
         request_id: str = f"spawn:{info.id}"
+        # Set only on the unreachable path, where it carries the refusal prose.
+        # Also the flag that picks the audit reason below, so the two cannot
+        # drift apart.
+        no_surface_error: str = ""
         try:
             from kiro_crew.security import (
                 redact_credentials,
@@ -750,13 +767,62 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 )
             finally:
                 info._awaiting_approval = False
+        except SpawnApprovalUnreachable as unreachable:
+            # Not a refusal: nobody was there to refuse. Ordered ABOVE the
+            # generic handler below, which would otherwise flatten this into the
+            # same "spawn rejected" a human decline produces — and it is the
+            # generic prose that made #2381 cost 30 minutes to read.
+            #
+            # The raiser names the missing SURFACE; the rungs are this gate's own
+            # cascade. Keeping the split means the sentence does not go stale
+            # when a channel learns to deliver the prompt itself.
+            detail = str(unreachable).strip() or "no interactive surface is attached"
+            # TWO AUDIENCES, and which text each gets is a security decision, not
+            # a formatting one. The rung list is the OPERATOR's: it names two
+            # `config.json` keys, and `security.py` records that `config.json` is
+            # writable by any auto-approved agent shell. `info.error` travels to
+            # the calling agent as a completion event — automation input — so
+            # putting the how-to there hands the party this gate CONSTRAINS the
+            # recipe for removing it, which an unattended or prompt-injected
+            # agent can simply follow. The log is where an operator looks (it is
+            # what #6484 asked for), so the how-to lives here and nowhere the
+            # agent can read it.
+            logger.warning(
+                "Subagent %s refused: the spawn approval prompt reached no "
+                "surface that could answer it (%s, parent=%s). To let spawns run "
+                "without a prompt, use any one of: spawn with "
+                'approval_mode="auto"; turn on Trust for the parent session in '
+                "the dashboard; set hooks.auto_approve_subagent_spawn to true in "
+                'config.json; or add "subagent" to hooks.auto_approve_sources.',
+                info.id,
+                detail,
+                info.parent_session_key or "<unowned>",
+            )
+            approved = False
+            # Terse, and names no file and no key — so it is actionable for the
+            # agent (tell the human, or stop delegating) without being followable
+            # into a self-granted bypass.
+            no_surface_error = (
+                "spawn rejected: no surface could show the approval prompt, so "
+                f"nobody could answer it ({detail}). The spawn was refused now "
+                "rather than held until the reaper's deadline. Ask the operator "
+                "to open the dashboard and spawn again, or to enable spawn "
+                "auto-approval."
+            )
         except Exception:
             logger.exception("Spawn approval failed for %s", info.id)
             approved = False
 
         if not approved:
             info.done = True
-            info.error = "spawn rejected"
+            # Prose only, deliberately no ``error_code``. The one reader of
+            # that field (``POST /api/spawn``) runs BEFORE this task does, so a
+            # code minted here would reach no caller — and an unread code is
+            # contract surface bought for nothing (see ``error_code``'s own
+            # note in ``subagent.py``). The audit ``reason`` below is what
+            # separates this from a decline for a machine; the prose is what
+            # separates it for the agent that receives the completion event.
+            info.error = no_surface_error or "spawn rejected"
             # Slot accounting through the one-shot token, NOT a bare decrement.
             # A user Stop funnels into `_force_reap` and can land while this
             # approval is still pending (a human prompt has no deadline), and
@@ -767,12 +833,19 @@ class SpawnAdmissionCoordinator(ManagerComponent):
                 self._manager._running_count -= 1
                 self._manager._drain_queue()
             self._manager._tasks.pop(info.id, None)
+            # ``outcome`` keeps its existing vocabulary — the refusal is still a
+            # rejection — and the reason rides in metadata, so an auditor can
+            # tell a declined spawn from an undeliverable one without a new
+            # outcome value to teach every reader.
+            _reject_meta: dict[str, str] = {"subagent_id": info.id}
+            if no_surface_error:
+                _reject_meta["reason"] = "no_approval_surface"
             sel().log_tool_invocation(
                 session_key=info.parent_session_key,
                 source="subagent",
                 tool_name="spawn_run",
                 outcome="rejected",
-                metadata={"subagent_id": info.id},
+                metadata=_reject_meta,
             )
             logger.info("Subagent %s spawn rejected", info.id)
             # Report ownership through the same claim every other terminal path

--- a/test/test_spawn_approval_no_surface_2381.py
+++ b/test/test_spawn_approval_no_surface_2381.py
@@ -1,0 +1,529 @@
+"""Regression tests for issue #2381 — a spawn approval nobody can answer must
+be refused now, not held until the reaper.
+
+The reported shape: a turn that originated on a channel (Telegram) calls
+``spawn_run`` on a headless install. None of the four auto-approve rungs in
+``subagent_manager/admission.py`` match, so the gate raises an interactive
+prompt — and the only two surfaces that can render one are a Slack owner DM and
+an attached dashboard client. With neither, the prompt is broadcast to nobody,
+the run sits registered at ``turn 0`` with ``pid: null``, and the caller learns
+nothing for ~30 minutes until the reaper kills it.
+
+What this change fixes is only the *hang*. The approval callback now reports
+"there is no surface here" by raising ``SpawnApprovalUnreachable`` at the exact
+point it would have parked, and the spawn gate turns that into an immediate,
+actionable refusal naming the rungs that would have let the spawn through.
+
+Deliberately NOT covered, because the change does not make them: delivering the
+prompt to the originating channel's own inline keyboard (the ideal fix, and much
+larger — every channel renderer plus its approval decider), the per-agent
+``auto_approve_spawn`` rung proposed on the issue, and any new tombstone field.
+Both of the latter are open maintainer decisions on #2381.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kiro_crew.subagent import SpawnApprovalUnreachable, SubagentManager
+
+pytestmark = pytest.mark.usefixtures("healthy_host_memory")
+
+
+# --------------------------------------------------------------------------
+# Manager-level doubles (same posture as test_subagent_spawn_approval_parked_6484)
+# --------------------------------------------------------------------------
+
+
+def _mock_sessions() -> MagicMock:
+    """SessionManager double with a DEFAULT install's posture: no session trust."""
+    sessions = MagicMock()
+    sessions.get_pid = MagicMock(return_value=None)
+    provider = AsyncMock()
+    provider.start = AsyncMock()
+    provider.shutdown = AsyncMock()
+    provider.context_usage_pct = lambda: 0.0
+
+    async def _empty_stream(*_args: object, **_kwargs: object):  # type: ignore[no-untyped-def]
+        return
+        yield  # noqa: unreachable — makes this an async generator
+
+    provider.stream = MagicMock(side_effect=lambda *a, **kw: _empty_stream())
+    sessions.get_or_create = AsyncMock(return_value=(provider, True, False))
+    sessions.release = MagicMock()
+    sessions.reset = AsyncMock()
+    sessions.record_success = MagicMock()
+    sessions.get_agent = MagicMock(return_value="")
+    sessions.get_approval_policy = MagicMock(return_value="ask")
+    return sessions
+
+
+def _mock_ctx_builder() -> MagicMock:
+    """ContextBuilder double with the default hooks posture (every rung off)."""
+    ctx = MagicMock()
+    ctx.build_message = MagicMock(return_value=("built_message", None))
+    ctx.hooks.on_tool_call = MagicMock()
+    ctx.hooks.auto_approve_subagent_spawn = False
+    return ctx
+
+
+def _manager(approval, on_done=None) -> SubagentManager:  # type: ignore[no-untyped-def]
+    return SubagentManager(
+        sessions=_mock_sessions(),
+        ctx_builder=_mock_ctx_builder(),
+        on_spawn_approval=approval,
+        on_done=on_done,
+        is_yolo=lambda: False,
+    )
+
+
+async def _settle(mgr: SubagentManager, info) -> None:  # type: ignore[no-untyped-def]
+    """Let the approval task run to its terminal state."""
+    for _ in range(50):
+        if info.done:
+            return
+        await asyncio.sleep(0)
+
+
+async def _unreachable(_rid: str, _desc: str, _parent: str = "") -> bool:
+    """Approval callback with nowhere to raise the prompt."""
+    raise SpawnApprovalUnreachable("spawn:test")
+
+
+async def _declined(_rid: str, _desc: str, _parent: str = "") -> bool:
+    """Approval callback a human answered with "no"."""
+    return False
+
+
+class _ParkedApproval:
+    """Approval callback that parks until released — a prompt that WAS delivered."""
+
+    def __init__(self) -> None:
+        self.gate = asyncio.Event()
+        self.calls = 0
+
+    async def __call__(self, _rid: str, _desc: str, _parent: str = "") -> bool:
+        self.calls += 1
+        await self.gate.wait()
+        return True
+
+
+class TestUnansweredablePromptIsRefusedNow:
+    """The bug: the gate waited out the reaper on a prompt nobody received."""
+
+    @pytest.mark.asyncio
+    async def test_refusal_is_immediate_and_actionable(self) -> None:
+        """The whole report, in one assertion set.
+
+        Red before this change: the raise fell into the gate's generic
+        ``except Exception`` and became the same ``"spawn rejected"`` a human
+        decline produces, so a caller could neither tell the two apart nor learn
+        what to do. (On main the prompt does not raise at all: it parks, which is
+        the hang itself.)
+        """
+        mgr = _manager(_unreachable)
+        info = mgr.spawn("Return only the result of 1+1", parent_session_key="telegram:1")
+        assert info is not None
+        await _settle(mgr, info)
+
+        assert info.done is True, "the spawn must not be left registered and waiting"
+        assert "no surface could show the approval prompt" in info.error
+        # Actionable for the agent means "who to ask", not "which key to flip" --
+        # see the security ratchet below for why.
+        assert "ask the operator" in info.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_the_refusal_quotes_the_raiser_on_which_surface_was_missing(self) -> None:
+        """The gate owns the rungs; the raiser owns the surfaces.
+
+        Keeping the split is what stops the sentence going stale when a channel
+        learns to deliver the prompt itself — the gate never names a surface it
+        does not know about.
+        """
+
+        async def _named(_r: str, _d: str, _p: str = "") -> bool:
+            raise SpawnApprovalUnreachable("no carrier pigeon is attached")
+
+        mgr = _manager(_named)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+        assert "no carrier pigeon is attached" in info.error
+
+    @pytest.mark.asyncio
+    async def test_a_bare_signal_still_reads_as_a_sentence(self) -> None:
+        """A raiser that supplies no detail must not produce "()" in the prose."""
+
+        async def _bare(_r: str, _d: str, _p: str = "") -> bool:
+            raise SpawnApprovalUnreachable()
+
+        mgr = _manager(_bare)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+        assert "()" not in info.error
+        assert "no interactive surface is attached" in info.error
+
+    @pytest.mark.asyncio
+    async def test_refusal_releases_the_slot(self) -> None:
+        """A refused spawn must not hold a concurrency slot, or the next one queues."""
+        mgr = _manager(_unreachable)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+        assert mgr.count == 0
+
+    @pytest.mark.asyncio
+    async def test_refusal_reaches_the_caller(self) -> None:
+        """The calling agent learns by completion event, so it must be announced."""
+        seen: list[object] = []
+
+        async def _on_done(info) -> None:  # type: ignore[no-untyped-def]
+            seen.append(info)
+
+        mgr = _manager(_unreachable, on_done=_on_done)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+        for _ in range(20):
+            if seen:
+                break
+            await asyncio.sleep(0)
+        assert seen and seen[0] is info
+
+    @pytest.mark.asyncio
+    async def test_refusal_is_audited_with_its_own_reason(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """An auditor must be able to separate a decline from an undeliverable prompt.
+
+        ``outcome`` keeps its existing value on purpose — this IS a rejection —
+        so the distinguishing fact has to be in the metadata.
+        """
+        import kiro_crew.subagent as subagent_mod
+
+        calls: list[dict] = []
+        recorder = MagicMock()
+        recorder.log_tool_invocation = MagicMock(side_effect=lambda **kw: calls.append(kw))
+        monkeypatch.setattr(subagent_mod, "sel", lambda: recorder)
+
+        mgr = _manager(_unreachable)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+
+        rejects = [c for c in calls if c.get("outcome") == "rejected"]
+        assert rejects, f"no rejection was audited: {calls!r}"
+        assert (rejects[-1].get("metadata") or {}).get("reason") == "no_approval_surface"
+
+    @pytest.mark.asyncio
+    async def test_it_says_so_in_the_log(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        """An operator grepping for the run id finds the cause, not just the effect.
+
+        Captured at the root logger: the coordinators are rebound onto
+        ``kiro_crew.subagent``'s namespace (``bind_component_globals``), so the
+        record is emitted under that name rather than under ``admission``.
+        """
+        mgr = _manager(_unreachable)
+        with caplog.at_level(logging.WARNING):
+            info = mgr.spawn("Return only the result of 1+1")
+            assert info is not None
+            await _settle(mgr, info)
+        keyed = [r.getMessage() for r in caplog.records if info.id in r.getMessage()]
+        assert keyed, f"no log record names run {info.id}"
+        assert any("surface" in m for m in keyed), keyed
+
+    @pytest.mark.asyncio
+    async def test_the_operator_log_names_every_rung(self, caplog) -> None:  # type: ignore[no-untyped-def]
+        """The how-to has an audience, and it is the human reading the logs.
+
+        Every rung that would have admitted this spawn must be somewhere, or the
+        refusal tells an operator on a channel nothing they can act on. It goes
+        in the log rather than in ``info.error`` for the reason the ratchet below
+        records.
+        """
+        mgr = _manager(_unreachable)
+        with caplog.at_level(logging.WARNING):
+            info = mgr.spawn("Return only the result of 1+1")
+            assert info is not None
+            await _settle(mgr, info)
+        logged = " ".join(r.getMessage() for r in caplog.records if info.id in r.getMessage())
+        for rung in (
+            'approval_mode="auto"',
+            "Trust",
+            "hooks.auto_approve_subagent_spawn",
+            "hooks.auto_approve_sources",
+        ):
+            assert rung in logged, f"operator log does not name {rung!r}: {logged!r}"
+
+    @pytest.mark.asyncio
+    async def test_the_agent_facing_refusal_carries_no_bypass_recipe(self) -> None:
+        """The refusal must not teach the agent how to remove its own gate.
+
+        Design Review r3 on PR #8914. ``info.error`` reaches the calling agent as
+        a completion event -- automation input -- and two of the four rungs are
+        ``config.json`` edits. ``security.py`` records that ``config.json`` is
+        "writable by any auto-approved agent shell", so naming those keys here
+        hands the party this gate CONSTRAINS the recipe for removing it: an
+        unattended or prompt-injected agent hits the refusal, follows the
+        instruction, and the human spawn-approval gate is gone with nobody ever
+        having seen a prompt.
+
+        The operator still gets the full how-to (test above); this pins that the
+        agent does not.
+        """
+        mgr = _manager(_unreachable)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+        for followable in (
+            "config.json",
+            "hooks.auto_approve_subagent_spawn",
+            "hooks.auto_approve_sources",
+            'approval_mode="auto"',
+        ):
+            assert (
+                followable not in info.error
+            ), f"agent-facing refusal leaks a self-grant recipe: {followable!r}"
+
+
+class TestTheOtherTwoOutcomesAreUnchanged:
+    """The refusal must not swallow a human decline, nor a prompt that landed."""
+
+    @pytest.mark.asyncio
+    async def test_a_human_decline_keeps_its_plain_refusal(self) -> None:
+        mgr = _manager(_declined)
+        info = mgr.spawn("Return only the result of 1+1")
+        assert info is not None
+        await _settle(mgr, info)
+        assert info.done is True
+        assert info.error == "spawn rejected"
+        assert info.error_code == "", "a decline is a decision, not a misconfiguration"
+
+    @pytest.mark.asyncio
+    async def test_a_delivered_prompt_still_waits_for_its_answer(self) -> None:
+        """The 1800s deadline is still correct when a surface DID receive the prompt."""
+        approval = _ParkedApproval()
+        mgr = _manager(approval)
+        try:
+            info = mgr.spawn("Return only the result of 1+1")
+            assert info is not None
+            for _ in range(20):
+                await asyncio.sleep(0)
+            assert approval.calls == 1
+            assert info.done is False
+            assert info._awaiting_approval is True
+            assert mgr.count == 1
+        finally:
+            approval.gate.set()
+            for t in list(mgr._tasks.values()):
+                t.cancel()
+            await asyncio.sleep(0)
+
+
+# --------------------------------------------------------------------------
+# The probe, and the callback that consults it
+# --------------------------------------------------------------------------
+
+
+def _probe(state: object, *, slack: object = MagicMock()) -> bool:
+    """Run ``_dashboard_client_attached`` against a hand-built gateway."""
+    from kiro_crew.slack.gateway import GatewayOrchestrator
+
+    fake = SimpleNamespace(slack=slack, _owner_id="U123", dashboard_state=state)
+    return GatewayOrchestrator._dashboard_client_attached(fake)  # type: ignore[arg-type]
+
+
+def _hub_count(sockets: list[dict]) -> int:
+    """Run the real ``dashboard_user_ws_count`` over hand-built sockets."""
+    from kiro_crew.dashboard.websocket_hub import WebSocketHub
+
+    class _Sock:
+        def __init__(self, *, closed: bool, dashboard_user: bool) -> None:
+            self.closed = closed
+            self._d = {"_is_dashboard_user": dashboard_user}
+
+        def get(self, key: str, default: object = None) -> object:
+            return self._d.get(key, default)
+
+    owner = SimpleNamespace(
+        _ws_clients=[
+            _Sock(closed=s.get("closed", False), dashboard_user=s["dashboard_user"])
+            for s in sockets
+        ]
+    )
+    hub = WebSocketHub.__new__(WebSocketHub)
+    object.__setattr__(hub, "_owner", owner)
+    return WebSocketHub.dashboard_user_ws_count(hub)
+
+
+class TestDashboardUserSocketCount:
+    """Only a dashboard USER's socket is somebody who could answer.
+
+    GPT round 2 on PR #8914. An app token registers on ``/api/ws`` as well, with
+    ``_is_dashboard_user`` False, and the broadcast chokepoint
+    (``_ws_client_allowed``) sends it an owner-surface frame only if its manifest
+    declared that event — so counting it reports a surface that received nothing,
+    which is round 1's Slack defect in a second location.
+    """
+
+    def test_an_app_token_socket_does_not_count(self) -> None:
+        assert _hub_count([{"dashboard_user": False}]) == 0
+
+    def test_a_dashboard_user_socket_counts(self) -> None:
+        assert _hub_count([{"dashboard_user": True}]) == 1
+
+    def test_an_app_socket_beside_a_dashboard_user_does_not_inflate_the_count(self) -> None:
+        assert _hub_count([{"dashboard_user": False}, {"dashboard_user": True}]) == 1
+
+    def test_a_closed_socket_does_not_count(self) -> None:
+        """The registry prunes lazily, on the next broadcast."""
+        assert _hub_count([{"dashboard_user": True, "closed": True}]) == 0
+
+
+class TestDashboardClientProbe:
+    """What counts as a client that could answer the prompt."""
+
+    def test_no_attached_client_is_no_surface(self) -> None:
+        state = MagicMock()
+        state.dashboard_user_ws_count = MagicMock(return_value=0)
+        assert _probe(state) is False
+
+    def test_an_attached_client_is_a_surface(self) -> None:
+        state = MagicMock()
+        state.dashboard_user_ws_count = MagicMock(return_value=1)
+        assert _probe(state) is True
+
+    def test_the_probe_asks_for_dashboard_users_not_every_socket(self) -> None:
+        """A raw ``ws_client_count`` would count an app token as a human."""
+        state = MagicMock()
+        state.dashboard_user_ws_count = MagicMock(return_value=0)
+        state.ws_client_count = MagicMock(return_value=7)
+        assert _probe(state) is False
+        state.ws_client_count.assert_not_called()
+
+    def test_a_configured_slack_owner_dm_does_not_make_it_reachable(self) -> None:
+        """The probe's one call site is reached only AFTER Slack has had its turn.
+
+        A Slack term here reports a surface that demonstrably did not receive the
+        prompt — either it was never configured, or posting to it raised — which
+        is the park this whole change removes. Both a configured and an absent
+        Slack must therefore read the same.
+        """
+        state = MagicMock()
+        state.dashboard_user_ws_count = MagicMock(return_value=0)
+        assert _probe(state, slack=MagicMock()) is False
+        assert _probe(state, slack=None) is False
+
+    def test_no_dashboard_state_is_no_surface(self) -> None:
+        assert _probe(None) is False
+
+    def test_an_unreadable_client_count_is_treated_as_attached(self) -> None:
+        """Fail toward today's behaviour: a broken probe must not refuse a spawn."""
+        state = MagicMock()
+        state.dashboard_user_ws_count = MagicMock(side_effect=RuntimeError("boom"))
+        assert _probe(state) is True
+
+
+def _callback(  # type: ignore[no-untyped-def]
+    monkeypatch, *, clients: int, raise_when_unreachable: bool, slack: object = None
+):
+    """Build one real ``_interactive_approval`` closure over a fake gateway."""
+    from kiro_crew.slack import gateway as gateway_mod
+
+    monkeypatch.setattr(
+        gateway_mod, "safety_override", lambda: SimpleNamespace(is_active=lambda: False)
+    )
+    state = MagicMock()
+    state._slots = {}
+    state.dashboard_user_ws_count = MagicMock(return_value=clients)
+    state.request_approval = AsyncMock(return_value=True)
+    fake = SimpleNamespace(
+        slack=slack,
+        _owner_id="U123" if slack is not None else "",
+        dashboard_state=state,
+        _cfg=SimpleNamespace(hooks={}),
+        _approval_mode="interactive",
+        autonudge_svc=None,
+        sessions=None,
+    )
+    # The closure calls ``self._dashboard_client_attached()``; bind the REAL one so
+    # the probe under test is production code, not a stand-in.
+    fake._dashboard_client_attached = (  # type: ignore[attr-defined]
+        lambda: gateway_mod.GatewayOrchestrator._dashboard_client_attached(fake)  # type: ignore[arg-type]
+    )
+    cb = gateway_mod.GatewayOrchestrator._interactive_approval(
+        fake,  # type: ignore[arg-type]
+        "subagent",
+        raise_when_unreachable=raise_when_unreachable,
+    )
+    return cb, state
+
+
+def _event():  # type: ignore[no-untyped-def]
+    from kiro_crew.providers.base import LLMEvent
+
+    return LLMEvent(kind="permission_request", request_id="spawn:abc123", title="spawn_run(x)")
+
+
+class TestOnlyTheSpawnGateRaises:
+    """The signal is opt-in, and it fires exactly where the park would have been."""
+
+    @pytest.mark.asyncio
+    async def test_spawn_gate_raises_instead_of_parking(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        cb, state = _callback(monkeypatch, clients=0, raise_when_unreachable=True)
+        with pytest.raises(SpawnApprovalUnreachable):
+            await cb(_event())
+        state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_spawn_gate_still_prompts_an_attached_dashboard(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        cb, state = _callback(monkeypatch, clients=1, raise_when_unreachable=True)
+        assert await cb(_event()) is True
+        state.request_approval.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_slack_post_still_fails_fast(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """A configured owner DM that cannot be posted to is not a surface.
+
+        GPT round 1 on PR #8914. The Slack branch is wrapped in its own
+        ``except`` and falls through to the dashboard-only fallback, so a Slack
+        outage on a channel install used to land right back in the park this
+        change exists to remove.
+        """
+        slack = MagicMock()
+        slack.open_dm = AsyncMock(return_value="D123")
+        slack.post_blocks = AsyncMock(side_effect=RuntimeError("slack is down"))
+        cb, state = _callback(monkeypatch, clients=0, raise_when_unreachable=True, slack=slack)
+        with pytest.raises(SpawnApprovalUnreachable):
+            await cb(_event())
+        state.request_approval.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_tool_approval_never_raises(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """A mid-run tool prompt has no terminal path, so it must keep parking.
+
+        Same zero-client posture that makes the spawn gate raise above.
+        """
+        cb, state = _callback(monkeypatch, clients=0, raise_when_unreachable=False)
+        assert await cb(_event()) is True
+        state.request_approval.assert_awaited_once()
+
+    def test_tool_approvals_stay_wired_to_the_non_raising_instance(self) -> None:
+        """Source ratchet: the two callbacks must not collapse back into one.
+
+        Wiring ``on_tool_approval`` to the raising instance would silently convert
+        every unanswered mid-run tool prompt into a hard failure — a behavioural
+        test on the manager cannot see which closure the gateway passed.
+        """
+        from pathlib import Path
+
+        import kiro_crew.slack.gateway as gateway_mod
+
+        src = Path(gateway_mod.__file__).read_text(encoding="utf-8")
+        assert "on_tool_approval=_approve_subagent," in src
+        assert "return await _approve_spawn_gate(event, parent_session_key)" in src
+        assert src.count("raise_when_unreachable=True") == 1


### PR DESCRIPTION
## Problem / Motivation

A `spawn_run` issued during a turn that originated on a **channel** (Telegram in the report) on a headless install hangs for ~30 minutes and is then killed.

None of the four auto-approve rungs in `subagent_manager/admission.py` match, so the gate raises an interactive approval prompt. Only two surfaces can render one: a Slack owner DM (Block Kit buttons) and an **attached** dashboard client (the approvals feed). With neither, `DashboardState.request_approval` broadcasts the prompt to nobody and waits out its timeout. The run sits registered at `turn 0` with `pid: null`, and the caller learns nothing until the reaper force-kills it.

The reporter also hit it from the **dashboard**, when the session lost its slot registration — so this is not "Telegram has no trust affordance". It is "any spawn whose prompt reaches no surface waits out the deadline".

## Why it matters

Sub-agent orchestration is unusable from a channel: every spawn hangs unless a human happens to be watching the dashboard. The 30-minute silent stall with no channel-side feedback is the expensive part — the reporter mis-diagnosed it twice from the surfaced message.

## What changed (motivation → approach → change)

**Symptom** → a spawn approval that nobody received is still waited on.
**Root cause** → nothing distinguishes "the prompt is unanswered" from "the prompt reached no one". Waiting is only correct in the first case; in the second the wait can only end one way, and the caller pays the full deadline to find that out.

**Why the check is in the callback, not in the gate's cascade.** Four non-human auto-approve shortcuts live inside `_interactive_approval` and never reach the gate: `hooks.auto_approve_sources`, the CLI `--approval` mode, the YOLO override, and slot trust. A gate-side probe would have to re-derive all four, and would refuse spawns those rungs mean to allow — one of them, adding `"subagent"` to `hooks.auto_approve_sources`, is this issue's own documented workaround.

**Why the check is at the dashboard-only fallback and nowhere else.** That branch is reached only after every shortcut was skipped *and* after the Slack branch either was not taken or fell through after failing to post. "Nobody received this prompt" is the only remaining reading there.

**What counts as a surface, and the two near-misses that do not.** Both are the same mistake — *a configured connection is not a reached one* — and both were caught in review:

- A **Slack owner DM** does not count at this branch, because reaching it means the DM was absent or posting to it raised. (GPT r1.)
- An **app-token socket** does not count either. It registers on `/api/ws` like any client, but `_ws_client_allowed` short-circuits only for a dashboard user; an app socket goes through the deny-by-default event-scope gate, so it receives the `approval` frame only if its manifest declared that event. An open app UI is not somebody who can answer. (GPT r2.)

So the probe asks one narrow question: is a **dashboard-user** socket open? `WebSocketHub.dashboard_user_ws_count()` lives beside `_ws_client_allowed`, whose first line it mirrors, rather than being re-derived in the gateway.

**The change**, five files:

1. `subagent.py` — a `SpawnApprovalUnreachable` signal a `SpawnApprovalCallback` may raise. Its message names the missing *surface*, because the raiser is the only party that knows what the surfaces are.
2. `dashboard/websocket_hub.py` + `dashboard/state.py` — `dashboard_user_ws_count()`, which skips app tokens and closed-but-unpruned sockets.
3. `slack/gateway.py` — `_dashboard_client_attached()`, and a **separate** callback instance for the spawn gate with `raise_when_unreachable=True` that raises at that one park point.
4. `subagent_manager/admission.py` — the gate catches the signal **above** its generic `except Exception` (which previously flattened it into the same `"spawn rejected"` a human decline produces) and refuses immediately. The audit row keeps `outcome="rejected"` and carries `reason: no_approval_surface`, so an auditor can separate the two without a new outcome value.

**The refusal has two audiences, and which text each gets is a security decision.** (Design r3.) The four-rung how-to is the **operator's** and goes only in the `logger.warning`: it names two `config.json` keys, and `security.py:8369` records that storing a control there "would leave it writable by any auto-approved agent shell". `info.error` travels to the calling agent as a completion event — automation input — so putting the how-to there hands the party this gate *constrains* the recipe for removing it, which an unattended or prompt-injected agent can simply follow. The agent's text is terse and names no file and no key: *ask the operator to open the dashboard, or to enable spawn auto-approval.* Actionable for an agent means "who to ask", not "which key to flip".

**Prose only, deliberately no `error_code`.** The single reader of that field (`POST /api/spawn`, `messaging.py:287`) runs *before* this task does — `api_spawn` checks `info.done and info.error` with no `await` after the synchronous `spawn()` — so a code minted here would reach no caller, and an unread code is contract surface bought for nothing (`error_code`'s own note says so). Round 1 shipped one; the First Principles lane caught it and it is now subtracted, which is also why no spec change is due.

A relay reader is not a false positive: it consumes the SSE stream (`dashboard/remote_mirror`) and never registers on `/api/ws` at all.

**Unchanged on purpose:**
- A prompt that *was* delivered still waits out its deadline.
- A human decline still reports the plain `"spawn rejected"`.
- Mid-run **tool** approvals keep parking — they have no terminal path that could report a refusal, so raising there would turn a recoverable park into a lost turn. That is why the spawn gate gets a separate closure instead of a flag on the shared one, with a source ratchet against the two collapsing back together.

The refusal reaches the calling agent as a completion event (the same channel a declined spawn uses), within milliseconds instead of ~30 minutes.

## Tests

`test/test_spawn_approval_no_surface_2381.py`, 26 tests in six groups:

- **The fix** — the refusal is immediate and actionable; it quotes the raiser's surface clause; a bare signal still reads as a sentence rather than `()`; it releases the concurrency slot; it reaches the caller through `on_done`; it audits `reason: no_approval_surface`; and it writes a log line keyed to the run id.
- **The two audiences** — the operator log names all four rungs, and a ratchet asserts none of `config.json`, `hooks.auto_approve_subagent_spawn`, `hooks.auto_approve_sources` or `approval_mode="auto"` appears in `info.error`. A ratchet rather than a behavioural check, because a leak reads exactly like a helpful message.
- **The other two outcomes are unchanged** — a human decline keeps `"spawn rejected"` with an empty `error_code`; a delivered prompt still parks with `_awaiting_approval` set and its slot held.
- **The socket count** — the real `dashboard_user_ws_count` over hand-built sockets: app-only → 0, dashboard user → 1, both → 1, closed → 0.
- **The probe** — no client → no surface; one client → surface; a *configured* Slack owner DM does not make it reachable (configured and absent must read identically here); no `dashboard_state` → no surface; a broken count reads as attached; and the probe never consults `ws_client_count` even when it would answer 7.
- **Only the spawn gate raises** — the real `_interactive_approval` closure raises with 0 clients and never awaits `request_approval`; **a failed Slack post still fails fast**; it still prompts with 1 client; the non-raising instance parks under the identical posture; plus a source ratchet that `on_tool_approval` stays wired to the non-raising closure.

**Red-before, proven rather than argued, once per round:**
- **r1** — against pristine `origin/main` `3094693`, a throwaway probe (deleted, not committed) showed that with no Slack and zero clients `_interactive_approval` **parks** on `request_approval` — the hang itself — and that any callback exception becomes `error == "spawn rejected"`, so main cannot express "nobody could answer". The new test file cannot even import on main.
- **r2** (Slack term) — re-adding it turns **4 of 19** tests red, including `DID NOT RAISE SpawnApprovalUnreachable`.
- **r3** (raw socket count) — reverting the probe to `ws_client_count()` turns **5 of 24** tests red, same marker test among them.
- **r4** (bypass recipe) — putting the rung list back into `info.error` turns the security ratchet red (**1 of 26**).

## Manual verification

N/A — the failure is entirely inside the approval callback and the spawn gate, and both are driven directly by the tests, including the real `_interactive_approval` closure and the real socket counter rather than stand-ins.

Local gates green: `black`, `isort`, `flake8`, `mypy` on all five changed modules; `pytest -k "subagent or spawn or slack or telegram or approval or gateway or websocket"` → **8747 passed, 0 failed**. (Two setup errors in `test_autonudge_reconciler.py` are a shared-venv `pytest-asyncio` `event_loop` fixture removal, identical on the base. A wider round-3 pass of 12151 tests also showed one `test_sandbox_argv.py` parallelism flake — 17/17 green in isolation, and this diff touches no sandbox code.)

## Two decisions still open for maintainers

Neither is taken here, per @bolichen97's triage:

1. **Is an operator-scoped per-agent `auto_approve_spawn` rung an acceptable shape?** (@cschnidr's proposal.) It would be a new per-agent security primitive — `KiroCrewAgentConfig` carries no approval or trust field today — which #4751's operator comment says should be specified once together with #4693. **No new rung is added by this PR**; the fix names the four that already exist.
2. **Should the tombstone carry the prompt target (`channel`, `surfaced`)?** **No tombstone field is added.** The reap epitaph from #7325 is untouched, and a fail-fast spawn never reaches the reaper at all.

## Residual work (why `Refs`, not `Closes`)

The issue's *first* suggested fix — delivering the spawn approval to the originating channel with approve/reject actions — is **not** in this PR. It is genuinely larger: Telegram already has an interactive approval keyboard (`telegram/renderer.py::on_prompt_choice` with `TelegramApprovalDecider` nonce arming), but it is driven by the provider's in-turn permission prompts, while a spawn approval goes through `on_spawn_approval` → `_interactive_approval` → dashboard/Slack only. Routing spawn approvals into each channel's renderer + decider is a separate reviewable change per channel.

The exception's surface-clause split is designed for exactly that follow-up: a Telegram raiser supplies its own clause and the gate's rung list stays put.

So this PR fixes the unambiguous defect only — the ~30-minute hang with nobody who could answer — and leaves channel-side delivery, plus both design questions above, open on #2381.

## Related Issues

Refs #2381

## Pattern harvest

Rule candidate: review-prompt
Pattern: **addressed is not delivered.** The defect and all three review rounds are one shape at four depths — waiting out a human deadline without checking the prompt reached a surface (the bug); counting a Slack DM that was never posted to (GPT r1); counting an app-token socket the frame is not delivered to (GPT r2); and, one level up, delivering the right information to the wrong *party* — a bypass how-to addressed to the agent the gate constrains (Design r3). A prompt-level rule would ask, of any message a fix emits: *who actually receives this, and is that who it is for?*

Sibling instance already on the issue: #2854 (a mid-turn *tool* permission never delivered, same 30-minute cap, different gate).

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — no spec change is due: no new `error_code` ships. The cascade docstring in `admission.py` was corrected, since it listed four rungs and omitted the pre-existing parent-trust one that the new refusal names
- [x] No secrets, credentials, or internal references in the diff
