### PR TITLE
fix(settings): back UI preferences up on the host, and stop config.json dropping nested unknown keys

### DIFF
--- a/docs/feature-map/README.md
+++ b/docs/feature-map/README.md
@@ -218,6 +218,7 @@ is `/settings/<key>`. Panels live in `pages/settings/`.
 | `developer` | Developer Mode gate, Feature Previews opt-ins (client flags), local-gateway switch | `DeveloperPanel.tsx`, `FeaturePreviewsSection.tsx` | — | — |
 | `releases` | Release channel, update check, changelog | `ReleasesPanel.tsx` | `handlers/updates.py` | `GET /api/update/check`, `POST /api/update`, `GET /api/changelog`, `GET /api/releases` |
 | `about` | Version, build, diagnostics bundle | `AboutPanel.tsx`, `ReportProblemCard.tsx` | `handlers/diagnostics.py`, `handlers/feedback.py` | `POST /api/diagnostics/collect`, `GET /api/diagnostics/download/{filename}` |
+| — (cross-cutting) | Host-side backup of the browser-held settings the tabs above write, so they survive a moved dashboard port or a relocated Electron `userData`. Restores on a profile that has never reached the host; allowlist-scoped (`DURABLE_PREF_KEYS`), not every browser key | — (no panel; `lib/uiPrefs.ts` is the client) | `handlers/ui_prefs.py` | `GET,PUT /api/ui-prefs` |
 
 Flagged-file delivery consent (`GET,POST,DELETE /api/file-delivery/consent`,
 owner-gated) is listed on the `security` row because that is the tab it belongs
@@ -230,6 +231,14 @@ the record sits on the sandbox-sealed keystone floor.
 Instances is deliberately not a rail row: it is set up here once and switched
 from the header tab strip. Webhooks carries both a preview flag and
 `hiddenFromNav`, so it surfaces as this Settings tab rather than a rail row.
+
+The UI-preference backup row carries no tab because it has no panel and nothing
+for a user to reach: it is the mechanism behind the tabs above, listed so its
+handler has an owner in this map. Its allowlist is explicit, so a preference
+absent from `DURABLE_PREF_KEYS` is still lost on an origin change, and a value
+that gates a safety confirmation (`mc-yolo-ack`) is deliberately excluded. The
+contract is in
+[../system-specs/modules/config.md](../system-specs/modules/config.md).
 
 ## Developer
 

--- a/docs/system-specs/modules/config.md
+++ b/docs/system-specs/modules/config.md
@@ -381,6 +381,149 @@ Returns `~/.kiro/crew/config.local.json` (or `$KIROCREW_HOME/config.local.json`)
 Recursively merges overlay into base. Dict values merge recursively; all other
 types in overlay replace base values.
 
+## Browser UI preferences (ui-prefs.json)
+
+`~/.kiro/crew/ui-prefs.json` is a backup of the dashboard settings that live in
+the renderer's `localStorage`, not in `config.json`. It exists because
+`localStorage` is keyed by ORIGIN and, in the desktop app, stored inside
+Electron's `userData` directory, so a moved dashboard port, a relocated
+`userData` directory, a switch between the stable and nightly builds, or a
+browser storage eviction wipes every setting the user chose — and reads to the
+user as "the upgrade lost my settings".
+
+Owned by `kiro_crew/ui_prefs.py`, served by `GET`/`PUT /api/ui-prefs`, and
+consumed by `website/src/lib/uiPrefs.ts`. Deliberately NOT a section of
+`config.json`:
+
+- `KiroCrewConfig.save()` re-emits the whole dataclass, so a key the running
+  build does not model is dropped on the next save. A bag of client-owned UI
+  keys is exactly the shape that loses that fight.
+- `config.json` is operator-facing; renderer layout keys do not belong in it.
+
+Contract:
+
+- Values are opaque UTF-8 strings (what `localStorage` holds). The server never
+  parses them. The file is `{"prefs": {...}}` and nothing else: an earlier
+  revision carried a `version` and an `updated_at` that no code read, and the
+  loader is tolerant of any shape it does not recognize, so a future reshape
+  needs no version field to be safe.
+- `PUT` is a merge patch; a `null` value deletes its key. BOTH methods are
+  owner-gated: the write so a viewer cannot overwrite the owner's settings, and
+  the read because some values name real paths on the host (the file explorer's
+  saved state, the cloud launch defaults). Gating the read costs nothing, since a
+  non-owner can never have written a backup.
+- Keys whose name looks like a credential (`token`, `secret`, `password`,
+  `credential`, `api_key`) are refused on write and filtered on read, so the
+  dashboard bearer token can never land here.
+- Bounds: 200 keys, 128-char keys, 64 KiB per value, 512 KiB total. A patch that
+  would breach them is rejected WHOLE; nothing partial is written. The client
+  answers a rejection by retrying the patch one key at a time, so one unstorable
+  value cannot discard the valid changes bundled with it.
+- An unreadable or malformed file means "no backup", never an error: the client
+  falls back to whatever `localStorage` holds.
+- The client reads the backup when this profile has never successfully reached
+  the host (`mc-ui-prefs-synced` absent) and only fills keys that are absent, so
+  it can never clobber a value the running profile already has. Keyed on
+  never-synced rather than no-settings-present so a boot whose fetch failed
+  retries on the next one instead of forfeiting the restore. Otherwise the client
+  is write-only: the backup is a backup, not a live cross-tab sync channel.
+- When the restore actually wrote something the page RELOADS instead of
+  rendering. Restoring before the first render is not sufficient on its own:
+  static imports are evaluated before the entry module's first statement, so a
+  store that reads its key at module scope (`hooks/useBottomTerminal.ts`) has
+  already captured the pre-restore value and its first write would persist that
+  stale copy back over the restored one. The reload is correct for every
+  module-scope reader without a per-store re-init hook, costs one extra load on a
+  fresh profile, and cannot loop because the synced marker is written first.
+- Every key the host holds is baselined with whatever is in `localStorage` for it
+  after the restore — including a local value that DIFFERS from the host's and
+  was kept. The hydrating origin is by definition the one that has not been
+  syncing, so uploading its value on first flush would overwrite the newer backup
+  with a possibly months-stale one; baselined, it stays in use locally and is
+  uploaded the moment the user changes it. A value the quota-safe writer had to
+  drop is NOT baselined, or the first flush would read it as a deletion and null
+  out a good host backup.
+- A FAILED first restore writes `mc-ui-prefs-hydrate-pending` holding the list of
+  durable keys the profile held AT THAT MOMENT. On the next successful restore a
+  key in that list — and any change the user made to it since — is the user's,
+  so local wins as usual; a key NOT in the list was written after the failure by
+  a page that rendered without its settings (a login screen counts; mount-time
+  hooks persist defaults), so for it the HOST wins — treating those defaults as
+  the user's choice would upload them over the real backup. A repeat failure
+  never widens the list. A never-failed first restore keeps the normal rule.
+  Letting the host win for every key instead had the mirror-image defect: a
+  returning user whose GET failed once and then changed a preference saw the
+  stale host value overwrite the change. The marker is cleared only after the
+  synced marker is written, so a crash between the two leaves the profile
+  pending rather than synced-with-untrusted-locals.
+- `mc-ui-prefs-synced` also holds the NAMES this profile last synced, which is
+  how a deletion made before a reload is still reported as a `null` while a key
+  this profile never synced is never nulled — that is what stops a second browser
+  from deleting the first one's settings.
+- Which keys are durable is the client's decision (`DURABLE_PREF_KEYS`).
+  Session-scoped and derived state (height caches, panel tabs, drafts, touched
+  files) is excluded, as are the settings `config.json` already owns (theme
+  mode/colour, language, onboarding flags) and keys a migration deliberately
+  deletes (`mc-zoom`, `mc-font-scale`), so no setting has two homes and nothing
+  resurrects a key a migration removed.
+- Also excluded: any value that GATES A SAFETY CONFIRMATION. `mc-yolo-ack` is the
+  instance — its presence makes the approval-mode picker skip the confirmation
+  and enable full auto-approval — and the reason is that this file sits in the
+  agent-writable data home, so a restorable ack is an ack an agent can forge for
+  the user's next fresh origin. Convenience does not outrank a human gate.
+
+## Unknown keys are preserved on round-trip
+
+`save()` re-emits the whole dataclass, so anything the running build does not
+model is absent from what it writes. Two capture fields stop that from erasing
+the operator's settings on an upgrade:
+
+- `_extra_sections` holds unknown TOP-LEVEL sections (an edition-contributed
+  section written by a companion), classified against `_KNOWN_CONFIG_SECTIONS`.
+- `_extra_keys` holds unknown keys INSIDE a modelled section, `{section: {key:
+  value}}`, captured by `resolution.capture_extra_section_keys`. Without it, a
+  build that renamed or removed `<section>.<key>` erased the value on the next
+  `save()` of any kind (a log-level change, adding a workspace, editing an
+  agent), with no backup on that path.
+
+Both restore a key only when the emitted document LACKS it, so a captured copy
+can never overwrite a live value or undo a deliberate deletion. `_extra_keys`
+has two shapes: `{key: value}` for a dataclass-backed section, and
+`{record_name: {key: value}}` for the maps of named records (`agents`,
+`workspaces`, `memory_stores`), whose records are parsed field-by-field and
+re-emitted with `asdict` and so lose unmodelled keys the same way a section
+does. `hooks` needs neither: it is emitted raw and round-trips whole. A record
+deleted in memory stays deleted — restore fills into existing records only.
+
+Both capture from the BASE view of the document, not the merged one. When
+`config.local.json` shadows an unknown key that `config.json` also holds, a
+capture of the merged value made `save()` emit the overlay's leaf, which the
+overlay subtraction then removed — permanently deleting the base file's own value,
+so removing the overlay later revealed nothing. The loader therefore records the
+base copy of every top-level section the overlay touches (`_shadowed_base_sections`)
+at the last moment both documents exist, and captures against that. `save()`
+then emits the base value, the subtraction leaves it (it differs from the overlay
+leaf), and the overlay still wins on the next load. The base copy rides in the
+validated-data cache's sidecar (`ConfigCache.get_with_sidecar`) so a cache hit — where
+the overlay is no longer in scope — captures exactly as the disk read did.
+
+A key is NOT captured when it is a field of the section's dataclass, starts with
+an underscore, or appears in one of two explicit maps in `resolution.py`:
+
+| map | why the key is excluded |
+| --- | --- |
+| `_SECTION_KEYS_EMITTED_ELSEWHERE` | `to_dict()` writes it from outside the section dataclass, either conditionally (`slack.channels`, `dm_activation`, `trusted_bot_ids` — absence is a deliberate deletion) or from the top-level object (`slack.observe_max_messages`, `observe_ttl_hours`). |
+| `_SECTION_KEYS_DELIBERATELY_DROPPED` | The build chose not to round-trip it: RENAMED (`knowledge.auto_ingest_doc_links`, still read, canonical spelling written) or RETIRED (the removed local-STT install paths — re-persisting them would keep offering a setting with nothing behind it). |
+
+A key the schema DOES model but validation rejected also stays dropped, because
+re-emitting it would make the bad value permanent and re-warn on every load.
+
+The failure direction is deliberate: forgetting an entry in
+`_SECTION_KEYS_DELIBERATELY_DROPPED` preserves a key that could have been
+dropped, which is cosmetic. The reverse is the data loss the mechanism exists to
+prevent. `test_default_emitted_section_keys_are_all_recognized` guards
+`_SECTION_KEYS_EMITTED_ELSEWHERE` against drift.
+
 ## APIs
 
 ### `KiroCrewConfig.load() -> KiroCrewConfig`

