### PR TITLE
fix: hold staged FFmpeg handle open until the child exits (#8918)

### DIFF
--- a/src/kiro_crew/apple_speech/__init__.py
+++ b/src/kiro_crew/apple_speech/__init__.py
@@ -30,6 +30,7 @@ import os
 import platform
 import stat
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -544,6 +545,7 @@ async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
     from kiro_crew.transcribe import (
         _close_ffmpeg_for_execution,
         _create_ffmpeg_subprocess,
+        _describe_ffmpeg_exit,
         _resolve_ffmpeg_for_execution,
         ensure_ffmpeg_in_path,
     )
@@ -576,44 +578,74 @@ async def _to_native_audio(audio_path: str) -> tuple[str, bool]:
     # still-running child can race the removal. Every cleanup step is
     # best-effort — the exception in flight is the one that must surface.
     try:
-        proc = await _create_ffmpeg_subprocess(
-            ffmpeg,
-            "-y",
-            "-i",
-            audio_path,
-            "-ar",
-            "16000",
-            "-ac",
-            "1",
-            out,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.PIPE,
-        )
         try:
-            _, err = await proc.communicate()
+            proc = await _create_ffmpeg_subprocess(
+                ffmpeg,
+                "-y",
+                "-i",
+                audio_path,
+                "-ar",
+                "16000",
+                "-ac",
+                "1",
+                out,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                _, err = await proc.communicate()
+            except BaseException:
+                try:
+                    proc.kill()
+                except (OSError, ProcessLookupError):
+                    pass
+                else:
+                    try:
+                        await proc.communicate()
+                    except BaseException:
+                        # A repeat cancellation can land on this await; swallow it
+                        # so the unlink below still runs and the ORIGINAL exception
+                        # is the one that propagates.
+                        pass
+                raise
         except BaseException:
             try:
-                proc.kill()
-            except (OSError, ProcessLookupError):
+                os.unlink(out)
+            except OSError:
                 pass
-            else:
-                try:
-                    await proc.communicate()
-                except BaseException:
-                    # A repeat cancellation can land on this await; swallow it
-                    # so the unlink below still runs and the ORIGINAL exception
-                    # is the one that propagates.
-                    pass
             raise
-    except BaseException:
+    finally:
+        # The authenticated handle must outlive the spawn (#8918): every branch
+        # above has already reaped the child (``communicate`` on success,
+        # kill-and-reap on failure) or never spawned one, so the staged image
+        # can be released now — off the loop, unconditionally, instead of by
+        # ``__del__`` running the close synchronously on the gateway event
+        # loop. ``preserve_active_exception`` is set only while an exception is
+        # genuinely in flight, so a cleanup failure never masks the original
+        # error and a cancellation landing on the close await of a success
+        # path still propagates.
         try:
-            os.unlink(out)
-        except OSError:
-            pass
-        raise
+            await _close_ffmpeg_for_execution(
+                ffmpeg,
+                preserve_active_exception=sys.exc_info()[1] is not None,
+            )
+        except BaseException:
+            # This await is the only suspension point between the child
+            # exiting and the success return transferring ``out`` to the
+            # caller. A cancellation landing exactly here (it can only raise
+            # on the no-exception-in-flight path) would otherwise propagate
+            # with the invocation-owned temp still on disk. The failure
+            # branches already unlinked, so this second unlink is a tolerated
+            # no-op there.
+            try:
+                os.unlink(out)
+            except OSError:
+                pass
+            raise
     if proc.returncode != 0:
+        tail = err.decode(errors="replace").strip()[-300:] if err else ""
         logger.warning(
-            "apple_speech: ffmpeg transcode failed: %s", err.decode(errors="replace")[-300:]
+            "apple_speech: ffmpeg transcode %s", _describe_ffmpeg_exit(proc.returncode, tail)
         )
         try:
             os.unlink(out)

--- a/src/kiro_crew/transcribe.py
+++ b/src/kiro_crew/transcribe.py
@@ -977,18 +977,50 @@ async def _close_ffmpeg_for_execution(
             raise
 
 
+def _describe_ffmpeg_exit(returncode: int | None, stderr_tail: str) -> str:
+    """Render an FFmpeg exit status for a log line, naming a signal death.
+
+    A negative return code is an external signal, not an FFmpeg error, and a
+    signalled child usually wrote no stderr, so a bare "exited -9 ...
+    (no stderr)" reads as corrupt audio. On macOS the likeliest sender for a
+    just-spawned staged binary is the asynchronous system policy assessment
+    denying the exec (#8918), so name that path in the line.
+    """
+    detail = stderr_tail or "(no stderr)"
+    if returncode is None or returncode >= 0:
+        return f"exited {returncode}: {detail}"
+    message = f"was killed by signal {-returncode}: {detail}"
+    if platform_compat.IS_MACOS:
+        message += (
+            "; on macOS a SIGKILL immediately after spawn usually means the"
+            " system policy assessment (Gatekeeper) denied the exec"
+        )
+    return message
+
+
 async def _create_ffmpeg_subprocess(
     executable: str | _AuthenticatedFfmpeg, *args: str, **kwargs: Any
 ) -> asyncio.subprocess.Process:
-    """Spawn FFmpeg while its authenticated image remains immutable/open."""
+    """Spawn FFmpeg while its authenticated image remains immutable/open.
+
+    A returning ``create_subprocess_exec`` means only that the fork/exec was
+    issued, not that the platform authorized it: on macOS the syspolicy
+    assessment resolves the staged *path* asynchronously after the spawn, so
+    closing the handle here (which removes the staged directory) had the
+    kernel deny the exec with SIGKILL (#8918). The caller therefore owns the
+    close and must run it once the child has exited. A failed spawn never
+    produced a child, so nothing depends on the path surviving and the handle
+    is closed here before the error propagates.
+    """
     if isinstance(executable, str):
         return await asyncio.create_subprocess_exec(executable, *args, **kwargs)
     try:
         if not platform_compat.IS_WINDOWS:
             kwargs["pass_fds"] = (executable.descriptor,)
         return await asyncio.create_subprocess_exec(executable.execution_path, *args, **kwargs)
-    finally:
-        await _close_ffmpeg_for_execution(executable)
+    except BaseException:
+        await _close_ffmpeg_for_execution(executable, preserve_active_exception=True)
+        raise
 
 
 def ensure_ffmpeg_in_path() -> None:
@@ -1402,66 +1434,96 @@ async def _transcribe_aws(audio_path: str, stt_config) -> str | None:  # type: i
             raise
         proc = None
         try:
-            proc = await _create_ffmpeg_subprocess(
-                ffmpeg_bin,
-                "-y",
-                "-i",
-                audio_path,
-                "-c:a",
-                "copy",
-                tmp_ogg,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
             try:
-                await asyncio.wait_for(proc.communicate(), timeout=10)
-            except asyncio.TimeoutError:
-                proc.kill()
-                await proc.communicate()
-                raise
-            if proc.returncode != 0:
-                raise RuntimeError(f"ffmpeg exited with {proc.returncode}")
-        except Exception:
-            logger.exception("ffmpeg remux failed for %s", audio_path)
-            if tmp_ogg:
-                await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
-            return None
-        except BaseException:
-            # ``CancelledError`` derives from ``BaseException``, so the
-            # ``Exception`` guard above never sees it: a cancellation landing
-            # mid-``communicate`` used to leave the ffmpeg child running and the
-            # owned temp on disk (#5780). Mirror ``_to_native_audio``'s cleanup
-            # (#5777): stop AND reap the child BEFORE the unlink — Windows keeps
-            # the output file locked until the child fully exits, and on POSIX a
-            # live child can race the removal. Every step is best-effort, and
-            # the unlink stays synchronous (one-file unlink, matching #5777): a
-            # repeat cancellation could eat an off-loop hop before it runs. The
-            # exception in flight is the one that must surface.
-            if proc is not None:
+                proc = await _create_ffmpeg_subprocess(
+                    ffmpeg_bin,
+                    "-y",
+                    "-i",
+                    audio_path,
+                    "-c:a",
+                    "copy",
+                    tmp_ogg,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
                 try:
+                    _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+                except asyncio.TimeoutError:
                     proc.kill()
-                except (OSError, ProcessLookupError):
-                    logger.debug(
-                        "ffmpeg kill during cancellation cleanup failed",
-                        exc_info=True,
-                    )
-                else:
+                    await proc.communicate()
+                    raise
+                if proc.returncode != 0:
+                    tail = stderr.decode(errors="replace").strip()[-500:] if stderr else ""
+                    raise RuntimeError(f"ffmpeg {_describe_ffmpeg_exit(proc.returncode, tail)}")
+            except Exception:
+                logger.exception("ffmpeg remux failed for %s", audio_path)
+                if tmp_ogg:
+                    await asyncio.to_thread(_unlink_if_exists, tmp_ogg)
+                return None
+            except BaseException:
+                # ``CancelledError`` derives from ``BaseException``, so the
+                # ``Exception`` guard above never sees it: a cancellation landing
+                # mid-``communicate`` used to leave the ffmpeg child running and the
+                # owned temp on disk (#5780). Mirror ``_to_native_audio``'s cleanup
+                # (#5777): stop AND reap the child BEFORE the unlink — Windows keeps
+                # the output file locked until the child fully exits, and on POSIX a
+                # live child can race the removal. Every step is best-effort, and
+                # the unlink stays synchronous (one-file unlink, matching #5777): a
+                # repeat cancellation could eat an off-loop hop before it runs. The
+                # exception in flight is the one that must surface.
+                if proc is not None:
                     try:
-                        await proc.communicate()
-                    except BaseException:
-                        # A repeat cancellation can land on this await; swallow
-                        # it so the unlink below still runs and the ORIGINAL
-                        # exception is the one that propagates.
+                        proc.kill()
+                    except (OSError, ProcessLookupError):
+                        logger.debug(
+                            "ffmpeg kill during cancellation cleanup failed",
+                            exc_info=True,
+                        )
+                    else:
+                        try:
+                            await proc.communicate()
+                        except BaseException:
+                            # A repeat cancellation can land on this await; swallow
+                            # it so the unlink below still runs and the ORIGINAL
+                            # exception is the one that propagates.
+                            pass
+                if tmp_ogg:
+                    try:
+                        _unlink_if_exists(tmp_ogg)
+                    except OSError:
+                        # A not-yet-exited child can still hold the file (Windows
+                        # lock); letting that escape would REPLACE the in-flight
+                        # cancellation with a PermissionError.
                         pass
-            if tmp_ogg:
-                try:
-                    _unlink_if_exists(tmp_ogg)
-                except OSError:
-                    # A not-yet-exited child can still hold the file (Windows
-                    # lock); letting that escape would REPLACE the in-flight
-                    # cancellation with a PermissionError.
-                    pass
-            raise
+                raise
+        finally:
+            # The authenticated handle must outlive the spawn (#8918): every
+            # branch above has already reaped the child (``communicate`` on
+            # success and on a nonzero exit, kill-and-reap on timeout and on
+            # cancellation), so the staged image can be released now. The
+            # ``finally`` makes the close unconditional — the staged 0700
+            # directory must never leak. ``preserve_active_exception`` is set
+            # only while an exception is genuinely in flight, so a cleanup
+            # failure never masks the original error and a cancellation landing
+            # on the close await of a success path still propagates.
+            try:
+                await _close_ffmpeg_for_execution(
+                    ffmpeg_bin,
+                    preserve_active_exception=sys.exc_info()[1] is not None,
+                )
+            except BaseException:
+                # This await is the only suspension point between the remux
+                # child exiting and ``actual_path`` taking ownership of the
+                # temp. A cancellation landing exactly here (it can only raise
+                # on the no-exception-in-flight path) would otherwise propagate
+                # with ``tmp_ogg`` still on disk; the failure branches already
+                # unlinked, and ``_unlink_if_exists`` tolerates that.
+                if tmp_ogg:
+                    try:
+                        _unlink_if_exists(tmp_ogg)
+                    except OSError:
+                        pass
+                raise
         actual_path = tmp_ogg
 
     transcript_parts: list[str] = []
@@ -1695,21 +1757,34 @@ async def _pcm_via_ffmpeg(audio_path: str, timeout_secs: int) -> np.ndarray | No
         if proc.returncode != 0:
             tail = stderr.decode(errors="replace").strip()[-500:] if stderr else ""
             logger.error(
-                "ffmpeg exited %s decoding %s: %s",
-                proc.returncode,
+                "ffmpeg %s decoding %s",
+                _describe_ffmpeg_exit(proc.returncode, tail),
                 audio_path,
-                tail or "(no stderr)",
             )
             return None
         return await asyncio.to_thread(_pcm_from_wav, tmp_wav)
     finally:
-        # Off the loop, and scheduled as its own task BEFORE it is awaited, so a
-        # repeat cancellation landing on the await abandons only the wait while
-        # the removal still runs to completion in its worker thread. ``shield``
-        # keeps that cancellation out of the removal task; the exception itself
-        # still reaches the awaiter.
+        # Off the loop, and scheduled as its own task BEFORE anything is
+        # awaited, so a repeat cancellation landing on an await abandons only
+        # the wait while the removal still runs to completion in its worker
+        # thread. ``shield`` keeps that cancellation out of the removal task;
+        # the exception itself still reaches the awaiter.
         rm = asyncio.ensure_future(asyncio.to_thread(_unlink_if_exists, tmp_wav))
-        await asyncio.shield(rm)
+        try:
+            # The authenticated handle must outlive the spawn (#8918): every
+            # path reaching this ``finally`` has already reaped the child
+            # (``communicate`` on success and on a nonzero exit, kill-and-reap
+            # on timeout and on cancellation) or never spawned one, so the
+            # staged image can be released now. ``preserve_active_exception``
+            # is set only while an exception is genuinely in flight, so a
+            # cleanup failure never masks the original error and a cancellation
+            # landing on the close await of a success path still propagates.
+            await _close_ffmpeg_for_execution(
+                ffmpeg_bin,
+                preserve_active_exception=sys.exc_info()[1] is not None,
+            )
+        finally:
+            await asyncio.shield(rm)
 
 
 async def _transcribe_local(audio_path: str, stt_config) -> str | None:  # type: ignore[no-untyped-def]

--- a/test/test_apple_speech.py
+++ b/test/test_apple_speech.py
@@ -562,6 +562,98 @@ class TestTranscodeTempOwnership:
         assert src.exists()
 
     @pytest.mark.asyncio
+    async def test_transcode_closes_authenticated_decoder_after_child_exit(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression guard for #8918 at this call site: the staged decoder
+        handle outlives the spawn (the macOS syspolicy assessment resolves the
+        staged path asynchronously after ``create_subprocess_exec`` returns) and
+        is released exactly once, after the child has exited, by the invocation
+        itself rather than by ``__del__`` on the gateway event loop."""
+        from kiro_crew import transcribe as tr
+
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+        events: list = []
+
+        binary = tmp_path / "ffmpeg"
+        binary.write_bytes(b"decoder")
+        descriptor = os.open(str(binary), os.O_RDONLY)
+
+        class _Recording(tr._AuthenticatedFfmpeg):
+            def close(self):
+                # Only the first effective close counts: ``close`` is
+                # idempotent and ``__del__`` re-enters it with the descriptor
+                # already surrendered.
+                if self.descriptor >= 0:
+                    events.append("closed")
+                super().close()
+
+        opened = _Recording(str(binary), descriptor, str(binary))
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                assert "closed" not in events, "handle closed before the child exited"
+                events.append("exited")
+                return b"", b""
+
+        async def fake_exec(*_args, **_kwargs):
+            assert "closed" not in events, "handle closed before the spawn returned"
+            return _Proc()
+
+        with (
+            patch(
+                "kiro_crew.transcribe._open_ffmpeg_for_execution",
+                return_value=opened,
+            ),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+        ):
+            result_path, is_temp = await apple_speech._to_native_audio(str(src))
+        assert result_path == str(owned)
+        assert is_temp is True
+        assert events == ["exited", "closed"]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_on_the_close_await_still_removes_the_owned_temp(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation landing exactly on the deferred close await -- the
+        only suspension point between the child exiting and the success return
+        transferring the temp to the caller -- must not propagate with the
+        invocation-owned ``.wav`` still on disk (#8918 round 2)."""
+        owned = self._owned_temp(tmp_path, monkeypatch)
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        proc = AsyncMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        async def cancelled_close(_executable, **_kwargs):
+            raise asyncio.CancelledError
+
+        with (
+            patch(
+                "kiro_crew.transcribe._open_ffmpeg_for_execution",
+                return_value="/fake/ffmpeg",
+            ),
+            patch("kiro_crew.transcribe.ensure_ffmpeg_in_path"),
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            patch(
+                "kiro_crew.transcribe._close_ffmpeg_for_execution",
+                side_effect=cancelled_close,
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await apple_speech._to_native_audio(str(src))
+        assert not owned.exists()
+        assert src.exists()
+
+    @pytest.mark.asyncio
     async def test_temp_creation_failure_closes_authenticated_decoder_off_loop(
         self, tmp_path, monkeypatch
     ):

--- a/test/test_transcribe.py
+++ b/test/test_transcribe.py
@@ -1933,11 +1933,20 @@ class TestBundledFfmpeg:
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
         assert await transcribe._create_ffmpeg_subprocess(opened, "-version") is sentinel
+        # The staged image must remain resolvable AFTER the spawn returns: the
+        # macOS syspolicy assessment resolves the path asynchronously (#8918),
+        # so the caller owns the close once the child has exited.
+        os.fstat(descriptor)
+        await transcribe._close_ffmpeg_for_execution(opened)
         with pytest.raises(OSError):
             os.fstat(descriptor)
 
     @pytest.mark.asyncio
-    async def test_authenticated_handle_closes_off_event_loop(self, monkeypatch, tmp_path):
+    async def test_failed_spawn_closes_handle_off_event_loop(self, monkeypatch, tmp_path):
+        """A spawn that raises never produced a child, so nothing depends on
+        the staged path surviving: the handle is closed immediately (and off
+        the event loop) before the error propagates. A SUCCESSFUL spawn must
+        NOT close here — see ``TestStagedFfmpegOutlivesSpawn`` (#8918)."""
         self._fake_package(monkeypatch, tmp_path)
         opened = transcribe._open_packaged_ffmpeg_resource()
         assert opened is not None
@@ -1951,12 +1960,13 @@ class TestBundledFfmpeg:
             original_close(self)
 
         async def fake_spawn(*_args, **_kwargs):
-            return object()
+            raise OSError("exec failed")
 
         monkeypatch.setattr(transcribe._AuthenticatedFfmpeg, "close", recording_close)
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_spawn)
 
-        await transcribe._create_ffmpeg_subprocess(opened, "-version")
+        with pytest.raises(OSError, match="exec failed"):
+            await transcribe._create_ffmpeg_subprocess(opened, "-version")
 
         assert len(close_threads) == 1
         assert close_threads[0] != event_loop_thread
@@ -2584,6 +2594,217 @@ class TestTranscribeAwsTempOwnership:
         # await, and wait() must never be touched.
         assert proc.communicate.await_count == 2
         proc.wait.assert_not_awaited()
+        assert not owned.exists()
+        assert src.exists()
+
+
+class TestStagedFfmpegOutlivesSpawn:
+    """Regression guards for #8918: the authenticated handle outlives the spawn.
+
+    On macOS the system policy assessment resolves the staged *path*
+    asynchronously after ``create_subprocess_exec`` returns; closing the handle
+    removes the staged directory, so the kernel denied the exec with SIGKILL
+    and STT was unconditionally broken on desktop installs. The contract
+    pinned here is platform-independent: the handle is never closed before the
+    spawned child has exited, and it is closed exactly once on the success,
+    timeout, and cancellation paths.
+    """
+
+    @staticmethod
+    def _recording_handle(tmp_path, monkeypatch, events):
+        binary = tmp_path / "staged-ffmpeg"
+        binary.write_bytes(b"decoder")
+        descriptor = os.open(str(binary), os.O_RDONLY)
+
+        # A subclass rather than a class-level ``close`` monkeypatch: the
+        # resolver patch below keeps the handle alive until teardown, and an
+        # instance ``__del__`` firing into a half-restored patched class
+        # attribute crashes the interpreter.
+        class _Recording(transcribe._AuthenticatedFfmpeg):
+            def close(self):
+                # Only the first effective close counts: ``close`` is
+                # idempotent and ``__del__`` re-enters it with the descriptor
+                # already surrendered.
+                if self.descriptor >= 0:
+                    events.append("closed")
+                super().close()
+
+        opened = _Recording(str(binary), descriptor, str(binary))
+        monkeypatch.setattr(transcribe, "_open_ffmpeg_for_execution", lambda: opened)
+        return opened
+
+    @pytest.mark.asyncio
+    async def test_success_path_closes_after_child_exit_exactly_once(self, tmp_path, monkeypatch):
+        events: list = []
+        self._recording_handle(tmp_path, monkeypatch, events)
+        owned = tmp_path / "owned.wav"
+        monkeypatch.setattr(transcribe, "_make_temp_wav", lambda: str(owned))
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                assert "closed" not in events, "handle closed before the child exited"
+                events.append("exited")
+                _write_wav(owned, _ramp_int16(80))
+                return b"", b""
+
+        async def fake_exec(*_args, **_kwargs):
+            assert "closed" not in events, "handle closed before the spawn returned"
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        result = await transcribe._pcm_via_ffmpeg(str(tmp_path / "memo.webm"), 1)
+        assert result is not None
+        assert result.size == 80
+        assert events == ["exited", "closed"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_timeout_path_closes_after_reap_exactly_once(self, tmp_path, monkeypatch):
+        events: list = []
+        self._recording_handle(tmp_path, monkeypatch, events)
+        owned = tmp_path / "owned.wav"
+        owned.write_bytes(b"")
+        monkeypatch.setattr(transcribe, "_make_temp_wav", lambda: str(owned))
+
+        class _Proc:
+            returncode = -9
+
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    raise asyncio.TimeoutError
+                assert "closed" not in events, "handle closed before the child was reaped"
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                assert "closed" not in events, "handle closed before the child was killed"
+                events.append("killed")
+
+        async def fake_exec(*_args, **_kwargs):
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        assert await transcribe._pcm_via_ffmpeg(str(tmp_path / "memo.webm"), 1) is None
+        assert events == ["killed", "reaped", "closed"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_closes_after_reap_exactly_once(self, tmp_path, monkeypatch):
+        events: list = []
+        self._recording_handle(tmp_path, monkeypatch, events)
+        owned = tmp_path / "owned.wav"
+        owned.write_bytes(b"")
+        monkeypatch.setattr(transcribe, "_make_temp_wav", lambda: str(owned))
+        started = asyncio.Event()
+
+        class _Proc:
+            returncode = None
+
+            def __init__(self):
+                self._calls = 0
+
+            async def communicate(self):
+                self._calls += 1
+                if self._calls == 1:
+                    started.set()
+                    await asyncio.sleep(3600)
+                assert "closed" not in events, "handle closed before the child was reaped"
+                events.append("reaped")
+                return b"", b""
+
+            def kill(self):
+                events.append("killed")
+
+        async def fake_exec(*_args, **_kwargs):
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        task = asyncio.create_task(transcribe._pcm_via_ffmpeg(str(tmp_path / "memo.webm"), 60))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert events == ["killed", "reaped", "closed"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_remux_path_closes_after_child_exit_exactly_once(self, tmp_path, monkeypatch):
+        """The webm→ogg remux call site owns the same deferred close: the
+        handle survives until the child has exited, then is released exactly
+        once even when the remux itself fails."""
+        events: list = []
+        self._recording_handle(tmp_path, monkeypatch, events)
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        TestTranscribeAwsTempOwnership._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = tmp_path / "owned.ogg"
+        owned.write_bytes(b"")
+        monkeypatch.setattr(transcribe, "_make_temp_ogg", lambda: str(owned))
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        class _Proc:
+            # A nonzero exit keeps the test inside the remux block: the child
+            # HAS exited when the error path runs, so the close must follow it.
+            returncode = 1
+
+            async def communicate(self):
+                assert "closed" not in events, "handle closed before the child exited"
+                events.append("exited")
+                return b"", b""
+
+        async def fake_exec(*_args, **_kwargs):
+            assert "closed" not in events, "handle closed before the spawn returned"
+            return _Proc()
+
+        monkeypatch.setattr(transcribe, "boto3", object())
+        monkeypatch.setattr(transcribe, "_load_aws_transcribe_components", lambda: (object, object))
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        assert await transcribe._transcribe_aws(str(src), cfg) is None
+        assert events == ["exited", "closed"]
+        assert not owned.exists()
+
+    @pytest.mark.asyncio
+    async def test_remux_cancellation_on_the_close_await_still_removes_the_temp(
+        self, tmp_path, monkeypatch
+    ):
+        """A cancellation landing exactly on the deferred close await -- the
+        only suspension point between the remux child exiting and the temp
+        changing owner -- must not propagate with ``tmp_ogg`` still on disk."""
+        events: list = []
+        self._recording_handle(tmp_path, monkeypatch, events)
+        cfg = SttConfig(enabled=True, provider="transcribe", timeout_secs=10)
+        TestTranscribeAwsTempOwnership._grant_consent(tmp_path, monkeypatch, cfg)
+        owned = tmp_path / "owned.ogg"
+        owned.write_bytes(b"")
+        monkeypatch.setattr(transcribe, "_make_temp_ogg", lambda: str(owned))
+        src = tmp_path / "voice.webm"
+        src.write_bytes(b"data")
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                events.append("exited")
+                return b"", b""
+
+        async def fake_exec(*_args, **_kwargs):
+            return _Proc()
+
+        async def cancelled_close(_executable, **_kwargs):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(transcribe, "boto3", object())
+        monkeypatch.setattr(transcribe, "_load_aws_transcribe_components", lambda: (object, object))
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(transcribe, "_close_ffmpeg_for_execution", cancelled_close)
+        with pytest.raises(asyncio.CancelledError):
+            await transcribe._transcribe_aws(str(src), cfg)
         assert not owned.exists()
         assert src.exists()
 


### PR DESCRIPTION
## Problem / Motivation

On macOS desktop (bundled-interpreter) installs, every speech-to-text request fails at the audio-decode step with `ffmpeg exited -9 ... (no stderr)`. The bundled FFmpeg is staged into a fresh 0700 directory under the gateway runtime root, and `_create_ffmpeg_subprocess` closed the authenticated handle in a `finally` that ran the moment `asyncio.create_subprocess_exec` returned — and closing removes the staged directory. A returning `create_subprocess_exec` means only that the fork/exec was issued: on macOS the syspolicy assessment resolves the staged *path* asynchronously, so `syspolicyd` stat'ed an already-unlinked path, failed closed, and the kernel denied the exec with SIGKILL. The reporter measured 5/5 failures on both `.ogg` and `.webm` — STT was unconditionally broken on that platform, and holding the descriptor via `pass_fds` does not help because the assessment resolves the path, not the inode.

## Why it matters

Dictation and voice-memo transcription are completely dead for every macOS desktop user, with no user-side workaround (every provider routes compressed input through the same decode path), and the log misdirects diagnosis toward corrupt audio.

## What changed (motivation → approach → change)

Symptom: SIGKILL with no stderr right after spawn. Root cause: the staged image's lifetime ended at spawn-return, but the platform's authorization of the exec extends past it. The change makes the authenticated handle outlive the spawn until the child has actually exited, at every call site, keeping the existing security model intact:

- `_create_ffmpeg_subprocess` no longer closes on a successful spawn. A FAILED spawn (no child produced, nothing depends on the path surviving) still closes immediately before the error propagates, and pre-spawn failure paths (temp-file creation) are unchanged.
- All three spawn call sites — the webm→ogg remux path and the PCM decode path in `src/kiro_crew/transcribe.py`, and `apple_speech._to_native_audio` — now release the handle in an unconditional `finally` around the whole spawn-plus-wait block, after the child has been reaped on every branch (communicate on success and nonzero exit, kill-and-reap on timeout and on cancellation). The off-loop close, the `asyncio.shield` semantics, and `preserve_active_exception` (set only while an exception is genuinely in flight, via `sys.exc_info`) are kept, so a cleanup failure never masks the original error and the staged 0700 directory cannot leak. Double-close is inert by construction (`_AuthenticatedFfmpeg.close` swaps the descriptor and cleanup path out first).
- A cancellation landing exactly on the deferred close await — the only suspension point between the child exiting and the temp output changing owner — unlinks the invocation-owned temp before propagating, at both the remux and `apple_speech` call sites (the PCM path already schedules its removal before the close and shields it).
- Diagnosis: a negative return code is now logged as a signal death via a shared `_describe_ffmpeg_exit` helper, with a macOS hint at the system-policy denial path, instead of a bare `exited -9 ... (no stderr)` that reads as corrupt audio.

## Tests

Eight new regression tests pin the platform-independent ordering contract — the authenticated handle is never closed before the spawned child has exited, it is closed exactly once on the success, timeout, and cancellation paths, and a cancellation raised from the close await leaves no temp behind:

- `test_transcribe.py::TestStagedFfmpegOutlivesSpawn` — success, timeout, and cancellation ordering on the PCM path, the remux call site, and the remux close-await cancellation leak guard.
- `test_apple_speech.py::TestTranscodeTempOwnership` — the `_to_native_audio` call site's close-after-exit ordering and its close-await cancellation leak guard.
- `test_transcribe.py::TestBundledFfmpeg::test_authenticated_bytes_remain_bound_until_spawn` updated: the descriptor must remain open AFTER the spawn returns; the off-loop close guarantee now pins the failed-spawn path (`test_failed_spawn_closes_handle_off_event_loop`).

Red-before proven by reverting the source changes with the tests kept: all eight fail on the old lifecycle.

## Manual verification

This defect only reproduces on macOS with a bundled interpreter, so CI verifies the lifecycle contract and the regression tests but not the end-to-end dictation path. A human on macOS should confirm dictation works on a desktop build. (Gates run on Linux; the tests deliberately assert close ordering relative to process exit rather than macOS-only behaviour.)

## Related Issues

Closes #8918

## Pattern harvest

Rule candidate: review-prompt
Pattern: resource released in a `finally` scoped to the spawn call instead of the child's lifetime — an async spawn returning does not mean the OS has finished consuming the resources named in it.

## Checklist

- [x] At most two commits (one is the norm), with a Conventional Commits title (`feat|fix|docs|refactor|perf|test|chore|ci|build|revert: ...`)
- [x] Existing tests pass and new tests added for new functionality
- [x] Self-review completed; code follows project style guidelines
- [ ] Documentation updated (if applicable)
- [x] No secrets, credentials, or internal references in the diff
