### PR TITLE
fix(acp): degrade a too-deeply-nested tool-result frame, not the turn

### DIFF
--- a/docs/system-specs/modules/agent-host-contract.md
+++ b/docs/system-specs/modules/agent-host-contract.md
@@ -256,6 +256,20 @@ the original text instead of substituting something worse. A frame carrying two
 DIFFERENT markers is refused rather than resolved to the first, since applying
 the wrong directive is worse than applying none.
 
+**Nesting depth is chosen by the tool, so the recovery degrades rather than
+raises.** The envelope's non-marker fields are copied by an ITERATIVE walk
+(`_elide_marker_value`, an explicit heap stack) because a recursive one raises
+`RecursionError` — a `RuntimeError`, outside the `(ValueError, TypeError)`
+handlers on this path, so it escapes `parse_session_update` and aborts the whole
+turn. `json.dumps` of that copy is a second, independent ceiling: it recurses in C
+against the process stack, so the depth it refuses at is a platform property (a
+branch that encodes on Linux raises on Windows). When it refuses, the copy
+degrades PER FIELD — every top-level field that encodes is kept and only the
+offending ones become `UNSERIALISABLE_SIBLING_VALUE` — because the two losses are
+not symmetric: a dropped directive silently unarms a loop the model was told was
+armed, while dropped sibling detail costs transcript content the user can see is
+missing. The directive is emitted even when no sibling copy survives at all.
+
 **A provider must declare:** whether its tool-result text arrives verbatim or
 pre-serialised, and — if any builder it adds can emit an `EVENT_TOOL_RESULT` —
 that the builder runs the repair. This is the one bucket in this document with a

--- a/src/kiro_crew/acp/_dispatch.py
+++ b/src/kiro_crew/acp/_dispatch.py
@@ -1221,6 +1221,12 @@ def _marker_bearing_text(payload: dict[str, Any], _max_nodes: int = 512) -> str 
 
 ELIDED_MARKER_VALUE = "[[directive marker emitted on its own line above]]"
 
+#: Stands in for one top-level sibling whose value the JSON encoder refuses (see
+#: :func:`_dumps_elided_siblings`). Visible in the transcript on purpose: the
+#: user can see that detail is missing, which is the whole difference between
+#: this and dropping the field.
+UNSERIALISABLE_SIBLING_VALUE = "[[value omitted: nested too deeply to serialise]]"
+
 
 def _elide_marker_value(payload: Any, marker: str) -> Any:
     """Copy *payload* with the one *marker*-bearing string replaced by a note.
@@ -1232,14 +1238,93 @@ def _elide_marker_value(payload: Any, marker: str) -> Any:
     the marker goes out verbatim and this copy carries everything ELSE, with the
     one value that already went out replaced by a short note instead of
     duplicated.
+
+    Iterative over an explicit heap stack, NOT recursive. The nesting depth comes
+    out of a tool's own output, so whatever produced the frame chooses it, and a
+    recursive walk raises ``RecursionError`` on a deep one -- a ``RuntimeError``,
+    which neither this module's ``(ValueError, TypeError)`` handlers nor any
+    caller catches, so it escapes ``parse_session_update`` and kills the whole
+    agent turn. A heap stack has no such ceiling, so no depth constant and no
+    refusal branch is needed.
+
+    ``payload`` is always JSON-DECODED input (``json.loads`` of a frame, or a
+    parsed JSON-RPC member), which cannot contain a reference cycle. That
+    invariant is what makes the unbounded loop safe.
     """