--- a/src/kiro_crew/config/loader.py
+++ b/src/kiro_crew/config/loader.py
@@ -12,6 +12,7 @@ dashboard URL via the config file. (The dashboard *port* is set with the
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import math  # noqa: F401 - historical loader namespace compatibility
@@ -28,6 +29,10 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlsplit as _urlsplit  # noqa: F401 - compatibility facade
 
+# Module alias for post-split helpers. The `from ... import` list below is a
+# FROZEN pre-split alias snapshot (test_loader_reexports_historical_snapshot_by_identity),
+# so new resolution helpers are reached through the module, not re-exported.
+import kiro_crew.config.resolution as _resolution
 from kiro_crew import __version__, model_registry, platform_compat, windows_acl
 from kiro_crew.acp_backends import ACP_BACKEND_CLAUDE
 
@@ -1925,9 +1930,39 @@ def _cached_validated_data(fp: tuple | None = None) -> dict | None:
     return _CONFIG_CACHE.get(fp if fp is not None else _config_fingerprint())
 
 
-def _store_validated_data(data: dict, fp: tuple) -> None:
-    """Cache a deep copy of *data* under fingerprint *fp* (see ConfigCache.store)."""
-    _CONFIG_CACHE.store(data, fp)
+def _store_validated_data(data: dict, fp: tuple, sidecar: dict | None = None) -> None:
+    """Cache a deep copy of *data* (+ *sidecar*) under *fp* (see ConfigCache.store)."""
+    _CONFIG_CACHE.store(data, fp, sidecar)
+
+
+#: Sidecar key under which the loader caches the pre-overlay base values of the
+#: top-level sections config.local.json touches. See ``_shadowed_base_sections``.
+_SIDECAR_BASE_SHADOW = "base_shadow"
+
+
+def _shadowed_base_sections(base: dict, overlay: dict) -> dict:
+    """The base document's copy of every top-level section the overlay touches.
+
+    ``_deep_merge`` lets an overlay leaf replace a base leaf, and after the merge
+    nothing remembers what the base held. That is fine for modelled keys — they
+    are parsed into fields and ``save()`` re-emits the field, while
+    ``_subtract_overlay`` keeps the overlay's value out of the base file. It is
+    NOT fine for the unknown keys ``_extra_sections`` / ``_extra_keys`` round-trip
+    verbatim: captured from the MERGED document they hold the overlay's value, so
+    ``save()`` emits it, the subtraction removes it (it equals the raw overlay
+    value), and the base file loses a key it had. Removing the overlay later then
+    reveals nothing — the base value is gone for good.
+
+    Capturing from the base instead makes the round-trip honest: ``save()`` emits
+    the base value, it differs from the overlay leaf so subtraction leaves it, and
+    the overlay still wins on the next load exactly as before.
+
+    Only sections the overlay names are kept (an overlay normally touches a few),
+    and only their base copy — the loader already has the merged copy. This rides
+    in the cache sidecar so a cache hit, where the overlay is no longer in scope,
+    can still capture correctly.
+    """
+    return {k: copy.deepcopy(base[k]) for k in overlay if k in base}
 
 
 def _invalidate_config_cache() -> None:
@@ -2245,6 +2280,16 @@ class KiroCrewConfig:
     # ConfigSchemaContributor seam — a companion writes its section, the core
     # round-trips it untouched.
     _extra_sections: dict = field(default_factory=dict)
+    # Unknown keys found INSIDE a modelled section, captured at load() and
+    # re-emitted by to_dict() for the same reason as _extra_sections one level
+    # up: a build that stops modelling ``<section>.<key>`` (a rename, a removal,
+    # an older config written by a newer edition) would otherwise erase the
+    # operator's value on the next save() of any kind, with no backup on that
+    # path. Shape: {section: {key: value}}. Populated only from disk, and only
+    # ever used to fill a key the emitted section LACKS, so it cannot clobber a
+    # live value. See resolution.capture_extra_section_keys for what counts as
+    # unknown (a schema-modelled key that validation rejected stays dropped).
+    _extra_keys: dict = field(default_factory=dict)
 
     def channel_config(self, channel_id: str) -> ChannelConfig:
         """Return the config for *channel_id*, falling back to defaults.
@@ -2361,9 +2406,18 @@ class KiroCrewConfig:
         # second pass would be filesystem I/O there for information already in
         # hand.
         fp = _config_fingerprint()
-        cached_data = _cached_validated_data(fp)
-        if cached_data is not None:
-            data = cached_data
+        # Data and sidecar come from ONE lock hold: fetched separately, a save()
+        # on another thread could clear the cache between the two and hand this
+        # load a merged document with an EMPTY base shadow — which would then be
+        # captured from as if no overlay existed (see _shadowed_base_sections).
+        cached = _CONFIG_CACHE.get_with_sidecar(fp)
+        # Pre-overlay base copy of the sections the overlay touched. Filled on the
+        # disk path below; read from the sidecar on a cache hit. Empty when there
+        # is no overlay, in which case the merged document IS the base.
+        base_shadow: dict = {}
+        if cached is not None:
+            data, sidecar = cached
+            base_shadow = sidecar.get(_SIDECAR_BASE_SHADOW, {})
         else:
             # fp was captured BEFORE reading, so a write landing during the read
             # is detected: we cache under it, it won't match the post-write
@@ -2425,6 +2479,9 @@ class KiroCrewConfig:
                     _mark_file_degraded(local_path)
 
             if local_data:
+                # Remember the base copy of what the overlay is about to shadow —
+                # the last moment both documents exist. See _shadowed_base_sections.
+                base_shadow = _shadowed_base_sections(data, local_data)
                 data = _deep_merge(data, local_data)
 
             # A present source that cannot be read or parsed may contain the
@@ -2486,8 +2543,10 @@ class KiroCrewConfig:
             # on the disk-read path; cache hits below already serve clamped values.
             _clamp_security_bounds(data)
             # Cache the validated, merged dict under the PRE-read fingerprint so
-            # a mid-read write self-heals (next load misses and re-reads).
-            _store_validated_data(data, pre_read_fp)
+            # a mid-read write self-heals (next load misses and re-reads). The
+            # base shadow rides along so a hit can capture unknown keys from the
+            # base document exactly as this disk read did.
+            _store_validated_data(data, pre_read_fp, {_SIDECAR_BASE_SHADOW: base_shadow})
 
         # Collected during the parse that discards them — the only moment the
         # evidence exists, since the migration below rewrites config.json in
@@ -2659,9 +2718,17 @@ class KiroCrewConfig:
         # survives the load()->to_dict()->save() round-trip instead of being
         # silently dropped. ``meta`` is stamped by save() itself, so it is never
         # treated as an unknown section to preserve.
+        #
+        # Captured from the BASE view, not the merged one: for any section the
+        # overlay touched, ``base_shadow`` holds what config.json itself said.
+        # Capturing the merged value would make save() emit the overlay's leaf,
+        # which _subtract_overlay then removes — deleting the base file's own
+        # value. See _shadowed_base_sections. Sections the overlay did not touch
+        # are identical in both views.
+        capture_view = {**data, **base_shadow}
         extra_sections = {
             k: v
-            for k, v in data.items()
+            for k, v in capture_view.items()
             if k not in _KNOWN_CONFIG_SECTIONS and k not in CONFIG_RESERVED_TOP_KEYS
         }
 
@@ -3697,6 +3764,13 @@ class KiroCrewConfig:
             _extra_sections=extra_sections,
         )
 
+        # Unknown keys nested inside a modelled section. Captured AFTER
+        # construction because deciding what is unknown needs the built
+        # dataclasses' own field sets, not a second hand-maintained list that
+        # could drift from them. Same base-not-merged view as _extra_sections
+        # above, for the same reason.
+        cfg._extra_keys = _resolution.capture_extra_section_keys(capture_view, cfg)
+
         # Write-back migration: if the on-disk config has legacy format
         # (flat workspace strings, missing sections), back up the original
         # and save the migrated version.  One-shot — subsequent loads see
@@ -3854,6 +3928,13 @@ class KiroCrewConfig:
         else:
             slack_section.pop("trusted_bot_ids", None)
         slack_section["observe_ttl_hours"] = self.observe_ttl_hours
+        # Restore unknown keys captured INSIDE a modelled section (and inside the
+        # named records of agents/workspaces/memory_stores). Last in the method
+        # on purpose: every conditional and derived emission above has already
+        # run, so the fill-only rule reads the final truth and a captured copy
+        # can only ever FILL a gap, never overwrite a live value or undo a
+        # deliberate deletion.
+        _resolution.restore_extra_section_keys(d, self._extra_keys)
         return d
 
     def save(self) -> None:

--- a/src/kiro_crew/config/resolution.py
+++ b/src/kiro_crew/config/resolution.py
@@ -8,6 +8,7 @@ validation modules.
 from __future__ import annotations
 
 import logging
+from dataclasses import fields, is_dataclass
 from pathlib import Path
 
 logger = logging.getLogger("kiro_crew.config.loader")
@@ -80,6 +81,206 @@ _KNOWN_CONFIG_SECTIONS: frozenset = frozenset(
         "connections_ui",
     }
 )
+
+# Section keys that to_dict() emits from somewhere OTHER than the section's own
+# dataclass fields. They are recognized (never captured as unknown) for two
+# distinct reasons, both of which make capture wrong:
+#
+#   * ``channels`` / ``dm_activation`` / ``trusted_bot_ids`` are emitted
+#     CONDITIONALLY and dropped when empty, so their absence from the emitted
+#     document is a deliberate deletion. Restoring them from a load-time capture
+#     would resurrect a channel or an allow-list the caller just cleared.
+#   * ``observe_max_messages`` / ``observe_ttl_hours`` are stored on the
+#     TOP-LEVEL config object, not on SlackConfig, and to_dict() writes them into
+#     the slack section unconditionally. Capturing them would be pure noise.
+#
+# Drift is caught by test_default_emitted_section_keys_are_all_recognized: every
+# key a default config emits per section must be recognized here or be a field.
+_SECTION_KEYS_EMITTED_ELSEWHERE: dict = {
+    "slack": frozenset(
+        {
+            "channels",
+            "dm_activation",
+            "trusted_bot_ids",
+            "observe_max_messages",
+            "observe_ttl_hours",
+        }
+    ),
+}
+
+# Section keys this build deliberately does NOT round-trip. Capture must skip
+# them, because preserving them defeats the decision that removed them.
+#
+# Two reasons land here, and the distinction matters when adding an entry:
+#   * RENAMED — the reader still accepts the old spelling but save() settles on
+#     the canonical one. Pinning the old spelling would make the migration never
+#     finish.
+#   * RETIRED — the feature behind the key is gone. Re-persisting the key would
+#     keep offering a setting with nothing behind it (see
+#     TestSttRemovedFieldsAreInert).
+#
+# The failure direction of THIS map is deliberate: forgetting an entry PRESERVES
+# a key that could have been dropped, which is cosmetic. The reverse — dropping a
+# key that should have been preserved — is the data loss this whole mechanism
+# exists to stop, so preservation is the default and every exception is written
+# down here. (_SECTION_KEYS_EMITTED_ELSEWHERE above does NOT share this safety:
+# forgetting a conditionally-emitted key there resurrects a cleared value, and
+# the default-config drift guard cannot see a key that is empty by default.)
+_SECTION_KEYS_DELIBERATELY_DROPPED: dict = {
+    # RENAMED: agent.dangerously_skip_permissions is also read as the camelCase
+    # `dangerouslySkipPermissions` (the spelling other agent tools use) and the
+    # legacy `yolo`; save() writes only the canonical snake_case. Preserving the
+    # older spellings would leave two of them in the file at once, so a user who
+    # turns the canonical grant OFF could still have an old `yolo: true` sitting
+    # beside it — a contradiction in the one key that controls standing,
+    # unattended auto-approval. See sections._read_dangerously_skip_permissions.
+    "agent": frozenset({"dangerouslySkipPermissions", "yolo"}),
+    # RENAMED: knowledge.auto_add_documents was auto_ingest_doc_links;
+    # sections._read_auto_add_documents still reads the old spelling.
+    "knowledge": frozenset({"auto_ingest_doc_links"}),
+    # RETIRED: the out-of-band installs the removed local STT providers needed.
+    "stt": frozenset({"whisper_path", "mlx_model", "parakeet_model", "device"}),
+}
+
+
+#: Sections that are MAPS OF NAMED RECORDS, each record a dataclass: the user
+#: picks the record names, so the names themselves are never "unknown", but a
+#: key INSIDE a record is parsed field-by-field and re-emitted with ``asdict``
+#: exactly like a section field — so an unmodelled ``agents.<name>.<key>`` was
+#: dropped on save just as ``agent.<key>`` was. Captured one level deeper, as
+#: ``{section: {record_name: {key: value}}}``. ``hooks`` is NOT here: it is
+#: emitted raw (``"hooks": self.hooks``) and round-trips whole.
+_RECORD_MAP_SECTIONS: frozenset = frozenset({"agents", "workspaces", "memory_stores"})
+
+
+def _unknown_keys_of(raw: dict, obj: object, recognized_extra: frozenset) -> dict:
+    recognized = {f.name for f in fields(obj)} | recognized_extra  # type: ignore[arg-type]
+    return {k: v for k, v in raw.items() if k not in recognized and not k.startswith("_")}
+
+
+def capture_extra_section_keys(data: dict, cfg: object) -> dict:
+    """Unknown keys found INSIDE a modelled section, per section.
+
+    The top-level counterpart of this is ``_extra_sections``: a whole section
+    this core does not model survives a load/save round-trip. A key nested one
+    level down had no such protection, so when a build stopped modelling
+    ``<section>.<key>`` — a rename, a removal, or simply an older config written
+    by a newer edition — the load ignored it and the next ``save()`` (triggered
+    by anything at all: a log-level change, adding a workspace, editing an
+    agent) rewrote the file without it. The operator's value was gone, silently,
+    with no backup on that path.
+
+    Two shapes of section are covered. A dataclass-backed section yields
+    ``{key: value}``. A map of named records (``_RECORD_MAP_SECTIONS``) yields
+    ``{record_name: {key: value}}``, because each record is itself parsed
+    field-by-field and would otherwise lose its unmodelled keys the same way.
+    ``hooks`` is neither: it is emitted raw and round-trips whole.
+
+    A key is recognized — and so NOT captured — when it is a field of the
+    section's dataclass (including private carriers, which to_dict() drops on
+    purpose), when it is listed in ``_SECTION_KEYS_EMITTED_ELSEWHERE`` or
+    ``_SECTION_KEYS_DELIBERATELY_DROPPED``, or when it starts with an underscore.
+    Note what this deliberately does NOT cover: a key the schema DOES model but
+    validation rejected (a bad enum value from an older build) stays dropped,
+    because re-emitting it would make the rejection permanent and re-warn on
+    every load.
+
+    Capture is a no-op safety net rather than an override: to_dict() restores a
+    captured key only if the emitted section lacks it, so a stale copy can never
+    clobber a live value.
+    """
+    captured: dict = {}
+    for section, raw in data.items():
+        if section not in _KNOWN_CONFIG_SECTIONS or not isinstance(raw, dict):
+            continue
+        section_obj = getattr(cfg, section, None)
+        extra = _SECTION_KEYS_EMITTED_ELSEWHERE.get(
+            section, frozenset()
+        ) | _SECTION_KEYS_DELIBERATELY_DROPPED.get(section, frozenset())
+
+        if section in _RECORD_MAP_SECTIONS and isinstance(section_obj, dict):
+            per_record: dict = {}
+            for name, entry in raw.items():
+                record = section_obj.get(name)
+                # A flat legacy entry (workspaces used to be plain strings) has
+                # no nested keys to lose; a record the load did not build (it was
+                # not a dict, or was rejected) has nothing to compare against.
+                if not isinstance(entry, dict) or record is None or not is_dataclass(record):
+                    continue
+                unknown = _unknown_keys_of(entry, record, extra)
+                if unknown:
+                    per_record[name] = unknown
+            if per_record:
+                logger.debug(
+                    "config: preserving unmodelled %s record key(s) on round-trip: %s",
+                    section,
+                    ", ".join(f"{n}.{k}" for n, ks in sorted(per_record.items()) for k in ks),
+                )
+                captured[section] = per_record
+            continue
+
+        if section_obj is None or isinstance(section_obj, type) or not is_dataclass(section_obj):
+            continue
+        unknown = _unknown_keys_of(raw, section_obj, extra)
+        if unknown:
+            logger.debug(
+                "config: preserving unmodelled %s key(s) on round-trip: %s",
+                section,
+                ", ".join(sorted(unknown)),
+            )
+            captured[section] = unknown
+    return captured
+
+
+def restore_extra_section_keys(emitted: dict, extra_keys: dict) -> None:
+    """Fill captured unknown keys back into *emitted* (the to_dict() document).
+
+    Fill only — a key already present in the emitted document is never
+    overwritten, so a captured copy can neither clobber a live value nor undo a
+    deliberate deletion. Handles both capture shapes (see
+    :func:`capture_extra_section_keys`). Owned here beside the capture so the
+    two shapes cannot drift apart.
+    """
+    for section, unknown in extra_keys.items():
+        node = emitted.get(section)
+        if not isinstance(node, dict):
+            continue
+        if section in _RECORD_MAP_SECTIONS:
+            for name, record_unknown in unknown.items():
+                record = node.get(name)
+                if not isinstance(record, dict):
+                    continue  # the record was deleted in memory: stay deleted
+                for k, v in record_unknown.items():
+                    if k not in record:
+                        record[k] = v
+            continue
+        for k, v in unknown.items():
+            if k not in node:
+                node[k] = v
+
+
+def drop_extra_section_keys(document: dict, extra_keys: dict) -> None:
+    """Remove captured unknown keys from *document* (a browser-facing view).
+
+    The masked config response masks by SCHEMA path, so an unknown key is
+    invisible to its sensitivity walk — a credential a previous build stored
+    under a since-renamed key would ship verbatim. Preserving such a key for
+    save() is the point of the capture; showing it to the browser is not. Same
+    shape handling as :func:`restore_extra_section_keys`.
+    """
+    for section, unknown in extra_keys.items():
+        node = document.get(section)
+        if not isinstance(node, dict):
+            continue
+        if section in _RECORD_MAP_SECTIONS:
+            for name, record_unknown in unknown.items():
+                record = node.get(name)
+                if isinstance(record, dict):
+                    for k in record_unknown:
+                        record.pop(k, None)
+            continue
+        for k in unknown:
+            node.pop(k, None)
 
 
 def _deep_merge(base: dict, overlay: dict) -> dict:

--- a/src/kiro_crew/config/validation.py
+++ b/src/kiro_crew/config/validation.py
@@ -283,8 +283,8 @@ class ConfigCache:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        # (fingerprint, deep-copyable validated data dict)
-        self._entry: tuple[tuple, dict] | None = None
+        # (fingerprint, deep-copyable validated data dict, opaque sidecar)
+        self._entry: tuple[tuple, dict, dict] | None = None
 
     def get(self, fingerprint: tuple) -> dict | None:
         """Return a deep copy of the cached dict if *fingerprint* matches, else None.
@@ -299,8 +299,26 @@ class ConfigCache:
                 return copy.deepcopy(self._entry[1])
         return None
 
-    def store(self, data: dict, fingerprint: tuple) -> None:
-        """Cache a deep copy of *data* under *fingerprint*.
+    def get_with_sidecar(self, fingerprint: tuple) -> tuple[dict, dict] | None:
+        """Return deep copies of ``(data, sidecar)`` from ONE lock hold, else None.
+
+        The sidecar carries facts about the SAME read that the merged dict cannot
+        express — today, the pre-overlay base values the loader needs to round-trip
+        unknown keys correctly. The two halves describe one read and must be
+        served together: a ``save()`` on another thread calls ``clear()``, and
+        fetching them in two steps let the dict land before the clear and the
+        sidecar after it — a merged document with an EMPTY base shadow, which the
+        loader would then capture from as if no overlay existed, deleting shadowed
+        base keys on the next save. There is deliberately no separate sidecar
+        accessor: the lock makes the pair all-or-nothing.
+        """
+        with self._lock:
+            if self._entry is not None and self._entry[0] == fingerprint:
+                return copy.deepcopy(self._entry[1]), copy.deepcopy(self._entry[2])
+        return None
+
+    def store(self, data: dict, fingerprint: tuple, sidecar: dict | None = None) -> None:
+        """Cache a deep copy of *data* (and *sidecar*) under *fingerprint*.
 
         *fingerprint* MUST be the one captured BEFORE the files were read (by
         ``load()``), not a fresh stat. If a write lands between the read and this
@@ -311,7 +329,7 @@ class ConfigCache:
         TOCTOU) and serve it as a false hit until the file changed again.
         """
         with self._lock:
-            self._entry = (fingerprint, copy.deepcopy(data))
+            self._entry = (fingerprint, copy.deepcopy(data), copy.deepcopy(sidecar or {}))
 
     def clear(self) -> None:
         """Drop the cached validated config (called after save()/write-back)."""

--- a/src/kiro_crew/dashboard/handlers/__init__.py
+++ b/src/kiro_crew/dashboard/handlers/__init__.py
@@ -483,6 +483,11 @@ from kiro_crew.dashboard.handlers.themes import (  # noqa: E402, F401
     api_themes_install,
 )
 
+# ── Browser UI preference backup (extracted to handlers/ui_prefs.py) ──
+from kiro_crew.dashboard.handlers.ui_prefs import (  # noqa: E402, F401
+    api_ui_prefs,
+)
+
 # ── Updates & Logs (extracted to handlers/updates.py) ──
 # NOTE: api_stream passes update_available= to status_snapshot (see updates.py)
 from kiro_crew.dashboard.handlers.updates import (  # noqa: E402, F401

--- a/src/kiro_crew/dashboard/handlers/core.py
+++ b/src/kiro_crew/dashboard/handlers/core.py
@@ -21,6 +21,7 @@ from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 import kiro_crew
+import kiro_crew.config.resolution as _resolution
 from kiro_crew import beacon, platform_compat, stt
 from kiro_crew.acp_backends import selectable_backend_values
 from kiro_crew.computer_use.types import MAX_SCREENSHOT_MAX_PX as _CU_MAX_SCREENSHOT_MAX_PX
@@ -225,6 +226,15 @@ def _masked_config_dict(cfg: KiroCrewConfig) -> dict:
     # so through its own masked route, not this core endpoint.)
     for _extra_key in getattr(cfg, "_extra_sections", {}):
         masked.pop(_extra_key, None)
+
+    # Same reasoning one level down (KiroCrewConfig._extra_keys): an unknown key
+    # captured INSIDE a modelled section — or inside a named agents/workspaces/
+    # memory_stores record — is absent from the schema too, so the sensitivity
+    # walk below cannot recognize it either; a credential a previous build stored
+    # under a since-renamed key (`slack.legacy_bot_token`) would ship verbatim.
+    # Preserving it for save() is the point of the capture; showing it to the
+    # browser is not.
+    _resolution.drop_extra_section_keys(masked, getattr(cfg, "_extra_keys", {}))
 
     def _walk(node: object, prefix: str) -> None:
         if isinstance(node, dict):

--- a/src/kiro_crew/dashboard/handlers/ui_prefs.py
+++ b/src/kiro_crew/dashboard/handlers/ui_prefs.py
@@ -1,0 +1,91 @@
+"""Dashboard endpoints for the browser-side UI preference backup.
+
+``GET /api/ui-prefs``  -> ``{"prefs": {key: value}}``
+``PUT /api/ui-prefs``  -> body ``{"prefs": {key: value | null}}``, merge patch,
+                          returns the merged mapping.
+
+The store is :mod:`kiro_crew.ui_prefs`; see that module for why the backup
+exists and why it is not part of ``config.json``. These handlers add only the
+wire shape, a single-writer lock, and the request-level validation that turns a
+bad patch into a 400 instead of a 500.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+from kiro_crew.dashboard.handlers._shared import (
+    read_bounded_json,
+    require_owner_dashboard_request,
+)
+from kiro_crew.ui_prefs import (
+    MAX_REQUEST_BYTES,
+    UiPrefsError,
+    load_ui_prefs,
+    merge_ui_prefs,
+)
+
+logger = logging.getLogger(__name__)
+
+#: One writer at a time. ``merge_ui_prefs`` is read-modify-write, so two
+#: concurrent PUTs (two tabs flushing at once) would otherwise race and one
+#: patch would be lost. Created lazily so importing this module does not need a
+#: running loop.
+_lock: asyncio.Lock | None = None
+
+
+def _get_lock() -> asyncio.Lock:
+    global _lock
+    if _lock is None:
+        _lock = asyncio.Lock()
+    return _lock
+
+
+async def api_ui_prefs(request: web.Request) -> web.Response:
+    """GET/PUT /api/ui-prefs — read or merge the browser UI preference backup.
+
+    BOTH methods are owner-gated. The write gate is obvious (a viewer must not
+    overwrite the owner's settings), but the READ needs one too: these values are
+    the owner's, and some of them name real paths on the host (the file
+    explorer's saved state, the cloud launch defaults). An authenticated
+    non-owner on a shared dashboard would otherwise disclose them with one GET
+    and hydrate them into their own browser. Nothing is lost by gating the read:
+    a non-owner can never have written a backup, so there is none to fetch.
+    """
+    denied = await require_owner_dashboard_request(request, f"ui_prefs.{request.method.lower()}")
+    if denied is not None:
+        return denied
+
+    if request.method == "GET":
+        prefs = await asyncio.to_thread(load_ui_prefs)
+        return web.json_response({"prefs": prefs})
+
+    # PUT. The gate above runs BEFORE body validation so a non-owner cannot tell
+    # a malformed patch from a rejected one. read_bounded_json is the sanctioned
+    # reader: it caps the body, enforces the object shape, and catches the two
+    # parse failures a bare `await request.json()` lets escape as a 500 — an
+    # unknown Content-Type charset (LookupError) and deeply nested JSON
+    # (RecursionError).
+    body, error = await read_bounded_json(request, max_bytes=MAX_REQUEST_BYTES)
+    if error is not None:
+        return error
+    assert body is not None  # allow_absent=False: a non-None body or an error
+    patch = body.get("prefs")
+    if not isinstance(patch, dict):
+        raise web.HTTPBadRequest(text="'prefs' must be an object")
+
+    async with _get_lock():
+        try:
+            merged = await asyncio.to_thread(merge_ui_prefs, patch)
+        except UiPrefsError as exc:
+            raise web.HTTPBadRequest(text=str(exc)) from None
+        except OSError as exc:
+            # A full or read-only data home must not 500 the dashboard: the
+            # client treats a failed flush as "keep the local copy and retry".
+            logger.warning("ui-prefs: write failed: %s", exc)
+            raise web.HTTPServiceUnavailable(text="could not persist UI preferences") from None
+
+    return web.json_response({"prefs": merged})

--- a/src/kiro_crew/dashboard/routes/agent_config.py
+++ b/src/kiro_crew/dashboard/routes/agent_config.py
@@ -43,6 +43,12 @@ def register(app: web.Application) -> None:
     app.router.add_patch("/api/config/kirocrew", handlers.api_kirocrew_config_patch)
     app.router.add_get("/api/config/theme", handlers.api_theme_config)
     app.router.add_put("/api/config/theme", handlers.api_theme_config)
