### PR TITLE
fix(doctor): point the Linux ffmpeg hint at locations the resolver searches (#8897)

### DIFF
--- a/src/kiro_crew/cli_doctor.py
+++ b/src/kiro_crew/cli_doctor.py
@@ -364,6 +364,25 @@ def _os_fix_hint(mac: str, linux: str, windows: str | None = None) -> str:
     return linux
 
 
+# The Linux arm of the missing-ffmpeg fix, a module constant so the test can hold
+# it against the resolver's real search set. An earlier version told the user to
+# drop a static build into ``~/.local/bin``, which ``transcribe._find_ffmpeg``
+# deliberately never searches (``_ffmpeg_candidate_dirs`` documents removing it:
+# a generic user-writable PATH dir would let agent-written code run as the
+# gateway), so a user who followed the advice still ended at "not found" (#8897).
+# Name only remedies that actually resolve: the dashboard's decoder download
+# installs into the digest-verified store ``_find_ffmpeg`` checks last and needs
+# no PATH reasoning (the working fix on distros with no packaged ffmpeg, e.g.
+# AL2023 — pinned artifacts exist for x86_64 and aarch64, the Linux ISAs the
+# desktop matrix ships; on any other ISA the fetch is refused and the second
+# clause is the remedy), and ``/usr/local/bin`` is both a real
+# ``_FFMPEG_CANDIDATE_DIRS`` entry and the conventional manual-install prefix.
+_FFMPEG_LINUX_HINT = (
+    "download the audio decoder from the dashboard (Settings → Speech-to-Text), "
+    "or install ffmpeg into /usr/local/bin"
+)
+
+
 # kiro-cli is the DEFAULT agent backend; the claude-agent-acp binary below belongs
 # to Claude Code, which is also selectable. Doctor reports it as an optional
 # backend, and the verdict comes from ``agent_sdk.probe_backend`` so doctor and the
@@ -3235,8 +3254,7 @@ def _doctor(platform_boot_error: "Exception | None" = None, bundle: bool = False
                 "               Fix: "
                 + _os_fix_hint(
                     "brew install ffmpeg",
-                    "drop a static ffmpeg build into ~/.local/bin "
-                    "(not in AL2023 repos; Kiro Crew auto-detects it)",
+                    _FFMPEG_LINUX_HINT,
                     windows="winget install Gyan.FFmpeg",
                 )
             )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4302,7 +4302,10 @@ class TestDoctorStt:
         )
 
         assert "ffmpeg:      ❌ not found" in out
-        assert "drop a static ffmpeg build into ~/.local/bin" in out
+        # The wiring assertion: doctor must print the module constant the
+        # resolvable-hint tests hold against the resolver's candidate list, so
+        # nobody can inline a literal back into the _os_fix_hint call (#8897).
+        assert _doc._FFMPEG_LINUX_HINT in out
         assert "reinstall Kiro Crew" not in out
         assert "❌ Fix these issues: " in out
         assert "ffmpeg" in out.split("❌ Fix these issues: ", 1)[1]

--- a/test/test_cli_doctor.py
+++ b/test/test_cli_doctor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -80,6 +81,42 @@ class TestFixHint:
         # No Windows arm supplied → keep the Linux text rather than inventing one.
         monkeypatch.setattr(cli_doctor._plat, "system", lambda: "Windows")
         assert cli_doctor._os_fix_hint("brew x", "linux x") == "linux x"
+
+
+class TestFfmpegLinuxHintResolvable:
+    """The Linux missing-ffmpeg hint names only locations the resolver searches (#8897).
+
+    An earlier hint told the user to drop a static build into ``~/.local/bin``,
+    which ``transcribe._find_ffmpeg`` deliberately never searches (its candidate
+    list documents removing that directory), so following the advice literally
+    still ended at "not found". Hold the hint against the resolver's own candidate
+    list rather than freezing its prose.
+    """
+
+    def test_hint_does_not_name_the_deliberately_excluded_dir(self) -> None:
+        assert ".local/bin" not in cli_doctor._FFMPEG_LINUX_HINT
+
+    def test_every_directory_named_is_actually_searched(self) -> None:
+        from kiro_crew import transcribe
+
+        dirs = re.findall(r"/[A-Za-z0-9._/-]+", cli_doctor._FFMPEG_LINUX_HINT)
+        assert dirs, "the hint must name at least one concrete install directory"
+        for directory in dirs:
+            assert (
+                directory in transcribe._FFMPEG_CANDIDATE_DIRS
+            ), f"{directory} is in the doctor hint but _find_ffmpeg never searches it"
+
+    def test_hint_offers_the_managed_store_download(self) -> None:
+        # The store download is the remedy that needs no PATH reasoning and works
+        # on distros with no packaged ffmpeg (the AL2023 case the old hint cited).
+        # Anchored to the decoder table, not the prose alone: if the pinned Linux
+        # artifacts were ever dropped, the hint would promise a download the
+        # gateway refuses (409 decoder_unsupported_platform).
+        from kiro_crew.stt import decoder
+
+        assert "dashboard" in cli_doctor._FFMPEG_LINUX_HINT
+        assert decoder.artifact_for("Linux", "x86_64") is not None
+        assert decoder.artifact_for("Linux", "aarch64") is not None
 
 
 class TestDataHome:


