### PR TITLE
refactor: drop the shadowed _HIDDEN_CATEGORIES binding in validation.py

### DIFF
--- a/docs/architecture/security-deep-dive.md
+++ b/docs/architecture/security-deep-dive.md
@@ -253,9 +253,12 @@ granted).
 
 Every MCP tool call is checked against a declarative `FieldSpec` + `ToolSchema`
 before the handler sees it: NFC unicode normalization with hidden-character
-stripping (control, format, private-use and surrogate code points, preserving
-`\n`/`\r`/`\t`), enum allow-lists, regex patterns for identifiers, range checks,
-unknown-field rejection, tiered length caps (`MAX_TOOL_NAME_LEN` 256,
+stripping (control, format and surrogate code points, preserving `\n`/`\r`/`\t`
+plus the four shaping marks in `_ALLOWED_FORMAT` when they sit next to non-ASCII
+text; private-use code points are deliberately kept, because Nerd Font and
+terminal-theme icon glyphs live there and are visible to a reader, so they cannot
+hide a credential from one), enum allow-lists, regex patterns for identifiers,
+range checks, unknown-field rejection, tiered length caps (`MAX_TOOL_NAME_LEN` 256,
 `MAX_SHORT_STRING` 500, `MAX_MEDIUM_STRING` 5 000, `MAX_LONG_STRING` 50 000, and
 the field-specific `MAX_CRON_MESSAGE` 50 000 for the cron `message` — a task
 prompt, enforced on the MCP schemas, both REST cron endpoints, and the

--- a/docs/system-specs/modules/security.md
+++ b/docs/system-specs/modules/security.md
@@ -1374,7 +1374,7 @@ Mermaid `securityLevel` is set to `'strict'` in `MarkdownRenderer.tsx`, renderin
 Centralized validation for all 12 MCP tool handlers (SDO-183):
 
 - **Type-safe schemas**: `FieldSpec` + `ToolSchema` declarative validation
-- **Unicode normalization**: NFC normalization + hidden character stripping (control chars, format chars, private use, surrogates — preserves `\n`, `\r`, `\t`)
+- **Unicode normalization**: NFC normalization + hidden character stripping (control chars, format chars, surrogates — preserves `\n`, `\r`, `\t`). Private-use code points are deliberately kept: Nerd Font and terminal-theme icon glyphs live there and are visible to a reader, so they cannot hide a credential from one.
 - **Allow-lists**: enum enforcement for lesson categories, cron schedule kinds
 - **Regex patterns**: agent name, job ID format validation
 - **Range checks**: positive numbers for timeouts/intervals, valid timestamps

--- a/src/kiro_crew/validation.py
+++ b/src/kiro_crew/validation.py
@@ -232,32 +232,16 @@ _JOB_ID_RE = re.compile(r"^[a-f0-9]{1,16}$")
 # must not abuse that upgrade).
 CRON_SESSION_RE = re.compile(r"^cron:[a-zA-Z0-9]+(?::[a-zA-Z0-9]+)?$")
 
-# Hidden Unicode categories to strip (control chars, format chars, etc.)
-# Keeps: letters, numbers, punctuation, symbols, separators (space/newline)
-# Categories removed wholesale. ``Cf`` (format) is deliberately NOT here: it
-# holds ZWJ U+200D, ZWNJ U+200C and the variation selectors that emoji
-# sequences and Arabic / Persian / Indic scripts REQUIRE to render correctly,
-# so deleting the category corrupts user content instead of hardening anything
-# (``dashboard/chat_folders.py`` already treats U+200D / U+FE0F as meaningful
-# emoji modifiers, and test_context_marker_neutralization asserts ZWNJ/ZWJ
-# survive). ``Co`` (private use) is likewise excluded — Nerd Fonts and terminal
-# themes carry real icon glyphs there. The genuinely dangerous Cf members are
-# removed by codepoint via ``_BIDI_CONTROLS`` instead of by category.
-_HIDDEN_CATEGORIES = frozenset(
-    {
-        "Cc",  # control (except \n \r \t)
-        "Cs",  # surrogate — never valid in well-formed text
-    }
-)
-
-# Categories removed wholesale. ``Cf`` (format) IS included — it is stripped by
-# default and only the shaping characters named in ``_ALLOWED_FORMAT`` below get
-# through. Fail-closed is required here rather than aesthetic: this sanitizer
-# runs BEFORE credential redaction, so any invisible character it preserves can
-# be inserted into a credential to defeat ``redact_credentials``' patterns and
-# carry a recoverable secret into the dashboard and the notification JSONL. An
-# allowlist means a newly-assigned or simply un-enumerated ``Cf`` codepoint is
-# blocked instead of silently becoming an evasion vector.
+# Unicode categories :func:`strip_hidden_unicode` strips, minus the
+# ``_ALLOWED_CONTROL`` / ``_ALLOWED_FORMAT`` carve-outs below. ``Cf`` (format)
+# IS included — it is stripped by default and only the shaping characters named
+# in ``_ALLOWED_FORMAT`` get through, and only next to non-ASCII text.
+# Fail-closed is required here rather than aesthetic: this sanitizer runs BEFORE
+# credential redaction, so any invisible character it preserves can be inserted into a
+# credential to defeat ``redact_credentials``' patterns and carry a recoverable
+# secret into the dashboard and the notification JSONL. An allowlist means a
+# newly-assigned or simply un-enumerated ``Cf`` codepoint is blocked instead of
+# silently becoming an evasion vector.
 #
 # ``Co`` (private use) is excluded: Nerd Fonts and terminal themes carry real
 # icon glyphs there, and unlike ``Cf`` those are visible, so they cannot hide a
@@ -273,8 +257,8 @@ _HIDDEN_CATEGORIES = frozenset(
 # The ONLY format characters allowed through. Each has a real text-shaping job
 # that scripts and emoji sequences cannot express without it, so removing them
 # corrupts user content (``dashboard/chat_folders.py`` treats U+200D as a
-# meaningful emoji modifier, and test_context_marker_neutralization asserts
-# ZWNJ/ZWJ survive).
+# meaningful emoji modifier, and ``test_validation.TestStripHiddenUnicode`` pins
+# ZWNJ/ZWJ survival here).
 #
 # Everything else in ``Cf`` stays denied, including ZWSP U+200B, the word joiner
 # and invisible operators U+2060-2064, BOM U+FEFF, the bidi embedding/override/


### PR DESCRIPTION
## Problem / Motivation

`src/kiro_crew/validation.py` bound `_HIDDEN_CATEGORIES` **twice at module scope**, on
adjacent statements, with two comment blocks that assert **opposite** security
postures:

- The first (dead) binding was `frozenset({"Cc", "Cs"})`, headed by a comment stating
  ``` ``Cf`` (format) is deliberately NOT here ``` and that the dangerous `Cf` members
  are instead ``removed by codepoint via ``_BIDI_CONTROLS`` ``.
- The second (live) binding is `frozenset({"Cc", "Cf", "Cs"})`, headed by a comment
  stating ``` ``Cf`` (format) IS included ``` and explaining that fail-closed `Cf`
  stripping is a **security requirement**, because this sanitizer runs before
  `redact_credentials` and any surviving invisible can be planted inside a credential
  to defeat its patterns.

Python's second assignment wins, so the live policy is the second one. A reader going
top-down hits the false claim first and concludes `strip_hidden_unicode` preserves
BOM, ZWSP and the bidi overrides. It does not. `_BIDI_CONTROLS`, the mechanism the
dead comment names as the real defence, **does not exist anywhere in the repo**.

`git log -S` puts both bindings in the *same* commit (`afb1c5f80`), whose parent had a
single `frozenset({"Cc","Cf","Co","Cs"})`. That commit narrowed to `{Cc, Cs}`, changed
its mind, appended `{Cc, Cf, Cs}`, and shipped the abandoned intermediate — so there is
no revision at which the deleted binding ever governed the sanitizer.

Two shipped specs carried the mirror-image error: both listed **private-use** code
points as stripped, when `_HIDDEN_CATEGORIES` deliberately excludes `Co`.

## Why it matters

No user-visible bug today — the effective policy has always been the correct,
fail-closed one. The cost is latent and lands on the next editor of a
security control: a maintainer or an agent acting on the first comment would
"restore" the documented behaviour by dropping `Cf` from the set, and that
single edit re-opens the credential-redaction evasion vector the live comment
exists to warn about (`AKIA<ZWJ>IOSFODNN7EXAMPLE` reaching the dashboard and the
notification JSONL unredacted). The two spec lines point the same wrong way about
which categories this control strips.

No linter can catch it: pyflakes `F811` fires on redefined imports/`def`/`class`,
not on plain module-scope reassignment, and mypy infers the same `frozenset[str]`
from either binding.

## What changed (motivation → approach → change)

Symptom: a security control documented two contradictory ways, plus two specs
describing a third behaviour. Root cause: an abandoned intermediate binding left in
place by an old commit, and no gate that can see it. Change, in three parts:

1. **Deleted the dead `_HIDDEN_CATEGORIES` binding and its 11-line comment block.**
   The surviving binding is byte-identical to what shipped.
2. **Rewrote the surviving block's lead line** to name its single consumer
   (`strip_hidden_unicode`) and to state the carve-outs accurately — the earlier
   "removed wholesale" overclaimed, since `Cc` keeps `_ALLOWED_CONTROL` and `Cf`
   keeps `_ALLOWED_FORMAT`, and even those marks only survive next to non-ASCII
   text. Every surviving claim was re-verified against the code, not restated on
   faith: `Cf` stripped by default, `_ALLOWED_FORMAT` as the narrow allowlist, the
   sanitize-before-redact ordering (`mcp_tools/apps.py:421`), and `Co` excluded.
3. **Corrected two adjacent inaccuracies rather than leaving half the claim fixed** —
   the campaign's consistency rule is that a criterion applied to one copy of a claim
   must be applied to every file it reaches:
   - The `_ALLOWED_FORMAT` comment cited `test_context_marker_neutralization` as the
     pin for ZWNJ/ZWJ survival. That module exists but never calls
     `strip_hidden_unicode` — its assertions run against
     `_neutralize_structural_markers`. Now cites
     `test_validation.TestStripHiddenUnicode`, which does pin this function. This diff
     deleted the *duplicate* of that same mis-citation, so leaving the survivor was
     exactly the half-applied-criterion drift to avoid.
   - `docs/system-specs/modules/security.md` and
     `docs/architecture/security-deep-dive.md` both listed private-use code points as
     stripped. Verified by execution that they survive
     (`strip_hidden_unicode("") == ""`, category `Co`); both now state
     that `Co` is deliberately kept, and why.

**No behaviour changes.** No matcher, guard, audit emit, redaction call or governance
intersection changes shape; no import is added, moved or deleted; nothing becomes
eager. `validation.py` is a keystone file, and the keystone prohibition is against
*reshaping* a control — this diff removes an unreachable binding and leaves the
effective one untouched, which is why it is in scope rather than excluded.

## Tests

No new tests. There is no behaviour to lock in: the change is provably a no-op on
executable semantics, and the existing suite already pins the live policy
(`test_validation.TestStripHiddenUnicode` — `test_format_chars_are_deny_by_default`,
`test_preserves_zwnj_and_variation_selector`, `test_shaping_marks_need_a_non_ascii_neighbour`,
`test_strips_directional_overrides`, `test_invisible_cannot_hide_a_credential_from_redaction`).

Adding a test asserting `_HIDDEN_CATEGORIES` is bound once would pin a lint property,
not a behaviour, in the one file where that shape can no longer occur. The generalizable
guard belongs in a detector — see Pattern harvest.

## Manual verification

Equivalence was **proved**, not asserted:

- **AST identity** — parsing both revisions and dropping only the shadowed
  `_HIDDEN_CATEGORIES` binding yields byte-identical `ast.dump` output. The two
  bindings are *adjacent* statements (module body indices 45 and 46), so nothing can
  interleave: no import, no decorator, no module-scope comprehension, no patch.
- **Bytecode identity** — all 50 functions/methods compare equal on `co_code`,
  `co_names`, `co_varnames`, recursive `co_consts` and `__defaults__`. All ~200 module
  attributes compare equal by repr once function addresses are normalized.
- **Differential fuzz, 1,030,766 inputs, 0 divergences** across
  `strip_hidden_unicode`, `normalize_unicode`, `sanitize_string` and
  `clamp_to_max_len`, running the pristine `origin/main` module side by side with this
  one. Corpus: full pair/triple cross-product over 66 atoms; **every** one of the
  139,751 `Cc`/`Cf`/`Cs`/`Co` codepoints and all 1,985 `Mn` codepoints, each bare,
  ASCII-framed, Arabic-framed and injected into `AKIA…IOSFODNN7EXAMPLE`; each
  invisible (and each doubled) at all 21 positions of that credential; real emoji ZWJ
  sequences, Persian/Devanagari ZWNJ spellings, the Trojan-Source `‮evil‬.txt`; and
  40,000 seeded random strings.
- **Reader audit** — `_HIDDEN_CATEGORIES` occurs at exactly two lines repo-wide, both
  in this file (definition and the single read inside `strip_hidden_unicode`). No
  importer, no `monkeypatch.setattr`, no `patch(...)`, no `importlib.reload`, no
  `getattr`/`globals()`/`vars()` string access, no `__all__`, no source-text or
  golden-file assertion on this module.

Gates, all exit 0 on the CI-parity Python 3.12 venv: `flake8`, `isort --check-only`,
`mypy src/kiro_crew`, `check_black_formatting.py`, `check_brand_name.py`,
`check_harness_parity.py`, `docs_lint.py --test`, `docs-lint.sh`,
`check_per_file_coverage.py --test`, `verify_vendor_manifest.py`,
`scrub-lint.sh --no-history`. Targeted suite: 464 passed across
`test_validation.py`, `test_validation_user_actions.py`, `test_api_input_validation.py`,
`test_cron_patch_name_validation.py`, `test_aws_profile_charset.py`,
`test_cron_message_cap.py`, `test_dashboard_sessions_search.py`,
`test_session_directive_transport.py`, `test_bug_validation_validate_field.py`,
`test_bug_validation_send_message_schema.py`.

<!-- no-visual-delta -->
**Why no screenshot:** backend and docs only — no file under `website/` is touched, and
the change removes an unreachable binding and rewrites comments, so no rendered pixel
differs.

## Related Issues

no linked issue: found by a detector sweep during the module-simplification campaign,
not reported.

## Pattern harvest

Rule candidate: `lint`
Pattern: a module-scope name assigned twice with no read in between — the earlier
binding is unreachable, and when each binding carries its own comment the dead one
becomes a false statement about live behaviour that no linter reports.

This generalizes and the detector is cheap: walk `ast.parse(src).body`, collect
`Assign`/`AnnAssign` targets that are bare `Name`s, and flag any name bound more than
once. Run tree-wide over `src/kiro_crew/` it yields **three** hits and the triage is
one line each:

- `validation.py:246` `_HIDDEN_CATEGORIES` — this defect.
- `dashboard/theme_validate.py:321` `_CSS_COMMENT_RE` — rebound at `:508` to an
  identical `re.compile(r"/\*.*?\*/", re.DOTALL)`. Harmless today, same shape. Left
  for its own PR: one module per PR, and it is not this module.
- `__init__.py:10` `__version__` — a **true negative**, deliberately overridden by
  `_apply_build_version_file`. So the rule needs an allow-list or a
  "same-value / documented-override" exemption before it can block, which is why the
  candidate is a lint with an exemption rather than a hard gate.

A three-hit tree-wide result is small enough to fix by hand and cheap enough to keep
as a ratchet, so the class does not re-accumulate silently the way this one did for the
lifetime of `afb1c5f80`.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