+    # Host-side backup of the renderer's own settings (localStorage), so an
+    # origin or userData change does not read as "the upgrade ate my settings".
+    # Deliberately NOT under /api/config: these keys are client-owned and never
+    # enter config.json. See kiro_crew/ui_prefs.py.
+    app.router.add_get("/api/ui-prefs", handlers.api_ui_prefs)
+    app.router.add_put("/api/ui-prefs", handlers.api_ui_prefs)
     app.router.add_get(
         "/api/onboarding/import/scan",
         handlers.api_onboarding_import_scan,

--- a/src/kiro_crew/security_posture.py
+++ b/src/kiro_crew/security_posture.py
@@ -1222,6 +1222,19 @@ _REDACTION_SINKS: tuple[tuple[str, str, str], ...] = (
         "peer's bytes become this dashboard's transcript re-applies the "
         "credential + exfiltration-URL chain itself, before any broadcast.",
     ),
+    (
+        "Host-side UI preference backup",
+        "ui_prefs.py",
+        "Every value read back from `~/.kiro/crew/ui-prefs.json` before it is "
+        "served by `GET /api/ui-prefs` and written into the renderer's "
+        "localStorage. The values are opaque strings the server never parses, "
+        "and the file sits in the agent-writable data home, so a credential or "
+        "exfiltration URL smuggled inside an innocent key would otherwise reach "
+        "the dashboard verbatim. A value the credential + exfiltration-URL chain "
+        "would alter is DROPPED rather than served redacted: a redacted "
+        "preference is not one the client can use, and the sync loop would "
+        "write the sentinel back over the file.",
+    ),
 )
 
 # Modules that call a redactor but are NOT an output egress boundary, so they do