### PR DESCRIPTION
## Summary

`kirocrew doctor` on Linux told the user to fix a missing ffmpeg by dropping a
static build into `~/.local/bin`, claiming "Kiro Crew auto-detects it". It does
not: `transcribe._find_ffmpeg` deliberately never searches `~/.local/bin` — its
candidate-dir docstring records removing that directory because a generic
user-writable PATH dir would let agent-written code run as the gateway. A user
following the hint literally still ended at "not found".

This PR fixes only the advice text (widening the search path is explicitly out
of scope; the exclusion is documented as deliberate):

- The Linux hint now names the two remedies that actually resolve:
  1. the dashboard's decoder download (Settings → Speech-to-Text), which
     installs into the digest-verified store `_find_ffmpeg` checks last and
     needs no PATH reasoning — the working fix on distros with no packaged
     ffmpeg (the AL2023 case the old hint cited); pinned artifacts exist for
     the Linux ISAs the desktop matrix ships (x86_64, aarch64);
  2. `/usr/local/bin`, a real `_FFMPEG_CANDIDATE_DIRS` entry and the
     conventional manual-install prefix.
- The hint is extracted to a module constant `_FFMPEG_LINUX_HINT` so tests can
  hold it against the resolver's own search set instead of freezing prose.

## Tests

- New `TestFfmpegLinuxHintResolvable` in `test/test_cli_doctor.py`:
  - every directory the hint names must be in `transcribe._FFMPEG_CANDIDATE_DIRS`
    (the round-trip assertion tying the prose to the resolver);
  - the deliberately excluded `.local/bin` must not reappear;
  - the managed-store remedy must stay offered, anchored to
    `stt.decoder.artifact_for("Linux", ...)` so the hint cannot promise a
    download the gateway would refuse.
- Updated the wiring assertion in `test/test_cli.py`
  (`test_doctor_stt_ffmpeg_is_a_prerequisite_of_every_provider`) to assert
  doctor prints `_FFMPEG_LINUX_HINT`, so a literal cannot be inlined back.
- Mutation-verified: pointing the hint back at `~/.local/bin`, naming an
  unsearched directory, dropping the store clause, and inlining a literal at
  the call site each fail a distinct test.
- Local gates green: black-baseline, isort, flake8, mypy, subprocess-encoding,
  brand-name, harness-parity; `test/test_cli_doctor.py` (149) and the STT
  slice of `test/test_cli.py` (21) pass.

## Pre-push review

Two model-pinned review lanes ran on the diff:
- GPT lane: NO-FINDINGS (verified the dashboard remedy is reachable on
  non-bundled Linux x86_64/aarch64, store-last resolver order, `/usr/local/bin`
  membership, no cross-OS regression).
- Opus lane: 1 BLOCKING (stale literal assertion in `test/test_cli.py:4305` —
  fixed, and upgraded into the wiring assertion above) + 3 CONCERNS
  (store-download test anchored to the decoder table — fixed; comment ISA
  overclaim — fixed with the x86_64/aarch64 caveat; hint-token regex could
  false-positive on a future URL — accepted as-is, the hint is directory-only
  and the test exists precisely to force that conversation on change).

Closes #8897

## Pattern harvest

Rule candidate: invariant test that round-trips user-facing remedy text against the mechanism it describes

Pattern: a doctor/CLI fix hint (or error remedy string) names a path, command, or setting that the code it advises about never consults — prose and mechanism drift apart because nothing ties them together. The fix here is the reusable shape: extract the advice to a module constant and add a test that parses the concrete claims out of it (directories, artifact availability) and asserts each against the resolver's own data (`_FFMPEG_CANDIDATE_DIRS`, `stt.decoder.artifact_for`). Sibling sites: any `_os_fix_hint` caller or doctor "Fix:" line naming a filesystem location.
