### PR TITLE
fix(safety-override): bind a queued breadcrumb publish to its own path

### DIFF
--- a/src/kiro_crew/safety_override.py
+++ b/src/kiro_crew/safety_override.py
@@ -1024,15 +1024,25 @@ class SafetyOverride:
         # ``take_dropped_grant`` were removed it would fail safe to silence.
         expires_at_wall = datetime.now(tz=timezone.utc).timestamp() + remaining
 
+        # Resolved HERE, on the calling thread, for exactly the reason the deadline
+        # above is: the publish runs later on the worker, and a job that resolved
+        # the path when it RAN would act on whatever the module names at that
+        # moment rather than on the file this transition was about. Nothing in
+        # production repoints it, so this changes no behaviour there -- but a job
+        # that outlives the context it was queued in was deleting and overwriting
+        # an unrelated file, which is issue #8586.
+        path = _breadcrumb_path()
+
         def _publish() -> None:
             with _breadcrumb_io_lock:
                 if gen < self._breadcrumb_published_gen:
                     return
                 self._breadcrumb_published_gen = gen
                 if not active:
-                    _clear_breadcrumb()
+                    _clear_breadcrumb(path)
                     return
                 _write_breadcrumb(
+                    path=path,
                     source=source,
                     expires_at_wall=expires_at_wall,
                     permanent=permanent,
@@ -1200,12 +1210,20 @@ def _breadcrumb_path() -> Path:
     return config_dir() / _BREADCRUMB_FILE
 
 
-def _write_breadcrumb(*, source: str, expires_at_wall: float, permanent: bool) -> None:
+def _write_breadcrumb(
+    *, path: Path, source: str, expires_at_wall: float, permanent: bool
+) -> None:
     """Record that a grant is live. Best-effort: never raises into the grant path.
 
     A failed write costs the operator a notice, never a grant, so it must not
     fail an activation -- and above all must not fail a DEACTIVATION, where
     raising would leave auto-approval on.
+
+    *path* is supplied by the caller rather than resolved here, for the same
+    reason ``expires_at_wall`` is computed at the transition: this runs on the
+    worker thread, so resolving ``_breadcrumb_path()`` here would bind the file
+    as it is WHENEVER THE WORKER GETS TO IT instead of as it was when the
+    transition was made.
     """
     try:
         payload = json.dumps(
@@ -1228,15 +1246,20 @@ def _write_breadcrumb(*, source: str, expires_at_wall: float, permanent: bool) -
             }
         )
         # 0600: the record names the auto-approval posture and its deadline.
-        atomic_write(_breadcrumb_path(), payload, mode=0o600)
+        atomic_write(path, payload, mode=0o600)
     except Exception:
         logger.debug("safety override: breadcrumb write failed", exc_info=True)
 
 
-def _clear_breadcrumb() -> None:
-    """Drop the record. Best-effort, for the same reason the write is."""
+def _clear_breadcrumb(path: Path) -> None:
+    """Drop the record. Best-effort, for the same reason the write is.
+
+    Takes the path for the same reason the write does: a queued clear that
+    resolved ``_breadcrumb_path()`` on the worker thread would unlink whatever
+    the module names at that moment, not the file its transition was about.
+    """
     try:
-        _breadcrumb_path().unlink(missing_ok=True)
+        path.unlink(missing_ok=True)
     except Exception:
         logger.debug("safety override: breadcrumb clear failed", exc_info=True)
 
@@ -1307,7 +1330,7 @@ def _consume_breadcrumb() -> Optional[DroppedGrant]:
     try:
         if path.is_symlink():
             logger.warning("safety override: discarding a restart record that is a link")
-            _clear_breadcrumb()
+            _clear_breadcrumb(path)
             return None
     except OSError:
         return None
@@ -1320,7 +1343,7 @@ def _consume_breadcrumb() -> Optional[DroppedGrant]:
         # ELOOP from O_NOFOLLOW lands here: a symlink IS a refusal, not an error
         # to investigate.
         logger.debug("safety override: breadcrumb could not be opened", exc_info=True)
