### PR TITLE
test(fixtures): restore crons-active fixture with assertions

### DIFF
--- a/src/kiro_crew/tests_fixtures/crons-active/config.json
+++ b/src/kiro_crew/tests_fixtures/crons-active/config.json
@@ -1,0 +1,22 @@
+{
+  "meta": {
+    "version": 1,
+    "created_by": "kirocrew-fixture"
+  },
+  "agent": {
+    "approval_mode": "interactive",
+    "bot_name": "kirocrew"
+  },
+  "workspaces": {
+    "default": {
+      "dir": "workspace"
+    }
+  },
+  "default_workspace": "default",
+  "dashboard": {
+    "host": "127.0.0.1",
+    "theme_mode": "dark",
+    "onboarded": true
+  },
+  "timezone": "UTC"
+}

--- a/src/kiro_crew/tests_fixtures/crons-active/crons.json
+++ b/src/kiro_crew/tests_fixtures/crons-active/crons.json
@@ -1,0 +1,65 @@
+{
+  "version": 2,
+  "jobs": [
+    {
+      "id": "fixture-cron-morning",
+      "name": "morning standup nudge",
+      "message": "summarize overnight CI",
+      "schedule": {
+        "kind": "cron",
+        "every_secs": null,
+        "at_ts": null,
+        "cron_expr": "0 9 * * 1-5"
+      },
+      "channel": null,
+      "thread_ts": null,
+      "enabled": true,
+      "user_paused": false,
+      "auto_paused": false,
+      "last_run_ts": null,
+      "last_status": null,
+      "last_error": null,
+      "created_ts": 1737000000.0
+    },
+    {
+      "id": "fixture-cron-hourly",
+      "name": "hourly inbox sweep",
+      "message": "check for new review comments",
+      "schedule": {
+        "kind": "cron",
+        "every_secs": null,
+        "at_ts": null,
+        "cron_expr": "0 * * * *"
+      },
+      "channel": null,
+      "thread_ts": null,
+      "enabled": true,
+      "user_paused": false,
+      "auto_paused": false,
+      "last_run_ts": null,
+      "last_status": null,
+      "last_error": null,
+      "created_ts": 1737000000.0
+    },
+    {
+      "id": "fixture-cron-paused",
+      "name": "weekly recap (paused)",
+      "message": "weekly recap",
+      "schedule": {
+        "kind": "cron",
+        "every_secs": null,
+        "at_ts": null,
+        "cron_expr": "0 17 * * 5"
+      },
+      "channel": null,
+      "thread_ts": null,
+      "enabled": false,
+      "user_paused": true,
+      "auto_paused": false,
+      "last_run_ts": null,
+      "last_status": null,
+      "last_error": null,
+      "created_ts": 1737000000.0
+    }
+  ]
+}

--- a/src/kiro_crew/tests_fixtures/crons-active/fixture.yaml
+++ b/src/kiro_crew/tests_fixtures/crons-active/fixture.yaml
@@ -1,0 +1,10 @@
+schema-version: 2026-04-28
+fixture-name: crons-active
+description: |
+  Three cron jobs test deterministic multi-row active filtering and ordering beyond minimal.
+  Two active jobs use weekday 09:00 and hourly expressions, while one paused
+  job uses a weekly expression, covering three distinct expression shapes.
+  Unlike minimal's single active row, this fixture makes ordering and filtering
+  multiple active rows observable. No script cron ships here: a script path is
+  resolved with expanduser, so any literal would point at the operator's real
+  home rather than the pod's isolated one.

--- a/test/test_fixture_crons_active.py
+++ b/test/test_fixture_crons_active.py
@@ -1,0 +1,35 @@
+"""Consumer assertions for the ``crons-active`` seeded-home fixture."""
+
+from kiro_crew.cron import CronService
+from kiro_crew.testing.fixtures import seeded_home
+
+
+def test_crons_active_loads_and_filters_multiple_active_jobs() -> None:
+    """The production cron loader preserves order and excludes the paused row."""
+    with seeded_home("crons-active") as home:
+        service = CronService(base_dir=home)
+
+        all_jobs = service.list_jobs(include_disabled=True)
+        enabled_jobs = service.list_jobs()
+
+        assert [job.id for job in all_jobs] == [
+            "fixture-cron-morning",
+            "fixture-cron-hourly",
+            "fixture-cron-paused",
+        ]
+        assert [job.id for job in enabled_jobs] == [
+            "fixture-cron-morning",
+            "fixture-cron-hourly",
+        ]
+        assert len(all_jobs) == 3
+        assert len(enabled_jobs) == 2
+        assert all(job.enabled for job in enabled_jobs)
+        assert all_jobs[2].enabled is False
+        assert all_jobs[2].user_paused is True
+        assert [job.schedule.cron_expr for job in all_jobs] == [
+            "0 9 * * 1-5",
+            "0 * * * *",
+            "0 17 * * 5",
+        ]
+        assert all(job.schedule.kind == "cron" for job in all_jobs)
+        assert all(job.script == "" for job in all_jobs)


### PR DESCRIPTION
# crons-active seed fixture

## Summary

Restores the `crons-active` seed fixture: an isolated `KIROCREW_HOME` with two enabled cron-expression jobs and one user-paused weekly job. Completes the specialized fixture set — this is the tenth and final restoration, held back until the first nine merged to keep concurrent fixture PRs at nine.

## Consumer test

`test/test_fixture_crons_active.py` drives `CronService`'s production loader — it never re-reads the fixture files. It proves exact three-row loading, deterministic two-row enabled ordering, paused-row filtering, expression preservation, and the absence of script jobs. No scheduler is started.

## Why this is not redundant with `minimal`

`minimal` seeds one active plus one paused cron, which cannot exercise multi-row active filtering or ordering. This fixture's case rests on two *active* rows and three expression shapes.

## Schema repairs

Cron records carry the current `user_paused` / `auto_paused` pause fields the preserved pre-split copy predated.

## Verification

161 tests passed with **all thirteen fixtures present on main** (fixture test + `test_pod_scenarios_command.py` + `test_pod_seed_scenarios.py` + `test_seed.py`) — the first acceptance run of the complete end-state on real main rather than a staged worktree. isort, flake8, black (`--target-version py310`) clean on the touched test file.

<!-- no-visual-delta -->
**Why no screenshots:** backend-only change — fixture data files plus one backend test; no frontend surface is touched.

## Pattern harvest

Not generalizable: fixture restoration validated against current production readers; no new rule.
