### PR TITLE
fix(ci): re-measure the drifted all-chunk bundle ceiling

### DIFF
--- a/website/scripts/check-bundle-size.mjs
+++ b/website/scripts/check-bundle-size.mjs
@@ -49,7 +49,14 @@ export const CHUNK_BUDGETS = {
   // catalogs on top of that baseline. The Drive gallery's keys across 13
   // catalogs ride inside the headroom that measurement already left, so this
   // branch does not move the ceiling.
-  all: 10490 * KB, // measured 9985 KB before the pod-system catalog keys (~5% headroom)
+  // Re-measured 2026-09-06: main @ 3a6478967 alone builds the chunk at
+  // 10,700,930 B (10450 KB) against the 10490 KB ceiling -- 0.4% headroom, so
+  // any feature PR shipping a normal set of keys across the 13 catalogs fails
+  // the gate on its merge ref (first seen on the Create Folders From Project
+  // takeover, 13 catalogs x 52 lines, ~55 KB). Same recurrence as the `t` and
+  // `App` entries below: a ceiling that drifted to <1% headroom fails on
+  // routine string growth rather than on the new library it exists to catch.
+  all: 10975 * KB, // measured 10450 KB on main 2026-09-06 (~5% headroom)
 
   // The i18n RUNTIME — the i18next singleton, `initI18n`, the English catalog —
   // named after `src/i18n/t.ts`. Held separately from `all` above because


### PR DESCRIPTION
## Problem / Motivation

Unblocker: main's `all` chunk (the eager i18n catalogs) has drifted to within 0.4% of its own bundle-size ceiling, so the Bundle Size Gate fails on the **merge ref of any feature PR that ships a normal set of translated strings** instead of on the new library or surface the ceiling exists to catch. First hit on #8924 (13 catalogs × 52 lines, ~55 KB of strings): `FAIL assets/all-*.js: 10.26 MB exceeds its 10.24 MB budget by 13.7 KB`.

no linked issue: gate breakage found while driving PR #8924; filed as a direct unblocker per the `t`-entry (#8412) and `App`-entry (#8519) precedents for the identical recurrence.

## Why it matters

Every open PR that adds i18n keys inherits this red on its merge ref, and the fix would otherwise get folded into unrelated feature PRs one at a time — each one re-justifying the same ceiling move.

## What changed (motivation → approach → change)

**Attribution (measured, not assumed).** main @ `3a6478967` alone, with no PR code, builds `assets/all-DdlRMre2.js` at **10,700.93 kB = 10,700,930 B (10450 KiB)** — CI job [101448257266](https://github.com/kirodotdev/KiroCrew/actions/runs/34018323966/job/101448257266) on main's own `ci.yml` run, passing with 40,830 B (0.38%) of headroom under the 10490 KiB (10,741,760 B) ceiling. #8924's 13 catalogs add ~54.8 kB on top, landing at 10,755,750 B. Nothing new reached the chunk: the app page in #8924 sits behind a lazy `import()` in `src/apps/builtinRegistry.ts` and the `App` chunk is unaffected.

**Change.** `all: 10490 * KB` → `all: 10975 * KB` (= 10450 KiB measured + ~5% headroom), matching the convention documented on the `t` and `App` entries. The entry's comment records the measurement, date, and recurrence class so the next re-measure has the trail.

## Tests

N/A — CI gate constant only. `src/test/checkBundleSize.test.ts` and `src/test/bundleReport.test.ts` do not pin the `all` value (verified by grep); `node -e "import('./scripts/check-bundle-size.mjs')"` loads and reports `all = 11238400`.

## Manual verification

N/A — the attribution above is CI's own measurement on main; this PR's own Bundle Size Gate run is the verification.

## Screenshots / video

<!-- no-visual-delta -->
**Why no screenshot:** CI gate constant only; no runtime code.

## Related Issues

Unblocks #8924. Precedents: #8412 (`t` entry), #8519 (`App` entry).

## Pattern harvest

Not generalizable: the `t` entry's comment already documents this recurrence class (a ceiling with <1% headroom fails on drift, not on defects) and the 5% headroom convention is the standing remedy; this PR applies it to the `all` entry.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