--- a/src/kiro_crew/ui_prefs.py
+++ b/src/kiro_crew/ui_prefs.py
@@ -1,0 +1,332 @@
+"""Durable backup for the dashboard's browser-side UI preferences.
+
+Why this module exists
+---------------------
+Most dashboard settings live only in the renderer's ``localStorage``: the whole
+chat-preferences blob (``mc-chat-config``: send-key mode, timestamps, content
+width, ...), the diff and file-viewer toggles, the artifact view/sort, the app
+nav order, and dozens more. ``localStorage`` is partitioned per ORIGIN and, in
+the desktop app, stored inside Electron's ``userData`` directory. Either can
+change without the user doing anything wrong:
+
+* the dashboard port moves (``KIROCREW_PORT`` set in one launch context and not
+  another, an edited ``dashboard.url``), so the origin — and with it every key —
+  changes;
+* ``userData`` is relocated (the ``kirocrew-electron-mac`` -> ``kirocrew-desktop``
+  package rename did exactly this) and only an allowlist of *electron-store*
+  keys is carried across, never ``Local Storage/leveldb``;
+* the user switches between the stable and nightly builds, which have separate
+  ``userData`` directories by design;
+* the browser evicts the origin's storage.
+
+In all of those the user sees the same thing: "after the upgrade most of my
+settings are gone and I had to set them again". Nothing on the host had actually
+lost the settings — nothing had ever written them to the host in the first place.
+
+This store is that host-side copy. It is deliberately a SEPARATE file rather
+than a section of ``config.json``:
+
+* ``KiroCrewConfig.save()`` re-emits the whole dataclass, so a key the running
+  build does not model is dropped on the next save. A bag of client-owned UI
+  keys is exactly the shape that loses that fight.
+* ``config.json`` is an operator-facing file. Forty renderer layout keys do not
+  belong in it.
+
+Shape and trust model
+---------------------
+Values are opaque UTF-8 strings, because ``localStorage`` values are strings —
+the server never parses or interprets them, so nothing here can grow into a code
+path. The client owns which keys are durable (see ``website/src/lib/uiPrefs.ts``);
+this module only enforces size bounds and refuses keys that are known to be
+credentials, so a buggy or malicious client cannot use the backup as a place to
+land the dashboard token in plaintext.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import stat
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from kiro_crew.atomic_write import atomic_write
+from kiro_crew.config.paths import config_dir
+from kiro_crew.security import redact_credentials, redact_exfiltration_urls
+
+logger = logging.getLogger(__name__)
+
+#: File name inside the data home. Sits next to ``config.json``.
+UI_PREFS_FILENAME = "ui-prefs.json"
+
+#: Bounds. These exist so an authenticated but buggy client cannot fill the
+#: disk, not as a security boundary — the endpoint is already auth-gated.
+MAX_KEYS = 200
+MAX_KEY_LEN = 128
+MAX_VALUE_BYTES = 64 * 1024
+MAX_TOTAL_BYTES = 512 * 1024
+
+#: Request-body ceiling for the PUT endpoint, owned HERE so it cannot drift from
+#: the store's own limits. The dashboard's shared default is 64 KiB — exactly
+#: ``MAX_VALUE_BYTES`` — so a value this store would happily accept could never
+#: reach it: the JSON envelope and escaping push it past the cap, the PUT 413s,
+#: and the per-key retry 413s too, leaving the preference silently un-backed-up.
+#:
+#: Sized at twice ``MAX_TOTAL_BYTES`` because a patch may legitimately carry the
+#: whole document and JSON escaping can up to double a string in the pathological
+#: case (every character a quote or control char). A body larger than that is
+#: rejected before decoding, and the per-value and total checks in
+#: :func:`merge_ui_prefs` remain the real limits.
+MAX_REQUEST_BYTES = 2 * MAX_TOTAL_BYTES
+
+#: Keys that MUST NEVER be persisted here, whatever the client asks for. The
+#: dashboard token is a bearer credential: it belongs in the browser's own
+#: storage for exactly as long as that origin lives, and writing it to a plain
+#: file in the data home would turn a UI-convenience backup into a credential
+#: store. Matching is exact plus a substring guard so a renamed variant of the
+#: same secret ("kiro_crew_token_v2") is refused too.
+DENY_KEYS = frozenset({"kiro_crew_token"})
+DENY_SUBSTRINGS = ("token", "secret", "password", "credential", "api_key", "apikey")
+
+
+class UiPrefsError(ValueError):
+    """A patch was rejected. The message is safe to return to the client."""
+
+
+def ui_prefs_path() -> Path:
+    """Absolute path of the UI-preferences file inside the data home."""
+    return config_dir() / UI_PREFS_FILENAME
+
+
+def _is_denied(key: str) -> bool:
+    if key in DENY_KEYS:
+        return True
+    lowered = key.lower()
+    return any(marker in lowered for marker in DENY_SUBSTRINGS)
+
+
+def _read_raw(path: Path, *, strict: bool) -> str | None:
+    """Read *path* defensively, or return ``None`` when there is nothing usable.
+
+    This file lives in the data home, which an AGENT can write, so the read is
+    hardened the same way the superseded-default ack file is:
+
+    * ``O_NOFOLLOW`` refuses a symlink at the final component, and the ``fstat``
+      check refuses anything that is not a regular file — otherwise an agent
+      could point ``ui-prefs.json`` at ``/dev/zero`` and an owner GET would read
+      forever until the gateway died.
+    * ``O_NONBLOCK`` means a FIFO planted here returns instead of parking the
+      event loop on an open that never completes.
+    * The size is capped before the read, so a large regular file cannot be
+      slurped either. A backup this store would refuse to WRITE is one it has no
+      reason to READ.
+
+    A refused file is "no usable backup" on both paths, not a read failure: there
+    was no legitimate content to lose, and the next :func:`merge_ui_prefs` writes
+    a real file over whatever was planted (``atomic_write`` renames onto the path
+    rather than writing through it). *strict* still governs a genuine read error —
+    see :func:`_read_prefs`.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    flags |= getattr(os, "O_BINARY", 0)  # Windows: no implicit newline translation
+    if os.path.islink(path):
+        # O_NOFOLLOW is POSIX-only; Windows would follow the link. Same verdict.
+        logger.warning("ui-prefs: refusing to read %s: not a regular file", path)
+        return None
+    try:
+        fd = os.open(path, flags)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        # ELOOP/ENXIO land here: a symlink refused by O_NOFOLLOW, or a device that
+        # cannot be opened non-blocking. Neither is a legitimate backup.
+        if exc.errno in (errno.ELOOP, errno.ENXIO, errno.EMLINK):
+            logger.warning("ui-prefs: refusing to read %s: not a regular file", path)
+            return None
+        if strict:
+            raise
+        logger.warning("ui-prefs: cannot read %s: %s", path, exc)
+        return None
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            logger.warning("ui-prefs: refusing to read %s: not a regular file", path)
+            return None
+        if st.st_size > MAX_TOTAL_BYTES:
+            logger.warning(
+                "ui-prefs: refusing to read %s: %d bytes exceeds the %d-byte store limit",
+                path,
+                st.st_size,
+                MAX_TOTAL_BYTES,
+            )
+            return None
+        chunks: list[bytes] = []
+        remaining = MAX_TOTAL_BYTES
+        while remaining > 0:
+            chunk = os.read(fd, min(65536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+    except OSError as exc:
+        if strict:
+            raise
+        logger.warning("ui-prefs: cannot read %s: %s", path, exc)
+        return None
+    finally:
+        os.close(fd)
+    try:
+        return b"".join(chunks).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        logger.warning("ui-prefs: %s is not valid UTF-8, ignoring it: %s", path, exc)
+        return None
+
+
+def _read_prefs(path: Path, *, strict: bool) -> dict[str, str]:
+    """Parse the store at *path*, or return ``{}`` when there is nothing usable.
+
+    *strict* selects what a READ FAILURE means. For a plain read (``strict=False``)
+    an unreadable file is just "no backup available", which the client already
+    handles. For a read-modify-write (``strict=True``) it is not: returning ``{}``
+    there would make the merge write a document holding only the new patch and
+    atomically replace a file whose contents it never saw — destroying every
+    other preference in it. A temporarily unreadable file in a writable directory
+    (EACCES, EIO, a lock) is exactly that case, so the merge lets the OSError out
+    and the endpoint answers 503 instead of quietly truncating the backup.
+
+    A MISSING, MALFORMED or REFUSED file legitimately means empty on both paths:
+    there is no prior content to lose.
+    """
+    raw = _read_raw(path, strict=strict)
+    if raw is None:
+        return {}
+    try:
+        doc: Any = json.loads(raw)
+    except (ValueError, RecursionError) as exc:
+        # ValueError covers malformed JSON; RecursionError covers a hand-written
+        # file nested past CPython's parse depth. Either way there is no usable
+        # backup, which is not an error.
+        logger.warning("ui-prefs: %s is not usable JSON, ignoring it: %s", path, exc)
+        return {}
+    if not isinstance(doc, dict):
+        return {}
+    prefs = doc.get("prefs")
+    if not isinstance(prefs, dict):
+        return {}
+    # Drop anything that is not a str->str pair rather than handing the client a
+    # value it cannot put back into localStorage — and drop any VALUE the shared
+    # redactors would alter. The key denylist above catches a credential filed
+    # under an honest name; this catches one smuggled inside an innocent key by
+    # whoever can write the data home (an agent). Dropping rather than serving
+    # the redacted form: a redacted preference is not a preference the client
+    # can use, and re-syncing it would write the sentinel back over the file.
+    return {
+        k: v
+        for k, v in prefs.items()
+        if isinstance(k, str) and isinstance(v, str) and not _is_denied(k) and _is_clean(v)
+    }
+
+
+def _is_clean(value: str) -> bool:
+    """True when neither redactor would change *value*."""
+    cleaned, _ = redact_exfiltration_urls(value)
+    cleaned, _ = redact_credentials(cleaned)
+    return cleaned == value
+
+
+def load_ui_prefs() -> dict[str, str]:
+    """Return the stored preferences, or ``{}`` when there are none.
+
+    Never raises: a missing, unreadable, truncated or hand-mangled file means
+    "no backup available", which the client already handles (it falls back to
+    whatever ``localStorage`` holds). Raising here would break a boot for a
+    file that is pure convenience.
+    """
+    return _read_prefs(ui_prefs_path(), strict=False)
+
+
+def _utf8_len(text: str, what: str) -> int:
+    """Byte length of *text*, or a client-safe rejection.
+
+    A lone surrogate (``"\\ud800"``) is valid JSON and a perfectly ordinary
+    ``str`` after parsing, but it cannot be encoded as UTF-8. Left to reach
+    ``encode()``/``json.dumps().encode()`` it raises ``UnicodeEncodeError``, which
+    is a ``ValueError`` but NOT a :class:`UiPrefsError`, so it escaped the handler
+    as a 500 and took the whole patch down with it.
+    """
+    try:
+        return len(text.encode("utf-8"))
+    except UnicodeEncodeError:
+        raise UiPrefsError(f"{what} is not encodable as UTF-8 (a lone surrogate?)") from None
+
+
+def _validate_patch(patch: Mapping[str, Any]) -> dict[str, str | None]:
+    """Normalize *patch* to ``{key: str | None}``, rejecting anything unusable.
+
+    ``None`` means "delete this key". A rejected patch is rejected WHOLE: a
+    partial apply would leave the client believing settings landed that did not.
+    """
+    cleaned: dict[str, str | None] = {}
+    for key, value in patch.items():
+        if not isinstance(key, str) or not key:
+            raise UiPrefsError("every key must be a non-empty string")
+        if len(key) > MAX_KEY_LEN:
+            raise UiPrefsError(f"key exceeds {MAX_KEY_LEN} characters: {key[:32]}...")
+        _utf8_len(key, "key")
+        if _is_denied(key):
+            raise UiPrefsError(f"key looks like a credential and is not storable: {key}")
+        if value is None:
+            cleaned[key] = None
+            continue
+        if not isinstance(value, str):
+            raise UiPrefsError(f"value for {key} must be a string or null")
+        if _utf8_len(value, f"value for {key}") > MAX_VALUE_BYTES:
+            raise UiPrefsError(f"value for {key} exceeds {MAX_VALUE_BYTES} bytes")
+        cleaned[key] = value
+    return cleaned
+
+
+def merge_ui_prefs(patch: Mapping[str, Any]) -> dict[str, str]:
+    """Apply *patch* onto the stored preferences and persist the result.
+
+    A ``None`` value deletes its key. Returns the merged mapping. Raises
+    :class:`UiPrefsError` when the patch or the resulting document is out of
+    bounds, in which case NOTHING is written.
+
+    Callers must serialize their own concurrency (the dashboard handler holds an
+    asyncio lock); the write itself is atomic, so a crash mid-write leaves the
+    previous file intact rather than a truncated one. A read failure PROPAGATES
+    as ``OSError`` (see ``_read_prefs``): this is a read-modify-write, so
+    starting from ``{}`` because the existing file could not be read would
+    replace it with just this patch.
+    """
+    cleaned = _validate_patch(patch)
+    merged = _read_prefs(ui_prefs_path(), strict=True)
+    for key, value in cleaned.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
+
+    if len(merged) > MAX_KEYS:
+        raise UiPrefsError(f"too many keys ({len(merged)} > {MAX_KEYS})")
+
+    document = {"prefs": merged}
+    # The bound below measures the EXACT bytes that land on disk: the trailing
+    # newline is part of the payload, and the payload is written as bytes so no
+    # platform newline translation can add to it (text mode turned each "\n"
+    # into "\r\n" on Windows and pushed a near-cap file over the read limit).
+    text = json.dumps(document, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if _utf8_len(text, "stored preferences") > MAX_TOTAL_BYTES:
+        raise UiPrefsError(f"stored preferences would exceed {MAX_TOTAL_BYTES} bytes")
+
+    # 0o600 plus restrict_to_owner: nothing here is a credential (see DENY_*), but
+    # these are one user's personal settings on a possibly shared host and some
+    # name real paths, and the data home's other per-user files are owner-only
+    # too. The POSIX mode does nothing on Windows, where a new file inherits the
+    # directory's DACL — restrict_to_owner is what narrows it there.
+    atomic_write(ui_prefs_path(), text.encode("utf-8"), mode=0o600, restrict_to_owner=True)
+    return merged

--- a/test/test_config_extra_keys.py
+++ b/test/test_config_extra_keys.py
@@ -1,0 +1,412 @@
+"""Round-trip preservation of unknown keys INSIDE a modelled config section.
+
+``_extra_sections`` protects a whole top-level section this core does not model.
+A key one level down had no equivalent, so a build that stopped modelling
+``<section>.<key>`` erased the operator's value on the next ``save()`` of any
+kind. See ``KiroCrewConfig._extra_keys`` and
+``config/resolution.capture_extra_section_keys``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew.config import loader as L
+from kiro_crew.config.loader import KiroCrewConfig
+
+
+@pytest.fixture
+def cfg_home(tmp_path, monkeypatch):
+    """Point every config path at a temp home and return the config.json path."""
+    cfgp = tmp_path / "config.json"
+    monkeypatch.setattr(L, "config_path", lambda: cfgp)
+    monkeypatch.setattr(L, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(L, "config_local_path", lambda: tmp_path / "config.local.json")
+    return cfgp
+
+
+def _write(cfgp, doc):
+    cfgp.write_text(json.dumps(doc), encoding="utf-8")
+
+
+# ── The defect ─────────────────────────────────────────────────────────────
+
+
+def test_unknown_section_key_survives_save(cfg_home):
+    """The regression: an unmodelled nested key used to vanish on any save()."""
+    _write(cfg_home, {"agent": {"provider": "acp", "retired_knob": "keep-me"}})
+
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_keys.get("agent") == {"retired_knob": "keep-me"}
+    assert cfg.to_dict()["agent"]["retired_knob"] == "keep-me"
+
+    cfg.save()
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["agent"]["retired_knob"] == "keep-me"
+    # And the modelled sibling is still there, i.e. capture did not replace the
+    # section with the raw copy.
+    assert after["agent"]["provider"] == "acp"
+
+
+def test_unknown_key_survives_a_save_that_changes_something_else(cfg_home):
+    """The real-world trigger: an unrelated write (log level, workspace, agent)."""
+    _write(cfg_home, {"dashboard": {"legacy_toggle": True}})
+
+    cfg = KiroCrewConfig.load()
+    cfg.timezone = "UTC"
+    cfg.save()
+
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["timezone"] == "UTC"
+    assert after["dashboard"]["legacy_toggle"] is True
+
+
+def test_unknown_keys_survive_repeated_round_trips(cfg_home):
+    """Preservation must not decay: load/save twice keeps the key."""
+    _write(cfg_home, {"memory": {"orphan": [1, 2, 3]}})
+
+    KiroCrewConfig.load().save()
+    KiroCrewConfig.load().save()
+
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["memory"]["orphan"] == [1, 2, 3]
+
+
+def test_several_sections_at_once(cfg_home):
+    _write(
+        cfg_home,
+        {
+            "agent": {"gone_a": 1},
+            "session": {"gone_b": "two"},
+            "telemetry": {"gone_c": {"nested": True}},
+        },
+    )
+    cfg = KiroCrewConfig.load()
+    assert set(cfg._extra_keys) == {"agent", "session", "telemetry"}
+    d = cfg.to_dict()
+    assert d["agent"]["gone_a"] == 1
+    assert d["session"]["gone_b"] == "two"
+    assert d["telemetry"]["gone_c"] == {"nested": True}
+
+
+# ── What must NOT be captured ──────────────────────────────────────────────
+
+
+def test_a_fully_modelled_config_captures_nothing(cfg_home):
+    """No pollution: a config written by this build has no unknown keys."""
+    _write(cfg_home, KiroCrewConfig().to_dict())
+    assert KiroCrewConfig.load()._extra_keys == {}
+
+
+def test_default_emitted_section_keys_are_all_recognized():
+    """INVARIANT, drift guard: every key to_dict() emits inside a dataclass-backed
+    section must be a field of that dataclass or listed in
+    _SECTION_KEYS_EMITTED_ELSEWHERE. A key that is neither gets captured as
+    "unknown" on every load -- noise at best, and a resurrected value at worst if
+    to_dict() ever stops emitting it."""
+    from dataclasses import fields, is_dataclass
+
+    from kiro_crew.config.resolution import _SECTION_KEYS_EMITTED_ELSEWHERE
+
+    cfg = KiroCrewConfig()
+    emitted = cfg.to_dict()
+    unaccounted: dict[str, set[str]] = {}
+    for section, value in emitted.items():
+        section_obj = getattr(cfg, section, None)
+        if not isinstance(value, dict) or not is_dataclass(section_obj):
+            continue
+        if isinstance(section_obj, type):
+            continue
+        recognized = {f.name for f in fields(section_obj)} | _SECTION_KEYS_EMITTED_ELSEWHERE.get(
+            section, frozenset()
+        )
+        extra = {k for k in value if k not in recognized and not k.startswith("_")}
+        if extra:
+            unaccounted[section] = extra
+    assert unaccounted == {}, (
+        "to_dict() emits section keys that capture would treat as unknown; add "
+        f"them to _SECTION_KEYS_EMITTED_ELSEWHERE: {unaccounted}"
+    )
+
+
+def test_hooks_is_not_captured_because_it_round_trips_raw(cfg_home):
+    """hooks is emitted as `self.hooks` verbatim, so nothing inside it can be lost
+    and nothing about it needs capturing."""
+    _write(cfg_home, {"hooks": {"my-hook": {"command": "true", "odd": 1}}})
+    cfg = KiroCrewConfig.load()
+    assert "hooks" not in cfg._extra_keys
+    assert cfg.to_dict()["hooks"]["my-hook"]["odd"] == 1
+
+
+def test_unknown_keys_inside_a_named_record_survive_save(cfg_home):
+    """agents/workspaces/memory_stores are maps of dataclass records parsed
+    field-by-field and re-emitted with asdict, so `agents.<name>.<key>` used to
+    vanish exactly like `agent.<key>`. Captured one level deeper."""
+    _write(
+        cfg_home,
+        {
+            "agents": {"my-agent": {"model": "auto", "retired_flag": True}},
+            "workspaces": {"my-ws": {"dir": "/tmp/ws", "colour": "teal"}},
+            "memory_stores": {"my-store": {"description": "d", "shard": 3}},
+        },
+    )
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_keys["agents"] == {"my-agent": {"retired_flag": True}}
+    assert cfg._extra_keys["workspaces"] == {"my-ws": {"colour": "teal"}}
+    assert cfg._extra_keys["memory_stores"] == {"my-store": {"shard": 3}}
+
+    cfg.save()
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["agents"]["my-agent"]["retired_flag"] is True
+    assert after["agents"]["my-agent"]["model"] == "auto"
+    assert after["workspaces"]["my-ws"]["colour"] == "teal"
+    assert after["memory_stores"]["my-store"]["shard"] == 3
+
+
+def test_a_deleted_record_does_not_come_back(cfg_home):
+    """Fill-only at record granularity too: deleting the record in memory must
+    not resurrect it via its captured unknown keys."""
+    _write(cfg_home, {"agents": {"gone": {"model": "auto", "retired_flag": True}}})
+    cfg = KiroCrewConfig.load()
+    cfg.agents.pop("gone")
+    assert "gone" not in cfg.to_dict()["agents"]
+
+
+def test_record_unknown_keys_are_not_shipped_to_the_browser(cfg_home):
+    from kiro_crew.dashboard.handlers.core import _masked_config_dict
+
+    _write(cfg_home, {"agents": {"a": {"model": "auto", "legacy_token": "xoxb-S"}}})
+    cfg = KiroCrewConfig.load()
+    assert cfg.to_dict()["agents"]["a"]["legacy_token"] == "xoxb-S"
+    masked = _masked_config_dict(cfg)
+    assert "xoxb-S" not in json.dumps(masked)
+
+
+def test_private_keys_are_not_captured(cfg_home):
+    """to_dict() drops private carriers on purpose; capture must not undo that."""
+    _write(cfg_home, {"mcp_gateway": {"_stub_roster": ["ghost"]}})
+    cfg = KiroCrewConfig.load()
+    assert "mcp_gateway" not in cfg._extra_keys
+    assert "_stub_roster" not in cfg.to_dict()["mcp_gateway"]
+
+
+def test_a_cleared_conditional_key_is_not_resurrected(cfg_home):
+    """slack.channels is emitted only when non-empty, so its absence is a
+    deliberate deletion -- restoring it from capture would undo the deletion."""
+    _write(
+        cfg_home,
+        {"slack": {"channels": {"C1": {"activation": "always"}}}},
+    )
+    cfg = KiroCrewConfig.load()
+    assert "slack" not in cfg._extra_keys
+
+    cfg.slack_channels = {}
+    cfg.save()
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert not after["slack"].get("channels")
+
+
+def test_a_rejected_modelled_value_stays_dropped(cfg_home):
+    """A key the schema DOES model but validation refused must not be restored:
+    re-emitting it would make the bad value permanent and re-warn every load."""
+    _write(cfg_home, {"agent": {"approval_mode": "not-a-real-mode"}})
+    cfg = KiroCrewConfig.load()
+    assert "agent" not in cfg._extra_keys
+    assert cfg.to_dict()["agent"]["approval_mode"] != "not-a-real-mode"
+
+
+def test_a_legacy_alias_is_not_pinned_in_the_file(cfg_home):
+    """knowledge.auto_ingest_doc_links is still READ but save() settles on the
+    canonical auto_add_documents; capture must not pin the old spelling."""
+    _write(cfg_home, {"knowledge": {"auto_ingest_doc_links": True}})
+    cfg = KiroCrewConfig.load()
+    assert "knowledge" not in cfg._extra_keys
+
+    d = cfg.to_dict()
+    assert d["knowledge"]["auto_add_documents"] is True
+    assert "auto_ingest_doc_links" not in d["knowledge"]
+
+
+def test_the_auto_approve_aliases_are_not_pinned(cfg_home):
+    """agent.dangerously_skip_permissions is also read as `dangerouslySkipPermissions`
+    and the legacy `yolo`, but save() writes only the canonical spelling. Keeping
+    the old ones would leave a contradiction in the file: the canonical grant off
+    and a stale `yolo: true` beside it."""
+    _write(cfg_home, {"agent": {"yolo": True, "dangerouslySkipPermissions": True}})
+    cfg = KiroCrewConfig.load()
+    assert "agent" not in cfg._extra_keys
+    assert cfg.agent.dangerously_skip_permissions is True
+
+    d = cfg.to_dict()
+    assert d["agent"]["dangerously_skip_permissions"] is True
+    assert "yolo" not in d["agent"]
+    assert "dangerouslySkipPermissions" not in d["agent"]
+
+
+def test_retired_keys_are_purged_not_preserved(cfg_home):
+    """The feature behind these keys is gone, so re-persisting them would keep
+    offering a setting with nothing behind it (TestSttRemovedFieldsAreInert)."""
+    _write(
+        cfg_home,
+        {
+            "stt": {
+                "language_code": "fr-FR",
+                "whisper_path": "/usr/local/bin/whisper",
+                "mlx_model": "mlx-community/whisper-large-v3-turbo",
+                "parakeet_model": "mlx-community/parakeet-tdt-0.6b-v3",
+                "device": "cpu",
+            }
+        },
+    )
+    cfg = KiroCrewConfig.load()
+    assert "stt" not in cfg._extra_keys
+
+    written = cfg.to_dict()["stt"]
+    for dead in ("whisper_path", "mlx_model", "parakeet_model", "device"):
+        assert dead not in written
+    # The live setting sharing the section is untouched.
+    assert written["language_code"] == "fr-FR"
+
+
+def test_an_unknown_nested_key_is_not_shipped_to_the_browser(cfg_home):
+    """The browser-facing config response drops captured keys.
+
+    ``_masked_config_dict`` masks by SCHEMA path, so an unknown key is invisible
+    to the sensitivity walk. A credential a previous build stored under a
+    since-renamed key would otherwise ship verbatim to any authenticated reader,
+    which is the same reason the response already drops ``_extra_sections``."""
+    from kiro_crew.dashboard.handlers.core import _masked_config_dict
+
+    _write(cfg_home, {"slack": {"legacy_bot_token": "xoxb-SECRET"}})
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_keys.get("slack") == {"legacy_bot_token": "xoxb-SECRET"}
+
+    # Preserved for save()...
+    assert cfg.to_dict()["slack"]["legacy_bot_token"] == "xoxb-SECRET"
+    # ...and absent from what the dashboard is handed.
+    masked = _masked_config_dict(cfg)
+    assert "legacy_bot_token" not in masked["slack"]
+    assert "xoxb-SECRET" not in json.dumps(masked)
+
+
+# ── Robustness ─────────────────────────────────────────────────────────────
+
+
+def test_a_non_dict_section_does_not_crash_capture(cfg_home):
+    _write(cfg_home, {"agent": "not-an-object", "session": [1, 2]})
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_keys == {}
+    cfg.save()  # must not raise
+
+
+def test_capture_never_overwrites_a_live_value(cfg_home):
+    """Capture only FILLS a gap. A modelled value set in memory must win."""
+    _write(cfg_home, {"agent": {"reasoning_effort": "low", "retired_knob": "x"}})
+    cfg = KiroCrewConfig.load()
+    cfg.agent.reasoning_effort = "high"
+    d = cfg.to_dict()
+    assert d["agent"]["reasoning_effort"] == "high"
+    assert d["agent"]["retired_knob"] == "x"
+
+
+def test_private_carriers_never_reach_the_file(cfg_home):
+    _write(cfg_home, {"agent": {"retired_knob": "x"}})
+    KiroCrewConfig.load().save()
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert "_extra_keys" not in after
+    assert "_extra_sections" not in after
+
+
+def test_an_overlay_only_unknown_key_does_not_leak_into_the_base_file(cfg_home, tmp_path):
+    """config.local.json values are subtracted on save; a key that exists ONLY in
+    the overlay is not captured at all (capture reads the base view), so nothing
+    about it can reach config.json."""
+    _write(cfg_home, {"agent": {"provider": "acp"}})
+    (tmp_path / "config.local.json").write_text(
+        json.dumps({"agent": {"overlay_only_knob": "local"}}), encoding="utf-8"
+    )
+
+    cfg = KiroCrewConfig.load()
+    assert "agent" not in cfg._extra_keys
+    cfg.save()
+
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert "overlay_only_knob" not in after["agent"]
+
+
+def test_an_overlay_shadowed_unknown_key_keeps_its_base_value(cfg_home, tmp_path):
+    """The base and the overlay both hold an unknown nested key with DIFFERENT
+    values. Capturing the merged value made save() emit the overlay's leaf, which
+    the overlay subtraction then removed -- permanently deleting the base file's
+    own value, so removing the overlay later revealed nothing. Capturing the base
+    view keeps the base value in config.json while the overlay still wins live."""
+    _write(cfg_home, {"agent": {"provider": "acp", "retired": "BASE"}})
+    (tmp_path / "config.local.json").write_text(
+        json.dumps({"agent": {"retired": "OVERLAY"}}), encoding="utf-8"
+    )
+
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_keys.get("agent") == {"retired": "BASE"}
+    cfg.save()
+
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["agent"]["retired"] == "BASE"
+
+
+def test_the_base_value_survives_a_cache_hit_too(cfg_home, tmp_path):
+    """The overlay is out of scope on a validated-data cache hit; the base copy
+    rides in the cache sidecar so the second load captures exactly as the first."""
+    _write(cfg_home, {"agent": {"provider": "acp", "retired": "BASE"}})
+    (tmp_path / "config.local.json").write_text(
+        json.dumps({"agent": {"retired": "OVERLAY"}}), encoding="utf-8"
+    )
+
+    first = KiroCrewConfig.load()  # disk path, populates the cache
+    second = KiroCrewConfig.load()  # cache path
+    assert first._extra_keys == second._extra_keys == {"agent": {"retired": "BASE"}}
+
+    second.save()
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["agent"]["retired"] == "BASE"
+
+
+def test_cache_data_and_sidecar_are_served_together_or_not_at_all():
+    """A clear() between two separate fetches would hand the loader a merged
+    document with an EMPTY base shadow; get_with_sidecar makes the pair atomic."""
+    from kiro_crew.config.validation import ConfigCache
+
+    cache = ConfigCache()
+    fp = ("fp",)
+    cache.store({"agent": {"k": "MERGED"}}, fp, {"base_shadow": {"agent": {"k": "BASE"}}})
+    got = cache.get_with_sidecar(fp)
+    assert got is not None
+    data, sidecar = got
+    assert data == {"agent": {"k": "MERGED"}}
+    assert sidecar == {"base_shadow": {"agent": {"k": "BASE"}}}
+    # Deep copies: mutating what was handed out cannot poison the cache.
+    data["agent"]["k"] = "X"
+    sidecar["base_shadow"]["agent"]["k"] = "Y"
+    assert cache.get_with_sidecar(fp) == (
+        {"agent": {"k": "MERGED"}},
+        {"base_shadow": {"agent": {"k": "BASE"}}},
+    )
+    cache.clear()
+    assert cache.get_with_sidecar(fp) is None
+    assert cache.get(fp) is None
+
+
+def test_an_overlay_shadowed_unknown_section_keeps_its_base_values(cfg_home, tmp_path):
+    """The same fix covers the older _extra_sections capture."""
+    _write(cfg_home, {"agent": {}, "amazon": {"flags": "-o -s", "keep": 1}})
+    (tmp_path / "config.local.json").write_text(
+        json.dumps({"amazon": {"flags": "-x"}}), encoding="utf-8"
+    )
+
+    cfg = KiroCrewConfig.load()
+    assert cfg._extra_sections.get("amazon") == {"flags": "-o -s", "keep": 1}
+    cfg.save()
+
+    after = json.loads(cfg_home.read_text(encoding="utf-8"))
+    assert after["amazon"] == {"flags": "-o -s", "keep": 1}

--- a/test/test_json_object_body_guard.py
+++ b/test/test_json_object_body_guard.py
@@ -173,6 +173,12 @@ _CAP_REGISTER: dict[str, tuple[str, str]] = {
         "TEAMS_MAX_ACTIVITY_BYTES",
         _BOUNDED_EXPLICIT,
     ),
+    # The UI-preference backup stores values up to MAX_VALUE_BYTES (64 KB) and a
+    # document up to MAX_TOTAL_BYTES, so the shared 64 KB default -- exactly one
+    # legal value, with no room for the JSON envelope -- would 413 a patch the
+    # store itself accepts. The cap is owned in kiro_crew/ui_prefs.py beside the
+    # limits it has to cover, so the two cannot drift apart again.
+    "handlers/ui_prefs.py::api_ui_prefs": ("MAX_REQUEST_BYTES", _BOUNDED_EXPLICIT),
     # agents.py tranche.
     "handlers/agents.py::api_agent_config": ("None", _UNBOUNDED_USER_CONTENT),
     "handlers/agents.py::api_default_agent": ("None", _CONTROL_FIELDS_CAP_PENDING),

--- a/test/test_ui_prefs.py
+++ b/test/test_ui_prefs.py
@@ -1,0 +1,314 @@
+"""Tests for the browser UI preference backup store (kiro_crew.ui_prefs)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kiro_crew import ui_prefs
+from kiro_crew.ui_prefs import (
+    MAX_KEYS,
+    MAX_TOTAL_BYTES,
+    MAX_VALUE_BYTES,
+    UiPrefsError,
+    load_ui_prefs,
+    merge_ui_prefs,
+    ui_prefs_path,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Point the data home at a temp dir so tests never touch the real one."""
+    monkeypatch.setattr(ui_prefs, "config_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def test_load_returns_empty_when_no_file():
+    assert load_ui_prefs() == {}
+
+
+def test_merge_persists_and_reloads():
+    merged = merge_ui_prefs({"mc-chat-config": '{"sendOnEnter":"ctrl-enter"}'})
+    assert merged == {"mc-chat-config": '{"sendOnEnter":"ctrl-enter"}'}
+    assert load_ui_prefs() == merged
+
+
+def test_merge_is_a_patch_not_a_replace():
+    merge_ui_prefs({"a": "1", "b": "2"})
+    merge_ui_prefs({"b": "3"})
+    assert load_ui_prefs() == {"a": "1", "b": "3"}
+
+
+def test_null_deletes_a_key():
+    merge_ui_prefs({"mc-dev-mode": "true"})
+    assert merge_ui_prefs({"mc-dev-mode": None}) == {}
+    assert load_ui_prefs() == {}
+
+
+def test_deleting_an_absent_key_is_not_an_error():
+    assert merge_ui_prefs({"never-stored": None}) == {}
+
+
+def test_envelope_shape_on_disk():
+    """`{"prefs": ...}` is the whole contract: no version stamp, no timestamp.
+
+    Both existed in an earlier revision with zero readers. The loader is tolerant
+    of any shape it does not recognize, so a future reshape needs no version
+    field to be safe, and a stamp nothing checks is just a claim."""
+    merge_ui_prefs({"mc-zoom": "1.1"})
+    doc = json.loads(ui_prefs_path().read_text(encoding="utf-8"))
+    assert doc == {"prefs": {"mc-zoom": "1.1"}}
+
+
+def test_file_is_owner_only(_isolated_home):
+    merge_ui_prefs({"mc-zoom": "1.0"})
+    mode = ui_prefs_path().stat().st_mode & 0o777
+    # Windows does not honour POSIX bits; assert only where they mean something.
+    if hasattr(__import__("os"), "getuid"):
+        assert mode == 0o600
+
+
+def _doc_bytes(prefs: dict) -> int:
+    """Byte length of the document as the store serializes it, newline excluded."""
+    return len(
+        json.dumps({"prefs": prefs}, ensure_ascii=False, indent=2, sort_keys=True).encode("utf-8")
+    )
+
+
+def test_a_document_exactly_at_the_cap_is_refused_not_written_one_byte_over():
+    """The size bound must measure the EXACT bytes written, trailing newline
+    included. The old check measured the document and then appended "\\n", so a
+    document of precisely MAX_TOTAL_BYTES landed on disk one byte over the read
+    cap, was refused on the next read, and the merge after that treated the
+    backup as empty -- discarding every preference in it."""
+    base = {f"k{i}": "y" * MAX_VALUE_BYTES for i in range(7)}
+    merge_ui_prefs(base)
+    fill = MAX_TOTAL_BYTES - _doc_bytes({**base, "k7": ""})
+    assert _doc_bytes({**base, "k7": "z" * fill}) == MAX_TOTAL_BYTES  # the exact boundary
+
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"k7": "z" * fill})
+    # Nothing was written, and the existing backup is intact and readable.
+    assert ui_prefs_path().stat().st_size <= MAX_TOTAL_BYTES
+    assert load_ui_prefs() == base
+
+
+def test_a_document_one_byte_under_the_cap_round_trips():
+    base = {f"k{i}": "y" * MAX_VALUE_BYTES for i in range(7)}
+    merge_ui_prefs(base)
+    fill = MAX_TOTAL_BYTES - _doc_bytes({**base, "k7": ""}) - 1
+    merged = merge_ui_prefs({"k7": "z" * fill})
+    # Exactly the measured bytes, on every platform: text-mode newline
+    # translation on Windows once added one byte per line here.
+    assert ui_prefs_path().stat().st_size == MAX_TOTAL_BYTES  # newline included
+    assert b"\r" not in ui_prefs_path().read_bytes()
+    assert load_ui_prefs() == merged
+
+
+# ── Rejections ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["kiro_crew_token", "some_api_key", "GITHUB_TOKEN", "user-password", "aws-credential"],
+)
+def test_credential_shaped_keys_are_refused(key):
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({key: "value"})
+    assert load_ui_prefs() == {}
+
+
+@pytest.mark.parametrize("bad", ["\ud800", "ok\udfff", "\ud800\ud800"])
+def test_a_lone_surrogate_is_refused_not_a_500(bad):
+    """Valid JSON, ordinary str, but not UTF-8 encodable. Left to reach encode()
+    it raised UnicodeEncodeError -- a ValueError but not a UiPrefsError -- so it
+    escaped the handler as a 500 and took the whole patch with it."""
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"mc-zoom": bad})
+    assert load_ui_prefs() == {}
+
+
+def test_a_lone_surrogate_in_a_key_is_refused():
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"mc-\ud800": "1"})
+
+
+def test_non_string_value_is_refused():
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"mc-zoom": 1.0})
+
+
+def test_empty_key_is_refused():
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"": "x"})
+
+
+def test_oversized_value_is_refused():
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"big": "x" * (MAX_VALUE_BYTES + 1)})
+
+
+def test_too_many_keys_is_refused():
+    merge_ui_prefs({f"k{i}": "v" for i in range(MAX_KEYS)})
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"one-too-many": "v"})
+
+
+def test_a_rejected_patch_writes_nothing():
+    merge_ui_prefs({"keep": "me"})
+    with pytest.raises(UiPrefsError):
+        merge_ui_prefs({"keep": "changed", "kiro_crew_token": "leak"})
+    # Whole-patch rejection: the legitimate half must not have landed either.
+    assert load_ui_prefs() == {"keep": "me"}
+
+
+# ── Corruption tolerance: a bad file means "no backup", never a crash ───────
+
+
+@pytest.mark.parametrize("body", ["", "not json", "[]", '{"prefs": 5}', '{"prefs": {"a": 5}}'])
+def test_unusable_file_degrades_to_empty(body):
+    ui_prefs_path().write_text(body, encoding="utf-8")
+    assert load_ui_prefs() == {}
+
+
+def test_credential_key_already_on_disk_is_not_served():
+    """A file written by an older or hostile client must not vend a token back."""
+    ui_prefs_path().write_text(
+        json.dumps({"version": 1, "prefs": {"mc-zoom": "1", "kiro_crew_token": "leak"}}),
+        encoding="utf-8",
+    )
+    assert load_ui_prefs() == {"mc-zoom": "1"}
+
+
+def test_a_value_carrying_a_credential_is_not_served(_isolated_home):
+    """The key denylist catches a credential filed under an honest name; this
+    catches one smuggled inside an innocent key by whoever can write the data
+    home. Dropped, not redacted: a redacted preference is unusable and would be
+    re-synced as the sentinel."""
+    ui_prefs_path().write_text(
+        json.dumps(
+            {
+                "prefs": {
+                    "mc-crews-view": "grid",
+                    "kc:file-explorer:state:v2": '{"note":"AKIAIOSFODNN7EXAMPLE"}',
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    served = load_ui_prefs()
+    assert served == {"mc-crews-view": "grid"}
+    assert "AKIA" not in json.dumps(served)
+
+
+def test_a_value_carrying_an_exfiltration_url_is_not_served(_isolated_home):
+    from kiro_crew.security import redact_exfiltration_urls
+
+    # Use whatever the shared redactor itself considers suspicious, so this test
+    # tracks its vocabulary rather than hard-coding one URL shape.
+    candidate = "see https://evil.example/collect?d=" + "x" * 300
+    cleaned, _ = redact_exfiltration_urls(candidate)
+    if cleaned == candidate:
+        pytest.skip("redactor does not flag this shape; nothing to assert")
+    ui_prefs_path().write_text(json.dumps({"prefs": {"mc-nav": candidate}}), encoding="utf-8")
+    assert load_ui_prefs() == {}
+
+
+def test_a_symlink_is_refused(_isolated_home):
+    """The data home is agent-writable, so a planted symlink must not be followed
+    (pointed at /dev/zero it would read until the gateway died)."""
+    import os
+
+    real = _isolated_home / "elsewhere.json"
+    real.write_text(json.dumps({"prefs": {"leaked": "value"}}), encoding="utf-8")
+    try:
+        os.symlink(real, ui_prefs_path())
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("symlinks unavailable on this platform/user")
+    assert load_ui_prefs() == {}
+
+
+def test_a_non_regular_file_is_refused(_isolated_home):
+    import os
+
+    if not hasattr(os, "mkfifo"):
+        pytest.skip("POSIX-only")
+    os.mkfifo(ui_prefs_path())
+    assert load_ui_prefs() == {}
+
+
+def test_an_oversized_file_is_refused(_isolated_home):
+    """A backup this store would refuse to WRITE is one it has no reason to READ."""
+    ui_prefs_path().write_text("x" * (ui_prefs.MAX_TOTAL_BYTES + 1), encoding="utf-8")
+    assert load_ui_prefs() == {}
+
+
+def test_a_merge_replaces_a_planted_symlink_with_a_real_file(_isolated_home):
+    """Remediation: the atomic write renames ONTO the path, so the planted object
+    is replaced rather than written through."""
+    import os
+
+    real = _isolated_home / "elsewhere.json"
+    real.write_text(json.dumps({"prefs": {"leaked": "value"}}), encoding="utf-8")
+    try:
+        os.symlink(real, ui_prefs_path())
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("symlinks unavailable on this platform/user")
+
+    merge_ui_prefs({"mc-zoom": "1"})
+    assert not ui_prefs_path().is_symlink()
+    assert load_ui_prefs() == {"mc-zoom": "1"}
+    # The symlink target is untouched.
+    assert json.loads(real.read_text(encoding="utf-8"))["prefs"] == {"leaked": "value"}
+
+
+def _deny_reads_of(monkeypatch, target):
+    """Make opening ``target`` fail, and return a switch to stop denying.
+
+    Injected at ``os.open`` because that is what the hardened reader uses (it
+    refuses symlinks and caps the size, which ``Path.read_text`` cannot do).
+
+    Deliberately not ``monkeypatch.undo()``: that would also revert the autouse
+    fixture's ``config_dir`` override and send the follow-up read to the real
+    data home.
+    """
+    state = {"deny": True}
+    real_open = ui_prefs.os.open
+
+    def _open(path, *a, **kw):
+        if state["deny"] and str(path) == str(target):
+            raise PermissionError(13, "Permission denied")
+        return real_open(path, *a, **kw)
+
+    monkeypatch.setattr(ui_prefs.os, "open", _open)
+    return state
+
+
+def test_an_unreadable_file_does_not_get_replaced_by_the_patch(monkeypatch):
+    """A read-modify-write must not start from {} when the read FAILED.
+
+    Doing so would atomically replace a file whose contents it never saw, losing
+    every other preference in it. Missing and malformed still mean empty."""
+    merge_ui_prefs({"keep": "me", "and": "this"})
+
+    state = _deny_reads_of(monkeypatch, ui_prefs_path())
+    with pytest.raises(OSError):
+        merge_ui_prefs({"new": "value"})
+
+    state["deny"] = False
+    # Untouched: the write never happened.
+    assert load_ui_prefs() == {"keep": "me", "and": "this"}
+
+
+def test_a_plain_read_still_degrades_to_empty(monkeypatch):
+    """The non-merge path must never raise: an unreadable backup is just absent."""
+    merge_ui_prefs({"keep": "me"})
+    _deny_reads_of(monkeypatch, ui_prefs_path())
+    assert load_ui_prefs() == {}
+
+
+def test_merge_over_a_corrupt_file_recovers():
+    ui_prefs_path().write_text("{ truncated", encoding="utf-8")
+    assert merge_ui_prefs({"mc-zoom": "1"}) == {"mc-zoom": "1"}

--- a/test/test_ui_prefs_api.py
+++ b/test/test_ui_prefs_api.py
@@ -1,0 +1,216 @@
+"""Tests for the GET/PUT /api/ui-prefs endpoint."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from kiro_crew import ui_prefs as ui_prefs_store
+from kiro_crew.dashboard.handlers import ui_prefs as ui_prefs_handler
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(ui_prefs_store, "config_dir", lambda: tmp_path)
+    # Each test gets its own writer lock, so a lock left held by a failing test
+    # cannot deadlock the next one.
+    monkeypatch.setattr(ui_prefs_handler, "_lock", None)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _owner_caller(monkeypatch):
+    """Run PAST the owner gate by default. The gate itself is asserted by
+    ``test_a_non_owner_cannot_write`` and by the registrar-wide invariant in
+    test_agent_config_owner_gate_invariant.py."""
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+        lambda request: True,
+    )
+
+
+def _make_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/api/ui-prefs", ui_prefs_handler.api_ui_prefs)
+    app.router.add_put("/api/ui-prefs", ui_prefs_handler.api_ui_prefs)
+    return app
+
+
+def _client() -> TestClient:
+    """A client for the endpoint under test.
+
+    Deliberately a helper used via ``async with`` rather than a pytest fixture:
+    an async fixture needs a plugin this suite does not enable, and would error
+    at setup instead of running.
+    """
+    return TestClient(TestServer(_make_app()))
+
+
+@pytest.mark.asyncio
+async def test_get_on_a_fresh_host_returns_empty():
+    async with _client() as client:
+        res = await client.get("/api/ui-prefs")
+        assert res.status == 200
+        assert await res.json() == {"prefs": {}}
+
+
+@pytest.mark.asyncio
+async def test_put_then_get_round_trips():
+    async with _client() as client:
+        res = await client.put("/api/ui-prefs", json={"prefs": {"mc-chat-config": '{"a":1}'}})
+        assert res.status == 200
+        assert await res.json() == {"prefs": {"mc-chat-config": '{"a":1}'}}
+
+        res = await client.get("/api/ui-prefs")
+        assert await res.json() == {"prefs": {"mc-chat-config": '{"a":1}'}}
+
+
+@pytest.mark.asyncio
+async def test_put_merges_and_null_deletes():
+    async with _client() as client:
+        await client.put("/api/ui-prefs", json={"prefs": {"a": "1", "b": "2"}})
+        res = await client.put("/api/ui-prefs", json={"prefs": {"b": None, "c": "3"}})
+        assert await res.json() == {"prefs": {"a": "1", "c": "3"}}
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},  # no 'prefs'
+        {"prefs": []},  # wrong type
+        {"prefs": {"mc-zoom": 1}},  # non-string value
+        {"prefs": {"kiro_crew_token": "leak"}},  # credential-shaped key
+    ],
+)
+@pytest.mark.asyncio
+async def test_bad_bodies_are_400(body):
+    async with _client() as client:
+        res = await client.put("/api/ui-prefs", json=body)
+        assert res.status == 400
+
+
+@pytest.mark.asyncio
+async def test_non_json_body_is_400():
+    async with _client() as client:
+        res = await client.put(
+            "/api/ui-prefs", data=b"not json", headers={"Content-Type": "application/json"}
+        )
+        assert res.status == 400
+
+
+@pytest.mark.asyncio
+async def test_an_unwritable_home_is_503_not_500(monkeypatch):
+    def _boom(_patch):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(ui_prefs_handler, "merge_ui_prefs", _boom)
+    async with _client() as client:
+        res = await client.put("/api/ui-prefs", json={"prefs": {"a": "1"}})
+        assert res.status == 503
+
+
+@pytest.mark.asyncio
+async def test_a_non_owner_cannot_read(monkeypatch):
+    """These values are the owner's and some name real host paths (file-explorer
+    state, cloud launch defaults), so the READ is gated too, not just the write."""
+    ui_prefs_store.merge_ui_prefs({"kc:file-explorer:state:v2": '{"cwd":"/home/user"}'})
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+        lambda request: False,
+    )
+    async with _client() as client:
+        res = await client.get("/api/ui-prefs")
+        assert res.status in (401, 403)
+        assert "/home/user" not in await res.text()
+
+
+@pytest.mark.asyncio
+async def test_a_non_owner_cannot_write(monkeypatch):
+    """A shared dashboard's viewer must not overwrite the owner's settings."""
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+        lambda request: False,
+    )
+    async with _client() as client:
+        res = await client.put("/api/ui-prefs", json={"prefs": {"mc-zoom": "9"}})
+        assert res.status in (401, 403)
+    # And nothing landed.
+    assert ui_prefs_store.load_ui_prefs() == {}
+
+
+@pytest.mark.asyncio
+async def test_the_gate_runs_before_body_validation(monkeypatch):
+    """A non-owner must not be able to probe the validator's error messages."""
+    monkeypatch.setattr(
+        "kiro_crew.dashboard.handlers.source_providers.is_owner_dashboard_request",
+        lambda request: False,
+    )
+    async with _client() as client:
+        res = await client.put("/api/ui-prefs", json={"nonsense": True})
+        assert res.status in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_charset_is_400_not_500():
+    """A bare `await request.json()` lets LookupError escape as a 500."""
+    async with _client() as client:
+        res = await client.put(
+            "/api/ui-prefs",
+            data=b'{"prefs":{}}',
+            headers={"Content-Type": "application/json; charset=nope-not-a-codec"},
+        )
+        assert res.status == 400
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_json_is_400_not_500():
+    """RecursionError from CPython's parser must not reach the client as a 500."""
+    deep = "[" * 5000 + "]" * 5000
+    async with _client() as client:
+        res = await client.put(
+            "/api/ui-prefs",
+            data=('{"prefs":' + deep + "}").encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        assert res.status == 400
+
+
+@pytest.mark.asyncio
+async def test_a_max_size_value_is_accepted_not_413():
+    """The request cap must cover a value the STORE allows.
+
+    The dashboard's shared default is exactly MAX_VALUE_BYTES, so the JSON
+    envelope pushed a legal value past it: the PUT 413'd, the per-key retry 413'd
+    too, and the preference was silently never backed up."""
+    big = "x" * ui_prefs_store.MAX_VALUE_BYTES
+    async with _client() as client:
+        res = await client.put("/api/ui-prefs", json={"prefs": {"kc:file-explorer:state:v2": big}})
+        assert res.status == 200
+    assert ui_prefs_store.load_ui_prefs()["kc:file-explorer:state:v2"] == big
+
+
+@pytest.mark.asyncio
+async def test_a_body_past_the_endpoint_cap_is_refused():
+    """The cap still exists: it is sized to the store, not removed."""
+    async with _client() as client:
+        res = await client.put(
+            "/api/ui-prefs",
+            data=b'{"prefs":{"k":"' + b"x" * (ui_prefs_store.MAX_REQUEST_BYTES + 1024) + b'"}}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert res.status == 413
+
+
+@pytest.mark.asyncio
+async def test_concurrent_puts_do_not_lose_a_patch():
+    """Two tabs flushing at once must both land: merge is read-modify-write."""
+    async with _client() as client:
+        await asyncio.gather(
+            client.put("/api/ui-prefs", json={"prefs": {"from-tab-a": "1"}}),
+            client.put("/api/ui-prefs", json={"prefs": {"from-tab-b": "2"}}),
+        )
+        res = await client.get("/api/ui-prefs")
+        assert await res.json() == {"prefs": {"from-tab-a": "1", "from-tab-b": "2"}}

--- a/website/src/lib/uiPrefs.ts
+++ b/website/src/lib/uiPrefs.ts
@@ -1,0 +1,592 @@
+/**
+ * Host-side backup for the dashboard settings that live in `localStorage`.
+ *
+ * The problem this solves: most settings the user sets in the UI are stored
+ * only in the renderer's `localStorage`, and `localStorage` is keyed by ORIGIN
+ * and (in the desktop app) kept inside Electron's `userData` directory. Both
+ * can change without the user doing anything: the dashboard port moves, the
+ * `userData` directory is relocated by a package rename, the user switches
+ * between the stable and nightly builds, or the browser evicts the origin. Each
+ * of those looks identical from the user's chair — "I upgraded and had to set
+ * everything up again" — even though nothing on the host was lost, because
+ * nothing on the host was ever written.
+ *
+ * So: mirror the durable subset to the gateway (`/api/ui-prefs`, stored in the
+ * data home), and read it back when a profile shows up with none of those keys.
+ *
+ * Design decisions worth knowing before changing this file:
+ *
+ * 1. **Read on a COLD profile only.** The server copy is a backup, not a live
+ *    cross-tab sync channel. If any durable key exists locally, that copy wins
+ *    and the server is only written to. Reading on every boot would let a stale
+ *    backup fight a tab the user just changed, and would make two browsers on
+ *    one host tug settings back and forth.
+ * 2. **Snapshot-diff, not write interception.** ~300 call sites write
+ *    `localStorage` directly. Rather than route them all through one writer (a
+ *    migration that would go stale the next time someone adds a raw call), this
+ *    module periodically reads the allowlisted keys and PUTs what changed. Any
+ *    writer, present or future, is covered.
+ * 3. **Explicit allowlist, no prefix wildcards for session-scoped keys.**
+ *    Ephemeral and per-session state (height caches, panel tabs, drafts,
+ *    touched files, web-preview URLs) is deliberately excluded: it is worthless
+ *    on another origin, it is what the quota reclaimer already evicts, and
+ *    mirroring it would grow without bound.
+ * 4. **Keys already mirrored server-side are excluded** — theme mode, theme
+ *    colour, language and the onboarding flags reconcile through
+ *    `/api/config/theme` and `dashboard.*` config. Backing them up here too
+ *    would create a second source of truth for the same setting.
+ */
+
+import { safeGetItem, safeSetItem } from '../utils/safeStorage'
+
+/**
+ * Durable, user-chosen preferences. Exact keys only.
+ *
+ * A key belongs here when a user would be annoyed to set it twice, and would
+ * NOT be surprised to see it follow them to a new window. When in doubt leave
+ * it out: a missing backup degrades to today's behaviour, while backing up
+ * session-scoped state resurrects stale UI on an unrelated profile.
+ */
+export const DURABLE_PREF_KEYS: readonly string[] = [
+  // Chat preferences — one JSON blob holding ~16 settings (send-key mode,
+  // timestamps, turn stats, content width, collapse-steps, stream mode, ...).
+  // This single key is the most-reported loss; see issue #8705.
+  'mc-chat-config',
+  'mc-busy-send-mode',
+  // Typography and zoom.
+  //
+  // NOT here: 'mc-zoom' and 'mc-font-scale'. hooks/useZoom.ts runs a one-time
+  // migration that folds both legacy page-scaling keys into the native zoom
+  // factor and then DELETES them, so backing them up would restore them on the
+  // next cold profile and re-run the migration forever.
+  'mc-font-family',
+  // Navigation and shell layout the user arranged by hand.
+  'mc-nav',
+  'mc-app-nav-order',
+  'mc-apps-expanded',
+  'mc-bottom-terminal',
+  'mc-files-rail-open',
+  'mc-crews-view',
+  'mc-crew-switcher-pinned',
+  'mc-crew-switcher-stable-order',
+  'mc-filter-folders-shelved',
+  'mc-flat-hidden-folders',
+  'mc-input-height',
+  // Diff and file viewer toggles.
+  'mc-diff-plain',
+  'mc-diff-split',
+  'mc-file-linenums',
+  'mc-file-wordwrap',
+  'mc-file-collapse-unchanged',
+  // Artifacts browser.
+  'mc-artifacts-view',
+  'mc-artifacts-sort',
+  'mc-artifacts-pinned-only',
+  'mc-artifacts-session-docs-collapsed',
+  'mc-artifact-folders-expanded',
+  // Misc opt-ins and acknowledgements the user should not have to repeat.
+  //
+  // NOT here: 'mc-yolo-ack'. Its mere PRESENCE makes ApprovalModePicker skip the
+  // confirmation dialog and activate full auto-approval directly, and this backup
+  // lives in the agent-writable data home — so restoring it would let an agent
+  // that can write ~/.kiro/crew/ui-prefs.json pre-satisfy a human safety gate on
+  // the user's next fresh origin. The rule this key is an instance of: a value
+  // that GATES a safety confirmation must not be restorable from a file the agent
+  // can write, however convenient re-acknowledging is.
+  'mc-dev-mode',
+  'mc-agent-scene',
+  'mc-kb-graph-physics',
+  'mc:notif:activeKinds:v2',
+  'kirocrew:account-email-hidden',
+  'kirocrew:comment-hint-dismissed',
+  // Cloud launch defaults.
+  'mc-cloud-profile',
+  'mc-cloud-region',
+  'mc-cloud-size',
+  // Per-app preferences.
+  'kc-cron-folders-collapsed',
+  'kc:file-explorer:state:v2',
+  'kc:issue-radar:ui-state',
+  'telemetry:tab',
+  'telemetry:spend-group',
+  'mdnb-view',
+  'mdnb-sort',
+  'mdnb-list-view',
+  'mdnb-full-width',
+  'mdnb-panel-width',
+  'mdnb-panel-open',
+  'mdnb-auto-commit',
+  'mdnb-auto-sync',
+  'mdnb-auto-sync-mins',
+  'mdnb-sync-shortcut',
+  'ste_rail_w',
+]
+
+const ENDPOINT = '/api/ui-prefs'
+/**
+ * Fingerprints of the durable keys this profile last successfully synced with
+ * the host, as `{key: hash}`.
+ *
+ * Three jobs, all of which need to outlive a reload:
+ *  1. Change detection after a reload. `lastSent` is in-memory, so the first
+ *     flush of a new page had no baseline and re-PUT every local value — which
+ *     on a profile holding STALE values overwrote newer preferences another
+ *     origin had already backed up. Fingerprints make that first flush send only
+ *     what this profile actually changed.
+ *  2. Deletion detection. Without a persisted key set, a key this profile once
+ *     uploaded and has since deleted was never reported, and a later cold
+ *     profile restored the value the user had deleted.
+ *  3. "Have we ever reached the host?" Its absence is what makes the boot-time
+ *     hydrate retry. Without it, one failed fetch on a fresh profile burned the
+ *     only restore attempt the backup exists for, because the first setting
+ *     written afterwards made the profile look warm forever.
+ *
+ * Hashes rather than values: one of these keys can hold a large blob, and storing
+ * the values would double their footprint in the very storage this feature exists
+ * to protect. The hash only has to detect CHANGE, so a non-cryptographic string
+ * hash is the right tool — nothing here is a security decision.
+ *
+ * Bookkeeping, so deliberately NOT in DURABLE_PREF_KEYS: it describes this
+ * profile's relationship to the host, not a user preference.
+ */
+const SYNCED_KEYS_KEY = 'mc-ui-prefs-synced'
+/**
+ * Written when a never-synced profile's restore FAILED (network, 401/403, 5xx).
+ * Its value is the JSON list of durable keys the profile ALREADY HELD at that
+ * moment. It changes what the NEXT successful restore does with a key that is
+ * present both locally and on the host:
+ *
+ *   * a key in the list was the user's before anything went wrong, and any
+ *     change they made since is theirs too — local wins, as always;
+ *   * a key NOT in the list was written after the failure by a page that
+ *     rendered without its settings (a login screen counts): hooks that persist
+ *     on mount wrote defaults into localStorage. Treating those as the user's
+ *     choice would make the first flush upload defaults over the real backup —
+ *     the very thing the restore failed to read. For those keys the host wins.
+ *
+ * Letting the host win for EVERY key instead (an earlier version did) had the
+ * mirror-image defect: a returning user whose GET failed once, then changed a
+ * preference, saw the stale host value overwrite the change at next launch.
+ *
+ * A repeat failure never widens the list — the keys added since the first
+ * failure are exactly the untrusted ones. Cleared by the first successful
+ * restore. A warm profile upgrading into this feature cannot be caught by it:
+ * its first GET finds an empty host, succeeds, and there is nothing to override.
+ */
+const HYDRATE_PENDING_KEY = 'mc-ui-prefs-hydrate-pending'
+
+/** Keys the profile held when its first restore failed, or null if it never failed. */
+function ownedAtFailure(): Set<string> | null {
+  const raw = safeGetItem(HYDRATE_PENDING_KEY)
+  if (raw === null) return null
+  try {
+    return new Set((JSON.parse(raw) as string[]).filter((k) => typeof k === 'string'))
+  } catch {
+    return new Set()
+  }
+}
+
+/** Record a failed restore. Never widens an existing snapshot (see the key's doc). */
+function markHydrateFailed(): void {
+  if (safeGetItem(HYDRATE_PENDING_KEY) !== null) return
+  const owned = DURABLE_PREF_KEYS.filter((k) => safeGetItem(k) !== null)
+  safeSetItem(HYDRATE_PENDING_KEY, JSON.stringify(owned))
+}
+/** Debounce for a change-triggered flush. Long enough that dragging a splitter
+ *  produces one PUT, short enough that closing the window right after a click
+ *  still catches it (the visibility flush is the backstop). */
+const FLUSH_DEBOUNCE_MS = 1500
+/** Safety-net scan for writers that fire no event we listen to. */
+const POLL_INTERVAL_MS = 30_000
+/** The boot-time hydrate must not hold the first paint hostage on a slow or
+ *  unreachable gateway. On timeout we render with defaults, exactly as today. */
+const HYDRATE_TIMEOUT_MS = 3000
+
+/** Last state we successfully sent, so a flush PUTs only what changed. */
+let lastSent: Map<string, string> | null = null
+let flushTimer: ReturnType<typeof setTimeout> | undefined
+let pollTimer: ReturnType<typeof setInterval> | undefined
+let started = false
+let inFlight: Promise<void> | null = null
+/** A change arrived while a PUT was in flight: chain one more flush after it. */
+let dirtyDuringFlush = false
+
+function readLocalSnapshot(): Map<string, string> {
+  const snapshot = new Map<string, string>()
+  for (const key of DURABLE_PREF_KEYS) {
+    const value = safeGetItem(key)
+    if (value !== null) snapshot.set(key, value)
+  }
+  return snapshot
+}
+
+/**
+ * Non-cryptographic change detector: two independent 32-bit FNV-1a lanes plus
+ * the length, ~64 bits of separation. A collision here is not harmless — the
+ * changed value is read as "already synced", never uploaded, and an origin
+ * reset then restores the stale host copy over it — so one 32-bit lane
+ * (2^-32 per change) was too thin. Two lanes with different offset bases and a
+ * different multiplier walk unrelated orbits, and the length forecloses the
+ * cheapest constructed collisions. Storing the prior values themselves would
+ * be exact but doubles localStorage use for the largest keys; this is not a
+ * digest and does not claim adversarial resistance.
+ */
+function fingerprint(value: string): string {
+  let a = 0x811c9dc5
+  let b = 0x9747b28c
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i)
+    a ^= c
+    a = Math.imul(a, 0x01000193)
+    b ^= c
+    b = Math.imul(b, 0x5bd1e995)
+    b ^= b >>> 15
+  }
+  return `${value.length.toString(36)}.${(a >>> 0).toString(36)}.${(b >>> 0).toString(36)}`
+}
+
+function readSyncedPrints(): Map<string, string> {
+  const raw = safeGetItem(SYNCED_KEYS_KEY)
+  if (!raw) return new Map()
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return new Map()
+    const out = new Map<string, string>()
+    const durable = new Set(DURABLE_PREF_KEYS)
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      // Ignore a fingerprint for a key THIS build does not know. On a downgrade
+      // the marker still lists keys a newer build synced; keeping them would put
+      // them in `previousKeys` while `current` can never hold them (they are not
+      // read at all), so buildPatch would emit `null` and the older build would
+      // delete a preference the newer one owns.
+      if (typeof v === 'string' && durable.has(k)) out.set(k, v)
+    }
+    return out
+  } catch {
+    return new Map()
+  }
+}
+
+function writeSyncedPrints(values: Map<string, string>): void {
+  const prints: Record<string, string> = {}
+  for (const [k, v] of values) prints[k] = fingerprint(v)
+  safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(prints))
+}
+
+/**
+ * Update the persisted fingerprints for SOME keys, leaving the rest alone.
+ *
+ * `updates` maps a key to its accepted value, or to `null` for a key the host
+ * accepted a deletion of. Merging rather than replacing matters on the per-key
+ * retry path: rebuilding the whole map from that round's few keys would erase the
+ * fingerprints of every key the round never mentioned, and the next poll would
+ * then re-upload their stale values over newer host preferences.
+ */
+function mergeSyncedPrints(updates: Map<string, string | null>): void {
+  const prints = readSyncedPrints()
+  for (const [k, v] of updates) {
+    if (v === null) prints.delete(k)
+    else prints.set(k, fingerprint(v))
+  }
+  const out: Record<string, string> = {}
+  for (const [k, v] of prints) out[k] = v
+  safeSetItem(SYNCED_KEYS_KEY, JSON.stringify(out))
+}
+
+/**
+ * True when this profile has never successfully exchanged preferences with the
+ * host — a fresh browser profile, a new origin (moved port), a relocated
+ * Electron `userData`, or a boot whose fetch failed. That is exactly when the
+ * backup should be read, and staying true after a failure is what makes the read
+ * retry on the next boot instead of being forfeited.
+ */
+export function needsHydrate(): boolean {
+  return safeGetItem(SYNCED_KEYS_KEY) === null
+}
+
+/**
+ * Build the merge patch: changed and new keys as values, keys this profile
+ * previously synced but no longer holds as `null`, so the backup follows a
+ * deletion instead of resurrecting it.
+ *
+ * With no in-memory baseline (the first flush after a reload) the comparison runs
+ * against the persisted fingerprints, so an unchanged value is NOT re-sent. That
+ * matters beyond saving a request: re-sending everything from a profile holding
+ * stale values would overwrite newer preferences another origin had already
+ * backed up. A key this profile never synced is never nulled, which is what keeps
+ * a second browser from deleting the first one's settings.
+ */
+function buildPatch(current: Map<string, string>): Record<string, string | null> {
+  const patch: Record<string, string | null> = {}
+  const prints = lastSent ? null : readSyncedPrints()
+  for (const [key, value] of current) {
+    const unchanged = lastSent
+      ? lastSent.get(key) === value
+      : prints!.get(key) === fingerprint(value)
+    if (!unchanged) patch[key] = value
+  }
+  const previousKeys = lastSent ? new Set(lastSent.keys()) : new Set(prints!.keys())
+  for (const key of previousKeys) {
+    if (!current.has(key)) patch[key] = null
+  }
+  return patch
+}
+
+async function putPatch(
+  patch: Record<string, string | null>,
+  keepalive = false,
+): Promise<Response | null> {
+  try {
+    return await fetch(ENDPOINT, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prefs: patch }),
+      // Set on the pagehide flush only: a plain fetch is cancelled with the
+      // document, so a change made inside the debounce window before closing
+      // was never sent -- and reopening on a NEW origin then restored the stale
+      // host value over it (close, upgrade, port moves: this PR's own scenario).
+      // Browsers cap keepalive bodies at 64 KiB; a larger patch rejects here,
+      // returns null, and is retried on the next boot at the same origin.
+      keepalive,
+    })
+  } catch {
+    return null
+  }
+}
+
+/** Record a successful upload as the new baseline, on both sides. */
+function commitSent(current: Map<string, string>): void {
+  lastSent = current
+  writeSyncedPrints(current)
+}
+
+/**
+ * Re-send a refused patch one key at a time, so one unstorable value cannot
+ * silently discard every other change in the same round. Keys the host accepts
+ * enter the baseline; the offender stays out of it and is simply not backed up
+ * (its local value still works, and the next flush tries it again).
+ *
+ * Only the keys THIS round touched are written to the baseline. Rebuilding it
+ * from them would drop the fingerprints of every other synced key — after a
+ * reload, where the in-memory baseline is empty, that is all of them — and the
+ * next poll would re-upload their stale values over newer host preferences.
+ */
+async function retryPerKey(patch: Record<string, string | null>): Promise<void> {
+  const hadBaseline = lastSent !== null
+  const accepted = new Map<string, string>(lastSent ?? [])
+  const landed = new Map<string, string | null>()
+  for (const [key, value] of Object.entries(patch)) {
+    const res = await putPatch({ [key]: value })
+    if (res === null) break // went offline mid-retry: keep what landed, retry the rest
+    if (!res.ok) continue
+    landed.set(key, value)
+    if (value === null) accepted.delete(key)
+    else accepted.set(key, value)
+  }
+  if (landed.size === 0) return
+  // Only adopt an in-memory baseline if there already WAS one. Built from an
+  // empty start (the first flush after a reload) `accepted` holds just this
+  // round's keys, and a PARTIAL in-memory baseline is worse than none: every key
+  // missing from it reads as changed, so the next flush re-uploads stale values
+  // over newer host preferences, and deletions of keys absent from it go
+  // unreported. Left null, the next flush falls back to the persisted
+  // fingerprints, which the merge below has just brought up to date.
+  if (hadBaseline) lastSent = accepted
+  mergeSyncedPrints(landed)
+}
+
+/**
+ * Read the host-side backup into `localStorage`.
+ *
+ * Only keys that are ABSENT locally are written, so this can never clobber a
+ * value the running profile already has. Returns the number of keys restored.
+ * Resolves (0) rather than rejecting when the gateway is unreachable: a missing
+ * backup is not an error. A successful fetch — even an empty one — records the
+ * synced key set, which is what stops the next boot from asking again.
+ */
+export async function hydrateUiPrefs(): Promise<number> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), HYDRATE_TIMEOUT_MS)
+  // A previous restore on this profile failed; local values for keys the
+  // profile did NOT hold at that moment are untrusted, so for those the host
+  // wins (see the key's doc). Null means no failure on record: local wins.
+  const owned = ownedAtFailure()
+  try {
+    const res = await fetch(ENDPOINT, { signal: controller.signal })
+    if (!res.ok) {
+      markHydrateFailed()
+      return 0
+    }
+    const body: unknown = await res.json()
+    const prefs = (body as { prefs?: unknown } | null)?.prefs
+    if (!prefs || typeof prefs !== 'object') return 0
+    const hostValues = prefs as Record<string, unknown>
+    let restored = 0
+    for (const key of DURABLE_PREF_KEYS) {
+      const value = hostValues[key]
+      if (typeof value !== 'string') continue
+      const local = safeGetItem(key)
+      if (local === value) continue
+      if (local !== null && (owned === null || owned.has(key))) continue
+      if (safeSetItem(key, value)) restored += 1
+    }
+    // The host answered, so this profile is in touch with it. Baseline every
+    // key the host holds with whatever is NOW in localStorage for it:
+    //   * equal to the host's -- synced in the plain sense;
+    //   * different from the host's (this profile kept its own value) -- also
+    //     baselined, deliberately. This origin is by definition the one that has
+    //     NOT been syncing; the host's copy came from an origin that has. Not
+    //     baselining would make the first flush upload this profile's possibly
+    //     months-stale value over the newer backup, unconditionally. Baselined,
+    //     the local value stays in use here and is uploaded the moment the user
+    //     changes it; the only way it is ever lost is a LATER storage wipe here,
+    //     which then restores the host's -- a second failure, not the first.
+    //   * a value `safeSetItem` had to drop (quota) stays OUT: recording it
+    //     would make the first flush read it as a deletion and null out a good
+    //     host backup.
+    const syncedNow = new Map<string, string>()
+    for (const key of DURABLE_PREF_KEYS) {
+      if (typeof hostValues[key] !== 'string') continue
+      const local = safeGetItem(key)
+      if (local !== null) syncedNow.set(key, local)
+    }
+    writeSyncedPrints(syncedNow)
+    // Cleared AFTER the synced marker is written, so a crash between the two
+    // leaves the profile still pending rather than synced-with-untrusted-locals.
+    try {
+      localStorage.removeItem(HYDRATE_PENDING_KEY)
+    } catch {
+      /* best-effort */
+    }
+    if (restored > 0) {
+      // Readers that already took their value need to re-read it. Some read it
+      // at MODULE scope, before this function ran at all — static imports are
+      // evaluated before any statement of the entry module, so e.g.
+      // hooks/useBottomTerminal.ts captures its state into a module-level `let`
+      // during import, and its own `storage` listener cannot help because
+      // `storage` fires for OTHER documents, never for a write this document
+      // made. Left unread, that stale module copy is persisted back over the
+      // restored value by the first interaction.
+      //
+      // A same-document event cannot fix a value already captured, so the caller
+      // reloads instead (see main.tsx). Announce the change as well for the
+      // live listeners that CAN act on it, in case a caller chooses not to.
+      window.dispatchEvent(new Event('mc-config-changed'))
+    }
+    return restored
+  } catch {
+    markHydrateFailed()
+    return 0
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** PUT whatever changed since the last successful flush. */
+export async function flushUiPrefs(keepalive = false): Promise<void> {
+  if (inFlight) {
+    // Do NOT hand back the in-flight promise: it carries the OLD snapshot, so a
+    // caller awaiting it (pagehide) would believe a newer change had been sent.
+    // Mark dirty instead and let the running flush chain another round.
+    dirtyDuringFlush = true
+    return
+  }
+  const current = readLocalSnapshot()
+  const patch = buildPatch(current)
+  if (Object.keys(patch).length === 0) return
+
+  inFlight = (async () => {
+    try {
+      const res = await putPatch(patch, keepalive)
+      if (res === null) return // offline / gateway restarting — retry next trigger
+      if (res.ok) {
+        commitSent(current)
+        return
+      }
+      if (res.status === 401 || res.status === 403) {
+        // Either the access cookie lapsed (routine: useRefreshScheduler and the
+        // API client's own recovery repair it within the session) or this is not
+        // the owner's dashboard. Both look the same from here, and stopping for
+        // the session on the first turned a routine cookie lapse into "nothing
+        // changed after it is backed up until the next reload". So: treat like
+        // 5xx -- baseline untouched, next trigger retries. A true non-owner
+        // costs one refused PUT per change, at most every 30s.
+        return
+      }
+      if (res.status >= 400 && res.status < 500) {
+        // The server refuses a patch WHOLE, so nothing landed. Advancing the
+        // baseline for every key would abandon the valid changes bundled with
+        // the offending one.
+        await retryPerKey(patch)
+      }
+      // 5xx: leave the baseline alone so the next trigger retries.
+    } finally {
+      inFlight = null
+    }
+  })()
+  await inFlight
+  if (dirtyDuringFlush) {
+    dirtyDuringFlush = false
+    await flushUiPrefs()
+  }
+}
+
+function scheduleFlush(): void {
+  if (flushTimer !== undefined) clearTimeout(flushTimer)
+  flushTimer = setTimeout(() => {
+    flushTimer = undefined
+    void flushUiPrefs()
+  }, FLUSH_DEBOUNCE_MS)
+}
+
+/** Unload-path flush: the request must outlive the document (see putPatch). */
+function flushNow(): void {
+  void flushUiPrefs(true)
+}
+
+function flushIfHidden(): void {
+  if (document.visibilityState === 'hidden') flushNow()
+}
+
+/**
+ * Start mirroring durable preferences to the host. Idempotent.
+ *
+ * The baseline starts empty on purpose, so the first flush uploads whatever
+ * this profile currently holds. That is what seeds the backup for a user
+ * upgrading into this feature, and on a just-hydrated cold profile it costs one
+ * idempotent PUT of values the server already has — cheaper than a branch that
+ * has to decide which case it is in.
+ */
+export function startUiPrefsSync(): void {
+  if (started) return
+  started = true
+  lastSent = null
+
+  window.addEventListener('mc-config-changed', scheduleFlush)
+  // `storage` fires for OTHER tabs on the same origin, so a change made in one
+  // window is backed up even while this one is idle.
+  window.addEventListener('storage', scheduleFlush)
+  // Best-effort catch of a change made just before the window goes away. A
+  // `fetch` on unload may not complete; the debounce plus the poll are what
+  // actually guarantee delivery, so nothing depends on this landing.
+  window.addEventListener('pagehide', flushNow)
+  document.addEventListener('visibilitychange', flushIfHidden)
+  pollTimer = setInterval(scheduleFlush, POLL_INTERVAL_MS)
+  // First flush right away: on a warm profile this is what creates the backup.
+  scheduleFlush()
+}
+
+export function __resetUiPrefsSyncForTests(): void {
+  started = false
+  if (flushTimer !== undefined) clearTimeout(flushTimer)
+  if (pollTimer !== undefined) clearInterval(pollTimer)
+  flushTimer = undefined
+  pollTimer = undefined
+  window.removeEventListener('mc-config-changed', scheduleFlush)
+  window.removeEventListener('storage', scheduleFlush)
+  window.removeEventListener('pagehide', flushNow)
+  document.removeEventListener('visibilitychange', flushIfHidden)
+  lastSent = null
+  inFlight = null
+  dirtyDuringFlush = false
+}

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -30,6 +30,7 @@ import ErrorBoundary from './components/ErrorBoundary'
 import DashboardBootstrap from './components/DashboardBootstrap'
 import { installPageZoomSuppression } from './utils/pageZoom'
 import { installStaleShellHeal } from './lib/staleShellHeal'
+import { hydrateUiPrefs, needsHydrate, startUiPrefsSync } from './lib/uiPrefs'
 import 'katex/dist/katex.min.css'
 import './index.css'
 import './styles/cli-mode.css'
@@ -143,7 +144,7 @@ startMemoryWatch('main')
 // element enters the tree on a normal load.
 installCommitProfilerConsoleApi()
 
-createRoot(document.getElementById('root')!).render(
+const appTree = (
   <StrictMode>
     <ErrorBoundary root scope="app-shell">
       <QueryClientProvider client={queryClient}>
@@ -180,5 +181,53 @@ createRoot(document.getElementById('root')!).render(
         </Provider>
       </QueryClientProvider>
     </ErrorBoundary>
-  </StrictMode>,
+  </StrictMode>
 )
+
+// Restore the host-side backup of the renderer's own settings BEFORE the first
+// render, on any profile that has never successfully reached the host — a fresh
+// browser profile, a moved dashboard port (localStorage is per-origin), or a
+// relocated Electron userData directory. That is the case where the user would
+// otherwise see every setting back at its default and conclude the upgrade ate
+// them. Keyed on "never synced" rather than "no settings present" so a boot whose
+// fetch failed retries on the next one instead of forfeiting the restore.
+//
+// When something WAS restored we reload rather than render. Restoring before the
+// first render is not enough on its own: static imports are evaluated before any
+// statement here, so a store that reads its key at module scope (e.g.
+// hooks/useBottomTerminal.ts) has already captured the pre-restore value, and its
+// first write would persist that stale copy back over what we just restored. A
+// reload is the one move that is correct for every module-scope reader, present
+// and future, without a per-store re-init hook a new store would silently miss.
+// It costs one extra load on a fresh profile and cannot loop: hydrateUiPrefs
+// records the synced marker, so the next boot does not hydrate, and even with
+// that write dropped the second pass finds the keys present and restores nothing.
+//
+// Sync starts ONLY once this profile knows the host's state — i.e. the GET landed,
+// which is what clears needsHydrate(). If the fetch failed we render but do NOT
+// sync: the local keys at that moment are whatever the defaults-persisting hooks
+// just wrote, and uploading those would overwrite the very backup the failed
+// restore was trying to read. No sync means no backup for this session and the
+// next boot retries the restore. The asymmetry is deliberate — losing one
+// session's backup is recoverable, overwriting the host's copy is not.
+//
+// A profile that has synced pays nothing: needsHydrate() is a synchronous
+// localStorage read, so the usual launch renders on the same tick as before. The
+// first-time path is bounded by hydrateUiPrefs' own timeout, and a gateway that
+// never answers renders defaults rather than hanging the boot. See lib/uiPrefs.ts.
+function boot(startSync: boolean): void {
+  createRoot(document.getElementById('root')!).render(appTree)
+  if (startSync) startUiPrefsSync()
+}
+
+if (needsHydrate()) {
+  void hydrateUiPrefs().then(
+    (restored) => {
+      if (restored > 0) window.location.reload()
+      else boot(!needsHydrate())
+    },
+    () => boot(false),
+  )
+} else {
+  boot(true)
+}

--- a/website/src/test/uiPrefs.test.ts
+++ b/website/src/test/uiPrefs.test.ts
@@ -1,0 +1,602 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  DURABLE_PREF_KEYS,
+  hydrateUiPrefs,
+  needsHydrate,
+  flushUiPrefs,
+  startUiPrefsSync,
+  __resetUiPrefsSyncForTests,
+} from '../lib/uiPrefs'
+
+const SYNCED_KEYS_KEY = 'mc-ui-prefs-synced'
+
+function mockFetch(impl: (url: string, init?: RequestInit) => unknown) {
+  const spy = vi.fn((url: string, init?: RequestInit) => Promise.resolve(impl(url, init)))
+  vi.stubGlobal('fetch', spy as unknown as typeof fetch)
+  return spy
+}
+
+function okJson(body: unknown) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) }
+}
+
+/** The last PUT body the spy saw, parsed. */
+function lastPatch(spy: ReturnType<typeof mockFetch>): Record<string, string | null> {
+  const puts = spy.mock.calls.filter((c) => (c[1] as RequestInit | undefined)?.method === 'PUT')
+  const body = (puts.at(-1)?.[1] as RequestInit).body as string
+  return JSON.parse(body).prefs
+}
+
+describe('uiPrefs', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    __resetUiPrefsSyncForTests()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    __resetUiPrefsSyncForTests()
+  })
+
+  describe('the allowlist', () => {
+    it('holds no duplicates', () => {
+      expect(new Set(DURABLE_PREF_KEYS).size).toBe(DURABLE_PREF_KEYS.length)
+    })
+
+    it('excludes session-scoped and derived state', () => {
+      // These are per-session or pure caches: mirroring them would grow without
+      // bound and resurrect stale UI on an unrelated profile.
+      for (const forbidden of [
+        'vc_heights_',
+        'mc-panel-tabs',
+        'mc-chat-drafts',
+        'mc-comment-drafts',
+        'mc-paste-store-v1',
+        'kirocrew:touched-files:',
+        'mc-webpreview-url',
+        'mc-active-slot-chat',
+      ]) {
+        expect(DURABLE_PREF_KEYS.some((k) => k.startsWith(forbidden))).toBe(false)
+      }
+    })
+
+    it('excludes the bearer token and the keys config.json already owns', () => {
+      // The token is a credential; theme/language/onboarding reconcile through
+      // /api/config/theme, so backing them up here would fork the truth.
+      for (const owned of [
+        'kiro_crew_token',
+        'mc-lang',
+        'mc-color-theme',
+        'mc-theme',
+        'mc-onboarded',
+        'mc-import-onboarded',
+      ]) {
+        expect(DURABLE_PREF_KEYS).not.toContain(owned)
+      }
+    })
+
+    it('excludes any key that gates a safety confirmation', () => {
+      // mc-yolo-ack's presence makes ApprovalModePicker skip the confirmation and
+      // enable full auto-approval. This backup lives in the agent-writable data
+      // home, so restoring it would let an agent pre-satisfy a human safety gate.
+      expect(DURABLE_PREF_KEYS).not.toContain('mc-yolo-ack')
+    })
+
+    it('excludes the legacy scaling keys a migration deliberately deletes', () => {
+      // hooks/useZoom.ts folds both into the native zoom factor and REMOVES
+      // them; backing them up would restore them and re-run the migration.
+      expect(DURABLE_PREF_KEYS).not.toContain('mc-zoom')
+      expect(DURABLE_PREF_KEYS).not.toContain('mc-font-scale')
+    })
+
+    it('excludes its own sync bookkeeping keys', () => {
+      expect(DURABLE_PREF_KEYS).not.toContain(SYNCED_KEYS_KEY)
+      expect(DURABLE_PREF_KEYS).not.toContain('mc-ui-prefs-hydrate-pending')
+    })
+  })
+
+  describe('needsHydrate', () => {
+    it('is true on a profile that has never reached the host', () => {
+      localStorage.setItem('mc-chat-config', '{}') // warm, but never synced
+      expect(needsHydrate()).toBe(true)
+    })
+
+    it('is false once a fetch has succeeded', async () => {
+      mockFetch(() => okJson({ prefs: {} }))
+      await hydrateUiPrefs()
+      expect(needsHydrate()).toBe(false)
+    })
+
+    it('stays true after a failed fetch, so the next boot retries', async () => {
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      await hydrateUiPrefs()
+      expect(needsHydrate()).toBe(true)
+    })
+  })
+
+  describe('hydrateUiPrefs', () => {
+    it('restores keys that are missing locally', async () => {
+      mockFetch(() => okJson({ prefs: { 'mc-chat-config': '{"sendOnEnter":"ctrl-enter"}' } }))
+      expect(await hydrateUiPrefs()).toBe(1)
+      expect(localStorage.getItem('mc-chat-config')).toBe('{"sendOnEnter":"ctrl-enter"}')
+    })
+
+    it('never overwrites a value this profile already has', async () => {
+      localStorage.setItem('mc-chat-config', 'local-wins')
+      mockFetch(() => okJson({ prefs: { 'mc-chat-config': 'server-copy' } }))
+      expect(await hydrateUiPrefs()).toBe(0)
+      expect(localStorage.getItem('mc-chat-config')).toBe('local-wins')
+    })
+
+    it('ignores keys outside the allowlist', async () => {
+      mockFetch(() => okJson({ prefs: { 'vc_heights_x': '{}', 'kiro_crew_token': 'leak' } }))
+      expect(await hydrateUiPrefs()).toBe(0)
+      expect(localStorage.getItem('kiro_crew_token')).toBeNull()
+    })
+
+    it('ignores non-string values', async () => {
+      mockFetch(() => okJson({ prefs: { 'mc-font-family': 1.5 } }))
+      expect(await hydrateUiPrefs()).toBe(0)
+    })
+
+    it('notifies readers only when something was restored', async () => {
+      const onChange = vi.fn()
+      window.addEventListener('mc-config-changed', onChange)
+      mockFetch(() => okJson({ prefs: {} }))
+      await hydrateUiPrefs()
+      expect(onChange).not.toHaveBeenCalled()
+
+      mockFetch(() => okJson({ prefs: { 'mc-font-family': '1.2' } }))
+      await hydrateUiPrefs()
+      expect(onChange).toHaveBeenCalledTimes(1)
+      window.removeEventListener('mc-config-changed', onChange)
+    })
+
+    it('after a FAILED restore, the host wins for keys the profile did NOT hold at the failure', async () => {
+      // Boot 1: GET fails (expired cookie). The app renders (login screen), and a
+      // hook persists a default locally.
+      mockFetch(() => ({ ok: false, status: 403, json: () => Promise.resolve({}) }))
+      await hydrateUiPrefs()
+      expect(needsHydrate()).toBe(true)
+      localStorage.setItem('mc-crews-view', 'DEFAULT-WRITTEN-WHILE-LOGGED-OUT')
+
+      // Boot 2: GET succeeds. Without the pending flag the local default would
+      // have been kept, fingerprinted as "differs", and the first flush would
+      // have uploaded it over the real backup.
+      mockFetch(() => okJson({ prefs: { 'mc-crews-view': 'HOST' } }))
+      const restored = await hydrateUiPrefs()
+      expect(restored).toBe(1)
+      expect(localStorage.getItem('mc-crews-view')).toBe('HOST')
+      expect(needsHydrate()).toBe(false)
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('a normal (never-failed) first restore still lets local win', async () => {
+      localStorage.setItem('mc-crews-view', 'MINE')
+      mockFetch(() => okJson({ prefs: { 'mc-crews-view': 'HOST' } }))
+      await hydrateUiPrefs()
+      expect(localStorage.getItem('mc-crews-view')).toBe('MINE')
+    })
+
+    it('after a FAILED restore, a key the profile ALREADY held stays local -- including a later change', async () => {
+      // A returning user: the profile holds a real value, one GET fails
+      // transiently, the user then changes the preference. The host's copy is
+      // now the STALE one; letting it win would erase the change at next launch.
+      localStorage.setItem('mc-crews-view', 'MINE')
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      await hydrateUiPrefs()
+      localStorage.setItem('mc-crews-view', 'MINE-CHANGED-AFTER-FAILURE')
+      // ...while a default written by the settings-less render is still untrusted.
+      localStorage.setItem('mc-nav', 'DEFAULT-WRITTEN-WHILE-DOWN')
+
+      mockFetch(() => okJson({ prefs: { 'mc-crews-view': 'HOST-STALE', 'mc-nav': 'HOST' } }))
+      const restored = await hydrateUiPrefs()
+      expect(restored).toBe(1)
+      expect(localStorage.getItem('mc-crews-view')).toBe('MINE-CHANGED-AFTER-FAILURE')
+      expect(localStorage.getItem('mc-nav')).toBe('HOST')
+    })
+
+    it('a repeat failure does not widen the owned-at-failure snapshot', async () => {
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      await hydrateUiPrefs()
+      localStorage.setItem('mc-crews-view', 'DEFAULT-AFTER-FIRST-FAILURE')
+      await hydrateUiPrefs() // second failure: the default above must NOT become "owned"
+      mockFetch(() => okJson({ prefs: { 'mc-crews-view': 'HOST' } }))
+      await hydrateUiPrefs()
+      expect(localStorage.getItem('mc-crews-view')).toBe('HOST')
+    })
+
+    it('the pending marker records the owned keys and is cleared by a successful restore', async () => {
+      localStorage.setItem('mc-crews-view', 'MINE')
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      await hydrateUiPrefs()
+      expect(JSON.parse(localStorage.getItem('mc-ui-prefs-hydrate-pending') ?? 'null')).toEqual([
+        'mc-crews-view',
+      ])
+      mockFetch(() => okJson({ prefs: {} }))
+      await hydrateUiPrefs()
+      expect(localStorage.getItem('mc-ui-prefs-hydrate-pending')).toBeNull()
+    })
+
+    it('baselines a local value that differs from the host instead of uploading it', async () => {
+      // This origin has not been syncing (it is hydrating); the host's copy came
+      // from one that has. Uploading the local value here would clobber the
+      // newer backup with a possibly months-stale one on first flush.
+      localStorage.setItem('mc-crews-view', 'STALE-FROM-OLD-ORIGIN')
+      mockFetch(() => okJson({ prefs: { 'mc-crews-view': 'NEWER-HOST' } }))
+      await hydrateUiPrefs()
+      expect(localStorage.getItem('mc-crews-view')).toBe('STALE-FROM-OLD-ORIGIN') // still in use here
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+
+      // ...but the moment the user changes it here, it is theirs and goes up.
+      localStorage.setItem('mc-crews-view', 'CHANGED-HERE')
+      const spy2 = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy2)).toEqual({ 'mc-crews-view': 'CHANGED-HERE' })
+    })
+
+    it('marks a local value that already equals the host as synced', async () => {
+      localStorage.setItem('mc-crews-view', 'SAME')
+      mockFetch(() => okJson({ prefs: { 'mc-crews-view': 'SAME' } }))
+      await hydrateUiPrefs()
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('records only the keys that actually landed locally', async () => {
+      // A value safeSetItem has to drop (quota) must NOT be recorded as synced:
+      // the first flush would read it as a deletion and null out a good backup.
+      const realSet = Storage.prototype.setItem
+      vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+        this: Storage,
+        k: string,
+        v: string,
+      ) {
+        if (k === 'mc-dev-mode') throw new DOMException('full', 'QuotaExceededError')
+        realSet.call(this, k, v)
+      })
+      mockFetch(() => okJson({ prefs: { 'mc-dev-mode': 'true', 'mc-crews-view': 'grid' } }))
+      await hydrateUiPrefs()
+      vi.restoreAllMocks()
+
+      expect(localStorage.getItem('mc-dev-mode')).toBeNull()
+      expect(Object.keys(JSON.parse(localStorage.getItem(SYNCED_KEYS_KEY)!))).toEqual([
+        'mc-crews-view',
+      ])
+
+      // The follow-up flush must not delete the host's copy of the key it failed
+      // to store locally.
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      const puts = spy.mock.calls.filter((c) => (c[1] as RequestInit | undefined)?.method === 'PUT')
+      const patch = puts.length
+        ? JSON.parse((puts.at(-1)![1] as RequestInit).body as string).prefs
+        : {}
+      expect(patch['mc-dev-mode']).toBeUndefined()
+    })
+
+    it.each([
+      ['a non-2xx response', () => ({ ok: false, status: 500, json: () => Promise.resolve({}) })],
+      ['a malformed payload', () => okJson({ prefs: 'nope' })],
+      ['a payload with no prefs', () => okJson({})],
+    ])('degrades to 0 restored on %s', async (_label, impl) => {
+      mockFetch(impl)
+      expect(await hydrateUiPrefs()).toBe(0)
+    })
+
+    it('degrades to 0 restored when the gateway is unreachable', async () => {
+      vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new Error('ECONNREFUSED'))))
+      expect(await hydrateUiPrefs()).toBe(0)
+    })
+  })
+
+  describe('flushUiPrefs', () => {
+    it('sends nothing when there is nothing to send', async () => {
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('uploads a change whose value collides with the prior one on a single 32-bit FNV-1a lane', async () => {
+      // These two strings hash identically under plain 32-bit FNV-1a. With only
+      // that lane, the second value read as "already synced": never uploaded, and
+      // an origin reset would restore the stale first value over it.
+      localStorage.setItem('mc-cloud-profile', 'pref-ijfpMFqy')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      localStorage.setItem('mc-cloud-profile', 'pref-F51SMhug')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-cloud-profile': 'pref-F51SMhug' })
+    })
+
+    it('sends the durable keys and nothing else', async () => {
+      localStorage.setItem('mc-font-family', '1.25')
+      localStorage.setItem('vc_heights_abc', '{"0":10}')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-font-family': '1.25' })
+    })
+
+    it('sends only what changed since the last successful flush', async () => {
+      localStorage.setItem('mc-font-family', '1')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      localStorage.setItem('mc-dev-mode', 'true')
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-dev-mode': 'true' })
+    })
+
+    it('sends null for a key the user cleared', async () => {
+      localStorage.setItem('mc-dev-mode', 'true')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      localStorage.removeItem('mc-dev-mode')
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-dev-mode': null })
+    })
+
+    it('retries the same patch after a failed flush', async () => {
+      localStorage.setItem('mc-zoom-unused', 'x') // non-durable, ignored
+      localStorage.setItem('mc-dev-mode', 'true')
+      const failing = mockFetch(() => ({ ok: false, status: 503, json: () => Promise.resolve({}) }))
+      await flushUiPrefs()
+      expect(lastPatch(failing)).toEqual({ 'mc-dev-mode': 'true' })
+      // The baseline must NOT have advanced, or the value would be dropped.
+      const retry = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(retry)).toEqual({ 'mc-dev-mode': 'true' })
+    })
+
+    it('a refused patch is retried per key so valid changes still land', async () => {
+      localStorage.setItem('mc-dev-mode', 'true')
+      localStorage.setItem('kc:file-explorer:state:v2', 'too-big')
+      // Whole-patch PUT is refused; per-key retry accepts everything except the
+      // offending value.
+      const spy = mockFetch((_url, init) => {
+        const body = JSON.parse((init as RequestInit).body as string)
+        const keys = Object.keys(body.prefs)
+        if (keys.length > 1) return { ok: false, status: 400, json: () => Promise.resolve({}) }
+        if (keys[0] === 'kc:file-explorer:state:v2') {
+          return { ok: false, status: 400, json: () => Promise.resolve({}) }
+        }
+        return okJson({ prefs: {} })
+      })
+      await flushUiPrefs()
+
+      const sent = spy.mock.calls
+        .filter((c) => (c[1] as RequestInit | undefined)?.method === 'PUT')
+        .map((c) => Object.keys(JSON.parse((c[1] as RequestInit).body as string).prefs))
+      expect(sent).toContainEqual(['mc-dev-mode'])
+      expect(sent).toContainEqual(['kc:file-explorer:state:v2'])
+
+      // The accepted key is now baselined (not resent), the refused one is not.
+      const after = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(after)).toEqual({ 'kc:file-explorer:state:v2': 'too-big' })
+    })
+
+    it('after a reload it re-sends nothing when nothing changed', async () => {
+      // A stale origin re-PUTting every value would overwrite the newer
+      // preferences another origin already backed up.
+      localStorage.setItem('mc-dev-mode', 'true')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      __resetUiPrefsSyncForTests() // page reload: in-memory baseline gone
+
+      const after = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(after).not.toHaveBeenCalled()
+    })
+
+    it('after a reload it sends only the value this profile changed', async () => {
+      localStorage.setItem('mc-dev-mode', 'true')
+      localStorage.setItem('mc-crews-view', 'list')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      __resetUiPrefsSyncForTests()
+      localStorage.setItem('mc-crews-view', 'grid')
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-crews-view': 'grid' })
+    })
+
+    it('a per-key retry after a reload keeps the untouched fingerprints', async () => {
+      localStorage.setItem('mc-dev-mode', 'true')
+      localStorage.setItem('mc-crews-view', 'list')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      __resetUiPrefsSyncForTests() // reload: in-memory baseline gone
+
+      // One key changes and the host refuses the whole patch, forcing per-key
+      // retry with an EMPTY in-memory baseline.
+      localStorage.setItem('mc-crews-view', 'grid')
+      mockFetch((_url, init) => {
+        const keys = Object.keys(JSON.parse((init as RequestInit).body as string).prefs)
+        return keys.length > 1
+          ? { ok: false, status: 400, json: () => Promise.resolve({}) }
+          : okJson({ prefs: {} })
+      })
+      await flushUiPrefs()
+
+      // mc-dev-mode was never in this round, so its fingerprint must survive —
+      // otherwise the next poll re-uploads its stale value.
+      const prints = JSON.parse(localStorage.getItem(SYNCED_KEYS_KEY)!)
+      expect(Object.keys(prints).sort()).toEqual(['mc-crews-view', 'mc-dev-mode'])
+
+      __resetUiPrefsSyncForTests()
+      const after = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(after).not.toHaveBeenCalled()
+    })
+
+    it('does not delete a key a newer build synced (downgrade safety)', async () => {
+      // The marker still lists a key this build's allowlist does not contain. It
+      // can never appear in `current`, so treating it as previously-synced would
+      // emit null and delete a preference the newer build owns.
+      localStorage.setItem(
+        SYNCED_KEYS_KEY,
+        JSON.stringify({ 'mc-from-a-newer-build': 'abc', 'mc-dev-mode': 'zzz' }),
+      )
+      localStorage.setItem('mc-dev-mode', 'true')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      const patch = lastPatch(spy)
+      expect(patch['mc-from-a-newer-build']).toBeUndefined()
+      expect(patch['mc-dev-mode']).toBe('true')
+    })
+
+    it('reports a deletion made before a reload', async () => {
+      // A previous session synced the key...
+      localStorage.setItem('mc-dev-mode', 'true')
+      mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      // ...then the page reloads (in-memory baseline gone) and the user clears it.
+      __resetUiPrefsSyncForTests()
+      localStorage.removeItem('mc-dev-mode')
+
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-dev-mode': null })
+    })
+
+    it('never nulls a key this profile has not synced', async () => {
+      // A second browser holds a key on the host that this profile never had.
+      localStorage.setItem(SYNCED_KEYS_KEY, JSON.stringify({}))
+      localStorage.setItem('mc-dev-mode', 'true')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await flushUiPrefs()
+      expect(lastPatch(spy)).toEqual({ 'mc-dev-mode': 'true' })
+    })
+
+    it('a change during an in-flight PUT is not swallowed', async () => {
+      localStorage.setItem('mc-dev-mode', 'true')
+      let release: (() => void) | undefined
+      const gate = new Promise<void>((r) => {
+        release = r
+      })
+      let calls = 0
+      const spy = vi.fn((_url: string, _init?: RequestInit) => {
+        calls += 1
+        // Hold the FIRST request open so the second flush lands mid-flight.
+        return calls === 1
+          ? gate.then(() => okJson({ prefs: {} }))
+          : Promise.resolve(okJson({ prefs: {} }))
+      })
+      vi.stubGlobal('fetch', spy as unknown as typeof fetch)
+
+      const first = flushUiPrefs()
+      localStorage.setItem('mc-crews-view', 'grid')
+      await flushUiPrefs() // in-flight: marks dirty, returns immediately
+      release!()
+      await first
+
+      const puts = spy.mock.calls.map((c) =>
+        Object.keys(JSON.parse((c[1] as RequestInit).body as string).prefs),
+      )
+      expect(puts.length).toBe(2)
+      expect(puts[1]).toEqual(['mc-crews-view'])
+    })
+
+    it('does not overlap two in-flight flushes', async () => {
+      localStorage.setItem('mc-font-family', '1')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      await Promise.all([flushUiPrefs(), flushUiPrefs()])
+      expect(spy.mock.calls.length).toBe(1)
+    })
+
+    it('keeps syncing through a 403, so a routine cookie lapse does not stop backups for the session', async () => {
+      // The access cookie lapses mid-session (the app's own refresh scheduler
+      // repairs it). The refused patch stays pending and goes up once auth is
+      // back -- with the change made during the lapse.
+      localStorage.setItem('mc-font-family', '1')
+      mockFetch(() => ({ ok: false, status: 403, json: () => Promise.resolve({}) }))
+      startUiPrefsSync()
+      await vi.advanceTimersByTimeAsync(2000)
+
+      const after = mockFetch(() => okJson({ prefs: {} }))
+      localStorage.setItem('mc-dev-mode', 'true')
+      window.dispatchEvent(new Event('mc-config-changed'))
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(lastPatch(after)).toEqual({ 'mc-font-family': '1', 'mc-dev-mode': 'true' })
+    })
+  })
+
+  describe('startUiPrefsSync', () => {
+    it('flushes on pagehide with keepalive, so a change made just before closing survives teardown', async () => {
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      startUiPrefsSync()
+      await vi.advanceTimersByTimeAsync(2000)
+      spy.mockClear()
+
+      localStorage.setItem('mc-dev-mode', 'true') // inside the debounce window...
+      window.dispatchEvent(new Event('mc-config-changed'))
+      window.dispatchEvent(new Event('pagehide')) // ...and the tab closes
+      await vi.advanceTimersByTimeAsync(0)
+      expect(spy).toHaveBeenCalledTimes(1)
+      const init = spy.mock.calls[0][1] as RequestInit
+      expect(init.keepalive).toBe(true)
+      expect(JSON.parse(init.body as string)).toEqual({ prefs: { 'mc-dev-mode': 'true' } })
+    })
+
+    it('ordinary flushes do not use keepalive (its 64 KiB body cap would reject large patches)', async () => {
+      localStorage.setItem('mc-font-family', '1.5')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      startUiPrefsSync()
+      await vi.advanceTimersByTimeAsync(2000)
+      expect((spy.mock.calls[0][1] as RequestInit).keepalive).toBe(false)
+    })
+
+    it('uploads the current profile on start, so an upgrading user gets a backup', async () => {
+      localStorage.setItem('mc-font-family', '1.5')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      startUiPrefsSync()
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(lastPatch(spy)).toEqual({ 'mc-font-family': '1.5' })
+    })
+
+    it('debounces a burst of changes into one PUT', async () => {
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      startUiPrefsSync()
+      for (let i = 0; i < 5; i++) {
+        localStorage.setItem('mc-font-family', String(i))
+        window.dispatchEvent(new Event('mc-config-changed'))
+      }
+      await vi.advanceTimersByTimeAsync(2000)
+      const puts = spy.mock.calls.filter((c) => (c[1] as RequestInit | undefined)?.method === 'PUT')
+      expect(puts.length).toBe(1)
+      expect(lastPatch(spy)).toEqual({ 'mc-font-family': '4' })
+    })
+
+    it('is idempotent', async () => {
+      localStorage.setItem('mc-font-family', '1')
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      startUiPrefsSync()
+      startUiPrefsSync()
+      await vi.advanceTimersByTimeAsync(2000)
+      const puts = spy.mock.calls.filter((c) => (c[1] as RequestInit | undefined)?.method === 'PUT')
+      expect(puts.length).toBe(1)
+    })
+
+    it('backs up a change another tab made', async () => {
+      const spy = mockFetch(() => okJson({ prefs: {} }))
+      startUiPrefsSync()
+      await vi.advanceTimersByTimeAsync(2000)
+      localStorage.setItem('mc-dev-mode', 'true')
+      window.dispatchEvent(new Event('storage'))
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(lastPatch(spy)).toEqual({ 'mc-dev-mode': 'true' })
+    })
+  })
+})


