### PR TITLE
fix(dashboard): carry machine-readable codes on chat title refusals

### DIFF
--- a/error-code-baseline.json
+++ b/error-code-baseline.json
@@ -1,11 +1,11 @@
 {
   "_comment": "Error responses without a machine-readable `code`, per file. Generated - regenerate with `python test/test_error_code_contract.py --update`. This is both the CI ratchet and the Track B worklist: drive `missing_code` to zero, one PR per file or per directory, moving each frontend consumer in the same PR. Never raise a number to make CI pass. See test/test_error_code_contract.py for what each bucket means and which false negatives it accepts.",
   "_totals": {
-    "missing_code": 1150,
+    "missing_code": 1145,
     "opaque_body": 18,
     "dynamic_status": 43
   },
-  "_compliant": 1628,
+  "_compliant": 1697,
   "files": {
     "apps/builtins/auto_research/handlers.py": {
       "dynamic_status": 1,
@@ -50,9 +50,6 @@
     },
     "dashboard/chat_slack.py": {
       "missing_code": 9
-    },
-    "dashboard/chat_title.py": {
-      "missing_code": 5
     },
     "dashboard/chat_voice.py": {
       "missing_code": 9

--- a/src/kiro_crew/dashboard/chat_title.py
+++ b/src/kiro_crew/dashboard/chat_title.py
@@ -1207,7 +1207,7 @@ async def api_chat_slot_generate_title(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
 
     logger.info("Manual title generation requested for slot %s", name)
     fallback_is_placeholder = False
@@ -1249,16 +1249,16 @@ async def api_chat_slot_rename(request: web.Request) -> web.Response:
     name = request.match_info["slot"]
     slot = state._slots.get(name)
     if not slot:
-        return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"error": "not found", "code": "slot_not_found"}, status=404)
     try:
         body = await request.json()
     except Exception:
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "invalid_json"}, status=400)
     if not isinstance(body, dict):
-        return web.json_response({"error": "invalid JSON"}, status=400)
+        return web.json_response({"error": "invalid JSON", "code": "body_not_object"}, status=400)
     title = body.get("title", "").strip()[:200]
     if not title:
-        return web.json_response({"error": "title required"}, status=400)
+        return web.json_response({"error": "title required", "code": "title_required"}, status=400)
     slot.title = title
     slot._titled = True
     # A manual rename is final: origin "user" locks the background refresh out

