### PR TITLE
fix(dashboard): derive capture-loss drag ends from the last tracked position

### DIFF
--- a/website/src/hooks/usePointerDrag.test.tsx
+++ b/website/src/hooks/usePointerDrag.test.tsx
@@ -105,4 +105,50 @@ describe('usePointerDrag capture-loss termination', () => {
     fireEvent.pointerUp(handle, { pointerId: 2, clientX: 35, clientY: 30 })
     expect(onEnd).toHaveBeenCalledTimes(2)
   })
+
+  it('ends a capture-loss drag from the last moved-to position, not the event coordinates', () => {
+    // The Pointer Events spec does not define pointer coordinates on
+    // lostpointercapture; browsers commonly deliver 0,0. If the end payload
+    // trusted them, dx would resolve to ≈ -startX and consumers that
+    // persist(apply(sign * dx)) in onEnd would commit a clamped/collapsed
+    // layout to storage — a persisted wrong layout on the rare path.
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd, threshold: 0 })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 150, clientY: 110 })
+    fireEvent.lostPointerCapture(handle, { pointerId: 1, clientX: 0, clientY: 0 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({
+      dx: 50, dy: 10, x: 150, y: 110, committed: true,
+    })
+  })
+
+  it('a normal pointerup still ends from its own (real) coordinates', () => {
+    // Control: up/cancel coordinates are spec-defined — they stay
+    // authoritative and refresh the tracked position.
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd, threshold: 0 })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 150, clientY: 100 })
+    fireEvent.pointerUp(handle, { pointerId: 1, clientX: 160, clientY: 105 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({ dx: 60, dy: 5, x: 160, y: 105 })
+  })
+
+  it('a capture loss before any move ends at the drag origin (dx 0), not at 0,0', () => {
+    const onEnd = vi.fn()
+    const { handle } = renderHandle({ onMove: () => {}, onEnd })
+
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 100, clientY: 100 })
+    fireEvent.lostPointerCapture(handle, { pointerId: 1, clientX: 0, clientY: 0 })
+
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(onEnd.mock.calls[0][0]).toMatchObject({
+      dx: 0, dy: 0, x: 100, y: 100, committed: false,
+    })
+  })
 })

