### PR TITLE
fix(sandbox): refuse carve-outs shadowed by a foreign mask (#8795)

### DIFF
--- a/src/kiro_crew/apps/backend.py
+++ b/src/kiro_crew/apps/backend.py
@@ -41,6 +41,7 @@ from kiro_crew.sandbox import (
     RLIMIT_PROFILE_BUILD,
     RLIMIT_PROFILE_TOOL,
     app_backend_visible_targets,
+    carveout_shadowed_by_foreign_mask,
     cgroup_scope_argv,
     popen_limited,
     run_limited,
@@ -1152,7 +1153,16 @@ def _start_app_backend_body(app_name: str, manifest) -> AppProcess | None:
     if is_builtin_app(app_root=execution_path, app_name=app_name):
         _visible = app_backend_visible_targets(app_name)
     if _cache_visible:
-        _visible = _visible + (str(policy_cache_dir()),)
+        # SECURITY (#8795): refuse rather than carve when the cache sits beneath an
+        # independently masked directory (a data home relocated under a credential
+        # tree). ``extra_visible_dirs`` cancels any hidden mask entry that CONTAINS
+        # a visible path, so carving the cache out would unmask that whole foreign
+        # tree for this spawn. With the mask kept, the cache-only child fails
+        # closed on the unreadable cache — strictly safer — and the guard's log
+        # line names the offending ancestor so the misconfiguration is actionable.
+        _cache_target = str(policy_cache_dir())
+        if not carveout_shadowed_by_foreign_mask(_cache_target):
+            _visible = _visible + (_cache_target,)
     sandboxed_cmd, cleanup_path = wrap_argv(cmd, mode="standard", extra_visible_dirs=_visible)
     if _cache_visible and list(sandboxed_cmd) == list(cmd):
         # The wrap was a no-op, so this host has no OS confinement at all: no sandbox backend,

--- a/src/kiro_crew/sandbox.py
+++ b/src/kiro_crew/sandbox.py
@@ -373,7 +373,7 @@ _APP_BACKEND_OWNED_LEAVES: dict[str, tuple[str, ...]] = {
 }
 
 
-def app_backend_visible_targets(app_name: str) -> tuple[str, ...]:
+def app_backend_visible_targets(app_name: str, mode: str = "standard") -> tuple[str, ...]:
     """Absolute paths of the hidden leaves *app_name*'s own backend owns.
 
     Resolved the same way the launcher and seatbelt builders spell their hidden
@@ -381,7 +381,16 @@ def app_backend_visible_targets(app_name: str) -> tuple[str, ...]:
     paths when ``KIROCREW_HOME`` moves the data home — so each returned path matches
     its mask entry exactly and ``_hidden_path_contains_visible_path`` lifts it.
 
+    A spelling that sits BENEATH an independently masked directory is REFUSED,
+    not carved (see :func:`carveout_shadowed_by_foreign_mask`): carving it out
+    would take that whole foreign mask down with it. The backend keeps its
+    EPERM on such a host — the pre-existing shape of #8762 — which is strictly
+    safer than unmasking a foreign tree.
+
     Returns ``()`` for an app with no owned leaves, leaving its spawn unchanged.
+    *mode* is the tier the caller passes to :func:`wrap_argv` for the same
+    spawn — the shadow guard judges against that tier (post-clamp), so a
+    future caller wrapping at ``cc``/``strict`` must say so here too.
     """
     leaves = _APP_BACKEND_OWNED_LEAVES.get(app_name)
     if not leaves:
@@ -389,7 +398,119 @@ def app_backend_visible_targets(app_name: str) -> tuple[str, ...]:
     home = str(Path.home())
     targets = [os.path.join(home, entry) for entry in _crew_home_entries(leaves)]
     targets.extend(_relocated_crew_targets(leaves))
-    return tuple(targets)
+    return tuple(
+        target for target in targets if not carveout_shadowed_by_foreign_mask(target, mode=mode)
+    )
+
+
+def carveout_shadowed_by_foreign_mask(path: str, mode: str = "standard") -> bool:
+    """Whether carving *path* out of the sandbox masks would unmask a foreign tree.
+
+    ``_hidden_path_contains_visible_path`` cancels any hidden mask entry that
+    CONTAINS a visible path, so an ``extra_visible_dirs`` spelling that sits
+    beneath an independently masked directory takes that whole foreign mask
+    down with it — a data home relocated beneath a credential directory (e.g.
+    ``KIROCREW_HOME`` under ``~/.aws``) would hand every spawn that asks for a
+    crew-home carve-out the entire credential tree (#8795). Both EQUALITY-shaped
+    crew-home carve-out producers call this before adding a spelling —
+    :func:`app_backend_visible_targets` and the policy-cache site in
+    ``apps/backend.py``. (The aws-control per-call staging carve-out is the
+    ANCESTOR-LIFT shape — its temp dir is a proper descendant of its own mask
+    by design — so this guard as written would refuse it on every layout; its
+    own-ancestor-exempt variant is tracked in #8961.) On refusal the mask stays
+    and the carve-out's consumer fails closed (EPERM for an app backend's own
+    state, an unreadable cache for a cache-only backend), which is strictly
+    safer than unmasking a foreign tree. The refusal is logged with the
+    offending ancestor so the misconfiguration is actionable.
+
+    The mask universe is the EFFECTIVE tier's dir list — *mode* run through the
+    same ``sandbox.min_level`` clamp :func:`wrap_argv` applies (see
+    :func:`effective_sandbox_mode`) — NOT the union of every tier: ``standard``
+    deliberately leaves ``~/.aws`` visible, so a data home relocated beneath it
+    shadows nothing in an ungoverned standard-mode spawn, and refusing there
+    would break the carve-out's consumer for zero security gain. A governed
+    floor that clamps the spawn up is honoured by construction, because the
+    clamp result is what selects the list. Two deliberate asymmetries, both in
+    the refusal direction: ``cc`` uses the launcher's list on every platform
+    (the macOS profile builder drops ``.aws`` from it in favour of file-level
+    rules, so macOS ``cc`` can only over-refuse), and a tier that cannot be
+    resolved falls back to the union of every tier. The relocated mask entries
+    the builders add in every mode are included on BOTH paths, so a carve-out
+    leaf beneath a relocated wholesale mask is judged against it too. Two
+    builder additions are deliberately absent: ``_voice_runtime_sandbox_paths``
+    (fixed runtime sockets no crew-home carve-out can sit beneath) and a
+    caller's ``extra_hidden_dirs`` (neither guarded producer's spawn passes
+    any).
+
+    The floor is re-read by ``wrap_argv`` at wrap time; a floor RAISED in the
+    interval between this check and the wrap is honoured for the masks but not
+    for this refusal. Exploiting that window requires an operator to both
+    tighten governance and have already relocated the data home beneath a
+    newly-masked tree — operator actions, not agent-reachable ones.
+
+    Equality is not shadowing — carve-out spellings ARE masked entries, and
+    unhiding exactly themselves is the carve-out's whole job; only a PROPER
+    ancestor is foreign.
+
+    Fails toward refusal, never raises: when home (or the path itself) cannot
+    be resolved the mask universe cannot be checked, so the spelling is
+    reported shadowed and the spawn proceeds with the mask intact.
+    """
+    try:
+        home = str(Path.home())
+        candidate = os.path.abspath(path)
+    except Exception:
+        logger.debug("could not resolve home for the carve-out shadow check", exc_info=True)
+        return True
+    try:
+        effective = effective_sandbox_mode(mode)
+        policy = _sandbox_policy()
+        if effective == "strict":
+            tier_dirs = list(policy.strict_dirs())
+        elif effective == "cc":
+            tier_dirs = list(policy.cc_dirs())
+        else:
+            # "standard" — and "off", where no mask exists and ``wrap_argv``
+            # ignores ``extra_visible_dirs`` entirely, so the verdict is inert.
+            tier_dirs = list(_STANDARD_DIRS)
+    except Exception:
+        # Deliberately swallows PlatformCompositionError, which
+        # ``_governance_sandbox_floor`` otherwise propagates so a floor never
+        # silently downgrades DENY to ALLOW: here the union fallback is a
+        # SUPERSET of every tier (refusal-leaning, the opposite of a
+        # downgrade), and ``wrap_argv`` re-reads the floor at wrap time and
+        # still raises for real.
+        tier_dirs = list(dict.fromkeys([*_STRICT_DIRS, *_CC_DIRS, *_STANDARD_DIRS]))
+    ancestors = [os.path.abspath(os.path.join(home, rel)) for rel in dict.fromkeys(tier_dirs)]
+    # The builders extend every mode's hidden set with the relocated crew
+    # entries; mirror that (on both the resolved-tier and fallback paths) so a
+    # relocated wholesale mask still counts. Both helpers never raise.
+    ancestors.extend(
+        os.path.abspath(entry)
+        for entry in (
+            *_relocated_crew_targets(_CREW_HIDDEN_LEAVES),
+            *_relocated_policy_cache_dirs(),
+        )
+    )
+    for ancestor in dict.fromkeys(ancestors):
+        if candidate == ancestor:
+            continue
+        try:
+            contained = os.path.commonpath((ancestor, candidate)) == ancestor
+        except ValueError:
+            continue
+        if contained:
+            logger.warning(
+                "SECURITY: refusing the sandbox carve-out for %s — it sits beneath "
+                "the independently masked directory %s, and carving it out would "
+                "unmask that whole tree. The carve-out's consumer will keep failing "
+                "on the masked path until the data home moves out from under that "
+                "directory.",
+                path,
+                ancestor,
+            )
+            return True
+    return False
 
 
 #: The subset of ``_CREW_READONLY_LEAVES`` the launcher may CREATE in order to seal.

--- a/test/test_sandbox_governance_mask.py
+++ b/test/test_sandbox_governance_mask.py
@@ -488,3 +488,130 @@ class TestAppBackendOwnedLeaves:
         src = inspect.getsource(backend_mod._start_app_backend_body)
         assert "app_backend_visible_targets(app_name)" in src
         assert "is_builtin_app(app_root=execution_path, app_name=app_name)" in src
+
+
+class TestForeignMaskShadowGuard:
+    """A carve-out spelling beneath a FOREIGN mask is refused, not carved (#8795).
+
+    ``_hidden_path_contains_visible_path`` cancels any hidden mask entry that
+    CONTAINS a visible path, so an ``extra_visible_dirs`` spelling planted beneath
+    an independently masked directory (a data home relocated under a credential
+    tree) would take that whole foreign mask down with it. Both crew-home carve-out
+    producers — the policy-cache site in ``apps/backend.py`` and
+    ``app_backend_visible_targets`` — must refuse such a spelling and keep the mask;
+    their consumers fail closed on the masked path, which is strictly safer.
+    """
+
+    def test_a_path_beneath_a_masked_credential_tree_is_shadowed(self) -> None:
+        # ``.gnupg`` is masked at EVERY tier, standard included, so a data home
+        # planted beneath it shadows at the tier the app-backend spawn asks for.
+        planted = os.path.join(_home(), ".gnupg", "crew", "policy_cache")
+        assert sandbox.carveout_shadowed_by_foreign_mask(planted)
+
+    def test_standard_mode_ignores_a_strict_only_mask(self) -> None:
+        """``standard`` deliberately leaves ``~/.aws`` visible; there is no mask
+        to take down, so an ungoverned standard-mode carve-out must be allowed
+        (refusing would break md-notebook and cache-only backends for nothing)."""
+        planted = os.path.join(_home(), ".aws", "crew", "policy_cache")
+        assert not sandbox.carveout_shadowed_by_foreign_mask(planted, mode="standard")
+
+    def test_strict_mode_refuses_beneath_a_strict_mask(self) -> None:
+        planted = os.path.join(_home(), ".aws", "crew", "policy_cache")
+        assert sandbox.carveout_shadowed_by_foreign_mask(planted, mode="strict")
+
+    def test_cc_mode_refuses_beneath_a_cc_mask(self) -> None:
+        planted = os.path.join(_home(), ".aws", "crew", "policy_cache")
+        assert sandbox.carveout_shadowed_by_foreign_mask(planted, mode="cc")
+
+    def test_a_sibling_prefix_is_not_an_ancestor(self) -> None:
+        """``~/.gnupg-backup`` shares ``~/.gnupg``'s string prefix but is not
+        beneath it — a ``startswith`` misimplementation reds here."""
+        planted = os.path.join(_home(), ".gnupg-backup", "crew", "policy_cache")
+        assert not sandbox.carveout_shadowed_by_foreign_mask(planted)
+
+    def test_the_producer_threads_its_mode_to_the_guard(self, monkeypatch, tmp_path) -> None:
+        """``app_backend_visible_targets(mode=...)`` must reach the guard: the
+        same relocated spelling under a strict-only mask survives a standard
+        spawn and is dropped from a strict one."""
+        monkeypatch.setattr(sandbox.Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / ".aws" / "relocated-crew"))
+        reloc = str(tmp_path / ".aws" / "relocated-crew" / "workspace" / "md-notebook" / "pat")
+
+        assert reloc in sandbox.app_backend_visible_targets("md-notebook")
+        assert reloc not in sandbox.app_backend_visible_targets("md-notebook", mode="strict")
+
+    def test_a_governance_floor_clamps_the_check_up(self, monkeypatch) -> None:
+        """A ``sandbox.min_level`` floor raises the tier the masks are built for,
+        so the shadow check must judge against the clamped tier, not the ask."""
+        monkeypatch.setattr(sandbox, "_governance_sandbox_floor", lambda: "strict")
+        planted = os.path.join(_home(), ".aws", "crew", "policy_cache")
+        assert sandbox.carveout_shadowed_by_foreign_mask(planted, mode="standard")
+
+    def test_a_masked_entry_itself_is_not_shadowed(self) -> None:
+        """Equality is the carve-out's whole job; only a PROPER ancestor is foreign."""
+        for target in (
+            _crew_path(".kiro/crew", "workspace/md-notebook/pat"),
+            # The default policy-cache spelling IS a masked entry (every tier list
+            # carries ``.kiro/crew/policy_cache``); the cache-only carve-out must
+            # keep working on a default layout.
+            _crew_path(".kiro/crew", "policy_cache"),
+        ):
+            assert not sandbox.carveout_shadowed_by_foreign_mask(target), target
+
+    def test_an_unmasked_location_is_not_shadowed(self) -> None:
+        assert not sandbox.carveout_shadowed_by_foreign_mask(
+            os.path.join(_home(), "projects", "notes")
+        )
+
+    def test_an_unresolvable_home_fails_toward_refusal(self, monkeypatch) -> None:
+        """No mask universe to check means no carve-out, never a carve-anyway."""
+
+        def _boom() -> object:
+            raise RuntimeError("no home")
+
+        monkeypatch.setattr(sandbox.Path, "home", staticmethod(_boom))
+        assert sandbox.carveout_shadowed_by_foreign_mask("/anywhere/at/all")
+
+    def test_the_md_notebook_carveout_drops_a_shadowed_spelling(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A data home relocated beneath a masked tree keeps that tree's mask.
+
+        ``.gnupg`` is masked at the ``standard`` tier the app-backend spawn asks
+        for. ``Path.home`` is pinned to ``tmp_path`` so the resolver (which
+        CREATES the relocated directory) never writes beneath the real home.
+        """
+        monkeypatch.setattr(sandbox.Path, "home", staticmethod(lambda: tmp_path))
+        monkeypatch.setenv("KIROCREW_HOME", str(tmp_path / ".gnupg" / "relocated-crew"))
+
+        # Positive first, so the absence loop below cannot pass vacuously: the
+        # relocated spelling really is minted by the resolver and really does
+        # trip the guard.
+        shadowed_leaf = str(
+            tmp_path / ".gnupg" / "relocated-crew" / "workspace" / "md-notebook" / "pat"
+        )
+        assert shadowed_leaf in sandbox._relocated_crew_targets(("workspace/md-notebook/pat",))
+        assert sandbox.carveout_shadowed_by_foreign_mask(shadowed_leaf)
+
+        targets = sandbox.app_backend_visible_targets("md-notebook")
+
+        shadowed_root = str(tmp_path / ".gnupg") + os.sep
+        assert targets, "the default home spellings must survive the refusal"
+        for target in targets:
+            assert not target.startswith(shadowed_root), f"{target} would unmask ~/.gnupg"
+        # The refusal is per-spelling: the default-home entries are still carved.
+        assert os.path.join(str(tmp_path), ".kiro/crew/workspace/md-notebook/pat") in targets
+
+    def test_the_cache_site_guards_its_carveout(self) -> None:
+        """`apps/backend.py` must thread the cache path through the shadow guard.
+
+        Asserted structurally rather than by a full spawn (which needs a manifest, a
+        reserved port, and a live interpreter), mirroring the sibling test above: the
+        cache-only carve-out must consult the guard before widening ``_visible``.
+        """
+        import inspect
+
+        from kiro_crew.apps import backend as backend_mod
+
+        src = inspect.getsource(backend_mod._start_app_backend_body)
+        assert "carveout_shadowed_by_foreign_mask(_cache_target)" in src


### PR DESCRIPTION
## Summary

`_hidden_path_contains_visible_path` (sandbox.py) cancels any hidden mask entry that CONTAINS a visible path. The policy-cache carve-out in `apps/backend.py` (`POLICY_CACHE_ONLY_ENV`) passed `policy_cache_dir()` into `extra_visible_dirs` unguarded, so a governance cache relocated beneath an independently masked tree (`KIROCREW_HOME` under a credential directory) would take that whole foreign mask down for every cache-only app-backend spawn. The generalized md-notebook carve-out (`app_backend_visible_targets`, #8794) had the same gap.

Closes #8795

## Fix

A shared guard, `carveout_shadowed_by_foreign_mask(path, mode)`, called by both EQUALITY-shaped crew-home carve-out producers before adding a spelling:

- A path beneath a PROPER masked ancestor is refused; equality is the carve-out's own entry and stays allowed (the default `policy_cache` spelling IS a masked entry).
- The mask universe is the EFFECTIVE tier's dir list — the requested mode run through the same `sandbox.min_level` clamp `wrap_argv` applies (`effective_sandbox_mode`) — not the union of every tier: `standard` deliberately leaves the AWS config dir visible, so an ungoverned standard-mode spawn under a strict-only mask is allowed (refusing there broke md-notebook and cache-only backends for zero gain; caught by the pre-push GPT review lane).
- The relocated mask entries the builders add in every mode are included on both the resolved-tier and fallback paths.
- Unresolvable home and unresolvable tier both fail toward refusal; the refusal is logged with the offending ancestor.
- On refusal the consumer fails closed: EPERM for an app backend's own state, an unreadable cache for a cache-only backend (which refuses to start rather than degrading).

Known residual, documented in the guard's docstring: the floor is re-read by `wrap_argv` at wrap time, so a floor RAISED between the guard and the wrap is honoured for the masks but not for this refusal — exploiting it requires operator actions (tighten governance AND have already relocated the data home beneath a newly-masked tree).

## Tests

`test/test_sandbox_governance_mask.py::TestForeignMaskShadowGuard` (10 tests): shadow beneath a standard-tier mask refused; strict-only mask ignored at ungoverned standard (the GPT-lane regression); strict and cc modes refuse; a governance floor clamps the check up; equality (md-notebook leaf AND default policy-cache spelling) allowed; sibling string prefix (`.gnupg-backup`) not an ancestor (kills a `startswith` misimplementation); unresolvable home fails toward refusal; relocated data home under a masked tree drops exactly the shadowed spellings (with a positive mint-and-trip assertion so the absence loop cannot pass vacuously); mode threading from `app_backend_visible_targets` to the guard; structural assertion that the cache site consults the guard.

Mutation-verified: 9 distinct mutations (guard disabled, equality treated as shadowing, either producer skipping the guard, home-failure failing open, clamp ignored, all-tier union restored, `startswith` substitution, mode threading dropped) each caught by a distinct test.

Local gates green: black-baseline, isort, flake8, mypy, subprocess-encoding, brand-name, harness-parity, targeted pytest (671 tests across the two affected files' suites). One pre-existing host-environmental failure (`test_ci_surface_tests.py::test_explicit_cli_target_bypasses_collect_ignore`) reproduces byte-identically on pristine main.

## Review provenance

Two model-pinned pre-push review lanes ran read-only on the diff:

- GPT (gpt-5.6-sol): 1 BLOCKING — the initial all-tier-union check falsely refused legitimate carve-outs on ungoverned standard-mode hosts. Fixed at root by the effective-tier redesign above; regressions added.
- Opus (claude-opus-5): first attempt timed out at 30 min mid-probe; a static-only rerun returned 1 BLOCKING + 6 CONCERNS. The BLOCKING (a third carve-out producer, aws-control per-call staging, remains unguarded and the docstring overclaimed coverage) is dispositioned as: docstring narrowed to the two equality-shaped producers it covers, and the third site filed as #8961 — it is the ANCESTOR-LIFT shape (its temp dir is a proper descendant of its own mask by design), so this guard verbatim would refuse every transfer on every layout; it needs an own-ancestor-exempt variant. All 6 CONCERNS addressed: mode threaded through `app_backend_visible_targets`; positive mint-and-trip assertion added; sibling-prefix and cc-mode tests added; the fallback's exception-swallow documented (refusal-leaning superset; `wrap_argv` re-reads and raises for real) and the relocated entries moved out of the `try` so both paths carry them; the two deliberate universe omissions (`_voice_runtime_sandbox_paths`, callers' `extra_hidden_dirs`) named in the docstring with why they cannot matter; `abspath` moved inside the guarded block so "never raises" holds for the path argument too.

## Pattern harvest

Rule candidate: an `extra_visible_dirs` producer must judge its spelling against the EFFECTIVE (post-clamp) tier's mask list, not a union of tiers — unions over-refuse on ungoverned hosts, per-tier under-refuses under a floor.
Class: carve-out producers whose visible path can sit beneath a foreign mask entry; members found: `app_backend_visible_targets` (fixed here), the policy-cache site in `apps/backend.py` (fixed here), the aws-control per-call staging site (ancestor-lift shape, filed as #8961).
<!-- readiness-refresh 446840f74 -->
<!-- readiness-refresh-2 446840f74 -->
<!-- readiness-refresh-3 446840f74 -->