-    if isinstance(payload, str):
-        return ELIDED_MARKER_VALUE if payload == marker else payload
-    if isinstance(payload, dict):
-        return {k: _elide_marker_value(v, marker) for k, v in payload.items()}
-    if isinstance(payload, list):
-        return [_elide_marker_value(v, marker) for v in payload]
-    return payload
+    # One slot to receive the root, so the loop can write every result through
+    # the same (container, key) mechanism.
+    root: list[Any] = [None]
+    stack: list[tuple[Any, Any, Any]] = [(payload, root, 0)]
+    while stack:
+        node, target, key = stack.pop()
+        if isinstance(node, str):
+            target[key] = ELIDED_MARKER_VALUE if node == marker else node
+        elif isinstance(node, dict):
+            copied: dict[Any, Any] = {}
+            target[key] = copied
+            for k, v in node.items():
+                # Reserve the slot NOW so the copy keeps the source's key order
+                # regardless of the order the stack pops the children in.
+                copied[k] = None
+                stack.append((v, copied, k))
+        elif isinstance(node, list):
+            listed: list[Any] = [None] * len(node)
+            target[key] = listed
+            for i, v in enumerate(node):
+                stack.append((v, listed, i))
+        else:
+            target[key] = node
+    return root[0]
+
+
+def _dumps_elided_siblings(payload: Any, marker: str) -> str | None:
+    """Serialise *payload*'s marker-elided copy, or None if it cannot be encoded.
+
+    The second, independent limit on this path: ``json.dumps`` recurses in C
+    against the PROCESS stack rather than ``sys.recursionlimit``, so a payload
+    :func:`_elide_marker_value` copies fine can still overflow the ENCODER -- and
+    at a depth that differs per platform, since a thread's stack size does. The
+    depth is chosen by whatever produced the frame, so the encoder can always be
+    reached, and the failure is the same uncaught ``RecursionError`` that kills
+    the turn.
+
+    Degrades per FIELD rather than all-or-nothing, because the two possible
+    losses are not symmetric. A lost directive silently unarms a loop the model
+    was told was armed -- there is no error anywhere and no way to notice. Lost
+    sibling detail costs transcript content the user can SEE is missing. So the
+    marker (emitted by the caller, not here) always survives, every top-level
+    field that encodes is kept whole, and only the offending branches become
+    :data:`UNSERIALISABLE_SIBLING_VALUE`. Returns None only when even the reduced
+    object will not encode, leaving the caller to emit the directive alone.
+    """
+    elided = _elide_marker_value(payload, marker)
+    try:
+        return json.dumps(elided, default=str)
+    except RecursionError:
+        pass
+
+    def _encodable(value: Any) -> bool:
+        try:
+            json.dumps(value, default=str)
+        except RecursionError:
+            return False
+        return True
+
+    # Re-encoding the survivors together adds exactly one level over the deepest
+    # of them, which each one just cleared on its own -- but a value sitting on
+    # the boundary can still fail there, so the outer dump stays guarded too.
+    if isinstance(elided, dict):
+        reduced: Any = {
+            k: (v if _encodable(v) else UNSERIALISABLE_SIBLING_VALUE) for k, v in elided.items()
+        }
+    elif isinstance(elided, list):
+        reduced = [(v if _encodable(v) else UNSERIALISABLE_SIBLING_VALUE) for v in elided]
+    else:
+        return None
+    try:
+        return json.dumps(reduced, default=str)
+    except RecursionError:
+        return None
 
 
 def _repair_escaped_marker(text: str) -> str | None:
@@ -1285,7 +1370,10 @@ def _repair_escaped_marker(text: str) -> str | None:
     # loop armed and nothing to inspect).
     try:
         outer = json.loads(text)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, RecursionError):
+        # RecursionError is listed because the C scanner raises it on text nested
+        # past the interpreter's limit, and it is a RuntimeError -- so the two
+        # ValueError-family names alone let it escape and abort the turn.
         outer = None
     if isinstance(outer, str):
         # One sentinel only, the same bar ``_marker_bearing_text`` holds the dict
@@ -1305,8 +1393,10 @@ def _repair_escaped_marker(text: str) -> str | None:
             # only this one survives display: session_directive.strip_marker cuts
             # from the sentinel to the END of the string, so anything after the
             # marker is dropped from the transcript the user actually reads.
-            siblings = json.dumps(_elide_marker_value(outer, inner), default=str)
-            return siblings + "\n" + inner
+            # A None here means the encoder could not represent the siblings at
+            # all, so the directive goes out alone rather than not at all.
+            siblings = _dumps_elided_siblings(outer, inner)
+            return inner if siblings is None else siblings + "\n" + inner
 
     if text.count(session_directive.SENTINEL) > 1:
         # Ambiguous for the LINE-BASED recovery only: (2) below reads the FIRST