### PR DESCRIPTION
## The problem

Most dashboard settings live **only** in the renderer's `localStorage`. Nothing on the host ever held a copy:

| what the user set | where it lives today |
| --- | --- |
| ~16 chat preferences (send-key mode, timestamps, turn stats, content width, collapse steps, stream mode, ...) | one `localStorage` key, `mc-chat-config` |
| diff + file-viewer toggles, artifacts view/sort, app nav order, dev mode, yolo ack, per-app prefs | ~40 more `localStorage` keys |
| theme mode/colour, language, onboarding flags | `config.json` (these survive) |

`localStorage` is partitioned per **origin** and, in the desktop app, stored inside Electron's `userData` directory. Both can change without the user doing anything wrong:

- the dashboard port moves (`KIROCREW_PORT` set in one launch context and not another, an edited `dashboard.url`) — new origin, every key stranded at the old one;
- `userData` is relocated: the `kirocrew-electron-mac` → `kirocrew-desktop` package rename did exactly this, and `website/electron/store-rename.js` carries only ten *electron-store* keys across, never `Local Storage/leveldb`;
- the user moves between the stable and nightly builds, which have separate `userData` directories by design;
- the browser evicts the origin's storage.

Each one reads to the user as *"I upgraded and had to set everything up again"* — and because the `config.json`-backed settings do survive, the loss looks arbitrary rather than explainable. That is #8705.

