### PR TITLE
feat(crews): accept per-state expressions and sounds in the crew avatar record

### DIFF
--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -949,8 +949,11 @@ and it is deliberately NOT re-exported from `loader.py` — the loader's
   booleans must be real JSON booleans (`bool("false")` is `True`, so a
   string-typed value is read as `False`); `tile` is the one pinned value — it is
   interpolated into SVG markup, so it goes through the same `#rrggbb` validator
-  as `session_color`. An all-empty trait set collapses to `{}` (the one canonical
-  "reset" spelling) rather than storing a featureless third state.
+  as `session_color`. An all-empty trait set drops the `traits` key rather than
+  storing a featureless third state, and a ghost override left with nothing but
+  `kind` collapses to `{}` (the one canonical "reset" spelling). `traits` is
+  therefore optional: `{"kind": "ghost", "sounds": {...}}` is valid and means
+  "name-derived face, plus these per-state overrides".
 - `{"kind": "image", "v": <int>, "file": "<16-hex>.<png|jpg|webp>"}` — the crew
   wears an uploaded picture served from `GET /api/agents/{name}/avatar`; the
   file itself lives under `<data home>/run/avatars/` and the record only marks
@@ -959,8 +962,35 @@ and it is deliberately NOT re-exported from `loader.py` — the loader's
   content-addressed variant and must match `^[0-9a-f]{16}\.(png|jpg|webp)$`.
   Wire-only keys (`promote`, `token`) never reach the record.
 
-Anything else — a non-dict, an unknown `kind`, a ghost override without a
-`traits` dict — collapses to `{}` on load (config.json is hand-editable and
+**Per-state overrides (`expressions`, `sounds`).** Both kinds may carry two
+optional keys, keyed on the agent lifecycle state (`working`, `done`, `error`
+exactly; any other key is dropped, so a version-skewed caller cannot grow the
+key set):
+
+- `expressions: {"<state>": {"eyes"?: str, "mouth"?: str}}` — only those two
+  axes, under the same 32-char truncation as a trait, with an empty string
+  dropped (it already means "absent"). The identity axes
+  (`brows`/`accessory`/`prop`/`tile`/`blush`/`flip`) are deliberately not
+  accepted per state: a crew must stay recognisable as itself while its
+  expression changes. Legal on `kind: "image"` too — stored, and ignored by the
+  picture renderer.
+- `sounds: {"<state>": "none"|"chime"|"ding"|"blip"|"pop"|"pulse"}` — a shipped
+  cue preset. Unlike a trait value this IS pinned to a vocabulary, because the
+  name selects a shipped asset rather than an option the renderer can resolve to
+  absent. `"none"` is kept as explicit silence, distinct from an absent state
+  (also silent), so one state can opt out of a cue the others use. No per-crew
+  audio upload exists.
+
+Either key is omitted from the record when validation leaves it empty, so a
+stored avatar never carries `{}` for one. Junk (`expressions: "x"`,
+`sounds: {"working": 5}`, a list) is stripped silently and never refused: the
+same forgiveness traits get, so a malformed per-state value costs that value and
+never the crew's whole avatar. The roster masks the `eyes`/`mouth` values like
+any other user-authored string (`_roster_avatar`) and leaves the preset-pinned
+`sounds` intact, for the same reason it leaves `file` intact.
+
+Anything else — a non-dict, an unknown `kind`, a ghost override carrying no
+trait, expression or sound that survives validation — collapses to `{}` on load (config.json is hand-editable and
 agent-writable, so junk must never crash the load), while the endpoints answer a
 non-empty raw value the coercer collapses with 400 `invalid_avatar` — except a
 well-formed ghost override whose traits all coerce to absent, which is the

--- a/docs/system-specs/modules/learn-cron-dashboard.md
+++ b/docs/system-specs/modules/learn-cron-dashboard.md
@@ -1583,7 +1583,10 @@ Triggers pane) and both follow the editor's two-step Apply → Save: Apply commi
 to the editor draft only, Save changes writes the record. The **ghost tier** is
 pure config — POST `/api/agents` and PUT `/api/agents/{name}` accept
 `avatar: {"kind":"ghost","traits":{…}}` (or `{}` to reset) and reject any other