@@ -1669,9 +1759,11 @@ def _build_tool_result_event(update: dict[str, Any], cache_scope: str = "") -> A
                                     # They go BEFORE the marker: strip_marker cuts
                                     # from the sentinel to the end of the string,
                                     # so anything after it is lost from display.
-                                    output_parts.append(
-                                        json.dumps(_elide_marker_value(j, _mcp_text), default=str)
-                                    )
+                                    # A None means the encoder could not represent
+                                    # them; the marker below still goes out.
+                                    _siblings = _dumps_elided_siblings(j, _mcp_text)
+                                    if _siblings is not None:
+                                        output_parts.append(_siblings)
                                 output_parts.append(_mcp_text)
                             else:
                                 output_parts.append(json.dumps(j, default=str))

--- a/test/test_session_directive_transport.py
+++ b/test/test_session_directive_transport.py
@@ -26,14 +26,19 @@ Each test here drives a REAL boundary end-to-end:
 
 import ast
 import json
+import sys
 import types
 
 import pytest
 from source_corpus import parsed_candidates, src_root
 
 from kiro_crew import session_directive as sd
+from kiro_crew.acp import _dispatch
 from kiro_crew.acp._dispatch import (
+    ELIDED_MARKER_VALUE,
+    UNSERIALISABLE_SIBLING_VALUE,
     _build_tool_result_event,
+    _elide_marker_value,
     _mcp_content_text,
     _repair_escaped_marker,
     parse_session_update,
@@ -791,3 +796,182 @@ class TestUnknownKindWithholdsThePayload:
         assert reason.startswith("unknown-kind"), reason
         assert CANARY not in reason, "the payload's kind reached the log"
         assert "len=" in reason and "sha=" in reason, reason
+
+
+def _nest(depth: int, leaf: object) -> dict[str, object]:
+    """A ``depth``-deep chain of single-key dicts ending in *leaf*."""
+    node: object = {"leaf": leaf}
+    for _ in range(depth):
+        node = {"n": node}
+    assert isinstance(node, dict)
+    return node
+
+
+def _leaf(node: object) -> object:
+    """Walk a :func:`_nest` chain iteratively -- a recursive reader has the bug."""
+    while isinstance(node, dict) and "n" in node:
+        node = node["n"]
+    return node["leaf"] if isinstance(node, dict) else node
+
+
+def _depth_of(node: object) -> int:
+    """Nesting depth of *node*, measured without recursing."""
+    deepest = 0
+    stack: list[tuple[object, int]] = [(node, 1)]
+    while stack:
+        current, level = stack.pop()
+        deepest = max(deepest, level)
+        if isinstance(current, dict):
+            stack.extend((v, level + 1) for v in current.values())
+        elif isinstance(current, list):
+            stack.extend((v, level + 1) for v in current)
+    return deepest
+
+
+def _encoder_refusing_past(limit: int):
+    """A ``json`` stand-in whose ``dumps`` raises like the C encoder does.
+
+    The real encoder recurses in C against the PROCESS stack, so the depth it
+    refuses at is a property of the platform's thread stack size rather than of
+    ``sys.recursionlimit``: a branch that encodes on Linux raises on Windows. A
+    test that reproduces the overflow by NESTING therefore passes for the wrong
+    reason on the machine most people run it on and reds only on the Windows
+    shard. Raising the encoder's error directly makes the degrade path
+    deterministic everywhere.
+
+    Returned as a whole module stand-in, patched over ``_dispatch.json``, so the
+    injected fault reaches only the module under test -- ``session_directive``
+    parses the marker with the real ``json`` on the same call.
+    """
+    real = json.dumps
+
+    def _dumps(obj, **kwargs):
+        if _depth_of(obj) > limit:
+            raise RecursionError("maximum recursion depth exceeded")
+        return real(obj, **kwargs)
+
+    return types.SimpleNamespace(dumps=_dumps, loads=json.loads, JSONDecoder=json.JSONDecoder)
+
+
+class TestPathologicallyNestedEnvelopeDegrades:
+    """A frame too deep for the walk or the encoder must degrade, not kill the turn.
+
+    The nesting depth comes out of a TOOL's own output, so whatever produced the
+    frame chooses it. Two independent limits sit on the marker path, and both
+    raise ``RecursionError`` -- a ``RuntimeError``, so the module's
+    ``(ValueError, TypeError)`` handlers do not catch it and it escapes
+    ``parse_session_update`` and aborts the whole agent turn:
+
+    * the elision walk that copies the envelope's siblings, bounded by
+      ``sys.recursionlimit`` while it recurses;
+    * ``json.dumps`` of that copy, bounded by the process stack instead.
+
+    The directive is what must survive either one. Losing it silently unarms a
+    loop the model was told was armed; losing sibling detail costs transcript
+    content the user can see is missing.
+    """
+
+    def test_elision_walk_survives_depth_past_the_recursion_limit(self):
+        # The walk is pure Python, so sys.recursionlimit bounds it -- which makes
+        # this depth deterministic on every platform, unlike the encoder's.
+        marker = _monitor()
+        payload = {"out": marker, "sib": _nest(sys.getrecursionlimit() * 3, CANARY)}
+        copied = _elide_marker_value(payload, marker)
+        assert copied["out"] == ELIDED_MARKER_VALUE, "the marker value is elided"
+        assert _leaf(copied["sib"]) == CANARY, "the deep sibling branch is copied whole"
+        assert copied is not payload and copied["sib"] is not payload["sib"], "it is a copy"
+
+    def test_elision_walk_preserves_key_order(self):
+        # The iterative walk reserves each slot before pushing the child, so the
+        # copy dumps in the source's field order rather than the pop order.
+        marker = _monitor()
+        payload = {"z": 1, "out": marker, "a": [2, {"b": 3}]}
+        assert list(_elide_marker_value(payload, marker)) == ["z", "out", "a"]
+
+    def test_deep_envelope_yields_a_readable_directive(self):
+        # End to end, at a depth the recursive walk could not take. Only the
+        # directive is asserted: whether the REAL encoder also refuses this depth
+        # is platform-dependent, and the frame must stay readable either way.
+        out = _runtime_output(
+            _update(
+                rawOutput={
+                    "items": [
+                        {"Json": {"out": _monitor(), "sib": _nest(sys.getrecursionlimit() * 3, 1)}}
+                    ]
+                }
+            )
+        )
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS), "the directive stays readable"
+
+    def test_encoder_refusal_keeps_the_directive(self, monkeypatch):
+        # The encoder error raised DIRECTLY -- see _encoder_refusing_past.
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(0))
+        out = _runtime_output(
+            _update(rawOutput={"items": [{"Json": {"out": _monitor(), "sib": {"deep": 1}}}]})
+        )
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS), "the directive still arms the loop"
+
+    def test_encoder_refusal_keeps_the_siblings_it_can_encode(self, monkeypatch):
+        # An all-or-nothing bail drops SHALLOW sibling output the encoder had no
+        # trouble with, so the degrade is per field.
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(4))
+        out = _runtime_output(
+            _update(
+                rawOutput={
+                    "items": [
+                        {
+                            "Json": {
+                                "out": _monitor(),
+                                "stderr": CANARY,
+                                "exit_status": 7,
+                                "sib": _nest(40, 1),
+                            }
+                        }
+                    ]
+                }
+            )
+        )
+        assert sd.peek(out) == ("monitor_start", MONITOR_ARGS), "the directive survives"
+        assert CANARY in out and "exit_status" in out, "encodable siblings survive"
+        assert UNSERIALISABLE_SIBLING_VALUE in out, "the refused field is named, not dropped"
+
+    def test_repair_survives_a_scanner_refusal(self, monkeypatch):
+        # json.loads' C scanner raises RecursionError on text nested past its own
+        # limit, and RecursionError is a RuntimeError -- outside the ValueError
+        # family that handler names. Raised directly for the same reason the
+        # encoder's is: the depth it gives up at is a platform property.
+        frame = json.dumps({"out": _monitor(), "note": CANARY})
+
+        def _refuse(*_args, **_kwargs):
+            raise RecursionError("maximum recursion depth exceeded")
+
+        monkeypatch.setattr(
+            _dispatch,
+            "json",
+            types.SimpleNamespace(dumps=json.dumps, loads=_refuse, JSONDecoder=json.JSONDecoder),
+        )
+        repaired = _repair_escaped_marker(frame)
+        assert repaired is not None, "the escaped-line recovery still runs"
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+
+    def test_repair_encoder_refusal_returns_the_directive_alone(self, monkeypatch):
+        frame = json.dumps({"out": _monitor(), "note": CANARY})
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(0))
+        repaired = _repair_escaped_marker(frame)
+        assert repaired is not None, "the directive is recovered even with no siblings"
+        assert sd.peek(repaired) == ("monitor_start", MONITOR_ARGS)
+
+    def test_parse_session_update_does_not_abort_the_turn(self, monkeypatch):
+        # The seam the RecursionError escaped through. Both limits at once.
+        monkeypatch.setattr(_dispatch, "json", _encoder_refusing_past(2))
+        events = parse_session_update(
+            _update(
+                rawOutput={
+                    "items": [
+                        {"Json": {"out": _monitor(), "sib": _nest(sys.getrecursionlimit() * 3, 1)}}
+                    ]
+                }
+            ),
+            cache_scope="scope",
+        )
+        assert [e for e in events if e.kind == EVENT_TOOL_RESULT], "the result event still arrives"


