### PR TITLE
docs(ec2): fix the ffmpeg ~/.local/bin hint in the EC2 guide (#8897)

### DIFF
--- a/docs/guides/remote-crew-on-ec2.md
+++ b/docs/guides/remote-crew-on-ec2.md
@@ -134,9 +134,10 @@ port into the CSRF allowlist — see
 
 ### Non-fatal warnings you can ignore
 
-- **`ffmpeg: not found`** — only needed for speech-to-text. Drop a static ffmpeg
-  build into `~/.local/bin` (it's not in the AL2023 repos; Kiro Crew auto-detects
-  it).
+- **`ffmpeg: not found`**: only needed for speech-to-text. Install ffmpeg into
+  `/usr/local/bin` (a location Kiro Crew searches; it's not in the AL2023 repos),
+  or fetch a decoder from the dashboard Speech-to-Text card
+  (Settings > Voice, then Download now).
 - **`Vector Memory … vendored runtime failed to load`** — the in-process embedding
   runtime couldn't load its shared library on this host; memory falls back
   gracefully and keeps working. Safe to ignore unless you specifically rely on


### PR DESCRIPTION
Addresses the documentation surface of #8897 that [PR #8937](https://github.com/kirodotdev/KiroCrew/pull/8937) does not cover.

## Why this is separate from #8937
#8937 is review-ready and CI-green, and it fixes the doctor hint in `src/kiro_crew/cli_doctor.py` plus the tests. It does **not** touch the second surface the issue flags. This PR is now scoped to that single missing piece so the two don't overlap. Its net diff is one file.

## Change
- `docs/guides/remote-crew-on-ec2.md` (line ~137): the `ffmpeg: not found` note no longer tells users to drop a static build into `~/.local/bin` and claim auto-detection (a directory the resolver never searches). It now says to install ffmpeg into `/usr/local/bin` (a location the resolver searches; not in the AL2023 repos), or fetch a decoder from the dashboard Speech-to-Text card (Settings > Voice, then Download now) via the `POST /api/stt/ffmpeg/download` path added in #8427.

## Tests
N/A -- doc-only change, no code touched.

## Manual verification
N/A -- unit coverage sufficient; verified `scripts/docs-lint.sh` passes clean on the changed file.

## Note
If #8937 merges first, this remains a clean, non-conflicting doc-only follow-up. If a maintainer prefers a single PR, the EC2 guide change can instead be cherry-picked onto #8937 and this PR closed.

Closes #8897