-non-empty shape with 400 `invalid_avatar`, mirroring `session_color`. The
+non-empty shape with 400 `invalid_avatar`, mirroring `session_color`. Either kind
+may also carry the optional per-state `expressions` and `sounds` keys (see
+`config.md`), which are validated and then round-tripped, and whose junk is
+stripped rather than refused, so a malformed cue never costs the crew its face. The
 **picture tier** adds two owner-only, SEL-audited routes and a staging protocol
 whose invariant is that *no request other than a successful config save changes
 what the roster serves*: POST `/api/agents/{name}/avatar` (multipart, read into

--- a/src/kiro_crew/config/sections.py
+++ b/src/kiro_crew/config/sections.py
@@ -488,6 +488,64 @@ _AVATAR_IMAGE_EXTS = ("png", "jpg", "webp")
 #: currently committed file, so nothing overwrites a committed picture before
 #: the config save that commits its replacement.
 _AVATAR_FILE_PIN_RE = _re.compile(r"^[0-9a-f]{16}\.(?:png|jpg|webp)$")
+#: Agent lifecycle states a crew face may react to. A per-state override keys
+#: on one of these exactly; any other key is dropped, so a version-skewed or
+#: typo'd state name cannot smuggle an unbounded key set into config.json.
+_AVATAR_STATES = ("working", "done", "error")
+#: The only trait axes a per-state expression may move. The identity axes
+#: (brows/accessory/prop/tile/blush/flip) are deliberately excluded: a crew
+#: must stay recognisable as itself while its expression changes.
+_AVATAR_EXPRESSION_AXES = ("eyes", "mouth")
+#: Preset cue names a per-state sound may select. `"none"` is a real value
+#: (explicit silence), distinct from an absent state (the default, also
+#: silent) -- so a crew can opt one state out of a fleet-wide cue.
+_AVATAR_SOUNDS = ("none", "chime", "ding", "blip", "pop", "pulse")
+
+
+def _safe_expressions(value: object) -> dict:
+    """Return validated per-state expression overrides, or ``{}``.
+
+    Same forgiveness as the trait coercer: junk is dropped silently rather
+    than refused, because config.json is hand-editable and a malformed
+    expression must never cost the crew its otherwise-valid avatar. A state
+    whose axes all drop out is omitted, so the record never stores an empty
+    per-state dict.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, dict[str, str]] = {}
+    for state in _AVATAR_STATES:
+        raw = value.get(state)
+        if not isinstance(raw, dict):
+            continue
+        axes = {}
+        for axis in _AVATAR_EXPRESSION_AXES:
+            v = raw.get(axis)
+            # An empty string is "absent", which is what omitting the axis
+            # already means -- storing it would be a second spelling of the
+            # same state.
+            if isinstance(v, str) and v:
+                axes[axis] = v[:_AVATAR_TRAIT_MAX_LEN]
+        if axes:
+            out[state] = axes
+    return out
+
+
+def _safe_sounds(value: object) -> dict:
+    """Return validated per-state sound cues, or ``{}``.
+
+    Unlike a trait value, a cue name IS pinned to a vocabulary: it selects a
+    shipped preset rather than naming an option the renderer can resolve to
+    absent, so an unknown name has no meaning to carry and is dropped.
+    """
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, str] = {}
+    for state in _AVATAR_STATES:
+        v = value.get(state)
+        if isinstance(v, str) and v in _AVATAR_SOUNDS:
+            out[state] = v
+    return out
 
 
 def _safe_avatar(value: object) -> dict:
@@ -496,7 +554,11 @@ def _safe_avatar(value: object) -> dict:
     Accepted shapes:
 
     - ``{"kind": "ghost", "traits": {...}}`` — pins the ghost face
-      trait-by-trait instead of deriving it from the crew name.
+      trait-by-trait instead of deriving it from the crew name. ``traits`` may
+      be absent (or empty) when the override carries only ``expressions`` /
+      ``sounds``: that spelling means "name-derived face, plus these
+      per-state overrides", and the record omits the key entirely rather than
+      storing ``{}``.
     - ``{"kind": "image"}`` (optional int ``v``, optional ``file``) — the crew
       wears an uploaded picture, served from ``GET /api/agents/{name}/avatar``.
       The file itself lives under the data home's agent-fenced
@@ -513,6 +575,25 @@ def _safe_avatar(value: object) -> dict:
     face. config.json is hand-editable (and agent-writable), so junk collapses
     to ``{}`` rather than crashing the load.
 
+    Both kinds may also carry two optional per-state keys, validated and then
+    round-tripped through the endpoints and config persistence (a string axis is
+    normalized by the same 32-char truncation a trait gets, so a longer value
+    comes back shortened rather than verbatim):
+
+    - ``expressions: {"<state>": {"eyes"?: str, "mouth"?: str}}`` — the face
+      moves those two axes while the agent is in that state. Only ``eyes`` and
+      ``mouth`` are accepted, so the identity axes stay put and the crew
+      remains recognisable as itself. Legal on ``kind: "image"`` too — stored,
+      and ignored by the picture renderer.
+    - ``sounds: {"<state>": "none"|"chime"|"ding"|"blip"|"pop"|"pulse"}`` — a
+      shipped cue preset per state. ``"none"`` is explicit silence, kept
+      distinct from an absent state so one state can opt out of a cue the
+      others use.
+
+    ``<state>`` is one of ``working``, ``done``, ``error``. Either key is
+    omitted from the record when validation leaves it empty, so a stored
+    avatar never carries ``{}`` for one.
+
     Trait *values* are deliberately not checked against the frontend's trait
     vocabulary: the renderer resolves an unknown option to "absent"
     (``EYES[k] ?? ''``), and keeping the vocabulary in one place (the style
@@ -522,6 +603,8 @@ def _safe_avatar(value: object) -> dict:
     """
     if not isinstance(value, dict):
         return {}
+    expressions = _safe_expressions(value.get("expressions"))
+    sounds = _safe_sounds(value.get("sounds"))
     if value.get("kind") == "image":
         out: dict[str, object] = {"kind": "image"}
         v = value.get("v")
@@ -531,30 +614,45 @@ def _safe_avatar(value: object) -> dict:
         f = value.get("file")
         if isinstance(f, str) and _AVATAR_FILE_PIN_RE.fullmatch(f):
             out["file"] = f
+        if expressions:
+            out["expressions"] = expressions
+        if sounds:
+            out["sounds"] = sounds
         return out
     if value.get("kind") != "ghost":
         return {}
     raw = value.get("traits")
-    if not isinstance(raw, dict):
-        return {}
     traits: dict[str, object] = {}
-    for key in _AVATAR_GHOST_STR_TRAITS:
-        v = raw.get(key, "")
-        traits[key] = v[:_AVATAR_TRAIT_MAX_LEN] if isinstance(v, str) else ""
-    for key in _AVATAR_GHOST_BOOL_TRAITS:
-        # `is True`, not bool(): config.json is hand-editable and
-        # bool("false") is True, so a string-typed value would render the
-        # opposite of what its author wrote. Only a real boolean counts.
-        traits[key] = raw.get(key, False) is True
-    traits["tile"] = _safe_color(raw.get("tile", ""))
-    # An all-empty trait set (every axis absent) is indistinguishable in
-    # intent from "no override" but would render a featureless ghost. The
-    # builder cannot produce it (Apply always carries the seeded defaults), so
-    # it only arrives via hand-written config or direct API use — collapse it
-    # to the one canonical "reset" spelling instead of storing a third state.
-    if all(not v for v in traits.values()):
+    if isinstance(raw, dict):
+        for key in _AVATAR_GHOST_STR_TRAITS:
+            v = raw.get(key, "")
+            traits[key] = v[:_AVATAR_TRAIT_MAX_LEN] if isinstance(v, str) else ""
+        for key in _AVATAR_GHOST_BOOL_TRAITS:
+            # `is True`, not bool(): config.json is hand-editable and
+            # bool("false") is True, so a string-typed value would render the
+            # opposite of what its author wrote. Only a real boolean counts.
+            traits[key] = raw.get(key, False) is True
+        traits["tile"] = _safe_color(raw.get("tile", ""))
+        # An all-empty trait set (every axis absent) is indistinguishable in
+        # intent from "no override" but would render a featureless ghost. The
+        # builder cannot produce it (Apply always carries the seeded
+        # defaults), so it only arrives via hand-written config or direct API
+        # use — drop it to the one canonical "no traits" spelling instead of
+        # storing a third state.
+        if all(not v for v in traits.values()):
+            traits = {}
+    ghost: dict[str, object] = {"kind": "ghost"}
+    if traits:
+        ghost["traits"] = traits
+    if expressions:
+        ghost["expressions"] = expressions
+    if sounds:
+        ghost["sounds"] = sounds
+    # `kind` alone carries no override — a bare ghost is the name-derived face,
+    # which is what an absent field already means.
+    if len(ghost) == 1:
         return {}
-    return {"kind": "ghost", "traits": traits}
+    return ghost
 
 
 def _meta(label: str, help: str, **kwargs: object) -> dict:

--- a/src/kiro_crew/dashboard/handlers/agents.py
+++ b/src/kiro_crew/dashboard/handlers/agents.py
@@ -2730,10 +2730,13 @@ def _roster_avatar(value: object) -> dict:
       one: the pin REFUSES a bad value where masking would destroy a good one, and
       a masked ``file`` makes the per-crew avatar endpoint resolve nothing --
       silently breaking the image.
-    - ``traits`` values are the only user-authored strings here, so they go through
-      ``_roster_mask`` like any other roster string. The renderer resolves an
-      unrecognized trait to absent (``EYES[k] ?? ''``), so a masked trait degrades
-      that axis rather than breaking the face.
+    - ``traits`` values, and the ``eyes``/``mouth`` values of each
+      ``expressions`` state, are the only user-authored strings here, so they go
+      through ``_roster_mask`` like any other roster string. The renderer resolves
+      an unrecognized trait to absent (``EYES[k] ?? ''``), so a masked trait
+      degrades that axis rather than breaking the face.
+    - ``sounds`` values are constrained by ``_safe_sounds`` to a shipped preset
+      name, so they are pinned rather than masked -- the same reason ``file`` is.
 
     Honest limit on how far the two rules can be told apart: because
     ``_safe_avatar`` already pins every non-``traits`` leaf to a shape the redactors
@@ -2754,6 +2757,17 @@ def _roster_avatar(value: object) -> dict:
         safe["traits"] = {
             axis: (_roster_mask(val) if isinstance(val, str) else val)
             for axis, val in traits.items()
+        }
+    expressions = safe.get("expressions")
+    if isinstance(expressions, dict):
+        safe = dict(safe)
+        safe["expressions"] = {
+            state: {
+                axis: (_roster_mask(val) if isinstance(val, str) else val)
+                for axis, val in axes.items()
+            }
+            for state, axes in expressions.items()
+            if isinstance(axes, dict)
         }
     return safe
 
@@ -3655,7 +3669,17 @@ async def api_kirocrew_agent_update(request: web.Request) -> web.Response:
                         },
                         status=400,
                     )