### PR DESCRIPTION
# fix(acp): degrade a too-deeply-nested tool-result frame, not the turn

Fixes #8886.

## Summary

A tool result whose envelope carries a directive marker beside a deeply nested sibling branch aborted the whole agent turn: `_elide_marker_value` in `src/kiro_crew/acp/_dispatch.py` recursed with no depth bound, and the escaping `RecursionError` (a `RuntimeError`, so caught by no handler on the path) killed the turn via `_build_tool_result_event` → `parse_session_update`. A second limit sat on the same path: `json.dumps` recurses in C against the process stack, so a depth that encodes on Linux overflows on the Windows shard. Both limits are fixed.

## The degrade rule

Directive plus per-field best-effort: the elision walk is now iterative (a heap stack, so `RecursionError` is structurally impossible at any depth), and when the encoder still refuses, every top-level field that encodes is kept whole while only the offending branches become a visible `UNSERIALISABLE_SIBLING_VALUE` placeholder. The directive is emitted even when no sibling copy survives — the asymmetry drives the design: a lost directive silently unarms a loop the model was told was armed, while lost sibling detail is visibly missing. `_repair_escaped_marker`'s `json.loads` scanner-depth exposure is covered by the same seam.

## Red-first evidence

Six behaviours, all raising `RecursionError` on the pre-fix module: the elision walk at depth, the readable-directive degrade, encoder-refusal keeping the directive, encoder-refusal keeping shallow siblings, and both repair-path variants. Per the issue's guidance, the encoder tests raise the encoder error directly rather than nesting deeply, so they cannot pass vacuously on Linux. An extra real-stack check ran `_dumps_elided_siblings` at genuine depth 60000 against the real C encoder: 181 bytes out, both shallow siblings kept, refused field named, readable directive end-to-end through `parse_session_update`.