-        _clear_breadcrumb()
+        _clear_breadcrumb(path)
         return None
 
     # The verdict is decided while the descriptor is open, but every unlink
@@ -1354,13 +1377,13 @@ def _consume_breadcrumb() -> Optional[DroppedGrant]:
             pass
 
     if discard or raw is None:
-        _clear_breadcrumb()
+        _clear_breadcrumb(path)
         return None
 
     try:
         record = json.loads(raw)
         if not isinstance(record, dict):
-            _clear_breadcrumb()
+            _clear_breadcrumb(path)
             return None
         writer_image = str(record.get("image") or "")
         permanent = bool(record.get("permanent"))
@@ -1368,7 +1391,7 @@ def _consume_breadcrumb() -> Optional[DroppedGrant]:
         source = str(record.get("source") or "")
     except Exception:
         logger.debug("safety override: breadcrumb unreadable", exc_info=True)
-        _clear_breadcrumb()
+        _clear_breadcrumb(path)
         return None
 
     # THIS process image's own live grant. Left untouched -- consuming it would
@@ -1388,7 +1411,7 @@ def _consume_breadcrumb() -> Optional[DroppedGrant]:
     # From here the record belongs to a previous process, so it is consumed
     # whatever the verdict: one dropped grant cannot notify twice, and a record
     # left by an older install cannot notify forever.
-    _clear_breadcrumb()
+    _clear_breadcrumb(path)
 
     if permanent:
         return None

--- a/test/test_safety_override_restart_drop.py
+++ b/test/test_safety_override_restart_drop.py
@@ -285,6 +285,91 @@ class TestThisProcessOwnRecordIsNotADropNotice:
         assert not _isolated_breadcrumb.exists()
 
 
