### PR TITLE
fix(security): stop re-asking a command-level guard per payload

### DIFF
--- a/src/kiro_crew/security.py
+++ b/src/kiro_crew/security.py
@@ -3957,7 +3957,48 @@ _SCRIPT_EXECUTES_RE = re.compile(
 )
 
 
-def _data_consumer_exempt(index: int, token: str, programs: "list[str]", tokens: "list[str]") -> bool:
+def _data_consumer_command_disqualified(tokens: "list[str]") -> bool:
+    """True where NO token in *tokens* can claim the data-consumer exemption.
+
+    The three guards collected here read ONLY *tokens*, so their answer is a
+    property of the whole command and is the same for every token in it.  They
+    live in one function so a caller holding a fixed argv can charge them ONCE
+    instead of once per candidate token: :func:`_data_consumer_exempt` is called
+    per payload inside a loop over a fixed argv, and the ``_SCRIPT_EXECUTES_RE``
+    sweep below is itself O(len(tokens)), so re-asking made the enclosing walk
+    quadratic in payload count (#8595 -- 18k payloads, ~293s).
+
+    Splitting them out cannot change any verdict: each is a pure function of
+    *tokens* and each REFUSES the exemption, so hoisting alters only how often
+    the same answer is computed, never what it is.
+    """
+    if _pipes_into_evaluator(tokens):
+        return True
+    # ``$(printf <name>) <verb>`` puts the consumer INSIDE a substitution that occupies
+    # program position, so its OUTPUT is what runs -- the words are not inert data.
+    if tokens and tokens[0].lstrip("\"'").startswith("$(") or (
+        tokens and tokens[0].lstrip("\"'").startswith("`")
+    ):
+        return True
+    # A "data consumer" that can EXECUTE is not one for this command.  ``awk`` has
+    # ``system()`` and pipe-to-command; GNU ``sed`` has the ``e`` flag.  The exemption is
+    # withdrawn per-command when the script text carries such a construct, rather than
+    # dropping ``awk`` from the list entirely -- that would also refuse ordinary
+    # ``awk '{print $1}' <file>``, and the list is deliberately a denylist of consumers so
+    # that a mistake here costs a false positive, never a bypass.
+    if any(_SCRIPT_EXECUTES_RE.search(tok) for tok in tokens):
+        return True
+    return False
+
+
+def _data_consumer_exempt(
+    index: int,
+    token: str,
+    programs: "list[str]",
+    tokens: "list[str]",
+    *,
+    command_disqualified: "bool | None" = None,
+) -> bool:
     """True if *token* is an ARGUMENT of a command that treats arguments as data.
 
     ``echo <name> <verb>`` prints two words -- a mention, not an invocation.
@@ -3978,21 +4019,13 @@ def _data_consumer_exempt(index: int, token: str, programs: "list[str]", tokens:
         return False
     if _CONTROL_OPERATOR_RE.search(token):
         return False
-    if _pipes_into_evaluator(tokens):
-        return False
-    # ``$(printf <name>) <verb>`` puts the consumer INSIDE a substitution that occupies
-    # program position, so its OUTPUT is what runs -- the words are not inert data.
-    if tokens and tokens[0].lstrip("\"'").startswith("$(") or (
-        tokens and tokens[0].lstrip("\"'").startswith("`")
-    ):
-        return False
-    # A "data consumer" that can EXECUTE is not one for this command.  ``awk`` has
-    # ``system()`` and pipe-to-command; GNU ``sed`` has the ``e`` flag.  The exemption is
-    # withdrawn per-command when the script text carries such a construct, rather than
-    # dropping ``awk`` from the list entirely -- that would also refuse ordinary
-    # ``awk '{print $1}' <file>``, and the list is deliberately a denylist of consumers so
-    # that a mistake here costs a false positive, never a bypass.
-    if any(_SCRIPT_EXECUTES_RE.search(tok) for tok in tokens):
+    # Command-level guards, hoisted into ``_data_consumer_command_disqualified``.
+    # *command_disqualified* lets a caller iterating one fixed argv charge them
+    # once; ``None`` means "compute them here", which is what every caller that
+    # asks about a single token does, so their behaviour is unchanged.
+    if command_disqualified is None:
+        command_disqualified = _data_consumer_command_disqualified(tokens)
+    if command_disqualified:
         return False
     return programs[index] in _DATA_CONSUMER_PROGRAMS
 
@@ -18707,6 +18740,23 @@ def _deny_segment_views(segment: str, emit_self: bool = True) -> tuple[str, ...]
                 tokens, allow_join=allow_join, joined_out=joined_here
             )
             programs = _argv_programs(tokens) if payloads else []
+            # Both values below read ONLY ``tokens``, which is fixed for this
+            # whole walk, so they are charged ONCE here instead of once per
+            # payload.  Asking per payload is what made this loop quadratic in
+            # payload count (#8595 -- 18k payloads, ~293s): the exemption's
+            # command-level guards sweep the whole argv, and recovering a
+            # payload's positions with ``enumerate`` sweeps it again, so N
+            # payloads cost N x len(tokens).  Neither hoist can change a verdict:
+            # same inputs, same answers, computed once rather than N times.  Both
+            # are skipped when there are no payloads so an ordinary command --
+            # the common case -- pays nothing new.
+            command_disqualified = (
+                _data_consumer_command_disqualified(tokens) if payloads else False
+            )
+            token_positions: dict[str, list[int]] = {}
+            if payloads:
+                for _pos, _tok in enumerate(tokens):
+                    token_positions.setdefault(_tok, []).append(_pos)
             for payload in payloads:
                 if len(payload) >= parent_len:
                     continue
@@ -18742,9 +18792,16 @@ def _deny_segment_views(segment: str, emit_self: bool = True) -> tuple[str, ...]
                 # payload can also be a coincidental substring of an unrelated
                 # token, and one wrong position could wrongly exempt a payload that
                 # really executes.
-                occurrences = [i for i, tok in enumerate(tokens) if tok == payload]
+                occurrences = token_positions.get(payload, [])
                 if occurrences and all(
-                    _data_consumer_exempt(i, payload, programs, tokens) for i in occurrences
+                    _data_consumer_exempt(
+                        i,
+                        payload,
+                        programs,
+                        tokens,
+                        command_disqualified=command_disqualified,
+                    )
+                    for i in occurrences
                 ):
                     continue
                 # A payload is a command LINE, so it gets the same PRE-LEX treatment

--- a/test/test_denied_commands_security.py
+++ b/test/test_denied_commands_security.py
@@ -6364,3 +6364,194 @@ class TestPolynomialBacktrackingStaysBounded:
         matcher.match(subject)
         elapsed = time.perf_counter() - start
         assert elapsed < 1.0, f"deny evaluation took {elapsed:.1f}s — gate would stall"
+
+
+class TestDataConsumerGuardIsChargedPerCommandNotPerPayload:
+    """#8595 -- the deny walk was quadratic in nested payload COUNT.
+
+    ``_data_consumer_exempt`` is called once per extracted payload, and three of
+    its guards read only ``tokens`` -- a value the caller binds once, outside the
+    payload loop.  One of those guards sweeps the whole argv with
+    ``_SCRIPT_EXECUTES_RE``, so re-asking per payload cost N x len(tokens):
+    18,000 payloads took ~209s measured, against ~2.5s once the answer is
+    charged once.
+
+    These assertions are STRUCTURAL on purpose.  A wall-clock bound would claim
+    a performance budget for every other pass in the gate and would flake on a
+    slower runner, so what is pinned is the bounded QUANTITY -- how many times
+    the command-level answer is computed -- which is the property the fix
+    actually establishes.
+    """
+
+    @staticmethod
+    def _spaced(n: int) -> str:
+        """The issue's repro shape: ``bash -c a0pay -c a1pay ...``."""
+        return "bash" + "".join(f" -c a{i}pay" for i in range(n))
+
+    @staticmethod
+    def _count_guard_calls(monkeypatch, cmd: str) -> int:
+        calls = {"n": 0}
+        real = security._data_consumer_command_disqualified
+
+        def counting(tokens):
+            calls["n"] += 1
+            return real(tokens)
+
+        monkeypatch.setattr(security, "_data_consumer_command_disqualified", counting)
+        security.is_denied(cmd)
+        return calls["n"]
+
+    @staticmethod
+    def _count_argv_sweeps(monkeypatch, cmd: str) -> int:
+        calls = {"n": 0}
+        real = security._SCRIPT_EXECUTES_RE
+
+        class Counting:
+            def search(self, s):
+                calls["n"] += 1
+                return real.search(s)
+
+            def __getattr__(self, name):
+                return getattr(real, name)
+
+        monkeypatch.setattr(security, "_SCRIPT_EXECUTES_RE", Counting())
+        security.is_denied(cmd)
+        return calls["n"]
+
+    def test_guard_is_charged_once_however_many_payloads(self, monkeypatch):
+        # The count must not scale with the payload count.  Measured: 1 at every
+        # size here; before the fix the guard's work was re-done per payload.
+        counts = {n: self._count_guard_calls(monkeypatch, self._spaced(n)) for n in (30, 60, 120)}
+        assert counts[30] == counts[60] == counts[120], (
+            f"command-level guard is charged per payload, not per command: {counts}"
+        )
+        # Belt as well as braces: a future change making it 2*N would still keep
+        # the three counts EQUAL to each other only by accident, so bound it
+        # against the payload count directly.
+        assert counts[120] < 30, f"guard charged {counts[120]} times for 120 payloads"
+
+    @pytest.mark.parametrize("n", [30, 60, 120])
+    def test_argv_sweep_is_linear_in_the_argv_not_quadratic_in_payloads(self, monkeypatch, n):
+        # ``_SCRIPT_EXECUTES_RE`` sweeps every token.  Charged once per command
+        # that is O(len(tokens)); charged once per payload it was
+        # O(len(tokens) x payloads).  Measured before the fix: 1830 / 7260 /
+        # 28920 sweeps at n = 30 / 60 / 120 (ratio ~3.98, quadratic).  After:
+        # 61 / 121 / 241 (ratio ~1.99, linear).  The bound below is ~3x the argv
+        # length, which the linear form clears with room and the quadratic form
+        # misses by a factor of forty at n=120.
+        cmd = self._spaced(n)
+        argv_len = len(security.normalize_shell_command(cmd))
+        sweeps = self._count_argv_sweeps(monkeypatch, cmd)
+        assert sweeps <= 3 * argv_len, (
+            f"argv sweep is quadratic in payload count: {sweeps} sweeps for an "
+            f"argv of {argv_len} tokens ({n} payloads)"
+        )
+
+    @staticmethod
+    def _count_argv_elements(monkeypatch, cmd: str) -> "tuple[int, int]":
+        """(argv elements consumed, argv length) for one ``is_denied`` call.
+
+        The argv is handed out as a list subclass whose iterator counts the
+        elements taken from it, which is what separates ONE hoisted pass over
+        the argv from one pass PER PAYLOAD.
+        """
+        counted = {"n": 0}
+
+        class CountingList(list):
+            def __iter__(self):
+                for item in list.__iter__(self):
+                    counted["n"] += 1
+                    yield item
+
+        real = security._shell_tokens
+
+        def wrapped(*args, **kwargs):
+            return CountingList(real(*args, **kwargs))
+
+        monkeypatch.setattr(security, "_shell_tokens", wrapped)
+        security.is_denied(cmd)
+        return counted["n"], len(real(cmd))
+
+    @pytest.mark.parametrize("n", [30, 60, 120, 240])
+    def test_argv_is_walked_per_command_not_per_payload(self, monkeypatch, n):
+        # The second half of #8595: recovering a payload's token positions with
+        # ``[i for i, tok in enumerate(tokens) if tok == payload]`` walks the
+        # whole argv once per payload.  Hoisting the guard alone leaves the walk
+        # quadratic -- measured 1.37s / 4.30s / 15.56s at 4k / 8k / 16k payloads,
+        # ratios 3.15 and 3.62 -- so this half is load-bearing, not tidying.
+        #
+        # Measured argv elements consumed, 30 / 60 / 120 / 240 payloads:
+        #   both hoists      1154 /  2294 /  4574 /   9134   (ratio ~2.00, linear)
+        #   position reverted 2984 /  9554 / 33494 / 124574   (ratio ~3.72, quadratic)
+        # The bound below sits at 40x the argv length: the linear form uses ~19x
+        # and the quadratic form ~259x at n=240.
+        cmd = self._spaced(n)
+        elements, argv_len = self._count_argv_elements(monkeypatch, cmd)
+        assert elements <= 40 * argv_len, (
+            f"argv walked per payload: {elements} elements consumed for an argv of "
+            f"{argv_len} tokens ({n} payloads) -- expected O(argv), not O(argv x payloads)"
+        )
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # pipes into an evaluator -- the printed text IS the command
+            f"echo {_NAME} {_TOK} | sh",
+            f"echo '{_PK} -f {_NAME}' | bash",
+            # substitution occupies program position -- its OUTPUT runs
+            f"$(printf echo) {_NAME} {_TOK}",
+            f"`printf echo` {_PK} -f {_NAME}",
+            # the script text can EXECUTE rather than print
+            f'awk \'system("{_PK} -f {_NAME}")\'',
+            f"awk 'BEGIN{{print | \"{_PK} -f {_NAME}\"}}'",
+            # a control operator inside the token starts a command that runs
+            f"echo foo;{_PK} -f {_NAME}",
+        ],
+    )
+    def test_every_way_the_exemption_is_refused_still_refuses(self, cmd):
+        # Hoisting must not widen the exemption.  A faster deny gate that misses
+        # one case is strictly worse than a slow one, so each documented refusal
+        # route is pinned here alongside the cost assertions above.
+        assert _denied_by(cmd) is not None
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            f"echo {_NAME} {_TOK}",
+            f"printf '{_NAME} {_TOK}'",
+            "awk '{print $1}' file",
+            "sed 's/a/b/' file",
+        ],
+    )
+    def test_the_ordinary_data_consumer_is_still_exempt(self, cmd):
+        # The other direction: hoisting must not NARROW the exemption either, or
+        # the change trades a latency fix for a false positive.
+        assert _denied_by(cmd) is None
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            f"echo {_NAME} {_TOK}",
+            f"echo {_NAME} {_TOK} | sh",
+            f'awk \'system("{_PK} -f {_NAME}")\'',
+            "awk '{print $1}' file",
+            f"$(printf echo) {_NAME} {_TOK}",
+        ],
+    )
+    def test_precomputed_and_self_computed_guards_agree(self, cmd):
+        # The three call sites this change does not touch pass no precomputed
+        # value, so they take the ``None`` branch.  That branch must give the
+        # same answer as the hoisted one, or those callers silently change
+        # behaviour.
+        tokens = security.normalize_shell_command(cmd)
+        programs = security._argv_programs(tokens)
+        hoisted = security._data_consumer_command_disqualified(tokens)
+        for i, token in enumerate(tokens):
+            self_computed = security._data_consumer_exempt(i, token, programs, tokens)
+            passed_in = security._data_consumer_exempt(
+                i, token, programs, tokens, command_disqualified=hoisted
+            )
+            assert self_computed == passed_in, (
+                f"token {i} ({token!r}) disagrees: self-computed={self_computed} "
+                f"passed-in={passed_in}"
+            )