## Verification

2965 focused tests green (directive transport, all `test_acp_*.py`, directive/monitor/autonudge surface); the one failure (`test_autonudge.py::TestSentinelPathRepair::test_unnormalized_path_escaping_legacy_is_preserved`) reproduces identically with the fix stashed — pre-existing on the base. Re-verified after rebasing onto main carrying #8841, which widened the set of frames reaching this path: 79 + 603 tests green post-rebase, so the fix composes with the merged marker-recovery change. mypy clean over 1302 files; isort/flake8/black clean on touched files. Spec `docs/system-specs/features/agent-host-contract.md` updated in the same commit.

## Pod verification (pilot friction note)

Not pod-verifiable today, deliberately documented: the frame originates inside an agent turn, the session-control recipe that could drive one is the acceptance trace for the known `pod api` auth gap (live probe: HTTP 403 `internal_secret_required`), and the trigger depth comes from a tool's own output so a pod repro would need a hostile fixture MCP tool. Unit coverage pins the same invariant at the seam the exception escaped through, one layer below where a pod would observe it.

<!-- no-visual-delta -->
**Why no screenshots:** backend-only change — ACP dispatch internals plus tests; no frontend surface is touched.

## Pattern harvest

Rule candidate: any recursive walk over payloads whose shape an external producer controls needs either an iterative rewrite or an explicit depth bound, and its tests must provoke the platform-dependent C-stack limit directly rather than by nesting depth.