A second, independent defect surfaced while tracing it, and is fixed here too: **`config.json` loses unknown keys nested inside a modelled section.** `_extra_sections` preserves an unknown TOP-LEVEL section, but a key one level down had no equivalent, so when a build stopped modelling `<section>.<key>` — a rename, a removal, an older config written by a newer edition — the load ignored it and the next `save()` (triggered by anything: a log-level change, adding a workspace, editing an agent) rewrote the file without it. No backup is taken on that path.

## The fix

**Browser settings** get a host-side copy: `ui-prefs.json` in the data home (`src/kiro_crew/ui_prefs.py`), served by owner-gated `GET`/`PUT /api/ui-prefs`, mirrored by `website/src/lib/uiPrefs.ts`.

**Nested config keys** get the same protection `_extra_sections` gives whole sections: `KiroCrewConfig._extra_keys` captures them at load (`resolution.capture_extra_section_keys`) and `to_dict()` restores any the emitted section lacks.

## Design decisions worth reviewing

**A separate file, not a `config.json` section.** `KiroCrewConfig.save()` re-emits the whole dataclass, so a key the running build does not model is dropped on the next save — exactly the fight a bag of client-owned UI keys loses. (That the *general* form of this bug is also fixed here does not change the call: `config.json` is operator-facing, and renderer layout keys do not belong in it.)