### PR DESCRIPTION
## Problem / Motivation

`is_denied` is quadratic in the number of nested shell payloads a command
carries, so a large-but-ordinary-looking command makes the deny gate run for
minutes.

Measured on current main, spaced repro from #8595 (`bash -c a0pay -c a1pay ...`,
18,000 pairs, a 222,894-byte command):

| payloads | command bytes | `is_denied` on main |
|---|---|---|
| 4,000 | 46,894 | 10.63s |
| 18,000 | 222,894 | **209.19s** |

Doubling the payload count multiplies the time by ~3.9, not ~2: ratios
1.99 / 3.41 / 3.79 / 3.87 across 250 -> 500 -> 1k -> 2k -> 4k payloads, a
fitted growth exponent of **1.95**. The reporter measured ~293s at 18k on their
own workstation; this is the same curve on a different machine.

The extractor is not the bottleneck and never was: `_nested_shell_payloads` is
linear on the same inputs (ratios 1.92 / 2.02 / 2.03 / 2.02, 0.166s at 18k).

## Why it matters

The gate is what decides whether a command may run, and a command string is
attacker-influenced input. Extrapolating the measured fit, ~6,300 payloads
(about 74KB of command text) is enough to cross a 25s-class watchdog on this
host. When the watchdog fires first, the outcome is not a slow decision but an
interrupted one, so this is availability of the deny path rather than mere
latency.