--- a/website/src/hooks/usePointerDrag.ts
+++ b/website/src/hooks/usePointerDrag.ts
@@ -33,6 +33,12 @@ export interface PointerDragOptions {
 interface DragInternal {
   startX: number
   startY: number
+  /** last position from a coordinate-bearing event (down/move/up/cancel).
+   *  got/lostpointercapture coordinates are not defined by the Pointer Events
+   *  spec (browsers commonly deliver 0,0), so the end payload derives from
+   *  this instead of trusting the terminal event. */
+  lastX: number
+  lastY: number
   active: boolean
   committed: boolean
 }
@@ -44,7 +50,7 @@ interface DragInternal {
  */
 export function usePointerDrag(opts: PointerDragOptions) {
   const st = useRef<DragInternal>({
-    startX: 0, startY: 0, active: false, committed: false,
+    startX: 0, startY: 0, lastX: 0, lastY: 0, active: false, committed: false,
   })
   const optsRef = useRef(opts)
   optsRef.current = opts
@@ -57,6 +63,8 @@ export function usePointerDrag(opts: PointerDragOptions) {
     const s = st.current
     s.startX = e.clientX
     s.startY = e.clientY
+    s.lastX = e.clientX
+    s.lastY = e.clientY
     s.active = true
     s.committed = (optsRef.current.threshold ?? 10) <= 0
     optsRef.current.onStart?.(e)
@@ -69,6 +77,10 @@ export function usePointerDrag(opts: PointerDragOptions) {
   const onPointerMove = useCallback((e: React.PointerEvent) => {
     const s = st.current
     if (!s.active) return
+    // Track pre-threshold moves too: a capture loss during hysteresis must
+    // still end from the true (small) delta, not a stale origin.
+    s.lastX = e.clientX
+    s.lastY = e.clientY
     const dx = e.clientX - s.startX
     const dy = e.clientY - s.startY
     const threshold = optsRef.current.threshold ?? 10
@@ -91,11 +103,25 @@ export function usePointerDrag(opts: PointerDragOptions) {
     // click on a thin handle would leave that state set forever. dx/dy reflect
     // actual movement (≈0 for a tap); `committed` tells the consumer whether the
     // gesture crossed the threshold so it can skip drag-only work.
+    //
+    // The payload derives from the last coordinate-bearing event, not from
+    // this event unconditionally: pointerup/pointercancel carry real
+    // coordinates and refresh the tracker here, but the Pointer Events spec
+    // leaves got/lostpointercapture coordinates undefined and browsers
+    // commonly deliver 0,0. Trusting those would hand consumers dx of
+    // roughly -startX on a mid-drag capture loss: resizers run
+    // persist(apply(sign * dx)) in onEnd, which would snap the pane to a
+    // clamped extreme or its collapsed state and WRITE it to localStorage,
+    // a persisted wrong layout on the exact path this hook exists to heal.
+    if (e.type !== 'lostpointercapture') {
+      s.lastX = e.clientX
+      s.lastY = e.clientY
+    }
     optsRef.current.onEnd?.({
-      dx: e.clientX - s.startX,
-      dy: e.clientY - s.startY,
-      x: e.clientX,
-      y: e.clientY,
+      dx: s.lastX - s.startX,
+      dy: s.lastY - s.startY,
+      x: s.lastX,
+      y: s.lastY,
       first: false,
       committed: s.committed,
     })


### PR DESCRIPTION
## Problem / Motivation

#8904 (merged) ends pointer drags when capture is lost, so panes no longer stick to the cursor after a `lostpointercapture`. The Design Review thread on that PR flagged a residual: `lostpointercapture` can arrive with `clientX`/`clientY` of `0,0` in several engines, and the merged handler derives the commit payload from the event's coordinates. A capture loss mid-drag can therefore commit a corrupted delta (`dx` on the order of `-startX`) into consumers that persist their result, such as column layouts that write widths to storage.

## Why it matters

A user who drags a column and hits a capture loss (context menu, alt-tab, browser-initiated grab) can have a garbage width persisted, and it stays wrong across reloads until they re-drag. The corruption is silent: the drag just ends, and the bad value looks like a deliberate resize.

## What changed (motivation → approach → change)

The commit payload now always derives from the last tracked pointer position instead of the raw event coordinates. The tracker is refreshed from the event's coordinates immediately before payload derivation on every end path except `lostpointercapture`, so:

- `pointerup` / `pointercancel` behave byte-identically to today (the refresh makes tracker-derived and event-derived payloads equal by construction).
- `lostpointercapture` commits the last position actually observed (`pointerdown` or the latest `pointermove`), never the event's `0,0`.
- Pre-threshold moves are tracked too, so a capture loss during hysteresis ends at the true small delta rather than a fabricated one.

The single-fire re-entry guard (`active = false` before `releasePointerCapture`) is untouched.

## Tests

- Attack: capture loss at `0,0` after `down(100,100)` commits `x:100 y:100 dx:0 dy:0` (fails on main as merged with `dx:-100, x:0, y:0`, passes with this fix).
- Fresher-event: `down(100,100)` → `move(150,110)` → capture loss at `0,0` commits `150,110 / dx:50 / dy:10`.
- Pre-move capture loss commits at origin with `dx:0`, `committed:false`.
- Control: the normal `pointerup` path commits event coordinates unchanged.
- Full `src/hooks/` suite: 22 files, 260 passed at this head. `tsc --noEmit` exit 0, `eslint` exit 0 on both changed files.

## Manual verification

Drag a column, trigger a capture loss (open a context menu mid-drag), release: the column keeps the width from the last real pointer position instead of collapsing toward zero, and the persisted value matches what was on screen.

## Screenshots / video

No visual delta: this changes which coordinates a drag-end computation reads, not any rendered output. Behavior is pinned by the attack/control tests above.

## Related Issues

Follow-up to #8904 (fix for #8271); implements the hardening surfaced by the Design Review thread on that PR.

## Pattern harvest

Event-derived commit payloads are only as trustworthy as the event: end-of-interaction events fired by the platform rather than the user (`lostpointercapture`, and by analogy blur-driven cancels) can carry sentinel coordinates, so any handler that persists a delta should derive it from tracked state and treat platform-fired ends as "commit what you last saw".

Rule candidate: when a handler family commits state on interaction end, review whether every end path derives its payload from user-observed positions rather than the terminating event's own coordinates.

## Checklist

- [x] Tests added for the change (attack, fresher-event, pre-move, control)
- [x] All tests pass locally (`src/hooks/`: 260 passed)
- [x] Lint and typecheck clean (`eslint`, `tsc --noEmit` both exit 0)
- [x] One topic, minimal diff (2 files: hook + its test)

## Contribution License Agreement

Per the template placeholder (CLA text pending): offered under the same terms as my prior merged contributions to this repository (#8835, #8904).