+class TestAQueuedPublishActsOnThePathItWasQueuedFor:
+    """A publish runs LATER, on the worker thread. It must act on the file its own
+    transition was about -- not on whatever ``_breadcrumb_path`` names by then.
+
+    Regression for #8586. Sibling test files in the same xdist worker call real
+    transitions, so they enqueue real publishes onto this module's long-lived
+    queue; this file's autouse fixture repoints ``_breadcrumb_path`` at its own
+    tmp_path. A job that resolved the path when it RAN therefore deleted or
+    overwrote THIS test's record, and the read that followed reported no notice --
+    surfacing on CI as ``assert None is not None`` in whichever test happened to
+    be running, unreproducible by rerunning and structurally unreproducible when
+    this file is run alone, because then nothing else ever enqueues anything.
+
+    The publish is CAPTURED rather than run on the worker: that makes the
+    interleaving exact instead of load-dependent, runs the real ``_publish``
+    closure, and leaves no thread behind. Each test asserts on BOTH paths, so a
+    job that quietly did nothing cannot pass either of them.
+    """
+
+    def test_a_queued_clear_does_not_unlink_a_later_path(self, tmp_path: Path, monkeypatch) -> None:
+        sibling = tmp_path / "sibling" / "last_grant.json"
+        victim = tmp_path / "victim" / "last_grant.json"
+        for parent in (sibling.parent, victim.parent):
+            parent.mkdir(parents=True, exist_ok=True)
+
+        jobs: list = []
+        monkeypatch.setattr(so, "_breadcrumb_path", lambda: sibling)
+        monkeypatch.setattr(so, "_enqueue_breadcrumb", jobs.append)
+
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("slack")
+        override.deactivate("slack")
+        assert len(jobs) == 2, "expected a publish for the activation and one for the revocation"
+
+        jobs[0]()  # the sibling's activation lands its own record
+        assert sibling.exists(), "the captured publish never ran, so this test proves nothing"
+
+        # Now this file's fixture-style repoint, and this test's own record.
+        monkeypatch.setattr(so, "_breadcrumb_path", lambda: victim)
+        _write(victim, source="dashboard", offset_secs=600)
+
+        jobs[1]()  # the sibling's revocation, arriving late
+
+        assert not sibling.exists(), "the queued clear did not act at all"
+        assert victim.exists(), "a clear queued for another path unlinked this record"
+        dropped = so.take_dropped_grant()
+        assert dropped is not None, "the notice was owed and a foreign clear swallowed it"
+        assert dropped.source == "dashboard"
+
+    def test_a_queued_write_does_not_overwrite_a_later_path(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # The same defect's other arm, and the one the issue's remaining candidate
+        # named: a foreign write stamps THIS image's token, so the own-image guard
+        # then correctly refuses a record that is no longer this test's.
+        sibling = tmp_path / "sibling" / "last_grant.json"
+        victim = tmp_path / "victim" / "last_grant.json"
+        for parent in (sibling.parent, victim.parent):
+            parent.mkdir(parents=True, exist_ok=True)
+
+        jobs: list = []
+        monkeypatch.setattr(so, "_breadcrumb_path", lambda: sibling)
+        monkeypatch.setattr(so, "_enqueue_breadcrumb", jobs.append)
+
+        override = so.safety_override()
+        override.adhoc_ttl = 3600
+        override.activate("slack")
+        assert len(jobs) == 1
+
+        monkeypatch.setattr(so, "_breadcrumb_path", lambda: victim)
+        _write(victim, source="dashboard", offset_secs=600)
+
+        jobs[0]()  # the sibling's activation, arriving late
+
+        # Each path holds its OWN record -- pairing, not merely non-emptiness.
+        assert sibling.exists(), "the queued write did not act at all"
+        assert _record(sibling)["source"] == "slack"
+        assert _record(victim)["source"] == "dashboard"
+        assert "image" not in _record(victim), "a foreign write stamped this image onto the record"
+        dropped = so.take_dropped_grant()
+        assert dropped is not None, "the notice was owed and a foreign write swallowed it"
+        assert dropped.source == "dashboard"
+
+
 class TestTheCourtesyNeverEndangersTheGrant:
     """The record is a courtesy; the grant is a decision. Failures stay separated."""
 


### PR DESCRIPTION
## Problem / Motivation

`test_safety_override_restart_drop.py` failed once on CI with `assert None is not
None` and then passed on a plain rerun of the identical commit, so no notice was
delivered where one was owed. A second occurrence was recorded on a different test
in the same file. Neither was reproducible locally: the reporter ran the file alone
six times (30 passed each time) and replayed the real shard on the same commit
without hitting it.

The record itself narrowed `_consume_breadcrumb` returning `None` to three causes
and ruled out the deadline one, leaving two undistinguished candidates: a foreign
write being skipped by the own-record guard, and cross-test state left in
`safety_override` on the same xdist worker.

Both candidates are the same defect, and it is a real defect in the module rather
than a property of the test.

## Why it matters

`take_dropped_grant` is the one place that tells an operator their auto-approval
(YOLO) grant was cut short by a restart. It is single-shot by construction, so a
notice that is swallowed is not merely delayed -- the record is gone and the
operator is never told. The queued publish that swallows it can also delete or
overwrite a record belonging to something else entirely, which is silent.

In production the module resolves exactly one path, so nobody has been losing
notices to this in the field. What the CI failure exposed is that the guarantee
rests on nothing: it holds only because the path happens not to change.

## What changed (motivation -> approach -> change)

`SafetyOverride._sync_breadcrumb` hands the file write to a long-lived daemon
worker, because its callers sit on the gateway's event loop. Its `_publish`
closure carefully snapshots the generation, the posture, the source and the
deadline -- the deadline with a comment saying it is computed at the transition
"not as it is whenever the worker gets to it".

It did not snapshot the path. `_write_breadcrumb` and `_clear_breadcrumb` each
called `_breadcrumb_path()` at the moment the job ran, on the worker thread. So a
publish that outlived the context it was queued in acted on whatever the module
named by then:

- a queued clear (any `deactivate`) unlinked the current path's record, so the
  read that followed found no file and reported no notice;
- a queued write (any `activate`) overwrote the current path's record and stamped
  `_IMAGE_TOKEN` of this process onto it, after which the own-record guard
  correctly refused a record that was no longer the reader's.

That is the chain from symptom to root cause, and it is why both surviving
candidates in the issue reduce to one bug.

The fix resolves the path on the calling thread, next to the deadline that is
already snapshotted there for exactly this reason, and passes it into both
helpers. Both now require it, so the unbound form is unreachable rather than
discouraged -- there is no call site left that can omit it. The six synchronous
clears inside `_consume_breadcrumb` now reuse the path that function already
resolved at the top, so a single consume can no longer straddle two files either.

No behaviour changes in production, where `_breadcrumb_path()` is constant.

Why this surfaced in tests and not in the field: 16 test files call real
`activate`/`deactivate` on the singleton, so they enqueue real publishes onto the
module's shared queue. Only `test_safety_override_restart_drop.py` redirects
`_breadcrumb_path`, and its autouse fixture runs publishes inline. With
`--dist loadgroup` those files share a worker process, so a sibling's job could
still be in flight when this file's tests ran. Running the file alone can never
reproduce it, because then nothing else ever enqueues anything -- which is exactly
what the reporter observed.

## Tests

Two regression tests, in the file that was failing:

- `test_a_queued_clear_does_not_unlink_a_later_path`
- `test_a_queued_write_does_not_overwrite_a_later_path`

Each captures the real `_publish` closure instead of running it on the worker, so
the interleaving is exact rather than load-dependent, the product code under test
is the real one, and no thread is left behind. Each asserts on BOTH paths -- the
sibling's record and this test's -- so a job that quietly did nothing cannot pass.

Mutation-verified against the shipped head, four mutations, each applied from a
file patch that asserts its anchor is unique, each red classified from the FAILED
line:

    A1  unbind the clear     -> 1 red: "the queued clear did not act at all"
    A2  clear both paths     -> 1 red: "a clear queued for another path unlinked this record"
    B1  unbind the write     -> 1 red: "the queued write did not act at all"
    B2  write both paths     -> 1 red: assert 'slack' == 'dashboard'

The two mutations per test are deliberate: A1 and B1 fire the complement, which
would otherwise leave the regression assertion decorative, so A2 and B2 are shaped
so the complement PASSES and the regression assertion must fire. The remaining
assertions in each test (the stamped image token, the returned notice and its
source) corroborate the same observable rather than adding independent ones.

Gates: `test/test_safety_override_restart_drop.py` 32 passed at `-n0` (30 before,
plus these two). flake8, isort and mypy (`src/kiro_crew`, 1302 files) clean.
`scripts/check_black_formatting.py` passes; `src/kiro_crew/safety_override.py` is
on the black baseline so it was deliberately not reformatted, and only the test
file (which is not on the baseline) was.

## Manual verification

A standalone probe drove the mechanism before any code changed, with forced
ordering via an Event rather than a sleep, and both columns printed:

    CONTROL, no queued job  -> DroppedGrant(source='dashboard', remaining_secs=599)
    queued clear, path A    -> victim existed before, gone after, notice None
    queued write, path A    -> record became source='slack', image was ours, notice None

The control can fail, so it discriminates.

What is measured and what is not, stated plainly: the defect, both arms, the
sibling co-residency and the fix are measured. That this exact interleaving
produced run 33918173569 is inferred -- CI thread scheduling is not observable
after the fact. It is the only candidate that predicts every observation in the
report, including the file-alone immunity. If a notice is ever missed again, the
record to capture is still the one the reporter named: whether the breadcrumb file
existed at read time.

## Related Issues

Closes #8586

Not #8806, which was checked and is a different mechanism: that one is Windows
only, is pytest-asyncio's event-loop post-finalizer failing in `_make_self_pipe`,
and takes 660 tests down together.

## Pattern harvest

Rule candidate: review-prompt
Pattern: work deferred to a worker thread snapshots its values but resolves a
module-level indirection when it runs, so the job acts on the caller's data and
someone else's target.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