**Read the backup when the profile has never reached the host, not when it looks empty.** Keying on "no durable key present" made the restore one-shot: one failed fetch, then the first setting written afterwards made the profile look warm forever, and the backup was never read again — recreating the exact bug on the origin-move path. `mc-ui-prefs-synced` records the successful exchange, so a failed boot retries on the next one.

**Snapshot-diff, not write interception.** ~300 call sites write `localStorage` directly. Rather than route them all through one writer — a migration that goes stale the next time someone adds a raw call — the module periodically diffs the allowlisted keys and PUTs what changed. Every writer is covered, present and future, with no call-site churn.

**Preservation is the DEFAULT, and every exception is written down.** For nested config keys the failure direction is deliberate: forgetting to declare a key retired preserves a key that could have been dropped, which is cosmetic. The reverse is the data loss the mechanism exists to prevent. Two explicit maps in `resolution.py` carry the exceptions — `_SECTION_KEYS_EMITTED_ELSEWHERE` (a conditionally-emitted key's absence is a deliberate deletion; restoring it would resurrect a cleared channel) and `_SECTION_KEYS_DELIBERATELY_DROPPED` (RENAMED, or RETIRED because the feature is gone). A key the schema models but validation rejected also stays dropped, or the bad value would become permanent.

**Security.** Values are opaque strings; the server never parses them. Credential-shaped key names are refused on write **and** filtered on read, so the bearer token cannot land in the file even via a hand-edited one. Both methods are owner-gated — the read too, because some values name real host paths (file-explorer state, cloud launch defaults). Bounds are 200 keys / 128-char keys / 64 KiB per value / 512 KiB total; a breaching patch is rejected WHOLE, and the client answers a rejection by retrying per key so one unstorable value cannot discard the valid changes bundled with it. `0o600` via `atomic_write`.

**What is excluded from the allowlist.** Session-scoped and derived state (height caches, panel tabs, drafts, touched files); the settings `config.json` already owns (theme, language, onboarding); and `mc-zoom` / `mc-font-scale`, which `hooks/useZoom.ts` folds into the native zoom factor and then **deletes** — backing those up would restore them and re-run the migration forever.

**Boot latency.** A synced profile pays nothing: `needsHydrate()` is a synchronous `localStorage` read, so the usual launch renders on the same tick as before. The first-time path is bounded by a 3s timeout and renders defaults if the gateway never answers.

**Unknown keys are captured from the BASE document, not the merged one.** When `config.local.json` shadows an unknown key that `config.json` also holds, capturing the merged value made `save()` emit the overlay's leaf, which the overlay subtraction then removed — permanently deleting the base file's own value, so removing the overlay later revealed nothing. This predates the PR (measured identical with and without the capture) but the capture made it a named, visible path, so it is fixed here rather than deferred: the loader records the base copy of every top-level section the overlay touches at the last moment both documents exist (`_shadowed_base_sections`), and both `_extra_sections` and `_extra_keys` capture against that view. `save()` then emits the base value, the subtraction leaves it, and the overlay still wins on the next load. The base copy rides in the validated-data cache as an opaque sidecar (`ConfigCache.get_sidecar`), keyed by the same fingerprint, so a cache hit — where the overlay is out of scope — captures exactly as the disk read did. No migration, no on-disk format change: a pure read-path correction, covered by disk-path, cache-hit, and `_extra_sections` tests.

## Tests

**Backend — 57 tests.** `test/test_ui_prefs.py` and `test/test_ui_prefs_api.py`: merge semantics, `null` deletion, envelope shape, `0o600`, credential-key refusal (including one already on disk), size and key-count ceilings, whole-patch rejection leaving the previous file intact, corrupt/truncated/wrong-typed files degrading to "no backup", the owner gate on **both** methods (and that a refused read discloses no path), a read-only home answering 503 not 500, and two concurrent PUTs both landing. `test/test_config_extra_keys.py`: the nested-key regression itself, survival across an unrelated save and repeated round-trips, and the four things that must NOT be captured — free-form name-keyed sections, private carriers, a cleared conditional key, a validation-rejected value, a legacy alias, and a retired key — plus a drift guard asserting every key a default config emits is accounted for.

**Frontend — 32 tests** (`website/src/test/uiPrefs.test.ts`): allowlist invariants (no duplicates, no session-scoped keys, no bearer token, nothing `config.json` owns, no migration-deleted keys, not its own bookkeeping key), hydrate filling only absent keys, `needsHydrate` staying true after a failure, diff and delete patches, a deletion made before a reload still reported, a key this profile never synced never nulled, retry-on-5xx, per-key retry on 4xx, permanent stop on 403, a change during an in-flight PUT not swallowed, burst debouncing, idempotent start, cross-tab pickup.

Green locally: 57 backend + 32 frontend, the full `-k config` suite (3565 passed), `flake8` + `mypy` + `tsc --noEmit` + `eslint` clean, and the four baselined gate scripts plus `test_agent_config_owner_gate_invariant.py` (which is what caught the missing owner gate on the first pass).

## Pattern harvest

Rule candidate: a serializer that rebuilds its output from an explicit field list must state, for every key it does NOT re-emit, whether the omission is deliberate — and default to preserving what it cannot classify. `Config.save()` re-emits `config.json` from dataclass fields, so any key the running build does not model is deleted on the next write by omission rather than by decision. The top-level case had been noticed and fixed (`_extra_sections`); the nested case had not, and nothing failed when it silently erased an operator's value, because a test can only assert about keys someone remembered to name.

Two supporting observations from this change, both worth generalizing:

- **The exceptions are the specification.** Blanket preservation was wrong in four distinct ways this repo already knew about but had never written down in one place: conditionally-emitted keys (absence means deletion), top-level-owned keys emitted into a nested section, renamed keys mid-migration, and retired keys whose feature is gone. Each had a passing test that encoded the intent locally; none had a name the serializer could consult. The fix is not the preservation loop, it is `_SECTION_KEYS_EMITTED_ELSEWHERE` and `_SECTION_KEYS_DELIBERATELY_DROPPED` making those four decisions explicit and greppable.
- **"Restore once" is not a restore.** The first revision gated the settings restore on the profile looking empty. That is a self-erasing condition: the restore's own failure mode (one bad fetch) is indistinguishable from success, and the very next write makes the profile ineligible forever. Any one-shot recovery path keyed on a symptom rather than on a recorded outcome has this shape.