It is reachable on main today through the spaced spelling, and the glued
spelling reaches the same code path since #8491 merged (glued: 10.22s at 18k).

## What changed (motivation -> approach -> change)

**Symptom -> curve.** Timed the real `is_denied` over 250 to 32,000 payloads
rather than trusting the word "super-linear". It is quadratic, not exponential,
which decides what kind of fix is needed.

**Curve -> root cause, and this is where the issue's own diagnosis is wrong.**
#8595 attributes the cost to "N payloads x M rules x payload length". That
product is *linear* in N, because each payload is about ten bytes, so it cannot
produce an exponent of 1.95. Profiling at 2,000 payloads (6.18s total) locates
the real term:

- `_deny_pattern_matches`, the per-payload x per-rule scan that all three
  suggested mitigations aim at: 282,282 calls, **0.477s, 7.7% of the time**.
- `_data_consumer_exempt`, called once per payload: **4.912s, 79%**. Inside it,
  `any(_SCRIPT_EXECUTES_RE.search(tok) for tok in tokens)` runs **8,004,000**
  iterations, which is exactly 2000 x 4002 = payloads x len(tokens).

`_data_consumer_exempt` has three guards that read only `tokens`, and `tokens`
is bound once by the caller, outside the payload loop, as is `programs`. So a
command-level question was being re-answered once per payload. Recovering each
payload's token positions with `[i for i, tok in enumerate(tokens) if tok ==
payload]` walked the same argv a second time, once per payload.

**Root cause -> change.** Both values are now computed once per command and
passed into the loop:

- the three command-level guards move into `_data_consumer_command_disqualified`,
  and `_data_consumer_exempt` takes an optional `command_disqualified`;
- the payload's token positions come from a `token_positions` index built once.

Neither can change a verdict. Each hoisted guard is a pure function of `tokens`
and each one *refuses* the exemption, so hoisting alters how often the same
answer is computed, never what it is. `token_positions.get(payload, [])` returns
the same ascending index list the comprehension produced. Callers that ask about
a single token pass nothing and keep the old self-computing path, so the three
call sites this PR does not touch are unchanged. A command carrying no nested
payload skips both, so ordinary commands pay nothing new.

**Deviation from the issue's suggested directions, stated up front.** #8595
proposes dedup, a cap with fail-closed, or precompiled/aggregated rules, and two
operators routed the issue to `needs-investigation` on the grounds that choosing
between them is a contract decision. That reading of those three options is
correct, and it is why none of them is implemented here: they all target the
7.7% term. Specifically, dedup cannot help this shape at all, since `a0pay` to
`a17999pay` are already distinct; and a cap or a rule-scan rewrite would each
pick a policy where `_AltWorkBudget`'s own docstring records three revisions
failing open. Hoisting a loop-invariant needs no cap, no dedup, no budget
threaded through the extraction sites and no contract choice. If maintainers
still want a cap as defence-in-depth for other amplification axes, that is
separable from this fix and unaffected by it.

**Both halves are load-bearing, measured rather than assumed.** Reverting only
the position index, keeping the guard hoist, leaves the walk quadratic: 1.37s /
4.30s / 15.56s at 4k / 8k / 16k payloads, ratios 3.15 and 3.62. So this is one
defect with two expressions at one call site, not a fix plus a tidy-up.

## Tests

Cost is pinned **structurally**, never on elapsed time. A wall-clock bound would
claim a performance budget for every other pass in the gate and would flake on a
slower runner, so what the tests assert is the bounded quantity.

- `test_guard_is_charged_once_however_many_payloads` -- the command-level guard
  is charged the same number of times at 30, 60 and 120 payloads.
- `test_argv_sweep_is_linear_in_the_argv_not_quadratic_in_payloads` -- the
  `_SCRIPT_EXECUTES_RE` argv sweep count stays within 3x the argv length.
  Measured before: 1,830 / 7,260 / 28,920 sweeps at 30 / 60 / 120 payloads
  (ratio ~3.98). After: 61 / 121 / 241 (ratio ~1.99).
- `test_argv_is_walked_per_command_not_per_payload` -- argv elements consumed
  stay within 40x the argv length. Before: 2,984 / 9,554 / 33,494 / 124,574 at
  30 / 60 / 120 / 240 payloads (ratio ~3.72). After: 1,154 / 2,294 / 4,574 /
  9,134 (ratio ~2.00).
- `test_every_way_the_exemption_is_refused_still_refuses` and
  `test_the_ordinary_data_consumer_is_still_exempt` -- every documented route by
  which the exemption is refused, and the ordinary exempt case, in both
  directions, so the change can neither widen nor narrow the exemption.
- `test_precomputed_and_self_computed_guards_agree` -- the `None` branch used by
  the untouched callers gives the same answer as the hoisted value, token by
  token.

Before and after, `is_denied`, measured not extrapolated:

| payloads | spelling | before | after |
|---|---|---|---|
| 18,000 | spaced | 209.19s | **2.55s** |
| 18,000 | glued | 10.22s | **2.33s** |

Growth is now linear. Doubling ratios over 4k -> 8k -> 16k -> 32k payloads are
1.89 / 2.04 / 2.06, a fitted exponent of **1.04**, against 1.95 before. At
32,000 payloads (a 404,894-byte command) the gate takes 4.51s.

Suite: `pytest -n0 test/test_denied_commands_security.py` -> 695 passed.
`flake8`, `isort --check-only`, `mypy src/kiro_crew/` (1302 files) and the black
gate all clean.

Five mutations, each hand-applied and asserted to have applied, each reddening a
different observable with a different assertion:

1. remove the hoisted guard argument -> guard counts become 31 / 61 / 121, and
   sweeps become 1,891 against a bound of 183.
2. restore the `enumerate` position scan -> 2,984 elements against a bound of
   2,440.
3. guard always reports "not disqualified" -> `echo <name> <verb> | sh` is
   allowed when it must be denied.
4. guard always reports "disqualified" -> `echo <name> <verb>` is denied when it
   must be allowed.
5. `None` branch stops self-computing -> the agreement test reports
   `self-computed=True passed-in=False`, and a refusal case flips to allowed.

Mutations 3 and 4 fail in opposite directions on the same guard, which is what
rules out a test that reddens indiscriminately.

## Manual verification

Deny-set identity was proven by running the same matrix under main and under
this branch and diffing the results, rather than arguing it from the diff: 79
commands x 3 rule tiers, byte-identical verdicts, 50 of the 79 denials. The
matrix covers destructive and credential and publish shapes, nested payloads
behind six different launchers, every documented refusal route for the
data-consumer exemption, ordinary allowed commands, and the #8595 repro shape
with a real denial embedded at several positions. Controls: the comparison
detects a deliberate one-character change, and the two outputs are non-empty
(22,528 bytes each), so an empty-vs-empty comparison cannot pass for agreement.

All measurements were taken in a detached worktree at a pinned main with none of
this branch's code present, with the imported module's path asserted, so the
before numbers are attributable to main alone.

## Related Issues

Closes #8595

Context, not changed here: #8197 and #8491 are the glued-payload extraction work
this issue was found alongside; #8491 is merged, and the 2x2 in #8595 correctly
attributes the cost to main rather than to that PR. #8338 and #8282 concern cost
in command *length*, a different axis that this change does not address.

## Pattern harvest

Rule candidate: review-prompt

Pattern: a predicate that reads only a loop-invariant collection, evaluated
inside a loop over that same collection, turns an O(n) helper into O(n^2) at the
call site. The tell here was a guard taking both an index and the whole argv,
where two of its three checks never used the index.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [x] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