-                _av = {"kind": "image", "v": stamp, "file": _avatar_pin}
+                # Rebuilt, not mutated, so the record carries exactly the
+                # committed stamp and pin. The per-state keys are validated
+                # input rather than commit output, so they have to be carried
+                # across explicitly -- otherwise saving a sound on a crew that
+                # wears a picture reports success and stores nothing.
+                _av = {
+                    "kind": "image",
+                    "v": stamp,
+                    "file": _avatar_pin,
+                    **{k: v for k, v in _av.items() if k in ("expressions", "sounds")},
+                }
             elif agent.avatar.get("kind") == "image":
                 # Leaving the picture tier: the stored file must not linger
                 # as a silently-retrievable orphan — but only once the config

--- a/test/test_agent_avatar.py
+++ b/test/test_agent_avatar.py
@@ -2,6 +2,7 @@
 
 Covers:
 - _safe_avatar validation (shape guards, trait coercion, tile hex pinning)
+- Per-state expression and sound overrides on both avatar kinds
 - The field's defaults and asdict serialization
 - Round-trip through the agents-section from-dict parse
 """
@@ -9,6 +10,7 @@ Covers:
 import dataclasses
 import json
 import tempfile
+import types
 import unittest.mock
 from pathlib import Path
 
@@ -18,7 +20,7 @@ from kiro_crew.config.loader import (
     KiroCrewAgentConfig,
     KiroCrewConfig,
 )
-from kiro_crew.config.sections import _safe_avatar
+from kiro_crew.config.sections import _AVATAR_SOUNDS, _AVATAR_TRAIT_MAX_LEN, _safe_avatar
 
 
 def _load_from_dict(data: dict) -> KiroCrewConfig:
@@ -956,3 +958,340 @@ class TestUploadedAvatarEndpoints:
         stored = KiroCrewConfig.load().agents[seeded_agent].avatar
         assert "promote" not in stored and "token" not in stored
         assert stored["kind"] == "image"
+
+
+_EXPRESSIONS = {"working": {"eyes": "squint"}, "error": {"eyes": "x", "mouth": "frown"}}
+_SOUNDS = {"working": "blip", "done": "chime", "error": "pulse"}
+
+
+class TestSafeAvatarPerStateOverrides:
+    """`expressions` and `sounds`: accepted on both kinds, junk dropped silently.
+
+    The forgiveness direction is the load-bearing one. `config.json` is
+    hand-editable and agent-writable, so a malformed per-state value must cost
+    the crew that value and nothing else -- never its whole avatar, and never a
+    400 at the endpoints.
+    """
+
+    def test_ghost_keeps_both_keys(self):
+        got = _safe_avatar({**_GHOST, "expressions": _EXPRESSIONS, "sounds": _SOUNDS})
+        assert got["traits"] == _GHOST["traits"]
+        assert got["expressions"] == _EXPRESSIONS
+        assert got["sounds"] == _SOUNDS
+
+    def test_image_keeps_both_keys(self):
+        got = _safe_avatar(
+            {
+                "kind": "image",
+                "v": 17,
+                "file": "0123456789abcdef.png",
+                "expressions": _EXPRESSIONS,
+                "sounds": _SOUNDS,
+            }
+        )
+        assert got == {
+            "kind": "image",
+            "v": 17,
+            "file": "0123456789abcdef.png",
+            "expressions": _EXPRESSIONS,
+            "sounds": _SOUNDS,
+        }
+
+    def test_ghost_without_traits_is_valid_when_it_carries_overrides(self):
+        """The new shape: name-derived face plus per-state overrides.
+
+        `traits` is omitted from the record rather than stored as `{}`, so the
+        frontend's "missing or empty means name-derived" rule reads one
+        spelling.
+        """
+        got = _safe_avatar({"kind": "ghost", "sounds": {"done": "ding"}})
+        assert got == {"kind": "ghost", "sounds": {"done": "ding"}}
+        assert "traits" not in got
+
+    def test_empty_traits_dict_also_yields_no_traits_key(self):
+        got = _safe_avatar({"kind": "ghost", "traits": {}, "expressions": {"done": {"eyes": "o"}}})
+        assert got == {"kind": "ghost", "expressions": {"done": {"eyes": "o"}}}
+
+    def test_bare_ghost_still_collapses(self):
+        assert _safe_avatar({"kind": "ghost"}) == {}
+
+    def test_ghost_whose_overrides_all_drop_out_collapses(self):
+        """`kind` alone is not an override -- it must read as "no override"."""
+        assert _safe_avatar({"kind": "ghost", "expressions": {"nope": {"eyes": "o"}}}) == {}
+        assert _safe_avatar({"kind": "ghost", "sounds": {"working": "airhorn"}}) == {}
+
+    def test_unknown_state_is_dropped(self):
+        got = _safe_avatar(
+            {
+                **_GHOST,
+                "expressions": {"working": {"eyes": "o"}, "idle": {"eyes": "o"}},
+                "sounds": {"done": "pop", "thinking": "pop"},
+            }
+        )
+        assert got["expressions"] == {"working": {"eyes": "o"}}
+        assert got["sounds"] == {"done": "pop"}
+
+    def test_only_eyes_and_mouth_move_per_state(self):
+        """Identity axes must not change with state, or the crew stops being itself."""
+        got = _safe_avatar(
+            {
+                **_GHOST,
+                "expressions": {
+                    "working": {
+                        "eyes": "squint",
+                        "mouth": "oh",
+                        "brows": "raised",
+                        "accessory": "halo",
+                        "prop": "mug",
+                        "tile": "#ffffff",
+                        "blush": True,
+                        "flip": True,
+                    }
+                },
+            }
+        )
+        assert got["expressions"] == {"working": {"eyes": "squint", "mouth": "oh"}}
+
+    def test_expression_values_are_truncated_like_traits(self):
+        got = _safe_avatar({**_GHOST, "expressions": {"working": {"eyes": "e" * 99}}})
+        assert got["expressions"]["working"]["eyes"] == "e" * _AVATAR_TRAIT_MAX_LEN
+
+    def test_empty_expression_value_is_dropped(self):
+        """An empty string already means "absent" -- do not store a second spelling."""
+        got = _safe_avatar({**_GHOST, "expressions": {"working": {"eyes": "", "mouth": "oh"}}})
+        assert got["expressions"] == {"working": {"mouth": "oh"}}
+
+    def test_a_state_left_with_no_axes_is_omitted(self):
+        got = _safe_avatar({**_GHOST, "expressions": {"working": {"eyes": ""}}})
+        assert "expressions" not in got
+
+    @pytest.mark.parametrize("preset", _AVATAR_SOUNDS)
+    def test_every_shipped_preset_is_accepted(self, preset):
+        got = _safe_avatar({**_GHOST, "sounds": {"working": preset}})
+        assert got["sounds"] == {"working": preset}
+
+    def test_none_is_kept_as_explicit_silence(self):
+        """Distinct from an absent state: one state can opt out of a fleet cue."""
+        got = _safe_avatar({**_GHOST, "sounds": {"working": "none", "done": "chime"}})
+        assert got["sounds"] == {"working": "none", "done": "chime"}
+
+    def test_unknown_preset_is_dropped(self):
+        got = _safe_avatar({**_GHOST, "sounds": {"working": "airhorn", "done": "chime"}})
+        assert got["sounds"] == {"done": "chime"}
+
+    def test_empty_objects_are_omitted_not_stored(self):
+        got = _safe_avatar({**_GHOST, "expressions": {}, "sounds": {}})
+        assert got == _GHOST
+
+    @pytest.mark.parametrize(
+        "junk",
+        [
+            "x",
+            7,
+            ["working"],
+            None,
+            {"working": 5},
+            {"working": "squint"},
+            {"working": ["squint"]},
+            {"working": {"eyes": 5}},
+            {"working": {"eyes": ["a"]}},
+        ],
+    )
+    def test_junk_expressions_never_collapse_a_valid_avatar(self, junk):
+        got = _safe_avatar({**_GHOST, "expressions": junk})
+        assert got["traits"] == _GHOST["traits"]
+        assert "expressions" not in got
+
+    @pytest.mark.parametrize(
+        "junk",
+        ["x", 7, ["chime"], None, {"working": 5}, {"working": ["chime"]}, {"working": {"a": "b"}}],
+    )
+    def test_junk_sounds_never_collapse_a_valid_avatar(self, junk):
+        got = _safe_avatar({**_GHOST, "sounds": junk})
+        assert got["traits"] == _GHOST["traits"]
+        assert "sounds" not in got
+
+    def test_junk_never_collapses_a_valid_image(self):
+        got = _safe_avatar({"kind": "image", "v": 3, "expressions": "x", "sounds": 9})
+        assert got == {"kind": "image", "v": 3}
+
+    def test_stored_overrides_survive_a_config_load(self):
+        avatar = {**_GHOST, "expressions": _EXPRESSIONS, "sounds": _SOUNDS}
+        cfg = _load_from_dict({"agents": {"radar": {"kiro_agent": "kirocrew", "avatar": avatar}}})
+        assert cfg.agents["radar"].avatar == avatar
+
+
+class TestPerStateOverridesRoundTripThroughTheEndpoints:
+    """PUT stores the per-state keys and GET hands them back, on both kinds."""
+
+    @staticmethod
+    def _app():
+        from aiohttp import web
+
+        from kiro_crew.dashboard.handlers import (
+            api_kirocrew_agent_avatar_upload,
+            api_kirocrew_agent_update,
+            api_kirocrew_agents,
+        )
+
+        app = web.Application()
+        app["state"] = types.SimpleNamespace(conversation_log=None)
+        app.router.add_get("/api/agents", api_kirocrew_agents)
+        app.router.add_post("/api/agents/{name}/avatar", api_kirocrew_agent_avatar_upload)
+        app.router.add_put("/api/agents/{name}", api_kirocrew_agent_update)
+        return app
+
+    @pytest.fixture(autouse=True)
+    def _owner_caller(self, monkeypatch):
+        monkeypatch.setattr(
+            "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+            lambda request: True,
+        )
+
+    @pytest.fixture()
+    def seeded_agent(self):
+        cfg = KiroCrewConfig.load()
+        cfg.agents["existing"] = KiroCrewAgentConfig(kiro_agent="kirocrew")
+        cfg.save()
+        return "existing"
+
+    @staticmethod
+    async def _roster_avatar_of(client, name: str):
+        resp = await client.get("/api/agents")
+        assert resp.status == 200
+        rows = (await resp.json())["agents"]
+        return next(r["avatar"] for r in rows if r["name"] == name)
+
+    @pytest.mark.asyncio
+    async def test_ghost_crew_round_trip(self, seeded_agent):
+        from aiohttp.test_utils import TestClient, TestServer
+
+        avatar = {**_GHOST, "expressions": _EXPRESSIONS, "sounds": _SOUNDS}
+        async with TestClient(TestServer(self._app())) as client:
+            put = await client.put(f"/api/agents/{seeded_agent}", json={"avatar": avatar})
+            assert put.status == 200
+            got = await self._roster_avatar_of(client, seeded_agent)
+        assert got["expressions"] == _EXPRESSIONS
+        assert got["sounds"] == _SOUNDS
+        assert KiroCrewConfig.load().agents[seeded_agent].avatar == avatar
+
+    @pytest.mark.asyncio
+    async def test_ghost_crew_without_traits_round_trip(self, seeded_agent):
+        from aiohttp.test_utils import TestClient, TestServer
+
+        avatar = {"kind": "ghost", "expressions": _EXPRESSIONS, "sounds": _SOUNDS}
+        async with TestClient(TestServer(self._app())) as client:
+            put = await client.put(f"/api/agents/{seeded_agent}", json={"avatar": avatar})
+            assert put.status == 200, await put.json()
+            got = await self._roster_avatar_of(client, seeded_agent)
+        assert got == avatar
+        assert KiroCrewConfig.load().agents[seeded_agent].avatar == avatar
+
+    @pytest.mark.asyncio
+    async def test_image_crew_keeps_its_sounds_across_the_commit(self, seeded_agent):
+        """The commit rebuilds the record from the stamp and pin.
+
+        A per-state key is validated INPUT, not commit output, so it has to be
+        carried across that rebuild -- otherwise saving a sound on a crew that
+        wears a picture returns 200 and stores nothing.
+        """
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async with TestClient(TestServer(self._app())) as client:
+            up = await client.post(f"/api/agents/{seeded_agent}/avatar", data=self._form(_PNG))
+            assert up.status == 200
+            put = await client.put(
+                f"/api/agents/{seeded_agent}",
+                json={
+                    "avatar": {
+                        "kind": "image",
+                        "promote": True,
+                        "token": (await up.json())["token"],
+                        "expressions": _EXPRESSIONS,
+                        "sounds": _SOUNDS,
+                    }
+                },
+            )
+            assert put.status == 200, await put.json()
+            got = await self._roster_avatar_of(client, seeded_agent)
+        assert got["kind"] == "image"
+        assert got["expressions"] == _EXPRESSIONS
+        assert got["sounds"] == _SOUNDS
+        stored = KiroCrewConfig.load().agents[seeded_agent].avatar
+        assert stored["expressions"] == _EXPRESSIONS and stored["sounds"] == _SOUNDS
+
+    @pytest.mark.asyncio
+    async def test_keeping_the_current_picture_carries_the_overrides(self, seeded_agent):
+        """The other image branch: no fresh upload, only per-state edits."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async with TestClient(TestServer(self._app())) as client:
+            up = await client.post(f"/api/agents/{seeded_agent}/avatar", data=self._form(_PNG))
+            first = await client.put(
+                f"/api/agents/{seeded_agent}",
+                json={
+                    "avatar": {
+                        "kind": "image",
+                        "promote": True,
+                        "token": (await up.json())["token"],
+                    }
+                },
+            )
+            assert first.status == 200
+            pin = KiroCrewConfig.load().agents[seeded_agent].avatar["file"]
+            again = await client.put(
+                f"/api/agents/{seeded_agent}",
+                json={"avatar": {"kind": "image", "sounds": {"done": "pop"}}},
+            )
+            assert again.status == 200, await again.json()
+        stored = KiroCrewConfig.load().agents[seeded_agent].avatar
+        assert stored["file"] == pin, "the keep-current-picture branch lost the pin"
+        assert stored["sounds"] == {"done": "pop"}
+
+    @pytest.mark.asyncio
+    async def test_a_ghost_carrying_only_junk_is_still_refused(self, seeded_agent):
+        """The 400 gate is unchanged for a payload with no surviving content.
+
+        A traits-less ghost is now a legal shape, so this case is worth pinning
+        deliberately: when nothing in it survives validation it is a mistyped
+        payload, not an intentional reset, and refusing it is what keeps it from
+        silently deleting a crew's committed picture. Same answer a bare
+        ``{"kind": "ghost"}`` already gets.
+        """
+        from aiohttp.test_utils import TestClient, TestServer
+
+        cfg = KiroCrewConfig.load()
+        cfg.agents[seeded_agent].avatar = {"kind": "ghost", "sounds": {"done": "ding"}}
+        cfg.save()
+        async with TestClient(TestServer(self._app())) as client:
+            resp = await client.put(
+                f"/api/agents/{seeded_agent}",
+                json={"avatar": {"kind": "ghost", "sounds": {"done": "airhorn"}}},
+            )
+            assert resp.status == 400
+            assert (await resp.json())["code"] == "invalid_avatar"
+        assert KiroCrewConfig.load().agents[seeded_agent].avatar == {
+            "kind": "ghost",
+            "sounds": {"done": "ding"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_junk_per_state_values_are_not_a_400(self, seeded_agent):
+        """Same forgiveness traits already get -- strip, never refuse."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        async with TestClient(TestServer(self._app())) as client:
+            resp = await client.put(
+                f"/api/agents/{seeded_agent}",
+                json={"avatar": {**_GHOST, "expressions": "x", "sounds": ["chime"]}},
+            )
+            assert resp.status == 200, await resp.json()
+        assert KiroCrewConfig.load().agents[seeded_agent].avatar == _GHOST
+
+    @staticmethod
+    def _form(data: bytes):
+        from aiohttp import FormData
+
+        form = FormData()
+        form.add_field("file", data, filename="face.bin", content_type="application/octet-stream")
+        return form

--- a/test/test_agents_roster_contract.py
+++ b/test/test_agents_roster_contract.py
@@ -436,6 +436,33 @@ class TestAvatarIsShapeAllowlistedNotMasked:
         assert _carries_mask(avatar["traits"]["eyes"]), "a user-authored trait was not masked"
         assert self.PROBE not in json.dumps(row)
 
+    def test_a_credential_shaped_expression_value_is_masked(self) -> None:
+        """The per-state axes carry user text too, so they mask like traits."""
+        row = _agent_roster_row(
+            "probe",
+            "global",
+            cast(
+                KiroCrewAgentConfig,
+                types.SimpleNamespace(
+                    **{
+                        **{f.name: "" for f in dataclasses.fields(KiroCrewAgentConfig)},
+                        "avatar": {
+                            "kind": "ghost",
+                            "expressions": {"working": {"eyes": self.PROBE}},
+                            "sounds": {"working": "chime"},
+                        },
+                    }
+                ),
+            ),
+            redact=False,
+        )
+        avatar = cast(dict, row["avatar"])
+        assert _carries_mask(avatar["expressions"]["working"]["eyes"])
+        assert self.PROBE not in json.dumps(row)
+        # The direction that rots: a cue name is pinned to a shipped preset by
+        # `_safe_sounds`, so masking it would break the cue and buy nothing.
+        assert avatar["sounds"] == {"working": "chime"}
+
     def test_the_pinned_file_and_kind_survive_intact(self) -> None:
         """The direction that rots. `file` is regex-pinned, so it needs no mask.
 


### PR DESCRIPTION
## Problem / Motivation

A crew's face is static. The `avatar` record pins traits or an uploaded picture, and nothing in it can say "look different while you are working" or "make this sound when you finish". `_safe_avatar` strips any key it does not recognise, so there is nowhere for a reactive renderer to read that intent from — the frontend half of "crew avatars react to agent state" has no wire contract to build against.

There is also a shape gap the reactive case needs: `{"kind": "ghost"}` with no `traits` collapses to `{}` today, so "keep the name-derived face, just give it these per-state overrides" cannot be expressed at all.

## Why it matters

This is the backend half of a two-part feature; the frontend half is being built in parallel against exactly this contract. Without it, a per-state override either cannot be sent or is silently dropped on save — the worst failure mode for a settings surface, because the endpoint returns 200 and the setting is simply gone on reload.

## What changed (motivation → approach → change)

Goal: let a crew record carry per-state face and sound overrides, without loosening the coercer that keeps a hand-edited (and agent-writable) `config.json` from crashing the load.

Approach: extend `_safe_avatar` with two optional keys rather than adding a parallel field, so the whole override travels as one value through the existing endpoints, the existing 400 gate, and existing persistence. Both keys are keyed on the agent lifecycle state, and the state key set is a closed literal set:

```
"expressions": { "<state>": { "eyes"?: str, "mouth"?: str } }
"sounds":      { "<state>": "none"|"chime"|"ding"|"blip"|"pop"|"pulse" }
```

`<state>` is `working | done | error` exactly; any other key is dropped, so a version-skewed or typo'd caller cannot grow the key set stored in config.

Three design choices worth the reader's attention:

- **Only `eyes` and `mouth` move per state.** The identity axes (`brows`, `accessory`, `prop`, `tile`, `blush`, `flip`) are not accepted there, so a crew stays recognisable as itself while its expression changes. `tile` in particular is interpolated into SVG markup and is hex-pinned once, on the identity; letting a state re-supply it would add a second place that has to be pinned.
- **A cue name IS pinned to a vocabulary, unlike a trait value.** Trait values are deliberately unchecked because the renderer resolves an unknown option to "absent", so a new hat needs no backend release. A cue name instead selects a shipped asset, so an unknown name has no meaning to carry and is dropped. `"none"` is kept as explicit silence — distinct from an absent state, which is also silent — so one state can opt out of a cue the others use.
- **Junk is stripped, never refused.** Same forgiveness traits already get: `config.json` is hand-editable and agent-writable, so `expressions: "x"` or `sounds: {"working": 5}` costs that value and never the crew's whole avatar. An object left empty after validation is omitted from the record rather than stored as `{}`, so there is one spelling of "no override" rather than two.

Two consequences that reach beyond the validator:

- **`traits` becomes optional on a ghost.** A ghost carrying only `expressions`/`sounds` is now valid and means "name-derived face plus these overrides"; the record omits the `traits` key entirely rather than storing `{}`, so the frontend's missing-or-empty rule reads one spelling. A bare `{"kind": "ghost"}` with nothing else still collapses to `{}` — `kind` alone is not an override. The endpoints' 400 gate is unchanged: a ghost whose content all drops out is a mistyped payload, not an intentional reset, and refusing it is what stops it silently deleting a committed picture.
- **The picture commit had to carry the new keys across its rebuild.** `handlers/agents.py` rebuilds the record as `{"kind": "image", "v": stamp, "file": pin}` from the freshly promoted upload, and a per-state key is validated *input* rather than commit output. Without carrying it explicitly, saving a sound on a crew that wears a picture returned 200 and stored nothing — on both the promote branch and the keep-current-picture branch, which share that rebuild.

The roster serializer masks the `eyes`/`mouth` values like any other user-authored string and leaves the preset-pinned `sounds` intact, for the same reason it already leaves `file` intact: a value a regex refuses is safer than one masking would destroy, and masking a cue name would break the cue while disclosing nothing.

No frontend change is in this PR — it is the schema half only, and the renderer that consumes `expressions` lands separately.

## Tests

`test/test_agent_avatar.py`

- `TestSafeAvatarPerStateOverrides` — both keys survive on ghost and on image; a ghost with no `traits` (and one with `traits: {}`) is valid when it carries an override and omits the key; a bare ghost still collapses; a ghost whose overrides all drop out collapses; an unknown state key is dropped; only `eyes`/`mouth` move per state (the six identity axes are asserted absent); values truncate at `_AVATAR_TRAIT_MAX_LEN`; an empty axis value and a state left with no axes are dropped; every one of the six presets is accepted (parametrized off `_AVATAR_SOUNDS`, so adding a preset without a test is impossible); `"none"` is kept; an unknown preset is dropped; empty objects are omitted, not stored; 9 junk `expressions` shapes and 7 junk `sounds` shapes never collapse a valid ghost or a valid image; the stored record survives a real config load.
- `TestPerStateOverridesRoundTripThroughTheEndpoints` — PUT then `GET /api/agents` round-trip for a ghost crew, for a traits-less ghost crew, for an image crew through the staged-upload commit, and for the keep-current-picture branch (which also asserts the `file` pin is not lost); junk per-state values return 200 rather than 400; a ghost carrying only junk is still refused 400 `invalid_avatar` and leaves the stored record untouched.

`test/test_agents_roster_contract.py` — a credential-shaped `expressions.working.eyes` is masked in the roster row and absent from the serialized JSON, while the preset-pinned `sounds` value survives intact (the direction that rots — a test that only checked masking would pass against a blanket mask that breaks the cue).

Revert-verified load-bearing: dropping the per-state keys from the ghost branch fails 19 tests, from the image branch 3, removing the commit-rebuild carry-through 2, and removing the roster masking 1.

## Manual verification

N/A — unit coverage sufficient: every path is a pure validator or an endpoint round-trip, and both are driven end-to-end through the real aiohttp handlers (including the real staged-upload commit) rather than mocked.

## Related Issues

no linked issue: the backend half of a two-part feature tracked in conversation, not in an issue.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