--- a/test/test_chat_title.py
+++ b/test/test_chat_title.py
@@ -6,8 +6,11 @@ import logging
 import threading
 import unicodedata
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
 
 from kiro_crew.dashboard import chat_title
 from kiro_crew.dashboard.chat_title import (
@@ -25,6 +28,7 @@ from kiro_crew.dashboard.chat_title import (
     _message_attachment_paths,
     _title_text,
 )
+from kiro_crew.dashboard.state import DashboardState, _ChatSlot
 
 
 def test_prompt_isolates_and_delimits_transcript():
@@ -808,3 +812,81 @@ def test_refresh_note_precedes_the_keep_contract():
     assert prompt is not None
     head = _head_of(prompt)
     assert head.index(_TITLE_TRUNCATION_NOTE.strip()) < head.index("exactly KEEP")
+
+
+class TestSlotTitleRouteRefusalCodes:
+    """The generate-title and rename routes carry machine-readable `code`
+    fields beside their unchanged error prose, on the same contract the
+    error-code worklist drives across the dashboard."""
+
+    def _make_app(self, state: MagicMock) -> web.Application:
+        app = web.Application()
+        app["state"] = state
+        app.router.add_post(
+            "/api/chat/slots/{slot}/generate-title",
+            chat_title.api_chat_slot_generate_title,
+        )
+        app.router.add_patch("/api/chat/slots/{slot}/title", chat_title.api_chat_slot_rename)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_generate_title_unknown_slot_returns_404_with_code(self):
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        async with TestClient(TestServer(self._make_app(state))) as client:
+            resp = await client.post("/api/chat/slots/missing/generate-title")
+            assert resp.status == 404
+            body = await resp.json()
+            assert body["error"] == "not found"
+            assert body["code"] == "slot_not_found"
+
+    @pytest.mark.asyncio
+    async def test_rename_unknown_slot_returns_404_with_code(self):
+        state = MagicMock(spec=DashboardState)
+        state._slots = {}
+        async with TestClient(TestServer(self._make_app(state))) as client:
+            resp = await client.patch("/api/chat/slots/missing/title", json={"title": "New name"})
+            assert resp.status == 404
+            body = await resp.json()
+            assert body["error"] == "not found"
+            assert body["code"] == "slot_not_found"
+
+    @pytest.mark.asyncio
+    async def test_rename_unparseable_body_returns_400_with_code(self):
+        slot = _ChatSlot("s")
+        state = MagicMock(spec=DashboardState)
+        state._slots = {"s": slot}
+        async with TestClient(TestServer(self._make_app(state))) as client:
+            resp = await client.patch(
+                "/api/chat/slots/s/title",
+                data="{not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+            body = await resp.json()
+            assert body["error"] == "invalid JSON"
+            assert body["code"] == "invalid_json"
+
+    @pytest.mark.asyncio
+    async def test_rename_non_object_body_returns_400_with_code(self):
+        slot = _ChatSlot("s")
+        state = MagicMock(spec=DashboardState)
+        state._slots = {"s": slot}
+        async with TestClient(TestServer(self._make_app(state))) as client:
+            resp = await client.patch("/api/chat/slots/s/title", json=["title"])
+            assert resp.status == 400
+            body = await resp.json()
+            assert body["error"] == "invalid JSON"
+            assert body["code"] == "body_not_object"
+
+    @pytest.mark.asyncio
+    async def test_rename_blank_title_returns_400_with_code(self):
+        slot = _ChatSlot("s")
+        state = MagicMock(spec=DashboardState)
+        state._slots = {"s": slot}
+        async with TestClient(TestServer(self._make_app(state))) as client:
+            resp = await client.patch("/api/chat/slots/s/title", json={"title": "   "})
+            assert resp.status == 400
+            body = await resp.json()
+            assert body["error"] == "title required"
+            assert body["code"] == "title_required"


### PR DESCRIPTION
## Problem / Motivation

The two chat-title routes refuse requests with bare prose bodies. Five responses across those two routes carry no machine-readable `code` field, the one the dashboard's other refusal responses already carry:

- `POST /api/chat/slots/{slot}/generate-title`: unknown slot → 404 `{"error": "not found"}`
- `PATCH /api/chat/slots/{slot}/title`: unknown slot → 404 `{"error": "not found"}`; a body that fails to parse → 400 `{"error": "invalid JSON"}`; a body that parses but is not an object → 400 with the same prose; a blank title after stripping → 400 `{"error": "title required"}`

The contract is non-2xx JSON carrying a `code` beside the prose, enforced by `test_error_code_contract.py` and tracked per file in `error-code-baseline.json`. These routes sat there as the `dashboard/chat_title.py` row (five violations) while the sibling slot routes already comply: the same unknown-slot 404 on `POST /api/chat/slots/{slot}/continue` has carried `slot_not_found` for a while (the spelling appears 36 times across the dashboard), so these two routes were the odd ones out in their own family.

## Why it matters

Nothing user-visible breaks today, and I'd rather be upfront about that: the frontend helper that wraps these calls throws on any non-2xx response and every caller catches, so nobody renders the prose. The cost is quieter. Anything that wants to branch on why a title request was refused, a script, a test, or a future surface that shows typed errors, has to match on English strings, which is exactly what the `code` field exists to avoid. The mismatch sits right next to sibling routes that already speak the contract, so anyone writing against the dashboard API learns two conventions for one endpoint family. There is also the ratchet itself: the baseline is an upward-only ceiling on contract violations, and a row left open keeps its count measuring five violations that no longer exist after this PR.

## What changed (motivation → approach → change)

Symptom: codeless refusals on the two title routes. Root cause: these routes missed the convention that adopted the rest of the dashboard, and the ratchet tracked them rather than letting them through. The change: five sites gain a `code` beside unchanged prose and status codes, with spellings taken from the dashboard's established inventory rather than invented:

- `slot_not_found` for both 404s, the spelling the `/continue` route's own test already pins
- `invalid_json` for a body that fails to parse
- `body_not_object` for a body that parses but is not an object
- `title_required` for a blank title, in the `<field>_required` family (`name_required`, `content_required`)

Leaving the prose and status untouched is part of the change, not laziness. Any consumer matching today on `{"error": "invalid JSON"}` keeps matching byte-identically, so this PR cannot break anyone.

The change is three files:

- `src/kiro_crew/dashboard/chat_title.py` — the five `json_response` sites gain their code fields
- `test/test_chat_title.py` — a new `TestSlotTitleRouteRefusalCodes`, five route-level tests. The file previously covered only the prompt builder and title generation, so these two handlers had no route tests at all; the new ones travel through the real HTTP stack (an aiohttp `TestClient` against the actual handlers) and assert status, prose, and code
- `error-code-baseline.json` — the `chat_title` row removed through the contract test's own `--update`, moving the ratchet's `missing_code` total from 1150 to 1145 and the compliant count from 1628 to 1697. The baseline edit is the gate doing its job: the file tracks stragglers per file, and closing a file means pruning its row in the same commit

No frontend change, deliberately. The client's response helper throws on non-2xx and the callers (the title rename in `ChatPage.tsx` and `ChatSidebar.tsx`, the regenerate-title button in `ChatPage.tsx`) all fail soft, so there was nothing to update and no catalog strings touched.

## Tests

- TDD, red first. The five new tests assert the full contract at each site and were watched failing with `KeyError: 'code'` before the handler changed, then passing after. That proves the tests catch a regression at these sites rather than just going green at the end.
- `test/test_chat_title.py` — 86/86, including the five new ones.
- `test/test_error_code_contract.py` — 6/6 after the baseline update, so the ratchet stays green on the tighter count.
- The guard suites around the same refusal-code contract: `test_chat_regenerate_refusal_codes.py`, `test_chat_fork_error_codes.py`, `test_title_refresh.py`, `test_pending_title.py` — 111 passed, untouched.
- `flake8`, `isort`, and a scoped `mypy` run are clean. Both touched files sit on the black formatting baseline, so I kept the added hunks black-clean by hand rather than reformatting the surrounding files.

## Manual verification

N/A in the UI sense, and I'd rather say that plainly than stage a screenshot: the only observable surface is the response body, the tests above exercise it through the real HTTP stack, and there is no pixel change because every consumer fails soft. For a reviewer who wants to see it live, start the dashboard and:

```bash
curl -s -X PATCH http://127.0.0.1:<port>/api/chat/slots/<slot>/title \
  -H 'Content-Type: application/json' -d '{"title": "   "}'
```

which now returns `{"error": "title required", "code": "title_required"}` with a 400 status, and likewise for the other four refusals. Before this PR the same response carried no `code` field.

## Related Issues

No dedicated issue for these five sites. The worklist they came from is `error-code-baseline.json`'s own header comment, and the contract they now satisfy is `test_error_code_contract.py`.

## Pattern harvest

Rule candidate: review-prompt
Pattern: a dashboard refusal returning bare `{"error": ...}` prose without a machine-readable code is a contract violation; close one file per PR, keep the prose and status unchanged so consumers stay byte-compatible, and prune the baseline row in the same commit

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`fix: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable) — N/A: no spec documents these two routes' refusal bodies; the contract they follow is documented in `test_error_code_contract.py` itself
- [x] No secrets, credentials, or internal references in the diff